### PR TITLE
Ponto: surface templates crypto flag in /health

### DIFF
--- a/backend/apps/insumos/src/routes/ponto.js
+++ b/backend/apps/insumos/src/routes/ponto.js
@@ -818,6 +818,7 @@ export async function handlePontoRoutes({
         version: 2,
         storage: 'd1',
         cryptoAuditHmac: !!String(env?.PONTO_AUDIT_HMAC_KEY || '').trim(),
+        cryptoTemplates: !!String(env?.PONTO_TEMPLATES_KEY || '').trim(),
         employees: Number(row?.n || 0) || 0,
         devices: Number(devices?.n || 0) || 0,
         records: Number(records?.n || 0) || 0,


### PR DESCRIPTION
Adds a boolean cryptoTemplates to /api/ponto/health so production validation of PONTO_TEMPLATES_KEY is objective via the existing Diagnostics panel.