### PR TITLE
Website: retries robustos no sync de Instagram

### DIFF
--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Forçar sync completo"
+        required: false
+        default: "false"
+      include_stories:
+        description: "Incluir stories"
+        required: false
+        default: "true"
 
 concurrency:
   group: website-instagram-sync
@@ -34,28 +43,59 @@ jobs:
         run: |
           set -euo pipefail
 
-          force_bool="false"
-          stories_bool="true"
+          FORCE_INPUT="${{ github.event.inputs.force || 'false' }}"
+          STORIES_INPUT="${{ github.event.inputs.include_stories || 'true' }}"
 
-          # Manual dispatch executes a full refresh; scheduled runs are incremental.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            force_bool="true"
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            FORCE_INPUT="false"
+            STORIES_INPUT="true"
           fi
 
-          payload=$(printf '{"force":%s,"includeStories":%s,"maxFeedItems":72,"concurrency":3,"source":"github_actions_schedule"}' \
+          force_bool="false"
+          stories_bool="true"
+          case "${FORCE_INPUT,,}" in
+            1|true|yes) force_bool="true" ;;
+          esac
+          case "${STORIES_INPUT,,}" in
+            0|false|no) stories_bool="false" ;;
+          esac
+
+          payload=$(printf '{"force":%s,"includeStories":%s,"maxFeedItems":72,"concurrency":3,"maxHandleRetries":2,"retryDelayMs":1200,"source":"github_actions_schedule"}' \
             "${force_bool}" "${stories_bool}")
 
-          echo "POST ${WEBSITE_BASE_URL}/api/instagram/sync"
-          status=$(curl -sS -o response.json -w "%{http_code}" \
-            -X POST "${WEBSITE_BASE_URL}/api/instagram/sync" \
-            -H "content-type: application/json" \
-            -H "authorization: Bearer ${INSTAGRAM_SYNC_TOKEN}" \
-            --data "$payload")
+          max_http_attempts=3
+          http_success="false"
+          status="000"
+
+          for attempt in $(seq 1 "${max_http_attempts}"); do
+            echo "POST ${WEBSITE_BASE_URL}/api/instagram/sync (tentativa ${attempt}/${max_http_attempts})"
+            status=$(curl -sS -o response.json -w "%{http_code}" \
+              -X POST "${WEBSITE_BASE_URL}/api/instagram/sync" \
+              -H "content-type: application/json" \
+              -H "authorization: Bearer ${INSTAGRAM_SYNC_TOKEN}" \
+              --data "$payload" || true)
+
+            if [[ "$status" -ge 200 && "$status" -lt 300 ]] && jq -e '.ok == true' response.json >/dev/null 2>&1; then
+              http_success="true"
+              break
+            fi
+
+            if [[ "$attempt" -lt "$max_http_attempts" ]]; then
+              sleep $((attempt * 5))
+            fi
+          done
 
           cat response.json
           echo
 
-          if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
-            echo "Sync falhou com HTTP ${status}"
+          if [[ "$http_success" != "true" ]]; then
+            echo "Sync falhou após ${max_http_attempts} tentativas (último HTTP ${status})"
+            exit 1
+          fi
+
+          failure_count=$(jq -r '.failureCount // 0' response.json)
+          if [[ "$failure_count" -gt 0 ]]; then
+            echo "Sync concluído com ${failure_count} falhas após retries internos por handle."
+            jq -c '.results[] | select(.ok != true) | {handle,error,attempts}' response.json || true
             exit 1
           fi

--- a/website/src/app/api/instagram/sync/route.ts
+++ b/website/src/app/api/instagram/sync/route.ts
@@ -5,6 +5,7 @@ import {
     isInstagramProfileStale,
     normalizeInstagramHandleInput,
     resolveDoctorInstagramHandles,
+    type SyncHandleResult,
     syncInstagramHandlesBatch,
 } from "@/lib/instagramSync";
 
@@ -16,7 +17,13 @@ type SyncPayload = {
     force?: boolean;
     maxFeedItems?: number;
     concurrency?: number;
+    maxHandleRetries?: number;
+    retryDelayMs?: number;
     source?: string;
+};
+
+type SyncHandleResultWithAttempts = SyncHandleResult & {
+    attempts: number;
 };
 
 function json(data: unknown, init?: ResponseInit) {
@@ -53,6 +60,10 @@ function normalizePositiveInt(value: unknown, fallback: number, min: number, max
     return Math.min(max, Math.max(min, out));
 }
 
+async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function POST(request: Request) {
     if (!(await assertToken(request))) {
         return json({ ok: false, error: "unauthorized" }, { status: 401 });
@@ -69,6 +80,8 @@ export async function POST(request: Request) {
     const force = normalizeBool(payload.force, false);
     const maxFeedItems = normalizePositiveInt(payload.maxFeedItems, 72, 9, 120);
     const concurrency = normalizePositiveInt(payload.concurrency, 3, 1, 8);
+    const maxHandleRetries = normalizePositiveInt(payload.maxHandleRetries, 2, 0, 4);
+    const retryDelayMs = normalizePositiveInt(payload.retryDelayMs, 1200, 250, 10000);
     const source = typeof payload.source === "string" && payload.source.trim() ? payload.source.trim().slice(0, 80) : "api_instagram_sync";
 
     const requestedHandles = Array.isArray(payload.handles)
@@ -107,12 +120,67 @@ export async function POST(request: Request) {
     }
 
     const startedAtMs = Date.now();
-    const results = await syncInstagramHandlesBatch({
-        handles: targetHandles,
-        includeStories,
-        maxFeedItems,
-        source,
-        concurrency,
+    const resultsByHandle = new Map<string, SyncHandleResult>();
+    const attemptsByHandle = new Map<string, number>();
+    const batchSummaries: Array<{
+        attempt: number;
+        handles: string[];
+        successCount: number;
+        failureCount: number;
+    }> = [];
+
+    let pendingHandles = [...targetHandles];
+    for (let attempt = 1; attempt <= maxHandleRetries + 1; attempt++) {
+        if (!pendingHandles.length) break;
+
+        const batchResults = await syncInstagramHandlesBatch({
+            handles: pendingHandles,
+            includeStories,
+            maxFeedItems,
+            source: `${source}:attempt_${attempt}`,
+            concurrency,
+        });
+
+        const failed: string[] = [];
+        let successCount = 0;
+        for (const result of batchResults) {
+            attemptsByHandle.set(result.handle, (attemptsByHandle.get(result.handle) ?? 0) + 1);
+            const previous = resultsByHandle.get(result.handle);
+            if (!previous || result.ok || !previous.ok) {
+                resultsByHandle.set(result.handle, result);
+            }
+            if (result.ok) successCount += 1;
+            else failed.push(result.handle);
+        }
+
+        batchSummaries.push({
+            attempt,
+            handles: pendingHandles,
+            successCount,
+            failureCount: failed.length,
+        });
+
+        if (!failed.length) break;
+        pendingHandles = [...new Set(failed)];
+        if (attempt <= maxHandleRetries) {
+            await sleep(retryDelayMs * attempt);
+        }
+    }
+
+    const results: SyncHandleResultWithAttempts[] = targetHandles.map((handle) => {
+        const result = resultsByHandle.get(handle) ?? {
+            handle,
+            ok: false,
+            userId: null,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: "sync_not_executed",
+        };
+        return {
+            ...result,
+            attempts: attemptsByHandle.get(handle) ?? 0,
+        };
     });
 
     const okCount = results.filter((r) => r.ok).length;
@@ -133,8 +201,11 @@ export async function POST(request: Request) {
             force,
             maxFeedItems,
             concurrency,
+            maxHandleRetries,
+            retryDelayMs,
             source,
         },
+        retrySummary: batchSummaries,
         results,
     });
 }


### PR DESCRIPTION
## O que muda\n- endpoint  agora faz retry por handle com backoff (configurável)\n- workflow agendado agora faz retry HTTP da chamada ao endpoint\n- workflow falha explicitamente se ainda houver handles com erro após retries\n\n## Objetivo\nAumentar resiliência contra intermitência do Instagram ( transitório, timeout/rede) mantendo observabilidade de falhas persistentes.