### PR TITLE
Add resizable dialog windows on desktop

### DIFF
--- a/frontend/dialog.tsx
+++ b/frontend/dialog.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from "react"
+import { ComponentProps, useEffect, useRef, useState } from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import XIcon from "lucide-react/dist/esm/icons/x"
 
@@ -6,6 +6,7 @@ import { cn } from "@/utils"
 
 type DialogSize = "default" | "wideTable"
 type DialogContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
+  resizable?: boolean
   size?: DialogSize
 }
 
@@ -50,15 +51,77 @@ function DialogOverlay({
 }
 
 function DialogContent({
+  resizable,
   size = "default",
   className,
   children,
   ...props
 }: DialogContentProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [canResize, setCanResize] = useState(false)
+  const [resizeSize, setResizeSize] = useState<{ width: number; height: number } | null>(null)
   const sizeClassName =
     size === "wideTable"
       ? "lg:w-[96vw] lg:max-w-[96rem] xl:w-[94vw] xl:max-w-[112rem]"
       : ""
+  const allowResize = resizable ?? true
+
+  useEffect(() => {
+    if (!allowResize || typeof window === "undefined") {
+      setCanResize(false)
+      return
+    }
+    const media = window.matchMedia("(pointer: coarse)")
+    const update = () => {
+      setCanResize(!media.matches && window.innerWidth >= 768)
+    }
+    update()
+    try {
+      media.addEventListener("change", update)
+      window.addEventListener("resize", update)
+      return () => {
+        media.removeEventListener("change", update)
+        window.removeEventListener("resize", update)
+      }
+    } catch {
+      media.addListener(update)
+      window.addEventListener("resize", update)
+      return () => {
+        media.removeListener(update)
+        window.removeEventListener("resize", update)
+      }
+    }
+  }, [allowResize])
+
+  const handleResizeStart = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!canResize || !contentRef.current) return
+    const rect = contentRef.current.getBoundingClientRect()
+    const startX = event.clientX
+    const startY = event.clientY
+    const startWidth = rect.width
+    const startHeight = rect.height
+    const minWidth = 420
+    const minHeight = 260
+    const onMove = (moveEvent: PointerEvent) => {
+      const dx = moveEvent.clientX - startX
+      const dy = moveEvent.clientY - startY
+      const maxWidth = window.innerWidth - 16
+      const maxHeight = window.innerHeight - 16
+      const nextWidth = Math.min(maxWidth, Math.max(minWidth, startWidth + dx))
+      const nextHeight = Math.min(maxHeight, Math.max(minHeight, startHeight + dy))
+      setResizeSize({ width: nextWidth, height: nextHeight })
+    }
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  const mergedStyle = resizeSize ? { ...props.style, width: resizeSize.width, height: resizeSize.height } : props.style
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -69,9 +132,22 @@ function DialogContent({
           sizeClassName,
           className
         )}
+        ref={contentRef}
+        style={mergedStyle}
         {...props}
       >
         {children}
+        {canResize ? (
+          <div
+            className="absolute bottom-2 right-2 h-4 w-4 cursor-se-resize text-blue-200/50 hover:text-blue-100/80"
+            onPointerDown={handleResizeStart}
+            aria-hidden="true"
+          >
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M4 12h8M7 15h5M10 9h2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </div>
+        ) : null}
         <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none sm:top-4 sm:right-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
           <span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary
- add a resize handle to dialogs on desktop (pointer fine)
- allow drag-to-resize with min/max bounds
- keep mobile/touch behavior unchanged

## Validation
- npm -C frontend run build
