### PR TITLE
[codex] padroniza ações rápidas e estoque

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -437,8 +437,8 @@ export default function AppFunctionalNeatlab() {
                 }, [estoqueThresholds])
 
                 const estoqueBadgeTone = React.useMemo(() => {
-                    const value = insumosHeaderEstoque?.value
-                    if (!Number.isFinite(Number(value))) return 'neutral'
+                    const value = Number(insumosHeaderEstoque?.value)
+                    if (!Number.isFinite(value)) return 'neutral'
                     if (value < estoqueThresholds.critical) return 'critical'
                     if (value < estoqueThresholds.warning) return 'warning'
                     return 'ok'

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,6 +20,7 @@ const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
 const INSUMOS_OVERVIEW_FROM_KEY = 'skincos.insumos.overview.from.v1'
 const INSUMOS_OVERVIEW_TO_KEY = 'skincos.insumos.overview.to.v1'
+const INSUMOS_ESTOQUE_THRESHOLDS_KEY = 'skincos.insumos.estoque.thresholds.v1'
 // Demo banners are not allowed. Keep the UI strictly real-data oriented.
 
 function fmtMoneyBRLCompact(value: number) {
@@ -328,11 +329,34 @@ export default function AppFunctionalNeatlab() {
 			        unidades: string[]
 			        allowedUnits: string[]
 			    } | null>(null)
-                    const [insumosHeaderEstoque, setInsumosHeaderEstoque] = useState<{
+				    const [insumosHeaderEstoque, setInsumosHeaderEstoque] = useState<{
                         value: number | null
                         loading: boolean
                         percent: number | null
+                        entradaValor?: number | null
+                        saidaValor?: number | null
                     } | null>(null)
+                    const defaultEstoqueThresholds = React.useMemo(() => ({ warning: 50000, critical: 20000 }), [])
+                    const [estoqueThresholds, setEstoqueThresholds] = useState<{ warning: number; critical: number }>(() => {
+                        try {
+                            const raw = localStorage.getItem(INSUMOS_ESTOQUE_THRESHOLDS_KEY)
+                            if (raw) {
+                                const parsed = JSON.parse(raw || '{}')
+                                const warning = Number(parsed?.warning)
+                                const critical = Number(parsed?.critical)
+                                if (Number.isFinite(warning) && Number.isFinite(critical)) {
+                                    return { warning, critical }
+                                }
+                            }
+                        } catch { /* ignore */ }
+                        return { warning: defaultEstoqueThresholds.warning, critical: defaultEstoqueThresholds.critical }
+                    })
+                    const [estoqueThresholdsOpen, setEstoqueThresholdsOpen] = useState(false)
+                    const [estoqueThresholdsDraft, setEstoqueThresholdsDraft] = useState<{ warning: string; critical: string }>({
+                        warning: String(estoqueThresholds.warning),
+                        critical: String(estoqueThresholds.critical)
+                    })
+                    const [estoqueThresholdsError, setEstoqueThresholdsError] = useState<string | null>(null)
 				    const unitOptions = useMemo(() => DEFAULT_UNIT_OPTIONS, [])
 				    const { selectedUnit, setSelectedUnit, effectiveUnit } = useGlobalUnitSelection(unitOptions)
 				    const setSelectedUnitRef = React.useRef(setSelectedUnit)
@@ -387,6 +411,48 @@ export default function AppFunctionalNeatlab() {
 		            .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
 		            .join(' ')
 
+                const parseCurrencyInput = React.useCallback((raw: string) => {
+                    if (!raw) return null
+                    const cleaned = String(raw)
+                        .replace(/[^\d,.-]/g, '')
+                        .replace(/\./g, '')
+                        .replace(',', '.')
+                    const value = Number(cleaned)
+                    return Number.isFinite(value) ? value : null
+                }, [])
+
+                React.useEffect(() => {
+                    if (!estoqueThresholdsOpen) return
+                    setEstoqueThresholdsDraft({
+                        warning: String(estoqueThresholds.warning),
+                        critical: String(estoqueThresholds.critical)
+                    })
+                    setEstoqueThresholdsError(null)
+                }, [estoqueThresholds, estoqueThresholdsOpen])
+
+                React.useEffect(() => {
+                    try {
+                        localStorage.setItem(INSUMOS_ESTOQUE_THRESHOLDS_KEY, JSON.stringify(estoqueThresholds))
+                    } catch { /* ignore */ }
+                }, [estoqueThresholds])
+
+                const estoqueBadgeTone = React.useMemo(() => {
+                    const value = insumosHeaderEstoque?.value
+                    if (!Number.isFinite(Number(value))) return 'neutral'
+                    if (value < estoqueThresholds.critical) return 'critical'
+                    if (value < estoqueThresholds.warning) return 'warning'
+                    return 'ok'
+                }, [estoqueThresholds.critical, estoqueThresholds.warning, insumosHeaderEstoque?.value])
+
+                const estoqueBadgeClass =
+                    estoqueBadgeTone === 'ok'
+                        ? 'bg-emerald-500/25 text-emerald-100 border-emerald-400/40'
+                        : estoqueBadgeTone === 'warning'
+                          ? 'bg-amber-500/30 text-amber-100 border-amber-400/40'
+                          : estoqueBadgeTone === 'critical'
+                            ? 'bg-rose-500/30 text-rose-100 border-rose-400/40'
+                            : 'bg-white/10 text-blue-100/70 border-white/15'
+
 			    React.useEffect(() => {
 			        if (active !== 'insumos') return
 			        try {
@@ -399,10 +465,14 @@ export default function AppFunctionalNeatlab() {
                         const detail = (event as CustomEvent)?.detail || {}
                         const rawValue = detail?.value
                         const value = rawValue == null || Number.isNaN(Number(rawValue)) ? null : Number(rawValue)
+                        const entradaValor = Number.isFinite(Number(detail?.entradaValor)) ? Number(detail?.entradaValor) : null
+                        const saidaValor = Number.isFinite(Number(detail?.saidaValor)) ? Number(detail?.saidaValor) : null
                         setInsumosHeaderEstoque({
                             value,
                             loading: Boolean(detail?.loading),
-                            percent: typeof detail?.percent === 'number' ? detail.percent : null
+                            percent: typeof detail?.percent === 'number' ? detail.percent : null,
+                            entradaValor,
+                            saidaValor
                         })
                     }
                     window.addEventListener('skincos:insumos:estoque', handler)
@@ -684,6 +754,75 @@ export default function AppFunctionalNeatlab() {
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
+            <Dialog open={estoqueThresholdsOpen} onOpenChange={setEstoqueThresholdsOpen}>
+                <DialogContent className="max-w-sm">
+                    <DialogHeader>
+                        <DialogTitle>Faixas do estoque</DialogTitle>
+                        <DialogDescription>
+                            Defina quando o estoque fica amarelo ou vermelho. Valores em reais.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3">
+                        {estoqueThresholdsError ? (
+                            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-100">
+                                {estoqueThresholdsError}
+                            </div>
+                        ) : null}
+                        <div>
+                            <div className="text-xs text-blue-200/70 mb-1">Atenção (amarelo) abaixo de</div>
+                            <Input
+                                value={estoqueThresholdsDraft.warning}
+                                onChange={(e) => setEstoqueThresholdsDraft((prev) => ({ ...prev, warning: e.target.value }))}
+                                placeholder="ex: 50000"
+                            />
+                        </div>
+                        <div>
+                            <div className="text-xs text-blue-200/70 mb-1">Crítico (vermelho) abaixo de</div>
+                            <Input
+                                value={estoqueThresholdsDraft.critical}
+                                onChange={(e) => setEstoqueThresholdsDraft((prev) => ({ ...prev, critical: e.target.value }))}
+                                placeholder="ex: 20000"
+                            />
+                        </div>
+                    </div>
+                    <DialogFooter className="gap-2">
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setEstoqueThresholds({
+                                    warning: defaultEstoqueThresholds.warning,
+                                    critical: defaultEstoqueThresholds.critical
+                                })
+                                setEstoqueThresholdsOpen(false)
+                            }}
+                        >
+                            Resetar padrão
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            onClick={() => {
+                                const warning = parseCurrencyInput(estoqueThresholdsDraft.warning)
+                                const critical = parseCurrencyInput(estoqueThresholdsDraft.critical)
+                                if (!Number.isFinite(Number(warning)) || !Number.isFinite(Number(critical))) {
+                                    setEstoqueThresholdsError('Informe valores numéricos válidos.')
+                                    return
+                                }
+                                if ((warning as number) <= (critical as number)) {
+                                    setEstoqueThresholdsError('Atenção deve ser maior que Crítico.')
+                                    return
+                                }
+                                setEstoqueThresholds({
+                                    warning: warning as number,
+                                    critical: critical as number
+                                })
+                                setEstoqueThresholdsOpen(false)
+                            }}
+                        >
+                            Salvar
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
 
             {/* Premium Background with animated gradient */}
             <div className="min-h-screen relative overflow-hidden">
@@ -950,47 +1089,47 @@ export default function AppFunctionalNeatlab() {
 					                                                        </>
 					                                                    ) : null}
 
-					                                                    <Button
-					                                                    size="icon"
-					                                                        variant="ghost"
-					                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
-				                                                        onClick={() => {
-			                                                            try {
-			                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'ENTRADA' } }))
-			                                                            } catch { /* ignore */ }
+						                                                    <Button
+						                                                    size="icon"
+						                                                        variant="ghost"
+						                                                        className="h-9 w-9 rounded-md bg-emerald-500/25 text-emerald-100 hover:bg-emerald-500/35"
+					                                                        onClick={() => {
+				                                                            try {
+				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'ENTRADA' } }))
+				                                                            } catch { /* ignore */ }
 	                                                        }}
 			                                                        title="Entrada"
 			                                                        aria-label="Entrada"
 			                                                    >
-			                                                        <img src="/icons/shortcut-entrada.svg" alt="" aria-hidden className="h-9 w-9" />
+				                                                        <img src="/icons/shortcut-entrada.svg" alt="" aria-hidden className="h-5 w-5" />
 			                                                    </Button>
-			                                                    <Button
-			                                                    size="icon"
-			                                                        variant="ghost"
-			                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
-			                                                        onClick={() => {
-			                                                            try {
-			                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'BAIXA' } }))
-			                                                            } catch { /* ignore */ }
+						                                                    <Button
+						                                                    size="icon"
+						                                                        variant="ghost"
+						                                                        className="h-9 w-9 rounded-md bg-rose-500/30 text-rose-100 hover:bg-rose-500/40"
+					                                                        onClick={() => {
+				                                                            try {
+				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'BAIXA' } }))
+				                                                            } catch { /* ignore */ }
 	                                                        }}
 			                                                        title="Saída"
 			                                                        aria-label="Saída"
 			                                                    >
-			                                                        <img src="/icons/shortcut-saida.svg" alt="" aria-hidden className="h-9 w-9" />
+				                                                        <img src="/icons/shortcut-saida.svg" alt="" aria-hidden className="h-5 w-5" />
 			                                                    </Button>
-			                                                    <Button
-			                                                    size="icon"
-			                                                        variant="ghost"
-			                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
-			                                                        onClick={() => {
-			                                                            try {
-			                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'TRANSFERENCIA' } }))
-			                                                            } catch { /* ignore */ }
+				                                                    <Button
+				                                                    size="icon"
+				                                                        variant="ghost"
+				                                                        className="h-9 w-9 rounded-md bg-sky-500/30 text-sky-100 hover:bg-sky-500/40"
+				                                                        onClick={() => {
+				                                                            try {
+				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'TRANSFERENCIA' } }))
+				                                                            } catch { /* ignore */ }
 	                                                        }}
 			                                                        title="Transferência"
 			                                                        aria-label="Transferência"
 				                                                    >
-				                                                        <img src="/icons/shortcut-transferencia.svg" alt="" aria-hidden className="h-9 w-9" />
+					                                                        <img src="/icons/shortcut-transferencia.svg" alt="" aria-hidden className="h-5 w-5" />
 					                                                    </Button>
 					
 			                                                </div>
@@ -1067,9 +1206,18 @@ export default function AppFunctionalNeatlab() {
 
 		                                <div className="flex items-center gap-4">
 		                                    {active === 'insumos' ? (
-		                                        <div className="flex items-center gap-2 min-w-[160px] justify-between rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-blue-200/70">
-		                                            <span className="uppercase tracking-wide text-blue-200/60">Estoque</span>
-		                                            <span className="ml-auto text-right font-mono text-blue-50">
+		                                        <div className="flex items-start gap-2 min-w-[180px] justify-between rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-blue-200/70">
+		                                            <button
+		                                                type="button"
+		                                                className="inline-flex"
+		                                                onClick={() => setEstoqueThresholdsOpen(true)}
+		                                                title="Editar faixas de estoque"
+		                                                aria-label="Editar faixas de estoque"
+		                                            >
+		                                                <Badge className={`uppercase tracking-wide border ${estoqueBadgeClass}`}>Estoque</Badge>
+		                                            </button>
+		                                            <span className="ml-auto text-right">
+		                                                <span className="block font-mono text-blue-50">
 		                                                {insumosHeaderEstoque?.loading ? (
 		                                                    <span className="inline-flex items-center gap-2">
 		                                                        <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
@@ -1078,6 +1226,21 @@ export default function AppFunctionalNeatlab() {
 		                                                ) : (
 		                                                    insumosHeaderEstoque?.value != null ? fmtMoneyBRLCompact(insumosHeaderEstoque.value) : '-'
 		                                                )}
+		                                                </span>
+		                                                {!insumosHeaderEstoque?.loading ? (
+		                                                    <span className="mt-1 flex flex-col items-end text-[10px] leading-tight">
+		                                                        <span className="text-emerald-300">
+		                                                            {insumosHeaderEstoque?.entradaValor != null
+		                                                                ? `+ ${fmtMoneyBRLCompact(insumosHeaderEstoque.entradaValor)}`
+		                                                                : '-'}
+		                                                        </span>
+		                                                        <span className="text-rose-300">
+		                                                            {insumosHeaderEstoque?.saidaValor != null
+		                                                                ? `- ${fmtMoneyBRLCompact(insumosHeaderEstoque.saidaValor)}`
+		                                                                : '-'}
+		                                                        </span>
+		                                                    </span>
+		                                                ) : null}
 		                                            </span>
 		                                        </div>
 		                                    ) : null}
@@ -1086,7 +1249,7 @@ export default function AppFunctionalNeatlab() {
 		                                            <Button
 		                                                size="icon"
 		                                                variant="ghost"
-		                                                className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
+		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
 		                                                    try {
 		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'expandAll' } }))
@@ -1103,7 +1266,7 @@ export default function AppFunctionalNeatlab() {
 		                                            <Button
 		                                                size="icon"
 		                                                variant="ghost"
-		                                                className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
+		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
 		                                                    try {
 		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'collapseAll' } }))
@@ -1120,7 +1283,7 @@ export default function AppFunctionalNeatlab() {
 		                                            <Button
 		                                                size="icon"
 		                                                variant="ghost"
-		                                                className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-9 rounded-full"
+		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
 		                                                    try {
 		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'reset' } }))

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -4697,74 +4697,6 @@ export function InsumosModule() {
     []
   )
 
-  const resolveChartSlot = React.useCallback(
-    (slot: ChartSlotConfig) => {
-      const preset = presetSupports(slot.presetId)
-      const groupBy: ChartGroupBy | undefined =
-        slot.presetId === 'distribution'
-          ? slot.groupBy === 'marca' || slot.groupBy === 'item'
-            ? slot.groupBy
-            : 'categoria'
-          : slot.presetId === 'movements'
-            ? slot.groupBy === 'categoria'
-              ? 'categoria'
-              : 'tempo'
-            : undefined
-      const mode: MovementsMode | undefined =
-        slot.presetId === 'movements'
-          ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
-            ? slot.mode
-            : groupBy === 'categoria'
-              ? 'saida'
-              : 'inout'
-          : undefined
-      const viewOptions = presetViewOptions({ ...slot, groupBy, mode })
-      const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as ChartView
-      const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
-      const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as ChartMetric
-      const topN = Math.max(5, Math.min(15, Number(slot.topN) || 8))
-      const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
-      const layout = (preset as any).layout as ChartLayout | undefined
-      return { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout }
-    },
-    [presetSupports, presetViewOptions]
-  )
-
-  const chartSlotsView = React.useMemo(() => {
-    const search = chartsSearch.trim().toLowerCase()
-    return chartSlots
-      .map((slot, idx) => ({ slot, idx, meta: resolveChartSlot(slot) }))
-      .filter(({ slot, meta }) => {
-        if (chartsFilterTipo !== '__ALL__' && slot.presetId !== chartsFilterTipo) return false
-        if (chartsFilterY !== '__ALL__' && meta.groupBy !== chartsFilterY) return false
-        if (chartsFilterX !== '__ALL__' && meta.metric !== chartsFilterX) return false
-        if (chartsFilterView !== '__ALL__' && meta.view !== chartsFilterView) return false
-        if (chartsFilterTop !== '__ALL__' && String(meta.topN) !== String(chartsFilterTop)) return false
-        if (!search) return true
-        const hay = [
-          meta.preset.label,
-          slot.presetId,
-          meta.groupBy || '',
-          meta.metric,
-          meta.view,
-          meta.mode || '',
-          String(meta.topN)
-        ]
-          .join(' ')
-          .toLowerCase()
-        return hay.includes(search)
-      })
-  }, [
-    chartSlots,
-    chartsFilterTipo,
-    chartsFilterY,
-    chartsFilterX,
-    chartsFilterView,
-    chartsFilterTop,
-    chartsSearch,
-    resolveChartSlot
-  ])
-
 	  const stockAgg = React.useMemo(() => {
 	    const byCategoria = new Map<string, { name: string; qtd: number; valor: number }>()
 	    const byMarca = new Map<string, { name: string; qtd: number; valor: number }>()
@@ -4870,18 +4802,86 @@ export function InsumosModule() {
     []
   )
 
-	  const presetViewOptions = React.useCallback((slot: ChartSlotConfig): ChartView[] => {
-	    if (slot.presetId === 'distribution') {
-	      const gb = slot.groupBy === 'item' ? 'item' : slot.groupBy === 'marca' ? 'marca' : 'categoria'
-	      return gb === 'item' ? ['bar'] : ['pie', 'bar']
-	    }
+  const presetViewOptions = React.useCallback((slot: ChartSlotConfig): ChartView[] => {
+    if (slot.presetId === 'distribution') {
+      const gb = slot.groupBy === 'item' ? 'item' : slot.groupBy === 'marca' ? 'marca' : 'categoria'
+      return gb === 'item' ? ['bar'] : ['pie', 'bar']
+    }
 	    if (slot.presetId === 'movements') {
 	      const gb = slot.groupBy === 'categoria' ? 'categoria' : 'tempo'
 	      return gb === 'tempo' ? ['bar', 'line'] : ['bar', 'pie']
 	    }
-	    if (slot.presetId === 'roi_risk') return ['bar', 'pie']
-	    return ['bar', 'line']
-	  }, [])
+    if (slot.presetId === 'roi_risk') return ['bar', 'pie']
+    return ['bar', 'line']
+  }, [])
+
+  const resolveChartSlot = React.useCallback(
+    (slot: ChartSlotConfig) => {
+      const preset = presetSupports(slot.presetId)
+      const groupBy: ChartGroupBy | undefined =
+        slot.presetId === 'distribution'
+          ? slot.groupBy === 'marca' || slot.groupBy === 'item'
+            ? slot.groupBy
+            : 'categoria'
+          : slot.presetId === 'movements'
+            ? slot.groupBy === 'categoria'
+              ? 'categoria'
+              : 'tempo'
+            : undefined
+      const mode: MovementsMode | undefined =
+        slot.presetId === 'movements'
+          ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
+            ? slot.mode
+            : groupBy === 'categoria'
+              ? 'saida'
+              : 'inout'
+          : undefined
+      const viewOptions = presetViewOptions({ ...slot, groupBy, mode })
+      const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as ChartView
+      const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
+      const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as ChartMetric
+      const topN = Math.max(5, Math.min(15, Number(slot.topN) || 8))
+      const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
+      const layout = (preset as any).layout as ChartLayout | undefined
+      return { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout }
+    },
+    [presetSupports, presetViewOptions]
+  )
+
+  const chartSlotsView = React.useMemo(() => {
+    const search = chartsSearch.trim().toLowerCase()
+    return chartSlots
+      .map((slot, idx) => ({ slot, idx, meta: resolveChartSlot(slot) }))
+      .filter(({ slot, meta }) => {
+        if (chartsFilterTipo !== '__ALL__' && slot.presetId !== chartsFilterTipo) return false
+        if (chartsFilterY !== '__ALL__' && meta.groupBy !== chartsFilterY) return false
+        if (chartsFilterX !== '__ALL__' && meta.metric !== chartsFilterX) return false
+        if (chartsFilterView !== '__ALL__' && meta.view !== chartsFilterView) return false
+        if (chartsFilterTop !== '__ALL__' && String(meta.topN) !== String(chartsFilterTop)) return false
+        if (!search) return true
+        const hay = [
+          meta.preset.label,
+          slot.presetId,
+          meta.groupBy || '',
+          meta.metric,
+          meta.view,
+          meta.mode || '',
+          String(meta.topN)
+        ]
+          .join(' ')
+          .toLowerCase()
+        return hay.includes(search)
+      })
+  }, [
+    chartSlots,
+    chartsFilterTipo,
+    chartsFilterY,
+    chartsFilterX,
+    chartsFilterView,
+    chartsFilterTop,
+    chartsSearch,
+    resolveChartSlot
+  ])
 
   const renderChart = React.useCallback(
     (slot: ChartSlotConfig, opts?: { height?: number }) => {

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -1540,19 +1540,33 @@ export function InsumosModule() {
 
   React.useEffect(() => {
     try {
+      const entradaValor = Number.isFinite(Number(overviewMovResumo?.entradaValor))
+        ? Number(overviewMovResumo?.entradaValor)
+        : null
+      const saidaValor = Number.isFinite(Number(overviewMovResumo?.saidaValor))
+        ? Number(overviewMovResumo?.saidaValor)
+        : null
       window.dispatchEvent(
         new CustomEvent('skincos:insumos:estoque', {
           detail: {
             value: overviewResumo?.valorEstoqueTotal ?? null,
             loading: showOverviewLoadingProgress,
-            percent: loadingPercent
+            percent: loadingPercent,
+            entradaValor,
+            saidaValor
           }
         })
       )
     } catch {
       // ignore
     }
-  }, [loadingPercent, overviewResumo?.valorEstoqueTotal, showOverviewLoadingProgress])
+  }, [
+    loadingPercent,
+    overviewMovResumo?.entradaValor,
+    overviewMovResumo?.saidaValor,
+    overviewResumo?.valorEstoqueTotal,
+    showOverviewLoadingProgress
+  ])
   const renderInlinePercent = React.useCallback(
     (active: boolean, className = '') => {
       if (!active) return null
@@ -4558,7 +4572,7 @@ export function InsumosModule() {
 	      { id: 'roi_risk', label: 'ROI (perdas & risco)', supportsMetric: true, supportsView: true, defaultView: 'bar', layout: 'square' }
 	    ]
 
-	  const [chartSlots, setChartSlots] = React.useState<ChartSlotConfig[]>(() => {
+  const [chartSlots, setChartSlots] = React.useState<ChartSlotConfig[]>(() => {
 	    try {
 	      const raw = window.localStorage.getItem(CHARTS_SLOTS_KEY)
 	      if (!raw) return DEFAULT_CHART_SLOTS
@@ -4633,6 +4647,13 @@ export function InsumosModule() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   })
 
+  const [chartsFilterTipo, setChartsFilterTipo] = React.useState<ChartPresetId | '__ALL__'>('__ALL__')
+  const [chartsFilterY, setChartsFilterY] = React.useState<ChartGroupBy | '__ALL__'>('__ALL__')
+  const [chartsFilterX, setChartsFilterX] = React.useState<ChartMetric | '__ALL__'>('__ALL__')
+  const [chartsFilterView, setChartsFilterView] = React.useState<ChartView | '__ALL__'>('__ALL__')
+  const [chartsFilterTop, setChartsFilterTop] = React.useState<'5' | '8' | '10' | '15' | '__ALL__'>('__ALL__')
+  const [chartsSearch, setChartsSearch] = React.useState('')
+
   React.useEffect(() => {
     try {
       window.localStorage.setItem(CHARTS_SLOTS_KEY, JSON.stringify(chartSlots))
@@ -4675,6 +4696,74 @@ export function InsumosModule() {
     },
     []
   )
+
+  const resolveChartSlot = React.useCallback(
+    (slot: ChartSlotConfig) => {
+      const preset = presetSupports(slot.presetId)
+      const groupBy: ChartGroupBy | undefined =
+        slot.presetId === 'distribution'
+          ? slot.groupBy === 'marca' || slot.groupBy === 'item'
+            ? slot.groupBy
+            : 'categoria'
+          : slot.presetId === 'movements'
+            ? slot.groupBy === 'categoria'
+              ? 'categoria'
+              : 'tempo'
+            : undefined
+      const mode: MovementsMode | undefined =
+        slot.presetId === 'movements'
+          ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
+            ? slot.mode
+            : groupBy === 'categoria'
+              ? 'saida'
+              : 'inout'
+          : undefined
+      const viewOptions = presetViewOptions({ ...slot, groupBy, mode })
+      const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as ChartView
+      const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
+      const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as ChartMetric
+      const topN = Math.max(5, Math.min(15, Number(slot.topN) || 8))
+      const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
+      const layout = (preset as any).layout as ChartLayout | undefined
+      return { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout }
+    },
+    [presetSupports, presetViewOptions]
+  )
+
+  const chartSlotsView = React.useMemo(() => {
+    const search = chartsSearch.trim().toLowerCase()
+    return chartSlots
+      .map((slot, idx) => ({ slot, idx, meta: resolveChartSlot(slot) }))
+      .filter(({ slot, meta }) => {
+        if (chartsFilterTipo !== '__ALL__' && slot.presetId !== chartsFilterTipo) return false
+        if (chartsFilterY !== '__ALL__' && meta.groupBy !== chartsFilterY) return false
+        if (chartsFilterX !== '__ALL__' && meta.metric !== chartsFilterX) return false
+        if (chartsFilterView !== '__ALL__' && meta.view !== chartsFilterView) return false
+        if (chartsFilterTop !== '__ALL__' && String(meta.topN) !== String(chartsFilterTop)) return false
+        if (!search) return true
+        const hay = [
+          meta.preset.label,
+          slot.presetId,
+          meta.groupBy || '',
+          meta.metric,
+          meta.view,
+          meta.mode || '',
+          String(meta.topN)
+        ]
+          .join(' ')
+          .toLowerCase()
+        return hay.includes(search)
+      })
+  }, [
+    chartSlots,
+    chartsFilterTipo,
+    chartsFilterY,
+    chartsFilterX,
+    chartsFilterView,
+    chartsFilterTop,
+    chartsSearch,
+    resolveChartSlot
+  ])
 
 	  const stockAgg = React.useMemo(() => {
 	    const byCategoria = new Map<string, { name: string; qtd: number; valor: number }>()
@@ -6982,7 +7071,7 @@ export function InsumosModule() {
                                     <div className="hidden sm:flex items-center gap-3 text-xs text-blue-200/70">
                                       <span className="inline-flex items-center gap-1">
                                         <span
-                                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/15 text-red-300 border border-red-400/40"
+                                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/40 text-red-50"
                                           title="Crítico"
                                           aria-label="Crítico"
                                         >
@@ -7004,7 +7093,7 @@ export function InsumosModule() {
                                       </span>
                                       <span className="inline-flex items-center gap-1">
                                         <span
-                                          className="inline-flex h-5 w-5 items-center justify-center text-amber-300"
+                                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500/35 text-amber-100"
                                           title="Atenção"
                                           aria-label="Atenção"
                                         >
@@ -7012,9 +7101,9 @@ export function InsumosModule() {
                                             <path
                                               d="M12 3l9 16H3l9-16z"
                                               fill="currentColor"
-                                              fillOpacity="0.15"
+                                              fillOpacity="0.45"
                                               stroke="currentColor"
-                                              strokeWidth="1.8"
+                                              strokeWidth="1.4"
                                               strokeLinejoin="round"
                                             />
                                             <path d="M12 9v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
@@ -7034,13 +7123,13 @@ export function InsumosModule() {
                                       </span>
                                     </div>
                                   </div>
-                                  <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0 justify-end">
+                                  <div className="flex flex-1 flex-wrap md:flex-nowrap items-center gap-2 min-w-0 justify-end">
                                     <Select value={alertasStatus} onValueChange={(v) => setAlertasStatus(v as any)}>
                                       <SelectTrigger className="h-8 w-24">
                                         <SelectValue placeholder="Status" />
                                       </SelectTrigger>
                                       <SelectContent>
-                                        <SelectItem value="TODOS">Todos</SelectItem>
+                                        <SelectItem value="TODOS">–</SelectItem>
                                         <SelectItem value="ATENCAO">Atenção</SelectItem>
                                         <SelectItem value="URGENTE">Crítico</SelectItem>
                                         <SelectItem value="INFO">Info</SelectItem>
@@ -7054,7 +7143,7 @@ export function InsumosModule() {
                                         <SelectValue placeholder="Categoria" />
                                       </SelectTrigger>
                                       <SelectContent>
-                                        <SelectItem value="__ALL__">Todos</SelectItem>
+                                        <SelectItem value="__ALL__">–</SelectItem>
                                         {alertasCategorias.map((c) => (
                                           <SelectItem key={c} value={c}>
                                             {c}
@@ -7067,7 +7156,7 @@ export function InsumosModule() {
                                         <SelectValue placeholder="Fluxo" />
                                       </SelectTrigger>
                                       <SelectContent>
-                                        <SelectItem value="TODOS">Todos</SelectItem>
+                                        <SelectItem value="TODOS">–</SelectItem>
                                         <SelectItem value="ENTRADA">Entrada</SelectItem>
                                         <SelectItem value="SAIDA">Saída</SelectItem>
                                         <SelectItem value="DESCARTE">Descarte</SelectItem>
@@ -7078,7 +7167,7 @@ export function InsumosModule() {
                                       value={alertasBusca}
                                       onChange={(e) => setAlertasBusca(e.target.value)}
                                       placeholder="Buscar"
-                                      className="h-8 min-w-[140px] flex-1 max-w-[320px]"
+                                      className="h-8 flex-1 min-w-[120px] max-w-[420px] md:min-w-0 md:max-w-none"
                                     />
                                     <div className="flex items-center gap-2 shrink-0">
                                       <Button
@@ -7284,9 +7373,12 @@ export function InsumosModule() {
                               <div className="flex flex-wrap gap-2">
                                 {rec?.kind === 'TRANSFERENCIA' ? (
                                   <Button
-                                    variant="outline"
-                                    className="h-8 px-2 text-xs"
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-8 w-8 bg-sky-500/30 text-sky-100 hover:bg-sky-500/45"
                                     disabled={!canQuick}
+                                    title="Transferir"
+                                    aria-label="Transferir"
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       openQuickOperation('TRANSFERENCIA', {
@@ -7298,14 +7390,25 @@ export function InsumosModule() {
                                       })
                                     }}
                                   >
-                                    Transferir
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                      <path
+                                        d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3"
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                      />
+                                    </svg>
                                   </Button>
                                 ) : null}
                                 {rec?.kind === 'ENTRADA' ? (
                                   <Button
-                                    variant="outline"
-                                    className="h-8 px-2 text-xs"
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-8 w-8 bg-emerald-500/30 text-emerald-100 hover:bg-emerald-500/45"
                                     disabled={!canQuick}
+                                    title="Entrada"
+                                    aria-label="Entrada"
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       openQuickOperation('ENTRADA', {
@@ -7315,14 +7418,25 @@ export function InsumosModule() {
                                       })
                                     }}
                                   >
-                                    Entrada
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                      <path
+                                        d="M12 5v10m0 0-4-4m4 4 4-4M5 19h14"
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                      />
+                                    </svg>
                                   </Button>
                                 ) : null}
                                 {hasExpiringAction ? (
                                   <Button
-                                    variant={a.tags.includes('EXPIRADO') ? 'destructive' : 'secondary'}
-                                    className="h-8 px-2 text-xs"
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-8 w-8 bg-rose-500/35 text-rose-100 hover:bg-rose-500/50"
                                     disabled={!canQuick}
+                                    title={a.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
+                                    aria-label={a.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       openQuickOperation('BAIXA', {
@@ -7332,7 +7446,15 @@ export function InsumosModule() {
                                       })
                                     }}
                                   >
-                                    {a.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                      <path
+                                        d="M12 19V9m0 0-4 4m4-4 4 4M5 5h14"
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                      />
+                                    </svg>
                                   </Button>
                                 ) : null}
                                 {hasQualityAction ? (
@@ -7391,7 +7513,7 @@ export function InsumosModule() {
 	                        <div ref={dragProvided.innerRef} {...dragProvided.draggableProps}>
 		                          <Card className="bg-black/20 border border-white/10">
                               <CardHeader className="flex flex-col gap-2">
-                                <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:justify-between">
+                                <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:gap-3">
                                   <div className="flex items-center gap-3 min-w-0">
                                     <button
                                       type="button"
@@ -7406,10 +7528,74 @@ export function InsumosModule() {
                                     </button>
                                     <CardTitle className="text-white text-base">Gráficos</CardTitle>
                                   </div>
-                                  <div className="flex flex-1 items-center justify-end gap-2">
+                                  <div className="flex flex-1 flex-wrap md:flex-nowrap items-center gap-2 min-w-0 justify-end">
+                                    <Select value={chartsFilterTipo} onValueChange={(v) => setChartsFilterTipo(v as any)}>
+                                      <SelectTrigger className="h-8 w-32">
+                                        <SelectValue placeholder="Tipo" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="__ALL__">–</SelectItem>
+                                        <SelectItem value="distribution">Distribuição</SelectItem>
+                                        <SelectItem value="movements">Movimentações</SelectItem>
+                                        <SelectItem value="roi_risk">ROI</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <Select value={chartsFilterY} onValueChange={(v) => setChartsFilterY(v as any)}>
+                                      <SelectTrigger className="h-8 w-28">
+                                        <SelectValue placeholder="Eixo Y" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="__ALL__">–</SelectItem>
+                                        <SelectItem value="categoria">Categoria</SelectItem>
+                                        <SelectItem value="marca">Marca</SelectItem>
+                                        <SelectItem value="item">Item</SelectItem>
+                                        <SelectItem value="tempo">Tempo</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <Select value={chartsFilterX} onValueChange={(v) => setChartsFilterX(v as any)}>
+                                      <SelectTrigger className="h-8 w-24">
+                                        <SelectValue placeholder="Eixo X" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="__ALL__">–</SelectItem>
+                                        <SelectItem value="qtd">Qtd</SelectItem>
+                                        <SelectItem value="valor">R$</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <Select value={chartsFilterView} onValueChange={(v) => setChartsFilterView(v as any)}>
+                                      <SelectTrigger className="h-8 w-32">
+                                        <SelectValue placeholder="Representação" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="__ALL__">–</SelectItem>
+                                        <SelectItem value="pie">Pizza</SelectItem>
+                                        <SelectItem value="bar">Barras</SelectItem>
+                                        <SelectItem value="line">Linhas</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <Select value={chartsFilterTop} onValueChange={(v) => setChartsFilterTop(v as any)}>
+                                      <SelectTrigger className="h-8 w-24">
+                                        <SelectValue placeholder="Top" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="__ALL__">–</SelectItem>
+                                        <SelectItem value="5">Top 5</SelectItem>
+                                        <SelectItem value="8">Top 8</SelectItem>
+                                        <SelectItem value="10">Top 10</SelectItem>
+                                        <SelectItem value="15">Top 15</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <Input
+                                      value={chartsSearch}
+                                      onChange={(e) => setChartsSearch(e.target.value)}
+                                      placeholder="Buscar"
+                                      className="h-8 flex-1 min-w-[120px] max-w-[420px] md:min-w-0 md:max-w-none"
+                                    />
+                                    <div className="flex items-center gap-2 shrink-0">
                                     <Button
-                                      variant="outline"
+                                      variant="ghost"
                                       size="icon"
+                                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
                                       onClick={() => {
                                         if (chartSlots.length >= MAX_CHARTS) return
                                         setChartSlots((prev) => [
@@ -7426,8 +7612,9 @@ export function InsumosModule() {
                                       </svg>
                                     </Button>
                                     <Button
-                                      variant="outline"
+                                      variant="ghost"
                                       size="icon"
+                                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
                                       onClick={() => setChartSlots(DEFAULT_CHART_SLOTS)}
                                       disabled={overviewLoading || insightsLoading}
                                       title="Resetar gráficos"
@@ -7462,52 +7649,29 @@ export function InsumosModule() {
                                         </svg>
                                       )}
                                     </Button>
+                                    </div>
                                   </div>
                                 </div>
                               </CardHeader>
                             {panelOpen ? (
                               <CardContent className="space-y-3">
               <div
-                className={`grid gap-3 ${chartSlots.length === 1
+                className={`grid gap-3 ${chartSlotsView.length <= 1
                   ? 'grid-cols-1'
-                  : chartSlots.length === 2
+                  : chartSlotsView.length === 2
                     ? 'grid-cols-1 lg:grid-cols-2'
                     : 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3 xl:grid-flow-dense'
                   }`}
               >
-	                {chartSlots.map((slot, idx) => {
-	                  const preset = presetSupports(slot.presetId)
-	                  const groupBy: ChartGroupBy | undefined =
-	                    slot.presetId === 'distribution'
-	                      ? slot.groupBy === 'marca' || slot.groupBy === 'item'
-	                        ? slot.groupBy
-	                        : 'categoria'
-	                      : slot.presetId === 'movements'
-	                        ? slot.groupBy === 'categoria'
-	                          ? 'categoria'
-	                          : 'tempo'
-	                        : undefined
-	                  const mode: MovementsMode | undefined =
-	                    slot.presetId === 'movements'
-	                      ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
-	                        ? slot.mode
-	                        : groupBy === 'categoria'
-	                          ? 'saida'
-	                          : 'inout'
-	                      : undefined
-	                  const viewOptions = presetViewOptions({ ...slot, groupBy, mode })
-	                  const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as any
-	                  const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
-	                  const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as any
-	                  const topN = Math.max(5, Math.min(15, Number(slot.topN) || 8))
-	                  const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
-	                  const layout = (preset as any).layout as ChartLayout | undefined
-                  const baseH = chartSlots.length === 1 ? 360 : chartSlots.length === 2 ? 300 : 260
-                  const height = layout === 'tall' ? baseH + (chartSlots.length === 1 ? 180 : 120) : baseH
-                  const cardSpan = chartSlots.length >= 3 && layout === 'wide' ? 'xl:col-span-2' : ''
+	                {chartSlotsView.length ? (
+                    chartSlotsView.map(({ slot, idx, meta }) => {
+                      const { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout } = meta
+                      const baseH = chartSlotsView.length === 1 ? 360 : chartSlotsView.length === 2 ? 300 : 260
+                      const height = layout === 'tall' ? baseH + (chartSlotsView.length === 1 ? 180 : 120) : baseH
+                      const cardSpan = chartSlotsView.length >= 3 && layout === 'wide' ? 'xl:col-span-2' : ''
 
-                  return (
-                    <Card key={`${slot.presetId}-${idx}`} className={`bg-black/20 border border-white/10 ${cardSpan}`}>
+                      return (
+                        <Card key={`${slot.presetId}-${idx}`} className={`bg-black/20 border border-white/10 ${cardSpan}`}>
 	                      <CardHeader className="space-y-2">
 	                        <div className="flex items-center gap-2">
 	                          <Select
@@ -7684,8 +7848,13 @@ export function InsumosModule() {
                         {renderChart({ ...slot, view, metric, topN }, { height })}
                       </CardContent>
                     </Card>
-                  )
-                })}
+                      )
+                    })
+                  ) : (
+                    <div className="rounded-xl border border-white/10 bg-black/10 p-6 text-sm text-blue-100/70">
+                      Nenhum gráfico encontrado para esses filtros.
+                    </div>
+                  )}
               </div>
 
 	                              </CardContent>
@@ -8891,7 +9060,7 @@ export function InsumosModule() {
                           <SelectValue placeholder="Fluxo" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="TODOS">Todos</SelectItem>
+                          <SelectItem value="TODOS">–</SelectItem>
                           <SelectItem value="ENTRADA">Entrada</SelectItem>
                           <SelectItem value="SAÍDA">Saída</SelectItem>
                           <SelectItem value="AJUSTE">Ajuste</SelectItem>
@@ -8905,7 +9074,7 @@ export function InsumosModule() {
                           <SelectValue placeholder="Categoria" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="__ALL__">Todos</SelectItem>
+                          <SelectItem value="__ALL__">–</SelectItem>
                           {lotCategorias.map((c) => (
                             <SelectItem key={c} value={c}>
                               {c}
@@ -8918,7 +9087,7 @@ export function InsumosModule() {
                           <SelectValue placeholder="Marca" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="__ALL__">Todos</SelectItem>
+                          <SelectItem value="__ALL__">–</SelectItem>
                           {insumosMarcas.map((m) => (
                             <SelectItem key={m} value={m}>
                               {m}

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -9003,50 +9003,6 @@ export function InsumosModule() {
           {movPanelOpen ? (
             <CardContent className="space-y-3">
 
-        {(selectedCodigoBarras.trim() || movFilterCategoria.trim() || movFilterMarca.trim() || movSearch.trim()) ? (
-          <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-blue-100/80 flex flex-wrap items-center justify-between gap-2">
-            <div className="min-w-0">
-              <span className="text-blue-200/70">Filtrando por:</span>{' '}
-              {selectedCodigoBarras.trim() ? (
-                <>
-                  {selectedInsumo?.produto ? <span className="text-blue-50 font-semibold">{selectedInsumo.produto}</span> : <span className="text-blue-50 font-semibold">Insumo</span>}{' '}
-                  • <span className="font-mono">{selectedCodigoBarras.trim()}</span>
-                </>
-              ) : null}
-              {movFilterCategoria.trim() ? (
-                <>
-                  {selectedCodigoBarras.trim() ? <span className="text-blue-200/60"> • </span> : null}
-                  <span className="text-blue-50 font-semibold">{movFilterCategoria.trim()}</span>
-                </>
-              ) : null}
-              {movFilterMarca.trim() ? (
-                <>
-                  {(selectedCodigoBarras.trim() || movFilterCategoria.trim()) ? <span className="text-blue-200/60"> • </span> : null}
-                  <span className="text-blue-50 font-semibold">{movFilterMarca.trim()}</span>
-                </>
-              ) : null}
-              {movSearch.trim() ? (
-                <>
-                  {(selectedCodigoBarras.trim() || movFilterCategoria.trim() || movFilterMarca.trim()) ? <span className="text-blue-200/60"> • </span> : null}
-                  <span className="text-blue-50 font-semibold">{movSearch.trim()}</span>
-                </>
-              ) : null}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setSelectedCodigoBarras('')
-                setMovFilterCategoria('')
-                setMovFilterMarca('')
-                setMovSearch('')
-              }}
-            >
-              Limpar
-            </Button>
-          </div>
-        ) : null}
-
         <div ref={movListContainerRef} className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
           <table className="w-full table-fixed text-sm">
             <thead className="bg-black/30 text-blue-100/80">


### PR DESCRIPTION
## Problema
A UI de Insumos tinha inconsistências visuais/operacionais em ações rápidas e no indicador de estoque do cabeçalho, além de não expor entradas/saídas do período. Isso gerava baixa visibilidade e padrões diferentes do restante do CRM.

## Impacto
- Ações rápidas (entrada/saída/transferência) menos legíveis e inconsistentes com o padrão de ícones.
- Indicador de estoque sem faixas configuráveis e sem sinalização de entrada/saída do período.

## Causa raiz
Padrões de botões e do header de estoque não estavam centralizados nem parametrizados com thresholds editáveis e dados de movimentação do período.

## Correção
- Padroniza ações rápidas como ícones com cor (entrada/saída/transferência), preservando destaque visual.
- Adiciona faixas configuráveis para o badge de estoque (verde/amarelo/vermelho) via modal de edição.
- Exibe valores de entrada e saída do período abaixo do estoque no header.
- Ajusta callbacks e ordenação interna para não gerar warnings de TS.

## Testes
- `npm -C frontend run typecheck`
