### PR TITLE
Secure escala API and add CRM editor

### DIFF
--- a/.github/workflows/uptime-slo.yml
+++ b/.github/workflows/uptime-slo.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          urls="${OBS_HEALTHCHECK_URLS:-https://crm.skincos.com.br/api/health,https://api.skincos.com.br/health,https://api.skincos.com.br/insumos/health}"
+          urls="${OBS_HEALTHCHECK_URLS:-https://crm.skincos.com.br/api/health,https://crm.skincos.com.br/api/escala/_proxy-status,https://api.skincos.com.br/health,https://api.skincos.com.br/insumos/health,https://escala-api.skincos.com.br/api/escala/health}"
           max_ms="${OBS_LATENCY_MS:-800}"
           timeout_sec="${OBS_TIMEOUT_SEC:-10}"
           IFS=',' read -ra list <<< "$urls"

--- a/backend/apps/escala-api/README.md
+++ b/backend/apps/escala-api/README.md
@@ -31,7 +31,21 @@ Ou:
 - `GET /api/escala/overview`
 - `GET /api/escala/professionals?unit=...`
 - `GET /api/escala/schedule?unit=...&month=YYYY-MM`
+- `POST /api/escala/schedule` (add)
+- `PUT /api/escala/schedule` (replace day)
+- `DELETE /api/escala/schedule` (remove)
+- `POST /api/escala/closed-days`
+- `DELETE /api/escala/closed-days`
+- `POST /api/escala/holidays`
+- `DELETE /api/escala/holidays`
 - `GET /health`
 
 ## Vars
 - `APP_ORIGIN` (CORS)
+- `ESCALA_ACTOR_HMAC_KEY` (auth)
+
+## Auth (CRM proxy)
+Os endpoints `/api/escala/*` exigem headers assinados:
+- `x-crm-user` (base64url JSON do ator)
+- `x-crm-ts` (timestamp ms)
+- `x-crm-signature` (HMAC SHA-256 de `${ts}.${payload}`)

--- a/backend/apps/escala-api/migrations-d1/0002_audit.sql
+++ b/backend/apps/escala-api/migrations-d1/0002_audit.sql
@@ -1,0 +1,11 @@
+ALTER TABLE schedule_entries ADD COLUMN created_by TEXT;
+ALTER TABLE schedule_entries ADD COLUMN updated_by TEXT;
+ALTER TABLE schedule_entries ADD COLUMN updated_at TEXT;
+
+ALTER TABLE closed_days ADD COLUMN created_by TEXT;
+ALTER TABLE closed_days ADD COLUMN updated_by TEXT;
+ALTER TABLE closed_days ADD COLUMN updated_at TEXT;
+
+ALTER TABLE holidays ADD COLUMN created_by TEXT;
+ALTER TABLE holidays ADD COLUMN updated_by TEXT;
+ALTER TABLE holidays ADD COLUMN updated_at TEXT;

--- a/backend/apps/escala-api/worker.js
+++ b/backend/apps/escala-api/worker.js
@@ -1,3 +1,5 @@
+const ACTOR_SKEW_MS = 5 * 60 * 1000
+
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -8,14 +10,22 @@ function jsonResponse(body, init = {}) {
   })
 }
 
+function newRequestId() {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `${Date.now()}_${Math.random().toString(16).slice(2)}`
+  }
+}
+
 function buildCorsHeaders(request, env) {
   const origin = request.headers.get('origin') || ''
   const allowed = env.APP_ORIGIN ? String(env.APP_ORIGIN) : '*'
   const allowOrigin = allowed === '*' ? '*' : (origin && origin === allowed ? origin : allowed)
   const headers = {
     'Access-Control-Allow-Origin': allowOrigin,
-    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization'
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization,x-crm-user,x-crm-ts,x-crm-signature,x-request-id'
   }
   if (allowOrigin !== '*') {
     headers['Access-Control-Allow-Credentials'] = 'true'
@@ -23,26 +33,131 @@ function buildCorsHeaders(request, env) {
   return headers
 }
 
-async function handleOverview(env) {
+function normalizeRole(value) {
+  const raw = String(value || '').trim().toUpperCase()
+  if (!raw) return ''
+  if (raw === 'ADMIN') return 'GESTOR'
+  if (raw === 'OPERADOR') return 'INJETOR'
+  return raw
+}
+
+function base64UrlDecode(input) {
+  const padded = input.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((input.length + 3) % 4)
+  const bin = atob(padded)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+function base64UrlEncode(bytes) {
+  const bin = String.fromCharCode(...new Uint8Array(bytes))
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+async function signHmacSha256(secret, message) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message))
+  return base64UrlEncode(sig)
+}
+
+async function requireActor(request, env) {
+  const payload = request.headers.get('x-crm-user') || ''
+  const tsRaw = request.headers.get('x-crm-ts') || ''
+  const sig = request.headers.get('x-crm-signature') || ''
+  if (!payload || !tsRaw || !sig) {
+    return { ok: false, status: 401, body: { ok: false, error: 'UNAUTHORIZED' } }
+  }
+  const secret = String(env.ESCALA_ACTOR_HMAC_KEY || '').trim()
+  if (!secret) {
+    return { ok: false, status: 503, body: { ok: false, error: 'ACTOR_KEY_MISSING' } }
+  }
+  const ts = Number(tsRaw)
+  if (!Number.isFinite(ts)) {
+    return { ok: false, status: 400, body: { ok: false, error: 'ACTOR_TS_INVALID' } }
+  }
+  if (Math.abs(Date.now() - ts) > ACTOR_SKEW_MS) {
+    return { ok: false, status: 401, body: { ok: false, error: 'ACTOR_TS_SKEW' } }
+  }
+  const expected = await signHmacSha256(secret, `${tsRaw}.${payload}`)
+  if (expected !== sig) {
+    return { ok: false, status: 401, body: { ok: false, error: 'ACTOR_SIGNATURE_INVALID' } }
+  }
+  let actor = null
+  try {
+    const decoded = base64UrlDecode(payload)
+    actor = JSON.parse(new TextDecoder().decode(decoded))
+  } catch {
+    actor = null
+  }
+  if (!actor || typeof actor !== 'object') {
+    return { ok: false, status: 400, body: { ok: false, error: 'ACTOR_INVALID' } }
+  }
+  const role = normalizeRole(actor.role)
+  if (!(role === 'GESTOR' || role === 'GERENTE')) {
+    return { ok: false, status: 403, body: { ok: false, error: 'FORBIDDEN' } }
+  }
+  const allowedUnits = Array.isArray(actor.allowedUnits) ? actor.allowedUnits.map(String).filter(Boolean) : []
+  return {
+    ok: true,
+    actor: {
+      id: String(actor.id || actor.email || actor.username || ''),
+      email: actor.email ? String(actor.email) : undefined,
+      name: actor.name ? String(actor.name) : undefined,
+      role,
+      allowedUnits
+    }
+  }
+}
+
+function ensureUnitAllowed(actor, unit) {
+  if (!unit) return { ok: true }
+  if (!actor.allowedUnits.length) return { ok: true }
+  return actor.allowedUnits.includes(unit)
+    ? { ok: true }
+    : { ok: false, status: 403, body: { ok: false, error: 'FORBIDDEN_UNIT' } }
+}
+
+function isValidDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(String(value || ''))
+}
+
+function isValidMonth(value) {
+  return /^\d{4}-\d{2}$/.test(String(value || ''))
+}
+
+function normalizeName(value) {
+  return String(value || '').trim()
+}
+
+async function handleOverview(env, actor) {
+  const unitFilter = actor.allowedUnits.length ? ` where unit in (${actor.allowedUnits.map(() => '?').join(',')})` : ''
+  const unitValues = actor.allowedUnits.length ? actor.allowedUnits : []
   const unitsQuery = `
-    select distinct unit from schedule_entries
+    select distinct unit from schedule_entries${unitFilter}
     union
-    select distinct unit from closed_days
+    select distinct unit from closed_days${unitFilter}
     union
-    select distinct unit from holidays
+    select distinct unit from holidays${unitFilter}
     order by unit;
   `
+  const units = await env.DB.prepare(unitsQuery).bind(...unitValues, ...unitValues, ...unitValues).all()
+
   const monthsQuery = `
     select distinct substr(date, 1, 7) as month
-    from schedule_entries
+    from schedule_entries${unitFilter}
     order by month;
   `
-  const units = await env.DB.prepare(unitsQuery).all()
-  const months = await env.DB.prepare(monthsQuery).all()
+  const months = await env.DB.prepare(monthsQuery).bind(...unitValues).all()
   return { units: (units.results || []).map((r) => r.unit), months: (months.results || []).map((r) => r.month) }
 }
 
-async function handleProfessionals(env, unit) {
+async function handleProfessionals(env, unit, actor) {
   if (unit) {
     const stmt = env.DB.prepare(
       `select name, status, role, shift, nickname, phone, email, instagram, units_json
@@ -58,15 +173,21 @@ async function handleProfessionals(env, unit) {
     }))
     return { data }
   }
+
   const res = await env.DB.prepare(
     `select name, status, role, shift, nickname, phone, email, instagram, units_json
      from professionals
      order by name`
   ).all()
+  const allowed = new Set(actor.allowedUnits || [])
   const data = (res.results || []).map((row) => ({
     ...row,
     units: JSON.parse(row.units_json || '[]')
-  }))
+  })).filter((row) => {
+    if (!allowed.size) return true
+    if (!row.units || !row.units.length) return true
+    return row.units.some((u) => allowed.has(u))
+  })
   return { data }
 }
 
@@ -74,19 +195,24 @@ function buildScheduleWhere(params) {
   const clauses = []
   const values = []
   if (params.unit) {
+    clauses.push('unit = ?')
     values.push(params.unit)
-    clauses.push(`unit = ?${values.length}`)
   }
   if (params.month) {
-    values.push(`${params.month}-`)
-    clauses.push(`date like ?${values.length} || '%'`)
+    clauses.push('date like ?')
+    values.push(`${params.month}-%`)
+  }
+  if (params.allowedUnits && params.allowedUnits.length) {
+    const placeholders = params.allowedUnits.map(() => '?').join(',')
+    clauses.push(`unit in (${placeholders})`)
+    values.push(...params.allowedUnits)
   }
   const where = clauses.length ? `where ${clauses.join(' and ')}` : ''
   return { where, values }
 }
 
-async function handleSchedule(env, unit, month) {
-  const { where, values } = buildScheduleWhere({ unit, month })
+async function handleSchedule(env, unit, month, actor) {
+  const { where, values } = buildScheduleWhere({ unit, month, allowedUnits: actor.allowedUnits })
   const scheduleRes = await env.DB.prepare(
     `select date, unit, professional_name as professional
      from schedule_entries
@@ -115,10 +241,173 @@ async function handleSchedule(env, unit, month) {
   }
 }
 
+async function readJson(request) {
+  if (request.method === 'GET' || request.method === 'HEAD') return null
+  const text = await request.text()
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+async function listKnownProfessionals(env, names) {
+  const unique = Array.from(new Set(names))
+  if (!unique.length) return []
+  const placeholders = unique.map(() => '?').join(',')
+  const res = await env.DB.prepare(
+    `select name from professionals where name in (${placeholders})`
+  ).bind(...unique).all()
+  return (res.results || []).map((r) => r.name)
+}
+
+async function handleSchedulePost(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const professionals = Array.isArray(body?.professionals) ? body.professionals : []
+  const single = normalizeName(body?.professional)
+  if (single) professionals.push(single)
+  const names = Array.from(new Set(professionals.map(normalizeName).filter(Boolean)))
+  if (!unit || !date || !isValidDate(date) || !names.length) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  const known = await listKnownProfessionals(env, names)
+  if (known.length !== names.length) {
+    return { ok: false, status: 400, body: { ok: false, error: 'UNKNOWN_PROFESSIONAL' } }
+  }
+  const now = new Date().toISOString()
+  const stmt = env.DB.prepare(
+    `insert or ignore into schedule_entries
+     (id, date, unit, professional_name, created_at, updated_at, created_by, updated_by)
+     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+  )
+  for (const name of names) {
+    await stmt.bind(crypto.randomUUID(), date, unit, name, now, now, actor.id, actor.id).run()
+  }
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleSchedulePut(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const professionals = Array.isArray(body?.professionals) ? body.professionals : []
+  const names = Array.from(new Set(professionals.map(normalizeName).filter(Boolean)))
+  if (!unit || !date || !isValidDate(date) || !names.length) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  const known = await listKnownProfessionals(env, names)
+  if (known.length !== names.length) {
+    return { ok: false, status: 400, body: { ok: false, error: 'UNKNOWN_PROFESSIONAL' } }
+  }
+  await env.DB.prepare(
+    `delete from schedule_entries where date = ?1 and unit = ?2`
+  ).bind(date, unit).run()
+  const now = new Date().toISOString()
+  const stmt = env.DB.prepare(
+    `insert into schedule_entries
+     (id, date, unit, professional_name, created_at, updated_at, created_by, updated_by)
+     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+  )
+  for (const name of names) {
+    await stmt.bind(crypto.randomUUID(), date, unit, name, now, now, actor.id, actor.id).run()
+  }
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleScheduleDelete(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const professional = normalizeName(body?.professional)
+  if (!unit || !date || !isValidDate(date)) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  if (professional) {
+    await env.DB.prepare(
+      `delete from schedule_entries where date = ?1 and unit = ?2 and professional_name = ?3`
+    ).bind(date, unit, professional).run()
+  } else {
+    await env.DB.prepare(
+      `delete from schedule_entries where date = ?1 and unit = ?2`
+    ).bind(date, unit).run()
+  }
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleClosedDayPost(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const reason = normalizeName(body?.reason)
+  if (!unit || !date || !isValidDate(date)) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  const now = new Date().toISOString()
+  await env.DB.prepare(
+    `insert or replace into closed_days
+     (id, date, unit, reason, created_at, updated_at, created_by, updated_by)
+     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+  ).bind(crypto.randomUUID(), date, unit, reason || null, now, now, actor.id, actor.id).run()
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleClosedDayDelete(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  if (!unit || !date || !isValidDate(date)) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  await env.DB.prepare(`delete from closed_days where date = ?1 and unit = ?2`).bind(date, unit).run()
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleHolidayPost(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const name = normalizeName(body?.name)
+  if (!unit || !date || !isValidDate(date) || !name) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  const now = new Date().toISOString()
+  await env.DB.prepare(
+    `insert or replace into holidays
+     (id, date, unit, name, created_at, updated_at, created_by, updated_by)
+     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+  ).bind(crypto.randomUUID(), date, unit, name, now, now, actor.id, actor.id).run()
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
+async function handleHolidayDelete(env, actor, body) {
+  const unit = normalizeName(body?.unit)
+  const date = normalizeName(body?.date)
+  const name = normalizeName(body?.name)
+  if (!unit || !date || !isValidDate(date) || !name) {
+    return { ok: false, status: 400, body: { ok: false, error: 'INVALID_INPUT' } }
+  }
+  const unitAllowed = ensureUnitAllowed(actor, unit)
+  if (!unitAllowed.ok) return unitAllowed
+  await env.DB.prepare(
+    `delete from holidays where date = ?1 and unit = ?2 and name = ?3`
+  ).bind(date, unit, name).run()
+  return { ok: true, status: 200, body: { ok: true } }
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url)
     const path = url.pathname
+    const requestId = request.headers.get('x-request-id') || newRequestId()
     const corsHeaders = buildCorsHeaders(request, env)
 
     if (request.method === 'OPTIONS') {
@@ -126,35 +415,117 @@ export default {
     }
 
     if (path === '/health' || path === '/api/escala/health') {
-      return jsonResponse({ ok: true }, { headers: corsHeaders })
+      return jsonResponse({ ok: true }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
     }
 
     if (!path.startsWith('/api/escala')) {
-      return jsonResponse({ ok: false, error: 'Not found' }, { status: 404, headers: corsHeaders })
+      return jsonResponse({ ok: false, error: 'Not found' }, { status: 404, headers: { ...corsHeaders, 'x-request-id': requestId } })
     }
+
+    const auth = await requireActor(request, env)
+    if (!auth.ok) {
+      return jsonResponse(auth.body, { status: auth.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+    }
+
+    const actor = auth.actor
 
     try {
       if (path === '/api/escala/overview') {
-        const data = await handleOverview(env)
-        return jsonResponse({ ok: true, ...data }, { headers: corsHeaders })
+        const data = await handleOverview(env, actor)
+        console.log(JSON.stringify({ event: 'escala.overview', requestId, actor: actor.id }))
+        return jsonResponse({ ok: true, ...data }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
       }
 
       if (path === '/api/escala/professionals') {
         const unit = url.searchParams.get('unit') || ''
-        const data = await handleProfessionals(env, unit)
-        return jsonResponse({ ok: true, ...data }, { headers: corsHeaders })
+        const unitAllowed = ensureUnitAllowed(actor, unit)
+        if (!unitAllowed.ok) {
+          return jsonResponse(unitAllowed.body, { status: unitAllowed.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        const data = await handleProfessionals(env, unit, actor)
+        console.log(JSON.stringify({ event: 'escala.professionals', requestId, actor: actor.id, unit }))
+        return jsonResponse({ ok: true, ...data }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
       }
 
       if (path === '/api/escala/schedule') {
-        const unit = url.searchParams.get('unit') || ''
-        const month = url.searchParams.get('month') || ''
-        const data = await handleSchedule(env, unit || null, month || null)
-        return jsonResponse({ ok: true, ...data }, { headers: corsHeaders })
+        if (request.method === 'GET') {
+          const unit = url.searchParams.get('unit') || ''
+          const month = url.searchParams.get('month') || ''
+          if (month && !isValidMonth(month)) {
+            return jsonResponse({ ok: false, error: 'INVALID_MONTH' }, { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } })
+          }
+          const unitAllowed = ensureUnitAllowed(actor, unit)
+          if (!unitAllowed.ok) {
+            return jsonResponse(unitAllowed.body, { status: unitAllowed.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+          }
+          const data = await handleSchedule(env, unit || null, month || null, actor)
+          console.log(JSON.stringify({ event: 'escala.schedule.read', requestId, actor: actor.id, unit, month }))
+          return jsonResponse({ ok: true, ...data }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+
+        const body = await readJson(request)
+        if (!body) {
+          return jsonResponse({ ok: false, error: 'INVALID_JSON' }, { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+
+        if (request.method === 'POST') {
+          const result = await handleSchedulePost(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.schedule.add', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'PUT') {
+          const result = await handleSchedulePut(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.schedule.replace', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'DELETE') {
+          const result = await handleScheduleDelete(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.schedule.delete', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        return jsonResponse({ ok: false, error: 'METHOD_NOT_ALLOWED' }, { status: 405, headers: { ...corsHeaders, 'x-request-id': requestId } })
       }
 
-      return jsonResponse({ ok: false, error: 'Not found' }, { status: 404, headers: corsHeaders })
+      if (path === '/api/escala/closed-days') {
+        const body = await readJson(request)
+        if (!body) {
+          return jsonResponse({ ok: false, error: 'INVALID_JSON' }, { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'POST') {
+          const result = await handleClosedDayPost(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.closed.add', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'DELETE') {
+          const result = await handleClosedDayDelete(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.closed.delete', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        return jsonResponse({ ok: false, error: 'METHOD_NOT_ALLOWED' }, { status: 405, headers: { ...corsHeaders, 'x-request-id': requestId } })
+      }
+
+      if (path === '/api/escala/holidays') {
+        const body = await readJson(request)
+        if (!body) {
+          return jsonResponse({ ok: false, error: 'INVALID_JSON' }, { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'POST') {
+          const result = await handleHolidayPost(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.holiday.add', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        if (request.method === 'DELETE') {
+          const result = await handleHolidayDelete(env, actor, body)
+          console.log(JSON.stringify({ event: 'escala.holiday.delete', requestId, actor: actor.id, status: result.status }))
+          return jsonResponse(result.body, { status: result.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
+        }
+        return jsonResponse({ ok: false, error: 'METHOD_NOT_ALLOWED' }, { status: 405, headers: { ...corsHeaders, 'x-request-id': requestId } })
+      }
+
+      return jsonResponse({ ok: false, error: 'Not found' }, { status: 404, headers: { ...corsHeaders, 'x-request-id': requestId } })
     } catch (err) {
-      return jsonResponse({ ok: false, error: err?.message || 'Internal error' }, { status: 500, headers: corsHeaders })
+      console.log(JSON.stringify({ event: 'escala.error', requestId, error: err?.message || String(err) }))
+      return jsonResponse({ ok: false, error: err?.message || 'Internal error' }, { status: 500, headers: { ...corsHeaders, 'x-request-id': requestId } })
     }
   }
 }

--- a/docs/escala-runbook.md
+++ b/docs/escala-runbook.md
@@ -1,0 +1,52 @@
+---
+title: Runbook Escala
+---
+
+# Runbook Escala
+
+## Escopo
+- Módulo Escala no CRM (frontend + proxy Pages Functions)
+- Worker `escala-api` e banco D1 `skincos-escala`
+
+## Endpoints críticos
+- CRM Proxy: `https://crm.skincos.com.br/api/escala/_proxy-status`
+- Worker health: `https://escala-api.skincos.com.br/api/escala/health`
+- Worker overview: `https://escala-api.skincos.com.br/api/escala/overview`
+
+## Sinais básicos de saúde
+1. `_proxy-status` retorna `ok: true`, `targetConfigured: true`, `actorKeyConfigured: true`.
+2. `/api/escala/health` retorna 200.
+3. `/api/escala/overview` retorna `units` e `months` (pode ser vazio, mas não erro).
+
+## Logs e correlação
+- Todos os requests carregam `x-request-id`.
+- Workers logs têm eventos `escala.*` e `escala.error`.
+- Filtre no Cloudflare Logs com `event: "escala."` ou pelo `x-request-id`.
+
+## Erros comuns e correção rápida
+- **401 UNAUTHORIZED / ACTOR_SIGNATURE_INVALID**:
+  - Verifique `ESCALA_ACTOR_HMAC_KEY` no Pages Functions e no Worker.
+  - Confirme o horário do servidor (skew máximo 5 min).
+- **403 FORBIDDEN / FORBIDDEN_UNIT**:
+  - Usuário sem role `GESTOR`/`GERENTE`.
+  - `allowedUnits` não inclui a unidade solicitada.
+- **503 ACTOR_KEY_MISSING / ESCALA_API_TARGET nao configurado**:
+  - Secrets ausentes no Pages Functions.
+
+## D1: checagens rápidas
+```bash
+cd backend/apps/escala-api
+npx wrangler d1 execute skincos-escala --remote \
+  --command "select count(*) as total from schedule_entries"
+```
+
+## Atualização de HMAC (rotina)
+1. Gerar segredo novo.
+2. Atualizar `ESCALA_ACTOR_HMAC_KEY` no Worker e no Pages Functions.
+3. Validar `_proxy-status` e `/api/escala/health`.
+
+## Checklist de validação pós-deploy
+1. Acessar CRM com usuário gestor e abrir módulo Escala.
+2. Criar escala para uma data e confirmar atualização na lista.
+3. Adicionar e remover bloqueio e feriado.
+4. Confirmar logs com `x-request-id`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,7 +23,7 @@ Workflow: `.github/workflows/uptime-slo.yml`
 
 Variáveis (repo → Settings → Variables → Actions):
 - `OBS_HEALTHCHECK_URLS` (CSV)  
-  Ex.: `https://crm.skincos.com.br/api/health,https://api.skincos.com.br/health,https://api.skincos.com.br/insumos/health`
+  Ex.: `https://crm.skincos.com.br/api/health,https://crm.skincos.com.br/api/escala/_proxy-status,https://api.skincos.com.br/health,https://api.skincos.com.br/insumos/health,https://escala-api.skincos.com.br/api/escala/health`
 - `OBS_LATENCY_MS` (default: `800`)
 - `OBS_TIMEOUT_SEC` (default: `10`)
 
@@ -81,6 +81,6 @@ Observação: os alertas de **5xx/latência/D1/R2/429** podem depender de produt
 ## Runbook mínimo
 
 1. Validar status com os endpoints de health.
-2. Verificar logs de Worker/Pages e CRM API.
+2. Verificar logs de Worker/Pages e CRM API (Escala emite eventos `escala.*` e `escala.error`).
 3. Confirmar D1/R2 status no painel Cloudflare.
 4. Mitigar (rollback, fix, rate limits, cache) e registrar incidente.

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -224,7 +224,7 @@ export default function AppFunctionalNeatlab() {
         (moduleKey: string) => {
             const key = String(moduleKey || '').trim()
             if (!key) return false
-            if (key === 'escala-profissionais') return roleKey === 'GESTOR'
+            if (key === 'escala-profissionais') return roleKey === 'GESTOR' || roleKey === 'GERENTE'
             if (roleKey === 'GESTOR') return true
             const allowed = Array.isArray(user?.allowedModules)
                 ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -626,7 +626,7 @@ export function EscalaProfissionaisModule() {
                 <div className="space-y-1">
                   <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Profissional único</div>
                   <Select value={editorSingleProfessional} onValueChange={setEditorSingleProfessional}>
-                    <SelectTrigger className="bg-white/5">
+                    <SelectTrigger className="bg-white/5" data-testid="escala-editor-professional">
                       <SelectValue placeholder="Selecione" />
                     </SelectTrigger>
                     <SelectContent>

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
@@ -7,7 +8,18 @@ import { LoadingPercentText } from '@/LoadingPattern'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { useAuth } from '@/contexts'
 import { cn, getStatusColor } from '@/utils'
-import { fetchEscalaOverview, fetchEscalaProfessionals, fetchEscalaSchedule } from '@/escalaApi'
+import {
+  addClosedDay,
+  addHoliday,
+  addScheduleEntry,
+  fetchEscalaOverview,
+  fetchEscalaProfessionals,
+  fetchEscalaSchedule,
+  removeClosedDay,
+  removeHoliday,
+  removeScheduleEntry,
+  replaceScheduleEntries
+} from '@/escalaApi'
 
 type CalendarCell = {
   date: string
@@ -81,7 +93,7 @@ function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional
 export function EscalaProfissionaisModule() {
   const { user } = useAuth()
   const roleKey = String(user?.role || '').trim().toUpperCase()
-  const canAccess = roleKey === 'GESTOR'
+  const canAccess = roleKey === 'GESTOR' || roleKey === 'GERENTE'
 
   const [units, setUnits] = useState<string[]>([])
   const [months, setMonths] = useState<string[]>([])
@@ -97,78 +109,222 @@ export function EscalaProfissionaisModule() {
   const [loadingSchedule, setLoadingSchedule] = useState(false)
   const [loadingProfessionals, setLoadingProfessionals] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [editorDate, setEditorDate] = useState('')
+  const [editorProfessionals, setEditorProfessionals] = useState('')
+  const [editorSingleProfessional, setEditorSingleProfessional] = useState('')
+  const [editorReason, setEditorReason] = useState('')
+  const [editorHolidayName, setEditorHolidayName] = useState('')
+  const [editorLoading, setEditorLoading] = useState(false)
 
-  useEffect(() => {
-    let active = true
-    const loadOverview = async () => {
-      setLoadingOverview(true)
-      const res = await fetchEscalaOverview()
-      if (!active) return
-      if (!res.ok) {
-        setError(res.error || 'Não foi possível carregar a escala.')
-        setLoadingOverview(false)
-        return
-      }
-      const nextUnits = Array.isArray(res.units) ? res.units : []
-      const nextMonths = Array.isArray(res.months) ? res.months : []
-      setUnits(nextUnits)
-      setMonths(nextMonths)
-      if (!selectedUnit && nextUnits.length) setSelectedUnit(nextUnits[0])
-      if (!selectedMonth && nextMonths.length) setSelectedMonth(nextMonths[nextMonths.length - 1])
-      setError(null)
+  const refreshOverview = useCallback(async () => {
+    setLoadingOverview(true)
+    const res = await fetchEscalaOverview()
+    if (!res.ok) {
+      setError(res.error || 'Não foi possível carregar a escala.')
       setLoadingOverview(false)
+      return
     }
-    loadOverview()
-    return () => {
-      active = false
+    const nextUnits = Array.isArray(res.units) ? res.units : []
+    const nextMonths = Array.isArray(res.months) ? res.months : []
+    setUnits(nextUnits)
+    setMonths(nextMonths)
+    setSelectedUnit((prev) => (prev || nextUnits[0] || prev))
+    setSelectedMonth((prev) => (prev || nextMonths[nextMonths.length - 1] || prev))
+    setError(null)
+    setLoadingOverview(false)
+  }, [])
+
+  const refreshProfessionals = useCallback(async (unitOverride?: string) => {
+    const unit = unitOverride || selectedUnit
+    if (!unit) return
+    setLoadingProfessionals(true)
+    const res = await fetchEscalaProfessionals(unit)
+    if (!res.ok) {
+      setError(res.error || 'Não foi possível carregar profissionais.')
+      setLoadingProfessionals(false)
+      return
     }
+    setProfessionals(Array.isArray(res.data) ? res.data : [])
+    setError(null)
+    setLoadingProfessionals(false)
+  }, [selectedUnit])
+
+  const refreshSchedule = useCallback(async (unitOverride?: string, monthOverride?: string) => {
+    const unit = unitOverride || selectedUnit
+    const month = monthOverride || selectedMonth
+    if (!unit || !month) return
+    setLoadingSchedule(true)
+    const res = await fetchEscalaSchedule(unit, month)
+    if (!res.ok) {
+      setError(res.error || 'Não foi possível carregar a agenda.')
+      setLoadingSchedule(false)
+      return
+    }
+    setSchedule(Array.isArray(res.schedule) ? res.schedule : [])
+    setClosedDays(Array.isArray(res.closedDays) ? res.closedDays : [])
+    setHolidays(Array.isArray(res.holidays) ? res.holidays : [])
+    setError(null)
+    setLoadingSchedule(false)
+  }, [selectedMonth, selectedUnit])
+
+  const parseProfessionals = useCallback((value: string) => {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }, [])
+
+  const ensureEditorReady = () => {
+    if (!selectedUnit) {
+      toast.error('Selecione uma unidade antes de editar a escala.')
+      return false
+    }
+    if (!editorDate) {
+      toast.error('Informe a data da escala.')
+      return false
+    }
+    return true
+  }
+
+  const handleReplaceSchedule = async () => {
+    if (!ensureEditorReady()) return
+    const list = parseProfessionals(editorProfessionals)
+    if (!list.length) {
+      toast.error('Informe ao menos um profissional para substituir a agenda.')
+      return
+    }
+    setEditorLoading(true)
+    const res = await replaceScheduleEntries({ date: editorDate, unit: selectedUnit, professionals: list })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao atualizar a agenda.')
+      return
+    }
+    toast.success('Agenda atualizada.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleAddScheduleEntry = async () => {
+    if (!ensureEditorReady()) return
+    const professional = editorSingleProfessional.trim()
+    if (!professional) {
+      toast.error('Selecione um profissional para adicionar.')
+      return
+    }
+    setEditorLoading(true)
+    const res = await addScheduleEntry({ date: editorDate, unit: selectedUnit, professional })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao adicionar profissional.')
+      return
+    }
+    toast.success('Profissional adicionado ao dia.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleRemoveScheduleEntry = async () => {
+    if (!ensureEditorReady()) return
+    const professional = editorSingleProfessional.trim()
+    if (!professional) {
+      toast.error('Selecione um profissional para remover.')
+      return
+    }
+    setEditorLoading(true)
+    const res = await removeScheduleEntry({ date: editorDate, unit: selectedUnit, professional })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao remover profissional.')
+      return
+    }
+    toast.success('Profissional removido do dia.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleCloseDay = async () => {
+    if (!ensureEditorReady()) return
+    setEditorLoading(true)
+    const res = await addClosedDay({ date: editorDate, unit: selectedUnit, reason: editorReason })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao bloquear dia.')
+      return
+    }
+    toast.success('Dia bloqueado.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleOpenDay = async () => {
+    if (!ensureEditorReady()) return
+    setEditorLoading(true)
+    const res = await removeClosedDay({ date: editorDate, unit: selectedUnit })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao remover bloqueio.')
+      return
+    }
+    toast.success('Bloqueio removido.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleAddHoliday = async () => {
+    if (!ensureEditorReady()) return
+    if (!editorHolidayName.trim()) {
+      toast.error('Informe o nome do feriado.')
+      return
+    }
+    setEditorLoading(true)
+    const res = await addHoliday({ date: editorDate, unit: selectedUnit, name: editorHolidayName })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao cadastrar feriado.')
+      return
+    }
+    toast.success('Feriado cadastrado.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const handleRemoveHoliday = async () => {
+    if (!ensureEditorReady()) return
+    if (!editorHolidayName.trim()) {
+      toast.error('Informe o nome do feriado.')
+      return
+    }
+    setEditorLoading(true)
+    const res = await removeHoliday({ date: editorDate, unit: selectedUnit, name: editorHolidayName })
+    setEditorLoading(false)
+    if (!res.ok) {
+      toast.error(res.error || 'Falha ao remover feriado.')
+      return
+    }
+    toast.success('Feriado removido.')
+    void refreshSchedule()
+    void refreshOverview()
+  }
+
+  const scrollToEditor = useCallback(() => {
+    const el = document.getElementById('escala-editor')
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [])
 
   useEffect(() => {
+    void refreshOverview()
+  }, [refreshOverview])
+
+  useEffect(() => {
     if (!selectedUnit) return
-    let active = true
-    const loadProfessionals = async () => {
-      setLoadingProfessionals(true)
-      const res = await fetchEscalaProfessionals(selectedUnit)
-      if (!active) return
-      if (!res.ok) {
-        setError(res.error || 'Não foi possível carregar profissionais.')
-        setLoadingProfessionals(false)
-        return
-      }
-      setProfessionals(Array.isArray(res.data) ? res.data : [])
-      setError(null)
-      setLoadingProfessionals(false)
-    }
-    loadProfessionals()
-    return () => {
-      active = false
-    }
-  }, [selectedUnit])
+    void refreshProfessionals(selectedUnit)
+  }, [selectedUnit, refreshProfessionals])
 
   useEffect(() => {
     if (!selectedUnit || !selectedMonth) return
-    let active = true
-    const loadSchedule = async () => {
-      setLoadingSchedule(true)
-      const res = await fetchEscalaSchedule(selectedUnit, selectedMonth)
-      if (!active) return
-      if (!res.ok) {
-        setError(res.error || 'Não foi possível carregar a agenda.')
-        setLoadingSchedule(false)
-        return
-      }
-      setSchedule(Array.isArray(res.schedule) ? res.schedule : [])
-      setClosedDays(Array.isArray(res.closedDays) ? res.closedDays : [])
-      setHolidays(Array.isArray(res.holidays) ? res.holidays : [])
-      setError(null)
-      setLoadingSchedule(false)
-    }
-    loadSchedule()
-    return () => {
-      active = false
-    }
-  }, [selectedMonth, selectedUnit])
+    void refreshSchedule(selectedUnit, selectedMonth)
+  }, [selectedMonth, selectedUnit, refreshSchedule])
 
   const scheduleNames = useMemo(() => new Set(schedule.map((e) => e.professional)), [schedule])
   const mergedProfessionals = useMemo(() => mergeProfessionals(scheduleNames, professionals), [scheduleNames, professionals])
@@ -184,6 +340,10 @@ export function EscalaProfissionaisModule() {
     if (!needle) return list
     return list.filter((p) => p.name.toLowerCase().includes(needle) || p.role.toLowerCase().includes(needle))
   }, [professionalsByUnit, search])
+
+  const professionalOptions = useMemo(() => {
+    return professionalsByUnit.map((prof) => prof.name)
+  }, [professionalsByUnit])
 
   const scheduleForMonth = schedule
   const closedDaysForMonth = closedDays
@@ -268,8 +428,8 @@ export function EscalaProfissionaisModule() {
               <Button variant="outline" className="border-white/20 bg-white/5 text-white/90" disabled>
                 Exportar resumo
               </Button>
-              <Button variant="premium" disabled>
-                Editor em desenvolvimento
+              <Button variant="premium" onClick={scrollToEditor}>
+                Ir para o editor
               </Button>
             </div>
           </div>
@@ -431,6 +591,105 @@ export function EscalaProfissionaisModule() {
         </Card>
 
         <div className="flex min-h-0 flex-col gap-4">
+          <Card className="glass-card" id="escala-editor">
+            <CardHeader className="border-b border-white/10">
+              <CardTitle className="text-white">Editor da escala</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-xs text-blue-100/80">
+              <div className="grid gap-3">
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Data</div>
+                  <Input
+                    type="date"
+                    value={editorDate}
+                    onChange={(event) => setEditorDate(event.target.value)}
+                    className="bg-white/5"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Profissionais (CSV)</div>
+                  <Input
+                    value={editorProfessionals}
+                    onChange={(event) => setEditorProfessionals(event.target.value)}
+                    placeholder="ex: Dra. Ana, Dr. Lucas"
+                    className="bg-white/5"
+                  />
+                  <Button
+                    variant="outline"
+                    className="mt-2 border-white/20 bg-white/5 text-white/90"
+                    onClick={handleReplaceSchedule}
+                    disabled={editorLoading}
+                  >
+                    Substituir agenda do dia
+                  </Button>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Profissional único</div>
+                  <Select value={editorSingleProfessional} onValueChange={setEditorSingleProfessional}>
+                    <SelectTrigger className="bg-white/5">
+                      <SelectValue placeholder="Selecione" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {professionalOptions.length ? (
+                        professionalOptions.map((name) => (
+                          <SelectItem key={name} value={name}>
+                            {name}
+                          </SelectItem>
+                        ))
+                      ) : (
+                        <SelectItem value="__empty" disabled>
+                          Nenhum profissional encontrado
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Button variant="premium" onClick={handleAddScheduleEntry} disabled={editorLoading}>
+                      Adicionar ao dia
+                    </Button>
+                    <Button variant="outline" onClick={handleRemoveScheduleEntry} disabled={editorLoading}>
+                      Remover do dia
+                    </Button>
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Bloqueio do dia</div>
+                  <Input
+                    value={editorReason}
+                    onChange={(event) => setEditorReason(event.target.value)}
+                    placeholder="Motivo do bloqueio"
+                    className="bg-white/5"
+                  />
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Button variant="premium" onClick={handleCloseDay} disabled={editorLoading}>
+                      Bloquear dia
+                    </Button>
+                    <Button variant="outline" onClick={handleOpenDay} disabled={editorLoading}>
+                      Remover bloqueio
+                    </Button>
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-blue-100/50">Feriado</div>
+                  <Input
+                    value={editorHolidayName}
+                    onChange={(event) => setEditorHolidayName(event.target.value)}
+                    placeholder="Nome do feriado"
+                    className="bg-white/5"
+                  />
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Button variant="premium" onClick={handleAddHoliday} disabled={editorLoading}>
+                      Adicionar feriado
+                    </Button>
+                    <Button variant="outline" onClick={handleRemoveHoliday} disabled={editorLoading}>
+                      Remover feriado
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
           <Card className="glass-card">
             <CardHeader className="border-b border-white/10">
               <div className="flex items-center justify-between">

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -56,8 +56,8 @@ test.describe('escala', () => {
 
     await expect(page.getByText('Escala de Profissionais')).toBeVisible({ timeout: 30000 })
     await expect(page.getByRole('button', { name: /Dra\. Ana/i })).toBeVisible()
-    await expect(page.getByText('Dia do Cliente')).toBeVisible()
-    await expect(page.getByText('Feriado local')).toBeVisible()
+    await expect(page.getByText('Dia do Cliente').first()).toBeVisible()
+    await expect(page.getByText('Feriado local').first()).toBeVisible()
   })
 
   test('edits schedule entries via editor', async ({ page }) => {

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -55,7 +55,7 @@ test.describe('escala', () => {
     await page.goto('/?module=escala-profissionais')
 
     await expect(page.getByText('Escala de Profissionais')).toBeVisible({ timeout: 30000 })
-    await expect(page.getByText('Dra. Ana')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Dra\. Ana/i })).toBeVisible()
     await expect(page.getByText('Dia do Cliente')).toBeVisible()
     await expect(page.getByText('Feriado local')).toBeVisible()
   })

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -59,4 +59,132 @@ test.describe('escala', () => {
     await expect(page.getByText('Dia do Cliente')).toBeVisible()
     await expect(page.getByText('Feriado local')).toBeVisible()
   })
+
+  test('edits schedule entries via editor', async ({ page }) => {
+    let replacePayload: any = null
+    let closedAddPayload: any = null
+    let closedRemovePayload: any = null
+    let holidayAddPayload: any = null
+    let holidayRemovePayload: any = null
+
+    await page.route('**/api/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
+      })
+    })
+
+    await page.route('**/api/insumos/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] }, csrfToken: 'e2e' })
+      })
+    })
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      const req = route.request()
+      if (req.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            schedule: [],
+            closedDays: [],
+            holidays: []
+          })
+        })
+        return
+      }
+      if (req.method() === 'PUT') {
+        replacePayload = await req.postDataJSON()
+      }
+      if (req.method() === 'POST') {
+        // Optional: add individual entry if needed later
+      }
+      if (req.method() === 'DELETE') {
+        // Optional: remove individual entry if needed later
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+    })
+
+    await page.route('**/api/escala/closed-days**', async (route) => {
+      const req = route.request()
+      if (req.method() === 'POST') closedAddPayload = await req.postDataJSON()
+      if (req.method() === 'DELETE') closedRemovePayload = await req.postDataJSON()
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+    })
+
+    await page.route('**/api/escala/holidays**', async (route) => {
+      const req = route.request()
+      if (req.method() === 'POST') holidayAddPayload = await req.postDataJSON()
+      if (req.method() === 'DELETE') holidayRemovePayload = await req.postDataJSON()
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+    })
+
+    await page.goto('/?module=escala-profissionais')
+
+    await page.locator('#escala-editor input[type="date"]').fill('2026-03-15')
+    await page.locator('#escala-editor input[placeholder="ex: Dra. Ana, Dr. Lucas"]').fill('Dra. Ana, Dr. Lucas')
+    await page.getByRole('button', { name: 'Substituir agenda do dia' }).click()
+
+    await expect.poll(() => replacePayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      professionals: ['Dra. Ana', 'Dr. Lucas']
+    })
+
+    await page.locator('#escala-editor input[placeholder="Motivo do bloqueio"]').fill('Manutenção')
+    await page.getByRole('button', { name: 'Bloquear dia' }).click()
+    await expect.poll(() => closedAddPayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      reason: 'Manutenção'
+    })
+
+    await page.getByRole('button', { name: 'Remover bloqueio' }).click()
+    await expect.poll(() => closedRemovePayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo'
+    })
+
+    await page.locator('#escala-editor input[placeholder="Nome do feriado"]').fill('Dia do Cliente')
+    await page.getByRole('button', { name: 'Adicionar feriado' }).click()
+    await expect.poll(() => holidayAddPayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      name: 'Dia do Cliente'
+    })
+
+    await page.getByRole('button', { name: 'Remover feriado' }).click()
+    await expect.poll(() => holidayRemovePayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      name: 'Dia do Cliente'
+    })
+  })
 })

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -62,6 +62,8 @@ test.describe('escala', () => {
 
   test('edits schedule entries via editor', async ({ page }) => {
     let replacePayload: any = null
+    let addPayload: any = null
+    let removePayload: any = null
     let closedAddPayload: any = null
     let closedRemovePayload: any = null
     let holidayAddPayload: any = null
@@ -124,10 +126,10 @@ test.describe('escala', () => {
         replacePayload = await req.postDataJSON()
       }
       if (req.method() === 'POST') {
-        // Optional: add individual entry if needed later
+        addPayload = await req.postDataJSON()
       }
       if (req.method() === 'DELETE') {
-        // Optional: remove individual entry if needed later
+        removePayload = await req.postDataJSON()
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
     })
@@ -156,6 +158,23 @@ test.describe('escala', () => {
       date: '2026-03-15',
       unit: 'Novo Hamburgo',
       professionals: ['Dra. Ana', 'Dr. Lucas']
+    })
+
+    await page.getByTestId('escala-editor-professional').click()
+    await page.getByRole('option', { name: 'Dra. Ana' }).click()
+    await page.getByRole('button', { name: 'Adicionar ao dia' }).click()
+
+    await expect.poll(() => addPayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      professional: 'Dra. Ana'
+    })
+
+    await page.getByRole('button', { name: 'Remover do dia' }).click()
+    await expect.poll(() => removePayload).toEqual({
+      date: '2026-03-15',
+      unit: 'Novo Hamburgo',
+      professional: 'Dra. Ana'
     })
 
     await page.locator('#escala-editor input[placeholder="Motivo do bloqueio"]').fill('Manutenção')

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('escala', () => {
+  test('renders overview and schedule from API', async ({ page }) => {
+    await page.route('**/api/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
+      })
+    })
+
+    await page.route('**/api/insumos/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] }, csrfToken: 'e2e' })
+      })
+    })
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [{ date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }],
+          closedDays: [{ date: '2026-03-10', unit: 'Novo Hamburgo', reason: 'Feriado local' }],
+          holidays: [{ date: '2026-03-20', unit: 'Novo Hamburgo', name: 'Dia do Cliente' }]
+        })
+      })
+    })
+
+    await page.goto('/?module=escala-profissionais')
+
+    await expect(page.getByText('Escala de Profissionais')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText('Dra. Ana')).toBeVisible()
+    await expect(page.getByText('Dia do Cliente')).toBeVisible()
+    await expect(page.getByText('Feriado local')).toBeVisible()
+  })
+})

--- a/frontend/escalaApi.ts
+++ b/frontend/escalaApi.ts
@@ -1,6 +1,4 @@
-const DEFAULT_ESCALA_API_BASE = (import.meta as any).env?.PROD
-  ? 'https://escala-api.skincos.com.br/api/escala'
-  : '/api/escala'
+const DEFAULT_ESCALA_API_BASE = '/api/escala'
 
 export const ESCALA_API_BASE =
   (import.meta as any).env?.VITE_ESCALA_API_URL || DEFAULT_ESCALA_API_BASE
@@ -10,6 +8,21 @@ type ApiResponse<T> = { ok: boolean; error?: string } & T
 async function apiGet<T>(path: string): Promise<ApiResponse<T>> {
   const url = `${ESCALA_API_BASE}${path}`
   const res = await fetch(url, { credentials: 'include', headers: { accept: 'application/json' } })
+  const json = await res.json().catch(() => null)
+  if (!res.ok || !json) {
+    return { ok: false, error: json?.error || `HTTP ${res.status}` } as ApiResponse<T>
+  }
+  return json as ApiResponse<T>
+}
+
+async function apiWrite<T>(path: string, method: string, body?: any): Promise<ApiResponse<T>> {
+  const url = `${ESCALA_API_BASE}${path}`
+  const res = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
   const json = await res.json().catch(() => null)
   if (!res.ok || !json) {
     return { ok: false, error: json?.error || `HTTP ${res.status}` } as ApiResponse<T>
@@ -32,4 +45,32 @@ export async function fetchEscalaSchedule(unit?: string, month?: string) {
   if (month) params.set('month', month)
   const qs = params.toString() ? `?${params.toString()}` : ''
   return apiGet<{ schedule: any[]; closedDays: any[]; holidays: any[] }>(`/schedule${qs}`)
+}
+
+export async function addScheduleEntry(payload: { date: string; unit: string; professional?: string; professionals?: string[] }) {
+  return apiWrite<{ ok: boolean }>(`/schedule`, 'POST', payload)
+}
+
+export async function replaceScheduleEntries(payload: { date: string; unit: string; professionals: string[] }) {
+  return apiWrite<{ ok: boolean }>(`/schedule`, 'PUT', payload)
+}
+
+export async function removeScheduleEntry(payload: { date: string; unit: string; professional?: string }) {
+  return apiWrite<{ ok: boolean }>(`/schedule`, 'DELETE', payload)
+}
+
+export async function addClosedDay(payload: { date: string; unit: string; reason?: string }) {
+  return apiWrite<{ ok: boolean }>(`/closed-days`, 'POST', payload)
+}
+
+export async function removeClosedDay(payload: { date: string; unit: string }) {
+  return apiWrite<{ ok: boolean }>(`/closed-days`, 'DELETE', payload)
+}
+
+export async function addHoliday(payload: { date: string; unit: string; name: string }) {
+  return apiWrite<{ ok: boolean }>(`/holidays`, 'POST', payload)
+}
+
+export async function removeHoliday(payload: { date: string; unit: string; name: string }) {
+  return apiWrite<{ ok: boolean }>(`/holidays`, 'DELETE', payload)
 }

--- a/frontend/functions/_lib/crmAuth.ts
+++ b/frontend/functions/_lib/crmAuth.ts
@@ -17,8 +17,18 @@ const json = (status: number, body: any) =>
 
 export async function getCrmUser(context: any): Promise<CrmAuthUser | null> {
   const env = context?.env || {}
+  const requestOrigin = (() => {
+    try {
+      const url = context?.request?.url
+      if (!url) return ''
+      return new URL(url).origin
+    } catch {
+      return ''
+    }
+  })()
   const targetOrigin =
     (env.AUTH_API_TARGET as string | undefined) ||
+    requestOrigin ||
     (env.INSUMOS_API_TARGET as string | undefined) ||
     'https://api.skincos.com.br'
 

--- a/frontend/functions/api/escala/[[path]].ts
+++ b/frontend/functions/api/escala/[[path]].ts
@@ -1,0 +1,179 @@
+import { requireCrmUser } from '../../_lib/crmAuth'
+
+const json = (status: number, body: any, extraHeaders: Record<string, string> = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      ...extraHeaders,
+    },
+  })
+
+function newRequestId(): string {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `${Date.now()}_${Math.random().toString(16).slice(2)}`
+  }
+}
+
+function normalizeRole(value: unknown): string {
+  const raw = String(value || '').trim().toUpperCase()
+  if (!raw) return ''
+  if (raw === 'ADMIN') return 'GESTOR'
+  if (raw === 'OPERADOR') return 'INJETOR'
+  return raw
+}
+
+function buildUpstreamHeaders(request: Request, requestId: string): Headers {
+  const allow = new Set([
+    'accept',
+    'content-type',
+    'range',
+    'if-none-match',
+    'if-modified-since',
+    'cache-control',
+    'pragma',
+    'user-agent',
+  ])
+
+  const headers = new Headers()
+  for (const [k, v] of request.headers.entries()) {
+    const key = k.toLowerCase()
+    if (!allow.has(key)) continue
+    headers.set(k, v)
+  }
+
+  headers.set('x-request-id', requestId)
+  return headers
+}
+
+function b64UrlEncodeBytes(bytes: ArrayBuffer): string {
+  const bin = String.fromCharCode(...new Uint8Array(bytes))
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function b64UrlEncodeString(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  return b64UrlEncodeBytes(bytes.buffer)
+}
+
+async function signHmacSha256B64Url(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message))
+  return b64UrlEncodeBytes(sig)
+}
+
+export async function onRequest(context: any): Promise<Response> {
+  const request: Request = context.request
+  const url = new URL(request.url)
+  const requestId = newRequestId()
+
+  const userOrRes = await requireCrmUser(context)
+  if (userOrRes instanceof Response) return userOrRes
+
+  const role = normalizeRole((userOrRes as any)?.role)
+  if (!(role === 'GESTOR' || role === 'GERENTE')) {
+    return json(
+      403,
+      { ok: false, error: 'FORBIDDEN', hint: 'Acesso restrito a gestores.' },
+      { 'x-request-id': requestId },
+    )
+  }
+
+  const actor = {
+    id: String((userOrRes as any).id || ''),
+    username: (userOrRes as any).username ? String((userOrRes as any).username) : undefined,
+    email: (userOrRes as any).email ? String((userOrRes as any).email) : undefined,
+    name: (userOrRes as any).displayName ? String((userOrRes as any).displayName) : undefined,
+    role,
+    allowedUnits: Array.isArray((userOrRes as any).allowedUnits) ? (userOrRes as any).allowedUnits : undefined,
+  }
+
+  const actorB64 = b64UrlEncodeString(JSON.stringify(actor))
+  const actorTs = String(Date.now())
+  const actorKey = String(context?.env?.ESCALA_ACTOR_HMAC_KEY || '').trim()
+
+  const prefix = '/api/escala'
+  const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
+
+  if (rest === '/_proxy-status' || rest === '/_proxy-status/') {
+    const targetOrigin = (context.env?.ESCALA_API_TARGET as string | undefined) || ''
+    return json(
+      200,
+      {
+        ok: true,
+        targetConfigured: !!targetOrigin,
+        actorKeyConfigured: !!actorKey,
+        hint: !targetOrigin
+          ? 'Configure ESCALA_API_TARGET no Cloudflare Pages/Functions (ex: https://escala-api.skincos.com.br).'
+          : undefined,
+      },
+      { 'x-request-id': requestId },
+    )
+  }
+
+  const targetOrigin = (context.env?.ESCALA_API_TARGET as string | undefined) || ''
+  if (!targetOrigin) {
+    return json(
+      503,
+      {
+        ok: false,
+        error: 'ESCALA_API_TARGET nao configurado',
+        hint: 'Defina ESCALA_API_TARGET no Cloudflare Pages/Functions.',
+      },
+      { 'x-request-id': requestId },
+    )
+  }
+  if (!actorKey) {
+    return json(
+      503,
+      {
+        ok: false,
+        error: 'ESCALA_ACTOR_HMAC_KEY nao configurado',
+        hint: 'Defina ESCALA_ACTOR_HMAC_KEY no Cloudflare Pages/Functions.',
+      },
+      { 'x-request-id': requestId },
+    )
+  }
+
+  const targetUrl = new URL(targetOrigin)
+  const basePath = targetUrl.pathname.replace(/\/$/, '')
+  targetUrl.pathname = `${basePath}/api/escala${rest.startsWith('/') ? '' : '/'}${rest}`
+  targetUrl.search = url.search
+
+  const headers = buildUpstreamHeaders(request, requestId)
+  headers.set('x-crm-user', actorB64)
+  headers.set('x-crm-ts', actorTs)
+  const sig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
+  headers.set('x-crm-signature', sig)
+
+  const method = (request.method || 'GET').toUpperCase()
+  const body = method === 'GET' || method === 'HEAD' ? undefined : request.body
+
+  const upstreamRequest = new Request(targetUrl.toString(), {
+    method,
+    headers,
+    body,
+    redirect: 'manual',
+  })
+
+  const upstream = await fetch(upstreamRequest)
+
+  const outHeaders = new Headers(upstream.headers)
+  outHeaders.set('Cache-Control', 'no-store')
+  outHeaders.set('x-request-id', requestId)
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: outHeaders,
+  })
+}

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -9,10 +9,10 @@ bucket_name = "skincos-share"
 
 [env.production.vars]
 INSUMOS_API_TARGET = "https://api.skincos.com.br"
+ESCALA_API_TARGET = "https://escala-api.skincos.com.br"
 REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET = "true"
 R2_KEY_PREFIX = ""
 R2_PRODUCTION_BRANCH = "main"
-VITE_ESCALA_API_URL = "https://escala-api.skincos.com.br/api/escala"
 
 [[env.preview.r2_buckets]]
 binding = "SHARE_BUCKET"
@@ -20,7 +20,7 @@ bucket_name = "skincos-share"
 
 [env.preview.vars]
 INSUMOS_API_TARGET = "https://api.skincos.com.br"
+ESCALA_API_TARGET = "https://escala-api-staging.skincos.com.br"
 REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET = "false"
 R2_KEY_PREFIX = "preview/"
 R2_PRODUCTION_BRANCH = "main"
-VITE_ESCALA_API_URL = "https://escala-api-staging.skincos.com.br/api/escala"


### PR DESCRIPTION
## Context
The Escala module was read-only and the escala-api endpoints were publicly accessible. The CRM needed to become the source of truth (editing in the UI), with authenticated access and minimal auditability.

## What changed
- Added a CRM Pages Function proxy for `/api/escala/*` that authenticates CRM sessions and signs requests via HMAC.
- Secured escala-api with signed actor headers + role checks (GESTOR/GERENTE) and added CRUD endpoints for schedule, closed days, and holidays.
- Added audit columns for escala tables via D1 migration.
- Updated Escala UI with an editor to create/replace/delete day schedules, blocks, and holidays.
- Added a basic Escala e2e smoke test.
- Switched frontend API base to `/api/escala` (same-origin proxy).

## Root cause
The Escala service was originally shipped as a read-only view and exposed without auth. There was no way to manage the schedule inside the CRM and no protections for PII.

## Fix
Introduce a CRM-authenticated proxy + HMAC verification in the worker, implement write endpoints, and provide a minimal editor in the CRM UI. Add audit columns for traceability.

## Tests
- Not run (added e2e spec `frontend/e2e/escala-module.spec.ts`).
