### PR TITLE
ci: audit Cloudflare Pages env vars

### DIFF
--- a/.github/workflows/cloudflare-pages-audit.yml
+++ b/.github/workflows/cloudflare-pages-audit.yml
@@ -1,0 +1,90 @@
+name: Cloudflare Pages Audit
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard Cloudflare credentials
+        id: guard
+        env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare secrets missing; cannot audit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch Pages project config
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+        run: |
+          set -euo pipefail
+          curl -sS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${PROJECT}" \
+            > pages_project.json
+
+          python - <<'PY'
+          import json
+          with open("pages_project.json","r",encoding="utf-8") as f:
+            data=json.load(f)
+          if not data.get("success"):
+            raise SystemExit("Cloudflare API returned success=false: %s" % (data.get("errors") or data))
+          res=data.get("result") or {}
+          print("Project:", res.get("name"))
+          print("Production branch:", res.get("production_branch"))
+          cfg=res.get("deployment_configs") or {}
+          for env in ("production","preview"):
+            env_cfg=cfg.get(env) or {}
+            env_vars=env_cfg.get("env_vars") or {}
+            keys=sorted(env_vars.keys())
+            print(f"{env} env var keys ({len(keys)}):", ", ".join(keys) if keys else "(none)")
+          PY
+
+      - name: Check required env vars (presence only)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          required = [
+            "PONTO_API_TARGET",
+            # recommended hardening:
+            "PONTO_PROXY_TOKEN",
+            "PONTO_ACTOR_HMAC_KEY",
+          ]
+          with open("pages_project.json","r",encoding="utf-8") as f:
+            data=json.load(f)
+          res=(data.get("result") or {})
+          cfg=res.get("deployment_configs") or {}
+          prod=(cfg.get("production") or {}).get("env_vars") or {}
+          prev=(cfg.get("preview") or {}).get("env_vars") or {}
+          def has(env, k):
+            return k in env
+          print("Required vars presence (prod/preview):")
+          missing=[]
+          for k in required:
+            p=has(prod,k); v=has(prev,k)
+            print(f" - {k}: prod={'yes' if p else 'no'} preview={'yes' if v else 'no'}")
+            if not p:
+              missing.append(k)
+          if missing:
+            print("\nMissing in production:", ", ".join(missing))
+          PY
+


### PR DESCRIPTION
Adds a workflow that queries the Cloudflare Pages project config (via existing CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID) and prints ONLY the presence of key env vars (no secret values), so we can confirm whether PONTO_API_TARGET is configured on the Cloudflare side.