### PR TITLE
fix(insumos): health readiness (ready) + frontend gating

### DIFF
--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -1040,9 +1040,11 @@ export default {
 
         // Public endpoints
         if (url.pathname === "/health") {
+            const ready = d1Enabled;
             return withCORS(
                 JSON.stringify({
-                    ok: true,
+                    ok: ready,
+                    ready,
                     service: "insumos",
                     runtime: "cloudflare-workers",
                     storage: "d1",

--- a/backend/scripts/crm-smoke.sh
+++ b/backend/scripts/crm-smoke.sh
@@ -34,6 +34,23 @@ req200_json() {
   fi
 }
 
+assert_body_has() {
+  local pattern="$1"
+  local description="$2"
+  if ! grep -qE "$pattern" "$TMP_BODY"; then
+    echo "[crm-smoke] FAIL (missing: $description)" >&2
+    echo "[crm-smoke] Body:" >&2
+    cat "$TMP_BODY" >&2 || true
+    exit 1
+  fi
+}
+
+assert_insumos_health_payload() {
+  assert_body_has "\"storage\"\\s*:\\s*\"d1\"" "storage=d1"
+  assert_body_has "\"dbConfigured\"\\s*:\\s*(true|false)" "dbConfigured boolean"
+  assert_body_has "\"ready\"\\s*:\\s*(true|false)" "ready boolean"
+}
+
 echo "[crm-smoke] CRM_URL=$CRM_URL"
 echo "[crm-smoke] API_URL=$API_URL"
 
@@ -42,9 +59,10 @@ req200_json "$CRM_URL/api/health"
 
 # Same-origin proxy sanity
 req200_json "$CRM_URL/api/insumos/health"
+assert_insumos_health_payload
 
 # Worker direct sanity
 req200_json "$API_URL/insumos/health"
+assert_insumos_health_payload
 
 echo "[crm-smoke] OK"
-

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -435,17 +435,21 @@ export default function AppFunctionalNeatlab() {
 		            try {
 		                const healthRes = await fetch('/api/insumos/health', { credentials: 'include', signal: ac.signal }).catch(() => null)
 
-			                let online: boolean | null = null
-			                let integrated: boolean | null = null
-			                let unidades: string[] = []
-		                if (healthRes?.ok) {
-		                    const h: any = await healthRes.json().catch(() => null)
-		                    online = Boolean(h?.ok)
-		                    integrated = typeof h?.dbConfigured === 'boolean' ? Boolean(h.dbConfigured) : null
-		                    unidades = Array.isArray(h?.unidades) ? h.unidades.filter(Boolean).map((x: any) => String(x)) : []
-		                } else if (healthRes) {
-		                    online = false
-		                }
+                let online: boolean | null = null
+                let integrated: boolean | null = null
+                let unidades: string[] = []
+                if (healthRes?.ok) {
+                    const h: any = await healthRes.json().catch(() => null)
+                    const ready =
+                        typeof h?.ready === 'boolean'
+                            ? h.ready
+                            : (typeof h?.dbConfigured === 'boolean' ? h.dbConfigured : Boolean(h?.ok))
+                    online = true
+                    integrated = typeof ready === 'boolean' ? Boolean(ready) : null
+                    unidades = Array.isArray(h?.unidades) ? h.unidades.filter(Boolean).map((x: any) => String(x)) : []
+                } else if (healthRes) {
+                    online = false
+                }
 
 		                const authed: boolean | null = Boolean(user?.username)
 		                const allowedUnits: string[] = Array.isArray(user?.allowedUnits)

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -13,6 +13,7 @@ import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, Pie, PieCh
 
 type InsumosHealth = {
   ok?: boolean
+  ready?: boolean
   service?: string
   runtime?: string
   storage?: string
@@ -1034,7 +1035,11 @@ export function InsumosModule() {
     }
   })
 
-  const canUseApi = !!health?.ok
+  const canUseApi = Boolean(
+    typeof health?.ready === 'boolean'
+      ? health.ready
+      : (typeof health?.dbConfigured === 'boolean' ? health.dbConfigured : health?.ok)
+  )
   const isAuthed = !!user?.username
   const allowedUnits = Array.isArray(user?.allowedUnits) ? user!.allowedUnits!.filter(Boolean) : []
   const autoSyncSuspended = autoSyncSuspendedUntil > Date.now()

--- a/frontend/SystemStatusModule.tsx
+++ b/frontend/SystemStatusModule.tsx
@@ -199,14 +199,23 @@ export function SystemStatusModule() {
       const next: ServiceRow[] = []
 
       if (insHealth.status === 'fulfilled') {
-        const online = insHealth.value.ok && Boolean(insHealth.value.json?.ok)
-        const storage = String(insHealth.value.json?.storage || '').toLowerCase() || '—'
+        const healthJson = (insHealth.value.json || {}) as any
+        const online = Boolean(insHealth.value.ok)
+        const storage = String(healthJson?.storage || '').toLowerCase() || '—'
         const lockedToD1 = storage === 'd1'
+        const ready =
+          typeof healthJson?.ready === 'boolean'
+            ? healthJson.ready
+            : (typeof healthJson?.dbConfigured === 'boolean' ? healthJson.dbConfigured : Boolean(healthJson?.ok))
+        const status = online ? (ready ? (lockedToD1 ? 'ok' : 'warn') : 'warn') : 'error'
+        const subtitle = online
+          ? (ready ? `Online • ${storage.toUpperCase()}` : `Online • ${storage.toUpperCase()} • Indisponível`)
+          : 'Offline'
         next.push({
           key: 'insumos-api',
           title: 'Insumos',
-          status: online ? (lockedToD1 ? 'ok' : 'warn') : 'error',
-          subtitle: online ? `Online • ${storage.toUpperCase()}` : 'Offline'
+          status,
+          subtitle
         })
       } else {
         next.push({ key: 'insumos-api', title: 'Insumos', status: 'error', subtitle: 'Erro ao consultar' })


### PR DESCRIPTION
Adds a readiness signal to Insumos health and uses it to gate UI.

Changes:
- Worker `/insumos/health`: adds `ready` and makes `ok` reflect readiness (D1 binding present).
- Frontend Insumos: treats API usable only when `ready` (or dbConfigured) is true.
- System Status + Insumos header: uses `ready` instead of relying on `ok`.
- CRM smoke: asserts `ready` exists on Insumos health payload.

Validation:
- `bash backend/scripts/crm-smoke.sh` (after deploy; asserts `ready` in payload)
- `node frontend/scripts/insumos-ui-smoke.cjs`
