### PR TITLE
ci: evitar overwrite de placeholders em secrets do website

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -77,10 +77,15 @@ jobs:
         continue-on-error: true
         working-directory: website
         run: |
+          is_placeholder() {
+            local value="$1"
+            [ "${value}" = "__KEEP_EXISTING__" ]
+          }
+
           put_secret() {
             local name="$1"
             local value="$2"
-            if [ -n "${value}" ]; then
+            if [ -n "${value}" ] && ! is_placeholder "${value}"; then
               printf "%s" "${value}" | npx wrangler secret put "${name}" --name espacofacial-site
             fi
           }


### PR DESCRIPTION
## Contexto
Após a migração do website para skincos, alguns secrets SMTP não puderam ser copiados por serem write-only.

## Mudança
- Ajusta o workflow deploy-website-cloudflare.yml para ignorar valores placeholder __KEEP_EXISTING__ no passo de sync de secrets do Worker.

## Resultado
- Permite bootstrap de secrets no GitHub sem risco de sobrescrever secrets reais no Cloudflare.
- Mantém deploy e automações funcionando.