### PR TITLE
[codex] Fix config lint docstrings

### DIFF
--- a/backend/archive/tools/repo_checks/main.py
+++ b/backend/archive/tools/repo_checks/main.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-import argparse, hashlib, json, os, subprocess, sys
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
 from typing import List, Dict
 
 

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,7 +1,4 @@
-"""
-Módulo de configurações centralizadas do sistema.
-Responsável por carregar, validar e gerenciar todas as configurações.
-"""
+"""Módulo de configurações centralizadas do sistema."""
 
 from .manager import ConfigManager
 from .constants import ConfigConstants

--- a/backend/config/constants.py
+++ b/backend/config/constants.py
@@ -1,6 +1,4 @@
-"""
-Constantes e configurações centralizadas do sistema.
-"""
+"""Constantes e configurações centralizadas do sistema."""
 
 from dataclasses import dataclass
 from typing import Optional, List
@@ -32,7 +30,7 @@ class SystemConstants:
 
 
 class ConfigConstants:
-    """Configurações centralizadas do sistema"""
+    """Configurações centralizadas do sistema."""
 
     API_ENDPOINTS = APIEndpoints()
     SYSTEM = SystemConstants()
@@ -48,14 +46,14 @@ class ConfigConstants:
 
     @classmethod
     def get_instance(cls):
-        """Retorna instância singleton"""
+        """Retorna instância singleton."""
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
 
     @classmethod
     def load_config(cls):
-        """Carrega configuração do arquivo config.json"""
+        """Carrega configuração do arquivo config.json."""
         if cls._config is None:
             try:
                 backend_dir = os.path.dirname(os.path.dirname(__file__))
@@ -73,7 +71,7 @@ class ConfigConstants:
 
     @property
     def SCOPES(self):
-        """Retorna os scopes do Google configurados"""
+        """Retorna os scopes do Google configurados."""
         config = self.load_config()
         return config.get(
             "google_scopes",
@@ -85,13 +83,13 @@ class ConfigConstants:
 
     @property
     def EXECUTIONS(self):
-        """Retorna as configurações de execução"""
+        """Retorna as configurações de execução."""
         config = self.load_config()
         return config.get("units", {})
 
     @property
     def CELL_REFERENCES(self):
-        """Retorna as referências de células"""
+        """Retorna as referências de células."""
         executions = self.EXECUTIONS
         refs = {}
 
@@ -107,7 +105,7 @@ class ConfigConstants:
 
     @property
     def MOTIVATIONAL_PHRASES(self):
-        """Retorna as frases motivacionais configuradas"""
+        """Retorna as frases motivacionais configuradas."""
         config = self.load_config()
         return config.get(
             "motivational_phrases",
@@ -133,6 +131,6 @@ class ConfigConstants:
 
     @property
     def GLOBAL_CONFIG(self):
-        """Retorna configurações globais"""
+        """Retorna configurações globais."""
         config = self.load_config()
         return config.get("global", {})

--- a/backend/config/environment.py
+++ b/backend/config/environment.py
@@ -1,6 +1,4 @@
-"""
-Sistema de detecção de ambiente e gerenciamento de credenciais.
-"""
+"""Sistema de detecção de ambiente e gerenciamento de credenciais."""
 
 import os
 import json
@@ -10,46 +8,46 @@ logger = logging.getLogger(__name__)
 
 
 class EnvironmentDetector:
-    """Sistema para detectar e adaptar execução baseado no ambiente"""
+    """Sistema para detectar e adaptar execução baseado no ambiente."""
 
     @staticmethod
     def is_github_actions() -> bool:
-        """Detecta se está rodando no GitHub Actions"""
+        """Detecta se está rodando no GitHub Actions."""
         return os.environ.get("GITHUB_ACTIONS") == "true"
 
     @staticmethod
     def is_local_development() -> bool:
-        """Detecta se está em ambiente de desenvolvimento local"""
+        """Detecta se está em ambiente de desenvolvimento local."""
         return not EnvironmentDetector.is_github_actions()
 
     @staticmethod
     def get_execution_mode() -> str:
-        """Retorna o modo de execução atual"""
+        """Retorna o modo de execução atual."""
         if EnvironmentDetector.is_github_actions():
             return "github_actions"
         return "local_development"
 
 
 class CredentialManager:
-    """Gerenciador de credenciais baseado no ambiente"""
+    """Gerenciador de credenciais baseado no ambiente."""
 
     @staticmethod
     def get_google_credentials(base_config: dict) -> dict:
-        """Obtém credenciais do Google baseado no ambiente"""
+        """Obtém credenciais do Google baseado no ambiente."""
         if EnvironmentDetector.is_github_actions():
             return CredentialManager._load_google_from_github_actions(base_config)
         return CredentialManager._load_google_from_local(base_config)
 
     @staticmethod
     def get_umbler_credentials(base_config: dict) -> dict:
-        """Obtém credenciais do Umbler baseado no ambiente"""
+        """Obtém credenciais do Umbler baseado no ambiente."""
         if EnvironmentDetector.is_github_actions():
             return CredentialManager._load_umbler_from_github_actions(base_config)
         return CredentialManager._load_umbler_from_local(base_config)
 
     @staticmethod
     def _load_google_from_github_actions(base_config: dict) -> dict:
-        """Carrega credenciais do Google dos secrets do GitHub"""
+        """Carrega credenciais do Google dos secrets do GitHub."""
         logger.info("🔄 GitHub Actions: Google check")
 
         # Verificar se o secret está disponível
@@ -68,7 +66,7 @@ class CredentialManager:
 
     @staticmethod
     def _load_google_from_local(base_config: dict) -> dict:
-        """Carrega credenciais do Google do arquivo local"""
+        """Carrega credenciais do Google do arquivo local."""
         logger.info("🔄 Local: Usando credenciais Google")
         # Em ambiente local, as credenciais já estão no config.json
         if "google_service_account" in base_config:
@@ -79,7 +77,7 @@ class CredentialManager:
 
     @staticmethod
     def _load_umbler_from_github_actions(base_config: dict) -> dict:
-        """Carrega credenciais do Umbler dos secrets do GitHub"""
+        """Carrega credenciais do Umbler dos secrets do GitHub."""
         logger.info("🔄 GitHub Actions: Verificando Umbler")
 
         # Mapear secrets para campos do umbler_config
@@ -110,7 +108,7 @@ class CredentialManager:
 
     @staticmethod
     def _load_umbler_from_local(base_config: dict) -> dict:
-        """Carrega credenciais do Umbler do arquivo local"""
+        """Carrega credenciais do Umbler do arquivo local."""
         logger.info("🔄 Local: Usando configurações Umbler")
         if "umbler_config" in base_config:
             logger.info("✅ Local: Umbler OK")


### PR DESCRIPTION
## Contexto
A CI ainda falhava em flake8 por docstrings e imports em `backend/config` e `backend/archive/tools/repo_checks`.

## Solução
- Separar imports no `repo_checks/main.py` (E401).
- Padronizar docstrings em `backend/config/__init__.py`, `constants.py` e `environment.py`.

## Como validar
- `JS/TS Checks (workspace)` passa sem falhas de flake8.

## Testes
- CI (GitHub Actions).
