### PR TITLE
ci(ponto): smoke check after Workers deploy

### DIFF
--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -77,3 +77,48 @@ jobs:
           else
             bash backend/scripts/cloudflare-workers.sh deploy --before "$GITHUB_BEFORE_SHA" --after "$GITHUB_SHA"
           fi
+
+      - name: Smoke check Ponto (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && github.ref_name == 'main' }}
+        env:
+          BASE_URL: https://crm.skincos.com.br
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, sys, time, urllib.request
+
+          base = os.environ.get("BASE_URL", "").rstrip("/")
+          if not base:
+            raise SystemExit("BASE_URL not set")
+
+          def fetch_json(path: str):
+            url = f"{base}{path}"
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoDeploySmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+              data = resp.read().decode("utf-8", "ignore")
+              return json.loads(data)
+
+          def check():
+            proxy = fetch_json("/api/ponto/_proxy-status")
+            if not proxy.get("ok"):
+              raise SystemExit(f"proxy-status ok=false: {proxy}")
+            if not proxy.get("effectiveTargetConfigured"):
+              raise SystemExit(f"proxy-status effectiveTargetConfigured=false: {proxy}")
+            if not proxy.get("adminTokenConfigured"):
+              raise SystemExit(f"proxy-status adminTokenConfigured=false: {proxy}")
+            health = fetch_json("/api/ponto/health")
+            if not health.get("ok"):
+              raise SystemExit(f"health ok=false: {health}")
+            return True
+
+          for i in range(1, 6):
+            try:
+              check()
+              print("Ponto deploy smoke OK")
+              sys.exit(0)
+            except Exception as exc:
+              print(f"Attempt {i} failed: {exc}")
+              if i >= 5:
+                raise
+              time.sleep(6)
+          PY


### PR DESCRIPTION
Adiciona smoke check (/_proxy-status + /health) ao final do workflow deploy-insumos-worker.yml em main, para validar rapidamente CRM→Proxy→Worker logo após publicar.