### PR TITLE
ci(crm-pages): redeploy when Ponto env drift detected

### DIFF
--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -90,44 +90,10 @@ jobs:
           set -euo pipefail
           echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
 
-      - name: Setup Node
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install frontend deps
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        run: npm ci
-        working-directory: frontend
-
-      - name: Build frontend
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        env:
-          VITE_BUILD_SHA: ${{ steps.sha.outputs.sha }}
-        run: npm run build
-        working-directory: frontend
-
-      - name: Deploy to Cloudflare Pages (wrangler)
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PAGES_PROJECT: ${{ steps.guard.outputs.project }}
-          BRANCH_NAME: main
-          GIT_SHA: ${{ steps.sha.outputs.sha }}
-          GIT_MESSAGE: ${{ steps.sha.outputs.message }}
-        run: |
-          set -euo pipefail
-          PROJECT="${PAGES_PROJECT:-skincos}"
-          echo "Reconciling Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME sha=$GIT_SHA"
-          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
-        working-directory: frontend
-
-      - name: Smoke check Ponto (production)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+      - name: Smoke check Ponto (production, pre-flight)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' && steps.flags.outputs.force != 'true' }}
+        id: ponto_smoke_pre
+        continue-on-error: true
         env:
           BASE_URL: https://crm.skincos.com.br
         run: |
@@ -154,6 +120,110 @@ jobs:
               raise SystemExit(f"proxy-status effectiveTargetConfigured=false: {proxy}")
             if not proxy.get("adminTokenConfigured"):
               raise SystemExit(f"proxy-status adminTokenConfigured=false: {proxy}")
+            if not proxy.get("proxyTokenConfigured"):
+              raise SystemExit(f"proxy-status proxyTokenConfigured=false: {proxy}")
+            if not proxy.get("actorKeyConfigured"):
+              raise SystemExit(f"proxy-status actorKeyConfigured=false: {proxy}")
+            health = fetch_json("/api/ponto/health")
+            if not health.get("ok"):
+              raise SystemExit(f"health ok=false: {health}")
+            return True
+
+          # When the SHA is already deployed, this check is primarily for env drift (Pages vars/secrets changed).
+          # Keep it short to avoid wasting cycles; if it fails we'll force a redeploy.
+          for i in range(1, 6):
+            try:
+              check()
+              print("Ponto pre-flight OK")
+              sys.exit(0)
+            except Exception as exc:
+              print(f"Attempt {i} failed: {exc}")
+              if i >= 5:
+                raise
+              time.sleep(5)
+          PY
+
+      - name: Decide redeploy (env drift)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' && steps.flags.outputs.force != 'true' }}
+        id: redeploy
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.ponto_smoke_pre.outcome }}" == "success" ]]; then
+            echo "need=false" >> "$GITHUB_OUTPUT"
+            echo "Ponto pre-flight succeeded; no redeploy needed."
+          else
+            echo "need=true" >> "$GITHUB_OUTPUT"
+            echo "Ponto pre-flight failed; forcing redeploy to pick up env changes."
+          fi
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
+        env:
+          VITE_BUILD_SHA: ${{ steps.sha.outputs.sha }}
+        run: npm run build
+        working-directory: frontend
+
+      - name: Deploy to Cloudflare Pages (wrangler)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PAGES_PROJECT: ${{ steps.guard.outputs.project }}
+          BRANCH_NAME: main
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+          GIT_MESSAGE: ${{ steps.sha.outputs.message }}
+        run: |
+          set -euo pipefail
+          PROJECT="${PAGES_PROJECT:-skincos}"
+          echo "Reconciling Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME sha=$GIT_SHA"
+          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
+        working-directory: frontend
+
+      - name: Smoke check Ponto (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
+        env:
+          BASE_URL: https://crm.skincos.com.br
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, sys, time, urllib.request
+
+          base = os.environ.get("BASE_URL", "").rstrip("/")
+          if not base:
+            raise SystemExit("BASE_URL not set")
+
+          def fetch_json(path: str):
+            url = f"{base}{path}"
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+              data = resp.read().decode("utf-8", "ignore")
+              return json.loads(data)
+
+          def check():
+            proxy = fetch_json("/api/ponto/_proxy-status")
+            if not proxy.get("ok"):
+              raise SystemExit(f"proxy-status ok=false: {proxy}")
+            if not proxy.get("effectiveTargetConfigured"):
+              raise SystemExit(f"proxy-status effectiveTargetConfigured=false: {proxy}")
+            if not proxy.get("adminTokenConfigured"):
+              raise SystemExit(f"proxy-status adminTokenConfigured=false: {proxy}")
+            if not proxy.get("proxyTokenConfigured"):
+              raise SystemExit(f"proxy-status proxyTokenConfigured=false: {proxy}")
+            if not proxy.get("actorKeyConfigured"):
+              raise SystemExit(f"proxy-status actorKeyConfigured=false: {proxy}")
             health = fetch_json("/api/ponto/health")
             if not health.get("ok"):
               raise SystemExit(f"health ok=false: {health}")
@@ -174,19 +244,19 @@ jobs:
           PY
 
       - name: Cache Playwright browsers (UI smoke)
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium
 
       - name: Install Playwright Chromium (UI smoke)
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
         run: npx --yes playwright install --with-deps chromium
         working-directory: frontend
 
       - name: Ponto UI smoke (production)
-        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
         env:
           CRM_URL: https://crm.skincos.com.br
           EXPECT_BUILD_SHA: ${{ steps.sha.outputs.sha }}

--- a/frontend/scripts/bootstrap-ponto-smoke-admin.cjs
+++ b/frontend/scripts/bootstrap-ponto-smoke-admin.cjs
@@ -1,0 +1,191 @@
+/* eslint-disable no-console */
+/**
+ * Bootstrap / repair the GitHub Actions smoke user so the Ponto UI Smoke workflow can run with mutate=true.
+ *
+ * What it does (idempotent):
+ * 1) Uses an existing authenticated CRM session (storageState) to call `/api/admin/*`
+ * 2) Ensures a dedicated admin user exists (`SMOKE_USERNAME`) with role ADMIN
+ * 3) Rotates its password to a fresh random value
+ * 4) Updates GitHub repo secrets:
+ *    - PONTO_SMOKE_EMAIL
+ *    - PONTO_SMOKE_PASSWORD
+ *
+ * Preconditions:
+ * - You must already have a valid admin session saved at `output/playwright/storage-crm.json`.
+ *   (You can create it by running `node frontend/scripts/ponto-ui-smoke.cjs` once with HEADED=1 and logging in.)
+ *
+ * Safety:
+ * - This script NEVER prints the generated password.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const { chromium } = require('playwright')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const ARTIFACT_DIR = path.join(REPO_ROOT, 'output', 'playwright')
+const STORAGE_STATE_PATH = path.join(ARTIFACT_DIR, 'storage-crm.json')
+
+const CRM_URL = process.env.CRM_URL || 'https://crm.skincos.com.br'
+const SMOKE_USERNAME = String(process.env.SMOKE_USERNAME || 'ponto-smoke-bot').trim()
+const SMOKE_EMAIL = String(process.env.SMOKE_EMAIL || 'ponto.smoke@skincos.com.br').trim()
+const SMOKE_DISPLAY_NAME = String(process.env.SMOKE_DISPLAY_NAME || 'Ponto Smoke Bot').trim()
+
+function die(msg) {
+  console.error(`[bootstrap-ponto-smoke-admin] ${msg}`)
+  process.exit(1)
+}
+
+function randomPassword(len = 20) {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%*'
+  const bytes = new Uint32Array(len)
+  crypto.getRandomValues(bytes)
+  let out = ''
+  for (let i = 0; i < len; i++) out += alphabet[bytes[i] % alphabet.length]
+  return out
+}
+
+function gh(args, input) {
+  const res = spawnSync('gh', args, {
+    encoding: 'utf-8',
+    input: input === undefined ? undefined : String(input),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  if (res.status !== 0) {
+    const err = String(res.stderr || res.stdout || '').trim()
+    die(`gh ${args.join(' ')} failed${err ? `: ${err}` : ''}`)
+  }
+  return String(res.stdout || '').trim()
+}
+
+function resolveRepo() {
+  const direct = String(process.env.GITHUB_REPO || '').trim()
+  if (direct) return direct
+  return gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'])
+}
+
+async function main() {
+  fs.mkdirSync(ARTIFACT_DIR, { recursive: true })
+  if (!fs.existsSync(STORAGE_STATE_PATH)) {
+    die(`Missing storage state: ${STORAGE_STATE_PATH}`)
+  }
+
+  const repo = resolveRepo()
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--disable-extensions',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      '--disable-background-timer-throttling',
+      '--mute-audio',
+      '--disable-gpu',
+    ],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 1365, height: 860 },
+    storageState: STORAGE_STATE_PATH,
+  })
+  await context.route('**/*', async (route) => {
+    const type = route.request().resourceType()
+    if (type === 'image' || type === 'media' || type === 'font') return route.abort()
+    return route.continue()
+  })
+
+  try {
+    const req = context.request
+
+    // IMPORTANT: don't load the SPA. It may call /api/auth/me in the background and rotate CSRF mid-run.
+    const authRes = await req.get(`${CRM_URL}/api/auth/me`)
+    const authText = await authRes.text()
+    let authJson = null
+    try { authJson = authText ? JSON.parse(authText) : null } catch { authJson = null }
+    const auth = {
+      ok: authRes.ok(),
+      status: authRes.status(),
+      username: String(authJson?.user?.username || ''),
+      role: String(authJson?.user?.role || '').toUpperCase(),
+      csrfToken: String(authJson?.csrfToken || '').trim(),
+      json: authJson,
+    }
+
+    if (!auth.ok) {
+      die(`Not authenticated (or session expired): /api/auth/me HTTP ${auth.status}`)
+    }
+    if (!(auth.role === 'ADMIN' || auth.role === 'GESTOR' || auth.role === 'GERENTE')) {
+      die(`Current session is not admin enough (role=${auth.role || 'unknown'}).`)
+    }
+    if (!auth.csrfToken) die('Missing csrfToken from /api/auth/me; cannot perform admin mutations.')
+
+    const password = randomPassword(22)
+
+    // Prefer create; if already exists, update role + reset password.
+    const createRes = await req.post(`${CRM_URL}/api/crm/admin/users`, {
+      headers: { 'x-csrf-token': auth.csrfToken },
+      data: {
+        username: SMOKE_USERNAME,
+        email: SMOKE_EMAIL,
+        displayName: SMOKE_DISPLAY_NAME,
+        role: 'ADMIN',
+        allowedUnits: [],
+        allowedModules: [],
+        ativo: true,
+        password,
+      },
+    })
+    const createdText = await createRes.text()
+    let createdJson = null
+    try { createdJson = createdText ? JSON.parse(createdText) : null } catch { createdJson = null }
+    const created = { ok: createRes.ok(), status: createRes.status(), json: createdJson, text: String(createdText || '').slice(0, 240) }
+
+    if (!created.ok) {
+      const err = String(created?.json?.error || created?.json?.code || '').trim()
+      if (created.status !== 409 || err !== 'USERNAME_TAKEN') {
+        die(`Failed to create smoke user: HTTP ${created.status}${created.text ? ` • ${created.text}` : ''}`)
+      }
+
+      const updatedRes = await req.put(`${CRM_URL}/api/crm/admin/users/${encodeURIComponent(SMOKE_USERNAME)}`, {
+        headers: { 'x-csrf-token': auth.csrfToken },
+        data: {
+          email: SMOKE_EMAIL,
+          displayName: SMOKE_DISPLAY_NAME,
+          role: 'ADMIN',
+          allowedUnits: [],
+          allowedModules: [],
+          ativo: true,
+        },
+      })
+      const updatedText = await updatedRes.text()
+      let updatedJson = null
+      try { updatedJson = updatedText ? JSON.parse(updatedText) : null } catch { updatedJson = null }
+      const updated = { ok: updatedRes.ok(), status: updatedRes.status(), json: updatedJson, text: String(updatedText || '').slice(0, 240) }
+      if (!updated.ok) die(`Failed to update smoke user: HTTP ${updated.status}${updated.text ? ` • ${updated.text}` : ''}`)
+
+      const resetRes = await req.post(`${CRM_URL}/api/crm/admin/users/${encodeURIComponent(SMOKE_USERNAME)}/reset-password`, {
+        headers: { 'x-csrf-token': auth.csrfToken },
+        data: { newPassword: password },
+      })
+      const resetText = await resetRes.text()
+      let resetJson = null
+      try { resetJson = resetText ? JSON.parse(resetText) : null } catch { resetJson = null }
+      const reset = { ok: resetRes.ok(), status: resetRes.status(), json: resetJson, text: String(resetText || '').slice(0, 240) }
+      if (!reset.ok) die(`Failed to reset smoke password: HTTP ${reset.status}${reset.text ? ` • ${reset.text}` : ''}`)
+    }
+
+    // Update GitHub secrets without echoing values.
+    // `gh secret set` reads the value from stdin when `--body` isn't provided.
+    gh(['secret', 'set', 'PONTO_SMOKE_EMAIL', '--repo', repo], `${SMOKE_EMAIL}\n`)
+    gh(['secret', 'set', 'PONTO_SMOKE_PASSWORD', '--repo', repo], `${password}\n`)
+
+    console.log(`[bootstrap-ponto-smoke-admin] OK: smoke user ensured and repo secrets updated for ${repo}.`)
+    console.log(`[bootstrap-ponto-smoke-admin] Next: run "Ponto UI Smoke (prod)" with mutate=true.`)
+  } finally {
+    await context.close().catch(() => {})
+    await browser.close().catch(() => {})
+  }
+}
+
+main().catch((e) => die(e?.stack || e?.message || String(e)))


### PR DESCRIPTION
Fixes a production failure mode where Pages env vars for Ponto are patched (Cloudflare API) but the already-deployed SHA is skipped, leaving Functions without PONTO_* secrets until a forced redeploy.\n\nChanges:\n- Add pre-flight Ponto smoke when SHA is cached; if it fails, force a redeploy and re-run post-deploy smoke + UI smoke.\n- Add a one-time helper script to bootstrap the GitHub smoke user via CRM admin APIs (does not print passwords).