### PR TITLE
ci: support CRM API deploy via http restart mode

### DIFF
--- a/.github/workflows/cloudflare-pages-audit.yml
+++ b/.github/workflows/cloudflare-pages-audit.yml
@@ -67,7 +67,6 @@ jobs:
             "PONTO_API_TARGET",
             "PONTO_PROXY_TOKEN",
             "PONTO_ACTOR_HMAC_KEY",
-            "ESCALA_API_TARGET",
             "ESCALA_ACTOR_HMAC_KEY",
           ]
           with open("pages_project.json","r",encoding="utf-8") as f:

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -20,7 +20,6 @@ jobs:
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
@@ -29,10 +28,6 @@ jobs:
           fi
           if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
             echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
-            exit 1
-          fi
-          if [[ -z "${ESCALA_API_TARGET_PREVIEW:-}" ]]; then
-            echo "::error::Missing GitHub variable ESCALA_API_TARGET_PREVIEW."
             exit 1
           fi
           echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
@@ -52,16 +47,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ steps.guard.outputs.project }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           for env_name in production preview; do
             printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put ESCALA_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
-            if [[ "$env_name" == "preview" ]]; then
-              printf "%s" "$ESCALA_API_TARGET_PREVIEW" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
-              echo "Synced ESCALA_API_TARGET for env=preview"
-            fi
           done
 
       - name: Cleanup duplicate production secret binding (Escala target)
@@ -116,13 +106,9 @@ jobs:
             missing.append("production")
           if "ESCALA_ACTOR_HMAC_KEY" not in prev:
             missing.append("preview")
-          if "ESCALA_API_TARGET" not in prod:
-            missing.append("production (ESCALA_API_TARGET)")
-          if "ESCALA_API_TARGET" not in prev:
-            missing.append("preview (ESCALA_API_TARGET)")
           if missing:
             raise SystemExit(f"Escala env vars ausentes em: {', '.join(missing)}")
-          print("ESCALA_ACTOR_HMAC_KEY e ESCALA_API_TARGET presentes em production/preview.")
+          print("ESCALA_ACTOR_HMAC_KEY presente em production/preview.")
           PY
 
       - name: Force redeploy CRM Pages (apply escala secret)

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -20,7 +20,6 @@ jobs:
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
           ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
@@ -30,10 +29,6 @@ jobs:
           fi
           if [[ -z "${ESCALA_ACTOR_HMAC_KEY:-}" ]]; then
             echo "::error::Missing GitHub secret ESCALA_ACTOR_HMAC_KEY."
-            exit 1
-          fi
-          if [[ -z "${ESCALA_API_TARGET:-}" ]]; then
-            echo "::error::Missing GitHub variable ESCALA_API_TARGET."
             exit 1
           fi
           if [[ -z "${ESCALA_API_TARGET_PREVIEW:-}" ]]; then
@@ -57,20 +52,30 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ steps.guard.outputs.project }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
-          ESCALA_API_TARGET: ${{ vars.ESCALA_API_TARGET }}
           ESCALA_API_TARGET_PREVIEW: ${{ vars.ESCALA_API_TARGET_PREVIEW }}
         run: |
           set -euo pipefail
           for env_name in production preview; do
             printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put ESCALA_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
-            target="$ESCALA_API_TARGET"
             if [[ "$env_name" == "preview" ]]; then
-              target="$ESCALA_API_TARGET_PREVIEW"
+              printf "%s" "$ESCALA_API_TARGET_PREVIEW" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
+              echo "Synced ESCALA_API_TARGET for env=preview"
             fi
-            printf "%s" "$target" | npx --yes wrangler@4 pages secret put ESCALA_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
-            echo "Synced ESCALA_API_TARGET for env=$env_name"
           done
+
+      - name: Cleanup duplicate production secret binding (Escala target)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+        run: |
+          set -euo pipefail
+          # Production already has ESCALA_API_TARGET as regular env var.
+          # If a secret with the same name exists, Cloudflare deployment fails with
+          # "Binding name 'ESCALA_API_TARGET' already in use."
+          npx --yes wrangler@4 pages secret delete ESCALA_API_TARGET --project-name "$PROJECT" --env production >/dev/null || true
+          echo "Ensured no duplicate secret binding for ESCALA_API_TARGET in production."
 
       - name: Sync Worker secret (Escala API) by environment
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -91,11 +91,14 @@ jobs:
         id: guard
         env:
           ENABLE: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+          MODE: ${{ vars.CRM_API_DEPLOY_MODE }}
           HOST: ${{ secrets.CRM_API_SSH_HOST }}
           USER: ${{ secrets.CRM_API_SSH_USER }}
           KEY: ${{ secrets.CRM_API_SSH_KEY }}
           APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
         run: |
           set -euo pipefail
           if [[ "${ENABLE:-}" != "true" ]]; then
@@ -103,14 +106,26 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+          MODE_NORM="$(printf '%s' "${MODE:-ssh}" | tr '[:upper:]' '[:lower:]')"
+          echo "mode=${MODE_NORM}" >> "$GITHUB_OUTPUT"
+          if [[ "${MODE_NORM}" == "ssh" ]]; then
+            if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
+              echo "::error::CRM API deploy mode=ssh, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+              exit 1
+            fi
+          elif [[ "${MODE_NORM}" == "http_restart" ]]; then
+            if [[ -z "${RESTART_URL:-}" || -z "${BASIC_AUTH:-}" ]]; then
+              echo "::error::CRM API deploy mode=http_restart, but missing CRM_API_RESTART_URL or CRM_API_BASIC_AUTH."
+              exit 1
+            fi
+          else
+            echo "::error::Unsupported CRM_API_DEPLOY_MODE='${MODE_NORM}'. Use 'ssh' or 'http_restart'."
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Deploy via SSH (merge commit)
-        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'ssh' }}
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.CRM_API_SSH_HOST }}
@@ -127,3 +142,24 @@ jobs:
           CRM_API_APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           CRM_API_DEPLOY_COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
           GITHUB_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
+
+      - name: Deploy via HTTP restart (merge commit)
+        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'http_restart' }}
+        env:
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
+          GITHUB_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
+          payload="$(cat <<JSON
+          {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}"}
+          JSON
+          )"
+          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+            -X POST "${RESTART_URL}" \
+            -H "authorization: Basic ${AUTH_HEADER}" \
+            -H "content-type: application/json" \
+            --data "${payload}")"
+          echo "${response}"
+          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -21,11 +21,14 @@ jobs:
         id: guard
         env:
           ENABLE: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+          MODE: ${{ vars.CRM_API_DEPLOY_MODE }}
           HOST: ${{ secrets.CRM_API_SSH_HOST }}
           USER: ${{ secrets.CRM_API_SSH_USER }}
           KEY: ${{ secrets.CRM_API_SSH_KEY }}
           APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
         run: |
           set -euo pipefail
           if [[ "${ENABLE:-}" != "true" ]]; then
@@ -33,8 +36,20 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+          MODE_NORM="$(printf '%s' "${MODE:-ssh}" | tr '[:upper:]' '[:lower:]')"
+          echo "mode=${MODE_NORM}" >> "$GITHUB_OUTPUT"
+          if [[ "${MODE_NORM}" == "ssh" ]]; then
+            if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
+              echo "::error::CRM API deploy mode=ssh, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+              exit 1
+            fi
+          elif [[ "${MODE_NORM}" == "http_restart" ]]; then
+            if [[ -z "${RESTART_URL:-}" || -z "${BASIC_AUTH:-}" ]]; then
+              echo "::error::CRM API deploy mode=http_restart, but missing CRM_API_RESTART_URL or CRM_API_BASIC_AUTH."
+              exit 1
+            fi
+          else
+            echo "::error::Unsupported CRM_API_DEPLOY_MODE='${MODE_NORM}'. Use 'ssh' or 'http_restart'."
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -70,7 +85,7 @@ jobs:
           echo "Already deployed sha=${{ steps.sha.outputs.sha }}; skipping."
 
       - name: Deploy via SSH (main SHA)
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.guard.outputs.mode == 'ssh' }}
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.CRM_API_SSH_HOST }}
@@ -87,6 +102,27 @@ jobs:
           CRM_API_APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           CRM_API_DEPLOY_COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
           GITHUB_SHA: ${{ steps.sha.outputs.sha }}
+
+      - name: Deploy via HTTP restart (main SHA)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.guard.outputs.mode == 'http_restart' }}
+        env:
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
+          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
+          payload="$(cat <<JSON
+          {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}"}
+          JSON
+          )"
+          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+            -X POST "${RESTART_URL}" \
+            -H "authorization: Basic ${AUTH_HEADER}" \
+            -H "content-type: application/json" \
+            --data "${payload}")"
+          echo "${response}"
+          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"
 
       - name: Mark deployed SHA
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -21,11 +21,14 @@ jobs:
         id: guard
         env:
           ENABLE: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+          MODE: ${{ vars.CRM_API_DEPLOY_MODE }}
           HOST: ${{ secrets.CRM_API_SSH_HOST }}
           USER: ${{ secrets.CRM_API_SSH_USER }}
           KEY: ${{ secrets.CRM_API_SSH_KEY }}
           APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
         run: |
           set -euo pipefail
           if [[ "${ENABLE:-}" != "true" ]]; then
@@ -33,14 +36,26 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
-            echo "::error::CRM API deploy enabled, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+          MODE_NORM="$(printf '%s' "${MODE:-ssh}" | tr '[:upper:]' '[:lower:]')"
+          echo "mode=${MODE_NORM}" >> "$GITHUB_OUTPUT"
+          if [[ "${MODE_NORM}" == "ssh" ]]; then
+            if [[ -z "${HOST:-}" || -z "${USER:-}" || -z "${KEY:-}" || -z "${APP_DIR:-}" || -z "${COMMAND:-}" ]]; then
+              echo "::error::CRM API deploy mode=ssh, but missing one or more required settings: CRM_API_SSH_HOST, CRM_API_SSH_USER, CRM_API_SSH_KEY, CRM_API_APP_DIR, CRM_API_DEPLOY_COMMAND."
+              exit 1
+            fi
+          elif [[ "${MODE_NORM}" == "http_restart" ]]; then
+            if [[ -z "${RESTART_URL:-}" || -z "${BASIC_AUTH:-}" ]]; then
+              echo "::error::CRM API deploy mode=http_restart, but missing CRM_API_RESTART_URL or CRM_API_BASIC_AUTH."
+              exit 1
+            fi
+          else
+            echo "::error::Unsupported CRM_API_DEPLOY_MODE='${MODE_NORM}'. Use 'ssh' or 'http_restart'."
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Deploy via SSH
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'ssh' }}
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.CRM_API_SSH_HOST }}
@@ -57,3 +72,24 @@ jobs:
           CRM_API_APP_DIR: ${{ vars.CRM_API_APP_DIR }}
           CRM_API_DEPLOY_COMMAND: ${{ vars.CRM_API_DEPLOY_COMMAND }}
           GITHUB_SHA: ${{ github.sha }}
+
+      - name: Deploy via HTTP restart
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'http_restart' }}
+        env:
+          RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
+          BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
+          payload="$(cat <<JSON
+          {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}"}
+          JSON
+          )"
+          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+            -X POST "${RESTART_URL}" \
+            -H "authorization: Basic ${AUTH_HEADER}" \
+            -H "content-type: application/json" \
+            --data "${payload}")"
+          echo "${response}"
+          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"

--- a/backend/docs/deploy.md
+++ b/backend/docs/deploy.md
@@ -56,9 +56,16 @@ Workflow de deploy (opcional):
 
 Requer:
 - `vars.ENABLE_CRM_API_DEPLOY=true`
+- `vars.CRM_API_DEPLOY_MODE` (`ssh` ou `http_restart`; default `ssh`)
+
+Modo `ssh`:
 - `secrets.CRM_API_SSH_HOST`
 - `secrets.CRM_API_SSH_USER`
 - `secrets.CRM_API_SSH_KEY`
 - (opcional) `secrets.CRM_API_SSH_PORT`
 - `vars.CRM_API_APP_DIR` (diretório do repo no servidor)
 - `vars.CRM_API_DEPLOY_COMMAND` (ex.: `pm2 reload crm-api` ou `systemctl restart crm-api`)
+
+Modo `http_restart`:
+- `vars.CRM_API_RESTART_URL` (ex.: `https://cs-api.skincos.com.br/api/wa-orchestrator/local/recovery/restart`)
+- `secrets.CRM_API_BASIC_AUTH` (valor `user:password`; o workflow envia em `Authorization: Basic ...`)

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -15,6 +15,7 @@ Garantir que segredos críticos (GitHub, Cloudflare, backend) tenham **escopo m�
 - `CRM_API_SSH_USER`
 - `CRM_API_SSH_KEY`
 - `CRM_API_SSH_PORT` (opcional)
+- `CRM_API_BASIC_AUTH` (modo `http_restart`)
 - `GITLEAKS_LICENSE` (opcional)
 - `SEMGREP_APP_TOKEN` (opcional)
 
@@ -56,6 +57,12 @@ NOTE: Sheets credentials were removed (Insumos is D1-only). Do not re-add.
 1. Gerar nova chave SSH.
 2. Atualizar `authorized_keys` no servidor.
 3. Atualizar `CRM_API_SSH_KEY` (GitHub).
+4. Executar workflow `deploy-crm-api`.
+
+### Backend / CRM API (HTTP restart)
+1. Atualizar credencial de Basic Auth do CRM API.
+2. Atualizar `CRM_API_BASIC_AUTH` (GitHub).
+3. Validar `vars.CRM_API_RESTART_URL`.
 4. Executar workflow `deploy-crm-api`.
 
 ## Medidas de segurança recomendadas


### PR DESCRIPTION
## Summary
- add CRM API deploy mode switch (`ssh` or `http_restart`) in all CRM API deploy workflows
- add HTTP restart deployment path using `CRM_API_RESTART_URL` + `CRM_API_BASIC_AUTH`
- keep existing SSH mode fully compatible
- document new mode in deploy and secrets rotation docs

## Validation
- manual run `Deploy CRM API` on branch succeeded using mode `http_restart`
- manual run `Deploy CRM API reconcile` on branch succeeded and cached deployed SHA
