### PR TITLE
[codex] wire cs-api auth

### DIFF
--- a/backend/apps/crm-api/scripts/run-evolution.sh
+++ b/backend/apps/crm-api/scripts/run-evolution.sh
@@ -18,7 +18,8 @@ fi
 export WA_ORCHESTRATOR_PROVIDER="evolution"
 export EVOLUTION_API_URL="http://localhost:8080"
 export EVOLUTION_API_KEY
-export CRM_PUBLIC_URL="https://crm-api.skincos.com.br"
+export CRM_PUBLIC_URL="https://cs-api.skincos.com.br"
+export CRM_BASIC_AUTH="crm:5S-OGr036xzXSQ6unFjS4Ej0"
 export CRM_API_PORT="8099"
 export PORT="8099"
 

--- a/frontend/functions/api/wa-orchestrator/[[path]].ts
+++ b/frontend/functions/api/wa-orchestrator/[[path]].ts
@@ -33,14 +33,30 @@ export async function onRequest(context: any): Promise<Response> {
     return raw === 'https://api.skincos.com.br' || raw.endsWith('.skincos.com.br')
   })()
 
+  const basicAuthRaw = String(context.env?.WA_ORCHESTRATOR_BASIC_AUTH || context.env?.CRM_BASIC_AUTH || '').trim()
+  const hasBasicAuth = Boolean(basicAuthRaw && basicAuthRaw.includes(':'))
+  const sanitizeUrl = (value: string) => {
+    try {
+      const u = new URL(value)
+      if (u.username || u.password) {
+        u.username = ''
+        u.password = ''
+      }
+      return u.toString()
+    } catch {
+      return value
+    }
+  }
+
   if (rest === '/_proxy-status' || rest === '/_proxy-status/') {
     return new Response(
       JSON.stringify({
         ok: true,
-        target: targetOrigin,
+        target: sanitizeUrl(targetOrigin),
         isProductionTarget,
         requestOrigin,
-        targets: rawTargets,
+        targets: rawTargets.map(sanitizeUrl),
+        hasBasicAuth
       }),
       {
         status: 200,
@@ -61,6 +77,15 @@ export async function onRequest(context: any): Promise<Response> {
     headers.set('accept', 'text/event-stream')
   } else {
     headers.set('accept', 'application/json')
+  }
+  if (hasBasicAuth && !headers.has('authorization')) {
+    const toBase64 = (value: string) => {
+      if (typeof btoa === 'function') return btoa(value)
+      // @ts-expect-error - Buffer is available in some runtimes
+      if (typeof Buffer !== 'undefined') return Buffer.from(value).toString('base64')
+      return value
+    }
+    headers.set('authorization', `Basic ${toBase64(basicAuthRaw)}`)
   }
   headers.delete('host')
   headers.delete('content-length')


### PR DESCRIPTION
## Context
The CRM Pages proxy for `/api/wa-orchestrator/*` was hitting the Node orchestrator without Basic Auth, so the online CRM could not connect to the WhatsApp orchestrator (401/404).

## Root cause
The Pages function forwarded requests without injecting Basic Auth, while the Node orchestrator enforces `CRM_BASIC_AUTH`.

## Fix
- Inject Basic Auth in the Pages proxy when `WA_ORCHESTRATOR_BASIC_AUTH`/`CRM_BASIC_AUTH` is configured.
- Sanitize `_proxy-status` output to avoid leaking credentials.
- Align the local `crm-api` run script with the new public URL and Basic Auth requirement.

## Validation
- `curl https://crm.skincos.com.br/api/wa-orchestrator/status` → 200
- `_proxy-status` shows `hasBasicAuth: true` and targets `cs-api`.

## Notes
Untracked meta-ads files are intentionally not included in this PR.
