### PR TITLE
[codex] fix booking agenda sync

### DIFF
--- a/backend/apps/automations/scraper/README.md
+++ b/backend/apps/automations/scraper/README.md
@@ -34,6 +34,7 @@ Runner único via ações do Codex (sem menu).
 - `EF_DRY_RUN` (`1`/`0`)
 - `EF_DEBUG_RETENTION_DAYS` (default: `7`)
 - `EF_DATE_RANGE_MODE` (`prev_month`)
+- `EF_INDEX_FUTURE_DAYS` (opcional; limita agenda/index para janela móvel, ex.: `28`)
 - `EF_RECORDER_PURGE` (`1`/`0`)
 - `EF_AGENDA_SYNC_URL` (endpoint de sync, ex.: `https://espacofacial.com/api/agenda/sync`)
 - `EF_AGENDA_SYNC_TOKEN` (Bearer token do endpoint de sync)
@@ -117,6 +118,12 @@ Ele testa imports, export CSV/XLSX e se o Chrome abre a tela de login (sem logar
 - `./scripts/rotate_agenda_sync_token.sh`
 
 O script gera um token novo, atualiza `~/.config/espacofacial/agenda_sync.env`, atualiza `AGENDA_SYNC_TOKEN` em `website/.env.local`, publica a secret no Worker Cloudflare (`espacofacial-site`) e valida o endpoint de sync.
+
+## Backfill completo da agenda sincronizada
+
+- `HEADLESS=1 EF_INDEX_FUTURE_DAYS=28 EF_UNITS='BarraShoppingSul,Novo Hamburgo' EF_AGENDA_SYNC_URL='https://espacofacial.com/api/agenda/sync' ./run_agenda_full_sync_all_units.sh`
+
+Esse fluxo faz scrape completo por unidade e publica todos os agendamentos como `added`, útil para repovoar `agenda_appointments` com `duration_min`.
 
 ## Desenvolvimento (opcional)
 

--- a/backend/apps/automations/scraper/codex-automations/agenda-delta-00.automation.toml
+++ b/backend/apps/automations/scraper/codex-automations/agenda-delta-00.automation.toml
@@ -1,7 +1,7 @@
 version = 1
 id = "agenda-delta-00"
 name = "Agenda"
-prompt = "Rodar delta de agendamentos para dias remanescentes do mês em todas as unidades. Execute: HEADLESS=1 EF_INDEX_REMAINING_MONTH=1 EF_UNITS='BarraShoppingSul,Novo Hamburgo' EF_AGENDA_SYNC_URL='https://espacofacial.com/api/agenda/sync' ./run_agenda_delta_all_units.sh. O token de sync deve vir do ambiente (EF_AGENDA_SYNC_TOKEN), carregado automaticamente de ~/.config/espacofacial/agenda_sync.env quando existir, sem hardcode no comando. Para cada unidade, se existir report/*/agendamentos_espacofacial_mudancas.json, reporte ADICIONADOS e REMOVIDOS e se houve exportação de agendamentos_espacofacial_delta.csv. Crie um item de inbox com o resumo. Se a execução concluir sem erro/bloqueio, após o inbox item adicione ::archive-thread{} para arquivar automaticamente a run."
+prompt = "Rodar delta de agendamentos para hoje + próximas 4 semanas em todas as unidades. Execute: HEADLESS=1 EF_INDEX_FUTURE_DAYS=28 EF_UNITS='BarraShoppingSul,Novo Hamburgo' EF_AGENDA_SYNC_URL='https://espacofacial.com/api/agenda/sync' ./run_agenda_delta_all_units.sh. O token de sync deve vir do ambiente (EF_AGENDA_SYNC_TOKEN), carregado automaticamente de ~/.config/espacofacial/agenda_sync.env quando existir, sem hardcode no comando. Para cada unidade, se existir report/*/agendamentos_espacofacial_mudancas.json, reporte ADICIONADOS e REMOVIDOS e se houve exportação de agendamentos_espacofacial_delta.csv. Crie um item de inbox com o resumo. Se a execução concluir sem erro/bloqueio, após o inbox item adicione ::archive-thread{} para arquivar automaticamente a run."
 status = "ACTIVE"
 rrule = "FREQ=HOURLY;INTERVAL=1;BYMINUTE=0;BYDAY=SU,MO,TU,WE,TH,FR,SA"
 execution_environment = "local"

--- a/backend/apps/automations/scraper/espacofacial/appointments.py
+++ b/backend/apps/automations/scraper/espacofacial/appointments.py
@@ -140,6 +140,27 @@ def _extract_event_info(title_text: str, time_text: str) -> dict[str, str]:
     }
 
 
+def parse_duration_minutes_from_time_text(time_text: str) -> int | None:
+    text = (time_text or "").strip()
+    if not text:
+        return None
+
+    matches = re.findall(r"\b(\d{1,2}:\d{2})\b", text)
+    if len(matches) < 2:
+        return None
+
+    try:
+        start = datetime.strptime(matches[0], "%H:%M")
+        end = datetime.strptime(matches[1], "%H:%M")
+    except ValueError:
+        return None
+
+    delta_minutes = int((end - start).total_seconds() // 60)
+    if delta_minutes <= 0 or delta_minutes > 24 * 60:
+        return None
+    return delta_minutes
+
+
 def _safe_outer_html(element) -> str:
     try:
         html = element.get_attribute("outerHTML") or ""
@@ -696,6 +717,8 @@ def scrape_complete(
 
             base = _extract_event_info(title_text, time_text)
             base["Data"] = _extract_event_date(driver, event)
+            duration_min = parse_duration_minutes_from_time_text(time_text)
+            base["Duração Min"] = str(duration_min) if duration_min else ""
             base.setdefault("Telefone", "")
             base.setdefault("CPF", "")
             base.setdefault("Por onde nos conheceu", "")
@@ -750,6 +773,9 @@ def scrape_complete(
                     base["Data"] = str(details["Data"])
                 if details.get("Horário"):
                     base["Horário"] = str(details["Horário"])
+                    details_duration_min = parse_duration_minutes_from_time_text(base["Horário"])
+                    if details_duration_min:
+                        base["Duração Min"] = str(details_duration_min)
             except Exception:
                 missing_modal_count += 1
             finally:
@@ -866,6 +892,7 @@ def save(rows: list[dict[str, str]], *, output_dir: Path, prefix: str) -> tuple[
         "Cliente",
         "Tipo de Agendamento",
         "Profissional",
+        "Duração Min",
         "Telefone",
         "CPF",
         "Por onde nos conheceu",

--- a/backend/apps/automations/scraper/run_agenda_full_sync_all_units.sh
+++ b/backend/apps/automations/scraper/run_agenda_full_sync_all_units.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+sync_env_file="${EF_AGENDA_SYNC_ENV_FILE:-$HOME/.config/espacofacial/agenda_sync.env}"
+if [ -f "$sync_env_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$sync_env_file"
+  set +a
+fi
+
+login_env_file="${EF_LOGIN_ENV_FILE:-$HOME/.config/espacofacial/login.env}"
+if [ -f "$login_env_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$login_env_file"
+  set +a
+fi
+
+if [ -x "./.venv/bin/python" ]; then
+  PY="./.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PY="python3"
+elif command -v python >/dev/null 2>&1; then
+  PY="python"
+else
+  echo "ERROR: Python not found. Install Python 3 and try again." >&2
+  exit 127
+fi
+
+units_raw="${EF_UNITS:-${EF_UNIT_OPTIONS:-BarraShoppingSul,Novo Hamburgo}}"
+base_output="${EF_OUTPUT_BASE_DIR:-$(pwd)/report}"
+
+IFS=',' read -r -a units <<< "$units_raw"
+
+if [ "${#units[@]}" -eq 0 ]; then
+  echo "ERROR: No units defined. Set EF_UNITS or EF_UNIT_OPTIONS." >&2
+  exit 2
+fi
+
+if [ -z "${EF_AGENDA_SYNC_URL:-}" ] || [ -z "${EF_AGENDA_SYNC_TOKEN:-}" ]; then
+  echo "ERROR: Full sync requires EF_AGENDA_SYNC_URL and EF_AGENDA_SYNC_TOKEN." >&2
+  exit 2
+fi
+
+for unit in "${units[@]}"; do
+  unit="$(echo "$unit" | xargs)"
+  if [ -z "$unit" ]; then
+    continue
+  fi
+  safe_unit="$(echo "$unit" | tr ' /' '__' | tr -cd '[:alnum:]_-')"
+  if [ -z "$safe_unit" ]; then
+    safe_unit="unit"
+  fi
+  output_dir="${base_output}/${safe_unit}"
+  mkdir -p "$output_dir"
+
+  EF_MODE="agenda" \
+  EF_NON_INTERACTIVE="${EF_NON_INTERACTIVE:-1}" \
+  EF_AGENDA_SYNC_FULL="1" \
+  EF_UNIT_NAME="$unit" \
+  EF_OUTPUT_DIR="$output_dir" \
+  "${PY}" "run_scraper.py"
+done

--- a/backend/apps/automations/scraper/scraper_final.py
+++ b/backend/apps/automations/scraper/scraper_final.py
@@ -14,8 +14,9 @@ import email.utils
 import urllib.request
 import urllib.error
 from collections import Counter
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
+from typing import Callable
 
 from selenium.webdriver.common.by import By
 
@@ -76,6 +77,41 @@ def _filter_remaining_month(rows: list[dict[str, str]], *, today: date) -> list[
             continue
         out.append(row)
     return out
+
+
+def _filter_date_window(rows: list[dict[str, str]], *, start_date: date, end_date: date) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for row in rows:
+        d = _parse_ddmmyyyy(row.get("Data", ""))
+        if d is None:
+            continue
+        if d < start_date or d > end_date:
+            continue
+        out.append(row)
+    return out
+
+
+def _resolve_date_filter(today: date) -> tuple[Callable[[list[dict[str, str]]], list[dict[str, str]]] | None, str | None]:
+    future_days_raw = os.getenv("EF_INDEX_FUTURE_DAYS", "").strip()
+    if future_days_raw:
+        try:
+            future_days = int(future_days_raw)
+        except ValueError:
+            future_days = 0
+        if future_days > 0:
+            end_date = today + timedelta(days=future_days - 1)
+            return (
+                lambda rows: _filter_date_window(rows, start_date=today, end_date=end_date),
+                f"rolling {future_days} days",
+            )
+
+    if _env_truthy("EF_INDEX_REMAINING_MONTH"):
+        return (
+            lambda rows: _filter_remaining_month(rows, today=today),
+            "remaining month",
+        )
+
+    return None, None
 
 
 def _count_signatures(rows: list[dict[str, str]]) -> Counter[str]:
@@ -140,6 +176,7 @@ def _write_changes_report(
                     "Mudança": "ADICIONADO",
                     "Data": r.get("Data", ""),
                     "Horário": r.get("Horário", ""),
+                    "Duração Min": r.get("Duração Min", ""),
                     "Cliente": r.get("Cliente", ""),
                     "Tipo de Agendamento": r.get("Tipo de Agendamento", ""),
                     "Profissional": r.get("Profissional", ""),
@@ -153,6 +190,7 @@ def _write_changes_report(
                     "Mudança": "REMOVIDO",
                     "Data": r.get("Data", ""),
                     "Horário": r.get("Horário", ""),
+                    "Duração Min": r.get("Duração Min", ""),
                     "Cliente": r.get("Cliente", ""),
                     "Tipo de Agendamento": r.get("Tipo de Agendamento", ""),
                     "Profissional": r.get("Profissional", ""),
@@ -165,7 +203,7 @@ def _write_changes_report(
     with csv_path.open("w", encoding="utf-8", newline="") as fh:
         writer = csv.DictWriter(
             fh,
-            fieldnames=["Mudança", "Data", "Horário", "Cliente", "Tipo de Agendamento", "Profissional"],
+            fieldnames=["Mudança", "Data", "Horário", "Duração Min", "Cliente", "Tipo de Agendamento", "Profissional"],
         )
         writer.writeheader()
         writer.writerows(report_rows)
@@ -207,6 +245,7 @@ def _post_agenda_sync(
             item = {
                 "data": row.get("Data", ""),
                 "horario": row.get("Horário", "") or row.get("Horario", ""),
+                "duration_min": row.get("Duração Min", "") or row.get("Duracao Min", ""),
                 "cliente": row.get("Cliente", ""),
                 "tipo": row.get("Tipo de Agendamento", ""),
                 "profissional": row.get("Profissional", ""),
@@ -220,6 +259,12 @@ def _post_agenda_sync(
 
     payload["added"] = added
     payload["removed"] = removed
+    return _post_agenda_sync_payload(payload=payload, endpoint=endpoint, token=token)
+
+
+def _post_agenda_sync_payload(*, payload: dict[str, object], endpoint: str, token: str) -> bool:
+    if not endpoint:
+        return False
 
     def _retry_after_seconds(err: urllib.error.HTTPError) -> int | None:
         header = ""
@@ -291,6 +336,44 @@ def _post_agenda_sync(
 
     log(f"ERROR: agenda sync failed: {last_error}")
     return False
+
+
+def _post_agenda_full_sync(
+    *,
+    unit_name: str,
+    rows: list[dict[str, str]],
+    endpoint: str,
+    token: str,
+) -> bool:
+    added: list[dict[str, str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        added.append(
+            {
+                "data": row.get("Data", ""),
+                "horario": row.get("Horário", "") or row.get("Horario", ""),
+                "duration_min": row.get("Duração Min", "") or row.get("Duracao Min", ""),
+                "cliente": row.get("Cliente", ""),
+                "tipo": row.get("Tipo de Agendamento", ""),
+                "profissional": row.get("Profissional", ""),
+                "telefone": row.get("Telefone", ""),
+                "cpf": row.get("CPF", ""),
+                "servico": row.get("Serviço a realizar", "") or row.get("Servico a realizar", ""),
+                "observacoes": row.get("Observações", "") or row.get("Observacoes", ""),
+                "status": row.get("Status", ""),
+                "source": "scraper_full",
+            }
+        )
+
+    payload: dict[str, object] = {
+        "unit": unit_name,
+        "runId": datetime.now().strftime("%Y%m%d_%H%M%S"),
+        "schema_version": 1,
+        "added": added,
+        "removed": [],
+    }
+    return _post_agenda_sync_payload(payload=payload, endpoint=endpoint, token=token)
 
 
 def _load_index_rows(path: Path) -> list[dict[str, str]]:
@@ -439,8 +522,8 @@ def main(mode: str = "full") -> bool:
         signature_mode = os.getenv("EF_INDEX_SIGNATURE_MODE", "dt").strip().lower()
         include_title = not _signature_mode_is_dt(signature_mode)
         dry_run = os.getenv("EF_DRY_RUN", "").strip().lower() in {"1", "true", "yes", "y", "sim"}
-        filter_remaining = _env_truthy("EF_INDEX_REMAINING_MONTH")
         today = datetime.now().date()
+        date_filter, date_filter_label = _resolve_date_filter(today)
 
         if mode_norm == "index":
             rows_index = _run_with_scrape_retries(
@@ -450,10 +533,10 @@ def main(mode: str = "full") -> bool:
                 cfg=cfg,
                 creds=creds,
             )
-            if filter_remaining:
+            if date_filter is not None:
                 before = len(rows_index)
-                rows_index = _filter_remaining_month(rows_index, today=today)
-                log(f"Index filter (remaining month): {before} -> {len(rows_index)}")
+                rows_index = date_filter(rows_index)
+                log(f"Index filter ({date_filter_label}): {before} -> {len(rows_index)}")
             if dry_run:
                 log("DRY-RUN: skipping export files")
                 log(f"DRY-RUN: extracted rows = {len(rows_index)}")
@@ -478,14 +561,14 @@ def main(mode: str = "full") -> bool:
                 cfg=cfg,
                 creds=creds,
             )
-            if filter_remaining:
+            if date_filter is not None:
                 before = len(rows_index)
-                rows_index = _filter_remaining_month(rows_index, today=today)
-                log(f"Index filter (remaining month): {before} -> {len(rows_index)}")
+                rows_index = date_filter(rows_index)
+                log(f"Index filter ({date_filter_label}): {before} -> {len(rows_index)}")
             new_counts = _count_signatures(rows_index)
             old_rows = _load_index_rows(index_csv)
-            if filter_remaining:
-                old_rows = _filter_remaining_month(old_rows, today=today)
+            if date_filter is not None:
+                old_rows = date_filter(old_rows)
             old_counts = _load_index_signatures(old_rows, signature_mode=signature_mode)
 
             added = new_counts - old_counts
@@ -573,6 +656,14 @@ def main(mode: str = "full") -> bool:
             log("ERROR: No appointments extracted")
             return False
 
+        if date_filter is not None:
+            before = len(rows)
+            rows = date_filter(rows)
+            log(f"Full filter ({date_filter_label}): {before} -> {len(rows)}")
+        if not rows:
+            log("ERROR: No appointments extracted after date filter")
+            return False
+
         if dry_run:
             log("DRY-RUN: skipping export files")
             log(f"DRY-RUN: extracted rows = {len(rows)}")
@@ -581,6 +672,18 @@ def main(mode: str = "full") -> bool:
         csv_path, xlsx_path = save(rows, output_dir=cfg.output_dir, prefix=FULL_PREFIX)
         log(f"✓ Saved CSV: {csv_path}")
         log(f"✓ Saved Excel: {xlsx_path}")
+        endpoint = os.getenv("EF_AGENDA_SYNC_URL", "").strip()
+        token = os.getenv("EF_AGENDA_SYNC_TOKEN", "").strip()
+        if endpoint and _env_truthy("EF_AGENDA_SYNC_FULL"):
+            if _post_agenda_full_sync(
+                unit_name=cfg.unit_name,
+                rows=rows,
+                endpoint=endpoint,
+                token=token,
+            ):
+                log("✓ Agenda full sync posted")
+            else:
+                log("WARNING: agenda full sync failed")
         return True
     except Exception as e:
         log_exception("ERROR: Unexpected failure", e)

--- a/backend/apps/automations/scraper/tests_test_booking.py
+++ b/backend/apps/automations/scraper/tests_test_booking.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import unittest
 
 from espacofacial.booking import BookingRequest
+from espacofacial.appointments import parse_duration_minutes_from_time_text
 
 
 class BookingRequestTests(unittest.TestCase):
+    def test_extracts_duration_from_time_range(self) -> None:
+        self.assertEqual(parse_duration_minutes_from_time_text("13:00 - 13:30"), 30)
+        self.assertEqual(parse_duration_minutes_from_time_text("17:40 - 18:00"), 20)
+        self.assertIsNone(parse_duration_minutes_from_time_text("18:00"))
+
     def test_parses_portuguese_payload(self) -> None:
         request = BookingRequest.from_payload(
             {

--- a/website/scripts/smoke.mjs
+++ b/website/scripts/smoke.mjs
@@ -97,7 +97,7 @@ async function run() {
     }
     {
         const unit = "barrashoppingsul";
-        const doctor = "smoke";
+        const doctor = "any";
         const service = "botox";
         const durationMinutes = 30;
         const url = `/api/booking/slots?unit=${encodeURIComponent(unit)}&doctor=${encodeURIComponent(doctor)}&service=${encodeURIComponent(service)}&durationMinutes=${durationMinutes}&date=${encodeURIComponent(tomorrowKey)}`;

--- a/website/src/app/api/agenda/sync/route.ts
+++ b/website/src/app/api/agenda/sync/route.ts
@@ -44,6 +44,10 @@ type Payload = {
     schema_version?: number | string;
 };
 
+const UNKNOWN_CLIENT = "[agenda-sync]";
+const UNKNOWN_TYPE = "[desconhecido]";
+const UNKNOWN_PROFESSIONAL = "[desconhecido]";
+
 function json(data: unknown, init?: ResponseInit) {
     return NextResponse.json(data, init);
 }
@@ -120,11 +124,11 @@ export async function POST(request: Request) {
     for (const item of added) {
         const dateKey = parseDateKey(item.data ?? "");
         const timeKey = parseTimeKey(item.horario ?? "");
-        const client = normalizeOneLine(item.cliente ?? "");
-        const tipo = normalizeOneLine(item.tipo ?? "");
-        const profissional = normalizeOneLine(item.profissional ?? "");
+        const client = normalizeOneLine(item.cliente ?? "") || UNKNOWN_CLIENT;
+        const tipo = normalizeOneLine(item.tipo ?? "") || UNKNOWN_TYPE;
+        const profissional = normalizeOneLine(item.profissional ?? "") || UNKNOWN_PROFESSIONAL;
         const durationMin = parseDurationMin(item.duration_min);
-        if (!dateKey || !timeKey || !client || !tipo || !profissional) {
+        if (!dateKey || !timeKey) {
             addedSkipped += 1;
             continue;
         }

--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -4,9 +4,12 @@ import { getServiceById } from "@/data/services";
 import { getUnitDoctorsResult } from "@/lib/injectorsDirectory";
 import { getAgendaDb } from "@/lib/agendaDb";
 import { sendBookingNotifications } from "@/lib/bookingNotifications";
-import { fetchEscalaDaySchedule, normalizePersonKey } from "@/lib/escalaDb";
+import { doctorSlugMatchesQuery } from "@/lib/doctorSlug";
+import { fetchEscalaDaySchedule, personNameMatches } from "@/lib/escalaDb";
 
 export const dynamic = "force-dynamic";
+
+type AgendaRange = { start: number; end: number; professionalName: string | null };
 
 type Payload = {
     unitSlug?: string;
@@ -54,6 +57,12 @@ function clientIp(request: Request): string | null {
     const xff = (request.headers.get("x-forwarded-for") ?? "").trim();
     if (xff) return xff.split(",")[0]?.trim() || null;
     return null;
+}
+
+function normalizeAgendaProfessionalName(value: string | null | undefined): string | null {
+    const raw = (value ?? "").toString().trim();
+    if (!raw || raw.startsWith("[")) return null;
+    return raw;
 }
 
 async function verifyTurnstile(params: { secret: string; token: string; ip: string | null }): Promise<{ ok: boolean }> {
@@ -150,17 +159,18 @@ async function upsertCustomer(
     return id;
 }
 
-async function hasAgendaConflict(params: { unitSlug: string; date: string; startAtMs: number; endAtMs: number }): Promise<boolean> {
+async function listAgendaRanges(params: { unitSlug: string; date: string }): Promise<AgendaRange[]> {
     const agendaDb = await getAgendaDb();
     const agendaRows = await agendaDb
         .prepare(
-            `SELECT time_key, duration_min
+            `SELECT time_key, duration_min, profissional
              FROM agenda_appointments
              WHERE unit_slug = ? AND date_key = ? AND removed_at_ms IS NULL`,
         )
         .bind(params.unitSlug, params.date)
-        .all<{ time_key: string; duration_min: number | null }>();
+        .all<{ time_key: string; duration_min: number | null; profissional: string | null }>();
 
+    const agendaRanges: AgendaRange[] = [];
     for (const row of agendaRows.results ?? []) {
         const timeKey = (row.time_key ?? "").toString().trim();
         if (!isValidTimeKey(timeKey)) continue;
@@ -170,14 +180,28 @@ async function hasAgendaConflict(params: { unitSlug: string; date: string; start
 
         const durationMin = Number(row.duration_min ?? 0);
         const agendaDurationMs = Number.isFinite(durationMin) && durationMin > 0 ? durationMin * 60_000 : 1;
-        const agendaEndMs = agendaStartMs + agendaDurationMs;
-
-        if (agendaStartMs < params.endAtMs && agendaEndMs > params.startAtMs) {
-            return true;
-        }
+        agendaRanges.push({
+            start: agendaStartMs,
+            end: agendaStartMs + agendaDurationMs,
+            professionalName: normalizeAgendaProfessionalName(row.profissional),
+        });
     }
 
-    return false;
+    return agendaRanges;
+}
+
+function hasAgendaConflictForDoctor(params: {
+    agendaRanges: AgendaRange[];
+    startAtMs: number;
+    endAtMs: number;
+    doctorNameKey: string | null;
+}): boolean {
+    return params.agendaRanges.some(
+        (range) =>
+            range.start < params.endAtMs &&
+            range.end > params.startAtMs &&
+            (range.professionalName === null || (params.doctorNameKey !== null && personNameMatches(range.professionalName, params.doctorNameKey))),
+    );
 }
 
 export async function POST(request: Request) {
@@ -347,8 +371,9 @@ export async function POST(request: Request) {
     if (doctors.length === 0) {
         return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
     }
+    const doctorNameKeyBySlug = new Map(doctors.map((doctor) => [doctor.slug, doctor.name]));
 
-    const selectedDoctor = wantsAnyDoctor ? null : doctors.find((doctor) => doctor.slug === doctorSlug) ?? null;
+    const selectedDoctor = wantsAnyDoctor ? null : doctors.find((doctor) => doctorSlugMatchesQuery(doctorSlug, doctor)) ?? null;
     if (!wantsAnyDoctor && !selectedDoctor) {
         return json({ ok: false, error: "invalid_doctor" }, { status: 400 });
     }
@@ -360,16 +385,17 @@ export async function POST(request: Request) {
             return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
 
-        const scheduledNameKeys = new Set(daySchedule.professionalNames.map((name) => normalizePersonKey(name)));
-        doctorsAvailableBySchedule = doctors.filter((doctor) => scheduledNameKeys.has(normalizePersonKey(doctor.name)));
+        doctorsAvailableBySchedule = doctors.filter((doctor) => daySchedule.professionalNames.some((name) => personNameMatches(name, doctor.name)));
 
-        if (!wantsAnyDoctor && selectedDoctor && !scheduledNameKeys.has(normalizePersonKey(selectedDoctor.name))) {
+        if (!wantsAnyDoctor && selectedDoctor && !daySchedule.professionalNames.some((name) => personNameMatches(name, selectedDoctor.name))) {
             return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
         if (wantsAnyDoctor && doctorsAvailableBySchedule.length === 0) {
             return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
     }
+
+    const agendaRanges = await listAgendaRanges({ unitSlug, date });
 
     const db = await getBookingDb();
 
@@ -407,7 +433,11 @@ export async function POST(request: Request) {
             activeByDoctor.set(slug, cur);
         }
 
-        const pick = doctorsForSelection.find((doctor) => !activeByDoctor.has(doctor.slug)) ?? null;
+        const pick = doctorsForSelection.find((doctor) => {
+            if (activeByDoctor.has(doctor.slug)) return false;
+            const doctorNameKey = doctorNameKeyBySlug.get(doctor.slug) ?? null;
+            return !hasAgendaConflictForDoctor({ agendaRanges, startAtMs, endAtMs, doctorNameKey });
+        }) ?? null;
         if (!pick) {
             const anyPending = Array.from(activeByDoctor.values()).some((v) => v.hasPending);
             return json({ ok: false, error: anyPending ? "slot_in_review" : "no_availability" }, { status: 409 });
@@ -417,7 +447,8 @@ export async function POST(request: Request) {
         safeDoctorName = clampText(pick.name, 120);
     }
 
-    const blockedByAgenda = await hasAgendaConflict({ unitSlug, date, startAtMs, endAtMs });
+    const effectiveDoctorNameKey = wantsAnyDoctor ? doctorNameKeyBySlug.get(effectiveDoctorSlug) ?? null : selectedDoctor ? selectedDoctor.name : null;
+    const blockedByAgenda = hasAgendaConflictForDoctor({ agendaRanges, startAtMs, endAtMs, doctorNameKey: effectiveDoctorNameKey });
     if (blockedByAgenda) {
         return json({ ok: false, error: "no_availability" }, { status: 409 });
     }

--- a/website/src/app/api/booking/slots/route.ts
+++ b/website/src/app/api/booking/slots/route.ts
@@ -3,11 +3,12 @@ import { getBookingDb, nowMs, addMinutes, isValidDateKey, isValidTimeKey, toSaoP
 import { getAgendaDb } from "@/lib/agendaDb";
 import { getServiceById } from "@/data/services";
 import { getUnitDoctorsResult } from "@/lib/injectorsDirectory";
-import { fetchEscalaDaySchedule, normalizePersonKey } from "@/lib/escalaDb";
+import { doctorSlugMatchesQuery } from "@/lib/doctorSlug";
+import { fetchEscalaDaySchedule, personNameMatches } from "@/lib/escalaDb";
 
 export const dynamic = "force-dynamic";
 
-type AgendaRange = { start: number; end: number };
+type AgendaRange = { start: number; end: number; professionalName: string | null };
 type AgendaCacheEntry = { expiresAtMs: number; ranges: AgendaRange[]; count: number };
 
 const agendaCache = new Map<string, AgendaCacheEntry>();
@@ -85,6 +86,12 @@ function buildUnavailableSlots(params: { date: string; durationMinutes: number; 
     });
 }
 
+function normalizeAgendaProfessionalName(value: string | null | undefined): string | null {
+    const raw = (value ?? "").toString().trim();
+    if (!raw || raw.startsWith("[")) return null;
+    return raw;
+}
+
 async function expireIfNeeded(db: Awaited<ReturnType<typeof getBookingDb>>, id: string) {
     // Best-effort: mark pending approvals as expired after confirm_by.
     const row = await db
@@ -152,10 +159,14 @@ export async function GET(req: Request) {
     }
 
     const unitDoctors = unitDoctorsResult.ok ? unitDoctorsResult.doctors : [];
-    const knownDoctor = !wantsAnyDoctor ? unitDoctors.find((doctor) => doctor.slug === doctorSlug) ?? null : null;
-    let doctorSlugs = wantsAnyDoctor ? unitDoctors.map((doctor) => doctor.slug) : [doctorSlug];
+    const knownDoctor = !wantsAnyDoctor ? unitDoctors.find((doctor) => doctorSlugMatchesQuery(doctorSlug, doctor)) ?? null : null;
+    const resolvedDoctorSlug = knownDoctor?.slug ?? doctorSlug;
+    let doctorSlugs = wantsAnyDoctor ? unitDoctors.map((doctor) => doctor.slug) : knownDoctor ? [knownDoctor.slug] : [doctorSlug];
     if (wantsAnyDoctor && doctorSlugs.length === 0) {
         return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
+    }
+    if (!wantsAnyDoctor && !knownDoctor) {
+        return json({ ok: false, error: "invalid_doctor" }, { status: 400 });
     }
 
     const daySchedule = await fetchEscalaDaySchedule(unitSlug, date);
@@ -165,22 +176,21 @@ export async function GET(req: Request) {
     }
 
     if (daySchedule) {
-        const scheduledNameKeys = new Set(daySchedule.professionalNames.map((name) => normalizePersonKey(name)));
-        if (scheduledNameKeys.size === 0) {
+        if (daySchedule.professionalNames.length === 0) {
             const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
             return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
         }
 
         if (wantsAnyDoctor) {
             doctorSlugs = unitDoctors
-                .filter((doctor) => scheduledNameKeys.has(normalizePersonKey(doctor.name)))
+                .filter((doctor) => daySchedule.professionalNames.some((name) => personNameMatches(name, doctor.name)))
                 .map((doctor) => doctor.slug);
 
             if (doctorSlugs.length === 0) {
                 const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
                 return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
             }
-        } else if (knownDoctor && !scheduledNameKeys.has(normalizePersonKey(knownDoctor.name))) {
+        } else if (knownDoctor && !daySchedule.professionalNames.some((name) => personNameMatches(name, knownDoctor.name))) {
             const slots = buildUnavailableSlots({ date, durationMinutes, daySlots, reason: "doctor_off" });
             return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
         }
@@ -200,12 +210,12 @@ export async function GET(req: Request) {
         const agendaDb = await getAgendaDb();
         const agendaRows = await agendaDb
             .prepare(
-                `SELECT time_key, duration_min
+                `SELECT time_key, duration_min, profissional
                  FROM agenda_appointments
                  WHERE unit_slug = ? AND date_key = ? AND removed_at_ms IS NULL`,
             )
             .bind(unitSlug, date)
-            .all<{ time_key: string; duration_min: number | null }>();
+            .all<{ time_key: string; duration_min: number | null; profissional: string | null }>();
         agendaRanges = [];
         for (const row of agendaRows.results ?? []) {
             const time = (row.time_key ?? "").toString().trim();
@@ -215,7 +225,11 @@ export async function GET(req: Request) {
             if (!Number.isFinite(startMs)) continue;
             const durationMin = Number(row.duration_min ?? 0);
             const durationMs = Number.isFinite(durationMin) && durationMin > 0 ? durationMin * 60_000 : 1;
-            agendaRanges.push({ start: startMs, end: startMs + durationMs });
+            agendaRanges.push({
+                start: startMs,
+                end: startMs + durationMs,
+                professionalName: normalizeAgendaProfessionalName(row.profissional),
+            });
         }
         agendaRowsCount = agendaRows.results?.length ?? 0;
         agendaCache.set(cacheKey, {
@@ -272,6 +286,15 @@ export async function GET(req: Request) {
     }
 
     let agendaBlockedCount = 0;
+    const overlapsAgendaForDoctor = (slug: string, startMs: number, endMs: number) => {
+        const doctorName = unitDoctors.find((doctor) => doctor.slug === slug)?.name ?? null;
+        return agendaRanges.some(
+            (r) =>
+                r.start < endMs &&
+                r.end > startMs &&
+                (r.professionalName === null || (doctorName !== null && personNameMatches(r.professionalName, doctorName))),
+        );
+    };
     const out = daySlots.map((s) => {
         const time = s.time;
         if (!isValidTimeKey(time)) {
@@ -290,7 +313,7 @@ export async function GET(req: Request) {
             return { time, startAtMs: startMs, endAtMs: endMs, available: false, reason: "past" };
         }
 
-        if (agendaRanges.some((r) => r.start < endMs && r.end > startMs)) {
+        if (!wantsAnyDoctor && overlapsAgendaForDoctor(resolvedDoctorSlug, startMs, endMs)) {
             agendaBlockedCount += 1;
             return { time, available: false, reason: "agenda" };
         }
@@ -306,22 +329,26 @@ export async function GET(req: Request) {
         } else {
             let hasPending = false;
             let hasConfirmed = false;
+            let hasAgendaConflict = false;
             let anyFree = false;
 
             for (const slug of doctorSlugs) {
+                const agendaOverlap = overlapsAgendaForDoctor(slug, startMs, endMs);
                 const ranges = byDoctor.get(slug) ?? [];
                 const overlap = ranges.some((e) => e.start < endMs && e.end > startMs);
-                if (!overlap) {
+                if (!agendaOverlap && !overlap) {
                     anyFree = true;
                     break;
                 }
+                if (agendaOverlap) hasAgendaConflict = true;
                 if (ranges.some((e) => e.start < endMs && e.end > startMs && e.isConfirmed)) hasConfirmed = true;
                 if (ranges.some((e) => e.start < endMs && e.end > startMs && !e.isConfirmed)) hasPending = true;
             }
 
             if (!anyFree) {
                 available = false;
-                reason = hasPending ? "in_review" : hasConfirmed ? "booked" : "booked";
+                reason = hasPending ? "in_review" : hasConfirmed ? "booked" : hasAgendaConflict ? "agenda" : "booked";
+                if (reason === "agenda") agendaBlockedCount += 1;
             }
         }
 

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -8,7 +8,7 @@ import { services, type Service } from "@/data/services";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { useTeamDirectory } from "@/hooks/useTeamDirectory";
 import { clearBookingDraft, persistBookingDraft, readBookingDraft, type BookingDraftState } from "@/lib/bookingDraft";
-import { doctorSlugFromTeamMember, normalizeDoctorSlug } from "@/lib/doctorSlug";
+import { doctorSlugFromTeamMember, doctorSlugMatchesQuery, normalizeDoctorSlug } from "@/lib/doctorSlug";
 import { trackBookingFunnelStep, trackBookingRequestSubmitted, trackDoctorInstagramClick } from "@/lib/leadTracking";
 import { setStoredUnitSlug } from "@/lib/unitSelection";
 import DoctorInstagramModal, { InstagramIcon, type DoctorInstagramProfile } from "@/components/DoctorInstagramModal";
@@ -473,9 +473,10 @@ export default function BookingFlow() {
         }
 
         const match = doctorsForUnit.find((d) => {
-            if (normalizeDoctorSlug(d.slug) === doctorQuery) return true;
-            if (normalizeDoctorSlug(d.handle ?? "") === doctorQuery) return true;
-            return normalizeDoctorSlug(d.name) === doctorQuery;
+            return doctorSlugMatchesQuery(doctorQuery, {
+                name: d.name,
+                instagramHandle: d.handle ?? null,
+            });
         });
 
         if (!match) return;

--- a/website/src/lib/doctorSlug.ts
+++ b/website/src/lib/doctorSlug.ts
@@ -1,7 +1,27 @@
+import { doctors as marketingDoctors } from "@/data/doctors";
+
 export type DoctorSlugInput = {
     name: string;
     instagramHandle: string | null;
 };
+
+function stripDiacritics(value: string): string {
+    return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function normalizeNameAlias(value: string): string {
+    return stripDiacritics(value ?? "")
+        .toLowerCase()
+        .replace(/\b(dr|dra|doutor|doutora)\b/g, " ")
+        .replace(/[^a-z0-9]+/g, "")
+        .trim();
+}
+
+function normalizeSlugAlias(value: string | null | undefined): string {
+    return stripDiacritics(normalizeDoctorSlug(value))
+        .replace(/[^a-z0-9]+/g, "")
+        .trim();
+}
 
 export function doctorSlugFromTeamMember(member: DoctorSlugInput): string {
     const handle = (member.instagramHandle ?? "").trim();
@@ -11,4 +31,28 @@ export function doctorSlugFromTeamMember(member: DoctorSlugInput): string {
 
 export function normalizeDoctorSlug(value: string | null | undefined): string {
     return (value ?? "").trim().toLowerCase().replace(/^@/, "");
+}
+
+export function doctorSlugAliases(member: DoctorSlugInput): string[] {
+    const aliases = new Set<string>();
+    const handle = normalizeDoctorSlug(member.instagramHandle);
+    const slug = normalizeDoctorSlug(doctorSlugFromTeamMember(member));
+    const nameAlias = normalizeNameAlias(member.name);
+
+    if (handle) aliases.add(handle);
+    if (slug) aliases.add(slug);
+    if (nameAlias) aliases.add(nameAlias);
+
+    for (const doctor of marketingDoctors) {
+        if (normalizeNameAlias(doctor.name) !== nameAlias) continue;
+        aliases.add(normalizeDoctorSlug(doctor.slug));
+    }
+
+    return Array.from(aliases).filter(Boolean);
+}
+
+export function doctorSlugMatchesQuery(query: string | null | undefined, member: DoctorSlugInput): boolean {
+    const queryAlias = normalizeSlugAlias(query);
+    if (!queryAlias) return false;
+    return doctorSlugAliases(member).some((alias) => normalizeSlugAlias(alias) === queryAlias);
 }

--- a/website/src/lib/escalaDb.ts
+++ b/website/src/lib/escalaDb.ts
@@ -74,6 +74,45 @@ export function normalizePersonKey(value: string): string {
         .replace(/[^a-z0-9]+/g, "");
 }
 
+const PERSON_IGNORED_TOKENS = new Set(["dr", "dra", "doutor", "doutora", "de", "da", "do", "dos", "das"]);
+
+export function tokenizePersonName(value: string): string[] {
+    return String(value ?? "")
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, " ")
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((token) => !PERSON_IGNORED_TOKENS.has(token));
+}
+
+export function personNameMatches(left: string, right: string): boolean {
+    const leftKey = normalizePersonKey(left);
+    const rightKey = normalizePersonKey(right);
+    if (!leftKey || !rightKey) return false;
+    if (leftKey === rightKey) return true;
+
+    const leftTokens = tokenizePersonName(left);
+    const rightTokens = tokenizePersonName(right);
+    if (!leftTokens.length || !rightTokens.length) return false;
+
+    if (leftTokens.join("") === rightTokens.join("")) return true;
+
+    const [shorter, longer] = leftTokens.length <= rightTokens.length ? [leftTokens, rightTokens] : [rightTokens, leftTokens];
+    if (shorter[0] !== longer[0]) return false;
+    if (shorter[shorter.length - 1] !== longer[longer.length - 1]) return false;
+
+    let shorterIndex = 0;
+    for (const token of longer) {
+        if (token === shorter[shorterIndex]) shorterIndex += 1;
+        if (shorterIndex >= shorter.length) return true;
+    }
+
+    return false;
+}
+
 export function unitLabelFromEscalaUnitSlug(unitSlug: string): string | null {
     const key = normalizeUnitKey(unitSlug);
     if (!key) return null;

--- a/website/src/lib/injectorsDirectory.ts
+++ b/website/src/lib/injectorsDirectory.ts
@@ -464,8 +464,8 @@ export async function fetchActiveInjectors(): Promise<TeamMember[]> {
 }
 
 export async function getUnitDoctorsResult(unitSlug: string): Promise<
-    | { ok: true; doctors: Array<{ slug: string; name: string }> }
-    | { ok: false; doctors: Array<{ slug: string; name: string }>; error: InjectorsDirectoryError }
+    | { ok: true; doctors: Array<{ slug: string; name: string; instagramHandle: string | null }> }
+    | { ok: false; doctors: Array<{ slug: string; name: string; instagramHandle: string | null }>; error: InjectorsDirectoryError }
 > {
     const label = unitLabelFromBookingUnitSlug(unitSlug);
     if (!label) return { ok: true, doctors: [] };
@@ -475,12 +475,12 @@ export async function getUnitDoctorsResult(unitSlug: string): Promise<
 
     const doctors = membersResult.members
         .filter((m) => m.units.map((u) => u.toLowerCase()).includes(label.toLowerCase()))
-        .map((m) => ({ slug: doctorSlugFromTeamMember(m), name: m.name }));
+        .map((m) => ({ slug: doctorSlugFromTeamMember(m), name: m.name, instagramHandle: m.instagramHandle ?? null }));
 
     return { ok: true, doctors };
 }
 
-export async function getUnitDoctors(unitSlug: string): Promise<Array<{ slug: string; name: string }>> {
+export async function getUnitDoctors(unitSlug: string): Promise<Array<{ slug: string; name: string; instagramHandle: string | null }>> {
     const result = await getUnitDoctorsResult(unitSlug);
     return result.doctors;
 }

--- a/website/tests/agendaDb.test.ts
+++ b/website/tests/agendaDb.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseDateKey, parseTimeKey } from "../src/lib/agendaDb";
+import { personNameMatches } from "../src/lib/escalaDb";
+import { doctorSlugMatchesQuery } from "../src/lib/doctorSlug";
+import { doctors as marketingDoctors } from "../src/data/doctors";
 
 test("parseDateKey returns yyyy-mm-dd", () => {
     assert.equal(parseDateKey("03/03/2026"), "2026-03-03");
@@ -20,4 +23,36 @@ test("parseTimeKey returns hh:mm", () => {
 test("parseTimeKey rejects invalid", () => {
     assert.equal(parseTimeKey("9:00"), "");
     assert.equal(parseTimeKey("25:00"), "");
+});
+
+test("personNameMatches accepts honorific and middle-name variations", () => {
+    assert.equal(personNameMatches("Dra. Josiele de Souza", "Josiele Maiara de Souza"), true);
+    assert.equal(personNameMatches("Josiele de Souza", "Josiele Maiara de Souza"), true);
+});
+
+test("personNameMatches rejects different professionals", () => {
+    assert.equal(personNameMatches("Viviane Mondin", "Josiele Maiara de Souza"), false);
+});
+
+test("doctorSlugMatchesQuery accepts public doctor aliases", () => {
+    assert.equal(
+        doctorSlugMatchesQuery("drajosielesouza", {
+            name: "Josiele de Souza",
+            instagramHandle: "dra.josiele",
+        }),
+        true,
+    );
+});
+
+test("doctorSlugMatchesQuery covers all public doctor slugs by name alias", () => {
+    for (const doctor of marketingDoctors) {
+        assert.equal(
+            doctorSlugMatchesQuery(doctor.slug, {
+                name: doctor.name,
+                instagramHandle: null,
+            }),
+            true,
+            `expected alias for ${doctor.slug}`,
+        );
+    }
 });


### PR DESCRIPTION
## Resumo

Esta mudança corrige o fluxo de agendamento público para que a disponibilidade de horários reflita corretamente a combinação entre escala do CRM e agenda ocupada sincronizada pelo scraper.

O problema percebido pelo usuário era específico, mas vinha de mais de uma causa: os dias de atendimento eram bloqueados corretamente pela escala, porém os horários dentro dos dias válidos apareciam como livres mesmo quando havia ocupações na agenda real. Além disso, a seleção de doutora no site público podia usar um slug diferente do slug operacional retornado pelo diretório da equipe, o que fazia com que alguns links públicos antigos não resolvessem para a profissional correta.

## Causa raiz

Havia quatro causas principais trabalhando juntas:

1. O scraper/sync não propagava `duration_min` de forma confiável, então a agenda ocupada bloqueava intervalos incorretos.
2. O endpoint de sync descartava parte das ocupações quando vinham metadados incompletos, mesmo quando data e horário estavam presentes.
3. O matching entre profissional da agenda, profissional da escala e profissional do site era rígido demais. Variações como `Dra. Josiele de Souza`, `Josiele de Souza` e `Josiele Maiara de Souza` não eram tratadas como a mesma pessoa.
4. O site público usava aliases de slug como `drajosielesouza`, enquanto o diretório operacional retornava `dra.josiele`. O backend do booking resolvia um deles, mas a checagem final da agenda ainda usava o slug bruto da query em vez do slug resolvido.

## O que foi corrigido

### Scraper e sync de agenda

- O scraper agora extrai e carrega `duration_min` a partir da faixa do horário.
- O delta e o full sync passam `duration_min` até o endpoint do site.
- O endpoint `/api/agenda/sync` aceita ocupações com dados mínimos (`date` + `time`) e preenche placeholders para os demais campos quando o modal do scraper vier incompleto.
- Foi adicionado um fluxo de full sync para repovoar a base de agenda ocupada com os dados corrigidos.
- A automação de agenda foi ajustada de "restante do mês" para janela móvel de `hoje + 28 dias`, alinhando a coleta com a experiência do site.

### Website público

- `/api/booking/slots` e `/api/booking/request` passaram a cruzar agenda ocupada por profissional, não mais por unidade inteira.
- O matching de nomes foi flexibilizado para suportar honoríficos e nomes intermediários.
- Foi introduzida uma camada de aliases de slug para unificar slugs públicos e operacionais das doutoras.
- A seleção de doutora no `BookingFlow` também passou a aceitar esses aliases.
- O smoke do website foi atualizado para usar um slug válido e refletir o contrato atual do endpoint.

## Efeito para o usuário

Depois desta mudança:

- os dias continuam respeitando a escala do CRM;
- os horários ocupados respeitam a agenda ocupada sincronizada pelo scraper;
- a escolha de doutora específica bloqueia somente os horários ocupados daquela profissional;
- links públicos e queries antigas com slugs alternativos continuam funcionando.

Validação de produção após deploy local da correção:

- `doctor=drajosielesouza` em Novo Hamburgo (`2026-03-13`) voltou a bloquear `28` horários por `agenda`;
- `doctor=dra.josiele` retorna o mesmo resultado;
- `doctor=any` mantém o bloqueio da agenda mais ampla da unidade.

## Validação executada

### Scraper

- `PYTHONPATH=. ./.venv/bin/python -m unittest tests_test_booking.py`

### Website

- `npm run test:agenda`
- `npm run typecheck`
- `npm run lint`
- `npm run smoke:strict`

### Produção

- validação direta em `https://espacofacial.com/api/booking/slots`
- consulta remota em D1 para confirmar os registros da agenda sincronizada
- verificação do build marker publicado no HTML do `/agendamento`

## Deploy

O repositório já possui workflow de deploy do website para Cloudflare/OpenNext em merge para `main`. Como este PR altera arquivos em `website/**`, o auto-merge deve disparar o auto-deploy do site na esteira padrão.
