### PR TITLE
[codex] refresh insumos and escala

### DIFF
--- a/backend/apps/escala-api/migrations-d1/0003_professional_color.sql
+++ b/backend/apps/escala-api/migrations-d1/0003_professional_color.sql
@@ -1,0 +1,1 @@
+ALTER TABLE professionals ADD COLUMN color TEXT;

--- a/backend/apps/escala-api/worker.js
+++ b/backend/apps/escala-api/worker.js
@@ -188,7 +188,7 @@ async function handleOverview(env, actor) {
 
 async function handleProfessionals(env, unit, actor) {
   const res = await env.DB.prepare(
-    `select name, status, role, shift, nickname, phone, email, instagram, units_json
+    `select name, status, role, shift, nickname, phone, email, instagram, color, units_json
      from professionals
      order by name`
   ).all()
@@ -295,6 +295,7 @@ async function handleProfessionalPut(env, actor, body) {
   const phone = normalizeName(body?.phone)
   const email = normalizeName(body?.email)
   const instagram = normalizeName(body?.instagram)
+  const color = normalizeName(body?.color)
   const unitsInput = Array.isArray(body?.units) ? body.units : []
   const units = Array.from(new Set(unitsInput.map(normalizeName).filter(Boolean)))
 
@@ -333,9 +334,10 @@ async function handleProfessionalPut(env, actor, body) {
          phone = ?6,
          email = ?7,
          instagram = ?8,
-         units_json = ?9,
-         updated_at = ?10
-     where name = ?11`
+         color = ?9,
+         units_json = ?10,
+         updated_at = ?11
+     where name = ?12`
   ).bind(
     nextName,
     status || null,
@@ -345,6 +347,7 @@ async function handleProfessionalPut(env, actor, body) {
     phone || null,
     email || null,
     instagram || null,
+    color || null,
     JSON.stringify(units),
     now,
     currentName,
@@ -372,6 +375,7 @@ async function handleProfessionalPost(env, actor, body) {
   const phone = normalizeName(body?.phone)
   const email = normalizeName(body?.email)
   const instagram = normalizeName(body?.instagram)
+  const color = normalizeName(body?.color)
   const unitsInput = Array.isArray(body?.units) ? body.units : []
   const units = Array.from(new Set(unitsInput.map(normalizeName).filter(Boolean)))
 
@@ -393,8 +397,8 @@ async function handleProfessionalPost(env, actor, body) {
   const now = new Date().toISOString()
   await env.DB.prepare(
     `insert into professionals
-     (id, name, status, role, shift, nickname, phone, email, instagram, units_json, created_at, updated_at)
-     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)`
+     (id, name, status, role, shift, nickname, phone, email, instagram, color, units_json, created_at, updated_at)
+     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)`
   ).bind(
     crypto.randomUUID(),
     name,
@@ -405,6 +409,7 @@ async function handleProfessionalPost(env, actor, body) {
     phone || null,
     email || null,
     instagram || null,
+    color || null,
     JSON.stringify(units),
     now,
     now,

--- a/backend/apps/escala-api/worker.test.js
+++ b/backend/apps/escala-api/worker.test.js
@@ -60,7 +60,7 @@ class FakeD1 {
   all(sql, params) {
     const query = normalizeSql(sql)
 
-    if (query.includes('select name, status, role, shift, nickname, phone, email, instagram, units_json from professionals')) {
+    if (query.includes('select name, status, role, shift, nickname, phone, email, instagram, color, units_json from professionals')) {
       return [...this.professionals]
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((prof) => ({ ...prof }))
@@ -110,15 +110,16 @@ class FakeD1 {
         phone: params[6],
         email: params[7],
         instagram: params[8],
-        units_json: params[9],
-        created_at: params[10],
-        updated_at: params[11],
+        color: params[9],
+        units_json: params[10],
+        created_at: params[11],
+        updated_at: params[12],
       })
       return
     }
 
     if (query.startsWith('update professionals set name = ?1')) {
-      const index = this.professionals.findIndex((prof) => prof.name === params[10])
+      const index = this.professionals.findIndex((prof) => prof.name === params[11])
       if (index >= 0) {
         this.professionals[index] = {
           ...this.professionals[index],
@@ -130,8 +131,9 @@ class FakeD1 {
           phone: params[5],
           email: params[6],
           instagram: params[7],
-          units_json: params[8],
-          updated_at: params[9],
+          color: params[8],
+          units_json: params[9],
+          updated_at: params[10],
         }
       }
       return
@@ -229,6 +231,8 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
         role: 'Injetor',
         phone: '5551999999999',
         email: 'ana@local.test',
+        instagram: 'draana',
+        color: '#22c55e',
       },
     }),
     env,
@@ -237,6 +241,7 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
   assert.equal(db.professionals.length, 1)
   assert.equal(db.professionals[0].name, 'Dra. Ana')
   assert.equal(JSON.parse(db.professionals[0].units_json)[0], 'Novo Hamburgo')
+  assert.equal(db.professionals[0].color, '#22c55e')
 
   const scheduleResponse = await worker.fetch(
     await signedRequest('https://escala.local/api/escala/schedule', {
@@ -266,8 +271,10 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
         status: 'Ativo',
         units: ['Novo Hamburgo'],
         role: 'Injetor, Consultor',
-        phone: '5551888888888',
+        phone: '+55 (51) 88888-8888',
         email: 'anita@local.test',
+        instagram: 'draanita',
+        color: '#0ea5e9',
       },
     }),
     env,
@@ -289,8 +296,10 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
   assert.equal(professionalsJson.data[0].name, 'Dra. Anita')
   assert.equal(professionalsJson.data[0].status, 'Ativo')
   assert.equal(professionalsJson.data[0].role, 'Injetor, Consultor')
-  assert.equal(professionalsJson.data[0].phone, '5551888888888')
+  assert.equal(professionalsJson.data[0].phone, '+55 (51) 88888-8888')
   assert.equal(professionalsJson.data[0].email, 'anita@local.test')
+  assert.equal(professionalsJson.data[0].instagram, 'draanita')
+  assert.equal(professionalsJson.data[0].color, '#0ea5e9')
   assert.deepEqual(professionalsJson.data[0].units, ['Novo Hamburgo'])
 
   const updatedScheduleResponse = await worker.fetch(

--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -23,6 +23,156 @@ function normalizeTipo(tipo) {
   return String(tipo || '').toUpperCase().replace('Í', 'I');
 }
 
+function extractTransferFreeText(observacoes) {
+  const raw = String(observacoes || '').trim();
+  if (!raw) return '';
+  const sep = raw.indexOf(' | ');
+  return sep >= 0 ? raw.slice(sep + 3).trim() : '';
+}
+
+function buildTransferObservacoes(kind, fromUnidade, toUnidade, freeText) {
+  const tipo = normalizeTipo(kind);
+  const from = String(fromUnidade || '').trim();
+  const to = String(toUnidade || '').trim();
+  const note = String(freeText || '').trim();
+  const prefix = tipo.includes('SAIDA') ? `Transferência para ${to}` : `Transferência de ${from}`;
+  return note ? `${prefix} | ${note}` : prefix;
+}
+
+function computeMovementDelta(row) {
+  const tipo = normalizeTipo(row?.tipo);
+  if (tipo === 'AJUSTE') {
+    return toInt(row?.estoque_novo, 0) - toInt(row?.estoque_anterior, 0);
+  }
+  if (tipo.includes('ENTRADA')) return Math.max(1, toInt(row?.quantidade, 1));
+  if (tipo.includes('SAIDA')) return -Math.max(1, toInt(row?.quantidade, 1));
+  return 0;
+}
+
+async function recomputeMovementLedgerForRegistro({ env, registro, overrides = new Map() }) {
+  const reg = String(registro || '').trim();
+  if (!reg) throw new Error('Registro inválido');
+
+  const movementRows = await env.DB.prepare(
+    `SELECT
+        id,
+        data_hora,
+        tipo,
+        codigo_barras,
+        registro_insumo,
+        lote,
+        data_validade,
+        produto,
+        quantidade,
+        estoque_anterior,
+        estoque_novo,
+        unidade,
+        unidade_origem,
+        unidade_destino,
+        id_transferencia,
+        usuario,
+        motivo,
+        observacoes
+     FROM insumos_movements
+     WHERE registro_insumo = ?
+     ORDER BY data_hora ASC, id ASC`
+  ).bind(reg).all();
+
+  const rows = (movementRows?.results || []).map((row) => ({ ...row }));
+
+  const stockRows = await env.DB.prepare(
+    `SELECT unidade, quantidade
+     FROM insumos_stocks
+     WHERE registro = ?`
+  ).bind(reg).all();
+
+  const currentStockByUnit = new Map();
+  for (const row of stockRows?.results || []) {
+    const unit = String(row?.unidade || '').trim();
+    if (!unit) continue;
+    currentStockByUnit.set(unit, toInt(row?.quantidade, 0));
+  }
+
+  const historicalDeltaByUnit = new Map();
+  for (const row of rows) {
+    const unit = String(row?.unidade || '').trim();
+    if (!unit) continue;
+    historicalDeltaByUnit.set(unit, toInt(historicalDeltaByUnit.get(unit), 0) + computeMovementDelta(row));
+  }
+
+  const baseStockByUnit = new Map();
+  const allUnits = new Set([...currentStockByUnit.keys(), ...historicalDeltaByUnit.keys()]);
+  for (const unit of allUnits) {
+    const current = toInt(currentStockByUnit.get(unit), 0);
+    const delta = toInt(historicalDeltaByUnit.get(unit), 0);
+    baseStockByUnit.set(unit, current - delta);
+  }
+
+  const rowsWithOverrides = rows.map((row) => {
+    const patch = overrides instanceof Map ? overrides.get(String(row.id || '').trim()) : null;
+    return patch ? { ...row, ...patch } : row;
+  });
+
+  const nextStockByUnit = new Map(baseStockByUnit);
+  const movementUpdates = [];
+  for (const row of rowsWithOverrides) {
+    const unit = String(row?.unidade || '').trim();
+    if (!unit) continue;
+    const tipo = normalizeTipo(row?.tipo);
+    const before = toInt(nextStockByUnit.get(unit), 0);
+    let quantidade = Math.max(1, toInt(row?.quantidade, 1));
+    let after = before;
+
+    if (tipo === 'AJUSTE') {
+      after = Math.max(0, toInt(row?.estoque_novo, before));
+      quantidade = Math.abs(after - before);
+    } else if (tipo.includes('ENTRADA')) {
+      after = before + quantidade;
+    } else if (tipo.includes('SAIDA')) {
+      after = before - quantidade;
+    }
+
+    nextStockByUnit.set(unit, after);
+    movementUpdates.push({
+      id: String(row.id || '').trim(),
+      quantidade,
+      estoqueAnterior: before,
+      estoqueNovo: after,
+      motivo: String(row?.motivo || '').trim(),
+      observacoes: String(row?.observacoes || '').trim(),
+    });
+  }
+
+  const statements = [];
+  for (const row of movementUpdates) {
+    statements.push(
+      env.DB.prepare(
+        `UPDATE insumos_movements
+         SET quantidade = ?, estoque_anterior = ?, estoque_novo = ?, motivo = ?, observacoes = ?
+         WHERE id = ?`
+      ).bind(row.quantidade, row.estoqueAnterior, row.estoqueNovo, row.motivo, row.observacoes, row.id)
+    );
+  }
+
+  for (const [unit, qty] of nextStockByUnit.entries()) {
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO insumos_stocks (registro, unidade, quantidade, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(registro, unidade) DO UPDATE SET quantidade = excluded.quantidade, updated_at = excluded.updated_at`
+      ).bind(reg, unit, toInt(qty, 0), nowIso())
+    );
+  }
+
+  if (statements.length) await env.DB.batch(statements);
+
+  return {
+    registro: reg,
+    movimentos: movementUpdates,
+    estoqueAtual: Object.fromEntries(Array.from(nextStockByUnit.entries()).map(([unit, qty]) => [unit, toInt(qty, 0)])),
+  };
+}
+
 function normalizeTipoUnidade(raw) {
   const v = String(raw || '')
     .trim()
@@ -1386,6 +1536,136 @@ export async function d1Transfer({ env, body }) {
   };
 }
 
+export async function d1UpdateMovimentacao({ env, id, body }) {
+  const movementId = String(id || '').trim();
+  if (!movementId) return { ok: false, status: 400, error: 'Movimentação inválida' };
+
+  const movement = await env.DB.prepare(
+    `SELECT
+        id,
+        data_hora,
+        tipo,
+        codigo_barras,
+        registro_insumo,
+        lote,
+        data_validade,
+        produto,
+        quantidade,
+        estoque_anterior,
+        estoque_novo,
+        unidade,
+        unidade_origem,
+        unidade_destino,
+        id_transferencia,
+        usuario,
+        motivo,
+        observacoes
+     FROM insumos_movements
+     WHERE id = ?`
+  ).bind(movementId).first();
+  if (!movement) return { ok: false, status: 404, error: 'Movimentação não encontrada' };
+
+  const registro = String(movement?.registro_insumo || '').trim();
+  if (!registro) return { ok: false, status: 400, error: 'Movimentação sem registro de insumo' };
+
+  const tipo = normalizeTipo(movement?.tipo);
+  const overrides = new Map();
+
+  if (String(movement?.id_transferencia || '').trim()) {
+    const transferId = String(movement.id_transferencia || '').trim();
+    const pairRowsRes = await env.DB.prepare(
+      `SELECT
+          id,
+          tipo,
+          unidade,
+          unidade_origem,
+          unidade_destino,
+          quantidade,
+          observacoes
+       FROM insumos_movements
+       WHERE id_transferencia = ?
+       ORDER BY data_hora ASC, id ASC`
+    ).bind(transferId).all();
+    const pairRows = (pairRowsRes?.results || []).map((row) => ({ ...row }));
+    if (!pairRows.length) return { ok: false, status: 404, error: 'Transferência vinculada não encontrada' };
+
+    const quantidadeProvided = Object.prototype.hasOwnProperty.call(body || {}, 'quantidade');
+    const quantidade = quantidadeProvided ? toInt(body?.quantidade, NaN) : toInt(movement?.quantidade, 1);
+    if (!Number.isFinite(quantidade) || quantidade < 1) {
+      return { ok: false, status: 400, error: 'Quantidade inválida' };
+    }
+
+    const freeText = Object.prototype.hasOwnProperty.call(body || {}, 'observacoes')
+      ? String(body?.observacoes || '').trim()
+      : extractTransferFreeText(movement?.observacoes);
+
+    for (const row of pairRows) {
+      overrides.set(String(row.id || '').trim(), {
+        quantidade,
+        observacoes: buildTransferObservacoes(row?.tipo, row?.unidade_origem, row?.unidade_destino, freeText),
+      });
+    }
+  } else if (tipo === 'AJUSTE') {
+    const targetProvided = Object.prototype.hasOwnProperty.call(body || {}, 'estoqueNovo');
+    const motivoProvided = Object.prototype.hasOwnProperty.call(body || {}, 'motivo');
+    const observacoesProvided = Object.prototype.hasOwnProperty.call(body || {}, 'observacoes');
+    const estoqueNovo = targetProvided ? toInt(body?.estoqueNovo, NaN) : toInt(movement?.estoque_novo, NaN);
+    const motivo = motivoProvided ? String(body?.motivo || '').trim() : String(movement?.motivo || '').trim();
+    const observacoes = observacoesProvided ? String(body?.observacoes || '').trim() : String(movement?.observacoes || '').trim();
+
+    if (!Number.isFinite(estoqueNovo) || estoqueNovo < 0) {
+      return { ok: false, status: 400, error: 'Novo estoque inválido' };
+    }
+    if (!motivo) return { ok: false, status: 400, error: 'Motivo é obrigatório' };
+
+    overrides.set(movementId, { estoque_novo: estoqueNovo, motivo, observacoes });
+  } else {
+    const quantidadeProvided = Object.prototype.hasOwnProperty.call(body || {}, 'quantidade');
+    const observacoesProvided = Object.prototype.hasOwnProperty.call(body || {}, 'observacoes');
+    const quantidade = quantidadeProvided ? toInt(body?.quantidade, NaN) : toInt(movement?.quantidade, 1);
+    const observacoes = observacoesProvided ? String(body?.observacoes || '').trim() : String(movement?.observacoes || '').trim();
+    if (!Number.isFinite(quantidade) || quantidade < 1) {
+      return { ok: false, status: 400, error: 'Quantidade inválida' };
+    }
+    overrides.set(movementId, { quantidade, observacoes });
+  }
+
+  const recomputed = await recomputeMovementLedgerForRegistro({ env, registro, overrides });
+
+  const updatedRowsRes = await env.DB.prepare(
+    `SELECT
+        id,
+        data_hora AS dataHora,
+        tipo,
+        codigo_barras AS codigoBarras,
+        produto,
+        quantidade,
+        estoque_anterior AS estoqueAnterior,
+        estoque_novo AS estoqueNovo,
+        unidade,
+        unidade_origem AS unidadeOrigem,
+        unidade_destino AS unidadeDestino,
+        id_transferencia AS transferId,
+        usuario,
+        motivo,
+        observacoes,
+        registro_insumo AS registroInsumo,
+        lote,
+        data_validade AS dataValidade
+     FROM insumos_movements
+     WHERE id = ? OR (? != '' AND id_transferencia = ?)
+     ORDER BY data_hora ASC, id ASC`
+  ).bind(movementId, String(movement?.id_transferencia || '').trim(), String(movement?.id_transferencia || '').trim()).all();
+
+  return {
+    ok: true,
+    registro,
+    transferId: String(movement?.id_transferencia || '').trim() || null,
+    movimentos: updatedRowsRes?.results || [],
+    estoqueAtual: recomputed.estoqueAtual,
+  };
+}
+
 export async function d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina, limite, codigoBarras }) {
   const where = [];
   const binds = [];
@@ -1423,6 +1703,7 @@ export async function d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina,
 
   const rows = await env.DB.prepare(
     `SELECT
+        m.id AS id,
         m.data_hora AS dataHora,
         m.tipo AS tipo,
         m.codigo_barras AS codigoBarras,

--- a/backend/apps/insumos/src/routes/movimentacoes.js
+++ b/backend/apps/insumos/src/routes/movimentacoes.js
@@ -3,9 +3,17 @@
 export async function handleMovimentacoesRoutes({
     request,
     url,
+    env,
+    ctx,
     appOrigin,
     withCORS,
     unidade,
+    requireRoles,
+    appendAuditLog,
+    enqueueNotificationsRefresh,
+    ip,
+    userAgent,
+    idempotencyKey,
 
     d1,
 }) {
@@ -31,6 +39,52 @@ export async function handleMovimentacoesRoutes({
                 return withCORS(JSON.stringify({ success: true, movimentos: out.movimentos, resumo: out.resumo }), { status: 200 }, appOrigin);
             } catch (err) {
                 return withCORS(JSON.stringify({ success: false, error: err.message }), { status: 500 }, appOrigin);
+            }
+        }
+
+        if (url.pathname.startsWith("/movimentacoes/") && request.method === "PUT") {
+            try {
+                const auth = await requireRoles(['ADMIN', 'GESTOR', 'GERENTE', 'OPERADOR']);
+                if (!auth.ok) return auth.response;
+
+                const id = decodeURIComponent(url.pathname.split('/')[2] || '').trim();
+                if (!id) {
+                    return withCORS(JSON.stringify({ success: false, error: 'Movimentação inválida' }), { status: 400 }, appOrigin);
+                }
+
+                const body = await request.json().catch(() => ({}));
+                const out = await d1.updateMovimentacao({ id, body });
+                if (!out.ok) {
+                    return withCORS(JSON.stringify({ success: false, error: out.error }), { status: out.status || 400 }, appOrigin);
+                }
+
+                await appendAuditLog({
+                    env,
+                    actor: auth.user.username,
+                    role: auth.user.role,
+                    ip,
+                    userAgent,
+                    idempotencyKey,
+                    action: 'UPDATE',
+                    entity: 'MOVIMENTACAO',
+                    entityId: id,
+                    unidade: String(url.searchParams.get('unidade') || unidade || '').trim(),
+                    before: null,
+                    after: { payload: body, registro: out.registro, transferId: out.transferId || null }
+                });
+
+                if (out?.estoqueAtual && typeof out.estoqueAtual === 'object') {
+                    const units = Array.from(new Set(Object.keys(out.estoqueAtual).map((v) => String(v || '').trim()).filter(Boolean)));
+                    for (const unit of units) {
+                        ctx.waitUntil(enqueueNotificationsRefresh(env, unit));
+                    }
+                } else {
+                    ctx.waitUntil(enqueueNotificationsRefresh(env, String(url.searchParams.get('unidade') || unidade || '').trim()));
+                }
+
+                return withCORS(JSON.stringify({ success: true, data: out.movimentos || [] }), { status: 200 }, appOrigin);
+            } catch (err) {
+                return withCORS(JSON.stringify({ success: false, error: err.message || String(err || '') }), { status: 500 }, appOrigin);
             }
         }
         return null;

--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -26,6 +26,7 @@ import {
     d1Ajuste,
     d1Transfer,
     d1ListMovimentacoes,
+    d1UpdateMovimentacao,
     d1ListInsumosPaged,
     d1ListInsumosOptions,
     d1GetUserByUsername,
@@ -1479,14 +1480,23 @@ export default {
             transfer: ({ body }) => d1Transfer({ env, body }),
             listMovimentacoes: ({ unidade, tipo, de, ate, pagina, limite, codigoBarras }) =>
                 d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina, limite, codigoBarras }),
+            updateMovimentacao: ({ id, body }) => d1UpdateMovimentacao({ env, id, body }),
         };
 
         const movResp = await handleMovimentacoesRoutes({
             request,
             url,
+            env,
+            ctx,
             appOrigin,
             withCORS,
             unidade,
+            requireRoles,
+            appendAuditLog,
+            enqueueNotificationsRefresh,
+            ip,
+            userAgent,
+            idempotencyKey,
             d1,
         });
         if (movResp) return movResp;

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -392,19 +392,22 @@ function NoAttendanceChip({
   blocked?: boolean
   label?: string
 }) {
+  const text = String(label || 'Sem atendimento').trim() || 'Sem atendimento'
+
   return (
     <div
       className={cn(
-        'inline-flex h-8 w-fit items-center gap-1.5 rounded-full border px-2.5 text-[10px] font-semibold shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+        'inline-flex min-h-8 w-fit max-w-full items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-semibold shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
         blocked
           ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
           : 'border-white/10 bg-white/5 text-slate-200/80',
       )}
       data-testid={`escala-no-attendance-icon-${date}`}
-      aria-label="Sem atendimento"
-      title={label || 'Sem atendimento'}
+      aria-label={text}
+      title={text}
     >
       <CalendarX2 className="h-3.5 w-3.5" />
+      <span className="truncate">{text}</span>
     </div>
   )
 }

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -407,7 +407,7 @@ function NoAttendanceChip({
       title={text}
     >
       <CalendarX2 className="h-3.5 w-3.5" />
-      <span className="truncate">{text}</span>
+      {label ? <span className="truncate">{text}</span> : null}
     </div>
   )
 }
@@ -1180,8 +1180,9 @@ export function EscalaProfissionaisModule() {
                     ? cell.day
                     : 0
                 const adjacentTotal = cell.monthOffset === -1 ? previousMonthCellsCount : nextMonthCellsCount
-                const blockReason = dayBlockReasons[cell.date] || closedReasonByDate.get(cell.date) || ''
-                const blockBadgeLabel = String(closedReasonByDate.get(cell.date) || blockReason || '').trim() || 'Sem atendimento'
+                const localBlockReason = String(dayBlockReasons[cell.date] || '').trim()
+                const blockReason = localBlockReason || closedReasonByDate.get(cell.date) || ''
+                const blockBadgeLabel = String(blockReason || '').trim() || 'Sem atendimento'
                 const trackedCardStyle = matchesSelectedProfessional
                   ? getProfessionalCardHighlightStyle(selectedProfessional, selectedProfessionalColor)
                   : matchesHighlightMode && highlightMode === 'scheduled'
@@ -1311,7 +1312,11 @@ export function EscalaProfissionaisModule() {
                             </div>
                           ) : null}
                           {!isAdjacentMonth && !displayEntryNames.length && isBlocked ? (
-                            <NoAttendanceChip date={cell.date} blocked label={blockBadgeLabel} />
+                            <NoAttendanceChip
+                              date={cell.date}
+                              blocked
+                              label={localBlockReason ? blockBadgeLabel : undefined}
+                            />
                           ) : null}
                           {!isAdjacentMonth && !displayEntryNames.length && !isBlocked && (
                             <div className={cn(highlightMode === 'empty' && isEmptyDay && '[&_div]:border-amber-300/35 [&_div]:bg-amber-400/12 [&_div]:text-amber-50')}>

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronLeft, ChevronRight, CircleSlash, Pencil, Plus, Save, Shield, X } from 'lucide-react'
+import { CalendarX2, ChevronLeft, ChevronRight, Pencil, Plus, Save, Shield, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { Badge } from '@/badge'
 import { Button } from '@/button'
@@ -40,6 +40,7 @@ type EscalaProfessional = {
   phone: string
   email: string
   instagram: string
+  color: string
 }
 
 type EscalaScheduleEntry = { date: string; unit: string; professional: string }
@@ -55,6 +56,7 @@ const NEW_TEAM_MEMBER_KEY = '__new__'
 const STATUS_OPTIONS = ['Ativo', 'Inativo']
 const UNIT_OPTIONS = ['BarraShoppingSul', 'Novo Hamburgo']
 const ROLE_OPTIONS = ['Diretor', 'Gerente', 'Coordenador', 'Responsável Técnico', 'Injetor', 'Consultor']
+const DEFAULT_TEAM_COLOR = '#ec4899'
 
 function formatMonthLabel(value: string) {
   if (MONTH_LABELS.has(value)) return MONTH_LABELS.get(value) as string
@@ -130,6 +132,49 @@ function normalizeText(value: string) {
   return String(value || '').trim().toLowerCase()
 }
 
+function normalizeHexColor(value: string) {
+  const raw = String(value || '').trim().toLowerCase()
+  if (!raw) return ''
+  const normalized = raw.startsWith('#') ? raw : `#${raw}`
+  if (/^#[0-9a-f]{6}$/.test(normalized)) return normalized
+  if (/^#[0-9a-f]{3}$/.test(normalized)) {
+    const [, r, g, b] = normalized
+    return `#${r}${r}${g}${g}${b}${b}`
+  }
+  return ''
+}
+
+function hexToRgba(value: string, alpha: number) {
+  const hex = normalizeHexColor(value)
+  if (!hex) return `rgba(236, 72, 153, ${alpha})`
+  const red = Number.parseInt(hex.slice(1, 3), 16)
+  const green = Number.parseInt(hex.slice(3, 5), 16)
+  const blue = Number.parseInt(hex.slice(5, 7), 16)
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+}
+
+function formatBrazilPhone(value: string) {
+  const digits = String(value || '').replace(/\D/g, '')
+  if (!digits) return ''
+  const normalized = (digits.startsWith('55') ? digits : `55${digits}`).slice(0, 13)
+  const country = normalized.slice(0, 2)
+  const area = normalized.slice(2, 4)
+  const subscriber = normalized.slice(4)
+  let formatted = `+${country}`
+  if (area) {
+    formatted += ` (${area}`
+    if (area.length === 2) formatted += ')'
+  }
+  if (subscriber) {
+    const prefixLength = subscriber.length > 8 ? 5 : Math.min(4, subscriber.length)
+    const prefix = subscriber.slice(0, prefixLength)
+    const suffix = subscriber.slice(prefixLength)
+    formatted += ` ${prefix}`
+    if (suffix) formatted += `-${suffix}`
+  }
+  return formatted
+}
+
 function normalizeUnitKey(value: string) {
   return String(value || '')
     .normalize('NFD')
@@ -172,7 +217,8 @@ function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional
       nickname: '',
       phone: '',
       email: '',
-      instagram: ''
+      instagram: '',
+      color: '',
     })
   })
   return Array.from(map.values())
@@ -206,6 +252,7 @@ function normalizeProfessionalForCompare(prof: EscalaProfessional | null) {
     phone: String(prof.phone || '').trim(),
     email: String(prof.email || '').trim(),
     instagram: String(prof.instagram || '').trim(),
+    color: normalizeHexColor(prof.color),
   }
 }
 
@@ -227,17 +274,26 @@ function hashString(value: string) {
   return Math.abs(hash)
 }
 
-function getProfessionalBadgeStyle(name: string, mode: 'default' | 'active' | 'muted' = 'default') {
+function getProfessionalBadgeStyle(
+  name: string,
+  mode: 'default' | 'active' | 'muted' = 'default',
+  accentColor?: string,
+) {
+  const color = normalizeHexColor(accentColor || '')
   const hash = hashString(name)
   const hue = hash % 360
-  const baseText = `hsl(${hue} 88% 92%)`
+  const baseText = color ? 'white' : `hsl(${hue} 88% 92%)`
 
   if (mode === 'active') {
     return {
-      background: `linear-gradient(135deg, hsla(${hue}, 82%, 56%, 0.38), hsla(${(hue + 28) % 360}, 82%, 58%, 0.26))`,
-      borderColor: `hsla(${hue}, 88%, 74%, 0.9)`,
+      background: color
+        ? `linear-gradient(135deg, ${hexToRgba(color, 0.55)}, ${hexToRgba(color, 0.28)})`
+        : `linear-gradient(135deg, hsla(${hue}, 82%, 56%, 0.38), hsla(${(hue + 28) % 360}, 82%, 58%, 0.26))`,
+      borderColor: color ? hexToRgba(color, 0.92) : `hsla(${hue}, 88%, 74%, 0.9)`,
       color: 'white',
-      boxShadow: `0 0 0 1px hsla(${hue}, 90%, 74%, 0.45), 0 16px 28px hsla(${hue}, 90%, 20%, 0.28), inset 0 1px 0 rgba(255,255,255,0.18)`,
+      boxShadow: color
+        ? `0 0 0 1px ${hexToRgba(color, 0.45)}, 0 16px 28px ${hexToRgba(color, 0.28)}, inset 0 1px 0 rgba(255,255,255,0.18)`
+        : `0 0 0 1px hsla(${hue}, 90%, 74%, 0.45), 0 16px 28px hsla(${hue}, 90%, 20%, 0.28), inset 0 1px 0 rgba(255,255,255,0.18)`,
       opacity: 1,
     } as React.CSSProperties
   }
@@ -253,20 +309,29 @@ function getProfessionalBadgeStyle(name: string, mode: 'default' | 'active' | 'm
   }
 
   return {
-    background: `linear-gradient(135deg, hsla(${hue}, 78%, 56%, 0.22), hsla(${(hue + 24) % 360}, 78%, 58%, 0.14))`,
-    borderColor: `hsla(${hue}, 84%, 72%, 0.4)`,
+    background: color
+      ? `linear-gradient(135deg, ${hexToRgba(color, 0.28)}, ${hexToRgba(color, 0.16)})`
+      : `linear-gradient(135deg, hsla(${hue}, 78%, 56%, 0.22), hsla(${(hue + 24) % 360}, 78%, 58%, 0.14))`,
+    borderColor: color ? hexToRgba(color, 0.5) : `hsla(${hue}, 84%, 72%, 0.4)`,
     color: baseText,
-    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.05)',
+    boxShadow: color
+      ? `inset 0 1px 0 rgba(255,255,255,0.08), 0 0 0 1px ${hexToRgba(color, 0.12)}`
+      : 'inset 0 1px 0 rgba(255,255,255,0.05)',
     opacity: 1,
   } as React.CSSProperties
 }
 
-function getProfessionalCardHighlightStyle(name: string) {
+function getProfessionalCardHighlightStyle(name: string, accentColor?: string) {
+  const color = normalizeHexColor(accentColor || '')
   const hue = hashString(name) % 360
   return {
-    borderColor: `hsla(${hue}, 88%, 74%, 0.72)`,
-    background: `linear-gradient(180deg, hsla(${hue}, 86%, 54%, 0.12), rgba(15, 23, 42, 0.34))`,
-    boxShadow: `0 0 0 1px hsla(${hue}, 88%, 74%, 0.25), 0 18px 34px hsla(${hue}, 90%, 18%, 0.24), inset 0 1px 0 rgba(255,255,255,0.06)`,
+    borderColor: color ? hexToRgba(color, 0.78) : `hsla(${hue}, 88%, 74%, 0.72)`,
+    background: color
+      ? `linear-gradient(180deg, ${hexToRgba(color, 0.18)}, rgba(15, 23, 42, 0.34))`
+      : `linear-gradient(180deg, hsla(${hue}, 86%, 54%, 0.12), rgba(15, 23, 42, 0.34))`,
+    boxShadow: color
+      ? `0 0 0 1px ${hexToRgba(color, 0.24)}, 0 18px 34px ${hexToRgba(color, 0.24)}, inset 0 1px 0 rgba(255,255,255,0.06)`
+      : `0 0 0 1px hsla(${hue}, 88%, 74%, 0.25), 0 18px 34px hsla(${hue}, 90%, 18%, 0.24), inset 0 1px 0 rgba(255,255,255,0.06)`,
   } as React.CSSProperties
 }
 
@@ -314,7 +379,34 @@ function createEmptyProfessional(selectedUnit?: string): EscalaProfessional {
     phone: '',
     email: '',
     instagram: '',
+    color: '',
   }
+}
+
+function NoAttendanceChip({
+  date,
+  blocked,
+  label,
+}: {
+  date: string
+  blocked?: boolean
+  label?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'inline-flex h-8 w-fit items-center gap-1.5 rounded-full border px-2.5 text-[10px] font-semibold shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+        blocked
+          ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
+          : 'border-white/10 bg-white/5 text-slate-200/80',
+      )}
+      data-testid={`escala-no-attendance-icon-${date}`}
+      aria-label="Sem atendimento"
+      title={label || 'Sem atendimento'}
+    >
+      <CalendarX2 className="h-3.5 w-3.5" />
+    </div>
+  )
 }
 
 type MultiSelectFieldProps = {
@@ -516,6 +608,10 @@ export function EscalaProfissionaisModule() {
   const visibleInjectors = useMemo(() => professionalsByUnit.filter(isVisibleInjector), [professionalsByUnit])
   const activeInjectors = useMemo(() => visibleInjectors.filter(isActiveInjector), [visibleInjectors])
   const inactiveInjectors = useMemo(() => visibleInjectors.filter(isInactiveInjector), [visibleInjectors])
+  const professionalMap = useMemo(
+    () => new Map(mergedProfessionals.map((prof) => [prof.name, prof])),
+    [mergedProfessionals],
+  )
   const professionalOptions = useMemo(() => uniqueNames(activeInjectors.map((prof) => prof.name)), [activeInjectors])
   const headerProfessionalOptions = useMemo(
     () => uniqueNames(selectedProfessional !== ALL_PROFESSIONALS_OPTION ? [...professionalOptions, selectedProfessional] : professionalOptions),
@@ -587,7 +683,8 @@ export function EscalaProfissionaisModule() {
         normalizedDraft.nickname ||
         normalizedDraft.phone ||
         normalizedDraft.email ||
-        normalizedDraft.instagram
+        normalizedDraft.instagram ||
+        normalizedDraft.color
       )
     }
     const base = normalizeProfessionalForCompare(selectedTeamMemberBase)
@@ -869,7 +966,13 @@ export function EscalaProfissionaisModule() {
         ...prev,
         [draftKey]: {
           ...current,
-          [field]: field === 'units' ? parseUnitsInput(value) : value
+          [field]: field === 'units'
+            ? parseUnitsInput(value)
+            : field === 'phone'
+              ? formatBrazilPhone(value)
+              : field === 'color'
+                ? normalizeHexColor(value)
+                : value
         }
       }
     })
@@ -961,6 +1064,7 @@ export function EscalaProfissionaisModule() {
       phone: normalizedDraft.phone || '',
       email: normalizedDraft.email || '',
       instagram: normalizedDraft.instagram || '',
+      color: normalizedDraft.color || '',
     }
     const res = teamFormMode === 'add'
       ? await addEscalaProfessional(payload)
@@ -1064,6 +1168,9 @@ export function EscalaProfissionaisModule() {
                 const isAdjacentMonth = cell.monthOffset !== 0
                 const isPrevMonthShortcut = index === firstCurrentMonthIndex - 1
                 const isNextMonthShortcut = cell.monthOffset === 1 && cell.day === 1
+                const selectedProfessionalColor = selectedProfessional !== ALL_PROFESSIONALS_OPTION
+                  ? professionalMap.get(selectedProfessional)?.color
+                  : ''
                 const adjacentPosition = cell.monthOffset === -1
                   ? index + 1
                   : cell.monthOffset === 1
@@ -1071,9 +1178,9 @@ export function EscalaProfissionaisModule() {
                     : 0
                 const adjacentTotal = cell.monthOffset === -1 ? previousMonthCellsCount : nextMonthCellsCount
                 const blockReason = dayBlockReasons[cell.date] || closedReasonByDate.get(cell.date) || ''
-                const blockBadgeLabel = String(closedReasonByDate.get(cell.date) || blockReason || '').trim() || 'Sem Atendimento'
+                const blockBadgeLabel = String(closedReasonByDate.get(cell.date) || blockReason || '').trim() || 'Sem atendimento'
                 const trackedCardStyle = matchesSelectedProfessional
-                  ? getProfessionalCardHighlightStyle(selectedProfessional)
+                  ? getProfessionalCardHighlightStyle(selectedProfessional, selectedProfessionalColor)
                   : matchesHighlightMode && highlightMode === 'scheduled'
                     ? {
                         borderColor: 'rgba(125, 211, 252, 0.68)',
@@ -1175,6 +1282,7 @@ export function EscalaProfissionaisModule() {
                               {displayEntryNames.map((name) => {
                                 const isActiveSelection = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name === selectedProfessional
                                 const isMuted = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name !== selectedProfessional
+                                const accentColor = professionalMap.get(name)?.color
                                 return (
                                   <button
                                     key={`${cell.date}__${name}`}
@@ -1186,7 +1294,7 @@ export function EscalaProfissionaisModule() {
                                       isActiveSelection && 'escala-entry-pill--active',
                                       isMuted && 'escala-entry-pill--muted',
                                     )}
-                                    style={getProfessionalBadgeStyle(name, isActiveSelection ? 'active' : (isMuted ? 'muted' : 'default'))}
+                                    style={getProfessionalBadgeStyle(name, isActiveSelection ? 'active' : (isMuted ? 'muted' : 'default'), accentColor)}
                                     onClick={(event) => {
                                       event.stopPropagation()
                                       focusProfessional(name)
@@ -1200,21 +1308,11 @@ export function EscalaProfissionaisModule() {
                             </div>
                           ) : null}
                           {!isAdjacentMonth && !displayEntryNames.length && isBlocked ? (
-                            <Badge variant="outline" className="max-w-full border-rose-200/35 bg-rose-500/16 px-1.5 py-0.5 text-[10px] text-rose-50">
-                              {blockBadgeLabel}
-                            </Badge>
+                            <NoAttendanceChip date={cell.date} blocked label={blockBadgeLabel} />
                           ) : null}
                           {!isAdjacentMonth && !displayEntryNames.length && !isBlocked && (
-                            <div
-                              className={cn(
-                                'inline-flex w-fit items-center rounded-full border border-white/10 bg-white/5 px-1.5 py-0.5 text-slate-300/80',
-                                highlightMode === 'empty' && isEmptyDay && 'border-amber-300/35 bg-amber-400/12 text-amber-50'
-                              )}
-                              data-testid={`escala-empty-day-icon-${cell.date}`}
-                              aria-label="Sem atendimento"
-                              title="Sem atendimento"
-                            >
-                              <CircleSlash className="h-3.5 w-3.5" />
+                            <div className={cn(highlightMode === 'empty' && isEmptyDay && '[&_div]:border-amber-300/35 [&_div]:bg-amber-400/12 [&_div]:text-amber-50')}>
+                              <NoAttendanceChip date={cell.date} label="Sem atendimento" />
                             </div>
                           )}
                           {!isAdjacentMonth && holidayLabels.length ? (
@@ -1308,7 +1406,7 @@ export function EscalaProfissionaisModule() {
                             'rounded-full border px-3 py-1.5 text-[11px] font-medium transition-all',
                             isCurrent ? 'text-white shadow-[0_14px_26px_rgba(15,23,42,0.24)]' : 'text-slate-200/80 hover:text-white'
                           )}
-                          style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default')}
+                          style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default', prof.color)}
                           onClick={() => selectTeamMember(prof.name)}
                           data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
                         >
@@ -1449,9 +1547,46 @@ export function EscalaProfissionaisModule() {
                         <Input
                           value={selectedTeamMemberDraft.phone}
                           onChange={(event) => updateSelectedTeamMemberField('phone', event.target.value)}
+                          placeholder="+55 (51) 99999-9999"
                           className="h-10 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
                           data-testid="escala-team-field-phone"
                         />
+                      </label>
+
+                      <label className="space-y-1.5">
+                        <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                          INSTAGRAM
+                        </span>
+                        <Input
+                          value={selectedTeamMemberDraft.instagram}
+                          onChange={(event) => updateSelectedTeamMemberField('instagram', event.target.value)}
+                          className="h-10 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                          data-testid="escala-team-field-instagram"
+                        />
+                      </label>
+
+                      <label className="space-y-1.5">
+                        <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                          COR
+                        </span>
+                        <div className="flex h-10 items-center gap-3 rounded-md border border-white/10 bg-white/[0.05] px-3">
+                          <input
+                            type="color"
+                            value={normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                            onChange={(event) => updateSelectedTeamMemberField('color', event.target.value)}
+                            className="h-7 w-10 cursor-pointer rounded border-0 bg-transparent p-0"
+                            data-testid="escala-team-field-color"
+                            aria-label="Escolher cor do injetor"
+                          />
+                          <div
+                            className="h-5 w-5 rounded-full border border-white/20"
+                            style={{ background: normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR }}
+                            aria-hidden="true"
+                          />
+                          <span className="text-xs text-slate-300/75">
+                            {normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                          </span>
+                        </div>
                       </label>
 
                     </div>
@@ -1556,7 +1691,7 @@ export function EscalaProfissionaisModule() {
                         'flex min-w-0 cursor-pointer items-center gap-2 rounded-xl border px-2 py-1.5 text-xs transition-all',
                         checked ? 'shadow-[0_10px_24px_rgba(15,23,42,0.18)]' : 'bg-white/[0.03]',
                       )}
-                      style={getProfessionalBadgeStyle(name, checked ? 'active' : 'default')}
+                      style={getProfessionalBadgeStyle(name, checked ? 'active' : 'default', professionalMap.get(name)?.color)}
                     >
                       <Checkbox
                         checked={checked}

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -59,6 +59,7 @@ type Insumo = {
 }
 
 type Movimentacao = {
+  id?: string
   dataHora?: string
   tipo?: string
   codigoBarras?: string
@@ -591,6 +592,17 @@ function fmtDateOnlyBR(value?: string | null) {
   if (/^\d{2}\/\d{2}\/\d{4}$/.test(v)) return v
   const iso = dateInputToIso(v)
   return iso ? isoToBrDate(iso) : v
+}
+
+function normalizeMovimentacaoTipo(value?: string | null) {
+  return String(value || '').toUpperCase().replace('Í', 'I')
+}
+
+function extractTransferMovementNote(value?: string | null) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+  const sep = raw.indexOf(' | ')
+  return sep >= 0 ? raw.slice(sep + 3).trim() : ''
 }
 
 function statusBadgeVariant(status?: string): 'default' | 'secondary' | 'destructive' {
@@ -1155,6 +1167,8 @@ export function InsumosModule() {
   const [insumosTotal, setInsumosTotal] = React.useState<number | null>(null)
   const [insumosHasMore, setInsumosHasMore] = React.useState(false)
   const insumosRef = React.useRef<Insumo[]>([])
+  const insumosCacheRef = React.useRef<Map<string, Map<string, Insumo>>>(new Map())
+  const [insumosCacheVersion, setInsumosCacheVersion] = React.useState(0)
   const [selectedCodigoBarras, setSelectedCodigoBarras] = React.useState('')
   const [createOpen, setCreateOpen] = React.useState(false)
   const [createScanOpen, setCreateScanOpen] = React.useState(false)
@@ -1249,6 +1263,13 @@ export function InsumosModule() {
   >('dataHora')
   const [movSortDir, setMovSortDir] = React.useState<'asc' | 'desc'>('desc')
   const movListContainerRef = React.useRef<HTMLDivElement | null>(null)
+  const [editMovOpen, setEditMovOpen] = React.useState(false)
+  const [editMovTarget, setEditMovTarget] = React.useState<Movimentacao | null>(null)
+  const [editMovQuantidade, setEditMovQuantidade] = React.useState('1')
+  const [editMovNovoEstoque, setEditMovNovoEstoque] = React.useState('')
+  const [editMovObservacoes, setEditMovObservacoes] = React.useState('')
+  const [editMovMotivo, setEditMovMotivo] = React.useState('')
+  const [editMovSaving, setEditMovSaving] = React.useState(false)
 
   // Backups/auditoria foram movidos para o módulo Status do sistema.
 
@@ -1613,6 +1634,59 @@ export function InsumosModule() {
     },
     [DashboardLoadingButton, isAuthed, renderLoadingText, shouldShowDashboardLoading]
   )
+
+  const upsertInsumosCache = React.useCallback((items: Insumo[]) => {
+    if (!Array.isArray(items) || !items.length) return
+    let changed = false
+    for (const it of items) {
+      const codes = getInsumoBarcodes(it)
+      if (!codes.length) continue
+      const registro = String(it?.registro || '').trim() || `__no_registro__:${codes[0]}`
+      for (const codigo of codes) {
+        let byRegistro = insumosCacheRef.current.get(codigo)
+        if (!byRegistro) {
+          byRegistro = new Map<string, Insumo>()
+          insumosCacheRef.current.set(codigo, byRegistro)
+        }
+        const prev = byRegistro.get(registro)
+        if (!prev) {
+          byRegistro.set(registro, it)
+          changed = true
+          continue
+        }
+        const merged: Insumo = {
+          ...prev,
+          ...it,
+          estoques: { ...(prev.estoques || {}), ...(it.estoques || {}) },
+          statusValidade: it.statusValidade || prev.statusValidade
+        }
+        byRegistro.set(registro, merged)
+        changed = true
+      }
+    }
+    if (changed) setInsumosCacheVersion((v) => v + 1)
+  }, [])
+
+  const readCachedInsumosByCodigo = React.useCallback(
+    ({ codigoBarras, ctxUnidade }: { codigoBarras: string; ctxUnidade: string }) => {
+      const codigo = String(codigoBarras || '').trim()
+      if (!codigo) return []
+      const byRegistro = insumosCacheRef.current.get(codigo)
+      if (!byRegistro || !byRegistro.size) return []
+      return Array.from(byRegistro.values()).map((item) => {
+        const unit = String(ctxUnidade || '').trim()
+        if (!unit || !item?.estoques) return item
+        const stockForUnit = Number(item.estoques?.[unit])
+        if (!Number.isFinite(stockForUnit)) return item
+        return { ...item, estoqueAtual: stockForUnit }
+      })
+    },
+    []
+  )
+
+  React.useEffect(() => {
+    upsertInsumosCache(insumos || [])
+  }, [insumos, upsertInsumosCache])
 
   const visibleMainPanels = React.useMemo(() => {
     const allowed = new Set(DEFAULT_MAIN_PANELS)
@@ -2217,7 +2291,9 @@ export function InsumosModule() {
           })
           const out = await apiJson<{ success?: boolean; data?: Insumo[] }>(`/insumos?${params.toString()}`)
           if (token !== quickSearchRemoteTokenRef.current) return
-          setQuickSearchRemote(Array.isArray(out?.data) ? out.data : [])
+          const items = Array.isArray(out?.data) ? out.data : []
+          if (items.length) upsertInsumosCache(items)
+          setQuickSearchRemote(items)
         } catch (e: any) {
           if (token !== quickSearchRemoteTokenRef.current) return
           const message = e?.message || 'Falha ao buscar insumos.'
@@ -2235,7 +2311,7 @@ export function InsumosModule() {
       })()
     }, 250)
     return () => window.clearTimeout(t)
-  }, [apiJson, canUseApi, isAuthed, quickOp, quickSearch, transferFrom, unidade])
+  }, [apiJson, canUseApi, isAuthed, quickOp, quickSearch, transferFrom, unidade, upsertInsumosCache])
 
   React.useEffect(() => {
     const query = quickSearch.trim()
@@ -2345,6 +2421,8 @@ export function InsumosModule() {
     async ({ codigoBarras, ctxUnidade }: { codigoBarras: string; ctxUnidade: string }) => {
       const codigo = String(codigoBarras || '').trim()
       if (!codigo) return []
+      const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
+      if (cached.length) return cached
       const params = new URLSearchParams({
         unidade: ctxUnidade,
         q: codigo,
@@ -2353,10 +2431,11 @@ export function InsumosModule() {
       })
       const out = await apiJson<{ success?: boolean; data?: Insumo[]; resumo?: any }>(`/insumos?${params.toString()}`)
       const list = Array.isArray(out?.data) ? out.data : []
+      if (list.length) upsertInsumosCache(list)
       const exact = list.filter((i) => getInsumoBarcodes(i).includes(codigo))
       return exact.length ? exact : list
     },
-    [apiJson]
+    [apiJson, readCachedInsumosByCodigo, upsertInsumosCache]
   )
 
   const lookupInsumosByCodigos = React.useCallback(
@@ -2364,14 +2443,26 @@ export function InsumosModule() {
       const list = Array.isArray(codigosBarras) ? codigosBarras : []
       const cleaned = Array.from(new Set(list.map((v) => String(v || '').trim()).filter(Boolean)))
       if (!cleaned.length) return []
+      const cachedItems = cleaned.flatMap((codigo) => readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade }))
+      const cachedCodes = new Set(cachedItems.flatMap((item) => getInsumoBarcodes(item)))
+      const missingCodes = cleaned.filter((codigo) => !cachedCodes.has(codigo))
+      if (!missingCodes.length) return cachedItems
       const params = new URLSearchParams({ unidade: ctxUnidade })
       const out = await apiJson<{ success?: boolean; data?: Insumo[] }>(`/insumos/lookup?${params.toString()}`, {
         method: 'POST',
-        body: { codigos: cleaned }
+        body: { codigos: missingCodes }
       })
-      return Array.isArray(out?.data) ? out.data : []
+      const fetched = Array.isArray(out?.data) ? out.data : []
+      if (fetched.length) upsertInsumosCache(fetched)
+      const deduped = new Map<string, Insumo>()
+      for (const item of [...cachedItems, ...fetched]) {
+        const key = String(item?.registro || '').trim() || getInsumoBarcodes(item).join('|')
+        if (!key) continue
+        deduped.set(key, item)
+      }
+      return Array.from(deduped.values())
     },
-    [apiJson]
+    [apiJson, readCachedInsumosByCodigo, upsertInsumosCache]
   )
 
   React.useEffect(() => {
@@ -2387,6 +2478,15 @@ export function InsumosModule() {
       return
     }
     const ctxUnidade = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
+    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
+    if (cached.length) {
+      setQuickLookupLoading(false)
+      setQuickLookupError(null)
+      setQuickLookupItems(cached)
+      setQuickLookupCode(codigo)
+      setQuickLookupCtxUnidade(ctxUnidade)
+      return
+    }
     const token = ++quickLookupTokenRef.current
     setQuickLookupLoading(true)
     setQuickLookupError(null)
@@ -2418,7 +2518,7 @@ export function InsumosModule() {
 	    }, 250)
 
     return () => window.clearTimeout(t)
-  }, [canUseApi, isAuthed, lookupInsumosByCodigo, quickCodigo, quickOp, transferFrom, unidade])
+  }, [canUseApi, isAuthed, lookupInsumosByCodigo, quickCodigo, quickOp, readCachedInsumosByCodigo, transferFrom, unidade])
 
   const createLookupApplyPrefill = React.useCallback((items: Insumo[]) => {
     const it = Array.isArray(items) && items.length ? items[0] : null
@@ -2465,6 +2565,14 @@ export function InsumosModule() {
       setCreateLookupItems([])
       return
     }
+    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade: unidade })
+    if (cached.length) {
+      setCreateLookupLoading(false)
+      setCreateLookupError(null)
+      setCreateLookupItems(cached)
+      createLookupApplyPrefill(cached)
+      return
+    }
     const token = ++createLookupTokenRef.current
     setCreateLookupLoading(true)
     setCreateLookupError(null)
@@ -2486,7 +2594,7 @@ export function InsumosModule() {
 	      })()
 	    }, 250)
     return () => window.clearTimeout(t)
-  }, [canUseApi, createCodigo, createLookupApplyPrefill, createOpen, isAuthed, lookupInsumosByCodigo, unidade])
+  }, [canUseApi, createCodigo, createLookupApplyPrefill, createOpen, isAuthed, lookupInsumosByCodigo, readCachedInsumosByCodigo, unidade])
 
   React.useEffect(() => {
     if (!quickOp) return
@@ -3342,6 +3450,22 @@ export function InsumosModule() {
     setEditOpen(true)
   }, [getPolicyForItem])
 
+  const openMovementEditDialog = React.useCallback((m: Movimentacao) => {
+    const movementId = String(m?.id || '').trim()
+    if (!movementId) {
+      toast.error('Movimentação sem identificador para edição.')
+      return
+    }
+    const tipo = normalizeMovimentacaoTipo(m?.tipo)
+    setEditMovTarget(m)
+    setEditMovQuantidade(String(Math.max(1, Number(m?.quantidade) || 1)))
+    setEditMovNovoEstoque(String(Number.isFinite(Number(m?.estoqueNovo)) ? Number(m.estoqueNovo) : 0))
+    setEditMovObservacoes(m?.transferId ? extractTransferMovementNote(m?.observacoes) : String(m?.observacoes || ''))
+    setEditMovMotivo(String(m?.motivo || ''))
+    if (tipo !== 'AJUSTE') setEditMovMotivo('')
+    setEditMovOpen(true)
+  }, [])
+
   const openQualityFix = React.useCallback(
     async (issue: QualityIssue) => {
       if (!isAuthed) {
@@ -4059,6 +4183,84 @@ export function InsumosModule() {
 	    [autoSyncSuspendedUntil, insightsLoaded, loadInsights, loadOverview, overviewLoaded]
 	  )
 
+  const saveMovementEdit = React.useCallback(async () => {
+    const target = editMovTarget
+    const movementId = String(target?.id || '').trim()
+    if (!movementId) {
+      toast.error('Movimentação inválida.')
+      return
+    }
+    if (!canUseApi || !isAuthed) return
+
+    const tipo = normalizeMovimentacaoTipo(target?.tipo)
+    const body: Record<string, unknown> = {
+      observacoes: editMovObservacoes.trim()
+    }
+
+    if (String(target?.transferId || '').trim()) {
+      const quantidade = parseInt(editMovQuantidade, 10)
+      if (!Number.isFinite(quantidade) || quantidade < 1) {
+        toast.error('Informe uma quantidade válida.')
+        return
+      }
+      body.quantidade = quantidade
+    } else if (tipo === 'AJUSTE') {
+      const estoqueNovo = parseInt(editMovNovoEstoque, 10)
+      if (!Number.isFinite(estoqueNovo) || estoqueNovo < 0) {
+        toast.error('Informe o novo estoque.')
+        return
+      }
+      const motivo = editMovMotivo.trim()
+      if (!motivo) {
+        toast.error('Informe o motivo do ajuste.')
+        return
+      }
+      body.estoqueNovo = estoqueNovo
+      body.motivo = motivo
+    } else {
+      const quantidade = parseInt(editMovQuantidade, 10)
+      if (!Number.isFinite(quantidade) || quantidade < 1) {
+        toast.error('Informe uma quantidade válida.')
+        return
+      }
+      body.quantidade = quantidade
+    }
+
+    setEditMovSaving(true)
+    try {
+      await mutateJson<{ success?: boolean }>(
+        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(String(target?.unidade || unidade || '').trim() || unidade)}`,
+        {
+          method: 'PUT',
+          body,
+          queueLabel: 'Edição de movimentação'
+        }
+      )
+      toast.success('Lançamento atualizado.')
+      setEditMovOpen(false)
+      setEditMovTarget(null)
+      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+      schedulePostMutationRefresh({ overview: true, insights: true })
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e))
+    } finally {
+      setEditMovSaving(false)
+    }
+  }, [
+    canUseApi,
+    editMovMotivo,
+    editMovNovoEstoque,
+    editMovObservacoes,
+    editMovQuantidade,
+    editMovTarget,
+    isAuthed,
+    loadMovimentacoes,
+    mutateJson,
+    refreshInsumos,
+    schedulePostMutationRefresh,
+    unidade
+  ])
+
   const runQuickAction = React.useCallback(
     async (kind: 'ENTRADA' | 'BAIXA' | 'AJUSTE'): Promise<boolean> => {
       if (!canUseApi || !isAuthed) return false
@@ -4395,45 +4597,6 @@ export function InsumosModule() {
   }, [canUseApi, insumosLimite, insumosQuery, isAuthed, loadInsumosPaged, unidade])
 
   const filteredInsumos = insumos
-
-  const insumosCacheRef = React.useRef<Map<string, Map<string, Insumo>>>(new Map())
-  const [insumosCacheVersion, setInsumosCacheVersion] = React.useState(0)
-
-  const upsertInsumosCache = React.useCallback((items: Insumo[]) => {
-    if (!Array.isArray(items) || !items.length) return
-    let changed = false
-    for (const it of items) {
-      const codes = getInsumoBarcodes(it)
-      if (!codes.length) continue
-      const registro = String(it?.registro || '').trim() || `__no_registro__:${codes[0]}`
-      for (const codigo of codes) {
-        let byRegistro = insumosCacheRef.current.get(codigo)
-        if (!byRegistro) {
-          byRegistro = new Map<string, Insumo>()
-          insumosCacheRef.current.set(codigo, byRegistro)
-        }
-        const prev = byRegistro.get(registro)
-        if (!prev) {
-          byRegistro.set(registro, it)
-          changed = true
-          continue
-        }
-        const merged: Insumo = {
-          ...prev,
-          ...it,
-          estoques: { ...(prev.estoques || {}), ...(it.estoques || {}) },
-          statusValidade: it.statusValidade || prev.statusValidade
-        }
-        byRegistro.set(registro, merged)
-        changed = true
-      }
-    }
-    if (changed) setInsumosCacheVersion((v) => v + 1)
-  }, [])
-
-  React.useEffect(() => {
-    upsertInsumosCache(insumos || [])
-  }, [insumos, upsertInsumosCache])
 
   const selectedInsumo = React.useMemo(() => {
     const code = selectedCodigoBarras.trim()
@@ -6236,7 +6399,7 @@ export function InsumosModule() {
         open={quickOp != null}
         onOpenChange={(open) => {
           if (open) return
-          resetQuickOperationState({ keepFeedback: !!quickActionFeedback })
+          resetQuickOperationState()
           setQuickOp(null)
         }}
       >
@@ -6546,6 +6709,18 @@ export function InsumosModule() {
                 onClose={() => setQuickScanOpen(false)}
               />
             ) : null}
+
+            {quickActionFeedback ? (
+              <div
+                className={`rounded-lg border px-3 py-2 text-sm ${
+                  quickActionFeedback.type === 'success'
+                    ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                    : 'border-red-400/40 bg-red-500/10 text-red-100'
+                }`}
+              >
+                {quickActionFeedback.message}
+              </div>
+            ) : null}
           </div>
 
           <DialogFooter>
@@ -6565,7 +6740,6 @@ export function InsumosModule() {
                   const ok = await runTransfer()
                   if (ok) {
                     resetQuickOperationState({ keepFeedback: true })
-                    setQuickOp(null)
                   }
                 }}
                 disabled={quickActionLoading || !isAuthed}
@@ -6594,7 +6768,6 @@ export function InsumosModule() {
                   const ok = await runQuickAction(quickOp === 'ENTRADA' ? 'ENTRADA' : 'BAIXA')
                   if (ok) {
                     resetQuickOperationState({ keepFeedback: true })
-                    setQuickOp(null)
                   }
                 }}
                 disabled={quickActionLoading || !isAuthed}
@@ -6615,28 +6788,99 @@ export function InsumosModule() {
       </Dialog>
 
       <Dialog
-        open={!!quickActionFeedback}
+        open={editMovOpen}
         onOpenChange={(open) => {
-          if (!open) setQuickActionFeedback(null)
+          setEditMovOpen(open)
+          if (!open) {
+            setEditMovTarget(null)
+            setEditMovSaving(false)
+          }
         }}
       >
         <DialogContent className={`${dialogSmallClass} dark bg-corporate-900 border-white/10 text-white`}>
           <DialogHeader>
             <DialogTitle className="text-white">
-              {quickActionFeedback?.type === 'success' ? 'Sucesso' : 'Falha'}
+              {(() => {
+                const tipo = normalizeMovimentacaoTipo(editMovTarget?.tipo)
+                if (String(editMovTarget?.transferId || '').trim()) return 'Editar transferência'
+                if (tipo === 'AJUSTE') return 'Editar ajuste'
+                if (tipo.includes('ENTRADA')) return 'Editar entrada'
+                if (tipo.includes('SAIDA')) return 'Editar saída'
+                return 'Editar lançamento'
+              })()}
             </DialogTitle>
             <DialogDescription className="text-blue-100/70">
-              {quickActionFeedback?.type === 'success'
-                ? 'A operacao foi registrada.'
-                : 'Nao foi possivel concluir a operacao.'}
+              Edite os dados do lançamento sem abrir o cadastro do insumo.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-lg border border-white/10 bg-black/30 px-3 py-3 text-sm text-blue-50">
-            {quickActionFeedback?.message || '-'}
+
+          <div className="space-y-3">
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-blue-100/80">
+              <div><span className="text-blue-200/60">Produto:</span> {String(editMovTarget?.produto || '-')}</div>
+              <div><span className="text-blue-200/60">Data:</span> {fmtDate(editMovTarget?.dataHora) || '-'}</div>
+              <div>
+                <span className="text-blue-200/60">Unidade:</span>{' '}
+                {String(editMovTarget?.transferId || '').trim()
+                  ? `${unidadeLabel(String(editMovTarget?.unidadeOrigem || ''))} → ${unidadeLabel(String(editMovTarget?.unidadeDestino || ''))}`
+                  : unidadeLabel(String(editMovTarget?.unidade || unidade))}
+              </div>
+              {editMovTarget?.registroInsumo ? (
+                <div><span className="text-blue-200/60">Registro:</span> <span className="font-mono">{String(editMovTarget.registroInsumo)}</span></div>
+              ) : null}
+            </div>
+
+            {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <div>
+                  <div className="text-xs text-blue-200/70 mb-1">Novo estoque</div>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={editMovNovoEstoque}
+                    onChange={(e) => setEditMovNovoEstoque(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <div className="text-xs text-blue-200/70 mb-1">Motivo</div>
+                  <Input value={editMovMotivo} onChange={(e) => setEditMovMotivo(e.target.value)} />
+                </div>
+              </div>
+            ) : (
+              <div>
+                <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
+                <Input
+                  type="number"
+                  min={1}
+                  value={editMovQuantidade}
+                  onChange={(e) => setEditMovQuantidade(e.target.value)}
+                />
+              </div>
+            )}
+
+            <div>
+              <div className="text-xs text-blue-200/70 mb-1">Observações</div>
+              <Textarea
+                value={editMovObservacoes}
+                onChange={(e) => setEditMovObservacoes(e.target.value)}
+                placeholder="opcional"
+                rows={3}
+              />
+            </div>
           </div>
+
           <DialogFooter>
-            <Button variant="secondary" onClick={() => setQuickActionFeedback(null)}>
-              Fechar
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setEditMovOpen(false)
+                setEditMovTarget(null)
+              }}
+              disabled={editMovSaving}
+            >
+              Cancelar
+            </Button>
+            <Button onClick={() => void saveMovementEdit()} disabled={editMovSaving || !isAuthed}>
+              {editMovSaving ? 'Salvando...' : 'Salvar lançamento'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -9381,11 +9625,8 @@ export function InsumosModule() {
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => {
-                              if (insumo) openEditDialog(insumo)
-                              else if (codigoBarras) openInsumosListModal({ codigoBarras })
-                            }}
-                            disabled={!isAuthed || !codigoBarras}
+                            onClick={() => openMovementEditDialog(m)}
+                            disabled={!isAuthed || !String(m.id || '').trim()}
                           >
                             Editar
                           </Button>

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -33,9 +33,9 @@ test.describe('escala', () => {
 	        body: JSON.stringify({
 	          ok: true,
 	          data: [
-	            { name: 'Dra. Ana', status: 'Ativo', units: ['novo-hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' },
-	            { name: 'Bruna', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Consultor', shift: '', nickname: '', phone: '', email: '', instagram: '' },
-	            { name: 'Carla', status: 'Inativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' }
+	            { name: 'Dra. Ana', status: 'Ativo', units: ['novo-hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+	            { name: 'Bruna', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Consultor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '' },
+	            { name: 'Carla', status: 'Inativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#ef4444' }
 	          ]
 	        })
 	      })
@@ -60,14 +60,15 @@ test.describe('escala', () => {
     await expect(page.getByTestId('escala-day-2026-03-05')).toBeVisible()
     await expect(page.getByText('Dra. Ana').first()).toBeVisible()
     await expect(page.getByText('Dia do Cliente').first()).toBeVisible()
-    await expect(page.getByTestId('escala-day-2026-03-10')).toContainText('Feriado local')
+    await expect(page.getByTestId('escala-no-attendance-icon-2026-03-10')).toBeVisible()
+    await expect(page.getByTestId('escala-day-2026-03-10')).not.toContainText('Feriado local')
     await expect(page.getByTestId('escala-team-member-dra-ana')).toBeVisible()
     await expect(page.getByTestId('escala-team-member-bruna')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-member-carla')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-inactive-toggle')).toContainText('Inativos (1)')
     await page.getByTestId('escala-team-inactive-toggle').click()
     await expect(page.getByTestId('escala-team-member-carla')).toBeVisible()
-    await expect(page.getByTestId('escala-empty-day-icon-2026-03-01')).toBeVisible()
+    await expect(page.getByTestId('escala-no-attendance-icon-2026-03-01')).toBeVisible()
 
     await page.getByRole('combobox', { name: '' }).nth(3).click()
     await expect(page.getByRole('option', { name: 'Dra. Ana' })).toBeVisible()
@@ -116,8 +117,8 @@ test.describe('escala', () => {
         body: JSON.stringify({
           ok: true,
           data: [
-            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' },
-            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' }
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' }
           ]
         })
       })
@@ -220,8 +221,8 @@ test.describe('escala', () => {
         body: JSON.stringify({
           ok: true,
           data: [
-            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' },
-            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '' }
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' }
           ]
         })
       })
@@ -282,7 +283,8 @@ test.describe('escala', () => {
         nickname: 'Ana',
         phone: '',
         email: 'ana@local.test',
-        instagram: 'draana'
+        instagram: 'draana',
+        color: '#22c55e'
       }
     ]
     let scheduleState = {
@@ -337,7 +339,8 @@ test.describe('escala', () => {
           nickname: payload.nickname,
           phone: payload.phone,
           email: payload.email,
-          instagram: payload.instagram
+          instagram: payload.instagram,
+          color: payload.color
         }]
         scheduleState = {
           ...scheduleState,
@@ -390,7 +393,8 @@ test.describe('escala', () => {
     await expect(page.getByTestId('escala-team-close')).toBeVisible()
     await expect(page.getByTestId('escala-team-field-shift')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-field-nickname')).toHaveCount(0)
-    await expect(page.getByTestId('escala-team-field-instagram')).toHaveCount(0)
+    await expect(page.getByTestId('escala-team-field-instagram')).toHaveValue('draana')
+    await expect(page.getByTestId('escala-team-field-color')).toHaveValue('#22c55e')
     const calendarPanelAfterEdit = await page.getByTestId('escala-calendar-panel').boundingBox()
     const teamPanelAfterEdit = await page.getByTestId('escala-team-panel').boundingBox()
     const teamPanelOverflowAfterEdit = await page.getByTestId('escala-team-panel').evaluate((element) => ({
@@ -409,6 +413,8 @@ test.describe('escala', () => {
     await expect(page.getByTestId('escala-team-field-name')).toHaveValue('Dra. Ana')
     await page.getByTestId('escala-team-field-name').fill('Dra. Anita')
     await page.getByTestId('escala-team-field-phone').fill('5551999999999')
+    await page.getByTestId('escala-team-field-instagram').fill('draanita')
+    await page.getByTestId('escala-team-field-color').fill('#0ea5e9')
     await page.getByTestId('escala-team-save').click()
 
     await expect.poll(() => professionalPayloads).toEqual([
@@ -420,9 +426,10 @@ test.describe('escala', () => {
         role: 'Injetor',
         shift: 'Manhã',
         nickname: 'Ana',
-        phone: '5551999999999',
+        phone: '+55 (51) 99999-9999',
         email: 'ana@local.test',
-        instagram: 'draana'
+        instagram: 'draanita',
+        color: '#0ea5e9'
       }
     ])
 
@@ -443,7 +450,8 @@ test.describe('escala', () => {
         nickname: 'Ana',
         phone: '',
         email: 'ana@local.test',
-        instagram: 'draana'
+        instagram: 'draana',
+        color: '#22c55e'
       }
     ]
 
@@ -510,9 +518,13 @@ test.describe('escala', () => {
     await page.getByRole('option', { name: 'Inativo' }).click()
     await expect(page.getByTestId('escala-team-field-shift')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-field-nickname')).toHaveCount(0)
-    await expect(page.getByTestId('escala-team-field-instagram')).toHaveCount(0)
+    await expect(page.getByTestId('escala-team-field-instagram')).toHaveValue('')
+    await expect(page.getByTestId('escala-team-field-color')).toHaveValue('#ec4899')
     await page.getByTestId('escala-team-field-role').click()
     await page.getByTestId('escala-team-field-role-injetor').click()
+    await page.getByTestId('escala-team-field-phone').fill('51999999999')
+    await page.getByTestId('escala-team-field-instagram').fill('paulanova')
+    await page.getByTestId('escala-team-field-color').fill('#f97316')
     await page.getByTestId('escala-team-save').click()
 
     await expect.poll(() => professionalPayloads).toEqual([
@@ -523,9 +535,10 @@ test.describe('escala', () => {
         role: 'Injetor',
         shift: '',
         nickname: '',
-        phone: '',
+        phone: '+55 (51) 99999-9999',
         email: '',
-        instagram: ''
+        instagram: 'paulanova',
+        color: '#f97316'
       }
     ])
 

--- a/frontend/escalaApi.ts
+++ b/frontend/escalaApi.ts
@@ -103,6 +103,7 @@ export async function updateEscalaProfessional(payload: {
   phone: string
   email: string
   instagram: string
+  color: string
 }) {
   return apiWrite<{ ok: boolean }>(`/professionals`, 'PUT', payload)
 }
@@ -117,6 +118,7 @@ export async function addEscalaProfessional(payload: {
   phone: string
   email: string
   instagram: string
+  color: string
 }) {
   return apiWrite<{ ok: boolean }>(`/professionals`, 'POST', payload)
 }

--- a/frontend/functions/api/escala/[[path]].ts
+++ b/frontend/functions/api/escala/[[path]].ts
@@ -90,6 +90,7 @@ type LocalProfessional = {
   phone: string
   email: string
   instagram: string
+  color: string
 }
 
 type LocalScheduleEntry = { date: string; unit: string; professional: string }
@@ -213,6 +214,7 @@ function getEscalaLocalStore(): EscalaLocalStore {
         phone: '',
         email: 'ana@local.test',
         instagram: '',
+        color: '',
       },
       {
         name: 'Dr. Lucas',
@@ -224,6 +226,7 @@ function getEscalaLocalStore(): EscalaLocalStore {
         phone: '',
         email: 'lucas@local.test',
         instagram: '',
+        color: '',
       },
       {
         name: 'Dra. Carla',
@@ -235,6 +238,7 @@ function getEscalaLocalStore(): EscalaLocalStore {
         phone: '',
         email: 'carla@local.test',
         instagram: '',
+        color: '',
       },
     ],
     schedule: [],
@@ -516,6 +520,63 @@ async function handleLocalEscalaRequest(
       return prof.units.some((u) => canUseUnit(actor, u))
     })
     return done(200, { ok: true, data: visible, source: 'local-mock' })
+  }
+
+  if (rest === '/professionals' && method === 'POST') {
+    const payload = await readJson(request)
+    const name = String(payload?.name || '').trim()
+    const unitsInput = Array.isArray(payload?.units) ? payload.units : []
+    const nextUnits: string[] = Array.from(new Set(unitsInput.map((item) => String(item || '').trim()).filter(Boolean)))
+    if (!name) return done(400, { ok: false, error: 'INVALID_PAYLOAD' })
+    if (store.professionals.some((prof) => prof.name === name)) {
+      return done(409, { ok: false, error: 'PROFESSIONAL_ALREADY_EXISTS' })
+    }
+    store.professionals.push({
+      name,
+      status: String(payload?.status || '').trim(),
+      units: nextUnits,
+      role: String(payload?.role || '').trim(),
+      shift: String(payload?.shift || '').trim(),
+      nickname: String(payload?.nickname || '').trim(),
+      phone: String(payload?.phone || '').trim(),
+      email: String(payload?.email || '').trim(),
+      instagram: String(payload?.instagram || '').trim(),
+      color: String(payload?.color || '').trim(),
+    })
+    return done(200, { ok: true, source: 'local-mock' })
+  }
+
+  if (rest === '/professionals' && method === 'PUT') {
+    const payload = await readJson(request)
+    const currentName = String(payload?.currentName || '').trim()
+    const nextName = String(payload?.name || '').trim()
+    const unitsInput = Array.isArray(payload?.units) ? payload.units : []
+    const nextUnits: string[] = Array.from(new Set(unitsInput.map((item) => String(item || '').trim()).filter(Boolean)))
+    if (!currentName || !nextName) return done(400, { ok: false, error: 'INVALID_PAYLOAD' })
+    const index = store.professionals.findIndex((prof) => prof.name === currentName)
+    if (index < 0) return done(404, { ok: false, error: 'PROFESSIONAL_NOT_FOUND' })
+    if (currentName !== nextName && store.professionals.some((prof) => prof.name === nextName)) {
+      return done(409, { ok: false, error: 'PROFESSIONAL_ALREADY_EXISTS' })
+    }
+    store.professionals[index] = {
+      ...store.professionals[index],
+      name: nextName,
+      status: String(payload?.status || '').trim(),
+      units: nextUnits,
+      role: String(payload?.role || '').trim(),
+      shift: String(payload?.shift || '').trim(),
+      nickname: String(payload?.nickname || '').trim(),
+      phone: String(payload?.phone || '').trim(),
+      email: String(payload?.email || '').trim(),
+      instagram: String(payload?.instagram || '').trim(),
+      color: String(payload?.color || '').trim(),
+    }
+    if (currentName !== nextName) {
+      store.schedule = store.schedule.map((row) => (
+        row.professional === currentName ? { ...row, professional: nextName } : row
+      ))
+    }
+    return done(200, { ok: true, source: 'local-mock' })
   }
 
   if (rest === '/schedule' && method === 'GET') {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -165,6 +165,7 @@ type LocalProfessional = {
   phone: string
   email: string
   instagram: string
+  color: string
 }
 
 type LocalScheduleEntry = { date: string; unit: string; professional: string }
@@ -210,7 +211,8 @@ const localEscalaStore: {
       nickname: 'Ana',
       phone: '',
       email: 'ana@local.test',
-      instagram: ''
+      instagram: '',
+      color: ''
     },
     {
       name: 'Dr. Lucas',
@@ -221,7 +223,8 @@ const localEscalaStore: {
       nickname: 'Lucas',
       phone: '',
       email: 'lucas@local.test',
-      instagram: ''
+      instagram: '',
+      color: ''
     },
     {
       name: 'Dra. Carla',
@@ -232,7 +235,8 @@ const localEscalaStore: {
       nickname: 'Carla',
       phone: '',
       email: 'carla@local.test',
-      instagram: ''
+      instagram: '',
+      color: ''
     }
   ],
   schedule: [],
@@ -789,6 +793,7 @@ async function maybeHandleLocalEscala(req: any, res: any): Promise<boolean> {
         phone: String(payload?.phone || '').trim(),
         email: String(payload?.email || '').trim(),
         instagram: String(payload?.instagram || '').trim(),
+        color: String(payload?.color || '').trim(),
       })
       toJson(res, 200, { ok: true, source: 'local-mock' }, { 'x-request-id': requestId })
       return true
@@ -823,6 +828,7 @@ async function maybeHandleLocalEscala(req: any, res: any): Promise<boolean> {
         phone: String(payload?.phone || '').trim(),
         email: String(payload?.email || '').trim(),
         instagram: String(payload?.instagram || '').trim(),
+        color: String(payload?.color || '').trim(),
       }
       if (currentName !== nextName) {
         localEscalaStore.schedule = localEscalaStore.schedule.map((row) => (

--- a/website/src/components/DoctorInstagramModal.tsx
+++ b/website/src/components/DoctorInstagramModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 
@@ -32,6 +33,22 @@ export type DoctorInstagramProfile = {
 };
 
 const INSTAGRAM_PAGE_SIZE = 9;
+const FOCUSABLE_SELECTORS = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getInstagramMediaLabel(item: InstagramMedia): string {
+    if (item.isStory) return "Story";
+    if (item.isReel) return "Reel";
+    if (item.mediaType === "video") return "Vídeo";
+    if (item.mediaType === "carousel") return "Carrossel";
+    return "Post";
+}
 
 async function sleep(ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
@@ -73,6 +90,19 @@ async function fetchInstagramFeed(params: {
     return null;
 }
 
+function formatInstagramDate(timestampMs: number | null): string | null {
+    if (!timestampMs || !Number.isFinite(timestampMs)) return null;
+    try {
+        return new Intl.DateTimeFormat("pt-BR", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+        }).format(new Date(timestampMs));
+    } catch {
+        return null;
+    }
+}
+
 export function InstagramIcon(props: { size?: number }) {
     const size = props.size ?? 16;
     return (
@@ -92,6 +122,8 @@ export default function DoctorInstagramModal(props: {
     const { profile, onClose } = props;
     const [instagramItems, setInstagramItems] = useState<InstagramMedia[]>([]);
     const [instagramUserId, setInstagramUserId] = useState<string | null>(null);
+    const [instagramUserName, setInstagramUserName] = useState<string | null>(null);
+    const [instagramUserBio, setInstagramUserBio] = useState<string | null>(null);
     const [instagramNextCursor, setInstagramNextCursor] = useState<string | null>(null);
     const [instagramHasMore, setInstagramHasMore] = useState(false);
     const [instagramLoading, setInstagramLoading] = useState(false);
@@ -101,22 +133,8 @@ export default function DoctorInstagramModal(props: {
     const [instagramReloadToken, setInstagramReloadToken] = useState(0);
     const instagramScrollRef = useRef<HTMLDivElement | null>(null);
     const instagramInfiniteSentinelRef = useRef<HTMLDivElement | null>(null);
-
-    useEffect(() => {
-        if (!profile) return;
-
-        function onKeyDown(event: KeyboardEvent) {
-            if (event.key !== "Escape") return;
-            if (activeInstagramMediaId) {
-                setActiveInstagramMediaId(null);
-                return;
-            }
-            onClose();
-        }
-
-        document.addEventListener("keydown", onKeyDown);
-        return () => document.removeEventListener("keydown", onKeyDown);
-    }, [activeInstagramMediaId, onClose, profile]);
+    const modalCardRef = useRef<HTMLDivElement | null>(null);
+    const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
     const loadMoreInstagram = useCallback(async () => {
         if (!profile || !instagramUserId || !instagramNextCursor || instagramLoadingMore) return;
@@ -161,6 +179,8 @@ export default function DoctorInstagramModal(props: {
             setInstagramError(null);
             setInstagramItems([]);
             setInstagramUserId(null);
+            setInstagramUserName(null);
+            setInstagramUserBio(null);
             setInstagramNextCursor(null);
             setInstagramHasMore(false);
             setActiveInstagramMediaId(null);
@@ -180,6 +200,8 @@ export default function DoctorInstagramModal(props: {
 
                 setInstagramItems(Array.isArray(json.items) ? json.items : []);
                 setInstagramUserId(json.user?.id || null);
+                setInstagramUserName(json.user?.name || null);
+                setInstagramUserBio(json.user?.bio || null);
                 setInstagramNextCursor(json.nextCursor ?? null);
                 setInstagramHasMore(Boolean(json.hasMore && json.nextCursor));
             } catch {
@@ -205,9 +227,82 @@ export default function DoctorInstagramModal(props: {
         if (activeInstagramMediaIndex < 0) return null;
         return instagramItems[activeInstagramMediaIndex] ?? null;
     }, [activeInstagramMediaIndex, instagramItems]);
+    const activeInstagramMediaDate = useMemo(() => formatInstagramDate(activeInstagramMedia?.takenAtMs ?? null), [activeInstagramMedia?.takenAtMs]);
 
     const hasPrevInstagramMedia = activeInstagramMediaIndex > 0;
     const hasNextInstagramMedia = activeInstagramMediaIndex >= 0 && activeInstagramMediaIndex < instagramItems.length - 1;
+
+    useEffect(() => {
+        if (!profile) return;
+
+        const previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        window.setTimeout(() => closeButtonRef.current?.focus(), 0);
+
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === "Escape") {
+                if (activeInstagramMediaId) {
+                    setActiveInstagramMediaId(null);
+                    return;
+                }
+                onClose();
+                return;
+            }
+
+            if (!activeInstagramMediaId) return;
+
+            if (event.key === "ArrowLeft" && hasPrevInstagramMedia) {
+                event.preventDefault();
+                setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex - 1]?.id ?? null);
+            }
+
+            if (event.key === "ArrowRight" && hasNextInstagramMedia) {
+                event.preventDefault();
+                setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex + 1]?.id ?? null);
+            }
+
+            if (event.key === "Tab") {
+                const container = modalCardRef.current;
+                if (!container) return;
+                const focusableElements = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+                    (element) => !element.hasAttribute("disabled") && element.tabIndex !== -1,
+                );
+                if (focusableElements.length === 0) return;
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+                const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+                if (event.shiftKey && activeElement === firstElement) {
+                    event.preventDefault();
+                    lastElement.focus();
+                } else if (!event.shiftKey && activeElement === lastElement) {
+                    event.preventDefault();
+                    firstElement.focus();
+                }
+            }
+        }
+
+        document.addEventListener("keydown", onKeyDown);
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            document.removeEventListener("keydown", onKeyDown);
+            previousActiveElement?.focus?.();
+        };
+    }, [activeInstagramMediaId, activeInstagramMediaIndex, hasNextInstagramMedia, hasPrevInstagramMedia, instagramItems, onClose, profile]);
+
+    useEffect(() => {
+        if (!activeInstagramMediaId) return;
+        if (instagramScrollRef.current) instagramScrollRef.current.scrollTop = 0;
+    }, [activeInstagramMediaId]);
+
+    useEffect(() => {
+        if (!activeInstagramMediaId || !instagramHasMore || instagramLoadingMore) return;
+        if (activeInstagramMediaIndex < 0) return;
+        if (activeInstagramMediaIndex >= instagramItems.length - 3) {
+            void loadMoreInstagram();
+        }
+    }, [activeInstagramMediaId, activeInstagramMediaIndex, instagramHasMore, instagramItems.length, instagramLoadingMore, loadMoreInstagram]);
 
     useEffect(() => {
         if (!profile || !instagramHasMore || instagramLoading || instagramLoadingMore) return;
@@ -234,6 +329,9 @@ export default function DoctorInstagramModal(props: {
 
     if (!profile) return null;
 
+    const profileUrl = `https://www.instagram.com/${profile.handle}/`;
+    const activeInstagramMediaUrl = activeInstagramMedia?.permalink || profileUrl;
+
     return (
         <div
             className="modalOverlay"
@@ -244,13 +342,16 @@ export default function DoctorInstagramModal(props: {
                 if (event.target === event.currentTarget) onClose();
             }}
         >
-            <div className="modalCard instagramModalCard">
+            <div className="modalCard instagramModalCard" ref={modalCardRef}>
                 <div className="modalHeader">
                     <div>
                         <div className="modalTitle">{profile.name}</div>
-                        <div className="modalSubtitle">@{profile.handle}</div>
+                        <div className="modalSubtitle">
+                            @{profile.handle}
+                            {instagramUserName && instagramUserName !== profile.name ? <span className="instagramHeaderMeta">· {instagramUserName}</span> : null}
+                        </div>
                     </div>
-                    <button className="modalClose" type="button" onClick={onClose} aria-label="Fechar">
+                    <button className="modalClose" type="button" onClick={onClose} aria-label="Fechar" ref={closeButtonRef}>
                         ×
                     </button>
                 </div>
@@ -277,97 +378,182 @@ export default function DoctorInstagramModal(props: {
 
                     {activeInstagramMedia ? (
                         <div className="instagramViewer">
-                            <div className="instagramViewerTop">
-                                <button className="btn btnGhost instagramViewerBack" type="button" onClick={() => setActiveInstagramMediaId(null)}>
-                                    Voltar ao grid
-                                </button>
-                                <div className="instagramViewerNav">
-                                    <button
-                                        className="btn btnGhost instagramViewerStep"
-                                        type="button"
-                                        disabled={!hasPrevInstagramMedia}
-                                        onClick={() => {
-                                            if (!hasPrevInstagramMedia) return;
-                                            setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex - 1]?.id ?? null);
-                                        }}
+                            <div className="instagramViewerShell">
+                                <div className="instagramViewerStage">
+                                    <div
+                                        className="instagramViewerMediaWrap"
+                                        style={
+                                            {
+                                                "--instagram-viewer-image": `url("${activeInstagramMedia.thumbnailUrl}")`,
+                                            } as CSSProperties
+                                        }
                                     >
-                                        Anterior
-                                    </button>
-                                    <button
-                                        className="btn btnGhost instagramViewerStep"
-                                        type="button"
-                                        disabled={!hasNextInstagramMedia}
-                                        onClick={() => {
-                                            if (!hasNextInstagramMedia) return;
-                                            setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex + 1]?.id ?? null);
-                                        }}
-                                    >
-                                        Próximo
-                                    </button>
+                                        {hasPrevInstagramMedia ? (
+                                            <button
+                                                className="instagramViewerArrow instagramViewerArrow--left"
+                                                type="button"
+                                                onClick={() => setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex - 1]?.id ?? null)}
+                                                aria-label="Ver publicação anterior"
+                                            >
+                                                ‹
+                                            </button>
+                                        ) : null}
+
+                                        {activeInstagramMedia.mediaType === "video" && activeInstagramMedia.videoUrl ? (
+                                            <video
+                                                className="instagramViewerMedia"
+                                                src={activeInstagramMedia.videoUrl}
+                                                poster={activeInstagramMedia.thumbnailUrl}
+                                                controls
+                                                playsInline
+                                                preload="metadata"
+                                            />
+                                        ) : (
+                                            <Image
+                                                className="instagramViewerMedia"
+                                                src={activeInstagramMedia.thumbnailUrl}
+                                                alt={`Publicação de ${profile.name}`}
+                                                width={1400}
+                                                height={1400}
+                                                loading="lazy"
+                                                unoptimized
+                                            />
+                                        )}
+
+                                        {hasNextInstagramMedia ? (
+                                            <button
+                                                className="instagramViewerArrow instagramViewerArrow--right"
+                                                type="button"
+                                                onClick={() => setActiveInstagramMediaId(instagramItems[activeInstagramMediaIndex + 1]?.id ?? null)}
+                                                aria-label="Ver próxima publicação"
+                                            >
+                                                ›
+                                            </button>
+                                        ) : null}
+                                    </div>
                                 </div>
-                            </div>
 
-                            <div className="instagramViewerMediaWrap">
-                                {activeInstagramMedia.mediaType === "video" && activeInstagramMedia.videoUrl ? (
-                                    <video
-                                        className="instagramViewerMedia"
-                                        src={activeInstagramMedia.videoUrl}
-                                        poster={activeInstagramMedia.thumbnailUrl}
-                                        controls
-                                        playsInline
-                                        preload="metadata"
-                                    />
-                                ) : (
-                                    <Image
-                                        className="instagramViewerMedia"
-                                        src={activeInstagramMedia.thumbnailUrl}
-                                        alt={`Publicação de ${profile.name}`}
-                                        width={1200}
-                                        height={1200}
-                                        loading="lazy"
-                                        unoptimized
-                                    />
-                                )}
-                            </div>
+                                <aside className="instagramViewerSidebar">
+                                    <div className="instagramViewerTop">
+                                        <div className="instagramViewerMeta">
+                                            <span className="instagramViewerBadge">{getInstagramMediaLabel(activeInstagramMedia)}</span>
+                                            <span className="instagramViewerCounter">
+                                                {activeInstagramMediaIndex + 1} de {instagramItems.length}
+                                            </span>
+                                        </div>
+                                        <div className="instagramViewerNav">
+                                            <button className="btn btnGhost instagramViewerBack" type="button" onClick={() => setActiveInstagramMediaId(null)}>
+                                                Ver grade
+                                            </button>
+                                        </div>
+                                    </div>
 
-                            {activeInstagramMedia.caption ? <p className="instagramViewerCaption">{activeInstagramMedia.caption}</p> : null}
+                                    <div className="instagramViewerCopy">
+                                        <div className="instagramViewerHandleRow">
+                                            <div className="instagramViewerHandle">@{profile.handle}</div>
+                                            {activeInstagramMediaDate ? <div className="instagramViewerDate">{activeInstagramMediaDate}</div> : null}
+                                        </div>
+                                        {activeInstagramMedia.caption ? (
+                                            <p className="instagramViewerCaption">{activeInstagramMedia.caption}</p>
+                                        ) : (
+                                            <p className="instagramViewerCaption instagramViewerCaption--muted">
+                                                Sem legenda pública nesta publicação.
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    <div className="modalActions">
+                                        <a className="btn btnPrimary" href={activeInstagramMediaUrl} target="_blank" rel="noreferrer">
+                                            Ver no Instagram
+                                        </a>
+                                        <a className="btn btnGhost" href={profileUrl} target="_blank" rel="noreferrer">
+                                            Abrir perfil
+                                        </a>
+                                    </div>
+
+                                    <div className="instagramViewerThumbs" aria-label="Outras publicações">
+                                        {instagramItems.map((item, index) => (
+                                            <button
+                                                key={item.id}
+                                                type="button"
+                                                className={`instagramViewerThumb ${activeInstagramMediaId === item.id ? "instagramViewerThumb--active" : ""}`.trim()}
+                                                onClick={() => setActiveInstagramMediaId(item.id)}
+                                                aria-label={`Abrir ${getInstagramMediaLabel(item).toLowerCase()} ${index + 1}`}
+                                            >
+                                                <Image
+                                                    className="instagramViewerThumbImage"
+                                                    src={item.thumbnailUrl}
+                                                    alt=""
+                                                    width={120}
+                                                    height={120}
+                                                    loading="lazy"
+                                                    unoptimized
+                                                />
+                                                {item.isReel || item.mediaType !== "image" ? (
+                                                    <span className="instagramViewerThumbBadge">{getInstagramMediaLabel(item)}</span>
+                                                ) : null}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </aside>
+                            </div>
                         </div>
                     ) : null}
 
-                    {instagramItems.length > 0 ? (
-                        <div className="instagramGrid">
-                            {instagramItems.map((item) => {
-                                const label = item.isStory
-                                    ? "Story"
-                                    : item.isReel
-                                      ? "Reel"
-                                      : item.mediaType === "video"
-                                        ? "Vídeo"
-                                        : item.mediaType === "carousel"
-                                          ? "Carrossel"
-                                          : "Post";
-                                return (
-                                    <button
-                                        key={item.id}
-                                        type="button"
-                                        className={`instagramMediaBtn ${activeInstagramMediaId === item.id ? "instagramMediaBtn--active" : ""}`.trim()}
-                                        onClick={() => setActiveInstagramMediaId(item.id)}
-                                        aria-label={`Abrir ${label.toLowerCase()} de ${profile.name}`}
-                                    >
-                                        <Image
-                                            className="instagramMediaThumb"
-                                            src={item.thumbnailUrl}
-                                            alt={`Publicação de ${profile.name}`}
-                                            width={320}
-                                            height={320}
-                                            loading="lazy"
-                                            unoptimized
-                                        />
-                                        {label !== "Post" ? <span className="instagramMediaBadge">{label}</span> : null}
-                                    </button>
-                                );
-                            })}
-                        </div>
+                    {instagramItems.length > 0 && !activeInstagramMedia ? (
+                        <>
+                            <div className="instagramGalleryIntro">
+                                <div className="instagramGalleryIntroCopy">
+                                    <div className="instagramGalleryEyebrow">Galeria do Instagram</div>
+                                    <p className="instagramGalleryLead">
+                                        Toque em qualquer publicação para abrir um viewer com navegação lateral, atalhos de teclado e acesso direto ao Instagram.
+                                    </p>
+                                    {instagramUserBio ? <p className="instagramGalleryBio">{instagramUserBio}</p> : null}
+                                </div>
+                                <div className="instagramGalleryStats" aria-label="Resumo do perfil">
+                                    <div className="instagramGalleryStat">
+                                        <strong>{instagramItems.length}</strong>
+                                        <span>itens carregados</span>
+                                    </div>
+                                    <div className="instagramGalleryStat">
+                                        <strong>{instagramHasMore ? "Ao vivo" : "Completo"}</strong>
+                                        <span>{instagramHasMore ? "mais publicações disponíveis" : "feed carregado"}</span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="instagramGrid">
+                                {instagramItems.map((item) => {
+                                    const label = getInstagramMediaLabel(item);
+                                    const itemDate = formatInstagramDate(item.takenAtMs);
+                                    return (
+                                        <button
+                                            key={item.id}
+                                            type="button"
+                                            className={`instagramMediaBtn ${activeInstagramMediaId === item.id ? "instagramMediaBtn--active" : ""}`.trim()}
+                                            onClick={() => setActiveInstagramMediaId(item.id)}
+                                            aria-label={`Abrir ${label.toLowerCase()} de ${profile.name}`}
+                                        >
+                                            <Image
+                                                className="instagramMediaThumb"
+                                                src={item.thumbnailUrl}
+                                                alt={`Publicação de ${profile.name}`}
+                                                width={320}
+                                                height={320}
+                                                loading="lazy"
+                                                unoptimized
+                                            />
+                                            <span className="instagramMediaOverlay" aria-hidden="true">
+                                                <span className="instagramMediaOverlayLabel">{label}</span>
+                                                <span className="instagramMediaOverlayAction">Abrir</span>
+                                            </span>
+                                            {label !== "Post" ? <span className="instagramMediaBadge">{label}</span> : null}
+                                            {itemDate ? <span className="instagramMediaDate">{itemDate}</span> : null}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </>
                     ) : null}
 
                     {instagramError && instagramItems.length > 0 ? (
@@ -388,7 +574,7 @@ export default function DoctorInstagramModal(props: {
 
                     {instagramHasMore ? <div className="instagramInfiniteSentinel" ref={instagramInfiniteSentinelRef} aria-hidden="true" /> : null}
                     {instagramLoadingMore ? <div className="instagramLoadingMoreInline">Carregando mais publicações…</div> : null}
-                    <div className="modalNote">Posts, reels e stories são exibidos dentro desta janela para manter você no site.</div>
+                    <div className="modalNote">Posts, reels e stories são exibidos dentro desta janela para manter você no site. Use `Esc` para fechar e as setas do teclado para navegar.</div>
                 </div>
             </div>
         </div>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -2579,6 +2579,79 @@ video.heroMediaEl {
   gap: 10px;
 }
 
+.instagramGalleryIntro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.08), transparent 30%),
+    rgba(255, 255, 255, 0.04);
+}
+
+.instagramGalleryIntroCopy {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.instagramGalleryEyebrow {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.instagramGalleryLead,
+.instagramGalleryBio {
+  margin: 0;
+}
+
+.instagramGalleryLead {
+  max-width: 58ch;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.instagramGalleryBio {
+  max-width: 62ch;
+  font-size: 13px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.62);
+  white-space: pre-wrap;
+}
+
+.instagramGalleryStats {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.instagramGalleryStat {
+  min-width: 132px;
+  display: grid;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.instagramGalleryStat strong {
+  font-size: 18px;
+  line-height: 1.1;
+}
+
+.instagramGalleryStat span {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.62);
+}
+
 .instagramMediaBtn {
   position: relative;
   appearance: none;
@@ -2589,6 +2662,18 @@ video.heroMediaEl {
   margin: 0;
   background: rgba(255, 255, 255, 0.04);
   cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.instagramMediaBtn:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.26);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.instagramMediaBtn:hover .instagramMediaOverlay,
+.instagramMediaBtn:focus-visible .instagramMediaOverlay {
+  opacity: 1;
 }
 
 .instagramMediaBtn--active {
@@ -2603,6 +2688,33 @@ video.heroMediaEl {
   background: rgba(255, 255, 255, 0.05);
 }
 
+.instagramMediaOverlay {
+  position: absolute;
+  inset: auto 10px 10px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(7, 7, 8, 0.18), rgba(7, 7, 8, 0.72));
+  backdrop-filter: blur(10px);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.instagramMediaOverlayLabel,
+.instagramMediaOverlayAction,
+.instagramMediaDate {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.instagramMediaOverlayAction {
+  color: rgba(255, 255, 255, 0.72);
+}
+
 .instagramMediaBadge {
   position: absolute;
   top: 8px;
@@ -2615,24 +2727,119 @@ video.heroMediaEl {
   background: rgba(0, 0, 0, 0.58);
 }
 
+.instagramMediaDate {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.42);
+}
+
 .instagramViewer {
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 14px;
-  padding: 10px;
-  background: rgba(255, 255, 255, 0.04);
+  padding: 12px;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 34%),
+    rgba(255, 255, 255, 0.04);
+}
+
+.instagramViewerShell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.8fr);
+  gap: 14px;
+  align-items: stretch;
+}
+
+.instagramViewerStage {
+  min-width: 0;
 }
 
 .instagramViewerTop {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
-  margin-bottom: 10px;
+}
+
+.instagramViewerMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.instagramViewerBadge,
+.instagramViewerCounter,
+.instagramViewerThumbBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.instagramViewerBadge,
+.instagramViewerThumbBadge {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.96);
+}
+
+.instagramViewerCounter {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .instagramViewerNav {
   display: flex;
   gap: 8px;
+}
+
+.instagramViewerSidebar {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.instagramViewerCopy {
+  display: grid;
+  gap: 8px;
+}
+
+.instagramViewerHandle {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.instagramViewerHandleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.instagramViewerDate {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.instagramHeaderMeta {
+  margin-left: 6px;
+  color: rgba(255, 255, 255, 0.52);
 }
 
 .instagramViewerBack,
@@ -2649,26 +2856,135 @@ video.heroMediaEl {
 }
 
 .instagramViewerMediaWrap {
-  border-radius: 12px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: clamp(340px, 62vh, 720px);
+  padding: 22px;
+  border-radius: 18px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.05);
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.instagramViewerMediaWrap::before,
+.instagramViewerMediaWrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.instagramViewerMediaWrap::before {
+  background-image: var(--instagram-viewer-image);
+  background-position: center;
+  background-size: cover;
+  filter: blur(36px) saturate(0.95);
+  transform: scale(1.08);
+  opacity: 0.52;
+}
+
+.instagramViewerMediaWrap::after {
+  background: linear-gradient(180deg, rgba(9, 9, 10, 0.12), rgba(9, 9, 10, 0.44));
+}
+
+.instagramViewerArrow {
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  width: 46px;
+  height: 46px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(9, 9, 10, 0.52);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 28px;
+  line-height: 1;
+  transform: translateY(-50%);
+  backdrop-filter: blur(10px);
+}
+
+.instagramViewerArrow--left {
+  left: 16px;
+}
+
+.instagramViewerArrow--right {
+  right: 16px;
 }
 
 .instagramViewerMedia {
+  position: relative;
+  z-index: 1;
   display: block;
-  width: 100%;
-  max-height: 64vh;
+  width: auto;
+  max-width: min(100%, 620px);
+  max-height: min(70vh, 720px);
   height: auto;
   object-fit: contain;
-  background: #0c0c0d;
+  border-radius: 20px;
+  background: rgba(12, 12, 13, 0.18);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
 }
 
 .instagramViewerCaption {
-  margin: 10px 2px 0;
   font-size: 13px;
   line-height: 1.5;
   color: rgba(255, 255, 255, 0.86);
   white-space: pre-wrap;
+  margin: 0;
+}
+
+.instagramViewerCaption--muted {
+  color: rgba(255, 255, 255, 0.54);
+}
+
+.instagramViewerThumbs {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
+}
+
+.instagramViewerThumb {
+  position: relative;
+  flex: 0 0 84px;
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 14px;
+  overflow: hidden;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.instagramViewerThumb:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.instagramViewerThumb--active {
+  border-color: rgba(255, 255, 255, 0.75);
+}
+
+.instagramViewerThumbImage {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.instagramViewerThumbBadge {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  padding: 4px 7px;
+  font-size: 10px;
+  background: rgba(0, 0, 0, 0.62);
 }
 
 .instagramInlineError {
@@ -2745,6 +3061,40 @@ video.heroMediaEl {
 
   .instagramGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .instagramGalleryIntro {
+    padding: 12px;
+  }
+
+  .instagramGalleryStat {
+    min-width: 0;
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .instagramGalleryIntro {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .instagramGalleryStats {
+    justify-content: stretch;
+  }
+
+  .instagramViewerShell {
+    grid-template-columns: 1fr;
+  }
+
+  .instagramViewerMediaWrap {
+    min-height: clamp(280px, 54vh, 560px);
+    padding: 14px;
+  }
+
+  .instagramViewerMedia {
+    max-width: 100%;
+    max-height: min(58vh, 560px);
   }
 }
 


### PR DESCRIPTION
# Refresh insumos and escala

This PR updates the insumos flow so quick launches reuse cached item data between operations, keeps the movement edit action bound to the launch record itself, and adds backend support to edit movement rows while recomputing stock consistently.

It also includes the companion escala/front-end changes already present in this branch so the online version matches the current workspace state.

Validation:
- `npm run typecheck` in `frontend/`
- `node --check backend/apps/insumos/src/d1Store.js`
- `node --check backend/apps/insumos/src/routes/movimentacoes.js`
- `node --check backend/apps/insumos/src/worker.js`
