### PR TITLE
fix(insumos): zero demo + reduce health storm + remove sheets restore

### DIFF
--- a/backend/apps/insumos/src/routes/backup.js
+++ b/backend/apps/insumos/src/routes/backup.js
@@ -133,26 +133,17 @@ export async function handleBackupRoutes({
 
             const snap = await loadBackupSnapshot({ env, id });
             const p = snap?.payload;
-            const hasSheets = !!(p?.sheets?.insumosValues && p?.sheets?.usersValues && p?.sheets?.movValues);
-	            const hasD1Insumos = !!(
-	                p?.d1 &&
-	                (Array.isArray(p.d1.insumosItems) ||
-	                    Array.isArray(p.d1.crmUsers) ||
-	                    Array.isArray(p.d1.insumosUsers) ||
-	                    Array.isArray(p.d1.insumosStocks) ||
-	                    Array.isArray(p.d1.insumosMovements))
-	            );
+            const hasD1Insumos = !!(
+                p?.d1 &&
+                (Array.isArray(p.d1.insumosItems) ||
+                    Array.isArray(p.d1.crmUsers) ||
+                    Array.isArray(p.d1.insumosUsers) ||
+                    Array.isArray(p.d1.insumosStocks) ||
+                    Array.isArray(p.d1.insumosMovements))
+            );
 
-            if (!hasSheets && !hasD1Insumos) {
+            if (!hasD1Insumos) {
                 return withCORS(JSON.stringify({ success: false, error: 'Payload inválido' }), { status: 400 }, appOrigin);
-            }
-
-            if (hasSheets && !hasD1Insumos) {
-                return withCORS(
-                    JSON.stringify({ success: false, error: 'Backup legado (Sheets) não é suportado. Gere um novo backup a partir do D1.' }),
-                    { status: 400 },
-                    appOrigin
-                );
             }
 
             // Restore D1 (includes Insumos tables + snapshots; does not touch jobs/backups)

--- a/backend/scripts/ci-no-demo-guard.sh
+++ b/backend/scripts/ci-no-demo-guard.sh
@@ -15,7 +15,7 @@ fail_if_found() {
   local pattern="$1"
   local description="$2"
   local output
-  output="$(grep -R --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git -n "${pattern}" "${FRONTEND_DIR}" || true)"
+  output="$(grep -R --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git --exclude-dir=e2e --exclude-dir=test-results --exclude-dir=.playwright-output -n "${pattern}" "${FRONTEND_DIR}" || true)"
   if [[ -n "${output}" ]]; then
     echo "[no-demo-guard] ERROR: ${description}" >&2
     echo "${output}" >&2
@@ -23,21 +23,16 @@ fail_if_found() {
   fi
 }
 
-ensure_present() {
-  local pattern="$1"
-  local file="$2"
-  local description="$3"
-  if ! grep -q "${pattern}" "${file}"; then
-    echo "[no-demo-guard] ERROR: ${description}" >&2
-    failures=$((failures + 1))
-  fi
-}
-
 fail_if_found "Mock WebSocket send" "Mock WebSocket log reintroduced in frontend source."
 fail_if_found "demoNotifications" "Demo notification seed found in frontend source."
+fail_if_found "VITE_DEMO_DATA" "Demo-data env flag must not be referenced in frontend source."
+fail_if_found "DEMO_DATA_ACTIVE" "Demo-data toggle must not exist in frontend source."
 
-ensure_present "enabled = import.meta.env.DEV" "${FRONTEND_DIR}/useWebSocket.ts" "WebSocket must stay disabled by default in production."
-ensure_present "const DEMO_DATA_ACTIVE = (import.meta as any)?.env?.VITE_DEMO_DATA === 'true'" "${FRONTEND_DIR}/App.tsx" "DEMO_DATA_ACTIVE must only activate via explicit env flag."
+# Keep WebSocket disabled by default in production.
+if ! grep -q "enabled = import.meta.env.DEV" "${FRONTEND_DIR}/useWebSocket.ts"; then
+  echo "[no-demo-guard] ERROR: WebSocket must stay disabled by default in production." >&2
+  failures=$((failures + 1))
+fi
 
 if [[ "${failures}" -gt 0 ]]; then
   echo "[no-demo-guard] FAILED with ${failures} issue(s)." >&2

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -22,10 +22,7 @@ Garantir que segredos cr√≠ticos (GitHub, Cloudflare, backend) tenham **escopo m√
 - `SESSION_SECRET`
 - `MIGRATION_TOKEN`
 - `INTEGRATIONS_ENCRYPTION_SECRET`
-- `GOOGLE_PRIVATE_KEY`
-- `GOOGLE_SERVICE_ACCOUNT_EMAIL`
-- `SPREADSHEET_ID`
-- `SHEET_ID`
+NOTE: Sheets credentials were removed (Insumos is D1-only). Do not re-add.
 
 ### CRM API / Infra
 - Chaves SSH do deploy (mesmas de GitHub)

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,7 +20,7 @@ const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
 const INSUMOS_OVERVIEW_FROM_KEY = 'skincos.insumos.overview.from.v1'
 const INSUMOS_OVERVIEW_TO_KEY = 'skincos.insumos.overview.to.v1'
-const DEMO_DATA_ACTIVE = false
+// Demo banners are not allowed. Keep the UI strictly real-data oriented.
 
 function BuildCornerBadge() {
     const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()
@@ -1222,25 +1222,6 @@ export default function AppFunctionalNeatlab() {
                                     <div className="ml-auto">
                                         <Badge className="bg-red-500/20 text-red-100 border-red-400/30 text-xs">
                                             DEVELOPMENT ONLY
-                                        </Badge>
-                                    </div>
-                                </div>
-                            </div>
-                        )}
-                        {DEMO_DATA_ACTIVE && (
-                            <div className="bg-gradient-to-r from-amber-600/80 via-yellow-600/70 to-amber-600/80 border-b border-amber-500/30 px-8 py-3">
-                                <div className="flex items-center gap-3">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-xl">⚠️</span>
-                                        <span className="font-bold text-white text-sm">DADOS SIMULADOS</span>
-                                    </div>
-                                    <div className="w-px h-4 bg-white/30"></div>
-                                    <div className="text-xs text-white/90">
-                                        Alguns módulos exibem dados de demonstração. Configure integrações para dados reais.
-                                    </div>
-                                    <div className="ml-auto">
-                                        <Badge className="bg-amber-500/20 text-amber-100 border-amber-400/30 text-xs">
-                                            DEMO
                                         </Badge>
                                     </div>
                                 </div>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,7 +20,7 @@ const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
 const INSUMOS_OVERVIEW_FROM_KEY = 'skincos.insumos.overview.from.v1'
 const INSUMOS_OVERVIEW_TO_KEY = 'skincos.insumos.overview.to.v1'
-const DEMO_DATA_ACTIVE = (import.meta as any)?.env?.VITE_DEMO_DATA === 'true'
+const DEMO_DATA_ACTIVE = false
 
 function BuildCornerBadge() {
     const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()
@@ -331,10 +331,15 @@ export default function AppFunctionalNeatlab() {
 			    } | null>(null)
 				    const unitOptions = useMemo(() => DEFAULT_UNIT_OPTIONS, [])
 				    const { selectedUnit, setSelectedUnit, effectiveUnit } = useGlobalUnitSelection(unitOptions)
+				    const setSelectedUnitRef = React.useRef(setSelectedUnit)
+				    React.useEffect(() => {
+				        setSelectedUnitRef.current = setSelectedUnit
+				    }, [setSelectedUnit])
 				    const effectiveUnitRef = React.useRef(effectiveUnit)
 				    React.useEffect(() => {
 				        effectiveUnitRef.current = effectiveUnit
 				    }, [effectiveUnit])
+				    const insumosHeaderFetchRef = React.useRef<{ lastAt: number; inflight: boolean }>({ lastAt: 0, inflight: false })
 				    const canonicalUnitValues = useMemo(() => unitOptions.map((o) => o.value), [unitOptions])
 				    const insumosUnitsForHeaderSelect = useMemo(() => {
 				        const fromApi = insumosHeaderStatus?.unidades?.length ? insumosHeaderStatus.unidades : canonicalUnitValues
@@ -414,24 +419,26 @@ export default function AppFunctionalNeatlab() {
 	        try { localStorage.setItem('app.activeModule', active) } catch { /* ignore */ }
 	    }, [active])
 
-			    React.useEffect(() => {
-			        if (active !== 'insumos' || !isAuthenticated) {
-			            setInsumosHeaderStatus(null)
-			            return
-			        }
+				    React.useEffect(() => {
+				        if (active !== 'insumos' || !isAuthenticated) {
+				            setInsumosHeaderStatus(null)
+				            return
+				        }
 
-	        const ac = new AbortController()
+		        const ac = new AbortController()
+		        const now = Date.now()
+		        if (insumosHeaderFetchRef.current.inflight) return () => ac.abort()
+		        if (now - insumosHeaderFetchRef.current.lastAt < 2500) return () => ac.abort()
+		        insumosHeaderFetchRef.current.inflight = true
+		        insumosHeaderFetchRef.current.lastAt = now
 
-	        ;(async () => {
-	            try {
-	                const [healthRes, meRes] = await Promise.all([
-	                    fetch('/api/insumos/health', { credentials: 'include', signal: ac.signal }).catch(() => null),
-	                    fetch('/api/auth/me', { credentials: 'include', signal: ac.signal }).catch(() => null),
-	                ])
+		        ;(async () => {
+		            try {
+		                const healthRes = await fetch('/api/insumos/health', { credentials: 'include', signal: ac.signal }).catch(() => null)
 
-		                let online: boolean | null = null
-		                let integrated: boolean | null = null
-		                let unidades: string[] = []
+			                let online: boolean | null = null
+			                let integrated: boolean | null = null
+			                let unidades: string[] = []
 		                if (healthRes?.ok) {
 		                    const h: any = await healthRes.json().catch(() => null)
 		                    online = Boolean(h?.ok)
@@ -441,17 +448,10 @@ export default function AppFunctionalNeatlab() {
 		                    online = false
 		                }
 
-	                let authed: boolean | null = null
-	                let allowedUnits: string[] = []
-	                if (meRes?.ok) {
-	                    const m: any = await meRes.json().catch(() => null)
-	                    authed = Boolean(m?.user?.username)
-	                    allowedUnits = Array.isArray(m?.user?.allowedUnits)
-	                        ? m.user.allowedUnits.filter(Boolean).map((x: any) => String(x))
-	                        : []
-	                } else if (meRes) {
-	                    authed = false
-	                }
+		                const authed: boolean | null = Boolean(user?.username)
+		                const allowedUnits: string[] = Array.isArray(user?.allowedUnits)
+		                    ? user.allowedUnits.filter(Boolean).map((x: any) => String(x))
+		                    : []
 
 	                const candidateUnits = unidades.length ? unidades : ['novo-hamburgo', 'barra-shopping-sul']
 	                const filteredUnits = allowedUnits.length
@@ -465,17 +465,19 @@ export default function AppFunctionalNeatlab() {
 		                    const saved = localStorage.getItem(INSUMOS_UNIT_KEY)
 		                    if (saved) nextUnit = saved
 		                } catch { /* ignore */ }
-		                if (!options.includes(nextUnit)) nextUnit = options[0]
-		                if (nextUnit && nextUnit !== currentUnit) setSelectedUnit(nextUnit)
+			                if (!options.includes(nextUnit)) nextUnit = options[0]
+			                if (nextUnit && nextUnit !== currentUnit) setSelectedUnitRef.current(nextUnit)
 
-		                setInsumosHeaderStatus({ online, authed, integrated, unidades: options, allowedUnits })
-		            } catch {
-		                setInsumosHeaderStatus({ online: false, authed: false, integrated: null, unidades: [], allowedUnits: [] })
-		            }
-	        })()
+			                setInsumosHeaderStatus({ online, authed, integrated, unidades: options, allowedUnits })
+			            } catch {
+			                setInsumosHeaderStatus({ online: false, authed: false, integrated: null, unidades: [], allowedUnits: [] })
+			            } finally {
+			                insumosHeaderFetchRef.current.inflight = false
+			            }
+		        })()
 
-			        return () => ac.abort()
-					    }, [active, isAuthenticated, setSelectedUnit])
+				        return () => ac.abort()
+						    }, [active, isAuthenticated, user?.allowedUnits?.join('|'), user?.username])
 
 		    React.useEffect(() => {
 		        if (active !== 'insumos') return

--- a/frontend/useReplitAuth.ts
+++ b/frontend/useReplitAuth.ts
@@ -66,8 +66,10 @@ export function useReplitAuth() {
       return mapped;
     },
     retry: false, // Don't retry on 401
-    staleTime: 0,
+    staleTime: 30 * 1000,
     refetchOnMount: 'always',
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     enabled: !noAuth && !!queryClient, // In NO_AUTH mode we bypass /me entirely
   });
 


### PR DESCRIPTION
- Remove legacy Sheets restore check; enforce D1-only restore
- Disable demo-data banner in production by default
- Reduce redundant /api/insumos/health + /api/auth/me churn in App header
- Adjust auth query caching to avoid aggressive refetch

Tests:
- npm -C frontend run test:e2e -- insumos-no-request-storm.spec.ts insumos-zero-demo-default.spec.ts