### PR TITLE
ci(crm-api): disable syncAutoStash in deploy workflows

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -148,7 +148,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
+          {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -113,7 +113,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
+          {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -83,7 +83,7 @@ jobs:
           set -euo pipefail
           AUTH_HEADER="$(printf '%s' "${BASIC_AUTH}" | base64)"
           payload="$(cat <<JSON
-          {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":true}
+          {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
           response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \


### PR DESCRIPTION
## Summary
- set `syncAutoStash` to `false` in CRM API deploy workflows
- keep `syncRepo` enabled so SHA alignment still happens
- prevent CI-triggered auto stash/reset from overwriting local uncommitted changes

## Files
- .github/workflows/deploy-crm-api.yml
- .github/workflows/deploy-crm-api-reconcile.yml
- .github/workflows/deploy-crm-api-after-automerge.yml

## Validation
- loaded all 3 YAML files with `yaml.safe_load`
- confirmed all payloads now send `syncAutoStash:false`
