### PR TITLE
Unify roles under gestor

### DIFF
--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -499,7 +499,25 @@ const VISUAL_THEME_FILE = process.env.CRM_VISUAL_THEME_FILE || path.join(CORE_ST
 let visualThemeState = { themes: {} }
 let saveVisualThemeTimer = null
 
-const ADMIN_ROLES = new Set(['ADMIN', 'GESTOR', 'GERENTE'])
+const ROLE_ALIASES = new Map([
+    ['ADMIN', 'GESTOR'],
+    ['OPERADOR', 'INJETOR'],
+])
+
+const normalizeRole = (value) => {
+    const raw = String(value || '').trim().toUpperCase()
+    if (!raw) return ''
+    return ROLE_ALIASES.get(raw) || raw
+}
+
+const normalizeCrmUser = (user) => {
+    if (!user || typeof user !== 'object') return user
+    const role = normalizeRole(user.role)
+    if (!role || role === user.role) return user
+    return { ...user, role }
+}
+
+const ADMIN_ROLES = new Set(['GESTOR', 'GERENTE'])
 
 function resolveTenantKey(req) {
     const header = String(req.headers['x-tenant-key'] || req.headers['x-tenant'] || '').trim()
@@ -517,7 +535,7 @@ function resolveRoleFromReq(req) {
     const header = req.headers['x-user-role'] || req.headers['x-crm-role'] || req.headers['x-role']
     let role = header ? String(header) : ''
     if (!role && req.user?.role) role = String(req.user.role)
-    return role.trim().toUpperCase()
+    return normalizeRole(role)
 }
 
 function requireVisualThemeAdmin(req, res) {
@@ -720,7 +738,7 @@ async function fetchCrmUserFromAuth(req) {
                 displayName: raw.displayName || raw.name || raw.username || raw.email,
                 name: raw.name,
                 email: raw.email,
-                role: raw.role,
+                role: normalizeRole(raw.role),
                 allowedUnits: raw.allowedUnits,
                 allowedModules: raw.allowedModules,
             }
@@ -734,9 +752,10 @@ async function fetchCrmUserFromAuth(req) {
 async function resolveCrmUser(req) {
     if (devAuthEnabled && typeof devAuthSessionResolver === 'function') {
         const session = devAuthSessionResolver(req)
-        if (session?.user) return session.user
+        if (session?.user) return normalizeCrmUser(session.user)
     }
-    return fetchCrmUserFromAuth(req)
+    const user = await fetchCrmUserFromAuth(req)
+    return normalizeCrmUser(user)
 }
 
 app.use('/api/meta-ads', async (req, res, next) => {
@@ -826,7 +845,7 @@ if (LOCAL_INSUMOS_AUTH_STUB) {
             success: true,
             user: {
                 username: user?.username || user?.email || 'local-admin',
-                role: user?.role || 'ADMIN',
+                role: normalizeRole(user?.role || 'GESTOR'),
                 allowedUnits: Array.isArray(user?.allowedUnits) ? user.allowedUnits : ['novo-hamburgo']
             },
             csrfToken: 'local-dev'
@@ -903,8 +922,8 @@ if (DEV_AUTH_ENABLED) {
 
     const requireDevAdmin = (req, res) => {
         const session = getDevSession(req)
-        const role = String(session?.user?.role || '').trim().toUpperCase()
-        const ok = role === 'ADMIN' || role === 'GESTOR' || role === 'GERENTE'
+        const role = normalizeRole(session?.user?.role)
+        const ok = role === 'GESTOR' || role === 'GERENTE'
         if (!ok) {
             res.status(401).json({ ok: false, success: false, error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' })
             return null
@@ -918,14 +937,37 @@ if (DEV_AUTH_ENABLED) {
     }
     devAuthRequireAdmin = requireDevAdmin
 
+    const normalizeCrmStore = (store) => {
+        const usersIn = Array.isArray(store?.users) ? store.users : []
+        const invitesIn = Array.isArray(store?.invites) ? store.invites : []
+        let changed = false
+        const users = usersIn.map((user) => {
+            if (!user || typeof user !== 'object') return user
+            const role = normalizeRole(user.role)
+            if (role && role !== user.role) changed = true
+            return { ...user, role: role || user.role }
+        })
+        const invites = invitesIn.map((invite) => {
+            if (!invite || typeof invite !== 'object') return invite
+            const role = normalizeRole(invite.role)
+            if (role && role !== invite.role) changed = true
+            return { ...invite, role: role || invite.role }
+        })
+        return { store: { users, invites }, changed }
+    }
+
     const loadLocalCrmStore = async () => {
         try {
             const raw = await fs.readFile(LOCAL_CRM_STORE_FILE, 'utf8')
             const json = raw ? JSON.parse(raw) : {}
-            return {
+            const normalized = normalizeCrmStore({
                 users: Array.isArray(json?.users) ? json.users : [],
                 invites: Array.isArray(json?.invites) ? json.invites : [],
+            })
+            if (normalized.changed) {
+                await fs.writeFile(LOCAL_CRM_STORE_FILE, JSON.stringify(normalized.store, null, 2), 'utf8')
             }
+            return normalized.store
         } catch {
             return { users: [], invites: [] }
         }
@@ -955,7 +997,7 @@ if (DEV_AUTH_ENABLED) {
             username,
             email: String(body.email || '').trim() || null,
             displayName: String(body.displayName || body.name || username).trim(),
-            role: String(body.role || 'OPERADOR').trim().toUpperCase(),
+            role: normalizeRole(body.role || 'INJETOR'),
             allowedUnits: Array.isArray(body.allowedUnits) ? body.allowedUnits.map((x) => String(x)).filter(Boolean) : [],
             allowedModules: Array.isArray(body.allowedModules) ? body.allowedModules.map((x) => String(x)).filter(Boolean) : [],
             ativo: body.ativo !== false,
@@ -981,7 +1023,7 @@ if (DEV_AUTH_ENABLED) {
             ...cur,
             email: body.email !== undefined ? (String(body.email || '').trim() || null) : cur.email,
             displayName: body.displayName !== undefined ? String(body.displayName || '').trim() : cur.displayName,
-            role: body.role !== undefined ? String(body.role || '').trim().toUpperCase() : cur.role,
+            role: body.role !== undefined ? normalizeRole(body.role) : cur.role,
             allowedUnits: body.allowedUnits !== undefined ? (Array.isArray(body.allowedUnits) ? body.allowedUnits.map((x) => String(x)).filter(Boolean) : []) : cur.allowedUnits,
             allowedModules: body.allowedModules !== undefined ? (Array.isArray(body.allowedModules) ? body.allowedModules.map((x) => String(x)).filter(Boolean) : []) : cur.allowedModules,
             ativo: body.ativo !== undefined ? Boolean(body.ativo) : cur.ativo,
@@ -1025,7 +1067,7 @@ if (DEV_AUTH_ENABLED) {
         const invite = {
             id: randomBytes(8).toString('hex'),
             tokenHint,
-            role: String(body.role || 'OPERADOR').trim().toUpperCase(),
+            role: normalizeRole(body.role || 'INJETOR'),
             allowedUnits: Array.isArray(body.allowedUnits) ? body.allowedUnits.map((x) => String(x)).filter(Boolean) : [],
             allowedModules: Array.isArray(body.allowedModules) ? body.allowedModules.map((x) => String(x)).filter(Boolean) : [],
             maxUses,
@@ -3283,12 +3325,12 @@ app.post('/api/actions/:action', (req, res) => {
             conv.humanInControl = true
             conv.status = 'active'
             result = { message: 'human took control' }
-            addMessage(conversationId, { direction: 'system', type: 'event', text: 'Operador assumiu a conversa.' })
+            addMessage(conversationId, { direction: 'system', type: 'event', text: 'Injetor assumiu a conversa.' })
             break
         case 'release-control':
             conv.humanInControl = false
             result = { message: 'human released control' }
-            addMessage(conversationId, { direction: 'system', type: 'event', text: 'Operador liberou a conversa para IA.' })
+            addMessage(conversationId, { direction: 'system', type: 'event', text: 'Injetor liberou a conversa para IA.' })
             break
         case 'correct-ai':
             {

--- a/backend/apps/crm-api/server/pontoRoutes.js
+++ b/backend/apps/crm-api/server/pontoRoutes.js
@@ -364,11 +364,19 @@ export function registerPontoRoutes(app, { coreStateDir }) {
     return alt || ''
   }
 
+  function normalizeRole(value) {
+    const raw = String(value || '').trim().toUpperCase()
+    if (!raw) return ''
+    if (raw === 'ADMIN') return 'GESTOR'
+    if (raw === 'OPERADOR') return 'INJETOR'
+    return raw
+  }
+
   function requireAdmin(req, res) {
     const devUser = tryDevSessionUser(req)
     if (devUser?.email) {
-      const role = String(devUser.role || '').toUpperCase()
-      if (role === 'ADMIN' || role === 'GESTOR' || role === 'GERENTE') {
+      const role = normalizeRole(devUser.role)
+      if (role === 'GESTOR' || role === 'GERENTE') {
         return actorFromReq(req, { kind: 'admin', id: devUser.email, label: devUser.name || devUser.email })
       }
     }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -146,6 +146,7 @@ const InsumosModule = lazy(() => import('@/InsumosModule').then(m => ({ default:
 const UsersModule = lazy(() => import('@/UsersModule').then(m => ({ default: m.UsersModule })))
 const SystemStatusModule = lazy(() => import('@/SystemStatusModule').then(m => ({ default: m.SystemStatusModule })))
 const PontoModule = lazy(() => import('@/PontoModule').then(m => ({ default: m.PontoModule })))
+const EscalaProfissionaisModule = lazy(() => import('@/EscalaProfissionaisModule').then(m => ({ default: m.EscalaProfissionaisModule })))
 
 // TODO: Add remaining modules if needed
 
@@ -165,6 +166,7 @@ const modules: { key: string; label: string; icon: React.ReactNode; component: R
     { key: 'leads', label: 'Leads', icon: '💎', component: <LeadsManager /> },
     { key: 'notifications', label: 'Notificações', icon: '🔔', component: <NotificationCenter /> },
     { key: 'atendimento', label: 'Atendimento', icon: '💬', component: <AtendimentoModule /> },
+    { key: 'escala-profissionais', label: 'Escala', icon: '🗓️', component: <EscalaProfissionaisModule /> },
     { key: 'meta-ads', label: 'Meta Ads', icon: '📢', component: <MetaAdsManager /> },
     { key: 'meta-command', label: 'Meta Command', icon: '🧭', component: <MetaCommandCenter /> },
     { key: 'meta-sync', label: 'Meta Sync', icon: '🔄', component: <MetaSyncMonitor /> },
@@ -215,7 +217,6 @@ export default function AppFunctionalNeatlab() {
     const isLocalDev = import.meta.env.DEV && (window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost')
     const devEmail = String(user?.email || '').trim().toLowerCase()
     const pontoCanAdmin =
-        roleKey === 'ADMIN' ||
         roleKey === 'GESTOR' ||
         roleKey === 'GERENTE' ||
         (isLocalDev && devEmail.endsWith('@local.test'))
@@ -223,7 +224,8 @@ export default function AppFunctionalNeatlab() {
         (moduleKey: string) => {
             const key = String(moduleKey || '').trim()
             if (!key) return false
-            if (roleKey === 'ADMIN') return true
+            if (key === 'escala-profissionais') return roleKey === 'GESTOR'
+            if (roleKey === 'GESTOR') return true
             const allowed = Array.isArray(user?.allowedModules)
                 ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)
                 : []
@@ -295,7 +297,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'escala-profissionais']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)

--- a/frontend/AtendimentoModule.tsx
+++ b/frontend/AtendimentoModule.tsx
@@ -56,7 +56,7 @@ export function AtendimentoModule() {
     (moduleKey: string) => {
       const key = String(moduleKey || '').trim()
       if (!key) return false
-      if (roleKey === 'ADMIN') return true
+      if (roleKey === 'GESTOR') return true
       const allowed = Array.isArray(user?.allowedModules)
         ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)
         : []

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -81,7 +81,7 @@ function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional
 export function EscalaProfissionaisModule() {
   const { user } = useAuth()
   const roleKey = String(user?.role || '').trim().toUpperCase()
-  const canAccess = roleKey === 'ADMIN'
+  const canAccess = roleKey === 'GESTOR'
 
   const [units, setUnits] = useState<string[]>([])
   const [months, setMonths] = useState<string[]>([])
@@ -236,7 +236,7 @@ export function EscalaProfissionaisModule() {
           <CardTitle className="text-white">Acesso restrito</CardTitle>
         </CardHeader>
         <CardContent className="text-sm text-blue-100/70">
-          O módulo de escala está disponível apenas para usuários administradores.
+          O módulo de escala está disponível apenas para usuários gestores.
         </CardContent>
       </Card>
     )

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -1443,7 +1443,7 @@ export function InsumosModule() {
   const autoSyncSuspended = autoSyncSuspendedUntil > Date.now()
   const autoSyncRemainingSeconds = autoSyncSuspended ? Math.max(1, Math.ceil((autoSyncSuspendedUntil - Date.now()) / 1000)) : 0
 
-  const isManagerRole = ['ADMIN', 'GESTOR', 'GERENTE'].includes(String(user?.role || '').toUpperCase())
+  const isManagerRole = ['GESTOR', 'GERENTE'].includes(String(user?.role || '').toUpperCase())
 
   const markAutoSyncFailure = React.useCallback(
     (error: unknown) => {

--- a/frontend/PontoModule.tsx
+++ b/frontend/PontoModule.tsx
@@ -659,7 +659,7 @@ export function PontoModule() {
 
   const isDev = import.meta.env.DEV
   const crmRole = String(crmMe?.user?.role || '').toUpperCase()
-  const canAdmin = crmRole === 'ADMIN' || crmRole === 'GESTOR' || crmRole === 'GERENTE'
+  const canAdmin = crmRole === 'GESTOR' || crmRole === 'GERENTE'
   const canAdminActions = canAdmin
   const canSeeSensitive = canAdmin || (me && 'linked' in me && me.linked)
   const maskSensitive = (value?: string | null, mask: string = '•••') => {
@@ -1210,7 +1210,7 @@ export function PontoModule() {
   }, [mePunchOpen, meStep, meFaceAutoRunning, faceDetectorMode, me, allowedUnits, resolvedMeUnit])
 
   async function adminRefreshAll() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setLoading(true)
     try {
       const [emps, devs] = await Promise.all([
@@ -1257,7 +1257,7 @@ export function PontoModule() {
   }
 
   async function adminCreateEmployee(opts: { enrollAfter?: boolean } = {}) {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     const name = newEmployeeName.trim()
     if (!name) return toast.error('Nome é obrigatório')
     const loginEmail = newEmployeeLoginEmail.trim()
@@ -1406,7 +1406,7 @@ export function PontoModule() {
   }
 
   async function adminSaveEmployeeEdit() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = editName.trim()
     if (!name) return toast.error('Nome é obrigatório')
@@ -1456,7 +1456,7 @@ export function PontoModule() {
   }
 
   async function adminDeleteEmployee() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = selectedEmployee?.name || 'este funcionário'
     const confirmed = window.confirm(`Tem certeza que deseja remover ${name}?`)
@@ -1503,7 +1503,7 @@ export function PontoModule() {
       const action = String(detail.action || '').trim()
       if (!action) return
       if (!canAdminActions) {
-        toast.error('Acesso restrito a administradores')
+        toast.error('Acesso restrito a gestores')
         return
       }
       if (action === 'create') {
@@ -1528,7 +1528,7 @@ export function PontoModule() {
   }, [canAdminActions, adminDevices.length, adminRefreshAll, openSelectEmployee])
 
   async function adminLoadSelectedRecords() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     setSelectedRecordsLoading(true)
     setSelectedRecordsError(null)
@@ -1552,7 +1552,7 @@ export function PontoModule() {
   }
 
   async function adminLoadEmailConflicts() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1572,7 +1572,7 @@ export function PontoModule() {
   }
 
   async function adminResolveEmailConflict(email: string, keepEmployeeId: string) {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1594,7 +1594,7 @@ export function PontoModule() {
   }
 
   async function adminCreateDevice() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     if (!newDeviceUnit.trim()) return toast.error('Unidade é obrigatória')
     setLoading(true)
     try {
@@ -1615,7 +1615,7 @@ export function PontoModule() {
   }
 
   async function adminRevokeDevice(deviceId: string) {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setLoading(true)
     try {
       await apiJson('/api/ponto/admin/devices/' + deviceId + '/revoke', { method: 'POST' })
@@ -1630,7 +1630,7 @@ export function PontoModule() {
   }
 
   async function adminLoadRecords() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setLoading(true)
     try {
       const qs = new URLSearchParams()
@@ -1653,7 +1653,7 @@ export function PontoModule() {
   }
 
   async function adminExportCsv() {
-    if (!canAdminActions) return toast.error('Acesso restrito a administradores')
+    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
     setLoading(true)
     try {
       const qs = new URLSearchParams()
@@ -1851,7 +1851,7 @@ export function PontoModule() {
                 ) : (
                   <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm">
                     <div className="font-medium">Unidade não configurada</div>
-                    <div className="opacity-80">Seu usuário não possui unidade permitida. Contate o administrador.</div>
+                    <div className="opacity-80">Seu usuário não possui unidade permitida. Contate o gestor.</div>
                   </div>
                 )
               ) : null}

--- a/frontend/SocialNetworksStudio.tsx
+++ b/frontend/SocialNetworksStudio.tsx
@@ -323,7 +323,7 @@ export function SocialNetworksStudio() {
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) {
         if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') {
-          throw new Error(data?.hint || 'Permissão insuficiente: este módulo exige ADMIN/GESTOR/GERENTE.')
+          throw new Error(data?.hint || 'Permissão insuficiente: este módulo exige GESTOR/GERENTE.')
         }
         if (res.status === 403 && data?.code === 'CSRF_INVALID') {
           throw new Error('Sessão inválida: recarregue a página e faça login novamente.')
@@ -397,7 +397,7 @@ export function SocialNetworksStudio() {
     if (setupAuthed !== true) return false
     if (setup?.admin?.isAdmin === true) return true
     const role = String(setup?.admin?.role || setup?.user?.role || '').trim().toUpperCase()
-    return role === 'ADMIN'
+    return role === 'GESTOR' || role === 'GERENTE'
   }, [setup?.admin?.isAdmin, setup?.admin?.role, setup?.user?.role, setupAuthed])
 
   useEffect(() => {
@@ -477,7 +477,7 @@ export function SocialNetworksStudio() {
       })
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) {
-        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: GESTOR/GERENTE.')
         if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
         if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
         throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
@@ -502,7 +502,7 @@ export function SocialNetworksStudio() {
       })
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) {
-        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: GESTOR/GERENTE.')
         if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
         if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
         throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
@@ -534,7 +534,7 @@ export function SocialNetworksStudio() {
       })
       const data = (await res.json().catch(() => null)) as any
       if (!res.ok) {
-        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: ADMIN/GESTOR/GERENTE.')
+        if (res.status === 403 && data?.code === 'ADMIN_REQUIRED') throw new Error(data?.hint || 'Permissão insuficiente: GESTOR/GERENTE.')
         if (res.status === 403 && data?.code === 'CSRF_INVALID') throw new Error('Sessão inválida: recarregue e faça login novamente.')
         if (res.status === 403 && data?.code === 'ORIGIN_INVALID') throw new Error('Requisição bloqueada (ORIGIN). Recarregue e tente novamente.')
         throw new Error(data?.hint || data?.error || `HTTP ${res.status}`)
@@ -851,8 +851,8 @@ export function SocialNetworksStudio() {
               <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3 space-y-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <div className="text-sm text-white font-medium">2) Permissão de Admin</div>
-                    <div className="text-xs text-blue-200/70">Somente ADMIN/GESTOR/GERENTE podem configurar contas e publicar.</div>
+                    <div className="text-sm text-white font-medium">2) Permissão de Gestor</div>
+                    <div className="text-xs text-blue-200/70">Somente GESTOR/GERENTE podem configurar contas e publicar.</div>
                   </div>
                   {adminReady ? (
                     <Badge variant="outline" className="border-white/20 text-white">
@@ -872,7 +872,7 @@ export function SocialNetworksStudio() {
                   </div>
                 ) : (
                   <div className="text-sm text-red-200">
-                    Somente ADMIN/GESTOR/GERENTE podem configurar/publicar neste módulo{detectedRole ? ` (seu role: ${detectedRole})` : ''}.
+                    Somente GESTOR/GERENTE podem configurar/publicar neste módulo{detectedRole ? ` (seu role: ${detectedRole})` : ''}.
                   </div>
                 )}
               </div>

--- a/frontend/SystemStatusModule.tsx
+++ b/frontend/SystemStatusModule.tsx
@@ -152,7 +152,7 @@ export function SystemStatusModule() {
 
   const hasInsumosSession = Boolean(insumosMe?.user?.username)
   const insumosRole = String(insumosMe?.user?.role || '').toUpperCase()
-  const canManageBackups = hasInsumosSession && (insumosRole === 'ADMIN' || insumosRole === 'GESTOR')
+  const canManageBackups = hasInsumosSession && insumosRole === 'GESTOR'
 
   const [backupLoading, setBackupLoading] = React.useState(false)
   const [backupStatus, setBackupStatus] = React.useState<BackupStatus | null>(null)
@@ -311,7 +311,7 @@ export function SystemStatusModule() {
     }
   }, [canManageBackups])
 
-  const canManageUsers = hasInsumosSession && (insumosRole === 'ADMIN' || insumosRole === 'GESTOR' || insumosRole === 'GERENTE')
+  const canManageUsers = hasInsumosSession && (insumosRole === 'GESTOR' || insumosRole === 'GERENTE')
   const [usersLoading, setUsersLoading] = React.useState(false)
   const [usersQuery, setUsersQuery] = React.useState('')
   const [users, setUsers] = React.useState<AdminUser[]>([])
@@ -335,7 +335,7 @@ export function SystemStatusModule() {
     }
   }, [canManageUsers, usersQuery])
 
-  const canViewAudit = hasInsumosSession && (insumosRole === 'ADMIN' || insumosRole === 'GESTOR' || insumosRole === 'GERENTE')
+  const canViewAudit = hasInsumosSession && (insumosRole === 'GESTOR' || insumosRole === 'GERENTE')
   const loadAudit = React.useCallback(async () => {
     if (!canViewAudit) return
     setAuditLoading(true)
@@ -601,7 +601,7 @@ export function SystemStatusModule() {
       <Card className="glass-morphism border border-white/10">
         <CardHeader className="space-y-2">
           <CardTitle className="text-white text-base flex items-center justify-between gap-2">
-            <span>Admin</span>
+            <span>Gestor</span>
             <div className="flex items-center gap-2">
               <Button variant="secondary" onClick={() => setAdminOpen((v) => !v)}>
                 {adminOpen ? 'Ocultar usuários' : 'Usuários'}
@@ -931,7 +931,7 @@ function AdminUserForm({
               <SelectValue placeholder="Selecione" />
             </SelectTrigger>
             <SelectContent>
-              {['CONSULTOR', 'OPERADOR', 'GERENTE', 'GESTOR', 'ADMIN'].map((r) => (
+              {['CONSULTOR', 'INJETOR', 'GERENTE', 'GESTOR'].map((r) => (
                 <SelectItem key={r} value={r}>
                   {r}
                 </SelectItem>

--- a/frontend/UsersModule.tsx
+++ b/frontend/UsersModule.tsx
@@ -115,10 +115,10 @@ export function UsersModule() {
 
   const isAuthed = !!me?.user?.username
   const role = String(me?.user?.role || '').trim().toUpperCase()
-  const canManageInvites = role === 'ADMIN' || role === 'GESTOR'
-  const inviteRoleOptions = role === 'ADMIN'
-    ? ['OPERADOR', 'GERENTE', 'GESTOR', 'ADMIN']
-    : ['OPERADOR', 'GERENTE', 'GESTOR']
+  const canManageInvites = role === 'GESTOR'
+  const inviteRoleOptions = role === 'GESTOR'
+    ? ['INJETOR', 'GERENTE', 'GESTOR']
+    : ['INJETOR', 'GERENTE']
 
   const allowedUnits = Array.isArray(me?.user?.allowedUnits) ? me!.user!.allowedUnits!.filter(Boolean) : []
 
@@ -171,7 +171,7 @@ export function UsersModule() {
   const [inviteOpen, setInviteOpen] = React.useState(false)
   const [invitesLoading, setInvitesLoading] = React.useState(false)
   const [invites, setInvites] = React.useState<Invite[]>([])
-  const [inviteRole, setInviteRole] = React.useState<string>('OPERADOR')
+  const [inviteRole, setInviteRole] = React.useState<string>('INJETOR')
   const [inviteMaxUses, setInviteMaxUses] = React.useState<string>('1')
   const [inviteExpiresInDays, setInviteExpiresInDays] = React.useState<string>('30')
   const [inviteAllowedUnits, setInviteAllowedUnits] = React.useState<string>('')
@@ -210,7 +210,7 @@ export function UsersModule() {
     setInviteTokenOnce(null)
     setInviteTokenHint(null)
     setInviteNote('')
-    setInviteRole((cur) => (inviteRoleOptions.includes(cur) ? cur : 'OPERADOR'))
+    setInviteRole((cur) => (inviteRoleOptions.includes(cur) ? cur : 'INJETOR'))
     setInviteAllowedUnits((cur) => {
       if (cur.trim()) return cur
       return allowedUnits.length ? allowedUnits.join(',') : ''

--- a/frontend/e2e/insumos-api-concurrency.spec.ts
+++ b/frontend/e2e/insumos-api-concurrency.spec.ts
@@ -49,7 +49,7 @@ test.describe('insumos', () => {
           if (path.startsWith('/api/insumos/movimentacoes')) return { success: true, data: [] }
           if (path.startsWith('/api/insumos/alertas/estoque')) return { success: true, data: [] }
           if (path.startsWith('/api/insumos/health')) return { ok: true, service: 'insumos', runtime: 'e2e', storage: 'd1', dbConfigured: true, unidades: ['novo-hamburgo', 'barra-shopping-sul'] }
-          if (path.startsWith('/api/insumos/auth/me')) return { success: true, user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] }, csrfToken: 'e2e' }
+          if (path.startsWith('/api/insumos/auth/me')) return { success: true, user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] }, csrfToken: 'e2e' }
           return { success: true }
         })()
 
@@ -63,7 +63,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
       })
     })
 

--- a/frontend/e2e/insumos-circuit-breaker.spec.ts
+++ b/frontend/e2e/insumos-circuit-breaker.spec.ts
@@ -35,7 +35,7 @@ test.describe('insumos', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             success: true,
-            user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] },
+            user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] },
             csrfToken: 'e2e'
           })
         })
@@ -72,7 +72,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
       })
     })
 

--- a/frontend/e2e/insumos-edit-modal-policy.spec.ts
+++ b/frontend/e2e/insumos-edit-modal-policy.spec.ts
@@ -29,7 +29,7 @@ test.describe('insumos', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             success: true,
-            user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] },
+            user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] },
             csrfToken: 'e2e'
           })
         })
@@ -87,7 +87,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
       })
     })
 

--- a/frontend/e2e/insumos-no-request-storm.spec.ts
+++ b/frontend/e2e/insumos-no-request-storm.spec.ts
@@ -38,7 +38,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
       })
     })
 

--- a/frontend/e2e/insumos-zero-demo-default.spec.ts
+++ b/frontend/e2e/insumos-zero-demo-default.spec.ts
@@ -28,7 +28,7 @@ test.describe('insumos', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             success: true,
-            user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] },
+            user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] },
             csrfToken: 'e2e'
           })
         })
@@ -42,7 +42,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'ADMIN', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
       })
     })
 

--- a/frontend/functions/_lib/socialAuth.ts
+++ b/frontend/functions/_lib/socialAuth.ts
@@ -6,13 +6,21 @@ const json = (status: number, body: any) =>
     headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
   })
 
-const ADMIN_ROLES = new Set(['ADMIN', 'GESTOR', 'GERENTE'])
+const ADMIN_ROLES = new Set(['GESTOR', 'GERENTE'])
+
+const normalizeRole = (value: unknown) => {
+  const raw = String(value || '').trim().toUpperCase()
+  if (!raw) return ''
+  if (raw === 'ADMIN') return 'GESTOR'
+  if (raw === 'OPERADOR') return 'INJETOR'
+  return raw
+}
 
 export async function requireSocialAdmin(context: any) {
   const userOrRes = await requireCrmUser(context)
   if (userOrRes instanceof Response) return userOrRes
 
-  const role = String((userOrRes as any).role || '').trim().toUpperCase()
+  const role = normalizeRole((userOrRes as any).role)
   if (ADMIN_ROLES.has(role)) return userOrRes
 
   return json(403, {
@@ -20,6 +28,6 @@ export async function requireSocialAdmin(context: any) {
     error: 'FORBIDDEN',
     code: 'ADMIN_REQUIRED',
     role,
-    hint: `Seu role atual é ${role || '(vazio)'}. Este módulo exige ADMIN/GESTOR/GERENTE.`,
+    hint: `Seu role atual é ${role || '(vazio)'}. Este módulo exige GESTOR/GERENTE.`,
   })
 }

--- a/frontend/functions/api/ponto/[[path]].ts
+++ b/frontend/functions/api/ponto/[[path]].ts
@@ -171,11 +171,12 @@ export async function onRequest(context: any): Promise<Response> {
     }
     if (isAdminRoute) {
       const role = String(user.role || '').toUpperCase()
-      isAdminUser = role === 'ADMIN' || role === 'GESTOR' || role === 'GERENTE'
+      const effectiveRole = role === 'ADMIN' ? 'GESTOR' : role === 'OPERADOR' ? 'INJETOR' : role
+      isAdminUser = effectiveRole === 'GESTOR' || effectiveRole === 'GERENTE'
       if (!isAdminUser) {
         return json(
           403,
-          { ok: false, error: 'FORBIDDEN', hint: 'Acesso restrito a administradores.' },
+          { ok: false, error: 'FORBIDDEN', hint: 'Acesso restrito a gestores.' },
           { 'x-request-id': requestId },
         )
       }

--- a/frontend/functions/api/social/setup/status.ts
+++ b/frontend/functions/api/social/setup/status.ts
@@ -27,7 +27,8 @@ export async function onRequestGet(context: any): Promise<Response> {
   const defaultUnitsFromEnv = parseCsv(context?.env?.SOCIAL_DEFAULT_UNITS)
   const role = String((userOrRes as any)?.role || '').trim()
   const normalizedRole = role.toUpperCase()
-  const isAdmin = normalizedRole === 'ADMIN' || normalizedRole === 'GESTOR' || normalizedRole === 'GERENTE'
+  const effectiveRole = normalizedRole === 'ADMIN' ? 'GESTOR' : normalizedRole === 'OPERADOR' ? 'INJETOR' : normalizedRole
+  const isAdmin = effectiveRole === 'GESTOR' || effectiveRole === 'GERENTE'
 
   return json(200, {
     ok: true,

--- a/frontend/scripts/bootstrap-ponto-smoke-admin.cjs
+++ b/frontend/scripts/bootstrap-ponto-smoke-admin.cjs
@@ -4,7 +4,7 @@
  *
  * What it does (idempotent):
  * 1) Uses an existing authenticated CRM session (storageState) to call `/api/admin/*`
- * 2) Ensures a dedicated admin user exists (`SMOKE_USERNAME`) with role ADMIN
+ * 2) Ensures a dedicated admin user exists (`SMOKE_USERNAME`) with role GESTOR
  * 3) Rotates its password to a fresh random value
  * 4) Updates GitHub repo secrets:
  *    - PONTO_SMOKE_EMAIL
@@ -115,7 +115,7 @@ async function main() {
     if (!auth.ok) {
       die(`Not authenticated (or session expired): /api/auth/me HTTP ${auth.status}`)
     }
-    if (!(auth.role === 'ADMIN' || auth.role === 'GESTOR' || auth.role === 'GERENTE')) {
+    if (!(auth.role === 'GESTOR' || auth.role === 'GERENTE')) {
       die(`Current session is not admin enough (role=${auth.role || 'unknown'}).`)
     }
     if (!auth.csrfToken) die('Missing csrfToken from /api/auth/me; cannot perform admin mutations.')
@@ -129,7 +129,7 @@ async function main() {
         username: SMOKE_USERNAME,
         email: SMOKE_EMAIL,
         displayName: SMOKE_DISPLAY_NAME,
-        role: 'ADMIN',
+        role: 'GESTOR',
         allowedUnits: [],
         allowedModules: [],
         ativo: true,
@@ -152,7 +152,7 @@ async function main() {
         data: {
           email: SMOKE_EMAIL,
           displayName: SMOKE_DISPLAY_NAME,
-          role: 'ADMIN',
+          role: 'GESTOR',
           allowedUnits: [],
           allowedModules: [],
           ativo: true,

--- a/frontend/scripts/ponto-ui-smoke.cjs
+++ b/frontend/scripts/ponto-ui-smoke.cjs
@@ -347,7 +347,7 @@ async function main() {
         let json = null
         try { json = text ? JSON.parse(text) : null } catch {}
         const role = String(json?.user?.role || '').toUpperCase()
-        out.isAdmin = role === 'ADMIN' || role === 'GESTOR' || role === 'GERENTE'
+        out.isAdmin = role === 'GESTOR' || role === 'GERENTE'
         out.actorEmail = json?.user?.email ? String(json.user.email) : ''
         const allowed = Array.isArray(json?.user?.allowedUnits)
           ? json.user.allowedUnits.map((u) => String(u || '').trim()).filter(Boolean)


### PR DESCRIPTION
## Context
The CRM still used the legacy roles `ADMIN` and `OPERADOR`. You requested to rename `OPERADOR` to `INJETOR` and migrate `ADMIN` into `GESTOR`, unifying access under `GESTOR`. Without this, the UI and APIs keep surfacing the old roles and admin-only gates keep excluding Gestor users.

## What changed
- Added role normalization (ADMIN -> GESTOR, OPERADOR -> INJETOR) in the CRM API and local store migration.
- Updated admin gates to rely on GESTOR/GERENTE only (ADMIN removed).
- Updated UI role pickers and labels to show INJETOR/GERENTE/GESTOR (removed ADMIN).
- Updated Escala and other module access checks to use GESTOR.
- Updated smoke/e2e fixtures to use GESTOR roles.

## Root cause
Legacy role strings were hardcoded across UI, API, and tests, so role renames/migrations were not applied consistently.

## Fix
Centralized role normalization in the CRM API and updated role lists + access checks in the frontend to align with `GESTOR` as the top-level role and `INJETOR` as the former `OPERADOR`.

## Tests
- Not run (string/role migration + access-gate changes only).
