### PR TITLE
[codex] Redesign homepage doctor tooltip actions

### DIFF
--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -264,7 +264,7 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                         content={
                                             <>
                                                 <div className="bookingFlow__doctorTooltipName">{fullName}</div>
-                                                <div className="unitDoctorsCompact__tooltipActions">
+                                                <div className="unitDoctorsCompact__tooltipActions" data-single={instagramHandle ? undefined : "true"}>
                                                     <Link
                                                         className="unitDoctorsCompact__tooltipAction"
                                                         href={bookingHref}
@@ -279,7 +279,8 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                         aria-label={`Agendar com ${fullName}`}
                                                         title="Agendar"
                                                     >
-                                                        {bookingIcon()}
+                                                        <span className="unitDoctorsCompact__tooltipActionIcon">{bookingIcon()}</span>
+                                                        <span className="unitDoctorsCompact__tooltipActionLabel">Agendar</span>
                                                     </Link>
                                                     {instagramHandle ? (
                                                         <button
@@ -289,7 +290,10 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                             aria-label={`Abrir Instagram de ${fullName}`}
                                                             title="Instagram"
                                                         >
-                                                            <InstagramIcon size={14} />
+                                                            <span className="unitDoctorsCompact__tooltipActionIcon">
+                                                                <InstagramIcon size={14} />
+                                                            </span>
+                                                            <span className="unitDoctorsCompact__tooltipActionLabel">Instagram</span>
                                                         </button>
                                                     ) : null}
                                                 </div>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -4078,8 +4078,8 @@ video.heroMediaEl {
 
 .unitDoctorsCompact__tooltip {
   display: grid;
-  gap: 8px;
-  min-width: 138px;
+  gap: 10px;
+  min-width: 176px;
 }
 
 .unitDoctorsCompact__tooltip .bookingFlow__doctorTooltipName {
@@ -4087,32 +4087,50 @@ video.heroMediaEl {
 }
 
 .unitDoctorsCompact__tooltipActions {
-  display: flex;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
   justify-content: center;
 }
 
+.unitDoctorsCompact__tooltipActions[data-single="true"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .unitDoctorsCompact__tooltipAction {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  padding: 0;
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  gap: 6px;
+  min-height: 62px;
+  padding: 8px 10px;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 999px;
+  border-radius: 14px;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
   text-decoration: none;
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
-  flex: 0 0 auto;
 }
 
 .unitDoctorsCompact__tooltipAction svg,
 .unitDoctorsCompact__tooltipAction path,
 .unitDoctorsCompact__tooltipAction span {
   cursor: pointer;
+}
+
+.unitDoctorsCompact__tooltipActionIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+}
+
+.unitDoctorsCompact__tooltipActionLabel {
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .unitDoctorsCompact__tooltipAction:hover {


### PR DESCRIPTION
## Summary
This resizes and re-diagrams the doctor tooltip actions on the homepage.

The icon-only tooltip actions were compact, but they no longer communicated their meaning instantly. The user asked for a clearer action layout with icon plus text label.

## Root cause
The previous tooltip layout optimized for compactness only. That reduced clarity because the actions relied on icon recognition alone inside a small floating surface.

## Fix
The homepage doctor tooltip now:
- uses a wider tooltip surface
- lays out the actions as small vertical cards
- places the icon on top and the label below
- keeps a one-column layout automatically when only one action is available

## Validation
- `npm run typecheck`
- `npm run lint`
