### PR TITLE
[codex] stabilize whatsapp refresh disconnect and menus

### DIFF
--- a/backend/apps/crm-api/server.js
+++ b/backend/apps/crm-api/server.js
@@ -5877,7 +5877,7 @@ app.get('/api/wa-orchestrator/status', async (req, res) => {
             maybeAutoBootstrapSync(status)
             const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
             const connectedInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'connected').length
-            const freeInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'free').length
+            const freeInstances = scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length
             const errorInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'error').length
             const startingInstances = scopedChannels.filter((item) => {
                 const value = String(item?.status || '').toLowerCase()
@@ -5900,8 +5900,8 @@ app.get('/api/wa-orchestrator/status', async (req, res) => {
                 bootstrapSync,
                 sseClients: waEventClients.size,
                 webhookMetrics: waWebhookMetrics,
-                availableChannelsList: scopedChannels.filter((c) => c.status === 'free').map((c) => c.channel),
-                freeChannelsList: scopedChannels.filter((c) => c.status === 'free').map((c) => c.channel),
+                availableChannelsList: scopedChannels.filter((c) => isWaChannelIdleStatus(c?.status)).map((c) => c.channel),
+                freeChannelsList: scopedChannels.filter((c) => isWaChannelIdleStatus(c?.status)).map((c) => c.channel),
                 recoverySuggestions: null,
                 endpoints: {
                     channels: '/api/wa-orchestrator/channels',
@@ -5919,7 +5919,7 @@ app.get('/api/wa-orchestrator/status', async (req, res) => {
         const status = whatsappOrchestrator.getStatus()
         const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
         const connectedInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'connected').length
-        const freeInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'free').length
+        const freeInstances = scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length
         const errorInstances = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'error').length
         const startingInstances = scopedChannels.filter((item) => {
             const value = String(item?.status || '').toLowerCase()
@@ -6242,9 +6242,10 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
         }
         const limit = Math.min(Math.max(parseInt(String(req.query.limit || '50'), 10) || 50, 1), 200)
         const offset = Math.max(parseInt(String(req.query.offset || '0'), 10) || 0, 0)
+        const archivedOnly = normalizeBoolean(req.query.archivedOnly, false)
 
         if (USE_EVOLUTION_ORCHESTRATOR) {
-            const data = await evolutionOrchestrator.fetchChats(channel, { limit, offset })
+            const data = await evolutionOrchestrator.fetchChats(channel, { limit, offset, archivedOnly })
             const chats = Array.isArray(data) ? data : (data?.chats || data?.data || [])
             const mapped = chats.map((chat) => {
                 upsertWaContactDirectoryEntry(channel, {
@@ -6270,6 +6271,26 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                 const lastMessageId = String(chat?.lastMessage?.id || chat?.lastMessage?.key?.id || '').trim()
                 const updatedAt = normalizeEvolutionTimestamp(chat.updatedAt || chat.lastMessage?.messageTimestamp)
                 const profilePic = chat.profilePicUrl || chat.profilePictureUrl || chat.avatarUrl || chat.avatar || chat.imgUrl || chat.pictureUrl || chat.photoUrl || null
+                const labels = Array.isArray(chat?.labels)
+                    ? chat.labels
+                    : Array.isArray(chat?.tags)
+                        ? chat.tags
+                        : []
+                const hasArchivedLabel = labels.some((label) => {
+                    const normalized = String(label || '').trim().toLowerCase()
+                    return normalized === 'archived' || normalized === 'arquivada' || normalized === '__archived__'
+                })
+                const isArchived = normalizeBoolean(
+                    chat?.archived ??
+                    chat?.isArchived ??
+                    chat?.archive ??
+                    chat?.isArchive ??
+                    chat?.chat?.archived ??
+                    chat?.chat?.archive ??
+                    chat?.metadata?.archived ??
+                    hasArchivedLabel,
+                    false
+                )
                 const mappedItem = {
                     conversationId: identity.rawJid || identity.normalizedJid,
                     rawJid: rawIdentity.rawJid || identity.rawJid || identity.normalizedJid,
@@ -6298,6 +6319,8 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                             : undefined,
                     updatedAt,
                     unreadCount: chat.unreadCount ?? chat.unreadMessages ?? 0,
+                    archived: isArchived,
+                    isArchived,
                     aliases: Array.from(new Set([...(rawIdentity.aliases || []), ...(identity.aliases || []), ...(altIdentity.aliases || [])]))
                 }
                 const directoryEntry = lookupWaContactDirectoryEntry(channel, [
@@ -6330,6 +6353,7 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                 const currentUpdatedAt = Date.parse(item.updatedAt || '') || 0
                 const newest = currentUpdatedAt >= prevUpdatedAt ? item : previous
                 const mergedAliases = Array.from(new Set([...(previous.aliases || []), ...(item.aliases || [])]))
+                const mergedArchived = Boolean(previous?.archived || previous?.isArchived || item?.archived || item?.isArchived)
                 dedupedMap.set(key, {
                     ...previous,
                     ...newest,
@@ -6338,6 +6362,8 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                     normalizedJid: newest.normalizedJid || previous.normalizedJid,
                     phone: newest.phone || previous.phone,
                     aliases: mergedAliases,
+                    archived: mergedArchived,
+                    isArchived: mergedArchived,
                     unreadCount: Number(previous.unreadCount || 0) + Number(item.unreadCount || 0),
                     name: (
                         (newest.name && !/^\d{10,}$/.test(String(newest.name || ''))) ? newest.name : null
@@ -6362,7 +6388,9 @@ app.get('/api/wa-orchestrator/channels/:channel/conversations', async (req, res)
                 platform: 'whatsapp',
                 lastMessage: c.lastMessage || 'Sem mensagens',
                 updatedAt: c.updatedAt || new Date().toISOString(),
-                unreadCount: c.unreadCount || 0
+                unreadCount: c.unreadCount || 0,
+                archived: Boolean(c.archived),
+                isArchived: Boolean(c.archived)
             }))
         return res.json({ success: true, items, meta: { limit, offset, hasMore: false } })
     } catch (error) {
@@ -6623,6 +6651,38 @@ app.post('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/read',
             success: true,
             conversationId: normalizedRemoteJid,
             readCount: readMessages.length,
+            result
+        })
+    } catch (error) {
+        return res.status(500).json({ success: false, error: error.message })
+    }
+})
+
+app.post('/api/wa-orchestrator/channels/:channel/conversations/:remoteJid/archive', async (req, res) => {
+    try {
+        const channel = parseInt(req.params.channel, 10)
+        if (isNaN(channel) || channel < 1 || channel > 9) {
+            return res.status(400).json({ success: false, error: 'Invalid channel. Must be between 1 and 9.' })
+        }
+        if (!USE_EVOLUTION_ORCHESTRATOR) {
+            return res.status(400).json({ success: false, error: 'Archive sync is only available for Evolution provider.' })
+        }
+        const normalizedRemoteJid = normalizeWhatsAppJid(req.params.remoteJid)
+        if (!normalizedRemoteJid) {
+            return res.status(400).json({ success: false, error: 'remoteJid is required' })
+        }
+        const archive = normalizeBoolean(req.body?.archive, true)
+        const result = await evolutionOrchestrator.archiveChat(channel, normalizedRemoteJid, archive)
+        broadcastWaEvent({
+            type: 'conversation_archive_toggled',
+            channel,
+            remoteJid: normalizedRemoteJid,
+            archived: archive
+        })
+        return res.json({
+            success: true,
+            conversationId: normalizedRemoteJid,
+            archived: archive,
             result
         })
     } catch (error) {
@@ -7238,7 +7298,7 @@ app.get('/api/wa-orchestrator/free-port', async (req, res) => {
         if (USE_EVOLUTION_ORCHESTRATOR) {
             const status = await evolutionOrchestrator.getStatus()
             const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
-            const free = scopedChannels.find((item) => String(item?.status || '').toLowerCase() === 'free')
+            const free = scopedChannels.find((item) => isWaChannelIdleStatus(item?.status))
             if (free) {
                 return res.json({
                     success: true,
@@ -7252,8 +7312,8 @@ app.get('/api/wa-orchestrator/free-port', async (req, res) => {
                 error: 'No free ports available',
                 status: {
                     totalChannels: scopedChannels.length,
-                    availableChannels: scopedChannels.filter((item) => item.status === 'free').length,
-                    freeInstances: scopedChannels.filter((item) => item.status === 'free').length,
+                    availableChannels: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
+                    freeInstances: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
                     connectedInstances: scopedChannels.filter((item) => item.status === 'connected').length,
                     errorInstances: scopedChannels.filter((item) => item.status === 'error').length
                 }
@@ -7262,7 +7322,7 @@ app.get('/api/wa-orchestrator/free-port', async (req, res) => {
 
         const status = whatsappOrchestrator.getStatus()
         const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
-        const free = scopedChannels.find((item) => String(item?.status || '').toLowerCase() === 'free')
+        const free = scopedChannels.find((item) => isWaChannelIdleStatus(item?.status))
         if (free) {
             return res.json({
                 success: true,
@@ -7276,8 +7336,8 @@ app.get('/api/wa-orchestrator/free-port', async (req, res) => {
             error: 'No free ports available',
             status: {
                 totalChannels: scopedChannels.length,
-                availableChannels: scopedChannels.filter((item) => item.status === 'free').length,
-                freeInstances: scopedChannels.filter((item) => item.status === 'free').length,
+                availableChannels: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
+                freeInstances: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
                 connectedInstances: scopedChannels.filter((item) => item.status === 'connected').length,
                 errorInstances: scopedChannels.filter((item) => item.status === 'error').length
             }
@@ -7299,7 +7359,7 @@ app.get('/api/wa-orchestrator/channels', async (req, res) => {
             maybeAutoBootstrapSync(status)
         }
         const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
-        const freeChannels = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'free').map((item) => item.channel)
+        const freeChannels = scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).map((item) => item.channel)
         const connectedCount = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'connected').length
         const errorCount = scopedChannels.filter((item) => String(item?.status || '').toLowerCase() === 'error').length
         const startingCount = scopedChannels.filter((item) => {
@@ -7733,7 +7793,7 @@ app.get('/api/wa-orchestrator/next-channel', async (req, res) => {
         if (USE_EVOLUTION_ORCHESTRATOR) {
             const status = await evolutionOrchestrator.getStatus()
             const scopedChannels = scopeWaChannelsForActor(status.channels, req.waActor)
-            const free = scopedChannels.find((c) => c.status === 'free')
+            const free = scopedChannels.find((c) => isWaChannelIdleStatus(c?.status))
             if (free) {
                 return res.json({
                     success: true,
@@ -7747,8 +7807,8 @@ app.get('/api/wa-orchestrator/next-channel', async (req, res) => {
                 error: 'No available channels',
                 status: {
                     totalChannels: scopedChannels.length,
-                    availableChannels: scopedChannels.filter((c) => c.status === 'free').length,
-                    freeInstances: scopedChannels.filter((c) => c.status === 'free').length,
+                    availableChannels: scopedChannels.filter((c) => isWaChannelIdleStatus(c?.status)).length,
+                    freeInstances: scopedChannels.filter((c) => isWaChannelIdleStatus(c?.status)).length,
                     connectedInstances: scopedChannels.filter((c) => c.status === 'connected').length,
                     errorInstances: scopedChannels.filter((c) => c.status === 'error').length
                 }
@@ -7772,8 +7832,8 @@ app.get('/api/wa-orchestrator/next-channel', async (req, res) => {
                 error: 'No available channels',
                 status: {
                     totalChannels: scopedChannels.length,
-                    availableChannels: scopedChannels.filter((item) => item.status === 'free').length,
-                    freeInstances: scopedChannels.filter((item) => item.status === 'free').length,
+                    availableChannels: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
+                    freeInstances: scopedChannels.filter((item) => isWaChannelIdleStatus(item?.status)).length,
                     connectedInstances: scopedChannels.filter((item) => item.status === 'connected').length,
                     errorInstances: scopedChannels.filter((item) => item.status === 'error').length
                 }

--- a/backend/apps/crm-api/services/__tests__/evolutionOrchestrator.test.js
+++ b/backend/apps/crm-api/services/__tests__/evolutionOrchestrator.test.js
@@ -52,6 +52,36 @@ test('getStatus degrades gracefully when Evolution is offline', async () => {
   assert.ok(status.channels.every((channel) => channel.status === 'error'))
 })
 
+test('getStatus treats disconnected and available-like states as free', async () => {
+  process.env.EVOLUTION_API_URL = 'http://evolution.local'
+  process.env.EVOLUTION_API_KEY = 'test-key'
+  process.env.EVOLUTION_INSTANCE_PREFIX = 'crm-channel-'
+  process.env.EVOLUTION_AUTO_RECOVERY_ENABLED = 'false'
+
+  global.fetch = async (url) => {
+    if (String(url) === 'http://evolution.local/instance/fetchInstances') {
+      return mockJsonResponse([
+        { name: 'crm-channel-1', connectionStatus: 'disconnected', profileName: 'Canal 1' },
+        { name: 'crm-channel-2', connectionStatus: 'available', profileName: 'Canal 2' },
+        { name: 'crm-channel-3', connectionStatus: 'closed', profileName: 'Canal 3' },
+        { name: 'crm-channel-4', connectionStatus: 'open', profileName: 'Canal 4' }
+      ])
+    }
+    return mockJsonResponse([])
+  }
+
+  const status = await evolutionOrchestrator.getStatus()
+  const byChannel = new Map(status.channels.map((item) => [item.channel, item.status]))
+
+  assert.equal(byChannel.get(1), 'free')
+  assert.equal(byChannel.get(2), 'free')
+  assert.equal(byChannel.get(3), 'free')
+  assert.equal(byChannel.get(4), 'connected')
+  assert.equal(status.freeInstances, 8)
+  assert.equal(status.connectedInstances, 1)
+  assert.equal(status.errorInstances, 0)
+})
+
 test('fetchChats sends the expected Evolution endpoint and pagination payload', async () => {
   process.env.EVOLUTION_API_URL = 'http://evolution.local'
   process.env.EVOLUTION_API_KEY = 'test-key'
@@ -71,7 +101,24 @@ test('fetchChats sends the expected Evolution endpoint and pagination payload', 
   assert.equal(capturedUrl, 'http://evolution.local/chat/findChats/crm-channel-3')
   assert.equal(capturedInit.method, 'POST')
   assert.equal(capturedInit.headers.get('apikey'), 'test-key')
-  assert.deepEqual(JSON.parse(capturedInit.body), { take: 25, skip: 50 })
+  assert.deepEqual(JSON.parse(capturedInit.body), { take: 25, skip: 50, where: { archived: false } })
+})
+
+test('fetchChats sends archived=true filter when archivedOnly is requested', async () => {
+  process.env.EVOLUTION_API_URL = 'http://evolution.local'
+  process.env.EVOLUTION_API_KEY = 'test-key'
+  process.env.EVOLUTION_INSTANCE_PREFIX = 'crm-channel-'
+  process.env.EVOLUTION_AUTO_RECOVERY_ENABLED = 'false'
+
+  let capturedBody = null
+  global.fetch = async (_url, init) => {
+    capturedBody = JSON.parse(init.body)
+    return mockJsonResponse({ records: [] })
+  }
+
+  await evolutionOrchestrator.fetchChats(4, { limit: 10, offset: 20, archivedOnly: true })
+
+  assert.deepEqual(capturedBody, { take: 10, skip: 20, where: { archived: true } })
 })
 
 test('fetchContacts sends the expected Evolution endpoint and pagination payload', async () => {
@@ -154,6 +201,27 @@ test('sendText uses /message/sendText with number and quoted reply metadata', as
         conversation: 'Mensagem original'
       }
     }
+  })
+})
+
+test('archiveChat uses /chat/archiveChat with normalized remoteJid and archive flag', async () => {
+  process.env.EVOLUTION_API_URL = 'http://evolution.local'
+  process.env.EVOLUTION_AUTO_RECOVERY_ENABLED = 'false'
+
+  let capturedUrl = ''
+  let capturedBody = null
+  global.fetch = async (url, init) => {
+    capturedUrl = String(url)
+    capturedBody = JSON.parse(init.body)
+    return mockJsonResponse({ archived: true })
+  }
+
+  await evolutionOrchestrator.archiveChat(2, '5511999998888', true)
+
+  assert.equal(capturedUrl, 'http://evolution.local/chat/archiveChat/crm-channel-2')
+  assert.deepEqual(capturedBody, {
+    chat: '5511999998888@s.whatsapp.net',
+    archive: true
   })
 })
 

--- a/backend/apps/crm-api/services/evolutionOrchestrator.js
+++ b/backend/apps/crm-api/services/evolutionOrchestrator.js
@@ -154,8 +154,16 @@ function mapStateToStatus(state) {
   const normalized = String(state || '').toLowerCase()
   if (normalized === 'open' || normalized === 'connected') return 'connected'
   if (normalized === 'connecting') return 'qr_pending'
-  if (normalized === 'close' || normalized === 'closed') return 'free'
-  if (normalized === 'available') return 'available'
+  if (
+    normalized === 'close' ||
+    normalized === 'closed' ||
+    normalized === 'available' ||
+    normalized === 'disconnected' ||
+    normalized === 'disconnect' ||
+    normalized === 'stopped' ||
+    normalized === 'idle' ||
+    normalized === 'logout'
+  ) return 'free'
   return 'error'
 }
 
@@ -234,6 +242,25 @@ function normalizeQrValue(raw) {
   }
 
   return value
+}
+
+function resolveEvolutionErrorMessage(responseLike) {
+  const json = responseLike?.json
+  const direct = String(json?.error || json?.message || '').trim()
+  if (direct && direct.toLowerCase() !== 'internal server error') return direct
+  const nestedMessage = json?.response?.message
+  if (Array.isArray(nestedMessage)) {
+    for (const entry of nestedMessage) {
+      if (typeof entry === 'string' && entry.trim()) return entry.trim()
+      if (entry && typeof entry === 'object') {
+        const candidate = String(entry?.message?.[1] || entry?.message || entry?.error || '').trim()
+        if (candidate) return candidate
+      }
+    }
+  }
+  const fallback = String(responseLike?.text || '').trim()
+  if (fallback) return fallback
+  return `HTTP ${Number(responseLike?.status) || 500}`
 }
 
 function debugQr(event, payload = {}) {
@@ -327,7 +354,53 @@ async function ensureInstance(channel, instanceName) {
   return res.json?.instance || null
 }
 
+function normalizeInstanceSettingsPayload(raw = {}) {
+  return {
+    rejectCall: Boolean(raw?.rejectCall),
+    msgCall: typeof raw?.msgCall === 'string' ? raw.msgCall : '',
+    groupsIgnore: Boolean(raw?.groupsIgnore),
+    alwaysOnline: Boolean(raw?.alwaysOnline),
+    readMessages: Boolean(raw?.readMessages),
+    readStatus: Boolean(raw?.readStatus),
+    syncFullHistory: Boolean(raw?.syncFullHistory),
+    wavoipToken: typeof raw?.wavoipToken === 'string' ? raw.wavoipToken : ''
+  }
+}
+
+async function ensureHistorySyncEnabled(instanceName) {
+  try {
+    const currentRes = await evolutionFetch(`/settings/find/${encodeURIComponent(instanceName)}`, {
+      disableAutoRecovery: true
+    })
+    let payload = normalizeInstanceSettingsPayload(currentRes?.json || {})
+    if (payload.syncFullHistory) return
+    payload = {
+      ...payload,
+      syncFullHistory: true
+    }
+    const setRes = await evolutionFetch(`/settings/set/${encodeURIComponent(instanceName)}`, {
+      method: 'POST',
+      body: payload,
+      disableAutoRecovery: true
+    })
+    if (!setRes.ok) {
+      console.warn('[WA_ORCHESTRATOR] Failed to enforce syncFullHistory', {
+        instanceName,
+        status: setRes.status
+      })
+      return
+    }
+    console.info('[WA_ORCHESTRATOR] syncFullHistory enabled', { instanceName })
+  } catch (error) {
+    console.warn('[WA_ORCHESTRATOR] Could not verify/enforce syncFullHistory', {
+      instanceName,
+      error: error?.message || String(error)
+    })
+  }
+}
+
 async function connectInstance(instanceName) {
+  await ensureHistorySyncEnabled(instanceName)
   const res = await evolutionFetch(`/instance/connect/${encodeURIComponent(instanceName)}`)
   debugQr('connectInstance:response', {
     instanceName,
@@ -344,6 +417,33 @@ async function connectInstance(instanceName) {
   if (res.json) return res.json
   if (res.text) return { rawText: res.text }
   return null
+}
+
+function isAlreadyDisconnectedMessage(message) {
+  const value = String(message || '').toLowerCase()
+  return (
+    value.includes('not connected') ||
+    value.includes('is not connected') ||
+    value.includes('already disconnected') ||
+    value.includes('já desconectado') ||
+    value.includes('nao conectado') ||
+    value.includes('não conectado')
+  )
+}
+
+async function getInstanceConnectionState(instanceName) {
+  try {
+    const res = await evolutionFetch(`/instance/connectionState/${encodeURIComponent(instanceName)}`, {
+      disableAutoRecovery: true
+    })
+    if (!res.ok) return null
+    const rawState = res?.json?.instance?.state ?? res?.json?.state ?? null
+    if (rawState == null) return null
+    const state = normalizeState(rawState)
+    return state === 'unknown' ? null : state
+  } catch {
+    return null
+  }
 }
 
 async function getStatus() {
@@ -383,7 +483,7 @@ async function getStatus() {
     }
   }
 
-  const channels = DEFAULT_CHANNELS.map((channel) => {
+  const channels = await Promise.all(DEFAULT_CHANNELS.map(async (channel) => {
     const name = channelName(channel, instancePrefix)
     const instance = instances.find((inst) => String(inst?.name) === name)
     if (!instance) {
@@ -397,8 +497,15 @@ async function getStatus() {
         updatedAt: null
       }
     }
-    const state = normalizeState(instance.connectionStatus)
-    const status = mapStateToStatus(state)
+    let state = normalizeState(instance.connectionStatus)
+    let status = mapStateToStatus(state)
+    if (status !== 'free') {
+      const liveState = await getInstanceConnectionState(name)
+      if (liveState) {
+        state = liveState
+        status = mapStateToStatus(state)
+      }
+    }
     return {
       id: `wa-channel-${channel}`,
       channel,
@@ -409,10 +516,10 @@ async function getStatus() {
       updatedAt: instance.updatedAt || null,
       metadata: {
         phoneNumber: instance.number || instance.ownerJid || null,
-        errorMessage: instance.disconnectionReasonCode || null
+        errorMessage: status === 'connected' ? null : (instance.disconnectionReasonCode || null)
       }
     }
-  })
+  }))
 
   return {
     totalChannels: DEFAULT_CHANNELS.length,
@@ -499,10 +606,21 @@ async function stopChannel(channel) {
   const name = channelName(channel, instancePrefix)
   const res = await evolutionFetch(`/instance/logout/${encodeURIComponent(name)}`, { method: 'DELETE' })
   if (!res.ok) {
-    const message = res.json?.error || res.json?.message || res.text || `HTTP ${res.status}`
-    throw new Error(message)
+    const message = resolveEvolutionErrorMessage(res)
+    if (!isAlreadyDisconnectedMessage(message)) {
+      throw new Error(message)
+    }
   }
-  return { success: true, channel, port: 3001 }
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const liveState = await getInstanceConnectionState(name)
+    const mapped = mapStateToStatus(liveState)
+    if (!liveState || mapped === 'free') {
+      return { success: true, channel, port: 3001, state: liveState || 'close' }
+    }
+    await wait(700)
+  }
+  return { success: true, channel, port: 3001, state: 'disconnecting' }
 }
 
 async function restartChannel(channel) {
@@ -516,14 +634,20 @@ async function restartChannel(channel) {
   return { success: true, channel, port: 3001 }
 }
 
-async function fetchChats(channel, { limit = 50, offset = 0 } = {}) {
+async function fetchChats(channel, { limit = 50, offset = 0, archivedOnly = false, includeArchived = false } = {}) {
   const { instancePrefix } = resolveEvolutionConfig()
   const name = channelName(channel, instancePrefix)
+  const normalizedLimit = Math.max(1, Number(limit) || 50)
+  const normalizedOffset = Math.max(0, Number(offset) || 0)
+  const where = archivedOnly
+    ? { archived: true }
+    : (includeArchived ? undefined : { archived: false })
   const res = await evolutionFetch(`/chat/findChats/${encodeURIComponent(name)}`, {
     method: 'POST',
     body: {
-      take: limit,
-      skip: offset
+      take: normalizedLimit,
+      skip: normalizedOffset,
+      ...(where ? { where } : {})
     }
   })
   if (!res.ok) {
@@ -607,6 +731,27 @@ async function sendText(channel, remoteJid, text, options = {}) {
   })
   if (!res.ok) {
     const message = res.json?.error || res.json?.message || res.text || `HTTP ${res.status}`
+    throw new Error(message)
+  }
+  return res.json
+}
+
+async function archiveChat(channel, remoteJid, archive = true) {
+  const { instancePrefix } = resolveEvolutionConfig()
+  const name = channelName(channel, instancePrefix)
+  const jid = normalizeRemoteJid(remoteJid)
+  if (!jid) {
+    throw new Error('remoteJid is required')
+  }
+  const res = await evolutionFetch(`/chat/archiveChat/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    body: {
+      chat: jid,
+      archive: Boolean(archive)
+    }
+  })
+  if (!res.ok) {
+    const message = resolveEvolutionErrorMessage(res)
     throw new Error(message)
   }
   return res.json
@@ -703,6 +848,7 @@ export const evolutionOrchestrator = {
   fetchChats,
   fetchMessages,
   sendText,
+  archiveChat,
   markMessagesAsRead,
   getBase64FromMediaMessage,
   setWebhook,

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react"
+import { createPortal } from "react-dom"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/card"
 import { Badge } from "@/badge"
 import { Button } from "@/button"
@@ -215,6 +216,34 @@ interface OrchestratorStatus {
   instances: ChannelInstance[]
   availableChannelsList: number[]
   freeChannelsList: number[]
+  bootstrapSync?: Record<string, any>
+}
+
+function normalizeChannelStatus(value: any): ChannelStatus {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (!normalized) return 'free'
+  if (
+    normalized === 'free' ||
+    normalized === 'available' ||
+    normalized === 'stopped' ||
+    normalized === 'disconnected' ||
+    normalized === 'idle' ||
+    normalized === 'close' ||
+    normalized === 'closed' ||
+    normalized === 'logout'
+  ) return 'free'
+  if (normalized === 'open') return 'connected'
+  if (normalized === 'connecting') return 'qr_pending'
+  if (
+    normalized === 'starting' ||
+    normalized === 'qr_pending' ||
+    normalized === 'connected' ||
+    normalized === 'error' ||
+    normalized === 'stopping'
+  ) {
+    return normalized as ChannelStatus
+  }
+  return 'error'
 }
 
 interface QRData {
@@ -504,6 +533,20 @@ type ParticipantRenderMeta = MentionRenderMeta & {
 
 type RenderFormattedTextOptions = {
   resolveMention?: (token: string) => MentionRenderMeta | null
+}
+
+function buildMessageUiAnchorKey(message: any, index: number) {
+  const messageId = String(message?.id || message?.provider_message_id || '').trim() || 'msg'
+  const timestamp = String(message?.createdAt || message?.timestamp || message?.created_at || '').trim() || 'ts'
+  const sender = String(
+    message?.senderJid ||
+    message?.senderLid ||
+    message?.senderPhone ||
+    message?.senderName ||
+    message?.direction ||
+    ''
+  ).trim() || 'sender'
+  return `${messageId}::${timestamp}::${sender}::${index}`
 }
 
 const GROUP_SENDER_PALETTE = [
@@ -942,7 +985,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
   const [openMessageActionMenuId, setOpenMessageActionMenuId] = useState<string | null>(null)
   const [expandedReactionMenuId, setExpandedReactionMenuId] = useState<string | null>(null)
   const [messageActionMenuLayout, setMessageActionMenuLayout] = useState<{
-    messageId: string
+    anchorKey: string
     top: number
     left: number
     maxHeight: number
@@ -961,16 +1004,20 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
   const [messageScrollState, setMessageScrollState] = useState({ canScrollUp: false, canScrollDown: false })
   const [scrollAffordanceZone, setScrollAffordanceZone] = useState<'top' | 'bottom' | null>(null)
   const [orchestratorStatus, setOrchestratorStatus] = useState<OrchestratorStatus | null>(null)
+  const orchestratorStatusRef = useRef<OrchestratorStatus | null>(null)
   const [statusFailureCount, setStatusFailureCount] = useState(0)
   const [statusPausedUntil, setStatusPausedUntil] = useState<number | null>(null)
   const [channelQR, setChannelQR] = useState<Map<number, QRData>>(new Map())
   const [qrDialogChannel, setQrDialogChannel] = useState<number | null>(null)
+  const [waInitialSyncChannel, setWaInitialSyncChannel] = useState<number | null>(null)
+  const waInitialSyncChannelRef = useRef<number | null>(null)
   const qrPollingRef = useRef<Map<number, NodeJS.Timeout>>(new Map())
   const qrDialogChannelRef = useRef<number | null>(null)
   const waEventsRefreshTimerRef = useRef<number | null>(null)
   const waConversationRefreshTimerRef = useRef<number | null>(null)
   const [waStatusOpen, setWaStatusOpen] = useState(false)
   const [connectedChannelAction, setConnectedChannelAction] = useState<Record<number, 'refresh' | 'disconnect' | undefined>>({})
+  const [refreshAllChannelsLoading, setRefreshAllChannelsLoading] = useState(false)
   const [igStatusOpen, setIgStatusOpen] = useState(false)
   const [igDialogOpen, setIgDialogOpen] = useState(false)
   const [igOauthStatus, setIgOauthStatus] = useState<{ configured: boolean; missing?: string[] } | null>(null)
@@ -1054,7 +1101,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         : Number.isFinite(ch?.port)
           ? Math.max(1, Number(ch.port) - 3000)
           : index + 1
-      const status = (ch?.status === 'available' ? 'free' : ch?.status) || 'free'
+      const status = normalizeChannelStatus(ch?.status)
       return {
         id: ch?.id || `channel-${resolvedChannel}`,
         port: ch?.port ?? (3000 + resolvedChannel),
@@ -1079,7 +1126,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       availableChannelsList:
         payload?.availableChannelsList ?? normalizedInstances.map((c) => c.channel),
       freeChannelsList:
-        payload?.freeChannelsList ?? normalizedInstances.filter((c) => c.status === 'free').map((c) => c.channel)
+        payload?.freeChannelsList ?? normalizedInstances.filter((c) => c.status === 'free').map((c) => c.channel),
+      bootstrapSync:
+        payload?.bootstrapSync && typeof payload.bootstrapSync === 'object'
+          ? payload.bootstrapSync
+          : {}
     } satisfies OrchestratorStatus
   }, [])
 
@@ -1139,10 +1190,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
   }, [])
 
-  const loadConversations = useCallback(async () => {
-    if (!provider) return
-    if (conversationsPausedUntil && Date.now() < conversationsPausedUntil) return
-    if (provider === 'evolution' && conversationsCount === 0) {
+  const loadConversations = useCallback(async (options?: { disableCache?: boolean }) => {
+    const disableCache = Boolean(options?.disableCache)
+    if (!provider) return []
+    if (conversationsPausedUntil && Date.now() < conversationsPausedUntil) return []
+    if (!disableCache && provider === 'evolution' && conversationsCount === 0) {
       const cached = readConversationCache()
       if (cached?.length) {
         setConversations(cached)
@@ -1151,18 +1203,20 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     setLoadingConversations(conversationsCount === 0)
     try {
       if (provider === 'evolution') {
+        const archivedOnly = conversationFilter === 'archived'
+        const fetchLimit = archivedOnly ? 200 : CONVERSATION_FETCH_LIMIT
         const channels =
           orchestratorStatus?.instances
             ?.filter((instance) => instance.status === 'connected')
             .map((instance) => instance.channel) || []
         if (!channels.length) {
           setConversations([])
-          return
+          return []
         }
         const results = await Promise.all(
           channels.map(async (channel) => {
             const res = await fetch(
-              `/api/wa-orchestrator/channels/${channel}/conversations?limit=${CONVERSATION_FETCH_LIMIT}`,
+              `/api/wa-orchestrator/channels/${channel}/conversations?limit=${fetchLimit}${archivedOnly ? '&archivedOnly=1' : ''}`,
               { headers: buildCrmBasicAuthHeaders() }
             )
             const data = await res.json().catch(() => ({}))
@@ -1173,6 +1227,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         const merged = results.flat()
         setConversations(merged)
         if (merged.length) writeConversationCache(merged)
+        return merged
       } else {
         const res = await fetch('/api/conversations')
         const data = await res.json()
@@ -1180,10 +1235,12 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
           const merged = data?.items || data || []
           setConversations(merged)
           if (merged?.length) writeConversationCache(merged)
+          return merged
         }
       }
       setConversationsFailureCount(0)
       setConversationsPausedUntil(null)
+      return []
     } catch {
       setConversationsFailureCount((prev) => {
         const next = prev + 1
@@ -1193,17 +1250,160 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         }
         return next
       })
+      return []
     } finally {
       setLoadingConversations(false)
     }
   }, [
     provider,
     orchestratorStatus,
+    conversationFilter,
     conversationsPausedUntil,
     conversationsCount,
     readConversationCache,
     writeConversationCache
   ])
+
+  const finishInitialWhatsAppSync = useCallback((channel: number) => {
+    if (waInitialSyncChannelRef.current !== channel) return
+    waInitialSyncChannelRef.current = null
+    setWaInitialSyncChannel(null)
+    if (qrDialogChannelRef.current === channel) {
+      setQrDialogChannel(null)
+    }
+    setWaStatusOpen(false)
+  }, [])
+
+  const runInitialWhatsAppSync = useCallback(async (channel: number) => {
+    if (!Number.isFinite(channel) || channel <= 0) return
+    if (waInitialSyncChannelRef.current === channel) return
+    waInitialSyncChannelRef.current = channel
+    setWaInitialSyncChannel(channel)
+
+    let finished = false
+    let failedReason = ''
+    const maxAttempts = 60
+    const startedAt = Date.now()
+    const baselineState = orchestratorStatusRef.current?.bootstrapSync?.[String(channel)] || null
+    const baselineStartedAt = String(baselineState?.startedAt || '')
+    const baselineFailedAt = String(baselineState?.failedAt || '')
+    const baselineCompletedAt = String(baselineState?.completedAt || '')
+    let runStartedAt = baselineState?.running ? baselineStartedAt : ''
+    let observedRun = Boolean(runStartedAt)
+
+    try {
+      await fetch(`/api/wa-orchestrator/channels/${channel}/bootstrap-sync`, {
+        method: 'POST',
+        headers: buildCrmBasicAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ force: true, reason: 'post-qr-connect' })
+      })
+        .then(async (response) => response.json().catch(() => null))
+        .then((payload) => {
+          const syncState = payload?.state || null
+          const candidateStartedAt = String(syncState?.startedAt || '')
+          if (candidateStartedAt && candidateStartedAt !== baselineStartedAt) {
+            runStartedAt = candidateStartedAt
+            observedRun = true
+          }
+        })
+        .catch(() => null)
+    } catch {
+      // keep going; we'll still poll status + conversations
+    }
+
+    try {
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        await loadStatus()
+        const list = await loadConversations({ disableCache: true })
+        const items = Array.isArray(list) ? list : []
+        const hasChannelConversations = items.some((item: any) => Number(item?.channel) === channel)
+        const statusSnapshot = orchestratorStatusRef.current
+        const bootstrapState = statusSnapshot?.bootstrapSync?.[String(channel)] || null
+        const channelState = String(
+          statusSnapshot?.instances?.find((item) => Number(item?.channel) === channel)?.status || ''
+        ).toLowerCase()
+        const phase = String(bootstrapState?.progress?.phase || '').trim().toLowerCase()
+        const running = Boolean(bootstrapState?.running) || phase === 'running' || phase === 'syncing'
+        const failed = phase === 'failed' || Boolean(bootstrapState?.lastError)
+        const completed = phase === 'completed' || Boolean(bootstrapState?.completedAt)
+        const currentStartedAt = String(bootstrapState?.startedAt || '')
+        const currentFailedAt = String(bootstrapState?.failedAt || '')
+        const currentCompletedAt = String(bootstrapState?.completedAt || '')
+
+        if (!observedRun && currentStartedAt && currentStartedAt !== baselineStartedAt) {
+          observedRun = true
+          runStartedAt = currentStartedAt
+        }
+
+        if (observedRun && !runStartedAt && currentStartedAt) {
+          runStartedAt = currentStartedAt
+        }
+
+        if (failed && currentFailedAt && currentFailedAt !== baselineFailedAt) {
+          failedReason = String(bootstrapState?.lastError || '').trim() || 'Falha na sincronização inicial.'
+          finished = true
+          break
+        }
+
+        const completedThisRun =
+          observedRun &&
+          completed &&
+          currentCompletedAt &&
+          currentCompletedAt !== baselineCompletedAt &&
+          (!runStartedAt || Date.parse(currentCompletedAt) >= Date.parse(runStartedAt))
+
+        if (completedThisRun) {
+          finished = true
+          break
+        }
+
+        // If no explicit bootstrap telemetry appears, fallback only after long wait.
+        if (!observedRun && attempt >= 24 && hasChannelConversations && channelState === 'connected') {
+          finished = true
+          break
+        }
+
+        if (channelState && channelState !== 'connected' && channelState !== 'starting' && channelState !== 'qr_pending') {
+          failedReason = `Canal ${channel} saiu de conectado durante sincronização (${channelState}).`
+          finished = true
+          break
+        }
+
+        if (running) {
+          await new Promise((resolve) => window.setTimeout(resolve, 1500))
+          continue
+        }
+
+        // Prevent premature close if backend has not yet moved bootstrap state.
+        if (!observedRun) {
+          await new Promise((resolve) => window.setTimeout(resolve, 1500))
+          continue
+        }
+
+        if (attempt > 8 && hasChannelConversations && channelState === 'connected') {
+          finished = true
+          break
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, 1500))
+      }
+    } finally {
+      const elapsed = Date.now() - startedAt
+      if (elapsed < 2000) {
+        await new Promise((resolve) => window.setTimeout(resolve, 2000 - elapsed))
+      }
+      finishInitialWhatsAppSync(channel)
+    }
+
+    if (finished && !failedReason) {
+      toast.success(`WhatsApp conectado no canal ${channel}`)
+      return
+    }
+    if (failedReason) {
+      toast.error(`Canal ${channel} conectado, mas a sincronização inicial falhou: ${failedReason}`)
+      return
+    }
+    toast.message(`Canal ${channel} conectado. A sincronização inicial continuará em segundo plano.`)
+  }, [finishInitialWhatsAppSync, loadConversations, loadStatus])
 
   const loadMessages = useCallback(async (conv: any, opts?: { silent?: boolean }) => {
     if (!provider || !conv) return []
@@ -1467,11 +1667,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
   }, [messages, orchestratorStatus, selectedConversation])
 
-  const computeMessageActionMenuLayout = useCallback((messageId: string) => {
-    const normalizedId = String(messageId || '').trim()
+  const computeMessageActionMenuLayout = useCallback((anchorKey: string) => {
+    const normalizedKey = String(anchorKey || '').trim()
     const viewport = messagesViewportRef.current
-    const anchor = messageActionRootRefs.current.get(normalizedId) || null
-    if (!normalizedId || !viewport || !anchor) return null
+    const anchor = messageActionRootRefs.current.get(normalizedKey) || null
+    if (!normalizedKey || !viewport || !anchor) return null
 
     const viewportRect = viewport.getBoundingClientRect()
     const anchorRect = anchor.getBoundingClientRect()
@@ -1510,7 +1710,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     )
 
     return {
-      messageId: normalizedId,
+      anchorKey: normalizedKey,
       top,
       left,
       maxHeight: Math.max(180, Math.floor(maxHeight)),
@@ -1518,14 +1718,14 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
   }, [])
 
-  const syncMessageActionMenuLayout = useCallback((messageId: string) => {
-    const normalizedId = String(messageId || '').trim()
-    if (!normalizedId) return
-    const nextLayout = computeMessageActionMenuLayout(normalizedId)
+  const syncMessageActionMenuLayout = useCallback((anchorKey: string) => {
+    const normalizedKey = String(anchorKey || '').trim()
+    if (!normalizedKey) return
+    const nextLayout = computeMessageActionMenuLayout(normalizedKey)
     setMessageActionMenuLayout((current) => {
       if (!nextLayout) return current
       if (
-        current?.messageId === nextLayout.messageId &&
+        current?.anchorKey === nextLayout.anchorKey &&
         current.top === nextLayout.top &&
         current.left === nextLayout.left &&
         current.maxHeight === nextLayout.maxHeight &&
@@ -1537,15 +1737,15 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     })
   }, [computeMessageActionMenuLayout])
 
-  const scheduleMessageActionMenuLayout = useCallback((messageId: string) => {
-    const normalizedId = String(messageId || '').trim()
-    if (!normalizedId) return
+  const scheduleMessageActionMenuLayout = useCallback((anchorKey: string) => {
+    const normalizedKey = String(anchorKey || '').trim()
+    if (!normalizedKey) return
     if (messageActionMenuLayoutRafRef.current !== null) {
       window.cancelAnimationFrame(messageActionMenuLayoutRafRef.current)
     }
     messageActionMenuLayoutRafRef.current = window.requestAnimationFrame(() => {
       messageActionMenuLayoutRafRef.current = null
-      syncMessageActionMenuLayout(normalizedId)
+      syncMessageActionMenuLayout(normalizedKey)
     })
   }, [syncMessageActionMenuLayout])
 
@@ -1559,26 +1759,26 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     setMessageActionMenuLayout(null)
   }, [])
 
-  const toggleMessageActionMenu = useCallback((messageId: string) => {
-    const normalizedId = String(messageId || '').trim()
-    if (!normalizedId) return
+  const toggleMessageActionMenu = useCallback((anchorKey: string) => {
+    const normalizedKey = String(anchorKey || '').trim()
+    if (!normalizedKey) return
     setOpenMessageActionMenuId((current) => {
-      const nextOpen = current === normalizedId ? null : normalizedId
+      const nextOpen = current === normalizedKey ? null : normalizedKey
       setExpandedReactionMenuId((currentExpanded) => (
-        nextOpen && currentExpanded === normalizedId ? currentExpanded : null
+        nextOpen && currentExpanded === normalizedKey ? currentExpanded : null
       ))
-      setMessageActionMenuLayout(nextOpen ? computeMessageActionMenuLayout(normalizedId) : null)
+      setMessageActionMenuLayout(nextOpen ? computeMessageActionMenuLayout(normalizedKey) : null)
       return nextOpen
     })
   }, [computeMessageActionMenuLayout])
 
-  const openMessageActionMenu = useCallback((messageId: string) => {
-    const normalizedId = String(messageId || '').trim()
-    if (!normalizedId) return
+  const openMessageActionMenu = useCallback((anchorKey: string) => {
+    const normalizedKey = String(anchorKey || '').trim()
+    if (!normalizedKey) return
     setReactionPickerMessageId(null)
-    setOpenMessageActionMenuId(normalizedId)
+    setOpenMessageActionMenuId(normalizedKey)
     setExpandedReactionMenuId(null)
-    setMessageActionMenuLayout(computeMessageActionMenuLayout(normalizedId))
+    setMessageActionMenuLayout(computeMessageActionMenuLayout(normalizedKey))
   }, [computeMessageActionMenuLayout])
 
   const toggleReaction = useCallback(async (message: any, emoji: string) => {
@@ -1644,6 +1844,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
       const target = event.target instanceof Node ? event.target : null
       if (!target) return
+      if (messageActionMenuRef.current?.contains(target)) return
       const root = (target instanceof Element ? target.closest('[data-message-action-root]') : null) as HTMLElement | null
       if (root?.dataset.messageActionRoot === openMessageActionMenuId) return
       setOpenMessageActionMenuId(null)
@@ -2094,6 +2295,14 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     qrDialogChannelRef.current = qrDialogChannel
   }, [qrDialogChannel])
 
+  useEffect(() => {
+    waInitialSyncChannelRef.current = waInitialSyncChannel
+  }, [waInitialSyncChannel])
+
+  useEffect(() => {
+    orchestratorStatusRef.current = orchestratorStatus
+  }, [orchestratorStatus])
+
   const stopQrPolling = useCallback((channel?: number | null) => {
     if (typeof channel === 'number' && Number.isFinite(channel)) {
       const timer = qrPollingRef.current.get(channel)
@@ -2114,11 +2323,9 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     const instance = orchestratorStatus.instances.find((item) => item.channel === qrDialogChannel)
     if (instance?.status === 'connected') {
       stopQrPolling(qrDialogChannel)
-      toast.success(`WhatsApp conectado no canal ${qrDialogChannel}`)
-      setQrDialogChannel(null)
-      setWaStatusOpen(false)
+      void runInitialWhatsAppSync(qrDialogChannel)
     }
-  }, [orchestratorStatus, qrDialogChannel, stopQrPolling])
+  }, [orchestratorStatus, qrDialogChannel, runInitialWhatsAppSync, stopQrPolling])
 
   useEffect(() => {
     if (selectedConversation?.platform === 'instagram') {
@@ -2458,6 +2665,40 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     setSelectedConversation((current) => (isSameConversationRecord(current, target) ? null : current))
   }, [isSameConversationRecord])
 
+  const syncConversationArchive = useCallback(async (conv: any, archive: boolean) => {
+    if (provider !== 'evolution') return
+    const remoteJid = String(conv?.conversationId || conv?.rawJid || conv?.normalizedJid || conv?.phone || '').trim()
+    if (!remoteJid) {
+      throw new Error('Conversa sem identificador para arquivamento.')
+    }
+    const channels = Array.isArray(conv?.channels)
+      ? conv.channels.map((value: any) => Number(value)).filter((value: number) => Number.isFinite(value) && value > 0)
+      : []
+    const fallbackChannel = Number(conv?.channel || 0)
+    const targetChannels = channels.length ? channels : (fallbackChannel > 0 ? [fallbackChannel] : [])
+    if (!targetChannels.length) {
+      throw new Error('Canal do WhatsApp não identificado para arquivamento.')
+    }
+
+    await Promise.all(targetChannels.map(async (channel) => {
+      const response = await fetch(
+        `/api/wa-orchestrator/channels/${channel}/conversations/${encodeURIComponent(remoteJid)}/archive`,
+        {
+          method: 'POST',
+          headers: {
+            ...buildCrmBasicAuthHeaders(),
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ archive })
+        }
+      )
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok || !data?.success) {
+        throw new Error(data?.error || `Falha ao ${archive ? 'arquivar' : 'desarquivar'} conversa no canal ${channel}.`)
+      }
+    }))
+  }, [provider])
+
   const computeConversationActionMenuLayout = useCallback((conversationId: string) => {
     const normalizedId = String(conversationId || '').trim()
     const viewport = conversationScrollViewportRef.current
@@ -2558,9 +2799,24 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     }
 
     if (action === 'archive') {
-      updateConversationRecord(conv, (current) => ({ ...current, archived: !(current?.archived || current?.isArchived) }))
+      const previousArchived = Boolean(conv?.archived || conv?.isArchived)
+      const nextArchived = !previousArchived
+      updateConversationRecord(conv, (current) => ({ ...current, archived: nextArchived, isArchived: nextArchived }))
       closeConversationActionMenu()
-      toast.success('Status de arquivamento atualizado.')
+      void (async () => {
+        try {
+          await syncConversationArchive(conv, nextArchived)
+          await loadConversations()
+          toast.success(nextArchived ? 'Conversa arquivada.' : 'Conversa desarquivada.')
+        } catch (error: any) {
+          const reason = String(error?.message || '').trim()
+          if (reason) {
+            toast.error(`Arquivamento local aplicado, mas sem sincronização com WhatsApp: ${reason}`)
+          } else {
+            toast.error('Arquivamento local aplicado, mas sem sincronização com WhatsApp.')
+          }
+        }
+      })()
       return
     }
 
@@ -2656,7 +2912,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       closeConversationActionMenu()
       toast.success('Conversa removida da lista.')
     }
-  }, [closeConversationActionMenu, isSameConversationRecord, removeConversationRecord, selectedConversation, updateConversationRecord])
+  }, [closeConversationActionMenu, isSameConversationRecord, loadConversations, removeConversationRecord, selectedConversation, syncConversationArchive, updateConversationRecord])
 
   const renderConversationListMenuItems = useCallback((conv: any) => {
     const displayName = resolveConversationDisplayName(conv)
@@ -2801,6 +3057,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       const status = String(result?.status || '').toLowerCase()
       if (status === 'connected') {
         stopQrPolling(channel)
+        void runInitialWhatsAppSync(channel)
         return
       }
       queueNextPoll(3000)
@@ -2808,7 +3065,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       console.warn('[WA_QR_DEBUG] pollChannelQR:error', { channel, error: err?.message || String(err) })
       queueNextPoll(3500)
     }
-  }, [QR_DARK, QR_LIGHT, stopQrPolling])
+  }, [QR_DARK, QR_LIGHT, runInitialWhatsAppSync, stopQrPolling])
 
   useEffect(() => {
     if (!qrDialogChannel) return
@@ -2849,9 +3106,16 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     const instances = orchestratorStatus?.instances ?? []
     const sorted = [...instances].sort((a, b) => a.channel - b.channel)
 
-    const pending = sorted.find((instance) => instance.status === 'qr_pending' || instance.status === 'starting')
-    if (pending) {
-      return { channel: pending.channel, action: 'poll' as const }
+    const activeDialogChannel = qrDialogChannelRef.current
+    if (activeDialogChannel) {
+      const activePending = sorted.find(
+        (instance) =>
+          instance.channel === activeDialogChannel &&
+          (instance.status === 'qr_pending' || instance.status === 'starting')
+      )
+      if (activePending) {
+        return { channel: activePending.channel, action: 'poll' as const }
+      }
     }
 
     const free = sorted.find((instance) => instance.status === 'free')
@@ -2867,6 +3131,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     const availableFromList = [...(orchestratorStatus?.availableChannelsList ?? [])].sort((a, b) => a - b)[0]
     if (availableFromList) {
       return { channel: availableFromList, action: 'start' as const }
+    }
+
+    const pending = sorted.find((instance) => instance.status === 'qr_pending' || instance.status === 'starting')
+    if (pending) {
+      return { channel: pending.channel, action: 'poll' as const }
     }
 
     return null
@@ -2900,7 +3169,25 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
     })
   }, [])
 
-  const refreshConnectedChannel = useCallback(async (channel: number) => {
+  const refreshConnectedChannel = useCallback(async (channel: number, opts?: { silent?: boolean }) => {
+    const silent = Boolean(opts?.silent)
+    const sleep = (ms: number) => new Promise<void>((resolve) => window.setTimeout(resolve, ms))
+    const requestRecovery = async () => {
+      try {
+        await fetch('/api/wa-orchestrator/local/recovery/restart', {
+          method: 'POST',
+          headers: buildCrmBasicAuthHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({
+            mode: 'evolution',
+            trigger: 'manual-refresh-button',
+            reason: `channel-${channel}`
+          })
+        })
+      } catch {
+        /* ignore recovery errors */
+      }
+    }
+
     markConnectedChannelAction(channel, 'refresh')
     try {
       const response = await fetch(`/api/wa-orchestrator/channels/${channel}/restart`, {
@@ -2912,18 +3199,100 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       if (!response.ok || !result?.success) {
         throw new Error(String(result?.error || `Falha ao refrescar canal ${channel}`))
       }
-      toast.success(`Canal ${channel} refrescado.`)
+
+      let channelStatus = ''
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const stateResponse = await fetch(`/api/wa-orchestrator/channels/${channel}`, {
+          headers: buildCrmBasicAuthHeaders()
+        })
+        const stateData = await stateResponse.json().catch(() => ({}))
+        channelStatus = String(stateData?.status || stateData?.instance?.status || '').trim().toLowerCase()
+        if (channelStatus && !['starting', 'qr_pending'].includes(channelStatus)) break
+        await sleep(1200)
+      }
+
+      let bootstrapQueued = false
+      if (provider === 'evolution') {
+        const syncResponse = await fetch(`/api/wa-orchestrator/channels/${channel}/bootstrap-sync`, {
+          method: 'POST',
+          headers: buildCrmBasicAuthHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({
+            force: true,
+            reason: 'manual-refresh'
+          })
+        })
+        const syncData = await syncResponse.json().catch(() => ({}))
+        bootstrapQueued = Boolean(syncResponse.ok && syncData?.success)
+      }
+
       if (qrDialogChannelRef.current === channel) {
         void pollChannelQR(channel)
       }
+
       await loadStatus()
-      await loadConversations()
+      await loadConversations({ disableCache: true })
+
+      const selectedIsWhatsapp = selectedConversation?.platform === 'whatsapp'
+      const selectedChannels = Array.isArray(selectedConversation?.channels)
+        ? selectedConversation.channels
+        : [selectedConversation?.channel]
+      const selectedHasChannel = selectedChannels
+        .map((value: any) => Number(value))
+        .filter((value: number) => Number.isFinite(value) && value > 0)
+        .includes(channel)
+      if (selectedIsWhatsapp && selectedHasChannel && selectedConversation?.conversationId) {
+        await loadMessages(selectedConversation, { silent: true })
+      }
+
+      if (channelStatus === 'error') {
+        await requestRecovery()
+      }
+
+      if (!silent) {
+        const syncSuffix = bootstrapQueued ? ' • sync forçado' : ''
+        toast.success(`Canal ${channel} refrescado${syncSuffix}.`)
+      }
+      return true
     } catch (error: any) {
-      toast.error(String(error?.message || `Falha ao refrescar canal ${channel}`))
+      await requestRecovery()
+      await loadStatus()
+      await loadConversations({ disableCache: true })
+      if (!silent) {
+        toast.error(String(error?.message || `Falha ao refrescar canal ${channel}`))
+      }
+      return false
     } finally {
       markConnectedChannelAction(channel)
     }
-  }, [loadConversations, loadStatus, markConnectedChannelAction, pollChannelQR])
+  }, [loadConversations, loadMessages, loadStatus, markConnectedChannelAction, pollChannelQR, provider, selectedConversation])
+
+  const refreshAllConnectedChannels = useCallback(async () => {
+    const channels = (orchestratorStatus?.instances || [])
+      .filter((instance) => instance.status === 'connected')
+      .map((instance) => Number(instance.channel))
+      .filter((channel) => Number.isFinite(channel) && channel > 0)
+      .sort((a, b) => a - b)
+    if (!channels.length) {
+      toast.error('Nenhum canal conectado para refrescar.')
+      return
+    }
+
+    setRefreshAllChannelsLoading(true)
+    try {
+      const failed: number[] = []
+      for (const channel of channels) {
+        const ok = await refreshConnectedChannel(channel, { silent: true })
+        if (!ok) failed.push(channel)
+      }
+      if (failed.length) {
+        toast.error(`Falha ao refrescar canal(is): ${failed.join(', ')}`)
+        return
+      }
+      toast.success(`Refrescados ${channels.length} canal(is) com recarga completa.`)
+    } finally {
+      setRefreshAllChannelsLoading(false)
+    }
+  }, [orchestratorStatus?.instances, refreshConnectedChannel])
 
   const disconnectConnectedChannel = useCallback(async (channel: number) => {
     markConnectedChannelAction(channel, 'disconnect')
@@ -2937,6 +3306,44 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       if (!response.ok || !result?.success) {
         throw new Error(String(result?.error || `Falha ao desconectar canal ${channel}`))
       }
+
+      setOrchestratorStatus((prev) => {
+        if (!prev) return prev
+        const nextInstances = (prev.instances || []).map((instance) => (
+          Number(instance?.channel) === channel
+            ? {
+                ...instance,
+                status: 'free' as const,
+                metadata: {
+                  ...(instance?.metadata || {}),
+                  errorMessage: undefined
+                }
+              }
+            : instance
+        ))
+        const freeChannelsList = nextInstances
+          .filter((instance) => instance.status === 'free')
+          .map((instance) => instance.channel)
+        const connectedInstances = nextInstances.filter((instance) => instance.status === 'connected').length
+        const errorInstances = nextInstances.filter((instance) => instance.status === 'error').length
+        const startingInstances = nextInstances.filter((instance) => instance.status === 'starting' || instance.status === 'qr_pending').length
+        return {
+          ...prev,
+          instances: nextInstances,
+          availableChannels: freeChannelsList.length,
+          freeInstances: freeChannelsList.length,
+          connectedInstances,
+          errorInstances,
+          startingInstances,
+          availableChannelsList: nextInstances.map((instance) => instance.channel),
+          freeChannelsList
+        }
+      })
+
+      setConversations((prev) =>
+        (prev || []).filter((item) => Number(item?.channel || 0) !== channel)
+      )
+
       stopQrPolling(channel)
       setChannelQR((prev) => {
         const next = new Map(prev)
@@ -2946,13 +3353,32 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       if (qrDialogChannelRef.current === channel) {
         setQrDialogChannel(null)
       }
-      if (selectedConversation?.platform === 'whatsapp' && Number(selectedConversation?.channel) === channel) {
-        setSelectedConversation(null)
-        setMessages([])
+
+      if (selectedConversation?.platform === 'whatsapp') {
+        const selectedChannels = Array.isArray(selectedConversation?.channels)
+          ? selectedConversation.channels
+          : [selectedConversation?.channel]
+        const selectedChannelNumbers = selectedChannels
+          .map((value: any) => Number(value))
+          .filter((value: number) => Number.isFinite(value) && value > 0)
+        if (selectedChannelNumbers.includes(channel)) {
+          const remainingChannels = selectedChannelNumbers.filter((value) => value !== channel)
+          if (!remainingChannels.length) {
+            setSelectedConversation(null)
+            setMessages([])
+          } else {
+            setSelectedConversation((current) => current ? ({
+              ...current,
+              channel: remainingChannels[0],
+              channels: remainingChannels
+            }) : current)
+          }
+        }
       }
+
       toast.success(`Canal ${channel} desconectado.`)
       await loadStatus()
-      await loadConversations()
+      await loadConversations({ disableCache: true })
     } catch (error: any) {
       toast.error(String(error?.message || `Falha ao desconectar canal ${channel}`))
     } finally {
@@ -3375,6 +3801,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       preferredName: conv.preferredName || (conv.name && !isLikelyWhatsAppJid(conv.name) ? conv.name : undefined),
       phone: conv.phone || conv.contactPhone || conv.contact_phone || conv.contact_phone_raw,
       aliases: Array.isArray(conv.aliases) ? conv.aliases : [],
+      archived: Boolean(conv?.archived || conv?.isArchived),
+      isArchived: Boolean(conv?.archived || conv?.isArchived),
       channels: Number.isFinite(Number(conv.channel)) ? [Number(conv.channel)] : []
     }))
 
@@ -3431,6 +3859,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         const incomingName = String(item?.name || '')
         const useIncomingName = incomingName && !isLikelyWhatsAppJid(incomingName)
         const useExistingName = existingName && !isLikelyWhatsAppJid(existingName)
+        const mergedArchived = Boolean(existing?.archived || existing?.isArchived || item?.archived || item?.isArchived)
         merged[idx] = {
           ...existing,
           ...item,
@@ -3441,6 +3870,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
           normalizedJid: item.normalizedJid || existing.normalizedJid,
           aliases: Array.from(new Set([...(existing.aliases || []), ...(item.aliases || [])])),
           channels: Array.from(new Set([...(existing.channels || []), ...(item.channels || [])])).filter((n) => Number.isFinite(Number(n))),
+          archived: mergedArchived,
+          isArchived: mergedArchived,
           leadId: existing.leadId,
           stage: existing.stage,
           leadUpdatedAt: existing.leadUpdatedAt,
@@ -3577,6 +4008,21 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
       overdue: 'Atrasados (> 24h)',
       resolved: 'Resolvidos'
     } as const
+    const isInitialSyncActive = Number.isFinite(waInitialSyncChannel) && waInitialSyncChannel !== null
+    const renderWhatsAppSyncNotice = (mode: 'inline' | 'panel' = 'inline') => (
+      <div
+        className={`rounded-xl border border-cyan-300/30 bg-cyan-500/10 ${
+          mode === 'panel' ? 'px-4 py-5' : 'px-3 py-2.5'
+        }`}
+      >
+        <div className={`inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-400/15 px-3 py-1.5 text-sm font-medium text-cyan-100`}>
+          <CircleNotch className="h-4 w-4 animate-spin" />
+          <span>Carregando</span>
+        </div>
+        <div className="mt-2 text-sm text-cyan-100/90">Suas conversas estão sendo carregadas.</div>
+        <div className="mt-1 text-xs text-cyan-100/75">Mantenha o WhatsApp aberto nos dois dispositivos.</div>
+      </div>
+    )
     return (
       <div className="flex h-full min-h-0 flex-col gap-3">
         {paused ? (
@@ -3625,6 +4071,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                       {(loadingConversations || harmoniaInboxLoading) && (
                         <div className="text-sm text-blue-100/60 py-4 text-center">Carregando conversas...</div>
                       )}
+                      {isInitialSyncActive ? (
+                        <div className="py-1">
+                          {renderWhatsAppSyncNotice('inline')}
+                        </div>
+                      ) : null}
                       {harmoniaInboxError && (
                         <div className="text-xs text-red-200/80 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
                           {harmoniaInboxError}
@@ -3677,7 +4128,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                         conversationActionTriggerRefs.current.delete(conversationKey)
                                       }
                                     }}
-                                    className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition hover:border-white/20 hover:bg-white/10 hover:text-white"
+                                    className="absolute right-1 top-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition hover:border-white/20 hover:bg-white/10 hover:text-white"
                                     aria-label="Abrir ações da conversa"
                                     onClick={(event) => {
                                       event.stopPropagation()
@@ -3688,7 +4139,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                       })
                                     }}
                                   >
-                                    <DotsThreeVertical className="h-4 w-4" weight="bold" />
+                                    <DotsThreeVertical className="h-3 w-3" weight="bold" />
                                   </button>
 
                                   <div className="flex items-start gap-2">
@@ -3740,8 +4191,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                         </span>
                                       </div>
                                     </div>
-                                    <div className="ml-2 shrink-0 flex items-center gap-2">
-                                      <ConversationAvatar conv={conv} size={34} />
+                                    <div className="ml-2 shrink-0 self-center flex items-center gap-2">
+                                      <ConversationAvatar conv={conv} size={42} />
                                       {unreadCount > 0 ? (
                                         <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-sky-500/90 px-1 text-[10px] font-semibold text-white">
                                           {unreadCount > 99 ? '99+' : unreadCount}
@@ -3957,10 +4408,11 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                       <span>Carregando mensagens...</span>
                                     </div>
                                   </div>
-                                ) : messages.map((msg) => {
+                                ) : messages.map((msg, msgIndex) => {
                                 const outbound = isOutboundMessage(msg)
                                 const ts = msg.createdAt || msg.timestamp
-                                const messageId = String(msg?.id || '')
+                                const messageId = String(msg?.id || msg?.provider_message_id || '').trim()
+                                const messageAnchorKey = buildMessageUiAnchorKey(msg, msgIndex)
                                 const isGroupConversation = String(
                                   selectedConversation?.conversationId ||
                                   selectedConversation?.rawJid ||
@@ -4026,10 +4478,10 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                 const isFavoritedMessage = Boolean(msg?.favorite)
                                 const isPinnedMessage = Boolean(msg?.pinned)
                                 const isReportedMessage = Boolean(msg?.reported)
-                                const isMessageActionMenuOpen = openMessageActionMenuId === messageId
-                                const isReactionMenuExpanded = expandedReactionMenuId === messageId
+                                const isMessageActionMenuOpen = openMessageActionMenuId === messageAnchorKey
+                                const isReactionMenuExpanded = expandedReactionMenuId === messageAnchorKey
                                 return (
-                                  <div key={msg.id} className={`group flex items-end gap-2 ${outbound ? 'justify-end' : 'justify-start'}`}>
+                                  <div key={messageAnchorKey} className={`group flex items-end gap-2 ${outbound ? 'justify-end' : 'justify-start'}`}>
                                     {showReactionActions && outbound ? (
                                       <div className="relative flex items-center gap-1 self-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                                         <Button
@@ -4099,17 +4551,17 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                       onContextMenu={(event) => {
                                         event.preventDefault()
                                         event.stopPropagation()
-                                        openMessageActionMenu(messageId)
+                                        openMessageActionMenu(messageAnchorKey)
                                       }}
                                     >
                                       <div
                                         className={`absolute top-2 z-40 ${outbound ? 'left-2' : 'right-2'}`}
-                                        data-message-action-root={messageId}
+                                        data-message-action-root={messageAnchorKey}
                                         ref={(node) => {
                                           if (node) {
-                                            messageActionRootRefs.current.set(messageId, node)
+                                            messageActionRootRefs.current.set(messageAnchorKey, node)
                                           } else {
-                                            messageActionRootRefs.current.delete(messageId)
+                                            messageActionRootRefs.current.delete(messageAnchorKey)
                                           }
                                         }}
                                       >
@@ -4120,21 +4572,22 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                           className="h-6 w-6 rounded-full border border-white/10 bg-black/15 text-blue-100 opacity-75 transition-opacity hover:bg-black/25 hover:opacity-100"
                                           aria-label="Abrir ações da mensagem"
                                           aria-expanded={isMessageActionMenuOpen}
-                                          data-testid={`message-actions-trigger-${messageId}`}
+                                          data-testid={`message-actions-trigger-${messageAnchorKey}`}
                                           onClick={(event) => {
                                             event.stopPropagation()
-                                            toggleMessageActionMenu(messageId)
+                                            toggleMessageActionMenu(messageAnchorKey)
                                           }}
                                         >
                                           <CaretDown className="h-3.5 w-3.5" />
                                         </Button>
-                                        {isMessageActionMenuOpen ? (
+                                        {isMessageActionMenuOpen && typeof document !== 'undefined'
+                                          ? createPortal(
                                           <div
                                             ref={messageActionMenuRef}
                                             role="menu"
-                                            data-testid={`message-actions-menu-${messageId}`}
+                                            data-testid={`message-actions-menu-${messageAnchorKey}`}
                                             className="fixed z-[70] flex flex-col overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/72 p-1 text-sm text-blue-50 shadow-2xl backdrop-blur-xl"
-                                            style={messageActionMenuLayout?.messageId === messageId ? {
+                                            style={messageActionMenuLayout?.anchorKey === messageAnchorKey ? {
                                               top: `${messageActionMenuLayout.top}px`,
                                               left: `${messageActionMenuLayout.left}px`,
                                               maxHeight: `${messageActionMenuLayout.maxHeight}px`,
@@ -4162,7 +4615,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                               className="flex items-center gap-2 rounded-xl px-3 py-2 text-left transition-colors hover:bg-white/10"
                                               onClick={() => {
                                                 if (!showReactionActions) return
-                                                setExpandedReactionMenuId((current) => current === messageId ? null : messageId)
+                                                setExpandedReactionMenuId((current) => current === messageAnchorKey ? null : messageAnchorKey)
                                               }}
                                             >
                                               <Smiley className="h-4 w-4" />
@@ -4302,7 +4755,8 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                               <CheckCircle className="h-4 w-4" weight={isSelectedMessage ? 'fill' : 'regular'} />
                                               {isSelectedMessage ? 'Desselecionar mensagem' : 'Selecionar mensagens'}
                                             </button>
-                                          </div>
+                                          </div>,
+                                          document.body
                                         ) : null}
                                       </div>
                                       {Array.isArray(msg?.reactions) && msg.reactions.length > 0 ? (
@@ -4570,12 +5024,18 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                     </div>
                   ) : (
                     <div className="flex flex-1 items-center justify-center">
-                      <div className="rounded-lg border border-dashed border-white/10 bg-white/5 px-6 py-6 text-center max-w-sm">
-                        <div className="text-sm text-blue-100/70">Nenhuma conversa selecionada</div>
-                        <div className="text-xs text-blue-100/50 mt-2">
-                          As mensagens aparecerão aqui assim que as contas estiverem conectadas.
+                      {isInitialSyncActive ? (
+                        <div className="max-w-sm">
+                          {renderWhatsAppSyncNotice('panel')}
                         </div>
-                      </div>
+                      ) : (
+                        <div className="rounded-lg border border-dashed border-white/10 bg-white/5 px-6 py-6 text-center max-w-sm">
+                          <div className="text-sm text-blue-100/70">Nenhuma conversa selecionada</div>
+                          <div className="text-xs text-blue-100/50 mt-2">
+                            As mensagens aparecerão aqui assim que as contas estiverem conectadas.
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )}
                   </CardContent>
@@ -4681,6 +5141,24 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
               ))}
             </div>
             <div className="flex justify-end gap-2">
+              {connectedWhatsapps.length > 1 ? (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    void refreshAllConnectedChannels()
+                  }}
+                  disabled={refreshAllChannelsLoading || Object.values(connectedChannelAction).some(Boolean)}
+                >
+                  {refreshAllChannelsLoading ? (
+                    <>
+                      <CircleNotch className="mr-1 h-4 w-4 animate-spin" />
+                      Refrescando todos...
+                    </>
+                  ) : (
+                    'Refrescar todos'
+                  )}
+                </Button>
+              ) : null}
               <Button variant="outline" onClick={() => setWaStatusOpen(false)}>
                 Fechar
               </Button>
@@ -4903,11 +5381,26 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
         <Dialog open={qrDialogChannel !== null} onOpenChange={(open) => !open && setQrDialogChannel(null)}>
           <DialogContent className="max-w-md">
             <DialogHeader>
-              <DialogTitle>QR Code do canal {qrDialogChannel}</DialogTitle>
-              <DialogDescription>Use o WhatsApp para escanear.</DialogDescription>
+              <DialogTitle>
+                {waInitialSyncChannel === qrDialogChannel ? `Conectando canal ${qrDialogChannel}` : `QR Code do canal ${qrDialogChannel}`}
+              </DialogTitle>
+              <DialogDescription>
+                {waInitialSyncChannel === qrDialogChannel
+                  ? 'Sincronização inicial em andamento.'
+                  : 'Use o WhatsApp para escanear.'}
+              </DialogDescription>
             </DialogHeader>
             <div className="flex justify-center">
-              {qrDialogChannel && channelQR.get(qrDialogChannel)?.dataUrl ? (
+              {waInitialSyncChannel === qrDialogChannel ? (
+                <div className="w-full rounded-xl border border-cyan-300/30 bg-cyan-500/10 px-4 py-5">
+                  <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-400/15 px-3 py-1.5 text-sm font-medium text-cyan-100">
+                    <CircleNotch className="h-4 w-4 animate-spin" />
+                    <span>Carregando</span>
+                  </div>
+                  <div className="mt-3 text-sm text-cyan-100/90">Suas conversas estão sendo carregadas.</div>
+                  <div className="mt-1 text-xs text-cyan-100/75">Mantenha o WhatsApp aberto nos dois dispositivos.</div>
+                </div>
+              ) : qrDialogChannel && channelQR.get(qrDialogChannel)?.dataUrl ? (
                 <img src={channelQR.get(qrDialogChannel)?.dataUrl} alt={`QR ${qrDialogChannel}`} className="h-64 w-64 rounded-lg bg-white p-2" />
               ) : (
                 <div className="text-sm text-blue-100/70">Gerando QR...</div>

--- a/frontend/OmnichannelCenter.tsx
+++ b/frontend/OmnichannelCenter.tsx
@@ -4413,6 +4413,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                 const ts = msg.createdAt || msg.timestamp
                                 const messageId = String(msg?.id || msg?.provider_message_id || '').trim()
                                 const messageAnchorKey = buildMessageUiAnchorKey(msg, msgIndex)
+                                const messageActionTestIdKey = messageId || `msg-${msgIndex}`
                                 const isGroupConversation = String(
                                   selectedConversation?.conversationId ||
                                   selectedConversation?.rawJid ||
@@ -4572,7 +4573,7 @@ export const OmnichannelCenter = forwardRef<OmnichannelCenterHandle, Omnichannel
                                           className="h-6 w-6 rounded-full border border-white/10 bg-black/15 text-blue-100 opacity-75 transition-opacity hover:bg-black/25 hover:opacity-100"
                                           aria-label="Abrir ações da mensagem"
                                           aria-expanded={isMessageActionMenuOpen}
-                                          data-testid={`message-actions-trigger-${messageAnchorKey}`}
+                                          data-testid={`message-actions-trigger-${messageActionTestIdKey}`}
                                           onClick={(event) => {
                                             event.stopPropagation()
                                             toggleMessageActionMenu(messageAnchorKey)

--- a/frontend/command.tsx
+++ b/frontend/command.tsx
@@ -140,7 +140,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/frontend/context-menu.tsx
+++ b/frontend/context-menu.tsx
@@ -68,7 +68,7 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -128,7 +128,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -146,7 +146,7 @@ function ContextMenuCheckCircleboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -171,7 +171,7 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/frontend/dropdown-menu.tsx
+++ b/frontend/dropdown-menu.tsx
@@ -76,7 +76,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -94,7 +94,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -130,7 +130,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -213,7 +213,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className
       )}
       {...props}

--- a/frontend/menubar.tsx
+++ b/frontend/menubar.tsx
@@ -56,7 +56,7 @@ function MenubarTrigger({
     <MenubarPrimitive.Trigger
       data-slot="menubar-trigger"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
         className
       )}
       {...props}
@@ -103,7 +103,7 @@ function MenubarItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -121,7 +121,7 @@ function MenubarCheckCircleboxItem({
     <MenubarPrimitive.CheckboxItem
       data-slot="menubar-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -146,7 +146,7 @@ function MenubarRadioItem({
     <MenubarPrimitive.RadioItem
       data-slot="menubar-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -229,7 +229,7 @@ function MenubarSubTrigger({
       data-slot="menubar-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8",
         className
       )}
       {...props}

--- a/frontend/restart_crm.sh
+++ b/frontend/restart_crm.sh
@@ -245,6 +245,34 @@ API_PID=""; WEB_PID=""
 
 start_api() {
   if [[ $START_API -eq 1 ]]; then
+    # Prefer Evolution orchestrator locally when an Evolution .env with API key is available.
+    if [[ -z "${WA_ORCHESTRATOR_PROVIDER:-}" ]]; then
+      EVOLUTION_ENV_CANDIDATES=(
+        "$SKINCOS_ROOT/backend/apps/whatsapp/evolution-api/.env"
+        "$HOME/Automation/n8n/evolution-api/.env"
+      )
+      EVOLUTION_ENV_FILE=""
+      for candidate in "${EVOLUTION_ENV_CANDIDATES[@]}"; do
+        if [[ -f "$candidate" ]]; then
+          EVOLUTION_ENV_FILE="$candidate"
+          break
+        fi
+      done
+      if [[ -n "$EVOLUTION_ENV_FILE" ]]; then
+        EVOLUTION_KEY_RAW="$(/usr/bin/grep -E '^AUTHENTICATION_API_KEY=' "$EVOLUTION_ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
+        EVOLUTION_KEY="${EVOLUTION_KEY_RAW%\"}"
+        EVOLUTION_KEY="${EVOLUTION_KEY#\"}"
+        EVOLUTION_KEY="${EVOLUTION_KEY%\'}"
+        EVOLUTION_KEY="${EVOLUTION_KEY#\'}"
+        if [[ -n "$EVOLUTION_KEY" ]]; then
+          export WA_ORCHESTRATOR_PROVIDER="evolution"
+          export EVOLUTION_API_URL="${EVOLUTION_API_URL:-http://127.0.0.1:8080}"
+          export EVOLUTION_API_KEY="${EVOLUTION_API_KEY:-$EVOLUTION_KEY}"
+          echo "[restart_crm] Evolution local autodetect ativo ($EVOLUTION_ENV_FILE)"
+        fi
+      fi
+    fi
+
     echo "[restart_crm] Iniciando API (porta $CRM_API_PORT)${WATCH_MODE:+ [watch]}..."
     export CRM_API_PORT
     export PORT="$CRM_API_PORT"

--- a/frontend/select.tsx
+++ b/frontend/select.tsx
@@ -143,7 +143,7 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "flex cursor-pointer items-center justify-center py-1",
         className
       )}
       {...props}
@@ -161,7 +161,7 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "flex cursor-pointer items-center justify-center py-1",
         className
       )}
       {...props}


### PR DESCRIPTION
## Resumo
Este PR estabiliza o fluxo de canais do WhatsApp no módulo de atendimento, principalmente nos cenários de **refrescar** e **desconectar**, além de corrigir consistência de interação visual nos menus/contextos.

## Problema percebido pelo usuário
Em alguns cenários, ao desconectar um canal ele continuava aparecendo como conectado até hard refresh, e as conversas permaneciam visíveis por estado local desatualizado. Também havia inconsistência de feedback/ação em elementos de menu, reduzindo previsibilidade de clique.

## Causa raiz
1. O backend aceitava estados de conexão de forma permissiva sem sempre reconciliar com o `connectionState` real da instância no Evolution.
2. O frontend não fazia atualização otimista + reconciliação forçada suficiente após refresh/disconnect, deixando resquícios de estado em memória.
3. Alguns componentes de menu/contexto continuavam com cursor padrão, passando impressão de elemento não interativo.

## O que foi alterado
### Backend (`crm-api`)
- Reforço de reconciliação de status com consulta explícita ao estado real da instância.
- `stopChannel` com comportamento mais idempotente e robusto, incluindo tratamento de respostas “já desconectado”.
- Helpers adicionais para normalização de estado e recuperação.
- Ajustes de cobertura de teste para os novos caminhos de recuperação/retry.

### Frontend (`OmnichannelCenter`)
- Fluxo de `refrescar` de canal expandido para:
  - restart/poll de estado,
  - bootstrap sync forçado,
  - reload sem cache de conversas,
  - reload de mensagens da conversa ativa,
  - fallback de recuperação.
- Fluxo de `desconectar` com limpeza otimista imediata + reconciliação posterior sem cache.
- Inclusão de ação para refrescar todos os canais conectados.
- Ajustes de UX de interação em componentes de menu para cursor de clique (`cursor-pointer`) em itens acionáveis.

## Impacto para o usuário
- Menor incidência de canais “fantasma” após desconectar.
- Menor necessidade de hard refresh para refletir estado real.
- Maior previsibilidade ao interagir com menus/contextos.

## Validação executada
- `npm run -s typecheck` em `frontend`.
- `node --test backend/apps/crm-api/services/__tests__/evolutionOrchestrator.test.js`.
- Resultado: ambos concluídos com sucesso.
