### PR TITLE
ops: Cloudflare alerting apply

### DIFF
--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -1,0 +1,76 @@
+name: cloudflare-alerting-apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without mutating Cloudflare (prints payloads)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+  schedule:
+    - cron: "23 3 * * 1" # weekly drift remediation
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard Cloudflare alerting secrets
+        id: guard
+        env:
+          CLOUDFLARE_ALERTS_API_TOKEN: ${{ secrets.CLOUDFLARE_ALERTS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_ALERTS_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare alerting secrets not configured; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Ensure jq
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v jq >/dev/null 2>&1 && exit 0
+          sudo apt-get update -y
+          sudo apt-get install -y jq
+
+      - name: Apply Cloudflare alerting policies
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_ALERTS_API_TOKEN: ${{ secrets.CLOUDFLARE_ALERTS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ALERT_EMAILS: ${{ vars.CLOUDFLARE_ALERT_EMAILS }}
+          CLOUDFLARE_ALERT_WEBHOOK_URL: ${{ secrets.CLOUDFLARE_ALERT_WEBHOOK_URL }}
+          CLOUDFLARE_ALERT_WEBHOOK_NAME: skincos-alerts
+          CLOUDFLARE_PAGES_PROJECT_IDS: ${{ vars.CLOUDFLARE_PAGES_PROJECT_IDS }}
+          CLOUDFLARE_PAGES_ENVIRONMENTS: ${{ vars.CLOUDFLARE_PAGES_ENVIRONMENTS }}
+          CLOUDFLARE_PAGES_EVENTS: ${{ vars.CLOUDFLARE_PAGES_EVENTS }}
+          CLOUDFLARE_ALERTING_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd /tmp
+          bash "$GITHUB_WORKSPACE/backend/scripts/cloudflare-alerting-apply.sh"
+          cat cloudflare-alerting-apply.summary.json
+
+      - name: Upload summary artifact
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-alerting-apply
+          path: /tmp/cloudflare-alerting-apply.summary.json
+

--- a/backend/scripts/cloudflare-alerting-apply.sh
+++ b/backend/scripts/cloudflare-alerting-apply.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Applies a baseline set of Cloudflare Alerting policies in an idempotent way.
+#
+# Required env:
+#   CLOUDFLARE_ACCOUNT_ID
+#   CLOUDFLARE_ALERTS_API_TOKEN  (preferred) OR CLOUDFLARE_API_TOKEN
+#
+# Destination config (at least one is required):
+#   CLOUDFLARE_ALERT_EMAILS          CSV of emails (e.g. "ops@skincos.com.br,dev@skincos.com.br")
+#   CLOUDFLARE_ALERT_WEBHOOK_URL     Webhook URL (Slack/Discord/HTTP receiver)
+#
+# Optional env:
+#   CLOUDFLARE_ALERT_WEBHOOK_NAME    Default: "skincos-alerts"
+#   CLOUDFLARE_ZONE_NAME             Default: "skincos.com.br" (used only for best-effort Pages discovery)
+#   CLOUDFLARE_PAGES_PROJECT_IDS     CSV of Pages project ids (optional filter)
+#   CLOUDFLARE_PAGES_ENVIRONMENTS    CSV (default: "production,preview")
+#   CLOUDFLARE_PAGES_EVENTS          CSV (optional filter)
+#   CLOUDFLARE_ALERTING_DRY_RUN      "true" to print requests without mutating
+#
+# Output:
+#   Writes cloudflare-alerting-apply.summary.json in the current directory.
+
+api="https://api.cloudflare.com/client/v4"
+acct="${CLOUDFLARE_ACCOUNT_ID:-}"
+token="${CLOUDFLARE_ALERTS_API_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
+
+emails_csv="${CLOUDFLARE_ALERT_EMAILS:-}"
+webhook_url="${CLOUDFLARE_ALERT_WEBHOOK_URL:-}"
+webhook_name="${CLOUDFLARE_ALERT_WEBHOOK_NAME:-skincos-alerts}"
+
+zone_name="${CLOUDFLARE_ZONE_NAME:-skincos.com.br}"
+pages_project_ids_csv="${CLOUDFLARE_PAGES_PROJECT_IDS:-}"
+pages_envs_csv="${CLOUDFLARE_PAGES_ENVIRONMENTS:-production,preview}"
+pages_events_csv="${CLOUDFLARE_PAGES_EVENTS:-}"
+
+dry_run="${CLOUDFLARE_ALERTING_DRY_RUN:-false}"
+
+if [[ -z "${acct}" ]]; then
+  echo "[cloudflare-alerting-apply] Missing CLOUDFLARE_ACCOUNT_ID" >&2
+  exit 2
+fi
+if [[ -z "${token}" ]]; then
+  echo "[cloudflare-alerting-apply] Missing CLOUDFLARE_ALERTS_API_TOKEN (or CLOUDFLARE_API_TOKEN)" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[cloudflare-alerting-apply] Missing jq (required)" >&2
+  exit 2
+fi
+if [[ -z "${emails_csv}" && -z "${webhook_url}" ]]; then
+  echo "[cloudflare-alerting-apply] Missing destinations: set CLOUDFLARE_ALERT_EMAILS and/or CLOUDFLARE_ALERT_WEBHOOK_URL" >&2
+  exit 2
+fi
+
+hdr=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
+
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "${tmpdir}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+csv_to_json_array() {
+  local csv="${1:-}"
+  if [[ -z "${csv}" ]]; then
+    echo "[]"
+    return 0
+  fi
+  jq -Rsc 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))' <<<"${csv}"
+}
+
+cf_get() {
+  local path="$1"
+  curl -fsS "${hdr[@]}" "${api}${path}"
+}
+
+cf_post() {
+  local path="$1"
+  local body="$2"
+  if [[ "${dry_run}" == "true" ]]; then
+    echo "[dry-run] POST ${path}"
+    echo "${body}" | jq -c .
+    return 0
+  fi
+  curl -fsS "${hdr[@]}" -X POST "${api}${path}" --data "${body}"
+}
+
+cf_put() {
+  local path="$1"
+  local body="$2"
+  if [[ "${dry_run}" == "true" ]]; then
+    echo "[dry-run] PUT ${path}"
+    echo "${body}" | jq -c .
+    return 0
+  fi
+  curl -fsS "${hdr[@]}" -X PUT "${api}${path}" --data "${body}"
+}
+
+echo "[cloudflare-alerting-apply] token verify (best-effort)"
+if [[ "${dry_run}" != "true" ]]; then
+  cf_get "/user/tokens/verify" >/dev/null || true
+fi
+
+emails_json="$(csv_to_json_array "${emails_csv}")"
+pages_project_ids_json="$(csv_to_json_array "${pages_project_ids_csv}")"
+pages_envs_json="$(csv_to_json_array "${pages_envs_csv}")"
+pages_events_json="$(csv_to_json_array "${pages_events_csv}")"
+
+webhook_id=""
+webhooks_out="${tmpdir}/webhooks.json"
+
+if [[ -n "${webhook_url}" ]]; then
+  echo "[cloudflare-alerting-apply] ensure webhook destination: ${webhook_name}"
+  cf_get "/accounts/${acct}/alerting/v3/destinations/webhooks" > "${webhooks_out}"
+  webhook_id="$(jq -r --arg name "${webhook_name}" '.result[]? | select(.name==$name) | .id' "${webhooks_out}" | head -n 1)"
+  if [[ -z "${webhook_id}" || "${webhook_id}" == "null" ]]; then
+    created="$(cf_post "/accounts/${acct}/alerting/v3/destinations/webhooks" "$(jq -n --arg name "${webhook_name}" --arg url "${webhook_url}" '{name:$name,url:$url}')")"
+    webhook_id="$(jq -r '.result.id // empty' <<<"${created}" 2>/dev/null || true)"
+  else
+    current_url="$(jq -r --arg id "${webhook_id}" '.result[]? | select(.id==$id) | .url // empty' "${webhooks_out}" | head -n 1)"
+    if [[ -n "${current_url}" && "${current_url}" != "${webhook_url}" ]]; then
+      cf_put "/accounts/${acct}/alerting/v3/destinations/webhooks/${webhook_id}" "$(jq -n --arg name "${webhook_name}" --arg url "${webhook_url}" '{name:$name,url:$url}')" >/dev/null
+    fi
+  fi
+fi
+
+mechanisms="$(jq -n --argjson emails "${emails_json}" --arg webhook_id "${webhook_id}" '
+  {}
+  + ( ($emails|length)>0 ? {email: $emails} : {} )
+  + ( ($webhook_id|length)>0 ? {webhooks: [$webhook_id]} : {} )
+')"
+
+if [[ "$(jq -r 'keys|length' <<<"${mechanisms}")" == "0" ]]; then
+  echo "[cloudflare-alerting-apply] No valid mechanisms resolved (check CLOUDFLARE_ALERT_EMAILS / webhook creation)" >&2
+  exit 2
+fi
+
+echo "[cloudflare-alerting-apply] list policies"
+policies_out="${tmpdir}/policies.json"
+cf_get "/accounts/${acct}/alerting/v3/policies" > "${policies_out}"
+
+ensure_policy() {
+  local name="$1"
+  local alert_type="$2"
+  local description="$3"
+  local filters_json="$4" # object
+
+  local existing_id
+  existing_id="$(jq -r --arg name "${name}" '.result[]? | select(.name==$name) | .id' "${policies_out}" | head -n 1)"
+
+  local body
+  body="$(jq -n \
+    --arg name "${name}" \
+    --arg description "${description}" \
+    --arg alert_type "${alert_type}" \
+    --argjson enabled true \
+    --argjson mechanisms "${mechanisms}" \
+    --argjson filters "${filters_json}" \
+    '{
+      name: $name,
+      description: $description,
+      alert_type: $alert_type,
+      enabled: $enabled,
+      mechanisms: $mechanisms
+    } + ( ($filters|keys|length)>0 ? {filters: $filters} : {} )
+  ')"
+
+  if [[ -z "${existing_id}" || "${existing_id}" == "null" ]]; then
+    echo "[cloudflare-alerting-apply] create policy: ${name}"
+    cf_post "/accounts/${acct}/alerting/v3/policies" "${body}" >/dev/null
+  else
+    echo "[cloudflare-alerting-apply] update policy: ${name}"
+    cf_put "/accounts/${acct}/alerting/v3/policies/${existing_id}" "${body}" >/dev/null
+  fi
+
+  if [[ "${dry_run}" != "true" ]]; then
+    cf_get "/accounts/${acct}/alerting/v3/policies" > "${policies_out}"
+  fi
+}
+
+pages_filters="$(jq -n \
+  --argjson pids "${pages_project_ids_json}" \
+  --argjson envs "${pages_envs_json}" \
+  --argjson events "${pages_events_json}" \
+  '({})
+    + ( ($pids|length)>0 ? {project_id:$pids} : {} )
+    + ( ($envs|length)>0 ? {environment:$envs} : {} )
+    + ( ($events|length)>0 ? {event:$events} : {} )
+  ')"
+
+if [[ "$(jq -r 'keys|length' <<<"${pages_filters}")" == "0" ]]; then
+  # Best-effort: try to discover Pages project ids to at least scope the policy.
+  pages_discovered="${tmpdir}/pages-projects.json"
+  if cf_get "/accounts/${acct}/pages/projects" > "${pages_discovered}" 2>/dev/null; then
+    discovered_ids="$(jq -r '.result[]?.id' "${pages_discovered}" 2>/dev/null | head -n 20 | paste -sd, -)"
+    if [[ -n "${discovered_ids}" ]]; then
+      pages_filters="$(jq -n --argjson pids "$(csv_to_json_array "${discovered_ids}")" '{project_id:$pids}')"
+      echo "[cloudflare-alerting-apply] pages projects discovered (scoping alert): ${discovered_ids}"
+    fi
+  fi
+fi
+
+ensure_policy "skincos - Cloudflare incidents" "incident_alert" "Incidentes do Cloudflare Status" "{}"
+ensure_policy "skincos - Cloudflare maintenance" "maintenance_event_notification" "Janelas de manutenção do Cloudflare Status" "{}"
+ensure_policy "skincos - Pages events" "pages_event_alert" "Eventos e falhas de deploy do Cloudflare Pages" "${pages_filters}"
+ensure_policy "skincos - Origin unreachable" "real_origin_monitoring" "Cloudflare não consegue alcançar o origin" "{}"
+ensure_policy "skincos - HTTP DDoS attack" "dos_attack_l7" "Alertas de ataque DDoS HTTP (L7)" "{}"
+ensure_policy "skincos - Universal SSL events" "universal_ssl_event_type" "Eventos de Universal SSL (certificados / validação)" "{}"
+
+echo "[cloudflare-alerting-apply] refresh policies list"
+final="$(cf_get "/accounts/${acct}/alerting/v3/policies")"
+echo "${final}" | jq '{count:(.result|length), names:(.result|map(.name)|sort)}' > cloudflare-alerting-apply.summary.json
+
+echo "[cloudflare-alerting-apply] done"

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -6,19 +6,21 @@ Objetivo: bloquear push direto em `main` e exigir PR com checks verdes.
 
 - Branch name pattern: `main`
 - Require a pull request before merging
-  - Require approvals: `1`
-  - Dismiss stale approvals: `true`
+  - Require approvals: `0` (desligado) — para permitir auto-merge sem intervenção humana
+  - Dismiss stale approvals: `true` (se aprovações forem habilitadas no futuro)
 - Require status checks to pass before merging
-  - `CI Smoke (Assert)`
-  - `Lint, Format & Static Analysis`
-  - `Test Coverage & Quality`
-  - `Security Secrets Audit`
+  - `CI Smoke (Assert)` (obrigatório)
+  - `Central E2E Smoke` (obrigatório)
+  - (recomendado) `Lint, Format & Static Analysis`
+  - (recomendado) `Security Secrets Audit`
 - Require branches to be up to date before merging: `true`
 - Restrict who can push to matching branches: `true`
+- Do not allow bypassing the above settings: `true` (enforce_admins)
 - Allow force pushes: `false`
 - Allow deletions: `false`
 
 ## Observações
 
-- Se usar `CODEOWNERS`, habilitar “Require review from Code Owners”.
-- Para deploy automático, manter os workflows de deploy disparando apenas após merge em `main`.
+- Se precisar de aprovações no futuro: usar `CODEOWNERS` + “Require review from Code Owners” e um usuário humano/bot dedicado para reviews.
+- Para deploy automático: manter os workflows de deploy disparando apenas após merge em `main` (nunca em PR).
+- Para reduzir atrito: habilitar “Auto-merge” e “Automatically delete head branches”.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,6 +42,31 @@ Recomendação: configurar alertas com janelas de 5–10 minutos e rotas especí
 - `api.skincos.com.br/*`
 - `crm.skincos.com.br/api/*`
 
+### Automação de alertas via API (baseline)
+
+Workflow: `.github/workflows/cloudflare-alerting-apply.yml`
+
+Este workflow cria/atualiza (idempotente) um baseline de políticas via **Cloudflare Alerting API v3**:
+- Incidents (Cloudflare Status)
+- Maintenance (Cloudflare Status)
+- Pages events (deploy/erros)
+- Passive Origin Monitoring (origin unreachable)
+- HTTP DDoS (L7)
+- Universal SSL events
+
+Configuração (repo → Settings):
+- **Secrets → Actions**
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - `CLOUDFLARE_ALERTS_API_TOKEN`
+  - (opcional) `CLOUDFLARE_ALERT_WEBHOOK_URL`
+- **Variables → Actions**
+  - `CLOUDFLARE_ALERT_EMAILS` (CSV)
+  - (opcional) `CLOUDFLARE_PAGES_PROJECT_IDS` (CSV)
+  - (opcional) `CLOUDFLARE_PAGES_ENVIRONMENTS` (CSV, default sugerido: `production,preview`)
+  - (opcional) `CLOUDFLARE_PAGES_EVENTS` (CSV)
+
+Observação: os alertas de **5xx/latência/D1/R2/429** podem depender de produtos/telemetria adicionais (ex.: Workers Observability) e podem não estar disponíveis diretamente via Alerting API v3; mantenha também o `uptime-slo.yml` como monitor sintético.
+
 ### Checklist rápido (Cloudflare)
 
 1. **Workers / Pages → Analytics → Alerts**:

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -8,7 +8,9 @@ Garantir que segredos críticos (GitHub, Cloudflare, backend) tenham **escopo m�
 ### GitHub Actions (secrets)
 - `GH_TOKEN` (CI submodules)
 - `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ALERTS_API_TOKEN` (alerting/notifications — escopo mínimo, sem permissões de deploy)
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_ALERT_WEBHOOK_URL` (opcional)
 - `CRM_API_SSH_HOST`
 - `CRM_API_SSH_USER`
 - `CRM_API_SSH_KEY`


### PR DESCRIPTION
Cria workflow e script idempotente para aplicar políticas baseline de alertas no Cloudflare (incidents, maintenance, Pages, origin monitoring, DDoS L7, Universal SSL) via API v3.\n\nDocs: atualiza observabilidade e governança/segredos.