### PR TITLE
docs: deploy after automerge note

### DIFF
--- a/backend/docs/deploy-after-automerge.md
+++ b/backend/docs/deploy-after-automerge.md
@@ -1,0 +1,6 @@
+# Deploy after automerge (note)
+
+This repository deploys CRM Pages and CRM API via GitHub Actions.
+
+If a PR is merged via automerge, dedicated "after automerge" workflows run on the PR close event and can re-trigger deploys based on which paths changed.
+


### PR DESCRIPTION
Tiny doc-only PR used to verify that the new 'after automerge' deploy workflows actually trigger on PR closed events (and skip when no relevant paths changed).