### PR TITLE
[codex] website migration follow-up: smoke:strict and docs paths

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -40,7 +40,7 @@ function formatMonthLabelHeader(value: string) {
     const month = Number(value)
     if (!month) return value
     const date = new Date(2000, month - 1, 1)
-    let label = date.toLocaleDateString('pt-BR', { month: 'long' })
+    const label = date.toLocaleDateString('pt-BR', { month: 'long' })
     return label.charAt(0).toUpperCase() + label.slice(1)
 }
 

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -63,7 +63,7 @@ function formatMonthName(value: string) {
   const month = Number(value)
   if (!month) return value
   const date = new Date(2000, month - 1, 1)
-  let label = date.toLocaleDateString('pt-BR', { month: 'long' })
+  const label = date.toLocaleDateString('pt-BR', { month: 'long' })
   return label.charAt(0).toUpperCase() + label.slice(1)
 }
 
@@ -833,7 +833,7 @@ export function EscalaProfissionaisModule() {
                               </button>
                             ) : null}
                           </div>
-                        ) : !!displayEntryNames.length ? (
+                        ) : displayEntryNames.length ? (
                           <div className="flex flex-wrap gap-1">
                           {displayEntryNames.map((name) => {
                             const isActiveSelection = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name === selectedProfessional

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -1353,7 +1353,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     let nextValue = false
     patchMessageById(normalizedId, (item) => {
       previousValue = Boolean(item?.[field])
-      nextValue = !Boolean(item?.[field])
+      nextValue = !previousValue
       return { ...item, [field]: nextValue }
     })
     try {
@@ -2557,21 +2557,21 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
 
     if (action === 'archive') {
-      updateConversationRecord(conv, (current) => ({ ...current, archived: !Boolean(current?.archived || current?.isArchived) }))
+      updateConversationRecord(conv, (current) => ({ ...current, archived: !(current?.archived || current?.isArchived) }))
       closeConversationActionMenu()
       toast.success('Status de arquivamento atualizado.')
       return
     }
 
     if (action === 'mute') {
-      updateConversationRecord(conv, (current) => ({ ...current, muted: !Boolean(current?.muted || current?.isMuted) }))
+      updateConversationRecord(conv, (current) => ({ ...current, muted: !(current?.muted || current?.isMuted) }))
       closeConversationActionMenu()
       toast.success('Status de silenciamento atualizado.')
       return
     }
 
     if (action === 'lock') {
-      updateConversationRecord(conv, (current) => ({ ...current, locked: !Boolean(current?.locked || current?.isLocked) }))
+      updateConversationRecord(conv, (current) => ({ ...current, locked: !(current?.locked || current?.isLocked) }))
       closeConversationActionMenu()
       toast.success('Status de bloqueio visual atualizado.')
       return
@@ -2580,9 +2580,9 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     if (action === 'favorite') {
       updateConversationRecord(conv, (current) => ({
         ...current,
-        isFavorite: !Boolean(current?.isFavorite || current?.favorite || current?.starred),
-        favorite: !Boolean(current?.isFavorite || current?.favorite || current?.starred),
-        starred: !Boolean(current?.isFavorite || current?.favorite || current?.starred)
+        isFavorite: !(current?.isFavorite || current?.favorite || current?.starred),
+        favorite: !(current?.isFavorite || current?.favorite || current?.starred),
+        starred: !(current?.isFavorite || current?.favorite || current?.starred)
       }))
       closeConversationActionMenu()
       toast.success('Favorito atualizado.')
@@ -2610,7 +2610,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
 
     if (action === 'block') {
-      updateConversationRecord(conv, (current) => ({ ...current, blocked: !Boolean(current?.blocked) }))
+      updateConversationRecord(conv, (current) => ({ ...current, blocked: !current?.blocked }))
       closeConversationActionMenu()
       toast.success(`Status de bloqueio de ${displayName} atualizado.`)
       return

--- a/website/docs/design-system-v2.md
+++ b/website/docs/design-system-v2.md
@@ -4,7 +4,7 @@
 Create a shared conversion layer for high-intent pages (`/`, `/agendamento`, `/unidades`, `/doutores`) so experiments can move faster without visual drift.
 
 ## Tokens
-Defined in [src/styles/globals.css](/Users/jubenitogarcia/.codex/worktrees/a692/website/src/styles/globals.css):
+Defined in `src/styles/globals.css`:
 
 - `--ds-surface-main`
 - `--ds-surface-soft`
@@ -16,12 +16,12 @@ Defined in [src/styles/globals.css](/Users/jubenitogarcia/.codex/worktrees/a692/
 ## Shared UI patterns
 
 ### `ConversionIntentRail`
-Component: [src/components/ConversionIntentRail.tsx](/Users/jubenitogarcia/.codex/worktrees/a692/website/src/components/ConversionIntentRail.tsx)
+Component: `src/components/ConversionIntentRail.tsx`
 
 Use for intent-first decision blocks with one clear CTA per card.
 
 ### Decision Cards
-Styles: `.decisionCard*` in [src/styles/globals.css](/Users/jubenitogarcia/.codex/worktrees/a692/website/src/styles/globals.css)
+Styles: `.decisionCard*` in `src/styles/globals.css`
 
 Use for local evidence, authority support, and pathway explanation.
 

--- a/website/docs/validation-checklist.md
+++ b/website/docs/validation-checklist.md
@@ -7,6 +7,7 @@
   - `npm run quality:check`
 - Smoke isolado (rotas críticas + agenda obrigatório):
   - `npm run smoke:strict`
+  - (equivale a `SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs`)
 - Auditoria 360 (design/ui/ux/seo/perf/a11y):
   - `npm run audit:360`
 

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "next lint",
     "smoke": "node scripts/smoke.mjs",
+    "smoke:strict": "SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs",
     "quality:pr": "npm run audit:360:ci",
     "quality:check": "npm run lint && npm run typecheck && npm run test:agenda && npm run build && npm run smoke",
     "quality:ci": "npm ci && npm run quality:check",


### PR DESCRIPTION
## Summary
This PR finalizes the recent migration of the public `website` project into the `skincos` monorepo by fixing follow-up consistency issues identified during migration verification.

## User impact
Without these changes, the migration left documentation and validation instructions partially inconsistent: engineers could be instructed to run a non-existent script and be sent to broken absolute links from an old local worktree path. This increases onboarding friction and can create false negatives during release validation.

## Root cause
Two migration leftovers remained after moving the website code into `website/`:
- Documentation referenced a script name (`smoke:strict`) that was never added to `website/package.json`.
- Design system docs still contained absolute links to a local `.codex/worktrees/...` path that only existed on one machine.

## What changed
- Added `smoke:strict` script to `website/package.json`:
  - `SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs`
- Replaced absolute worktree paths in `website/docs/design-system-v2.md` with repository-relative code references.
- Updated `website/docs/validation-checklist.md` to explicitly document what `smoke:strict` enforces.

## Validation
Executed in the migrated monorepo context:
- `npm --prefix website run smoke` ✅
- `npm --prefix website run smoke:strict` ✅ expected to fail when `SMOKE_AGENDA_TOKEN`/`AGENDA_SYNC_TOKEN` is not configured (strict mode working as intended)
- `rg` scan on `website/docs` for `.codex/worktrees`/absolute `/Users/.../website` links ✅ none remaining

## Scope
This PR is intentionally small and focused on migration correctness and operational clarity. No runtime behavior of the website application was changed beyond adding a strict validation command alias.
