### PR TITLE
[codex] fix wa-orchestrator csrf

### DIFF
--- a/frontend/waOrchestratorAuth.ts
+++ b/frontend/waOrchestratorAuth.ts
@@ -1,3 +1,5 @@
+import { csrfHeader } from '@/csrf'
+
 export function getCrmBasicAuthToken() {
   try {
     return String(window.localStorage.getItem('crm.basicAuth') || '').trim()
@@ -10,5 +12,9 @@ export function buildCrmBasicAuthHeaders(init?: HeadersInit) {
   const headers = new Headers(init || {})
   const token = getCrmBasicAuthToken()
   if (token) headers.set('Authorization', `Basic ${token}`)
+  const csrf = csrfHeader()
+  Object.entries(csrf).forEach(([key, value]) => {
+    if (value) headers.set(key, value)
+  })
   return headers
 }


### PR DESCRIPTION
## Context
Clicking “Conectar novo” in Omnichannel did not start the Evolution connection because the POST was rejected with CSRF errors.

## Root cause
WA orchestrator POSTs were sent without the CSRF header required by the CRM API when a dev session cookie is present.

## Fix
- Extend `buildCrmBasicAuthHeaders` to also include `x-csrf-token` from the cookie (when available).

## Validation
- `POST /api/wa-orchestrator/channels/:channel/start` succeeds from the CRM UI (no CSRF error).

