### PR TITLE
[codex] Strengthen homepage tooltip button cursor

### DIFF
--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -4109,6 +4109,12 @@ video.heroMediaEl {
   flex: 0 0 auto;
 }
 
+.unitDoctorsCompact__tooltipAction svg,
+.unitDoctorsCompact__tooltipAction path,
+.unitDoctorsCompact__tooltipAction span {
+  cursor: pointer;
+}
+
 .unitDoctorsCompact__tooltipAction:hover {
   background: rgba(255, 255, 255, 0.16);
   border-color: rgba(255, 255, 255, 0.28);


### PR DESCRIPTION
## Summary
This makes the cursor behavior of the homepage doctor tooltip actions unambiguous.

The tooltip action buttons already had button styling, but depending on the exact hover target inside the control, the pointer cursor was not always visually obvious over the icon itself.

## Root cause
The action control had `cursor: pointer` on the outer button/link, but the SVG internals did not explicitly inherit the same cursor state.

## Fix
The homepage doctor tooltip action styles now also force `cursor: pointer` on the icon descendants inside each action button.

## Validation
- `npm run typecheck`
- `npm run lint`
