### PR TITLE
[codex] harden agenda type extraction input guard

### DIFF
--- a/backend/apps/automations/scraper/espacofacial/appointments.py
+++ b/backend/apps/automations/scraper/espacofacial/appointments.py
@@ -566,8 +566,13 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
             modal,
             labels=["Tipo de Agendamento"],
             prefer_multiselect=True,
-            allow_input=False,
+            allow_input=True,
         )
+        if _is_invalid_field_value(
+            details["Tipo de Agendamento"],
+            blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Status", "Origem do cliente"],
+        ):
+            details["Tipo de Agendamento"] = ""
 
         try:
             c = _find_field_container_by_label(modal, "WhatsApp do cliente")


### PR DESCRIPTION
## Summary

This PR hardens `Tipo de Agendamento` extraction in the agenda scraper by allowing input-based reads when needed while explicitly discarding invalid technical values.

## Why

Some CRM modal variants expose type through input-backed components instead of plain multiselect text. Previously we disabled input reads for this field to avoid ingesting internal values.

## Change

- Keep `Tipo de Agendamento` extraction through the existing label-based path.
- Enable input fallback for this field.
- Immediately sanitize with `_is_invalid_field_value(...)` so label text or internal numeric IDs are not persisted as appointment type.

## Validation

- Existing scraper unit suite remains green (`tests_test_booking.py`).
- End-to-end full sync for both units completed successfully after this hardening.
