### PR TITLE
[codex] fix agenda modal extraction for client and injector fields

### DIFF
--- a/backend/apps/automations/scraper/espacofacial/appointments.py
+++ b/backend/apps/automations/scraper/espacofacial/appointments.py
@@ -132,10 +132,54 @@ def navigate_to_reception(driver: WebDriver, reception_url: str, *, timeout_seco
 
 def _extract_event_info(title_text: str, time_text: str) -> dict[str, str]:
     parts = [p.strip() for p in title_text.split(" - ")]
+    appointment_type_keys = {
+        "avaliacao",
+        "compra antecipada",
+        "procedimento",
+        "revisao",
+        "retorno",
+        "consulta",
+    }
+
+    def _normalize_key(value: str) -> str:
+        raw = (value or "").strip().lower()
+        if not raw:
+            return ""
+        no_accents = "".join(ch for ch in unicodedata.normalize("NFD", raw) if unicodedata.category(ch) != "Mn")
+        return re.sub(r"\s+", " ", no_accents).strip()
+
+    def _is_appointment_type(value: str) -> bool:
+        return _normalize_key(value) in appointment_type_keys
+
+    cliente = parts[0] if len(parts) > 0 else ""
+    tipo = ""
+    profissional = ""
+
+    if len(parts) == 2:
+        second = parts[1]
+        if _is_appointment_type(second):
+            tipo = second
+        else:
+            profissional = second
+    elif len(parts) >= 3:
+        second = parts[1]
+        third = parts[2]
+        second_is_type = _is_appointment_type(second)
+        third_is_type = _is_appointment_type(third)
+        if second_is_type and not third_is_type:
+            tipo = second
+            profissional = third
+        elif third_is_type and not second_is_type:
+            tipo = third
+            profissional = second
+        else:
+            tipo = second
+            profissional = third
+
     return {
-        "Cliente": parts[0] if len(parts) > 0 else "",
-        "Tipo de Agendamento": parts[1] if len(parts) > 1 else "",
-        "Profissional": parts[2] if len(parts) > 2 else "",
+        "Cliente": cliente,
+        "Tipo de Agendamento": tipo,
+        "Profissional": profissional,
         "Horário": time_text.strip(),
     }
 
@@ -385,6 +429,58 @@ def _extract_multiselect_value_from_container(container) -> str:
     return ""
 
 
+def _extract_value_by_label(modal, *, labels: list[str], prefer_multiselect: bool = False, allow_input: bool = True) -> str:
+    for label in labels:
+        container = _find_field_container_by_label(modal, label)
+        if container is None:
+            continue
+        candidates = []
+        if prefer_multiselect:
+            candidates.append(_extract_multiselect_value_from_container(container))
+            if allow_input:
+                candidates.append(_extract_input_value_from_container(container))
+        else:
+            if allow_input:
+                candidates.append(_extract_input_value_from_container(container))
+            candidates.append(_extract_multiselect_value_from_container(container))
+        for candidate in candidates:
+            cleaned = _clean_placeholder(candidate)
+            if cleaned:
+                return cleaned
+    return ""
+
+
+def _collapse_repeated_phrase(value: str) -> str:
+    text = _normalize_spaces(value or "")
+    if not text:
+        return ""
+    parts = text.split(" ")
+    if len(parts) >= 2 and len(parts) % 2 == 0:
+        half = len(parts) // 2
+        if parts[:half] == parts[half:]:
+            return " ".join(parts[:half])
+    return text
+
+
+def _looks_like_internal_id(value: str) -> bool:
+    text = _normalize_spaces(value or "")
+    return bool(re.fullmatch(r"\d{10,14}", text))
+
+
+def _is_invalid_field_value(value: str, *, blocked_labels: list[str] | None = None) -> bool:
+    text = _normalize_spaces(value or "")
+    if not text:
+        return True
+    low = text.lower().strip(":")
+    if blocked_labels:
+        blocked = {b.lower().strip(":") for b in blocked_labels if b}
+        if low in blocked:
+            return True
+    if _looks_like_internal_id(text):
+        return True
+    return False
+
+
 def _find_first_text(modal, *, xpaths: list[str]) -> str:
     for xp in xpaths:
         try:
@@ -452,6 +548,27 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
         text = modal.text or ""
 
         # --- Extra fields seen in Recorder (WW modal): Telefone(WhatsApp), CPF, Origem, Serviço ---
+        details["Cliente"] = _extract_value_by_label(modal, labels=["Buscar cliente cadastrado"], prefer_multiselect=True, allow_input=False)
+        if not details["Cliente"]:
+            details["Cliente"] = _extract_value_by_label(
+                modal,
+                labels=["Nome do cliente", "Nome de cliente", "Cliente"],
+                prefer_multiselect=False,
+                allow_input=True,
+            )
+        details["Profissional"] = _extract_value_by_label(
+            modal,
+            labels=["Injetor", "Profissional"],
+            prefer_multiselect=True,
+            allow_input=True,
+        )
+        details["Tipo de Agendamento"] = _extract_value_by_label(
+            modal,
+            labels=["Tipo de Agendamento"],
+            prefer_multiselect=True,
+            allow_input=False,
+        )
+
         try:
             c = _find_field_container_by_label(modal, "WhatsApp do cliente")
             if c is not None:
@@ -487,34 +604,40 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
             pass
 
         # Prefer structured fields when present.
-        details["Cliente"] = _find_first_text(
-            modal,
-            xpaths=[
-                './/p[contains(., "Cliente")]/strong',
-                './/*[contains(normalize-space(.), "Cliente")]/strong',
-            ],
-        )
-        details["Profissional"] = _find_first_text(
-            modal,
-            xpaths=[
-                './/p[contains(., "Profissional")]/strong',
-                './/*[contains(normalize-space(.), "Profissional")]/strong',
-            ],
-        )
-        details["Telefone"] = _find_first_text(
-            modal,
-            xpaths=[
-                './/p[contains(., "Telefone")]/strong',
-                './/*[contains(normalize-space(.), "Telefone")]/strong',
-            ],
-        )
-        details["Tipo de Agendamento"] = _find_first_text(
-            modal,
-            xpaths=[
-                './/p[contains(., "Tipo de Agendamento")]/strong',
-                './/*[contains(normalize-space(.), "Tipo de Agendamento")]/strong',
-            ],
-        )
+        if not details["Cliente"]:
+            details["Cliente"] = _find_first_text(
+                modal,
+                xpaths=[
+                    './/p[contains(., "Cliente")]/strong',
+                    './/*[contains(normalize-space(.), "Cliente")]/strong',
+                ],
+            )
+        if not details["Profissional"]:
+            details["Profissional"] = _find_first_text(
+                modal,
+                xpaths=[
+                    './/p[contains(., "Injetor")]/strong',
+                    './/*[contains(normalize-space(.), "Injetor")]/strong',
+                    './/p[contains(., "Profissional")]/strong',
+                    './/*[contains(normalize-space(.), "Profissional")]/strong',
+                ],
+            )
+        if not details["Telefone"]:
+            details["Telefone"] = _find_first_text(
+                modal,
+                xpaths=[
+                    './/p[contains(., "Telefone")]/strong',
+                    './/*[contains(normalize-space(.), "Telefone")]/strong',
+                ],
+            )
+        if not details["Tipo de Agendamento"]:
+            details["Tipo de Agendamento"] = _find_first_text(
+                modal,
+                xpaths=[
+                    './/p[contains(., "Tipo de Agendamento")]/strong',
+                    './/*[contains(normalize-space(.), "Tipo de Agendamento")]/strong',
+                ],
+            )
         dt_text = _find_first_text(
             modal,
             xpaths=[
@@ -583,6 +706,20 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
                 labels=["Serviço a realizar", "Selecione o serviço", "Serviços"],
             )
         details["Serviço a realizar"] = _clean_placeholder(details.get("Serviço a realizar", ""))
+        if not details["Profissional"]:
+            by_text_prof = _clean_placeholder(_find_value_by_label_in_text(text, labels=["Injetor", "Profissional"]))
+            if not _is_invalid_field_value(
+                by_text_prof,
+                blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Status", "Origem do cliente"],
+            ):
+                details["Profissional"] = by_text_prof
+        if not details["Tipo de Agendamento"]:
+            by_text_type = _clean_placeholder(_find_value_by_label_in_text(text, labels=["Tipo de Agendamento"]))
+            if not _is_invalid_field_value(
+                by_text_type,
+                blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Status", "Origem do cliente"],
+            ):
+                details["Tipo de Agendamento"] = by_text_type
         if not details["Observações"]:
             lines = text.split("\n")
             for idx, line in enumerate(lines):
@@ -592,7 +729,11 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
                         details["Observações"] = obs2[:200]
                     break
 
-        details["Status"] = _extract_status(text)
+        if not details["Status"]:
+            details["Status"] = _extract_value_by_label(modal, labels=["Status"], prefer_multiselect=True, allow_input=False)
+        if not details["Status"]:
+            details["Status"] = _extract_status(text)
+        details["Status"] = _collapse_repeated_phrase(details["Status"])
     except Exception:
         return details
 

--- a/backend/apps/automations/scraper/tests_test_booking.py
+++ b/backend/apps/automations/scraper/tests_test_booking.py
@@ -5,7 +5,12 @@ from datetime import date
 from unittest.mock import patch
 
 from espacofacial.booking import BookingRequest
-from espacofacial.appointments import parse_duration_minutes_from_time_text
+from espacofacial.appointments import (
+    _collapse_repeated_phrase,
+    _extract_event_info,
+    _is_invalid_field_value,
+    parse_duration_minutes_from_time_text,
+)
 from scraper_final import _resolve_date_filter
 
 
@@ -14,6 +19,34 @@ class BookingRequestTests(unittest.TestCase):
         self.assertEqual(parse_duration_minutes_from_time_text("13:00 - 13:30"), 30)
         self.assertEqual(parse_duration_minutes_from_time_text("17:40 - 18:00"), 20)
         self.assertIsNone(parse_duration_minutes_from_time_text("18:00"))
+
+    def test_extract_event_info_two_parts_maps_second_to_injector_when_not_type(self) -> None:
+        row = _extract_event_info("Letícia Marques Kovalski - Viviane Mondin", "17:40 - 18:00")
+        self.assertEqual(row["Cliente"], "Letícia Marques Kovalski")
+        self.assertEqual(row["Tipo de Agendamento"], "")
+        self.assertEqual(row["Profissional"], "Viviane Mondin")
+
+    def test_extract_event_info_two_parts_maps_second_to_type_when_known_type(self) -> None:
+        row = _extract_event_info("Bianca Vicente de Camargo - Avaliação", "10:00 - 10:30")
+        self.assertEqual(row["Cliente"], "Bianca Vicente de Camargo")
+        self.assertEqual(row["Tipo de Agendamento"], "Avaliação")
+        self.assertEqual(row["Profissional"], "")
+
+    def test_extract_event_info_three_parts_accepts_type_professional_swap(self) -> None:
+        row = _extract_event_info("Bianca Vicente de Camargo - Marina Pereira Lima - Avaliação", "10:00 - 10:30")
+        self.assertEqual(row["Cliente"], "Bianca Vicente de Camargo")
+        self.assertEqual(row["Tipo de Agendamento"], "Avaliação")
+        self.assertEqual(row["Profissional"], "Marina Pereira Lima")
+
+    def test_collapse_repeated_phrase(self) -> None:
+        self.assertEqual(_collapse_repeated_phrase("Agendado Agendado"), "Agendado")
+        self.assertEqual(_collapse_repeated_phrase("Confirmado Confirmado"), "Confirmado")
+        self.assertEqual(_collapse_repeated_phrase("Atendido"), "Atendido")
+
+    def test_invalid_field_value_rejects_internal_id_and_labels(self) -> None:
+        self.assertTrue(_is_invalid_field_value("1773348000000"))
+        self.assertTrue(_is_invalid_field_value("Tipo de Agendamento", blocked_labels=["Tipo de Agendamento"]))
+        self.assertFalse(_is_invalid_field_value("Avaliação", blocked_labels=["Tipo de Agendamento"]))
 
     def test_parses_portuguese_payload(self) -> None:
         request = BookingRequest.from_payload(


### PR DESCRIPTION
## Summary

This PR fixes agenda modal field extraction in the scraper so booking occupancy data keeps the correct patient and injector metadata when the CRM modal uses alternate field layouts.

## Problem

Some appointments were arriving in `agenda_appointments` with missing or malformed metadata (`client/tipo/profissional`), even when the CRM modal had enough information. We observed concrete failures where:

- patient name was entered in `Nome do cliente` but not extracted
- injector came from `Injetor` but was not extracted
- status values appeared duplicated (for example `Agendado Agendado`)
- in a previous parser iteration, technical numeric values could leak into `tipo`

These issues reduced data quality and could create unstable appointment IDs across sync runs.

## Root Cause

The parser relied too much on a single modal representation and did not robustly reconcile:

- `Buscar cliente cadastrado` vs `Nome do cliente`
- `Injetor` vs `Profissional`
- optional `Tipo de Agendamento`

Additionally, label extraction needed stricter guards against internal numeric tokens and repeated display values.

## Fix

- Updated event-title parsing heuristics in `appointments.py` to correctly infer whether the second/third title segment is type or professional.
- Added modal label extraction helpers with guarded input usage.
- Prioritized patient extraction from `Buscar cliente cadastrado` and then `Nome do cliente`/`Nome de cliente`.
- Added explicit extraction for injector from `Injetor` and fallbacks.
- Restricted type extraction to `Tipo de Agendamento` and guarded invalid values (labels/internal IDs).
- Normalized repeated status phrases (`"Agendado Agendado" -> "Agendado"`).
- Added tests for the new title heuristics and invalid-value guards.

## Validation

- `PYTHONPATH=. ./.venv/bin/python -m unittest tests_test_booking.py`
- Result: `12 tests`, all passing.

## Operational check performed

After applying the parser fix, we performed a clean agenda re-sync (delete + full sync for both units) and verified that previously reported appointments now preserve expected fields for client/injector/status while keeping slot blocking behavior intact.
