### PR TITLE
fix(ponto): kiosk PIN fallback only after face fails

### DIFF
--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -1253,9 +1253,6 @@ export function PontoModule() {
                   <Button variant="outline" onClick={() => setAutoIdentify(v => !v)} disabled={loading || !stream}>
                     Auto-identificar: {autoIdentify ? 'ON' : 'OFF'}
                   </Button>
-                  <Button variant="outline" onClick={() => setDevicePinOpen(true)} disabled={loading}>
-                    Usar PIN
-                  </Button>
                 </div>
 
                 <div className="rounded-xl overflow-hidden border bg-black">


### PR DESCRIPTION
- Remove botão 'Usar PIN' do Kiosk\n- PIN aparece somente quando o fluxo por Face falhar (NOT_RECOGNIZED / modelos indisponíveis)\n