### PR TITLE
social: métricas do worker + deploy reconcile

### DIFF
--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
         run: npm run build
         working-directory: frontend
 

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ steps.sha.outputs.sha }}
         run: npm run build
         working-directory: frontend
 

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Build frontend
         if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
         run: npm run build
         working-directory: frontend
 

--- a/.github/workflows/deploy-social-publisher-worker-reconcile.yml
+++ b/.github/workflows/deploy-social-publisher-worker-reconcile.yml
@@ -1,0 +1,94 @@
+name: Deploy Social Publisher Worker reconcile
+
+on:
+  schedule:
+    # Workaround: merges performed via GitHub Actions can skip `on: push` deploy triggers.
+    # This job reconciles production to the latest `main` SHA.
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-social-publisher-reconcile-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard Cloudflare deploy secrets
+        id: guard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare deploy secrets not configured; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Resolve target SHA
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: sha
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          msg=$(git log -1 --pretty=%s | tr '\n' ' ')
+          echo "message=$msg" >> "$GITHUB_OUTPUT"
+
+      - name: Restore deploy cache (skip if already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          key: social-publisher-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/social_publisher_deployed_sha.txt
+
+      - name: Skip (already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Deploy Worker (wrangler)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          echo "Reconciling social-publisher worker sha=${{ steps.sha.outputs.sha }}"
+          npx --yes wrangler@3 deploy --config backend/apps/social-publisher/wrangler.toml --keep-vars
+
+      - name: Mark deployed SHA
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        run: |
+          set -euo pipefail
+          mkdir -p deploy-state
+          echo "${{ steps.sha.outputs.sha }}" > deploy-state/social_publisher_deployed_sha.txt
+
+      - name: Save deploy cache
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        uses: actions/cache/save@v4
+        with:
+          key: social-publisher-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/social_publisher_deployed_sha.txt
+

--- a/backend/apps/social-publisher/src/index.ts
+++ b/backend/apps/social-publisher/src/index.ts
@@ -441,66 +441,75 @@ async function processJobs(env: Env) {
   const bucket = env.SHARE_BUCKET
   const maxJobs = parsePositiveInt(env.SOCIAL_JOBS_MAX_PER_RUN) ?? 50
   const startedAt = Date.now()
+  let discovered = 0
   let processed = 0
   let okCount = 0
   let failCount = 0
+  let error: string | undefined
 
-  const { objects } = await listAll(bucket, { prefix: 'social/jobs/' })
-  const keys = (objects || []).map((o) => String(o.key || '')).filter(Boolean).slice(0, maxJobs)
-  for (const key of keys) {
-    const job = await getJsonObj<SocialPublishJob>(bucket, key).catch(() => null)
-    if (!job?.dateKey || !job?.groupKey || !job?.jobId) {
-      await deleteKeys(bucket, [key]).catch(() => null)
-      continue
-    }
+  try {
+    const { objects } = await listAll(bucket, { prefix: 'social/jobs/' })
+    const keys = (objects || []).map((o) => String(o.key || '')).filter(Boolean).slice(0, maxJobs)
+    discovered = keys.length
 
-    const group = await getJsonObj<SocialQueueGroup>(bucket, socialQueueGroupKey(job.dateKey, job.groupKey)).catch(() => null)
-    if (!group) {
+    for (const key of keys) {
+      const job = await getJsonObj<SocialPublishJob>(bucket, key).catch(() => null)
+      if (!job?.dateKey || !job?.groupKey || !job?.jobId) {
+        await deleteKeys(bucket, [key]).catch(() => null)
+        continue
+      }
+
+      const group = await getJsonObj<SocialQueueGroup>(bucket, socialQueueGroupKey(job.dateKey, job.groupKey)).catch(() => null)
+      if (!group) {
+        await putJsonObj(bucket, `social/job-results/${job.jobId}.json`, {
+          ok: false,
+          error: 'GROUP_NOT_FOUND',
+          jobId: job.jobId,
+          dateKey: job.dateKey,
+          groupKey: job.groupKey,
+          at: new Date().toISOString(),
+        }).catch(() => null)
+        await deleteKeys(bucket, [key]).catch(() => null)
+        processed += 1
+        failCount += 1
+        continue
+      }
+
+      const out = await publishGroup(env, group, { force: !!job.force }).catch((e) => ({
+        okCount: 0,
+        failCount: 1,
+        results: [],
+        error: e?.message || 'PUBLISH_FAILED',
+      }))
+
       await putJsonObj(bucket, `social/job-results/${job.jobId}.json`, {
-        ok: false,
-        error: 'GROUP_NOT_FOUND',
+        ok: !out?.error,
+        error: out?.error,
         jobId: job.jobId,
         dateKey: job.dateKey,
         groupKey: job.groupKey,
+        requestedAt: job.requestedAt,
+        requestedBy: job.requestedBy,
+        okCount: out?.okCount || 0,
+        failCount: out?.failCount || 0,
         at: new Date().toISOString(),
       }).catch(() => null)
+
       await deleteKeys(bucket, [key]).catch(() => null)
       processed += 1
-      failCount += 1
-      continue
+      okCount += out?.okCount || 0
+      failCount += out?.failCount || 0
     }
-
-    const out = await publishGroup(env, group, { force: !!job.force }).catch((e) => ({
-      okCount: 0,
-      failCount: 1,
-      results: [],
-      error: e?.message || 'PUBLISH_FAILED',
-    }))
-
-    await putJsonObj(bucket, `social/job-results/${job.jobId}.json`, {
-      ok: !out?.error,
-      error: out?.error,
-      jobId: job.jobId,
-      dateKey: job.dateKey,
-      groupKey: job.groupKey,
-      requestedAt: job.requestedAt,
-      requestedBy: job.requestedBy,
-      okCount: out?.okCount || 0,
-      failCount: out?.failCount || 0,
-      at: new Date().toISOString(),
-    }).catch(() => null)
-
-    await deleteKeys(bucket, [key]).catch(() => null)
-    processed += 1
-    okCount += out?.okCount || 0
-    failCount += out?.failCount || 0
-  }
-
-  if (processed > 0) {
+  } catch (e: any) {
+    error = e?.message || 'JOBS_RUN_FAILED'
+  } finally {
     await putJsonObj(bucket, 'social/metrics/last_jobs_run.json', {
+      discovered,
+      maxJobs,
       processed,
       okCount,
       failCount,
+      error,
       startedAt: new Date(startedAt).toISOString(),
       finishedAt: new Date().toISOString(),
     }).catch(() => null)

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -243,6 +243,9 @@ async function captureDescriptorStable(videoEl: HTMLVideoElement, samples = 2, w
 export function PontoModule() {
   const [tab, setTab] = useState<'employee' | 'device' | 'admin'>('employee')
 
+  const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()
+  const buildSha = buildShaRaw ? buildShaRaw.slice(0, 7) : (import.meta.env.DEV ? 'dev' : 'unknown')
+
   const [deviceToken, setDeviceToken] = useState(() => {
     try { return localStorage.getItem(LS_DEVICE_TOKEN) || '' } catch { return '' }
   })
@@ -991,6 +994,7 @@ export function PontoModule() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <Badge variant="outline" title={buildShaRaw || undefined}>Build: {buildSha}</Badge>
           {loading ? <Badge variant="secondary">Processando…</Badge> : null}
           {modelsReady === 'ready' ? <Badge variant="outline">Face OK</Badge> : null}
           {modelsReady === 'error' ? <Badge variant="destructive">Face indisponível</Badge> : null}


### PR DESCRIPTION
- Worker social-publisher passa a escrever o arquivo social/metrics/last_jobs_run.json em toda execução (mesmo quando não há jobs), para o Planner conseguir mostrar que o worker está vivo.
- Adiciona workflow de reconcile para garantir deploy do social-publisher alinhado ao branch main.
