### PR TITLE
ci(pages): corrigir workflow de sync do integrations secret

### DIFF
--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -120,20 +120,6 @@ jobs:
           print("Prepared patch for Pages env var key: INTEGRATIONS_ENCRYPTION_SECRET")
           PY
 
-      - name: Force redeploy CRM Pages (apply secret/env)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "deploy-crm-pages-reconcile.yml",
-              ref: "main",
-              inputs: { force: "true" },
-            })
-            core.info("Dispatched deploy-crm-pages-reconcile.yml with force=true")
-
           curl -sS -X PATCH \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -152,3 +138,17 @@ jobs:
             keys=sorted(((cfg.get(env_name) or {}).get("env_vars") or {}).keys())
             print(f"{env_name}: INTEGRATIONS_ENCRYPTION_SECRET present =", "INTEGRATIONS_ENCRYPTION_SECRET" in keys)
           PY
+
+      - name: Force redeploy CRM Pages (apply secret/env)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "deploy-crm-pages-reconcile.yml",
+              ref: "main",
+              inputs: { force: "true" },
+            })
+            core.info("Dispatched deploy-crm-pages-reconcile.yml with force=true")


### PR DESCRIPTION
Corrige a ordem/indentação do `.github/workflows/cloudflare-sync-integrations-encryption-secret.yml`.

Antes, o step “Force redeploy CRM Pages” foi inserido no meio do `run: |` do patch (quebrando YAML) e, na prática, o workflow parou de conseguir rodar via `workflow_dispatch` (422) e/ou falhava ao aplicar o secret.

Depois:
- O patch do Pages (criar `pages_patch.json` → PATCH via Cloudflare API → validação) fica inteiro dentro do step correto.
- O step de `github-script` para disparar `deploy-crm-pages-reconcile.yml` com `force=true` fica separado e executa depois do patch.

Impacto: o CRM Pages passa a aplicar `INTEGRATIONS_ENCRYPTION_SECRET` de forma consistente e o status “Crypto: faltando (required)” deixa de voltar.
