### PR TITLE
[codex] Fix atendimento lint and build errors

### DIFF
--- a/backend/config/manager.py
+++ b/backend/config/manager.py
@@ -58,13 +58,13 @@ class ConfigManager:
 
     @classmethod
     def reload_config(cls):
-        """Recarrega a configuração do arquivo"""
+        """Recarrega a configuração do arquivo."""
         cls._instance = None
         cls._config = None
         return cls.get_instance()
 
     def _define_schema(self) -> Dict[str, Dict[str, Any]]:
-        """Define o schema de validação da configuração"""
+        """Define o schema de validação da configuração."""
         return {
             "spreadsheet_id": {"type": str, "required": True},
             "google_service_account": {"type": dict, "required": True},
@@ -76,7 +76,7 @@ class ConfigManager:
         }
 
     def _validate_config(self):
-        """Valida a configuração carregada contra o schema"""
+        """Valida a configuração carregada contra o schema."""
         if not self._schema or not ConfigManager._config:
             logger.error("Schema não inicializado")
             return
@@ -91,9 +91,11 @@ class ConfigManager:
                 if expected_type and not isinstance(
                     ConfigManager._config[field], expected_type
                 ):
+                    expected_name = expected_type.__name__
+                    received_name = type(ConfigManager._config[field]).__name__
                     validation_errors.append(
-                        f"Tipo incorreto para {field}: esperado {expected_type.__name__}, "
-                        f"recebido {type(ConfigManager._config[field]).__name__}"
+                        f"Tipo incorreto para {field}: esperado {expected_name}, "
+                        f"recebido {received_name}"
                     )
 
         # Validações específicas
@@ -107,7 +109,7 @@ class ConfigManager:
             raise ValueError(error_msg)
 
     def _validate_whatsapp_config(self, validation_errors: list):
-        """Valida configuração específica do WhatsApp"""
+        """Valida configuração específica do WhatsApp."""
         if not ConfigManager._config:
             validation_errors.append("Configuração não inicializada")
             return
@@ -122,7 +124,7 @@ class ConfigManager:
                 )
 
     def _load_config(self) -> Dict[str, Any]:
-        """Carrega a configuração do arquivo config.json"""
+        """Carrega a configuração do arquivo config.json."""
         try:
             with open(self.CONFIG_FILE, "r", encoding="utf-8") as f:
                 config = json.load(f)

--- a/backend/libs/outbox.py
+++ b/backend/libs/outbox.py
@@ -101,13 +101,7 @@ def iter_events(stream: str) -> Iterable[Dict[str, Any]]:
 
 
 def idempotency_key_sent(stream: str, idempotency_key: str) -> bool:
-    """
-    Returns True if a SUCCESS event exists for the idempotency_key.
-
-    Convention:
-      - event["idempotency_key"] == idempotency_key
-      - event["status"] in {"sent", "success"}
-    """
+    """Return True if a SUCCESS event exists for the idempotency key."""
     key = (idempotency_key or "").strip()
     if not key:
         return False

--- a/backend/libs/whatsapp.py
+++ b/backend/libs/whatsapp.py
@@ -21,7 +21,8 @@ except ModuleNotFoundError as exc:  # pragma: no cover
     if getattr(exc, "name", None) == "requests":
         raise ModuleNotFoundError(
             "Dependência ausente: `requests`.\n"
-            "Instale as dependências do backend (ex.: `python3 -m pip install -r backend/requirements.txt`)."
+            "Instale as dependências do backend "
+            "(ex.: `python3 -m pip install -r backend/requirements.txt`)."
         ) from exc
     raise
 
@@ -95,7 +96,8 @@ class WhatsAppClient:
                             logger.info(f"✅ Endpoint saudável: {api_url}{status_path}")
                             return True
                         logger.warning(
-                            f"⚠️ Endpoint responde mas não está ready: {api_url}{status_path}"
+                            "⚠️ Endpoint responde mas não está ready: "
+                            f"{api_url}{status_path}"
                         )
                         continue
                 except requests.exceptions.RequestException:
@@ -136,7 +138,8 @@ class WhatsAppClient:
                 )
                 if response.status_code in [502, 503, 504]:
                     logger.warning(
-                        f"⚠️ Gateway error {response.status_code}, tentando próximo endpoint..."
+                        "⚠️ Gateway error "
+                        f"{response.status_code}, tentando próximo endpoint..."
                     )
                     self._current_endpoint_index = (
                         self._current_endpoint_index + 1
@@ -169,7 +172,7 @@ class WhatsAppClient:
             ("phone", {"phone": phone_number, "message": message}),
         ]
         last_exception = None
-        for format_label, payload in payload_formats:
+        for _format_label, payload in payload_formats:
             final_payload = payload.copy()
             if kwargs:
                 final_payload.update(kwargs)

--- a/frontend/InstagramStudioPro.tsx
+++ b/frontend/InstagramStudioPro.tsx
@@ -1051,6 +1051,7 @@ export function InstagramStudioPro() {
               </div>
             </DialogContent>
           </Dialog>
+        )}
         </div>
       </div>
     )


### PR DESCRIPTION
## Contexto
Os checks falharam por dois motivos:
1) Erro de parsing em `InstagramStudioPro.tsx` (JS/TS build).
2) Violações de lint/flake8 em `backend/config` e `backend/libs`.

## Problema (causa/impacto)
- Build do frontend falha (`TS1005`) impedindo deploy.
- Lint Python falha por docstrings e linhas longas, bloqueando CI.

## Solução
- Corrigir a expressão JSX faltando fechamento em `InstagramStudioPro.tsx`.
- Ajustar docstrings e quebras de linha em `backend/config/manager.py`, `backend/libs/outbox.py` e `backend/libs/whatsapp.py`.

## Como validar
- `JS/TS Checks (workspace)` e `Deploy CRM (Cloudflare Pages)` passam no CI.

## Testes
- CI (GitHub Actions).
