### PR TITLE
feat(insumos): search entry/exit and multiple barcodes

### DIFF
--- a/backend/apps/insumos/migrations/0013_insumos_barcodes.sql
+++ b/backend/apps/insumos/migrations/0013_insumos_barcodes.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS insumos_barcodes (
+  registro TEXT NOT NULL,
+  codigo_barras TEXT NOT NULL,
+  created_at TEXT,
+  PRIMARY KEY (registro, codigo_barras)
+);
+
+CREATE INDEX IF NOT EXISTS idx_insumos_barcodes_codigo ON insumos_barcodes (codigo_barras);
+
+INSERT OR IGNORE INTO insumos_barcodes (registro, codigo_barras, created_at)
+SELECT registro, codigo_barras, data_cadastro
+FROM insumos_items
+WHERE codigo_barras IS NOT NULL AND TRIM(codigo_barras) != '';

--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -16,6 +16,8 @@ function nowIso() {
 
 // D1/SQLite can reject statements with many bound variables.
 // Keep this deliberately conservative to avoid `too many SQL variables`.
+const MAX_SQL_BINDS = 400;
+
 function normalizeTipo(tipo) {
   return String(tipo || '').toUpperCase().replace('Í', 'I');
 }
@@ -36,6 +38,56 @@ function normalizeTipoUnidade(raw) {
   if (v === 'pacote') return 'pacote';
   if (v === 'rolo') return 'rolo';
   return '';
+}
+
+function normalizeBarcodeList(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input.map((v) => String(v || '').trim()).filter(Boolean);
+  }
+  return String(input)
+    .split(/[\n,;]+/g)
+    .map((v) => String(v || '').trim())
+    .filter(Boolean);
+}
+
+function mergeBarcodeList(primary, extras) {
+  const seen = new Set();
+  const out = [];
+  const add = (value) => {
+    const v = String(value || '').trim();
+    if (!v || seen.has(v)) return;
+    seen.add(v);
+    out.push(v);
+  };
+  add(primary);
+  for (const v of extras || []) add(v);
+  return out;
+}
+
+async function loadBarcodesByRegistro(env, registros) {
+  const map = new Map();
+  if (!env?.DB) return map;
+  const list = (registros || []).map((r) => String(r || '').trim()).filter(Boolean);
+  if (!list.length) return map;
+  for (let i = 0; i < list.length; i += MAX_SQL_BINDS) {
+    const chunk = list.slice(i, i + MAX_SQL_BINDS);
+    const placeholders = chunk.map(() => '?').join(',');
+    const res = await env.DB.prepare(
+      `SELECT registro, codigo_barras
+       FROM insumos_barcodes
+       WHERE registro IN (${placeholders})`
+    ).bind(...chunk).all();
+    for (const row of res?.results || []) {
+      const reg = String(row?.registro || '').trim();
+      const code = String(row?.codigo_barras || '').trim();
+      if (!reg || !code) continue;
+      const current = map.get(reg) || [];
+      current.push(code);
+      map.set(reg, current);
+    }
+  }
+  return map;
 }
 
 function calcularStatusValidade(dataValidade) {
@@ -136,9 +188,10 @@ function enforceLotExpiryPolicyOrError({ policy, lote, dataValidade }) {
 
 async function listRegistrosByCodigo(env, codigo) {
   const rows = await env.DB.prepare(
-    `SELECT registro, lote, data_validade
-     FROM insumos_items
-     WHERE codigo_barras = ?
+    `SELECT i.registro, i.lote, i.data_validade
+     FROM insumos_items i
+     JOIN insumos_barcodes b ON b.registro = i.registro
+     WHERE b.codigo_barras = ?
      ORDER BY (CASE WHEN data_validade IS NULL OR data_validade = '' THEN 1 ELSE 0 END),
               data_validade ASC,
               registro ASC`
@@ -158,9 +211,10 @@ async function listPickCandidates(env, { codigo, unidade }) {
             i.policy_requires_lot, i.policy_requires_expiry, i.policy_fefo,
             COALESCE(s.quantidade, 0) AS quantidade
      FROM insumos_items i
+     JOIN insumos_barcodes b ON b.registro = i.registro
      LEFT JOIN insumos_stocks s
        ON s.registro = i.registro AND s.unidade = ?
-     WHERE i.codigo_barras = ?
+     WHERE b.codigo_barras = ?
      ORDER BY (CASE WHEN i.data_validade IS NULL OR i.data_validade = '' THEN 1 ELSE 0 END),
               i.data_validade ASC,
               i.registro ASC`
@@ -198,14 +252,24 @@ async function pickRegistroOrAmbiguous(env, { codigo, registro, unidade, allowFe
     if (!row?.registro) return { ok: false, code: 'NOT_FOUND', error: 'Registro não encontrado' };
 
     const match = await env.DB.prepare(
-      `SELECT registro, codigo_barras
-       FROM insumos_items
-       WHERE registro = ?`
+      `SELECT 1
+       FROM insumos_barcodes
+       WHERE registro = ? AND codigo_barras = ?
+       LIMIT 1`
     )
-      .bind(normRegistro)
+      .bind(normRegistro, normCodigo)
       .first();
-    if (match?.codigo_barras && String(match.codigo_barras).trim() !== normCodigo) {
-      return { ok: false, code: 'MISMATCH', error: 'Registro não corresponde ao código informado' };
+    if (!match) {
+      const primary = await env.DB.prepare(
+        `SELECT codigo_barras
+         FROM insumos_items
+         WHERE registro = ?`
+      )
+        .bind(normRegistro)
+        .first();
+      if (String(primary?.codigo_barras || '').trim() !== normCodigo) {
+        return { ok: false, code: 'MISMATCH', error: 'Registro não corresponde ao código informado' };
+      }
     }
     return { ok: true, registro: normRegistro };
   }
@@ -348,6 +412,8 @@ export async function d1ListInsumos({ env, unidades, unidade }) {
      ORDER BY produto COLLATE NOCASE ASC, codigo_barras ASC, registro ASC`
   ).all();
   const items = itemsRes?.results || [];
+  const registros = items.map((it) => String(it?.registro || '').trim()).filter(Boolean);
+  const barcodesByRegistro = await loadBarcodesByRegistro(env, registros);
 
   const stocksRes = await env.DB.prepare(
     `SELECT registro, unidade, quantidade
@@ -369,9 +435,11 @@ export async function d1ListInsumos({ env, unidades, unidade }) {
     const estoques = byRegistro.get(registro) || {};
     const estoqueAtual = toInt(estoques?.[unidade], 0);
     const dataValidade = it.data_validade ? String(it.data_validade) : null;
+    const codigosBarras = mergeBarcodeList(String(it.codigo_barras || ''), barcodesByRegistro.get(registro));
     return {
       registro,
       codigoBarras: String(it.codigo_barras || ''),
+      codigosBarras,
       categoria: String(it.categoria || ''),
       marca: String(it.marca || ''),
       produto: String(it.produto || ''),
@@ -410,9 +478,14 @@ export async function d1ListInsumosPaged({ env, unidades, unidade, q, pagina, li
       codigo_barras LIKE ? COLLATE NOCASE OR
       categoria LIKE ? COLLATE NOCASE OR
       marca LIKE ? COLLATE NOCASE OR
-      lote LIKE ? COLLATE NOCASE
+      lote LIKE ? COLLATE NOCASE OR
+      EXISTS (
+        SELECT 1 FROM insumos_barcodes b
+        WHERE b.registro = insumos_items.registro
+          AND b.codigo_barras LIKE ? COLLATE NOCASE
+      )
     )`);
-    binds.push(like, like, like, like, like);
+    binds.push(like, like, like, like, like, like);
   }
   const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
 
@@ -451,6 +524,8 @@ export async function d1ListInsumosPaged({ env, unidades, unidade, q, pagina, li
     .bind(...binds, lim, offset)
     .all();
   const items = itemsRes?.results || [];
+  const registros = items.map((it) => String(it?.registro || '').trim()).filter(Boolean);
+  const barcodesByRegistro = await loadBarcodesByRegistro(env, registros);
 
   const byRegistro = new Map();
   if (items.length) {
@@ -482,9 +557,11 @@ export async function d1ListInsumosPaged({ env, unidades, unidade, q, pagina, li
     const estoques = byRegistro.get(registro) || {};
     const estoqueAtual = toInt(estoques?.[unidade], 0);
     const dataValidade = it.data_validade ? String(it.data_validade) : null;
+    const codigosBarras = mergeBarcodeList(String(it.codigo_barras || ''), barcodesByRegistro.get(registro));
     return {
       registro,
       codigoBarras: String(it.codigo_barras || ''),
+      codigosBarras,
       categoria: String(it.categoria || ''),
       marca: String(it.marca || ''),
       produto: String(it.produto || ''),
@@ -569,11 +646,21 @@ export async function d1GetInsumoByRegistro(env, registro) {
      FROM insumos_items
      WHERE registro = ?`
   ).bind(String(registro || '').trim()).first();
-  return row || null;
+  if (!row) return null;
+  const barcodes = await env.DB.prepare(
+    `SELECT codigo_barras FROM insumos_barcodes WHERE registro = ?`
+  ).bind(String(registro || '').trim()).all();
+  const codigosBarras = mergeBarcodeList(
+    String(row?.codigo_barras || ''),
+    (barcodes?.results || []).map((r) => r?.codigo_barras)
+  );
+  return { ...row, codigosBarras };
 }
 
 export async function d1CreateInsumo({ env, unidades, unidade, body }) {
-  const codigoBarras = String(body?.codigoBarras || '').trim();
+  const primaryCodigo = String(body?.codigoBarras || '').trim();
+  const codigosBarras = mergeBarcodeList(primaryCodigo, normalizeBarcodeList(body?.codigosBarras));
+  const codigoBarras = codigosBarras[0] || '';
   const produto = String(body?.produto || '').trim();
   if (!codigoBarras) return { ok: false, status: 400, error: 'Código de barras é obrigatório' };
   if (!produto) return { ok: false, status: 400, error: 'Produto é obrigatório' };
@@ -584,13 +671,23 @@ export async function d1CreateInsumo({ env, unidades, unidade, body }) {
   if (allowDuplicateLot && !lote) return { ok: false, status: 400, error: 'Lote é obrigatório para cadastrar novo lote' };
 
   if (!allowDuplicateLot) {
-    const exists = await env.DB.prepare('SELECT 1 FROM insumos_items WHERE codigo_barras = ? LIMIT 1').bind(codigoBarras).first();
-    if (exists) return { ok: false, status: 409, error: 'Código de barras já cadastrado' };
+    for (const code of codigosBarras) {
+      const exists = await env.DB.prepare(
+        'SELECT 1 FROM insumos_barcodes WHERE codigo_barras = ? LIMIT 1'
+      ).bind(code).first();
+      if (exists) return { ok: false, status: 409, error: 'Código de barras já cadastrado' };
+    }
   } else {
-    const existsSame = await env.DB.prepare(
-      'SELECT 1 FROM insumos_items WHERE codigo_barras = ? AND lote = ? LIMIT 1'
-    ).bind(codigoBarras, lote).first();
-    if (existsSame) return { ok: false, status: 409, error: 'Lote já cadastrado para este código de barras' };
+    for (const code of codigosBarras) {
+      const existsSame = await env.DB.prepare(
+        `SELECT 1
+         FROM insumos_barcodes b
+         JOIN insumos_items i ON i.registro = b.registro
+         WHERE b.codigo_barras = ? AND i.lote = ?
+         LIMIT 1`
+      ).bind(code, lote).first();
+      if (existsSame) return { ok: false, status: 409, error: 'Lote já cadastrado para este código de barras' };
+    }
   }
 
   const registro = await nextRegistro(env);
@@ -639,6 +736,15 @@ export async function d1CreateInsumo({ env, unidades, unidade, body }) {
     )
   );
 
+  for (const code of codigosBarras) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT OR IGNORE INTO insumos_barcodes (registro, codigo_barras, created_at)
+         VALUES (?, ?, ?)`
+      ).bind(registro, code, ts)
+    );
+  }
+
   // Stock only for selected unidade (others implied 0)
   statements.push(
     env.DB.prepare(
@@ -656,7 +762,7 @@ export async function d1UpdateInsumo({ env, registro, body }) {
   if (!reg) return { ok: false, status: 400, error: 'Registro inválido' };
 
   const existing = await env.DB.prepare(
-    'SELECT registro, categoria, lote, data_validade, policy_requires_lot, policy_requires_expiry, policy_fefo FROM insumos_items WHERE registro = ?'
+    'SELECT registro, codigo_barras, categoria, lote, data_validade, policy_requires_lot, policy_requires_expiry, policy_fefo FROM insumos_items WHERE registro = ?'
   )
     .bind(reg)
     .first();
@@ -682,7 +788,14 @@ export async function d1UpdateInsumo({ env, registro, body }) {
     vals.push(v);
   };
 
-  if (body?.codigoBarras !== undefined) set('codigo_barras', String(body.codigoBarras || '').trim());
+  const nextPrimary = body?.codigoBarras !== undefined
+    ? String(body.codigoBarras || '').trim()
+    : String(existing?.codigo_barras || '').trim();
+  const nextCodigosBarras = body?.codigosBarras !== undefined
+    ? mergeBarcodeList(nextPrimary, normalizeBarcodeList(body.codigosBarras))
+    : mergeBarcodeList(nextPrimary, []);
+
+  if (body?.codigoBarras !== undefined) set('codigo_barras', nextPrimary);
   if (body?.produto !== undefined) set('produto', String(body.produto || '').trim());
   if (body?.categoria !== undefined) set('categoria', String(body.categoria || '').trim());
   if (body?.marca !== undefined) set('marca', String(body.marca || '').trim());
@@ -705,6 +818,23 @@ export async function d1UpdateInsumo({ env, registro, body }) {
   const sql = `UPDATE insumos_items SET ${fields.join(', ')} WHERE registro = ?`;
   vals.push(reg);
   await env.DB.prepare(sql).bind(...vals).run();
+
+  if (body?.codigosBarras !== undefined) {
+    await env.DB.prepare('DELETE FROM insumos_barcodes WHERE registro = ?').bind(reg).run();
+    const ts = nowIso();
+    const inserts = nextCodigosBarras.map((code) =>
+      env.DB.prepare(
+        `INSERT OR IGNORE INTO insumos_barcodes (registro, codigo_barras, created_at)
+         VALUES (?, ?, ?)`
+      ).bind(reg, code, ts)
+    );
+    if (inserts.length) await env.DB.batch(inserts);
+  } else if (body?.codigoBarras !== undefined && nextPrimary) {
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO insumos_barcodes (registro, codigo_barras, created_at)
+       VALUES (?, ?, ?)`
+    ).bind(reg, nextPrimary, nowIso()).run();
+  }
   return { ok: true };
 }
 
@@ -714,6 +844,7 @@ export async function d1DeleteInsumo({ env, registro }) {
   const exists = await env.DB.prepare('SELECT 1 FROM insumos_items WHERE registro = ?').bind(reg).first();
   if (!exists) return { ok: false, status: 404, error: 'Registro não encontrado' };
   await env.DB.prepare('DELETE FROM insumos_items WHERE registro = ?').bind(reg).run();
+  await env.DB.prepare('DELETE FROM insumos_barcodes WHERE registro = ?').bind(reg).run();
   return { ok: true };
 }
 

--- a/backend/apps/insumos/src/routes/insumos.js
+++ b/backend/apps/insumos/src/routes/insumos.js
@@ -321,7 +321,12 @@ export async function handleInsumosRoutes({
             if (parts.length === 2 && maybeCodigo && !isReserved) {
                 try {
                     const items = await d1.listInsumos({ unidade });
-                    const byCodigo = items.filter((i) => String(i?.codigoBarras || '').trim() === maybeCodigo);
+                    const byCodigo = items.filter((i) => {
+                        const primary = String(i?.codigoBarras || '').trim();
+                        if (primary && primary === maybeCodigo) return true;
+                        const list = Array.isArray(i?.codigosBarras) ? i.codigosBarras : [];
+                        return list.some((code) => String(code || '').trim() === maybeCodigo);
+                    });
                     if (byCodigo.length === 1) {
                         return withCORS(JSON.stringify({ success: true, data: byCodigo[0] }), { status: 200 }, appOrigin);
                     }

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -4,6 +4,7 @@ import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-p
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { BrDatePickerInput } from '@/br-date-picker'
+import { AutocompleteInput } from '@/autocomplete-input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
 import { Checkbox } from '@/checkbox'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
@@ -2553,13 +2554,24 @@ export function InsumosModule() {
     setPolicyFormSuggestion('__NONE__')
   }, [])
 
-  const saveCategoryPolicy = React.useCallback(async () => {
-    if (!isManagerRole || !isAuthed) return
-    const label = String(policyFormLabel || '').trim()
-    const slugInput = String(policyFormSlug || '').trim()
-    const slug = slugifyCategoria(slugInput || label)
-    if (!slug) {
-      toast.error('Informe a categoria (nome)')
+	  const saveCategoryPolicy = React.useCallback(async () => {
+	    if (!isAuthed) {
+	      toast.error('Faça login para salvar a política.')
+	      return
+	    }
+	    if (!isManagerRole) {
+	      toast.error('Somente gestores podem alterar políticas.')
+	      return
+	    }
+	    if (!canUseApi) {
+	      toast.error('API indisponível ou não pronta. Aguarde carregar e tente novamente.')
+	      return
+	    }
+	    const label = String(policyFormLabel || '').trim()
+	    const slugInput = String(policyFormSlug || '').trim()
+	    const slug = slugifyCategoria(slugInput || label)
+	    if (!slug) {
+	      toast.error('Informe a categoria (nome)')
       return
     }
     const requiresLot = !!policyFormRequiresLot
@@ -2599,12 +2611,13 @@ export function InsumosModule() {
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e))
     }
-  }, [
-    isAuthed,
-    isManagerRole,
-    loadAdminCategoryPolicies,
-    loadCategoryPolicies,
-    mutateJson,
+	  }, [
+	    canUseApi,
+	    isAuthed,
+	    isManagerRole,
+	    loadAdminCategoryPolicies,
+	    loadCategoryPolicies,
+	    mutateJson,
     policyFormEditingSlug,
     policyFormFefo,
     policyFormLabel,
@@ -2614,11 +2627,22 @@ export function InsumosModule() {
     resetPolicyForm
   ])
 
-  const deleteCategoryPolicy = React.useCallback(
-    async (slugRaw: string) => {
-      if (!isManagerRole || !isAuthed) return
-      const slug = String(slugRaw || '').trim()
-      if (!slug) return
+	  const deleteCategoryPolicy = React.useCallback(
+	    async (slugRaw: string) => {
+	      if (!isAuthed) {
+	        toast.error('Faça login para excluir a política.')
+	        return
+	      }
+	      if (!isManagerRole) {
+	        toast.error('Somente gestores podem excluir políticas.')
+	        return
+	      }
+	      if (!canUseApi) {
+	        toast.error('API indisponível ou não pronta. Aguarde carregar e tente novamente.')
+	        return
+	      }
+	      const slug = String(slugRaw || '').trim()
+	      if (!slug) return
       const ok = window.confirm(`Remover política da categoria "${slug}"?`)
       if (!ok) return
 
@@ -2641,11 +2665,12 @@ export function InsumosModule() {
         toast.error(e instanceof Error ? e.message : String(e))
       }
     },
-    [
-      isAuthed,
-      isManagerRole,
-      loadAdminCategoryPolicies,
-      loadCategoryPolicies,
+	    [
+	      canUseApi,
+	      isAuthed,
+	      isManagerRole,
+	      loadAdminCategoryPolicies,
+	      loadCategoryPolicies,
       mutateJson,
       policyFormEditingSlug,
       resetPolicyForm
@@ -6996,31 +7021,26 @@ export function InsumosModule() {
                 <div className="mt-1 text-xs text-red-300">{editValidationErrors.produto}</div>
               ) : null}
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Categoria</div>
-              <Input
-                value={editCategoria}
-                onChange={(e) => {
-                  setEditCategoria(e.target.value)
-                  clearEditValidationError('categoria')
-                }}
-                placeholder="ex: toxina"
-                list="insumos-categorias-edit"
-                aria-invalid={editValidationErrors.categoria ? true : undefined}
-                className={
-                  editValidationErrors.categoria
-                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
-                    : undefined
-                }
-              />
-              <datalist id="insumos-categorias-edit">
-                {lotCategorias.map((c) => (
-                  <option key={c} value={c} />
-                ))}
-              </datalist>
-              {editValidationErrors.categoria ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.categoria}</div>
-              ) : null}
+	            <div>
+	              <div className="text-xs text-muted-foreground mb-1">Categoria</div>
+	              <AutocompleteInput
+	                value={editCategoria}
+	                onValueChange={(next) => {
+	                  setEditCategoria(next)
+	                  clearEditValidationError('categoria')
+	                }}
+	                placeholder="ex: toxina"
+	                options={lotCategorias}
+	                ariaInvalid={editValidationErrors.categoria ? true : undefined}
+	                inputClassName={
+	                  editValidationErrors.categoria
+	                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
+	                    : undefined
+	                }
+	              />
+	              {editValidationErrors.categoria ? (
+	                <div className="mt-1 text-xs text-red-300">{editValidationErrors.categoria}</div>
+	              ) : null}
             </div>
             <div
               className={`md:col-span-2 rounded-xl border p-3 ${
@@ -7077,32 +7097,25 @@ export function InsumosModule() {
                 <div className="mt-2 text-xs text-red-300">{editValidationErrors.policy}</div>
               ) : null}
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Marca</div>
-              <Input
-                value={editMarca}
-                onChange={(e) => {
-                  setEditMarca(e.target.value)
-                  clearEditValidationError('marca')
-                }}
-                placeholder="ex: Allergan"
-                list="insumos-marcas-edit"
-                aria-invalid={editValidationErrors.marca ? true : undefined}
-                className={
-                  editValidationErrors.marca
-                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
-                    : undefined
-                }
-              />
-              <datalist id="insumos-marcas-edit">
-                {insumosMarcas.map((m) => (
-                  <option key={m} value={m} />
-                ))}
-              </datalist>
-              {editValidationErrors.marca ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.marca}</div>
-              ) : null}
-            </div>
+	            <div>
+	              <div className="text-xs text-muted-foreground mb-1">Marca</div>
+	              <AutocompleteInput
+	                value={editMarca}
+	                onValueChange={(next) => {
+	                  setEditMarca(next)
+	                  clearEditValidationError('marca')
+	                }}
+	                placeholder="ex: Allergan"
+	                options={insumosMarcas}
+	                ariaInvalid={editValidationErrors.marca ? true : undefined}
+	                inputClassName={
+	                  editValidationErrors.marca ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined
+	                }
+	              />
+	              {editValidationErrors.marca ? (
+	                <div className="mt-1 text-xs text-red-300">{editValidationErrors.marca}</div>
+	              ) : null}
+	            </div>
             <div>
               <div className="text-xs text-muted-foreground mb-1">Unidade (medida)</div>
               <Select

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from '@/checkbox'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import { Input } from '@/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
+import { Textarea } from '@/textarea'
 import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 
 type InsumosHealth = {
@@ -35,6 +36,7 @@ type InsumosUser = {
 type Insumo = {
   registro?: string
   codigoBarras?: string
+  codigosBarras?: string[]
   categoria?: string
   marca?: string
   produto?: string
@@ -242,6 +244,26 @@ function normalizeTipoUnidadeToCanonical(raw: string): string {
   if (!normalized) return ''
   if (normalized === 'flaconete') return 'frasco'
   return CANONICAL_TIPOS_UNIDADE_SET.has(normalized) ? normalized : ''
+}
+
+function parseBarcodeInput(value: string): string[] {
+  return String(value || '')
+    .split(/[\n,;]+/g)
+    .map((v) => String(v || '').trim())
+    .filter(Boolean);
+}
+
+function getInsumoBarcodes(item: Insumo | null | undefined): string[] {
+  const codes = new Set<string>();
+  const add = (v?: string) => {
+    const value = String(v || '').trim();
+    if (value) codes.add(value);
+  };
+  add(item?.codigoBarras);
+  if (Array.isArray(item?.codigosBarras)) {
+    for (const v of item?.codigosBarras || []) add(String(v || ''));
+  }
+  return Array.from(codes);
 }
 
 function fmtMoneyBRL(value: number) {
@@ -932,6 +954,7 @@ export function InsumosModule() {
 
   const [quickOp, setQuickOp] = React.useState<'ENTRADA' | 'BAIXA' | 'TRANSFERENCIA' | null>(null)
   const [quickCodigo, setQuickCodigo] = React.useState('')
+  const [quickSearch, setQuickSearch] = React.useState('')
   const [quickRegistro, setQuickRegistro] = React.useState('')
   const [quickRegistros, setQuickRegistros] = React.useState<string[]>([])
   const [quickCandidates, setQuickCandidates] = React.useState<Array<{ registro: string; lote: string; dataValidade: string | null; estoque: number }>>([])
@@ -1027,6 +1050,7 @@ export function InsumosModule() {
   const [createOpen, setCreateOpen] = React.useState(false)
   const [createScanOpen, setCreateScanOpen] = React.useState(false)
   const [createCodigo, setCreateCodigo] = React.useState('')
+  const [createCodigosExtras, setCreateCodigosExtras] = React.useState('')
   const [createProduto, setCreateProduto] = React.useState('')
   const [createCategoria, setCreateCategoria] = React.useState('')
   const [createPolicyTouched, setCreatePolicyTouched] = React.useState(false)
@@ -1055,6 +1079,7 @@ export function InsumosModule() {
   const [editOpen, setEditOpen] = React.useState(false)
   const [editTarget, setEditTarget] = React.useState<Insumo | null>(null)
   const [editCodigo, setEditCodigo] = React.useState('')
+  const [editCodigosExtras, setEditCodigosExtras] = React.useState('')
   const [editProduto, setEditProduto] = React.useState('')
   const [editCategoria, setEditCategoria] = React.useState('')
   const [editCategoriaRequiresLot, setEditCategoriaRequiresLot] = React.useState(false)
@@ -1755,7 +1780,7 @@ export function InsumosModule() {
 
     const source = fromLookup ? quickLookupItems : (insumos || [])
     const items = source
-      .filter((i) => String(i.codigoBarras || '').trim() === codigo && String(i.registro || '').trim())
+      .filter((i) => getInsumoBarcodes(i).includes(codigo) && String(i.registro || '').trim())
       .map((i) => {
         const registro = String(i.registro || '').trim()
         const lote = String(i.lote || '').trim()
@@ -1784,6 +1809,48 @@ export function InsumosModule() {
     return list.sort(sortByValidade)
   }, [insumos, quickCodigo, quickOp, quickLookupCode, quickLookupCtxUnidade, quickLookupItems, transferFrom, unidade])
 
+  const quickSearchMatches = React.useMemo(() => {
+    const query = quickSearch.trim().toLowerCase()
+    if (!query) return []
+    const source = Array.isArray(insumos) ? insumos : []
+    const matches: Array<{ item: Insumo; matchedCode: string }> = []
+    for (const item of source) {
+      const codes = getInsumoBarcodes(item)
+      const produto = String(item?.produto || '').toLowerCase()
+      const categoria = String(item?.categoria || '').toLowerCase()
+      const marca = String(item?.marca || '').toLowerCase()
+      const hay = [produto, categoria, marca, ...codes].filter(Boolean).join(' ')
+      if (!hay.includes(query)) continue
+      const matchedCode = codes.find((c) => String(c || '').toLowerCase().includes(query)) || codes[0] || ''
+      matches.push({ item, matchedCode })
+      if (matches.length >= 8) break
+    }
+    return matches
+  }, [insumos, quickSearch])
+
+  const applyQuickSelection = React.useCallback((item: Insumo, preferredCode?: string) => {
+    const codes = getInsumoBarcodes(item)
+    const code = preferredCode && codes.includes(preferredCode) ? preferredCode : codes[0] || ''
+    if (!code) return
+    setQuickCodigo(code)
+    setQuickSearch(code)
+  }, [])
+
+  React.useEffect(() => {
+    const query = quickSearch.trim()
+    if (!query) {
+      if (quickCodigo) setQuickCodigo('')
+      return
+    }
+    if (query === quickCodigo) return
+    const looksLikeCode = /^[0-9]{4,}$/.test(query)
+    if (looksLikeCode) {
+      if (query !== quickCodigo) setQuickCodigo(query)
+      return
+    }
+    if (quickCodigo) setQuickCodigo('')
+  }, [quickSearch, quickCodigo])
+
   const quickLoteNeedsPick = (quickCandidates.length > 1) || (quickRegistros.length > 1) || (quickLotes.length > 1)
   const quickLotesForPicker = React.useMemo(() => {
     if (quickCandidates.length) return quickCandidates
@@ -1797,6 +1864,7 @@ export function InsumosModule() {
   }, [quickCandidates, quickLotes, quickRegistros.join('|')])
 
   const resetQuickOperationState = React.useCallback((opts?: { keepFeedback?: boolean }) => {
+    setQuickSearch('')
     setQuickCodigo('')
     setQuickRegistro('')
     setQuickRegistros([])
@@ -1828,7 +1896,11 @@ export function InsumosModule() {
       }
     ) => {
       resetQuickOperationState()
-      if (prefill?.codigoBarras) setQuickCodigo(String(prefill.codigoBarras).trim())
+      if (prefill?.codigoBarras) {
+        const code = String(prefill.codigoBarras).trim()
+        setQuickCodigo(code)
+        setQuickSearch(code)
+      }
       if (prefill?.quantidade != null) setQuickQuantidade(String(prefill.quantidade))
       if (prefill?.obs) setQuickObs(String(prefill.obs))
       if (prefill?.fromUnidade) setTransferFrom(String(prefill.fromUnidade))
@@ -1864,7 +1936,7 @@ export function InsumosModule() {
       })
       const out = await apiJson<{ success?: boolean; data?: Insumo[]; resumo?: any }>(`/insumos?${params.toString()}`)
       const list = Array.isArray(out?.data) ? out.data : []
-      const exact = list.filter((i) => String(i.codigoBarras || '').trim() === codigo)
+      const exact = list.filter((i) => getInsumoBarcodes(i).includes(codigo))
       return exact.length ? exact : list
     },
     [apiJson]
@@ -2799,7 +2871,10 @@ export function InsumosModule() {
     setEditTarget(i)
     setEditValidationErrors({})
     setEditSaveError(null)
-    setEditCodigo(String(i.codigoBarras || ''))
+    const primary = String(i.codigoBarras || '')
+    setEditCodigo(primary)
+    const extras = getInsumoBarcodes(i).filter((code) => code !== primary)
+    setEditCodigosExtras(extras.join('\n'))
     setEditProduto(String(i.produto || ''))
     setEditCategoria(String(i.categoria || ''))
     setEditMarca(String(i.marca || ''))
@@ -3258,6 +3333,8 @@ export function InsumosModule() {
       return
     }
     const codigoBarras = editCodigo.trim()
+    const extraCodes = parseBarcodeInput(editCodigosExtras)
+    const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
     const produto = editProduto.trim()
     if (!codigoBarras) {
       setEditValidationErrors({ codigoBarras: 'Obrigatorio.' })
@@ -3321,6 +3398,7 @@ export function InsumosModule() {
         queueLabel: 'Edição de insumo',
         body: {
           codigoBarras,
+          codigosBarras,
           produto,
           categoria,
           marca: editMarca.trim(),
@@ -3859,28 +3937,30 @@ export function InsumosModule() {
     if (!Array.isArray(items) || !items.length) return
     let changed = false
     for (const it of items) {
-      const codigo = String(it?.codigoBarras || '').trim()
-      if (!codigo) continue
-      const registro = String(it?.registro || '').trim() || `__no_registro__:${codigo}`
-      let byRegistro = insumosCacheRef.current.get(codigo)
-      if (!byRegistro) {
-        byRegistro = new Map<string, Insumo>()
-        insumosCacheRef.current.set(codigo, byRegistro)
-      }
-      const prev = byRegistro.get(registro)
-      if (!prev) {
-        byRegistro.set(registro, it)
+      const codes = getInsumoBarcodes(it)
+      if (!codes.length) continue
+      const registro = String(it?.registro || '').trim() || `__no_registro__:${codes[0]}`
+      for (const codigo of codes) {
+        let byRegistro = insumosCacheRef.current.get(codigo)
+        if (!byRegistro) {
+          byRegistro = new Map<string, Insumo>()
+          insumosCacheRef.current.set(codigo, byRegistro)
+        }
+        const prev = byRegistro.get(registro)
+        if (!prev) {
+          byRegistro.set(registro, it)
+          changed = true
+          continue
+        }
+        const merged: Insumo = {
+          ...prev,
+          ...it,
+          estoques: { ...(prev.estoques || {}), ...(it.estoques || {}) },
+          statusValidade: it.statusValidade || prev.statusValidade
+        }
+        byRegistro.set(registro, merged)
         changed = true
-        continue
       }
-      const merged: Insumo = {
-        ...prev,
-        ...it,
-        estoques: { ...(prev.estoques || {}), ...(it.estoques || {}) },
-        statusValidade: it.statusValidade || prev.statusValidade
-      }
-      byRegistro.set(registro, merged)
-      changed = true
     }
     if (changed) setInsumosCacheVersion((v) => v + 1)
   }, [])
@@ -5006,6 +5086,19 @@ export function InsumosModule() {
                         </div>
                       ) : null}
                     </div>
+                    <div className="mt-2">
+                      <div className="text-xs text-blue-200/70 mb-1">Códigos adicionais</div>
+                      <Textarea
+                        value={createCodigosExtras}
+                        onChange={(e) => setCreateCodigosExtras(e.target.value)}
+                        placeholder="um por linha"
+                        rows={3}
+                        className="bg-white/[0.06] border-white/20 text-white"
+                      />
+                      <div className="mt-1 text-[10px] text-blue-200/50">
+                        Opcional. Use para variações de código do mesmo produto.
+                      </div>
+                    </div>
                   </div>
                   <div className="md:col-span-2">
                     <div className="text-xs text-blue-200/70 mb-1">Produto</div>
@@ -5159,7 +5252,9 @@ export function InsumosModule() {
                     onClick={async () => {
                       const codigoBarras = createCodigo.trim()
                       if (!codigoBarras) return toast.error('Informe o código de barras')
-                      const existing = (insumos || []).find((i) => String(i.codigoBarras || '').trim() === codigoBarras)
+                      const extraCodes = parseBarcodeInput(createCodigosExtras)
+                      const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
+                      const existing = (insumos || []).find((i) => getInsumoBarcodes(i).includes(codigoBarras))
                       const categoria = createCategoria.trim() || String(existing?.categoria || '').trim()
                       const policy = {
                         requiresLot: !!createCategoriaRequiresLot,
@@ -5193,6 +5288,7 @@ export function InsumosModule() {
                           queueLabel: 'Cadastro de insumo',
                           body: {
                             codigoBarras,
+                            codigosBarras,
                             produto,
                             allowDuplicateLot,
                             categoria,
@@ -5214,6 +5310,7 @@ export function InsumosModule() {
                           }
                         })
                         toast.success('Insumo cadastrado.')
+                        setCreateCodigosExtras('')
                         setCreateOpen(false)
                         await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
                       } catch (e) {
@@ -5461,14 +5558,49 @@ export function InsumosModule() {
 
           <div className="space-y-3">
             <div>
-              <div className="text-xs text-blue-200/70 mb-1">Código de barras</div>
+              <div className="text-xs text-blue-200/70 mb-1">Buscar por produto, marca, categoria ou código</div>
               <div className="flex items-center gap-2">
-                <Input value={quickCodigo} onChange={(e) => setQuickCodigo(e.target.value)} placeholder="ex: 789..." />
+                <Input value={quickSearch} onChange={(e) => setQuickSearch(e.target.value)} placeholder="ex: Rennova, preenchedor, 789..." />
                 <Button variant="secondary" type="button" onClick={() => setQuickScanOpen((v) => !v)}>
                   {quickScanOpen ? 'Fechar' : 'Escanear'}
                 </Button>
               </div>
               <div className="mt-2">
+                {quickSearchMatches.length ? (
+                  <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+                    <div className="text-[11px] text-blue-200/60 mb-2">Selecione o produto para lançar a operação:</div>
+                    <div className="space-y-2">
+                      {quickSearchMatches.map(({ item, matchedCode }) => {
+                        const code = matchedCode || item.codigoBarras || ''
+                        return (
+                          <button
+                            key={`${item.registro || ''}-${code}`}
+                            type="button"
+                            onClick={() => applyQuickSelection(item, code)}
+                            className="w-full rounded-md border border-white/5 bg-white/5 px-2 py-2 text-left hover:bg-white/10"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="text-sm text-blue-50 font-semibold">{String(item.produto || 'Insumo')}</div>
+                              <div className="text-xs text-blue-200/60 font-mono">{code}</div>
+                            </div>
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
+                              {item.categoria ? (
+                                <Badge style={buildTagStyle(getCategoriaBgColor(String(item.categoria)))} className="border">
+                                  {String(item.categoria)}
+                                </Badge>
+                              ) : null}
+                              {item.marca ? (
+                                <Badge style={buildTagStyle(getMarcaBgColor(String(item.marca)))} className="border">
+                                  {String(item.marca)}
+                                </Badge>
+                              ) : null}
+                            </div>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ) : null}
                 {quickLookupLoading ? (
                   <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
                 ) : quickLookupError ? (
@@ -5608,6 +5740,7 @@ export function InsumosModule() {
               <BarcodeScannerInline
                 onDetected={(code) => {
                   setQuickCodigo(code)
+                  setQuickSearch(code)
                   setQuickScanOpen(false)
                   toast.success('Código detectado')
                 }}
@@ -6332,7 +6465,10 @@ export function InsumosModule() {
                             key={`${a.key}-${idx}`}
                             className={`hover:bg-white/5 ${a.codigoBarras ? 'cursor-pointer' : ''}`}
                             onClick={() => {
-                              if (code) setQuickCodigo(code)
+                              if (code) {
+                                setQuickCodigo(code)
+                                setQuickSearch(code)
+                              }
                             }}
                             title={a.codigoBarras ? 'Clique para usar este código de barras' : undefined}
                           >
@@ -7002,6 +7138,19 @@ export function InsumosModule() {
               ) : null}
             </div>
             <div className="md:col-span-2">
+              <div className="text-xs text-muted-foreground mb-1">Códigos adicionais</div>
+              <Textarea
+                value={editCodigosExtras}
+                onChange={(e) => setEditCodigosExtras(e.target.value)}
+                placeholder="um por linha"
+                rows={3}
+                className="bg-white/[0.06] border-white/20 text-white"
+              />
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                Opcional. Use para variações de código do mesmo produto.
+              </div>
+            </div>
+            <div className="md:col-span-2">
               <div className="text-xs text-muted-foreground mb-1">Produto</div>
               <Input
                 value={editProduto}
@@ -7545,6 +7694,19 @@ export function InsumosModule() {
                     </div>
                   ) : null}
                 </div>
+                <div className="mt-2">
+                  <div className="text-xs text-blue-200/70 mb-1">Códigos adicionais</div>
+                  <Textarea
+                    value={createCodigosExtras}
+                    onChange={(e) => setCreateCodigosExtras(e.target.value)}
+                    placeholder="um por linha"
+                    rows={3}
+                    className="bg-white/[0.06] border-white/20 text-white"
+                  />
+                  <div className="mt-1 text-[10px] text-blue-200/50">
+                    Opcional. Use para variações de código do mesmo produto.
+                  </div>
+                </div>
               </div>
               <div className="md:col-span-2">
                 <div className="text-xs text-blue-200/70 mb-1">Produto</div>
@@ -7750,7 +7912,9 @@ export function InsumosModule() {
                 onClick={async () => {
                   const codigoBarras = createCodigo.trim()
                   if (!codigoBarras) return toast.error('Informe o código de barras')
-                  const existing = (insumos || []).find((i) => String(i.codigoBarras || '').trim() === codigoBarras)
+                  const extraCodes = parseBarcodeInput(createCodigosExtras)
+                  const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
+                  const existing = (insumos || []).find((i) => getInsumoBarcodes(i).includes(codigoBarras))
                   const categoria = createCategoria.trim() || String(existing?.categoria || '').trim()
                   const policy = {
                     requiresLot: !!createCategoriaRequiresLot,
@@ -7784,6 +7948,7 @@ export function InsumosModule() {
                       queueLabel: 'Cadastro de insumo',
                       body: {
                         codigoBarras,
+                        codigosBarras,
                         produto,
                         allowDuplicateLot,
                         categoria,
@@ -7806,6 +7971,7 @@ export function InsumosModule() {
                     })
                     toast.success('Insumo cadastrado')
                     setCreateCodigo('')
+                    setCreateCodigosExtras('')
                     setCreateProduto('')
                     setCreateCategoria('')
                     setCreateMarca('')
@@ -7949,7 +8115,10 @@ export function InsumosModule() {
                           variant="secondary"
                           className="h-8 px-2 text-xs"
                           onClick={() => {
-                            if (i.codigoBarras) setQuickCodigo(i.codigoBarras)
+                            if (i.codigoBarras) {
+                              setQuickCodigo(i.codigoBarras)
+                              setQuickSearch(String(i.codigoBarras))
+                            }
                           }}
                         >
                           Usar

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -7031,6 +7031,7 @@ export function InsumosModule() {
 	                }}
 	                placeholder="ex: toxina"
 	                options={lotCategorias}
+	                inputTestId="insumos-edit-categoria"
 	                ariaInvalid={editValidationErrors.categoria ? true : undefined}
 	                inputClassName={
 	                  editValidationErrors.categoria
@@ -7107,6 +7108,7 @@ export function InsumosModule() {
 	                }}
 	                placeholder="ex: Allergan"
 	                options={insumosMarcas}
+	                inputTestId="insumos-edit-marca"
 	                ariaInvalid={editValidationErrors.marca ? true : undefined}
 	                inputClassName={
 	                  editValidationErrors.marca ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined

--- a/frontend/autocomplete-input.tsx
+++ b/frontend/autocomplete-input.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import ChevronDownIcon from 'lucide-react/dist/esm/icons/chevron-down'
+import { Popover, PopoverAnchor, PopoverContent } from '@/popover'
+import { Input } from '@/input'
+import { cn } from '@/utils'
+
+type AutocompleteInputProps = {
+  value: string
+  onValueChange: (next: string) => void
+  options: string[]
+  placeholder?: string
+  disabled?: boolean
+  ariaInvalid?: boolean
+  className?: string
+  inputClassName?: string
+  maxItems?: number
+}
+
+const normalizeForSearch = (value: string) =>
+  String(value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+
+export function AutocompleteInput({
+  value,
+  onValueChange,
+  options,
+  placeholder,
+  disabled,
+  ariaInvalid,
+  className,
+  inputClassName,
+  maxItems = 40
+}: AutocompleteInputProps) {
+  const [open, setOpen] = React.useState(false)
+
+  const filtered = React.useMemo(() => {
+    const q = normalizeForSearch(value)
+    if (!Array.isArray(options) || !options.length) return []
+    if (!q) return options.slice(0, maxItems)
+    const out: string[] = []
+    for (const opt of options) {
+      if (!opt) continue
+      if (normalizeForSearch(opt).includes(q)) out.push(opt)
+      if (out.length >= maxItems) break
+    }
+    return out
+  }, [maxItems, options, value])
+
+  const show = open && !!filtered.length && !disabled
+
+  return (
+    <Popover open={show} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className={cn('relative', className)}>
+          <Input
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setOpen(false)
+            }}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-invalid={ariaInvalid ? true : undefined}
+            className={cn('pr-9', inputClassName)}
+          />
+          <button
+            type="button"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:bg-muted/40 disabled:opacity-50"
+            onClick={() => setOpen((v) => !v)}
+            disabled={disabled}
+            aria-label="Abrir lista"
+          >
+            <ChevronDownIcon className="size-4 opacity-70" />
+          </button>
+        </div>
+      </PopoverAnchor>
+
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] p-1"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="max-h-64 overflow-y-auto overflow-x-hidden">
+          {filtered.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              className="w-full rounded px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                onValueChange(opt)
+                setOpen(false)
+              }}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+

--- a/frontend/autocomplete-input.tsx
+++ b/frontend/autocomplete-input.tsx
@@ -11,6 +11,7 @@ type AutocompleteInputProps = {
   placeholder?: string
   disabled?: boolean
   ariaInvalid?: boolean
+  inputTestId?: string
   className?: string
   inputClassName?: string
   maxItems?: number
@@ -30,6 +31,7 @@ export function AutocompleteInput({
   placeholder,
   disabled,
   ariaInvalid,
+  inputTestId,
   className,
   inputClassName,
   maxItems = 40
@@ -65,6 +67,7 @@ export function AutocompleteInput({
             placeholder={placeholder}
             disabled={disabled}
             aria-invalid={ariaInvalid ? true : undefined}
+            data-testid={inputTestId}
             className={cn('pr-9', inputClassName)}
           />
           <button
@@ -104,4 +107,3 @@ export function AutocompleteInput({
     </Popover>
   )
 }
-

--- a/frontend/e2e/insumos-edit-modal-policy.spec.ts
+++ b/frontend/e2e/insumos-edit-modal-policy.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('insumos', () => {
-  test('edit modal uses datalist for categoria/marca and surfaces policy validation errors', async ({ page }) => {
+  test('edit modal shows categoria/marca options and surfaces policy validation errors', async ({ page }) => {
     await page.route('**/api/insumos/**', async (route) => {
       const reqUrl = new URL(route.request().url())
       const path = reqUrl.pathname
@@ -99,12 +99,20 @@ test.describe('insumos', () => {
     await page.getByRole('button', { name: 'Editar' }).first().click()
     await expect(page.getByText('Editar insumo')).toBeVisible()
 
-    const categoriaInput = page.locator('input[list="insumos-categorias-edit"]')
-    const marcaInput = page.locator('input[list="insumos-marcas-edit"]')
+    const categoriaInput = page.getByTestId('insumos-edit-categoria')
+    const marcaInput = page.getByTestId('insumos-edit-marca')
     await expect(categoriaInput).toBeVisible()
     await expect(marcaInput).toBeVisible()
-    await expect(page.locator('datalist#insumos-categorias-edit option[value="Preenchedor"]')).toHaveCount(1)
-    await expect(page.locator('datalist#insumos-marcas-edit option[value="Rennova"]')).toHaveCount(1)
+
+    await categoriaInput.focus()
+    await expect(page.getByRole('button', { name: 'Preenchedor' })).toBeVisible()
+    await page.getByRole('button', { name: 'Preenchedor' }).click()
+    await expect(categoriaInput).toHaveValue('Preenchedor')
+
+    await marcaInput.focus()
+    await expect(page.getByRole('button', { name: 'Rennova' })).toBeVisible()
+    await page.getByRole('button', { name: 'Rennova' }).click()
+    await expect(marcaInput).toHaveValue('Rennova')
 
     // Trip policy validation: require expiry but leave date empty.
     await page.getByText('Validade obrigatória').click()


### PR DESCRIPTION
## O que mudou\n- Busca em entrada/saida por produto/marca/categoria/codigo com selecao\n- Suporte a multiplos codigos de barras por item (D1 + UI)\n- Insumos API agora expõe codigosBarras\n\n## Como validar\n- Abrir modal de Entrada/Saida e buscar por produto/marca/categoria/codigo\n- Cadastrar/editar insumo com codigos adicionais\n- Buscar por codigo alternativo e movimentar\n