### PR TITLE
feat(insumos): aggregate analytics endpoints + prod SLO alert + zero-demo CI guard

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -29,6 +29,11 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --recursive
 
+      - name: Guard zero-demo invariants
+        run: |
+          set -euo pipefail
+          bash backend/scripts/ci-no-demo-guard.sh
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/insumos-api-slo.yml
+++ b/.github/workflows/insumos-api-slo.yml
@@ -1,0 +1,44 @@
+name: insumos-api-slo
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard Insumos SLO credentials
+        id: guard
+        env:
+          INSUMOS_SLO_USERNAME: ${{ secrets.INSUMOS_SLO_USERNAME }}
+          INSUMOS_SLO_PASSWORD: ${{ secrets.INSUMOS_SLO_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${INSUMOS_SLO_USERNAME:-}" || -z "${INSUMOS_SLO_PASSWORD:-}" ]]; then
+            echo "::warning::Missing INSUMOS_SLO_USERNAME/INSUMOS_SLO_PASSWORD secrets. Skipping monitor."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Run Insumos API SLO monitor
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          INSUMOS_SLO_BASE_URL: ${{ vars.INSUMOS_SLO_BASE_URL != '' && vars.INSUMOS_SLO_BASE_URL || 'https://crm.skincos.com.br' }}
+          INSUMOS_SLO_UNIDADE: ${{ vars.INSUMOS_SLO_UNIDADE != '' && vars.INSUMOS_SLO_UNIDADE || 'novo-hamburgo' }}
+          INSUMOS_SLO_MAX_LATENCY_MS: ${{ vars.INSUMOS_SLO_MAX_LATENCY_MS != '' && vars.INSUMOS_SLO_MAX_LATENCY_MS || '1500' }}
+          INSUMOS_SLO_TIMEOUT_SEC: ${{ vars.INSUMOS_SLO_TIMEOUT_SEC != '' && vars.INSUMOS_SLO_TIMEOUT_SEC || '15' }}
+          INSUMOS_SLO_USERNAME: ${{ secrets.INSUMOS_SLO_USERNAME }}
+          INSUMOS_SLO_PASSWORD: ${{ secrets.INSUMOS_SLO_PASSWORD }}
+        run: |
+          set -euo pipefail
+          bash backend/scripts/insumos-api-slo.sh

--- a/backend/apps/insumos/src/routes/insights.js
+++ b/backend/apps/insumos/src/routes/insights.js
@@ -35,6 +35,94 @@ function safeNumber(v) {
     return Number.isFinite(n) ? n : 0;
 }
 
+function parseDateBound(raw, bound) {
+    const value = String(raw || '').trim();
+    if (!value) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        const suffix = bound === 'end' ? 'T23:59:59.999Z' : 'T00:00:00.000Z';
+        return toDateOrNull(`${value}${suffix}`);
+    }
+    return toDateOrNull(value);
+}
+
+function resolveWindow(url, fallbackDays = 30) {
+    const daysRaw = parseInt(url.searchParams.get('days') || `${fallbackDays}`, 10) || fallbackDays;
+    const days = Math.max(1, Math.min(366, daysRaw));
+    const now = new Date();
+    const from =
+        parseDateBound(url.searchParams.get('from') || url.searchParams.get('de'), 'start') ||
+        new Date(now.getTime() - days * 86400000);
+    const to = parseDateBound(url.searchParams.get('to') || url.searchParams.get('ate'), 'end') || now;
+    return { from, to, days };
+}
+
+function buildStockAlerts(insumos) {
+    return (Array.isArray(insumos) ? insumos : [])
+        .filter((i) => safeNumber(i?.estoqueMinimo) > 0 && safeNumber(i?.estoqueAtual) <= safeNumber(i?.estoqueMinimo))
+        .map((i) => ({
+            codigoBarras: i.codigoBarras,
+            produto: i.produto,
+            categoria: i.categoria,
+            estoqueAtual: i.estoqueAtual,
+            estoqueMinimo: i.estoqueMinimo,
+            diferenca: safeNumber(i.estoqueAtual) - safeNumber(i.estoqueMinimo),
+            percentual: safeNumber(i.estoqueMinimo) > 0 ? Math.round((safeNumber(i.estoqueAtual) / safeNumber(i.estoqueMinimo)) * 100) : null,
+            tipoAlerta: 'ESTOQUE_BAIXO'
+        }));
+}
+
+function computeMovementOverview({ movimentos, insumoByCode, from, to, unidade, maxSeriesPoints = 365 }) {
+    const resumo = { entradaQtd: 0, saidaQtd: 0, entradaValor: 0, saidaValor: 0 };
+    const byDay = new Map();
+    const limit = Math.max(1, Math.min(366, parseInt(String(maxSeriesPoints || 365), 10) || 365));
+
+    for (const m of Array.isArray(movimentos) ? movimentos : []) {
+        if (unidade && String(m?.unidade || '') !== String(unidade)) continue;
+        const d = toDateOrNull(m?.dataHora);
+        if (!d) continue;
+        if (from && d < from) continue;
+        if (to && d > to) continue;
+
+        const code = String(m?.codigoBarras || '').trim();
+        const item = code ? insumoByCode.get(code) || null : null;
+        const tipo = normalizeTipo(m?.tipo);
+        const qtd = safeNumber(m?.quantidade);
+        const preco = safeNumber(m?.preco) || safeNumber(item?.precoCusto);
+        const valor = qtd * preco;
+
+        if (tipo === 'ENTRADA') {
+            resumo.entradaQtd += qtd;
+            resumo.entradaValor += valor;
+        } else if (tipo === 'SAIDA' || tipo === 'SAÍDA') {
+            resumo.saidaQtd += qtd;
+            resumo.saidaValor += valor;
+        } else {
+            continue;
+        }
+
+        const day = d.toISOString().slice(0, 10);
+        const current = byDay.get(day) || { day, entrada: 0, saida: 0, entradaValor: 0, saidaValor: 0 };
+        if (tipo === 'ENTRADA') {
+            current.entrada += qtd;
+            current.entradaValor += valor;
+        } else {
+            current.saida += qtd;
+            current.saidaValor += valor;
+        }
+        byDay.set(day, current);
+    }
+
+    return {
+        movResumo: {
+            ...resumo,
+            saldoLiquido: resumo.entradaValor - resumo.saidaValor
+        },
+        movSeries: Array.from(byDay.values())
+            .sort((a, b) => String(a.day).localeCompare(String(b.day)))
+            .slice(-limit)
+    };
+}
+
 function computeTrends({ movimentos, insumoByCode, groupBy, from, to, unidade }) {
     const byBucket = new Map();
     const totals = { entradaQtd: 0, saidaQtd: 0, ajusteQtd: 0, entradaValor: 0, saidaValor: 0 };
@@ -142,6 +230,7 @@ export async function handleInsightsRoutes({
     buildActionables,
     buildRoi,
     buildQualityReport,
+    computeNotificationsForUnidade,
     stockDistribution,
     buildResumoEstoque,
     d1,
@@ -180,6 +269,97 @@ export async function handleInsightsRoutes({
             .all();
         return r?.results || [];
     };
+
+    if (url.pathname === "/analytics/overview" && request.method === "GET") {
+        try {
+            const unidadeQ = url.searchParams.get('unidade') || unidade;
+            const limitIssues = url.searchParams.get('limitIssues') || '120';
+            const { from, to, days } = resolveWindow(url, 30);
+
+            const [insumos, movimentos] = await Promise.all([
+                listInsumos(unidadeQ),
+                listMovimentos({
+                    unidadeQ,
+                    fromIso: from ? from.toISOString() : null,
+                    toIso: to ? to.toISOString() : null
+                }),
+            ]);
+
+            const resumo = buildResumoEstoque(insumos);
+            const notifications = computeNotificationsForUnidade(insumos, unidadeQ);
+            const actionables = buildActionables(insumos, unidadeQ);
+            const roi = buildRoi(insumos, unidadeQ);
+            const quality = buildQualityReport(insumos, unidadeQ, limitIssues);
+            const insumoByCode = new Map(insumos.map((i) => [String(i.codigoBarras || '').trim(), i]));
+            const movementData = computeMovementOverview({
+                movimentos,
+                insumoByCode,
+                from,
+                to,
+                unidade: unidadeQ,
+                maxSeriesPoints: days
+            });
+
+            const data = {
+                resumo,
+                itens: insumos,
+                notifications,
+                actionables,
+                roi,
+                quality,
+                ...movementData,
+                window: {
+                    from: from ? from.toISOString() : null,
+                    to: to ? to.toISOString() : null,
+                    days
+                }
+            };
+            return withCORS(JSON.stringify({ success: true, data }), { status: 200 }, appOrigin);
+        } catch (err) {
+            return withCORS(JSON.stringify({ success: false, error: err.message }), { status: 500 }, appOrigin);
+        }
+    }
+
+    if (url.pathname === "/analytics/insights" && request.method === "GET") {
+        try {
+            const unidadeQ = url.searchParams.get('unidade') || unidade;
+            const groupBy = (url.searchParams.get('groupBy') || 'day').toLowerCase();
+            const group = groupBy === 'week' || groupBy === 'month' ? groupBy : 'day';
+            const { from, to, days } = resolveWindow(url, 30);
+
+            const [insumos, movimentos] = await Promise.all([
+                listInsumos(unidadeQ),
+                listMovimentos({
+                    unidadeQ,
+                    fromIso: from ? from.toISOString() : null,
+                    toIso: to ? to.toISOString() : null
+                }),
+            ]);
+            const insumoByCode = new Map(insumos.map((i) => [String(i.codigoBarras || '').trim(), i]));
+            const trends = computeTrends({ movimentos, insumoByCode, groupBy: group, from, to, unidade: unidadeQ });
+            const turnoverSaida = computeCategoryTurnover({ movimentos, insumoByCode, from, to, unidade: unidadeQ, mode: 'saida' });
+            const turnoverEntrada = computeCategoryTurnover({ movimentos, insumoByCode, from, to, unidade: unidadeQ, mode: 'entrada' });
+
+            const data = {
+                alertas: buildStockAlerts(insumos),
+                trends,
+                turnover: {
+                    saida: turnoverSaida,
+                    entrada: turnoverEntrada
+                },
+                window: {
+                    from: from ? from.toISOString() : null,
+                    to: to ? to.toISOString() : null,
+                    days,
+                    groupBy: group
+                }
+            };
+            return withCORS(JSON.stringify({ success: true, data }), { status: 200 }, appOrigin);
+        } catch (err) {
+            return withCORS(JSON.stringify({ success: false, error: err.message }), { status: 500 }, appOrigin);
+        }
+    }
+
     // Stub analytics / relatorios / alertas / movimentacoes endpoints expected by frontend
     if (url.pathname === "/analytics/actionables" && request.method === "GET") {
         try {
@@ -211,12 +391,9 @@ export async function handleInsightsRoutes({
     }
     if (url.pathname === "/analytics/trends") {
         try {
-            const days = Math.max(1, Math.min(366, parseInt(url.searchParams.get('days') || '30', 10) || 30));
             const groupBy = (url.searchParams.get('groupBy') || 'day').toLowerCase();
             const group = groupBy === 'week' || groupBy === 'month' ? groupBy : 'day';
-            const now = new Date();
-            const from = toDateOrNull(url.searchParams.get('from')) || toDateOrNull(url.searchParams.get('de')) || new Date(now.getTime() - days * 86400000);
-            const to = toDateOrNull(url.searchParams.get('to')) || toDateOrNull(url.searchParams.get('ate')) || now;
+            const { from, to } = resolveWindow(url, 30);
 
             const [insumos, movimentos] = await Promise.all([
                 listInsumos(unidade),
@@ -236,10 +413,7 @@ export async function handleInsightsRoutes({
     }
     if (url.pathname === "/analytics/category-turnover") {
         try {
-            const days = Math.max(1, Math.min(366, parseInt(url.searchParams.get('days') || '30', 10) || 30));
-            const now = new Date();
-            const from = toDateOrNull(url.searchParams.get('from')) || toDateOrNull(url.searchParams.get('de')) || new Date(now.getTime() - days * 86400000);
-            const to = toDateOrNull(url.searchParams.get('to')) || toDateOrNull(url.searchParams.get('ate')) || now;
+            const { from, to } = resolveWindow(url, 30);
             const mode = (url.searchParams.get('mode') || 'saida').toLowerCase(); // saida|entrada|all
             const [insumos, movimentos] = await Promise.all([
                 listInsumos(unidade),
@@ -334,20 +508,7 @@ export async function handleInsightsRoutes({
     if (url.pathname === "/alertas/estoque") {
         try {
             const insumos = await listInsumos(unidade);
-            const alertas = insumos
-                .filter(i => i.estoqueMinimo > 0 && (i.estoqueAtual || 0) <= i.estoqueMinimo)
-                .map(i => ({
-                    codigoBarras: i.codigoBarras,
-                    produto: i.produto,
-                    categoria: i.categoria,
-                    estoqueAtual: i.estoqueAtual,
-                    estoqueMinimo: i.estoqueMinimo,
-                    diferenca: (i.estoqueAtual || 0) - (i.estoqueMinimo || 0),
-                    percentual: i.estoqueMinimo > 0
-                        ? Math.round(((i.estoqueAtual || 0) / i.estoqueMinimo) * 100)
-                        : null,
-                    tipoAlerta: 'ESTOQUE_BAIXO'
-                }));
+            const alertas = buildStockAlerts(insumos);
             return withCORS(JSON.stringify({ success: true, data: alertas }), { status: 200 }, appOrigin);
         } catch (err) {
             return withCORS(JSON.stringify({ success: false, error: err.message }), { status: 500 }, appOrigin);

--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -1442,6 +1442,7 @@ export default {
             buildActionables: (itens, u) => buildActionables(itens, u, config),
             buildRoi,
             buildQualityReport,
+            computeNotificationsForUnidade,
             stockDistribution,
             buildResumoEstoque,
             d1,

--- a/backend/scripts/ci-no-demo-guard.sh
+++ b/backend/scripts/ci-no-demo-guard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIR="${ROOT_DIR}/frontend"
+
+if [[ ! -d "${FRONTEND_DIR}" ]]; then
+  echo "[no-demo-guard] frontend directory not found: ${FRONTEND_DIR}" >&2
+  exit 2
+fi
+
+failures=0
+
+fail_if_found() {
+  local pattern="$1"
+  local description="$2"
+  local output
+  output="$(grep -R --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git -n "${pattern}" "${FRONTEND_DIR}" || true)"
+  if [[ -n "${output}" ]]; then
+    echo "[no-demo-guard] ERROR: ${description}" >&2
+    echo "${output}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+ensure_present() {
+  local pattern="$1"
+  local file="$2"
+  local description="$3"
+  if ! grep -q "${pattern}" "${file}"; then
+    echo "[no-demo-guard] ERROR: ${description}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+fail_if_found "Mock WebSocket send" "Mock WebSocket log reintroduced in frontend source."
+fail_if_found "demoNotifications" "Demo notification seed found in frontend source."
+
+ensure_present "enabled = import.meta.env.DEV" "${FRONTEND_DIR}/useWebSocket.ts" "WebSocket must stay disabled by default in production."
+ensure_present "const DEMO_DATA_ACTIVE = (import.meta as any)?.env?.VITE_DEMO_DATA === 'true'" "${FRONTEND_DIR}/App.tsx" "DEMO_DATA_ACTIVE must only activate via explicit env flag."
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "[no-demo-guard] FAILED with ${failures} issue(s)." >&2
+  exit 1
+fi
+
+echo "[no-demo-guard] PASS"

--- a/backend/scripts/insumos-api-slo.sh
+++ b/backend/scripts/insumos-api-slo.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${INSUMOS_SLO_BASE_URL:-https://crm.skincos.com.br}"
+USERNAME="${INSUMOS_SLO_USERNAME:-}"
+PASSWORD="${INSUMOS_SLO_PASSWORD:-}"
+UNIDADE="${INSUMOS_SLO_UNIDADE:-novo-hamburgo}"
+TIMEOUT_SEC="${INSUMOS_SLO_TIMEOUT_SEC:-15}"
+MAX_LATENCY_MS="${INSUMOS_SLO_MAX_LATENCY_MS:-1500}"
+
+if [[ -z "${USERNAME}" || -z "${PASSWORD}" ]]; then
+  echo "[insumos-slo] Missing credentials (INSUMOS_SLO_USERNAME / INSUMOS_SLO_PASSWORD)." >&2
+  exit 2
+fi
+
+if [[ "${BASE_URL}" != http://* && "${BASE_URL}" != https://* ]]; then
+  echo "[insumos-slo] Invalid INSUMOS_SLO_BASE_URL: ${BASE_URL}" >&2
+  exit 2
+fi
+
+TMP_BODY="$(mktemp -t insumos-slo-body.XXXXXX)"
+TMP_COOKIES="$(mktemp -t insumos-slo-cookies.XXXXXX)"
+cleanup() {
+  rm -f "$TMP_BODY" 2>/dev/null || true
+  rm -f "$TMP_COOKIES" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+today_utc() {
+  date -u +%F
+}
+
+days_ago_utc() {
+  local days="$1"
+  if date -u -d "${days} days ago" +%F >/dev/null 2>&1; then
+    date -u -d "${days} days ago" +%F
+    return 0
+  fi
+  if date -u -v-"${days}"d +%F >/dev/null 2>&1; then
+    date -u -v-"${days}"d +%F
+    return 0
+  fi
+  today_utc
+}
+
+TODAY="$(today_utc)"
+FROM_30D="$(days_ago_utc 30)"
+
+if [[ -n "${INSUMOS_SLO_ENDPOINTS:-}" ]]; then
+  ENDPOINTS="${INSUMOS_SLO_ENDPOINTS}"
+else
+  ENDPOINTS="/api/insumos/health,\
+/api/insumos/auth/me,\
+/api/insumos/insumos?unidade=${UNIDADE}&pagina=1&limite=50,\
+/api/insumos/movimentacoes?unidade=${UNIDADE}&pagina=1&limite=80,\
+/api/insumos/analytics/overview?unidade=${UNIDADE}&de=${FROM_30D}&ate=${TODAY}&days=30&limitIssues=120,\
+/api/insumos/analytics/insights?unidade=${UNIDADE}&groupBy=day&from=${FROM_30D}&to=${TODAY}&days=30"
+fi
+
+echo "[insumos-slo] BASE_URL=${BASE_URL}"
+echo "[insumos-slo] UNIDADE=${UNIDADE}"
+echo "[insumos-slo] TIMEOUT_SEC=${TIMEOUT_SEC} MAX_LATENCY_MS=${MAX_LATENCY_MS}"
+
+login_status="$(curl -sS -o "$TMP_BODY" -w "%{http_code}" \
+  -c "$TMP_COOKIES" \
+  -b "$TMP_COOKIES" \
+  --max-time "$TIMEOUT_SEC" \
+  -H "accept: application/json" \
+  -H "content-type: application/json" \
+  -X POST \
+  -d "{\"email\":\"${USERNAME}\",\"password\":\"${PASSWORD}\"}" \
+  "${BASE_URL}/api/insumos/auth/login" || true)"
+
+if [[ "${login_status}" != "200" ]]; then
+  echo "[insumos-slo] FAIL /api/insumos/auth/login status=${login_status}" >&2
+  cat "$TMP_BODY" >&2 || true
+  exit 1
+fi
+
+failures=0
+checks=0
+IFS=',' read -ra paths <<< "$ENDPOINTS"
+for raw in "${paths[@]}"; do
+  path="$(echo "$raw" | xargs)"
+  [[ -z "$path" ]] && continue
+  checks=$((checks + 1))
+  url="${BASE_URL}${path}"
+  out="$(curl -sS -o "$TMP_BODY" -w "%{http_code} %{time_total}" \
+    -b "$TMP_COOKIES" \
+    -c "$TMP_COOKIES" \
+    --max-time "$TIMEOUT_SEC" \
+    -H "accept: application/json" \
+    "$url" || true)"
+  code="$(echo "$out" | awk '{print $1}')"
+  time_s="$(echo "$out" | awk '{print $2}')"
+  latency_ms="$(awk -v t="${time_s:-0}" 'BEGIN{printf "%.0f", t*1000}')"
+  echo "[insumos-slo] path=${path} status=${code} latency_ms=${latency_ms}"
+
+  if [[ -z "$code" || "$code" -lt 200 || "$code" -ge 300 ]]; then
+    echo "[insumos-slo] ERROR status=${code} path=${path}" >&2
+    cat "$TMP_BODY" >&2 || true
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [[ "$latency_ms" -gt "$MAX_LATENCY_MS" ]]; then
+    echo "[insumos-slo] ERROR latency=${latency_ms}ms budget=${MAX_LATENCY_MS}ms path=${path}" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+echo "[insumos-slo] checks=${checks} failures=${failures}"
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi

--- a/backend/scripts/insumos-smoke.sh
+++ b/backend/scripts/insumos-smoke.sh
@@ -49,31 +49,26 @@ req "/health"
 req "/metrics"
 req "/insumos/health"
 
-health_json="$(curl -fsS "$BASE_URL/health" 2>/dev/null || true)"
-if echo "$health_json" | grep -Eq '"sheetsConfigured"[[:space:]]*:[[:space:]]*true'; then
-  if [[ -n "$SMOKE_USER" && -n "$SMOKE_PASS" ]]; then
-    echo "[smoke] Auth smoke enabled (sheetsConfigured=true)"
-    echo "[smoke] POST $BASE_URL/auth/login"
-    status="$(curl -sS -o "$TMP_BODY" -w "%{http_code}" \
-      -c "$TMP_COOKIES" \
-      -b "$TMP_COOKIES" \
-      -H "content-type: application/json" \
-      -d "{\"username\":\"$SMOKE_USER\",\"password\":\"$SMOKE_PASS\"}" \
-      "$BASE_URL/auth/login" || true)"
-    if [[ "$status" != "200" ]]; then
-      echo "[smoke] FAIL /auth/login (status=$status)" >&2
-      echo "[smoke] Body:" >&2
-      cat "$TMP_BODY" >&2 || true
-      exit 1
-    fi
-
-    req "/auth/me"
-    req "/insumos"
-  else
-    echo "[smoke] SKIP auth smoke (set INSUMOS_SMOKE_USER and INSUMOS_SMOKE_PASS)"
+if [[ -n "$SMOKE_USER" && -n "$SMOKE_PASS" ]]; then
+  echo "[smoke] Auth smoke enabled"
+  echo "[smoke] POST $BASE_URL/auth/login"
+  status="$(curl -sS -o "$TMP_BODY" -w "%{http_code}" \
+    -c "$TMP_COOKIES" \
+    -b "$TMP_COOKIES" \
+    -H "content-type: application/json" \
+    -d "{\"username\":\"$SMOKE_USER\",\"password\":\"$SMOKE_PASS\"}" \
+    "$BASE_URL/auth/login" || true)"
+  if [[ "$status" != "200" ]]; then
+    echo "[smoke] FAIL /auth/login (status=$status)" >&2
+    echo "[smoke] Body:" >&2
+    cat "$TMP_BODY" >&2 || true
+    exit 1
   fi
+
+  req "/auth/me"
+  req "/insumos"
 else
-  echo "[smoke] SKIP auth smoke (sheetsConfigured=false)"
+  echo "[smoke] SKIP auth smoke (set INSUMOS_SMOKE_USER and INSUMOS_SMOKE_PASS)"
 fi
 
 echo "[smoke] OK"

--- a/docs/insumos-runbook.md
+++ b/docs/insumos-runbook.md
@@ -12,6 +12,9 @@ Este documento descreve como validar, diagnosticar e operar o módulo **Insumos*
 - Modo de armazenamento: **D1-only**.
 - `zero demo` por padrão: dados simulados só com flag explícita.
 - Auto-sync resiliente: pausa temporária após falhas repetidas de API.
+- Overview/Insights com endpoints agregados:
+  - `/api/insumos/analytics/overview`
+  - `/api/insumos/analytics/insights`
 
 ## 3) Checklist rápido de saúde
 
@@ -73,8 +76,17 @@ Critérios:
 - Zero-demo por padrão.
 - Breaker ativo sob falhas repetidas.
 
-## 6) Regras de deploy e colaboração
+## 6) Alertas de produção (5xx/latência)
+- Workflow: `.github/workflows/insumos-api-slo.yml`
+- Script: `backend/scripts/insumos-api-slo.sh`
+- Frequência: a cada 10 minutos.
+- Alvo: endpoints autenticados `/api/insumos/*` (inclui overview/insights agregados).
+- Critério de falha:
+  - status fora de `2xx`
+  - latência acima do orçamento (`INSUMOS_SLO_MAX_LATENCY_MS`)
+
+## 7) Regras de deploy e colaboração
 - Sempre via PR curto e focado.
 - Habilitar auto-merge só com checks obrigatórios verdes.
 - Evitar editar em paralelo os mesmos arquivos grandes (`InsumosModule.tsx`, `App.tsx`) sem sincronizar `origin/main`.
-
+- CI guard anti-demo: `backend/scripts/ci-no-demo-guard.sh` (executado em `.github/workflows/ci-smoke.yml`).

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -136,6 +136,32 @@ type QualityReport = {
   issues?: QualityIssue[]
 }
 
+type OverviewBundleData = {
+  resumo?: EstoqueResumo | null
+  itens?: Insumo[] | null
+  notifications?: NotificationsSummary | null
+  actionables?: Actionables | null
+  roi?: RoiInsights | null
+  quality?: QualityReport | null
+  movResumo?: {
+    entradaQtd?: number
+    saidaQtd?: number
+    entradaValor?: number
+    saidaValor?: number
+    saldoLiquido?: number
+  } | null
+  movSeries?: Array<{ day?: string; entrada?: number; saida?: number; entradaValor?: number; saidaValor?: number }>
+}
+
+type InsightsBundleData = {
+  alertas?: EstoqueAlerta[] | null
+  trends?: any
+  turnover?: {
+    saida?: any
+    entrada?: any
+  } | null
+}
+
 type ShareFile = {
   name: string
   size?: number
@@ -2611,22 +2637,23 @@ export function InsumosModule() {
     return () => window.clearTimeout(t)
   }, [canUseApi, isAuthed, loadMovimentacoes, movAte, movDe, movTipo, selectedCodigoBarras, unidade])
 
-	  const loadOverview = React.useCallback(async (opts?: { force?: boolean }) => {
-	    if (!canUseApi || !isAuthed) return
-	    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
-	    try {
-	      overviewAbortRef.current?.abort()
-	    } catch {
-	      // ignore
-	    }
-	    const ac = new AbortController()
-	    overviewAbortRef.current = ac
-	    setOverviewLoading(true)
-	    try {
+  const loadOverview = React.useCallback(async (opts?: { force?: boolean }) => {
+    if (!canUseApi || !isAuthed) return
+    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
+    try {
+      overviewAbortRef.current?.abort()
+    } catch {
+      // ignore
+    }
+    const ac = new AbortController()
+    overviewAbortRef.current = ac
+    setOverviewLoading(true)
+    try {
       const now = new Date()
       const yyyyMmDd = (d: Date) => d.toISOString().slice(0, 10)
       let de = ''
       let ate = yyyyMmDd(now)
+      let days = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : 365
 
       if (overviewPeriod === 'custom') {
         const deIso = dateInputToIso(overviewCustomFrom)
@@ -2634,6 +2661,10 @@ export function InsumosModule() {
         if (deIso && ateIso) {
           de = deIso
           ate = ateIso
+          const fromMs = new Date(deIso).getTime()
+          const toMs = new Date(ateIso).getTime()
+          const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
+          days = Math.max(1, Math.min(365, diffDays))
         }
       }
 
@@ -2645,94 +2676,45 @@ export function InsumosModule() {
         de = yyyyMmDd(start)
       }
 
-		      const params = `unidade=${encodeURIComponent(unidade)}`
-		      const [estoque, notif, act, roi, quality, movs] = await Promise.all([
-		        apiJson<{ success?: boolean; data?: { resumo?: EstoqueResumo; itens?: Insumo[] } }>(`/relatorios/estoque?${params}`, { signal: ac.signal }),
-		        apiJson<{ success?: boolean; data?: NotificationsSummary }>(`/notifications/summary?${params}`, { signal: ac.signal }),
-		        apiJson<{ success?: boolean; data?: Actionables }>(`/analytics/actionables?${params}`, { signal: ac.signal }),
-		        apiJson<{ success?: boolean; data?: RoiInsights }>(`/analytics/roi?${params}`, { signal: ac.signal }),
-		        apiJson<{ success?: boolean; data?: QualityReport }>(`/quality/report?${new URLSearchParams({ unidade, limitIssues: '120' }).toString()}`, { signal: ac.signal }),
-		        apiJson<{ success?: boolean; data?: Movimentacao[]; movimentos?: Movimentacao[] }>(
-	          `/movimentacoes?${new URLSearchParams({
-	            unidade,
-	            limite: '400',
-	            de,
-	            ate
-	          }).toString()}`,
-	          { signal: ac.signal }
-	        )
-	      ])
-		      if (overviewAbortRef.current !== ac) return
-		      setOverviewResumo(estoque?.data?.resumo || null)
-		      setOverviewInsumos(Array.isArray(estoque?.data?.itens) ? (estoque!.data!.itens as any) : null)
-		      setOverviewNotifications(notif?.data || null)
-		      setOverviewActionables(act?.data || null)
+      const params = new URLSearchParams({
+        unidade,
+        de,
+        ate,
+        days: String(days),
+        limitIssues: '120'
+      })
+      const out = await apiJson<{ success?: boolean; data?: OverviewBundleData }>(`/analytics/overview?${params.toString()}`, { signal: ac.signal })
 
-      setOverviewRoi(roi?.data || null)
-      setOverviewQuality(quality?.data || null)
-
-      const movList = (movs as any)?.movimentos ?? movs?.data
-      const list: Movimentacao[] = Array.isArray(movList) ? movList : []
-      const resumo = list.reduce(
-        (acc, m) => {
-          const t = String(m.tipo || '').toUpperCase().replace('Í', 'I')
-          const qtd = Number(m.quantidade) || 0
-          const preco = Number(m.preco) || 0
-          const valor = preco * qtd
-          if (t === 'ENTRADA') {
-            acc.entradaQtd += qtd
-            acc.entradaValor += valor
-          } else if (t === 'SAIDA' || t === 'SAÍDA') {
-            acc.saidaQtd += qtd
-            acc.saidaValor += valor
-          }
-          return acc
-        },
-        { entradaQtd: 0, saidaQtd: 0, entradaValor: 0, saidaValor: 0 }
-      )
-      setOverviewMovResumo({ ...resumo, saldoLiquido: resumo.entradaValor - resumo.saidaValor })
-
-      const byDay = new Map<string, { day: string; entrada: number; saida: number; entradaValor: number; saidaValor: number }>()
-      for (const m of list) {
-        const d = new Date(m.dataHora || '')
-        if (Number.isNaN(d.getTime())) continue
-        const day = d.toISOString().slice(0, 10)
-        const cur = byDay.get(day) || { day, entrada: 0, saida: 0, entradaValor: 0, saidaValor: 0 }
-        const t = String(m.tipo || '').toUpperCase().replace('Í', 'I')
-        const qtd = Number(m.quantidade) || 0
-        const preco = Number((m as any).preco) || 0
-        const valor = preco * qtd
-        if (t === 'ENTRADA') {
-          cur.entrada += qtd
-          cur.entradaValor += valor
-        } else if (t === 'SAIDA' || t === 'SAÍDA') {
-          cur.saida += qtd
-          cur.saidaValor += valor
-        }
-        byDay.set(day, cur)
+      if (overviewAbortRef.current !== ac) return
+      const data = out?.data || null
+      setOverviewResumo(data?.resumo || null)
+      setOverviewInsumos(Array.isArray(data?.itens) ? (data?.itens as any) : null)
+      setOverviewNotifications(data?.notifications || null)
+      setOverviewActionables(data?.actionables || null)
+      setOverviewRoi(data?.roi || null)
+      setOverviewQuality(data?.quality || null)
+      setOverviewMovResumo((data?.movResumo as any) || null)
+      setOverviewMovSeries(Array.isArray(data?.movSeries) ? data.movSeries : [])
+    } catch (e) {
+      if ((e as any)?.name === 'AbortError') return
+      if (overviewAbortRef.current !== ac) return
+      markAutoSyncFailure(e)
+      toast.error(e instanceof Error ? e.message : String(e))
+      setOverviewResumo(null)
+      setOverviewNotifications(null)
+      setOverviewActionables(null)
+      setOverviewRoi(null)
+      setOverviewQuality(null)
+      setOverviewMovResumo(null)
+      setOverviewMovSeries([])
+    } finally {
+      if (overviewAbortRef.current === ac) {
+        setOverviewLoaded(true)
+        setOverviewLoading(false)
+        overviewAbortRef.current = null
       }
-      const limit = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : overviewPeriod === '90d' ? 90 : 365
-      setOverviewMovSeries(Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day)).slice(-limit))
-	    } catch (e) {
-	      if ((e as any)?.name === 'AbortError') return
-	      if (overviewAbortRef.current !== ac) return
-	      markAutoSyncFailure(e)
-	      toast.error(e instanceof Error ? e.message : String(e))
-	      setOverviewResumo(null)
-	      setOverviewNotifications(null)
-	      setOverviewActionables(null)
-	      setOverviewRoi(null)
-	      setOverviewQuality(null)
-	      setOverviewMovResumo(null)
-	      setOverviewMovSeries([])
-	    } finally {
-	      if (overviewAbortRef.current === ac) {
-	        setOverviewLoaded(true)
-	        setOverviewLoading(false)
-	        overviewAbortRef.current = null
-	      }
-	    }
-	  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, unidade, overviewCustomFrom, overviewCustomTo, overviewPeriod])
+    }
+  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, overviewCustomFrom, overviewCustomTo, overviewPeriod, unidade])
 
   const saveLot = React.useCallback(async () => {
     if (!lotSelecionado?.registro) {
@@ -2893,80 +2875,57 @@ export function InsumosModule() {
     }
   }, [canUseApi, editTarget?.registro, isAuthed, loadOverview, mutateJson, refreshInsumos, unidade])
 
-	  const loadInsights = React.useCallback(async (opts?: { force?: boolean }) => {
-	    if (!canUseApi || !isAuthed) return
-	    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
-	    try {
-	      insightsAbortRef.current?.abort()
-	    } catch {
-	      // ignore
-	    }
-	    const ac = new AbortController()
-	    insightsAbortRef.current = ac
-	    setInsightsLoading(true)
-	    try {
-	      const base = new URLSearchParams()
-	      base.set('unidade', unidade)
+  const loadInsights = React.useCallback(async (opts?: { force?: boolean }) => {
+    if (!canUseApi || !isAuthed) return
+    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
+    try {
+      insightsAbortRef.current?.abort()
+    } catch {
+      // ignore
+    }
+    const ac = new AbortController()
+    insightsAbortRef.current = ac
+    setInsightsLoading(true)
+    try {
+      const params = new URLSearchParams()
+      params.set('unidade', unidade)
+      params.set('groupBy', 'day')
 
-	      const trendsParams = new URLSearchParams(base.toString())
-	      trendsParams.set('groupBy', 'day')
-	      let days = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : 365
-	      const customFromIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomFrom) : ''
-	      const customToIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomTo) : ''
-	      if (overviewPeriod === 'custom' && customFromIso && customToIso) {
-	        const fromMs = new Date(customFromIso).getTime()
-	        const toMs = new Date(customToIso).getTime()
-	        const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
-	        days = Math.max(1, Math.min(365, diffDays))
-	      }
-	      trendsParams.set('days', String(days))
-	      if (overviewPeriod === 'custom' && customFromIso && customToIso) {
-	        trendsParams.set('from', customFromIso)
-	        trendsParams.set('to', customToIso)
-	      }
+      let days = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : 365
+      const customFromIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomFrom) : ''
+      const customToIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomTo) : ''
+      if (overviewPeriod === 'custom' && customFromIso && customToIso) {
+        const fromMs = new Date(customFromIso).getTime()
+        const toMs = new Date(customToIso).getTime()
+        const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
+        days = Math.max(1, Math.min(365, diffDays))
+        params.set('from', customFromIso)
+        params.set('to', customToIso)
+      }
+      params.set('days', String(days))
 
-	      const turnoverBaseParams = new URLSearchParams(base.toString())
-	      turnoverBaseParams.set('days', String(days))
-	      if (overviewPeriod === 'custom' && customFromIso && customToIso) {
-	        turnoverBaseParams.set('from', customFromIso)
-	        turnoverBaseParams.set('to', customToIso)
-	      }
-
-	      const turnoverSaidaParams = new URLSearchParams(turnoverBaseParams.toString())
-	      turnoverSaidaParams.set('mode', 'saida')
-	      const turnoverEntradaParams = new URLSearchParams(turnoverBaseParams.toString())
-	      turnoverEntradaParams.set('mode', 'entrada')
-
-	      const [alertas, trends, turnoverSaida, turnoverEntrada] = await Promise.all([
-	        apiJson<{ success?: boolean; data?: EstoqueAlerta[] }>(`/alertas/estoque?${base.toString()}`, { signal: ac.signal }),
-	        apiJson<{ success?: boolean; data?: any }>(`/analytics/trends?${trendsParams.toString()}`, { signal: ac.signal }),
-	        apiJson<{ success?: boolean; data?: any }>(`/analytics/category-turnover?${turnoverSaidaParams.toString()}`, { signal: ac.signal }),
-	        apiJson<{ success?: boolean; data?: any }>(`/analytics/category-turnover?${turnoverEntradaParams.toString()}`, { signal: ac.signal })
-	      ])
-	      if (insightsAbortRef.current !== ac) return
-
-	      setInsightsAlertas(Array.isArray(alertas?.data) ? alertas.data : [])
-	      setInsightsTrends(trends?.data || null)
-	      setInsightsTurnover({
-	        saida: turnoverSaida?.data || null,
-	        entrada: turnoverEntrada?.data || null
-	      })
-	    } catch (e) {
-	      if ((e as any)?.name === 'AbortError') return
-	      if (insightsAbortRef.current !== ac) return
-	      markAutoSyncFailure(e)
-	      toast.error(e instanceof Error ? e.message : String(e))
-	      setInsightsAlertas([])
-	      setInsightsTrends(null)
-	      setInsightsTurnover(null)
-	    } finally {
-	      if (insightsAbortRef.current === ac) {
-	        setInsightsLoaded(true)
-	        setInsightsLoading(false)
-	        insightsAbortRef.current = null
-	      }
-	    }
-	  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, overviewCustomFrom, overviewCustomTo, overviewPeriod, unidade])
+      const out = await apiJson<{ success?: boolean; data?: InsightsBundleData }>(`/analytics/insights?${params.toString()}`, { signal: ac.signal })
+      if (insightsAbortRef.current !== ac) return
+      const data = out?.data || null
+      setInsightsAlertas(Array.isArray(data?.alertas) ? data.alertas : [])
+      setInsightsTrends(data?.trends || null)
+      setInsightsTurnover(data?.turnover || null)
+    } catch (e) {
+      if ((e as any)?.name === 'AbortError') return
+      if (insightsAbortRef.current !== ac) return
+      markAutoSyncFailure(e)
+      toast.error(e instanceof Error ? e.message : String(e))
+      setInsightsAlertas([])
+      setInsightsTrends(null)
+      setInsightsTurnover(null)
+    } finally {
+      if (insightsAbortRef.current === ac) {
+        setInsightsLoaded(true)
+        setInsightsLoading(false)
+        insightsAbortRef.current = null
+      }
+    }
+  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, overviewCustomFrom, overviewCustomTo, overviewPeriod, unidade])
 
   const postMutationRefreshTimerRef = React.useRef<number | null>(null)
 	  const schedulePostMutationRefresh = React.useCallback(

--- a/frontend/e2e/insumos-api-concurrency.spec.ts
+++ b/frontend/e2e/insumos-api-concurrency.spec.ts
@@ -6,12 +6,8 @@ test.describe('insumos', () => {
     let trackedMax = 0
 
     const trackedPrefixes = [
-      '/api/insumos/relatorios/',
-      '/api/insumos/notifications/',
-      '/api/insumos/analytics/',
-      '/api/insumos/quality/',
-      '/api/insumos/movimentacoes',
-      '/api/insumos/alertas/',
+      '/api/insumos/analytics/overview',
+      '/api/insumos/analytics/insights',
     ]
 
     const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -30,6 +26,22 @@ test.describe('insumos', () => {
         if (shouldTrack) await delay(200)
 
         const json = (() => {
+          if (path.startsWith('/api/insumos/analytics/overview')) {
+            return {
+              success: true,
+              data: {
+                resumo: {},
+                itens: [],
+                notifications: {},
+                actionables: {},
+                roi: {},
+                quality: {},
+                movResumo: {},
+                movSeries: []
+              }
+            }
+          }
+          if (path.startsWith('/api/insumos/analytics/insights')) return { success: true, data: { alertas: [], trends: {}, turnover: { saida: {}, entrada: {} } } }
           if (path.startsWith('/api/insumos/relatorios/estoque')) return { success: true, data: { resumo: {}, itens: [] } }
           if (path.startsWith('/api/insumos/notifications/summary')) return { success: true, data: {} }
           if (path.startsWith('/api/insumos/analytics/')) return { success: true, data: {} }
@@ -64,4 +76,3 @@ test.describe('insumos', () => {
     expect(trackedMax).toBeLessThanOrEqual(4)
   })
 })
-

--- a/frontend/e2e/insumos-circuit-breaker.spec.ts
+++ b/frontend/e2e/insumos-circuit-breaker.spec.ts
@@ -5,11 +5,8 @@ test.describe('insumos', () => {
     let overviewRequests = 0
 
     const unstablePrefixes = [
-      '/api/insumos/relatorios/',
-      '/api/insumos/notifications/',
-      '/api/insumos/analytics/',
-      '/api/insumos/quality/',
-      '/api/insumos/alertas/',
+      '/api/insumos/analytics/overview',
+      '/api/insumos/analytics/insights',
     ]
 
     await page.route('**/api/insumos/**', async (route) => {
@@ -45,7 +42,7 @@ test.describe('insumos', () => {
         return
       }
 
-      if (path.startsWith('/api/insumos/relatorios/estoque')) {
+      if (path.startsWith('/api/insumos/analytics/overview')) {
         overviewRequests += 1
       }
 


### PR DESCRIPTION
## Summary
- add aggregated Insumos analytics endpoints (`/analytics/overview` and `/analytics/insights`) in the worker
- switch `frontend/InsumosModule.tsx` overview/insights loaders to aggregated endpoints to reduce request fan-out
- add production SLO monitor workflow for authenticated `/api/insumos/*` paths (`.github/workflows/insumos-api-slo.yml`)
- add CI guard script to block reintroduction of demo scaffolding (`backend/scripts/ci-no-demo-guard.sh`) and run it in CI Smoke
- remove residual Sheets-dependent condition from `backend/scripts/insumos-smoke.sh`
- update Insumos runbook and E2E mocks for new aggregated routes

## Validation
- `bash backend/scripts/ci-no-demo-guard.sh`
- `npm -C frontend run build`
- `npm -C frontend run test:e2e -- insumos-api-concurrency.spec.ts insumos-circuit-breaker.spec.ts insumos-no-request-storm.spec.ts insumos-zero-demo-default.spec.ts`
