### PR TITLE
ci(crm-api): use jq for robust restart response parsing

### DIFF
--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -163,7 +163,14 @@ jobs:
           response="$(cat "${response_file}")"
           rm -f "${response_file}"
           echo "${response}"
-          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          if ! decision="$(jq -r '
+            if (.success == true) then "DEPLOYED"
+            elif ((.error // "") == "RECOVERY_SYNC_REPO_DIRTY") then "SKIP_DIRTY"
+            else "FAIL:\((.error // "UNKNOWN_ERROR"))"
+            end
+          ' <<<"${response}" 2>/dev/null)"; then
+            decision="FAIL:INVALID_JSON"
+          fi
           case "${decision}" in
             DEPLOYED)
               echo "deployed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -128,7 +128,14 @@ jobs:
           response="$(cat "${response_file}")"
           rm -f "${response_file}"
           echo "${response}"
-          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          if ! decision="$(jq -r '
+            if (.success == true) then "DEPLOYED"
+            elif ((.error // "") == "RECOVERY_SYNC_REPO_DIRTY") then "SKIP_DIRTY"
+            else "FAIL:\((.error // "UNKNOWN_ERROR"))"
+            end
+          ' <<<"${response}" 2>/dev/null)"; then
+            decision="FAIL:INVALID_JSON"
+          fi
           case "${decision}" in
             DEPLOYED)
               echo "deployed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -97,7 +97,14 @@ jobs:
           response="$(cat "${response_file}")"
           rm -f "${response_file}"
           echo "${response}"
-          decision="$(python3 -c 'import json,sys; d=json.loads((sys.stdin.read() or "{}").strip() or "{}"); e=str(d.get("error") or "").strip(); print("DEPLOYED" if d.get("success") else ("SKIP_DIRTY" if e == "RECOVERY_SYNC_REPO_DIRTY" else f"FAIL:{e or \"UNKNOWN_ERROR\"}"))' <<<"${response}")"
+          if ! decision="$(jq -r '
+            if (.success == true) then "DEPLOYED"
+            elif ((.error // "") == "RECOVERY_SYNC_REPO_DIRTY") then "SKIP_DIRTY"
+            else "FAIL:\((.error // "UNKNOWN_ERROR"))"
+            end
+          ' <<<"${response}" 2>/dev/null)"; then
+            decision="FAIL:INVALID_JSON"
+          fi
           case "${decision}" in
             DEPLOYED)
               ;;


### PR DESCRIPTION
Fix parser crash on non-JSON/escaped payloads from restart endpoint.\n\n- replace inline python decision parser with jq-based parser + invalid-json fallback\n- keep SKIP_DIRTY behavior for RECOVERY_SYNC_REPO_DIRTY\n- apply to deploy/reconcile/after-automerge workflows