### PR TITLE
[codex] Use icons in homepage doctor tooltips

### DIFF
--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -276,16 +276,20 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                                 bookingUrl: bookingHref,
                                                             })
                                                         }
+                                                        aria-label={`Agendar com ${fullName}`}
+                                                        title="Agendar"
                                                     >
-                                                        Agendar
+                                                        {bookingIcon()}
                                                     </Link>
                                                     {instagramHandle ? (
                                                         <button
                                                             type="button"
                                                             className="unitDoctorsCompact__tooltipAction"
                                                             onClick={openInstagram}
+                                                            aria-label={`Abrir Instagram de ${fullName}`}
+                                                            title="Instagram"
                                                         >
-                                                            Instagram
+                                                            <InstagramIcon size={14} />
                                                         </button>
                                                     ) : null}
                                                 </div>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -4089,25 +4089,24 @@ video.heroMediaEl {
 .unitDoctorsCompact__tooltipActions {
   display: flex;
   gap: 6px;
+  justify-content: center;
 }
 
 .unitDoctorsCompact__tooltipAction {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 0;
-  flex: 1 1 0;
-  padding: 7px 10px;
+  width: 34px;
+  height: 34px;
+  padding: 0;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
   text-decoration: none;
-  font-size: 11px;
-  font-weight: 800;
-  line-height: 1;
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+  flex: 0 0 auto;
 }
 
 .unitDoctorsCompact__tooltipAction:hover {


### PR DESCRIPTION
## Summary
This updates the doctor tooltip actions in the homepage doctors section to use icons instead of text labels.

After the previous refinement, the homepage doctor tooltip already exposed the right actions, but the `Agendar` and `Instagram` labels still made the tooltip visually heavier than the rest of the doctor UI.

## Root cause
The tooltip action buttons reused a text-pill treatment even though the interaction only needs two universally recognizable actions. That left extra copy inside a very small tooltip surface.

## Fix
The homepage doctor tooltip now renders:
- the calendar icon for booking
- the Instagram icon for Instagram

The action buttons keep their existing behaviors and accessibility labels, but now use compact circular icon buttons and centered layout.

## Validation
- `npm run typecheck`
- `npm run lint`
