### PR TITLE
feat(ponto): expose build and extend smoke

### DIFF
--- a/backend/apps/insumos/src/routes/ponto.js
+++ b/backend/apps/insumos/src/routes/ponto.js
@@ -928,10 +928,12 @@ export async function handlePontoRoutes({
       const records = await db.prepare(`SELECT COUNT(*) AS n FROM ponto_records`).first()
       const audit = await db.prepare(`SELECT COUNT(*) AS n FROM ponto_audit`).first()
       const cacheAgeMs = allTemplatesCache?.ts ? Math.max(0, Date.now() - allTemplatesCache.ts) : null
+      const workerBuild = String(env?.PONTO_BUILD_SHA || env?.WORKER_BUILD_SHA || '').trim()
       return json(200, {
         ok: true,
         version: 2,
         storage: 'd1',
+        workerBuild: workerBuild || null,
         cryptoAuditHmac: !!String(env?.PONTO_AUDIT_HMAC_KEY || '').trim(),
         cryptoTemplates: !!String(env?.PONTO_TEMPLATES_KEY || '').trim(),
         templatesCacheTtlMs,

--- a/backend/scripts/cloudflare-workers.sh
+++ b/backend/scripts/cloudflare-workers.sh
@@ -58,12 +58,24 @@ resolve_insumos_db_name() {
   fi
 }
 
+resolve_build_var_flag() {
+  local sha="${WORKER_BUILD_SHA:-${GITHUB_SHA:-}}"
+  if [[ -z "${sha:-}" ]]; then
+    sha="$(git rev-parse HEAD 2>/dev/null || true)"
+  fi
+  if [[ -n "${sha:-}" ]]; then
+    BUILD_VAR_FLAG=(--var "PONTO_BUILD_SHA:${sha}")
+  else
+    BUILD_VAR_FLAG=()
+  fi
+}
+
 deploy_api() {
   echo "[workers] Deploying skincos-api..."
   (
     cd "$BACKEND_DIR"
     # NOTE: pnpm filtered exec runs with the package's CWD, so use package-local config path.
-    run_pnpm -F @skincos/api-worker exec wrangler deploy --config wrangler.toml --keep-vars "${ENV_FLAG[@]}"
+    run_pnpm -F @skincos/api-worker exec wrangler deploy --config wrangler.toml --keep-vars "${ENV_FLAG[@]}" "${BUILD_VAR_FLAG[@]}"
   )
 }
 
@@ -78,7 +90,7 @@ deploy_insumos() {
   echo "[workers] Deploying skincos-insumos..."
   (
     cd "$BACKEND_DIR"
-    run_pnpm -F @skincos/insumos-worker exec wrangler deploy --config wrangler.toml --keep-vars "${ENV_FLAG[@]}"
+    run_pnpm -F @skincos/insumos-worker exec wrangler deploy --config wrangler.toml --keep-vars "${ENV_FLAG[@]}" "${BUILD_VAR_FLAG[@]}"
   )
 }
 
@@ -141,6 +153,7 @@ shift || true
 ENV_NAME="${DEPLOY_ENV:-}"
 ENV_FLAG=()
 INSUMOS_DB_NAME=""
+BUILD_VAR_FLAG=()
 
 ensure_backend_deps
 
@@ -159,6 +172,7 @@ case "$cmd" in
     done
     resolve_env_flag
     resolve_insumos_db_name
+    resolve_build_var_flag
     deploy_by_changes "$before" "$after"
     ;;
   deploy-all)
@@ -171,6 +185,7 @@ case "$cmd" in
     done
     resolve_env_flag
     resolve_insumos_db_name
+    resolve_build_var_flag
     deploy_api
     deploy_insumos
     ;;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -33,6 +33,16 @@ function BuildCornerBadge() {
     )
 }
 
+function BuildHeaderBadge() {
+    const buildShaRaw = String(import.meta.env.VITE_BUILD_SHA || '').trim()
+    const buildSha = buildShaRaw ? buildShaRaw.slice(0, 7) : (import.meta.env.DEV ? 'dev' : 'unknown')
+    return (
+        <Badge variant="outline" className="bg-white/[0.06] text-white border-white/20 text-[10px] px-2 py-1">
+            Build: {buildSha}
+        </Badge>
+    )
+}
+
 type InsumosOverviewPeriod = '7d' | '30d' | '1y' | 'custom'
 
 type ApiError = {
@@ -1007,6 +1017,7 @@ export default function AppFunctionalNeatlab() {
 	                                </div>
 
 		                                <div className="flex items-center gap-4">
+		                                    <BuildHeaderBadge />
 		                                    {active === 'insumos' ? (
 		                                        <div className="flex items-center gap-1">
 		                                            <Button

--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -487,6 +487,47 @@ async function main() {
             }
             punch = punchJson?.data || null
 
+            const recordsRes = await fetch('/api/ponto/me/records?limit=5', { credentials: 'include' })
+            const recordsText = await recordsRes.text()
+            let recordsJson = null
+            try { recordsJson = recordsText ? JSON.parse(recordsText) : null } catch {}
+            if (!recordsRes.ok || !recordsJson?.ok || !Array.isArray(recordsJson?.data)) {
+              throw new Error(`me records failed: HTTP ${recordsRes.status} body=${recordsText.slice(0, 400)}`)
+            }
+            if (!recordsJson.data.some((r) => String(r.id || '') === String(punch?.id || ''))) {
+              throw new Error(`me records missing punch (punchId=${String(punch?.id || '')})`)
+            }
+
+            const csvRes = await fetch('/api/ponto/admin/records.csv?limit=5', { credentials: 'include' })
+            const csvText = await csvRes.text()
+            const csvType = String(csvRes.headers.get('content-type') || '')
+            if (!csvRes.ok || !csvType.includes('text/csv')) {
+              throw new Error(`admin records csv failed: HTTP ${csvRes.status} type=${csvType} body=${csvText.slice(0, 200)}`)
+            }
+            if (!csvText.includes('id,employeeId')) {
+              throw new Error('admin records csv missing header row')
+            }
+            if (punch?.id && !csvText.includes(String(punch.id))) {
+              throw new Error(`admin records csv missing punch (punchId=${String(punch.id)})`)
+            }
+
+            const cooldownRes = await fetch('/api/ponto/me/punch', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({ pin, type: 'AUTO', clientTime: new Date().toISOString() }),
+            })
+            const cooldownText = await cooldownRes.text()
+            let cooldownJson = null
+            try { cooldownJson = cooldownText ? JSON.parse(cooldownText) : null } catch {}
+            if (cooldownRes.status === 409) {
+              if (cooldownJson?.error !== 'COOLDOWN') {
+                throw new Error(`cooldown mismatch: HTTP ${cooldownRes.status} body=${cooldownText.slice(0, 240)}`)
+              }
+            } else if (!cooldownRes.ok) {
+              throw new Error(`cooldown check failed: HTTP ${cooldownRes.status} body=${cooldownText.slice(0, 240)}`)
+            }
+
             // Verify audit chain is still consistent after a punch write.
             const auditRes = await fetch('/api/ponto/admin/audit/verify', { credentials: 'include' })
             const auditText = await auditRes.text()


### PR DESCRIPTION
- add worker build id to /api/ponto/health\n- pass build SHA on worker deploy\n- show build badge in CRM header\n- extend ponto UI smoke for records/cooldown/csv