### PR TITLE
ci: auto-rerun transient workflow failures once

### DIFF
--- a/.github/workflows/ci-auto-rerun-transient.yml
+++ b/.github/workflows/ci-auto-rerun-transient.yml
@@ -1,0 +1,45 @@
+name: CI Auto Rerun (Transient)
+
+on:
+  workflow_run:
+    workflows:
+      - CI Smoke (Assert)
+      - Central E2E Smoke
+      - CodeQL (Monorepo)
+      - Lint, Format & Static Analysis
+      - Security & Secrets Audit
+      - Test Coverage & Quality
+    types: [completed]
+
+concurrency:
+  group: ci-auto-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun_failed_jobs_once:
+    name: Rerun failed jobs (once)
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.run_attempt == 1 &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            core.warning(
+              `Auto-rerun transient failure: ${run.name} (run_id=${run.id}, attempt=${run.run_attempt}, event=${run.event}, branch=${run.head_branch})`
+            );
+            await github.rest.actions.reRunWorkflowFailedJobs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+            });


### PR DESCRIPTION
Adds a workflow_run listener that reruns failed jobs once when a CI workflow fails on attempt 1 (same-repo branches). Helps recover from transient GitHub checkout 500/502 incidents without human intervention.