### PR TITLE
Redes Sociais: Sprint 2 (job status + métricas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Plataforma interna (local) para automações e operações da clínica.
 - Config (env, opcional): `SOCIAL_MEDIA_MAX_AGE_DAYS` e `SHARE_MAX_AGE_DAYS` (se definidos, links públicos antigos passam a retornar 404).
 - Config (env, opcional): `SOCIAL_ADMIN_EMAIL_ALLOWLIST` (lista de emails, separados por vírgula, exigidos para ações de admin Social).
 - Publicação manual agora **enfileira job** em `social/jobs/*` e o Worker `social-publisher` processa (habilite `SOCIAL_JOBS_ENABLED=true`).
+- Endpoint de status de job: `GET /api/social/job-status?jobId=...` (retorna `pending|done|unknown`).
 
 ### Dev local (Social via Pages Functions)
 - Recomendado: `cd frontend && npm run dev:pages` (sobe Vite + Pages Functions com bindings locais).

--- a/backend/apps/social-publisher/src/index.ts
+++ b/backend/apps/social-publisher/src/index.ts
@@ -440,6 +440,10 @@ async function processDate(env: Env, dateKey: string) {
 async function processJobs(env: Env) {
   const bucket = env.SHARE_BUCKET
   const maxJobs = parsePositiveInt(env.SOCIAL_JOBS_MAX_PER_RUN) ?? 50
+  const startedAt = Date.now()
+  let processed = 0
+  let okCount = 0
+  let failCount = 0
 
   const { objects } = await listAll(bucket, { prefix: 'social/jobs/' })
   const keys = (objects || []).map((o) => String(o.key || '')).filter(Boolean).slice(0, maxJobs)
@@ -461,6 +465,8 @@ async function processJobs(env: Env) {
         at: new Date().toISOString(),
       }).catch(() => null)
       await deleteKeys(bucket, [key]).catch(() => null)
+      processed += 1
+      failCount += 1
       continue
     }
 
@@ -485,6 +491,19 @@ async function processJobs(env: Env) {
     }).catch(() => null)
 
     await deleteKeys(bucket, [key]).catch(() => null)
+    processed += 1
+    okCount += out?.okCount || 0
+    failCount += out?.failCount || 0
+  }
+
+  if (processed > 0) {
+    await putJsonObj(bucket, 'social/metrics/last_jobs_run.json', {
+      processed,
+      okCount,
+      failCount,
+      startedAt: new Date(startedAt).toISOString(),
+      finishedAt: new Date().toISOString(),
+    }).catch(() => null)
   }
 }
 

--- a/frontend/SocialNetworksStudio.tsx
+++ b/frontend/SocialNetworksStudio.tsx
@@ -52,6 +52,8 @@ export function SocialNetworksStudio() {
   const [queueGroups, setQueueGroups] = useState<QueueGroup[]>([])
   const [queueResults, setQueueResults] = useState<Record<string, Record<string, any>>>({})
   const [queueResultsLoading, setQueueResultsLoading] = useState<Record<string, boolean>>({})
+  const [queueJobIds, setQueueJobIds] = useState<Record<string, string>>({})
+  const [queueJobStatus, setQueueJobStatus] = useState<Record<string, string>>({})
 
   const [adminToken, setAdminToken] = useState<string>(() => {
     try {
@@ -207,7 +209,14 @@ export function SocialNetworksStudio() {
       })
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
-      toast.success('Publish enfileirado')
+      if (data?.jobId) {
+        const key = `${g.group.dateKey}:${g.group.groupKey}`
+        setQueueJobIds((prev) => ({ ...prev, [key]: data.jobId }))
+        setQueueJobStatus((prev) => ({ ...prev, [key]: 'pending' }))
+        toast.success(`Publish enfileirado (${data.jobId})`)
+      } else {
+        toast.success('Publish enfileirado')
+      }
       await refreshQueue(g.group.dateKey)
       await loadResults(g)
     } catch (e: any) {
@@ -215,6 +224,24 @@ export function SocialNetworksStudio() {
     }
   }
 
+  const checkJobStatus = async (g: QueueGroup) => {
+    const key = `${g.group.dateKey}:${g.group.groupKey}`
+    const jobId = queueJobIds[key]
+    if (!jobId) return toast.error('JobId não encontrado. Reenfileire o publish.')
+    try {
+      const res = await fetch(`/api/social/job-status?jobId=${encodeURIComponent(jobId)}`, { credentials: 'include' })
+      const data = (await res.json().catch(() => null)) as any
+      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
+      const status = String(data?.status || 'unknown')
+      setQueueJobStatus((prev) => ({ ...prev, [key]: status }))
+      if (status === 'done') {
+        await loadResults(g)
+      }
+      toast.success(`Status do job: ${status}`)
+    } catch (e: any) {
+      toast.error(e?.message || 'Falha ao carregar status do job')
+    }
+  }
   const platformsLabel = (ps: SocialPlatform[]) => PLATFORM_ORDER.filter((p) => ps.includes(p)).join(', ')
 
   return (
@@ -433,6 +460,16 @@ export function SocialNetworksStudio() {
                         >
                           {queueResultsLoading[`${g.group.dateKey}:${g.group.groupKey}`] ? 'Carregando…' : 'Resultados'}
                         </Button>
+                        {queueJobIds[`${g.group.dateKey}:${g.group.groupKey}`] ? (
+                          <Button
+                            size="sm"
+                            onClick={() => checkJobStatus(g)}
+                            variant="outline"
+                            className="bg-white/[0.06] border-white/20 text-white"
+                          >
+                            Status: {queueJobStatus[`${g.group.dateKey}:${g.group.groupKey}`] || 'pendente'}
+                          </Button>
+                        ) : null}
                         <Button
                           size="sm"
                           onClick={() => publishNow(g)}

--- a/frontend/functions/api/social/job-status.ts
+++ b/frontend/functions/api/social/job-status.ts
@@ -1,0 +1,38 @@
+import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { getShareBucket, getJson } from '../../_lib/r2'
+
+const json = (status: number, body: any) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  })
+
+export async function onRequestGet(context: any): Promise<Response> {
+  const userOrRes = await requireInsumosUser(context)
+  if (userOrRes instanceof Response) return userOrRes
+
+  const bucket = getShareBucket(context)
+  if (!bucket) return json(503, { ok: false, error: 'SHARE_BUCKET not configured' })
+
+  const url = new URL(context.request.url)
+  const jobId = String(url.searchParams.get('jobId') || '').trim()
+  if (!jobId) return json(400, { ok: false, error: 'INVALID_INPUT', hint: 'Informe jobId.' })
+
+  const index = await getJson<any>(bucket, `social/job-index/${jobId}.json`).catch(() => null)
+  if (!index?.dateKey || !index?.groupKey) {
+    return json(404, { ok: false, error: 'JOB_NOT_FOUND' })
+  }
+
+  const result = await getJson<any>(bucket, `social/job-results/${jobId}.json`).catch(() => null)
+  if (result) {
+    return json(200, { ok: true, status: 'done', jobId, result })
+  }
+
+  const jobKey = `social/jobs/${index.dateKey}/${index.groupKey}/${jobId}.json`
+  const jobHead = await bucket.head(jobKey).catch(() => null)
+  if (jobHead) {
+    return json(200, { ok: true, status: 'pending', jobId, dateKey: index.dateKey, groupKey: index.groupKey })
+  }
+
+  return json(200, { ok: true, status: 'unknown', jobId, dateKey: index.dateKey, groupKey: index.groupKey })
+}

--- a/frontend/functions/api/social/publish.ts
+++ b/frontend/functions/api/social/publish.ts
@@ -32,6 +32,7 @@ export async function onRequestPost(context: any): Promise<Response> {
   const jobId = crypto.randomUUID()
   const requestedAt = new Date().toISOString()
   const jobKey = `social/jobs/${dateKey}/${groupKey}/${jobId}.json`
+  const jobIndexKey = `social/job-index/${jobId}.json`
   await putJson(bucket, jobKey, {
     jobId,
     dateKey,
@@ -40,6 +41,7 @@ export async function onRequestPost(context: any): Promise<Response> {
     requestedAt,
     requestedBy: { id: adminOrRes.id, email: adminOrRes.email, name: adminOrRes.name },
   })
+  await putJson(bucket, jobIndexKey, { jobId, dateKey, groupKey, force, requestedAt })
 
   await writeAuditEvent(bucket, {
     scope: 'social',


### PR DESCRIPTION
Entrega do Sprint 2 do módulo/aba Redes Sociais.

- /api/social/job-status: consulta status de job (pending|done|unknown)
- /api/social/publish grava índice de job (social/job-index)
- UI mostra jobId e permite consultar status
- social-publisher grava métricas básicas em social/metrics/last_jobs_run.json

Notas:
- npm -C frontend run lint passa com warnings preexistentes.
- npm -C frontend run typecheck falha por erros preexistentes fora do módulo Social.
