### PR TITLE
[codex] add pip-audit path exception for crawl4ai vendor

### DIFF
--- a/.github/security/pip-audit-path-exceptions.csv
+++ b/.github/security/pip-audit-path-exceptions.csv
@@ -1,3 +1,4 @@
 # requirements_path,expires_on,reason
 backend/apps/agent-zero/requirements.txt,2026-06-30,openai-whisper dependency resolution currently fails pip-audit build metadata
 backend/apps/agent-zero/requirements.unified.txt,2026-06-30,openai-whisper dependency resolution currently fails pip-audit build metadata
+backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt,2026-06-30,crawl4ai vendor stack triggers lxml source build in pip-audit and GitHub runner lacks libxml2/libxslt development packages

--- a/docs/security-exceptions.md
+++ b/docs/security-exceptions.md
@@ -29,3 +29,14 @@ Last review: 2026-03-10
   - `.github/security/pip-audit-path-exceptions.csv`
   - `.github/security/pip-audit-vuln-exceptions.csv`
 - **Enforcement**: expired exceptions fail CI in `.github/workflows/security-secrets-audit.yml`.
+
+### pip-audit dependency resolution (crawl4ai vendor requirements)
+
+- **Status**: Temporarily active with expiry control.
+- **Scope**:
+  - `backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt`
+- **Reason**: `pip-audit` resolves this vendor requirements file in an isolated env and attempts to build `lxml` from source; GitHub hosted runners currently do not provide the required `libxml2/libxslt` development packages for that build.
+- **Policy source of truth**:
+  - `.github/security/pip-audit-path-exceptions.csv`
+  - `.github/security/pip-audit-vuln-exceptions.csv`
+- **Enforcement**: expired exceptions fail CI in `.github/workflows/security-secrets-audit.yml`.


### PR DESCRIPTION
## Summary
- add a time-bounded pip-audit path exception for crawl4ai vendor requirements
- document the temporary exception in security exceptions doc

## Why
GitHub runner lacks libxml2/libxslt dev packages required to build lxml while pip-audit resolves backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt.

## Validation
- Pip Audit (Python) no longer fails due to lxml build error for this path
- exception has explicit expiry and reason
