### PR TITLE
Ponto: check-in funcionário (Face→PIN) + deploy after-automerge

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -1,0 +1,90 @@
+name: Deploy CRM API after automerge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: deploy-crm-api-after-automerge-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'codex/') &&
+      github.event.pull_request.user.login == 'jubenitogarcia' &&
+      github.event.pull_request.merged_by.login == 'app/github-actions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Detect CRM API changes
+        id: changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const changed = files.some((f) => {
+              const p = String(f.filename || '');
+              return (
+                p.startsWith('backend/apps/crm-api/') ||
+                p === 'backend/pnpm-lock.yaml' ||
+                p === 'backend/pnpm-workspace.yaml' ||
+                p === '.github/workflows/deploy-crm-api.yml'
+              );
+            });
+            core.setOutput('crm_api_changed', changed ? 'true' : 'false');
+
+      - name: Guard CRM API deploy secrets
+        if: ${{ steps.changes.outputs.crm_api_changed == 'true' }}
+        id: guard
+        env:
+          ENABLE: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+          HOST: ${{ secrets.CRM_API_SSH_HOST }}
+          USER: ${{ secrets.CRM_API_SSH_USER }}
+          KEY: ${{ secrets.CRM_API_SSH_KEY }}
+          APP_DIR: ${{ vars.CRM_API_APP_DIR }}
+          COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+        run: |
+          set -euo pipefail
+          if [[ "${ENABLE:-}" != "true" ]]; then
+            echo "CRM API deploy disabled; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
+            echo "CRM API deploy not configured; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy via SSH (merge commit)
+        if: ${{ steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.CRM_API_SSH_HOST }}
+          username: ${{ secrets.CRM_API_SSH_USER }}
+          key: ${{ secrets.CRM_API_SSH_KEY }}
+          port: ${{ secrets.CRM_API_SSH_PORT != '' && secrets.CRM_API_SSH_PORT || '22' }}
+          script: |
+            set -euo pipefail
+            cd "${CRM_API_APP_DIR}"
+            git fetch --all
+            git reset --hard "${GITHUB_SHA}"
+            ${CRM_API_DEPLOY_COMMAND}
+        env:
+          CRM_API_APP_DIR: ${{ vars.CRM_API_APP_DIR }}
+          CRM_API_DEPLOY_COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+          GITHUB_SHA: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -1,0 +1,103 @@
+name: Deploy CRM (Cloudflare Pages) after automerge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: deploy-crm-pages-after-automerge-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'codex/') &&
+      github.event.pull_request.user.login == 'jubenitogarcia' &&
+      github.event.pull_request.merged_by.login == 'app/github-actions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Detect frontend changes
+        id: changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const changed = files.some((f) => String(f.filename || '').startsWith('frontend/'));
+            core.setOutput('frontend_changed', changed ? 'true' : 'false');
+
+      - name: Guard Cloudflare Pages deploy
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' }}
+        id: guard
+        env:
+          ENABLE_PROD: ${{ vars.ENABLE_CRM_PAGES_DEPLOY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_PROD: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+          ENABLE="$ENABLE_PROD"
+          PROJECT="${PROJECT_PROD:-skincos}"
+          if [[ "${ENABLE:-}" != "true" ]]; then
+            echo "Deploy flag not enabled; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare deploy secrets not configured; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "project=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "branch=main" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout merge commit
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Setup Node
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        run: npm run build
+        working-directory: frontend
+
+      - name: Deploy to Cloudflare Pages (wrangler)
+        if: ${{ steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PAGES_PROJECT: ${{ steps.guard.outputs.project }}
+          BRANCH_NAME: ${{ steps.guard.outputs.branch }}
+        run: |
+          set -euo pipefail
+          PROJECT="${PAGES_PROJECT:-skincos}"
+          echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME (after automerge)"
+          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME"
+        working-directory: frontend

--- a/backend/apps/crm-api/server/pontoRoutes.js
+++ b/backend/apps/crm-api/server/pontoRoutes.js
@@ -20,6 +20,14 @@ function safeText(value, maxLen) {
   return s.length > maxLen ? s.slice(0, maxLen) : s
 }
 
+function normalizeEmail(value) {
+  const raw = String(value ?? '').trim().toLowerCase()
+  if (!raw) return ''
+  if (raw.length > 180) return ''
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw)) return ''
+  return raw
+}
+
 function getClientIp(req) {
   const xf = String(req.headers['x-forwarded-for'] || '').trim()
   if (xf) return xf.split(',')[0].trim()
@@ -31,6 +39,13 @@ function safeEqual(a, b) {
   const bb = Buffer.from(String(b || ''))
   if (aa.length !== bb.length) return false
   return crypto.timingSafeEqual(aa, bb)
+}
+
+function b64UrlToUtf8(b64url) {
+  const s = String(b64url || '').trim()
+  if (!s) return ''
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(s.length / 4) * 4, '=')
+  return Buffer.from(padded, 'base64').toString('utf-8')
 }
 
 function sha256Hex(input) {
@@ -161,6 +176,11 @@ export function registerPontoRoutes(app, { coreStateDir }) {
   const templatesKey = tryParseKey(process.env.PONTO_TEMPLATES_KEY)
   const auditHmacKey = tryParseKey(process.env.PONTO_AUDIT_HMAC_KEY)
 
+  // Optional hardening for /api/ponto/me (Cloudflare Pages proxy -> backend).
+  const proxyToken = String(process.env.PONTO_PROXY_TOKEN || '').trim()
+  const actorHmacKey = String(process.env.PONTO_ACTOR_HMAC_KEY || proxyToken).trim()
+  const actorSkewMs = clampInt(process.env.PONTO_ACTOR_SKEW_MS, 5_000, 60 * 60 * 1000, 5 * 60 * 1000)
+
   const maxDescriptors = clampInt(process.env.PONTO_MAX_DESCRIPTORS, 1, 30, 10)
   const faceThresholdDefault = clampFloat(process.env.PONTO_FACE_THRESHOLD, 0.2, 1.5, 0.52)
   const punchCooldownSeconds = clampInt(process.env.PONTO_PUNCH_COOLDOWN_SECONDS, 0, 3600, 10)
@@ -236,6 +256,7 @@ export function registerPontoRoutes(app, { coreStateDir }) {
       id: employee.id,
       code: employee.code || '',
       name: employee.name,
+      loginEmail: employee.loginEmail || '',
       active: employee.active !== false,
       createdAt: employee.createdAt,
       updatedAt: employee.updatedAt,
@@ -315,6 +336,84 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     return { device, actor: actorFromReq(req, { kind: 'device', id: device.id, label: device.label, unit: device.unit }) }
   }
 
+  function verifyActor(req) {
+    const actorB64 = String(req.headers['x-skincos-actor'] || '').trim()
+    const tsRaw = String(req.headers['x-skincos-actor-ts'] || '').trim()
+    const sig = String(req.headers['x-skincos-actor-sig'] || '').trim()
+
+    if (!actorB64 || !tsRaw) return { ok: false, code: 'ACTOR_MISSING' }
+    const ts = Number(tsRaw)
+    if (!Number.isFinite(ts) || ts <= 0) return { ok: false, code: 'ACTOR_TS_INVALID' }
+    if (Math.abs(Date.now() - ts) > actorSkewMs) return { ok: false, code: 'ACTOR_TS_SKEW' }
+
+    const actorJson = b64UrlToUtf8(actorB64)
+    let actor = null
+    try { actor = JSON.parse(actorJson) } catch { actor = null }
+    if (!actor || typeof actor !== 'object') return { ok: false, code: 'ACTOR_INVALID' }
+
+    const isDev = String(process.env.NODE_ENV || '').toLowerCase() === 'development'
+    const sigRequired = !isDev || !!actorHmacKey
+    if (sigRequired) {
+      if (!actorHmacKey) return { ok: false, code: 'ACTOR_KEY_MISSING' }
+      if (!sig) return { ok: false, code: 'ACTOR_SIG_MISSING' }
+      const expected = crypto.createHmac('sha256', actorHmacKey).update(`${tsRaw}.${actorB64}`).digest('base64url')
+      if (!safeEqual(sig, expected)) return { ok: false, code: 'ACTOR_SIG_INVALID' }
+    }
+
+    const email = normalizeEmail(actor.email)
+    if (!email) return { ok: false, code: 'ACTOR_EMAIL_MISSING' }
+    return { ok: true, actor: { ...actor, email } }
+  }
+
+  function requireEmployee(req, res) {
+    if (proxyToken) {
+      const token = String(req.headers['x-ponto-proxy-token'] || '').trim()
+      if (!token || token !== proxyToken) {
+        res.status(401).json({ ok: false, error: 'UNAUTHORIZED', code: 'PROXY_TOKEN_INVALID' })
+        return null
+      }
+    }
+
+    const verified = verifyActor(req)
+    if (!verified.ok) {
+      res.status(401).json({
+        ok: false,
+        error: 'UNAUTHORIZED',
+        code: verified.code,
+        hint: 'Missing/invalid actor headers. Requests must come from the CRM Pages proxy.'
+      })
+      return null
+    }
+
+    const email = verified.actor.email
+    return actorFromReq(req, { kind: 'employee', id: email, label: email })
+  }
+
+  function findEmployeeByLoginEmail(email) {
+    const needle = normalizeEmail(email)
+    if (!needle) return null
+    for (const e of state.employees) {
+      if (!e || e.deletedAt || e.active === false) continue
+      if (normalizeEmail(e.loginEmail) === needle) return e
+    }
+    return null
+  }
+
+  function matchEmployeeDescriptor(employeeId, descriptor, opts = {}) {
+    const threshold = clampFloat(opts.threshold ?? faceThresholdDefault, 0.2, 1.5, faceThresholdDefault)
+    const templates = faceCache.get(employeeId) || []
+    if (!templates.length) return { ok: false, code: 'FACE_NOT_ENROLLED', threshold }
+    let bestDistance = Number.POSITIVE_INFINITY
+    for (const tpl of templates) {
+      if (!isNumberArray(tpl, descriptor.length, descriptor.length)) continue
+      const dist = l2(descriptor, tpl)
+      if (dist < bestDistance) bestDistance = dist
+    }
+    if (!Number.isFinite(bestDistance)) return { ok: false, code: 'FACE_NOT_ENROLLED', threshold }
+    if (bestDistance > threshold) return { ok: false, code: 'FACE_NOT_RECOGNIZED', threshold, bestDistance }
+    return { ok: true, threshold, bestDistance }
+  }
+
   function migrateFromV1(loaded) {
     const employees = Array.isArray(loaded?.employees) ? loaded.employees.filter(Boolean) : []
     const records = Array.isArray(loaded?.records) ? loaded.records.filter(Boolean) : []
@@ -327,6 +426,7 @@ export function registerPontoRoutes(app, { coreStateDir }) {
         id,
         code: safeText(e.code, 40),
         name: safeText(e.name, 80) || 'Funcionario',
+        loginEmail: normalizeEmail(e.loginEmail || e.email || ''),
         active: e.active !== false,
         createdAt: e.createdAt || new Date().toISOString(),
         updatedAt: e.updatedAt || new Date().toISOString(),
@@ -506,6 +606,7 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     if (!actor) return
     const name = safeText(req.body?.name, 80)
     const code = safeText(req.body?.code, 40)
+    const loginEmail = normalizeEmail(req.body?.loginEmail)
     if (!name) return res.status(400).json({ ok: false, error: 'NAME_REQUIRED' })
 
     const now = new Date().toISOString()
@@ -513,6 +614,7 @@ export function registerPontoRoutes(app, { coreStateDir }) {
       id: crypto.randomUUID(),
       code,
       name,
+      loginEmail: loginEmail || '',
       active: true,
       createdAt: now,
       updatedAt: now,
@@ -536,11 +638,30 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     if (!actor) return
     const employee = findEmployee(req.params.id)
     if (!employee || employee.deletedAt) return res.status(404).json({ ok: false, error: 'NOT_FOUND' })
-    const name = safeText(req.body?.name, 80)
-    const code = safeText(req.body?.code, 40)
     const activeRaw = req.body?.active
-    if (name) employee.name = name
-    if (code || code === '') employee.code = code
+    const nameRaw = req.body?.name
+    const codeRaw = req.body?.code
+    const loginEmailRaw = req.body?.loginEmail
+
+    if (nameRaw !== undefined) {
+      const name = safeText(nameRaw, 80)
+      if (name) employee.name = name
+    }
+
+    if (codeRaw !== undefined) {
+      const code = safeText(codeRaw, 40)
+      employee.code = code
+    }
+
+    if (loginEmailRaw !== undefined) {
+      const next = normalizeEmail(loginEmailRaw)
+      const prev = normalizeEmail(employee.loginEmail)
+      employee.loginEmail = next || ''
+      await enqueueWrite(() =>
+        writeAudit(next ? 'EMPLOYEE_LINK_LOGIN' : 'EMPLOYEE_UNLINK_LOGIN', { employeeId: employee.id, prev, next: next || '' }, actor)
+      )
+    }
+
     if (typeof activeRaw === 'boolean') employee.active = activeRaw
     employee.updatedAt = new Date().toISOString()
     schedulePersist()
@@ -885,6 +1006,144 @@ export function registerPontoRoutes(app, { coreStateDir }) {
   })
 
   // -------------------------------------------------------------
+  // Employee APIs (self-service via Pages proxy actor headers)
+  // -------------------------------------------------------------
+  app.get('/api/ponto/me', async (req, res) => {
+    const actor = requireEmployee(req, res)
+    if (!actor) return
+    const email = actor.label
+    const employee = findEmployeeByLoginEmail(email)
+    if (!employee) {
+      return res.json({
+        ok: true,
+        linked: false,
+        actorEmail: email,
+        hint: 'Seu usuário ainda não está vinculado a um funcionário. Peça ao admin para definir o email no cadastro do funcionário.'
+      })
+    }
+    const lastPunch = findLastEmployeePunch(employee.id)
+    const cooldown = enforceCooldown(employee.id)
+    const hasFace = (faceCache.get(employee.id) || []).length > 0
+    return res.json({
+      ok: true,
+      linked: true,
+      actorEmail: email,
+      employee: publicEmployee(employee),
+      hasFace,
+      pinSet: !!employee.pinHash,
+      lastPunch: lastPunch || null,
+      cooldown: cooldown.ok ? { active: false } : { active: true, secondsRemaining: cooldown.secondsRemaining, last: cooldown.last },
+      suggestedNextMethod: hasFace ? 'FACE' : 'PIN'
+    })
+  })
+
+  app.get('/api/ponto/me/records', async (req, res) => {
+    const actor = requireEmployee(req, res)
+    if (!actor) return
+    const email = actor.label
+    const employee = findEmployeeByLoginEmail(email)
+    if (!employee) return res.status(404).json({ ok: false, error: 'EMPLOYEE_NOT_LINKED' })
+    const from = safeText(req.query?.from, 30)
+    const to = safeText(req.query?.to, 30)
+    const limit = clampInt(req.query?.limit, 1, 2000, 200)
+    const includeCorrections = String(req.query?.includeCorrections || '1') !== '0'
+
+    const fromMs = from ? new Date(from).getTime() : null
+    const toMs = to ? new Date(to).getTime() : null
+
+    const punches = []
+    const corrections = []
+    for (let i = state.records.length - 1; i >= 0; i--) {
+      const r = state.records[i]
+      if (!r) continue
+      if (r.employeeId !== employee.id && r.kind !== 'CORRECTION') continue
+      if (r.kind === 'CORRECTION' && r.employeeId !== employee.id) continue
+      const ms = new Date(r.at || r.createdAt).getTime()
+      if (fromMs != null && Number.isFinite(fromMs) && ms < fromMs) continue
+      if (toMs != null && Number.isFinite(toMs) && ms > toMs) continue
+      if (r.kind === 'CORRECTION') corrections.push(r)
+      if (r.kind === 'PUNCH') punches.push(r)
+      if (punches.length >= limit && corrections.length >= limit) break
+    }
+    const out = includeCorrections ? applyCorrections(punches, corrections) : punches
+    res.json({ ok: true, data: out, correctionsCount: includeCorrections ? corrections.length : 0 })
+  })
+
+  app.post('/api/ponto/me/punch', async (req, res) => {
+    const actor = requireEmployee(req, res)
+    if (!actor) return
+    const email = actor.label
+    const employee = findEmployeeByLoginEmail(email)
+    if (!employee) return res.status(404).json({ ok: false, error: 'EMPLOYEE_NOT_LINKED' })
+
+    const idempotencyKey = getIdempotencyKey(req)
+    const existing = findExistingByIdempotency({ deviceId: null, employeeId: employee.id, idempotencyKey })
+    if (existing) return res.json({ ok: true, data: existing, employee: publicEmployee(employee), idempotent: true })
+
+    const cooldown = enforceCooldown(employee.id)
+    if (!cooldown.ok) return res.status(409).json({ ok: false, error: 'COOLDOWN', secondsRemaining: cooldown.secondsRemaining, last: cooldown.last })
+
+    const descriptor = req.body?.descriptor
+    const pin = safeText(req.body?.pin, 20)
+    const hasFace = (faceCache.get(employee.id) || []).length > 0
+
+    let method = null
+    let matchDistance = null
+
+    if (descriptor !== undefined) {
+      if (!isNumberArray(descriptor, 64, 1024)) return res.status(400).json({ ok: false, error: 'DESCRIPTOR_INVALID' })
+      if (hasFace) {
+        const match = matchEmployeeDescriptor(employee.id, descriptor, { threshold: req.body?.threshold })
+        if (!match.ok) return res.status(401).json({ ok: false, error: match.code, next: 'PIN', threshold: match.threshold, bestDistance: match.bestDistance ?? null })
+        method = 'FACE'
+        matchDistance = match.bestDistance
+      }
+    }
+
+    if (!method && pin) {
+      if (!employee.pinHash) return res.status(400).json({ ok: false, error: 'PIN_NOT_SET' })
+      if (!verifyPin(pin, employee.pinHash)) return res.status(401).json({ ok: false, error: 'PIN_INVALID' })
+      method = 'PIN'
+    }
+
+    if (!method) {
+      return res.status(400).json({ ok: false, error: 'NEXT_METHOD_REQUIRED', next: hasFace ? 'FACE' : 'PIN' })
+    }
+
+    const type = computePunchType(req.body?.type, employee.id)
+    const unit = safeText(req.body?.unit, 80) || null
+    const note = safeText(req.body?.note, 240) || null
+    const now = new Date().toISOString()
+
+    const record = {
+      id: crypto.randomUUID(),
+      kind: 'PUNCH',
+      employeeId: employee.id,
+      employeeName: employee.name,
+      type,
+      at: now,
+      client: getClientTimeMeta(req),
+      unit,
+      deviceId: null,
+      deviceLabel: null,
+      ip: getClientIp(req),
+      userAgent: safeText(req.headers['user-agent'], 220) || null,
+      matchDistance,
+      method,
+      geo: null,
+      liveness: null,
+      note,
+      idempotencyKey: idempotencyKey || null,
+      createdAt: now
+    }
+
+    state.records.push(record)
+    schedulePersist()
+    await enqueueWrite(() => writeAudit(method === 'FACE' ? 'PUNCH_FACE' : 'PUNCH_PIN', { recordId: record.id, employeeId: employee.id, type, unit }, actor))
+    res.json({ ok: true, data: record, employee: publicEmployee(employee) })
+  })
+
+  // -------------------------------------------------------------
   // Device APIs
   // -------------------------------------------------------------
   app.get('/api/ponto/device/employees', async (req, res) => {
@@ -1024,4 +1283,3 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     res.json({ ok: true, data: record, employee: publicEmployee(employee) })
   })
 }
-

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -17,6 +17,7 @@ type PontoEmployeePublic = {
   id: string
   code?: string
   name: string
+  loginEmail?: string
   active?: boolean
   createdAt?: string
   updatedAt?: string
@@ -52,8 +53,44 @@ type PontoPunchRecord = {
   corrected?: { id: string; at: string; reason?: string | null } | null
 }
 
+type PontoMeResponse =
+  | { ok: true; linked: false; actorEmail?: string; hint?: string }
+  | {
+    ok: true
+    linked: true
+    actorEmail?: string
+    employee: PontoEmployeePublic
+    hasFace: boolean
+    pinSet: boolean
+    lastPunch: PontoPunchRecord | null
+    cooldown?: { active: boolean; secondsRemaining?: number }
+    suggestedNextMethod?: 'FACE' | 'PIN'
+  }
+
 const LS_DEVICE_TOKEN = 'skincos.ponto.deviceToken.v1'
 const LS_ADMIN_TOKEN = 'skincos.ponto.adminToken.v1'
+const LS_DEV_ACTOR_EMAIL = 'skincos.ponto.devActorEmail.v1'
+
+function b64UrlEncodeBytes(bytes: ArrayBuffer): string {
+  const bin = String.fromCharCode(...new Uint8Array(bytes))
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function b64UrlEncodeString(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  return b64UrlEncodeBytes(bytes.buffer)
+}
+
+function getDevEmployeeActorHeaders(): Record<string, string> {
+  if (!(import.meta as any).env?.DEV) return {}
+  let email = ''
+  try { email = String(localStorage.getItem(LS_DEV_ACTOR_EMAIL) || '').trim().toLowerCase() } catch { email = '' }
+  if (!email) return {}
+  const actor = { email }
+  const actorB64 = b64UrlEncodeString(JSON.stringify(actor))
+  const actorTs = String(Date.now())
+  return { 'x-skincos-actor': actorB64, 'x-skincos-actor-ts': actorTs }
+}
 
 function fmtDate(value?: string | null) {
   const v = String(value || '').trim()
@@ -65,6 +102,11 @@ function fmtDate(value?: string | null) {
   } catch {
     return d.toISOString()
   }
+}
+
+function toDateTimeLocalValue(d: Date) {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 function createRequestMeta() {
@@ -79,10 +121,10 @@ function createRequestMeta() {
 
 async function apiJson<T>(
   path: string,
-  opts: { method?: string; body?: unknown; adminToken?: string; deviceToken?: string; signal?: AbortSignal } = {}
+  opts: { method?: string; body?: unknown; adminToken?: string; deviceToken?: string; signal?: AbortSignal; headers?: Record<string, string> } = {}
 ): Promise<T> {
   const method = (opts.method || 'GET').toUpperCase()
-  const headers: Record<string, string> = { Accept: 'application/json' }
+  const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers || {}) }
   if (opts.body !== undefined) headers['content-type'] = 'application/json'
   if (opts.adminToken) headers.authorization = `Admin ${opts.adminToken}`
   if (opts.deviceToken) headers.authorization = `Device ${opts.deviceToken}`
@@ -198,7 +240,7 @@ async function captureDescriptorStable(videoEl: HTMLVideoElement, samples = 2, w
 }
 
 export function PontoModule() {
-  const [tab, setTab] = useState<'device' | 'admin'>('device')
+  const [tab, setTab] = useState<'employee' | 'device' | 'admin'>('employee')
 
   const [deviceToken, setDeviceToken] = useState(() => {
     try { return localStorage.getItem(LS_DEVICE_TOKEN) || '' } catch { return '' }
@@ -206,16 +248,30 @@ export function PontoModule() {
   const [adminToken, setAdminToken] = useState(() => {
     try { return localStorage.getItem(LS_ADMIN_TOKEN) || '' } catch { return '' }
   })
+  const [devActorEmail, setDevActorEmail] = useState(() => {
+    try { return localStorage.getItem(LS_DEV_ACTOR_EMAIL) || '' } catch { return '' }
+  })
 
+  const employeeVideoRef = useRef<HTMLVideoElement | null>(null)
   const deviceVideoRef = useRef<HTMLVideoElement | null>(null)
   const adminVideoRef = useRef<HTMLVideoElement | null>(null)
   const [stream, setStream] = useState<MediaStream | null>(null)
-  const [cameraOwner, setCameraOwner] = useState<'device' | 'admin' | null>(null)
+  const [cameraOwner, setCameraOwner] = useState<'employee' | 'device' | 'admin' | null>(null)
 
   const [modelsReady, setModelsReady] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [modelsError, setModelsError] = useState<string | null>(null)
 
   const [loading, setLoading] = useState(false)
+
+  const [me, setMe] = useState<PontoMeResponse | null>(null)
+  const [meError, setMeError] = useState<any>(null)
+  const [meLoading, setMeLoading] = useState(false)
+  const [mePunchOpen, setMePunchOpen] = useState(false)
+  const [meStep, setMeStep] = useState<'face' | 'pin'>('face')
+  const [mePin, setMePin] = useState('')
+  const [meRecords, setMeRecords] = useState<PontoPunchRecord[]>([])
+  const [meRecordsFrom, setMeRecordsFrom] = useState('')
+  const [meRecordsTo, setMeRecordsTo] = useState('')
 
   const [deviceStatus, setDeviceStatus] = useState<{ ok: boolean; unit?: string; device?: PontoDevicePublic } | null>(null)
   const [deviceEmployees, setDeviceEmployees] = useState<Array<{ id: string; name: string; code?: string; hasFace?: boolean; pinSet?: boolean }>>([])
@@ -238,6 +294,7 @@ export function PontoModule() {
   const [newEmployeeCode, setNewEmployeeCode] = useState('')
   const [selectedEmployeeId, setSelectedEmployeeId] = useState<string>('')
   const selectedEmployee = useMemo(() => adminEmployees.find(e => e.id === selectedEmployeeId) || null, [adminEmployees, selectedEmployeeId])
+  const [selectedEmployeeLoginEmail, setSelectedEmployeeLoginEmail] = useState('')
   const [pinAdminValue, setPinAdminValue] = useState('')
 
   const [enrollCount, setEnrollCount] = useState(5)
@@ -268,6 +325,22 @@ export function PontoModule() {
   useEffect(() => {
     try { localStorage.setItem(LS_ADMIN_TOKEN, adminToken) } catch { /* ignore */ }
   }, [adminToken])
+
+  useEffect(() => {
+    try { localStorage.setItem(LS_DEV_ACTOR_EMAIL, devActorEmail) } catch { /* ignore */ }
+  }, [devActorEmail])
+
+  useEffect(() => {
+    setSelectedEmployeeLoginEmail(selectedEmployee?.loginEmail || '')
+  }, [selectedEmployeeId, selectedEmployee])
+
+  useEffect(() => {
+    if (meRecordsFrom || meRecordsTo) return
+    const now = new Date()
+    const from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
+    setMeRecordsFrom(toDateTimeLocalValue(from))
+    setMeRecordsTo(toDateTimeLocalValue(now))
+  }, [meRecordsFrom, meRecordsTo])
 
   useEffect(() => {
     return () => {
@@ -369,8 +442,12 @@ export function PontoModule() {
     }
   }
 
-  async function startCameraFor(owner: 'device' | 'admin') {
-    const videoEl = owner === 'device' ? deviceVideoRef.current : adminVideoRef.current
+  async function startCameraFor(owner: 'employee' | 'device' | 'admin') {
+    const videoEl = owner === 'employee'
+      ? employeeVideoRef.current
+      : owner === 'device'
+        ? deviceVideoRef.current
+        : adminVideoRef.current
     if (!videoEl) return toast.error('Vídeo não disponível')
     setLoading(true)
     try {
@@ -386,11 +463,122 @@ export function PontoModule() {
     }
   }
 
-  async function stopCameraUI() {
+  async function stopCameraUI(opts: { silent?: boolean } = {}) {
     stopCamera(stream)
     setStream(null)
     setCameraOwner(null)
-    toast.message('Câmera desligada')
+    if (!opts.silent) toast.message('Câmera desligada')
+  }
+
+  async function meRefresh() {
+    setMeLoading(true)
+    setMeError(null)
+    try {
+      const res = await apiJson<PontoMeResponse>('/api/ponto/me', { headers: getDevEmployeeActorHeaders() })
+      setMe(res)
+    } catch (e: any) {
+      setMe(null)
+      setMeError(e)
+    } finally {
+      setMeLoading(false)
+    }
+  }
+
+  async function meLoadRecords() {
+    setMeLoading(true)
+    try {
+      const qs = new URLSearchParams()
+      if (meRecordsFrom) qs.set('from', new Date(meRecordsFrom).toISOString())
+      if (meRecordsTo) qs.set('to', new Date(meRecordsTo).toISOString())
+      qs.set('limit', '500')
+      const res = await apiJson<{ ok: boolean; data: PontoPunchRecord[] }>(
+        '/api/ponto/me/records?' + qs.toString(),
+        { headers: getDevEmployeeActorHeaders() }
+      )
+      setMeRecords(res.data || [])
+    } catch (e: any) {
+      toast.error(e?.message || String(e))
+    } finally {
+      setMeLoading(false)
+    }
+  }
+
+  async function mePunchFace() {
+    if (!me || !('linked' in me) || !me.linked) return toast.error('Usuário não vinculado a funcionário')
+    if (!me.hasFace) return toast.error('Biometria facial não cadastrada (use PIN)')
+    if (!stream || cameraOwner !== 'employee') return toast.error('Ative a câmera')
+    const videoEl = employeeVideoRef.current
+    if (!videoEl) return toast.error('Câmera não disponível')
+    const ok = await ensureModelsUI()
+    if (!ok) {
+      setMeStep('pin')
+      return toast.error('Modelos faciais indisponíveis (use PIN)')
+    }
+
+    setLoading(true)
+    try {
+      const descriptor = await captureDescriptorStable(videoEl, 2, 220)
+      const meta = createRequestMeta()
+      const res = await apiJson<{ ok: boolean; data: PontoPunchRecord }>(
+        '/api/ponto/me/punch',
+        { method: 'POST', body: { descriptor, ...meta }, headers: getDevEmployeeActorHeaders() }
+      )
+      toast.success(`Ponto registrado (${res.data.type})`)
+      setMePunchOpen(false)
+      setMeStep('face')
+      await stopCameraUI()
+      await meRefresh()
+      await meLoadRecords()
+    } catch (e: any) {
+      const details = e?.details as any
+      const code = String(details?.error || details?.code || '')
+      if (code === 'COOLDOWN') {
+        toast.error(`Aguarde ${details?.secondsRemaining || '?'}s para registrar novamente.`)
+      } else if (code === 'FACE_NOT_RECOGNIZED' || code === 'FACE_NOT_ENROLLED') {
+        toast.error('Rosto não reconhecido. Use PIN.')
+        setMeStep('pin')
+        await stopCameraUI()
+      } else {
+        toast.error(e?.message || String(e))
+        setMeStep('pin')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function mePunchPin() {
+    if (!me || !('linked' in me) || !me.linked) return toast.error('Usuário não vinculado a funcionário')
+    const pin = mePin.trim()
+    if (!pin) return toast.error('Informe o PIN')
+    setLoading(true)
+    try {
+      const meta = createRequestMeta()
+      const res = await apiJson<{ ok: boolean; data: PontoPunchRecord }>(
+        '/api/ponto/me/punch',
+        { method: 'POST', body: { pin, ...meta }, headers: getDevEmployeeActorHeaders() }
+      )
+      setMePin('')
+      toast.success(`Ponto registrado (${res.data.type})`)
+      setMePunchOpen(false)
+      setMeStep('face')
+      await meRefresh()
+      await meLoadRecords()
+    } catch (e: any) {
+      const details = e?.details as any
+      const code = String(details?.error || details?.code || '')
+      if (code === 'PIN_INVALID') {
+        toast.error('PIN inválido')
+      } else if (code === 'PIN_NOT_SET') {
+        toast.error('PIN não configurado para este funcionário')
+      } else if (code === 'COOLDOWN') {
+        toast.error(`Aguarde ${details?.secondsRemaining || '?'}s para registrar novamente.`)
+      } else {
+        toast.error(e?.message || String(e))
+      }
+    } finally {
+      setLoading(false)
+    }
   }
 
   async function deviceConnect() {
@@ -415,6 +603,20 @@ export function PontoModule() {
       setLoading(false)
     }
   }
+
+  useEffect(() => {
+    if (tab !== 'employee') return
+    void meRefresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab])
+
+  useEffect(() => {
+    if (tab !== 'employee') return
+    if (!me || !('linked' in me) || !me.linked) return
+    if (!meRecordsFrom || !meRecordsTo) return
+    void meLoadRecords()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, me, meRecordsFrom, meRecordsTo])
 
   useEffect(() => {
     if (tab !== 'device') return
@@ -552,6 +754,25 @@ export function PontoModule() {
       await adminRefreshAll()
       setSelectedEmployeeId(res.data.id)
       toast.success('Funcionário criado')
+    } catch (e: any) {
+      toast.error(e?.message || String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function adminSaveLoginEmail() {
+    if (!adminToken.trim()) return toast.error('Informe o token de admin')
+    if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
+    setLoading(true)
+    try {
+      await apiJson('/api/ponto/admin/employees/' + selectedEmployeeId, {
+        adminToken,
+        method: 'PATCH',
+        body: { loginEmail: selectedEmployeeLoginEmail.trim() }
+      })
+      await adminRefreshAll()
+      toast.success('Vínculo atualizado')
     } catch (e: any) {
       toast.error(e?.message || String(e))
     } finally {
@@ -745,9 +966,180 @@ export function PontoModule() {
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as any)}>
         <TabsList>
-          <TabsTrigger value="device">Dispositivo (relógio)</TabsTrigger>
+          <TabsTrigger value="employee">Funcionário</TabsTrigger>
+          <TabsTrigger value="device">Kiosk</TabsTrigger>
           <TabsTrigger value="admin">Admin</TabsTrigger>
         </TabsList>
+
+        <TabsContent value="employee" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Meu ponto</CardTitle>
+              <CardDescription>Bata ponto direto no CRM (fallback Face → PIN).</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                {meLoading ? <Badge variant="secondary">Carregando…</Badge> : null}
+                {me && 'linked' in me && me.linked ? (
+                  <>
+                    <Badge>Funcionário: {me.employee?.name || '-'}</Badge>
+                    <Badge variant="outline">Face: {me.hasFace ? 'OK' : '—'}</Badge>
+                    <Badge variant="outline">PIN: {me.pinSet ? 'OK' : '—'}</Badge>
+                    {me.cooldown?.active ? (
+                      <Badge variant="secondary">Cooldown: {me.cooldown.secondsRemaining ?? '?'}s</Badge>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+
+              {me && 'linked' in me && me.linked ? (
+                <div className="text-sm text-muted-foreground">
+                  Última batida: {me.lastPunch ? `${fmtDate(me.lastPunch.at)} • ${me.lastPunch.type} • ${me.lastPunch.method || '-'}` : '—'}
+                </div>
+              ) : me && 'linked' in me && !me.linked ? (
+                <div className="rounded-md border p-3 text-sm">
+                  <div className="font-medium">Usuário não vinculado</div>
+                  <div className="text-muted-foreground">{me.hint || 'Peça ao admin para vincular seu email a um funcionário.'}</div>
+                </div>
+              ) : meError ? (
+                <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm">
+                  <div className="font-medium">Falha ao carregar</div>
+                  <div className="opacity-80">{meError?.message || 'Erro desconhecido'}</div>
+                </div>
+              ) : null}
+
+              {(import.meta as any).env?.DEV ? (
+                <div className="rounded-md border p-3 text-sm space-y-2">
+                  <div className="font-medium">Dev: actor email (para testar local sem Pages proxy)</div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <div className="md:col-span-2 space-y-2">
+                      <Label>Email</Label>
+                      <Input value={devActorEmail} onChange={(e) => setDevActorEmail(e.target.value)} placeholder="ex: funcionario@empresa.com" />
+                    </div>
+                    <div className="flex items-end gap-2">
+                      <Button variant="outline" onClick={meRefresh} disabled={meLoading}>Recarregar</Button>
+                      <Button variant="secondary" onClick={() => setDevActorEmail('')} disabled={meLoading}>Limpar</Button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  onClick={() => {
+                    if (me && 'linked' in me && me.linked) setMeStep(me.hasFace ? 'face' : 'pin')
+                    else setMeStep('pin')
+                    setMePunchOpen(true)
+                  }}
+                  disabled={meLoading || !(me && 'linked' in me && me.linked)}
+                >
+                  Bater ponto
+                </Button>
+                <Button variant="outline" onClick={meRefresh} disabled={meLoading}>Atualizar status</Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Dialog
+            open={mePunchOpen}
+            onOpenChange={(open) => {
+              setMePunchOpen(open)
+              if (!open) void stopCameraUI({ silent: true })
+            }}
+          >
+            <DialogContent className="max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Bater ponto</DialogTitle>
+                <DialogDescription>Prioridade: Face → PIN. O próximo método aparece só se o anterior falhar/indisponível.</DialogDescription>
+              </DialogHeader>
+
+              {meStep === 'face' ? (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Button onClick={() => startCameraFor('employee')} disabled={loading}>Ativar câmera</Button>
+                    <Button variant="secondary" onClick={ensureModelsUI} disabled={loading}>Carregar modelos</Button>
+                    <Button variant="outline" onClick={() => void stopCameraUI()} disabled={loading || !stream}>Desligar</Button>
+                    <Button onClick={mePunchFace} disabled={loading || !stream}>Registrar por Face</Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => { setMeStep('pin'); void stopCameraUI({ silent: true }) }}
+                      disabled={loading}
+                    >
+                      Usar PIN
+                    </Button>
+                  </div>
+                  <div className="rounded-xl overflow-hidden border bg-black">
+                    <video ref={employeeVideoRef} className="w-full aspect-video object-cover" playsInline muted autoPlay />
+                  </div>
+                  {modelsError ? <div className="text-sm text-red-600">{modelsError}</div> : null}
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <Label>PIN</Label>
+                    <Input value={mePin} onChange={(e) => setMePin(e.target.value)} inputMode="numeric" placeholder="••••" />
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button onClick={mePunchPin} disabled={loading}>Registrar por PIN</Button>
+                    {me && 'linked' in me && me.linked && me.hasFace ? (
+                      <Button variant="outline" onClick={() => setMeStep('face')} disabled={loading}>Tentar Face</Button>
+                    ) : null}
+                  </div>
+                </div>
+              )}
+            </DialogContent>
+          </Dialog>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Meu histórico</CardTitle>
+              <CardDescription>Últimos registros (com correções, se existirem).</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div className="space-y-2">
+                  <Label>De</Label>
+                  <Input type="datetime-local" value={meRecordsFrom} onChange={(e) => setMeRecordsFrom(e.target.value)} />
+                </div>
+                <div className="space-y-2">
+                  <Label>Até</Label>
+                  <Input type="datetime-local" value={meRecordsTo} onChange={(e) => setMeRecordsTo(e.target.value)} />
+                </div>
+                <div className="flex items-end">
+                  <Button onClick={meLoadRecords} disabled={meLoading || !(me && 'linked' in me && me.linked)}>Buscar</Button>
+                </div>
+              </div>
+
+              <div className="border rounded-xl overflow-hidden">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Quando</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead>Unidade</TableHead>
+                      <TableHead>Método</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {meRecords.map(r => (
+                      <TableRow key={r.id}>
+                        <TableCell className="text-sm">{fmtDate(r.at)}</TableCell>
+                        <TableCell><Badge variant="outline">{r.type}</Badge></TableCell>
+                        <TableCell className="text-sm">{r.unit || '-'}</TableCell>
+                        <TableCell className="text-sm">{r.method || '-'}</TableCell>
+                      </TableRow>
+                    ))}
+                    {!meRecords.length ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-sm text-muted-foreground">Nenhum registro.</TableCell>
+                      </TableRow>
+                    ) : null}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
 
         <TabsContent value="device" className="space-y-6">
           <Card>
@@ -817,7 +1209,7 @@ export function PontoModule() {
 
                 <div className="flex flex-wrap gap-2">
                   <Button onClick={() => startCameraFor('device')} disabled={loading}>Ativar câmera</Button>
-                  <Button variant="outline" onClick={stopCameraUI} disabled={loading || !stream}>Desligar</Button>
+                  <Button variant="outline" onClick={() => void stopCameraUI()} disabled={loading || !stream}>Desligar</Button>
                   <Button variant="secondary" onClick={ensureModelsUI} disabled={loading}>Carregar modelos</Button>
                   <Button variant="outline" onClick={() => setAutoIdentify(v => !v)} disabled={loading || !stream}>
                     Auto-identificar: {autoIdentify ? 'ON' : 'OFF'}
@@ -939,6 +1331,20 @@ export function PontoModule() {
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div className="space-y-2">
+                    <Label>Email (vínculo login)</Label>
+                    <Input
+                      value={selectedEmployeeLoginEmail}
+                      onChange={(e) => setSelectedEmployeeLoginEmail(e.target.value)}
+                      placeholder="ex: funcionario@empresa.com"
+                    />
+                  </div>
+                  <div className="flex items-end">
+                    <Button onClick={adminSaveLoginEmail} disabled={loading || !adminToken.trim() || !selectedEmployeeId}>Salvar vínculo</Button>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <div className="space-y-2">
                     <Label>Novo PIN (min. 4)</Label>
                     <Input value={pinAdminValue} onChange={(e) => setPinAdminValue(e.target.value)} inputMode="numeric" placeholder="••••" />
                   </div>
@@ -993,7 +1399,7 @@ export function PontoModule() {
                   </label>
 
                   <div className="flex gap-2">
-                    <Button variant="outline" onClick={stopCameraUI} disabled={loading || !stream}>Desligar</Button>
+                    <Button variant="outline" onClick={() => void stopCameraUI()} disabled={loading || !stream}>Desligar</Button>
                     <Button onClick={adminEnrollFace} disabled={loading || !adminToken.trim() || !selectedEmployeeId}>
                       Capturar & salvar biometria
                     </Button>
@@ -1005,6 +1411,7 @@ export function PontoModule() {
                     <TableHeader>
                       <TableRow>
                         <TableHead>Nome</TableHead>
+                        <TableHead>Login</TableHead>
                         <TableHead>Status</TableHead>
                         <TableHead>Face</TableHead>
                         <TableHead>PIN</TableHead>
@@ -1015,6 +1422,7 @@ export function PontoModule() {
                       {adminEmployees.map(e => (
                         <TableRow key={e.id} className={e.id === selectedEmployeeId ? 'bg-muted/40' : ''}>
                           <TableCell className="font-medium">{e.name}</TableCell>
+                          <TableCell className="text-sm">{e.loginEmail || '-'}</TableCell>
                           <TableCell>{e.active === false ? <Badge variant="secondary">Inativo</Badge> : <Badge>Ativo</Badge>}</TableCell>
                           <TableCell><Badge variant="outline">{e.faceDescriptorsCount || 0}</Badge></TableCell>
                           <TableCell>{e.pinSet ? <Badge variant="outline">OK</Badge> : <Badge variant="secondary">—</Badge>}</TableCell>
@@ -1023,7 +1431,7 @@ export function PontoModule() {
                       ))}
                       {!adminEmployees.length ? (
                         <TableRow>
-                          <TableCell colSpan={5} className="text-sm text-muted-foreground">Nenhum funcionário.</TableCell>
+                          <TableCell colSpan={6} className="text-sm text-muted-foreground">Nenhum funcionário.</TableCell>
                         </TableRow>
                       ) : null}
                     </TableBody>

--- a/frontend/functions/api/ponto/[[path]].ts
+++ b/frontend/functions/api/ponto/[[path]].ts
@@ -1,0 +1,176 @@
+import { getInsumosUser } from '../../_lib/insumosAuth'
+
+const json = (status: number, body: any, extraHeaders: Record<string, string> = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      ...extraHeaders,
+    },
+  })
+
+function newRequestId(): string {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `${Date.now()}_${Math.random().toString(16).slice(2)}`
+  }
+}
+
+function buildUpstreamHeaders(request: Request, requestId: string, proxyToken: string, forwardAuthorization: boolean): Headers {
+  const allow = new Set([
+    'accept',
+    'content-type',
+    'range',
+    'if-none-match',
+    'if-modified-since',
+    'cache-control',
+    'pragma',
+    'user-agent',
+    'x-idempotency-key',
+  ])
+
+  const headers = new Headers()
+  for (const [k, v] of request.headers.entries()) {
+    const key = k.toLowerCase()
+    if (key === 'authorization' && !forwardAuthorization) continue
+    if (!allow.has(key) && key !== 'authorization') continue
+    headers.set(k, v)
+  }
+
+  headers.set('x-request-id', requestId)
+  if (proxyToken) headers.set('x-ponto-proxy-token', proxyToken)
+  return headers
+}
+
+function b64UrlEncodeBytes(bytes: ArrayBuffer): string {
+  const bin = String.fromCharCode(...new Uint8Array(bytes))
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function b64UrlEncodeString(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  return b64UrlEncodeBytes(bytes.buffer)
+}
+
+async function signHmacSha256B64Url(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message))
+  return b64UrlEncodeBytes(sig)
+}
+
+export async function onRequest(context: any): Promise<Response> {
+  const request: Request = context.request
+  const url = new URL(request.url)
+  const requestId = newRequestId()
+
+  // Incoming:  /api/ponto/<rest>
+  // Outgoing:  <PONTO_API_TARGET>/api/ponto/<rest>
+  const prefix = '/api/ponto'
+  const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
+
+  if (rest === '/_proxy-status' || rest === '/_proxy-status/') {
+    const targetOrigin = (context.env?.PONTO_API_TARGET as string | undefined) || ''
+    const proxyToken = (context.env?.PONTO_PROXY_TOKEN as string | undefined) || ''
+    const actorKey = (context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || proxyToken || ''
+    return json(
+      200,
+      {
+        ok: true,
+        targetConfigured: !!targetOrigin,
+        proxyTokenConfigured: !!proxyToken,
+        actorKeyConfigured: !!actorKey,
+        hint: !targetOrigin
+          ? 'Configure PONTO_API_TARGET no Cloudflare Pages/Functions para apontar para o backend do Ponto.'
+          : undefined,
+      },
+      { 'x-request-id': requestId },
+    )
+  }
+
+  const targetOrigin = (context.env?.PONTO_API_TARGET as string | undefined) || ''
+  if (!targetOrigin) {
+    return json(
+      503,
+      {
+        ok: false,
+        error: 'PONTO_API_TARGET nao configurado',
+        hint: 'Defina PONTO_API_TARGET (ex: https://crm-api.seudominio.com) no Cloudflare Pages/Functions.',
+      },
+      { 'x-request-id': requestId },
+    )
+  }
+
+  const isEmployeeRoute = rest === '/me' || rest.startsWith('/me/')
+
+  let actorB64 = ''
+  let actorTs = ''
+  let actorSig = ''
+
+  const proxyToken = (context.env?.PONTO_PROXY_TOKEN as string | undefined) || ''
+  const actorKey = String((context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || proxyToken || '').trim()
+
+  if (isEmployeeRoute) {
+    const user = await getInsumosUser(context)
+    if (!user) {
+      return json(
+        401,
+        { ok: false, error: 'UNAUTHORIZED', hint: 'Faça login para registrar seu ponto.' },
+        { 'x-request-id': requestId },
+      )
+    }
+    const actor = {
+      id: String(user.id || ''),
+      email: user.email ? String(user.email) : undefined,
+      name: user.displayName ? String(user.displayName) : (user.name ? String(user.name) : undefined),
+    }
+    actorB64 = b64UrlEncodeString(JSON.stringify(actor))
+    actorTs = String(Date.now())
+    if (actorKey) {
+      actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
+    }
+  }
+
+  const targetUrl = new URL(targetOrigin)
+  const basePath = targetUrl.pathname.replace(/\/$/, '')
+  targetUrl.pathname = `${basePath}/api/ponto${rest.startsWith('/') ? '' : '/'}${rest}`
+  targetUrl.search = url.search
+
+  // For employee routes, do NOT forward Authorization; for admin/device routes, allow it.
+  const headers = buildUpstreamHeaders(request, requestId, proxyToken, !isEmployeeRoute)
+  if (isEmployeeRoute) {
+    headers.set('x-skincos-actor', actorB64)
+    headers.set('x-skincos-actor-ts', actorTs)
+    if (actorSig) headers.set('x-skincos-actor-sig', actorSig)
+  }
+
+  const method = (request.method || 'GET').toUpperCase()
+  const body = method === 'GET' || method === 'HEAD' ? undefined : request.body
+
+  const upstreamRequest = new Request(targetUrl.toString(), {
+    method,
+    headers,
+    body,
+    redirect: 'manual',
+  })
+
+  const upstream = await fetch(upstreamRequest)
+
+  const outHeaders = new Headers(upstream.headers)
+  outHeaders.set('Cache-Control', 'no-store')
+  outHeaders.set('x-request-id', requestId)
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: outHeaders,
+  })
+}
+


### PR DESCRIPTION
Implementa modo **Funcionário** no Relógio-Ponto (sem device token) com fallback **Face → PIN**, mantendo **Kiosk** (Device token) e **Admin**.

Também adiciona garantias de deploy quando o merge acontece via auto-merge (`app/github-actions`):
- Pages: `.github/workflows/deploy-crm-pages-after-automerge.yml`
- CRM API: `.github/workflows/deploy-crm-api-after-automerge.yml`

Principais mudanças:
- Backend: `GET/POST /api/ponto/me*` + `loginEmail` no employee.
- Frontend: UI do Ponto com tabs Funcionário/Kiosk/Admin e fluxo Face → PIN.
- Cloudflare Pages Functions: proxy `/api/ponto/*` com actor headers em rotas `/me*`.

Validação mínima:
- `GET /api/ponto/health` ok
- Funcionário vinculado via email consegue bater ponto por Face ou PIN
- Auditoria continua íntegra (`GET /api/ponto/admin/audit/verify`).
