### PR TITLE
CI: Ponto UI smoke com punch + audit

### DIFF
--- a/.github/workflows/ponto-ui-smoke.yml
+++ b/.github/workflows/ponto-ui-smoke.yml
@@ -82,6 +82,7 @@ jobs:
           NO_SCREENSHOTS: "1"
           MUTATE_ADMIN: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
           MUTATE_EMPLOYEE: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
+          MUTATE_PUNCH: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
           NODE_PATH: frontend/node_modules
         run: |
           set -euo pipefail
@@ -100,6 +101,7 @@ jobs:
           FULL_PAGE: "1"
           MUTATE_ADMIN: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
           MUTATE_EMPLOYEE: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
+          MUTATE_PUNCH: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
           NODE_PATH: frontend/node_modules
         run: |
           set -euo pipefail

--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -307,7 +307,10 @@ async function main() {
       throw new Error(`Proxy status failed: HTTP ${diag.proxyStatus} body=${String(diag.proxyText || '').slice(0, 260)}`)
     }
     if (!diag.proxy.effectiveTargetConfigured) throw new Error('Proxy status: effectiveTargetConfigured=false')
-    if (!diag.proxy.targetConfigured) throw new Error('Proxy status: targetConfigured=false (PONTO_API_TARGET missing)')
+    if (!diag.proxy.targetConfigured) {
+      // Not a hard failure: the proxy can fall back to INSUMOS_API_TARGET. We still require an effective target above.
+      console.log('[ponto-ui-smoke] WARN: Proxy status: targetConfigured=false (PONTO_API_TARGET missing; using fallback target)')
+    }
     if (!diag.proxy.proxyTokenConfigured) throw new Error('Proxy status: proxyTokenConfigured=false')
     if (!diag.proxy.actorKeyConfigured) throw new Error('Proxy status: actorKeyConfigured=false')
     if (!diag.proxy.adminTokenConfigured) throw new Error('Proxy status: adminTokenConfigured=false')
@@ -466,6 +469,15 @@ async function main() {
               throw new Error(`me punch failed: HTTP ${punchRes.status} body=${punchText.slice(0, 400)}`)
             }
             punch = punchJson?.data || null
+
+            // Verify audit chain is still consistent after a punch write.
+            const auditRes = await fetch('/api/ponto/admin/audit/verify', { credentials: 'include' })
+            const auditText = await auditRes.text()
+            let auditJson = null
+            try { auditJson = auditText ? JSON.parse(auditText) : null } catch {}
+            if (!auditRes.ok || !auditJson?.ok) {
+              throw new Error(`audit verify failed: HTTP ${auditRes.status} body=${auditText.slice(0, 400)}`)
+            }
           }
 
           const delRes = await fetch(`/api/ponto/admin/employees/${encodeURIComponent(employeeId)}`, {


### PR DESCRIPTION
- Habilita `MUTATE_PUNCH` no workflow `Ponto UI Smoke (prod)`.
- No script, executa punch via `POST /api/ponto/me/punch` (PIN) e valida integridade via `GET /api/ponto/admin/audit/verify`.
- Ajusta check do proxy para não falhar quando `PONTO_API_TARGET` não estiver setado (usa o target efetivo/fallback).