### PR TITLE
fix(insumos): prevent health/me request storm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,4 +188,6 @@ backend/tools/xiaomi/token_extractor_docker/
 
 # Playwright artifacts (never commit)
 .playwright-cli/
+.playwright-output/
+frontend/test-results/
 output/

--- a/frontend/e2e/insumos-no-request-storm.spec.ts
+++ b/frontend/e2e/insumos-no-request-storm.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('insumos', () => {
+  test('does not storm health/me on enter', async ({ page }) => {
+    const counts = {
+      insumosHealth: 0,
+      insumosAuthMe: 0,
+      authMe: 0
+    }
+
+    await page.route('**/api/insumos/health**', async (route) => {
+      counts.insumosHealth += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: false,
+          service: 'insumos',
+          runtime: 'e2e',
+          storage: 'd1',
+          dbConfigured: true,
+          unidades: ['novo-hamburgo', 'barra-shopping-sul']
+        })
+      })
+    })
+
+    await page.route('**/api/insumos/auth/me**', async (route) => {
+      counts.insumosAuthMe += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, user: null, csrfToken: null })
+      })
+    })
+
+    await page.route('**/api/auth/me**', async (route) => {
+      counts.authMe += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+      })
+    })
+
+    await page.goto('/?insumos=1')
+    await expect(page.getByText('Insumos')).toBeVisible({ timeout: 30000 })
+    await page.getByText('Insumos').click()
+
+    await page.waitForTimeout(2500)
+    const snapshot = { ...counts }
+
+    expect(snapshot.insumosHealth).toBeLessThanOrEqual(3)
+    expect(snapshot.authMe).toBeLessThanOrEqual(2)
+    expect(snapshot.insumosAuthMe).toBeLessThanOrEqual(2)
+
+    await page.waitForTimeout(2500)
+    expect(counts).toEqual(snapshot)
+  })
+})
+

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,9 @@ const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
 
 export default defineConfig({
   testDir: './e2e',
+  // Keep Playwright artifacts outside `frontend/` to avoid dev-server watchers (Tailwind/Vite)
+  // tripping over rapidly-created/deleted trace resource files during E2E runs.
+  outputDir: '../.playwright-output',
   timeout: 60000,
   use: {
     baseURL,

--- a/frontend/spark-mock.ts
+++ b/frontend/spark-mock.ts
@@ -1,5 +1,5 @@
 // Lightweight, test-friendly KV store and React hook
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type KVStore = Record<string, any>
 const store: KVStore = {}
@@ -37,6 +37,8 @@ export function useKV<T = any>(key: string, defaultValue: T): [T, (next: T | ((p
     const [value, setValue] = useState<T>(initial)
     const keyRef = useRef(key)
     keyRef.current = key
+    const defaultRef = useRef(defaultValue)
+    defaultRef.current = defaultValue
 
     useEffect(() => {
         // Ensure a value exists for the key
@@ -67,13 +69,17 @@ export function useKV<T = any>(key: string, defaultValue: T): [T, (next: T | ((p
         }
     }, [key, defaultValue])
 
-    const update = (next: T | ((prev: T) => T)) => {
-        const prev = (key in store ? (store[key] as T) : defaultValue)
+    // Stable setter: many components put this function into `useEffect` deps.
+    // If its identity changes on every render, it can create request storms.
+    const update = useCallback((next: T | ((prev: T) => T)) => {
+        const currentKey = keyRef.current
+        const currentDefault = defaultRef.current
+        const prev = (currentKey in store ? (store[currentKey] as T) : currentDefault)
         const nextValue = typeof next === 'function' ? (next as (p: T) => T)(prev) : next
-        store[key] = nextValue
+        store[currentKey] = nextValue
         setValue(nextValue)
-        notify(key, nextValue)
-    }
+        notify(currentKey, nextValue)
+    }, [])
 
     return [value, update]
 }


### PR DESCRIPTION
Fixes request storm when entering Insumos (repeated /api/insumos/health + /api/auth/me) caused by unstable setter identity from useKV.\n\n- Stabilize useKV setter in frontend/spark-mock.ts\n- Add E2E guard to catch regressions\n- Move Playwright artifacts out of frontend/ + ignore artifacts\n\nAcceptance:\n- Entering Insumos triggers at most a couple of health/me calls (no continuous growth).