### PR TITLE
ci(crm-api): handle dirty workspace safely for http_restart

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -139,6 +139,7 @@ jobs:
           GITHUB_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
 
       - name: Deploy via HTTP restart (merge commit)
+        id: http_restart
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.guard.outputs.mode == 'http_restart' }}
         env:
           RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
@@ -151,23 +152,47 @@ jobs:
           {"mode":"stack","reason":"github-actions-after-automerge-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
-          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+          response_file="$(mktemp)"
+          http_code="$(curl -sS --retry 3 --retry-delay 2 --retry-connrefused \
+            -o "${response_file}" \
+            -w "%{http_code}" \
             -X POST "${RESTART_URL}" \
             -H "authorization: Basic ${AUTH_HEADER}" \
             -H "content-type: application/json" \
             --data "${payload}")"
+          response="$(cat "${response_file}")"
+          rm -f "${response_file}"
           echo "${response}"
-          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"
+          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          case "${decision}" in
+            DEPLOYED)
+              echo "deployed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            SKIP_DIRTY)
+              echo "::warning::CRM API after-automerge skipped repo sync because workspace is dirty (http=${http_code}); retry after workspace is clean."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            FAIL:*)
+              echo "::error::CRM API after-automerge http_restart failed (http=${http_code}, reason=${decision#FAIL:})."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected deploy decision '${decision}' (http=${http_code})."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+          esac
 
       - name: Mark deployed SHA
-        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() && (steps.guard.outputs.mode == 'ssh' || steps.http_restart.outputs.deployed == 'true') }}
         run: |
           set -euo pipefail
           mkdir -p deploy-state
           echo "${{ steps.pr.outputs.merge_commit_sha }}" > deploy-state/crm_api_after_automerge_sha.txt
 
       - name: Save deploy cache
-        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.crm_api_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() && (steps.guard.outputs.mode == 'ssh' || steps.http_restart.outputs.deployed == 'true') }}
         uses: actions/cache/save@v4
         with:
           key: crm-api-after-automerge-deploy-${{ steps.pr.outputs.merge_commit_sha }}

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -104,6 +104,7 @@ jobs:
           GITHUB_SHA: ${{ steps.sha.outputs.sha }}
 
       - name: Deploy via HTTP restart (main SHA)
+        id: http_restart
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.guard.outputs.mode == 'http_restart' }}
         env:
           RESTART_URL: ${{ vars.CRM_API_RESTART_URL }}
@@ -116,23 +117,47 @@ jobs:
           {"mode":"stack","reason":"github-actions-reconcile-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
-          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+          response_file="$(mktemp)"
+          http_code="$(curl -sS --retry 3 --retry-delay 2 --retry-connrefused \
+            -o "${response_file}" \
+            -w "%{http_code}" \
             -X POST "${RESTART_URL}" \
             -H "authorization: Basic ${AUTH_HEADER}" \
             -H "content-type: application/json" \
             --data "${payload}")"
+          response="$(cat "${response_file}")"
+          rm -f "${response_file}"
           echo "${response}"
-          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"
+          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          case "${decision}" in
+            DEPLOYED)
+              echo "deployed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            SKIP_DIRTY)
+              echo "::warning::CRM API reconcile skipped repo sync because workspace is dirty (http=${http_code}); retry will continue automatically."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            FAIL:*)
+              echo "::error::CRM API reconcile http_restart failed (http=${http_code}, reason=${decision#FAIL:})."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected deploy decision '${decision}' (http=${http_code})."
+              echo "deployed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+          esac
 
       - name: Mark deployed SHA
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() && (steps.guard.outputs.mode == 'ssh' || steps.http_restart.outputs.deployed == 'true') }}
         run: |
           set -euo pipefail
           mkdir -p deploy-state
           echo "${{ steps.sha.outputs.sha }}" > deploy-state/crm_api_deployed_sha.txt
 
       - name: Save deploy cache
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() && (steps.guard.outputs.mode == 'ssh' || steps.http_restart.outputs.deployed == 'true') }}
         uses: actions/cache/save@v4
         with:
           key: crm-api-deploy-${{ steps.sha.outputs.sha }}

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -86,10 +86,30 @@ jobs:
           {"mode":"stack","reason":"github-actions-deploy-crm-api","sha":"${GITHUB_SHA}","syncRepo":true,"syncSha":"${GITHUB_SHA}","syncAutoStash":false}
           JSON
           )"
-          response="$(curl -fsS --retry 3 --retry-delay 2 --retry-connrefused \
+          response_file="$(mktemp)"
+          http_code="$(curl -sS --retry 3 --retry-delay 2 --retry-connrefused \
+            -o "${response_file}" \
+            -w "%{http_code}" \
             -X POST "${RESTART_URL}" \
             -H "authorization: Basic ${AUTH_HEADER}" \
             -H "content-type: application/json" \
             --data "${payload}")"
+          response="$(cat "${response_file}")"
+          rm -f "${response_file}"
           echo "${response}"
-          python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); ok=bool(data.get("success")); sys.exit(0 if ok else 1)' <<<"${response}"
+          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          case "${decision}" in
+            DEPLOYED)
+              ;;
+            SKIP_DIRTY)
+              echo "::warning::CRM API http_restart skipped deploy sync because workspace is dirty (http=${http_code}); retry when workspace is clean."
+              ;;
+            FAIL:*)
+              echo "::error::CRM API http_restart failed (http=${http_code}, reason=${decision#FAIL:})."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected deploy decision '${decision}' (http=${http_code})."
+              exit 1
+              ;;
+          esac

--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -6022,10 +6022,15 @@ app.post('/api/wa-orchestrator/local/recovery/restart', async (req, res) => {
                     steps.push({ phase: 'repo-sync', ...syncStep })
                 }
                 if (!syncResult.success) {
-                    return res.status(500).json({
+                    const syncError = syncResult.error || 'RECOVERY_SYNC_FAILED'
+                    const syncStatus = syncError === 'RECOVERY_SYNC_REPO_DIRTY' ? 409 : 500
+                    return res.status(syncStatus).json({
                         success: false,
                         mode,
-                        error: syncResult.error || 'RECOVERY_SYNC_FAILED',
+                        error: syncError,
+                        hint: syncError === 'RECOVERY_SYNC_REPO_DIRTY'
+                            ? 'Workspace has uncommitted changes; retry after workspace is clean or allow auto-stash explicitly.'
+                            : undefined,
                         sync: syncSummary,
                         steps
                     })

--- a/backend/docs/deploy.md
+++ b/backend/docs/deploy.md
@@ -76,3 +76,4 @@ Modo `http_restart`:
   - `syncSha=<commit do deploy>` (alvo do `git reset --hard`)
   - `syncAutoStash=false` (não faz stash automático por padrão)
   - Se precisar permitir auto-stash explicitamente, defina `WA_LOCAL_RECOVERY_SYNC_ALLOW_AUTOSTASH=true` no ambiente do CRM API.
+  - Se o workspace local estiver sujo e `syncAutoStash=false`, o endpoint retorna `RECOVERY_SYNC_REPO_DIRTY` (`HTTP 409`) e os workflows marcam como `skip` (sem salvar cache de deploy), para tentar novamente depois sem sobrescrever mudanças locais.


### PR DESCRIPTION
## Summary
- keep `syncAutoStash=false` and preserve local changes from other agents
- update CRM API local recovery endpoint to return `HTTP 409` for `RECOVERY_SYNC_REPO_DIRTY`
- update CRM deploy workflows (`deploy`, `reconcile`, `after-automerge`) to:
  - parse HTTP response without failing on non-2xx by default
  - treat `RECOVERY_SYNC_REPO_DIRTY` as safe skip with warning
  - avoid writing deploy cache when deploy was skipped (reconcile/after-automerge)

## Why
- `http_restart` deploy mode currently depends on local repo sync.
- when local workspace is dirty, sync fails and workflows fail hard.
- this change avoids destructive auto-stash/reset while keeping pipelines operational and explicit.

## Validation
- `node --check backend/apps/crm-api/server.js`
- YAML parse via `yaml.safe_load` for the 3 workflow files
