### PR TITLE
[codex] Make homepage doctors section match booking

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -49,7 +49,7 @@ export default async function HomePage() {
 
         <section id="doutores" className="pageSection" style={{ marginTop: 50 }}>
           <h2 className="sectionTitle">Nossos Doutores</h2>
-          <UnitDoctorsGrid />
+          <UnitDoctorsGrid variant="booking-compact" />
         </section>
 
         <section id="unidades" className="pageSection" style={{ marginTop: 50 }}>

--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -54,7 +54,11 @@ function extractInstagramHandle(url: string | null): string | null {
     }
 }
 
-export default function UnitDoctorsGrid() {
+type UnitDoctorsGridProps = {
+    variant?: "directory" | "booking-compact";
+};
+
+export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGridProps) {
     const unit = useCurrentUnit();
     const unitLabel = unitLabelFromSlug(unit?.slug);
 
@@ -107,7 +111,10 @@ export default function UnitDoctorsGrid() {
         );
     }
 
-    const selectedUnitSubtitle = <p className="sectionSub">Conheça nossos doutores, veja seus perfis e procedimentos realizados.</p>;
+    const selectedUnitSubtitle =
+        variant === "booking-compact"
+            ? <p className="sectionSub">Conheça a equipe da unidade e entre no agendamento com o doutor já definido.</p>
+            : <p className="sectionSub">Conheça nossos doutores, veja seus perfis e procedimentos realizados.</p>;
 
     if (filtered === null) {
         return (
@@ -129,13 +136,93 @@ export default function UnitDoctorsGrid() {
         );
     }
 
+    if (variant === "booking-compact") {
+        return (
+            <>
+                {selectedUnitSubtitle}
+                <div className="card unitDoctorsCompact">
+                    <div className="unitDoctorsCompact__header">
+                        <div className="small unitDoctorsCompact__unit">
+                            Unidade: <span className="bookingFlow__unitName">{unit?.name ?? unitLabel}</span>
+                        </div>
+                        <div className="bookingFlow__cardSub">Escolha um doutor para abrir o agendamento com o profissional já selecionado.</div>
+                    </div>
+
+                    <div className="unitDoctorsCompact__rail" role="list" aria-label="Lista de doutores da unidade">
+                        {filtered.map((d) => {
+                            const fullName = d.name;
+                            const handle = d.instagramHandle;
+                            const href = d.instagramUrl;
+                            const instagramHandle = handle || extractInstagramHandle(href);
+                            const doctorSlug = doctorSlugFromTeamMember({ name: fullName, instagramHandle: handle });
+                            const bookingHref = unit?.slug
+                                ? `/agendamento?unit=${encodeURIComponent(unit.slug)}&doctor=${encodeURIComponent(doctorSlug)}`
+                                : "/agendamento";
+                            const openInstagram = () => {
+                                if (!instagramHandle) return;
+                                setActiveInstagram({ name: fullName, handle: instagramHandle });
+                                trackDoctorInstagramClick({
+                                    unitSlug: unit?.slug ?? null,
+                                    doctorName: fullName,
+                                    instagramUrl: href ?? `https://www.instagram.com/${instagramHandle}/`,
+                                });
+                            };
+
+                            return (
+                                <article key={`${fullName}-${href ?? "noinsta"}`} className="unitDoctorsCompact__item" role="listitem">
+                                    <Link
+                                        className="bookingFlow__doctorBadge unitDoctorsCompact__badgeLink"
+                                        href={bookingHref}
+                                        onClick={() =>
+                                            trackBookingStart({
+                                                placement: "doctor_grid",
+                                                unitSlug: unit?.slug ?? null,
+                                                doctorName: fullName,
+                                                bookingUrl: bookingHref,
+                                            })
+                                        }
+                                        aria-label={`Agendar com ${fullName}`}
+                                        title={`Agendar com ${fullName}`}
+                                    >
+                                        <span className="bookingFlow__doctorBadgeAvatar">
+                                            {instagramHandle ? (
+                                                <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={76} height={76} unoptimized />
+                                            ) : (
+                                                <span className="bookingFlow__doctorBadgeFallback">{fullName.charAt(0).toUpperCase()}</span>
+                                            )}
+                                        </span>
+                                    </Link>
+
+                                    <div className="unitDoctorsCompact__name">{fullName}</div>
+
+                                    {instagramHandle ? (
+                                        <button
+                                            type="button"
+                                            className="unitDoctorsCompact__instagram"
+                                            onClick={openInstagram}
+                                            aria-label={`Abrir Instagram de ${fullName}`}
+                                            title="Abrir Instagram"
+                                        >
+                                            <InstagramIcon size={14} />
+                                        </button>
+                                    ) : null}
+                                </article>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <DoctorInstagramModal profile={activeInstagram} onClose={() => setActiveInstagram(null)} />
+            </>
+        );
+    }
+
     return (
         <>
             {selectedUnitSubtitle}
             <div className="grid">
                 {filtered.map((d) => {
                     const fullName = d.name;
-                    const nickname = d.nickname;
                     const handle = d.instagramHandle;
                     const href = d.instagramUrl;
                     const instagramHandle = handle || extractInstagramHandle(href);
@@ -170,28 +257,24 @@ export default function UnitDoctorsGrid() {
                                     >
                                         <div style={{ width: 56, height: 56, borderRadius: 14, overflow: "hidden", background: "white" }}>
                                             {instagramHandle ? (
-                                                <Image src={avatarUrl(instagramHandle, nickname ?? fullName)} alt={nickname ?? fullName} width={56} height={56} unoptimized />
+                                                <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={56} height={56} unoptimized />
                                             ) : null}
                                         </div>
                                         <div style={{ flex: 1, minWidth: 0 }}>
                                             <h3 style={{ margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{fullName}</h3>
-                                            <p style={{ margin: 0, color: "var(--muted)", fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                                {nickname || unitLabel}
-                                            </p>
+                                            <p style={{ margin: 0, color: "var(--muted)", fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{unitLabel}</p>
                                         </div>
                                     </button>
                                 ) : (
                                     <div className="doctorCardMainLink" aria-label={fullName}>
                                         <div style={{ width: 56, height: 56, borderRadius: 14, overflow: "hidden", background: "white" }}>
                                             {instagramHandle ? (
-                                                <Image src={avatarUrl(instagramHandle, nickname ?? fullName)} alt={nickname ?? fullName} width={56} height={56} unoptimized />
+                                                <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={56} height={56} unoptimized />
                                             ) : null}
                                         </div>
                                         <div style={{ flex: 1, minWidth: 0 }}>
                                             <h3 style={{ margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{fullName}</h3>
-                                            <p style={{ margin: 0, color: "var(--muted)", fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                                {nickname || unitLabel}
-                                            </p>
+                                            <p style={{ margin: 0, color: "var(--muted)", fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{unitLabel}</p>
                                         </div>
                                     </div>
                                 )}

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -3667,6 +3667,93 @@ video.heroMediaEl {
   cursor: pointer;
 }
 
+.unitDoctorsCompact {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.unitDoctorsCompact__header {
+  display: grid;
+  gap: 4px;
+}
+
+.unitDoctorsCompact__unit {
+  color: var(--muted);
+}
+
+.unitDoctorsCompact__rail {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 8px 0 6px;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.unitDoctorsCompact__rail::-webkit-scrollbar {
+  height: 6px;
+}
+
+.unitDoctorsCompact__rail::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.22);
+  border-radius: 999px;
+}
+
+.unitDoctorsCompact__item {
+  flex: 0 0 auto;
+  width: 96px;
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.unitDoctorsCompact__badgeLink {
+  text-decoration: none;
+}
+
+.unitDoctorsCompact__badgeLink .bookingFlow__doctorBadgeAvatar {
+  width: 76px;
+  height: 76px;
+}
+
+.unitDoctorsCompact__badgeLink .bookingFlow__doctorBadgeAvatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.unitDoctorsCompact__name {
+  font-size: 13px;
+  font-weight: 900;
+  line-height: 1.15;
+  letter-spacing: -.03em;
+  text-wrap: balance;
+}
+
+.unitDoctorsCompact__instagram {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(17, 17, 17, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #111;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.unitDoctorsCompact__instagram:hover {
+  transform: translateY(-1px);
+  background: #fff;
+  border-color: rgba(17, 17, 17, 0.16);
+}
+
 .pageNarrative {
   display: grid;
   gap: 22px;


### PR DESCRIPTION
## Summary
This changes the doctors section on the homepage to use the same compact visual language as the doctor selector in the booking flow.

On the live homepage, the doctors grid was visually heavier and less consistent with the booking experience. It also surfaced doctor nicknames in places where the user asked to keep only the doctor name.

## Root cause
The homepage was still rendering the legacy `UnitDoctorsGrid` directory card layout, which uses larger stacked cards and also consumed `nickname` as part of the doctor presentation. The booking page already had a more compact, avatar-driven pattern, but that pattern was not available as a reusable variant for the homepage.

## Fix
The `UnitDoctorsGrid` component now accepts a `booking-compact` variant and the homepage uses that variant.

The compact variant:
- reuses the booking flow visual language for doctor avatars and unit emphasis
- renders a smaller horizontal doctor rail instead of the larger directory card grid
- opens booking with the selected doctor prefilled
- keeps the Instagram entry point available when the profile exists
- removes nickname usage so only the doctor name is shown

The legacy directory variant remains available for any place that still needs the larger card layout.

## Validation
- `npm run typecheck`
- `npm run lint`
