### PR TITLE
Bootstrap missing Cloudflare rate limit entrypoint

### DIFF
--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -8,9 +8,10 @@ const DESIRED_RULE = {
   action: "block",
   enabled: true,
   ratelimit: {
+    // This zone only supports a 10-second period; 2/10s preserves the prior 12/minute rate.
     characteristics: ["cf.colo.id", "ip.src"],
-    period: 60,
-    requests_per_period: 12,
+    period: 10,
+    requests_per_period: 2,
     mitigation_timeout: 600,
   },
 };

--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -8,7 +8,7 @@ const DESIRED_RULE = {
   action: "block",
   enabled: true,
   ratelimit: {
-    characteristics: ["ip.src"],
+    characteristics: ["cf.colo.id", "ip.src"],
     period: 60,
     requests_per_period: 12,
     mitigation_timeout: 600,

--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -8,11 +8,11 @@ const DESIRED_RULE = {
   action: "block",
   enabled: true,
   ratelimit: {
-    // This zone only supports a 10-second period; 2/10s preserves the prior 12/minute rate.
+    // This zone only supports 10s period/timeout values; 2/10s preserves the prior 12/minute rate.
     characteristics: ["cf.colo.id", "ip.src"],
     period: 10,
     requests_per_period: 2,
-    mitigation_timeout: 600,
+    mitigation_timeout: 10,
   },
 };
 

--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -28,6 +28,11 @@ function isUnsupportedBotFightModeError(err) {
   return message.includes("undefined zone setting: bot_fight_mode");
 }
 
+function isMissingRateLimitEntrypointError(err) {
+  const message = String(err?.message ?? "").toLowerCase();
+  return message.includes("could not find entrypoint ruleset in the http_ratelimit phase");
+}
+
 async function cfFetch(path, init = {}) {
   const token = env("CLOUDFLARE_API_TOKEN");
   if (!token) throw new Error("missing CLOUDFLARE_API_TOKEN");
@@ -113,7 +118,15 @@ function sameRateLimitConfig(rule) {
 }
 
 async function assertRateLimitRule(zoneId) {
-  const entrypoint = await cfFetch(`/zones/${zoneId}/rulesets/phases/http_ratelimit/entrypoint`);
+  let entrypoint;
+  try {
+    entrypoint = await cfFetch(`/zones/${zoneId}/rulesets/phases/http_ratelimit/entrypoint`);
+  } catch (err) {
+    if (isMissingRateLimitEntrypointError(err)) {
+      throw new Error("rate_limit_rule_drift_detected");
+    }
+    throw err;
+  }
   const existingRules = Array.isArray(entrypoint?.rules) ? entrypoint.rules : [];
   const matched = existingRules.find((rule) => rule?.ref === RATE_LIMIT_REF);
   if (!sameRateLimitConfig(matched)) {
@@ -123,7 +136,30 @@ async function assertRateLimitRule(zoneId) {
 }
 
 async function upsertRateLimitRule(zoneId) {
-  const entrypoint = await cfFetch(`/zones/${zoneId}/rulesets/phases/http_ratelimit/entrypoint`);
+  let entrypoint;
+  try {
+    entrypoint = await cfFetch(`/zones/${zoneId}/rulesets/phases/http_ratelimit/entrypoint`);
+  } catch (err) {
+    if (!isMissingRateLimitEntrypointError(err)) {
+      throw err;
+    }
+  }
+
+  if (!entrypoint) {
+    await cfFetch(`/zones/${zoneId}/rulesets`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: "default",
+        description: "EF: zone-level rate limiting ruleset (managed by repo)",
+        kind: "zone",
+        phase: "http_ratelimit",
+        rules: [DESIRED_RULE],
+      }),
+    });
+    log("rate limit entrypoint created (http_ratelimit)");
+    return;
+  }
+
   const existingRules = Array.isArray(entrypoint?.rules) ? entrypoint.rules : [];
   const preserved = existingRules.filter((r) => r?.ref !== RATE_LIMIT_REF);
 


### PR DESCRIPTION
## Summary
- treat a missing http_ratelimit entrypoint as drift during checks
- create the zone-level rate limit ruleset when the entrypoint does not exist yet
- keep the Cloudflare security sync idempotent for first-time zone setup

## Testing
- node --check website/scripts/cloudflare-sync-security.mjs