### PR TITLE
[codex] harden escala secret sync + worker auto deploy

### DIFF
--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -1,4 +1,4 @@
-name: Sync CRM Pages secret (Escala)
+name: Sync Escala auth secret (Pages + Worker)
 
 on:
   schedule:
@@ -20,43 +20,108 @@ jobs:
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
+          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
-            echo "Cloudflare secrets missing; cannot sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Cloudflare secrets missing (CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID)."
+            exit 1
           fi
           if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
-            echo "Missing GitHub secret ESCALA_ACTOR_HMAC_KEY; cannot sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
+            exit 1
+          fi
+          if [[ -z "${ESCALA_API_TARGET:-}" ]]; then
+            echo "::error::Missing GitHub variable ESCALA_API_TARGET."
+            exit 1
+          fi
+          if [[ -z "${ESCALA_API_TARGET_PREVIEW:-}" ]]; then
+            echo "::error::Missing GitHub variable ESCALA_API_TARGET_PREVIEW."
+            exit 1
           fi
           echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node
-        if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
+      - name: Checkout (for worker wrangler config)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v4
+
       - name: Sync Pages secret (Escala) by environment
-        if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ steps.guard.outputs.project }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
+          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           for env_name in production preview; do
             printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put ESCALA_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
+            target="$ESCALA_API_TARGET"
+            if [[ "$env_name" == "preview" ]]; then
+              target="$ESCALA_API_TARGET_PREVIEW"
+            fi
+            printf "%s" "$target" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
+            echo "Synced ESCALA_API_TARGET for env=$env_name"
           done
 
+      - name: Sync Worker secret (Escala API) by environment
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for worker env=production"
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml --env staging >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for worker env=staging"
+
+      - name: Verify Pages env var presence (Escala)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+        run: |
+          set -euo pipefail
+          curl -sS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${PROJECT}" \
+            > pages_project.json
+          python - <<'PY'
+          import json
+          with open("pages_project.json", "r", encoding="utf-8") as f:
+            payload = json.load(f)
+          if not payload.get("success"):
+            raise SystemExit(f"Cloudflare API returned success=false: {payload.get('errors') or payload}")
+          cfg = ((payload.get("result") or {}).get("deployment_configs") or {})
+          prod = ((cfg.get("production") or {}).get("env_vars") or {})
+          prev = ((cfg.get("preview") or {}).get("env_vars") or {})
+          missing = []
+          if "ESCALA_ACTOR_HMAC_KEY" not in prod:
+            missing.append("production")
+          if "ESCALA_ACTOR_HMAC_KEY" not in prev:
+            missing.append("preview")
+          if "ESCALA_API_TARGET" not in prod:
+            missing.append("production (ESCALA_API_TARGET)")
+          if "ESCALA_API_TARGET" not in prev:
+            missing.append("preview (ESCALA_API_TARGET)")
+          if missing:
+            raise SystemExit(f"Escala env vars ausentes em: {', '.join(missing)}")
+          print("ESCALA_ACTOR_HMAC_KEY e ESCALA_API_TARGET presentes em production/preview.")
+          PY
+
       - name: Force redeploy CRM Pages (apply escala secret)
-        if: ${{ steps.guard.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -104,9 +104,8 @@ jobs:
             exit 0
           fi
           if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "CRM API deploy not configured; skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+            exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -34,9 +34,8 @@ jobs:
             exit 0
           fi
           if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "CRM API deploy not configured; skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+            exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
@@ -102,4 +101,3 @@ jobs:
         with:
           key: crm-api-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/crm_api_deployed_sha.txt
-

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -34,9 +34,8 @@ jobs:
             exit 0
           fi
           if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "CRM API deploy not configured; skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+            exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-escala-api-reconcile.yml
+++ b/.github/workflows/deploy-escala-api-reconcile.yml
@@ -1,0 +1,161 @@
+name: Deploy Escala API Worker reconcile
+
+on:
+  schedule:
+    # Workaround: merges via automations can skip push-based deploy triggers.
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force redeploy even if current main SHA was already deployed."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: deploy-escala-api-reconcile-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Resolve flags
+        id: flags
+        run: |
+          set -euo pipefail
+          FORCE_RAW="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}"
+          FORCE="$(echo "${FORCE_RAW:-false}" | tr '[:upper:]' '[:lower:]' | xargs)"
+          if [[ "$FORCE" == "1" || "$FORCE" == "true" || "$FORCE" == "yes" || "$FORCE" == "on" ]]; then
+            echo "force=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Guard Escala deploy settings
+        id: guard
+        env:
+          ENABLE: ${{ vars.ENABLE_ESCALA_API_DEPLOY }}
+          ENABLE_STAGING: ${{ vars.ENABLE_ESCALA_API_DEPLOY_STAGING }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ "${ENABLE:-true}" != "true" ]]; then
+            echo "Deploy flag not enabled; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "::error::Cloudflare deploy secrets missing."
+            exit 1
+          fi
+          if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
+            echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
+            exit 1
+          fi
+          if [[ "${ENABLE_STAGING:-false}" == "true" ]]; then
+            echo "deploy_staging=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_staging=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Resolve target SHA
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: sha
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore deploy cache (skip if already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          key: escala-api-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/deployed_sha.txt
+
+      - name: Skip (already deployed)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit == 'true' && steps.flags.outputs.force != 'true' }}
+        run: |
+          set -euo pipefail
+          echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Sync Escala worker secret (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for production."
+
+      - name: Deploy Escala worker (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 deploy --config backend/apps/escala-api/wrangler.toml --keep-vars
+
+      - name: Sync Escala worker secret (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml --env staging >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for staging."
+
+      - name: Deploy Escala worker (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 deploy --config backend/apps/escala-api/wrangler.toml --env staging --keep-vars
+
+      - name: Smoke check Escala health
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H 'User-Agent: EscalaWorkerSmoke/1.0' https://escala-api.skincos.com.br/api/escala/health >/dev/null
+
+      - name: Mark deployed SHA
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        run: |
+          set -euo pipefail
+          mkdir -p deploy-state
+          echo "${{ steps.sha.outputs.sha }}" > deploy-state/deployed_sha.txt
+
+      - name: Save deploy cache
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        uses: actions/cache/save@v4
+        with:
+          key: escala-api-deploy-${{ steps.sha.outputs.sha }}
+          path: deploy-state/deployed_sha.txt
+

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -1,0 +1,103 @@
+name: Deploy Escala API Worker
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "backend/apps/escala-api/**"
+      - ".github/workflows/deploy-escala-api.yml"
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard Escala deploy settings
+        id: guard
+        env:
+          ENABLE: ${{ vars.ENABLE_ESCALA_API_DEPLOY }}
+          ENABLE_STAGING: ${{ vars.ENABLE_ESCALA_API_DEPLOY_STAGING }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ "${ENABLE:-true}" != "true" ]]; then
+            echo "Deploy flag not enabled; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "::error::Cloudflare deploy secrets missing."
+            exit 1
+          fi
+          if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
+            echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
+            exit 1
+          fi
+          if [[ "${ENABLE_STAGING:-false}" == "true" ]]; then
+            echo "deploy_staging=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_staging=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Sync Escala worker secret (production)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for production."
+
+      - name: Deploy Escala worker (production)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 deploy --config backend/apps/escala-api/wrangler.toml --keep-vars
+
+      - name: Sync Escala worker secret (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml --env staging >/dev/null
+          echo "Synced ESCALA_ACTOR_HMAC_KEY for staging."
+
+      - name: Deploy Escala worker (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 deploy --config backend/apps/escala-api/wrangler.toml --env staging --keep-vars
+
+      - name: Smoke check Escala health
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H 'User-Agent: EscalaWorkerSmoke/1.0' https://escala-api.skincos.com.br/api/escala/health >/dev/null
+


### PR DESCRIPTION
## Objetivo
Fechar lacunas de configuração para auto-merge/auto-deploy e eliminar erro recorrente de Escala (`ESCALA_ACTOR_HMAC_KEY nao configurado`).

## O que foi feito
- Endurecimento do workflow de sync de Escala:
  - `cloudflare-pages-sync-escala.yml` agora falha quando faltam secrets/vars críticos (não passa silenciosamente).
  - sincroniza `ESCALA_ACTOR_HMAC_KEY` e `ESCALA_API_TARGET` para `production` e `preview` no Cloudflare Pages.
  - no `workflow_dispatch`, sincroniza também `ESCALA_ACTOR_HMAC_KEY` no worker `escala-api` (produção e staging).
  - inclui verificação pós-sync para confirmar presença dos env vars no Pages.
- Novo auto-deploy do worker Escala:
  - `deploy-escala-api.yml` (push em `main` + manual).
  - `deploy-escala-api-reconcile.yml` (reconcile agendado + force).
- Deploy CRM API por SSH sem falso verde:
  - `deploy-crm-api.yml`, `deploy-crm-api-after-automerge.yml` e `deploy-crm-api-reconcile.yml` agora falham com erro explícito quando `ENABLE_CRM_API_DEPLOY=true` e faltar configuração de SSH/command.

## Configuração aplicada no repositório
- Secret criado: `ESCALA_ACTOR_HMAC_KEY`.
- Variáveis criadas:
  - `ESCALA_API_TARGET=https://escala-api.skincos.com.br`
  - `ESCALA_API_TARGET_PREVIEW=https://escala-api-staging.skincos.com.br`
  - `ENABLE_ESCALA_API_DEPLOY=true`
  - `ENABLE_ESCALA_API_DEPLOY_STAGING=false`

## Validação operacional já executada
- Disparado `Sync CRM Pages secret (Escala)` em `main`.
- Confirmado sync de `ESCALA_ACTOR_HMAC_KEY` para `production` e `preview` + trigger de redeploy do Pages reconcile.
- `Deploy CRM (Cloudflare Pages) reconcile` concluído com sucesso.

## Observação
O deploy de `CRM API` (via SSH) permanece dependente de configurar:
- `CRM_API_SSH_HOST`, `CRM_API_SSH_USER`, `CRM_API_SSH_KEY`
- `CRM_API_APP_DIR`, `CRM_API_DEPLOY_COMMAND`
