### PR TITLE
fix(pages): enable /api/ponto/* routes

### DIFF
--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -9,6 +9,7 @@
         "/api/instagram/*",
         "/api/instagram-module/*",
         "/api/social/*",
+        "/api/ponto/*",
         "/api/unit-monitor/*",
         "/share",
         "/share/*",


### PR DESCRIPTION
Adds /api/ponto/* to frontend/public/_routes.json so Cloudflare Pages routes Ponto API requests to Pages Functions (otherwise it serves index.html).