### PR TITLE
ci(workers): fix setup-node pnpm cache

### DIFF
--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -49,8 +49,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: backend/pnpm-lock.yaml
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -115,8 +115,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: backend/pnpm-lock.yaml
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' }}
@@ -136,4 +134,3 @@ jobs:
         run: |
           set -euo pipefail
           bash backend/scripts/cloudflare-workers.sh deploy-all
-

--- a/.github/workflows/deploy-workers-reconcile.yml
+++ b/.github/workflows/deploy-workers-reconcile.yml
@@ -64,8 +64,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: backend/pnpm-lock.yaml
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
@@ -99,4 +97,3 @@ jobs:
         with:
           key: workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
-


### PR DESCRIPTION
Remove o cache=pnpm do actions/setup-node (o runner nao tem pnpm antes do corepack), evitando falha em workflows de deploy de Workers.