### PR TITLE
ci(workers): fix after-automerge trigger reliability

### DIFF
--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -1,7 +1,7 @@
 name: Deploy Cloudflare Workers (API + Insumos) after automerge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Troca o evento de pull_request para pull_request_target no workflow de deploy after-automerge dos Workers, mantendo o filtro existente de elegibilidade.

Motivo: PRs recentes (ex.: #140/#141) não dispararam esse workflow em closed, enquanto os demais checks do PR dispararam normalmente.