### PR TITLE
Expose escala module to admins

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -146,6 +146,7 @@ const InsumosModule = lazy(() => import('@/InsumosModule').then(m => ({ default:
 const UsersModule = lazy(() => import('@/UsersModule').then(m => ({ default: m.UsersModule })))
 const SystemStatusModule = lazy(() => import('@/SystemStatusModule').then(m => ({ default: m.SystemStatusModule })))
 const PontoModule = lazy(() => import('@/PontoModule').then(m => ({ default: m.PontoModule })))
+const EscalaProfissionaisModule = lazy(() => import('@/EscalaProfissionaisModule').then(m => ({ default: m.EscalaProfissionaisModule })))
 
 // TODO: Add remaining modules if needed
 
@@ -165,6 +166,7 @@ const modules: { key: string; label: string; icon: React.ReactNode; component: R
     { key: 'leads', label: 'Leads', icon: '💎', component: <LeadsManager /> },
     { key: 'notifications', label: 'Notificações', icon: '🔔', component: <NotificationCenter /> },
     { key: 'atendimento', label: 'Atendimento', icon: '💬', component: <AtendimentoModule /> },
+    { key: 'escala-profissionais', label: 'Escala', icon: '🗓️', component: <EscalaProfissionaisModule /> },
     { key: 'meta-ads', label: 'Meta Ads', icon: '📢', component: <MetaAdsManager /> },
     { key: 'meta-command', label: 'Meta Command', icon: '🧭', component: <MetaCommandCenter /> },
     { key: 'meta-sync', label: 'Meta Sync', icon: '🔄', component: <MetaSyncMonitor /> },
@@ -223,6 +225,7 @@ export default function AppFunctionalNeatlab() {
         (moduleKey: string) => {
             const key = String(moduleKey || '').trim()
             if (!key) return false
+            if (key === 'escala-profissionais') return roleKey === 'ADMIN'
             if (roleKey === 'ADMIN') return true
             const allowed = Array.isArray(user?.allowedModules)
                 ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)
@@ -295,7 +298,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'escala-profissionais']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)


### PR DESCRIPTION
## Context
The Escala module was added earlier, but the CRM sidebar module list didn’t include it and the unlock gate didn’t allow it to appear. As a result, admins couldn’t see the module in the UI.

## What changed
- Added the Escala module to the CRM module registry.
- Added it to the unlocked modules set.
- Enforced access: only ADMIN users can open it.

## Root cause
App shell gating (`modules` list + `UNLOCKED_MODULE_KEYS`) didn’t include the new module, so it never rendered in the sidebar even for admins.

## Fix
Registered the Escala module in `App.tsx` and gated access to ADMIN users only.

## Tests
- Not run (UI-only change).
