### PR TITLE
[codex] fix ponto ui smoke without build badge

### DIFF
--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -248,29 +248,36 @@ async function main() {
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
     await page.waitForTimeout(1500)
 
+    const moduleTitle = page.locator('header h1', { hasText: /Ponto/i }).first()
+    await moduleTitle.waitFor({ timeout: 30_000 })
+
     const buildBadge = page
       .locator('text=/Build:\\s*[a-f0-9]{7,}|Build:\\s*(unknown|dev)|build:\\s*[a-f0-9]{7,}|build:\\s*(unknown|dev)/i')
       .first()
-    await buildBadge.waitFor({ timeout: 30_000 })
     if (EXPECT_BUILD_SHA) {
-      const expectedShort = EXPECT_BUILD_SHA.slice(0, 7)
-      const start = Date.now()
-      let lastText = ''
-      let attempt = 0
-      while (Date.now() - start < BUILD_BADGE_WAIT_MS) {
-        attempt += 1
-        const badgeText = String((await buildBadge.textContent().catch(() => '')) || '').toLowerCase()
-        lastText = badgeText
-        if (badgeText.includes(expectedShort)) break
-        // Sometimes Pages env + new deployment propagation can lag a little.
-        await page.waitForTimeout(3000)
-        await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
-        await page.waitForTimeout(1200)
-      }
-      if (!lastText.includes(expectedShort)) {
-        throw new Error(
-          `Build badge mismatch after ${Math.ceil(BUILD_BADGE_WAIT_MS / 1000)}s (expected ${expectedShort}). Got: ${lastText || '(empty)'}`
-        )
+      const badgeCount = await buildBadge.count()
+      if (badgeCount > 0) {
+        const expectedShort = EXPECT_BUILD_SHA.slice(0, 7)
+        const start = Date.now()
+        let lastText = ''
+        let attempt = 0
+        while (Date.now() - start < BUILD_BADGE_WAIT_MS) {
+          attempt += 1
+          const badgeText = String((await buildBadge.textContent().catch(() => '')) || '').toLowerCase()
+          lastText = badgeText
+          if (badgeText.includes(expectedShort)) break
+          // Sometimes Pages env + new deployment propagation can lag a little.
+          await page.waitForTimeout(3000)
+          await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+          await page.waitForTimeout(1200)
+        }
+        if (!lastText.includes(expectedShort)) {
+          throw new Error(
+            `Build badge mismatch after ${Math.ceil(BUILD_BADGE_WAIT_MS / 1000)}s (expected ${expectedShort}). Got: ${lastText || '(empty)'}`
+          )
+        }
+      } else {
+        console.log('[ponto-ui-smoke] Build badge not present; skipping EXPECT_BUILD_SHA check.')
       }
     }
     await maybeScreenshot('ponto-open')


### PR DESCRIPTION
## Problema
O deploy do CRM Pages após automerge falhou no job **Ponto UI smoke (production)** porque o script aguardava a badge de build (`Build: ...`) — elemento removido da UI por decisão de produto. O locator não encontra o texto e o smoke estoura timeout.

## Causa raiz
O script `frontend/scripts/ponto-ui-smoke.cjs` tratava a badge como elemento obrigatório, mesmo quando a UI não a exibe mais.

## O que mudou
- O smoke passa a esperar pelo header do módulo (`header h1` com texto **Ponto**) como sinal estável de carregamento.
- A verificação do `EXPECT_BUILD_SHA` continua suportada **apenas se a badge existir**; caso não exista, o script registra o skip e prossegue.

## Impacto
- Desbloqueia o deploy de Pages após automerge.
- Mantém compatibilidade com cenários que ainda exibem a badge.

## Validação
- CI: Ponto UI smoke (production) deve passar novamente.
- Sem testes locais adicionais neste PR.
