### PR TITLE
[codex] Make booking occupancy follow CRM day scale

### DIFF
--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -196,7 +196,11 @@ function hasAgendaConflictForDoctor(params: {
     startAtMs: number;
     endAtMs: number;
     doctorNameKey: string | null;
+    ignoreAgendaProfessionalField: boolean;
 }): boolean {
+    if (params.ignoreAgendaProfessionalField) {
+        return params.agendaRanges.some((range) => range.start < params.endAtMs && range.end > params.startAtMs);
+    }
     return params.agendaRanges.some(
         (range) =>
             range.start < params.endAtMs &&
@@ -404,6 +408,7 @@ export async function POST(request: Request) {
             return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
     }
+    const ignoreAgendaProfessionalField = !!daySchedule && daySchedule.professionalNames.length === 1;
 
     const agendaRanges = await listAgendaRanges({ unitSlug, date });
 
@@ -446,7 +451,13 @@ export async function POST(request: Request) {
         const pick = doctorsForSelection.find((doctor) => {
             if (activeByDoctor.has(doctor.slug)) return false;
             const doctorNameKey = doctorNameKeyBySlug.get(doctor.slug) ?? null;
-            return !hasAgendaConflictForDoctor({ agendaRanges, startAtMs, endAtMs, doctorNameKey });
+            return !hasAgendaConflictForDoctor({
+                agendaRanges,
+                startAtMs,
+                endAtMs,
+                doctorNameKey,
+                ignoreAgendaProfessionalField,
+            });
         }) ?? null;
         if (!pick) {
             const anyPending = Array.from(activeByDoctor.values()).some((v) => v.hasPending);
@@ -458,7 +469,13 @@ export async function POST(request: Request) {
     }
 
     const effectiveDoctorNameKey = wantsAnyDoctor ? doctorNameKeyBySlug.get(effectiveDoctorSlug) ?? null : selectedDoctor ? selectedDoctor.name : null;
-    const blockedByAgenda = hasAgendaConflictForDoctor({ agendaRanges, startAtMs, endAtMs, doctorNameKey: effectiveDoctorNameKey });
+    const blockedByAgenda = hasAgendaConflictForDoctor({
+        agendaRanges,
+        startAtMs,
+        endAtMs,
+        doctorNameKey: effectiveDoctorNameKey,
+        ignoreAgendaProfessionalField,
+    });
     if (blockedByAgenda) {
         return json({ ok: false, error: "no_availability" }, { status: 409 });
     }

--- a/website/src/app/api/booking/slots/route.ts
+++ b/website/src/app/api/booking/slots/route.ts
@@ -92,6 +92,12 @@ function normalizeAgendaProfessionalName(value: string | null | undefined): stri
     return raw;
 }
 
+function shouldIgnoreAgendaProfessional(params: { dayScheduleLoaded: boolean; professionalNamesCount: number }): boolean {
+    // Business rule: when CRM escala indicates a single doctor for the unit/day,
+    // every occupied slot from scraper must block that day regardless of "profissional".
+    return params.dayScheduleLoaded && params.professionalNamesCount === 1;
+}
+
 async function expireIfNeeded(db: Awaited<ReturnType<typeof getBookingDb>>, id: string) {
     // Best-effort: mark pending approvals as expired after confirm_by.
     const row = await db
@@ -195,6 +201,10 @@ export async function GET(req: Request) {
             return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
         }
     }
+    const ignoreAgendaProfessionalField = shouldIgnoreAgendaProfessional({
+        dayScheduleLoaded: !!daySchedule,
+        professionalNamesCount: daySchedule?.professionalNames.length ?? 0,
+    });
 
     const cacheKey = `${unitSlug}|${date}`;
     const cached = agendaCache.get(cacheKey);
@@ -287,6 +297,9 @@ export async function GET(req: Request) {
 
     let agendaBlockedCount = 0;
     const overlapsAgendaForDoctor = (slug: string, startMs: number, endMs: number) => {
+        if (ignoreAgendaProfessionalField) {
+            return agendaRanges.some((r) => r.start < endMs && r.end > startMs);
+        }
         const doctorName = unitDoctors.find((doctor) => doctor.slug === slug)?.name ?? null;
         return agendaRanges.some(
             (r) =>


### PR DESCRIPTION
## Problema
No agendamento do site, os dias eram bloqueados corretamente pela escala do CRM, mas em alguns dias os horários apareciam livres porque o bloqueio de ocupação dependia do campo `profissional` vindo do scraper, que pode vir vazio, errado ou inconsistente.

## Regra de negócio aplicada
- Quem atende no dia vem da escala CRM (`SKINCOS_ESCALA_DB`).
- Horários ocupados vêm do scraper (`agenda_appointments`).
- Em unidade/dia com **escala única** (1 profissional no CRM), todo horário ocupado daquele dia deve bloquear a agenda desse profissional, independentemente do `profissional` no registro sincronizado.

## Mudanças
1. `/api/booking/slots`
- Adicionada regra `shouldIgnoreAgendaProfessional(...)`.
- Quando a escala do dia está carregada e tem 1 profissional, o conflito de agenda passa a considerar apenas overlap temporal (`start/end`), ignorando `profissional` no registro sincronizado.

2. `/api/booking/request`
- A validação final de conflito ao criar pedido passou a usar a mesma regra.
- Tanto na seleção de `doctor=any` quanto no bloqueio do doutor efetivo, o conflito usa somente horário quando há escala única no dia.

## Validação
- `npm run test` (website) ✅
- `npm run typecheck` (website) ✅

Com isso, a montagem da agenda fica alinhada ao fluxo desejado: escala define o doutor do dia; scraper define os horários ocupados do dia.
