### PR TITLE
ci(pages): evitar falso negativo no smoke do Ponto

### DIFF
--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -149,26 +149,28 @@ jobs:
           def check():
             proxy = fetch_json("/api/ponto/_proxy-status")
             if not proxy.get("ok"):
-              raise SystemExit("proxy-status ok=false")
+              raise SystemExit(f"proxy-status ok=false: {proxy}")
             if not proxy.get("targetConfigured"):
-              raise SystemExit("proxy-status targetConfigured=false")
+              raise SystemExit(f"proxy-status targetConfigured=false: {proxy}")
             if not proxy.get("adminTokenConfigured"):
-              raise SystemExit("proxy-status adminTokenConfigured=false")
+              raise SystemExit(f"proxy-status adminTokenConfigured=false: {proxy}")
             health = fetch_json("/api/ponto/health")
             if not health.get("ok"):
-              raise SystemExit("health ok=false")
+              raise SystemExit(f"health ok=false: {health}")
             return True
 
-          for i in range(1, 6):
+          # After a Pages deploy, it can take some time for the new deployment + env vars to propagate.
+          # Be generous here to avoid false negatives.
+          for i in range(1, 16):
             try:
               check()
               print("Ponto smoke check OK")
               sys.exit(0)
             except Exception as exc:
               print(f"Attempt {i} failed: {exc}")
-              if i >= 5:
+              if i >= 15:
                 raise
-              time.sleep(6)
+              time.sleep(10)
           PY
 
       - name: Mark deployed SHA


### PR DESCRIPTION
Aumenta as tentativas/espera do smoke check do Ponto no reconcile do Cloudflare Pages.

Motivo: após `wrangler pages deploy`, pode existir uma janela de propagação onde `/api/ponto/_proxy-status` ainda reporta `targetConfigured=false` (stale), mesmo com as env vars corretamente setadas no Pages project.

Mudança:
- De 5 tentativas (6s) → 15 tentativas (10s)
- Logs agora incluem o JSON retornado (proxy-status/health) quando falhar.
