### PR TITLE
ci(pages): forçar redeploy após sync de secret

### DIFF
--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   sync:
@@ -118,6 +119,20 @@ jobs:
             json.dump(patch,f)
           print("Prepared patch for Pages env var key: INTEGRATIONS_ENCRYPTION_SECRET")
           PY
+
+      - name: Force redeploy CRM Pages (apply secret/env)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "deploy-crm-pages-reconcile.yml",
+              ref: "main",
+              inputs: { force: "true" },
+            })
+            core.info("Dispatched deploy-crm-pages-reconcile.yml with force=true")
 
           curl -sS -X PATCH \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -5,7 +5,13 @@ on:
     # Workaround: merges performed via GitHub Actions can skip `on: push` deploy triggers.
     # This job reconciles production to the latest `main` SHA.
     - cron: "*/5 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force redeploy even if current main SHA was already deployed (useful after secret/env changes)."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: deploy-crm-pages-reconcile-main
@@ -18,6 +24,18 @@ jobs:
       contents: read
 
     steps:
+      - name: Resolve flags
+        id: flags
+        run: |
+          set -euo pipefail
+          FORCE_RAW="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}"
+          FORCE="$(echo "${FORCE_RAW:-false}" | tr '[:upper:]' '[:lower:]' | xargs)"
+          if [[ "$FORCE" == "1" || "$FORCE" == "true" || "$FORCE" == "yes" || "$FORCE" == "on" ]]; then
+            echo "force=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Guard Cloudflare Pages deploy
         id: guard
         env:
@@ -67,13 +85,13 @@ jobs:
           path: deploy-state/deployed_sha.txt
 
       - name: Skip (already deployed)
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' && steps.flags.outputs.force != 'true' }}
         run: |
           set -euo pipefail
           echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
 
       - name: Setup Node
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -81,19 +99,19 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend deps
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         run: npm ci
         working-directory: frontend
 
       - name: Build frontend
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         env:
           VITE_BUILD_SHA: ${{ steps.sha.outputs.sha }}
         run: npm run build
         working-directory: frontend
 
       - name: Deploy to Cloudflare Pages (wrangler)
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
- Adiciona input `force` ao reconcile deploy do Cloudflare Pages para permitir redeploy mesmo com SHA já cacheado.
- Workflow de sync do `INTEGRATIONS_ENCRYPTION_SECRET` agora dispara um reconcile com `force=true` para garantir que o runtime do Pages pegue o secret (resolve flapping de `Crypto: faltando (required)`).

Objetivo: evitar 503 `INTEGRATIONS_ENCRYPTION_SECRET_REQUIRED` por falta de redeploy após atualizar secrets.
