### PR TITLE
fix: dashboards hook-order lint failures

### DIFF
--- a/frontend/ROIDashboard.tsx
+++ b/frontend/ROIDashboard.tsx
@@ -101,11 +101,10 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
       .finally(() => setMetaLoading(false))
   }, [mode])
 
-  if (mode === 'meta-ads') {
-    const spend = metaMetrics?.summary.spend ?? 0
-    const revenue = metaMetrics?.summary.revenue ?? 0
-    const roiPct = spend > 0 ? ((revenue - spend) / spend) * 100 : 0
-    return (
+  const spend = metaMetrics?.summary.spend ?? 0
+  const revenue = metaMetrics?.summary.revenue ?? 0
+  const roiPct = spend > 0 ? ((revenue - spend) / spend) * 100 : 0
+  const metaAdsView = (
       <div className="space-y-6">
         <Card>
           <CardHeader>
@@ -136,8 +135,7 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
           <div className="text-sm text-muted-foreground">Carregando...</div>
         ) : null}
       </div>
-    )
-  }
+  )
 
   // Initialize ROI data
   const [roiMetrics, setROIMetrics] = useKV<ROIMetric[]>("roi-metrics", [])
@@ -304,6 +302,10 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
       case 'trend': return <TrendUp className="h-4 w-4" />
       default: return <Sparkle className="h-4 w-4" />
     }
+  }
+
+  if (mode === 'meta-ads') {
+    return metaAdsView
   }
 
   return (

--- a/frontend/ReportsDashboard.tsx
+++ b/frontend/ReportsDashboard.tsx
@@ -123,8 +123,7 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
       .finally(() => setMetaLoading(false))
   }, [mode])
 
-  if (mode === 'meta-ads') {
-    return (
+  const metaAdsView = (
       <div className="space-y-6">
         <Card>
           <CardHeader>
@@ -181,8 +180,7 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
           </Card>
         )}
       </div>
-    )
-  }
+  )
 
   // Report Templates
   const reportTemplates: ReportTemplate[] = [
@@ -340,6 +338,10 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
       setReports(sampleReports)
     }
   }, [reports.length, setReports])
+
+  if (mode === 'meta-ads') {
+    return metaAdsView
+  }
 
   const handleCreateReport = (templateId?: string) => {
     const template = templateId ? reportTemplates.find(t => t.id === templateId) : null


### PR DESCRIPTION
## Resumo
- corrige ordem de hooks no `ReportsDashboard`
- corrige ordem de hooks no `ROIDashboard`
- remove erros `react-hooks/rules-of-hooks` que quebravam CI

## Validação
- `npm -C frontend run lint`
- `npm -C frontend run typecheck`
