### PR TITLE
fix(booking): bloquear agenda por unidade/dia e limitar janela a 4 semanas

### DIFF
--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -10,7 +10,7 @@ import { issueBookingStatusToken } from "@/lib/bookingSecurity";
 
 export const dynamic = "force-dynamic";
 
-type AgendaRange = { start: number; end: number; professionalName: string | null };
+type AgendaRange = { start: number; end: number };
 
 type Payload = {
     unitSlug?: string;
@@ -58,12 +58,6 @@ function clientIp(request: Request): string | null {
     const xff = (request.headers.get("x-forwarded-for") ?? "").trim();
     if (xff) return xff.split(",")[0]?.trim() || null;
     return null;
-}
-
-function normalizeAgendaProfessionalName(value: string | null | undefined): string | null {
-    const raw = (value ?? "").toString().trim();
-    if (!raw || raw.startsWith("[")) return null;
-    return raw;
 }
 
 async function verifyTurnstile(params: { secret: string; token: string; ip: string | null }): Promise<{ ok: boolean }> {
@@ -164,12 +158,12 @@ async function listAgendaRanges(params: { unitSlug: string; date: string }): Pro
     const agendaDb = await getAgendaDb();
     const agendaRows = await agendaDb
         .prepare(
-            `SELECT time_key, duration_min, profissional
+            `SELECT time_key, duration_min
              FROM agenda_appointments
              WHERE unit_slug = ? AND date_key = ? AND removed_at_ms IS NULL`,
         )
         .bind(params.unitSlug, params.date)
-        .all<{ time_key: string; duration_min: number | null; profissional: string | null }>();
+        .all<{ time_key: string; duration_min: number | null }>();
 
     const agendaRanges: AgendaRange[] = [];
     for (const row of agendaRows.results ?? []) {
@@ -184,7 +178,6 @@ async function listAgendaRanges(params: { unitSlug: string; date: string }): Pro
         agendaRanges.push({
             start: agendaStartMs,
             end: agendaStartMs + agendaDurationMs,
-            professionalName: normalizeAgendaProfessionalName(row.profissional),
         });
     }
 
@@ -195,18 +188,9 @@ function hasAgendaConflictForDoctor(params: {
     agendaRanges: AgendaRange[];
     startAtMs: number;
     endAtMs: number;
-    doctorNameKey: string | null;
-    ignoreAgendaProfessionalField: boolean;
 }): boolean {
-    if (params.ignoreAgendaProfessionalField) {
-        return params.agendaRanges.some((range) => range.start < params.endAtMs && range.end > params.startAtMs);
-    }
-    return params.agendaRanges.some(
-        (range) =>
-            range.start < params.endAtMs &&
-            range.end > params.startAtMs &&
-            (range.professionalName === null || (params.doctorNameKey !== null && personNameMatches(range.professionalName, params.doctorNameKey))),
-    );
+    // Business rule: agenda slots from scraper block by unit+day+time regardless of "profissional".
+    return params.agendaRanges.some((range) => range.start < params.endAtMs && range.end > params.startAtMs);
 }
 
 export async function POST(request: Request) {
@@ -385,7 +369,6 @@ export async function POST(request: Request) {
     if (doctors.length === 0) {
         return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
     }
-    const doctorNameKeyBySlug = new Map(doctors.map((doctor) => [doctor.slug, doctor.name]));
 
     const selectedDoctor = wantsAnyDoctor ? null : doctors.find((doctor) => doctorSlugMatchesQuery(doctorSlug, doctor)) ?? null;
     if (!wantsAnyDoctor && !selectedDoctor) {
@@ -408,8 +391,6 @@ export async function POST(request: Request) {
             return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
     }
-    const ignoreAgendaProfessionalField = !!daySchedule && daySchedule.professionalNames.length === 1;
-
     const agendaRanges = await listAgendaRanges({ unitSlug, date });
 
     const db = await getBookingDb();
@@ -450,13 +431,10 @@ export async function POST(request: Request) {
 
         const pick = doctorsForSelection.find((doctor) => {
             if (activeByDoctor.has(doctor.slug)) return false;
-            const doctorNameKey = doctorNameKeyBySlug.get(doctor.slug) ?? null;
             return !hasAgendaConflictForDoctor({
                 agendaRanges,
                 startAtMs,
                 endAtMs,
-                doctorNameKey,
-                ignoreAgendaProfessionalField,
             });
         }) ?? null;
         if (!pick) {
@@ -468,13 +446,10 @@ export async function POST(request: Request) {
         safeDoctorName = clampText(pick.name, 120);
     }
 
-    const effectiveDoctorNameKey = wantsAnyDoctor ? doctorNameKeyBySlug.get(effectiveDoctorSlug) ?? null : selectedDoctor ? selectedDoctor.name : null;
     const blockedByAgenda = hasAgendaConflictForDoctor({
         agendaRanges,
         startAtMs,
         endAtMs,
-        doctorNameKey: effectiveDoctorNameKey,
-        ignoreAgendaProfessionalField,
     });
     if (blockedByAgenda) {
         return json({ ok: false, error: "no_availability" }, { status: 409 });

--- a/website/src/app/api/booking/slots/route.ts
+++ b/website/src/app/api/booking/slots/route.ts
@@ -8,7 +8,7 @@ import { fetchEscalaDaySchedule, personNameMatches } from "@/lib/escalaDb";
 
 export const dynamic = "force-dynamic";
 
-type AgendaRange = { start: number; end: number; professionalName: string | null };
+type AgendaRange = { start: number; end: number };
 type AgendaCacheEntry = { expiresAtMs: number; ranges: AgendaRange[]; count: number };
 
 const agendaCache = new Map<string, AgendaCacheEntry>();
@@ -86,18 +86,6 @@ function buildUnavailableSlots(params: { date: string; durationMinutes: number; 
     });
 }
 
-function normalizeAgendaProfessionalName(value: string | null | undefined): string | null {
-    const raw = (value ?? "").toString().trim();
-    if (!raw || raw.startsWith("[")) return null;
-    return raw;
-}
-
-function shouldIgnoreAgendaProfessional(params: { dayScheduleLoaded: boolean; professionalNamesCount: number }): boolean {
-    // Business rule: when CRM escala indicates a single doctor for the unit/day,
-    // every occupied slot from scraper must block that day regardless of "profissional".
-    return params.dayScheduleLoaded && params.professionalNamesCount === 1;
-}
-
 async function expireIfNeeded(db: Awaited<ReturnType<typeof getBookingDb>>, id: string) {
     // Best-effort: mark pending approvals as expired after confirm_by.
     const row = await db
@@ -166,7 +154,6 @@ export async function GET(req: Request) {
 
     const unitDoctors = unitDoctorsResult.ok ? unitDoctorsResult.doctors : [];
     const knownDoctor = !wantsAnyDoctor ? unitDoctors.find((doctor) => doctorSlugMatchesQuery(doctorSlug, doctor)) ?? null : null;
-    const resolvedDoctorSlug = knownDoctor?.slug ?? doctorSlug;
     let doctorSlugs = wantsAnyDoctor ? unitDoctors.map((doctor) => doctor.slug) : knownDoctor ? [knownDoctor.slug] : [doctorSlug];
     if (wantsAnyDoctor && doctorSlugs.length === 0) {
         return json({ ok: false, error: "no_doctors_for_unit" }, { status: 400 });
@@ -201,11 +188,6 @@ export async function GET(req: Request) {
             return json({ ok: true, unitSlug, doctorSlug, serviceId, durationMinutes, date, slots }, { status: 200 });
         }
     }
-    const ignoreAgendaProfessionalField = shouldIgnoreAgendaProfessional({
-        dayScheduleLoaded: !!daySchedule,
-        professionalNamesCount: daySchedule?.professionalNames.length ?? 0,
-    });
-
     const cacheKey = `${unitSlug}|${date}`;
     const cached = agendaCache.get(cacheKey);
     const nowTs = Date.now();
@@ -238,7 +220,6 @@ export async function GET(req: Request) {
             agendaRanges.push({
                 start: startMs,
                 end: startMs + durationMs,
-                professionalName: normalizeAgendaProfessionalName(row.profissional),
             });
         }
         agendaRowsCount = agendaRows.results?.length ?? 0;
@@ -296,17 +277,9 @@ export async function GET(req: Request) {
     }
 
     let agendaBlockedCount = 0;
-    const overlapsAgendaForDoctor = (slug: string, startMs: number, endMs: number) => {
-        if (ignoreAgendaProfessionalField) {
-            return agendaRanges.some((r) => r.start < endMs && r.end > startMs);
-        }
-        const doctorName = unitDoctors.find((doctor) => doctor.slug === slug)?.name ?? null;
-        return agendaRanges.some(
-            (r) =>
-                r.start < endMs &&
-                r.end > startMs &&
-                (r.professionalName === null || (doctorName !== null && personNameMatches(r.professionalName, doctorName))),
-        );
+    const overlapsAgendaForDoctor = (startMs: number, endMs: number) => {
+        // Business rule: agenda slots from scraper block by unit+day+time regardless of "profissional".
+        return agendaRanges.some((r) => r.start < endMs && r.end > startMs);
     };
     const out = daySlots.map((s) => {
         const time = s.time;
@@ -326,7 +299,7 @@ export async function GET(req: Request) {
             return { time, startAtMs: startMs, endAtMs: endMs, available: false, reason: "past" };
         }
 
-        if (!wantsAnyDoctor && overlapsAgendaForDoctor(resolvedDoctorSlug, startMs, endMs)) {
+        if (!wantsAnyDoctor && overlapsAgendaForDoctor(startMs, endMs)) {
             agendaBlockedCount += 1;
             return { time, available: false, reason: "agenda" };
         }
@@ -346,7 +319,7 @@ export async function GET(req: Request) {
             let anyFree = false;
 
             for (const slug of doctorSlugs) {
-                const agendaOverlap = overlapsAgendaForDoctor(slug, startMs, endMs);
+                const agendaOverlap = overlapsAgendaForDoctor(startMs, endMs);
                 const ranges = byDoctor.get(slug) ?? [];
                 const overlap = ranges.some((e) => e.start < endMs && e.end > startMs);
                 if (!agendaOverlap && !overlap) {

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -53,6 +53,7 @@ type DoctorSelection = { slug: string; name: string; handle: string | null };
 
 const ANY_DOCTOR: DoctorSelection = { slug: "any", name: "Sem Preferência", handle: null };
 const OTHER_SERVICE: Service = { id: "any", name: "Outro", subtitle: "Outro procedimento ou combinação" };
+const BOOKING_WINDOW_WEEKS = 4;
 
 function isOkResponse(value: unknown): value is { ok: true } {
     return !!value && typeof value === "object" && (value as { ok?: unknown }).ok === true;
@@ -506,7 +507,7 @@ export default function BookingFlow() {
     const upcomingWeeks = useMemo(() => {
         const out: string[][] = [];
         const base = startOfCurrentWeek(new Date());
-        for (let weekIndex = 0; weekIndex < 8; weekIndex += 1) {
+        for (let weekIndex = 0; weekIndex < BOOKING_WINDOW_WEEKS; weekIndex += 1) {
             const week: string[] = [];
             for (let dayIndex = 0; dayIndex < 7; dayIndex += 1) {
                 const d = new Date(base);


### PR DESCRIPTION
## Resumo
- aplica a regra de negócio para bloquear horários ocupados da agenda por `unidade + dia + horário`, ignorando o campo `profissional` do scraper
- mantém validação de escala CRM para dias de atendimento, mas sem depender de `profissional` para bloquear slots ocupados
- limita o calendário de agendamento no frontend para 4 semanas (semana atual + próximas 3)

## Motivação
Evitar dias com horários liberados indevidamente quando o campo `profissional` do scraper vem incompleto/incorreto e alinhar a janela visual com a janela sincronizada pela automação.

## Validação
- `npm run typecheck` (website)
- `npm run test` (website)
- auditoria real via endpoints de produção após higienização + ressync: `anomalies = 0` na janela de 4 semanas
