### PR TITLE
Ponto: guardar smoke UI até configurar secrets

### DIFF
--- a/.github/workflows/ponto-ui-smoke.yml
+++ b/.github/workflows/ponto-ui-smoke.yml
@@ -23,6 +23,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Guard (enabled)
+        env:
+          ENABLE_PONTO_UI_SMOKE: ${{ vars.ENABLE_PONTO_UI_SMOKE }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+            echo "Manual run: proceeding regardless of ENABLE_PONTO_UI_SMOKE."
+            exit 0
+          fi
+          if [[ "${ENABLE_PONTO_UI_SMOKE:-}" != "true" ]]; then
+            echo "Ponto UI smoke is disabled (set repo variable ENABLE_PONTO_UI_SMOKE=true to enable scheduled runs)."
+            exit 0
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -71,6 +71,8 @@ Artefatos: `output/playwright/` (screenshots + trace).
 Workflow: `.github/workflows/ponto-ui-smoke.yml`
 
 **Requisitos**
+- Habilitar o agendamento (repo → Settings → Secrets and variables → Actions → Variables):
+  - `ENABLE_PONTO_UI_SMOKE=true`
 - Criar um usuário dedicado “smoke bot” no CRM (evite usar credenciais pessoais).
 - Configurar os secrets no GitHub (repo → Settings → Secrets and variables → Actions):
   - `PONTO_SMOKE_EMAIL`


### PR DESCRIPTION
- Evita que o cron do Ponto UI smoke gere falhas enquanto os secrets/vars não estão configurados
- Para habilitar o agendamento: defina ENABLE_PONTO_UI_SMOKE=true (repo variable)
