### PR TITLE
ci(crm): run Ponto UI smoke after Pages deploy

### DIFF
--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -173,6 +173,38 @@ jobs:
               time.sleep(10)
           PY
 
+      - name: Cache Playwright browsers (UI smoke)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-chromium
+
+      - name: Install Playwright Chromium (UI smoke)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        run: npx --yes playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Ponto UI smoke (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        env:
+          CRM_URL: https://crm.skincos.com.br
+          EXPECT_BUILD_SHA: ${{ steps.sha.outputs.sha }}
+          BUILD_BADGE_WAIT_MS: "120000"
+          AUTO_LOGIN: "1"
+          SMOKE_EMAIL: ${{ secrets.PONTO_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.PONTO_SMOKE_PASSWORD }}
+          LOGIN_WAIT_MS: "120000"
+          NO_SCREENSHOTS: "1"
+          NODE_PATH: frontend/node_modules
+        run: |
+          set -euo pipefail
+          if [[ -z "${SMOKE_EMAIL:-}" || -z "${SMOKE_PASSWORD:-}" ]]; then
+            echo "Missing GitHub Actions secrets: PONTO_SMOKE_EMAIL / PONTO_SMOKE_PASSWORD"
+            exit 1
+          fi
+          node frontend/scripts/ponto-ui-smoke.cjs
+
       - name: Mark deployed SHA
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
         run: |

--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -40,6 +40,10 @@ const SMOKE_PASSWORD = String(process.env.SMOKE_PASSWORD || '').trim()
 const CHANNEL = String(process.env.CHANNEL || '').trim()
 const PERSISTENT = process.env.PERSISTENT === '1' || process.env.PERSISTENT === 'true'
 const EXPECT_BUILD_SHA = String(process.env.EXPECT_BUILD_SHA || '').trim().toLowerCase()
+const BUILD_BADGE_WAIT_MS = Math.max(
+  5_000,
+  parseInt(String(process.env.BUILD_BADGE_WAIT_MS || ''), 10) || (process.env.CI ? 90_000 : 30_000)
+)
 const MUTATE_ADMIN = process.env.MUTATE_ADMIN === '1' || process.env.MUTATE_ADMIN === 'true'
 const MUTATE_EMPLOYEE = process.env.MUTATE_EMPLOYEE === '1' || process.env.MUTATE_EMPLOYEE === 'true'
 const MUTATE_PUNCH = process.env.MUTATE_PUNCH === '1' || process.env.MUTATE_PUNCH === 'true'
@@ -249,18 +253,23 @@ async function main() {
     await buildBadge.waitFor({ timeout: 30_000 })
     if (EXPECT_BUILD_SHA) {
       const expectedShort = EXPECT_BUILD_SHA.slice(0, 7)
+      const start = Date.now()
       let lastText = ''
-      for (let attempt = 1; attempt <= 4; attempt++) {
+      let attempt = 0
+      while (Date.now() - start < BUILD_BADGE_WAIT_MS) {
+        attempt += 1
         const badgeText = String((await buildBadge.textContent().catch(() => '')) || '').toLowerCase()
         lastText = badgeText
         if (badgeText.includes(expectedShort)) break
-        if (attempt >= 4) {
-          throw new Error(`Build badge mismatch (expected ${expectedShort}). Got: ${lastText || '(empty)'}`)
-        }
         // Sometimes Pages env + new deployment propagation can lag a little.
         await page.waitForTimeout(3000)
         await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
         await page.waitForTimeout(1200)
+      }
+      if (!lastText.includes(expectedShort)) {
+        throw new Error(
+          `Build badge mismatch after ${Math.ceil(BUILD_BADGE_WAIT_MS / 1000)}s (expected ${expectedShort}). Got: ${lastText || '(empty)'}`
+        )
       }
     }
     await maybeScreenshot('ponto-open')


### PR DESCRIPTION
Adds a headless Ponto UI smoke right after a *real* Pages deploy (new SHA or force=true), gated by var ENABLE_PONTO_UI_SMOKE.\n\nAlso makes build-badge SHA validation resilient to Pages propagation via BUILD_BADGE_WAIT_MS.