### PR TITLE
fix(atendimento): header badges and local stability

### DIFF
--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -772,6 +772,7 @@ app.use('/api/meta-ads', createProxyMiddleware({
 // Cloudflare target (default production). Override for local testing.
 const isLocalEnv = String(process.env.NODE_ENV || '').toLowerCase() !== 'production'
 const INSUMOS_API_TARGET = process.env.INSUMOS_API_TARGET || (isLocalEnv ? 'http://127.0.0.1:8787' : 'https://api.skincos.com.br')
+const LOCAL_INSUMOS_AUTH_STUB = isLocalEnv && String(process.env.NO_AUTH || '').toLowerCase() === 'true'
 
 function isLocalSafeMode() {
     // In local/dev, default to read-only for upstream production APIs unless explicitly allowed.
@@ -817,6 +818,21 @@ app.get('/api/insumos/_proxy-status', (_req, res) => {
         mutationsBlocked: safe && prod
     })
 })
+
+if (LOCAL_INSUMOS_AUTH_STUB) {
+    app.get('/api/insumos/auth/me', async (req, res) => {
+        const user = await resolveCrmUser(req).catch(() => null)
+        return res.status(200).set('cache-control', 'no-store').json({
+            success: true,
+            user: {
+                username: user?.username || user?.email || 'local-admin',
+                role: user?.role || 'ADMIN',
+                allowedUnits: Array.isArray(user?.allowedUnits) ? user.allowedUnits : ['novo-hamburgo']
+            },
+            csrfToken: 'local-dev'
+        })
+    })
+}
 
 app.use('/api/insumos', blockUpstreamMutationsIfNeeded(INSUMOS_API_TARGET))
 app.use('/api/insumos', createProxyMiddleware({

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1249,7 +1249,7 @@ export default function AppFunctionalNeatlab() {
 
 		                                <div className="flex items-center gap-4">
                                     {active === 'atendimento' ? (
-                                        <div className="hidden 2xl:flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                        <div className="flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                                             <Button
                                                 size="sm"
                                                 variant="ghost"

--- a/frontend/HarmoniaModule.tsx
+++ b/frontend/HarmoniaModule.tsx
@@ -229,10 +229,15 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
     setLoading(true)
     setError(null)
     try {
-      const [h, u, s] = await Promise.all([
-        apiJson<HarmoniaHealth>('/api/harmonia/health'),
-        apiJson<{ ok: boolean; data?: HarmoniaUnit[] }>('/api/harmonia/units').catch((e) => ({ ok: false, data: [], __err: e } as any)),
-        apiJson<{ ok: boolean; data?: HarmoniaTaskStats }>('/api/harmonia/tasks/stats').catch((e) => ({ ok: false, data: null, __err: e } as any)),
+      const h = await apiJson<HarmoniaHealth>('/api/harmonia/health')
+      const dbConfigured = Boolean(h?.harmonia?.dbConfigured)
+      const [u, s] = await Promise.all([
+        dbConfigured
+          ? apiJson<{ ok: boolean; data?: HarmoniaUnit[] }>('/api/harmonia/units').catch((e) => ({ ok: false, data: [], __err: e } as any))
+          : Promise.resolve({ ok: true, data: [] } as { ok: boolean; data?: HarmoniaUnit[] }),
+        dbConfigured
+          ? apiJson<{ ok: boolean; data?: HarmoniaTaskStats }>('/api/harmonia/tasks/stats').catch((e) => ({ ok: false, data: null, __err: e } as any))
+          : Promise.resolve({ ok: true, data: null } as { ok: boolean; data?: HarmoniaTaskStats | null }),
       ])
       setHealth(h || null)
       setUnits(Array.isArray((u as any)?.data) ? (u as any).data : [])

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -2178,7 +2178,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         className={`h-7 rounded-full border px-2.5 text-[11px] font-semibold leading-none ${
                           conversationFilter === item.id
                             ? 'border-blue-300/60 bg-blue-500/35 text-white'
-                            : 'border-white/20 bg-white/10 text-white/90 hover:bg-white/15 hover:text-white'
+                            : 'border-white/25 bg-white/15 text-white hover:bg-white/20 hover:text-white'
                         }`}
                         onClick={() => setConversationFilter(item.id as any)}
                       >
@@ -2192,8 +2192,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="h-9 bg-white/10 border-white/15 text-white placeholder:text-blue-100/55"
                   />
-                      <div className="flex-1 min-h-0 overflow-y-auto pr-2">
-                        <div className="space-y-1.5 pb-1">
+                      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-0">
+                        <div className="space-y-1.5 pb-1 pr-2">
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>
                       )}
@@ -2214,7 +2214,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         <div
                           key={`${conv.conversationId}-${conv.channel ?? conv.platform ?? ''}`}
                           data-testid="conversation-item"
-                          className={`w-full min-w-0 p-3 rounded-xl border cursor-pointer transition-colors hover:bg-white/10 ${
+                          className={`mx-0.5 box-border w-[calc(100%-4px)] min-w-0 p-3 rounded-xl border cursor-pointer transition-colors hover:bg-white/10 ${
                             selectedConversation?.conversationId === conv.conversationId &&
                             selectedConversation?.channel === conv.channel
                               ? 'border-blue-500/70 bg-blue-500/15'

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -2161,7 +2161,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         <div className="grid flex-1 min-h-0 grid-cols-1 gap-4 xl:grid-cols-12">
           <Card className="glass-card xl:col-span-4 flex min-h-0 flex-col overflow-hidden">
                 <CardContent className="flex min-h-0 flex-col gap-2 pt-4">
-                  <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/15 bg-white/10 p-1.5">
+                  <div data-testid="conversation-filters" className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/15 bg-white/10 p-1.5">
                     {[
                       { id: 'all', label: 'Todas' },
                       { id: 'unread', label: 'Não lidas' },
@@ -2187,12 +2187,13 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     ))}
                   </div>
                   <Input
+                    data-testid="omnichannel-search"
                     placeholder="Buscar por nome, telefone, perfil ou plataforma"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="h-9 bg-white/10 border-white/15 text-white placeholder:text-blue-100/55"
                   />
-                      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-0">
+                      <div data-testid="conversation-scroll" className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-0">
                         <div className="space-y-1.5 pb-1 pr-2">
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>

--- a/frontend/e2e/atendimento-left-column-layout.spec.ts
+++ b/frontend/e2e/atendimento-left-column-layout.spec.ts
@@ -45,22 +45,26 @@ test.describe('atendimento left column layout', () => {
     })
 
     await page.goto('/?module=atendimento')
-    const authInput = page.locator('#auth-email')
-    if (await authInput.isVisible().catch(() => false)) {
+    await page.waitForTimeout(1000)
+    const loginVisible = (await page.getByText(/Acessar Plataforma/i).count()) > 0
+    if (loginVisible) {
       if (!email || !password) test.skip(true, 'Missing E2E_EMAIL or E2E_PASSWORD')
-      await page.fill('#auth-email', email)
-      await page.fill('#auth-password', password)
+      const authInput = page.locator('#auth-email, input[placeholder*="empresa.com"], input[type="email"]').first()
+      await authInput.fill(email)
+      const passwordInput = page.locator('#auth-password, input[type="password"]').first()
+      await passwordInput.fill(password)
       await page.getByRole('button', { name: 'Acessar Plataforma' }).click()
     }
 
-    await expect(page.getByPlaceholder('Buscar por nome, telefone, perfil ou plataforma')).toBeVisible({ timeout: 30000 })
+    const searchInput = page.locator('[data-testid="omnichannel-search"], input[placeholder*="Buscar por nome"]')
+    await expect(searchInput.first()).toBeVisible({ timeout: 30000 })
     await expect(page.getByRole('heading', { name: 'Conversas' })).toHaveCount(0)
 
     const geometry = await page.evaluate(() => {
       const firstItem = document.querySelector('[data-testid="conversation-item"]') as HTMLElement | null
-      const viewport = firstItem?.closest('[data-slot="scroll-area-viewport"]') as HTMLElement | null
-      const filterBar = document.querySelector('[data-slot="scroll-area-viewport"]')?.parentElement?.parentElement?.querySelector('div.flex.flex-wrap.items-center') as HTMLElement | null
-      const search = document.querySelector('input[placeholder*="Buscar por nome"]') as HTMLElement | null
+      const viewport = document.querySelector('[data-testid="conversation-scroll"]') as HTMLElement | null
+      const filterBar = document.querySelector('[data-testid="conversation-filters"]') as HTMLElement | null
+      const search = document.querySelector('[data-testid="omnichannel-search"]') as HTMLElement | null
       if (!firstItem || !viewport || !filterBar || !search) return null
       const itemRect = firstItem.getBoundingClientRect()
       const viewportRect = viewport.getBoundingClientRect()

--- a/scripts/run-local-atendimento.sh
+++ b/scripts/run-local-atendimento.sh
@@ -59,6 +59,8 @@ free_port "$FRONTEND_PORT"
   export CRM_LOCAL_NO_AUTH="true"
   export WA_DEBUG_QR="true"
   export NODE_ENV="development"
+  export CRM_LOG_LEVEL="warn"
+  export INSUMOS_API_TARGET="${INSUMOS_API_TARGET:-https://api.skincos.com.br}"
   node backend/apps/crm-api/server.js
 ) &
 CRM_API_PID=$!


### PR DESCRIPTION
## Resumo
- mostra badges do Atendimento no cabeçalho em qualquer largura
- melhora contraste e corrige clipping na coluna de conversas do Omnichannel
- evita chamadas 503 de Harmonia quando DB não está configurado
- adiciona fallback local para /api/insumos/auth/me em NO_AUTH
- ajusta script local para INSUMOS_API_TARGET e CRM_LOG_LEVEL=warn

## Validação
- npm -C frontend run typecheck
- npm -C frontend run build
- screenshot local: /tmp/atendimento-latest.png