### PR TITLE
fix(atendimento): unificar threads do WhatsApp + fallback automático de rede

### DIFF
--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -4573,16 +4573,41 @@ function normalizePlatform(raw) {
 
 function extractPhoneFromJid(remoteJid) {
     if (!remoteJid) return ''
-    const value = String(remoteJid)
-    if (value.includes('@')) return value.split('@')[0]
-    return value
+    const value = String(remoteJid).trim()
+    if (!value) return ''
+    if (value.includes('@g.us') || value.includes('@broadcast')) {
+        return value.includes('@') ? value.split('@')[0] : value
+    }
+    const localPart = value.includes('@') ? value.split('@')[0] : value
+    return localPart.split(':')[0].replace(/\D/g, '')
 }
 
 function normalizeWhatsAppJid(value) {
     const raw = String(value || '').trim()
     if (!raw) return ''
+    if (raw.includes('@g.us') || raw.includes('@broadcast')) return raw
+    const localPart = raw.includes('@') ? raw.split('@')[0] : raw
+    const normalizedLocal = localPart.split(':')[0].replace(/\D/g, '')
+    if (normalizedLocal) return `${normalizedLocal}@s.whatsapp.net`
     if (raw.includes('@')) return raw
     return `${raw}@s.whatsapp.net`
+}
+
+function resolveChatConversationJid(chat) {
+    const candidates = [
+        chat?.remoteJid,
+        chat?.id,
+        chat?.chatId,
+        chat?.jid,
+        chat?.lastMessage?.key?.remoteJid,
+        chat?.lastMessage?.key?.participant,
+        chat?.lastMessage?.participant
+    ]
+    for (const candidate of candidates) {
+        const normalized = normalizeWhatsAppJid(candidate)
+        if (normalized) return normalized
+    }
+    return ''
 }
 
 function normalizeEvolutionTimestamp(value) {
@@ -4719,11 +4744,8 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
         if (USE_EVOLUTION_ORCHESTRATOR) {
             const data = await evolutionOrchestrator.fetchChats(channel, { limit, offset })
             const chats = Array.isArray(data) ? data : (data?.chats || data?.data || [])
-            const items = chats.map((chat) => {
-                const rawRemoteJid = chat.remoteJid || chat.id || chat.chatId || ''
-                const remoteJid = rawRemoteJid && String(rawRemoteJid).includes('@')
-                    ? String(rawRemoteJid)
-                    : (rawRemoteJid ? `${rawRemoteJid}@s.whatsapp.net` : '')
+            const mapped = chats.map((chat) => {
+                const remoteJid = resolveChatConversationJid(chat)
                 const lastMessageText = extractEvolutionMessageText(chat.lastMessage?.message || chat.lastMessage)
                 const updatedAt = normalizeEvolutionTimestamp(chat.updatedAt || chat.lastMessage?.messageTimestamp)
                 const profilePic = chat.profilePicUrl || chat.profilePictureUrl || chat.avatarUrl || chat.avatar || chat.imgUrl || chat.pictureUrl || chat.photoUrl || null
@@ -4738,6 +4760,33 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                     unreadCount: chat.unreadCount ?? chat.unreadMessages ?? 0
                 }
             }).filter((item) => item.conversationId)
+
+            const dedupedMap = new Map()
+            for (const item of mapped) {
+                const key = normalizeWhatsAppJid(item.conversationId || item.phone)
+                const previous = dedupedMap.get(key)
+                if (!previous) {
+                    dedupedMap.set(key, {
+                        ...item,
+                        conversationId: key,
+                        phone: extractPhoneFromJid(key)
+                    })
+                    continue
+                }
+                const prevUpdatedAt = Date.parse(previous.updatedAt || '') || 0
+                const currentUpdatedAt = Date.parse(item.updatedAt || '') || 0
+                const newest = currentUpdatedAt >= prevUpdatedAt ? item : previous
+                dedupedMap.set(key, {
+                    ...previous,
+                    ...newest,
+                    conversationId: key,
+                    phone: extractPhoneFromJid(key),
+                    unreadCount: Number(previous.unreadCount || 0) + Number(item.unreadCount || 0)
+                })
+            }
+
+            const items = Array.from(dedupedMap.values())
+                .sort((a, b) => (Date.parse(b.updatedAt || '') || 0) - (Date.parse(a.updatedAt || '') || 0))
             const hasMore = items.length >= limit
             return res.json({ success: true, items, meta: { limit, offset, hasMore } })
         }
@@ -4777,12 +4826,12 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/message
             const records = data?.messages?.records || []
                 const items = records.map((record) => {
                     const fromMe = !!record?.key?.fromMe
-                    const jid = record?.key?.remoteJid || remoteJid
+                    const jid = normalizeWhatsAppJid(record?.key?.remoteJid || remoteJid)
                     const meta = extractEvolutionMessageMeta(record?.message)
                     const replyTo = extractEvolutionReplyMeta(record)
                     return {
                         id: record?.id || record?.key?.id || `m_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-                        conversationId: jid,
+                        conversationId: normalizedRemoteJid || jid,
                         direction: fromMe ? 'outbound' : 'inbound',
                         type: meta.mediaType || record?.messageType || record?.type || 'text',
                         text: meta.text || extractEvolutionMessageText(record?.message),

--- a/backend/apps/crm-api/services/evolutionOrchestrator.js
+++ b/backend/apps/crm-api/services/evolutionOrchestrator.js
@@ -37,6 +37,10 @@ function normalizeRemoteJid(remoteJid) {
   if (!remoteJid) return ''
   const value = String(remoteJid).trim()
   if (!value) return ''
+  if (value.includes('@g.us') || value.includes('@broadcast')) return value
+  const localPart = value.includes('@') ? value.split('@')[0] : value
+  const normalizedLocal = localPart.split(':')[0].replace(/\D/g, '')
+  if (normalizedLocal) return `${normalizedLocal}@s.whatsapp.net`
   if (value.includes('@')) return value
   return `${value}@s.whatsapp.net`
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1556,11 +1556,11 @@ export default function AppFunctionalNeatlab() {
                         </header>
 
                         {/* Premium Main Content */}
-                        <main className={`flex-1 p-8 relative ${active === 'atendimento' ? 'overflow-hidden' : 'overflow-auto'}`}>
+                        <main className={`flex-1 p-8 relative ${active === 'atendimento' ? 'overflow-hidden flex min-h-0 flex-col' : 'overflow-auto'}`}>
                             {/* Content Background */}
                             <div className="absolute inset-0 bg-white/[0.02] backdrop-blur-sm"></div>
 
-                            <div className="relative z-10">
+                            <div className={`relative z-10 ${active === 'atendimento' ? 'flex h-full min-h-0 flex-col' : ''}`}>
                                 <div className="hidden">{search}</div>
                                 <ErrorBoundary>
                                     <Suspense fallback={
@@ -1571,7 +1571,7 @@ export default function AppFunctionalNeatlab() {
                                             </div>
                                         </div>
                                     }>
-                                    <div className="animate-fade-in">
+                                    <div className={`animate-fade-in ${active === 'atendimento' ? 'flex h-full min-h-0 flex-col' : ''}`}>
                                         {mountedModuleKeys
                                             .map((key) => permittedModulesSorted.find((m) => m.key === key))
                                             .filter((m) => Boolean(m) && UNLOCKED_MODULE_KEYS.has((m as any).key))
@@ -1579,7 +1579,7 @@ export default function AppFunctionalNeatlab() {
                                                 const moduleEntry = m as (typeof modules)[number]
                                                 const isActive = moduleEntry.key === active
                                                 return (
-                                                    <div key={moduleEntry.key} hidden={!isActive}>
+                                                    <div key={moduleEntry.key} hidden={!isActive} className={active === 'atendimento' ? 'h-full min-h-0' : undefined}>
                                                         {moduleEntry.component}
                                                     </div>
                                                 )

--- a/frontend/AtendimentoModule.tsx
+++ b/frontend/AtendimentoModule.tsx
@@ -36,12 +36,14 @@ function TabShell({ title, children }: { title: string; children: React.ReactNod
     >
       <Suspense
         fallback={
-          <div className="glass-morphism rounded-2xl p-6 border border-white/20 animate-pulse text-white">
+          <div className="glass-morphism h-full min-h-0 rounded-2xl p-6 border border-white/20 animate-pulse text-white">
             <LoadingPercentText label="Carregando módulo" className="text-white/90" showPercent={false} />
           </div>
         }
       >
-        {children}
+        <div className="h-full min-h-0">
+          {children}
+        </div>
       </Suspense>
     </ErrorBoundary>
   )

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -215,24 +215,6 @@ function extractPhoneFromId(value?: string | null) {
   return digits.length >= MIN_PHONE_LEN ? digits : ''
 }
 
-function normalizeName(value?: string | null) {
-  return String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/gi, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
-function namesMatch(a?: string | null, b?: string | null) {
-  const na = normalizeName(a)
-  const nb = normalizeName(b)
-  if (!na || !nb) return true
-  const tokensA = na.split(' ').filter((t) => t.length >= 3)
-  const tokensB = nb.split(' ').filter((t) => t.length >= 3)
-  if (!tokensA.length || !tokensB.length) return true
-  return tokensA.some((t) => tokensB.includes(t))
-}
-
 function isLikelyWhatsAppJid(value?: string | null) {
   const raw = String(value || '').trim().toLowerCase()
   if (!raw) return false
@@ -245,6 +227,10 @@ function isLikelyWhatsAppJid(value?: string | null) {
 function normalizeWhatsAppJid(value?: string | null) {
   const raw = String(value || '').trim()
   if (!raw) return ''
+  if (raw.includes('@g.us') || raw.includes('@broadcast')) return raw
+  const localPart = raw.includes('@') ? raw.split('@')[0] : raw
+  const normalizedLocal = localPart.split(':')[0].replace(/\D+/g, '')
+  if (normalizedLocal) return `${normalizedLocal}@s.whatsapp.net`
   if (raw.includes('@')) return raw
   const digits = normalizePhone(raw)
   if (!digits) return raw
@@ -2012,17 +1998,19 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       if (phoneKey && indexByPhone.has(phoneKey)) {
         const idx = indexByPhone.get(phoneKey)!
         const existing = merged[idx]
-        if (namesMatch(existing?.leadName || existing?.name, item.name)) {
-          merged[idx] = {
-            ...item,
-            leadId: existing.leadId,
-            stage: existing.stage,
-            leadUpdatedAt: existing.leadUpdatedAt,
-            leadName: existing.leadName,
-            leadPhone: existing.leadPhone,
-          }
-        } else {
-          pushWithIndex(item, phoneKey)
+        const existingName = String(existing?.name || '')
+        const incomingName = String(item?.name || '')
+        const useIncomingName = incomingName && !isLikelyWhatsAppJid(incomingName)
+        const useExistingName = existingName && !isLikelyWhatsAppJid(existingName)
+        merged[idx] = {
+          ...existing,
+          ...item,
+          name: useIncomingName ? incomingName : (useExistingName ? existingName : incomingName || existingName),
+          leadId: existing.leadId,
+          stage: existing.stage,
+          leadUpdatedAt: existing.leadUpdatedAt,
+          leadName: existing.leadName,
+          leadPhone: existing.leadPhone,
         }
       } else {
         pushWithIndex(item, phoneKey)
@@ -2040,21 +2028,17 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       if (phoneKey && indexByPhone.has(phoneKey)) {
         const idx = indexByPhone.get(phoneKey)!
         const current = merged[idx]
-        if (namesMatch(current?.name, item.name)) {
-          const currentTs = current.updatedAt ? new Date(current.updatedAt).getTime() : 0
-          const leadTs = item.updatedAt ? new Date(item.updatedAt).getTime() : 0
-          merged[idx] = {
-            ...current,
-            name: current.name || item.name,
-            leadId: item.leadId,
-            stage: item.stage,
-            leadUpdatedAt: item.leadUpdatedAt || current.leadUpdatedAt,
-            leadName: item.name,
-            leadPhone: item.phone,
-            updatedAt: leadTs > currentTs ? item.updatedAt : current.updatedAt,
-          }
-        } else {
-          pushWithIndex(item, phoneKey)
+        const currentTs = current.updatedAt ? new Date(current.updatedAt).getTime() : 0
+        const leadTs = item.updatedAt ? new Date(item.updatedAt).getTime() : 0
+        merged[idx] = {
+          ...current,
+          name: current.name || item.name,
+          leadId: item.leadId,
+          stage: item.stage,
+          leadUpdatedAt: item.leadUpdatedAt || current.leadUpdatedAt,
+          leadName: item.name,
+          leadPhone: item.phone,
+          updatedAt: leadTs > currentTs ? item.updatedAt : current.updatedAt,
         }
       } else {
         pushWithIndex(item, phoneKey)
@@ -2158,8 +2142,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
             </span>
           </div>
         ) : null}
-        <div className="grid flex-1 min-h-0 grid-cols-1 gap-4 xl:grid-cols-12">
-          <Card className="glass-card xl:col-span-4 flex min-h-0 flex-col overflow-hidden">
+        <div className="grid flex-1 min-h-0 grid-cols-1 grid-rows-[minmax(0,1fr)] gap-4 overflow-hidden xl:grid-cols-12">
+          <Card className="glass-card xl:col-span-4 flex h-full min-h-0 flex-col overflow-hidden">
                 <CardContent className="flex min-h-0 flex-col gap-2 pt-4">
                   <div data-testid="conversation-filters" className="flex flex-wrap items-center gap-1.5 rounded-xl border border-white/15 bg-white/10 p-1.5">
                     {[
@@ -2193,8 +2177,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="h-9 bg-white/10 border-white/15 text-white placeholder:text-blue-100/55"
                   />
-                      <div data-testid="conversation-scroll" className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-0">
-                        <div className="space-y-1.5 pb-1 pr-2">
+                      <div data-testid="conversation-scroll" className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-1">
+                        <div className="space-y-1.5 pb-1">
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>
                       )}
@@ -2215,7 +2199,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                         <div
                           key={`${conv.conversationId}-${conv.channel ?? conv.platform ?? ''}`}
                           data-testid="conversation-item"
-                          className={`mx-0.5 box-border w-[calc(100%-4px)] min-w-0 p-3 rounded-xl border cursor-pointer transition-colors hover:bg-white/10 ${
+                          className={`box-border w-full min-w-0 p-3 rounded-xl border cursor-pointer transition-colors hover:bg-white/10 ${
                             selectedConversation?.conversationId === conv.conversationId &&
                             selectedConversation?.channel === conv.channel
                               ? 'border-blue-500/70 bg-blue-500/15'
@@ -2283,7 +2267,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     </CardContent>
                   </Card>
 
-          <Card className="glass-card xl:col-span-8 flex min-h-0 flex-col overflow-hidden">
+          <Card className="glass-card xl:col-span-8 flex h-full min-h-0 flex-col overflow-hidden">
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between gap-3">
                     <CardTitle className="text-lg text-white">
@@ -2448,9 +2432,53 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                     : undefined)
                                 const showReactionActions = selectedConversation?.platform !== 'lead' && selectedConversation?.platform !== 'instagram'
                                 return (
-                                  <div key={msg.id} className={`flex ${outbound ? 'justify-end' : 'justify-start'}`}>
+                                  <div key={msg.id} className={`group flex items-end gap-2 ${outbound ? 'justify-end' : 'justify-start'}`}>
+                                    {showReactionActions && outbound ? (
+                                      <div className="relative flex items-center gap-1 self-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                        <Button
+                                          type="button"
+                                          variant="ghost"
+                                          className="h-6 rounded-full border border-white/15 bg-white/10 px-2 text-[10px] text-blue-100 hover:bg-white/20"
+                                          onClick={() => openReplyComposer(msg)}
+                                          aria-label="Responder mensagem"
+                                        >
+                                          <ArrowBendUpLeft className="h-3.5 w-3.5" />
+                                          Reply
+                                        </Button>
+                                        <div className="relative">
+                                          <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            className="h-6 w-6 rounded-full border border-white/15 bg-white/10 text-blue-100 hover:bg-white/20"
+                                            onClick={() => setReactionPickerMessageId((current) => current === messageId ? null : messageId)}
+                                            aria-label="Reagir mensagem"
+                                          >
+                                            <Smiley className="h-3.5 w-3.5" />
+                                          </Button>
+                                          {reactionPickerMessageId === messageId ? (
+                                            <div className="absolute right-0 top-7 z-20 flex items-center gap-1 rounded-full border border-white/10 bg-slate-950/95 p-1 shadow-lg">
+                                              {reactionOptions.map((emoji) => (
+                                                <button
+                                                  key={`${messageId}-${emoji}`}
+                                                  type="button"
+                                                  className="h-7 w-7 rounded-full hover:bg-white/10"
+                                                  onClick={() => {
+                                                    void toggleReaction(msg, emoji)
+                                                    setReactionPickerMessageId(null)
+                                                  }}
+                                                  disabled={reactionBusyKey === `${messageId}:${emoji}`}
+                                                >
+                                                  {emoji}
+                                                </button>
+                                              ))}
+                                            </div>
+                                          ) : null}
+                                        </div>
+                                      </div>
+                                    ) : null}
                                     <div
-                                      className={`group max-w-[88%] md:max-w-[75%] p-3 rounded-lg border ${outbound ? 'border-blue-300/20 bg-blue-500/35 text-white' : 'border-white/10 bg-white/10 text-blue-100'}`}
+                                      className={`max-w-[88%] md:max-w-[75%] p-3 rounded-lg border ${outbound ? 'border-blue-300/20 bg-blue-500/35 text-white' : 'border-white/10 bg-white/10 text-blue-100'}`}
                                       onDoubleClick={() => {
                                         openReplyComposer(msg)
                                       }}
@@ -2497,54 +2525,54 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                           ))}
                                         </div>
                                       ) : null}
-                                      {showReactionActions ? (
-                                        <div className="mt-2 flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                                          <Button
-                                            type="button"
-                                            variant="ghost"
-                                            className="h-6 rounded-full border border-white/15 bg-white/10 px-2 text-[10px] text-blue-100 hover:bg-white/20"
-                                            onClick={() => openReplyComposer(msg)}
-                                            aria-label="Responder mensagem"
-                                          >
-                                            <ArrowBendUpLeft className="h-3.5 w-3.5" />
-                                            Reply
-                                          </Button>
-                                          <div className="relative">
-                                            <Button
-                                              type="button"
-                                              size="icon"
-                                              variant="ghost"
-                                              className="h-6 w-6 rounded-full border border-white/15 bg-white/10 text-blue-100 hover:bg-white/20"
-                                              onClick={() => setReactionPickerMessageId((current) => current === messageId ? null : messageId)}
-                                              aria-label="Reagir mensagem"
-                                            >
-                                              <Smiley className="h-3.5 w-3.5" />
-                                            </Button>
-                                            {reactionPickerMessageId === messageId ? (
-                                              <div className="absolute right-0 top-7 z-20 flex items-center gap-1 rounded-full border border-white/10 bg-slate-950/95 p-1 shadow-lg">
-                                                {reactionOptions.map((emoji) => (
-                                                  <button
-                                                    key={`${messageId}-${emoji}`}
-                                                    type="button"
-                                                    className="h-7 w-7 rounded-full hover:bg-white/10"
-                                                    onClick={() => {
-                                                      void toggleReaction(msg, emoji)
-                                                      setReactionPickerMessageId(null)
-                                                    }}
-                                                    disabled={reactionBusyKey === `${messageId}:${emoji}`}
-                                                  >
-                                                    {emoji}
-                                                  </button>
-                                                ))}
-                                              </div>
-                                            ) : null}
-                                          </div>
-                                        </div>
-                                      ) : null}
                                       <div className={`text-xs mt-1 ${outbound ? 'text-blue-100/80' : 'text-blue-100/60'}`}>
                                         {ts ? new Date(ts).toLocaleTimeString() : ''}
                                       </div>
                                     </div>
+                                    {showReactionActions && !outbound ? (
+                                      <div className="relative flex items-center gap-1 self-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                        <Button
+                                          type="button"
+                                          variant="ghost"
+                                          className="h-6 rounded-full border border-white/15 bg-white/10 px-2 text-[10px] text-blue-100 hover:bg-white/20"
+                                          onClick={() => openReplyComposer(msg)}
+                                          aria-label="Responder mensagem"
+                                        >
+                                          <ArrowBendUpLeft className="h-3.5 w-3.5" />
+                                          Reply
+                                        </Button>
+                                        <div className="relative">
+                                          <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            className="h-6 w-6 rounded-full border border-white/15 bg-white/10 text-blue-100 hover:bg-white/20"
+                                            onClick={() => setReactionPickerMessageId((current) => current === messageId ? null : messageId)}
+                                            aria-label="Reagir mensagem"
+                                          >
+                                            <Smiley className="h-3.5 w-3.5" />
+                                          </Button>
+                                          {reactionPickerMessageId === messageId ? (
+                                            <div className="absolute left-0 top-7 z-20 flex items-center gap-1 rounded-full border border-white/10 bg-slate-950/95 p-1 shadow-lg">
+                                              {reactionOptions.map((emoji) => (
+                                                <button
+                                                  key={`${messageId}-${emoji}`}
+                                                  type="button"
+                                                  className="h-7 w-7 rounded-full hover:bg-white/10"
+                                                  onClick={() => {
+                                                    void toggleReaction(msg, emoji)
+                                                    setReactionPickerMessageId(null)
+                                                  }}
+                                                  disabled={reactionBusyKey === `${messageId}:${emoji}`}
+                                                >
+                                                  {emoji}
+                                                </button>
+                                              ))}
+                                            </div>
+                                          ) : null}
+                                        </div>
+                                      </div>
+                                    ) : null}
                                   </div>
                                   )
                                 })}

--- a/scripts/check-whatsapp-stack.sh
+++ b/scripts/check-whatsapp-stack.sh
@@ -12,6 +12,29 @@ if [[ -f "$N8N_ENV" ]]; then
   set +a
 fi
 
+NETWORK_FALLBACK_PROBE_URL="${NETWORK_FALLBACK_PROBE_URL:-https://cp.cloudflare.com/generate_204}"
+NETWORK_FALLBACK_STATE="/Users/jubenitogarcia/Automation/n8n/health/network-fallback.state"
+
+detect_wifi_interface() {
+  /usr/sbin/networksetup -listallhardwareports 2>/dev/null \
+    | awk '/Hardware Port: Wi-Fi/{getline; if($1=="Device:"){print $2; exit}}'
+}
+
+current_wifi_ssid() {
+  local iface="${1:-}"
+  if [[ -z "$iface" ]]; then
+    return 0
+  fi
+  local output
+  output="$(/usr/sbin/networksetup -getairportnetwork "$iface" 2>/dev/null || true)"
+  if printf '%s' "$output" | grep -qi "not associated"; then
+    return 0
+  fi
+  if [[ "$output" == *": "* ]]; then
+    printf '%s' "${output#*: }"
+  fi
+}
+
 echo "== Processos =="
 ps aux | grep -Ei "cloudflared|n8n start|crm-api/server.js|evolution-api" | grep -v grep || true
 
@@ -45,6 +68,7 @@ launchctl list | grep -E "com.jubenito.n8n-evolution|com.skincos.cloudflared.cs|
 launchctl list | grep -E "com.skincos.evolution-api" || true
 launchctl list | grep -E "com.skincos.crm-api" || true
 launchctl list | grep -E "com.skincos.keepawake.agent" || true
+launchctl list | grep -E "com.skincos.network-fallback" || true
 
 echo
 echo "== energia/awake =="
@@ -87,4 +111,22 @@ if [[ -n "${ALERT_WEBHOOK_URL:-}" ]] || [[ -n "${ALERT_EMAIL_TO:-}" ]]; then
   echo "           silêncio=${ALERT_QUIET_START_HOUR:-23}-${ALERT_QUIET_END_HOUR:-7}, limite diário=${ALERT_MAX_REMINDERS_PER_DAY:-6}"
 else
   echo "Canal de alerta NÃO configurado (use ALERT_WEBHOOK_URL ou SMTP + ALERT_EMAIL_TO no /Users/jubenitogarcia/Automation/n8n/.env)."
+fi
+
+echo
+echo "== fallback de rede =="
+WIFI_IFACE="$(detect_wifi_interface || true)"
+WIFI_SSID="$(current_wifi_ssid "$WIFI_IFACE" || true)"
+echo "Wi-Fi interface: ${WIFI_IFACE:-n/d}"
+echo "Wi-Fi SSID atual: ${WIFI_SSID:-n/d}"
+if curl -fsS -m 6 -o /dev/null "$NETWORK_FALLBACK_PROBE_URL"; then
+  echo "Probe internet: OK ($NETWORK_FALLBACK_PROBE_URL)"
+else
+  echo "Probe internet: FAIL ($NETWORK_FALLBACK_PROBE_URL)"
+fi
+if [[ -f "$NETWORK_FALLBACK_STATE" ]]; then
+  echo "Estado daemon:"
+  sed -n '1,12p' "$NETWORK_FALLBACK_STATE"
+else
+  echo "Estado daemon: arquivo não encontrado ($NETWORK_FALLBACK_STATE)"
 fi

--- a/scripts/network-fallback-daemon.sh
+++ b/scripts/network-fallback-daemon.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HEALTH_DIR="/Users/jubenitogarcia/Automation/n8n/health"
+STATE_FILE="$HEALTH_DIR/network-fallback.state"
+
+NETWORK_FALLBACK_ENABLED="${NETWORK_FALLBACK_ENABLED:-true}"
+NETWORK_FALLBACK_CHECK_INTERVAL_SEC="${NETWORK_FALLBACK_CHECK_INTERVAL_SEC:-30}"
+NETWORK_FALLBACK_PROBE_URL="${NETWORK_FALLBACK_PROBE_URL:-https://cp.cloudflare.com/generate_204}"
+NETWORK_FALLBACK_PROBE_TIMEOUT_SEC="${NETWORK_FALLBACK_PROBE_TIMEOUT_SEC:-6}"
+NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC="${NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC:-120}"
+NETWORK_FALLBACK_SSIDS="${NETWORK_FALLBACK_SSIDS:-}"
+NETWORK_FALLBACK_WIFI_INTERFACE="${NETWORK_FALLBACK_WIFI_INTERFACE:-}"
+NETWORK_FALLBACK_AUTO_DETECT_IPHONE="${NETWORK_FALLBACK_AUTO_DETECT_IPHONE:-true}"
+NETWORK_FALLBACK_AUTO_PATTERN="${NETWORK_FALLBACK_AUTO_PATTERN:-iPhone,Hotspot,Android,Galaxy,Pixel}"
+NETWORK_FALLBACK_PRIMARY_SSID="${NETWORK_FALLBACK_PRIMARY_SSID:-}"
+NETWORK_FALLBACK_PRIMARY_PASSWORD="${NETWORK_FALLBACK_PRIMARY_PASSWORD:-}"
+
+mkdir -p "$HEALTH_DIR"
+
+to_bool() {
+  local value="${1:-false}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  [[ "$value" == "1" || "$value" == "true" || "$value" == "yes" || "$value" == "on" ]]
+}
+
+sanitize_int() {
+  local value="${1:-}" default_value="${2:-0}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo "$default_value"
+  fi
+}
+
+trim() {
+  local input="${1:-}"
+  input="${input#"${input%%[![:space:]]*}"}"
+  input="${input%"${input##*[![:space:]]}"}"
+  printf '%s' "$input"
+}
+
+log_warn() {
+  printf '%s [network-fallback][WARN] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
+}
+
+log_error() {
+  printf '%s [network-fallback][ERROR] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
+}
+
+NETWORK_FALLBACK_CHECK_INTERVAL_SEC="$(sanitize_int "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC" "30")"
+NETWORK_FALLBACK_PROBE_TIMEOUT_SEC="$(sanitize_int "$NETWORK_FALLBACK_PROBE_TIMEOUT_SEC" "6")"
+NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC="$(sanitize_int "$NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC" "120")"
+
+if (( NETWORK_FALLBACK_CHECK_INTERVAL_SEC < 10 )); then
+  NETWORK_FALLBACK_CHECK_INTERVAL_SEC=10
+fi
+if (( NETWORK_FALLBACK_PROBE_TIMEOUT_SEC < 2 )); then
+  NETWORK_FALLBACK_PROBE_TIMEOUT_SEC=2
+fi
+if (( NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC < 30 )); then
+  NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC=30
+fi
+
+detect_wifi_interface() {
+  if [[ -n "$NETWORK_FALLBACK_WIFI_INTERFACE" ]]; then
+    printf '%s' "$NETWORK_FALLBACK_WIFI_INTERFACE"
+    return 0
+  fi
+
+  /usr/sbin/networksetup -listallhardwareports 2>/dev/null \
+    | awk '/Hardware Port: Wi-Fi/{getline; if($1=="Device:"){print $2; exit}}'
+}
+
+current_ssid() {
+  local iface="$1"
+  local output
+  output="$(/usr/sbin/networksetup -getairportnetwork "$iface" 2>/dev/null || true)"
+  if printf '%s' "$output" | grep -qi "not associated"; then
+    return 0
+  fi
+  if [[ "$output" == *": "* ]]; then
+    printf '%s' "${output#*: }"
+  fi
+}
+
+internet_ok() {
+  /usr/bin/curl -fsS -m "$NETWORK_FALLBACK_PROBE_TIMEOUT_SEC" -o /dev/null "$NETWORK_FALLBACK_PROBE_URL"
+}
+
+append_unique_candidate() {
+  local candidate="$1"
+  if [[ -z "$candidate" ]]; then
+    return 0
+  fi
+  local existing
+  for existing in "${CANDIDATE_SSIDS[@]:-}"; do
+    if [[ "$existing" == "$candidate" ]]; then
+      return 0
+    fi
+  done
+  CANDIDATE_SSIDS+=("$candidate")
+}
+
+build_candidates() {
+  local iface="$1"
+  local pattern_regex
+  pattern_regex="$(printf '%s' "$NETWORK_FALLBACK_AUTO_PATTERN" | tr ',' '|')"
+  CANDIDATE_SSIDS=()
+
+  if [[ -n "$NETWORK_FALLBACK_PRIMARY_SSID" ]]; then
+    append_unique_candidate "$(trim "$NETWORK_FALLBACK_PRIMARY_SSID")"
+  fi
+
+  local token
+  IFS=',;' read -r -a manual_tokens <<<"$NETWORK_FALLBACK_SSIDS"
+  for token in "${manual_tokens[@]:-}"; do
+    append_unique_candidate "$(trim "$token")"
+  done
+
+  if to_bool "$NETWORK_FALLBACK_AUTO_DETECT_IPHONE"; then
+    local preferred_ssid
+    while IFS= read -r preferred_ssid; do
+      preferred_ssid="$(trim "$preferred_ssid")"
+      if [[ -n "$preferred_ssid" ]] && printf '%s' "$preferred_ssid" | /usr/bin/grep -Eiq "$pattern_regex"; then
+        append_unique_candidate "$preferred_ssid"
+      fi
+    done < <(/usr/sbin/networksetup -listpreferredwirelessnetworks "$iface" 2>/dev/null | tail -n +2)
+  fi
+}
+
+connect_to_ssid() {
+  local iface="$1"
+  local ssid="$2"
+  /usr/sbin/networksetup -setairportpower "$iface" on >/dev/null 2>&1 || true
+  if [[ -n "$NETWORK_FALLBACK_PRIMARY_SSID" ]] \
+    && [[ "$ssid" == "$NETWORK_FALLBACK_PRIMARY_SSID" ]] \
+    && [[ -n "$NETWORK_FALLBACK_PRIMARY_PASSWORD" ]]; then
+    /usr/sbin/networksetup -setairportnetwork "$iface" "$ssid" "$NETWORK_FALLBACK_PRIMARY_PASSWORD" >/dev/null 2>&1
+  else
+    /usr/sbin/networksetup -setairportnetwork "$iface" "$ssid" >/dev/null 2>&1
+  fi
+}
+
+persist_state() {
+  local status="$1"
+  local iface="$2"
+  local ssid="$3"
+  local candidate_count="$4"
+  local message="$5"
+  local now_epoch
+  now_epoch="$(date +%s)"
+  cat >"$STATE_FILE" <<EOF
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+epoch=${now_epoch}
+status=${status}
+interface=${iface}
+current_ssid=${ssid}
+candidate_count=${candidate_count}
+last_switch_epoch=${LAST_SWITCH_EPOCH}
+check_interval_sec=${NETWORK_FALLBACK_CHECK_INTERVAL_SEC}
+probe_url=${NETWORK_FALLBACK_PROBE_URL}
+message=${message}
+EOF
+}
+
+LAST_SWITCH_EPOCH="$(grep -E '^last_switch_epoch=' "$STATE_FILE" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+LAST_SWITCH_EPOCH="$(sanitize_int "$LAST_SWITCH_EPOCH" "0")"
+LAST_FAILURE_LOG_EPOCH=0
+OFFLINE_NOTIFIED=false
+NO_CANDIDATE_NOTIFIED=false
+
+while true; do
+  if ! to_bool "$NETWORK_FALLBACK_ENABLED"; then
+    persist_state "disabled" "-" "-" "0" "network_fallback_disabled"
+    sleep 60
+    continue
+  fi
+
+  WIFI_IFACE="$(detect_wifi_interface || true)"
+  if [[ -z "$WIFI_IFACE" ]]; then
+    log_error "Interface Wi-Fi não encontrada."
+    persist_state "error" "-" "-" "0" "wifi_interface_not_found"
+    sleep "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC"
+    continue
+  fi
+
+  ACTIVE_SSID="$(current_ssid "$WIFI_IFACE" || true)"
+
+  if internet_ok; then
+    OFFLINE_NOTIFIED=false
+    NO_CANDIDATE_NOTIFIED=false
+    persist_state "online" "$WIFI_IFACE" "${ACTIVE_SSID:-none}" "0" "internet_ok"
+    sleep "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC"
+    continue
+  fi
+
+  if [[ "$OFFLINE_NOTIFIED" != "true" ]]; then
+    log_warn "Sem internet na interface ${WIFI_IFACE} (SSID: ${ACTIVE_SSID:-none}). Tentando fallback."
+    OFFLINE_NOTIFIED=true
+  fi
+
+  NOW_EPOCH="$(date +%s)"
+  if (( NOW_EPOCH - LAST_SWITCH_EPOCH < NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC )); then
+    persist_state "offline_cooldown" "$WIFI_IFACE" "${ACTIVE_SSID:-none}" "0" "cooldown_active"
+    sleep "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC"
+    continue
+  fi
+
+  build_candidates "$WIFI_IFACE"
+  CANDIDATE_COUNT="${#CANDIDATE_SSIDS[@]}"
+  if (( CANDIDATE_COUNT == 0 )); then
+    if [[ "$NO_CANDIDATE_NOTIFIED" != "true" ]]; then
+      log_error "Sem SSID candidato para fallback. Defina NETWORK_FALLBACK_SSIDS no /Users/jubenitogarcia/Automation/n8n/.env."
+      NO_CANDIDATE_NOTIFIED=true
+    fi
+    persist_state "offline_no_candidate" "$WIFI_IFACE" "${ACTIVE_SSID:-none}" "$CANDIDATE_COUNT" "no_candidate_ssids"
+    sleep "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC"
+    continue
+  fi
+
+  NO_CANDIDATE_NOTIFIED=false
+  CONNECTED=false
+  TARGET_SSID=""
+  for TARGET_SSID in "${CANDIDATE_SSIDS[@]}"; do
+    if connect_to_ssid "$WIFI_IFACE" "$TARGET_SSID"; then
+      sleep 4
+      ACTIVE_SSID="$(current_ssid "$WIFI_IFACE" || true)"
+      if internet_ok; then
+        LAST_SWITCH_EPOCH="$(date +%s)"
+        OFFLINE_NOTIFIED=false
+        LAST_FAILURE_LOG_EPOCH=0
+        log_warn "Fallback de internet ativo em '${ACTIVE_SSID:-$TARGET_SSID}'."
+        persist_state "fallback_connected" "$WIFI_IFACE" "${ACTIVE_SSID:-$TARGET_SSID}" "$CANDIDATE_COUNT" "fallback_ok"
+        CONNECTED=true
+        break
+      fi
+    fi
+  done
+
+  if [[ "$CONNECTED" != "true" ]]; then
+    if (( NOW_EPOCH - LAST_FAILURE_LOG_EPOCH >= NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC )); then
+      log_error "Falha ao recuperar internet via fallback (tentativas=${CANDIDATE_COUNT})."
+      LAST_FAILURE_LOG_EPOCH="$NOW_EPOCH"
+    fi
+    ACTIVE_SSID="$(current_ssid "$WIFI_IFACE" || true)"
+    persist_state "offline_retry_failed" "$WIFI_IFACE" "${ACTIVE_SSID:-none}" "$CANDIDATE_COUNT" "fallback_retry_failed"
+  fi
+
+  sleep "$NETWORK_FALLBACK_CHECK_INTERVAL_SEC"
+done

--- a/scripts/setup-network-fallback-service.sh
+++ b/scripts/setup-network-fallback-service.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UID_VALUE="$(id -u)"
+LABEL="com.skincos.network-fallback"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="/Users/jubenitogarcia/Automation/n8n/health"
+OUT_LOG="$LOG_DIR/network-fallback.out.log"
+ERR_LOG="$LOG_DIR/network-fallback.err.log"
+DAEMON_SCRIPT="/Users/jubenitogarcia/Automation/skincos/scripts/network-fallback-daemon.sh"
+N8N_ENV="/Users/jubenitogarcia/Automation/n8n/.env"
+
+if [[ -f "$N8N_ENV" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$N8N_ENV"
+  set +a
+fi
+
+NETWORK_FALLBACK_ENABLED="${NETWORK_FALLBACK_ENABLED:-true}"
+NETWORK_FALLBACK_CHECK_INTERVAL_SEC="${NETWORK_FALLBACK_CHECK_INTERVAL_SEC:-30}"
+NETWORK_FALLBACK_PROBE_URL="${NETWORK_FALLBACK_PROBE_URL:-https://cp.cloudflare.com/generate_204}"
+NETWORK_FALLBACK_PROBE_TIMEOUT_SEC="${NETWORK_FALLBACK_PROBE_TIMEOUT_SEC:-6}"
+NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC="${NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC:-120}"
+NETWORK_FALLBACK_SSIDS="${NETWORK_FALLBACK_SSIDS:-}"
+NETWORK_FALLBACK_WIFI_INTERFACE="${NETWORK_FALLBACK_WIFI_INTERFACE:-}"
+NETWORK_FALLBACK_AUTO_DETECT_IPHONE="${NETWORK_FALLBACK_AUTO_DETECT_IPHONE:-true}"
+NETWORK_FALLBACK_AUTO_PATTERN="${NETWORK_FALLBACK_AUTO_PATTERN:-iPhone,Hotspot,Android,Galaxy,Pixel}"
+NETWORK_FALLBACK_PRIMARY_SSID="${NETWORK_FALLBACK_PRIMARY_SSID:-}"
+NETWORK_FALLBACK_PRIMARY_PASSWORD="${NETWORK_FALLBACK_PRIMARY_PASSWORD:-}"
+
+mkdir -p "$HOME/Library/LaunchAgents"
+mkdir -p "$LOG_DIR"
+chmod +x "$DAEMON_SCRIPT"
+
+cat >"$PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>${DAEMON_SCRIPT}</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>StandardOutPath</key>
+  <string>${OUT_LOG}</string>
+  <key>StandardErrorPath</key>
+  <string>${ERR_LOG}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>NETWORK_FALLBACK_ENABLED</key>
+    <string>${NETWORK_FALLBACK_ENABLED}</string>
+    <key>NETWORK_FALLBACK_CHECK_INTERVAL_SEC</key>
+    <string>${NETWORK_FALLBACK_CHECK_INTERVAL_SEC}</string>
+    <key>NETWORK_FALLBACK_PROBE_URL</key>
+    <string>${NETWORK_FALLBACK_PROBE_URL}</string>
+    <key>NETWORK_FALLBACK_PROBE_TIMEOUT_SEC</key>
+    <string>${NETWORK_FALLBACK_PROBE_TIMEOUT_SEC}</string>
+    <key>NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC</key>
+    <string>${NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC}</string>
+    <key>NETWORK_FALLBACK_SSIDS</key>
+    <string>${NETWORK_FALLBACK_SSIDS}</string>
+    <key>NETWORK_FALLBACK_WIFI_INTERFACE</key>
+    <string>${NETWORK_FALLBACK_WIFI_INTERFACE}</string>
+    <key>NETWORK_FALLBACK_AUTO_DETECT_IPHONE</key>
+    <string>${NETWORK_FALLBACK_AUTO_DETECT_IPHONE}</string>
+    <key>NETWORK_FALLBACK_AUTO_PATTERN</key>
+    <string>${NETWORK_FALLBACK_AUTO_PATTERN}</string>
+    <key>NETWORK_FALLBACK_PRIMARY_SSID</key>
+    <string>${NETWORK_FALLBACK_PRIMARY_SSID}</string>
+    <key>NETWORK_FALLBACK_PRIMARY_PASSWORD</key>
+    <string>${NETWORK_FALLBACK_PRIMARY_PASSWORD}</string>
+  </dict>
+</dict>
+</plist>
+EOF
+
+if launchctl print "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1; then
+  launchctl bootout "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+fi
+
+launchctl bootstrap "gui/$UID_VALUE" "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl kickstart -k "gui/$UID_VALUE/$LABEL" >/dev/null 2>&1 || true
+
+echo "[network-fallback] Serviço aplicado: $LABEL"
+echo "[network-fallback] Plist: $PLIST_PATH"
+echo "[network-fallback] Probe: ${NETWORK_FALLBACK_PROBE_URL} (timeout ${NETWORK_FALLBACK_PROBE_TIMEOUT_SEC}s)"
+echo "[network-fallback] Check interval: ${NETWORK_FALLBACK_CHECK_INTERVAL_SEC}s | Cooldown: ${NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC}s"
+echo "[network-fallback] SSIDs manuais: ${NETWORK_FALLBACK_SSIDS:-<auto detect only>}"

--- a/scripts/setup-whatsapp-autostart.sh
+++ b/scripts/setup-whatsapp-autostart.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 UID_VALUE="$(id -u)"
 WATCHDOG_LABEL="com.skincos.whatsapp-watchdog"
+NETWORK_FALLBACK_LABEL="com.skincos.network-fallback"
 N8N_LABEL="com.jubenito.n8n-evolution"
 TUNNEL_LABEL="com.skincos.cloudflared.cs"
 EVOLUTION_LABEL="com.skincos.evolution-api"
@@ -48,8 +49,22 @@ upsert_env() {
     touch "$N8N_ENV_FILE"
   fi
   if grep -qE "^${key}=" "$N8N_ENV_FILE"; then
-    sed -i '' "s|^${key}=.*|${key}=${value}|" "$N8N_ENV_FILE"
+    local tmp_file
+    tmp_file="$(mktemp)"
+    awk -v key="$key" -v value="$value" 'BEGIN{updated=0} index($0, key"=")==1 {print key"="value; updated=1; next} {print} END{if(updated==0) print key"="value}' "$N8N_ENV_FILE" >"$tmp_file"
+    mv "$tmp_file" "$N8N_ENV_FILE"
   else
+    printf '\n%s=%s\n' "$key" "$value" >> "$N8N_ENV_FILE"
+  fi
+}
+
+upsert_env_if_missing() {
+  local key="$1"
+  local value="$2"
+  if [[ ! -f "$N8N_ENV_FILE" ]]; then
+    touch "$N8N_ENV_FILE"
+  fi
+  if ! grep -qE "^${key}=" "$N8N_ENV_FILE"; then
     printf '\n%s=%s\n' "$key" "$value" >> "$N8N_ENV_FILE"
   fi
 }
@@ -68,14 +83,35 @@ apply_power_defaults() {
   upsert_env "MAC_REQUIRE_PASSWORD_ON_LOCK" "true"
 }
 
+apply_network_defaults() {
+  upsert_env "NETWORK_FALLBACK_ENABLED" "true"
+  upsert_env "NETWORK_FALLBACK_CHECK_INTERVAL_SEC" "30"
+  upsert_env "NETWORK_FALLBACK_PROBE_URL" "https://cp.cloudflare.com/generate_204"
+  upsert_env "NETWORK_FALLBACK_PROBE_TIMEOUT_SEC" "6"
+  upsert_env "NETWORK_FALLBACK_SWITCH_COOLDOWN_SEC" "120"
+  upsert_env "NETWORK_FALLBACK_AUTO_DETECT_IPHONE" "true"
+  upsert_env "NETWORK_FALLBACK_AUTO_PATTERN" "iPhone,Hotspot,Android,Galaxy,Pixel"
+  upsert_env_if_missing "NETWORK_FALLBACK_SSIDS" ""
+  upsert_env_if_missing "NETWORK_FALLBACK_PRIMARY_SSID" ""
+  upsert_env_if_missing "NETWORK_FALLBACK_PRIMARY_PASSWORD" ""
+}
+
 chmod +x /Users/jubenitogarcia/Automation/n8n/scripts/ensure-whatsapp-stack.sh
 chmod +x /Users/jubenitogarcia/Automation/skincos/scripts/setup-mac-awake-service.sh
+chmod +x /Users/jubenitogarcia/Automation/skincos/scripts/setup-network-fallback-service.sh
+chmod +x /Users/jubenitogarcia/Automation/skincos/scripts/network-fallback-daemon.sh
 
 apply_power_defaults
+apply_network_defaults
 bash /Users/jubenitogarcia/Automation/skincos/scripts/setup-mac-awake-service.sh >/dev/null 2>&1
 if ! launchctl print "gui/$UID_VALUE/com.skincos.keepawake.agent" >/dev/null 2>&1; then
   echo "[setup] keepawake agent não carregou na primeira tentativa; retry com logs."
   bash /Users/jubenitogarcia/Automation/skincos/scripts/setup-mac-awake-service.sh
+fi
+bash /Users/jubenitogarcia/Automation/skincos/scripts/setup-network-fallback-service.sh >/dev/null 2>&1
+if ! launchctl print "gui/$UID_VALUE/$NETWORK_FALLBACK_LABEL" >/dev/null 2>&1; then
+  echo "[setup] network fallback não carregou na primeira tentativa; retry com logs."
+  bash /Users/jubenitogarcia/Automation/skincos/scripts/setup-network-fallback-service.sh
 fi
 
 bootstrap_if_missing "$N8N_LABEL" "$HOME/Library/LaunchAgents/com.jubenito.n8n-evolution.plist"
@@ -83,6 +119,7 @@ bootstrap_if_missing "$TUNNEL_LABEL" "$HOME/Library/LaunchAgents/com.skincos.clo
 bootstrap_if_missing "$EVOLUTION_LABEL" "$HOME/Library/LaunchAgents/com.skincos.evolution-api.plist"
 bootstrap_if_missing "$CRM_LABEL" "$HOME/Library/LaunchAgents/com.skincos.crm-api.plist"
 bootstrap_if_missing "$WATCHDOG_LABEL" "$HOME/Library/LaunchAgents/com.skincos.whatsapp-watchdog.plist"
+bootstrap_if_missing "$NETWORK_FALLBACK_LABEL" "$HOME/Library/LaunchAgents/com.skincos.network-fallback.plist"
 
 # Reload n8n job to apply updated EnvironmentVariables (N8N_MANAGE_EVOLUTION=0).
 if launchctl print "gui/$UID_VALUE/$N8N_LABEL" >/dev/null 2>&1; then
@@ -95,6 +132,7 @@ kickstart_job "$TUNNEL_LABEL"
 kickstart_job "$EVOLUTION_LABEL"
 kickstart_job "$CRM_LABEL"
 kickstart_job "$WATCHDOG_LABEL"
+kickstart_job "$NETWORK_FALLBACK_LABEL"
 
 for legacy in "${LEGACY_LABELS[@]}"; do
   disable_legacy "$legacy"


### PR DESCRIPTION
## Resumo
- corrige normalização de `conversationId`/JID para evitar separar mensagens inbound/outbound em conversas diferentes
- deduplica conversas por contato no endpoint do orchestrator
- ajusta layout do Atendimento para restaurar scroll interno da lista e do painel de mensagens
- move ações de reply/reação para fora do balão de mensagem
- adiciona daemon + launchd para fallback automático de internet para hotspot
- integra fallback de rede no setup e no check do stack

## Validação
- `node --check backend/apps/crm-api/server.js`
- `node --check backend/apps/crm-api/services/evolutionOrchestrator.js`
- `npm -C frontend run -s typecheck`
- smoke local via `/api/wa-orchestrator/channels/1/conversations` sem duplicação por telefone
