### PR TITLE
[codex] Refine homepage doctor tooltips and names

### DIFF
--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -1217,7 +1217,7 @@ export default function BookingFlow() {
                                                                         </button>
                                                                     ) : null}
                                                                 </div>
-                                                                <div className="bookingFlow__doctorTooltipSub">{d.nickname || unitLabel}</div>
+                                                                <div className="bookingFlow__doctorTooltipSub">{unitLabel}</div>
                                                             </>
                                                         }
                                                     >
@@ -1232,15 +1232,15 @@ export default function BookingFlow() {
                                                             <span className="bookingFlow__doctorBadgeAvatar">
                                                                 {d.handle ? (
                                                                     <Image
-                                                                        src={avatarUrl(d.handle, d.nickname ?? d.name)}
-                                                                        alt={d.nickname ?? d.name}
+                                                                        src={avatarUrl(d.handle, d.name)}
+                                                                        alt={d.name}
                                                                         fill
                                                                         sizes="76px"
                                                                         style={{ objectFit: "cover" }}
                                                                         unoptimized
                                                                     />
                                                                 ) : (
-                                                                    <span className="bookingFlow__doctorBadgeFallback">{initialsFromName(d.nickname ?? d.name)}</span>
+                                                                    <span className="bookingFlow__doctorBadgeFallback">{initialsFromName(d.name)}</span>
                                                                 )}
                                                             </span>
                                                         </button>

--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { createPortal } from "react-dom";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { doctorSlugFromTeamMember } from "@/lib/doctorSlug";
 import { trackBookingStart, trackDoctorInstagramClick } from "@/lib/leadTracking";
@@ -57,6 +58,101 @@ function extractInstagramHandle(url: string | null): string | null {
 type UnitDoctorsGridProps = {
     variant?: "directory" | "booking-compact";
 };
+
+function PortalTooltip(props: { content: ReactNode; children: ReactNode; className: string; disabled?: boolean }) {
+    const anchorRef = useRef<HTMLDivElement | null>(null);
+    const tooltipRef = useRef<HTMLDivElement | null>(null);
+    const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [open, setOpen] = useState(false);
+    const [position, setPosition] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
+
+    const clearCloseTimer = useCallback(() => {
+        if (!closeTimerRef.current) return;
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+    }, []);
+
+    const openTooltip = useCallback(() => {
+        if (props.disabled) return;
+        clearCloseTimer();
+        setOpen(true);
+    }, [clearCloseTimer, props.disabled]);
+
+    const scheduleClose = useCallback(() => {
+        clearCloseTimer();
+        closeTimerRef.current = setTimeout(() => setOpen(false), 120);
+    }, [clearCloseTimer]);
+
+    const updatePosition = useCallback(() => {
+        const anchor = anchorRef.current;
+        const tooltip = tooltipRef.current;
+        if (!anchor || !tooltip) return;
+        const anchorRect = anchor.getBoundingClientRect();
+        const tooltipRect = tooltip.getBoundingClientRect();
+        const viewportPadding = 8;
+        let left = anchorRect.left + anchorRect.width / 2;
+        const minLeft = viewportPadding + tooltipRect.width / 2;
+        const maxLeft = window.innerWidth - viewportPadding - tooltipRect.width / 2;
+        left = Math.max(minLeft, Math.min(maxLeft, left));
+        const top = anchorRect.bottom + 4;
+        setPosition({ left, top });
+    }, []);
+
+    useLayoutEffect(() => {
+        if (!open) return;
+        updatePosition();
+    }, [open, updatePosition, props.content]);
+
+    useEffect(() => {
+        if (!open) return;
+        const onWindowChange = () => updatePosition();
+        window.addEventListener("resize", onWindowChange);
+        window.addEventListener("scroll", onWindowChange, true);
+        return () => {
+            window.removeEventListener("resize", onWindowChange);
+            window.removeEventListener("scroll", onWindowChange, true);
+        };
+    }, [open, updatePosition]);
+
+    useEffect(() => {
+        return () => clearCloseTimer();
+    }, [clearCloseTimer]);
+
+    return (
+        <div
+            ref={anchorRef}
+            className="bookingFlow__tooltipAnchor"
+            onMouseEnter={openTooltip}
+            onMouseLeave={scheduleClose}
+            onFocusCapture={openTooltip}
+            onBlurCapture={scheduleClose}
+        >
+            {props.children}
+            {open && typeof document !== "undefined"
+                ? createPortal(
+                      <div
+                          ref={tooltipRef}
+                          className={props.className}
+                          role="tooltip"
+                          style={{
+                              position: "fixed",
+                              left: position.left,
+                              top: position.top,
+                              transform: "translateX(-50%)",
+                              display: "block",
+                              zIndex: 5000,
+                          }}
+                          onMouseEnter={openTooltip}
+                          onMouseLeave={scheduleClose}
+                      >
+                          {props.content}
+                      </div>,
+                      document.body,
+                  )
+                : null}
+        </div>
+    );
+}
 
 export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGridProps) {
     const unit = useCurrentUnit();
@@ -141,13 +237,6 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
             <>
                 {selectedUnitSubtitle}
                 <div className="card unitDoctorsCompact">
-                    <div className="unitDoctorsCompact__header">
-                        <div className="small unitDoctorsCompact__unit">
-                            Unidade: <span className="bookingFlow__unitName">{unit?.name ?? unitLabel}</span>
-                        </div>
-                        <div className="bookingFlow__cardSub">Escolha um doutor para abrir o agendamento com o profissional já selecionado.</div>
-                    </div>
-
                     <div className="unitDoctorsCompact__rail" role="list" aria-label="Lista de doutores da unidade">
                         {filtered.map((d) => {
                             const fullName = d.name;
@@ -170,42 +259,63 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
 
                             return (
                                 <article key={`${fullName}-${href ?? "noinsta"}`} className="unitDoctorsCompact__item" role="listitem">
-                                    <Link
-                                        className="bookingFlow__doctorBadge unitDoctorsCompact__badgeLink"
-                                        href={bookingHref}
-                                        onClick={() =>
-                                            trackBookingStart({
-                                                placement: "doctor_grid",
-                                                unitSlug: unit?.slug ?? null,
-                                                doctorName: fullName,
-                                                bookingUrl: bookingHref,
-                                            })
+                                    <PortalTooltip
+                                        className="bookingFlow__doctorTooltip unitDoctorsCompact__tooltip"
+                                        content={
+                                            <>
+                                                <div className="bookingFlow__doctorTooltipName">{fullName}</div>
+                                                <div className="unitDoctorsCompact__tooltipActions">
+                                                    <Link
+                                                        className="unitDoctorsCompact__tooltipAction"
+                                                        href={bookingHref}
+                                                        onClick={() =>
+                                                            trackBookingStart({
+                                                                placement: "doctor_grid",
+                                                                unitSlug: unit?.slug ?? null,
+                                                                doctorName: fullName,
+                                                                bookingUrl: bookingHref,
+                                                            })
+                                                        }
+                                                    >
+                                                        Agendar
+                                                    </Link>
+                                                    {instagramHandle ? (
+                                                        <button
+                                                            type="button"
+                                                            className="unitDoctorsCompact__tooltipAction"
+                                                            onClick={openInstagram}
+                                                        >
+                                                            Instagram
+                                                        </button>
+                                                    ) : null}
+                                                </div>
+                                            </>
                                         }
-                                        aria-label={`Agendar com ${fullName}`}
-                                        title={`Agendar com ${fullName}`}
                                     >
-                                        <span className="bookingFlow__doctorBadgeAvatar">
-                                            {instagramHandle ? (
-                                                <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={76} height={76} unoptimized />
-                                            ) : (
-                                                <span className="bookingFlow__doctorBadgeFallback">{fullName.charAt(0).toUpperCase()}</span>
-                                            )}
-                                        </span>
-                                    </Link>
+                                        <Link
+                                            className="bookingFlow__doctorBadge unitDoctorsCompact__badgeLink"
+                                            href={bookingHref}
+                                            onClick={() =>
+                                                trackBookingStart({
+                                                    placement: "doctor_grid",
+                                                    unitSlug: unit?.slug ?? null,
+                                                    doctorName: fullName,
+                                                    bookingUrl: bookingHref,
+                                                })
+                                            }
+                                            aria-label={`Agendar com ${fullName}`}
+                                        >
+                                            <span className="bookingFlow__doctorBadgeAvatar">
+                                                {instagramHandle ? (
+                                                    <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={76} height={76} unoptimized />
+                                                ) : (
+                                                    <span className="bookingFlow__doctorBadgeFallback">{fullName.charAt(0).toUpperCase()}</span>
+                                                )}
+                                            </span>
+                                        </Link>
+                                    </PortalTooltip>
 
                                     <div className="unitDoctorsCompact__name">{fullName}</div>
-
-                                    {instagramHandle ? (
-                                        <button
-                                            type="button"
-                                            className="unitDoctorsCompact__instagram"
-                                            onClick={openInstagram}
-                                            aria-label={`Abrir Instagram de ${fullName}`}
-                                            title="Abrir Instagram"
-                                        >
-                                            <InstagramIcon size={14} />
-                                        </button>
-                                    ) : null}
                                 </article>
                             );
                         })}

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -3669,23 +3669,15 @@ video.heroMediaEl {
 
 .unitDoctorsCompact {
   display: grid;
-  gap: 14px;
-  padding: 18px;
-}
-
-.unitDoctorsCompact__header {
-  display: grid;
-  gap: 4px;
-}
-
-.unitDoctorsCompact__unit {
-  color: var(--muted);
+  gap: 10px;
+  padding: 16px 18px 14px;
 }
 
 .unitDoctorsCompact__rail {
   display: flex;
   gap: 14px;
   align-items: flex-start;
+  justify-content: center;
   overflow-x: auto;
   overflow-y: hidden;
   padding: 8px 0 6px;
@@ -3734,24 +3726,44 @@ video.heroMediaEl {
   text-wrap: balance;
 }
 
-.unitDoctorsCompact__instagram {
+.unitDoctorsCompact__tooltip {
+  display: grid;
+  gap: 8px;
+  min-width: 138px;
+}
+
+.unitDoctorsCompact__tooltip .bookingFlow__doctorTooltipName {
+  text-align: center;
+}
+
+.unitDoctorsCompact__tooltipActions {
+  display: flex;
+  gap: 6px;
+}
+
+.unitDoctorsCompact__tooltipAction {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid rgba(17, 17, 17, 0.08);
+  min-width: 0;
+  flex: 1 1 0;
+  padding: 7px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.86);
-  color: #111;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  text-decoration: none;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
   cursor: pointer;
-  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
 
-.unitDoctorsCompact__instagram:hover {
+.unitDoctorsCompact__tooltipAction:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.28);
   transform: translateY(-1px);
-  background: #fff;
-  border-color: rgba(17, 17, 17, 0.16);
 }
 
 .pageNarrative {


### PR DESCRIPTION
## Summary
This refines the doctors presentation on the homepage and removes nickname leakage from the doctor tooltip in booking.

On the homepage, the compact doctors rail still contained booking-specific helper copy inside the card, the doctor items were not visually centered when there was spare horizontal space, and the Instagram action lived as a detached icon below each doctor. In booking, the doctor tooltip still displayed `nickname`, even though the desired UI is now based on the real doctor name only.

## Root cause
The homepage compact variant reused part of the booking visual language, but it still rendered temporary header copy that made sense only during selection flows and exposed actions as separate UI under the avatar instead of inside a contextual tooltip. Separately, the booking tooltip still used `nickname || unitLabel`, so the nickname remained visible there.

## Fix
The homepage compact doctors rail now:
- removes the in-card texts about unit and preselected booking
- centers the doctor rail horizontally when there is free space
- replaces the detached Instagram icon with a contextual tooltip containing action buttons
- exposes `Agendar` and `Instagram` actions inside the tooltip while keeping the compact card layout

The booking flow doctor tooltip now:
- shows the unit label instead of `nickname`
- uses the real doctor name for avatar alt text and fallback initials

## Validation
- `npm run typecheck`
- `npm run lint`
