### PR TITLE
[codex] lock modules and keep alive data

### DIFF
--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -249,7 +249,12 @@ async function main() {
     await page.waitForTimeout(1500)
 
     const moduleTitle = page.locator('header h1', { hasText: /Ponto/i }).first()
-    await moduleTitle.waitFor({ timeout: 30_000 })
+    const moduleVisible = await moduleTitle.isVisible().catch(() => false)
+    if (!moduleVisible) {
+      const fallbackTitle = await page.locator('header h1').first().textContent().catch(() => '')
+      console.log(`[ponto-ui-smoke] Ponto module not available (current title: ${fallbackTitle || 'unknown'}). Skipping.`)
+      return
+    }
 
     const buildBadge = page
       .locator('text=/Build:\\s*[a-f0-9]{7,}|Build:\\s*(unknown|dev)|build:\\s*[a-f0-9]{7,}|build:\\s*(unknown|dev)/i')


### PR DESCRIPTION
## Contexto
Precisamos limitar o acesso a módulos não prontos e evitar recarregamento de dados ao alternar abas.

## Problema
- Todos os módulos estavam destravados, permitindo acesso a telas incompletas.
- A troca de aba desmontava o módulo e forçava reload de dados, gerando custo/latência desnecessários.
- O smoke de Ponto falha quando o módulo é intencionalmente bloqueado.

## Causa raiz
- `UNLOCKED_MODULE_KEYS` incluía todos os módulos.
- A UI renderizava apenas o módulo ativo, desmontando o anterior ao trocar de aba.
- O script do smoke assumia sempre o módulo Ponto disponível.

## Solução
- Restringir módulos liberados para `insumos`, `atendimento`, `unit-monitor` e `redes sociais`.
- Implementar keep‑alive de módulos visitados (mantém montado e só alterna visibilidade).
- Evitar re‑disparo de eventos de Insumos quando unidade/período não mudam.
- Ajustar o smoke do Ponto para pular quando o módulo estiver bloqueado.

## Impacto para usuários
- Módulos não prontos ficam bloqueados.
- Dados já carregados permanecem ao alternar abas, reduzindo recargas desnecessárias.

## Testes
- `npm -C frontend run typecheck`
