### PR TITLE
fix(auth): determinismo no login e proxy de cookies

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,30 @@
+---
+title: Autenticação (CRM)
+---
+
+# Autenticação (CRM)
+
+## Source of truth
+
+O CRM usa **apenas um backend de autenticação**:
+- **Insumos Worker** (`api.skincos.com.br/insumos`) nas rotas `GET/POST /auth/*`
+
+O frontend (Cloudflare Pages) expõe um proxy estável:
+- `crm.skincos.com.br/api/auth/*` → `api.skincos.com.br/insumos/auth/*`
+
+## Sessão
+
+- Sessão é via **cookies HttpOnly** (`session`, `csrfToken`) emitidos pelo Worker.
+- Em `crm.skincos.com.br`, o proxy Pages preserva múltiplos `Set-Cookie` e remove `Domain=` para cookies host-only.
+- O dashboard só monta após a verificação determinística de sessão (`/api/auth/me`).
+
+## Endpoints (principais)
+
+- `POST /api/auth/login` → cria sessão
+- `POST /api/auth/register` → cria conta + sessão
+- `GET /api/auth/me` → retorna usuário + renova cookies
+- `POST /api/auth/logout` → encerra sessão
+
+## Configuração (produção)
+
+- `SESSION_SECRET` **obrigatório** no Worker Insumos (via `wrangler secret put SESSION_SECRET`).

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -186,7 +186,7 @@ const modules: { key: string; label: string; icon: React.ReactNode; component: R
 ]
 
 export default function AppFunctionalNeatlab() {
-    const { isAuthenticated, user, signOut } = useAuth()
+    const { isAuthenticated, user, signOut, initializing, initProgress } = useAuth()
 
     const DEFAULT_MODULE_KEY = 'insumos'
 
@@ -474,6 +474,24 @@ export default function AppFunctionalNeatlab() {
         () => modules.find(m => m.key === active) || modules.find(m => m.key === DEFAULT_MODULE_KEY),
         [DEFAULT_MODULE_KEY, active]
     )
+
+	    if (initializing) {
+	        return (
+	            <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-corporate-950 via-corporate-900 to-corporate-800 p-6">
+	                <div className="w-full max-w-md rounded-2xl border border-white/10 bg-black/20 p-6 text-center text-white shadow-2xl">
+	                    <div className="text-3xl mb-4">⏳</div>
+	                    <div className="text-lg font-semibold">Carregando sessão…</div>
+	                    <div className="text-sm text-blue-100/70 mt-1">Aguarde enquanto verificamos sua sessão.</div>
+	                    <div className="mt-6 flex items-center justify-center">
+	                        <Button variant="secondary" size="lg" disabled className="gap-2">
+	                            <span className="animate-pulse">🔄</span>
+	                            {`Carregando ${Math.max(0, Math.min(100, Number.isFinite(initProgress as any) ? (initProgress as any) : 0))}%`}
+	                        </Button>
+	                    </div>
+	                </div>
+	            </div>
+	        )
+	    }
 
 	    if (!isAuthenticated) {
 	        return <AuthScreen />

--- a/frontend/contexts.tsx
+++ b/frontend/contexts.tsx
@@ -24,6 +24,8 @@ export interface AuthUser {
 interface AuthContextValue {
   user: AuthUser | null
   loading: boolean
+  initializing: boolean
+  initProgress: number
   signIn: (email: string, password: string) => Promise<void>
   signUp: (name: string, email: string, password: string, inviteToken: string) => Promise<void>
   signOut: () => void
@@ -56,6 +58,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const isAuthenticated = replitAuth?.isAuthenticated || false
   const shouldShowLoadingOverlay = isLoading && !isNoAuthMode()
   const [actionLoading, setActionLoading] = useState(false)
+  const [initProgress, setInitProgress] = useState(0)
+  const initStartedAtRef = React.useRef<number | null>(null)
   const AUTH_ME_QUERY_KEY = ['/api/auth/me']
 
   const fetchWithTimeout = async (input: RequestInfo | URL, init: RequestInit, timeoutMs: number) => {
@@ -229,6 +233,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value: AuthContextValue = {
     user,
     loading: actionLoading,
+    initializing: shouldShowLoadingOverlay,
+    initProgress,
     signIn,
     signUp,
     signOut,
@@ -236,6 +242,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     token: null,
     isAuthenticated
   }
+
+  useEffect(() => {
+    if (!shouldShowLoadingOverlay) {
+      initStartedAtRef.current = null
+      setInitProgress(100)
+      const t = setTimeout(() => setInitProgress(0), 250)
+      return () => clearTimeout(t)
+    }
+
+    if (!initStartedAtRef.current) initStartedAtRef.current = Date.now()
+    const tick = () => {
+      const started = initStartedAtRef.current || Date.now()
+      const elapsed = Date.now() - started
+      const budgetMs = 12000
+      const pct = Math.min(95, Math.max(1, Math.floor((elapsed / budgetMs) * 95)))
+      setInitProgress(pct)
+    }
+    tick()
+    const id = window.setInterval(tick, 150)
+    return () => window.clearInterval(id)
+  }, [shouldShowLoadingOverlay])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -268,7 +295,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }}>
           <div style={{ textAlign: 'center' }}>
             <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>🔄</div>
-            <div>Inicializando autenticação...</div>
+            <div style={{ fontWeight: 700, marginBottom: '0.25rem' }}>Carregando…</div>
+            <div style={{ opacity: 0.9 }}>{initProgress}%</div>
           </div>
         </div>
       )}

--- a/frontend/functions/api/auth/[[path]].ts
+++ b/frontend/functions/api/auth/[[path]].ts
@@ -35,7 +35,35 @@ export async function onRequest(context: any): Promise<Response> {
     outHeaders.set('Cache-Control', 'no-store')
 
     try {
+        const splitSetCookie = (headerValue: string): string[] => {
+            const raw = String(headerValue || '').trim()
+            if (!raw) return []
+
+            const out: string[] = []
+            let start = 0
+            let inExpires = false
+
+            for (let i = 0; i < raw.length; i++) {
+                const ch = raw[i]
+                if (!inExpires && (ch === 'e' || ch === 'E')) {
+                    const maybe = raw.slice(i, i + 8).toLowerCase()
+                    if (maybe === 'expires=') inExpires = true
+                }
+                if (inExpires && ch === ';') inExpires = false
+                if (!inExpires && ch === ',') {
+                    const part = raw.slice(start, i).trim()
+                    if (part) out.push(part)
+                    start = i + 1
+                }
+            }
+
+            const tail = raw.slice(start).trim()
+            if (tail) out.push(tail)
+            return out
+        }
+
         const getSetCookie = (upstream.headers as any).getSetCookie
+        const getSetCookieMethod = (upstream.headers as any).getSetCookie?.bind?.(upstream.headers)
         const rewriteCookie = (cookie: string) => {
             if (!cookie) return cookie
             const parts = cookie.split(';').map(part => part.trim()).filter(Boolean)
@@ -50,12 +78,12 @@ export async function onRequest(context: any): Promise<Response> {
             for (const c of cookies) outHeaders.append('Set-Cookie', rewriteCookie(c))
         }
 
-        if (typeof getSetCookie === 'function') {
-            const cookies = getSetCookie.call(upstream.headers) as string[]
+        if (typeof getSetCookieMethod === 'function') {
+            const cookies = getSetCookieMethod() as string[]
             applyCookies(cookies)
         } else {
             const single = upstream.headers.get('set-cookie')
-            if (single) applyCookies([single])
+            if (single) applyCookies(splitSetCookie(single))
         }
     } catch {
         // ignore

--- a/frontend/functions/api/insumos/[[path]].ts
+++ b/frontend/functions/api/insumos/[[path]].ts
@@ -39,7 +39,34 @@ export async function onRequest(context: any): Promise<Response> {
 
     // Cloudflare-specific: preserve multiple Set-Cookie headers.
     try {
-        const getSetCookie = (upstream.headers as any).getSetCookie
+        const splitSetCookie = (headerValue: string): string[] => {
+            const raw = String(headerValue || '').trim()
+            if (!raw) return []
+
+            const out: string[] = []
+            let start = 0
+            let inExpires = false
+
+            for (let i = 0; i < raw.length; i++) {
+                const ch = raw[i]
+                if (!inExpires && (ch === 'e' || ch === 'E')) {
+                    const maybe = raw.slice(i, i + 8).toLowerCase()
+                    if (maybe === 'expires=') inExpires = true
+                }
+                if (inExpires && ch === ';') inExpires = false
+                if (!inExpires && ch === ',') {
+                    const part = raw.slice(start, i).trim()
+                    if (part) out.push(part)
+                    start = i + 1
+                }
+            }
+
+            const tail = raw.slice(start).trim()
+            if (tail) out.push(tail)
+            return out
+        }
+
+        const getSetCookieMethod = (upstream.headers as any).getSetCookie?.bind?.(upstream.headers)
         const rewriteCookie = (cookie: string) => {
             if (!cookie) return cookie
             const parts = cookie.split(';').map(part => part.trim()).filter(Boolean)
@@ -54,12 +81,12 @@ export async function onRequest(context: any): Promise<Response> {
             for (const c of cookies) outHeaders.append('Set-Cookie', rewriteCookie(c))
         }
 
-        if (typeof getSetCookie === 'function') {
-            const cookies = getSetCookie.call(upstream.headers) as string[]
+        if (typeof getSetCookieMethod === 'function') {
+            const cookies = getSetCookieMethod() as string[]
             applyCookies(cookies)
         } else {
             const single = upstream.headers.get('set-cookie')
-            if (single) applyCookies([single])
+            if (single) applyCookies(splitSetCookie(single))
         }
     } catch {
         // ignore


### PR DESCRIPTION
- Consolida o CRM para usar o Insumos Worker como source-of-truth de auth (documentado em docs/auth.md).\n- Evita UI enganosa durante verificação de sessão (mostra carregamento com % antes de decidir login vs dashboard).\n- Corrige proxy de Set-Cookie em Pages Functions (/api/auth e /api/insumos) para preservar múltiplos cookies mesmo quando headers são combinados (Expires com vírgula).\n\nImpacto esperado: login menos intermitente (cookies passam a persistir corretamente) e sem entrar no dashboard antes da sessão ser verificada.