### PR TITLE
ci: add Insumos UI smoke workflow

### DIFF
--- a/.github/workflows/insumos-ui-smoke.yml
+++ b/.github/workflows/insumos-ui-smoke.yml
@@ -1,0 +1,93 @@
+name: Insumos UI Smoke (prod)
+
+on:
+  schedule:
+    - cron: "27 * * * *"
+  workflow_dispatch:
+    inputs:
+      auto_login:
+        description: "Attempt login if INSUMOS_SMOKE_EMAIL/INSUMOS_SMOKE_PASSWORD are configured."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: insumos-ui-smoke-prod
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_INSUMOS_UI_SMOKE == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-chromium
+
+      - name: Install Playwright Chromium (with deps)
+        run: npx --yes playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Run UI smoke (unauth)
+        id: smoke
+        continue-on-error: true
+        env:
+          CRM_URL: https://crm.skincos.com.br
+          NO_SCREENSHOTS: "1"
+          NODE_PATH: frontend/node_modules
+        run: |
+          set -euo pipefail
+          node frontend/scripts/insumos-ui-smoke.cjs
+
+      - name: Run UI smoke (auto-login, optional)
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.auto_login == true || github.event.inputs.auto_login == 'true') }}
+        continue-on-error: true
+        env:
+          CRM_URL: https://crm.skincos.com.br
+          AUTO_LOGIN: "1"
+          SMOKE_EMAIL: ${{ secrets.INSUMOS_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.INSUMOS_SMOKE_PASSWORD }}
+          NO_SCREENSHOTS: "1"
+          NODE_PATH: frontend/node_modules
+        run: |
+          set -euo pipefail
+          if [[ -z "${SMOKE_EMAIL:-}" || -z "${SMOKE_PASSWORD:-}" ]]; then
+            echo "Missing GitHub Actions secrets: INSUMOS_SMOKE_EMAIL / INSUMOS_SMOKE_PASSWORD"
+            exit 1
+          fi
+          node frontend/scripts/insumos-ui-smoke.cjs
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: insumos-ui-smoke-artifacts
+          path: output/playwright/
+
+      - name: Fail if unauth smoke failed
+        if: ${{ steps.smoke.outcome != 'success' }}
+        run: exit 1
+


### PR DESCRIPTION
Adds a scheduled + manual Playwright smoke for Insumos using `frontend/scripts/insumos-ui-smoke.cjs`.

Notes:
- Runs unauth smoke by default (no secrets required).
- Optional AUTO_LOGIN on workflow_dispatch when INSUMOS_SMOKE_EMAIL/INSUMOS_SMOKE_PASSWORD are configured.
- Gated behind repo variable ENABLE_INSUMOS_UI_SMOKE=true for schedule runs.
