### PR TITLE
feat: atendimento media inline, reply/reactions + TS fixes

### DIFF
--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -9,9 +9,13 @@ import { fileURLToPath } from 'url'
 import { spawn, spawnSync } from 'child_process'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
+let devAuthSessionResolver = null
+let devAuthEnabled = false
+
 // WhatsApp Orchestrator (backend-only)
 import { whatsappOrchestrator } from './services/whatsappOrchestrator.js'
 import { evolutionOrchestrator } from './services/evolutionOrchestrator.js'
+import { waMessageMetaStore } from './services/waMessageMetaStore.js'
 
 // Ponto (reconhecimento facial + batidas)
 import { registerPontoRoutes } from './server/pontoRoutes.js'
@@ -67,6 +71,14 @@ try { await fs.mkdir(CORE_STATE_DIR, { recursive: true }) } catch { /* ignore */
 
 const app = express()
 
+const LOG_LEVEL = String(process.env.CRM_LOG_LEVEL || (process.env.NODE_ENV === 'development' ? 'warn' : 'info')).toLowerCase()
+const LOG_LEVEL_RANK = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 }
+const shouldLog = (level) => {
+    const current = LOG_LEVEL_RANK[String(level || 'info').toLowerCase()] ?? 3
+    const min = LOG_LEVEL_RANK[LOG_LEVEL] ?? 3
+    return current <= min
+}
+
 // -------------------------------------------------------------
 // Gateway hardening (Unit Monitor LAN gateway behind a tunnel)
 // -------------------------------------------------------------
@@ -95,7 +107,9 @@ app.use((req, res, next) => {
             duration_ms: Date.now() - startedAt,
             ip: req.ip,
         }
-        console.log(JSON.stringify(payload))
+        if (shouldLog(level)) {
+            console.log(JSON.stringify(payload))
+        }
     })
     next()
 })
@@ -259,7 +273,7 @@ app.use(cors({
     origin: true, // Allow all origins in development
     credentials: true, // Essential for SSE/EventSource and auth cookies
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'X-Requested-With', 'Accept'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'X-Requested-With', 'Accept', 'X-CSRF-Token', 'X-Tenant-Key', 'X-User-Role', 'X-CRM-Role', 'X-Role'],
     exposedHeaders: ['Content-Length', 'X-Total-Count'],
     optionsSuccessStatus: 200 // Legacy browser support
 }))
@@ -269,7 +283,7 @@ app.use((req, res, next) => {
     if (req.method === 'OPTIONS') {
         res.header('Access-Control-Allow-Origin', req.headers.origin || '*')
         res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS,PATCH')
-        res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control, X-Requested-With, Accept')
+        res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control, X-Requested-With, Accept, X-CSRF-Token, X-Tenant-Key, X-User-Role, X-CRM-Role, X-Role')
         res.header('Access-Control-Allow-Credentials', 'true')
         return res.sendStatus(200)
     }
@@ -313,6 +327,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }))
 // When running locally with `NO_AUTH=true`, provide a minimal cookie-based session.
 // -------------------------------------------------------------
 const DEV_AUTH_ENABLED = String(process.env.NO_AUTH || '').toLowerCase() === 'true' && String(process.env.NODE_ENV || '').toLowerCase() !== 'production'
+let devAuthRequireAdmin = null
 if (DEV_AUTH_ENABLED) {
     const DEV_AUTH_COOKIE = 'skincos_dev_session'
     const DEV_AUTH_SECRET = String(process.env.DEV_SESSION_SECRET || process.env.SESSION_SECRET || 'dev-only-session-secret')
@@ -413,6 +428,8 @@ if (DEV_AUTH_ENABLED) {
         const current = cookies[DEV_AUTH_COOKIE]
         return decodeSession(current)
     }
+    devAuthSessionResolver = getSessionFromReq
+    devAuthEnabled = true
 
     app.get('/api/auth/me', (req, res) => {
         res.setHeader('Cache-Control', 'no-store')
@@ -474,6 +491,109 @@ if (DEV_AUTH_ENABLED) {
         return res.json({ ok: true, unidades: units, source: 'local-dev' })
     })
 }
+
+// -------------------------------------------------------------
+// Visual Theme (branding/palettes) - file-based persistence
+// -------------------------------------------------------------
+const VISUAL_THEME_FILE = process.env.CRM_VISUAL_THEME_FILE || path.join(CORE_STATE_DIR, 'visual_theme.v1.json')
+let visualThemeState = { themes: {} }
+let saveVisualThemeTimer = null
+
+const ADMIN_ROLES = new Set(['ADMIN', 'GESTOR', 'GERENTE'])
+
+function resolveTenantKey(req) {
+    const header = String(req.headers['x-tenant-key'] || req.headers['x-tenant'] || '').trim()
+    let key = header || String(req.headers['x-forwarded-host'] || req.headers['host'] || '').trim().toLowerCase()
+    if (key.includes(',')) key = key.split(',')[0].trim()
+    key = key.replace(/^https?:\/\//, '')
+    if (key.includes('/')) key = key.split('/')[0].trim()
+    if (key.includes(':')) key = key.split(':')[0].trim()
+    key = key.replace(/[^a-z0-9._-]/g, '-')
+    if (!key) key = 'default'
+    return key
+}
+
+function resolveRoleFromReq(req) {
+    const header = req.headers['x-user-role'] || req.headers['x-crm-role'] || req.headers['x-role']
+    let role = header ? String(header) : ''
+    if (!role && req.user?.role) role = String(req.user.role)
+    return role.trim().toUpperCase()
+}
+
+function requireVisualThemeAdmin(req, res) {
+    if (devAuthRequireAdmin) return devAuthRequireAdmin(req, res)
+    const role = resolveRoleFromReq(req)
+    if (!role) {
+        res.status(401).json({ ok: false, error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' })
+        return null
+    }
+    if (!ADMIN_ROLES.has(role)) {
+        res.status(403).json({ ok: false, error: 'FORBIDDEN', code: 'FORBIDDEN' })
+        return null
+    }
+    return { user: { role } }
+}
+
+async function loadVisualThemeState() {
+    try {
+        const raw = await fs.readFile(VISUAL_THEME_FILE, 'utf-8')
+        const json = JSON.parse(raw)
+        if (json && typeof json === 'object') {
+            const themes = json.themes && typeof json.themes === 'object' ? json.themes : {}
+            visualThemeState = { themes }
+        }
+    } catch { /* ignore */ }
+}
+
+async function persistVisualThemeNow() {
+    try {
+        await fs.writeFile(VISUAL_THEME_FILE, JSON.stringify(visualThemeState, null, 2))
+    } catch (e) {
+        console.error('[VISUAL_THEME] Persist failed', e)
+    }
+}
+
+function schedulePersistVisualTheme() {
+    if (saveVisualThemeTimer) clearTimeout(saveVisualThemeTimer)
+    saveVisualThemeTimer = setTimeout(() => { persistVisualThemeNow() }, 500).unref()
+}
+
+await loadVisualThemeState()
+
+app.get('/api/visual-theme', (req, res) => {
+    res.setHeader('cache-control', 'no-store')
+    const tenantKey = resolveTenantKey(req)
+    const entry = visualThemeState.themes && typeof visualThemeState.themes === 'object'
+        ? visualThemeState.themes[tenantKey]
+        : null
+    return res.json({
+        ok: true,
+        tenantKey,
+        data: entry?.config || null,
+        meta: entry ? { updatedAt: entry.updatedAt || null, updatedBy: entry.updatedBy || null } : null
+    })
+})
+
+app.put('/api/visual-theme', async (req, res) => {
+    const session = requireVisualThemeAdmin(req, res)
+    if (!session) return
+    const tenantKey = resolveTenantKey(req)
+    const body = req.body && typeof req.body === 'object' ? req.body : {}
+    const config = body?.config && typeof body.config === 'object' ? body.config : body
+    if (!config || typeof config !== 'object') {
+        return res.status(400).json({ ok: false, error: 'CONFIG_REQUIRED', code: 'CONFIG_REQUIRED' })
+    }
+    if (!visualThemeState.themes || typeof visualThemeState.themes !== 'object') {
+        visualThemeState.themes = {}
+    }
+    visualThemeState.themes[tenantKey] = {
+        config,
+        updatedAt: new Date().toISOString(),
+        updatedBy: session?.user?.username || session?.user?.email || session?.user?.role || 'system'
+    }
+    schedulePersistVisualTheme()
+    return res.json({ ok: true, tenantKey, data: visualThemeState.themes[tenantKey] })
+})
 
 // -------------------------------------------------------------
 // Ponto (registro de ponto com identificação facial)
@@ -566,12 +686,84 @@ app.use('/api/instagram-module', createProxyMiddleware({
 // Meta Ads proxy (same-origin for CRM UI)
 // -------------------------------------------------------------
 const META_ADS_API_TARGET = process.env.META_ADS_API_TARGET || 'http://localhost:4000'
+const CRM_PROXY_SECRET = String(process.env.CRM_PROXY_SECRET || process.env.DEV_SESSION_SECRET || '').trim()
+const CRM_AUTH_TARGET = String(process.env.AUTH_API_TARGET || process.env.INSUMOS_API_TARGET || 'https://api.skincos.com.br').trim()
+const CRM_AUTH_PREFIX = (() => {
+    const raw = String(process.env.AUTH_PATH_PREFIX || '/api/auth').trim()
+    const prefix = raw.startsWith('/') ? raw : `/${raw}`
+    return prefix.replace(/\/$/, '') || '/api/auth'
+})()
+const CRM_AUTH_CANDIDATES = Array.from(new Set([CRM_AUTH_PREFIX, '/auth', '/api/auth']))
+
+function base64urlEncode(value) {
+    return Buffer.from(String(value || '')).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+async function fetchCrmUserFromAuth(req) {
+    try {
+        const cookie = req.headers?.cookie
+        if (!cookie) return null
+        const headers = { accept: 'application/json', cookie }
+        for (const prefix of CRM_AUTH_CANDIDATES) {
+            const url = new URL(CRM_AUTH_TARGET)
+            url.pathname = `${prefix}/me`
+            const res = await fetch(url.toString(), { method: 'GET', headers, redirect: 'manual' }).catch(() => null)
+            if (!res) continue
+            if (res.status === 404 || res.status === 405) continue
+            if (!res.ok) return null
+            const data = await res.json().catch(() => null)
+            const raw = data?.user || data?.usuario || data || null
+            if (!raw) return null
+            return {
+                id: raw.id || raw.username || raw.email,
+                username: raw.username,
+                displayName: raw.displayName || raw.name || raw.username || raw.email,
+                name: raw.name,
+                email: raw.email,
+                role: raw.role,
+                allowedUnits: raw.allowedUnits,
+                allowedModules: raw.allowedModules,
+            }
+        }
+        return null
+    } catch {
+        return null
+    }
+}
+
+async function resolveCrmUser(req) {
+    if (devAuthEnabled && typeof devAuthSessionResolver === 'function') {
+        const session = devAuthSessionResolver(req)
+        if (session?.user) return session.user
+    }
+    return fetchCrmUserFromAuth(req)
+}
+
+app.use('/api/meta-ads', async (req, res, next) => {
+    req.crmUser = await resolveCrmUser(req)
+    const hasBearer = String(req.headers?.authorization || '').toLowerCase().startsWith('bearer ')
+    if (!req.crmUser && !hasBearer) {
+        return res.status(401).json({ ok: false, error: 'UNAUTHORIZED', hint: 'Faça login no CRM para continuar.' })
+    }
+    return next()
+})
+
 app.use('/api/meta-ads', createProxyMiddleware({
     target: META_ADS_API_TARGET,
     changeOrigin: true,
     ws: false,
     logLevel: 'silent',
-    pathRewrite: { '^/api/meta-ads': '' }
+    pathRewrite: { '^/api/meta-ads': '' },
+    onProxyReq: (proxyReq, req) => {
+        const user = req.crmUser
+        if (!user) return
+        const payload = base64urlEncode(JSON.stringify(user))
+        proxyReq.setHeader('x-crm-user', payload)
+        if (CRM_PROXY_SECRET) {
+            const sig = createHmac('sha256', CRM_PROXY_SECRET).update(payload).digest('hex')
+            proxyReq.setHeader('x-crm-signature', sig)
+        }
+    }
 }))
 
 // -------------------------------------------------------------
@@ -708,6 +900,7 @@ if (DEV_AUTH_ENABLED) {
         }
         return session
     }
+    devAuthRequireAdmin = requireDevAdmin
 
     const loadLocalCrmStore = async () => {
         try {
@@ -1268,6 +1461,7 @@ function schedulePersistMessages() {
     saveMessagesTimer = setTimeout(() => { persistMessagesNow() }, 500).unref()
 }
 await loadMessages()
+await waMessageMetaStore.init()
 function ensureConv(convId) {
     if (!messages[convId]) messages[convId] = []
 }
@@ -4048,6 +4242,28 @@ function resolveWebhookHeaders() {
     return headers
 }
 
+function resolveMessageActor(req) {
+    const session = typeof devAuthSessionResolver === 'function' ? devAuthSessionResolver(req) : null
+    const user = session?.user || {}
+    const email = String(user?.email || req.get('x-user-email') || '').trim().toLowerCase()
+    const username = String(user?.username || req.get('x-user-name') || '').trim().toLowerCase()
+    const role = String(user?.role || req.get('x-user-role') || '').trim().toLowerCase()
+    if (email) return `email:${email}`
+    if (username) return `user:${username}`
+    if (role) return `role:${role}`
+    return `ip:${String(req.ip || 'unknown')}`
+}
+
+function buildWaMediaProxyUrl(req, { channel, remoteJid, messageId }) {
+    const base = resolveCrmPublicUrl(req)
+    const params = new URLSearchParams({
+        channel: String(channel),
+        remoteJid: String(remoteJid || ''),
+        messageId: String(messageId || '')
+    })
+    return `${base}/api/wa-orchestrator/media?${params.toString()}`
+}
+
 function recordWebhookSuccess() {
     waWebhookMetrics.total += 1
     waWebhookMetrics.lastAt = new Date().toISOString()
@@ -4116,30 +4332,174 @@ function extractEvolutionMessageText(message) {
 }
 
 function extractEvolutionMessageMeta(message) {
-    if (!message) return { text: '', caption: undefined, mediaType: undefined }
-    if (typeof message === 'string') return { text: message, caption: undefined, mediaType: undefined }
+    if (!message) {
+        return {
+            text: '',
+            caption: undefined,
+            mediaType: undefined,
+            mediaUrl: undefined,
+            mimeType: undefined,
+            fileName: undefined,
+            durationSec: undefined,
+            sizeBytes: undefined
+        }
+    }
+    if (typeof message === 'string') {
+        return {
+            text: message,
+            caption: undefined,
+            mediaType: undefined,
+            mediaUrl: undefined,
+            mimeType: undefined,
+            fileName: undefined,
+            durationSec: undefined,
+            sizeBytes: undefined
+        }
+    }
+    const resolveMediaUrl = (msg) => {
+        const candidate = (
+            msg?.mediaUrl ||
+            msg?.url ||
+            msg?.imageMessage?.url ||
+            msg?.videoMessage?.url ||
+            msg?.documentMessage?.url ||
+            msg?.audioMessage?.url ||
+            msg?.ptvMessage?.url ||
+            msg?.stickerMessage?.url
+        )
+        return typeof candidate === 'string' ? candidate : undefined
+    }
+    const resolveMimeType = (msg) => {
+        const candidate = (
+            msg?.mimetype ||
+            msg?.mimeType ||
+            msg?.imageMessage?.mimetype ||
+            msg?.videoMessage?.mimetype ||
+            msg?.documentMessage?.mimetype ||
+            msg?.audioMessage?.mimetype ||
+            msg?.ptvMessage?.mimetype ||
+            msg?.stickerMessage?.mimetype
+        )
+        return typeof candidate === 'string' ? candidate : undefined
+    }
+    const resolveFileName = (msg) => {
+        const candidate = (
+            msg?.fileName ||
+            msg?.documentMessage?.fileName ||
+            msg?.documentWithCaptionMessage?.fileName ||
+            msg?.imageMessage?.fileName ||
+            msg?.videoMessage?.fileName
+        )
+        return typeof candidate === 'string' ? candidate : undefined
+    }
+    const resolveDuration = (msg) => {
+        const candidate = (
+            msg?.duration ||
+            msg?.durationSec ||
+            msg?.audioMessage?.seconds ||
+            msg?.audioMessage?.duration ||
+            msg?.videoMessage?.seconds ||
+            msg?.ptvMessage?.seconds
+        )
+        const num = Number(candidate)
+        return Number.isFinite(num) && num > 0 ? num : undefined
+    }
+    const resolveSizeBytes = (msg) => {
+        const candidate = (
+            msg?.fileLength ||
+            msg?.sizeBytes ||
+            msg?.documentMessage?.fileLength ||
+            msg?.audioMessage?.fileLength ||
+            msg?.videoMessage?.fileLength ||
+            msg?.imageMessage?.fileLength
+        )
+        const num = Number(candidate)
+        return Number.isFinite(num) && num > 0 ? num : undefined
+    }
+    const fileName = resolveFileName(message)
+    const durationSec = resolveDuration(message)
+    const sizeBytes = resolveSizeBytes(message)
+    const mediaUrl = resolveMediaUrl(message)
+    const mimeType = resolveMimeType(message)
     if (message.conversation || message.text || message.extendedTextMessage?.text) {
-        return { text: extractEvolutionMessageText(message), caption: undefined, mediaType: undefined }
+        return {
+            text: extractEvolutionMessageText(message),
+            caption: undefined,
+            mediaType: undefined,
+            mediaUrl,
+            mimeType,
+            fileName,
+            durationSec,
+            sizeBytes
+        }
     }
     if (message.imageMessage) {
-        return { text: '', caption: message.imageMessage.caption, mediaType: 'image' }
+        return { text: '', caption: message.imageMessage.caption, mediaType: 'image', mediaUrl, mimeType, fileName, durationSec, sizeBytes }
     }
     if (message.videoMessage) {
-        return { text: '', caption: message.videoMessage.caption, mediaType: 'video' }
+        return { text: '', caption: message.videoMessage.caption, mediaType: 'video', mediaUrl, mimeType, fileName, durationSec, sizeBytes }
     }
     if (message.documentMessage || message.documentWithCaptionMessage) {
-        return { text: '', caption: message.documentMessage?.caption || message.documentWithCaptionMessage?.caption, mediaType: 'document' }
+        return {
+            text: '',
+            caption: message.documentMessage?.caption || message.documentWithCaptionMessage?.caption,
+            mediaType: 'document',
+            mediaUrl,
+            mimeType,
+            fileName,
+            durationSec,
+            sizeBytes
+        }
     }
     if (message.audioMessage) {
-        return { text: '', caption: undefined, mediaType: 'audio' }
+        return { text: '', caption: undefined, mediaType: 'audio', mediaUrl, mimeType, fileName, durationSec, sizeBytes }
     }
     if (message.stickerMessage) {
-        return { text: '', caption: undefined, mediaType: 'sticker' }
+        return { text: '', caption: undefined, mediaType: 'sticker', mediaUrl, mimeType, fileName, durationSec, sizeBytes }
     }
     if (message.ptvMessage) {
-        return { text: '', caption: undefined, mediaType: 'ptv' }
+        return { text: '', caption: undefined, mediaType: 'ptv', mediaUrl, mimeType, fileName, durationSec, sizeBytes }
     }
-    return { text: extractEvolutionMessageText(message), caption: undefined, mediaType: undefined }
+    return { text: extractEvolutionMessageText(message), caption: undefined, mediaType: undefined, mediaUrl, mimeType, fileName, durationSec, sizeBytes }
+}
+
+function extractEvolutionReplyMeta(record) {
+    const message = record?.message || {}
+    const quoted = (
+        message?.extendedTextMessage?.contextInfo?.quotedMessage ||
+        message?.imageMessage?.contextInfo?.quotedMessage ||
+        message?.videoMessage?.contextInfo?.quotedMessage ||
+        message?.documentMessage?.contextInfo?.quotedMessage ||
+        message?.audioMessage?.contextInfo?.quotedMessage ||
+        message?.conversation?.contextInfo?.quotedMessage ||
+        null
+    )
+    const quotedId = (
+        message?.extendedTextMessage?.contextInfo?.stanzaId ||
+        message?.imageMessage?.contextInfo?.stanzaId ||
+        message?.videoMessage?.contextInfo?.stanzaId ||
+        message?.documentMessage?.contextInfo?.stanzaId ||
+        message?.audioMessage?.contextInfo?.stanzaId ||
+        null
+    )
+    if (!quotedId) return null
+    const preview = extractEvolutionMessageText(quoted)
+    if (!preview) return null
+    return {
+        messageId: String(quotedId),
+        textPreview: preview.length > 240 ? `${preview.slice(0, 239)}…` : preview
+    }
+}
+
+function extractEvolutionMessageIdFromSendResult(result) {
+    return (
+        result?.key?.id ||
+        result?.id ||
+        result?.message?.key?.id ||
+        result?.response?.key?.id ||
+        result?.data?.key?.id ||
+        null
+    )
 }
 
 function normalizePlatform(raw) {
@@ -4156,6 +4516,13 @@ function extractPhoneFromJid(remoteJid) {
     const value = String(remoteJid)
     if (value.includes('@')) return value.split('@')[0]
     return value
+}
+
+function normalizeWhatsAppJid(value) {
+    const raw = String(value || '').trim()
+    if (!raw) return ''
+    if (raw.includes('@')) return raw
+    return `${raw}@s.whatsapp.net`
 }
 
 function normalizeEvolutionTimestamp(value) {
@@ -4293,14 +4660,19 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
             const data = await evolutionOrchestrator.fetchChats(channel, { limit, offset })
             const chats = Array.isArray(data) ? data : (data?.chats || data?.data || [])
             const items = chats.map((chat) => {
-                const remoteJid = chat.remoteJid || chat.id || chat.chatId || ''
+                const rawRemoteJid = chat.remoteJid || chat.id || chat.chatId || ''
+                const remoteJid = rawRemoteJid && String(rawRemoteJid).includes('@')
+                    ? String(rawRemoteJid)
+                    : (rawRemoteJid ? `${rawRemoteJid}@s.whatsapp.net` : '')
                 const lastMessageText = extractEvolutionMessageText(chat.lastMessage?.message || chat.lastMessage)
                 const updatedAt = normalizeEvolutionTimestamp(chat.updatedAt || chat.lastMessage?.messageTimestamp)
+                const profilePic = chat.profilePicUrl || chat.profilePictureUrl || chat.avatarUrl || chat.avatar || chat.imgUrl || chat.pictureUrl || chat.photoUrl || null
                 return {
                     conversationId: remoteJid,
                     name: chat.pushName || chat.name || chat.subject || remoteJid,
                     phone: extractPhoneFromJid(remoteJid),
                     platform: 'whatsapp',
+                    profilePic,
                     lastMessage: lastMessageText || 'Sem mensagens',
                     updatedAt,
                     unreadCount: chat.unreadCount ?? chat.unreadMessages ?? 0
@@ -4335,39 +4707,70 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/message
             return res.status(400).json({ success: false, error: 'Invalid channel. Must be between 1 and 9.' })
         }
         const { remoteJid } = req.params
+        const normalizedRemoteJid = normalizeWhatsAppJid(remoteJid)
         const limit = Math.min(Math.max(parseInt(String(req.query.limit || '50'), 10) || 50, 1), 200)
         const page = Math.max(parseInt(String(req.query.page || '1'), 10) || 1, 1)
+        const actor = resolveMessageActor(req)
 
         if (USE_EVOLUTION_ORCHESTRATOR) {
             const data = await evolutionOrchestrator.fetchMessages(channel, remoteJid, { limit, page })
             const records = data?.messages?.records || []
-            const items = records.map((record) => {
-                const fromMe = !!record?.key?.fromMe
-                const jid = record?.key?.remoteJid || remoteJid
-                const meta = extractEvolutionMessageMeta(record?.message)
-                return {
-                    id: record?.id || record?.key?.id || `m_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-                    conversationId: jid,
-                    direction: fromMe ? 'outbound' : 'inbound',
-                    type: meta.mediaType || record?.messageType || record?.type || 'text',
-                    text: meta.text || extractEvolutionMessageText(record?.message),
-                    caption: meta.caption,
-                    mediaType: meta.mediaType,
-                    createdAt: normalizeEvolutionTimestamp(record?.messageTimestamp || record?.timestamp)
+                const items = records.map((record) => {
+                    const fromMe = !!record?.key?.fromMe
+                    const jid = record?.key?.remoteJid || remoteJid
+                    const meta = extractEvolutionMessageMeta(record?.message)
+                    const replyTo = extractEvolutionReplyMeta(record)
+                    return {
+                        id: record?.id || record?.key?.id || `m_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+                        conversationId: jid,
+                        direction: fromMe ? 'outbound' : 'inbound',
+                        type: meta.mediaType || record?.messageType || record?.type || 'text',
+                        text: meta.text || extractEvolutionMessageText(record?.message),
+                        caption: meta.caption,
+                        mediaType: meta.mediaType,
+                        mediaUrl: meta.mediaUrl,
+                        mimeType: meta.mimeType,
+                        fileName: meta.fileName,
+                        durationSec: meta.durationSec,
+                        sizeBytes: meta.sizeBytes,
+                        replyTo,
+                        createdAt: normalizeEvolutionTimestamp(record?.messageTimestamp || record?.timestamp)
+                    }
+                })
+            const sortedItems = items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+            sortedItems.forEach((item) => {
+                if (item?.replyTo?.messageId && item?.id) {
+                    waMessageMetaStore.setReply(channel, normalizedRemoteJid, item.id, item.replyTo)
                 }
             })
-            const sortedItems = items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+            const decorated = waMessageMetaStore.decorateMessages(
+                channel,
+                normalizedRemoteJid,
+                sortedItems,
+                actor,
+                ({ channel: ch, remoteJid: jid, messageId }) =>
+                    buildWaMediaProxyUrl(req, { channel: ch, remoteJid: jid, messageId })
+            )
             const meta = {
                 total: data?.messages?.total,
                 pages: data?.messages?.pages,
                 page: data?.messages?.currentPage || page,
                 limit
             }
-            return res.json({ success: true, items: sortedItems, meta })
+            return res.json({ success: true, items: decorated, meta })
         }
 
         ensureConv(remoteJid)
-        return res.json({ success: true, items: messages[remoteJid] || [], meta: { page: 1, limit, total: (messages[remoteJid] || []).length } })
+        const baseItems = messages[remoteJid] || []
+        const decorated = waMessageMetaStore.decorateMessages(
+            channel,
+            normalizedRemoteJid,
+            baseItems,
+            actor,
+            ({ channel: ch, remoteJid: jid, messageId }) =>
+                buildWaMediaProxyUrl(req, { channel: ch, remoteJid: jid, messageId })
+        )
+        return res.json({ success: true, items: decorated, meta: { page: 1, limit, total: baseItems.length } })
     } catch (error) {
         res.status(500).json({ success: false, error: error.message })
     }
@@ -4381,21 +4784,174 @@ app.post('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/send',
             return res.status(400).json({ success: false, error: 'Invalid channel. Must be between 1 and 9.' })
         }
         const { remoteJid } = req.params
-        const { text } = req.body || {}
+        const { text, replyToMessageId, replyToPreview } = req.body || {}
         if (!text || !String(text).trim()) {
             return res.status(400).json({ success: false, error: 'text is required' })
         }
+        const normalizedRemoteJid = normalizeWhatsAppJid(remoteJid)
+        const actor = resolveMessageActor(req)
+        const replyMeta = replyToMessageId && replyToPreview
+            ? {
+                messageId: String(replyToMessageId),
+                textPreview: String(replyToPreview).slice(0, 240),
+                direction: 'inbound'
+            }
+            : null
 
         if (USE_EVOLUTION_ORCHESTRATOR) {
-            const result = await evolutionOrchestrator.sendText(channel, remoteJid, text)
-            return res.json({ success: true, result })
+            const result = await evolutionOrchestrator.sendText(channel, remoteJid, text, {
+                replyToMessageId: replyMeta?.messageId,
+                replyToPreview: replyMeta?.textPreview
+            })
+            const sentMessageId = extractEvolutionMessageIdFromSendResult(result)
+            if (sentMessageId && replyMeta) {
+                waMessageMetaStore.setReply(channel, normalizedRemoteJid, sentMessageId, replyMeta)
+            }
+            const responsePayload = {
+                success: true,
+                result,
+                ack: sentMessageId ? {
+                    id: sentMessageId,
+                    replyTo: replyMeta || undefined,
+                    reactions: waMessageMetaStore.listReactions(channel, normalizedRemoteJid, sentMessageId, actor)
+                } : undefined
+            }
+            if (sentMessageId && replyMeta) {
+                broadcastWaEvent({
+                    type: 'message_metadata_updated',
+                    channel,
+                    remoteJid: normalizedRemoteJid,
+                    messageId: sentMessageId,
+                    replyTo: replyMeta
+                })
+            }
+            return res.json(responsePayload)
         }
 
         const record = addMessage(remoteJid, { direction: 'human', type: 'text', text })
+        if (replyMeta) {
+            waMessageMetaStore.setReply(channel, normalizedRemoteJid, record.id, replyMeta)
+        }
         broadcastNewMessage(record)
-        return res.json({ success: true, message: record })
+        return res.json({
+            success: true,
+            message: {
+                ...record,
+                replyTo: replyMeta || undefined,
+                reactions: waMessageMetaStore.listReactions(channel, normalizedRemoteJid, record.id, actor)
+            }
+        })
     } catch (error) {
         res.status(500).json({ success: false, error: error.message })
+    }
+})
+
+app.post('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/messages/:messageId/reactions/toggle', async (req, res) => {
+    try {
+        const channel = parseInt(req.params.channel, 10)
+        if (isNaN(channel) || channel < 1 || channel > 9) {
+            return res.status(400).json({ success: false, error: 'Invalid channel. Must be between 1 and 9.' })
+        }
+        const remoteJid = normalizeWhatsAppJid(req.params.remoteJid)
+        const messageId = String(req.params.messageId || '').trim()
+        const emoji = String(req.body?.emoji || '').trim()
+        if (!remoteJid || !messageId || !emoji) {
+            return res.status(400).json({ success: false, error: 'channel, remoteJid, messageId and emoji are required' })
+        }
+        const actor = resolveMessageActor(req)
+        const reactions = waMessageMetaStore.toggleReaction(channel, remoteJid, messageId, emoji, actor)
+        const payload = {
+            type: 'message_reaction_updated',
+            channel,
+            remoteJid,
+            messageId,
+            reactions
+        }
+        broadcastWaEvent(payload)
+        return res.json({ success: true, reactions })
+    } catch (error) {
+        const message = error?.message || 'REACTION_TOGGLE_FAILED'
+        const status = message === 'EMOJI_INVALID' || message === 'ACTOR_REQUIRED' ? 400 : 500
+        return res.status(status).json({ success: false, error: message })
+    }
+})
+
+app.get('/api/wa-orchestrator/media', async (req, res) => {
+    try {
+        const channel = parseInt(String(req.query.channel || ''), 10)
+        const remoteJid = normalizeWhatsAppJid(String(req.query.remoteJid || ''))
+        const messageId = String(req.query.messageId || '').trim()
+        if (isNaN(channel) || channel < 1 || channel > 9 || !remoteJid || !messageId) {
+            return res.status(400).json({ success: false, error: 'channel, remoteJid and messageId are required' })
+        }
+
+        let media = waMessageMetaStore.findMedia(channel, remoteJid, messageId)
+        if (!media && USE_EVOLUTION_ORCHESTRATOR) {
+            try {
+                const data = await evolutionOrchestrator.fetchMessages(channel, remoteJid, { limit: 200, page: 1 })
+                const records = Array.isArray(data?.messages?.records) ? data.messages.records : []
+                const record = records.find((entry) => {
+                    const candidate = entry?.id || entry?.key?.id
+                    return String(candidate || '') === messageId
+                })
+                if (record) {
+                    const extracted = extractEvolutionMessageMeta(record?.message)
+                    if (extracted?.mediaUrl) {
+                        media = waMessageMetaStore.setMedia(channel, remoteJid, messageId, {
+                            type: extracted.mediaType || 'unknown',
+                            url: extracted.mediaUrl,
+                            mimeType: extracted.mimeType,
+                            fileName: extracted.fileName,
+                            durationSec: extracted.durationSec,
+                            sizeBytes: extracted.sizeBytes
+                        })
+                    }
+                }
+            } catch (error) {
+                if (shouldLog('warn')) {
+                    console.warn('[WA_MEDIA] Failed to refresh message metadata', {
+                        channel,
+                        remoteJid,
+                        messageId,
+                        error: error?.message || String(error)
+                    })
+                }
+            }
+        }
+
+        if (!media?.url) {
+            return res.status(404).json({ success: false, error: 'MEDIA_NOT_FOUND' })
+        }
+
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 12000)
+        let upstream
+        try {
+            upstream = await fetch(media.url, { signal: controller.signal })
+        } finally {
+            clearTimeout(timeoutId)
+        }
+        if (!upstream?.ok) {
+            return res.status(502).json({ success: false, error: 'MEDIA_UPSTREAM_FAILED', status: upstream?.status || 0 })
+        }
+
+        const mimeType = media.mimeType || upstream.headers.get('content-type') || 'application/octet-stream'
+        const fileName = String(media.fileName || `media-${messageId}`).replace(/[^\w.\-]/g, '_')
+        const buffer = Buffer.from(await upstream.arrayBuffer())
+        res.setHeader('Content-Type', mimeType)
+        res.setHeader('Cache-Control', 'private, max-age=60')
+        res.setHeader('Content-Disposition', `inline; filename="${fileName}"`)
+        return res.status(200).send(buffer)
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            return res.status(504).json({ success: false, error: 'MEDIA_TIMEOUT' })
+        }
+        if (shouldLog('error')) {
+            console.error('[WA_MEDIA] Proxy failed', {
+                error: error?.message || String(error)
+            })
+        }
+        return res.status(500).json({ success: false, error: 'MEDIA_PROXY_FAILED' })
     }
 })
 

--- a/backend/apps/crm-api/services/__tests__/waMessageMeta.test.js
+++ b/backend/apps/crm-api/services/__tests__/waMessageMeta.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { WaMessageMetaStore } from '../waMessageMetaStore.js'
+
+async function withStore(fn) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'wa-meta-test-'))
+  const file = path.join(dir, 'wa_message_meta.json')
+  const store = new WaMessageMetaStore(file)
+  await store.init()
+  try {
+    await fn(store, file)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+test('toggle reaction add/remove and aggregate', async () => {
+  await withStore(async (store) => {
+    const key = { channel: 1, remoteJid: '5511999990000@s.whatsapp.net', messageId: 'mid-1' }
+    let reactions = store.toggleReaction(key.channel, key.remoteJid, key.messageId, '👍', 'email:a@a.com')
+    assert.deepEqual(reactions, [{ emoji: '👍', count: 1, reactedByMe: true }])
+
+    reactions = store.toggleReaction(key.channel, key.remoteJid, key.messageId, '👍', 'email:b@a.com')
+    assert.deepEqual(reactions, [{ emoji: '👍', count: 2, reactedByMe: true }])
+
+    reactions = store.toggleReaction(key.channel, key.remoteJid, key.messageId, '👍', 'email:a@a.com')
+    assert.deepEqual(reactions, [{ emoji: '👍', count: 1, reactedByMe: false }])
+  })
+})
+
+test('persist and reload keeps metadata', async () => {
+  await withStore(async (store, file) => {
+    store.setReply(1, '5511999990000@s.whatsapp.net', 'mid-2', {
+      messageId: 'parent-1',
+      textPreview: 'Mensagem original',
+      direction: 'inbound'
+    })
+    store.toggleReaction(1, '5511999990000@s.whatsapp.net', 'mid-2', '❤️', 'email:a@a.com')
+    await store.persist()
+
+    const second = new WaMessageMetaStore(file)
+    await second.init()
+    const reactions = second.listReactions(1, '5511999990000@s.whatsapp.net', 'mid-2', 'email:a@a.com')
+    assert.equal(reactions.length, 1)
+    assert.equal(reactions[0].emoji, '❤️')
+    const record = second.getRecord(1, '5511999990000@s.whatsapp.net', 'mid-2')
+    assert.equal(record?.replyTo?.messageId, 'parent-1')
+  })
+})
+
+test('decorateMessages merges media/reply/reactions', async () => {
+  await withStore(async (store) => {
+    store.setReply(1, '5511999990000@s.whatsapp.net', 'mid-3', {
+      messageId: 'parent-2',
+      textPreview: 'Texto pai',
+      direction: 'outbound'
+    })
+    store.toggleReaction(1, '5511999990000@s.whatsapp.net', 'mid-3', '😂', 'email:a@a.com')
+    const items = store.decorateMessages(
+      1,
+      '5511999990000@s.whatsapp.net',
+      [
+        {
+          id: 'mid-3',
+          mediaType: 'audio',
+          mediaUrl: 'https://example.com/audio.ogg',
+          mimeType: 'audio/ogg'
+        }
+      ],
+      'email:a@a.com',
+      ({ channel, remoteJid, messageId }) => `https://crm.local/api/wa-orchestrator/media?channel=${channel}&remoteJid=${encodeURIComponent(remoteJid)}&messageId=${messageId}`
+    )
+    assert.equal(items.length, 1)
+    assert.equal(items[0].replyTo?.messageId, 'parent-2')
+    assert.equal(items[0].reactions?.[0]?.emoji, '😂')
+    assert.ok(items[0].mediaProxyUrl?.includes('messageId=mid-3'))
+    assert.equal(items[0].media?.type, 'audio')
+  })
+})

--- a/backend/apps/crm-api/services/evolutionOrchestrator.js
+++ b/backend/apps/crm-api/services/evolutionOrchestrator.js
@@ -354,19 +354,32 @@ async function fetchMessages(channel, remoteJid, { limit = 50, page = 1 } = {}) 
   return res.json
 }
 
-async function sendText(channel, remoteJid, text) {
+async function sendText(channel, remoteJid, text, options = {}) {
   const { instancePrefix } = resolveEvolutionConfig()
   const name = channelName(channel, instancePrefix)
   const number = normalizeNumber(remoteJid)
   if (!number) {
     throw new Error('Número inválido para envio.')
   }
+  const replyToMessageId = String(options?.replyToMessageId || '').trim()
+  const replyToPreview = String(options?.replyToPreview || '').trim()
+  const payload = {
+    number,
+    text
+  }
+  if (replyToMessageId) {
+    payload.quoted = {
+      key: {
+        id: replyToMessageId,
+        remoteJid: normalizeRemoteJid(remoteJid),
+        fromMe: false
+      },
+      message: replyToPreview ? { conversation: replyToPreview } : undefined
+    }
+  }
   const res = await evolutionFetch(`/message/sendText/${encodeURIComponent(name)}`, {
     method: 'POST',
-    body: {
-      number,
-      text
-    }
+    body: payload
   })
   if (!res.ok) {
     const message = res.json?.error || res.json?.message || res.text || `HTTP ${res.status}`

--- a/backend/apps/crm-api/services/waMessageMetaStore.js
+++ b/backend/apps/crm-api/services/waMessageMetaStore.js
@@ -1,0 +1,204 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SKINCOS_ROOT = path.resolve(__dirname, '..', '..', '..', '..')
+const BACKEND_ROOT = path.join(SKINCOS_ROOT, 'backend')
+const VAR_DIR = process.env.VAR_DIR || path.join(BACKEND_ROOT, 'var')
+const DEFAULT_FILE = process.env.WA_MESSAGE_META_FILE || path.join(VAR_DIR, 'core', 'wa_message_meta.json')
+
+const EMOJI_PATTERN = /[\p{Extended_Pictographic}\u200d\ufe0f]/u
+
+function normalizeRemoteJid(remoteJid) {
+  const value = String(remoteJid || '').trim()
+  if (!value) return ''
+  if (value.includes('@')) return value
+  return `${value}@s.whatsapp.net`
+}
+
+function normalizeText(value, max = 240) {
+  const text = String(value || '').trim()
+  if (!text) return ''
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`
+}
+
+function normalizeEmoji(value) {
+  const emoji = String(value || '').trim()
+  if (!emoji || emoji.length > 16 || !EMOJI_PATTERN.test(emoji)) return ''
+  return emoji
+}
+
+function buildKey(channel, remoteJid, messageId) {
+  return `${Number(channel) || 0}|${normalizeRemoteJid(remoteJid)}|${String(messageId || '').trim()}`
+}
+
+export class WaMessageMetaStore {
+  constructor(filePath = DEFAULT_FILE) {
+    this.filePath = filePath
+    this.loaded = false
+    this.saveTimer = null
+    this.state = { items: {} }
+  }
+
+  async init() {
+    if (this.loaded) return
+    this.loaded = true
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf-8')
+      const json = JSON.parse(raw)
+      if (json && typeof json === 'object' && json.items && typeof json.items === 'object') {
+        this.state = { items: json.items }
+      }
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        await fs.mkdir(path.dirname(this.filePath), { recursive: true })
+        await this.persist()
+        return
+      }
+      this.state = { items: {} }
+    }
+  }
+
+  async persist() {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true })
+    await fs.writeFile(this.filePath, JSON.stringify(this.state, null, 2))
+  }
+
+  schedulePersist() {
+    if (this.saveTimer) clearTimeout(this.saveTimer)
+    this.saveTimer = setTimeout(() => {
+      this.persist().catch(() => { /* ignore */ })
+    }, 250)
+    this.saveTimer.unref?.()
+  }
+
+  getOrCreateRecord(channel, remoteJid, messageId) {
+    const key = buildKey(channel, remoteJid, messageId)
+    if (!key.endsWith('|')) {
+      if (!this.state.items[key]) this.state.items[key] = { updatedAt: new Date().toISOString() }
+      return { key, record: this.state.items[key] }
+    }
+    return { key: '', record: null }
+  }
+
+  getRecord(channel, remoteJid, messageId) {
+    const key = buildKey(channel, remoteJid, messageId)
+    return key ? this.state.items[key] || null : null
+  }
+
+  setReply(channel, remoteJid, messageId, replyTo) {
+    const { key, record } = this.getOrCreateRecord(channel, remoteJid, messageId)
+    if (!key || !record) return null
+    const replyMessageId = String(replyTo?.messageId || '').trim()
+    const textPreview = normalizeText(replyTo?.textPreview || '')
+    if (!replyMessageId || !textPreview) return null
+    record.replyTo = {
+      messageId: replyMessageId,
+      textPreview,
+      direction: replyTo?.direction === 'outbound' ? 'outbound' : 'inbound'
+    }
+    record.updatedAt = new Date().toISOString()
+    this.schedulePersist()
+    return record.replyTo
+  }
+
+  setMedia(channel, remoteJid, messageId, media) {
+    const { key, record } = this.getOrCreateRecord(channel, remoteJid, messageId)
+    if (!key || !record) return null
+    const type = String(media?.type || media?.mediaType || 'unknown').toLowerCase()
+    const url = String(media?.url || media?.mediaUrl || '').trim()
+    if (!url) return null
+    record.media = {
+      type: type || 'unknown',
+      url,
+      mimeType: media?.mimeType || null,
+      fileName: media?.fileName || null,
+      durationSec: Number.isFinite(Number(media?.durationSec)) ? Number(media.durationSec) : undefined,
+      sizeBytes: Number.isFinite(Number(media?.sizeBytes)) ? Number(media.sizeBytes) : undefined
+    }
+    record.updatedAt = new Date().toISOString()
+    this.schedulePersist()
+    return record.media
+  }
+
+  listReactions(channel, remoteJid, messageId, actor) {
+    const record = this.getRecord(channel, remoteJid, messageId)
+    const reactions = record?.reactions && typeof record.reactions === 'object' ? record.reactions : {}
+    return Object.entries(reactions)
+      .map(([emoji, users]) => ({
+        emoji,
+        count: Array.isArray(users) ? users.length : 0,
+        reactedByMe: Array.isArray(users) ? users.includes(actor) : false
+      }))
+      .filter((item) => item.count > 0)
+      .sort((a, b) => b.count - a.count || a.emoji.localeCompare(b.emoji))
+  }
+
+  toggleReaction(channel, remoteJid, messageId, emojiRaw, actor) {
+    const emoji = normalizeEmoji(emojiRaw)
+    if (!emoji) throw new Error('EMOJI_INVALID')
+    const actorKey = String(actor || '').trim()
+    if (!actorKey) throw new Error('ACTOR_REQUIRED')
+
+    const { key, record } = this.getOrCreateRecord(channel, remoteJid, messageId)
+    if (!key || !record) throw new Error('MESSAGE_ID_REQUIRED')
+    if (!record.reactions || typeof record.reactions !== 'object') record.reactions = {}
+    const current = Array.isArray(record.reactions[emoji]) ? [...record.reactions[emoji]] : []
+    const idx = current.indexOf(actorKey)
+    if (idx >= 0) {
+      current.splice(idx, 1)
+    } else {
+      current.push(actorKey)
+    }
+    if (current.length) {
+      record.reactions[emoji] = current
+    } else {
+      delete record.reactions[emoji]
+    }
+    record.updatedAt = new Date().toISOString()
+    this.schedulePersist()
+    return this.listReactions(channel, remoteJid, messageId, actorKey)
+  }
+
+  decorateMessages(channel, remoteJid, items, actor, buildMediaProxyUrl) {
+    if (!Array.isArray(items)) return []
+    return items.map((item) => {
+      const messageId = String(item?.id || '').trim()
+      if (!messageId) return item
+      const record = this.getRecord(channel, remoteJid, messageId)
+      const runtimeMedia = item?.mediaUrl
+        ? {
+            type: String(item?.mediaType || item?.type || 'unknown').toLowerCase(),
+            url: String(item.mediaUrl),
+            mimeType: item?.mimeType || null,
+            fileName: item?.fileName || null,
+            durationSec: Number.isFinite(Number(item?.durationSec)) ? Number(item.durationSec) : undefined,
+            sizeBytes: Number.isFinite(Number(item?.sizeBytes)) ? Number(item.sizeBytes) : undefined
+          }
+        : null
+      if (!record?.media && runtimeMedia?.url) {
+        this.setMedia(channel, remoteJid, messageId, runtimeMedia)
+      }
+      const media = record?.media || runtimeMedia || null
+      const reactions = this.listReactions(channel, remoteJid, messageId, actor)
+      const mediaProxyUrl = media?.url && typeof buildMediaProxyUrl === 'function'
+        ? buildMediaProxyUrl({ channel, remoteJid, messageId })
+        : undefined
+      return {
+        ...item,
+        replyTo: record?.replyTo || undefined,
+        reactions,
+        media: media || undefined,
+        mediaProxyUrl
+      }
+    })
+  }
+
+  findMedia(channel, remoteJid, messageId) {
+    const record = this.getRecord(channel, remoteJid, messageId)
+    return record?.media || null
+  }
+}
+
+export const waMessageMetaStore = new WaMessageMetaStore()

--- a/frontend/HarmoniaModule.tsx
+++ b/frontend/HarmoniaModule.tsx
@@ -23,6 +23,7 @@ type HarmoniaHealth = {
     dbConfigured?: boolean
     googleConfigured?: boolean
     openAiConfigured?: boolean
+    execTokenConfigured?: boolean
     autoMigrate?: boolean
     storeRaw?: boolean
   }

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/card"
 import { Badge } from "@/badge"
@@ -13,8 +13,9 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { toast } from "sonner"
 import * as QRCode from "qrcode"
 import { getRelativeTime } from "@/utils"
-import { buildCrmBasicAuthHeaders } from "@/waOrchestratorAuth"
+import { buildCrmBasicAuthHeaders, getCrmBasicAuthToken } from "@/waOrchestratorAuth"
 import { useIntegrations } from "@/contexts"
+import { getCssVarValue } from "@/visualTheme"
 import {
   fetchRecentCommentLeads,
   fetchRecentDMConversations,
@@ -37,7 +38,12 @@ import {
   Warning,
   Sparkle,
   Ticket,
-  Star
+  Star,
+  Smiley,
+  ArrowBendUpLeft,
+  DownloadSimple,
+  FilePdf,
+  ImageSquare
 } from "@phosphor-icons/react"
 import type { Activity } from "@/types"
 
@@ -129,9 +135,33 @@ type HarmoniaInboxItem = {
   last_activity_at?: string | null
 }
 
+export interface OmnichannelHeaderState {
+  whatsappConnected: boolean
+  connectedWhatsapps: number
+  instagramConnected: boolean
+  facebookConfigured: boolean
+  supportStats: {
+    totalTickets: number
+    openWithin24: number
+    overdueTickets: number
+    resolvedTickets: number
+    avgSatisfaction: number
+  }
+  ticketFilter: 'total' | 'open' | 'overdue' | 'resolved'
+  paused: boolean
+}
+
+export interface OmnichannelCenterHandle {
+  openWhatsAppStatus: () => void
+  openInstagramStatus: () => void
+  openFacebookStatus: () => void
+  openTicketsModal: (filter: 'total' | 'open' | 'overdue' | 'resolved') => void
+}
+
 interface OmnichannelCenterProps {
   activities: Activity[]
   onStartConversation?: (channel: string, customerId: string) => void
+  onHeaderStateChange?: (state: OmnichannelHeaderState) => void
 }
 
 type ChannelStatus = 'free' | 'available' | 'starting' | 'qr_pending' | 'connected' | 'error' | 'stopping'
@@ -174,6 +204,7 @@ interface QRData {
 const HARMONIA_DEBUG_TOKEN_KEY = 'harmonia.debugToken'
 const HARMONIA_EXEC_TOKEN_KEY = 'harmonia.execToken'
 const HARMONIA_UNIT_KEY = 'harmonia.ui.unitSlug'
+const WA_CONVERSATIONS_CACHE_KEY = 'wa.orchestrator.conversations.cache'
 const MIN_PHONE_LEN = 8
 
 function normalizePhone(value?: string | null) {
@@ -210,6 +241,15 @@ function isLikelyWhatsAppJid(value?: string | null) {
   const digits = normalizePhone(raw)
   if (digits.length >= 10 && digits === raw.replace(/\D+/g, '')) return true
   return false
+}
+
+function normalizeWhatsAppJid(value?: string | null) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+  if (raw.includes('@')) return raw
+  const digits = normalizePhone(raw)
+  if (!digits) return raw
+  return `${digits}@s.whatsapp.net`
 }
 
 function formatPhone(value?: string | null) {
@@ -303,29 +343,6 @@ function getInitials(value?: string | null) {
   return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
 }
 
-function renderAvatar(conv: any, size = 36) {
-  const name = resolveConversationDisplayName(conv)
-  const src = resolveAvatarUrl(conv)
-  if (src) {
-    return (
-      <img
-        src={src}
-        alt={name}
-        className="rounded-full object-cover"
-        style={{ width: size, height: size }}
-      />
-    )
-  }
-  return (
-    <div
-      className="rounded-full bg-white/10 text-xs font-semibold text-blue-100 flex items-center justify-center"
-      style={{ width: size, height: size }}
-    >
-      {getInitials(name)}
-    </div>
-  )
-}
-
 function renderFormattedText(input?: string | null): ReactNode {
   const text = String(input || '')
   if (!text) return null
@@ -380,8 +397,250 @@ function renderFormattedText(input?: string | null): ReactNode {
   return <>{tokens}</>
 }
 
-export function OmnichannelCenter({ activities, onStartConversation }: OmnichannelCenterProps) {
+function ConversationAvatar({ conv, size = 36 }: { conv: any; size?: number }) {
+  const [failed, setFailed] = useState(false)
+  const name = resolveConversationDisplayName(conv)
+  const src = resolveAvatarUrl(conv)
+  if (src && !failed) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className="rounded-full object-cover border border-white/10 bg-white/5"
+        style={{ width: size, height: size }}
+        onError={() => setFailed(true)}
+        loading="lazy"
+      />
+    )
+  }
+  return (
+    <div
+      className="rounded-full bg-white/10 border border-white/10 text-xs font-semibold text-blue-100 flex items-center justify-center"
+      style={{ width: size, height: size }}
+      aria-label={name}
+    >
+      {getInitials(name)}
+    </div>
+  )
+}
+
+function AudioInlinePlayer({ src, mimeType, onError }: { src: string; mimeType?: string; onError?: () => void }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const [playing, setPlaying] = useState(false)
+  const [duration, setDuration] = useState(0)
+  const [currentTime, setCurrentTime] = useState(0)
+
+  const fmt = useCallback((seconds: number) => {
+    const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0
+    const m = Math.floor(safe / 60)
+    const s = safe % 60
+    return `${m}:${String(s).padStart(2, '0')}`
+  }, [])
+
+  return (
+    <div className="mt-2 rounded-lg border border-white/15 bg-black/20 p-2">
+      <audio
+        ref={audioRef}
+        src={src}
+        preload="metadata"
+        onLoadedMetadata={() => setDuration(audioRef.current?.duration || 0)}
+        onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime || 0)}
+        onEnded={() => setPlaying(false)}
+        onError={onError}
+      >
+        {mimeType ? <source src={src} type={mimeType} /> : null}
+      </audio>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 rounded-full border border-white/20 bg-white/10 text-white hover:bg-white/20"
+          onClick={() => {
+            const node = audioRef.current
+            if (!node) return
+            if (playing) {
+              node.pause()
+              setPlaying(false)
+            } else {
+              void node.play()
+              setPlaying(true)
+            }
+          }}
+          aria-label={playing ? 'Pausar áudio' : 'Reproduzir áudio'}
+        >
+          {playing ? '❚❚' : '▶'}
+        </Button>
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={Math.min(currentTime, duration || 0)}
+          className="flex-1 accent-emerald-400"
+          onChange={(event) => {
+            const next = Number(event.target.value)
+            if (!audioRef.current || Number.isNaN(next)) return
+            audioRef.current.currentTime = next
+            setCurrentTime(next)
+          }}
+        />
+        <span className="text-[10px] text-blue-100/70 min-w-[64px] text-right">
+          {fmt(currentTime)} / {fmt(duration)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function MessageMedia({
+  media,
+  mediaProxyUrl,
+  fallbackText,
+  onImagePreview
+}: {
+  media?: { type?: string; url?: string; mimeType?: string; fileName?: string; durationSec?: number }
+  mediaProxyUrl?: string
+  fallbackText?: string
+  onImagePreview: (payload: { src: string; alt?: string }) => void
+}) {
+  const [loadFailed, setLoadFailed] = useState(false)
+  const type = String(media?.type || '').toLowerCase()
+  let src = String(mediaProxyUrl || media?.url || '').trim()
+  const authToken = getCrmBasicAuthToken()
+  if (src && mediaProxyUrl && authToken && !src.includes('auth=')) {
+    try {
+      const url = new URL(src, window.location.origin)
+      url.searchParams.set('auth', authToken)
+      src = url.toString()
+    } catch {
+      const sep = src.includes('?') ? '&' : '?'
+      src = `${src}${sep}auth=${encodeURIComponent(authToken)}`
+    }
+  }
+  const mimeType = String(media?.mimeType || '').trim()
+  const isImage = type.includes('image')
+  const isAudio = type.includes('audio') || type.includes('ptt') || type.includes('voice')
+  const isPdf = type.includes('document') && (mimeType.includes('pdf') || String(media?.fileName || '').toLowerCase().endsWith('.pdf'))
+  const isDocument = type.includes('document') && !isPdf
+  const isVideo = type.includes('video') || type.includes('ptv')
+
+  if (!src || loadFailed) {
+    return (
+      <div className="mt-2 rounded-lg border border-dashed border-white/20 bg-white/5 p-2 text-xs text-blue-100/70">
+        <div className="inline-flex items-center gap-2">
+          <Warning className="h-4 w-4 text-amber-300" />
+          {fallbackText || 'Arquivo indisponível no momento.'}
+        </div>
+      </div>
+    )
+  }
+
+  if (isImage) {
+    return (
+      <button
+        type="button"
+        className="mt-2 block overflow-hidden rounded-lg border border-white/15 bg-black/20"
+        onClick={() => onImagePreview({ src, alt: media?.fileName || 'Imagem da mensagem' })}
+      >
+        <img
+          src={src}
+          alt={media?.fileName || 'Imagem'}
+          className="max-h-64 w-full object-cover"
+          loading="lazy"
+          onError={() => setLoadFailed(true)}
+        />
+      </button>
+    )
+  }
+
+  if (isAudio) {
+    return <AudioInlinePlayer src={src} mimeType={mimeType} onError={() => setLoadFailed(true)} />
+  }
+
+  if (isPdf) {
+    return (
+      <div className="mt-2 space-y-2 rounded-lg border border-white/15 bg-black/20 p-2">
+        <div className="overflow-hidden rounded-md border border-white/10 bg-black/30">
+          <iframe
+            title={media?.fileName || 'Documento PDF'}
+            src={src}
+            className="h-56 w-full"
+            loading="lazy"
+            onError={() => setLoadFailed(true)}
+          />
+        </div>
+        <a
+          href={src}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 rounded-md border border-white/15 bg-white/10 px-2 py-1 text-xs text-blue-100 hover:bg-white/20"
+        >
+          <DownloadSimple className="h-3.5 w-3.5" />
+          Download PDF
+        </a>
+      </div>
+    )
+  }
+
+  if (isDocument) {
+    return (
+      <div className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/15 bg-black/20 px-2 py-1.5 text-xs text-blue-100">
+        <FilePdf className="h-4 w-4" />
+        <a href={src} target="_blank" rel="noreferrer" className="underline-offset-2 hover:underline">
+          {media?.fileName || 'Abrir documento'}
+        </a>
+        <a
+          href={src}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] hover:bg-white/10"
+        >
+          Download
+        </a>
+      </div>
+    )
+  }
+
+  if (isVideo) {
+    return (
+      <video
+        src={src}
+        controls
+        className="mt-2 max-h-64 w-full rounded-lg border border-white/15 bg-black/20"
+        onError={() => setLoadFailed(true)}
+      >
+        {mimeType ? <source src={src} type={mimeType} /> : null}
+      </video>
+    )
+  }
+
+  return (
+    <a
+      href={src}
+      target="_blank"
+      rel="noreferrer"
+      className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/15 bg-black/20 px-2 py-1.5 text-xs text-blue-100 hover:bg-white/10"
+    >
+      <ImageSquare className="h-4 w-4" />
+      Abrir anexo
+    </a>
+  )
+}
+
+export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, OmnichannelCenterProps>(function OmnichannelCenter(
+  { activities, onStartConversation, onHeaderStateChange },
+  ref
+) {
   const { instagram, connectInstagram, refreshInstagram } = useIntegrations()
+  const normalizeQrColor = (value: string, fallback: string) => {
+    const v = String(value || "").trim()
+    if (!v) return fallback
+    if (v.startsWith("oklch") || v.startsWith("color(")) return fallback
+    return v
+  }
+  const QR_DARK = normalizeQrColor(getCssVarValue("--foreground", "#000000"), "#000000")
+  const QR_LIGHT = normalizeQrColor(getCssVarValue("--background", "#FFFFFF"), "#FFFFFF")
   const [systemConfig, setSystemConfig] = useKV<SystemConfig>("system-config", {
     integrations: { harmonia: { debugToken: '', execToken: '' }, facebook: { pageId: '', accessToken: '' } }
   })
@@ -431,18 +690,25 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   const [sendingMessage, setSendingMessage] = useState(false)
   const [messageInput, setMessageInput] = useState('')
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null)
+  const messagesViewportRef = useRef<HTMLDivElement | null>(null)
+  const autoScrollRef = useRef(false)
+  const lastMessageKeyRef = useRef<string>('')
   const [replyTarget, setReplyTarget] = useState<{
     id: string
     text: string
     direction?: string
     platform?: string
   } | null>(null)
+  const [imagePreview, setImagePreview] = useState<{ src: string; alt?: string } | null>(null)
+  const [reactionPickerMessageId, setReactionPickerMessageId] = useState<string | null>(null)
+  const [reactionBusyKey, setReactionBusyKey] = useState<string | null>(null)
   const [orchestratorStatus, setOrchestratorStatus] = useState<OrchestratorStatus | null>(null)
   const [statusFailureCount, setStatusFailureCount] = useState(0)
   const [statusPausedUntil, setStatusPausedUntil] = useState<number | null>(null)
   const [channelQR, setChannelQR] = useState<Map<number, QRData>>(new Map())
   const [qrDialogChannel, setQrDialogChannel] = useState<number | null>(null)
   const qrPollingRef = useRef<Map<number, NodeJS.Timeout>>(new Map())
+  const waEventsRefreshTimerRef = useRef<number | null>(null)
   const [waStatusOpen, setWaStatusOpen] = useState(false)
   const [igStatusOpen, setIgStatusOpen] = useState(false)
   const [igDialogOpen, setIgDialogOpen] = useState(false)
@@ -455,6 +721,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   const [fbAccessToken, setFbAccessToken] = useState('')
   const [fbPageId, setFbPageId] = useState('')
   const [igLoading, setIgLoading] = useState(false)
+  const reactionOptions = useMemo(() => ['👍', '❤️', '😂', '😮', '😢', '🙏'], [])
   const [igProfiles, setIgProfiles] = useState<Record<string, InstagramUserProfile>>({})
   const [igDMs, setIgDMs] = useState<Record<string, InstagramDMMessage[]>>({})
   const facebookConfig = systemConfig?.integrations?.facebook || { pageId: '', accessToken: '' }
@@ -571,10 +838,42 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
     }
   }, [normalizeOrchestratorStatus, statusPausedUntil])
 
+  const CONVERSATION_FETCH_LIMIT = 80
+  const conversationsCount = conversations.length
+  const CONVERSATION_CACHE_TTL = 2 * 60 * 1000
+
+  const readConversationCache = useCallback(() => {
+    try {
+      const raw = localStorage.getItem(WA_CONVERSATIONS_CACHE_KEY)
+      if (!raw) return null
+      const parsed = JSON.parse(raw)
+      if (!parsed?.ts || !Array.isArray(parsed?.items)) return null
+      if (Date.now() - parsed.ts > CONVERSATION_CACHE_TTL) return null
+      return parsed.items as any[]
+    } catch {
+      return null
+    }
+  }, [])
+
+  const writeConversationCache = useCallback((items: any[]) => {
+    try {
+      const trimmed = items.slice(0, 200)
+      localStorage.setItem(WA_CONVERSATIONS_CACHE_KEY, JSON.stringify({ ts: Date.now(), items: trimmed }))
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
   const loadConversations = useCallback(async () => {
     if (!provider) return
     if (conversationsPausedUntil && Date.now() < conversationsPausedUntil) return
-    setLoadingConversations(true)
+    if (provider === 'evolution' && conversationsCount === 0) {
+      const cached = readConversationCache()
+      if (cached?.length) {
+        setConversations(cached)
+      }
+    }
+    setLoadingConversations(conversationsCount === 0)
     try {
       if (provider === 'evolution') {
         const channels =
@@ -588,7 +887,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
         const results = await Promise.all(
           channels.map(async (channel) => {
             const res = await fetch(
-              `/api/wa-orchestrator/channels/${channel}/conversations?limit=200`,
+              `/api/wa-orchestrator/channels/${channel}/conversations?limit=${CONVERSATION_FETCH_LIMIT}`,
               { headers: buildCrmBasicAuthHeaders() }
             )
             const data = await res.json().catch(() => ({}))
@@ -596,12 +895,16 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
             return (data.items || []).map((item: any) => ({ ...item, channel, platform: 'whatsapp' }))
           })
         )
-        setConversations(results.flat())
+        const merged = results.flat()
+        setConversations(merged)
+        if (merged.length) writeConversationCache(merged)
       } else {
         const res = await fetch('/api/conversations')
         const data = await res.json()
         if (res.ok) {
-          setConversations(data?.items || data || [])
+          const merged = data?.items || data || []
+          setConversations(merged)
+          if (merged?.length) writeConversationCache(merged)
         }
       }
       setConversationsFailureCount(0)
@@ -618,11 +921,18 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
     } finally {
       setLoadingConversations(false)
     }
-  }, [provider, orchestratorStatus, conversationsPausedUntil])
+  }, [
+    provider,
+    orchestratorStatus,
+    conversationsPausedUntil,
+    conversationsCount,
+    readConversationCache,
+    writeConversationCache
+  ])
 
-  const loadMessages = useCallback(async (conv: any) => {
+  const loadMessages = useCallback(async (conv: any, opts?: { silent?: boolean }) => {
     if (!provider || !conv) return
-    setLoadingMessages(true)
+    if (!opts?.silent) setLoadingMessages(true)
     try {
       if (provider === 'evolution') {
         const channel = Number(conv?.channel)
@@ -633,19 +943,89 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
         )
         const data = await res.json()
         if (res.ok && data?.success) {
-          setMessages(data.items || [])
+          const items = data.items || []
+          setMessages(items)
+          return items
         }
       } else {
         const res = await fetch(`/api/conversations/${encodeURIComponent(conv.conversationId)}/messages?limit=80`)
         const data = await res.json()
         if (res.ok) {
-          setMessages(data.items || [])
+          const items = data.items || []
+          setMessages(items)
+          return items
         }
       }
     } finally {
-      setLoadingMessages(false)
+      if (!opts?.silent) setLoadingMessages(false)
     }
   }, [provider])
+
+  const patchMessageById = useCallback((messageId: string, updater: (current: any) => any) => {
+    setMessages((prev) => prev.map((item) => {
+      if (String(item?.id || '') !== String(messageId || '')) return item
+      return updater(item)
+    }))
+  }, [])
+
+  const openReplyComposer = useCallback((message: any) => {
+    const replyPreview = resolveReplyPreview(message?.text, message?.caption || message?.type)
+    const id = String(message?.id || '').trim()
+    if (!id) return
+    setReplyTarget({
+      id,
+      text: replyPreview,
+      direction: message?.direction,
+      platform: message?.platform
+    })
+    messageInputRef.current?.focus()
+  }, [])
+
+  const toggleReaction = useCallback(async (message: any, emoji: string) => {
+    if (!selectedConversation || selectedConversation?.platform === 'lead' || selectedConversation?.platform === 'instagram') return
+    const channel =
+      Number(selectedConversation?.channel) ||
+      orchestratorStatus?.instances?.find((instance) => instance.status === 'connected')?.channel
+    const remoteJid = normalizeWhatsAppJid(selectedConversation?.conversationId || selectedConversation?.phone || '')
+    const messageId = String(message?.id || '').trim()
+    if (!channel || !remoteJid || !messageId) return
+
+    const requestKey = `${messageId}:${emoji}`
+    if (reactionBusyKey === requestKey) return
+    setReactionBusyKey(requestKey)
+    try {
+      const optimistic = Array.isArray(message?.reactions) ? message.reactions : []
+      const target = optimistic.find((entry: any) => entry.emoji === emoji)
+      const nextOptimistic = target
+        ? optimistic.map((entry: any) =>
+            entry.emoji === emoji
+              ? { ...entry, reactedByMe: !entry.reactedByMe, count: Math.max(0, Number(entry.count || 0) + (entry.reactedByMe ? -1 : 1)) }
+              : entry
+          ).filter((entry: any) => Number(entry.count || 0) > 0)
+        : [...optimistic, { emoji, count: 1, reactedByMe: true }]
+      patchMessageById(messageId, (item) => ({ ...item, reactions: nextOptimistic }))
+
+      const response = await fetch(
+        `/api/wa-orchestrator/channels/${channel}/conversations/${encodeURIComponent(remoteJid)}/messages/${encodeURIComponent(messageId)}/reactions/toggle`,
+        {
+          method: 'POST',
+          headers: buildCrmBasicAuthHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ emoji })
+        }
+      )
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok || payload?.success === false) {
+        patchMessageById(messageId, (item) => ({ ...item, reactions: optimistic }))
+        toast.error(payload?.error || 'Falha ao reagir à mensagem.')
+        return
+      }
+      patchMessageById(messageId, (item) => ({ ...item, reactions: payload.reactions || [] }))
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao reagir à mensagem.')
+    } finally {
+      setReactionBusyKey((current) => (current === requestKey ? null : current))
+    }
+  }, [selectedConversation, orchestratorStatus, reactionBusyKey, patchMessageById])
 
   const loadInstagramConversations = useCallback(async () => {
     if (!instagram?.connected) return
@@ -753,13 +1133,12 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
     const isLeadOnly = selectedConversation?.platform === 'lead'
     setSendingMessage(true)
     try {
-      const outboundText = replyTarget
-        ? `${formatReplyPrefix(replyTarget.text)}\n${trimmed}`
-        : trimmed
+      const legacyReplyPrefix = replyTarget ? `${formatReplyPrefix(replyTarget.text)}\n` : ''
+      const outboundText = trimmed
       if (selectedConversation?.platform === 'instagram') {
         const sent = await sendDirectMessage(
           selectedConversation.conversationId,
-          outboundText,
+          `${legacyReplyPrefix}${outboundText}`,
           instagram.businessAccountId,
           igAccessToken || undefined
         )
@@ -781,7 +1160,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
         const phoneKey = extractPhoneFromId(selectedConversation?.phone || selectedConversation?.leadPhone || '')
         const remoteJid = isLeadOnly
           ? (phoneKey ? `${phoneKey}@s.whatsapp.net` : '')
-          : String(selectedConversation.conversationId || '')
+          : normalizeWhatsAppJid(selectedConversation.conversationId || selectedConversation.phone || '')
         if (!remoteJid) {
           toast.error('Número inválido para envio.')
           return
@@ -791,14 +1170,28 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
           {
             method: 'POST',
             headers: buildCrmBasicAuthHeaders({ 'Content-Type': 'application/json' }),
-            body: JSON.stringify({ text: outboundText })
+            body: JSON.stringify({
+              text: outboundText,
+              replyToMessageId: replyTarget?.id || undefined,
+              replyToPreview: replyTarget?.text || undefined
+            })
           }
         )
-        await res.json().catch(() => ({}))
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok || data?.success === false) {
+          toast.error(data?.error || 'Falha ao enviar mensagem.')
+          return
+        }
         if (isLeadOnly) {
           setHarmoniaMessages((prev) => [
             ...prev,
-            { id: `out-${Date.now()}`, direction: 'outbound', text: outboundText, created_at: new Date().toISOString() }
+            {
+              id: `out-${Date.now()}`,
+              direction: 'outbound',
+              text: outboundText,
+              created_at: new Date().toISOString(),
+              replyTo: replyTarget || undefined
+            }
           ])
         }
       } else if (isLeadOnly) {
@@ -808,7 +1201,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
         const res = await fetch(`/api/conversations/${encodeURIComponent(selectedConversation.conversationId)}/messages`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ direction: 'outbound', type: 'text', text: outboundText })
+          body: JSON.stringify({ direction: 'outbound', type: 'text', text: `${legacyReplyPrefix}${outboundText}` })
         })
         await res.json().catch(() => ({}))
       }
@@ -822,6 +1215,12 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
     }
   }, [igAccessToken, instagram.businessAccountId, loadMessages, messageInput, provider, selectedConversation, orchestratorStatus, replyTarget])
 
+  const scrollMessagesToBottom = useCallback(() => {
+    const viewport = messagesViewportRef.current
+    if (!viewport) return
+    viewport.scrollTop = viewport.scrollHeight
+  }, [])
+
   useEffect(() => {
     loadStatus()
   }, [loadStatus])
@@ -829,6 +1228,17 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   useEffect(() => {
     loadConversations()
   }, [loadConversations])
+
+  useEffect(() => {
+    if (!provider) return
+    if (provider !== 'evolution') return
+    if (!orchestratorStatus?.instances?.length) return
+    if (conversationsCount > 0) return
+    const anyConnected = orchestratorStatus.instances.some((instance) => instance.status === 'connected')
+    if (anyConnected) {
+      loadConversations()
+    }
+  }, [provider, orchestratorStatus, conversationsCount, loadConversations])
 
   useEffect(() => {
     void refreshInstagram()
@@ -870,6 +1280,76 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   }, [loadStatus])
 
   useEffect(() => {
+    if (provider !== 'evolution') return
+    const token = getCrmBasicAuthToken()
+    const params = token ? `?auth=${encodeURIComponent(token)}` : ''
+    const source = new EventSource(`/api/wa-orchestrator/events${params}`, { withCredentials: true })
+
+    source.onmessage = (event) => {
+      let payload: any = null
+      try {
+        payload = JSON.parse(event.data || '{}')
+      } catch {
+        return
+      }
+      if (!payload) return
+
+      if (payload.type === 'message_reaction_updated') {
+        const remoteJid = normalizeWhatsAppJid(payload.remoteJid || '')
+        const selectedJid = normalizeWhatsAppJid(selectedConversation?.conversationId || selectedConversation?.phone || '')
+        if (
+          payload.messageId &&
+          selectedConversation &&
+          remoteJid &&
+          selectedJid === remoteJid &&
+          Number(payload.channel) === Number(selectedConversation?.channel || payload.channel)
+        ) {
+          patchMessageById(String(payload.messageId), (item) => ({ ...item, reactions: payload.reactions || [] }))
+        }
+        return
+      }
+
+      if (payload.type === 'message_metadata_updated') {
+        const remoteJid = normalizeWhatsAppJid(payload.remoteJid || '')
+        const selectedJid = normalizeWhatsAppJid(selectedConversation?.conversationId || selectedConversation?.phone || '')
+        if (
+          payload.messageId &&
+          selectedConversation &&
+          remoteJid &&
+          selectedJid === remoteJid &&
+          Number(payload.channel) === Number(selectedConversation?.channel || payload.channel)
+        ) {
+          patchMessageById(String(payload.messageId), (item) => ({ ...item, replyTo: payload.replyTo || item.replyTo }))
+        }
+        return
+      }
+
+      const webhookEvent = String(payload.event || '').toLowerCase()
+      if (!selectedConversation) return
+      if (webhookEvent === 'messages.upsert' || webhookEvent === 'messages.update' || webhookEvent === 'chats.update') {
+        if (waEventsRefreshTimerRef.current) {
+          window.clearTimeout(waEventsRefreshTimerRef.current)
+        }
+        waEventsRefreshTimerRef.current = window.setTimeout(() => {
+          void loadMessages(selectedConversation, { silent: true })
+        }, 350)
+      }
+    }
+
+    source.onerror = () => {
+      source.close()
+    }
+
+    return () => {
+      if (waEventsRefreshTimerRef.current) {
+        window.clearTimeout(waEventsRefreshTimerRef.current)
+        waEventsRefreshTimerRef.current = null
+      }
+      source.close()
+    }
+  }, [provider, selectedConversation, loadMessages, patchMessageById])
+
+  useEffect(() => {
     if (!qrDialogChannel || !orchestratorStatus?.instances?.length) return
     const instance = orchestratorStatus.instances.find((item) => item.channel === qrDialogChannel)
     if (instance?.status === 'connected') {
@@ -893,7 +1373,48 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
 
   useEffect(() => {
     setReplyTarget(null)
+    setReactionPickerMessageId(null)
   }, [selectedConversation?.conversationId, selectedConversation?.channel])
+
+  useEffect(() => {
+    if (!selectedConversation) return
+    autoScrollRef.current = true
+  }, [selectedConversation?.conversationId, selectedConversation?.channel])
+
+  useEffect(() => {
+    if (!selectedConversation) return
+    if (selectedConversation.platform === 'lead' || selectedConversation.platform === 'instagram') return
+    if (provider !== 'evolution') return
+
+    const interval = window.setInterval(async () => {
+      const items = await loadMessages(selectedConversation, { silent: true })
+      const last = Array.isArray(items) && items.length ? items[items.length - 1] : null
+      const key = last?.id || last?.timestamp || last?.createdAt || ''
+      if (key && key !== lastMessageKeyRef.current) {
+        lastMessageKeyRef.current = key
+        scrollMessagesToBottom()
+      }
+    }, 5000)
+
+    return () => window.clearInterval(interval)
+  }, [loadMessages, provider, scrollMessagesToBottom, selectedConversation])
+
+  useEffect(() => {
+    const last = messages[messages.length - 1]
+    const key = last?.id || last?.timestamp || last?.createdAt || ''
+    if (key) lastMessageKeyRef.current = key
+  }, [messages])
+
+  useEffect(() => {
+    if (!autoScrollRef.current || !selectedConversation) return
+    if (selectedConversation.platform === 'lead' && harmoniaMessagesLoading) return
+    if (selectedConversation.platform !== 'lead' && loadingMessages) return
+    const raf = requestAnimationFrame(() => {
+      scrollMessagesToBottom()
+      autoScrollRef.current = false
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [selectedConversation, harmoniaMessagesLoading, loadingMessages, messages.length, harmoniaMessages.length, scrollMessagesToBottom])
 
   useEffect(() => {
     return () => {
@@ -1121,7 +1642,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
         const mime = normalized.startsWith('/9j/') ? 'jpeg' : 'png'
         return `data:image/${mime};base64,${normalized}`
       }
-      return QRCode.toDataURL(normalized, { width: 300, margin: 2, color: { dark: '#000000', light: '#FFFFFF' } })
+      return QRCode.toDataURL(normalized, { width: 300, margin: 2, color: { dark: QR_DARK, light: QR_LIGHT } })
     }
 
     try {
@@ -1177,7 +1698,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
           ? normalizedQr
           : (/^[A-Za-z0-9+/]+={0,2}$/.test(normalizedQr) && normalizedQr.length > 120)
             ? `data:image/${normalizedQr.startsWith('/9j/') ? 'jpeg' : 'png'};base64,${normalizedQr}`
-            : await QRCode.toDataURL(normalizedQr, { width: 300, margin: 2, color: { dark: '#000000', light: '#FFFFFF' } })
+            : await QRCode.toDataURL(normalizedQr, { width: 300, margin: 2, color: { dark: QR_DARK, light: QR_LIGHT } })
         console.info('[WA_QR_DEBUG] startChannel:resolved', {
           channel,
           qrType: normalizedQr.startsWith('data:image') ? 'image-data-url' : 'raw-text',
@@ -1316,6 +1837,64 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
     }
   }, [tickets])
 
+  const whatsappConnected = useMemo(
+    () => (orchestratorStatus?.connectedInstances ?? 0) > 0,
+    [orchestratorStatus?.connectedInstances]
+  )
+  const connectedWhatsapps = useMemo(
+    () => orchestratorStatus?.instances?.filter((instance) => instance.status === 'connected') ?? [],
+    [orchestratorStatus?.instances]
+  )
+  const paused = Boolean(
+    (statusPausedUntil && Date.now() < statusPausedUntil) ||
+      (conversationsPausedUntil && Date.now() < conversationsPausedUntil) ||
+      (harmoniaInboxPausedUntil && Date.now() < harmoniaInboxPausedUntil)
+  )
+  const headerState = useMemo<OmnichannelHeaderState>(
+    () => ({
+      whatsappConnected,
+      connectedWhatsapps: connectedWhatsapps.length,
+      instagramConnected: Boolean(instagram?.connected),
+      facebookConfigured,
+      supportStats,
+      ticketFilter,
+      paused
+    }),
+    [
+      whatsappConnected,
+      connectedWhatsapps.length,
+      instagram?.connected,
+      facebookConfigured,
+      supportStats,
+      ticketFilter,
+      paused
+    ]
+  )
+
+  useEffect(() => {
+    onHeaderStateChange?.(headerState)
+  }, [headerState, onHeaderStateChange])
+
+  const openTicketsModal = useCallback(
+    (filter: 'total' | 'open' | 'overdue' | 'resolved') => {
+      setTicketFilter(filter)
+      setShowNewTicket(false)
+      setTicketsModalOpen(true)
+    },
+    []
+  )
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openWhatsAppStatus: () => setWaStatusOpen(true),
+      openInstagramStatus: () => setIgStatusOpen(true),
+      openFacebookStatus: () => setFbStatusOpen(true),
+      openTicketsModal
+    }),
+    [openTicketsModal]
+  )
+
   const filteredTickets = useMemo(() => {
     const isOpen = (t: SupportTicket) => ['open', 'in-progress', 'waiting-customer'].includes(t.status)
     const isResolved = (t: SupportTicket) => ['resolved', 'closed'].includes(t.status)
@@ -1347,6 +1926,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   const combinedConversations = useMemo(() => {
     const whatsappItems = (conversations || []).map((conv) => ({
       ...conv,
+      conversationId: normalizeWhatsAppJid(conv.conversationId || conv.id || conv.remoteJid),
       platform: conv.platform || (provider === 'evolution' ? 'whatsapp' : provider),
       name: conv.name && !isLikelyWhatsAppJid(conv.name) ? conv.name : undefined,
       phone: conv.phone || conv.contactPhone || conv.contact_phone || conv.contact_phone_raw,
@@ -1530,9 +2110,6 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   }
 
   const renderOmnichannelChat = () => {
-    const whatsappConnected = (orchestratorStatus?.connectedInstances ?? 0) > 0
-    const connectedWhatsapps =
-      orchestratorStatus?.instances?.filter((instance) => instance.status === 'connected') ?? []
     const filterLabelMap = {
       total: 'Todos',
       open: 'Abertos (≤ 24h)',
@@ -1540,135 +2117,18 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
       resolved: 'Resolvidos'
     } as const
     return (
-      <div className="space-y-4">
-        <Card className="glass-card">
-          <CardHeader>
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <CardTitle className="text-white">Omnichannel</CardTitle>
-                <div className="mt-2 flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setWaStatusOpen(true)}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-blue-100/70 hover:bg-white/10"
-                  >
-                    <span className={`h-2.5 w-2.5 rounded-full ${whatsappConnected ? 'bg-emerald-400' : 'bg-white/20'}`} />
-                    <WhatsappLogo className="h-3.5 w-3.5 text-emerald-300" />
-                    <span>WhatsApp</span>
-                    <span className="text-blue-100/50">{connectedWhatsapps.length}</span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setIgStatusOpen(true)}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-blue-100/70 hover:bg-white/10"
-                  >
-                    <span className={`h-2.5 w-2.5 rounded-full ${instagram?.connected ? 'bg-pink-400' : 'bg-white/20'}`} />
-                    <InstagramLogo className="h-3.5 w-3.5 text-pink-300" />
-                    <span>Instagram</span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setFbStatusOpen(true)}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-blue-100/70 hover:bg-white/10"
-                  >
-                    <span className={`h-2.5 w-2.5 rounded-full ${facebookConfigured ? 'bg-blue-400' : 'bg-white/20'}`} />
-                    <FacebookLogo className="h-3.5 w-3.5 text-blue-300" />
-                    <span>Facebook</span>
-                  </button>
-                </div>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTicketFilter('total')
-                    setShowNewTicket(false)
-                    setTicketsModalOpen(true)
-                  }}
-                  className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs ${
-                    ticketFilter === 'total'
-                      ? 'border-blue-400/40 bg-blue-500/20 text-white'
-                      : 'border-white/10 bg-white/5 text-blue-100/70 hover:bg-white/10'
-                  }`}
-                >
-                  <Ticket className="h-3.5 w-3.5 text-blue-400" />
-                  <span>Total tickets</span>
-                  <span className="text-[11px] text-blue-100/60">{supportStats.totalTickets}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTicketFilter('open')
-                    setShowNewTicket(false)
-                    setTicketsModalOpen(true)
-                  }}
-                  className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs ${
-                    ticketFilter === 'open'
-                      ? 'border-orange-400/40 bg-orange-500/20 text-white'
-                      : 'border-white/10 bg-white/5 text-blue-100/70 hover:bg-white/10'
-                  }`}
-                >
-                  <Warning className="h-3.5 w-3.5 text-orange-400" />
-                  <span>Abertos</span>
-                  <span className="text-[11px] text-blue-100/60">{supportStats.openWithin24}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTicketFilter('overdue')
-                    setShowNewTicket(false)
-                    setTicketsModalOpen(true)
-                  }}
-                  className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs ${
-                    ticketFilter === 'overdue'
-                      ? 'border-red-400/40 bg-red-500/20 text-white'
-                      : 'border-white/10 bg-white/5 text-blue-100/70 hover:bg-white/10'
-                  }`}
-                >
-                  <Clock className="h-3.5 w-3.5 text-red-400" />
-                  <span>Atrasados</span>
-                  <span className="text-[11px] text-blue-100/60">{supportStats.overdueTickets}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTicketFilter('resolved')
-                    setShowNewTicket(false)
-                    setTicketsModalOpen(true)
-                  }}
-                  className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs ${
-                    ticketFilter === 'resolved'
-                      ? 'border-emerald-400/40 bg-emerald-500/20 text-white'
-                      : 'border-white/10 bg-white/5 text-blue-100/70 hover:bg-white/10'
-                  }`}
-                >
-                  <CheckCircle className="h-3.5 w-3.5 text-emerald-400" />
-                  <span>Resolvidos</span>
-                  <span className="text-[11px] text-blue-100/60">{supportStats.resolvedTickets}</span>
-                </button>
-                <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-blue-100/70">
-                  <Star className="h-3.5 w-3.5 text-purple-400" />
-                  <span>Satisfação média</span>
-                  <span className="text-[11px] text-blue-100/60">{supportStats.avgSatisfaction.toFixed(1)}</span>
-                </div>
-                {((statusPausedUntil && Date.now() < statusPausedUntil) ||
-                  (conversationsPausedUntil && Date.now() < conversationsPausedUntil) ||
-                  (harmoniaInboxPausedUntil && Date.now() < harmoniaInboxPausedUntil)) ? (
-                  <span className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-500/15 px-2.5 py-1 text-xs text-amber-100">
-                    Atualização pausada
-                  </span>
-                ) : null}
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 xl:grid-cols-12 gap-4 h-[640px]">
-              <Card className="glass-card xl:col-span-4">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-lg text-white">Conversas</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="mb-3 flex flex-wrap items-center gap-2">
+      <div className="flex h-full min-h-0 flex-col gap-3">
+        {paused ? (
+          <div className="flex justify-end">
+            <span className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-500/15 px-2.5 py-1 text-xs text-amber-100">
+              Atualização pausada
+            </span>
+          </div>
+        ) : null}
+        <div className="grid flex-1 min-h-0 grid-cols-1 gap-4 xl:grid-cols-12">
+          <Card className="glass-card xl:col-span-4 flex min-h-0 flex-col">
+                <CardContent className="flex min-h-0 flex-col gap-2 pt-4">
+                  <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 p-1.5">
                     {[
                       { id: 'all', label: 'Todas' },
                       { id: 'unread', label: 'Não lidas' },
@@ -1681,24 +2141,26 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                       <Button
                         key={item.id}
                         size="sm"
-                        variant={conversationFilter === item.id ? 'default' : 'outline'}
-                        className="h-7 rounded-full px-3 text-xs"
+                        variant="ghost"
+                        className={`h-7 rounded-full border px-2.5 text-[11px] font-medium leading-none ${
+                          conversationFilter === item.id
+                            ? 'border-white/30 bg-white/15 text-white'
+                            : 'border-white/10 bg-white/5 text-blue-100/80 hover:bg-white/10 hover:text-white'
+                        }`}
                         onClick={() => setConversationFilter(item.id as any)}
                       >
                         {item.label}
                       </Button>
                     ))}
                   </div>
-                  <div className="mb-3">
-                    <Input
-                      placeholder="Buscar por nome, telefone, perfil ou plataforma"
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="bg-white/5 border-white/10 text-white placeholder:text-blue-100/50"
-                    />
-                  </div>
-                      <ScrollArea className="h-[520px]">
-                        <div className="space-y-2">
+                  <Input
+                    placeholder="Buscar por nome, telefone, perfil ou plataforma"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="h-8 bg-white/5 border-white/10 text-white placeholder:text-blue-100/50"
+                  />
+                      <ScrollArea className="flex-1 min-h-0">
+                        <div className="space-y-1.5 pr-1">
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>
                       )}
@@ -1719,7 +2181,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                         <div
                           key={`${conv.conversationId}-${conv.channel ?? conv.platform ?? ''}`}
                           data-testid="conversation-item"
-                          className={`p-3 rounded-lg border cursor-pointer transition-colors hover:bg-white/5 ${
+                          className={`w-full p-3 rounded-lg border cursor-pointer transition-colors hover:bg-white/5 box-border ${
                             selectedConversation?.conversationId === conv.conversationId &&
                             selectedConversation?.channel === conv.channel
                               ? 'border-blue-500/70 bg-blue-500/15'
@@ -1740,7 +2202,14 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                           }}
                         >
                           <div className="flex items-start gap-2">
-                            <div className="mt-1">{getPlatformIcon(conv.platform || conv.channel || conv.type, conv.channel)}</div>
+                            <div className="mt-1 relative">
+                              {getPlatformIcon(conv.platform || conv.channel || conv.type, conv.channel)}
+                              {Number(conv.unreadCount || 0) > 0 ? (
+                                <span className="absolute -top-2 -right-2 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-semibold text-white">
+                                  {conv.unreadCount}
+                                </span>
+                              ) : null}
+                            </div>
                             <div className="min-w-0 flex-1">
                               <div className="text-sm font-medium text-white truncate">
                                 {resolveConversationDisplayName(conv)}
@@ -1758,7 +2227,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                               </div>
                             </div>
                             <div className="ml-2 shrink-0">
-                              {renderAvatar(conv, 34)}
+                              <ConversationAvatar conv={conv} size={34} />
                             </div>
                           </div>
                         </div>
@@ -1780,7 +2249,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                     </CardContent>
                   </Card>
 
-              <Card className="glass-card xl:col-span-8">
+          <Card className="glass-card xl:col-span-8 flex min-h-0 flex-col">
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between gap-3">
                     <CardTitle className="text-lg text-white">
@@ -1788,14 +2257,14 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                     </CardTitle>
                     {selectedConversation ? (
                       <div className="shrink-0">
-                        {renderAvatar(selectedConversation, 40)}
+                        <ConversationAvatar conv={selectedConversation} size={40} />
                       </div>
                     ) : null}
                   </div>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="flex min-h-0 flex-col gap-4">
                   {selectedConversation ? (
-                    <div className="space-y-4">
+                    <div className="flex min-h-0 flex-1 flex-col gap-4">
                       {selectedConversation.leadId ? (
                         <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-xs text-blue-100/70 space-y-2">
                           <div className="flex flex-wrap items-center gap-2">
@@ -1860,129 +2329,236 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                         </div>
                       ) : null}
 
-                      <ScrollArea className="h-[500px] border border-white/10 rounded-lg p-4">
-                        <div className="space-y-3">
-                          {selectedConversation.platform === 'lead' ? (
-                            harmoniaMessagesLoading ? (
-                              <div className="text-sm text-blue-100/60 text-center py-4">Carregando mensagens...</div>
-                            ) : (
-                              harmoniaMessages.map((m) => {
-                                const dir = String(m.direction || '')
-                                const isInbound = dir === 'inbound'
-                                const mediaLabel = resolveMediaLabel(m)
-                                const caption = resolveMessageCaption(m)
-                                const replyPreview = resolveReplyPreview(caption, mediaLabel || 'Mensagem')
-                                return (
-                                  <div
-                                    key={String(m.id || m.provider_message_id || Math.random())}
-                                    className={`rounded-xl border ${isInbound ? 'border-sky-500/20 bg-sky-500/10' : 'border-emerald-500/20 bg-emerald-500/10'} p-3`}
-                                    onDoubleClick={() => {
-                                      setReplyTarget({
-                                        id: String(m.id || m.provider_message_id || ''),
-                                        text: replyPreview,
-                                        direction: dir,
-                                        platform: 'lead'
-                                      })
-                                      messageInputRef.current?.focus()
-                                    }}
-                                  >
-                                    <div className="flex items-center justify-between gap-3 text-xs">
-                                      <div className="text-white/90 font-semibold">
-                                        {isInbound ? 'IN' : 'OUT'}
-                                      </div>
-                                      <div className="text-white/70">{fmtDateTime(m.created_at || null)}</div>
-                                    </div>
-                                    <div className="mt-2 space-y-1">
-                                      {mediaLabel ? (
-                                        <Badge className="bg-white/10 text-white border border-white/10 text-[11px] px-2 py-0.5 w-fit">
-                                          {mediaLabel}
-                                        </Badge>
-                                      ) : null}
-                                      <div className="text-sm text-white whitespace-pre-wrap break-words">
-                                        {caption ? renderFormattedText(caption) : <span className="text-white/60">—</span>}
-                                      </div>
-                                    </div>
-                                  </div>
-                                )
-                              })
-                            )
-                          ) : (
-                            <>
-                              {loadingMessages && (
+                      <div className="flex min-h-0 flex-1 flex-col rounded-xl border border-white/10 bg-white/5 p-4">
+                        <ScrollArea className="flex-1 min-h-0 pr-2" viewportRef={messagesViewportRef}>
+                          <div className="space-y-3">
+                            {selectedConversation.platform === 'lead' ? (
+                              harmoniaMessagesLoading ? (
                                 <div className="text-sm text-blue-100/60 text-center py-4">Carregando mensagens...</div>
-                              )}
+                              ) : (
+                                harmoniaMessages.map((m) => {
+                                  const dir = String(m.direction || '')
+                                  const isInbound = dir === 'inbound'
+                                  const mediaLabel = resolveMediaLabel(m)
+                                  const caption = resolveMessageCaption(m)
+                                  const replyPreview = resolveReplyPreview(caption, mediaLabel || 'Mensagem')
+                                  return (
+                                    <div
+                                      key={String(m.id || m.provider_message_id || Math.random())}
+                                      className={`rounded-xl border ${isInbound ? 'border-sky-500/20 bg-sky-500/10' : 'border-emerald-500/20 bg-emerald-500/10'} p-3`}
+                                      onDoubleClick={() => {
+                                        openReplyComposer({
+                                          id: String(m.id || m.provider_message_id || ''),
+                                          text: replyPreview,
+                                          direction: dir,
+                                          platform: 'lead'
+                                        })
+                                      }}
+                                    >
+                                      <div className="flex items-center justify-between gap-3 text-xs">
+                                        <div className="text-white/90 font-semibold">
+                                          {isInbound ? 'IN' : 'OUT'}
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                          <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            className="h-6 w-6 rounded-full border border-white/15 bg-white/10 text-blue-100 hover:bg-white/20"
+                                            onClick={() => openReplyComposer({
+                                              id: String(m.id || m.provider_message_id || ''),
+                                              text: caption || mediaLabel || 'Mensagem',
+                                              direction: dir,
+                                              platform: 'lead'
+                                            })}
+                                            aria-label="Responder mensagem"
+                                          >
+                                            <ArrowBendUpLeft className="h-3.5 w-3.5" />
+                                          </Button>
+                                          <div className="text-white/70">{fmtDateTime(m.created_at || null)}</div>
+                                        </div>
+                                      </div>
+                                      <div className="mt-2 space-y-1">
+                                        {mediaLabel ? (
+                                          <Badge className="bg-white/10 text-white border border-white/10 text-[11px] px-2 py-0.5 w-fit">
+                                            {mediaLabel}
+                                          </Badge>
+                                        ) : null}
+                                        <div className="text-sm text-white whitespace-pre-wrap break-words">
+                                          {caption ? renderFormattedText(caption) : <span className="text-white/60">—</span>}
+                                        </div>
+                                      </div>
+                                    </div>
+                                  )
+                                })
+                              )
+                            ) : (
+                              <>
+                                {loadingMessages && (
+                                  <div className="text-sm text-blue-100/60 text-center py-4">Carregando mensagens...</div>
+                                )}
                               {messages.map((msg) => {
                                 const outbound = msg.direction === 'outbound' || msg.direction === 'human'
                                 const ts = msg.createdAt || msg.timestamp
-                                const replyPreview = resolveReplyPreview(msg.text, msg.caption || msg.type)
+                                const messageId = String(msg?.id || '')
+                                const media =
+                                  msg?.media ||
+                                  (msg?.mediaUrl
+                                    ? {
+                                        type: msg.mediaType || msg.type,
+                                        url: msg.mediaUrl || msg.url,
+                                        mimeType: msg.mimeType,
+                                        fileName: msg.fileName,
+                                        durationSec: msg.durationSec
+                                      }
+                                    : undefined)
+                                const showReactionActions = selectedConversation?.platform !== 'lead' && selectedConversation?.platform !== 'instagram'
                                 return (
                                   <div key={msg.id} className={`flex ${outbound ? 'justify-end' : 'justify-start'}`}>
                                     <div
-                                      className={`max-w-[70%] p-3 rounded-lg ${outbound ? 'bg-blue-500/40 text-white' : 'bg-white/10 text-blue-100'}`}
+                                      className={`group max-w-[88%] md:max-w-[75%] p-3 rounded-lg border ${outbound ? 'border-blue-300/20 bg-blue-500/35 text-white' : 'border-white/10 bg-white/10 text-blue-100'}`}
                                       onDoubleClick={() => {
-                                        setReplyTarget({
-                                          id: String(msg.id || ''),
-                                          text: replyPreview,
-                                          direction: msg.direction,
-                                          platform: msg.platform
-                                        })
-                                        messageInputRef.current?.focus()
+                                        openReplyComposer(msg)
                                       }}
                                     >
+                                      {msg?.replyTo ? (
+                                        <button
+                                          type="button"
+                                          className="mb-2 w-full rounded-md border border-white/15 bg-black/20 px-2 py-1 text-left text-xs text-blue-100/80"
+                                        >
+                                          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-blue-100/60">
+                                            <ArrowBendUpLeft className="h-3 w-3" />
+                                            Resposta
+                                          </span>
+                                          <div className="truncate text-blue-100/90">{msg.replyTo.textPreview}</div>
+                                        </button>
+                                      ) : null}
                                       <div className="text-sm">
                                         {renderFormattedText(msg.text || msg.caption || `[${msg.type}]`)}
                                       </div>
+                                      {media ? (
+                                        <MessageMedia
+                                          media={media}
+                                          mediaProxyUrl={msg.mediaProxyUrl}
+                                          fallbackText="Mídia indisponível no momento."
+                                          onImagePreview={(payload) => setImagePreview(payload)}
+                                        />
+                                      ) : null}
+                                      {Array.isArray(msg?.reactions) && msg.reactions.length > 0 ? (
+                                        <div className="mt-2 flex flex-wrap gap-1">
+                                          {msg.reactions.map((reaction: any) => (
+                                            <button
+                                              key={`${messageId}-${reaction.emoji}`}
+                                              type="button"
+                                              className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] ${
+                                                reaction.reactedByMe
+                                                  ? 'border-emerald-400/50 bg-emerald-500/20 text-emerald-100'
+                                                  : 'border-white/15 bg-white/10 text-blue-100/80'
+                                              }`}
+                                              onClick={() => toggleReaction(msg, reaction.emoji)}
+                                            >
+                                              <span>{reaction.emoji}</span>
+                                              <span>{reaction.count}</span>
+                                            </button>
+                                          ))}
+                                        </div>
+                                      ) : null}
+                                      {showReactionActions ? (
+                                        <div className="mt-2 flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                                          <Button
+                                            type="button"
+                                            variant="ghost"
+                                            className="h-6 rounded-full border border-white/15 bg-white/10 px-2 text-[10px] text-blue-100 hover:bg-white/20"
+                                            onClick={() => openReplyComposer(msg)}
+                                            aria-label="Responder mensagem"
+                                          >
+                                            <ArrowBendUpLeft className="h-3.5 w-3.5" />
+                                            Reply
+                                          </Button>
+                                          <div className="relative">
+                                            <Button
+                                              type="button"
+                                              size="icon"
+                                              variant="ghost"
+                                              className="h-6 w-6 rounded-full border border-white/15 bg-white/10 text-blue-100 hover:bg-white/20"
+                                              onClick={() => setReactionPickerMessageId((current) => current === messageId ? null : messageId)}
+                                              aria-label="Reagir mensagem"
+                                            >
+                                              <Smiley className="h-3.5 w-3.5" />
+                                            </Button>
+                                            {reactionPickerMessageId === messageId ? (
+                                              <div className="absolute right-0 top-7 z-20 flex items-center gap-1 rounded-full border border-white/10 bg-slate-950/95 p-1 shadow-lg">
+                                                {reactionOptions.map((emoji) => (
+                                                  <button
+                                                    key={`${messageId}-${emoji}`}
+                                                    type="button"
+                                                    className="h-7 w-7 rounded-full hover:bg-white/10"
+                                                    onClick={() => {
+                                                      void toggleReaction(msg, emoji)
+                                                      setReactionPickerMessageId(null)
+                                                    }}
+                                                    disabled={reactionBusyKey === `${messageId}:${emoji}`}
+                                                  >
+                                                    {emoji}
+                                                  </button>
+                                                ))}
+                                              </div>
+                                            ) : null}
+                                          </div>
+                                        </div>
+                                      ) : null}
                                       <div className={`text-xs mt-1 ${outbound ? 'text-blue-100/80' : 'text-blue-100/60'}`}>
                                         {ts ? new Date(ts).toLocaleTimeString() : ''}
                                       </div>
                                     </div>
                                   </div>
-                                )
-                              })}
-                            </>
-                          )}
-                        </div>
-                      </ScrollArea>
-
-                      {replyTarget && (
-                        <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-blue-100/70">
-                          <div className="truncate">
-                            Respondendo: <span className="text-white/90">{replyTarget.text}</span>
+                                  )
+                                })}
+                              </>
+                            )}
                           </div>
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-6 w-6"
-                            onClick={() => setReplyTarget(null)}
-                            aria-label="Cancelar resposta"
-                          >
-                            ✕
+                        </ScrollArea>
+
+                        {replyTarget && (
+                          <div className="mt-3 flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-blue-100/70">
+                            <div className="truncate">
+                              Respondendo: <span className="text-white/90">{replyTarget.text}</span>
+                            </div>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-6 w-6"
+                              onClick={() => setReplyTarget(null)}
+                              aria-label="Cancelar resposta"
+                            >
+                              ✕
+                            </Button>
+                          </div>
+                        )}
+
+                        <div className="mt-3 flex gap-2">
+                          <Textarea
+                            placeholder="Digite sua mensagem..."
+                            value={messageInput}
+                            onChange={(e) => setMessageInput(e.target.value)}
+                            ref={messageInputRef}
+                            className="flex-1 bg-white/5 border-white/10 text-white placeholder:text-blue-100/50"
+                            rows={2}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault()
+                                sendMessage()
+                              }
+                            }}
+                          />
+                          <Button onClick={sendMessage} disabled={!messageInput.trim() || sendingMessage}>
+                            {sendingMessage ? '...' : 'Enviar'}
                           </Button>
                         </div>
-                      )}
-
-                      <div className="flex gap-2">
-                        <Textarea
-                          placeholder="Digite sua mensagem..."
-                          value={messageInput}
-                          onChange={(e) => setMessageInput(e.target.value)}
-                          ref={messageInputRef}
-                          className="flex-1 bg-white/5 border-white/10 text-white placeholder:text-blue-100/50"
-                          rows={2}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' && !e.shiftKey) {
-                              e.preventDefault()
-                              sendMessage()
-                            }
-                          }}
-                        />
-                        <Button onClick={sendMessage} disabled={!messageInput.trim() || sendingMessage}>
-                          {sendingMessage ? '...' : 'Enviar'}
-                        </Button>
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-center h-[520px]">
+                    <div className="flex flex-1 items-center justify-center">
                       <div className="rounded-lg border border-dashed border-white/10 bg-white/5 px-6 py-6 text-center max-w-sm">
                         <div className="text-sm text-blue-100/70">Nenhuma conversa selecionada</div>
                         <div className="text-xs text-blue-100/50 mt-2">
@@ -1991,11 +2567,23 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
                       </div>
                     </div>
                   )}
-                </CardContent>
-              </Card>
-            </div>
-          </CardContent>
-        </Card>
+                  </CardContent>
+                </Card>
+        </div>
+
+        <Dialog open={Boolean(imagePreview)} onOpenChange={(open) => { if (!open) setImagePreview(null) }}>
+          <DialogContent className="max-w-4xl">
+            <DialogHeader>
+              <DialogTitle>Visualizar imagem</DialogTitle>
+              <DialogDescription>Clique fora da janela para fechar.</DialogDescription>
+            </DialogHeader>
+            {imagePreview?.src ? (
+              <div className="max-h-[75vh] overflow-auto rounded-lg border border-white/10 bg-black/40 p-2">
+                <img src={imagePreview.src} alt={imagePreview.alt || 'Imagem'} className="mx-auto max-h-[70vh] w-auto object-contain" />
+              </div>
+            ) : null}
+          </DialogContent>
+        </Dialog>
 
         <Dialog open={waStatusOpen} onOpenChange={setWaStatusOpen}>
           <DialogContent className="max-w-sm">
@@ -2367,7 +2955,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
 
   if (!activities || activities.length === 0) {
     return (
-      <div className="space-y-6">
+      <div className="flex h-full min-h-0 flex-col">
         {renderOmnichannelChat()}
       </div>
     )
@@ -2419,7 +3007,7 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
   }
 
   return (
-    <div className="space-y-6">
+    <div className="flex h-full min-h-0 flex-col gap-6">
       {/* Channel Statistics */}
       <Card className="glass-card">
         <CardHeader>
@@ -2627,4 +3215,4 @@ export function OmnichannelCenter({ activities, onStartConversation }: Omnichann
       </Card>
     </div>
   )
-}
+})

--- a/frontend/ROIDashboard.tsx
+++ b/frontend/ROIDashboard.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useKV } from '@/spark-mock'
+import { metaAdsApi } from '@/metaAdsApi'
+import { MetaMetricsSchema, type MetaMetrics } from '@/metaMetrics'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/card"
 import { Button } from "@/button"
 import { Badge } from "@/badge"
@@ -64,69 +66,142 @@ interface PredictiveInsight {
   timeframe: string
 }
 
-export function ROIDashboard() {
+export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) {
   const [selectedPeriod, setSelectedPeriod] = useState("month")
   const [selectedCategory, setSelectedCategory] = useState("all")
   const [activeView, setActiveView] = useState("overview")
+  const [metaMetrics, setMetaMetrics] = useState<MetaMetrics | null>(null)
+  const [metaError, setMetaError] = useState<string | null>(null)
+  const [metaLoading, setMetaLoading] = useState(false)
+
+  useEffect(() => {
+    if (mode !== 'meta-ads') return
+    const { since, until } = (() => {
+      const end = new Date()
+      const start = new Date(end)
+      start.setDate(end.getDate() - 6)
+      const toYmd = (d: Date) => d.toISOString().slice(0, 10)
+      return { since: toYmd(start), until: toYmd(end) }
+    })()
+    setMetaLoading(true)
+    setMetaError(null)
+    metaAdsApi.summary({ since, until })
+      .then((sum: any) => {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+        const revenue = Number(sum?.spend || 0) * Number(sum?.roas || 0)
+        const parsed = MetaMetricsSchema.parse({
+          platform: 'meta-ads',
+          currency: 'USD',
+          period: { since, until, timezone: tz },
+          summary: { ...sum, revenue },
+        })
+        setMetaMetrics(parsed)
+      })
+      .catch((e) => setMetaError(e?.message || 'Falha ao carregar ROI Meta Ads'))
+      .finally(() => setMetaLoading(false))
+  }, [mode])
+
+  if (mode === 'meta-ads') {
+    const spend = metaMetrics?.summary.spend ?? 0
+    const revenue = metaMetrics?.summary.revenue ?? 0
+    const roiPct = spend > 0 ? ((revenue - spend) / spend) * 100 : 0
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>ROI Meta Ads</CardTitle>
+            <CardDescription>Estimado a partir de spend e ROAS.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div>
+              <div className="text-xs text-muted-foreground">Investimento</div>
+              <div className="text-2xl font-semibold">{spend}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Receita estimada</div>
+              <div className="text-2xl font-semibold">{revenue}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">ROI</div>
+              <div className="text-2xl font-semibold">{roiPct.toFixed(1)}%</div>
+            </div>
+          </CardContent>
+        </Card>
+        {metaError ? (
+          <Card className="border-red-500/30 bg-red-500/10">
+            <CardContent className="pt-4 text-sm text-red-200">{metaError}</CardContent>
+          </Card>
+        ) : null}
+        {metaLoading ? (
+          <div className="text-sm text-muted-foreground">Carregando...</div>
+        ) : null}
+      </div>
+    )
+  }
 
   // Initialize ROI data
-  const [roiMetrics, setROIMetrics] = useKV<ROIMetric[]>("roi-metrics", [
-    {
-      id: "1",
-      category: "Marketing Digital",
-      investment: 25000,
-      revenue: 95000,
-      roi: 280,
-      period: "Q1 2024",
-      status: "positive",
-      trend: "up",
-      details: "Campanhas de Google Ads e Facebook"
-    },
-    {
-      id: "2",
-      category: "CRM Software",
-      investment: 15000,
-      revenue: 85000,
-      roi: 467,
-      period: "Q1 2024",
-      status: "positive",
-      trend: "up",
-      details: "Licenças e implementação"
-    },
-    {
-      id: "3",
-      category: "Treinamento Equipe",
-      investment: 8000,
-      revenue: 45000,
-      roi: 463,
-      period: "Q1 2024",
-      status: "positive",
-      trend: "stable",
-      details: "Capacitação em vendas consultivas"
-    },
-    {
-      id: "4",
-      category: "Automação Marketing",
-      investment: 12000,
-      revenue: 68000,
-      roi: 467,
-      period: "Q1 2024",
-      status: "positive",
-      trend: "up",
-      details: "Ferramentas de email marketing e lead nurturing"
-    },
-    {
-      id: "5",
-      category: "IA e Analytics",
-      investment: 18000,
-      revenue: 125000,
-      roi: 594,
-      period: "Q1 2024",
-      status: "positive",
-      trend: "up",
-      details: "Implementação de chatbots e análise preditiva"
-    }
-  ])
+  const [roiMetrics, setROIMetrics] = useKV<ROIMetric[]>("roi-metrics", [])
+
+  useEffect(() => {
+    if (roiMetrics.length) return
+    setROIMetrics([
+      {
+        id: "1",
+        category: "Marketing Digital",
+        investment: 25000,
+        revenue: 95000,
+        roi: 280,
+        period: "Q1 2024",
+        status: "positive",
+        trend: "up",
+        details: "Campanhas de Google Ads e Facebook"
+      },
+      {
+        id: "2",
+        category: "CRM Software",
+        investment: 15000,
+        revenue: 85000,
+        roi: 467,
+        period: "Q1 2024",
+        status: "positive",
+        trend: "up",
+        details: "Licenças e implementação"
+      },
+      {
+        id: "3",
+        category: "Treinamento Equipe",
+        investment: 8000,
+        revenue: 45000,
+        roi: 463,
+        period: "Q1 2024",
+        status: "positive",
+        trend: "stable",
+        details: "Capacitação em vendas consultivas"
+      },
+      {
+        id: "4",
+        category: "Automação Marketing",
+        investment: 12000,
+        revenue: 68000,
+        roi: 467,
+        period: "Q1 2024",
+        status: "positive",
+        trend: "up",
+        details: "Ferramentas de email marketing e lead nurturing"
+      },
+      {
+        id: "5",
+        category: "IA e Analytics",
+        investment: 18000,
+        revenue: 125000,
+        roi: 594,
+        period: "Q1 2024",
+        status: "positive",
+        trend: "up",
+        details: "Implementação de chatbots e análise preditiva"
+      }
+    ])
+  }, [roiMetrics.length, setROIMetrics])
 
   // Calculate financial analysis
   const financialAnalysis: FinancialAnalysis = {

--- a/frontend/ReportsDashboard.tsx
+++ b/frontend/ReportsDashboard.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useIntegrations } from '@/contexts'
 import { useKV } from '@/spark-mock'
+import { metaAdsApi } from '@/metaAdsApi'
+import { MetaMetricsSchema, type MetaMetrics } from '@/metaMetrics'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/card"
 import { Button } from "@/button"
 import { Badge } from "@/badge"
@@ -84,12 +86,103 @@ interface ReportTemplate {
   popularity: number
 }
 
-export function ReportsDashboard() {
+export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) {
   const { instagram, syncInstagram } = useIntegrations()
   const [reports, setReports] = useKV<Report[]>('reports', [])
   const [selectedReport, setSelectedReport] = useState<string | null>(null)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [activeTab, setActiveTab] = useState('my-reports')
+  const [metaMetrics, setMetaMetrics] = useState<MetaMetrics | null>(null)
+  const [metaError, setMetaError] = useState<string | null>(null)
+  const [metaLoading, setMetaLoading] = useState(false)
+
+  useEffect(() => {
+    if (mode !== 'meta-ads') return
+    const { since, until } = (() => {
+      const end = new Date()
+      const start = new Date(end)
+      start.setDate(end.getDate() - 6)
+      const toYmd = (d: Date) => d.toISOString().slice(0, 10)
+      return { since: toYmd(start), until: toYmd(end) }
+    })()
+    setMetaLoading(true)
+    setMetaError(null)
+    Promise.all([metaAdsApi.summary({ since, until }), metaAdsApi.trend({ since, until })])
+      .then(([sum, tr]: any[]) => {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+        const parsed = MetaMetricsSchema.parse({
+          platform: 'meta-ads',
+          currency: 'USD',
+          period: { since, until, timezone: tz },
+          summary: sum,
+          trend: tr,
+        })
+        setMetaMetrics(parsed)
+      })
+      .catch((e) => setMetaError(e?.message || 'Falha ao carregar métricas Meta Ads'))
+      .finally(() => setMetaLoading(false))
+  }, [mode])
+
+  if (mode === 'meta-ads') {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Performance Meta Ads</CardTitle>
+            <CardDescription>Métricas consolidadas do período selecionado.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-4">
+            <div>
+              <div className="text-xs text-muted-foreground">Spend</div>
+              <div className="text-2xl font-semibold">{metaMetrics?.summary.spend ?? 0}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Impressões</div>
+              <div className="text-2xl font-semibold">{metaMetrics?.summary.impressions ?? 0}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Clicks</div>
+              <div className="text-2xl font-semibold">{metaMetrics?.summary.clicks ?? 0}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">ROAS</div>
+              <div className="text-2xl font-semibold">{metaMetrics?.summary.roas ?? 0}</div>
+            </div>
+          </CardContent>
+        </Card>
+        {metaError ? (
+          <Card className="border-red-500/30 bg-red-500/10">
+            <CardContent className="pt-4 text-sm text-red-200">{metaError}</CardContent>
+          </Card>
+        ) : null}
+        {!metaError && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Tendência (7 dias)</CardTitle>
+              <CardDescription>Spend diário.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {metaLoading ? (
+                <div className="text-sm text-muted-foreground">Carregando...</div>
+              ) : (
+                <div className="space-y-2 text-sm">
+                  {(metaMetrics?.trend || []).map((row) => (
+                    <div key={row.day} className="flex items-center justify-between">
+                      <span>{row.day}</span>
+                      <span>{row.spend}</span>
+                    </div>
+                  ))}
+                  {!metaMetrics?.trend?.length && (
+                    <div className="text-xs text-muted-foreground">Sem dados no período.</div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    )
+  }
 
   // Report Templates
   const reportTemplates: ReportTemplate[] = [

--- a/frontend/SystemConfiguration.tsx
+++ b/frontend/SystemConfiguration.tsx
@@ -287,6 +287,10 @@ export function SystemConfiguration() {
         harmonia: {
           debugToken: '',
           execToken: ''
+        },
+        facebook: {
+          pageId: '',
+          accessToken: ''
         }
       },
       advanced: {

--- a/frontend/e2e/atendimento-left-column-layout.spec.ts
+++ b/frontend/e2e/atendimento-left-column-layout.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+
+const email = process.env.E2E_EMAIL || ''
+const password = process.env.E2E_PASSWORD || ''
+
+test.describe('atendimento left column layout', () => {
+  test('coluna esquerda compacta sem clipping', async ({ page }) => {
+    await page.route('**/api/wa-orchestrator/status**', async (route: any) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          provider: 'evolution',
+          channels: [{ id: 'wa-channel-1', channel: 1, port: 3001, status: 'connected' }],
+          connectedInstances: 1,
+          freeInstances: 8,
+          errorInstances: 0
+        })
+      })
+    })
+
+    await page.route('**/api/wa-orchestrator/channels/1/conversations?**', async (route: any) => {
+      const now = new Date().toISOString()
+      const items = Array.from({ length: 12 }).map((_, i) => ({
+        conversationId: `55119999900${String(i).padStart(2, '0')}@s.whatsapp.net`,
+        name: `Contato ${i}`,
+        unreadCount: i % 3 === 0 ? i % 5 : 0,
+        lastMessage: `Mensagem ${i}`,
+        updatedAt: now
+      }))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, items })
+      })
+    })
+
+    await page.route('**/api/wa-orchestrator/channels/1/conversations/**/messages?**', async (route: any) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, items: [] })
+      })
+    })
+
+    await page.goto('/?module=atendimento')
+    const authInput = page.locator('#auth-email')
+    if (await authInput.isVisible().catch(() => false)) {
+      if (!email || !password) test.skip(true, 'Missing E2E_EMAIL or E2E_PASSWORD')
+      await page.fill('#auth-email', email)
+      await page.fill('#auth-password', password)
+      await page.getByRole('button', { name: 'Acessar Plataforma' }).click()
+    }
+
+    await expect(page.getByPlaceholder('Buscar por nome, telefone, perfil ou plataforma')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByRole('heading', { name: 'Conversas' })).toHaveCount(0)
+
+    const geometry = await page.evaluate(() => {
+      const firstItem = document.querySelector('[data-testid="conversation-item"]') as HTMLElement | null
+      const viewport = firstItem?.closest('[data-slot="scroll-area-viewport"]') as HTMLElement | null
+      const filterBar = document.querySelector('[data-slot="scroll-area-viewport"]')?.parentElement?.parentElement?.querySelector('div.flex.flex-wrap.items-center') as HTMLElement | null
+      const search = document.querySelector('input[placeholder*="Buscar por nome"]') as HTMLElement | null
+      if (!firstItem || !viewport || !filterBar || !search) return null
+      const itemRect = firstItem.getBoundingClientRect()
+      const viewportRect = viewport.getBoundingClientRect()
+      const filterRect = filterBar.getBoundingClientRect()
+      const searchRect = search.getBoundingClientRect()
+      return {
+        itemRight: itemRect.right,
+        viewportRight: viewportRect.right,
+        filterBottom: filterRect.bottom,
+        searchTop: searchRect.top,
+        searchBottom: searchRect.bottom,
+        firstItemTop: itemRect.top
+      }
+    })
+
+    expect(geometry).not.toBeNull()
+    expect((geometry as any).itemRight).toBeLessThanOrEqual((geometry as any).viewportRight + 1)
+    expect((geometry as any).filterBottom).toBeLessThan((geometry as any).searchTop + 2)
+    expect((geometry as any).searchBottom).toBeLessThan((geometry as any).firstItemTop + 6)
+  })
+})

--- a/frontend/e2e/atendimento-media-inline.spec.ts
+++ b/frontend/e2e/atendimento-media-inline.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test'
+
+const email = process.env.E2E_EMAIL || ''
+const password = process.env.E2E_PASSWORD || ''
+
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO4B6m8AAAAASUVORK5CYII='
+const PDF_DATA_URL = 'data:application/pdf;base64,JVBERi0xLjQKJcTl8uXrPgoxIDAgb2JqPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDIgMCBSPj5lbmRvYmoKMiAwIG9iajw8L1R5cGUvUGFnZXMvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjMgMCBvYmo8PC9UeXBlL1BhZ2UvUGFyZW50IDIgMCBSL01lZGlhQm94WzAgMCAzMDAgMTQ0XS9Db250ZW50cyA0IDAgUj4+ZW5kb2JqCjQgMCBvYmo8PC9MZW5ndGggNDQ+PnN0cmVhbQpCVCAvRjEgMTIgVGYgNzIgNzIgVGQgKEhlbGxvIFBERikgVGoKRVQKZW5kc3RyZWFtCmVuZG9iago1IDAgb2JqPDwvVHlwZS9Gb250L1N1YnR5cGUvVHlwZTEvTmFtZS9GMS9CYXNlRm9udC9IZWx2ZXRpY2E+PmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTAgMDAwMDAgbiAKMDAwMDAwMDA2MCAwMDAwMCBuIAowMDAwMDAwMTE3IDAwMDAwIG4gCjAwMDAwMDAyMTQgMDAwMDAgbiAKMDAwMDAwMDMwOCAwMDAwMCBuIAp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDY+PgpzdGFydHhyZWYKMzg0CiUlRU9G'
+const AUDIO_DATA_URL = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
+
+function mockCoreEndpoints(page: any) {
+  page.route('**/api/wa-orchestrator/status**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        provider: 'evolution',
+        totalChannels: 9,
+        freeInstances: 8,
+        connectedInstances: 1,
+        errorInstances: 0,
+        startingInstances: 0,
+        channels: [{ id: 'wa-channel-1', channel: 1, port: 3001, status: 'connected' }]
+      })
+    })
+  })
+  page.route('**/api/wa-orchestrator/channels/1/conversations?**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        items: [
+          {
+            conversationId: '5511999990000@s.whatsapp.net',
+            name: 'Contato Teste',
+            phone: '5511999990000',
+            platform: 'whatsapp',
+            unreadCount: 0,
+            lastMessage: 'Mídia',
+            updatedAt: new Date().toISOString(),
+            profilePic: ''
+          }
+        ]
+      })
+    })
+  })
+}
+
+test.describe('atendimento media inline', () => {
+  test('renderiza imagem, pdf e áudio inline', async ({ page }) => {
+    mockCoreEndpoints(page)
+    await page.route('**/api/wa-orchestrator/channels/1/conversations/**/messages?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          items: [
+            { id: 'm-img', direction: 'inbound', text: 'Imagem', createdAt: new Date().toISOString(), media: { type: 'image', url: PNG_DATA_URL, mimeType: 'image/png' }, mediaProxyUrl: PNG_DATA_URL },
+            { id: 'm-pdf', direction: 'inbound', text: 'PDF', createdAt: new Date().toISOString(), media: { type: 'document', url: PDF_DATA_URL, mimeType: 'application/pdf', fileName: 'teste.pdf' }, mediaProxyUrl: PDF_DATA_URL },
+            { id: 'm-aud', direction: 'inbound', text: 'Áudio', createdAt: new Date().toISOString(), media: { type: 'audio', url: AUDIO_DATA_URL, mimeType: 'audio/wav' }, mediaProxyUrl: AUDIO_DATA_URL }
+          ]
+        })
+      })
+    })
+
+    await page.goto('/?module=atendimento')
+
+    const authInput = page.locator('#auth-email')
+    if (await authInput.isVisible().catch(() => false)) {
+      if (!email || !password) test.skip(true, 'Missing E2E_EMAIL or E2E_PASSWORD')
+      await page.fill('#auth-email', email)
+      await page.fill('#auth-password', password)
+      await page.getByRole('button', { name: 'Acessar Plataforma' }).click()
+    }
+
+    await expect(page.getByRole('heading', { name: 'Atendimento' }).first()).toBeVisible({ timeout: 30000 })
+    await page.locator('[data-testid="conversation-item"]').first().click()
+
+    await expect(page.locator('img[alt="Imagem"]').first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('iframe[title="teste.pdf"]').first()).toBeVisible({ timeout: 15000 })
+    await expect(page.getByRole('button', { name: /reproduzir áudio|pausar áudio/i }).first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('span', { hasText: /0:00/ }).first()).toBeVisible({ timeout: 15000 })
+
+    await page.locator('img[alt="Imagem"]').first().click()
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('heading', { name: 'Visualizar imagem' })).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/frontend/e2e/atendimento-reactions.spec.ts
+++ b/frontend/e2e/atendimento-reactions.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+
+const email = process.env.E2E_EMAIL || ''
+const password = process.env.E2E_PASSWORD || ''
+
+function mockBase(page: any) {
+  page.route('**/api/wa-orchestrator/status**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        provider: 'evolution',
+        channels: [{ id: 'wa-channel-1', channel: 1, port: 3001, status: 'connected' }],
+        connectedInstances: 1,
+        freeInstances: 8,
+        errorInstances: 0
+      })
+    })
+  })
+  page.route('**/api/wa-orchestrator/channels/1/conversations?**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        items: [
+          {
+            conversationId: '5511999990000@s.whatsapp.net',
+            name: 'Contato Reação',
+            unreadCount: 0,
+            lastMessage: 'Reagir',
+            updatedAt: new Date().toISOString()
+          }
+        ]
+      })
+    })
+  })
+  page.route('**/api/wa-orchestrator/channels/1/conversations/**/messages?**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        items: [
+          {
+            id: 'm-reaction',
+            direction: 'inbound',
+            text: 'Mensagem com reação',
+            createdAt: new Date().toISOString(),
+            reactions: [{ emoji: '👍', count: 1, reactedByMe: false }]
+          }
+        ]
+      })
+    })
+  })
+}
+
+test.describe('atendimento reactions', () => {
+  test('toggle reação atualiza contador', async ({ page }) => {
+    mockBase(page)
+    let currentCount = 1
+    page.route('**/api/wa-orchestrator/channels/1/conversations/**/messages/**/reactions/toggle', async (route: any) => {
+      const body = route.request().postDataJSON() || {}
+      const emoji = body.emoji || '👍'
+      currentCount = currentCount === 1 ? 2 : 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          reactions: [{ emoji, count: currentCount, reactedByMe: currentCount > 1 }]
+        })
+      })
+    })
+
+    await page.goto('/?module=atendimento')
+    const authInput = page.locator('#auth-email')
+    if (await authInput.isVisible().catch(() => false)) {
+      if (!email || !password) test.skip(true, 'Missing E2E_EMAIL or E2E_PASSWORD')
+      await page.fill('#auth-email', email)
+      await page.fill('#auth-password', password)
+      await page.getByRole('button', { name: 'Acessar Plataforma' }).click()
+    }
+
+    await page.locator('[data-testid="conversation-item"]').first().click()
+    const firstMessage = page.locator('.group').first()
+    await firstMessage.hover()
+    await page.getByRole('button', { name: 'Reagir mensagem' }).first().click()
+    await page.locator('button').filter({ hasText: '👍' }).first().click()
+
+    await expect(page.locator('button').filter({ hasText: '👍' }).first()).toContainText('2')
+  })
+})

--- a/frontend/e2e/atendimento-reply.spec.ts
+++ b/frontend/e2e/atendimento-reply.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+const email = process.env.E2E_EMAIL || ''
+const password = process.env.E2E_PASSWORD || ''
+
+function mockBase(page: any) {
+  page.route('**/api/wa-orchestrator/status**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        provider: 'evolution',
+        channels: [{ id: 'wa-channel-1', channel: 1, port: 3001, status: 'connected' }],
+        connectedInstances: 1,
+        freeInstances: 8,
+        errorInstances: 0
+      })
+    })
+  })
+  page.route('**/api/wa-orchestrator/channels/1/conversations?**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        items: [
+          {
+            conversationId: '5511999990000@s.whatsapp.net',
+            name: 'Contato Reply',
+            unreadCount: 0,
+            lastMessage: 'Mensagem',
+            updatedAt: new Date().toISOString()
+          }
+        ]
+      })
+    })
+  })
+  page.route('**/api/wa-orchestrator/channels/1/conversations/**/messages?**', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        items: [
+          { id: 'm-1', direction: 'inbound', text: 'Mensagem base', createdAt: new Date().toISOString() }
+        ]
+      })
+    })
+  })
+}
+
+test.describe('atendimento reply', () => {
+  test('reply mostra referência e envia metadados', async ({ page }) => {
+    mockBase(page)
+    let requestBody: any = null
+    page.route('**/api/wa-orchestrator/channels/1/conversations/**/send', async (route: any) => {
+      requestBody = route.request().postDataJSON()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          ack: { id: 'm-sent-1', replyTo: { messageId: requestBody?.replyToMessageId, textPreview: requestBody?.replyToPreview } }
+        })
+      })
+    })
+
+    await page.goto('/?module=atendimento')
+    const authInput = page.locator('#auth-email')
+    if (await authInput.isVisible().catch(() => false)) {
+      if (!email || !password) test.skip(true, 'Missing E2E_EMAIL or E2E_PASSWORD')
+      await page.fill('#auth-email', email)
+      await page.fill('#auth-password', password)
+      await page.getByRole('button', { name: 'Acessar Plataforma' }).click()
+    }
+
+    await page.locator('[data-testid="conversation-item"]').first().click()
+    const messageBubble = page.locator('.group').first()
+    await messageBubble.hover()
+    await page.getByRole('button', { name: 'Responder mensagem' }).first().click()
+
+    await expect(page.getByText('Respondendo:')).toBeVisible({ timeout: 10000 })
+    await page.getByPlaceholder('Digite sua mensagem...').fill('Teste reply')
+    await page.getByRole('button', { name: 'Enviar' }).click()
+
+    await expect.poll(() => requestBody).not.toBeNull()
+    expect(String(requestBody?.replyToMessageId || '')).toBe('m-1')
+    expect(String(requestBody?.replyToPreview || '')).toContain('Mensagem base')
+  })
+})

--- a/frontend/functions/api/wa-orchestrator/[[path]].ts
+++ b/frontend/functions/api/wa-orchestrator/[[path]].ts
@@ -104,8 +104,8 @@ export async function onRequest(context: any): Promise<Response> {
   if (hasBasicAuth && !headers.has('authorization')) {
     const toBase64 = (value: string) => {
       if (typeof btoa === 'function') return btoa(value)
-      // @ts-expect-error - Buffer is available in some runtimes
-      if (typeof Buffer !== 'undefined') return Buffer.from(value).toString('base64')
+      const runtime = globalThis as { Buffer?: { from: (input: string) => { toString: (encoding: string) => string } } }
+      if (typeof runtime.Buffer !== 'undefined') return runtime.Buffer.from(value).toString('base64')
       return value
     }
     headers.set('authorization', `Basic ${toBase64(basicAuthRaw)}`)


### PR DESCRIPTION
## Resumo\n- adiciona metastore de metadados WhatsApp (reply/reactions/media) no CRM API\n- expande endpoints de mensagens/envio/reação e proxy de mídia\n- integra UI Omnichannel com renderização inline de mídia, reply explícito e reações\n- adiciona testes backend + Playwright para atendimento\n- corrige erros de TypeScript em módulos Harmonia/Reports/ROI/SystemConfig e proxy WA\n\n## Validação\n- node --test backend/apps/crm-api/services/__tests__/waMessageMeta.test.js\n- E2E_BASE_URL=http://localhost:5175 npm -C frontend run test:e2e -- frontend/e2e/atendimento-media-inline.spec.ts frontend/e2e/atendimento-reply.spec.ts frontend/e2e/atendimento-reactions.spec.ts frontend/e2e/atendimento-left-column-layout.spec.ts\n- npm -C frontend run typecheck