### PR TITLE
ponto: lock login-email conflicts and harden error visibility

### DIFF
--- a/backend/apps/crm-api/server/pontoRoutes.js
+++ b/backend/apps/crm-api/server/pontoRoutes.js
@@ -389,14 +389,31 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     return actorFromReq(req, { kind: 'employee', id: email, label: email })
   }
 
-  function findEmployeeByLoginEmail(email) {
+  function findEmployeesByLoginEmail(email) {
     const needle = normalizeEmail(email)
-    if (!needle) return null
+    if (!needle) return []
+    const out = []
     for (const e of state.employees) {
       if (!e || e.deletedAt || e.active === false) continue
-      if (normalizeEmail(e.loginEmail) === needle) return e
+      if (normalizeEmail(e.loginEmail) === needle) out.push(e)
     }
-    return null
+    return out
+  }
+
+  function resolveEmployeeByLoginEmail(email) {
+    const matches = findEmployeesByLoginEmail(email)
+    if (!matches.length) return { employee: null, conflict: null }
+    if (matches.length > 1) {
+      return {
+        employee: null,
+        conflict: {
+          error: 'LOGIN_EMAIL_AMBIGUOUS',
+          hint: 'Existe mais de um funcionário ativo vinculado a este email.',
+          matches: matches.map((e) => ({ id: e.id, name: e.name, code: e.code || '' }))
+        }
+      }
+    }
+    return { employee: matches[0], conflict: null }
   }
 
   function matchEmployeeDescriptor(employeeId, descriptor, opts = {}) {
@@ -608,6 +625,17 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     const code = safeText(req.body?.code, 40)
     const loginEmail = normalizeEmail(req.body?.loginEmail)
     if (!name) return res.status(400).json({ ok: false, error: 'NAME_REQUIRED' })
+    if (loginEmail) {
+      const [takenBy] = findEmployeesByLoginEmail(loginEmail)
+      if (takenBy) {
+        return res.status(409).json({
+          ok: false,
+          error: 'LOGIN_EMAIL_ALREADY_IN_USE',
+          employeeId: takenBy.id,
+          employeeName: takenBy.name
+        })
+      }
+    }
 
     const now = new Date().toISOString()
     const employee = {
@@ -656,6 +684,17 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     if (loginEmailRaw !== undefined) {
       const next = normalizeEmail(loginEmailRaw)
       const prev = normalizeEmail(employee.loginEmail)
+      if (next) {
+        const takenBy = findEmployeesByLoginEmail(next).find((e) => e.id !== employee.id)
+        if (takenBy) {
+          return res.status(409).json({
+            ok: false,
+            error: 'LOGIN_EMAIL_ALREADY_IN_USE',
+            employeeId: takenBy.id,
+            employeeName: takenBy.name
+          })
+        }
+      }
       employee.loginEmail = next || ''
       await enqueueWrite(() =>
         writeAudit(next ? 'EMPLOYEE_LINK_LOGIN' : 'EMPLOYEE_UNLINK_LOGIN', { employeeId: employee.id, prev, next: next || '' }, actor)
@@ -1012,7 +1051,11 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     const actor = requireEmployee(req, res)
     if (!actor) return
     const email = actor.label
-    const employee = findEmployeeByLoginEmail(email)
+    const resolved = resolveEmployeeByLoginEmail(email)
+    if (resolved.conflict) {
+      return res.status(409).json({ ok: false, ...resolved.conflict, actorEmail: email })
+    }
+    const employee = resolved.employee
     if (!employee) {
       return res.json({
         ok: true,
@@ -1041,7 +1084,9 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     const actor = requireEmployee(req, res)
     if (!actor) return
     const email = actor.label
-    const employee = findEmployeeByLoginEmail(email)
+    const resolved = resolveEmployeeByLoginEmail(email)
+    if (resolved.conflict) return res.status(409).json({ ok: false, ...resolved.conflict, actorEmail: email })
+    const employee = resolved.employee
     if (!employee) return res.status(404).json({ ok: false, error: 'EMPLOYEE_NOT_LINKED' })
     const from = safeText(req.query?.from, 30)
     const to = safeText(req.query?.to, 30)
@@ -1073,7 +1118,9 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     const actor = requireEmployee(req, res)
     if (!actor) return
     const email = actor.label
-    const employee = findEmployeeByLoginEmail(email)
+    const resolved = resolveEmployeeByLoginEmail(email)
+    if (resolved.conflict) return res.status(409).json({ ok: false, ...resolved.conflict, actorEmail: email })
+    const employee = resolved.employee
     if (!employee) return res.status(404).json({ ok: false, error: 'EMPLOYEE_NOT_LINKED' })
 
     const idempotencyKey = getIdempotencyKey(req)

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -132,6 +132,14 @@ GET /api/ponto/admin/audit/verify
 **Sinal:** erro `ADMIN_TOKEN_NOT_CONFIGURED`.  
 **Ação:** validar secrets do Pages em `_proxy-status`.
 
+### Vínculo de login não salva
+**Sinal:** erro `LOGIN_EMAIL_ALREADY_IN_USE`.  
+**Ação:** o email já está vinculado a outro funcionário ativo; revise no Admin e mantenha email único por funcionário.
+
+### Funcionário não consegue carregar `/me`
+**Sinal:** erro `LOGIN_EMAIL_AMBIGUOUS`.  
+**Ação:** há mais de um funcionário ativo com o mesmo email; corrija os cadastros duplicados antes de retestar.
+
 ### `_proxy-status` diz que secrets não estão configurados, mesmo após sync
 **Sinal:** `proxyTokenConfigured=false` / `actorKeyConfigured=false` / `adminTokenConfigured=false`, mas o workflow de sync está “success”.  
 **Causa provável:** em Cloudflare Pages, alterações de env vars podem exigir um novo deploy para entrarem em vigor no runtime.  
@@ -142,7 +150,11 @@ GET /api/ponto/admin/audit/verify
 **Sinal:** erro `NOT_RECOGNIZED`.  
 **Ação:** confirmar `face-models` carregados e biometria cadastrada.
 
+### Retorno HTML com Cloudflare 1101
+**Sinal:** erro com `UPSTREAM_WORKER_EXCEPTION` (ou tela “Worker threw exception”).  
+**Ação:** usar `x-request-id` + `cf-ray` no Cloudflare Logs para identificar a exceção do Worker upstream.
+
 ---
 
 ## 7) Logs e rastreio
-- Use o **x-request-id** exibido no diagnóstico ou nos erros para buscar no Cloudflare.
+- Use o **x-request-id** e **cf-ray** exibidos no diagnóstico/erros para buscar no Cloudflare.

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -164,17 +164,22 @@ async function apiJson<T>(
     json = null
   }
   if (res.ok) return json as T
-  const err = (json || {}) as ApiError
-  const code = String(err.error || err.code || '').trim()
-  const hint = typeof err.hint === 'string' ? err.hint.trim() : ''
+  const nonJsonText = String(text || '')
+  const htmlWorkerCrash = !json && (nonJsonText.includes('Worker threw exception') || nonJsonText.includes('Cloudflare Ray ID'))
+  const err = ((json || {}) as ApiError)
+  const inferredCode = htmlWorkerCrash ? 'UPSTREAM_WORKER_EXCEPTION' : ''
+  const code = String(err.error || err.code || inferredCode || '').trim()
+  const hintFromHtml = htmlWorkerCrash ? 'Falha no Worker upstream (Cloudflare 1101). Verifique logs com o request-id/cf-ray.' : ''
+  const hint = typeof err.hint === 'string' ? err.hint.trim() : hintFromHtml
   const base = err.error || err.message || `HTTP ${res.status}`
   const meta = errorMetaString({ code, requestId, cfRay })
   const e = new Error([base, hint, meta].filter(Boolean).join(' • '))
-  ;(e as any).details = json
+  ;(e as any).details = json || (code ? { error: code } : null)
   ;(e as any).status = res.status
   ;(e as any).requestId = requestId
   ;(e as any).cfRay = cfRay
   ;(e as any).code = code
+  ;(e as any).rawText = nonJsonText.slice(0, 240)
   throw e
 }
 
@@ -203,7 +208,7 @@ async function apiBlob(path: string, opts: { adminToken?: string; signal?: Abort
 async function fetchJsonWithMeta(
   path: string,
   opts: { method?: string; body?: unknown; signal?: AbortSignal; headers?: Record<string, string> } = {}
-): Promise<{ ok: boolean; status: number; requestId: string; json: any; text: string }> {
+): Promise<{ ok: boolean; status: number; requestId: string; cfRay: string; json: any; text: string }> {
   const method = (opts.method || 'GET').toUpperCase()
   const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers || {}) }
   if (opts.body !== undefined) headers['content-type'] = 'application/json'
@@ -216,6 +221,7 @@ async function fetchJsonWithMeta(
   })
 
   const requestId = String(res.headers.get('x-request-id') || '').trim()
+  const cfRay = String(res.headers.get('cf-ray') || '').trim()
   const text = await res.text()
   let json: any = null
   try {
@@ -223,7 +229,7 @@ async function fetchJsonWithMeta(
   } catch {
     json = null
   }
-  return { ok: res.ok, status: res.status, requestId, json, text }
+  return { ok: res.ok, status: res.status, requestId, cfRay, json, text }
 }
 
 let faceLibPromise: Promise<any> | null = null
@@ -310,8 +316,8 @@ export function PontoModule() {
   const [diagOpen, setDiagOpen] = useState(false)
   const [diagLoading, setDiagLoading] = useState(false)
   const [diagError, setDiagError] = useState<string | null>(null)
-  const [diagProxy, setDiagProxy] = useState<{ ok: boolean; status: number; requestId: string; json: any; text: string } | null>(null)
-  const [diagHealth, setDiagHealth] = useState<{ ok: boolean; status: number; requestId: string; json: any; text: string } | null>(null)
+  const [diagProxy, setDiagProxy] = useState<{ ok: boolean; status: number; requestId: string; cfRay: string; json: any; text: string } | null>(null)
+  const [diagHealth, setDiagHealth] = useState<{ ok: boolean; status: number; requestId: string; cfRay: string; json: any; text: string } | null>(null)
 
   const [deviceToken, setDeviceToken] = useState(() => {
     try { return localStorage.getItem(LS_DEVICE_TOKEN) || '' } catch { return '' }
@@ -556,9 +562,13 @@ export function PontoModule() {
       setCameraOwner(owner)
       toast.success('Câmera ativa')
     } catch (e: any) {
-      const details = e?.details as any
-      if (details?.error === 'LOGIN_EMAIL_ALREADY_IN_USE') {
-        toast.error(`Email já vinculado ao funcionário: ${details?.employeeName || details?.employeeId || 'outro usuário'}`)
+      const errName = String(e?.name || '')
+      if (errName === 'NotAllowedError') {
+        toast.error('Permissão de câmera negada. Libere a câmera no navegador e tente novamente.')
+      } else if (errName === 'NotReadableError') {
+        toast.error('Não foi possível acessar a câmera. Feche outros apps que estejam usando a câmera e tente novamente.')
+      } else if (errName === 'NotFoundError') {
+        toast.error('Nenhuma câmera foi encontrada neste dispositivo.')
       } else {
         toast.error(e?.message || String(e))
       }
@@ -619,7 +629,12 @@ export function PontoModule() {
       )
       setMeRecords(res.data || [])
     } catch (e: any) {
-      toast.error(e?.message || String(e))
+      const details = e?.details as any
+      if (details?.error === 'LOGIN_EMAIL_ALREADY_IN_USE') {
+        toast.error(`Email já vinculado ao funcionário: ${details?.employeeName || details?.employeeId || 'outro usuário'}`)
+      } else {
+        toast.error(e?.message || String(e))
+      }
       toastErrorMeta(e)
     } finally {
       setMeLoading(false)
@@ -1163,6 +1178,7 @@ export function PontoModule() {
                   <CardDescription className="break-words">
                     <span className="font-mono">GET /api/ponto/_proxy-status</span>
                     {diagProxy?.requestId ? <> • request: <span className="font-mono">{diagProxy.requestId}</span></> : null}
+                    {diagProxy?.cfRay ? <> • cf-ray: <span className="font-mono">{diagProxy.cfRay}</span></> : null}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -1180,6 +1196,7 @@ export function PontoModule() {
                   <CardDescription className="break-words">
                     <span className="font-mono">GET /api/ponto/health</span>
                     {diagHealth?.requestId ? <> • request: <span className="font-mono">{diagHealth.requestId}</span></> : null}
+                    {diagHealth?.cfRay ? <> • cf-ray: <span className="font-mono">{diagHealth.cfRay}</span></> : null}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>


### PR DESCRIPTION
## Summary
- enforce unique login email on Ponto employee create/patch
- prevent ambiguous `/api/ponto/me*` resolution when duplicate links exist
- improve Ponto UI error diagnostics for upstream HTML/Cloudflare 1101 responses
- show `cf-ray` in diagnostics and improve camera/login-link error messaging
- update Ponto runbook with new conflict/error playbook

## Validation
- `node --check backend/apps/crm-api/server/pontoRoutes.js`
- `npx eslint frontend/PontoModule.tsx`
- `CRM_URL=https://crm.skincos.com.br AUTO_LOGIN=1 ... node frontend/scripts/ponto-ui-smoke.cjs` (OK)

## Note
- Full frontend typecheck currently fails due pre-existing repo-wide TS issues unrelated to this change.
