### PR TITLE
[codex] Corrige corte nas bordas do carrossel de procedimentos

### DIFF
--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1577,7 +1577,7 @@ button:focus-visible {
   align-items: flex-start;
   width: max-content;
   min-width: max-content;
-  padding: 6px 0 6px;
+  padding: 6px 8px 6px;
 }
 
 .bookingFlow__procedureBadgeWrap {


### PR DESCRIPTION
## Resumo
Corrige o corte visual nas extremidades do carrossel de procedimentos dentro do box de agendamento.

## Problema para o usuário
O primeiro e o último ícone do carrossel de procedimentos apareciam parcialmente cortados nas bordas do container, mesmo com o scroll horizontal funcionando. Isso transmitia a sensação de que a área útil interna estava desalinhada em relação ao box externo.

## Causa raiz
O container rolável estava com largura correta, mas o grid interno dos badges de procedimento não tinha nenhum inset lateral. Como o carrossel usa `overflow-x: auto`, os badges das extremidades ficavam encostados exatamente no limite visível do viewport, o que fazia bordas, sombra e parte do conteúdo parecerem recortados.

## Correção aplicada
Ajustei apenas o `padding` lateral do `.bookingFlow__procedureBadgeGrid`, de `6px 0 6px` para `6px 8px 6px`.

Essa mudança é propositalmente mínima e preserva a estrutura atual:
- mantém a largura da janela rolável alinhada ao box externo;
- mantém o scroll horizontal como está;
- garante que o primeiro e o último badge fiquem totalmente visíveis;
- evita introduzir margem negativa, máscaras, áreas extras ou mudanças desnecessárias no JSX.

## Validação
- `npm run typecheck` ✅
- `npm run lint` ✅
