### PR TITLE
ci: harden after-automerge pipelines and multi-chat runbook

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -1,7 +1,7 @@
 name: Deploy CRM API after automerge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -1,7 +1,7 @@
 name: Deploy CRM (Cloudflare Pages) after automerge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -134,3 +134,47 @@ jobs:
         run: |
           set -euo pipefail
           bash backend/scripts/cloudflare-workers.sh deploy-all
+
+      - name: Smoke check Ponto (production)
+        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        env:
+          BASE_URL: https://crm.skincos.com.br
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, sys, time, urllib.request
+
+          base = os.environ.get("BASE_URL", "").rstrip("/")
+          if not base:
+            raise SystemExit("BASE_URL not set")
+
+          def fetch_json(path: str):
+            url = f"{base}{path}"
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoAfterAutomergeSmoke/1.0)"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+              return json.loads(resp.read().decode("utf-8", "ignore"))
+
+          def check():
+            proxy = fetch_json("/api/ponto/_proxy-status")
+            if not proxy.get("ok"):
+              raise SystemExit(f"proxy-status ok=false: {proxy}")
+            if not proxy.get("effectiveTargetConfigured"):
+              raise SystemExit(f"proxy-status effectiveTargetConfigured=false: {proxy}")
+            if not proxy.get("adminTokenConfigured"):
+              raise SystemExit(f"proxy-status adminTokenConfigured=false: {proxy}")
+            health = fetch_json("/api/ponto/health")
+            if not health.get("ok"):
+              raise SystemExit(f"health ok=false: {health}")
+            return True
+
+          for i in range(1, 6):
+            try:
+              check()
+              print("Ponto after-automerge smoke OK")
+              sys.exit(0)
+            except Exception as exc:
+              print(f"Attempt {i} failed: {exc}")
+              if i >= 5:
+                raise
+              time.sleep(6)
+          PY

--- a/docs/multi-chat-worktree-runbook.md
+++ b/docs/multi-chat-worktree-runbook.md
@@ -1,0 +1,53 @@
+# Multi-Chat Worktree Runbook
+
+## Objetivo
+Permitir trabalho paralelo em varios chats/agents sem perder alteracoes e sem conflito de workspace.
+
+## Regras obrigatorias
+- Um chat/agent por branch (`codex/...`).
+- Um chat/agent por worktree dedicado.
+- Nunca compartilhar o mesmo diretorio entre chats ativos.
+- Toda sessao termina com `commit + push + PR` (draft ou final).
+- Integracao em `main` apenas via PR com checks.
+
+## Fluxo recomendado
+1. Criar branch/worktree do chat.
+2. Trabalhar apenas no escopo definido.
+3. Abrir PR cedo (draft) para checkpoint.
+4. Atualizar branch com `origin/main` quando ficar `BEHIND`.
+5. Habilitar auto-merge quando checks estiverem verdes.
+6. Validar deploy/smoke apos merge.
+
+## Comandos padrao
+```bash
+# 1) Base atualizada
+git -C /Users/jubenitogarcia/Automation/skincos fetch origin
+
+# 2) Novo worktree para um chat
+git -C /Users/jubenitogarcia/Automation/skincos worktree add \
+  /Users/jubenitogarcia/Automation/skincos-<modulo>-<chat> \
+  -b codex/<modulo>-<chat> origin/main
+
+# 3) Publicar checkpoint
+cd /Users/jubenitogarcia/Automation/skincos-<modulo>-<chat>
+git add -A
+git commit -m "wip(<modulo>): checkpoint"
+git push -u origin codex/<modulo>-<chat>
+gh pr create --draft --base main --head codex/<modulo>-<chat> --title "WIP <modulo>"
+
+# 4) Se PR ficar BEHIND
+git fetch origin
+git merge --no-edit origin/main
+git push
+```
+
+## Convencoes de escopo
+- Nome do branch deve refletir modulo e objetivo.
+- Evitar dois chats alterando o mesmo arquivo ao mesmo tempo.
+- Se precisar do mesmo arquivo, encadear PR (B parte da branch de A) ou serializar.
+
+## Checklist de encerramento por chat
+- Branch/worktree limpos (`git status` sem alteracoes locais).
+- PR aberto e rastreavel.
+- Auto-merge configurado quando aplicavel.
+- Deploy/smoke verificados quando o PR for mergeado.


### PR DESCRIPTION
Três passos entregues:\n\n1) deploy-workers-after-automerge: adiciona smoke pós-deploy do Ponto (/_proxy-status + /health)\n2) Padroniza trigger de after-automerge para pull_request_target em Pages e CRM API\n3) Adiciona runbook de operação paralela por worktree/chat (docs/multi-chat-worktree-runbook.md)\n\nObjetivo: reduzir pontos cegos de deploy e formalizar colaboração multi-chat sem perda de alterações.