### PR TITLE
[codex] Prefer dedicated Cloudflare security token

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -122,7 +122,7 @@ jobs:
         working-directory: website
         run: npm run cf:security
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com
 
       - name: Verify Cloudflare security settings
@@ -130,7 +130,7 @@ jobs:
         working-directory: website
         run: npm run cf:security:check
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com
 
       - name: Deploy redirects worker (esfa.co)

--- a/.github/workflows/sync-website-cloudflare-security.yml
+++ b/.github/workflows/sync-website-cloudflare-security.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Guard Cloudflare security sync secrets
         id: guard
         run: |
-          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
+          if [ -z "${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN }}" ] && [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Cloudflare API token not configured; skipping website security sync."
+            echo "Cloudflare security token not configured; skipping website security sync."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -48,7 +48,7 @@ jobs:
         working-directory: website
         run: npm run cf:security
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com
 
       - name: Verify Cloudflare security settings
@@ -56,5 +56,5 @@ jobs:
         working-directory: website
         run: npm run cf:security:check
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com

--- a/website/docs/security/SETUP_CLOUDFLARE_SECURITY_SYNC.md
+++ b/website/docs/security/SETUP_CLOUDFLARE_SECURITY_SYNC.md
@@ -13,7 +13,8 @@ Este repositório inclui um script versionado para manter configurações de seg
 ## Requisitos
 
 GitHub Secret:
-- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_SECURITY_API_TOKEN` (preferido)
+- `CLOUDFLARE_API_TOKEN` (fallback)
 
 O token deve ter permissões suficientes na zona `espacofacial.com` para:
 - Ler zona


### PR DESCRIPTION
## Summary
Prefer a dedicated GitHub secret for website Cloudflare security syncs.

## Problem
The website deploy succeeded, but the workflow failed in the post-deploy security sync step because the shared `CLOUDFLARE_API_TOKEN` did not have the required zone-level permissions for WAF/rate-limit operations.

## Fix
- Prefer `CLOUDFLARE_SECURITY_API_TOKEN` for website security sync/check.
- Keep fallback to `CLOUDFLARE_API_TOKEN` to preserve compatibility.
- Update the setup guide to document the dedicated secret as the preferred path.

## Validation
- Confirmed the new GitHub secret `CLOUDFLARE_SECURITY_API_TOKEN` exists.
- After merge, the manual `Sync Website Cloudflare Security` workflow will be run to validate the new token end-to-end.
