### PR TITLE
fix(workers): include insumos src/lib in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ lib/
 lib64/
 parts/
 sdist/
+
+# Cloudflare Workers source (keep committed even though "lib/" is ignored globally)
+!backend/apps/insumos/src/lib/
+!backend/apps/insumos/src/lib/**
 # Local runtime state (do not commit)
 backend/var/
 # Legacy/compat (avoid using; prefer backend/var/)

--- a/backend/apps/insumos/src/lib/csv.js
+++ b/backend/apps/insumos/src/lib/csv.js
@@ -1,0 +1,13 @@
+function csvEscape(v) {
+    const s = `${v ?? ''}`;
+    const needsQuotes = s.includes(';') || s.includes('"') || s.includes('\n') || s.includes('\r');
+    const escaped = s.replace(/"/g, '""');
+    return needsQuotes ? `"${escaped}"` : escaped;
+}
+
+export function toCsv(headers, rows) {
+    const bom = '\ufeff';
+    const head = headers.map(csvEscape).join(';');
+    const body = rows.map((r) => r.map(csvEscape).join(';')).join('\n');
+    return `${bom}${head}\n${body}\n`;
+}

--- a/backend/apps/insumos/src/lib/json.js
+++ b/backend/apps/insumos/src/lib/json.js
@@ -1,0 +1,16 @@
+export function safeJson(value, maxLen = 45000) {
+    try {
+        const s = JSON.stringify(value ?? null);
+        return s.length > maxLen ? `${s.slice(0, maxLen)}…` : s;
+    } catch {
+        return '';
+    }
+}
+
+export function safeJsonNoTruncate(value) {
+    try {
+        return JSON.stringify(value ?? null);
+    } catch {
+        return 'null';
+    }
+}

--- a/backend/apps/insumos/src/lib/qr.js
+++ b/backend/apps/insumos/src/lib/qr.js
@@ -1,0 +1,8 @@
+import qrcode from 'qrcode-generator';
+
+export function qrSvg(text) {
+    const qr = qrcode(0, 'M');
+    qr.addData(text);
+    qr.make();
+    return qr.createSvgTag({ scalable: true, margin: 2 });
+}

--- a/backend/apps/insumos/src/lib/request.js
+++ b/backend/apps/insumos/src/lib/request.js
@@ -1,0 +1,11 @@
+export function getClientIp(request) {
+    return (
+        request.headers.get('cf-connecting-ip') ||
+        request.headers.get('x-forwarded-for')?.split(',')?.[0]?.trim() ||
+        '0.0.0.0'
+    );
+}
+
+export function getUserAgent(request) {
+    return request.headers.get('user-agent') || '';
+}


### PR DESCRIPTION
O deploy do Worker falhava no GitHub Actions porque `.gitignore` ignorava `lib/` globalmente, excluindo `backend/apps/insumos/src/lib/*` do repo.

Este PR:
- adiciona exceção no `.gitignore` para `backend/apps/insumos/src/lib/**`
- versiona os helpers usados pelo Worker (csv/json/qr/request)
