### PR TITLE
ci(workers): run wrangler d1 migrations apply --remote

### DIFF
--- a/backend/scripts/cloudflare-workers.sh
+++ b/backend/scripts/cloudflare-workers.sh
@@ -72,7 +72,8 @@ deploy_insumos() {
   (
     cd "$BACKEND_DIR"
     # NOTE: pnpm filtered exec runs with the package's CWD, so use package-local config path.
-    run_pnpm -F @skincos/insumos-worker exec wrangler d1 migrations apply "$INSUMOS_DB_NAME" --config wrangler.toml "${ENV_FLAG[@]}" || true
+    # IMPORTANT: CI should apply migrations to the remote D1 (not the local .wrangler state).
+    run_pnpm -F @skincos/insumos-worker exec wrangler d1 migrations apply "$INSUMOS_DB_NAME" --remote --config wrangler.toml "${ENV_FLAG[@]}"
   )
   echo "[workers] Deploying skincos-insumos..."
   (


### PR DESCRIPTION
O deploy estava aplicando migrações no DB local ('.wrangler/state') por padrão.

Este PR força o comando de migração a usar o D1 remoto (produção), garantindo que as tabelas do Ponto (e demais migrações) existam na D1 real.
