### PR TITLE
feat: sync repo before CRM API http restart

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -153,7 +153,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}"}
+          {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -113,7 +113,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}"}
+          {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -83,7 +83,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}"}
+          {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \

--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -207,6 +207,15 @@ async function runLocalRecoveryRepoSync({ sha = '', autoStash = true } = {}) {
         if (!isStepSuccessful(verifyShaStep)) {
             return { success: false, error: 'RECOVERY_SYNC_SHA_NOT_FOUND', repoDirty, steps }
         }
+        const verifyOnBranchStep = await pushStep(
+            'verify-sha-on-branch',
+            'git',
+            ['-C', repoDir, 'merge-base', '--is-ancestor', sha, `${remote}/${branch}`],
+            15_000
+        )
+        if (!isStepSuccessful(verifyOnBranchStep)) {
+            return { success: false, error: 'RECOVERY_SYNC_SHA_NOT_IN_TARGET_BRANCH', repoDirty, steps }
+        }
         targetRef = sha
     }
 

--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -82,6 +82,12 @@ const WA_LOCAL_RECOVERY_TIMEOUT_MS = Math.max(
     15_000,
     Number.parseInt(String(process.env.WA_LOCAL_RECOVERY_TIMEOUT_MS || '90000'), 10) || 90_000
 )
+const WA_LOCAL_RECOVERY_SYNC_REMOTE = String(process.env.WA_LOCAL_RECOVERY_SYNC_REMOTE || 'origin').trim() || 'origin'
+const WA_LOCAL_RECOVERY_SYNC_BRANCH = String(process.env.WA_LOCAL_RECOVERY_SYNC_BRANCH || 'main').trim() || 'main'
+const WA_LOCAL_RECOVERY_SYNC_TIMEOUT_MS = Math.max(
+    15_000,
+    Number.parseInt(String(process.env.WA_LOCAL_RECOVERY_SYNC_TIMEOUT_MS || '120000'), 10) || 120_000
+)
 const LOCAL_EVOLUTION_LAUNCHD_LABEL = String(
     process.env.LOCAL_EVOLUTION_LAUNCHD_LABEL || 'com.skincos.evolution-api'
 ).trim()
@@ -122,6 +128,102 @@ function truncateText(value, max = 3000) {
     const text = String(value || '')
     if (text.length <= max) return text
     return `${text.slice(0, max)}\n...[truncated]`
+}
+
+function normalizeBoolean(value, defaultValue = false) {
+    if (value === undefined || value === null) return Boolean(defaultValue)
+    const normalized = String(value).trim().toLowerCase()
+    if (!normalized) return Boolean(defaultValue)
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+    return Boolean(defaultValue)
+}
+
+function parseRecoverySyncSha(value) {
+    const text = String(value || '').trim()
+    if (!text) return { sha: '', invalid: false }
+    if (!/^[0-9a-f]{7,40}$/i.test(text)) return { sha: '', invalid: true }
+    return { sha: text.toLowerCase(), invalid: false }
+}
+
+function isStepSuccessful(step) {
+    if (!step) return false
+    if (step.timedOut) return false
+    if (typeof step.code === 'number' && step.code !== 0) return false
+    return true
+}
+
+async function runLocalRecoveryRepoSync({ sha = '', autoStash = true } = {}) {
+    const repoDir = REPO_ROOT
+    const remote = WA_LOCAL_RECOVERY_SYNC_REMOTE
+    const branch = WA_LOCAL_RECOVERY_SYNC_BRANCH
+    const timeoutMs = WA_LOCAL_RECOVERY_SYNC_TIMEOUT_MS
+    const steps = []
+
+    const pushStep = async (name, command, args, stepTimeoutMs = timeoutMs) => {
+        const step = await runCommandWithTimeout(command, args, { timeoutMs: stepTimeoutMs })
+        steps.push({ name, ...step })
+        return step
+    }
+
+    const insideRepo = await pushStep('repo-check', 'git', ['-C', repoDir, 'rev-parse', '--is-inside-work-tree'], 12_000)
+    if (!isStepSuccessful(insideRepo)) {
+        return { success: false, error: 'RECOVERY_SYNC_REPO_INVALID', steps }
+    }
+
+    const statusStep = await pushStep('status', 'git', ['-C', repoDir, 'status', '--porcelain'], 15_000)
+    if (!isStepSuccessful(statusStep)) {
+        return { success: false, error: 'RECOVERY_SYNC_STATUS_FAILED', steps }
+    }
+
+    const repoDirty = String(statusStep.stdout || '').trim().length > 0
+    if (repoDirty) {
+        if (!autoStash) {
+            return { success: false, error: 'RECOVERY_SYNC_REPO_DIRTY', repoDirty, steps }
+        }
+        const stashLabel = `wa-recovery-autostash-${new Date().toISOString()}`
+        const stashStep = await pushStep('stash', 'git', ['-C', repoDir, 'stash', 'push', '--include-untracked', '--message', stashLabel], 45_000)
+        if (!isStepSuccessful(stashStep)) {
+            return { success: false, error: 'RECOVERY_SYNC_STASH_FAILED', repoDirty, steps }
+        }
+    }
+
+    const fetchStep = await pushStep('fetch', 'git', ['-C', repoDir, 'fetch', remote, '--prune'], timeoutMs)
+    if (!isStepSuccessful(fetchStep)) {
+        return { success: false, error: 'RECOVERY_SYNC_FETCH_FAILED', repoDirty, steps }
+    }
+
+    let checkoutStep = await pushStep('checkout', 'git', ['-C', repoDir, 'checkout', branch], 30_000)
+    if (!isStepSuccessful(checkoutStep)) {
+        checkoutStep = await pushStep('checkout-create', 'git', ['-C', repoDir, 'checkout', '-B', branch, `${remote}/${branch}`], 30_000)
+        if (!isStepSuccessful(checkoutStep)) {
+            return { success: false, error: 'RECOVERY_SYNC_CHECKOUT_FAILED', repoDirty, steps }
+        }
+    }
+
+    let targetRef = `${remote}/${branch}`
+    if (sha) {
+        const verifyShaStep = await pushStep('verify-sha', 'git', ['-C', repoDir, 'cat-file', '-e', `${sha}^{commit}`], 15_000)
+        if (!isStepSuccessful(verifyShaStep)) {
+            return { success: false, error: 'RECOVERY_SYNC_SHA_NOT_FOUND', repoDirty, steps }
+        }
+        targetRef = sha
+    }
+
+    const resetStep = await pushStep('reset', 'git', ['-C', repoDir, 'reset', '--hard', targetRef], timeoutMs)
+    if (!isStepSuccessful(resetStep)) {
+        return { success: false, error: 'RECOVERY_SYNC_RESET_FAILED', repoDirty, steps }
+    }
+
+    const headStep = await pushStep('head', 'git', ['-C', repoDir, 'rev-parse', 'HEAD'], 10_000)
+    const appliedSha = isStepSuccessful(headStep) ? String(headStep.stdout || '').trim() : ''
+    return {
+        success: true,
+        repoDirty,
+        targetRef,
+        appliedSha,
+        steps
+    }
 }
 
 function runCommandWithTimeout(command, args = [], options = {}) {
@@ -5612,13 +5714,49 @@ app.post('/api/wa-orchestrator/local/recovery/restart', async (req, res) => {
                 allowed: ['evolution', 'stack']
             })
         }
+        const syncRepo = mode === 'stack' && normalizeBoolean(req.body?.syncRepo, false)
+        const syncAutoStash = normalizeBoolean(req.body?.syncAutoStash, true)
+        const parsedSyncSha = parseRecoverySyncSha(req.body?.syncSha || req.body?.sha)
+        if (syncRepo && parsedSyncSha.invalid) {
+            return res.status(400).json({
+                success: false,
+                error: 'INVALID_RECOVERY_SYNC_SHA',
+                hint: 'Provide a valid git commit SHA (7-40 hex chars).'
+            })
+        }
 
         const uid = Number(process.getuid?.() || os.userInfo().uid || 0)
         const launchdTarget = `gui/${uid}/${LOCAL_EVOLUTION_LAUNCHD_LABEL}`
 
         const steps = []
+        let syncSummary = null
         let coreStep = null
         if (mode === 'stack') {
+            if (syncRepo) {
+                const syncResult = await runLocalRecoveryRepoSync({
+                    sha: parsedSyncSha.sha,
+                    autoStash: syncAutoStash
+                })
+                syncSummary = {
+                    success: Boolean(syncResult.success),
+                    repoDirty: Boolean(syncResult.repoDirty),
+                    targetRef: syncResult.targetRef || null,
+                    appliedSha: syncResult.appliedSha || null,
+                    error: syncResult.error || null
+                }
+                for (const syncStep of Array.isArray(syncResult.steps) ? syncResult.steps : []) {
+                    steps.push({ phase: 'repo-sync', ...syncStep })
+                }
+                if (!syncResult.success) {
+                    return res.status(500).json({
+                        success: false,
+                        mode,
+                        error: syncResult.error || 'RECOVERY_SYNC_FAILED',
+                        sync: syncSummary,
+                        steps
+                    })
+                }
+            }
             const exists = fsSync.existsSync(WA_LOCAL_RECOVERY_SCRIPT)
             if (!exists) {
                 return res.status(500).json({
@@ -5631,15 +5769,15 @@ app.post('/api/wa-orchestrator/local/recovery/restart', async (req, res) => {
                 cwd: '/Users/jubenitogarcia/Automation/n8n',
                 timeoutMs: WA_LOCAL_RECOVERY_TIMEOUT_MS
             })
-            steps.push(coreStep)
+            steps.push({ phase: 'stack-restart', ...coreStep })
         } else {
-            steps.push(await runCommandWithTimeout('launchctl', ['stop', launchdTarget], {
+            steps.push({ phase: 'evolution-restart', ...(await runCommandWithTimeout('launchctl', ['stop', launchdTarget], {
                 timeoutMs: 8_000
-            }))
+            })) })
             coreStep = await runCommandWithTimeout('launchctl', ['kickstart', '-k', launchdTarget], {
                 timeoutMs: 20_000
             })
-            steps.push(coreStep)
+            steps.push({ phase: 'evolution-restart', ...coreStep })
         }
 
         let status = null
@@ -5663,6 +5801,7 @@ app.post('/api/wa-orchestrator/local/recovery/restart', async (req, res) => {
         return res.status(responseStatus).json({
             success: !hasFailure,
             mode,
+            sync: syncSummary,
             steps,
             status: status ? {
                 providerOnline: Boolean(status.providerOnline),

--- a/backend/docs/deploy.md
+++ b/backend/docs/deploy.md
@@ -69,3 +69,9 @@ Modo `ssh`:
 Modo `http_restart`:
 - `vars.CRM_API_RESTART_URL` (ex.: `https://cs-api.skincos.com.br/api/wa-orchestrator/local/recovery/restart`)
 - `secrets.CRM_API_BASIC_AUTH` (valor `user:password`; o workflow envia em `Authorization: Basic ...`)
+- O workflow envia payload com:
+  - `mode=stack`
+  - `sha=<commit do deploy>`
+  - `syncRepo=true` (sincroniza repo local antes do restart)
+  - `syncSha=<commit do deploy>` (alvo do `git reset --hard`)
+  - `syncAutoStash=true` (se houver mudanças locais, faz stash automático antes da sincronização)

--- a/docs/atendimento-evolution-runbook.md
+++ b/docs/atendimento-evolution-runbook.md
@@ -34,8 +34,19 @@
 - Webhook manual: `POST /api/wa-orchestrator/channels/:channel/webhook`
 - SSE: `GET /api/wa-orchestrator/events`
 - Proxy status: `GET /api/wa-orchestrator/_proxy-status`
+- Recovery local (restart + sync opcional): `POST /api/wa-orchestrator/local/recovery/restart`
 - Harmonia inbox: `GET /api/harmonia/conversations?unitSlug=<slug>`
 - Patch de conversa: `POST /api/harmonia/conversations/:id/patch`
+
+Exemplo de payload para recovery com sync de código:
+```json
+{
+  "mode": "stack",
+  "syncRepo": true,
+  "syncSha": "<sha>",
+  "syncAutoStash": true
+}
+```
 
 ## Diagnóstico de falhas
 ### Webhook 401


### PR DESCRIPTION
## Summary
- add repo sync support to `POST /api/wa-orchestrator/local/recovery/restart`
- support payload fields `syncRepo`, `syncSha`, and `syncAutoStash`
- when `syncRepo=true`, perform `git fetch + checkout main + reset --hard <sha|origin/main>` before stack restart
- protect against unsafe deploy by rejecting SHAs not contained in `origin/main`
- include sync details in endpoint response (`sync` + step phases)
- update CRM API HTTP restart workflows to always request sync before restart
- update runbooks/docs with the new payload and behavior

## Validation
- `node --check backend/apps/crm-api/server.js`
- YAML parse OK for deploy workflows
- after merge, deploy workflows will be validated on `main`
