### PR TITLE
Website: cache de Instagram em D1 + sync agendado

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -27,6 +27,7 @@ jobs:
       TITAN_SMTP_PASS_BARRA: ${{ secrets.TITAN_SMTP_PASS_BARRA }}
       TITAN_SMTP_USER_NH: ${{ secrets.TITAN_SMTP_USER_NH }}
       TITAN_SMTP_PASS_NH: ${{ secrets.TITAN_SMTP_PASS_NH }}
+      INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
 
     steps:
       - name: Guard Cloudflare deploy secrets
@@ -74,7 +75,7 @@ jobs:
         run: npm run lint
 
       - name: Sync worker secrets (optional)
-        if: ${{ steps.guard.outputs.skip != 'true' && (env.AGENDA_SYNC_TOKEN != '' || env.TURNSTILE_SECRET_KEY != '' || env.CADASTRO_WHEEL_SECRET != '' || env.TITAN_SMTP_HOST != '' || env.TITAN_SMTP_PORT != '' || env.TITAN_SMTP_USER_BARRA != '' || env.TITAN_SMTP_PASS_BARRA != '' || env.TITAN_SMTP_USER_NH != '' || env.TITAN_SMTP_PASS_NH != '') }}
+        if: ${{ steps.guard.outputs.skip != 'true' && (env.AGENDA_SYNC_TOKEN != '' || env.TURNSTILE_SECRET_KEY != '' || env.CADASTRO_WHEEL_SECRET != '' || env.TITAN_SMTP_HOST != '' || env.TITAN_SMTP_PORT != '' || env.TITAN_SMTP_USER_BARRA != '' || env.TITAN_SMTP_PASS_BARRA != '' || env.TITAN_SMTP_USER_NH != '' || env.TITAN_SMTP_PASS_NH != '' || env.INSTAGRAM_SYNC_TOKEN != '') }}
         continue-on-error: true
         working-directory: website
         run: |
@@ -100,6 +101,7 @@ jobs:
           put_secret "TITAN_SMTP_PASS_BARRA" "${TITAN_SMTP_PASS_BARRA}"
           put_secret "TITAN_SMTP_USER_NH" "${TITAN_SMTP_USER_NH}"
           put_secret "TITAN_SMTP_PASS_NH" "${TITAN_SMTP_PASS_NH}"
+          put_secret "INSTAGRAM_SYNC_TOKEN" "${INSTAGRAM_SYNC_TOKEN}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -1,0 +1,87 @@
+name: Website Instagram Sync
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Forçar sync completo"
+        required: false
+        default: "false"
+      include_stories:
+        description: "Incluir stories"
+        required: false
+        default: "true"
+
+concurrency:
+  group: website-instagram-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
+      WEBSITE_BASE_URL: https://espacofacial.com
+
+    steps:
+      - name: Guard sync settings
+        id: guard
+        run: |
+          if [[ -z "${INSTAGRAM_SYNC_TOKEN:-}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "INSTAGRAM_SYNC_TOKEN não configurado; pulando sync."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger website Instagram sync
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          set -euo pipefail
+
+          FORCE_INPUT="${{ github.event.inputs.force || 'false' }}"
+          STORIES_INPUT="${{ github.event.inputs.include_stories || 'true' }}"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            FORCE_INPUT="false"
+            STORIES_INPUT="true"
+          fi
+
+          force_bool="false"
+          stories_bool="true"
+          case "${FORCE_INPUT,,}" in
+            1|true|yes) force_bool="true" ;;
+          esac
+          case "${STORIES_INPUT,,}" in
+            0|false|no) stories_bool="false" ;;
+          esac
+
+          payload=$(cat <<JSON
+          {
+            "force": ${force_bool},
+            "includeStories": ${stories_bool},
+            "maxFeedItems": 72,
+            "concurrency": 3,
+            "source": "github_actions_schedule"
+          }
+JSON
+)
+
+          echo "POST ${WEBSITE_BASE_URL}/api/instagram/sync"
+          status=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "${WEBSITE_BASE_URL}/api/instagram/sync" \
+            -H "content-type: application/json" \
+            -H "authorization: Bearer ${INSTAGRAM_SYNC_TOKEN}" \
+            --data "$payload")
+
+          cat response.json
+          echo
+
+          if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
+            echo "Sync falhou com HTTP ${status}"
+            exit 1
+          fi

--- a/website/README.md
+++ b/website/README.md
@@ -66,6 +66,19 @@ Setup (produção/preview):
 - Veja o guia: `docs/booking/SETUP_CLOUDFLARE_D1.md`
 - Arquivo de exemplo para preview local: `.dev.vars.example`
 
+## Instagram dos doutores (cache nativo no banco)
+
+O modal de Instagram do site agora lê de cache persistido no `BOOKING_DB` (D1), com sync recorrente:
+- Tabelas: `instagram_profiles`, `instagram_media`, `instagram_sync_runs`
+- Migration: `migrations/0003_instagram_cache.sql`
+- Endpoint de sync protegido: `POST /api/instagram/sync`
+  - Auth: `Authorization: Bearer <INSTAGRAM_SYNC_TOKEN>` (ou header `x-instagram-sync-token`)
+  - Sem `handles` no payload, ele sincroniza automaticamente os handles dos doutores ativos do diretório
+
+Automação:
+- Workflow agendado: `.github/workflows/website-instagram-sync.yml` (a cada 30 min)
+- Secret exigido no GitHub + Worker: `INSTAGRAM_SYNC_TOKEN`
+
 Deploy do worker de redirects (domínio `esfa.co`):
 ```bash
 npm run deploy:esfa

--- a/website/migrations/0003_instagram_cache.sql
+++ b/website/migrations/0003_instagram_cache.sql
@@ -1,0 +1,54 @@
+-- Instagram cache (posts/reels/stories) for website-native loading
+-- Apply with:
+--   wrangler d1 migrations apply espacofacial-booking
+
+CREATE TABLE IF NOT EXISTS instagram_profiles (
+    handle TEXT PRIMARY KEY,
+    user_id TEXT,
+    full_name TEXT,
+    biography TEXT,
+    avatar_url TEXT,
+    last_success_sync_ms INTEGER NOT NULL DEFAULT 0,
+    last_attempt_sync_ms INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS instagram_media (
+    id TEXT PRIMARY KEY,
+    handle TEXT NOT NULL,
+    media_id TEXT NOT NULL,
+    code TEXT,
+    media_type TEXT NOT NULL,
+    is_reel INTEGER NOT NULL DEFAULT 0,
+    is_story INTEGER NOT NULL DEFAULT 0,
+    caption TEXT,
+    taken_at_ms INTEGER,
+    thumbnail_url TEXT,
+    video_url TEXT,
+    permalink TEXT,
+    payload_json TEXT,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    UNIQUE(handle, media_id, is_story)
+);
+
+CREATE INDEX IF NOT EXISTS idx_instagram_media_handle_taken
+ON instagram_media(handle, is_story, taken_at_ms DESC, updated_at_ms DESC);
+
+CREATE TABLE IF NOT EXISTS instagram_sync_runs (
+    id TEXT PRIMARY KEY,
+    source TEXT,
+    handle TEXT,
+    started_at_ms INTEGER NOT NULL,
+    finished_at_ms INTEGER,
+    success INTEGER NOT NULL DEFAULT 0,
+    fetched_items INTEGER NOT NULL DEFAULT 0,
+    fetched_stories INTEGER NOT NULL DEFAULT 0,
+    upserted_items INTEGER NOT NULL DEFAULT 0,
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_instagram_sync_runs_handle_started
+ON instagram_sync_runs(handle, started_at_ms DESC);

--- a/website/src/app/api/instagram-avatar/route.ts
+++ b/website/src/app/api/instagram-avatar/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getCachedInstagramAvatarUrl } from "@/lib/instagramSync";
 
 export const dynamic = "force-dynamic";
 
@@ -207,11 +208,18 @@ export async function GET(req: Request) {
             }
         }
 
-        const profilePicUrl = await fetchInstagramProfilePic(handle);
+        const cachedAvatarUrl = await getCachedInstagramAvatarUrl(handle);
+        const profilePicUrl = cachedAvatarUrl ?? (await fetchInstagramProfilePic(handle));
         const ogImageUrl = profilePicUrl ? null : await fetchInstagramOgImage(handle);
         const primaryUrl = profilePicUrl ?? ogImageUrl;
 
-        const source = profilePicUrl ? "profile_json" : ogImageUrl ? "og_image" : "placeholder_svg";
+        const source = cachedAvatarUrl
+            ? "db_cache"
+            : profilePicUrl
+              ? "profile_json"
+              : ogImageUrl
+                ? "og_image"
+                : "placeholder_svg";
 
         const primary = primaryUrl ? await fetchImage(primaryUrl) : { ok: false, contentType: null, bytes: null };
         if (primary.ok && primary.bytes) {

--- a/website/src/app/api/instagram-feed/route.ts
+++ b/website/src/app/api/instagram-feed/route.ts
@@ -1,83 +1,25 @@
 import { NextResponse } from "next/server";
+import {
+    fetchLiveInstagramFeedPage,
+    getCachedInstagramFeed,
+    INSTAGRAM_SYNC_TTL_MS,
+    isInstagramProfileStale,
+    normalizeInstagramHandleInput,
+    syncInstagramHandle,
+} from "@/lib/instagramSync";
 
 export const dynamic = "force-dynamic";
 
-const INSTAGRAM_APP_ID = "936619743392459";
 const FEED_PAGE_SIZE = 9;
-const MAX_FETCH_ATTEMPTS = 3;
-const RETRY_BASE_DELAY_MS = 250;
 const MIN_FEED_PAGE_SIZE = 1;
 const MAX_FEED_PAGE_SIZE = 24;
-
-type InstagramProfileResponse = {
-    data?: {
-        user?: {
-            id?: string;
-            username?: string;
-            full_name?: string;
-            biography?: string;
-        };
-    };
-};
-
-type InstagramProfileUser = NonNullable<InstagramProfileResponse["data"]>["user"];
 
 type CfCacheStorage = {
     default?: Cache;
 };
 
-type InstagramFeedImageCandidate = {
-    url?: string;
-    width?: number;
-    height?: number;
-};
-
-type InstagramFeedVideoVersion = {
-    url?: string;
-    width?: number;
-    height?: number;
-};
-
-type InstagramFeedItem = {
-    id?: string;
-    pk?: string;
-    code?: string;
-    media_type?: number;
-    product_type?: string;
-    taken_at?: number;
-    caption?: { text?: string | null } | null;
-    image_versions2?: { candidates?: InstagramFeedImageCandidate[] } | null;
-    video_versions?: InstagramFeedVideoVersion[] | null;
-    carousel_media?: InstagramFeedItem[] | null;
-};
-
-type InstagramFeedResponse = {
-    items?: InstagramFeedItem[];
-    more_available?: boolean;
-    next_max_id?: string | null;
-};
-
-type NormalizedInstagramMedia = {
-    id: string;
-    code: string | null;
-    mediaType: "image" | "video" | "carousel";
-    isReel: boolean;
-    caption: string | null;
-    takenAtMs: number | null;
-    thumbnailUrl: string;
-    videoUrl: string | null;
-};
-
-function sanitizeHandle(input: string): string {
-    return (input ?? "").trim().replace(/^@/, "").replace(/[^a-zA-Z0-9._]/g, "").toLowerCase();
-}
-
-function sanitizeUserId(input: string): string {
-    return (input ?? "").trim().replace(/[^0-9]/g, "");
-}
-
 function sanitizeCursor(input: string): string {
-    return (input ?? "").trim().slice(0, 500);
+    return (input ?? "").trim().slice(0, 128);
 }
 
 function sanitizeCount(input: string): number {
@@ -86,155 +28,36 @@ function sanitizeCount(input: string): number {
     return Math.min(MAX_FEED_PAGE_SIZE, Math.max(MIN_FEED_PAGE_SIZE, parsed));
 }
 
-function instagramRequestHeaders(): HeadersInit {
-    return {
-        "user-agent":
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        accept: "application/json,text/plain,*/*",
-        "accept-language": "pt-BR,pt;q=0.9,en;q=0.8",
-        "x-ig-app-id": INSTAGRAM_APP_ID,
-        origin: "https://www.instagram.com",
-        referer: "https://www.instagram.com/",
-    };
-}
-
 function getCloudflareCache(): Cache | null {
     const cachesAny = (globalThis as unknown as { caches?: CfCacheStorage }).caches;
     return cachesAny?.default ?? null;
 }
 
-function isRetryableStatus(status: number): boolean {
-    return status === 429 || status >= 500;
-}
-
-async function sleep(ms: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function fetchInstagramJson<T>(url: string): Promise<T | null> {
-    for (let attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt++) {
-        try {
-            const res = await fetch(url, {
-                redirect: "follow",
-                headers: instagramRequestHeaders(),
-                next: { revalidate: 60 * 5 },
-            });
-
-            if (!res.ok) {
-                if (attempt < MAX_FETCH_ATTEMPTS - 1 && isRetryableStatus(res.status)) {
-                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
-                    continue;
-                }
-                return null;
-            }
-
-            const raw = await res.text();
-            const cleaned = raw.replace(/^for \(;;\);\s*/, "");
-
-            try {
-                return JSON.parse(cleaned) as T;
-            } catch {
-                if (attempt < MAX_FETCH_ATTEMPTS - 1) {
-                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
-                    continue;
-                }
-                return null;
-            }
-        } catch {
-            if (attempt < MAX_FETCH_ATTEMPTS - 1) {
-                await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
-                continue;
-            }
-            return null;
-        }
-    }
-    return null;
-}
-
-async function fetchProfile(handle: string): Promise<InstagramProfileUser | null> {
-    const url = `https://www.instagram.com/api/v1/users/web_profile_info/?username=${encodeURIComponent(handle)}`;
-    const json = await fetchInstagramJson<InstagramProfileResponse>(url);
-    return json?.data?.user ?? null;
-}
-
-async function fetchFeed(params: { userId: string; cursor?: string | null; count?: number }): Promise<InstagramFeedResponse | null> {
-    const url = new URL(`https://www.instagram.com/api/v1/feed/user/${encodeURIComponent(params.userId)}/`);
-    url.searchParams.set("count", String(params.count ?? FEED_PAGE_SIZE));
-    if (params.cursor) url.searchParams.set("max_id", params.cursor);
-    return fetchInstagramJson<InstagramFeedResponse>(url.toString());
-}
-
-function pickLargestImage(candidates: InstagramFeedImageCandidate[] | null | undefined): string | null {
-    if (!Array.isArray(candidates) || candidates.length === 0) return null;
-    const sorted = [...candidates].sort((a, b) => {
-        const areaA = (a.width ?? 0) * (a.height ?? 0);
-        const areaB = (b.width ?? 0) * (b.height ?? 0);
-        return areaB - areaA;
-    });
-    const best = sorted[0];
-    return typeof best?.url === "string" ? best.url : null;
-}
-
-function pickLargestVideo(versions: InstagramFeedVideoVersion[] | null | undefined): string | null {
-    if (!Array.isArray(versions) || versions.length === 0) return null;
-    const sorted = [...versions].sort((a, b) => {
-        const areaA = (a.width ?? 0) * (a.height ?? 0);
-        const areaB = (b.width ?? 0) * (b.height ?? 0);
-        return areaB - areaA;
-    });
-    const best = sorted[0];
-    return typeof best?.url === "string" ? best.url : null;
-}
-
-function normalizeItem(item: InstagramFeedItem): NormalizedInstagramMedia | null {
-    const code = typeof item.code === "string" && item.code.trim() ? item.code.trim() : null;
-    const id = `${item.id ?? item.pk ?? code ?? ""}`.trim();
-    if (!id) return null;
-
-    const mediaTypeNumber = item.media_type ?? 1;
-    const isCarousel = mediaTypeNumber === 8;
-    const isVideo = mediaTypeNumber === 2;
-
-    let imageUrl = pickLargestImage(item.image_versions2?.candidates);
-    let videoUrl = pickLargestVideo(item.video_versions);
-
-    if (isCarousel && Array.isArray(item.carousel_media) && item.carousel_media.length > 0) {
-        const first = item.carousel_media[0];
-        imageUrl = imageUrl ?? pickLargestImage(first?.image_versions2?.candidates);
-        if (!videoUrl) videoUrl = pickLargestVideo(first?.video_versions);
-    }
-
-    if (!imageUrl && !videoUrl) return null;
-
-    return {
-        id,
-        code,
-        mediaType: isCarousel ? "carousel" : isVideo ? "video" : "image",
-        isReel: item.product_type === "clips",
-        caption: typeof item.caption?.text === "string" && item.caption.text.trim() ? item.caption.text.trim() : null,
-        takenAtMs: typeof item.taken_at === "number" ? item.taken_at * 1000 : null,
-        thumbnailUrl: imageUrl ?? videoUrl ?? "",
-        videoUrl: videoUrl ?? null,
-    };
+function isTrue(raw: string | null): boolean {
+    const normalized = (raw ?? "").trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
-    const handle = sanitizeHandle(searchParams.get("handle") ?? "");
+
+    const handle = normalizeInstagramHandleInput(searchParams.get("handle") ?? "");
     const cursor = sanitizeCursor(searchParams.get("cursor") ?? "");
     const count = sanitizeCount(searchParams.get("count") ?? "");
-    let userId = sanitizeUserId(searchParams.get("userId") ?? "");
+    const includeStories = isTrue(searchParams.get("includeStories")) || searchParams.get("includeStories") === null;
+    const forceRefresh = isTrue(searchParams.get("refresh"));
 
     if (!handle) {
         return NextResponse.json({ ok: false, error: "invalid_handle" }, { status: 400 });
     }
 
+    const cache = getCloudflareCache();
+    const cacheKey = new Request(
+        `https://espacofacial.com/__cache/instagram-feed?handle=${encodeURIComponent(handle)}&cursor=${encodeURIComponent(cursor)}&count=${count}&stories=${includeStories ? 1 : 0}`,
+    );
+
     try {
-        const cache = getCloudflareCache();
-        const cacheKey = new Request(
-            `https://espacofacial.com/__cache/instagram-feed?handle=${encodeURIComponent(handle)}&userId=${encodeURIComponent(userId)}&cursor=${encodeURIComponent(cursor)}&count=${count}`,
-        );
-        if (cache) {
+        if (cache && !forceRefresh) {
             const cached = await cache.match(cacheKey);
             if (cached) {
                 const payload = await cached.text();
@@ -243,45 +66,58 @@ export async function GET(req: Request) {
                     headers: {
                         "content-type": "application/json; charset=utf-8",
                         "cache-control": cached.headers.get("cache-control") ?? "public, max-age=60, s-maxage=300",
-                        "x-instagram-feed-source": "cache",
+                        "x-instagram-feed-source": "edge-cache",
                     },
                 });
             }
         }
 
-        let profile: InstagramProfileUser | null = null;
-        if (!userId) {
-            profile = await fetchProfile(handle);
-            userId = sanitizeUserId(profile?.id ?? "");
+        let page = await getCachedInstagramFeed({
+            handle,
+            cursor,
+            count,
+            includeStories,
+        });
+
+        const isFirstPage = !cursor;
+        const stale = isFirstPage ? await isInstagramProfileStale(handle, INSTAGRAM_SYNC_TTL_MS) : false;
+        const shouldSync = forceRefresh || !page || (isFirstPage && stale && !page?.items?.length);
+
+        if (shouldSync) {
+            await syncInstagramHandle(handle, {
+                includeStories,
+                maxFeedItems: 72,
+                source: forceRefresh ? "api_refresh" : "api_cache_miss",
+            });
+
+            page = await getCachedInstagramFeed({
+                handle,
+                cursor,
+                count,
+                includeStories,
+            });
         }
 
-        if (!userId) {
-            return NextResponse.json({ ok: false, error: "profile_not_found" }, { status: 404 });
+        if (!page) {
+            const liveFallback = await fetchLiveInstagramFeedPage({
+                handle,
+                cursor,
+                count,
+                includeStories,
+            });
+            if (!liveFallback) {
+                return NextResponse.json({ ok: false, error: "feed_unavailable" }, { status: 502 });
+            }
+            return NextResponse.json(liveFallback, {
+                status: 200,
+                headers: {
+                    "cache-control": "public, max-age=30, s-maxage=30",
+                    "x-instagram-feed-source": "live-fallback",
+                },
+            });
         }
 
-        const feed = await fetchFeed({ userId, cursor: cursor || null, count });
-        if (!feed) {
-            return NextResponse.json({ ok: false, error: "feed_unavailable" }, { status: 502 });
-        }
-
-        const items = (feed.items ?? []).map(normalizeItem).filter((v): v is NormalizedInstagramMedia => !!v);
-        const nextCursor = typeof feed.next_max_id === "string" && feed.next_max_id.trim() ? feed.next_max_id : null;
-        const hasMore = Boolean(feed.more_available && nextCursor);
-
-        const responseBody = {
-            ok: true,
-            user: {
-                id: userId,
-                handle: profile?.username ?? handle,
-                name: profile?.full_name ?? null,
-                bio: profile?.biography ?? null,
-            },
-            items,
-            hasMore,
-            nextCursor,
-        };
-
-        const payload = JSON.stringify(responseBody);
+        const payload = JSON.stringify(page);
         if (cache) {
             await cache.put(
                 cacheKey,
@@ -300,7 +136,7 @@ export async function GET(req: Request) {
             headers: {
                 "content-type": "application/json; charset=utf-8",
                 "cache-control": "public, max-age=60, s-maxage=300",
-                "x-instagram-feed-source": "origin",
+                "x-instagram-feed-source": shouldSync ? "db-sync" : "db-cache",
             },
         });
     } catch {

--- a/website/src/app/api/instagram/sync/route.ts
+++ b/website/src/app/api/instagram/sync/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import {
+    INSTAGRAM_SYNC_TTL_MS,
+    isInstagramProfileStale,
+    normalizeInstagramHandleInput,
+    resolveDoctorInstagramHandles,
+    syncInstagramHandlesBatch,
+} from "@/lib/instagramSync";
+
+export const dynamic = "force-dynamic";
+
+type SyncPayload = {
+    handles?: string[];
+    includeStories?: boolean;
+    force?: boolean;
+    maxFeedItems?: number;
+    concurrency?: number;
+    source?: string;
+};
+
+function json(data: unknown, init?: ResponseInit) {
+    return NextResponse.json(data, init);
+}
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+    return (request.headers.get("x-instagram-sync-token") ?? "").trim();
+}
+
+async function assertToken(request: Request): Promise<boolean> {
+    const secret = await getRuntimeSecret("INSTAGRAM_SYNC_TOKEN");
+    if (process.env.NODE_ENV === "production" && !secret) return false;
+    if (!secret) return true;
+    return readToken(request) === secret;
+}
+
+function normalizeBool(value: unknown, defaultValue: boolean): boolean {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+        const v = value.trim().toLowerCase();
+        if (v === "1" || v === "true" || v === "yes") return true;
+        if (v === "0" || v === "false" || v === "no") return false;
+    }
+    return defaultValue;
+}
+
+function normalizePositiveInt(value: unknown, fallback: number, min: number, max: number): number {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    const out = Math.floor(n);
+    return Math.min(max, Math.max(min, out));
+}
+
+export async function POST(request: Request) {
+    if (!(await assertToken(request))) {
+        return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+
+    let payload: SyncPayload = {};
+    try {
+        payload = ((await request.json()) ?? {}) as SyncPayload;
+    } catch {
+        payload = {};
+    }
+
+    const includeStories = normalizeBool(payload.includeStories, true);
+    const force = normalizeBool(payload.force, false);
+    const maxFeedItems = normalizePositiveInt(payload.maxFeedItems, 72, 9, 120);
+    const concurrency = normalizePositiveInt(payload.concurrency, 3, 1, 8);
+    const source = typeof payload.source === "string" && payload.source.trim() ? payload.source.trim().slice(0, 80) : "api_instagram_sync";
+
+    const requestedHandles = Array.isArray(payload.handles)
+        ? payload.handles.map((h) => normalizeInstagramHandleInput(String(h ?? ""))).filter(Boolean)
+        : [];
+
+    const discoveredHandles = requestedHandles.length ? requestedHandles : await resolveDoctorInstagramHandles();
+    const uniqueHandles = [...new Set(discoveredHandles)].sort();
+
+    if (!uniqueHandles.length) {
+        return json({
+            ok: false,
+            error: "no_handles_found",
+        }, { status: 400 });
+    }
+
+    const targetHandles: string[] = [];
+    if (force) {
+        targetHandles.push(...uniqueHandles);
+    } else {
+        for (const handle of uniqueHandles) {
+            const stale = await isInstagramProfileStale(handle, INSTAGRAM_SYNC_TTL_MS);
+            if (stale) targetHandles.push(handle);
+        }
+    }
+
+    if (!targetHandles.length) {
+        return json({
+            ok: true,
+            message: "up_to_date",
+            discoveredHandles: uniqueHandles.length,
+            scheduledHandles: 0,
+            staleTtlMs: INSTAGRAM_SYNC_TTL_MS,
+            results: [],
+        });
+    }
+
+    const startedAtMs = Date.now();
+    const results = await syncInstagramHandlesBatch({
+        handles: targetHandles,
+        includeStories,
+        maxFeedItems,
+        source,
+        concurrency,
+    });
+
+    const okCount = results.filter((r) => r.ok).length;
+    const failCount = results.length - okCount;
+
+    return json({
+        ok: true,
+        startedAtMs,
+        finishedAtMs: Date.now(),
+        discoveredHandles: uniqueHandles.length,
+        scheduledHandles: targetHandles.length,
+        syncedHandles: results.length,
+        successCount: okCount,
+        failureCount: failCount,
+        staleTtlMs: INSTAGRAM_SYNC_TTL_MS,
+        options: {
+            includeStories,
+            force,
+            maxFeedItems,
+            concurrency,
+            source,
+        },
+        results,
+    });
+}

--- a/website/src/components/DoctorInstagramModal.tsx
+++ b/website/src/components/DoctorInstagramModal.tsx
@@ -8,10 +8,12 @@ type InstagramMedia = {
     code: string | null;
     mediaType: "image" | "video" | "carousel";
     isReel: boolean;
+    isStory?: boolean;
     caption: string | null;
     takenAtMs: number | null;
     thumbnailUrl: string;
     videoUrl: string | null;
+    permalink?: string | null;
 };
 
 type InstagramFeedResponse =
@@ -335,7 +337,15 @@ export default function DoctorInstagramModal(props: {
                     {instagramItems.length > 0 ? (
                         <div className="instagramGrid">
                             {instagramItems.map((item) => {
-                                const label = item.isReel ? "Reel" : item.mediaType === "video" ? "Vídeo" : item.mediaType === "carousel" ? "Carrossel" : "Post";
+                                const label = item.isStory
+                                    ? "Story"
+                                    : item.isReel
+                                      ? "Reel"
+                                      : item.mediaType === "video"
+                                        ? "Vídeo"
+                                        : item.mediaType === "carousel"
+                                          ? "Carrossel"
+                                          : "Post";
                                 return (
                                     <button
                                         key={item.id}
@@ -378,7 +388,7 @@ export default function DoctorInstagramModal(props: {
 
                     {instagramHasMore ? <div className="instagramInfiniteSentinel" ref={instagramInfiniteSentinelRef} aria-hidden="true" /> : null}
                     {instagramLoadingMore ? <div className="instagramLoadingMoreInline">Carregando mais publicações…</div> : null}
-                    <div className="modalNote">Posts e reels são exibidos dentro desta janela para manter você no site.</div>
+                    <div className="modalNote">Posts, reels e stories são exibidos dentro desta janela para manter você no site.</div>
                 </div>
             </div>
         </div>

--- a/website/src/lib/instagramCacheDb.ts
+++ b/website/src/lib/instagramCacheDb.ts
@@ -1,0 +1,395 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+export type D1PreparedStatement = {
+    bind: (...values: unknown[]) => D1PreparedStatement;
+    all: <T = unknown>() => Promise<{ results: T[] }>;
+    first: <T = unknown>() => Promise<T | null>;
+    run: () => Promise<{ success: boolean; error?: string } | unknown>;
+};
+
+export type D1DatabaseLike = {
+    prepare: (query: string) => D1PreparedStatement;
+};
+
+type CloudflareEnv = {
+    BOOKING_DB?: D1DatabaseLike;
+};
+
+export type InstagramCachedProfile = {
+    handle: string;
+    user_id: string | null;
+    full_name: string | null;
+    biography: string | null;
+    avatar_url: string | null;
+    last_success_sync_ms: number;
+    last_attempt_sync_ms: number;
+    last_error: string | null;
+    created_at_ms: number;
+    updated_at_ms: number;
+};
+
+export type InstagramCachedMediaRow = {
+    id: string;
+    handle: string;
+    media_id: string;
+    code: string | null;
+    media_type: "image" | "video" | "carousel";
+    is_reel: number;
+    is_story: number;
+    caption: string | null;
+    taken_at_ms: number | null;
+    thumbnail_url: string | null;
+    video_url: string | null;
+    permalink: string | null;
+    payload_json: string | null;
+    created_at_ms: number;
+    updated_at_ms: number;
+};
+
+export type UpsertProfileInput = {
+    handle: string;
+    userId: string | null;
+    fullName: string | null;
+    biography: string | null;
+    avatarUrl: string | null;
+    lastError?: string | null;
+    syncedAtMs: number;
+};
+
+export type UpsertMediaInput = {
+    id: string;
+    handle: string;
+    mediaId: string;
+    code: string | null;
+    mediaType: "image" | "video" | "carousel";
+    isReel: boolean;
+    isStory: boolean;
+    caption: string | null;
+    takenAtMs: number | null;
+    thumbnailUrl: string | null;
+    videoUrl: string | null;
+    permalink: string | null;
+    payloadJson: string | null;
+    updatedAtMs: number;
+};
+
+let ensured = false;
+
+function getDbOrNull(): D1DatabaseLike | null {
+    try {
+        const { env } = getCloudflareContext();
+        const typed = env as unknown as CloudflareEnv;
+        return typed.BOOKING_DB ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export async function getInstagramCacheDb(): Promise<D1DatabaseLike | null> {
+    const db = getDbOrNull();
+    if (!db) return null;
+    if (!ensured) {
+        await ensureSchema(db);
+        ensured = true;
+    }
+    return db;
+}
+
+async function ensureSchema(db: D1DatabaseLike): Promise<void> {
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS instagram_profiles (
+                handle TEXT PRIMARY KEY,
+                user_id TEXT,
+                full_name TEXT,
+                biography TEXT,
+                avatar_url TEXT,
+                last_success_sync_ms INTEGER NOT NULL DEFAULT 0,
+                last_attempt_sync_ms INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            );`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS instagram_media (
+                id TEXT PRIMARY KEY,
+                handle TEXT NOT NULL,
+                media_id TEXT NOT NULL,
+                code TEXT,
+                media_type TEXT NOT NULL,
+                is_reel INTEGER NOT NULL DEFAULT 0,
+                is_story INTEGER NOT NULL DEFAULT 0,
+                caption TEXT,
+                taken_at_ms INTEGER,
+                thumbnail_url TEXT,
+                video_url TEXT,
+                permalink TEXT,
+                payload_json TEXT,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                UNIQUE(handle, media_id, is_story)
+            );`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE INDEX IF NOT EXISTS idx_instagram_media_handle_taken
+             ON instagram_media(handle, is_story, taken_at_ms DESC, updated_at_ms DESC);`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS instagram_sync_runs (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                handle TEXT,
+                started_at_ms INTEGER NOT NULL,
+                finished_at_ms INTEGER,
+                success INTEGER NOT NULL DEFAULT 0,
+                fetched_items INTEGER NOT NULL DEFAULT 0,
+                fetched_stories INTEGER NOT NULL DEFAULT 0,
+                upserted_items INTEGER NOT NULL DEFAULT 0,
+                error TEXT
+            );`,
+        )
+        .run();
+
+    await db
+        .prepare(
+            `CREATE INDEX IF NOT EXISTS idx_instagram_sync_runs_handle_started
+             ON instagram_sync_runs(handle, started_at_ms DESC);`,
+        )
+        .run();
+}
+
+export async function getInstagramCachedProfile(handle: string): Promise<InstagramCachedProfile | null> {
+    const db = await getInstagramCacheDb();
+    if (!db) return null;
+    return db
+        .prepare(
+            `SELECT handle, user_id, full_name, biography, avatar_url,
+                    last_success_sync_ms, last_attempt_sync_ms, last_error, created_at_ms, updated_at_ms
+             FROM instagram_profiles
+             WHERE handle = ?
+             LIMIT 1;`,
+        )
+        .bind(handle)
+        .first<InstagramCachedProfile>();
+}
+
+export async function upsertInstagramCachedProfile(input: UpsertProfileInput): Promise<void> {
+    const db = await getInstagramCacheDb();
+    if (!db) return;
+
+    const now = input.syncedAtMs;
+    await db
+        .prepare(
+            `INSERT INTO instagram_profiles (
+                handle, user_id, full_name, biography, avatar_url,
+                last_success_sync_ms, last_attempt_sync_ms, last_error,
+                created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(handle) DO UPDATE SET
+                user_id = excluded.user_id,
+                full_name = excluded.full_name,
+                biography = excluded.biography,
+                avatar_url = excluded.avatar_url,
+                last_success_sync_ms = excluded.last_success_sync_ms,
+                last_attempt_sync_ms = excluded.last_attempt_sync_ms,
+                last_error = excluded.last_error,
+                updated_at_ms = excluded.updated_at_ms;`,
+        )
+        .bind(
+            input.handle,
+            input.userId,
+            input.fullName,
+            input.biography,
+            input.avatarUrl,
+            now,
+            now,
+            input.lastError ?? null,
+            now,
+            now,
+        )
+        .run();
+}
+
+export async function markInstagramSyncAttempt(params: {
+    handle: string;
+    attemptAtMs: number;
+    error: string | null;
+}): Promise<void> {
+    const db = await getInstagramCacheDb();
+    if (!db) return;
+
+    await db
+        .prepare(
+            `INSERT INTO instagram_profiles (
+                handle, user_id, full_name, biography, avatar_url,
+                last_success_sync_ms, last_attempt_sync_ms, last_error,
+                created_at_ms, updated_at_ms
+            ) VALUES (?, NULL, NULL, NULL, NULL, 0, ?, ?, ?, ?)
+            ON CONFLICT(handle) DO UPDATE SET
+                last_attempt_sync_ms = excluded.last_attempt_sync_ms,
+                last_error = excluded.last_error,
+                updated_at_ms = excluded.updated_at_ms;`,
+        )
+        .bind(params.handle, params.attemptAtMs, params.error, params.attemptAtMs, params.attemptAtMs)
+        .run();
+}
+
+export async function upsertInstagramMediaBatch(items: UpsertMediaInput[]): Promise<number> {
+    const db = await getInstagramCacheDb();
+    if (!db || !items.length) return 0;
+
+    for (const item of items) {
+        const createdAtMs = item.takenAtMs ?? item.updatedAtMs;
+        await db
+            .prepare(
+                `INSERT INTO instagram_media (
+                    id, handle, media_id, code, media_type, is_reel, is_story, caption,
+                    taken_at_ms, thumbnail_url, video_url, permalink, payload_json,
+                    created_at_ms, updated_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    handle = excluded.handle,
+                    media_id = excluded.media_id,
+                    code = excluded.code,
+                    media_type = excluded.media_type,
+                    is_reel = excluded.is_reel,
+                    is_story = excluded.is_story,
+                    caption = excluded.caption,
+                    taken_at_ms = excluded.taken_at_ms,
+                    thumbnail_url = excluded.thumbnail_url,
+                    video_url = excluded.video_url,
+                    permalink = excluded.permalink,
+                    payload_json = excluded.payload_json,
+                    updated_at_ms = excluded.updated_at_ms;`,
+            )
+            .bind(
+                item.id,
+                item.handle,
+                item.mediaId,
+                item.code,
+                item.mediaType,
+                item.isReel ? 1 : 0,
+                item.isStory ? 1 : 0,
+                item.caption,
+                item.takenAtMs,
+                item.thumbnailUrl,
+                item.videoUrl,
+                item.permalink,
+                item.payloadJson,
+                createdAtMs,
+                item.updatedAtMs,
+            )
+            .run();
+    }
+
+    return items.length;
+}
+
+export async function listInstagramCachedMedia(params: {
+    handle: string;
+    includeStories: boolean;
+    limit: number;
+    offset: number;
+}): Promise<InstagramCachedMediaRow[]> {
+    const db = await getInstagramCacheDb();
+    if (!db) return [];
+
+    const rows = await db
+        .prepare(
+            `SELECT id, handle, media_id, code, media_type, is_reel, is_story, caption,
+                    taken_at_ms, thumbnail_url, video_url, permalink, payload_json,
+                    created_at_ms, updated_at_ms
+             FROM instagram_media
+             WHERE handle = ? AND (? = 1 OR is_story = 0)
+             ORDER BY COALESCE(taken_at_ms, 0) DESC, updated_at_ms DESC
+             LIMIT ? OFFSET ?;`,
+        )
+        .bind(params.handle, params.includeStories ? 1 : 0, params.limit, params.offset)
+        .all<InstagramCachedMediaRow>();
+
+    return rows.results ?? [];
+}
+
+export async function pruneInstagramCache(params: {
+    handle: string;
+    keepPosts: number;
+    removeStoriesOlderThanMs: number;
+}): Promise<void> {
+    const db = await getInstagramCacheDb();
+    if (!db) return;
+
+    await db
+        .prepare(
+            `DELETE FROM instagram_media
+             WHERE handle = ?
+               AND is_story = 1
+               AND COALESCE(taken_at_ms, updated_at_ms, 0) < ?;`,
+        )
+        .bind(params.handle, params.removeStoriesOlderThanMs)
+        .run();
+
+    await db
+        .prepare(
+            `DELETE FROM instagram_media
+             WHERE id IN (
+                SELECT id FROM instagram_media
+                WHERE handle = ? AND is_story = 0
+                ORDER BY COALESCE(taken_at_ms, 0) DESC, updated_at_ms DESC
+                LIMIT -1 OFFSET ?
+             );`,
+        )
+        .bind(params.handle, params.keepPosts)
+        .run();
+}
+
+export async function insertInstagramSyncRun(params: {
+    id: string;
+    source: string | null;
+    handle: string;
+    startedAtMs: number;
+    finishedAtMs: number;
+    success: boolean;
+    fetchedItems: number;
+    fetchedStories: number;
+    upsertedItems: number;
+    error: string | null;
+}): Promise<void> {
+    const db = await getInstagramCacheDb();
+    if (!db) return;
+
+    await db
+        .prepare(
+            `INSERT INTO instagram_sync_runs (
+                id, source, handle, started_at_ms, finished_at_ms, success,
+                fetched_items, fetched_stories, upserted_items, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`,
+        )
+        .bind(
+            params.id,
+            params.source,
+            params.handle,
+            params.startedAtMs,
+            params.finishedAtMs,
+            params.success ? 1 : 0,
+            params.fetchedItems,
+            params.fetchedStories,
+            params.upsertedItems,
+            params.error,
+        )
+        .run();
+}
+
+export function newInstagramSyncRunId(): string {
+    const random = Math.random().toString(16).slice(2);
+    return `igsync_${Date.now()}_${random}`;
+}

--- a/website/src/lib/instagramSync.ts
+++ b/website/src/lib/instagramSync.ts
@@ -1,0 +1,682 @@
+import { fetchActiveInjectors } from "@/lib/injectorsDirectory";
+import {
+    getInstagramCachedProfile,
+    insertInstagramSyncRun,
+    listInstagramCachedMedia,
+    markInstagramSyncAttempt,
+    newInstagramSyncRunId,
+    pruneInstagramCache,
+    upsertInstagramCachedProfile,
+    upsertInstagramMediaBatch,
+} from "@/lib/instagramCacheDb";
+
+const INSTAGRAM_APP_ID = "936619743392459";
+const FEED_PAGE_SIZE = 24;
+const MAX_FETCH_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 250;
+const MAX_FEED_PAGES = 4;
+
+export const INSTAGRAM_SYNC_TTL_MS = 30 * 60 * 1000;
+export const INSTAGRAM_KEEP_POSTS_PER_HANDLE = 180;
+export const INSTAGRAM_STORIES_RETENTION_MS = 72 * 60 * 60 * 1000;
+
+export type InstagramApiUser = {
+    id: string;
+    handle: string;
+    name: string | null;
+    bio: string | null;
+};
+
+export type InstagramApiMedia = {
+    id: string;
+    code: string | null;
+    mediaType: "image" | "video" | "carousel";
+    isReel: boolean;
+    isStory: boolean;
+    caption: string | null;
+    takenAtMs: number | null;
+    thumbnailUrl: string;
+    videoUrl: string | null;
+    permalink: string | null;
+};
+
+export type InstagramFeedPage = {
+    ok: true;
+    user: InstagramApiUser;
+    items: InstagramApiMedia[];
+    hasMore: boolean;
+    nextCursor: string | null;
+};
+
+type InstagramProfileResponse = {
+    data?: {
+        user?: {
+            id?: string;
+            username?: string;
+            full_name?: string;
+            biography?: string;
+            profile_pic_url_hd?: string;
+            profile_pic_url?: string;
+        };
+    };
+};
+
+type InstagramProfileUser = NonNullable<InstagramProfileResponse["data"]>["user"];
+
+type InstagramFeedImageCandidate = {
+    url?: string;
+    width?: number;
+    height?: number;
+};
+
+type InstagramFeedVideoVersion = {
+    url?: string;
+    width?: number;
+    height?: number;
+};
+
+type InstagramFeedItem = {
+    id?: string;
+    pk?: string;
+    code?: string;
+    media_type?: number;
+    product_type?: string;
+    taken_at?: number;
+    caption?: { text?: string | null } | null;
+    image_versions2?: { candidates?: InstagramFeedImageCandidate[] } | null;
+    video_versions?: InstagramFeedVideoVersion[] | null;
+    carousel_media?: InstagramFeedItem[] | null;
+};
+
+type InstagramFeedResponse = {
+    items?: InstagramFeedItem[];
+    more_available?: boolean;
+    next_max_id?: string | null;
+};
+
+type InstagramStoriesResponse = {
+    reels?: Record<string, { items?: InstagramFeedItem[] }>;
+};
+
+export type SyncHandleResult = {
+    handle: string;
+    ok: boolean;
+    userId: string | null;
+    fetchedItems: number;
+    fetchedStories: number;
+    upsertedItems: number;
+    error: string | null;
+};
+
+function sanitizeHandle(input: string): string {
+    return (input ?? "")
+        .trim()
+        .replace(/^@/, "")
+        .replace(/[^a-zA-Z0-9._]/g, "")
+        .toLowerCase();
+}
+
+function sanitizeUserId(input: string): string {
+    return (input ?? "").trim().replace(/[^0-9]/g, "");
+}
+
+function parseCursorOffset(cursor: string | null | undefined): number {
+    const raw = (cursor ?? "").trim();
+    if (!raw) return 0;
+    const match = /^(?:o:)?([0-9]+)$/.exec(raw);
+    if (!match) return 0;
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isFinite(parsed) || parsed < 0) return 0;
+    return parsed;
+}
+
+function buildCursorOffset(offset: number): string {
+    return `o:${Math.max(0, Math.floor(offset))}`;
+}
+
+function instagramRequestHeaders(): HeadersInit {
+    return {
+        "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        accept: "application/json,text/plain,*/*",
+        "accept-language": "pt-BR,pt;q=0.9,en;q=0.8",
+        "x-ig-app-id": INSTAGRAM_APP_ID,
+        origin: "https://www.instagram.com",
+        referer: "https://www.instagram.com/",
+    };
+}
+
+async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableStatus(status: number): boolean {
+    return status === 429 || status >= 500;
+}
+
+async function fetchInstagramJson<T>(url: string): Promise<T | null> {
+    for (let attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt++) {
+        try {
+            const res = await fetch(url, {
+                redirect: "follow",
+                headers: instagramRequestHeaders(),
+                next: { revalidate: 60 * 5 },
+            });
+
+            if (!res.ok) {
+                if (attempt < MAX_FETCH_ATTEMPTS - 1 && isRetryableStatus(res.status)) {
+                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                    continue;
+                }
+                return null;
+            }
+
+            const raw = await res.text();
+            const cleaned = raw.replace(/^for \(;;\);\s*/, "");
+            try {
+                return JSON.parse(cleaned) as T;
+            } catch {
+                if (attempt < MAX_FETCH_ATTEMPTS - 1) {
+                    await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                    continue;
+                }
+                return null;
+            }
+        } catch {
+            if (attempt < MAX_FETCH_ATTEMPTS - 1) {
+                await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+                continue;
+            }
+            return null;
+        }
+    }
+
+    return null;
+}
+
+async function fetchProfile(handle: string): Promise<InstagramProfileUser | null> {
+    const url = `https://www.instagram.com/api/v1/users/web_profile_info/?username=${encodeURIComponent(handle)}`;
+    const json = await fetchInstagramJson<InstagramProfileResponse>(url);
+    return json?.data?.user ?? null;
+}
+
+async function fetchFeedPage(params: { userId: string; cursor?: string | null; count?: number }): Promise<InstagramFeedResponse | null> {
+    const url = new URL(`https://www.instagram.com/api/v1/feed/user/${encodeURIComponent(params.userId)}/`);
+    url.searchParams.set("count", String(params.count ?? FEED_PAGE_SIZE));
+    if (params.cursor) url.searchParams.set("max_id", params.cursor);
+    return fetchInstagramJson<InstagramFeedResponse>(url.toString());
+}
+
+async function fetchStoryItems(userId: string): Promise<InstagramFeedItem[]> {
+    const url = new URL("https://www.instagram.com/api/v1/feed/reels_media/");
+    url.searchParams.set("reel_ids", userId);
+
+    const json = await fetchInstagramJson<InstagramStoriesResponse>(url.toString());
+    const reels = json?.reels;
+    if (!reels || typeof reels !== "object") return [];
+
+    const direct = reels[userId];
+    if (direct && Array.isArray(direct.items)) return direct.items;
+
+    for (const value of Object.values(reels)) {
+        if (value && Array.isArray(value.items)) return value.items;
+    }
+
+    return [];
+}
+
+function pickLargestImage(candidates: InstagramFeedImageCandidate[] | null | undefined): string | null {
+    if (!Array.isArray(candidates) || candidates.length === 0) return null;
+    const sorted = [...candidates].sort((a, b) => {
+        const areaA = (a.width ?? 0) * (a.height ?? 0);
+        const areaB = (b.width ?? 0) * (b.height ?? 0);
+        return areaB - areaA;
+    });
+    const best = sorted[0];
+    return typeof best?.url === "string" ? best.url : null;
+}
+
+function pickLargestVideo(versions: InstagramFeedVideoVersion[] | null | undefined): string | null {
+    if (!Array.isArray(versions) || versions.length === 0) return null;
+    const sorted = [...versions].sort((a, b) => {
+        const areaA = (a.width ?? 0) * (a.height ?? 0);
+        const areaB = (b.width ?? 0) * (b.height ?? 0);
+        return areaB - areaA;
+    });
+    const best = sorted[0];
+    return typeof best?.url === "string" ? best.url : null;
+}
+
+function normalizeItem(params: {
+    item: InstagramFeedItem;
+    handle: string;
+    isStory: boolean;
+}): InstagramApiMedia | null {
+    const { item, handle, isStory } = params;
+
+    const code = typeof item.code === "string" && item.code.trim() ? item.code.trim() : null;
+    const mediaId = `${item.id ?? item.pk ?? code ?? ""}`.trim();
+    if (!mediaId) return null;
+
+    const mediaTypeNumber = item.media_type ?? 1;
+    const isCarousel = mediaTypeNumber === 8;
+    const isVideo = mediaTypeNumber === 2;
+
+    let imageUrl = pickLargestImage(item.image_versions2?.candidates);
+    let videoUrl = pickLargestVideo(item.video_versions);
+
+    if (isCarousel && Array.isArray(item.carousel_media) && item.carousel_media.length > 0) {
+        const first = item.carousel_media[0];
+        imageUrl = imageUrl ?? pickLargestImage(first?.image_versions2?.candidates);
+        if (!videoUrl) videoUrl = pickLargestVideo(first?.video_versions);
+    }
+
+    if (!imageUrl && !videoUrl) return null;
+
+    const isReel = item.product_type === "clips";
+    const permalink = (() => {
+        if (isStory) {
+            const storyPk = `${item.pk ?? item.id ?? ""}`.trim();
+            return storyPk ? `https://www.instagram.com/stories/${handle}/${storyPk}/` : null;
+        }
+        if (!code) return null;
+        return isReel ? `https://www.instagram.com/reel/${code}/` : `https://www.instagram.com/p/${code}/`;
+    })();
+
+    return {
+        id: `${handle}:${isStory ? "story:" : ""}${mediaId}`,
+        code,
+        mediaType: isCarousel ? "carousel" : isVideo ? "video" : "image",
+        isReel,
+        isStory,
+        caption: typeof item.caption?.text === "string" && item.caption.text.trim() ? item.caption.text.trim() : null,
+        takenAtMs: typeof item.taken_at === "number" ? item.taken_at * 1000 : null,
+        thumbnailUrl: imageUrl ?? videoUrl ?? "",
+        videoUrl: videoUrl ?? null,
+        permalink,
+    };
+}
+
+async function fetchFeedItems(userId: string, maxItems: number): Promise<InstagramFeedItem[]> {
+    const items: InstagramFeedItem[] = [];
+    let cursor: string | null = null;
+
+    for (let page = 0; page < MAX_FEED_PAGES; page++) {
+        if (items.length >= maxItems) break;
+
+        const pageSize = Math.max(1, Math.min(FEED_PAGE_SIZE, maxItems - items.length));
+        const feed = await fetchFeedPage({ userId, cursor, count: pageSize });
+        if (!feed) break;
+
+        const nextItems = Array.isArray(feed.items) ? feed.items : [];
+        if (nextItems.length === 0) break;
+        items.push(...nextItems);
+
+        const nextCursor = typeof feed.next_max_id === "string" && feed.next_max_id.trim() ? feed.next_max_id : null;
+        if (!feed.more_available || !nextCursor) break;
+        cursor = nextCursor;
+    }
+
+    return items.slice(0, maxItems);
+}
+
+export async function isInstagramProfileStale(handleRaw: string, maxAgeMs = INSTAGRAM_SYNC_TTL_MS): Promise<boolean> {
+    const handle = sanitizeHandle(handleRaw);
+    if (!handle) return true;
+
+    const profile = await getInstagramCachedProfile(handle);
+    if (!profile) return true;
+
+    const now = Date.now();
+    return profile.last_success_sync_ms <= 0 || now - profile.last_success_sync_ms > maxAgeMs;
+}
+
+export async function getCachedInstagramFeed(params: {
+    handle: string;
+    cursor?: string | null;
+    count: number;
+    includeStories?: boolean;
+}): Promise<InstagramFeedPage | null> {
+    const handle = sanitizeHandle(params.handle);
+    if (!handle) return null;
+
+    const offset = parseCursorOffset(params.cursor);
+    const pageSize = Math.max(1, Math.min(24, params.count));
+    const includeStories = params.includeStories ?? true;
+
+    const profile = await getInstagramCachedProfile(handle);
+    const rows = await listInstagramCachedMedia({
+        handle,
+        includeStories,
+        limit: pageSize + 1,
+        offset,
+    });
+
+    if (!rows.length) return null;
+
+    const hasMore = rows.length > pageSize;
+    const windowRows = hasMore ? rows.slice(0, pageSize) : rows;
+
+    const items: InstagramApiMedia[] = windowRows
+        .map((row) => {
+            const mediaType = row.media_type === "video" || row.media_type === "carousel" ? row.media_type : "image";
+            const thumbnailUrl = (row.thumbnail_url ?? "").trim();
+            if (!thumbnailUrl) return null;
+
+            return {
+                id: row.id,
+                code: row.code,
+                mediaType,
+                isReel: row.is_reel === 1,
+                isStory: row.is_story === 1,
+                caption: row.caption,
+                takenAtMs: row.taken_at_ms,
+                thumbnailUrl,
+                videoUrl: row.video_url,
+                permalink: row.permalink,
+            } satisfies InstagramApiMedia;
+        })
+        .filter((item): item is InstagramApiMedia => !!item);
+
+    if (!items.length) return null;
+
+    const userId = sanitizeUserId(profile?.user_id ?? "");
+    return {
+        ok: true,
+        user: {
+            id: userId,
+            handle,
+            name: profile?.full_name ?? null,
+            bio: profile?.biography ?? null,
+        },
+        items,
+        hasMore,
+        nextCursor: hasMore ? buildCursorOffset(offset + pageSize) : null,
+    };
+}
+
+export async function fetchLiveInstagramFeedPage(params: {
+    handle: string;
+    cursor?: string | null;
+    count: number;
+    includeStories?: boolean;
+}): Promise<InstagramFeedPage | null> {
+    const handle = sanitizeHandle(params.handle);
+    if (!handle) return null;
+
+    const profile = await fetchProfile(handle);
+    const userId = sanitizeUserId(profile?.id ?? "");
+    if (!userId) return null;
+
+    const feed = await fetchFeedPage({
+        userId,
+        cursor: (params.cursor ?? "").trim() || null,
+        count: Math.max(1, Math.min(24, params.count)),
+    });
+    if (!feed) return null;
+
+    const feedItems = (Array.isArray(feed.items) ? feed.items : [])
+        .map((item) => normalizeItem({ item, handle, isStory: false }))
+        .filter((item): item is InstagramApiMedia => !!item);
+
+    let stories: InstagramApiMedia[] = [];
+    const includeStories = params.includeStories ?? true;
+    if (includeStories && !(params.cursor ?? "").trim()) {
+        const storyItems = await fetchStoryItems(userId);
+        stories = storyItems
+            .map((item) => normalizeItem({ item, handle, isStory: true }))
+            .filter((item): item is InstagramApiMedia => !!item);
+    }
+
+    const uniqueById = new Map<string, InstagramApiMedia>();
+    for (const item of [...stories, ...feedItems]) uniqueById.set(item.id, item);
+    const items = [...uniqueById.values()];
+
+    const nextCursor = typeof feed.next_max_id === "string" && feed.next_max_id.trim() ? feed.next_max_id : null;
+    const hasMore = Boolean(feed.more_available && nextCursor);
+
+    return {
+        ok: true,
+        user: {
+            id: userId,
+            handle: profile?.username?.trim() || handle,
+            name: profile?.full_name?.trim() || null,
+            bio: profile?.biography?.trim() || null,
+        },
+        items,
+        hasMore,
+        nextCursor,
+    };
+}
+
+export async function syncInstagramHandle(handleRaw: string, opts?: {
+    includeStories?: boolean;
+    maxFeedItems?: number;
+    source?: string;
+}): Promise<SyncHandleResult> {
+    const handle = sanitizeHandle(handleRaw);
+    const startedAtMs = Date.now();
+    const runId = newInstagramSyncRunId();
+
+    if (!handle) {
+        const out: SyncHandleResult = {
+            handle: handleRaw,
+            ok: false,
+            userId: null,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: "invalid_handle",
+        };
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle: handleRaw,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: false,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: out.error,
+        });
+        return out;
+    }
+
+    await markInstagramSyncAttempt({ handle, attemptAtMs: startedAtMs, error: null });
+
+    try {
+        const profile = await fetchProfile(handle);
+        const userId = sanitizeUserId(profile?.id ?? "");
+        if (!userId) {
+            const error = "profile_not_found";
+            await markInstagramSyncAttempt({ handle, attemptAtMs: Date.now(), error });
+            await insertInstagramSyncRun({
+                id: runId,
+                source: opts?.source ?? null,
+                handle,
+                startedAtMs,
+                finishedAtMs: Date.now(),
+                success: false,
+                fetchedItems: 0,
+                fetchedStories: 0,
+                upsertedItems: 0,
+                error,
+            });
+            return {
+                handle,
+                ok: false,
+                userId: null,
+                fetchedItems: 0,
+                fetchedStories: 0,
+                upsertedItems: 0,
+                error,
+            };
+        }
+
+        const maxFeedItems = Math.max(FEED_PAGE_SIZE, Math.min(120, opts?.maxFeedItems ?? 54));
+        const includeStories = opts?.includeStories ?? true;
+
+        const [feedItems, storyItems] = await Promise.all([
+            fetchFeedItems(userId, maxFeedItems),
+            includeStories ? fetchStoryItems(userId) : Promise.resolve([]),
+        ]);
+
+        const normalizedFeed = feedItems
+            .map((item) => normalizeItem({ item, handle, isStory: false }))
+            .filter((item): item is InstagramApiMedia => !!item);
+
+        const normalizedStories = storyItems
+            .map((item) => normalizeItem({ item, handle, isStory: true }))
+            .filter((item): item is InstagramApiMedia => !!item);
+
+        const uniqueById = new Map<string, InstagramApiMedia>();
+        for (const item of [...normalizedStories, ...normalizedFeed]) {
+            uniqueById.set(item.id, item);
+        }
+        const allItems = [...uniqueById.values()];
+
+        const syncedAtMs = Date.now();
+        await upsertInstagramCachedProfile({
+            handle,
+            userId,
+            fullName: profile?.full_name?.trim() || null,
+            biography: profile?.biography?.trim() || null,
+            avatarUrl: profile?.profile_pic_url_hd ?? profile?.profile_pic_url ?? null,
+            lastError: null,
+            syncedAtMs,
+        });
+
+        const upsertedItems = await upsertInstagramMediaBatch(
+            allItems.map((item) => ({
+                id: item.id,
+                handle,
+                mediaId: item.id.replace(`${handle}:`, ""),
+                code: item.code,
+                mediaType: item.mediaType,
+                isReel: item.isReel,
+                isStory: item.isStory,
+                caption: item.caption,
+                takenAtMs: item.takenAtMs,
+                thumbnailUrl: item.thumbnailUrl,
+                videoUrl: item.videoUrl,
+                permalink: item.permalink,
+                payloadJson: null,
+                updatedAtMs: syncedAtMs,
+            })),
+        );
+
+        await pruneInstagramCache({
+            handle,
+            keepPosts: INSTAGRAM_KEEP_POSTS_PER_HANDLE,
+            removeStoriesOlderThanMs: syncedAtMs - INSTAGRAM_STORIES_RETENTION_MS,
+        });
+
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: true,
+            fetchedItems: normalizedFeed.length,
+            fetchedStories: normalizedStories.length,
+            upsertedItems,
+            error: null,
+        });
+
+        return {
+            handle,
+            ok: true,
+            userId,
+            fetchedItems: normalizedFeed.length,
+            fetchedStories: normalizedStories.length,
+            upsertedItems,
+            error: null,
+        };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "sync_exception";
+        await markInstagramSyncAttempt({ handle, attemptAtMs: Date.now(), error: message });
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: false,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: message,
+        });
+
+        return {
+            handle,
+            ok: false,
+            userId: null,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: message,
+        };
+    }
+}
+
+export async function resolveDoctorInstagramHandles(): Promise<string[]> {
+    try {
+        const members = await fetchActiveInjectors();
+        const unique = new Set<string>();
+        for (const member of members) {
+            const handle = sanitizeHandle(member.instagramHandle ?? "");
+            if (handle) unique.add(handle);
+        }
+        return [...unique.values()].sort();
+    } catch {
+        return [];
+    }
+}
+
+export async function syncInstagramHandlesBatch(params: {
+    handles: string[];
+    includeStories?: boolean;
+    maxFeedItems?: number;
+    source?: string;
+    concurrency?: number;
+}): Promise<SyncHandleResult[]> {
+    const inputHandles = params.handles.map((h) => sanitizeHandle(h)).filter(Boolean);
+    const handles = [...new Set(inputHandles)];
+    if (!handles.length) return [];
+
+    const concurrency = Math.max(1, Math.min(8, Math.floor(params.concurrency ?? 3)));
+    const queue = [...handles];
+    const results: SyncHandleResult[] = [];
+
+    async function worker(): Promise<void> {
+        for (;;) {
+            const next = queue.shift();
+            if (!next) return;
+            const result = await syncInstagramHandle(next, {
+                includeStories: params.includeStories,
+                maxFeedItems: params.maxFeedItems,
+                source: params.source,
+            });
+            results.push(result);
+        }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(concurrency, handles.length) }, () => worker()));
+    return results;
+}
+
+export async function getCachedInstagramAvatarUrl(handleRaw: string): Promise<string | null> {
+    const handle = sanitizeHandle(handleRaw);
+    if (!handle) return null;
+
+    const profile = await getInstagramCachedProfile(handle);
+    const url = (profile?.avatar_url ?? "").trim();
+    return url || null;
+}
+
+export function normalizeInstagramHandleInput(raw: string): string {
+    return sanitizeHandle(raw);
+}


### PR DESCRIPTION
## Resumo\n- troca carregamento live do Instagram por cache nativo em D1\n- adiciona endpoint protegido \n- adiciona workflow agendado de sync a cada 30 min\n- inclui migration de tabelas de perfil/mídia/runs\n\n## Validação\n- typecheck e lint executados na branch original antes do isolamento do commit\n- deploy de website executado com etapa principal de publicação concluída\n