### PR TITLE
docs: after-automerge smoke 2

### DIFF
--- a/backend/docs/deploy-after-automerge.md
+++ b/backend/docs/deploy-after-automerge.md
@@ -4,3 +4,4 @@ This repository deploys CRM Pages and CRM API via GitHub Actions.
 
 If a PR is merged via automerge, dedicated "after automerge" workflows run on the PR close event and can re-trigger deploys based on which paths changed.
 
+Smoke check: this file exists to validate that the "after automerge" workflows can be triggered via a merged PR.


### PR DESCRIPTION
Second smoke PR created from latest main (includes the new after-automerge deploy workflows) to verify they trigger on PR closed events.