### PR TITLE
Add resizable dialog windows on desktop

### DIFF
--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -1170,6 +1170,7 @@ export function InsumosModule() {
   const [movFilterProduto, setMovFilterProduto] = React.useState('')
   const [movFilterCategoria, setMovFilterCategoria] = React.useState('')
   const [movFilterMarca, setMovFilterMarca] = React.useState('')
+  const [movSearch, setMovSearch] = React.useState('')
   const [movSortKey, setMovSortKey] = React.useState<
     'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'
   >('dataHora')
@@ -4896,11 +4897,26 @@ export function InsumosModule() {
     const filterProduto = normalizeText(movFilterProduto)
     const filterCategoria = normalizeText(movFilterCategoria)
     const filterMarca = normalizeText(movFilterMarca)
+    const filterSearch = normalizeText(movSearch)
 
     const applyFiltersAndSort = (base: Movimentacao[]) => {
       const filtered = base.filter((m) => {
         if (selectedCode) {
           if (String(m?.codigoBarras || '').trim() !== selectedCode) return false
+        } else if (filterSearch) {
+          const insumo = pickInsumoForMov(m)
+          const produtoNome = normalizeText(String(insumo?.produto || m?.produto || '').trim())
+          const categoriaNome = normalizeText(insumo?.categoria || '')
+          const codigoBarras = normalizeText(String(m?.codigoBarras || insumo?.codigoBarras || '').trim())
+          if (
+            !(
+              (produtoNome && produtoNome.includes(filterSearch)) ||
+              (categoriaNome && categoriaNome.includes(filterSearch)) ||
+              (codigoBarras && codigoBarras.includes(filterSearch))
+            )
+          ) {
+            return false
+          }
         } else if (filterProduto) {
           const insumo = pickInsumoForMov(m)
           const produtoNome = normalizeText(String(insumo?.produto || m?.produto || '').trim())
@@ -5016,6 +5032,7 @@ export function InsumosModule() {
     movFilterCategoria,
     movFilterMarca,
     movFilterProduto,
+    movSearch,
     movimentacoes,
     pickInsumoForMov,
     selectedCodigoBarras
@@ -5378,7 +5395,7 @@ export function InsumosModule() {
                     <th className="text-right p-3 hidden sm:table-cell w-[5.5rem] whitespace-nowrap">Mín</th>
                     <th className="text-left p-3 hidden xl:table-cell w-[7.5rem] whitespace-nowrap">Validade</th>
                     <th className="text-right p-3 hidden xl:table-cell w-[8.5rem] whitespace-nowrap">Valor</th>
-                    <th className="text-right p-3 w-[11.5rem] whitespace-nowrap">Ações</th>
+                    <th className="text-right p-3 w-[7.5rem] whitespace-nowrap">Ações</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
@@ -5409,20 +5426,8 @@ export function InsumosModule() {
                         <td className="p-3 text-blue-100/70 hidden xl:table-cell align-middle whitespace-nowrap">{fmtDateOnlyBR(i.dataValidade || '')}</td>
                         <td className="p-3 text-right text-blue-100/80 hidden xl:table-cell align-middle whitespace-nowrap">{fmtMoneyBRL(valor)}</td>
                         <td className="p-3 text-right align-middle whitespace-nowrap">
-                          <div className="flex items-center justify-end gap-2">
-                            <Button
-                              variant="secondary"
-                              size="sm"
-                              className="h-8 px-2 text-xs"
-                              onClick={() => {
-                                if (codigoBarras) setSelectedCodigoBarras(codigoBarras)
-                                setInsumosListModalOpen(false)
-                              }}
-                              disabled={!codigoBarras}
-                            >
-                              Mov
-                            </Button>
-                            <Button variant="outline" size="sm" className="h-8 px-2 text-xs" onClick={() => openEditDialog(i)} disabled={!isAuthed}>
+                          <div className="flex items-center justify-end">
+                            <Button variant="outline" size="sm" className="h-8 px-3 text-xs" onClick={() => openEditDialog(i)} disabled={!isAuthed}>
                               Editar
                             </Button>
                           </div>
@@ -8296,7 +8301,7 @@ export function InsumosModule() {
           {movPanelOpen ? (
             <CardContent className="space-y-3">
 
-        {(selectedCodigoBarras.trim() || movFilterProduto.trim() || movFilterCategoria.trim() || movFilterMarca.trim()) ? (
+        {(selectedCodigoBarras.trim() || movFilterProduto.trim() || movFilterCategoria.trim() || movFilterMarca.trim() || movSearch.trim()) ? (
           <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-blue-100/80 flex flex-wrap items-center justify-between gap-2">
             <div className="min-w-0">
               <span className="text-blue-200/70">Filtrando por:</span>{' '}
@@ -8322,6 +8327,12 @@ export function InsumosModule() {
                   <span className="text-blue-50 font-semibold">{movFilterMarca.trim()}</span>
                 </>
               ) : null}
+              {movSearch.trim() ? (
+                <>
+                  {(selectedCodigoBarras.trim() || movFilterProduto.trim() || movFilterCategoria.trim() || movFilterMarca.trim()) ? <span className="text-blue-200/60"> • </span> : null}
+                  <span className="text-blue-50 font-semibold">{movSearch.trim()}</span>
+                </>
+              ) : null}
             </div>
             <Button
               variant="outline"
@@ -8331,6 +8342,7 @@ export function InsumosModule() {
                 setMovFilterProduto('')
                 setMovFilterCategoria('')
                 setMovFilterMarca('')
+                setMovSearch('')
               }}
             >
               Limpar
@@ -8360,6 +8372,15 @@ export function InsumosModule() {
           <div className="w-48">
             <div className="text-xs text-blue-200/70 mb-1">Até</div>
             <BrDatePickerInput value={movAte} onChange={setMovAte} placeholder="DD/MM/AA" ariaLabel="Até" />
+          </div>
+          <div className="min-w-[220px] flex-1">
+            <div className="text-xs text-blue-200/70 mb-1">Buscar insumo</div>
+            <Input
+              value={movSearch}
+              onChange={(e) => setMovSearch(e.target.value)}
+              placeholder="nome, codigo, categoria"
+              className="w-full"
+            />
           </div>
         </div>
 

--- a/frontend/dialog.tsx
+++ b/frontend/dialog.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from "react"
+import { ComponentProps, useEffect, useRef, useState } from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import XIcon from "lucide-react/dist/esm/icons/x"
 
@@ -6,6 +6,7 @@ import { cn } from "@/utils"
 
 type DialogSize = "default" | "wideTable"
 type DialogContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
+  resizable?: boolean
   size?: DialogSize
 }
 
@@ -50,15 +51,77 @@ function DialogOverlay({
 }
 
 function DialogContent({
+  resizable,
   size = "default",
   className,
   children,
   ...props
 }: DialogContentProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [canResize, setCanResize] = useState(false)
+  const [resizeSize, setResizeSize] = useState<{ width: number; height: number } | null>(null)
   const sizeClassName =
     size === "wideTable"
       ? "lg:w-[96vw] lg:max-w-[96rem] xl:w-[94vw] xl:max-w-[112rem]"
       : ""
+  const allowResize = resizable ?? true
+
+  useEffect(() => {
+    if (!allowResize || typeof window === "undefined") {
+      setCanResize(false)
+      return
+    }
+    const media = window.matchMedia("(pointer: coarse)")
+    const update = () => {
+      setCanResize(!media.matches && window.innerWidth >= 768)
+    }
+    update()
+    try {
+      media.addEventListener("change", update)
+      window.addEventListener("resize", update)
+      return () => {
+        media.removeEventListener("change", update)
+        window.removeEventListener("resize", update)
+      }
+    } catch {
+      media.addListener(update)
+      window.addEventListener("resize", update)
+      return () => {
+        media.removeListener(update)
+        window.removeEventListener("resize", update)
+      }
+    }
+  }, [allowResize])
+
+  const handleResizeStart = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!canResize || !contentRef.current) return
+    const rect = contentRef.current.getBoundingClientRect()
+    const startX = event.clientX
+    const startY = event.clientY
+    const startWidth = rect.width
+    const startHeight = rect.height
+    const minWidth = 420
+    const minHeight = 260
+    const onMove = (moveEvent: PointerEvent) => {
+      const dx = moveEvent.clientX - startX
+      const dy = moveEvent.clientY - startY
+      const maxWidth = window.innerWidth - 16
+      const maxHeight = window.innerHeight - 16
+      const nextWidth = Math.min(maxWidth, Math.max(minWidth, startWidth + dx))
+      const nextHeight = Math.min(maxHeight, Math.max(minHeight, startHeight + dy))
+      setResizeSize({ width: nextWidth, height: nextHeight })
+    }
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  const mergedStyle = resizeSize ? { ...props.style, width: resizeSize.width, height: resizeSize.height } : props.style
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -69,9 +132,22 @@ function DialogContent({
           sizeClassName,
           className
         )}
+        ref={contentRef}
+        style={mergedStyle}
         {...props}
       >
         {children}
+        {canResize ? (
+          <div
+            className="absolute bottom-2 right-2 h-4 w-4 cursor-se-resize text-blue-200/50 hover:text-blue-100/80"
+            onPointerDown={handleResizeStart}
+            aria-hidden="true"
+          >
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M4 12h8M7 15h5M10 9h2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </div>
+        ) : null}
         <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none sm:top-4 sm:right-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
           <span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary
- add a resize handle to dialogs on desktop (pointer fine)
- allow drag-to-resize with min/max bounds
- keep mobile/touch behavior unchanged

## Validation
- npm -C frontend run build
