### PR TITLE
ci: keep CRM API deployed (reconcile)

### DIFF
--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -1,0 +1,105 @@
+name: Deploy CRM API reconcile
+
+on:
+  schedule:
+    # Ensure CRM API follows `main` even when merges performed by GitHub Actions skip `on: push` triggers.
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-crm-api-reconcile-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard CRM API deploy secrets
+        id: guard
+        env:
+          ENABLE: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+          HOST: ${{ secrets.CRM_API_SSH_HOST }}
+          USER: ${{ secrets.CRM_API_SSH_USER }}
+          KEY: ${{ secrets.CRM_API_SSH_KEY }}
+          APP_DIR: ${{ vars.CRM_API_APP_DIR }}
+          COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+        run: |
+          set -euo pipefail
+          if [[ "${ENABLE:-}" != "true" ]]; then
+            echo "CRM API deploy disabled; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
+            echo "CRM API deploy not configured; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Resolve target SHA
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: sha
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          msg=$(git log -1 --pretty=%s | tr '\n' ' ')
+          echo "message=$msg" >> "$GITHUB_OUTPUT"
+
+      - name: Restore deploy cache (skip if already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          key: crm-api-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/crm_api_deployed_sha.txt
+
+      - name: Skip (already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
+
+      - name: Deploy via SSH (main SHA)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.CRM_API_SSH_HOST }}
+          username: ${{ secrets.CRM_API_SSH_USER }}
+          key: ${{ secrets.CRM_API_SSH_KEY }}
+          port: ${{ secrets.CRM_API_SSH_PORT != '' && secrets.CRM_API_SSH_PORT || '22' }}
+          script: |
+            set -euo pipefail
+            cd "${CRM_API_APP_DIR}"
+            git fetch --all
+            git reset --hard "${GITHUB_SHA}"
+            ${CRM_API_DEPLOY_COMMAND}
+        env:
+          CRM_API_APP_DIR: ${{ vars.CRM_API_APP_DIR }}
+          CRM_API_DEPLOY_COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
+
+      - name: Mark deployed SHA
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        run: |
+          set -euo pipefail
+          mkdir -p deploy-state
+          echo "${{ steps.sha.outputs.sha }}" > deploy-state/crm_api_deployed_sha.txt
+
+      - name: Save deploy cache
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        uses: actions/cache/save@v4
+        with:
+          key: crm-api-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/crm_api_deployed_sha.txt
+


### PR DESCRIPTION
Adds `.github/workflows/deploy-crm-api-reconcile.yml` (cron every 10 minutes + manual) to keep the SSH-deployed CRM API aligned with `main` even when merges performed by GitHub Actions skip `on: push` triggers. Uses cache to avoid redeploying the same SHA.