### PR TITLE
feat(ponto): mostrar build SHA na UI

### DIFF
--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
         run: npm run build
         working-directory: frontend
 

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ steps.sha.outputs.sha }}
         run: npm run build
         working-directory: frontend
 

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
         run: npm run build
         working-directory: frontend
 

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -243,6 +243,9 @@ async function captureDescriptorStable(videoEl: HTMLVideoElement, samples = 2, w
 export function PontoModule() {
   const [tab, setTab] = useState<'employee' | 'device' | 'admin'>('employee')
 
+  const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()
+  const buildSha = buildShaRaw ? buildShaRaw.slice(0, 7) : (import.meta.env.DEV ? 'dev' : 'unknown')
+
   const [deviceToken, setDeviceToken] = useState(() => {
     try { return localStorage.getItem(LS_DEVICE_TOKEN) || '' } catch { return '' }
   })
@@ -991,6 +994,7 @@ export function PontoModule() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <Badge variant="outline" title={buildShaRaw || undefined}>Build: {buildSha}</Badge>
           {loading ? <Badge variant="secondary">Processando…</Badge> : null}
           {modelsReady === 'ready' ? <Badge variant="outline">Face OK</Badge> : null}
           {modelsReady === 'error' ? <Badge variant="destructive">Face indisponível</Badge> : null}


### PR DESCRIPTION
- Mostra o build SHA no header do módulo Ponto para eliminar dúvidas de cache/versão.\n- Injeta VITE_BUILD_SHA nos workflows de deploy do Cloudflare Pages (push, after-automerge, reconcile).\n\nValidação:\n- Abrir Ponto e confirmar badge "Build: <sha>".\n- Após deploy, o badge deve mudar com o commit.