### PR TITLE
CI: make Ponto smoke checks use browser UA

### DIFF
--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -158,7 +158,8 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            with urllib.request.urlopen(url, timeout=15) as resp:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)
 

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -123,7 +123,8 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            with urllib.request.urlopen(url, timeout=15) as resp:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)
 

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -116,7 +116,8 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            with urllib.request.urlopen(url, timeout=15) as resp:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)
 

--- a/.github/workflows/ponto-smoke.yml
+++ b/.github/workflows/ponto-smoke.yml
@@ -26,7 +26,8 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            with urllib.request.urlopen(url, timeout=15) as resp:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)
 


### PR DESCRIPTION
## Summary\n- Use a browser-like User-Agent for Ponto smoke checks to avoid CF 403\n\n## Testing\n- Not run (workflow change only)\n