### PR TITLE
CI: corrigir sintaxe YAML do sync de Instagram

### DIFF
--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -42,16 +42,8 @@ jobs:
             force_bool="true"
           fi
 
-          payload=$(cat <<JSON
-          {
-            "force": ${force_bool},
-            "includeStories": ${stories_bool},
-            "maxFeedItems": 72,
-            "concurrency": 3,
-            "source": "github_actions_schedule"
-          }
-JSON
-)
+          payload=$(printf '{"force":%s,"includeStories":%s,"maxFeedItems":72,"concurrency":3,"source":"github_actions_schedule"}' \
+            "${force_bool}" "${stories_bool}")
 
           echo "POST ${WEBSITE_BASE_URL}/api/instagram/sync"
           status=$(curl -sS -o response.json -w "%{http_code}" \


### PR DESCRIPTION
Corrige a sintaxe do workflow  removendo heredoc mal indentado que invalidava o YAML no GitHub Actions.