### PR TITLE
security: require SESSION_SECRET; disable unsigned legacy sessions

### DIFF
--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -852,17 +852,13 @@ async function decodeSessionV2(token, secret) {
 }
 
 async function decodeSessionCookie(token, secret) {
-    if (!token) return null;
+    if (!token || !secret) return null;
+    if (!String(token).includes('.')) return null;
     try {
-        if (secret && String(token).includes('.')) return await decodeSessionV2(token, secret);
+        return await decodeSessionV2(token, secret);
     } catch {
-        // fall back
+        return null;
     }
-    const legacy = decodeSessionLegacy(token);
-    if (!legacy) return null;
-    const exp = Number(legacy?.exp || 0);
-    if (exp && Date.now() > exp) return null;
-    return legacy;
 }
 
 function deleteAuthCookies({ secure } = {}) {
@@ -1406,13 +1402,16 @@ export default {
             }
         }
 
-        const sessionSecret = env.SESSION_SECRET || '';
+        const sessionSecret = String(env.SESSION_SECRET || '').trim();
+        if (!sessionSecret) {
+            return withCORS(JSON.stringify({ error: "SESSION_SECRET not configured" }), { status: 500 }, appOrigin);
+        }
 
         const issueAuthCookies = async (sessionPayload) => {
             const csrf = crypto.randomUUID();
             const exp = Date.now() + 7 * 24 * 60 * 60 * 1000;
             const payload = { ...sessionPayload, csrf, exp };
-            const token = sessionSecret ? await encodeSessionV2(payload, sessionSecret) : encodeSessionLegacy(payload);
+            const token = await encodeSessionV2(payload, sessionSecret);
 
             // Dev (http) cannot set Secure cookies; SameSite=None also requires Secure.
             const sameSite = isSecureContext ? 'None' : 'Lax';

--- a/backend/apps/insumos/wrangler.toml
+++ b/backend/apps/insumos/wrangler.toml
@@ -67,7 +67,7 @@ MOVIMENTACOES_RANGE = "Movimentacoes!A:AZ"
 # Sheets é opcional (apenas para migração/restore legado) e pode ficar desabilitado em produção.
 #
 # Secrets (set via `wrangler secret put`):
-# - SESSION_SECRET (recommended)
+# - SESSION_SECRET (required)
 # - MIGRATION_TOKEN (optional, one-time)  # permite chamar POST /admin/migrate/sheets-to-d1 sem sessão/CSRF
 #
 # Optional legacy (Sheets):

--- a/backend/apps/whatsapp/official-module/official-whatsapp.js
+++ b/backend/apps/whatsapp/official-module/official-whatsapp.js
@@ -100,8 +100,14 @@ app.use(helmet({
 app.set('trust proxy', 1);
 
 // Session configuration for CSRF protection
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (IS_PRODUCTION && !SESSION_SECRET) {
+    throw new Error('SESSION_SECRET is required in production');
+}
+
 app.use(session({
-    secret: process.env.SESSION_SECRET || crypto.randomBytes(64).toString('hex'),
+    secret: SESSION_SECRET || crypto.randomBytes(64).toString('hex'),
     resave: false,
     saveUninitialized: false,
     cookie: {


### PR DESCRIPTION
- Insumos Worker: torna SESSION_SECRET obrigatório e desabilita fallback de cookie de sessão não-assinado (legacy).
- WhatsApp official module: exige SESSION_SECRET em produção (remove secret randômico em prod).

Nota: se SESSION_SECRET não estiver configurado no ambiente, o Worker retornará 500 (fail-closed) — configure via: wrangler secret put SESSION_SECRET
