### PR TITLE
ci: add cloudflare access headers to ponto smokes

### DIFF
--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -153,6 +153,8 @@ jobs:
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.guard.outputs.branch == 'main' }}
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -164,7 +166,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -96,6 +96,8 @@ jobs:
         continue-on-error: true
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -107,7 +109,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)
@@ -204,6 +212,8 @@ jobs:
         continue-on-error: true
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -215,7 +225,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -110,6 +110,8 @@ jobs:
         if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.branch == 'main' }}
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -121,7 +123,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)

--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -82,6 +82,8 @@ jobs:
         if: ${{ steps.guard.outputs.skip != 'true' && github.ref_name == 'main' }}
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -93,7 +95,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoDeploySmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoDeploySmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -140,6 +140,8 @@ jobs:
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' }}
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -151,7 +153,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoAfterAutomergeSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoAfterAutomergeSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               return json.loads(resp.read().decode("utf-8", "ignore"))
 

--- a/.github/workflows/deploy-workers-reconcile.yml
+++ b/.github/workflows/deploy-workers-reconcile.yml
@@ -103,6 +103,8 @@ jobs:
         continue-on-error: true
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -114,7 +116,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoWorkersReconcile/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoWorkersReconcile/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)

--- a/.github/workflows/ponto-smoke.yml
+++ b/.github/workflows/ponto-smoke.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Smoke check Ponto endpoints
         env:
           BASE_URL: https://crm.skincos.com.br
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -26,7 +28,13 @@ jobs:
 
           def fetch_json(path: str):
             url = f"{base}{path}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"})
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; PontoSmoke/1.0)"}
+            cid = os.environ.get("CF_ACCESS_CLIENT_ID", "").strip()
+            csec = os.environ.get("CF_ACCESS_CLIENT_SECRET", "").strip()
+            if cid and csec:
+              headers["CF-Access-Client-Id"] = cid
+              headers["CF-Access-Client-Secret"] = csec
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:
               data = resp.read().decode("utf-8", "ignore")
               return json.loads(data)


### PR DESCRIPTION
Adds optional Cloudflare Access headers to Ponto smoke checks so GitHub Actions can reach protected endpoints when CF_ACCESS_CLIENT_ID/SECRET are set.