### PR TITLE
Social: admin global + remover referencias de Insumos

### DIFF
--- a/backend/docs/deploy-after-automerge.md
+++ b/backend/docs/deploy-after-automerge.md
@@ -4,3 +4,4 @@ This repository deploys CRM Pages and CRM API via GitHub Actions.
 
 If a PR is merged via automerge, dedicated "after automerge" workflows run on the PR close event and can re-trigger deploys based on which paths changed.
 
+Smoke check: this file exists to validate that the "after automerge" workflows can be triggered via a merged PR.

--- a/backend/docs/social.md
+++ b/backend/docs/social.md
@@ -22,23 +22,23 @@ Este documento cobre o módulo “Redes Sociais” (Instagram/Facebook/Threads) 
 
 ## Setup guiado (CRM)
 O Planner do módulo “Redes Sociais” possui um checklist de primeiro acesso que valida:
-- login (sessão/cookies do Insumos),
-- permissões de admin (role/email/token),
+- login (sessão/cookies do CRM),
+- permissão de admin (role global `ADMIN`),
 - contas configuradas por unidade/plataforma,
 - (opcional) métricas do Worker.
 
 Endpoints usados pelo checklist:
-- `GET /api/social/setup/status` (retorna status de R2/prefix, criptografia, policy de admin e defaults)
+- `GET /api/social/setup/status` (retorna status de R2/prefix, criptografia, admin global e defaults)
 - `GET /api/social/metrics/last-jobs-run` (lê `social/metrics/last_jobs_run.json` no R2)
 
 ## Bloqueio de abas por onboarding (Planner obrigatório)
 Por padrão, as abas **Instagram/Facebook/Threads** ficam **visíveis porém bloqueadas** até o usuário finalizar o Planner.
 
 Critério de liberação (para o escopo selecionado no Planner):
-- Login Insumos OK (`/api/social/setup/status` não pode retornar 401)
+- Login no CRM OK (`/api/social/setup/status` não pode retornar 401)
 - R2 configurado (`setup.r2.bucketConfigured === true`)
 - Se criptografia for obrigatória, secret configurado (`setup.encryption.required === true` ⇒ `setup.encryption.configured === true`)
-- Permissão Admin Social OK (via role/email allowlist, ou token validado)
+- Permissão de Admin OK (`setup.admin.isAdmin === true`)
 - Contas configuradas para todas combinações `(unidade × plataforma)` do escopo (sem `missingAccounts`)
 
 Preferências/persistência no browser (localStorage):
@@ -51,7 +51,7 @@ Reset (re-onboarding):
 - Limpar os itens acima do `localStorage` (ou “Limpar dados do site” no browser).
 
 ## Unidades (personalização)
-O módulo Social usa chaves curtas de unidade (hoje: `BSS` e `NH`). Para personalização, a UI tenta mapear unidades vindas do Insumos:
+O módulo Social usa chaves curtas de unidade (hoje: `BSS` e `NH`). Para personalização, a UI tenta mapear unidades vindas da sessão do CRM:
 - `barra-shopping-sul` → `BSS`
 - `novo-hamburgo` → `NH`
 
@@ -76,21 +76,13 @@ Preferências locais no browser:
 - `internal/audit/social/{yyyy-mm-dd}/{eventId}.json`
 - `internal/share/index/{yyyy-mm-dd}/*` (base para cleanup de shares)
 
-## Autenticação admin
-As rotas admin exigem usuário autenticado no Insumos e seguem a ordem:
-1) **Role allowlist**: `SOCIAL_ADMIN_ROLE_ALLOWLIST` (roles separadas por vírgula).
-2) **Email allowlist**: `SOCIAL_ADMIN_EMAIL_ALLOWLIST` (emails separados por vírgula).
-3) **Token**: `SOCIAL_ADMIN_TOKEN` via header `x-social-admin-token`.
-
-> Se `SOCIAL_ADMIN_ROLE_ALLOWLIST` estiver configurado e o usuário tiver uma role permitida, o token deixa de ser necessário.
+## Admin (global)
+As rotas de admin do módulo Social (`/api/social/admin/*` e `/api/social/publish`) exigem usuário autenticado no CRM com role global `ADMIN`.
 
 ## Variáveis de ambiente (CRM/Pages)
 - `INTEGRATIONS_ENCRYPTION_SECRET` (recomendado)
 - `REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET=true` (falha fechado se secret ausente)
 - `R2_KEY_PREFIX` (recomendado para separar preview/prod)
-- `SOCIAL_ADMIN_TOKEN` (fallback para admin)
-- `SOCIAL_ADMIN_EMAIL_ALLOWLIST`
-- `SOCIAL_ADMIN_ROLE_ALLOWLIST`
 - `SOCIAL_MEDIA_MAX_AGE_DAYS` / `SHARE_MAX_AGE_DAYS`
 
 ## Variáveis de ambiente (Worker social-publisher)
@@ -113,7 +105,7 @@ As rotas admin exigem usuário autenticado no Insumos e seguem a ordem:
 - `R2_KEY_PREFIX` definido para preview (ou `R2_PRODUCTION_BRANCH` correto) — preview não pode escrever em prod.
 - `SOCIAL_PUBLISHER_ENABLED=true` e cron ativo no Worker.
 - `SOCIAL_JOBS_ENABLED=true` (publish assíncrono).
-- `SOCIAL_ADMIN_ROLE_ALLOWLIST` ou `SOCIAL_ADMIN_TOKEN` definidos.
+- Usuários `ADMIN` do CRM conseguem configurar contas e publicar.
 - URLs públicas (`/social-media/*`, `/share/*`) acessíveis no domínio correto.
 
 ## Matriz de ambientes (mínimo recomendado)
@@ -121,15 +113,12 @@ As rotas admin exigem usuário autenticado no Insumos e seguem a ordem:
 - **Preview**: `R2_KEY_PREFIX=preview/<branch>/`, `SOCIAL_PUBLISHER_ENABLED=false` (evita publicar real), `SOCIAL_JOBS_ENABLED=true` se quiser testar fila/worker.
 
 ## Runbook (diagnóstico rápido)
-- **“FORBIDDEN”** em admin:
-  - Verifique `SOCIAL_ADMIN_ROLE_ALLOWLIST` e `SOCIAL_ADMIN_EMAIL_ALLOWLIST`.
-  - Se não usar allowlist, inclua `x-social-admin-token` válido.
-- **“SOCIAL_ADMIN_TOKEN_NOT_CONFIGURED”**:
-  - Configure `SOCIAL_ADMIN_TOKEN` ou adote `SOCIAL_ADMIN_ROLE_ALLOWLIST`.
+- **“ADMIN_REQUIRED”** em rotas admin:
+  - Confirme que o usuário logado no CRM tem role global `ADMIN`.
 - **Job pendente sem resultado**:
   - Confirme `SOCIAL_PUBLISHER_ENABLED=true` e cron ativo no Worker.
   - Consulte logs do Worker (wrangler tail / Cloudflare logs).
 - **Mídia 404**:
   - Verifique `R2_KEY_PREFIX` e `SOCIAL_MEDIA_MAX_AGE_DAYS`.
 - **UNAUTHORIZED**:
-  - Sessão do Insumos expirada ou ausente (login necessário).
+  - Sessão do CRM expirada ou ausente (login necessário).

--- a/frontend/SocialNetworksStudio.tsx
+++ b/frontend/SocialNetworksStudio.tsx
@@ -20,13 +20,7 @@ type SetupStatus = {
   user?: { username?: string; displayName?: string; email?: string; role?: string; allowedUnits?: string[] }
   r2?: { bucketConfigured?: boolean; effectiveKeyPrefix?: string }
   encryption?: { required?: boolean; configured?: boolean }
-  adminPolicy?: {
-    roleAllowlistConfigured?: boolean
-    emailAllowlistConfigured?: boolean
-    tokenConfigured?: boolean
-    userCanAdminWithoutToken?: boolean
-    tokenRequiredForThisUser?: boolean
-  }
+  admin?: { isAdmin?: boolean; role?: string }
   socialDefaults?: { defaultUnitsFromEnv?: string[] }
 }
 
@@ -45,7 +39,7 @@ type QueueGroup = {
 
 const PLATFORM_ORDER: SocialPlatform[] = ['instagram', 'facebook', 'threads']
 
-function mapInsumosUnitToSocialUnitKey(unit: string): string | null {
+function mapUserUnitToSocialUnitKey(unit: string): string | null {
   const raw = String(unit || '').trim()
   if (!raw) return null
   const upper = raw.toUpperCase()
@@ -209,14 +203,6 @@ export function SocialNetworksStudio() {
   const [lastJobsRun, setLastJobsRun] = useState<any | null>(null)
   const [lastJobsRunError, setLastJobsRunError] = useState<string | null>(null)
 
-  const [adminToken, setAdminToken] = useState<string>(() => {
-    try {
-      return sessionStorage.getItem('social.adminToken') || ''
-    } catch {
-      return ''
-    }
-  })
-  const [adminValidated, setAdminValidated] = useState(false)
   const [accountsLoadedOnce, setAccountsLoadedOnce] = useState(false)
   const [accountsLoading, setAccountsLoading] = useState(false)
   const [accounts, setAccounts] = useState<
@@ -245,7 +231,7 @@ export function SocialNetworksStudio() {
       if (res.status === 401) {
         setSetupAuthed(false)
         setSetup(null)
-        setSetupError('Faça login no módulo Insumos para usar as integrações.')
+        setSetupError('Faça login no CRM para usar este módulo.')
         return false
       }
       const data = (await res.json().catch(() => null)) as any
@@ -323,25 +309,25 @@ export function SocialNetworksStudio() {
     }
   }
 
-  const refreshAccounts = async (opts: { silent?: boolean; markValidated?: boolean } = {}) => {
+  const refreshAccounts = async (opts: { silent?: boolean } = {}) => {
     setAccountsLoading(true)
     try {
-      const headers: Record<string, string> = {}
-      if (adminToken.trim()) headers['x-social-admin-token'] = adminToken.trim()
       const res = await fetch('/api/social/admin/accounts', {
         credentials: 'include',
-        headers,
       })
       const data = (await res.json().catch(() => null)) as any
-      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
+      if (!res.ok) {
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') {
+          throw new Error('Permissão insuficiente: somente ADMIN pode configurar este módulo.')
+        }
+        throw new Error(data?.error || `HTTP ${res.status}`)
+      }
       setAccounts((data?.accounts || []) as any)
-      if (opts.markValidated) setAdminValidated(true)
       return true
     } catch (e: any) {
       const msg = e?.message || 'Falha ao carregar contas'
       if (!opts.silent) toast.error(msg)
       setAccounts([])
-      if (opts.markValidated) setAdminValidated(false)
       return false
     } finally {
       setAccountsLoading(false)
@@ -358,7 +344,7 @@ export function SocialNetworksStudio() {
 
   const suggestedUnitKey = useMemo(() => {
     const allowed = Array.isArray(setup?.user?.allowedUnits) ? setup!.user!.allowedUnits!.filter(Boolean) : []
-    const mapped = [...new Set(allowed.map(mapInsumosUnitToSocialUnitKey).filter(Boolean) as string[])]
+    const mapped = [...new Set(allowed.map(mapUserUnitToSocialUnitKey).filter(Boolean) as string[])]
     return mapped.length === 1 ? mapped[0] : null
   }, [setup?.user?.allowedUnits])
 
@@ -396,20 +382,22 @@ export function SocialNetworksStudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const adminViaRole = !!setup?.adminPolicy?.userCanAdminWithoutToken
-  const tokenConfigured = !!setup?.adminPolicy?.tokenConfigured
-  const tokenRequiredForThisUser = !!setup?.adminPolicy?.tokenRequiredForThisUser
-  const adminReady = adminViaRole || adminValidated
+  const adminReady = useMemo(() => {
+    if (setupAuthed !== true) return false
+    if (setup?.admin?.isAdmin === true) return true
+    const role = String(setup?.admin?.role || setup?.user?.role || '').trim().toUpperCase()
+    return role === 'ADMIN'
+  }, [setup?.admin?.isAdmin, setup?.admin?.role, setup?.user?.role, setupAuthed])
 
   useEffect(() => {
     if (tab !== 'planner') return
     if (!setup || setupAuthed !== true) return
-    if (!adminViaRole) return
+    if (!adminReady) return
     if (autoTriedAccounts) return
     setAutoTriedAccounts(true)
     void refreshAccounts({ silent: true })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [adminViaRole, autoTriedAccounts, setupAuthed, tab])
+  }, [adminReady, autoTriedAccounts, setupAuthed, tab])
 
   const selectedScopeUnits = useMemo(() => {
     const cleaned = (scopeUnits || [])
@@ -458,20 +446,12 @@ export function SocialNetworksStudio() {
     }
   }
 
-  const saveAdminToken = (v: string) => {
-    setAdminToken(v)
-    try {
-      sessionStorage.setItem('social.adminToken', v)
-    } catch {}
-  }
-
   const saveAccount = async () => {
     if (!accountUnit.trim() || !accountPlatform || !accountId.trim() || !accountToken.trim()) {
       return toast.error('Preencha unit/platform/accountId/accessToken.')
     }
     try {
       const headers: Record<string, string> = { 'content-type': 'application/json', ...csrfHeader() }
-      if (adminToken.trim()) headers['x-social-admin-token'] = adminToken.trim()
       const res = await fetch('/api/social/admin/accounts', {
         method: 'POST',
         credentials: 'include',
@@ -499,7 +479,6 @@ export function SocialNetworksStudio() {
     if (!confirm(`Remover conta ${u}/${p}?`)) return
     try {
       const headers: Record<string, string> = { ...csrfHeader() }
-      if (adminToken.trim()) headers['x-social-admin-token'] = adminToken.trim()
       const res = await fetch(`/api/social/admin/accounts?unitKey=${encodeURIComponent(u)}&platform=${encodeURIComponent(p)}`, {
         method: 'DELETE',
         credentials: 'include',
@@ -526,7 +505,6 @@ export function SocialNetworksStudio() {
   const publishNow = async (g: QueueGroup, force = false) => {
     try {
       const headers: Record<string, string> = { 'content-type': 'application/json', ...csrfHeader() }
-      if (adminToken.trim()) headers['x-social-admin-token'] = adminToken.trim()
       const res = await fetch('/api/social/publish', {
         method: 'POST',
         credentials: 'include',
@@ -595,7 +573,7 @@ export function SocialNetworksStudio() {
 
   const infraOk = setupAuthed === true && !!setup?.r2?.bucketConfigured
   const encryptionOk = setupAuthed === true && (!setup?.encryption?.required || !!setup?.encryption?.configured)
-  const adminOk = setupAuthed === true && (adminViaRole || (tokenConfigured && adminValidated))
+  const adminOk = adminReady
   const accountsOk = setupAuthed === true && adminOk && missingAccounts.length === 0
   const unlockReady = scopeValid && infraOk && encryptionOk && adminOk && accountsOk
 
@@ -686,15 +664,15 @@ export function SocialNetworksStudio() {
 
                 {setupAuthed === true ? (
                   <Badge variant="outline" className="border-white/20 text-white">
-                    Insumos: OK
+                    Sessão: OK
                   </Badge>
                 ) : setupAuthed === false ? (
                   <Badge variant="outline" className="border-red-200/50 text-red-100">
-                    Insumos: login necessário
+                    Sessão: login necessário
                   </Badge>
                 ) : (
                   <Badge variant="outline" className="border-white/20 text-white">
-                    Insumos: …
+                    Sessão: …
                   </Badge>
                 )}
 
@@ -816,8 +794,8 @@ export function SocialNetworksStudio() {
               <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 space-y-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <div className="text-sm text-white font-medium">1) Login (Insumos)</div>
-                    <div className="text-xs text-blue-200/70">A aba usa a sessão do Insumos (cookies + CSRF).</div>
+                    <div className="text-sm text-white font-medium">1) Login (CRM)</div>
+                    <div className="text-xs text-blue-200/70">A aba usa a sessão do CRM (cookies + CSRF).</div>
                   </div>
                   {setupAuthed === true ? (
                     <Badge variant="outline" className="border-white/20 text-white">
@@ -831,7 +809,7 @@ export function SocialNetworksStudio() {
                 </div>
                 {setupAuthed === false ? (
                   <div className="text-sm text-blue-200/80">
-                    Faça login no módulo <span className="font-semibold">Insumos</span> e volte aqui para recarregar o status.
+                    Faça login no <span className="font-semibold">CRM</span> e volte aqui para recarregar o status.
                   </div>
                 ) : null}
               </div>
@@ -839,11 +817,8 @@ export function SocialNetworksStudio() {
               <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 space-y-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <div className="text-sm text-white font-medium">2) Permissão Admin Social</div>
-                    <div className="text-xs text-blue-200/70">
-                      Admin por role (<span className="font-mono">SOCIAL_ADMIN_ROLE_ALLOWLIST</span>) / email (<span className="font-mono">SOCIAL_ADMIN_EMAIL_ALLOWLIST</span>) / token (
-                      <span className="font-mono">x-social-admin-token</span>).
-                    </div>
+                    <div className="text-sm text-white font-medium">2) Permissão de Admin</div>
+                    <div className="text-xs text-blue-200/70">Somente usuários com role global ADMIN podem configurar contas e publicar.</div>
                   </div>
                   {adminReady ? (
                     <Badge variant="outline" className="border-white/20 text-white">
@@ -855,46 +830,13 @@ export function SocialNetworksStudio() {
                     </Badge>
                   )}
                 </div>
-
-                {adminViaRole ? (
-                  <div className="text-sm text-blue-200/80">
-                    Você já tem permissão via role allowlist (<span className="font-mono">SOCIAL_ADMIN_ROLE_ALLOWLIST</span>). Token é opcional.
-                  </div>
-                ) : tokenConfigured ? (
-                  <div className="text-sm text-blue-200/80">
-                    Informe o token admin para validar e habilitar ações de admin nesta aba.
-                  </div>
+                {setupAuthed !== true ? (
+                  <div className="text-sm text-blue-200/70">Faça login para validar permissões.</div>
+                ) : adminReady ? (
+                  <div className="text-sm text-blue-200/80">Você é ADMIN.</div>
                 ) : (
-                  <div className="text-sm text-red-200">
-                    Admin não configurado no ambiente. Configure <span className="font-mono">SOCIAL_ADMIN_ROLE_ALLOWLIST</span> ou <span className="font-mono">SOCIAL_ADMIN_TOKEN</span>.
-                  </div>
+                  <div className="text-sm text-red-200">Somente ADMIN pode configurar/publicar neste módulo.</div>
                 )}
-
-                <div className="grid md:grid-cols-3 gap-3">
-                  <div className="md:col-span-2 space-y-2">
-                    <Label className="text-blue-200">SOCIAL_ADMIN_TOKEN</Label>
-                    <Input
-                      value={adminToken}
-                      onChange={(e) => saveAdminToken(e.target.value)}
-                      placeholder="Cole aqui (se necessário)"
-                      className="bg-white/[0.06] border-white/20 text-white"
-                    />
-                  </div>
-                  <div className="flex items-end gap-2">
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        if (adminViaRole) return refreshAccounts({ silent: false })
-                        if (!adminToken.trim()) return toast.error('Informe o token admin.')
-                        return refreshAccounts({ silent: false, markValidated: true })
-                      }}
-                      disabled={accountsLoading || setupAuthed !== true || (!adminViaRole && tokenRequiredForThisUser && !adminToken.trim())}
-                      className="bg-white/[0.06] border-white/20 text-white"
-                    >
-                      {accountsLoading ? 'Validando…' : (adminViaRole ? 'Carregar contas' : 'Validar token')}
-                    </Button>
-                  </div>
-                </div>
               </div>
 
               <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 space-y-3">

--- a/frontend/functions/_lib/crmAuth.ts
+++ b/frontend/functions/_lib/crmAuth.ts
@@ -1,0 +1,60 @@
+export type CrmAuthUser = {
+  id: string
+  username?: string
+  displayName?: string
+  name?: string
+  email?: string
+  role?: string
+  allowedUnits?: string[]
+}
+
+const json = (status: number, body: any) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  })
+
+export async function getCrmUser(context: any): Promise<CrmAuthUser | null> {
+  const env = context?.env || {}
+  const targetOrigin =
+    (env.AUTH_API_TARGET as string | undefined) ||
+    (env.INSUMOS_API_TARGET as string | undefined) ||
+    'https://api.skincos.com.br'
+
+  const url = new URL(targetOrigin)
+  // Auth backend path (internal implementation detail; UI/docs must not mention it)
+  url.pathname = '/insumos/auth/me'
+
+  const headers = new Headers()
+  headers.set('accept', 'application/json')
+  const cookie = context?.request?.headers?.get?.('cookie')
+  if (cookie) headers.set('cookie', cookie)
+
+  const res = await fetch(url.toString(), { method: 'GET', headers, redirect: 'manual' }).catch(() => null)
+  if (!res || !res.ok) return null
+
+  const data = await res.json().catch(() => null)
+  const raw = data?.user || data?.usuario || data || null
+  const username = raw?.username || undefined
+  const email = raw?.email || undefined
+  const id = username || email || raw?.id
+  if (!id) return null
+
+  const displayName = raw?.displayName || raw?.name || raw?.username || raw?.email || undefined
+  return {
+    id: String(id),
+    username: username ? String(username) : undefined,
+    displayName: displayName ? String(displayName) : undefined,
+    name: displayName ? String(displayName) : undefined,
+    email: email ? String(email) : undefined,
+    role: raw?.role || undefined,
+    allowedUnits: Array.isArray(raw?.allowedUnits) ? raw.allowedUnits : undefined,
+  }
+}
+
+export async function requireCrmUser(context: any): Promise<CrmAuthUser | Response> {
+  const user = await getCrmUser(context)
+  if (!user) return json(401, { ok: false, error: 'UNAUTHORIZED', hint: 'Faça login no CRM para continuar.' })
+  return user
+}
+

--- a/frontend/functions/_lib/insumosAuth.ts
+++ b/frontend/functions/_lib/insumosAuth.ts
@@ -1,52 +1,14 @@
-export type InsumosAuthUser = {
-  id: string
-  username?: string
-  displayName?: string
-  name?: string
-  email?: string
-  role?: string
-  allowedUnits?: string[]
-}
+// Compat shim: historically this file was named "insumosAuth" because auth is backed by /insumos/auth/*,
+// but these helpers represent CRM session auth for Pages Functions.
+import type { CrmAuthUser } from './crmAuth'
+import { getCrmUser, requireCrmUser } from './crmAuth'
 
-const json = (status: number, body: any) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
-  })
+export type InsumosAuthUser = CrmAuthUser
 
 export async function getInsumosUser(context: any): Promise<InsumosAuthUser | null> {
-  const targetOrigin = (context?.env?.INSUMOS_API_TARGET as string | undefined) || 'https://api.skincos.com.br'
-  const url = new URL(targetOrigin)
-  url.pathname = '/insumos/auth/me'
-
-  const headers = new Headers()
-  headers.set('accept', 'application/json')
-  const cookie = context?.request?.headers?.get?.('cookie')
-  if (cookie) headers.set('cookie', cookie)
-
-  const res = await fetch(url.toString(), { method: 'GET', headers, redirect: 'manual' }).catch(() => null)
-  if (!res || !res.ok) return null
-
-  const data = await res.json().catch(() => null)
-  const raw = data?.user || data?.usuario || data || null
-  const username = raw?.username || undefined
-  const email = raw?.email || undefined
-  const id = username || email || raw?.id
-  if (!id) return null
-  const displayName = raw?.displayName || raw?.name || raw?.username || raw?.email || undefined
-  return {
-    id: String(id),
-    username: username ? String(username) : undefined,
-    displayName: displayName ? String(displayName) : undefined,
-    name: displayName ? String(displayName) : undefined,
-    email: email ? String(email) : undefined,
-    role: raw?.role || undefined,
-    allowedUnits: Array.isArray(raw?.allowedUnits) ? raw.allowedUnits : undefined,
-  }
+  return getCrmUser(context)
 }
 
 export async function requireInsumosUser(context: any): Promise<InsumosAuthUser | Response> {
-  const user = await getInsumosUser(context)
-  if (!user) return json(401, { ok: false, error: 'UNAUTHORIZED', hint: 'Faça login para usar a integração Instagram.' })
-  return user
+  return requireCrmUser(context)
 }

--- a/frontend/functions/_lib/socialAuth.ts
+++ b/frontend/functions/_lib/socialAuth.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from './insumosAuth'
+import { requireCrmUser } from './crmAuth'
 
 const json = (status: number, body: any) =>
   new Response(JSON.stringify(body), {
@@ -6,43 +6,12 @@ const json = (status: number, body: any) =>
     headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
   })
 
-function parseAllowlist(raw: any): Set<string> {
-  const parts = String(raw || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean)
-  return new Set(parts)
-}
-
-function parseRoles(raw: any): Set<string> {
-  const parts = String(raw || '')
-    .split(',')
-    .map((s) => s.trim().toUpperCase())
-    .filter(Boolean)
-  return new Set(parts)
-}
-
 export async function requireSocialAdmin(context: any) {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
-  const roleAllowlist = parseRoles(context?.env?.SOCIAL_ADMIN_ROLE_ALLOWLIST)
-  if (roleAllowlist.size) {
-    const role = String((userOrRes as any).role || '').trim().toUpperCase()
-    if (role && roleAllowlist.has(role)) return userOrRes
-  }
+  const role = String((userOrRes as any).role || '').trim().toUpperCase()
+  if (role === 'ADMIN') return userOrRes
 
-  const allowlist = parseAllowlist(context?.env?.SOCIAL_ADMIN_EMAIL_ALLOWLIST)
-  if (allowlist.size) {
-    const email = String(userOrRes.email || '').trim().toLowerCase()
-    if (!email || !allowlist.has(email)) return json(403, { ok: false, error: 'FORBIDDEN' })
-  }
-
-  const expected = String(context?.env?.SOCIAL_ADMIN_TOKEN || '').trim()
-  if (!expected) return json(503, { ok: false, error: 'SOCIAL_ADMIN_TOKEN_NOT_CONFIGURED' })
-
-  const got = String(context?.request?.headers?.get?.('x-social-admin-token') || '').trim()
-  if (!got || got !== expected) return json(403, { ok: false, error: 'FORBIDDEN' })
-
-  return userOrRes
+  return json(403, { ok: false, error: 'FORBIDDEN', code: 'ADMIN_REQUIRED' })
 }

--- a/frontend/functions/api/instagram/comment-reply.ts
+++ b/frontend/functions/api/instagram/comment-reply.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphPost } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -13,7 +13,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/instagram/comments.ts
+++ b/frontend/functions/api/instagram/comments.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/instagram/connect.ts
+++ b/frontend/functions/api/instagram/connect.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { writeConnection } from '../../_lib/instagramStore'
@@ -13,7 +13,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/instagram/disconnect.ts
+++ b/frontend/functions/api/instagram/disconnect.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { deleteConnection } from '../../_lib/instagramStore'
 import { requireCsrfForMutations } from '../../_lib/csrf'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/instagram/media.ts
+++ b/frontend/functions/api/instagram/media.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/instagram/metrics.ts
+++ b/frontend/functions/api/instagram/metrics.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/instagram/oauth/callback.ts
+++ b/frontend/functions/api/instagram/oauth/callback.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucket } from '../../../_lib/r2'
 import { verifyState } from '../../../_lib/oauthState'
 import { graphGet } from '../../../_lib/instagramGraph'
@@ -39,7 +39,7 @@ async function fetchJson(url: string) {
 }
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/instagram/oauth/complete.ts
+++ b/frontend/functions/api/instagram/oauth/complete.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucket } from '../../../_lib/r2'
 import { deletePending, readPendingDecrypted, writeConnection } from '../../../_lib/instagramStore'
 import { requireCsrfForMutations } from '../../../_lib/csrf'
@@ -12,7 +12,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/instagram/oauth/start.ts
+++ b/frontend/functions/api/instagram/oauth/start.ts
@@ -1,8 +1,8 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { signState } from '../../../_lib/oauthState'
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const appId = String(context?.env?.META_APP_ID || '').trim()
@@ -35,4 +35,3 @@ export async function onRequestGet(context: any): Promise<Response> {
 
   return Response.redirect(`https://www.facebook.com/v20.0/dialog/oauth?${qs.toString()}`, 302)
 }
-

--- a/frontend/functions/api/instagram/publish.ts
+++ b/frontend/functions/api/instagram/publish.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphPost } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -15,7 +15,7 @@ const json = (status: number, body: any) =>
 type PublishType = 'image' | 'carousel' | 'story'
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/instagram/status.ts
+++ b/frontend/functions/api/instagram/status.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/instagram/stories.ts
+++ b/frontend/functions/api/instagram/stories.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { graphGet } from '../../_lib/instagramGraph'
 import { readConnectionDecrypted } from '../../_lib/instagramStore'
@@ -11,7 +11,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/share/upload.ts
+++ b/frontend/functions/api/share/upload.ts
@@ -1,5 +1,5 @@
 import { requireCsrfForMutations } from '../../_lib/csrf'
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket } from '../../_lib/r2'
 import { requestAuditMeta, writeAuditEvent } from '../../_lib/audit'
 import { shareIndexDayKeyUtc, shareIndexKey } from '../../_lib/shareIndex'
@@ -22,7 +22,7 @@ const sanitizeName = (name: string) => {
 }
 
 export async function onRequestPost(context: { request: Request; env?: Record<string, unknown> }): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const csrfRes = requireCsrfForMutations(context)

--- a/frontend/functions/api/social/job-status.ts
+++ b/frontend/functions/api/social/job-status.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket, getJson } from '../../_lib/r2'
 
 const json = (status: number, body: any) =>
@@ -8,7 +8,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/social/metrics/last-jobs-run.ts
+++ b/frontend/functions/api/social/metrics/last-jobs-run.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucket, getJson } from '../../../_lib/r2'
 
 const json = (status: number, body: any) =>
@@ -8,7 +8,7 @@ const json = (status: number, body: any) =>
   })
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)
@@ -25,4 +25,3 @@ export async function onRequestGet(context: any): Promise<Response> {
 
   return json(200, { ok: true, metrics })
 }
-

--- a/frontend/functions/api/social/queue/list.ts
+++ b/frontend/functions/api/social/queue/list.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucket, getJson } from '../../../_lib/r2'
 import { isPublished } from '../../../_lib/socialQueue'
 import { socialQueueGroupKey } from '../../../_lib/socialKeys'
@@ -26,7 +26,7 @@ async function listAll(bucket: R2Bucket, opts: { prefix: string; delimiter?: str
 }
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)
@@ -67,4 +67,3 @@ export async function onRequestGet(context: any): Promise<Response> {
   groups.sort((a, b) => String(a.group.scheduledAt).localeCompare(String(b.group.scheduledAt)))
   return json(200, { ok: true, dateKey, groups })
 }
-

--- a/frontend/functions/api/social/queue/upload.ts
+++ b/frontend/functions/api/social/queue/upload.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucket, getJson, putJson } from '../../../_lib/r2'
 import { socialAssetFileKey, socialAssetMetaKey, socialQueueGroupKey } from '../../../_lib/socialKeys'
 import { groupKeyFromFilename, groupKeyFromMsBrt, normalizeIsoOrThrow, scheduledAtFromGroupKeyBrt, dateKeyFromMsBrt, dateKeyFromGroupKey } from '../../../_lib/socialTime'
@@ -35,7 +35,7 @@ const parsePlatforms = (raw: string): SocialPlatform[] => {
 }
 
 export async function onRequestPost(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
   const csrfRes = requireCsrfForMutations(context)
   if (csrfRes) return csrfRes

--- a/frontend/functions/api/social/results.ts
+++ b/frontend/functions/api/social/results.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../_lib/insumosAuth'
+import { requireCrmUser } from '../../_lib/crmAuth'
 import { getShareBucket, getJson } from '../../_lib/r2'
 
 const json = (status: number, body: any) =>
@@ -21,7 +21,7 @@ async function listAll(bucket: R2Bucket, opts: { prefix: string }) {
 }
 
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const bucket = getShareBucket(context)

--- a/frontend/functions/api/social/setup/status.ts
+++ b/frontend/functions/api/social/setup/status.ts
@@ -1,4 +1,4 @@
-import { requireInsumosUser } from '../../../_lib/insumosAuth'
+import { requireCrmUser } from '../../../_lib/crmAuth'
 import { getShareBucketInfo } from '../../../_lib/r2'
 import { getIntegrationsEncryptionSecret, integrationsEncryptionSecretRequired } from '../../../_lib/integrationsEncryption'
 
@@ -16,29 +16,17 @@ const parseCsv = (raw: any): string[] => {
   return [...new Set(parts)]
 }
 
-const parseCsvLower = (raw: any): Set<string> => new Set(parseCsv(raw).map((s) => s.toLowerCase()))
-const parseCsvUpper = (raw: any): Set<string> => new Set(parseCsv(raw).map((s) => s.toUpperCase()))
-
 export async function onRequestGet(context: any): Promise<Response> {
-  const userOrRes = await requireInsumosUser(context)
+  const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
   const { bucketConfigured, effectiveKeyPrefix } = getShareBucketInfo(context)
   const secret = getIntegrationsEncryptionSecret(context)
   const encryptionRequired = integrationsEncryptionSecretRequired(context)
 
-  const roleAllowlist = parseCsvUpper(context?.env?.SOCIAL_ADMIN_ROLE_ALLOWLIST)
-  const emailAllowlist = parseCsvLower(context?.env?.SOCIAL_ADMIN_EMAIL_ALLOWLIST)
-  const tokenConfigured = !!String(context?.env?.SOCIAL_ADMIN_TOKEN || '').trim()
-
-  const roleAllowlistConfigured = roleAllowlist.size > 0
-  const emailAllowlistConfigured = emailAllowlist.size > 0
-
-  const role = String((userOrRes as any)?.role || '').trim().toUpperCase()
-  const userCanAdminWithoutToken = roleAllowlistConfigured && !!role && roleAllowlist.has(role)
-  const tokenRequiredForThisUser = !userCanAdminWithoutToken && tokenConfigured
-
   const defaultUnitsFromEnv = parseCsv(context?.env?.SOCIAL_DEFAULT_UNITS)
+  const role = String((userOrRes as any)?.role || '').trim()
+  const isAdmin = role.toUpperCase() === 'ADMIN'
 
   return json(200, {
     ok: true,
@@ -51,14 +39,7 @@ export async function onRequestGet(context: any): Promise<Response> {
     },
     r2: { bucketConfigured, effectiveKeyPrefix },
     encryption: { required: encryptionRequired, configured: !!secret },
-    adminPolicy: {
-      roleAllowlistConfigured,
-      emailAllowlistConfigured,
-      tokenConfigured,
-      userCanAdminWithoutToken,
-      tokenRequiredForThisUser,
-    },
+    admin: { isAdmin, role: role || undefined },
     socialDefaults: { defaultUnitsFromEnv },
   })
 }
-


### PR DESCRIPTION
## O que mudou
- UX/docs do módulo Redes Sociais não mencionam mais "Insumos" (tratado como CRM)
- Admin do Social passa a ser global: apenas role=ADMIN em /api/social/admin/* e /api/social/publish
- Introduz helper de auth `frontend/functions/_lib/crmAuth.ts` (o backend real continua usando /insumos/auth/me como detalhe interno)

## Validação
- npm -C frontend run build
