### PR TITLE
[codex] unify website scheduling with escala d1

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -58,7 +58,9 @@ npm run deploy
 
 ## Agendamento (MVP) — Cloudflare D1
 
-O fluxo de agendamento em `/agendamento` persiste pedidos no **Cloudflare D1** via binding `BOOKING_DB`.
+O fluxo de agendamento em `/agendamento` usa dois bindings **Cloudflare D1**:
+- `BOOKING_DB` para pedidos/reservas.
+- `SKINCOS_ESCALA_DB` para equipe/escala (fonte CRM unificada para doutores e dias de atendimento).
 
 Setup (produção/preview):
 - Veja o guia: `docs/booking/SETUP_CLOUDFLARE_D1.md`

--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -4,6 +4,7 @@ import { getServiceById } from "@/data/services";
 import { getUnitDoctorsResult } from "@/lib/injectorsDirectory";
 import { getAgendaDb } from "@/lib/agendaDb";
 import { sendBookingNotifications } from "@/lib/bookingNotifications";
+import { fetchEscalaDaySchedule, normalizePersonKey } from "@/lib/escalaDb";
 
 export const dynamic = "force-dynamic";
 
@@ -338,28 +339,52 @@ export async function POST(request: Request) {
         }
     }
 
+    const doctorsResult = await getUnitDoctorsResult(unitSlug);
+    if (!doctorsResult.ok) {
+        return json({ ok: false, error: "doctors_unavailable" }, { status: 503 });
+    }
+    const doctors = doctorsResult.doctors;
+    if (doctors.length === 0) {
+        return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
+    }
+
+    const selectedDoctor = wantsAnyDoctor ? null : doctors.find((doctor) => doctor.slug === doctorSlug) ?? null;
+    if (!wantsAnyDoctor && !selectedDoctor) {
+        return json({ ok: false, error: "invalid_doctor" }, { status: 400 });
+    }
+
+    const daySchedule = await fetchEscalaDaySchedule(unitSlug, date);
+    let doctorsAvailableBySchedule = doctors;
+    if (daySchedule) {
+        if (daySchedule.closed) {
+            return json({ ok: false, error: "no_availability" }, { status: 409 });
+        }
+
+        const scheduledNameKeys = new Set(daySchedule.professionalNames.map((name) => normalizePersonKey(name)));
+        doctorsAvailableBySchedule = doctors.filter((doctor) => scheduledNameKeys.has(normalizePersonKey(doctor.name)));
+
+        if (!wantsAnyDoctor && selectedDoctor && !scheduledNameKeys.has(normalizePersonKey(selectedDoctor.name))) {
+            return json({ ok: false, error: "no_availability" }, { status: 409 });
+        }
+        if (wantsAnyDoctor && doctorsAvailableBySchedule.length === 0) {
+            return json({ ok: false, error: "no_availability" }, { status: 409 });
+        }
+    }
+
     const db = await getBookingDb();
 
     // If the user has no preference, pick a free doctor for that unit+slot.
     let effectiveDoctorSlug = doctorSlug;
-    let safeDoctorName = clampText(doctorName || doctorSlug, 120);
+    let safeDoctorName = clampText(selectedDoctor?.name || doctorName || doctorSlug, 120);
     if (wantsAnyDoctor) {
-        const doctorsResult = await getUnitDoctorsResult(unitSlug);
-        if (!doctorsResult.ok) {
-            return json({ ok: false, error: "doctors_unavailable" }, { status: 503 });
-        }
+        const doctorsForSelection = daySchedule ? doctorsAvailableBySchedule : doctors;
 
-        const doctors = doctorsResult.doctors;
-        if (doctors.length === 0) {
-            return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
-        }
-
-        const placeholders = doctors.map(() => "?").join(", ");
+        const placeholders = doctorsForSelection.map(() => "?").join(", ");
         const overlapsRes = await db
             .prepare(
                 `SELECT id, doctor_slug, status, confirm_by_ms, start_at_ms, end_at_ms FROM booking_requests WHERE unit_slug = ? AND doctor_slug IN (${placeholders}) AND start_at_ms < ? AND end_at_ms > ?`,
             )
-            .bind(unitSlug, ...doctors.map((d) => d.slug), endAtMs, startAtMs)
+            .bind(unitSlug, ...doctorsForSelection.map((doctor) => doctor.slug), endAtMs, startAtMs)
             .all<{ id: string; doctor_slug: string; status: string; confirm_by_ms: number; start_at_ms: number; end_at_ms: number }>();
 
         await expireStaleOverlaps(db, overlapsRes.results);
@@ -382,7 +407,7 @@ export async function POST(request: Request) {
             activeByDoctor.set(slug, cur);
         }
 
-        const pick = doctors.find((d) => !activeByDoctor.has(d.slug)) ?? null;
+        const pick = doctorsForSelection.find((doctor) => !activeByDoctor.has(doctor.slug)) ?? null;
         if (!pick) {
             const anyPending = Array.from(activeByDoctor.values()).some((v) => v.hasPending);
             return json({ ok: false, error: anyPending ? "slot_in_review" : "no_availability" }, { status: 409 });

--- a/website/src/app/api/booking/slots/route.ts
+++ b/website/src/app/api/booking/slots/route.ts
@@ -3,6 +3,7 @@ import { getBookingDb, nowMs, addMinutes, isValidDateKey, isValidTimeKey, toSaoP
 import { getAgendaDb } from "@/lib/agendaDb";
 import { getServiceById } from "@/data/services";
 import { getUnitDoctorsResult } from "@/lib/injectorsDirectory";
+import { fetchEscalaDaySchedule, normalizePersonKey } from "@/lib/escalaDb";
 
 export const dynamic = "force-dynamic";
 
@@ -71,6 +72,19 @@ function buildDaySlots(unitSlug: string, dateKey: string, durationMinutes: numbe
     return slots;
 }
 
+function buildUnavailableSlots(params: { date: string; durationMinutes: number; daySlots: Array<{ time: string }>; reason: string }) {
+    return params.daySlots.map((slot) => {
+        const startAtMs = Date.parse(toSaoPauloIso(params.date, slot.time));
+        return {
+            time: slot.time,
+            startAtMs,
+            endAtMs: addMinutes(startAtMs, params.durationMinutes),
+            available: false,
+            reason: params.reason,
+        };
+    });
+}
+
 async function expireIfNeeded(db: Awaited<ReturnType<typeof getBookingDb>>, id: string) {
     // Best-effort: mark pending approvals as expired after confirm_by.
     const row = await db
@@ -132,15 +146,44 @@ export async function GET(req: Request) {
 
     const db = await getBookingDb();
     const wantsAnyDoctor = doctorSlug === "any";
-    const unitDoctorsResult = wantsAnyDoctor ? await getUnitDoctorsResult(unitSlug) : null;
-    if (wantsAnyDoctor && unitDoctorsResult && !unitDoctorsResult.ok) {
+    const unitDoctorsResult = await getUnitDoctorsResult(unitSlug);
+    if (wantsAnyDoctor && !unitDoctorsResult.ok) {
         return json({ ok: false, error: "doctors_unavailable" }, { status: 503 });
     }
 
-    const unitDoctors = wantsAnyDoctor ? unitDoctorsResult!.doctors : [];
-    const doctorSlugs = wantsAnyDoctor ? unitDoctors.map((d) => d.slug) : [doctorSlug];
+    const unitDoctors = unitDoctorsResult.ok ? unitDoctorsResult.doctors : [];
+    const knownDoctor = !wantsAnyDoctor ? unitDoctors.find((doctor) => doctor.slug === doctorSlug) ?? null : null;
+    let doctorSlugs = wantsAnyDoctor ? unitDoctors.map((doctor) => doctor.slug) : [doctorSlug];
     if (wantsAnyDoctor && doctorSlugs.length === 0) {
         return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
+    }
+
+    const daySchedule = await fetchEscalaDaySchedule(unitSlug, date);
+    if (daySchedule?.closed) {
+        const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "closed_day" });
+        return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
+    }
+
+    if (daySchedule) {
+        const scheduledNameKeys = new Set(daySchedule.professionalNames.map((name) => normalizePersonKey(name)));
+        if (scheduledNameKeys.size === 0) {
+            const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
+            return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
+        }
+
+        if (wantsAnyDoctor) {
+            doctorSlugs = unitDoctors
+                .filter((doctor) => scheduledNameKeys.has(normalizePersonKey(doctor.name)))
+                .map((doctor) => doctor.slug);
+
+            if (doctorSlugs.length === 0) {
+                const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
+                return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
+            }
+        } else if (knownDoctor && !scheduledNameKeys.has(normalizePersonKey(knownDoctor.name))) {
+            const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
+            return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
+        }
     }
 
     const cacheKey = `${unitSlug}|${date}`;

--- a/website/src/lib/escalaDb.ts
+++ b/website/src/lib/escalaDb.ts
@@ -1,0 +1,212 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+type D1PreparedStatement = {
+    bind: (...values: unknown[]) => D1PreparedStatement;
+    all: <T = unknown>() => Promise<{ results: T[] }>;
+    first: <T = unknown>() => Promise<T | null>;
+};
+
+type D1DatabaseLike = {
+    prepare: (query: string) => D1PreparedStatement;
+};
+
+type CloudflareEnv = {
+    SKINCOS_ESCALA_DB?: D1DatabaseLike;
+};
+
+type RawProfessionalRow = {
+    name: string;
+    status: string | null;
+    role: string | null;
+    nickname: string | null;
+    instagram: string | null;
+    units_json: string | null;
+};
+
+type RawNameRow = { professional: string };
+type RawCountRow = { total: number };
+
+export type EscalaProfessional = {
+    name: string;
+    status: string | null;
+    role: string | null;
+    nickname: string | null;
+    instagram: string | null;
+    units: string[];
+};
+
+export type EscalaDaySchedule = {
+    closed: boolean;
+    professionalNames: string[];
+};
+
+type CachedDaySchedule = {
+    expiresAtMs: number;
+    value: EscalaDaySchedule;
+};
+
+const DAY_SCHEDULE_TTL_MS = 60_000;
+const dayScheduleCache = new Map<string, CachedDaySchedule>();
+
+function getEscalaDb(): D1DatabaseLike | null {
+    try {
+        const { env } = getCloudflareContext();
+        const typedEnv = env as unknown as CloudflareEnv;
+        return typedEnv.SKINCOS_ESCALA_DB ?? null;
+    } catch {
+        return null;
+    }
+}
+
+function normalizeUnitKey(value: string): string {
+    return String(value ?? "")
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "");
+}
+
+export function normalizePersonKey(value: string): string {
+    return String(value ?? "")
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "");
+}
+
+export function unitLabelFromEscalaUnitSlug(unitSlug: string): string | null {
+    const key = normalizeUnitKey(unitSlug);
+    if (!key) return null;
+    if (key === "barrashoppingsul") return "BarraShoppingSul";
+    if (key === "novohamburgo") return "Novo Hamburgo";
+    return null;
+}
+
+function parseUnitsJson(value: string | null): string[] {
+    if (!value) return [];
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        if (!Array.isArray(parsed)) return [];
+        return parsed.map((item) => String(item ?? "").trim()).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+function normalizeOneLine(value: string | null): string {
+    return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeInstagramHandle(value: string | null): string | null {
+    const raw = normalizeOneLine(value);
+    if (!raw) return null;
+    const noAt = raw.startsWith("@") ? raw.slice(1) : raw;
+    const fromUrl = noAt.match(/instagram\.com\/(?:@)?([^/?#]+)/i)?.[1] ?? noAt;
+    const cleaned = fromUrl.replace(/[^a-zA-Z0-9._]/g, "");
+    return cleaned || null;
+}
+
+export async function fetchEscalaProfessionals(unitSlug: string | null): Promise<EscalaProfessional[] | null> {
+    const db = getEscalaDb();
+    if (!db) return null;
+
+    try {
+        const unitLabel = unitSlug ? unitLabelFromEscalaUnitSlug(unitSlug) : null;
+        const unitKey = normalizeUnitKey(unitLabel ?? "");
+        const result = await db
+            .prepare(
+                `SELECT name, status, role, nickname, instagram, units_json
+                 FROM professionals
+                 ORDER BY name ASC`,
+            )
+            .all<RawProfessionalRow>();
+
+        const professionals = (result.results ?? [])
+            .map((row) => {
+                const units = parseUnitsJson(row.units_json);
+                return {
+                    name: normalizeOneLine(row.name),
+                    status: normalizeOneLine(row.status),
+                    role: normalizeOneLine(row.role),
+                    nickname: normalizeOneLine(row.nickname),
+                    instagram: normalizeInstagramHandle(row.instagram),
+                    units,
+                };
+            })
+            .filter((row) => {
+                if (!row.name) return false;
+                const status = row.status.toLowerCase();
+                if (status && status !== "ativo") return false;
+
+                if (!unitKey) return true;
+                const rowUnitKeys = row.units.map((unit) => normalizeUnitKey(unit));
+                if (!rowUnitKeys.length) return false;
+                return rowUnitKeys.includes(unitKey);
+            })
+            .map((row) => ({
+                name: row.name,
+                status: row.status || null,
+                role: row.role || null,
+                nickname: row.nickname || null,
+                instagram: row.instagram,
+                units: row.units,
+            }));
+
+        return professionals;
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchEscalaDaySchedule(unitSlug: string, dateKey: string): Promise<EscalaDaySchedule | null> {
+    const unitLabel = unitLabelFromEscalaUnitSlug(unitSlug);
+    if (!unitLabel) return null;
+
+    const cacheKey = `${normalizeUnitKey(unitLabel)}|${dateKey}`;
+    const now = Date.now();
+    const cached = dayScheduleCache.get(cacheKey);
+    if (cached && cached.expiresAtMs > now) return cached.value;
+
+    const db = getEscalaDb();
+    if (!db) return null;
+
+    try {
+        const scheduleResult = await db
+            .prepare(
+                `SELECT professional_name AS professional
+                 FROM schedule_entries
+                 WHERE unit = ? AND date = ?
+                 ORDER BY professional_name ASC`,
+            )
+            .bind(unitLabel, dateKey)
+            .all<RawNameRow>();
+
+        const closedDaysCount = await db
+            .prepare("SELECT COUNT(*) AS total FROM closed_days WHERE unit = ? AND date = ?")
+            .bind(unitLabel, dateKey)
+            .first<RawCountRow>();
+
+        const holidaysCount = await db
+            .prepare("SELECT COUNT(*) AS total FROM holidays WHERE unit = ? AND date = ?")
+            .bind(unitLabel, dateKey)
+            .first<RawCountRow>();
+
+        const names = Array.from(
+            new Set(
+                (scheduleResult.results ?? [])
+                    .map((row) => normalizeOneLine(row.professional))
+                    .filter(Boolean),
+            ),
+        );
+
+        const value: EscalaDaySchedule = {
+            closed: Number(closedDaysCount?.total ?? 0) > 0 || Number(holidaysCount?.total ?? 0) > 0,
+            professionalNames: names,
+        };
+
+        dayScheduleCache.set(cacheKey, { value, expiresAtMs: now + DAY_SCHEDULE_TTL_MS });
+        return value;
+    } catch {
+        return null;
+    }
+}

--- a/website/src/lib/injectorsDirectory.ts
+++ b/website/src/lib/injectorsDirectory.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { doctorSlugFromTeamMember } from "@/lib/doctorSlug";
+import { fetchEscalaProfessionals, unitLabelFromEscalaUnitSlug } from "@/lib/escalaDb";
 
 type TeamMember = {
     name: string;
@@ -318,9 +319,7 @@ function normalizeRoles(value: string): string[] {
 export { doctorSlugFromTeamMember };
 
 export function unitLabelFromBookingUnitSlug(unitSlug: string): string | null {
-    if (unitSlug === "barrashoppingsul") return "BarraShoppingSul";
-    if (unitSlug === "novo-hamburgo" || unitSlug === "novohamburgo") return "Novo Hamburgo";
-    return null;
+    return unitLabelFromEscalaUnitSlug(unitSlug);
 }
 
 export async function fetchActiveInjectorsResult(): Promise<InjectorsResult> {
@@ -330,6 +329,36 @@ export async function fetchActiveInjectorsResult(): Promise<InjectorsResult> {
 
     inflightInjectorsLoad = (async () => {
     try {
+        // Prefer CRM escala D1 when bound to the website worker.
+        const escalaProfessionals = await fetchEscalaProfessionals(null);
+        if (escalaProfessionals) {
+            const members = escalaProfessionals
+                .map((row) => {
+                    const roleRaw = (row.role ?? "").trim();
+                    const roles = normalizeRoles(roleRaw);
+                    const isInjector = roles.length ? roles.some((r) => r.toLowerCase() === "injetor") : true;
+                    if (!isInjector) return null;
+
+                    const instagramHandle = normalizeInstagramHandle(row.instagram ?? "");
+                    const instagramUrl = instagramHandle ? `https://www.instagram.com/${instagramHandle}/` : null;
+
+                    return {
+                        name: row.name,
+                        nickname: row.nickname,
+                        units: row.units,
+                        role: roles.length ? roles.join(", ") : roleRaw,
+                        roles,
+                        instagramHandle,
+                        instagramUrl,
+                    } satisfies TeamMember;
+                })
+                .filter((member): member is TeamMember => !!member);
+
+            members.sort((a, b) => (a.nickname ?? a.name).localeCompare(b.nickname ?? b.name));
+
+            return { ok: true, members };
+        }
+
         const env = getEnv();
         const serviceAccountJson = (env.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON ?? env.GOOGLE_SERVICE_ACCOUNT_JSON ?? "").trim();
         const sheetId = (env.GOOGLE_SHEETS_SHEET_ID ?? SHEET_ID).trim();

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -21,3 +21,8 @@ binding = "ASSETS"
 binding = "BOOKING_DB"
 database_name = "espacofacial-booking"
 database_id = "9765b1fb-11a4-462c-9657-8a438c755725" # criado via: wrangler d1 create espacofacial-booking
+
+[[d1_databases]]
+binding = "SKINCOS_ESCALA_DB"
+database_name = "skincos-escala"
+database_id = "594fef1b-5597-476e-86f9-59920f284215"


### PR DESCRIPTION
Issue
The website booking flow was still reading team/doctor data from Google Sheets while schedule constraints lived outside the CRM stack. In production this caused recurring "Equipe indisponível" failures and allowed slot calculations that ignored doctor day-level scale.

Root cause
`/api/equipe` and `getUnitDoctorsResult` depended on Sheets (`injectorsDirectory`). `booking/slots` and `booking/request` used only unit working hours + booking conflicts, without enforcing CRM scale day assignments (who actually works each day).

Fix
This PR unifies website scheduling data with the CRM escala D1 dataset inside the monorepo:
- Added `website/src/lib/escalaDb.ts` to read professionals and day schedule directly from `SKINCOS_ESCALA_DB`.
- Updated `injectorsDirectory` to prefer escala D1 as primary source, with Sheets kept as fallback.
- Updated `booking/slots` to enforce day-level availability from escala (`closed_day` / `doctor_off`) and to limit "Sem Preferência" to doctors scheduled that day.
- Updated `booking/request` to enforce the same escala constraints server-side before persisting bookings.
- Added `SKINCOS_ESCALA_DB` D1 binding in `website/wrangler.toml`.
- Updated website README with the dual-DB model (`BOOKING_DB` + `SKINCOS_ESCALA_DB`).

User impact
- Team loading no longer depends on Sheets when the escala DB binding is present.
- Dates where a selected doctor does not work are blocked consistently.
- "Sem Preferência" now respects the real daily schedule instead of offering invalid combinations.
- Backend validation now matches the frontend availability view.

Validation
- `npm --prefix website run build`
- `npm --prefix website run typecheck`
- `npm --prefix website run lint`
- `npm --prefix website run smoke`
