### PR TITLE
fix(insumos): enforce d1-only storage + lazy load overview

### DIFF
--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -1037,17 +1037,19 @@ export default {
         }
 
         const d1Enabled = !!env?.DB;
+        const storageMode = String(env?.INSUMOS_STORAGE || 'd1').trim().toLowerCase() || 'd1';
+        const storageOk = storageMode === 'd1';
 
         // Public endpoints
         if (url.pathname === "/health") {
-            const ready = d1Enabled;
+            const ready = d1Enabled && storageOk;
             return withCORS(
                 JSON.stringify({
                     ok: ready,
                     ready,
                     service: "insumos",
                     runtime: "cloudflare-workers",
-                    storage: "d1",
+                    storage: storageMode,
                     dbConfigured: d1Enabled,
                     unidades: UNIDADES,
                 }),
@@ -1057,6 +1059,15 @@ export default {
         }
         if (url.pathname === "/api/metrics" || url.pathname === "/metrics") {
             return withCORS(JSON.stringify({ success: true }), { status: 200 }, appOrigin);
+        }
+
+        // D1-only: reject any non-d1 storage mode explicitly.
+        if (!storageOk) {
+            return withCORS(
+                JSON.stringify({ success: false, error: 'STORAGE_NOT_SUPPORTED', code: 'STORAGE_NOT_SUPPORTED' }),
+                { status: 503, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } },
+                appOrigin
+            );
         }
 
         // D1-only: if DB is not configured, fail fast (no legacy Sheets fallback).

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -796,6 +796,8 @@ export function InsumosModule() {
   const insightsAbortRef = React.useRef<AbortController | null>(null)
   const apiFailureTimestampsRef = React.useRef<number[]>([])
   const [autoSyncSuspendedUntil, setAutoSyncSuspendedUntil] = React.useState<number>(0)
+  const [overviewVisible, setOverviewVisible] = React.useState(false)
+  const [overviewEverVisible, setOverviewEverVisible] = React.useState(false)
   const [sharePayload, setSharePayload] = React.useState<SharePayload | null>(null)
   const [shareHidden, setShareHidden] = React.useState(false)
   const [shareSourceId, setShareSourceId] = React.useState<string | null>(null)
@@ -1034,6 +1036,28 @@ export function InsumosModule() {
       return {}
     }
   })
+
+  React.useEffect(() => {
+    const el = overviewSectionRef.current
+    if (!el) return
+    if (typeof IntersectionObserver === 'undefined') {
+      setOverviewVisible(true)
+      setOverviewEverVisible(true)
+      return
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        const isVisible = entry.isIntersecting || entry.intersectionRatio > 0
+        setOverviewVisible(isVisible)
+        if (isVisible) setOverviewEverVisible(true)
+      },
+      { root: null, rootMargin: '120px 0px', threshold: 0.15 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
 
   const canUseApi = Boolean(
     typeof health?.ready === 'boolean'
@@ -3158,13 +3182,21 @@ export function InsumosModule() {
 
   React.useEffect(() => {
     if (!canUseApi || !isAuthed) return
-    void loadOverview()
-  }, [canUseApi, isAuthed, loadOverview])
+    if (!overviewVisible && !overviewEverVisible) return
+    const t = window.setTimeout(() => {
+      void loadOverview()
+    }, 1200)
+    return () => window.clearTimeout(t)
+  }, [canUseApi, isAuthed, loadOverview, overviewEverVisible, overviewVisible])
 
   React.useEffect(() => {
     if (!canUseApi || !isAuthed) return
-    void loadInsights()
-  }, [canUseApi, isAuthed, loadInsights])
+    if (!overviewVisible && !overviewEverVisible) return
+    const t = window.setTimeout(() => {
+      void loadInsights()
+    }, 2200)
+    return () => window.clearTimeout(t)
+  }, [canUseApi, isAuthed, loadInsights, overviewEverVisible, overviewVisible])
 
   React.useEffect(() => {
     const onOp = (event: Event) => {

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -2668,6 +2668,8 @@ export function InsumosModule() {
 
   const loadOverview = React.useCallback(async (opts?: { force?: boolean }) => {
     if (!canUseApi || !isAuthed) return
+    // If the user triggered analytics loads (or they are visible), unlock subsequent auto-refreshes.
+    setOverviewEverVisible(true)
     if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
     try {
       overviewAbortRef.current?.abort()
@@ -2906,6 +2908,8 @@ export function InsumosModule() {
 
   const loadInsights = React.useCallback(async (opts?: { force?: boolean }) => {
     if (!canUseApi || !isAuthed) return
+    // If the user triggered analytics loads (or they are visible), unlock subsequent auto-refreshes.
+    setOverviewEverVisible(true)
     if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
     try {
       insightsAbortRef.current?.abort()
@@ -3185,7 +3189,7 @@ export function InsumosModule() {
     if (!overviewVisible && !overviewEverVisible) return
     const t = window.setTimeout(() => {
       void loadOverview()
-    }, 1200)
+    }, 250)
     return () => window.clearTimeout(t)
   }, [canUseApi, isAuthed, loadOverview, overviewEverVisible, overviewVisible])
 
@@ -3194,7 +3198,7 @@ export function InsumosModule() {
     if (!overviewVisible && !overviewEverVisible) return
     const t = window.setTimeout(() => {
       void loadInsights()
-    }, 2200)
+    }, 450)
     return () => window.clearTimeout(t)
   }, [canUseApi, isAuthed, loadInsights, overviewEverVisible, overviewVisible])
 


### PR DESCRIPTION
## Summary\n- Enforce D1-only storage in Insumos worker (reject non-d1 storage).\n- Lazy-load overview/insights after visibility + small delay to reduce burst on entry.\n\n## Testing\n- node frontend/scripts/insumos-ui-smoke.cjs