### PR TITLE
[codex] tighten procedure spacing and fix clipped booking tooltips

### DIFF
--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1507,21 +1507,21 @@ button:focus-visible {
 .bookingFlow__doctorTooltip {
   position: absolute;
   left: 50%;
-  top: calc(100% + 10px);
+  top: 6px;
   bottom: auto;
   transform: translateX(-50%);
   display: none;
   width: max-content;
-  min-width: 132px;
-  max-width: 210px;
-  padding: 8px 10px;
-  border-radius: 12px;
+  min-width: 118px;
+  max-width: 184px;
+  padding: 6px 8px;
+  border-radius: 10px;
   background: rgba(17, 17, 17, 0.96);
   color: #fff;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
   white-space: normal;
   pointer-events: auto;
-  z-index: 4;
+  z-index: 5;
 }
 
 .bookingFlow__doctorTooltipHeader {
@@ -1539,13 +1539,13 @@ button:focus-visible {
 .bookingFlow__doctorTooltipName {
   font-weight: 900;
   line-height: 1.1;
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .bookingFlow__doctorTooltipSub {
-  margin-top: 2px;
-  font-size: 11px;
-  line-height: 1.3;
+  margin-top: 1px;
+  font-size: 10px;
+  line-height: 1.2;
   color: rgba(255, 255, 255, 0.72);
 }
 
@@ -1571,7 +1571,7 @@ button:focus-visible {
 .bookingFlow__procedureBadgeGrid {
   display: flex;
   flex-wrap: nowrap;
-  gap: 12px;
+  gap: 8px;
   align-items: flex-start;
   width: max-content;
   min-width: max-content;
@@ -1583,8 +1583,8 @@ button:focus-visible {
   display: grid;
   justify-items: center;
   gap: 5px;
-  width: 112px;
-  min-width: 112px;
+  width: 92px;
+  min-width: 92px;
   flex: 0 0 auto;
   padding: 0;
   border: 0;
@@ -1655,12 +1655,12 @@ button:focus-visible {
 .bookingFlow__procedureBadgeLabel {
   font-size: 12px;
   font-weight: 900;
-  line-height: 1.15;
+  line-height: 1.1;
   text-align: center;
   text-wrap: pretty;
   overflow-wrap: anywhere;
   width: 100%;
-  min-height: 2.3em;
+  min-height: 2.2em;
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeLabel {
@@ -1762,6 +1762,24 @@ button:focus-visible {
   opacity: 0;
   transition: opacity 140ms ease;
   z-index: 1;
+}
+
+.bookingFlow__cardProcedure .bookingFlow__tooltipTrigger[data-tooltip]::after {
+  top: 2px;
+  bottom: auto;
+  max-width: 148px;
+  padding: 5px 7px;
+  font-size: 10px;
+  line-height: 1.15;
+  white-space: normal;
+  text-wrap: balance;
+  text-align: center;
+  transform: translateX(-50%) translateY(2px);
+  z-index: 6;
+}
+
+.bookingFlow__cardProcedure .bookingFlow__tooltipTrigger[data-tooltip]::before {
+  display: none;
 }
 
 .bookingFlow__timeBtn[data-tooltip]:hover::after,


### PR DESCRIPTION
## Resumo

Ajusta a seção de procedimentos em `/agendamento` para corrigir dois problemas visuais reportados em produção:

- espaçamento dos ícones de procedimentos estava excessivo em comparação ao carrossel de doutores
- tooltip de procedimentos e doutores estava sendo exibido baixo demais e ficando cortado dentro do box

## Causa

As últimas alterações tinham ampliado a largura dos itens do carrossel de procedimentos e deslocado o espaço útil de forma a causar excesso de distância visual. Além disso, a posição dos tooltips ficava abaixo do item em um container com clipping visual perceptível durante o hover.

## Correções

Arquivo alterado:

- `website/src/styles/globals.css`

Mudanças principais:

- procedimentos:
  - `gap` reduzido para ficar próximo ao padrão dos doutores
  - largura dos badges reduzida para evitar espaçamento artificial
- tooltips de procedimentos:
  - versão compacta
  - reposicionada próxima/por cima do ícone para evitar corte
  - seta inferior desativada nesse contexto para evitar artefato visual
- tooltips de doutores:
  - reposicionados e compactados
  - ajuste de `z-index`/dimensões para voltar a aparecer corretamente

## Validação

- revisão do diff CSS no escopo de `bookingFlow`
- confirmação de que a alteração foi isolada ao `globals.css`, sem incluir mudanças paralelas em outros arquivos do repositório
