### PR TITLE
[codex] Fix atendimento hooks ordering

### DIFF
--- a/frontend/AtendimentoModule.tsx
+++ b/frontend/AtendimentoModule.tsx
@@ -142,19 +142,6 @@ export function AtendimentoModule() {
   const [n8nKey, setN8nKey] = useState(0)
   const [activePanel, setActivePanel] = useState<PanelKey | null>(null)
 
-  if (!canWhatsApp && !canWhatsAppN8n && !canHarmonia && !canOmnichannel && !canHelpdesk && !canInstagram) {
-    return (
-      <Card className="glass-card">
-        <CardHeader>
-          <CardTitle className="text-white">Sem acesso ao módulo de atendimento</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-blue-100/70">
-          Solicite permissões para WhatsApp, Harmonia, Omnichannel ou Help Desk.
-        </CardContent>
-      </Card>
-    )
-  }
-
   const panelOptions = useMemo(
     () =>
       [
@@ -216,6 +203,19 @@ export function AtendimentoModule() {
     if (activePanel && panelOptions.some((panel) => panel.key === activePanel)) return
     setActivePanel(panelOptions[0]?.key ?? null)
   }, [activePanel, availableKeys, panelOptions])
+
+  if (!canWhatsApp && !canWhatsAppN8n && !canHarmonia && !canOmnichannel && !canHelpdesk && !canInstagram) {
+    return (
+      <Card className="glass-card">
+        <CardHeader>
+          <CardTitle className="text-white">Sem acesso ao módulo de atendimento</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-blue-100/70">
+          Solicite permissões para WhatsApp, Harmonia, Omnichannel ou Help Desk.
+        </CardContent>
+      </Card>
+    )
+  }
 
   const renderActivePanel = () => {
     switch (activePanel) {


### PR DESCRIPTION
## Contexto
O eslint falhava por hooks condicionais em `AtendimentoModule.tsx`.

## Solução
- Mover o early return de "Sem acesso" para depois dos hooks.

## Como validar
- `JS/TS Checks (workspace)` passa sem erros `react-hooks/rules-of-hooks`.

## Testes
- CI (GitHub Actions).
