### PR TITLE
[codex] fix escala pages sync/audit binding behavior

### DIFF
--- a/.github/workflows/cloudflare-pages-audit.yml
+++ b/.github/workflows/cloudflare-pages-audit.yml
@@ -67,7 +67,6 @@ jobs:
             "PONTO_API_TARGET",
             "PONTO_PROXY_TOKEN",
             "PONTO_ACTOR_HMAC_KEY",
-            "ESCALA_API_TARGET",
             "ESCALA_ACTOR_HMAC_KEY",
           ]
           with open("pages_project.json","r",encoding="utf-8") as f:

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -20,7 +20,6 @@ jobs:
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
@@ -29,10 +28,6 @@ jobs:
           fi
           if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
             echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
-            exit 1
-          fi
-          if [[ -z "${ESCALA_API_TARGET_PREVIEW:-}" ]]; then
-            echo "::error::Missing GitHub variable ESCALA_API_TARGET_PREVIEW."
             exit 1
           fi
           echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
@@ -52,16 +47,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ steps.guard.outputs.project }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           for env_name in production preview; do
             printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put ESCALA_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
-            if [[ "$env_name" == "preview" ]]; then
-              printf "%s" "$ESCALA_API_TARGET_PREVIEW" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
-              echo "Synced ESCALA_API_TARGET for env=preview"
-            fi
           done
 
       - name: Cleanup duplicate production secret binding (Escala target)
@@ -116,13 +106,9 @@ jobs:
             missing.append("production")
           if "ESCALA_ACTOR_HMAC_KEY" not in prev:
             missing.append("preview")
-          if "ESCALA_API_TARGET" not in prod:
-            missing.append("production (ESCALA_API_TARGET)")
-          if "ESCALA_API_TARGET" not in prev:
-            missing.append("preview (ESCALA_API_TARGET)")
           if missing:
             raise SystemExit(f"Escala env vars ausentes em: {', '.join(missing)}")
-          print("ESCALA_ACTOR_HMAC_KEY e ESCALA_API_TARGET presentes em production/preview.")
+          print("ESCALA_ACTOR_HMAC_KEY presente em production/preview.")
           PY
 
       - name: Force redeploy CRM Pages (apply escala secret)

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -20,7 +20,6 @@ jobs:
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
           ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
@@ -30,10 +29,6 @@ jobs:
           fi
           if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
             echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
-            exit 1
-          fi
-          if [[ -z "${ESCALA_API_TARGET:-}" ]]; then
-            echo "::error::Missing GitHub variable ESCALA_API_TARGET."
             exit 1
           fi
           if [[ -z "${ESCALA_API_TARGET_PREVIEW:-}" ]]; then
@@ -57,20 +52,30 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ steps.guard.outputs.project }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
           ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           for env_name in production preview; do
             printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put ESCALA_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
-            target="$ESCALA_API_TARGET"
             if [[ "$env_name" == "preview" ]]; then
-              target="$ESCALA_API_TARGET_PREVIEW"
+              printf "%s" "$ESCALA_API_TARGET_PREVIEW" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
+              echo "Synced ESCALA_API_TARGET for env=preview"
             fi
-            printf "%s" "$target" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
-            echo "Synced ESCALA_API_TARGET for env=$env_name"
           done
+
+      - name: Cleanup duplicate production secret binding (Escala target)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+        run: |
+          set -euo pipefail
+          # Production already has ESCALA_API_TARGET as regular env var.
+          # If a secret with the same name exists, Cloudflare deployment fails with
+          # "Binding name 'ESCALA_API_TARGET' already in use."
+          npx --yes wrangler@4 pages secret delete ESCALA_API_TARGET --project-name "$PROJECT" --env production >/dev/null || true
+          echo "Ensured no duplicate secret binding for ESCALA_API_TARGET in production."
 
       - name: Sync Worker secret (Escala API) by environment
         if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Ajuste final para evitar conflito de binding no Pages e falso negativo no audit de Escala.\n\n- Remove sync de ESCALA_API_TARGET como secret (já vem do wrangler.toml).\n- Mantém sync/validação apenas de ESCALA_ACTOR_HMAC_KEY.\n- Remove ESCALA_API_TARGET da lista obrigatória do cloudflare-pages-audit (checagem de dashboard), evitando falso negativo por var definida no deploy config.\n- Mantém cleanup defensivo de secret duplicado em production.\n