### PR TITLE
chore(frontend): disable demo scaffolding by default

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,7 +20,7 @@ const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
 const INSUMOS_OVERVIEW_FROM_KEY = 'skincos.insumos.overview.from.v1'
 const INSUMOS_OVERVIEW_TO_KEY = 'skincos.insumos.overview.to.v1'
-const DEMO_DATA_ACTIVE = (import.meta as any)?.env?.VITE_DEMO_DATA !== 'false'
+const DEMO_DATA_ACTIVE = (import.meta as any)?.env?.VITE_DEMO_DATA === 'true'
 
 function BuildCornerBadge() {
     const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()

--- a/frontend/contexts.tsx
+++ b/frontend/contexts.tsx
@@ -613,47 +613,6 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   })
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return
-    if (notifications.length === 0) {
-      const demoNotifications: Notification[] = [
-        {
-          id: '1',
-          title: 'Nova oportunidade qualificada',
-          message: 'Lead TechCorp passou para etapa de qualificação com score IA: 92%',
-          type: 'success',
-          priority: 'high',
-          timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-          read: false,
-          category: 'sales',
-          relatedId: '1',
-          relatedType: 'opportunity'
-        },
-        {
-          id: '2',
-          title: 'Cliente em risco de churn',
-          message: 'DataFlow Corp não interage há 30 dias. Ação recomendada: campanha reativação',
-          type: 'warning',
-          priority: 'high',
-          timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-          read: false,
-          category: 'retention'
-        },
-        {
-          id: '3',
-          title: 'Meta mensal atingida',
-          message: 'Parabéns! Você atingiu 105% da meta de vendas deste mês',
-          type: 'success',
-          priority: 'medium',
-          timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-          read: true,
-          category: 'achievement'
-        }
-      ]
-      setNotifications(demoNotifications)
-    }
-  }, [notifications.length, setNotifications])
-
-  useEffect(() => {
     const unsubscribe = webSocket.subscribe('notification', (data) => {
       const notification: Notification = {
         id: data.id || Date.now().toString(),
@@ -678,60 +637,6 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
     return unsubscribe
   }, [webSocket, setNotifications])
-
-  useEffect(() => {
-    if (!import.meta.env.DEV) return
-    if (!webSocket.isConnected) return
-
-    const simulateNotifications = () => {
-      const notificationTypes = [
-        {
-          title: 'Nova mensagem WhatsApp',
-          message: 'Cliente Tech Solutions enviou uma mensagem',
-          type: 'info' as const,
-          priority: 'medium' as const,
-          category: 'communication'
-        },
-        {
-          title: 'Oportunidade movida',
-          message: 'Oportunidade CloudCorp movida para "Negociação"',
-          type: 'info' as const,
-          priority: 'low' as const,
-          category: 'pipeline'
-        },
-        {
-          title: 'Tarefa vencida',
-          message: 'Follow-up com NextGen está atrasado em 2 dias',
-          type: 'warning' as const,
-          priority: 'high' as const,
-          category: 'tasks'
-        },
-        {
-          title: 'Novo lead qualificado',
-          message: 'IA identificou lead de alta qualidade: InnovateX',
-          type: 'success' as const,
-          priority: 'high' as const,
-          category: 'leads'
-        }
-      ]
-
-      if (Math.random() < 0.2) {
-        const randomNotification = notificationTypes[Math.floor(Math.random() * notificationTypes.length)]
-
-        const notification: Notification = {
-          id: Date.now().toString(),
-          ...randomNotification,
-          timestamp: new Date().toISOString(),
-          read: false
-        }
-
-        setNotifications(prev => [notification, ...prev.slice(0, 49)])
-      }
-    }
-
-    const interval = setInterval(simulateNotifications, 60000)
-    return () => clearInterval(interval)
-  }, [webSocket.isConnected, setNotifications])
 
   const addNotification = (notificationData: Omit<Notification, 'id' | 'timestamp' | 'read'>) => {
     const notification: Notification = {

--- a/frontend/useWebSocket.ts
+++ b/frontend/useWebSocket.ts
@@ -216,7 +216,6 @@ export function useWebSocket(config: WebSocketConfig = {}) {
 
       const fullMessage: WebSocketMessage = { ...message, timestamp: toISODateString(new Date()) }
       if (import.meta.env.DEV && String(message.type || '').toLowerCase() === 'ping') {
-        // eslint-disable-next-line no-console
         console.debug('[ws] ping')
       }
       wsRef.current.send(JSON.stringify(fullMessage))
@@ -236,18 +235,6 @@ export function useWebSocket(config: WebSocketConfig = {}) {
     connect()
     return () => disconnect()
   }, [connect, disconnect])
-
-  useEffect(() => {
-    if (!import.meta.env.DEV) return
-    if (!enabled) return
-    const interval = setInterval(() => {
-      if (Math.random() < 0.05 && state.isConnected) {
-        console.log('Simulating connection issue...')
-        handleClose()
-      }
-    }, 30000)
-    return () => clearInterval(interval)
-  }, [enabled, handleClose, state.isConnected])
 
   return { ...state, connect, disconnect, send, subscribe }
 }


### PR DESCRIPTION
What
- Turned `DEMO_DATA_ACTIVE` into opt-in (`VITE_DEMO_DATA === "true"`) instead of default-on.
- Removed demo notification seeding in `NotificationProvider`.
- Removed simulated notification generator and simulated websocket connection flapping.

Why
- Project policy is now zero-demo across modules: all data must be real and integration-backed.
- Demo scaffolding was leaking into runtime behavior and confusing operations.

Validation
- `npm -C frontend run test:e2e -- insumos-no-request-storm.spec.ts insumos-api-concurrency.spec.ts` (pass)
- `npm -C frontend run lint` (warnings only, no errors; pre-existing hook warnings)
- `npm -C frontend run typecheck` still fails with pre-existing global TS issues not introduced by this PR.
