### PR TITLE
fix(atendimento): restore header badges and stabilize omnichannel layout

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -47,6 +47,22 @@ type InsumosMeResponse = {
     csrfToken?: string
 }
 
+type AtendimentoHeaderState = {
+    whatsappConnected: boolean
+    connectedWhatsapps: number
+    instagramConnected: boolean
+    facebookConfigured: boolean
+    supportStats: {
+        totalTickets: number
+        openWithin24: number
+        overdueTickets: number
+        resolvedTickets: number
+        avgSatisfaction: number
+    }
+    ticketFilter: 'total' | 'open' | 'overdue' | 'resolved'
+    paused: boolean
+}
+
 async function insumosApiJson<T>(
     path: string,
     opts: {
@@ -315,7 +331,7 @@ export default function AppFunctionalNeatlab() {
     const sidebarExpanded = sidebarPinned || !sidebarCanHover || sidebarHover
 
 	    // Persist active module to survive remounts/reloads and avoid accidental resets
-		    const [active, setActive] = useState<string>(() => {
+	    const [active, setActive] = useState<string>(() => {
 		        try {
 		            const saved = localStorage.getItem('app.activeModule')
 		            const candidate = saved || DEFAULT_MODULE_KEY
@@ -338,6 +354,7 @@ export default function AppFunctionalNeatlab() {
 	        setActive(DEFAULT_MODULE_KEY)
 	    }, [DEFAULT_MODULE_KEY, UNLOCKED_MODULE_KEYS, active])
 	    const [search, setSearch] = useState('')
+        const [atendimentoHeaderState, setAtendimentoHeaderState] = useState<AtendimentoHeaderState | null>(null)
 				    const [insumosHeaderStatus, setInsumosHeaderStatus] = useState<{
 			        online: boolean | null
 			        authed: boolean | null
@@ -497,6 +514,25 @@ export default function AppFunctionalNeatlab() {
                     }
                     window.addEventListener('skincos:insumos:estoque', handler)
                     return () => window.removeEventListener('skincos:insumos:estoque', handler)
+                }, [])
+
+                React.useEffect(() => {
+                    const handler = (event: Event) => {
+                        const detail = (event as CustomEvent<AtendimentoHeaderState | null>)?.detail || null
+                        if (!detail || typeof detail !== 'object') {
+                            setAtendimentoHeaderState(null)
+                            return
+                        }
+                        setAtendimentoHeaderState(detail)
+                    }
+                    window.addEventListener('skincos:atendimento:header', handler as EventListener)
+                    return () => window.removeEventListener('skincos:atendimento:header', handler as EventListener)
+                }, [])
+
+                const dispatchAtendimentoHeaderAction = React.useCallback((action: string) => {
+                    try {
+                        window.dispatchEvent(new CustomEvent('skincos:atendimento:header-action', { detail: { action } }))
+                    } catch { /* ignore */ }
                 }, [])
 
 	    // Allow forcing a module via URL, e.g. http://localhost:5173/?module=capabilities
@@ -1212,6 +1248,69 @@ export default function AppFunctionalNeatlab() {
 	                                </div>
 
 		                                <div className="flex items-center gap-4">
+                                    {active === 'atendimento' ? (
+                                        <div className="hidden 2xl:flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className={`h-7 rounded-full border px-2.5 text-xs ${atendimentoHeaderState?.whatsappConnected ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-100' : 'border-white/15 bg-white/5 text-blue-100/80'}`}
+                                                onClick={() => dispatchAtendimentoHeaderAction('wa')}
+                                            >
+                                                WhatsApp {atendimentoHeaderState?.connectedWhatsapps ?? 0}
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className={`h-7 rounded-full border px-2.5 text-xs ${atendimentoHeaderState?.instagramConnected ? 'border-pink-400/40 bg-pink-500/15 text-pink-100' : 'border-white/15 bg-white/5 text-blue-100/80'}`}
+                                                onClick={() => dispatchAtendimentoHeaderAction('ig')}
+                                            >
+                                                Instagram
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className={`h-7 rounded-full border px-2.5 text-xs ${atendimentoHeaderState?.facebookConfigured ? 'border-blue-400/40 bg-blue-500/15 text-blue-100' : 'border-white/15 bg-white/5 text-blue-100/80'}`}
+                                                onClick={() => dispatchAtendimentoHeaderAction('fb')}
+                                            >
+                                                Facebook
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-7 rounded-full border border-sky-400/40 bg-sky-500/15 px-2.5 text-xs text-sky-100"
+                                                onClick={() => dispatchAtendimentoHeaderAction('tickets-total')}
+                                            >
+                                                Total {atendimentoHeaderState?.supportStats?.totalTickets ?? 0}
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-7 rounded-full border border-amber-400/40 bg-amber-500/15 px-2.5 text-xs text-amber-100"
+                                                onClick={() => dispatchAtendimentoHeaderAction('tickets-open')}
+                                            >
+                                                Abertos {atendimentoHeaderState?.supportStats?.openWithin24 ?? 0}
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-7 rounded-full border border-rose-400/40 bg-rose-500/15 px-2.5 text-xs text-rose-100"
+                                                onClick={() => dispatchAtendimentoHeaderAction('tickets-overdue')}
+                                            >
+                                                Atrasados {atendimentoHeaderState?.supportStats?.overdueTickets ?? 0}
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-7 rounded-full border border-emerald-400/40 bg-emerald-500/15 px-2.5 text-xs text-emerald-100"
+                                                onClick={() => dispatchAtendimentoHeaderAction('tickets-resolved')}
+                                            >
+                                                Resolvidos {atendimentoHeaderState?.supportStats?.resolvedTickets ?? 0}
+                                            </Button>
+                                            <span className="inline-flex h-7 items-center rounded-full border border-violet-400/40 bg-violet-500/15 px-2.5 text-xs text-violet-100">
+                                                Satisfação {Number(atendimentoHeaderState?.supportStats?.avgSatisfaction || 0).toFixed(1)}
+                                            </span>
+                                        </div>
+                                    ) : null}
 		                                    {active === 'insumos' ? (
 		                                        <div className="flex items-start gap-2 min-w-[220px] justify-between rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-blue-200/70">
 		                                            <button
@@ -1455,7 +1554,7 @@ export default function AppFunctionalNeatlab() {
                         </header>
 
                         {/* Premium Main Content */}
-                        <main className="flex-1 overflow-auto p-8 relative">
+                        <main className={`flex-1 p-8 relative ${active === 'atendimento' ? 'overflow-hidden' : 'overflow-auto'}`}>
                             {/* Content Background */}
                             <div className="absolute inset-0 bg-white/[0.02] backdrop-blur-sm"></div>
 

--- a/frontend/AtendimentoModule.tsx
+++ b/frontend/AtendimentoModule.tsx
@@ -1,10 +1,25 @@
-import React, { Suspense, lazy, useCallback, useState } from 'react'
-import { Badge } from '@/badge'
+import React, { Suspense, lazy, useCallback, useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
 import { ErrorBoundary } from '@/ErrorBoundary'
 import { useAuth } from '@/contexts'
 import { LoadingPercentText } from '@/LoadingPattern'
 const OmnichannelCenter = lazy(() => import('@/OmnichannelCenter').then(m => ({ default: m.OmnichannelCenter })))
+
+type AtendimentoHeaderState = {
+  whatsappConnected: boolean
+  connectedWhatsapps: number
+  instagramConnected: boolean
+  facebookConfigured: boolean
+  supportStats: {
+    totalTickets: number
+    openWithin24: number
+    overdueTickets: number
+    resolvedTickets: number
+    avgSatisfaction: number
+  }
+  ticketFilter: 'total' | 'open' | 'overdue' | 'resolved'
+  paused: boolean
+}
 
 function TabShell({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -60,6 +75,24 @@ export function AtendimentoModule() {
 
   const [omniKey, setOmniKey] = useState(0)
 
+  const publishHeaderState = useCallback((state: AtendimentoHeaderState) => {
+    try {
+      window.dispatchEvent(new CustomEvent('skincos:atendimento:header', { detail: state }))
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      try {
+        window.dispatchEvent(new CustomEvent('skincos:atendimento:header', { detail: null }))
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [])
+
   if (!canOmnichannel) {
     return (
       <Card className="glass-card">
@@ -78,6 +111,7 @@ export function AtendimentoModule() {
       <OmnichannelCenter
         key={`omni-${omniKey}`}
         activities={[] as any}
+        onHeaderStateChange={publishHeaderState}
         onStartConversation={(channel) => {
           const c = String(channel || '').toLowerCase()
           if (c === 'whatsapp') {
@@ -89,13 +123,8 @@ export function AtendimentoModule() {
   )
 
   return (
-    <div className="space-y-6 atendimento-surface">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="text-2xl font-semibold text-white">Atendimento</h2>
-        <Badge variant="secondary">Central</Badge>
-      </div>
-
-      <div className="space-y-4">
+    <div className="h-full min-h-0 atendimento-surface">
+      <div className="h-full min-h-0">
         {renderActivePanel()}
       </div>
     </div>

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/car
 import { Badge } from "@/badge"
 import { Button } from "@/button"
 import { Input } from "@/input"
-import { ScrollArea } from "@/scroll-area"
 import { Textarea } from "@/textarea"
 import { Label } from "@/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/select"
@@ -819,8 +818,15 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     if (statusPausedUntil && Date.now() < statusPausedUntil) return
     try {
       const res = await fetch('/api/wa-orchestrator/status', { headers: buildCrmBasicAuthHeaders() })
+      if (res.status === 304) {
+        setStatusFailureCount(0)
+        setStatusPausedUntil(null)
+        return
+      }
       const data = await res.json().catch(() => null)
-      if (!res.ok || data?.success === false) return
+      if (!res.ok || data?.success === false) {
+        throw new Error(data?.error || `HTTP ${res.status}`)
+      }
       setProvider(data?.provider || null)
       const normalized = normalizeOrchestratorStatus(data)
       setOrchestratorStatus(normalized)
@@ -1486,10 +1492,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
 
   const refreshHarmonia = useCallback(async () => {
     try {
-      const [h, u] = await Promise.all([
-        harmoniaApiJson<HarmoniaHealth>('/api/harmonia/health'),
-        harmoniaApiJson<{ ok: boolean; data?: HarmoniaUnit[] }>('/api/harmonia/units').catch(() => ({ ok: false, data: [] })),
-      ])
+      const h = await harmoniaApiJson<HarmoniaHealth>('/api/harmonia/health')
+      let u: { ok: boolean; data?: HarmoniaUnit[] } = { ok: false, data: [] }
+      if (h?.harmonia?.dbConfigured) {
+        u = await harmoniaApiJson<{ ok: boolean; data?: HarmoniaUnit[] }>('/api/harmonia/units').catch(() => ({ ok: false, data: [] }))
+      }
       setHarmoniaHealth(h || null)
       setHarmoniaUnits(Array.isArray((u as any)?.data) ? (u as any).data : [])
     } catch {
@@ -1670,11 +1677,6 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       }
 
       if (qrDataUrl) {
-        console.info('[WA_QR_DEBUG] pollChannelQR:resolved', {
-          channel,
-          qrType: String(result.qr || '').startsWith('data:image') ? 'image-data-url' : 'raw-text',
-          qrLength: typeof result.qr === 'string' ? result.qr.length : 0
-        })
         setChannelQR(prev => new Map(prev.set(channel, { qr: result.qr || qrDataUrl, dataUrl: qrDataUrl })))
       }
     } catch (err: any) {
@@ -1699,11 +1701,6 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
           : (/^[A-Za-z0-9+/]+={0,2}$/.test(normalizedQr) && normalizedQr.length > 120)
             ? `data:image/${normalizedQr.startsWith('/9j/') ? 'jpeg' : 'png'};base64,${normalizedQr}`
             : await QRCode.toDataURL(normalizedQr, { width: 300, margin: 2, color: { dark: QR_DARK, light: QR_LIGHT } })
-        console.info('[WA_QR_DEBUG] startChannel:resolved', {
-          channel,
-          qrType: normalizedQr.startsWith('data:image') ? 'image-data-url' : 'raw-text',
-          qrLength: normalizedQr.length
-        })
         setChannelQR(prev => new Map(prev.set(channel, { qr: result.qr || qrDataUrl, dataUrl: qrDataUrl })))
       }
       toast.success(`Canal ${channel} iniciado`)
@@ -1894,6 +1891,42 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }),
     [openTicketsModal]
   )
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const action = String((event as CustomEvent<{ action?: string }>)?.detail?.action || '').trim()
+      if (!action) return
+      if (action === 'wa') {
+        setWaStatusOpen(true)
+        return
+      }
+      if (action === 'ig') {
+        setIgStatusOpen(true)
+        return
+      }
+      if (action === 'fb') {
+        setFbStatusOpen(true)
+        return
+      }
+      if (action === 'tickets-total') {
+        openTicketsModal('total')
+        return
+      }
+      if (action === 'tickets-open') {
+        openTicketsModal('open')
+        return
+      }
+      if (action === 'tickets-overdue') {
+        openTicketsModal('overdue')
+        return
+      }
+      if (action === 'tickets-resolved') {
+        openTicketsModal('resolved')
+      }
+    }
+    window.addEventListener('skincos:atendimento:header-action', handler as EventListener)
+    return () => window.removeEventListener('skincos:atendimento:header-action', handler as EventListener)
+  }, [openTicketsModal])
 
   const filteredTickets = useMemo(() => {
     const isOpen = (t: SupportTicket) => ['open', 'in-progress', 'waiting-customer'].includes(t.status)
@@ -2126,9 +2159,9 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
           </div>
         ) : null}
         <div className="grid flex-1 min-h-0 grid-cols-1 gap-4 xl:grid-cols-12">
-          <Card className="glass-card xl:col-span-4 flex min-h-0 flex-col">
+          <Card className="glass-card xl:col-span-4 flex min-h-0 flex-col overflow-hidden">
                 <CardContent className="flex min-h-0 flex-col gap-2 pt-4">
-                  <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 p-1.5">
+                  <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/15 bg-white/10 p-1.5">
                     {[
                       { id: 'all', label: 'Todas' },
                       { id: 'unread', label: 'Não lidas' },
@@ -2142,10 +2175,10 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         key={item.id}
                         size="sm"
                         variant="ghost"
-                        className={`h-7 rounded-full border px-2.5 text-[11px] font-medium leading-none ${
+                        className={`h-7 rounded-full border px-2.5 text-[11px] font-semibold leading-none ${
                           conversationFilter === item.id
-                            ? 'border-white/30 bg-white/15 text-white'
-                            : 'border-white/10 bg-white/5 text-blue-100/80 hover:bg-white/10 hover:text-white'
+                            ? 'border-blue-300/60 bg-blue-500/35 text-white'
+                            : 'border-white/20 bg-white/10 text-white/90 hover:bg-white/15 hover:text-white'
                         }`}
                         onClick={() => setConversationFilter(item.id as any)}
                       >
@@ -2157,10 +2190,10 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     placeholder="Buscar por nome, telefone, perfil ou plataforma"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="h-8 bg-white/5 border-white/10 text-white placeholder:text-blue-100/50"
+                    className="h-9 bg-white/10 border-white/15 text-white placeholder:text-blue-100/55"
                   />
-                      <ScrollArea className="flex-1 min-h-0">
-                        <div className="space-y-1.5 pr-1">
+                      <div className="flex-1 min-h-0 overflow-y-auto pr-2">
+                        <div className="space-y-1.5 pb-1">
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>
                       )}
@@ -2181,7 +2214,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         <div
                           key={`${conv.conversationId}-${conv.channel ?? conv.platform ?? ''}`}
                           data-testid="conversation-item"
-                          className={`w-full p-3 rounded-lg border cursor-pointer transition-colors hover:bg-white/5 box-border ${
+                          className={`w-full min-w-0 p-3 rounded-xl border cursor-pointer transition-colors hover:bg-white/10 ${
                             selectedConversation?.conversationId === conv.conversationId &&
                             selectedConversation?.channel === conv.channel
                               ? 'border-blue-500/70 bg-blue-500/15'
@@ -2233,7 +2266,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         </div>
                       ))}
                         </div>
-                      </ScrollArea>
+                      </div>
                       {harmoniaInboxCursor?.cursorTs && (
                         <div className="pt-3">
                           <Button
@@ -2249,7 +2282,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     </CardContent>
                   </Card>
 
-          <Card className="glass-card xl:col-span-8 flex min-h-0 flex-col">
+          <Card className="glass-card xl:col-span-8 flex min-h-0 flex-col overflow-hidden">
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between gap-3">
                     <CardTitle className="text-lg text-white">
@@ -2330,7 +2363,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                       ) : null}
 
                       <div className="flex min-h-0 flex-1 flex-col rounded-xl border border-white/10 bg-white/5 p-4">
-                        <ScrollArea className="flex-1 min-h-0 pr-2" viewportRef={messagesViewportRef}>
+                        <div ref={messagesViewportRef} className="flex-1 min-h-0 overflow-y-auto pr-2">
                           <div className="space-y-3">
                             {selectedConversation.platform === 'lead' ? (
                               harmoniaMessagesLoading ? (
@@ -2517,7 +2550,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                               </>
                             )}
                           </div>
-                        </ScrollArea>
+                        </div>
 
                         {replyTarget && (
                           <div className="mt-3 flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-blue-100/70">

--- a/frontend/ROIDashboard.tsx
+++ b/frontend/ROIDashboard.tsx
@@ -101,11 +101,10 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
       .finally(() => setMetaLoading(false))
   }, [mode])
 
-  if (mode === 'meta-ads') {
-    const spend = metaMetrics?.summary.spend ?? 0
-    const revenue = metaMetrics?.summary.revenue ?? 0
-    const roiPct = spend > 0 ? ((revenue - spend) / spend) * 100 : 0
-    return (
+  const spend = metaMetrics?.summary.spend ?? 0
+  const revenue = metaMetrics?.summary.revenue ?? 0
+  const roiPct = spend > 0 ? ((revenue - spend) / spend) * 100 : 0
+  const metaAdsView = (
       <div className="space-y-6">
         <Card>
           <CardHeader>
@@ -136,8 +135,7 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
           <div className="text-sm text-muted-foreground">Carregando...</div>
         ) : null}
       </div>
-    )
-  }
+  )
 
   // Initialize ROI data
   const [roiMetrics, setROIMetrics] = useKV<ROIMetric[]>("roi-metrics", [])
@@ -304,6 +302,10 @@ export function ROIDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads' }) 
       case 'trend': return <TrendUp className="h-4 w-4" />
       default: return <Sparkle className="h-4 w-4" />
     }
+  }
+
+  if (mode === 'meta-ads') {
+    return metaAdsView
   }
 
   return (

--- a/frontend/ReportsDashboard.tsx
+++ b/frontend/ReportsDashboard.tsx
@@ -123,8 +123,7 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
       .finally(() => setMetaLoading(false))
   }, [mode])
 
-  if (mode === 'meta-ads') {
-    return (
+  const metaAdsView = (
       <div className="space-y-6">
         <Card>
           <CardHeader>
@@ -181,8 +180,7 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
           </Card>
         )}
       </div>
-    )
-  }
+  )
 
   // Report Templates
   const reportTemplates: ReportTemplate[] = [
@@ -340,6 +338,10 @@ export function ReportsDashboard({ mode = 'full' }: { mode?: 'full' | 'meta-ads'
       setReports(sampleReports)
     }
   }, [reports.length, setReports])
+
+  if (mode === 'meta-ads') {
+    return metaAdsView
+  }
 
   const handleCreateReport = (templateId?: string) => {
     const template = templateId ? reportTemplates.find(t => t.id === templateId) : null

--- a/frontend/metaMetrics.ts
+++ b/frontend/metaMetrics.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+const numberLike = z.preprocess((value) => {
+  if (typeof value === "number") return value
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}, z.number().finite())
+
+const summarySchema = z.object({
+  spend: numberLike.default(0),
+  impressions: numberLike.default(0),
+  clicks: numberLike.default(0),
+  roas: numberLike.default(0),
+  revenue: numberLike.default(0),
+})
+
+const trendRowSchema = z.object({
+  day: z.string().default(""),
+  spend: numberLike.default(0),
+  impressions: numberLike.default(0),
+  clicks: numberLike.default(0),
+  roas: numberLike.default(0),
+  revenue: numberLike.default(0),
+})
+
+export const MetaMetricsSchema = z.object({
+  platform: z.literal("meta-ads"),
+  currency: z.string().default("USD"),
+  period: z.object({
+    since: z.string(),
+    until: z.string(),
+    timezone: z.string().default("UTC"),
+  }),
+  summary: summarySchema,
+  trend: z.array(trendRowSchema).default([]),
+})
+
+export type MetaMetrics = z.infer<typeof MetaMetricsSchema>

--- a/frontend/visualTheme.ts
+++ b/frontend/visualTheme.ts
@@ -1,0 +1,10 @@
+export function getCssVarValue(variableName: string, fallback = ""): string {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return fallback
+  }
+
+  const node = document.documentElement
+  const rawValue = window.getComputedStyle(node).getPropertyValue(variableName)
+  const value = String(rawValue || "").trim()
+  return value || fallback
+}


### PR DESCRIPTION
## Summary
- republish Omnichannel header state to App header and wire header badges/actions
- remove duplicate Atendimento page title and keep module surface full-height
- fix Omnichannel left/right panes for internal scrolling and prevent clipped conversation cards
- harden WA status polling (304 handling, 500 fallback) and avoid noisy Harmonia unit fetch when DB is not configured

## Validation
- npm -C frontend run typecheck
- npm -C frontend run build
- local Playwright screenshot checks on /?module=atendimento