### PR TITLE
[codex] Skip unsupported bot fight mode setting

### DIFF
--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -23,6 +23,11 @@ function log(msg) {
   console.log(`[cf-security] ${msg}`);
 }
 
+function isUnsupportedBotFightModeError(err) {
+  const message = String(err?.message ?? "").toLowerCase();
+  return message.includes("undefined zone setting: bot_fight_mode");
+}
+
 async function cfFetch(path, init = {}) {
   const token = env("CLOUDFLARE_API_TOKEN");
   if (!token) throw new Error("missing CLOUDFLARE_API_TOKEN");
@@ -53,7 +58,16 @@ async function getZoneIdByName(zoneName) {
 }
 
 async function tryEnableBotFightMode(zoneId) {
-  const current = await cfFetch(`/zones/${zoneId}/settings/bot_fight_mode`);
+  let current;
+  try {
+    current = await cfFetch(`/zones/${zoneId}/settings/bot_fight_mode`);
+  } catch (err) {
+    if (isUnsupportedBotFightModeError(err)) {
+      log("bot_fight_mode unsupported for this zone; skipping");
+      return;
+    }
+    throw err;
+  }
   const currentValue = (current?.value ?? "").toLowerCase();
   if (CHECK_MODE) {
     if (currentValue !== "on") {
@@ -68,10 +82,18 @@ async function tryEnableBotFightMode(zoneId) {
     return;
   }
 
-  await cfFetch(`/zones/${zoneId}/settings/bot_fight_mode`, {
-    method: "PATCH",
-    body: JSON.stringify({ value: "on" }),
-  });
+  try {
+    await cfFetch(`/zones/${zoneId}/settings/bot_fight_mode`, {
+      method: "PATCH",
+      body: JSON.stringify({ value: "on" }),
+    });
+  } catch (err) {
+    if (isUnsupportedBotFightModeError(err)) {
+      log("bot_fight_mode unsupported for this zone; skipping");
+      return;
+    }
+    throw err;
+  }
   log("bot_fight_mode enabled");
 }
 


### PR DESCRIPTION
## Summary
Treat unsupported `bot_fight_mode` zone settings as best-effort in the website Cloudflare security sync.

## Problem
After switching to the dedicated security token, the workflow stopped failing with `Unauthorized` and started failing with `Undefined zone setting: bot_fight_mode`.

That means the token was correct, but the script was treating an unsupported zone setting as a hard failure, even though the repo docs already describe Bot Fight Mode as best-effort.

## Fix
- Detect the specific Cloudflare API error for unsupported `bot_fight_mode`.
- Skip that setting when the zone does not expose it.
- Keep the rate-limit ruleset sync/check as mandatory.

## Validation
- `node --check website/scripts/cloudflare-sync-security.mjs`
- Manual workflow will be re-run after merge.
