### PR TITLE
ci: corrigir Semgrep workflow

### DIFF
--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -126,10 +126,8 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           config: auto
-          generateSarif: true
-          sarifFile: semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN || '' }}
+          args: --sarif --output semgrep.sarif
+          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep SARIF
         if: ${{ hashFiles('semgrep.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Corrige o workflow `.github/workflows/security-secrets-audit.yml` para usar inputs compatíveis com `returntocorp/semgrep-action@v1`.

Motivo:
- O step Semgrep estava falhando com "Unexpected input(s) 'generateSarif', 'sarifFile'".

Resultado esperado:
- Check `Semgrep (SAST)` volta a rodar e publicar `semgrep.sarif`.
