### PR TITLE
[codex] Fix agenda type extraction sync

### DIFF
--- a/backend/apps/automations/scraper/espacofacial/appointments.py
+++ b/backend/apps/automations/scraper/espacofacial/appointments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import unicodedata
 import time
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -312,8 +313,9 @@ def build_event_signature(
 def _find_value_by_label_in_text(text: str, *, labels: list[str]) -> str:
     """Best-effort label/value extraction from modal text.
 
-    Works for layouts where the label is on one line and the value is on the same
-    line (after a colon) or on the next line.
+    Works for layouts where the label is on one line and the value is:
+    - on the same line (with or without ":" / "-"), or
+    - on the next line.
     """
 
     lines = [_normalize_spaces(l) for l in (text or "").split("\n")]
@@ -328,7 +330,21 @@ def _find_value_by_label_in_text(text: str, *, labels: list[str]) -> str:
         for lab, lab_low in zip(labels, labels_low):
             if lab_low not in low:
                 continue
-            # Same-line value: "Label: value"
+            # Same-line value variants:
+            # - "Label: value"
+            # - "Label - value"
+            # - "Label value"
+            stripped = _normalize_spaces(
+                re.sub(
+                    rf"^\s*{re.escape(lab)}\s*[:\-]?\s*",
+                    "",
+                    line,
+                    flags=re.IGNORECASE,
+                )
+            )
+            if stripped and stripped.lower() not in ignore_values and stripped.lower() != low:
+                return stripped
+
             if ":" in line:
                 after = _normalize_spaces(line.split(":", 1)[1])
                 if after and after.lower() not in ignore_values:
@@ -366,20 +382,46 @@ def _clean_placeholder(value: str) -> str:
 def _find_field_container_by_label(modal, label: str):
     """Locate a field container by visible label inside the modal."""
 
-    xps = [
-        f'.//*[self::h2 or self::p or self::label or self::span][contains(normalize-space(.), "{label}")]',
-    ]
-    for xp in xps:
-        try:
-            el = modal.find_element(By.XPATH, xp)
-            # Walk up a bit to find a container that likely holds an input/select.
+    upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ"
+    lower = "abcdefghijklmnopqrstuvwxyzàáâãäåçèéêëìíîïñòóôõöùúûüý"
+    label_low = (label or "").strip().lower()
+    if not label_low:
+        return None
+
+    xp = (
+        './/*[self::h2 or self::p or self::label or self::span]'
+        f'[contains(translate(normalize-space(.), "{upper}", "{lower}"), "{label_low}")]'
+    )
+    try:
+        label_nodes = modal.find_elements(By.XPATH, xp)
+    except Exception:
+        return None
+
+    if not label_nodes:
+        return None
+
+    control_probe = './/input | .//textarea | .//*[contains(@class, "multiselect")]'
+    for el in label_nodes:
+        candidate_paths = [
+            ".",
+            "./parent::div[1]",
+            "./parent::div[1]/parent::div[1]",
+            "./parent::div[1]/following-sibling::div[1]",
+            "./parent::div[1]/following-sibling::div[.//input or .//textarea or .//*[contains(@class, 'multiselect')]][1]",
+        ]
+        for cpath in candidate_paths:
             try:
-                return el.find_element(By.XPATH, "./ancestor::div[1]")
+                container = el.find_element(By.XPATH, cpath)
             except Exception:
-                return el
-        except Exception:
-            continue
-    return None
+                continue
+            try:
+                if container.find_elements(By.XPATH, control_probe):
+                    return container
+            except Exception:
+                continue
+
+    # Last resort: return the first visible label node.
+    return label_nodes[0]
 
 
 def _extract_input_value_from_container(container) -> str:
@@ -474,11 +516,23 @@ def _is_invalid_field_value(value: str, *, blocked_labels: list[str] | None = No
     low = text.lower().strip(":")
     if blocked_labels:
         blocked = {b.lower().strip(":") for b in blocked_labels if b}
-        if low in blocked:
-            return True
+        for b in blocked:
+            if low == b or low.startswith(f"{b} ") or low.startswith(f"{b}:") or low.startswith(f"{b}-"):
+                return True
     if _looks_like_internal_id(text):
         return True
     return False
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.getenv(name, "").strip().lower()) in {"1", "true", "yes", "on"}
+
+
+def _truncate(text: str, *, limit: int = 1600) -> str:
+    raw = (text or "").strip()
+    if len(raw) <= limit:
+        return raw
+    return raw[:limit] + "..."
 
 
 def _find_first_text(modal, *, xpaths: list[str]) -> str:
@@ -564,13 +618,13 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
         )
         details["Tipo de Agendamento"] = _extract_value_by_label(
             modal,
-            labels=["Tipo de Agendamento"],
+            labels=["Tipo de Agendamento", "Tipo de agendamento", "Tipo do agendamento"],
             prefer_multiselect=True,
             allow_input=True,
         )
         if _is_invalid_field_value(
             details["Tipo de Agendamento"],
-            blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Status", "Origem do cliente"],
+            blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Tipo do agendamento", "Status", "Origem do cliente"],
         ):
             details["Tipo de Agendamento"] = ""
 
@@ -719,10 +773,15 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
             ):
                 details["Profissional"] = by_text_prof
         if not details["Tipo de Agendamento"]:
-            by_text_type = _clean_placeholder(_find_value_by_label_in_text(text, labels=["Tipo de Agendamento"]))
+            by_text_type = _clean_placeholder(
+                _find_value_by_label_in_text(
+                    text,
+                    labels=["Tipo de Agendamento", "Tipo de agendamento", "Tipo do agendamento"],
+                )
+            )
             if not _is_invalid_field_value(
                 by_text_type,
-                blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Status", "Origem do cliente"],
+                blocked_labels=["Injetor", "Profissional", "Tipo de Agendamento", "Tipo do agendamento", "Status", "Origem do cliente"],
             ):
                 details["Tipo de Agendamento"] = by_text_type
         if not details["Observações"]:
@@ -739,6 +798,71 @@ def _try_modal_details(driver: WebDriver) -> dict[str, str]:
         if not details["Status"]:
             details["Status"] = _extract_status(text)
         details["Status"] = _collapse_repeated_phrase(details["Status"])
+        details["Profissional"] = _collapse_repeated_phrase(details["Profissional"])
+        details["Tipo de Agendamento"] = _collapse_repeated_phrase(details["Tipo de Agendamento"])
+        details["Por onde nos conheceu"] = _collapse_repeated_phrase(details["Por onde nos conheceu"])
+
+        # Defensive rule: when type accidentally mirrors injector, trust the explicit
+        # "Tipo ..." text labels instead of keeping a likely wrong value.
+        if details["Tipo de Agendamento"] and details["Profissional"]:
+            if _normalize_signature_text(details["Tipo de Agendamento"]) == _normalize_signature_text(details["Profissional"]):
+                details["Tipo de Agendamento"] = ""
+                by_text_type = _clean_placeholder(
+                    _find_value_by_label_in_text(
+                        text,
+                        labels=["Tipo de Agendamento", "Tipo de agendamento", "Tipo do agendamento"],
+                    )
+                )
+                if (
+                    by_text_type
+                    and not _is_invalid_field_value(
+                        by_text_type,
+                        blocked_labels=[
+                            "Injetor",
+                            "Profissional",
+                            "Tipo de Agendamento",
+                            "Tipo do agendamento",
+                            "Status",
+                            "Origem do cliente",
+                        ],
+                    )
+                    and _normalize_signature_text(by_text_type) != _normalize_signature_text(details["Profissional"])
+                ):
+                    details["Tipo de Agendamento"] = by_text_type
+
+        type_equals_professional = (
+            bool(details.get("Tipo de Agendamento"))
+            and bool(details.get("Profissional"))
+            and _normalize_signature_text(details["Tipo de Agendamento"]) == _normalize_signature_text(details["Profissional"])
+        )
+        if _env_truthy("EF_DEBUG_MODAL_DUMP") and (not details["Tipo de Agendamento"] or type_equals_professional):
+            client_filter = (os.getenv("EF_DEBUG_MODAL_CLIENT_CONTAINS", "") or "").strip().lower()
+            haystack = f'{details.get("Cliente", "")} {text}'.lower()
+            if not client_filter or client_filter in haystack:
+                reason = "missing" if not details["Tipo de Agendamento"] else "equals_professional"
+                log_file_only(
+                    "DEBUG modal type issue (%s) | Cliente=%r | Profissional=%r | Tipo=%r | Status=%r"
+                    % (
+                        reason,
+                        details.get("Cliente", ""),
+                        details.get("Profissional", ""),
+                        details.get("Tipo de Agendamento", ""),
+                        details.get("Status", ""),
+                    )
+                )
+                tipo_lines = [ln.strip() for ln in text.split("\n") if "tipo" in ln.lower()]
+                for ln in tipo_lines[:8]:
+                    log_file_only("DEBUG line(tipo): " + _truncate(ln, limit=300))
+
+                tipo_container = _find_field_container_by_label(modal, "Tipo de Agendamento")
+                if tipo_container is None:
+                    tipo_container = _find_field_container_by_label(modal, "Tipo de agendamento")
+                if tipo_container is not None:
+                    log_file_only("DEBUG tipo container html: " + _truncate(_safe_outer_html(tipo_container)))
+                    log_file_only("DEBUG tipo multiselect: " + _truncate(_extract_multiselect_value_from_container(tipo_container), limit=300))
+                    log_file_only("DEBUG tipo input: " + _truncate(_extract_input_value_from_container(tipo_container), limit=300))
+                else:
+                    log_file_only("DEBUG tipo container not found")
     except Exception:
         return details
 

--- a/backend/apps/automations/scraper/espacofacial/auth.py
+++ b/backend/apps/automations/scraper/espacofacial/auth.py
@@ -61,6 +61,11 @@ def get_log_file_path() -> Optional[Path]:
 def _append_to_file(line: str) -> None:
     if _LOG_FILE_PATH is None:
         return
+    try:
+        with _LOG_FILE_PATH.open("a", encoding="utf-8") as f:
+            f.write(line.rstrip("\n") + "\n")
+    except Exception:
+        return
 
 
 def _append_to_json(payload: dict) -> None:
@@ -69,11 +74,6 @@ def _append_to_json(payload: dict) -> None:
     try:
         with _LOG_JSON_PATH.open("a", encoding="utf-8") as f:
             f.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    except Exception:
-        return
-    try:
-        with _LOG_FILE_PATH.open("a", encoding="utf-8") as f:
-            f.write(line.rstrip("\n") + "\n")
     except Exception:
         return
 

--- a/backend/apps/automations/scraper/tests_test_booking.py
+++ b/backend/apps/automations/scraper/tests_test_booking.py
@@ -8,6 +8,7 @@ from espacofacial.booking import BookingRequest
 from espacofacial.appointments import (
     _collapse_repeated_phrase,
     _extract_event_info,
+    _find_value_by_label_in_text,
     _is_invalid_field_value,
     parse_duration_minutes_from_time_text,
 )
@@ -46,7 +47,21 @@ class BookingRequestTests(unittest.TestCase):
     def test_invalid_field_value_rejects_internal_id_and_labels(self) -> None:
         self.assertTrue(_is_invalid_field_value("1773348000000"))
         self.assertTrue(_is_invalid_field_value("Tipo de Agendamento", blocked_labels=["Tipo de Agendamento"]))
+        self.assertTrue(_is_invalid_field_value("Injetor Marina Pereira Lima", blocked_labels=["Injetor"]))
         self.assertFalse(_is_invalid_field_value("Avaliação", blocked_labels=["Tipo de Agendamento"]))
+
+    def test_find_value_by_label_in_text_supports_same_line_without_colon(self) -> None:
+        text = "\n".join(
+            [
+                "Nome do cliente Bianca Vicente de Camargo",
+                "Tipo do agendamento Avaliação",
+                "Injetor Marina Pereira Lima",
+            ]
+        )
+        self.assertEqual(
+            _find_value_by_label_in_text(text, labels=["Tipo de Agendamento", "Tipo de agendamento", "Tipo do agendamento"]),
+            "Avaliação",
+        )
 
     def test_parses_portuguese_payload(self) -> None:
         request = BookingRequest.from_payload(


### PR DESCRIPTION
## Contexto
Na agenda sincronizada do site, alguns agendamentos estavam com `tipo` ausente ou incorreto mesmo quando o modal no CRM tinha a informação de tipo preenchida. Isso gerava inconsistência na base e impactava a qualidade dos dados usados para disponibilidade/ocupação.

## Causa raiz
A extração de campos no modal tinha dois problemas principais:
1. A leitura textual do label não cobria variações reais do CRM (ex.: `Tipo do agendamento`, valor na mesma linha sem `:`).
2. Em alguns cenários, o valor de `Tipo de Agendamento` acabava espelhando o `Injetor`, produzindo dados incorretos (`tipo == profissional`).

Além disso, o logger de arquivo estava quebrado (`_append_to_file` sem escrita efetiva), dificultando depuração com evidência persistida.

## Correção aplicada
- Robustez na leitura textual por label:
  - Suporte a valor na mesma linha com ou sem separador (`:`, `-` ou apenas espaço).
  - Inclusão da variação `Tipo do agendamento`.
- Lookup de container por label mais seguro/case-insensitive:
  - Busca por elementos de label (`h2/p/label/span`) com `translate(...)` para normalização de caixa.
  - Restrição a containers próximos com controles (`input/textarea/multiselect`) para evitar capturas amplas.
- Regras defensivas de qualidade de dado:
  - Rejeita valores que começam por labels bloqueados (ex.: `Injetor Marina ...`).
  - Colapsa duplicações de frase em campos de saída.
  - Se `tipo` vier igual a `profissional`, força fallback via leitura textual do `Tipo ...` antes de persistir.
- Correção de logging:
  - `_append_to_file` voltou a escrever no arquivo.
  - `_append_to_json` não tenta mais escrever linha textual inválida.
- Testes:
  - Cobertura para extração `Tipo ...` na mesma linha sem `:`.
  - Cobertura para rejeição de valor iniciado por label bloqueado.

## Validação
- Unit tests:
  - `python -m unittest tests_test_booking.py` ✅
- Validação funcional no scraper (janela atual + próximas 3 semanas):
  - Reexecução full para Barra e NH ✅
  - Registro crítico validado: Bianca (Barra, 12/03/2026 16:30) persistindo com `tipo = Avaliação`, `profissional = Marina Pereira Lima`, `status = Confirmado` ✅
- Limpeza única e repovoamento do D1 remoto:
  - `agenda_changes` e `agenda_appointments` limpos e repovoados com parser corrigido ✅
  - Contagem final: `agenda_appointments=133`, `agenda_changes=134` ✅
