### PR TITLE
ci: harden after-automerge trigger reliability

### DIFF
--- a/.github/workflows/codex-automerge.yml
+++ b/.github/workflows/codex-automerge.yml
@@ -16,9 +16,20 @@ jobs:
       github.event.pull_request.user.login == 'jubenitogarcia'
     runs-on: ubuntu-latest
     steps:
+      - name: Token mode
+        env:
+          HAS_GH_TOKEN_SECRET: ${{ secrets.GH_TOKEN != '' }}
+        run: |
+          if [[ "${HAS_GH_TOKEN_SECRET}" == "true" ]]; then
+            echo "Using GH_TOKEN secret for auto-merge mutation."
+          else
+            echo "GH_TOKEN secret is missing; falling back to GITHUB_TOKEN (downstream workflow triggers may be suppressed)."
+          fi
+
       - name: Enable auto-merge (squash)
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
           script: |
             const prId = context.payload.pull_request.node_id;
             const mutation = `

--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -1,4 +1,5 @@
 name: Deploy CRM API after automerge
+run-name: CRM API after-automerge PR #${{ github.event.pull_request.number || github.event.inputs.pr_number || 'manual' }}
 
 on:
   pull_request_target:

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -1,4 +1,5 @@
 name: Deploy CRM (Cloudflare Pages) after automerge
+run-name: CRM Pages after-automerge PR #${{ github.event.pull_request.number || github.event.inputs.pr_number || 'manual' }}
 
 on:
   pull_request_target:

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -1,4 +1,5 @@
 name: Deploy Cloudflare Workers (API + Insumos) after automerge
+run-name: Workers after-automerge PR #${{ github.event.pull_request.number || github.event.inputs.pr_number || 'manual' }}
 
 on:
   pull_request_target:

--- a/.github/workflows/dispatch-after-automerge-fallback.yml
+++ b/.github/workflows/dispatch-after-automerge-fallback.yml
@@ -1,0 +1,82 @@
+name: Dispatch after-automerge fallback
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch missing after-automerge deploy workflows
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = Date.now();
+            const windowMs = 90 * 60 * 1000; // 90 minutes
+            const workflows = [
+              { id: "deploy-workers-after-automerge.yml", label: "workers" },
+              { id: "deploy-crm-api-after-automerge.yml", label: "crm-api" },
+              { id: "deploy-crm-pages-after-automerge.yml", label: "crm-pages" },
+            ];
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "closed",
+              base: "main",
+              sort: "updated",
+              direction: "desc",
+              per_page: 100,
+            });
+
+            const recent = pulls.filter((pr) => {
+              if (!pr.merged_at) return false;
+              if (now - Date.parse(pr.merged_at) > windowMs) return false;
+              if (pr.head?.repo?.full_name !== `${owner}/${repo}`) return false;
+              if (!String(pr.head?.ref || "").startsWith("codex/")) return false;
+              return true;
+            });
+
+            if (!recent.length) {
+              core.info("No recent merged codex PRs in fallback window.");
+              return;
+            }
+
+            for (const pr of recent) {
+              const prNumber = String(pr.number);
+              const titleNeedle = `PR #${prNumber}`;
+              core.info(`Evaluating merged PR #${prNumber} (${pr.head?.ref || "?"})`);
+              for (const wf of workflows) {
+                const runsResp = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: wf.id,
+                  per_page: 50,
+                });
+                const hasRun = runsResp.data.workflow_runs.some((run) => {
+                  const title = String(run.display_title || "");
+                  return title.includes(titleNeedle);
+                });
+                if (hasRun) {
+                  core.info(`- ${wf.label}: already has run for ${titleNeedle}`);
+                  continue;
+                }
+                core.warning(`- ${wf.label}: missing run for ${titleNeedle}; dispatching fallback`);
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: wf.id,
+                  ref: "main",
+                  inputs: { pr_number: prNumber },
+                });
+              }
+            }


### PR DESCRIPTION
## Summary
- use `GH_TOKEN` (fallback to `GITHUB_TOKEN`) in `codex-automerge` when enabling auto-merge
- add explicit `run-name` (includes PR number) in all three `deploy-*after-automerge` workflows
- add scheduled/manual fallback dispatcher that scans recent merged `codex/*` PRs and dispatches missing deploy workflows

## Why
Some PRs merged by `app/github-actions` were not triggering `pull_request_target: closed` deploy workflows automatically, forcing manual dispatch.

## Validation
- YAML parse OK for all changed workflows
- fallback dispatcher checks run title (`PR #<n>`) before dispatching to avoid duplicate runs
