### PR TITLE
Fix CRM logout flow and Escala response handling

### DIFF
--- a/frontend/contexts.tsx
+++ b/frontend/contexts.tsx
@@ -32,7 +32,7 @@ interface AuthContextValue {
   initProgress: number
   signIn: (email: string, password: string) => Promise<void>
   signUp: (name: string, email: string, password: string, inviteToken: string) => Promise<void>
-  signOut: () => void
+  signOut: () => Promise<void>
   updateProfile: (data: Partial<Pick<AuthUser, 'name' | 'avatarUrl'>>) => void
   token: string | null
   isAuthenticated: boolean
@@ -221,10 +221,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const signOut = () => {
-    fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })
-      .catch(() => null)
-      .finally(() => { window.location.href = '/' })
+  const isLocalHost =
+    typeof window !== 'undefined' &&
+    ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)
+
+  const signOut = async () => {
+    // In local development, allow explicit logout by disabling auth bypass for this browser.
+    if (import.meta.env.DEV && isLocalHost) {
+      try {
+        localStorage.setItem('crm.localAuth', 'off')
+      } catch {
+        // ignore storage errors
+      }
+      try {
+        document.cookie = 'crm.localAuth=off; Path=/; Max-Age=31536000; SameSite=Lax'
+      } catch {
+        // ignore cookie errors
+      }
+    }
+
+    await fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { accept: 'application/json', ...csrfHeader() }
+    }).catch(() => null)
+
+    // Reset any cached auth state before reloading.
+    queryClient.setQueryData(AUTH_ME_QUERY_KEY, null)
+    queryClient.removeQueries({ queryKey: AUTH_ME_QUERY_KEY, exact: true })
+    window.location.assign('/')
   }
 
   const updateProfile = () => {

--- a/frontend/escalaApi.ts
+++ b/frontend/escalaApi.ts
@@ -29,14 +29,14 @@ async function apiGet<T>(path: string): Promise<ApiResponse<T>> {
   const res = await fetch(url, { credentials: 'include', headers: { accept: 'application/json' } })
   const text = await res.text()
   const json = parseJsonResponse(text)
+  const contentType = String(res.headers.get('content-type') || '').toLowerCase()
+  const likelyJson = contentType.includes('application/json')
   if (!res.ok || json?.ok === false) {
     return { ok: false, error: normalizeApiError(res, json, text) } as ApiResponse<T>
   }
   if (!json || typeof json !== 'object') {
-    return { ok: false, error: 'Resposta inválida do servidor.' } as ApiResponse<T>
-  }
-  if (!json) {
-    return { ok: false, error: 'Resposta inválida do servidor.' } as ApiResponse<T>
+    const hint = likelyJson ? 'Payload JSON inválido.' : 'Retorno não-JSON.'
+    return { ok: false, error: `${hint} Verifique /api/escala/_proxy-status.` } as ApiResponse<T>
   }
   return json as ApiResponse<T>
 }
@@ -51,14 +51,14 @@ async function apiWrite<T>(path: string, method: string, body?: any): Promise<Ap
   })
   const text = await res.text()
   const json = parseJsonResponse(text)
+  const contentType = String(res.headers.get('content-type') || '').toLowerCase()
+  const likelyJson = contentType.includes('application/json')
   if (!res.ok || json?.ok === false) {
     return { ok: false, error: normalizeApiError(res, json, text) } as ApiResponse<T>
   }
   if (!json || typeof json !== 'object') {
-    return { ok: false, error: 'Resposta inválida do servidor.' } as ApiResponse<T>
-  }
-  if (!json) {
-    return { ok: false, error: 'Resposta inválida do servidor.' } as ApiResponse<T>
+    const hint = likelyJson ? 'Payload JSON inválido.' : 'Retorno não-JSON.'
+    return { ok: false, error: `${hint} Verifique /api/escala/_proxy-status.` } as ApiResponse<T>
   }
   return json as ApiResponse<T>
 }

--- a/frontend/functions/_lib/crmAuth.ts
+++ b/frontend/functions/_lib/crmAuth.ts
@@ -35,6 +35,18 @@ function parseList(value: unknown): string[] | undefined {
   return items.length ? items : undefined
 }
 
+function parseCookieValue(rawCookie: string, name: string): string {
+  const cookie = String(rawCookie || '')
+  if (!cookie || !name) return ''
+  const parts = cookie.split(';')
+  for (const part of parts) {
+    const [k, ...rest] = part.split('=')
+    if (String(k || '').trim() !== name) continue
+    return decodeURIComponent(rest.join('=').trim())
+  }
+  return ''
+}
+
 export function isLocalDevAuthBypassEnabled(context: any): boolean {
   const env = context?.env || {}
   const rawToggle =
@@ -43,17 +55,33 @@ export function isLocalDevAuthBypassEnabled(context: any): boolean {
     env.DEV_AUTH_BYPASS ??
     ''
   const toggle = String(rawToggle).trim().toLowerCase()
-  if (toggle === 'false' || toggle === '0' || toggle === 'no') return false
-  if (toggle === 'true' || toggle === '1' || toggle === 'yes') return true
-
   const requestUrl = String(context?.request?.url || '')
   if (!requestUrl) return false
+  let localHost = false
   try {
     const { hostname } = new URL(requestUrl)
-    return isLocalHostname(hostname)
+    localHost = isLocalHostname(hostname)
   } catch {
     return false
   }
+  if (!localHost) return false
+
+  const cookieHeader = String(context?.request?.headers?.get?.('cookie') || '')
+  const cookieToggle =
+    parseCookieValue(cookieHeader, 'crm.localAuth') ||
+    parseCookieValue(cookieHeader, 'crm_local_auth')
+  const cookieNormalized = String(cookieToggle || '').trim().toLowerCase()
+  if (cookieNormalized === 'false' || cookieNormalized === '0' || cookieNormalized === 'no' || cookieNormalized === 'off') {
+    return false
+  }
+  if (cookieNormalized === 'true' || cookieNormalized === '1' || cookieNormalized === 'yes' || cookieNormalized === 'on') {
+    return true
+  }
+
+  if (toggle === 'false' || toggle === '0' || toggle === 'no') return false
+  if (toggle === 'true' || toggle === '1' || toggle === 'yes') return true
+
+  return true
 }
 
 export function getLocalDevAuthUser(context: any): CrmAuthUser {

--- a/frontend/functions/api/auth/[[path]].ts
+++ b/frontend/functions/api/auth/[[path]].ts
@@ -26,9 +26,11 @@ export async function onRequest(context: any): Promise<Response> {
             )
         }
         if (rest === '/logout' && method === 'POST') {
+            const headers = new Headers({ 'content-type': 'application/json', 'cache-control': 'no-store' })
+            headers.append('Set-Cookie', 'crm.localAuth=off; Path=/; Max-Age=31536000; SameSite=Lax')
             return new Response(
                 JSON.stringify({ ok: true }),
-                { status: 200, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' } }
+                { status: 200, headers }
             )
         }
     }
@@ -117,6 +119,16 @@ export async function onRequest(context: any): Promise<Response> {
         } else {
             const single = upstream.headers.get('set-cookie')
             if (single) applyCookies(splitSetCookie(single))
+        }
+
+        // Backward-compat: old deployments could have host-only auth cookies.
+        // On logout, clear both host-only and shared-domain variants.
+        if (rest === '/logout' && method === 'POST') {
+            const secureAttr = url.protocol === 'https:' ? '; Secure' : ''
+            const sameSite = url.protocol === 'https:' ? 'None' : 'Lax'
+            outHeaders.append('Set-Cookie', `session=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}; HttpOnly`)
+            outHeaders.append('Set-Cookie', `csrfToken=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}`)
+            outHeaders.append('Set-Cookie', 'crm.localAuth=off; Path=/; Max-Age=31536000; SameSite=Lax')
         }
     } catch {
         // ignore


### PR DESCRIPTION
## Summary
- make CRM logout robust by awaiting logout request and clearing local auth cache
- clear both shared-domain and host-only auth cookies on `/api/auth/logout` to handle legacy sessions
- allow local dev logout to disable auth bypass per browser
- improve Escala API client diagnostics for non-JSON responses (instead of generic invalid response)

## Validation
- `npm run typecheck` (frontend) in `/Users/jubenitogarcia/Automation/skincos/frontend`
- `npm run build` (frontend) in `/Users/jubenitogarcia/Automation/skincos/frontend`
- `curl -X POST https://crm.skincos.com.br/api/auth/logout` (verified host-only + domain cookie clears in response)
- verified Cloudflare Pages/Workers secrets include `ESCALA_ACTOR_HMAC_KEY` for prod/preview
