### PR TITLE
fix(ponto): câmera + admin token no Pages

### DIFF
--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -20,6 +20,7 @@ jobs:
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
+          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
         run: |
           set -euo pipefail
           if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
@@ -27,8 +28,8 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -z "${PONTO_PROXY_TOKEN:-}" || -z "${PONTO_ACTOR_HMAC_KEY:-}" ]]; then
-            echo "Missing GitHub secrets PONTO_PROXY_TOKEN/PONTO_ACTOR_HMAC_KEY; cannot sync."
+          if [[ -z "${PONTO_PROXY_TOKEN:-}" || -z "${PONTO_ACTOR_HMAC_KEY:-}" || -z "${PONTO_ADMIN_TOKEN:-}" ]]; then
+            echo "Missing GitHub secrets PONTO_PROXY_TOKEN/PONTO_ACTOR_HMAC_KEY/PONTO_ADMIN_TOKEN; cannot sync."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -58,6 +59,7 @@ jobs:
           PONTO_API_TARGET: "https://api.skincos.com.br"
           PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
+          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -73,7 +75,8 @@ jobs:
           target=os.environ.get("PONTO_API_TARGET","").strip()
           proxy=os.environ.get("PONTO_PROXY_TOKEN","").strip()
           actor=os.environ.get("PONTO_ACTOR_HMAC_KEY","").strip()
-          if not target or not proxy or not actor:
+          admin=os.environ.get("PONTO_ADMIN_TOKEN","").strip()
+          if not target or not proxy or not actor or not admin:
             raise SystemExit("Missing required envs for patch")
           for env_name in ("production","preview"):
             env_cfg=cfg.get(env_name) or {}
@@ -82,12 +85,13 @@ jobs:
             env_vars["PONTO_API_TARGET"]={"value": target, "type":"secret_text"}
             env_vars["PONTO_PROXY_TOKEN"]={"value": proxy, "type":"secret_text"}
             env_vars["PONTO_ACTOR_HMAC_KEY"]={"value": actor, "type":"secret_text"}
+            env_vars["PONTO_ADMIN_TOKEN"]={"value": admin, "type":"secret_text"}
             env_cfg["env_vars"]=env_vars
             cfg[env_name]=env_cfg
           patch={"deployment_configs": cfg}
           with open("pages_patch.json","w",encoding="utf-8") as f:
             json.dump(patch,f)
-          print("Prepared patch for env vars: PONTO_API_TARGET, PONTO_PROXY_TOKEN, PONTO_ACTOR_HMAC_KEY")
+          print("Prepared patch for env vars: PONTO_API_TARGET, PONTO_PROXY_TOKEN, PONTO_ACTOR_HMAC_KEY, PONTO_ADMIN_TOKEN")
           PY
 
           curl -sS -X PATCH \
@@ -106,5 +110,11 @@ jobs:
           cfg=(data.get("result") or {}).get("deployment_configs") or {}
           for env_name in ("production","preview"):
             keys=sorted(((cfg.get(env_name) or {}).get("env_vars") or {}).keys())
-            print(f"{env_name} env var keys now include Ponto:", "PONTO_API_TARGET" in keys, "PONTO_PROXY_TOKEN" in keys, "PONTO_ACTOR_HMAC_KEY" in keys)
+            print(
+              f"{env_name} env var keys now include Ponto:",
+              "PONTO_API_TARGET" in keys,
+              "PONTO_PROXY_TOKEN" in keys,
+              "PONTO_ACTOR_HMAC_KEY" in keys,
+              "PONTO_ADMIN_TOKEN" in keys,
+            )
           PY

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -11,7 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import * as QRCode from 'qrcode'
 
-type ApiError = { ok?: boolean; error?: string; message?: string; code?: string }
+type ApiError = { ok?: boolean; error?: string; message?: string; code?: string; hint?: string }
 
 type PontoEmployeePublic = {
   id: string
@@ -68,7 +68,6 @@ type PontoMeResponse =
   }
 
 const LS_DEVICE_TOKEN = 'skincos.ponto.deviceToken.v1'
-const LS_ADMIN_TOKEN = 'skincos.ponto.adminToken.v1'
 const LS_DEV_ACTOR_EMAIL = 'skincos.ponto.devActorEmail.v1'
 
 function b64UrlEncodeBytes(bytes: ArrayBuffer): string {
@@ -143,7 +142,9 @@ async function apiJson<T>(
   }
   if (res.ok) return json as T
   const err = (json || {}) as ApiError
-  const e = new Error(err.error || err.message || `HTTP ${res.status}`)
+  const hint = typeof err.hint === 'string' ? err.hint.trim() : ''
+  const base = err.error || err.message || `HTTP ${res.status}`
+  const e = new Error([base, hint].filter(Boolean).join(' • '))
   ;(e as any).details = json
   ;(e as any).status = res.status
   throw e
@@ -245,9 +246,6 @@ export function PontoModule() {
   const [deviceToken, setDeviceToken] = useState(() => {
     try { return localStorage.getItem(LS_DEVICE_TOKEN) || '' } catch { return '' }
   })
-  const [adminToken, setAdminToken] = useState(() => {
-    try { return localStorage.getItem(LS_ADMIN_TOKEN) || '' } catch { return '' }
-  })
   const [devActorEmail, setDevActorEmail] = useState(() => {
     try { return localStorage.getItem(LS_DEV_ACTOR_EMAIL) || '' } catch { return '' }
   })
@@ -256,6 +254,7 @@ export function PontoModule() {
   const deviceVideoRef = useRef<HTMLVideoElement | null>(null)
   const adminVideoRef = useRef<HTMLVideoElement | null>(null)
   const [stream, setStream] = useState<MediaStream | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
   const [cameraOwner, setCameraOwner] = useState<'employee' | 'device' | 'admin' | null>(null)
 
   const [modelsReady, setModelsReady] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
@@ -326,9 +325,6 @@ export function PontoModule() {
   useEffect(() => {
     try { localStorage.setItem(LS_DEVICE_TOKEN, deviceToken) } catch { /* ignore */ }
   }, [deviceToken])
-  useEffect(() => {
-    try { localStorage.setItem(LS_ADMIN_TOKEN, adminToken) } catch { /* ignore */ }
-  }, [adminToken])
 
   useEffect(() => {
     try { localStorage.setItem(LS_DEV_ACTOR_EMAIL, devActorEmail) } catch { /* ignore */ }
@@ -350,8 +346,7 @@ export function PontoModule() {
   const crmRole = String(crmMe?.user?.role || '').toUpperCase()
   const canAdmin = crmRole === 'ADMIN' || crmRole === 'GESTOR' || crmRole === 'GERENTE'
   const showAdminTab = canAdmin || isDev
-  const adminAuth = isDev && adminToken.trim() ? { adminToken } : {}
-  const canAdminActions = canAdmin || (isDev && adminToken.trim())
+  const canAdminActions = canAdmin || isDev
 
   const loadCrmMe = React.useCallback(async () => {
     setCrmMeLoading(true)
@@ -375,12 +370,14 @@ export function PontoModule() {
   }, [showAdminTab, tab])
 
   useEffect(() => {
-    return () => {
-      stopCamera(stream)
-      setStream(null)
-      setCameraOwner(null)
-    }
+    streamRef.current = stream
   }, [stream])
+
+  useEffect(() => {
+    return () => {
+      stopCamera(streamRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     let alive = true
@@ -414,7 +411,7 @@ export function PontoModule() {
       return
     }
 
-    stopCamera(stream)
+    stopCamera(streamRef.current)
     setStream(null)
     setCameraOwner(null)
 
@@ -483,7 +480,7 @@ export function PontoModule() {
     if (!videoEl) return toast.error('Vídeo não disponível')
     setLoading(true)
     try {
-      stopCamera(stream)
+      stopCamera(streamRef.current)
       const s = await startUserCamera(videoEl)
       setStream(s)
       setCameraOwner(owner)
@@ -496,7 +493,7 @@ export function PontoModule() {
   }
 
   async function stopCameraUI(opts: { silent?: boolean } = {}) {
-    stopCamera(stream)
+    stopCamera(streamRef.current)
     setStream(null)
     setCameraOwner(null)
     if (!opts.silent) toast.message('Câmera desligada')
@@ -764,8 +761,8 @@ export function PontoModule() {
     setLoading(true)
     try {
       const [emps, devs] = await Promise.all([
-        apiJson<{ ok: boolean; data: PontoEmployeePublic[] }>('/api/ponto/admin/employees', adminAuth),
-        apiJson<{ ok: boolean; data: PontoDevicePublic[] }>('/api/ponto/admin/devices', adminAuth)
+        apiJson<{ ok: boolean; data: PontoEmployeePublic[] }>('/api/ponto/admin/employees'),
+        apiJson<{ ok: boolean; data: PontoDevicePublic[] }>('/api/ponto/admin/devices')
       ])
       setAdminEmployees(emps.data || [])
       setAdminDevices(devs.data || [])
@@ -786,7 +783,7 @@ export function PontoModule() {
     try {
       const res = await apiJson<{ ok: boolean; data: PontoEmployeePublic }>(
         '/api/ponto/admin/employees',
-        { ...adminAuth, method: 'POST', body: { name, code: newEmployeeCode.trim() } }
+        { method: 'POST', body: { name, code: newEmployeeCode.trim() } }
       )
       setNewEmployeeName('')
       setNewEmployeeCode('')
@@ -806,7 +803,6 @@ export function PontoModule() {
     setLoading(true)
     try {
       await apiJson('/api/ponto/admin/employees/' + selectedEmployeeId, {
-        ...adminAuth,
         method: 'PATCH',
         body: { loginEmail: selectedEmployeeLoginEmail.trim() }
       })
@@ -827,7 +823,6 @@ export function PontoModule() {
     setLoading(true)
     try {
       await apiJson('/api/ponto/admin/employees/' + selectedEmployeeId + '/pin', {
-        ...adminAuth,
         method: 'POST',
         body: { pin }
       })
@@ -864,7 +859,6 @@ export function PontoModule() {
         await new Promise(r => setTimeout(r, 650))
       }
       await apiJson('/api/ponto/admin/employees/' + selectedEmployeeId + '/enroll', {
-        ...adminAuth,
         method: 'POST',
         body: { descriptors, replace: enrollReplace, consentConfirmed: true }
       })
@@ -884,7 +878,7 @@ export function PontoModule() {
     try {
       const res = await apiJson<{ ok: boolean; data: PontoDevicePublic; tokenOnce: string }>(
         '/api/ponto/admin/devices',
-        { ...adminAuth, method: 'POST', body: { unit: newDeviceUnit.trim(), label: newDeviceLabel.trim() } }
+        { method: 'POST', body: { unit: newDeviceUnit.trim(), label: newDeviceLabel.trim() } }
       )
       setNewDeviceTokenOnce(res.tokenOnce)
       setNewDeviceLabel('')
@@ -901,7 +895,7 @@ export function PontoModule() {
     if (!canAdminActions) return toast.error('Acesso restrito a administradores')
     setLoading(true)
     try {
-      await apiJson('/api/ponto/admin/devices/' + deviceId + '/revoke', { ...adminAuth, method: 'POST' })
+      await apiJson('/api/ponto/admin/devices/' + deviceId + '/revoke', { method: 'POST' })
       await adminRefreshAll()
       toast.success('Dispositivo revogado')
     } catch (e: any) {
@@ -923,7 +917,7 @@ export function PontoModule() {
       if (adminPunchNote.trim()) body.note = adminPunchNote.trim()
       const res = await apiJson<{ ok: boolean; data: PontoPunchRecord }>(
         '/api/ponto/admin/punch',
-        { ...adminAuth, method: 'POST', body }
+        { method: 'POST', body }
       )
       toast.success(`Ponto manual: ${res.data.employeeName} (${res.data.type})`)
       setAdminPunchNote('')
@@ -945,7 +939,7 @@ export function PontoModule() {
       qs.set('limit', '500')
       const res = await apiJson<{ ok: boolean; data: PontoPunchRecord[] }>(
         '/api/ponto/admin/records?' + qs.toString(),
-        adminAuth
+        {}
       )
       setRecords(res.data || [])
       toast.success('Registros carregados')
@@ -964,7 +958,7 @@ export function PontoModule() {
       if (recordsFrom) qs.set('from', new Date(recordsFrom).toISOString())
       if (recordsTo) qs.set('to', new Date(recordsTo).toISOString())
       if (selectedEmployeeId) qs.set('employeeId', selectedEmployeeId)
-      const blob = await apiBlob('/api/ponto/admin/records.csv?' + qs.toString(), adminAuth)
+      const blob = await apiBlob('/api/ponto/admin/records.csv?' + qs.toString())
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
@@ -1099,13 +1093,6 @@ export function PontoModule() {
                     <Button variant="secondary" onClick={ensureModelsUI} disabled={loading}>Carregar modelos</Button>
                     <Button variant="outline" onClick={() => void stopCameraUI()} disabled={loading || !stream}>Desligar</Button>
                     <Button onClick={mePunchFace} disabled={loading || !stream}>Registrar por Face</Button>
-                    <Button
-                      variant="outline"
-                      onClick={() => { setMeStep('pin'); void stopCameraUI({ silent: true }) }}
-                      disabled={loading}
-                    >
-                      Usar PIN
-                    </Button>
                   </div>
                   <div className="rounded-xl overflow-hidden border bg-black">
                     <video ref={employeeVideoRef} className="w-full aspect-video object-cover" playsInline muted autoPlay />

--- a/frontend/SocialNetworksStudio.tsx
+++ b/frontend/SocialNetworksStudio.tsx
@@ -318,7 +318,13 @@ export function SocialNetworksStudio() {
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) {
         if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') {
-          throw new Error('Permissão insuficiente: somente ADMIN pode configurar este módulo.')
+          throw new Error(data?.hint || 'Permissão insuficiente: este módulo exige ADMIN/GESTOR/GERENTE.')
+        }
+        if (res.status === 403 && data?.code === 'CSRF_INVALID') {
+          throw new Error('Sessão inválida: recarregue a página e faça login novamente.')
+        }
+        if (res.status === 403 && data?.code === 'ORIGIN_INVALID') {
+          throw new Error('Requisição bloqueada (ORIGIN). Recarregue a página e tente novamente.')
         }
         throw new Error(data?.error || `HTTP ${res.status}`)
       }
@@ -465,7 +471,12 @@ export function SocialNetworksStudio() {
         }),
       })
       const data = (await res.json().catch(() => null)) as any
-      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
+      if (!res.ok) {
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
+        if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
+        throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
+      }
       toast.success('Conta salva')
       setAccountId('')
       setAccountToken('')
@@ -485,7 +496,12 @@ export function SocialNetworksStudio() {
         headers,
       })
       const data = (await res.json().catch(() => null)) as any
-      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
+      if (!res.ok) {
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
+        if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
+        throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
+      }
       toast.success('Conta removida')
       await refreshAccounts({ silent: true })
     } catch (e: any) {
@@ -512,7 +528,12 @@ export function SocialNetworksStudio() {
         body: JSON.stringify({ dateKey: g.group.dateKey, groupKey: g.group.groupKey, force }),
       })
       const data = (await res.json().catch(() => null)) as any
-      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`)
+      if (!res.ok) {
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
+        if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
+        throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
+      }
       if (data?.jobId) {
         const key = `${g.group.dateKey}:${g.group.groupKey}`
         setQueueJobIds((prev) => ({ ...prev, [key]: data.jobId }))

--- a/frontend/functions/_lib/socialAuth.ts
+++ b/frontend/functions/_lib/socialAuth.ts
@@ -15,5 +15,11 @@ export async function requireSocialAdmin(context: any) {
   const role = String((userOrRes as any).role || '').trim().toUpperCase()
   if (ADMIN_ROLES.has(role)) return userOrRes
 
-  return json(403, { ok: false, error: 'FORBIDDEN', code: 'ADMIN_REQUIRED' })
+  return json(403, {
+    ok: false,
+    error: 'FORBIDDEN',
+    code: 'ADMIN_REQUIRED',
+    role,
+    hint: `Seu role atual é ${role || '(vazio)'}. Este módulo exige ADMIN/GESTOR/GERENTE.`,
+  })
 }

--- a/frontend/functions/api/ponto/[[path]].ts
+++ b/frontend/functions/api/ponto/[[path]].ts
@@ -14,7 +14,10 @@ function newRequestId(): string {
   try {
     return crypto.randomUUID()
   } catch {
-    return `${Date.now()}_${Math.random().toString(16).slice(2)}`
+    const bytes = new Uint8Array(16)
+    crypto.getRandomValues(bytes)
+    const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('')
+    return `${Date.now()}_${hex}`
   }
 }
 
@@ -80,6 +83,7 @@ export async function onRequest(context: any): Promise<Response> {
     const targetOrigin = (context.env?.PONTO_API_TARGET as string | undefined) || ''
     const proxyToken = (context.env?.PONTO_PROXY_TOKEN as string | undefined) || ''
     const actorKey = (context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || proxyToken || ''
+    const adminToken = (context.env?.PONTO_ADMIN_TOKEN as string | undefined) || ''
     return json(
       200,
       {
@@ -87,6 +91,7 @@ export async function onRequest(context: any): Promise<Response> {
         targetConfigured: !!targetOrigin,
         proxyTokenConfigured: !!proxyToken,
         actorKeyConfigured: !!actorKey,
+        adminTokenConfigured: !!String(adminToken || '').trim(),
         hint: !targetOrigin
           ? 'Configure PONTO_API_TARGET no Cloudflare Pages/Functions para apontar para o backend do Ponto.'
           : undefined,


### PR DESCRIPTION
- Corrige bug que desligava a câmera imediatamente (cleanup de useEffect mexia no state do stream).\n- Remove botão manual de fallback para PIN no fluxo Face do Funcionário (fallback agora é somente quando Face falhar/indisponível).\n- Sync do secret PONTO_ADMIN_TOKEN para Cloudflare Pages via workflow de env sync (desbloqueia Admin → Criar funcionário/dispositivo no site).\n- /api/ponto/_proxy-status agora reporta adminTokenConfigured.