### PR TITLE
ci: skip cloudflare-alerting-apply when destinations missing

### DIFF
--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -26,10 +26,15 @@ jobs:
         env:
           CLOUDFLARE_ALERTS_API_TOKEN: ${{ secrets.CLOUDFLARE_ALERTS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ALERT_EMAILS: ${{ vars.CLOUDFLARE_ALERT_EMAILS }}
+          CLOUDFLARE_ALERT_WEBHOOK_URL: ${{ secrets.CLOUDFLARE_ALERT_WEBHOOK_URL }}
         run: |
           set -euo pipefail
           if [[ -z "${CLOUDFLARE_ALERTS_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
             echo "Cloudflare alerting secrets not configured; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [[ -z "${CLOUDFLARE_ALERT_EMAILS:-}" && -z "${CLOUDFLARE_ALERT_WEBHOOK_URL:-}" ]]; then
+            echo "Cloudflare alerting destinations not configured (email/webhook); skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -73,4 +78,3 @@ jobs:
         with:
           name: cloudflare-alerting-apply
           path: /tmp/cloudflare-alerting-apply.summary.json
-


### PR DESCRIPTION
Evita falhas do workflow semanal quando nenhum destino (email/webhook) estiver configurado.