### PR TITLE
[codex] refine booking picker tooltips and hover scroll behavior

### DIFF
--- a/ops/obs-alert-webhook/README.md
+++ b/ops/obs-alert-webhook/README.md
@@ -1,0 +1,29 @@
+# OBS Alert Webhook
+
+Webhook endpoint for uptime alerts.
+
+## What it does
+- Accepts `POST` JSON alerts.
+- Validates `X-OBS-Token`.
+- Creates a GitHub issue in `jubenitogarcia/skincos`.
+
+## Deploy
+```bash
+cd ops/obs-alert-webhook
+npx wrangler secret put GITHUB_TOKEN
+npx wrangler secret put WEBHOOK_TOKEN
+npx wrangler deploy
+```
+
+## Request format
+Headers:
+- `Content-Type: application/json`
+- `X-OBS-Token: <token>`
+
+Body example:
+```json
+{
+  "source": "uptime-slo",
+  "text": "[SLO][FAIL] run url ..."
+}
+```

--- a/ops/obs-alert-webhook/src/index.ts
+++ b/ops/obs-alert-webhook/src/index.ts
@@ -1,0 +1,106 @@
+interface Env {
+  GITHUB_OWNER: string;
+  GITHUB_REPO: string;
+  GITHUB_TOKEN: string;
+  WEBHOOK_TOKEN: string;
+}
+
+type IncomingPayload = {
+  text?: string;
+  subject?: string;
+  message?: string;
+  source?: string;
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function normalizeMessage(payload: IncomingPayload, fallbackText: string): string {
+  const pieces = [payload.subject, payload.message, payload.text]
+    .map((value) => (value || "").trim())
+    .filter((value) => value.length > 0);
+
+  if (pieces.length === 0) {
+    return fallbackText;
+  }
+
+  // Keep the message compact and deterministic for issue body generation.
+  return pieces.join("\n\n");
+}
+
+async function createGithubIssue(env: Env, title: string, body: string): Promise<Response> {
+  const apiUrl = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/issues`;
+  return fetch(apiUrl, {
+    method: "POST",
+    headers: {
+      "authorization": `Bearer ${env.GITHUB_TOKEN}`,
+      "accept": "application/vnd.github+json",
+      "content-type": "application/json",
+      "user-agent": "skincos-obs-alert-webhook",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      title,
+      body,
+    }),
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method !== "POST") {
+      return jsonResponse(405, { error: "method_not_allowed" });
+    }
+
+    const incomingToken = request.headers.get("x-obs-token") || "";
+    if (!env.WEBHOOK_TOKEN || incomingToken !== env.WEBHOOK_TOKEN) {
+      return jsonResponse(401, { error: "unauthorized" });
+    }
+
+    let payload: IncomingPayload = {};
+    let rawBody = "";
+    try {
+      rawBody = await request.text();
+      payload = rawBody ? (JSON.parse(rawBody) as IncomingPayload) : {};
+    } catch {
+      payload = {};
+    }
+
+    const now = new Date().toISOString();
+    const source = payload.source?.trim() || request.headers.get("x-alert-source") || "uptime-slo";
+    const message = normalizeMessage(payload, rawBody || "alert without payload body");
+
+    const title = `[SLO][FAIL] ${source} - ${now}`;
+    const body = [
+      "Alerta automático recebido pelo webhook de observabilidade.",
+      "",
+      `- Source: ${source}`,
+      `- Time (UTC): ${now}`,
+      "",
+      "```text",
+      message,
+      "```",
+    ].join("\n");
+
+    const issueRes = await createGithubIssue(env, title, body);
+    if (!issueRes.ok) {
+      const errorText = await issueRes.text();
+      return jsonResponse(502, {
+        error: "github_issue_create_failed",
+        status: issueRes.status,
+        details: errorText.slice(0, 500),
+      });
+    }
+
+    const issue = (await issueRes.json()) as { html_url?: string; number?: number };
+    return jsonResponse(202, {
+      ok: true,
+      issue_url: issue.html_url || null,
+      issue_number: issue.number || null,
+    });
+  },
+};

--- a/ops/obs-alert-webhook/wrangler.toml
+++ b/ops/obs-alert-webhook/wrangler.toml
@@ -1,0 +1,8 @@
+name = "skincos-obs-alert-webhook"
+main = "src/index.ts"
+compatibility_date = "2026-03-12"
+workers_dev = true
+
+[vars]
+GITHUB_OWNER = "jubenitogarcia"
+GITHUB_REPO = "skincos"

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -203,6 +203,20 @@ function HoverScrollPicker(props: { ariaLabel: string; children: ReactNode; clas
         return () => window.removeEventListener("resize", onResize);
     }, []);
 
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        update();
+
+        if (typeof ResizeObserver === "undefined") return;
+
+        const observer = new ResizeObserver(() => update());
+        observer.observe(el);
+        Array.from(el.children).forEach((child) => observer.observe(child));
+        return () => observer.disconnect();
+    }, [props.children]);
+
     const stopHoverScroll = () => {
         if (!hoverTimerRef.current) return;
         clearInterval(hoverTimerRef.current);
@@ -1173,50 +1187,55 @@ export default function BookingFlow() {
                                 {services.map((s) => {
                                     const active = selectedServices.some((item) => item.id === s.id);
                                     return (
-                                        <button
-                                            key={s.id}
-                                            type="button"
-                                            role="listitem"
-                                            disabled={!canPickProcedure}
-                                            className={`bookingFlow__procedureBadge${s.subtitle ? " bookingFlow__tooltipTrigger bookingFlow__procedureBadge--hasTooltip" : ""}`}
-                                            data-active={active ? "true" : "false"}
-                                            data-tooltip={s.subtitle ?? undefined}
-                                            onClick={() => toggleProcedure(s)}
-                                        >
-                                            <span className="bookingFlow__procedureBadgeAvatar">
-                                                {s.highlightImage ? (
-                                                    <Image
-                                                        src={s.highlightImage}
-                                                        alt=""
-                                                        fill
-                                                        sizes="76px"
-                                                        style={{ objectFit: "cover" }}
-                                                        unoptimized
-                                                        aria-hidden="true"
-                                                    />
-                                                ) : (
-                                                    <span className="bookingFlow__procedureBadgeFallback">EF</span>
-                                                )}
-                                            </span>
-                                            <span className="bookingFlow__procedureBadgeLabel">{s.name}</span>
-                                        </button>
+                                        <div key={s.id} className="bookingFlow__procedureBadgeWrap" role="listitem" data-active={active ? "true" : "false"}>
+                                            <button
+                                                type="button"
+                                                disabled={!canPickProcedure}
+                                                className="bookingFlow__procedureBadge"
+                                                data-active={active ? "true" : "false"}
+                                                onClick={() => toggleProcedure(s)}
+                                            >
+                                                <span className="bookingFlow__procedureBadgeAvatar">
+                                                    {s.highlightImage ? (
+                                                        <Image
+                                                            src={s.highlightImage}
+                                                            alt=""
+                                                            fill
+                                                            sizes="76px"
+                                                            style={{ objectFit: "cover" }}
+                                                            unoptimized
+                                                            aria-hidden="true"
+                                                        />
+                                                    ) : (
+                                                        <span className="bookingFlow__procedureBadgeFallback">EF</span>
+                                                    )}
+                                                </span>
+                                                <span className="bookingFlow__procedureBadgeLabel">{s.name}</span>
+                                            </button>
+                                            {s.subtitle ? <div className="bookingFlow__procedureTooltip" role="tooltip">{s.subtitle}</div> : null}
+                                        </div>
                                     );
                                 })}
 
-                                <button
-                                    type="button"
+                                <div
+                                    className="bookingFlow__procedureBadgeWrap"
                                     role="listitem"
-                                    disabled={!canPickProcedure}
-                                    className="bookingFlow__procedureBadge bookingFlow__tooltipTrigger bookingFlow__procedureBadge--hasTooltip"
                                     data-active={selectedServices.some((item) => item.id === OTHER_SERVICE.id) ? "true" : "false"}
-                                    data-tooltip="Outro procedimento ou combinação"
-                                    onClick={() => toggleProcedure(OTHER_SERVICE)}
                                 >
-                                    <span className="bookingFlow__procedureBadgeAvatar bookingFlow__procedureBadgeAvatar--all">
-                                        <span className="bookingFlow__procedureBadgeFallback bookingFlow__procedureBadgeFallback--all">Outro</span>
-                                    </span>
-                                    <span className="bookingFlow__procedureBadgeLabel">Outro</span>
-                                </button>
+                                    <button
+                                        type="button"
+                                        disabled={!canPickProcedure}
+                                        className="bookingFlow__procedureBadge"
+                                        data-active={selectedServices.some((item) => item.id === OTHER_SERVICE.id) ? "true" : "false"}
+                                        onClick={() => toggleProcedure(OTHER_SERVICE)}
+                                    >
+                                        <span className="bookingFlow__procedureBadgeAvatar bookingFlow__procedureBadgeAvatar--all">
+                                            <span className="bookingFlow__procedureBadgeFallback bookingFlow__procedureBadgeFallback--all">Outro</span>
+                                        </span>
+                                        <span className="bookingFlow__procedureBadgeLabel">Outro</span>
+                                    </button>
+                                    <div className="bookingFlow__procedureTooltip" role="tooltip">Outro procedimento ou combinação</div>
+                                </div>
                             </div>
                         </HoverScrollPicker>
                     </div>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1571,7 +1571,7 @@ button:focus-visible {
 .bookingFlow__procedureBadgeGrid {
   display: flex;
   flex-wrap: nowrap;
-  gap: 8px;
+  gap: 12px;
   align-items: flex-start;
   width: max-content;
   min-width: max-content;
@@ -1583,8 +1583,8 @@ button:focus-visible {
   display: grid;
   justify-items: center;
   gap: 5px;
-  width: 92px;
-  min-width: 92px;
+  width: 112px;
+  min-width: 112px;
   flex: 0 0 auto;
   padding: 0;
   border: 0;
@@ -1655,12 +1655,12 @@ button:focus-visible {
 .bookingFlow__procedureBadgeLabel {
   font-size: 12px;
   font-weight: 900;
-  line-height: 1.1;
+  line-height: 1.15;
   text-align: center;
   text-wrap: pretty;
   overflow-wrap: anywhere;
   width: 100%;
-  min-height: 2.2em;
+  min-height: 2.3em;
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeLabel {

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1504,10 +1504,21 @@ button:focus-visible {
   padding-top: 6px;
 }
 
-.bookingFlow__doctorTooltip {
+.bookingFlow__picker--doctor.bookingFlow__picker--rail::before,
+.bookingFlow__picker--doctor.bookingFlow__picker--rail::after {
+  background: transparent;
+}
+
+.bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap:hover,
+.bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap:focus-within {
+  z-index: 30;
+}
+
+.bookingFlow__doctorTooltip,
+.bookingFlow__procedureTooltip {
   position: absolute;
   left: 50%;
-  top: 6px;
+  top: calc(100% + 4px);
   bottom: auto;
   transform: translateX(-50%);
   display: none;
@@ -1521,7 +1532,7 @@ button:focus-visible {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
   white-space: normal;
   pointer-events: auto;
-  z-index: 5;
+  z-index: 40;
 }
 
 .bookingFlow__doctorTooltipHeader {
@@ -1533,6 +1544,11 @@ button:focus-visible {
 
 .bookingFlow__doctorBadgeWrap:hover .bookingFlow__doctorTooltip,
 .bookingFlow__doctorBadgeWrap:focus-within .bookingFlow__doctorTooltip {
+  display: block;
+}
+
+.bookingFlow__procedureBadgeWrap:hover .bookingFlow__procedureTooltip,
+.bookingFlow__procedureBadgeWrap:focus-within .bookingFlow__procedureTooltip {
   display: block;
 }
 
@@ -1571,11 +1587,21 @@ button:focus-visible {
 .bookingFlow__procedureBadgeGrid {
   display: flex;
   flex-wrap: nowrap;
-  gap: 8px;
+  gap: 6px;
   align-items: flex-start;
   width: max-content;
   min-width: max-content;
   padding: 8px 0 14px;
+}
+
+.bookingFlow__procedureBadgeWrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.bookingFlow__procedureBadgeWrap:hover,
+.bookingFlow__procedureBadgeWrap:focus-within {
+  z-index: 30;
 }
 
 .bookingFlow__procedureBadge {
@@ -1583,8 +1609,8 @@ button:focus-visible {
   display: grid;
   justify-items: center;
   gap: 5px;
-  width: 92px;
-  min-width: 92px;
+  width: 88px;
+  min-width: 88px;
   flex: 0 0 auto;
   padding: 0;
   border: 0;
@@ -1667,13 +1693,6 @@ button:focus-visible {
   color: #111;
 }
 
-.bookingFlow__procedureBadge--hasTooltip::after {
-  max-width: 188px;
-  text-align: center;
-  white-space: normal;
-  text-wrap: balance;
-}
-
 .bookingFlow__dateBtn {
   border-radius: 12px;
 }
@@ -1721,13 +1740,11 @@ button:focus-visible {
   border-color: #d1d5db;
 }
 
-.bookingFlow__timeBtn[data-tooltip],
-.bookingFlow__tooltipTrigger[data-tooltip] {
+.bookingFlow__timeBtn[data-tooltip] {
   position: relative;
 }
 
-.bookingFlow__timeBtn[data-tooltip]::after,
-.bookingFlow__tooltipTrigger[data-tooltip]::after {
+.bookingFlow__timeBtn[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;
   left: 50%;
@@ -1747,8 +1764,7 @@ button:focus-visible {
   z-index: 2;
 }
 
-.bookingFlow__timeBtn[data-tooltip]::before,
-.bookingFlow__tooltipTrigger[data-tooltip]::before {
+.bookingFlow__timeBtn[data-tooltip]::before {
   content: "";
   position: absolute;
   left: 50%;
@@ -1764,30 +1780,10 @@ button:focus-visible {
   z-index: 1;
 }
 
-.bookingFlow__cardProcedure .bookingFlow__tooltipTrigger[data-tooltip]::after {
-  top: 2px;
-  bottom: auto;
-  max-width: 148px;
-  padding: 5px 7px;
-  font-size: 10px;
-  line-height: 1.15;
-  white-space: normal;
-  text-wrap: balance;
-  text-align: center;
-  transform: translateX(-50%) translateY(2px);
-  z-index: 6;
-}
-
-.bookingFlow__cardProcedure .bookingFlow__tooltipTrigger[data-tooltip]::before {
-  display: none;
-}
-
 .bookingFlow__timeBtn[data-tooltip]:hover::after,
 .bookingFlow__timeBtn[data-tooltip]:hover::before,
-.bookingFlow__tooltipTrigger[data-tooltip]:hover::after,
-.bookingFlow__tooltipTrigger[data-tooltip]:hover::before,
-.bookingFlow__tooltipTrigger[data-tooltip]:focus-visible::after,
-.bookingFlow__tooltipTrigger[data-tooltip]:focus-visible::before {
+.bookingFlow__timeBtn[data-tooltip]:focus-visible::after,
+.bookingFlow__timeBtn[data-tooltip]:focus-visible::before {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
@@ -1870,11 +1866,13 @@ button:focus-visible {
 
 .bookingFlow__scrollWindow--doctor {
   padding-top: 8px !important;
+  padding-bottom: 56px !important;
 }
 
 .bookingFlow__cardProcedure .bookingFlow__scrollWindow {
   padding-left: 14px !important;
   padding-right: 14px !important;
+  padding-bottom: 52px !important;
   scroll-padding-left: 14px !important;
   scroll-padding-right: 14px !important;
 }
@@ -1883,7 +1881,7 @@ button:focus-visible {
   position: absolute;
   top: 8px;
   height: 82px;
-  z-index: 3;
+  z-index: 45;
   width: 56px;
   border: 0;
   padding: 0;

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1571,7 +1571,7 @@ button:focus-visible {
 .bookingFlow__procedureBadgeGrid {
   display: flex;
   flex-wrap: nowrap;
-  gap: 12px;
+  gap: 8px;
   align-items: flex-start;
   width: max-content;
   min-width: max-content;
@@ -1583,8 +1583,8 @@ button:focus-visible {
   display: grid;
   justify-items: center;
   gap: 5px;
-  width: 112px;
-  min-width: 112px;
+  width: 92px;
+  min-width: 92px;
   flex: 0 0 auto;
   padding: 0;
   border: 0;
@@ -1655,12 +1655,12 @@ button:focus-visible {
 .bookingFlow__procedureBadgeLabel {
   font-size: 12px;
   font-weight: 900;
-  line-height: 1.15;
+  line-height: 1.1;
   text-align: center;
   text-wrap: pretty;
   overflow-wrap: anywhere;
   width: 100%;
-  min-height: 2.3em;
+  min-height: 2.2em;
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeLabel {


### PR DESCRIPTION
## Contexto
Na página de agendamento, havia regressões de usabilidade na área de seleção de doutores e procedimentos:
- tooltip dos doutores e dos procedimentos com comportamento inconsistente;
- rolagem horizontal por aproximação do mouse nas laterais deixando de responder em alguns cenários;
- espaçamento dos ícones de procedimentos mais aberto do que o desejado;
- trilho visual da seção de doutores adicionando camada de cor extra, em vez de deixar apenas o fundo do card.

## Causa raiz
Os problemas vieram de uma combinação de estrutura e camadas CSS:
- o picker horizontal dependia apenas de atualização inicial/resize e não reagia bem quando o conteúdo/medidas mudavam, deixando o estado de setas laterais desatualizado;
- tooltips de procedimentos usavam pseudo-elementos (`::after`/`::before`) com regra específica diferente dos doutores;
- gradientes de trilho e z-index de overlays competiam entre si em estados de hover/focus;
- dimensões/gap dos badges de procedimentos estavam maiores que o desejado.

## O que foi corrigido
- **Hover scroll restaurado e estabilizado**
  - adicionado `ResizeObserver` no `HoverScrollPicker` para recalcular disponibilidade de rolagem quando conteúdo muda;
  - mantida atualização por `scroll` e `resize`.
- **Tooltip de procedimentos unificado com o de doutores**
  - removido padrão por pseudo-elemento para procedimentos;
  - adotado tooltip real em elemento dedicado (`.bookingFlow__procedureTooltip`), com mesmo padrão visual/posicionamento abaixo do ícone.
- **Aproximação dos ícones de procedimentos**
  - ajuste de `gap` da grade e largura dos badges para reduzir distância visual.
- **Trilho dos doutores sem camada de cor extra**
  - gradientes laterais do picker de doutores ficaram transparentes.
- **Camadas/interação lateral**
  - ajuste de `z-index` nas zonas de hover laterais para preservar interação do scroll.
- **Espaço para tooltips sem recorte**
  - mantido/ajustado `padding-bottom` nas áreas de scroll para evitar clipping.

## Impacto para usuários
- navegação mais previsível e fluida no agendamento;
- tooltips consistentes entre doutores e procedimentos;
- seleção de procedimentos mais compacta e legível;
- retorno do scroll lateral por aproximação do mouse nas bordas.

## Validação executada
- `npm run typecheck` em `website`.
- validação funcional local com Playwright:
  - scroll lateral por hover nas bordas voltou a mover a lista de procedimentos;
  - tooltip de procedimentos exibindo no hover no novo padrão.
