### PR TITLE
Fix Escala interactivity and unit permission matching

### DIFF
--- a/backend/apps/escala-api/worker.js
+++ b/backend/apps/escala-api/worker.js
@@ -103,6 +103,7 @@ async function requireActor(request, env) {
     return { ok: false, status: 403, body: { ok: false, error: 'FORBIDDEN' } }
   }
   const allowedUnits = Array.isArray(actor.allowedUnits) ? actor.allowedUnits.map(String).filter(Boolean) : []
+  const allowedUnitKeys = Array.from(new Set(allowedUnits.map((unit) => normalizeUnitKey(unit)).filter(Boolean)))
   return {
     ok: true,
     actor: {
@@ -110,15 +111,16 @@ async function requireActor(request, env) {
       email: actor.email ? String(actor.email) : undefined,
       name: actor.name ? String(actor.name) : undefined,
       role,
-      allowedUnits
+      allowedUnits,
+      allowedUnitKeys
     }
   }
 }
 
 function ensureUnitAllowed(actor, unit) {
   if (!unit) return { ok: true }
-  if (!actor.allowedUnits.length) return { ok: true }
-  return actor.allowedUnits.includes(unit)
+  if (!actor.allowedUnitKeys.length) return { ok: true }
+  return isUnitVisibleForActor(actor, unit)
     ? { ok: true }
     : { ok: false, status: 403, body: { ok: false, error: 'FORBIDDEN_UNIT' } }
 }
@@ -135,59 +137,85 @@ function normalizeName(value) {
   return String(value || '').trim()
 }
 
+function normalizeUnitKey(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .trim()
+}
+
+function isUnitVisibleForActor(actor, unit) {
+  const key = normalizeUnitKey(unit)
+  if (!key) return true
+  if (!Array.isArray(actor.allowedUnitKeys) || !actor.allowedUnitKeys.length) return true
+  return actor.allowedUnitKeys.includes(key)
+}
+
 async function handleOverview(env, actor) {
-  const unitFilter = actor.allowedUnits.length ? ` where unit in (${actor.allowedUnits.map(() => '?').join(',')})` : ''
-  const unitValues = actor.allowedUnits.length ? actor.allowedUnits : []
   const unitsQuery = `
-    select distinct unit from schedule_entries${unitFilter}
+    select distinct unit from schedule_entries
     union
-    select distinct unit from closed_days${unitFilter}
+    select distinct unit from closed_days
     union
-    select distinct unit from holidays${unitFilter}
+    select distinct unit from holidays
     order by unit;
   `
-  const units = await env.DB.prepare(unitsQuery).bind(...unitValues, ...unitValues, ...unitValues).all()
+  const units = await env.DB.prepare(unitsQuery).all()
 
   const monthsQuery = `
-    select distinct substr(date, 1, 7) as month
-    from schedule_entries${unitFilter}
-    order by month;
+    select distinct unit, substr(date, 1, 7) as month
+    from schedule_entries
+    order by month, unit;
   `
-  const months = await env.DB.prepare(monthsQuery).bind(...unitValues).all()
-  return { units: (units.results || []).map((r) => r.unit), months: (months.results || []).map((r) => r.month) }
+  const months = await env.DB.prepare(monthsQuery).all()
+
+  const visibleUnits = (units.results || [])
+    .map((r) => String(r.unit || ''))
+    .filter(Boolean)
+    .filter((unit) => isUnitVisibleForActor(actor, unit))
+
+  const visibleMonths = new Set(
+    (months.results || [])
+      .filter((r) => isUnitVisibleForActor(actor, r.unit))
+      .map((r) => String(r.month || ''))
+      .filter(Boolean)
+  )
+
+  return { units: visibleUnits, months: Array.from(visibleMonths).sort() }
 }
 
 async function handleProfessionals(env, unit, actor) {
-  if (unit) {
-    const stmt = env.DB.prepare(
-      `select name, status, role, shift, nickname, phone, email, instagram, units_json
-       from professionals
-       where json_array_length(units_json) = 0
-          or exists (select 1 from json_each(units_json) where value = ?)
-       order by name`
-    ).bind(unit)
-    const res = await stmt.all()
-    const data = (res.results || []).map((row) => ({
-      ...row,
-      units: JSON.parse(row.units_json || '[]')
-    }))
-    return { data }
-  }
-
   const res = await env.DB.prepare(
     `select name, status, role, shift, nickname, phone, email, instagram, units_json
      from professionals
      order by name`
   ).all()
-  const allowed = new Set(actor.allowedUnits || [])
-  const data = (res.results || []).map((row) => ({
-    ...row,
-    units: JSON.parse(row.units_json || '[]')
-  })).filter((row) => {
-    if (!allowed.size) return true
-    if (!row.units || !row.units.length) return true
-    return row.units.some((u) => allowed.has(u))
-  })
+  const requestedUnitKey = normalizeUnitKey(unit)
+  const allowed = new Set(actor.allowedUnitKeys || [])
+  const data = (res.results || [])
+    .map((row) => {
+      let units = []
+      try {
+        units = JSON.parse(row.units_json || '[]')
+      } catch {
+        units = []
+      }
+      const unitKeys = Array.isArray(units) ? units.map((u) => normalizeUnitKey(u)).filter(Boolean) : []
+      return {
+        ...row,
+        units: Array.isArray(units) ? units : [],
+        unitKeys
+      }
+    })
+    .filter((row) => {
+      if (requestedUnitKey && row.unitKeys.length && !row.unitKeys.includes(requestedUnitKey)) return false
+      if (!allowed.size) return true
+      if (!row.unitKeys.length) return true
+      return row.unitKeys.some((key) => allowed.has(key))
+    })
+    .map(({ unitKeys, ...row }) => row)
   return { data }
 }
 
@@ -202,17 +230,12 @@ function buildScheduleWhere(params) {
     clauses.push('date like ?')
     values.push(`${params.month}-%`)
   }
-  if (params.allowedUnits && params.allowedUnits.length) {
-    const placeholders = params.allowedUnits.map(() => '?').join(',')
-    clauses.push(`unit in (${placeholders})`)
-    values.push(...params.allowedUnits)
-  }
   const where = clauses.length ? `where ${clauses.join(' and ')}` : ''
   return { where, values }
 }
 
 async function handleSchedule(env, unit, month, actor) {
-  const { where, values } = buildScheduleWhere({ unit, month, allowedUnits: actor.allowedUnits })
+  const { where, values } = buildScheduleWhere({ unit, month })
   const scheduleRes = await env.DB.prepare(
     `select date, unit, professional_name as professional
      from schedule_entries
@@ -235,9 +258,9 @@ async function handleSchedule(env, unit, month, actor) {
   ).bind(...values).all()
 
   return {
-    schedule: scheduleRes.results || [],
-    closedDays: closedRes.results || [],
-    holidays: holidaysRes.results || []
+    schedule: (scheduleRes.results || []).filter((row) => isUnitVisibleForActor(actor, row.unit)),
+    closedDays: (closedRes.results || []).filter((row) => isUnitVisibleForActor(actor, row.unit)),
+    holidays: (holidaysRes.results || []).filter((row) => isUnitVisibleForActor(actor, row.unit))
   }
 }
 

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -405,8 +405,8 @@ export function EscalaProfissionaisModule() {
   return (
     <div className="escala-surface flex h-full min-h-0 flex-col gap-4 px-4 pb-6 pt-2">
       <Card className="glass-card escala-hero relative overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.45),_rgba(14,165,233,0.18),_transparent_70%)]" />
-        <CardHeader>
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.45),_rgba(14,165,233,0.18),_transparent_70%)]" />
+        <CardHeader className="relative z-10">
           <div className="relative flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <CardTitle className="text-white">Escala de Profissionais</CardTitle>
@@ -434,7 +434,7 @@ export function EscalaProfissionaisModule() {
             </div>
           </div>
         </CardHeader>
-        <CardContent className="flex flex-col gap-4">
+        <CardContent className="relative z-10 flex flex-col gap-4">
           <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
             <div className="space-y-1">
               <div className="text-xs uppercase tracking-[0.2em] text-slate-300/70">Unidade</div>

--- a/frontend/functions/api/escala/[[path]].ts
+++ b/frontend/functions/api/escala/[[path]].ts
@@ -128,6 +128,20 @@ function isValidIsoDate(value: unknown): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(String(value || ''))
 }
 
+function normalizeUnitKey(value: unknown): string {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .trim()
+}
+
+function getAllowedUnitKeySet(actor: EscalaActor): Set<string> {
+  const raw = Array.isArray(actor.allowedUnits) ? actor.allowedUnits : []
+  return new Set(raw.map((unit) => normalizeUnitKey(unit)).filter(Boolean))
+}
+
 function sanitizeCsvNames(input: unknown): string[] {
   if (Array.isArray(input)) {
     return input
@@ -232,9 +246,11 @@ function getEscalaLocalStore(): EscalaLocalStore {
 }
 
 function canUseUnit(actor: EscalaActor, unit: string): boolean {
-  const allowed = Array.isArray(actor.allowedUnits) ? actor.allowedUnits.filter(Boolean) : []
-  if (!allowed.length) return true
-  return allowed.includes(unit)
+  const requested = normalizeUnitKey(unit)
+  if (!requested) return true
+  const allowed = getAllowedUnitKeySet(actor)
+  if (!allowed.size) return true
+  return allowed.has(requested)
 }
 
 function visibleByAllowedUnits<T extends { unit: string }>(rows: T[], actor: EscalaActor): T[] {
@@ -493,8 +509,9 @@ async function handleLocalEscalaRequest(
   }
 
   if (rest === '/professionals' && method === 'GET') {
+    const requestedUnitKey = normalizeUnitKey(unit)
     const visible = store.professionals.filter((prof) => {
-      if (unit && prof.units.length && !prof.units.includes(unit)) return false
+      if (requestedUnitKey && prof.units.length && !prof.units.some((u) => normalizeUnitKey(u) === requestedUnitKey)) return false
       if (!prof.units.length) return true
       return prof.units.some((u) => canUseUnit(actor, u))
     })


### PR DESCRIPTION
## Summary
- make the Escala hero overlay ignore pointer events so controls stay clickable
- normalize unit matching in `escala-api` auth filtering (`novo-hamburgo` == `Novo Hamburgo`)
- apply the same unit-normalization logic in the local Pages Escala proxy/mock for parity

## Validation
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `cd frontend && E2E_BASE_URL=http://127.0.0.1:5174 npx playwright test e2e/escala-module.spec.ts`
- local proxy smoke: `GET /api/escala/_proxy-status`
