### PR TITLE
Ponto: require actor HMAC key + audit PIN failures

### DIFF
--- a/backend/apps/insumos/src/routes/ponto.js
+++ b/backend/apps/insumos/src/routes/ponto.js
@@ -513,7 +513,7 @@ async function requireEmployee({ request, env, withCORS, appOrigin, actorSkewMs 
     return { ok: false, response: withCORS(JSON.stringify({ ok: false, error: 'UNAUTHORIZED', code: 'ACTOR_EMAIL_MISSING' }), { status: 401 }, appOrigin) }
   }
 
-  const actorHmacKey = String(env?.PONTO_ACTOR_HMAC_KEY || env?.PONTO_PROXY_TOKEN || '').trim()
+  const actorHmacKey = String(env?.PONTO_ACTOR_HMAC_KEY || '').trim()
   if (!actorHmacKey) {
     return { ok: false, response: withCORS(JSON.stringify({ ok: false, error: 'UNAUTHORIZED', code: 'ACTOR_KEY_MISSING' }), { status: 401 }, appOrigin) }
   }
@@ -1335,6 +1335,13 @@ export async function handlePontoRoutes({
       const okPin = await verifyPin(pin, { alg: employee.pin_alg, saltB64: employee.pin_salt, hashB64: employee.pin_hash, iters: employee.pin_iters })
       if (!okPin) {
         const failure = await recordPinFailure(db, employee.id, pinMaxFailures, pinLockoutSeconds)
+        await writeAudit(
+          db,
+          env,
+          failure.locked ? 'PIN_LOCKED' : 'PIN_FAILURE',
+          { employeeId: employee.id, kind: 'employee', remaining: failure.remaining, secondsRemaining: failure.secondsRemaining || 0 },
+          auth.actor
+        )
         if (failure.locked) {
           return json(409, { ok: false, error: 'PIN_LOCKED', secondsRemaining: failure.secondsRemaining })
         }
@@ -1587,6 +1594,13 @@ export async function handlePontoRoutes({
     const okPin = await verifyPin(pin, { alg: employee.pin_alg, saltB64: employee.pin_salt, hashB64: employee.pin_hash, iters: employee.pin_iters })
     if (!okPin) {
       const failure = await recordPinFailure(db, employee.id, pinMaxFailures, pinLockoutSeconds)
+      await writeAudit(
+        db,
+        env,
+        failure.locked ? 'PIN_LOCKED' : 'PIN_FAILURE',
+        { employeeId: employee.id, kind: 'device', deviceId: auth.device.id, unit: auth.device.unit, remaining: failure.remaining, secondsRemaining: failure.secondsRemaining || 0 },
+        auth.actor
+      )
       if (failure.locked) {
         return json(409, { ok: false, error: 'PIN_LOCKED', secondsRemaining: failure.secondsRemaining })
       }

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -14,7 +14,7 @@ Este documento descreve **como validar, diagnosticar e operar** o módulo **Pont
 ### Cloudflare Pages (CRM)
 - `PONTO_API_TARGET` → URL do backend (ex.: `https://api.skincos.com.br`)
 - `PONTO_PROXY_TOKEN` → secret de autenticação do proxy
-- `PONTO_ACTOR_HMAC_KEY` → secret para assinatura do actor (employee)
+- `PONTO_ACTOR_HMAC_KEY` → **obrigatório**: secret para assinatura do actor (employee) (não há fallback para `PONTO_PROXY_TOKEN`)
 - `PONTO_ADMIN_TOKEN` → secret para rotas admin (injeção no proxy)
 
 ### Cloudflare Workers (API/Insumos)

--- a/frontend/functions/api/ponto/[[path]].ts
+++ b/frontend/functions/api/ponto/[[path]].ts
@@ -82,7 +82,7 @@ export async function onRequest(context: any): Promise<Response> {
   if (rest === '/_proxy-status' || rest === '/_proxy-status/') {
     const targetOrigin = (context.env?.PONTO_API_TARGET as string | undefined) || ''
     const proxyToken = (context.env?.PONTO_PROXY_TOKEN as string | undefined) || ''
-    const actorKey = (context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || proxyToken || ''
+    const actorKey = (context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || ''
     const adminToken = (context.env?.PONTO_ADMIN_TOKEN as string | undefined) || ''
     return json(
       200,
@@ -90,7 +90,7 @@ export async function onRequest(context: any): Promise<Response> {
         ok: true,
         targetConfigured: !!targetOrigin,
         proxyTokenConfigured: !!proxyToken,
-        actorKeyConfigured: !!actorKey,
+        actorKeyConfigured: !!String(actorKey || '').trim(),
         adminTokenConfigured: !!String(adminToken || '').trim(),
         hint: !targetOrigin
           ? 'Configure PONTO_API_TARGET no Cloudflare Pages/Functions para apontar para o backend do Ponto.'
@@ -121,7 +121,7 @@ export async function onRequest(context: any): Promise<Response> {
   let actorSig = ''
 
   const proxyToken = (context.env?.PONTO_PROXY_TOKEN as string | undefined) || ''
-  const actorKey = String((context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || proxyToken || '').trim()
+  const actorKey = String((context.env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || '').trim()
   const adminToken = String((context.env?.PONTO_ADMIN_TOKEN as string | undefined) || '').trim()
   let isAdminUser = false
 
@@ -135,6 +135,13 @@ export async function onRequest(context: any): Promise<Response> {
       )
     }
     if (isEmployeeRoute) {
+      if (!actorKey) {
+        return json(
+          503,
+          { ok: false, error: 'ACTOR_KEY_NOT_CONFIGURED', hint: 'Configure PONTO_ACTOR_HMAC_KEY nas variáveis do Pages.' },
+          { 'x-request-id': requestId },
+        )
+      }
       const actor = {
         id: String(user.id || ''),
         email: user.email ? String(user.email) : undefined,
@@ -142,9 +149,7 @@ export async function onRequest(context: any): Promise<Response> {
       }
       actorB64 = b64UrlEncodeString(JSON.stringify(actor))
       actorTs = String(Date.now())
-      if (actorKey) {
-        actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
-      }
+      actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
     }
     if (isAdminRoute) {
       const role = String(user.role || '').toUpperCase()


### PR DESCRIPTION
## Summary
- Remove fallback from actor signature key to proxy token (defense in depth)
- Add audit events for PIN failures/lockouts
- Update runbook to document required actor key

## Notes
- Requires PONTO_ACTOR_HMAC_KEY configured in Pages + Workers (already a GitHub secret).
