### PR TITLE
fix(ponto): bypass insumos SESSION_SECRET for /ponto

### DIFF
--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -1302,6 +1302,17 @@ export default {
             return res;
         };
 
+        // Ponto routes must not depend on Insumos session cookies/config (SESSION_SECRET, CSRF, etc).
+        // They have their own auth model (proxy token + signed actor headers / admin token / device token).
+        const pontoEarlyResp = await handlePontoRoutes({
+            request,
+            url,
+            env,
+            appOrigin,
+            withCORS,
+        });
+        if (pontoEarlyResp) return pontoEarlyResp;
+
         const enforceRateLimit = async (kind) => {
             if (!env.RATE_LIMITER) return { allowed: true };
             const windowSec = 60;
@@ -1782,17 +1793,7 @@ export default {
             }
         }
 
-        const pontoPrefix = url.pathname === "/ponto" || url.pathname.startsWith("/ponto/") || url.pathname === "/api/ponto" || url.pathname.startsWith("/api/ponto/");
-        const isPublicEndpoint = pontoPrefix || url.pathname === "/api/metrics" || url.pathname === "/metrics";
-
-        const pontoResp = await handlePontoRoutes({
-            request,
-            url,
-            env,
-            appOrigin,
-            withCORS,
-        });
-        if (pontoResp) return pontoResp;
+        const isPublicEndpoint = url.pathname === "/api/metrics" || url.pathname === "/metrics";
         if (!isPublicEndpoint && !url.pathname.startsWith("/auth/")) {
             if (!sessionUsername) {
                 return withCORS(


### PR DESCRIPTION
Move o handler de /ponto para o inicio do fetch do Worker, evitando erro 500 (SESSION_SECRET not configured) no skincos-api. O modulo de Ponto tem auth propria (proxy token + actor/admin/device).