### PR TITLE
Improve insumos modal responsiveness and compact layouts

### DIFF
--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -15,8 +15,9 @@ function nowIso() {
 }
 
 // D1/SQLite can reject statements with many bound variables.
-// Keep this deliberately conservative to avoid `too many SQL variables`.
-const MAX_SQL_BINDS = 200;
+// D1 can reject large IN(...) bind lists on some plans/regions.
+// Keep this low to avoid `too many SQL variables` on overview/insights loads.
+const MAX_SQL_BINDS = 80;
 
 function normalizeTipo(tipo) {
   return String(tipo || '').toUpperCase().replace('Í', 'I');

--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -16,7 +16,7 @@ function nowIso() {
 
 // D1/SQLite can reject statements with many bound variables.
 // Keep this deliberately conservative to avoid `too many SQL variables`.
-const MAX_SQL_BINDS = 400;
+const MAX_SQL_BINDS = 200;
 
 function normalizeTipo(tipo) {
   return String(tipo || '').toUpperCase().replace('Í', 'I');

--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -71,15 +71,31 @@ async function loadBarcodesByRegistro(env, registros) {
   if (!env?.DB) return map;
   const list = (registros || []).map((r) => String(r || '').trim()).filter(Boolean);
   if (!list.length) return map;
+  const queryChunk = async (chunk) => {
+    if (!chunk.length) return [];
+    const placeholders = chunk.map(() => '?').join(',');
+    try {
+      const res = await env.DB.prepare(
+        `SELECT registro, codigo_barras
+         FROM insumos_barcodes
+         WHERE registro IN (${placeholders})`
+      ).bind(...chunk).all();
+      return res?.results || [];
+    } catch (err) {
+      const message = String(err?.message || err || '');
+      if (/too many sql variables/i.test(message) && chunk.length > 1) {
+        const splitAt = Math.max(1, Math.floor(chunk.length / 2));
+        const left = await queryChunk(chunk.slice(0, splitAt));
+        const right = await queryChunk(chunk.slice(splitAt));
+        return left.concat(right);
+      }
+      throw err;
+    }
+  };
   for (let i = 0; i < list.length; i += MAX_SQL_BINDS) {
     const chunk = list.slice(i, i + MAX_SQL_BINDS);
-    const placeholders = chunk.map(() => '?').join(',');
-    const res = await env.DB.prepare(
-      `SELECT registro, codigo_barras
-       FROM insumos_barcodes
-       WHERE registro IN (${placeholders})`
-    ).bind(...chunk).all();
-    for (const row of res?.results || []) {
+    const rows = await queryChunk(chunk);
+    for (const row of rows) {
       const reg = String(row?.registro || '').trim();
       const code = String(row?.codigo_barras || '').trim();
       if (!reg || !code) continue;

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -939,12 +939,29 @@ async function apiJson<T>(
 export function InsumosModule() {
   const rootRef = React.useRef<HTMLDivElement | null>(null)
   const { width: viewportWidth, height: viewportHeight } = useViewportSize()
+  const [isCoarsePointer, setIsCoarsePointer] = React.useState(false)
+  React.useEffect(() => {
+    const media = window.matchMedia('(pointer: coarse)')
+    const update = () => setIsCoarsePointer(!!media.matches)
+    update()
+    try {
+      media.addEventListener('change', update)
+      return () => media.removeEventListener('change', update)
+    } catch {
+      media.addListener(update)
+      return () => media.removeListener(update)
+    }
+  }, [])
+  const isPhoneViewport = viewportWidth > 0 && viewportWidth < 640
   const isCompactViewport = viewportWidth > 0 && viewportWidth < 1024
+  const isAdaptiveCompact = isPhoneViewport || (isCompactViewport && isCoarsePointer)
   const dialogMaxHeight = viewportHeight > 0 && viewportHeight < 720 ? 'max-h-[88vh]' : 'max-h-[92vh]'
-  const dialogWideClass = `${dialogMaxHeight} overflow-y-auto overflow-x-hidden ${isCompactViewport ? 'w-[calc(100vw-1rem)] max-w-[96vw]' : 'w-[calc(100vw-1.5rem)] max-w-6xl'}`
-  const dialogLargeClass = `${dialogMaxHeight} overflow-y-auto overflow-x-hidden ${isCompactViewport ? 'w-[calc(100vw-1rem)] max-w-[96vw]' : 'w-[calc(100vw-1.5rem)] max-w-5xl'}`
-  const dialogMediumClass = `${dialogMaxHeight} overflow-y-auto overflow-x-hidden ${isCompactViewport ? 'w-[calc(100vw-1rem)] max-w-[96vw]' : 'max-w-4xl'}`
-  const dialogSmallClass = `${dialogMaxHeight} overflow-y-auto overflow-x-hidden ${isCompactViewport ? 'w-[calc(100vw-1rem)] max-w-[96vw]' : 'max-w-2xl'}`
+  const dialogPaddingClass = isAdaptiveCompact ? 'p-3' : 'p-4 sm:p-5'
+  const dialogBodyClass = `${dialogMaxHeight} min-w-0 overflow-auto`
+  const dialogWideClass = `${dialogBodyClass} ${isAdaptiveCompact ? 'w-[calc(100vw-0.75rem)] max-w-[97vw]' : 'w-[calc(100vw-1.5rem)] max-w-6xl'} ${dialogPaddingClass}`
+  const dialogLargeClass = `${dialogBodyClass} ${isAdaptiveCompact ? 'w-[calc(100vw-0.75rem)] max-w-[97vw]' : 'w-[calc(100vw-1.5rem)] max-w-5xl'} ${dialogPaddingClass}`
+  const dialogMediumClass = `${dialogBodyClass} ${isAdaptiveCompact ? 'w-[calc(100vw-0.75rem)] max-w-[97vw]' : 'max-w-4xl'} ${dialogPaddingClass}`
+  const dialogSmallClass = `${dialogBodyClass} ${isAdaptiveCompact ? 'w-[calc(100vw-0.75rem)] max-w-[97vw]' : 'max-w-2xl'} ${dialogPaddingClass}`
   const [health, setHealth] = React.useState<InsumosHealth | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [healthLoading, setHealthLoading] = React.useState(true)
@@ -5009,7 +5026,7 @@ export function InsumosModule() {
   }, [movimentacoes])
 
   return (
-    <div ref={rootRef} className="p-6 space-y-6">
+    <div ref={rootRef} className="px-3 py-4 sm:p-6 space-y-4 sm:space-y-6">
       {autoSyncSuspended ? (
         <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-amber-100 flex flex-wrap items-center gap-3">
           <div className="text-sm">
@@ -5049,7 +5066,7 @@ export function InsumosModule() {
 
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <Input
                   value={insumosQuery}
                   onChange={(e) => setInsumosQuery(e.target.value)}
@@ -5087,7 +5104,7 @@ export function InsumosModule() {
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
                   <div>
                     <div className="text-xs text-blue-200/70 mb-1">Código de barras</div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <Input value={createCodigo} onChange={(e) => setCreateCodigo(e.target.value)} placeholder="789..." />
                       <Button variant="secondary" type="button" onClick={() => setCreateScanOpen((v) => !v)}>
                         {createScanOpen ? 'Fechar' : 'Escanear'}
@@ -5349,7 +5366,7 @@ export function InsumosModule() {
             <div
               ref={insumosModalListContainerRef}
               onScroll={onInsumosModalScroll}
-              className="overflow-y-auto overflow-x-hidden max-h-[60vh] rounded-xl border border-white/10"
+              className="overflow-auto max-h-[60vh] rounded-xl border border-white/10"
             >
               <table className="w-full table-auto text-sm">
                 <thead className="bg-black/30 text-blue-100/80">
@@ -5577,8 +5594,13 @@ export function InsumosModule() {
           <div className="space-y-3">
             <div>
               <div className="text-xs text-blue-200/70 mb-1">Buscar por produto, marca, categoria ou código</div>
-              <div className="flex items-center gap-2">
-                <Input value={quickSearch} onChange={(e) => setQuickSearch(e.target.value)} placeholder="ex: Rennova, preenchedor, 789..." />
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  value={quickSearch}
+                  onChange={(e) => setQuickSearch(e.target.value)}
+                  placeholder="ex: Rennova, preenchedor, 789..."
+                  className="w-full sm:flex-1 sm:min-w-[240px]"
+                />
                 <Button variant="secondary" type="button" onClick={() => setQuickScanOpen((v) => !v)}>
                   {quickScanOpen ? 'Fechar' : 'Escanear'}
                 </Button>
@@ -5595,11 +5617,11 @@ export function InsumosModule() {
                             key={`${item.registro || ''}-${code}`}
                             type="button"
                             onClick={() => applyQuickSelection(item, code)}
-                            className="w-full rounded-md border border-white/5 bg-white/5 px-2 py-2 text-left hover:bg-white/10"
+                            className="w-full min-w-0 rounded-md border border-white/5 bg-white/5 px-2 py-2 text-left hover:bg-white/10"
                           >
                             <div className="flex flex-wrap items-center justify-between gap-2">
-                              <div className="text-sm text-blue-50 font-semibold">{String(item.produto || 'Insumo')}</div>
-                              <div className="text-xs text-blue-200/60 font-mono">{code}</div>
+                              <div className="text-sm text-blue-50 font-semibold break-words">{String(item.produto || 'Insumo')}</div>
+                              <div className="text-xs text-blue-200/60 font-mono break-all">{code}</div>
                             </div>
                             <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
                               {item.categoria ? (
@@ -5708,7 +5730,7 @@ export function InsumosModule() {
               </div>
             ) : null}
 
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               <div>
                 <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
                 <Input value={quickQuantidade} onChange={(e) => setQuickQuantidade(e.target.value)} type="number" min={1} />
@@ -5720,7 +5742,7 @@ export function InsumosModule() {
             </div>
 
             {quickOp === 'TRANSFERENCIA' ? (
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
                   <div className="text-xs text-blue-200/70 mb-1">Origem</div>
                   <Select value={transferFrom} onValueChange={setTransferFrom}>
@@ -5950,8 +5972,8 @@ export function InsumosModule() {
                     <thead className="bg-black/30 text-blue-100/80">
                       <tr>
                         <th className="text-left p-3">Produto</th>
-                        <th className="text-left p-3">Categoria</th>
-                        <th className="text-left p-3">Código</th>
+                        <th className="text-left p-3 hidden md:table-cell">Categoria</th>
+                        <th className="text-left p-3 hidden sm:table-cell">Código</th>
                         <th className="text-right p-3">Qtd sugerida</th>
                         <th className="text-right p-3">Valor</th>
                         <th className="text-right p-3">Ação</th>
@@ -5964,8 +5986,8 @@ export function InsumosModule() {
                             <td className="p-3 text-blue-50">
                               <div className="font-medium">{it.produto || '-'}</div>
                             </td>
-                            <td className="p-3 text-blue-100/80">{it.categoria || cat}</td>
-                            <td className="p-3 font-mono text-blue-100/80">{it.codigoBarras || ''}</td>
+                            <td className="p-3 text-blue-100/80 hidden md:table-cell">{it.categoria || cat}</td>
+                            <td className="p-3 font-mono text-blue-100/80 hidden sm:table-cell break-all">{it.codigoBarras || ''}</td>
                             <td className="p-3 text-right font-mono text-blue-100/80">{it.suggestedPurchaseQty ?? 0}</td>
                             <td className="p-3 text-right font-mono text-blue-100/80">
                               {fmtMoneyBRL(Number(it.estimatedValue) || 0)}
@@ -6459,7 +6481,7 @@ export function InsumosModule() {
                   </div>
                 </div>
 
-                <div className="overflow-y-auto overflow-x-hidden max-h-[60vh] rounded-xl border border-white/10">
+                <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
                   <table className="w-full table-auto text-sm">
                     <thead className="bg-black/30 text-blue-100/80">
                       <tr>
@@ -6468,7 +6490,7 @@ export function InsumosModule() {
                         <th className="text-left p-3">Status</th>
                         <th className="text-left p-3">Ação</th>
                         <th className="text-right p-3">Atual</th>
-                        <th className="text-right p-3">Mín</th>
+                        <th className="text-right p-3 hidden sm:table-cell">Mín</th>
                         <th className="hidden lg:table-cell text-right p-3">Dif</th>
                         <th className="hidden lg:table-cell text-right p-3">%</th>
                       </tr>
@@ -6505,7 +6527,7 @@ export function InsumosModule() {
                                 </div>
                               ) : null}
                             </td>
-                            <td className="p-3 text-blue-100/80">
+                            <td className="p-3 text-blue-100/80 hidden sm:table-cell">
                               <div className="flex items-center gap-2">
                                 <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: getCategoriaBgColor(a.categoria || 'Outros') }} />
                                 <span className="break-words">{a.categoria || '-'}</span>
@@ -6581,7 +6603,7 @@ export function InsumosModule() {
                               </div>
                             </td>
                             <td className="p-3 text-right text-blue-100/80">{a.estoqueAtual ?? '-'}</td>
-                            <td className="p-3 text-right text-blue-100/70">{a.estoqueMinimo ?? '-'}</td>
+                            <td className="p-3 text-right text-blue-100/70 hidden sm:table-cell">{a.estoqueMinimo ?? '-'}</td>
                             <td className="hidden lg:table-cell p-3 text-right text-blue-100/70">{a.diferenca ?? '-'}</td>
                             <td className="hidden lg:table-cell p-3 text-right text-blue-100/70">{a.percentual != null ? `${a.percentual}%` : '-'}</td>
                           </tr>
@@ -6662,14 +6684,14 @@ export function InsumosModule() {
                   ) : null}
 
                 {overviewQuality?.issues?.length ? (
-                  <div className="overflow-y-auto overflow-x-hidden max-h-[60vh] rounded-xl border border-white/10">
+                  <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
                     <table className="w-full table-auto text-sm">
                       <thead className="bg-black/30 text-blue-100/80">
                         <tr>
                           <th className="text-left p-3">Nível</th>
-                          <th className="text-left p-3">Código</th>
+                          <th className="text-left p-3 hidden sm:table-cell">Código</th>
                           <th className="text-left p-3">Mensagem</th>
-                          <th className="text-left p-3">Ação</th>
+                          <th className="text-left p-3 w-[1%] whitespace-nowrap">Ação</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-white/5">
@@ -6688,7 +6710,7 @@ export function InsumosModule() {
                               <td className="p-3">
                                 <Badge variant={badgeVariant as any}>{sev || 'INFO'}</Badge>
                               </td>
-                              <td className="p-3 font-mono text-blue-100/70">{it.code || '-'}</td>
+                              <td className="p-3 font-mono text-blue-100/70 hidden sm:table-cell break-all">{it.code || '-'}</td>
                               <td className="p-3 text-blue-50 break-words">
                                 {it.message || '-'}
                                 {(it.codigoBarras || it.produto) ? (
@@ -7054,14 +7076,14 @@ export function InsumosModule() {
               )}
             </DialogDescription>
           </DialogHeader>
-          <div className="overflow-y-auto overflow-x-hidden max-h-[60vh] rounded-xl border border-white/10">
+          <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
             <table className="min-w-full text-sm">
               <thead className="bg-black/30 text-blue-100/80">
                 <tr>
                   <th className="text-left p-3">Registro</th>
                   <th className="text-left p-3">Produto</th>
-                  <th className="text-left p-3">Lote</th>
-                  <th className="text-left p-3">Estoque ({unidadeLabel(unidade)})</th>
+                        <th className="text-left p-3 hidden md:table-cell">Lote</th>
+                        <th className="text-left p-3 hidden sm:table-cell">Estoque ({unidadeLabel(unidade)})</th>
                   <th className="text-left p-3">Ações</th>
                 </tr>
               </thead>
@@ -7073,10 +7095,10 @@ export function InsumosModule() {
                     <tr key={registro || String(item?.codigoBarras || '')} className="hover:bg-white/5">
                       <td className="p-3 font-mono text-blue-100/80">{registro || '-'}</td>
                       <td className="p-3 text-blue-50">{String(item?.produto || '-')}</td>
-                      <td className="p-3 text-blue-100/70">{String(item?.lote || '-')}</td>
-                      <td className="p-3 text-blue-100/70">{Number(item?.estoqueAtual || 0)}</td>
+                      <td className="p-3 text-blue-100/70 hidden md:table-cell">{String(item?.lote || '-')}</td>
+                      <td className="p-3 text-blue-100/70 hidden sm:table-cell">{Number(item?.estoqueAtual || 0)}</td>
                       <td className="p-3">
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
                           <Button
                             size="sm"
                             variant="outline"
@@ -8029,7 +8051,7 @@ export function InsumosModule() {
           </div>
         ) : null}
 
-        <div ref={insumosListContainerRef} onScroll={onInsumosScroll} className="overflow-y-auto overflow-x-hidden max-h-[60vh] rounded-xl border border-white/10">
+        <div ref={insumosListContainerRef} onScroll={onInsumosScroll} className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
           <table className="w-full table-auto text-sm">
             <thead className="bg-black/30 text-blue-100/80">
               <tr>
@@ -8364,22 +8386,22 @@ export function InsumosModule() {
 	              <tr>
                   {(
                     [
-                      { key: 'dataHora', label: 'Data', compact: true },
+                      { key: 'dataHora', label: 'Data', compact: true, className: '' },
                       { key: 'produto', label: 'Produto' },
-                      { key: 'categoria', label: 'Categoria', compact: true },
-                      { key: 'marca', label: 'Marca', compact: true },
+                      { key: 'categoria', label: 'Categoria', compact: true, className: 'hidden md:table-cell' },
+                      { key: 'marca', label: 'Marca', compact: true, className: 'hidden lg:table-cell' },
                       { key: 'estoque', label: 'Estoque', compact: true },
                       { key: 'valor', label: 'Valor', compact: true },
-                      { key: 'usuario', label: 'Usuário', compact: true },
-                      { key: 'observacao', label: 'Observação' },
+                      { key: 'usuario', label: 'Usuário', compact: true, className: 'hidden xl:table-cell' },
+                      { key: 'observacao', label: 'Observação', className: 'hidden md:table-cell' },
                       { key: null, label: 'Ações', compact: true }
-                    ] as Array<{ key: null | 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'; label: string; compact?: boolean }>
+                    ] as Array<{ key: null | 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'; label: string; compact?: boolean; className?: string }>
                   ).map((col) => {
                     const isActive = !!col.key && movSortKey === col.key
                     return (
 	                      <th
 	                        key={col.label}
-	                        className={`p-3 text-center align-middle ${col.compact ? 'whitespace-nowrap w-[1%]' : ''} sticky top-0 z-10 bg-black/40 backdrop-blur`}
+	                        className={`p-3 text-center align-middle ${col.compact ? 'whitespace-nowrap w-[1%]' : ''} ${col.className || ''} sticky top-0 z-10 bg-black/40 backdrop-blur`}
 	                      >
 	                        <div className="flex items-center justify-center gap-2">
                             {col.key ? (
@@ -8463,7 +8485,7 @@ export function InsumosModule() {
 	                    <td className="p-3 text-center align-middle">
 	                      <button
 	                        type="button"
-	                        className="w-full text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 rounded-sm cursor-pointer"
+	                        className="w-full text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 rounded-sm cursor-pointer break-words"
 	                        onClick={() => {
                             const p = String(produtoNome || '').trim()
                             if (!p || p === '-') return
@@ -8478,7 +8500,7 @@ export function InsumosModule() {
 	                        {produtoNome}
 	                      </button>
 		                    </td>
-                      <td className="p-3 text-center align-middle whitespace-nowrap">
+                      <td className="p-3 text-center align-middle whitespace-nowrap hidden md:table-cell">
                         {categoriaNome && categoriaNome !== '-' ? (
                           <button
                             type="button"
@@ -8499,7 +8521,7 @@ export function InsumosModule() {
                           <span className="text-blue-100/70">-</span>
                         )}
                       </td>
-                      <td className="p-3 text-center align-middle whitespace-nowrap">
+                      <td className="p-3 text-center align-middle whitespace-nowrap hidden lg:table-cell">
                         {marcaNome && marcaNome !== '-' ? (
                           <button
                             type="button"
@@ -8533,8 +8555,8 @@ export function InsumosModule() {
                           {valorEstoqueTotal != null ? fmtMoneyBRL0(valorEstoqueTotal) : ''}
                         </div>
                       </td>
-	                    <td className="p-3 text-center align-middle text-blue-100/70 whitespace-nowrap">{m.usuario || '-'}</td>
-	                    <td className="p-3 text-center align-middle text-blue-100/60">
+	                    <td className="p-3 text-center align-middle text-blue-100/70 whitespace-nowrap hidden xl:table-cell">{m.usuario || '-'}</td>
+	                    <td className="p-3 text-center align-middle text-blue-100/60 hidden md:table-cell">
 	                      <div className="space-y-1">
 	                        {m.transferId ? (
 	                          <div>

--- a/frontend/dialog.tsx
+++ b/frontend/dialog.tsx
@@ -55,13 +55,13 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-1rem)] max-h-[calc(100dvh-1rem)] translate-x-[-50%] translate-y-[-50%] gap-3 overflow-y-auto overscroll-contain rounded-lg border p-3 shadow-lg duration-200 sm:max-w-lg sm:max-h-[calc(100dvh-2rem)] sm:gap-4 sm:p-5",
           className
         )}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none sm:top-4 sm:right-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
@@ -74,7 +74,7 @@ function DialogHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn("flex flex-col gap-2 text-left pr-10", className)}
       {...props}
     />
   )
@@ -85,7 +85,7 @@ function DialogFooter({ className, ...props }: ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:items-center [&>button]:w-full sm:[&>button]:w-auto",
         className
       )}
       {...props}
@@ -100,7 +100,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-lg leading-tight font-semibold break-words", className)}
       {...props}
     />
   )
@@ -113,7 +113,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-sm break-words", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary\n- make dialog containers adapt better to compact/coarse-pointer devices\n- reduce modal/table clipping by switching critical containers to overflow-auto\n- stack quick-operation form fields and action buttons on small viewports\n- hide secondary columns on small screens to keep actions accessible\n\n## Validation\n- npm -C frontend run build\n