### PR TITLE
fix(rate-limit): login não bloquear por IP 0.0.0.0

### DIFF
--- a/backend/apps/insumos/src/lib/request.js
+++ b/backend/apps/insumos/src/lib/request.js
@@ -1,4 +1,6 @@
 export function getClientIp(request) {
+    const skincosIp = request.headers.get('x-skincos-client-ip');
+    if (skincosIp && String(skincosIp).trim()) return String(skincosIp).trim();
     return (
         request.headers.get('cf-connecting-ip') ||
         request.headers.get('x-forwarded-for')?.split(',')?.[0]?.trim() ||

--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -1322,7 +1322,10 @@ export default {
                 read: { limit: 240 },
                 write: { limit: 60 }
             }[kind] || { limit: 120 };
-            const id = env.RATE_LIMITER.idFromName(ip);
+            const ipKey = String(ip || '').trim();
+            const uaKey = String(userAgent || '').trim().slice(0, 80);
+            const idName = ipKey && ipKey !== '0.0.0.0' ? ipKey : `ua:${uaKey || 'unknown'}`;
+            const id = env.RATE_LIMITER.idFromName(idName);
             const stub = env.RATE_LIMITER.get(id);
             const res = await stub.fetch(`https://rl/?key=${encodeURIComponent(kind)}&limit=${cfg.limit}&window=${windowSec}`);
             const data = await res.json().catch(() => ({}));
@@ -1380,9 +1383,16 @@ export default {
 
         // Basic rate limiting (Durable Object)
         try {
-            const isAuth = url.pathname.startsWith('/auth/');
             const isMutating = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method);
-            const kind = isAuth ? 'auth' : (isMutating ? 'write' : 'read');
+            const authSensitive = [
+                '/auth/login',
+                '/auth/register',
+                '/auth/signup',
+                '/auth/password/request',
+                '/auth/password/reset',
+            ];
+            const isAuthSensitive = authSensitive.includes(url.pathname);
+            const kind = isAuthSensitive ? 'auth' : (isMutating ? 'write' : 'read');
             const rl = await enforceRateLimit(kind);
             if (!rl.allowed) {
                 return withCORS(JSON.stringify({ success: false, error: 'Rate limit excedido', code: 'RATE_LIMITED' }), { status: 429 }, appOrigin);

--- a/frontend/functions/api/auth/[[path]].ts
+++ b/frontend/functions/api/auth/[[path]].ts
@@ -13,6 +13,8 @@ export async function onRequest(context: any): Promise<Response> {
     targetUrl.search = url.search
 
     const headers = new Headers(request.headers)
+    const clientIp = headers.get('cf-connecting-ip') || headers.get('x-forwarded-for')?.split(',')?.[0]?.trim()
+    if (clientIp) headers.set('x-skincos-client-ip', clientIp)
     headers.delete('host')
     headers.delete('content-length')
     headers.delete('content-encoding')

--- a/frontend/functions/api/insumos/[[path]].ts
+++ b/frontend/functions/api/insumos/[[path]].ts
@@ -13,6 +13,8 @@ export async function onRequest(context: any): Promise<Response> {
     targetUrl.search = url.search
 
     const headers = new Headers(request.headers)
+    const clientIp = headers.get('cf-connecting-ip') || headers.get('x-forwarded-for')?.split(',')?.[0]?.trim()
+    if (clientIp) headers.set('x-skincos-client-ip', clientIp)
     headers.delete('host')
     headers.delete('content-length')
     headers.delete('content-encoding')


### PR DESCRIPTION
Causa: rate limit no Worker usava chave só por IP, e quando chamado via Pages proxy o Worker recebia IP como 0.0.0.0/ausente. Resultado: vários logins compartilhavam o mesmo bucket e recebiam 429.\n\nCorreções:\n- Pages Functions (/api/auth e /api/insumos) propagam IP real em x-skincos-client-ip\n- Worker usa esse header para getClientIp\n- Rate limit classifica apenas rotas sensíveis (login/register/reset) como 'auth' (20/min); /auth/me agora é 'read'\n- Fallback do rate-limit id usa user-agent quando IP é ausente\n\nIsso deve eliminar o 'Rate limit excedido' intermitente na tela de login.