### PR TITLE
chore(insumos): staging durable object bindings

### DIFF
--- a/backend/apps/insumos/wrangler.toml
+++ b/backend/apps/insumos/wrangler.toml
@@ -38,6 +38,14 @@ APP_ORIGIN = "https://crm.skincos.com.br"
 name = "skincos-insumos-staging"
 routes = ["api-staging.skincos.com.br/insumos/*"]
 
+[[env.staging.durable_objects.bindings]]
+name = "RATE_LIMITER"
+class_name = "RateLimiter"
+
+[[env.staging.durable_objects.bindings]]
+name = "JOB_QUEUE"
+class_name = "JobQueue"
+
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "skincos-db-staging"


### PR DESCRIPTION
Removes Wrangler warning by defining Durable Object bindings under env.staging for Insumos (RATE_LIMITER, JOB_QUEUE).\n\nValidation:  no longer warns about non-inherited durable_objects.