### PR TITLE
[codex] Remove glass blur e ajusta trilhos full-width no agendamento

### DIFF
--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -342,11 +342,7 @@ function HoverScrollPicker(props: { ariaLabel: string; children: ReactNode; clas
     };
 
     return (
-        <div
-            className={["bookingFlow__picker", props.className].filter(Boolean).join(" ")}
-            data-left-fade={canLeft ? "true" : "false"}
-            data-right-fade={canRight ? "true" : "false"}
-        >
+        <div className={["bookingFlow__picker", props.className].filter(Boolean).join(" ")}>
             <button
                 type="button"
                 className="bookingFlow__hoverZone bookingFlow__hoverZone--left"

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1805,8 +1805,7 @@ button:focus-visible {
 }
 
 .bookingFlow__picker {
-  --picker-side-space: 54px;
-  --picker-fade-width: 34px;
+  --picker-arrow-zone: 46px;
   --picker-edge-height: 84px;
   position: relative;
   margin-top: 4px;
@@ -1822,38 +1821,7 @@ button:focus-visible {
 
 .bookingFlow__picker--rail::before,
 .bookingFlow__picker--rail::after {
-  content: "";
-  position: absolute;
-  top: 8px;
-  width: var(--picker-fade-width);
-  height: var(--picker-edge-height);
-  border-radius: 0;
-  pointer-events: none;
-  opacity: 0;
-  backdrop-filter: blur(5px) saturate(104%);
-  -webkit-backdrop-filter: blur(5px) saturate(104%);
-  z-index: 46;
-  transition: opacity 160ms ease;
-}
-
-.bookingFlow__picker--rail::before {
-  left: var(--picker-side-space);
-  transform: translateX(-30%);
-  background: linear-gradient(90deg, rgba(244, 244, 244, 0.82) 0%, rgba(244, 244, 244, 0.38) 48%, rgba(244, 244, 244, 0) 100%);
-}
-
-.bookingFlow__picker--rail::after {
-  right: var(--picker-side-space);
-  transform: translateX(30%);
-  background: linear-gradient(270deg, rgba(244, 244, 244, 0.82) 0%, rgba(244, 244, 244, 0.38) 48%, rgba(244, 244, 244, 0) 100%);
-}
-
-.bookingFlow__picker[data-left-fade="true"]::before {
-  opacity: 1;
-}
-
-.bookingFlow__picker[data-right-fade="true"]::after {
-  opacity: 1;
+  display: none;
 }
 
 .bookingFlow__picker .bookingFlow__scrollWindow {
@@ -1861,12 +1829,12 @@ button:focus-visible {
   margin-left: 0;
   margin-right: 0;
   margin-top: 0;
-  padding-left: var(--picker-side-space);
-  padding-right: var(--picker-side-space);
+  padding-left: 0;
+  padding-right: 0;
   padding-top: 8px;
   padding-bottom: 10px;
-  scroll-padding-left: var(--picker-side-space);
-  scroll-padding-right: var(--picker-side-space);
+  scroll-padding-left: 0;
+  scroll-padding-right: 0;
 }
 
 .bookingFlow__scrollWindow--doctor {
@@ -1883,7 +1851,7 @@ button:focus-visible {
   top: 8px;
   height: var(--picker-edge-height);
   z-index: 55;
-  width: var(--picker-side-space);
+  width: var(--picker-arrow-zone);
   border: 0;
   padding: 0;
   background: transparent;
@@ -1905,12 +1873,12 @@ button:focus-visible {
 }
 
 .bookingFlow__hoverZone--left {
-  left: 0;
+  left: calc(var(--picker-arrow-zone) * -1);
   justify-content: center;
 }
 
 .bookingFlow__hoverZone--right {
-  right: 0;
+  right: calc(var(--picker-arrow-zone) * -1);
   justify-content: center;
 }
 
@@ -1936,16 +1904,12 @@ button:focus-visible {
 
 @media (hover: hover) and (pointer: fine) {
   .bookingFlow__cardProcedure .bookingFlow__scrollWindow {
-    scroll-padding-left: var(--picker-side-space) !important;
-    scroll-padding-right: var(--picker-side-space) !important;
+    scroll-padding-left: 0 !important;
+    scroll-padding-right: 0 !important;
   }
 }
 
 @media (hover: none), (pointer: coarse) {
-  .bookingFlow__picker {
-    --picker-side-space: 0px;
-  }
-
   .bookingFlow__picker .bookingFlow__scrollWindow {
     width: 100%;
     margin-left: 0;
@@ -1954,11 +1918,6 @@ button:focus-visible {
     padding-right: 0;
     scroll-padding-left: 0;
     scroll-padding-right: 0;
-  }
-
-  .bookingFlow__picker--rail::before,
-  .bookingFlow__picker--rail::after {
-    display: none;
   }
 
   .bookingFlow__hoverZone {


### PR DESCRIPTION
## Resumo
Remove totalmente o efeito lateral de glass + blur nos carrosséis de agendamento e ajusta a janela de scroll horizontal para ocupar a mesma largura do box limitador, tanto em doutores quanto em procedimentos.

## O que mudou
- Removidos os overlays/pseudo-elementos de fade/blur (`bookingFlow__picker--rail::before/::after`).
- Removidos os atributos de estado visual de fade (`data-left-fade`, `data-right-fade`) no `HoverScrollPicker`.
- `scrollWindow` agora usa largura total do card (`width: 100%`) com paddings laterais zerados para não criar “janela menor” interna.
- Mantido o comportamento de scroll horizontal com setas, posicionando as zonas de seta fora da área útil dos ícones para não sobrepor o conteúdo.

## Resultado esperado
- Sem qualquer efeito glass/blur.
- A faixa de ícones acompanha a largura do box de “Escolha o seu doutor”.
- Mesmo comportamento para “Escolha os procedimentos”.

## Validação
- `npm run typecheck` ✅
- `npm run lint` ✅
