### PR TITLE
ci: keep CRM Pages deployed (reconcile)

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -29,13 +29,19 @@ jobs:
             const prNumber = (() => {
               const n = context.payload?.pull_request?.number;
               if (n) return n;
-              const input = core.getInput('pr_number');
+              const input = context.payload?.inputs?.pr_number;
               const parsed = Number(String(input || '').trim());
               if (!Number.isFinite(parsed) || parsed <= 0) {
-                throw new Error(`Invalid pr_number: ${input}`);
+                core.warning(`Invalid or missing workflow_dispatch input pr_number: ${input}`);
+                return null;
               }
               return parsed;
             })();
+
+            if (!prNumber) {
+              core.setOutput('eligible', 'false');
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -29,13 +29,19 @@ jobs:
             const prNumber = (() => {
               const n = context.payload?.pull_request?.number;
               if (n) return n;
-              const input = core.getInput('pr_number');
+              const input = context.payload?.inputs?.pr_number;
               const parsed = Number(String(input || '').trim());
               if (!Number.isFinite(parsed) || parsed <= 0) {
-                throw new Error(`Invalid pr_number: ${input}`);
+                core.warning(`Invalid or missing workflow_dispatch input pr_number: ${input}`);
+                return null;
               }
               return parsed;
             })();
+
+            if (!prNumber) {
+              core.setOutput('eligible', 'false');
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -132,5 +138,5 @@ jobs:
           set -euo pipefail
           PROJECT="${PAGES_PROJECT:-skincos}"
           echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME (after automerge)"
-          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME"
+          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "${{ steps.pr.outputs.merge_commit_sha }}" --commit-message "after-automerge PR #${{ steps.pr.outputs.pr_number }}"
         working-directory: frontend

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -1,0 +1,121 @@
+name: Deploy CRM (Cloudflare Pages) reconcile
+
+on:
+  schedule:
+    # Workaround: merges performed via GitHub Actions can skip `on: push` deploy triggers.
+    # This job reconciles production to the latest `main` SHA.
+    - cron: "*/5 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-crm-pages-reconcile-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard Cloudflare Pages deploy
+        id: guard
+        env:
+          ENABLE_PROD: ${{ vars.ENABLE_CRM_PAGES_DEPLOY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_PROD: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+          ENABLE="$ENABLE_PROD"
+          PROJECT="${PROJECT_PROD:-skincos}"
+          if [[ "${ENABLE:-}" != "true" ]]; then
+            echo "Deploy flag not enabled; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare deploy secrets not configured; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "project=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Resolve target SHA
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: sha
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          msg=$(git log -1 --pretty=%s | tr '\n' ' ')
+          echo "message=$msg" >> "$GITHUB_OUTPUT"
+
+      - name: Restore deploy cache (skip if already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          key: crm-pages-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/deployed_sha.txt
+
+      - name: Skip (already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        run: npm run build
+        working-directory: frontend
+
+      - name: Deploy to Cloudflare Pages (wrangler)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PAGES_PROJECT: ${{ steps.guard.outputs.project }}
+          BRANCH_NAME: main
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+          GIT_MESSAGE: ${{ steps.sha.outputs.message }}
+        run: |
+          set -euo pipefail
+          PROJECT="${PAGES_PROJECT:-skincos}"
+          echo "Reconciling Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME sha=$GIT_SHA"
+          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
+        working-directory: frontend
+
+      - name: Mark deployed SHA
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        run: |
+          set -euo pipefail
+          mkdir -p deploy-state
+          echo "${{ steps.sha.outputs.sha }}" > deploy-state/deployed_sha.txt
+
+      - name: Save deploy cache
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        uses: actions/cache/save@v4
+        with:
+          key: crm-pages-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/deployed_sha.txt

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -84,15 +84,17 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PAGES_PROJECT: ${{ steps.guard.outputs.project }}
           BRANCH_NAME: ${{ steps.guard.outputs.branch }}
+          GIT_SHA: ${{ github.sha }}
+          GIT_MESSAGE: ${{ github.event.head_commit.message || github.sha }}
           WRANGLER_CWD: ${{ steps.guard.outputs.wrangler_cwd }}
         run: |
           set -euo pipefail
           PROJECT="${PAGES_PROJECT:-skincos}"
           if [[ -n "${WRANGLER_CWD:-}" ]]; then
             echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME (wrangler cwd=$WRANGLER_CWD)"
-            npx --yes wrangler@3 --cwd "$WRANGLER_CWD" pages deploy ../dist --project-name "$PROJECT" --branch "$BRANCH_NAME"
+            npx --yes wrangler@3 --cwd "$WRANGLER_CWD" pages deploy ../dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
           else
             echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME"
-            npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME"
+            npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
           fi
         working-directory: frontend


### PR DESCRIPTION
Problem: merges performed by GitHub Actions (app/github-actions) do not trigger push workflows, so Cloudflare Pages deploy can silently stop updating.

This PR:
- Adds scheduled reconciler `.github/workflows/deploy-crm-pages-reconcile.yml` (every 5 minutes) that deploys current main if it has not been deployed yet (cache-based).
- Attaches commit metadata to Pages deploys via wrangler flags `--commit-hash` and `--commit-message`.
- Fixes workflow_dispatch input handling in after-automerge deploy workflows.