### PR TITLE
[codex] fix escala doctor visibility and compact doctor tooltip

### DIFF
--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -205,12 +205,23 @@ function isVisibleInjector(prof: EscalaProfessional) {
 }
 
 function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional[]) {
-  const map = new Map(base.map((p) => [p.name, p]))
+  const map = new Map<string, EscalaProfessional>()
+  base.forEach((prof) => {
+    const isScheduled = scheduleNames.has(prof.name)
+    const role = String(prof.role || '').trim() || (isScheduled ? 'Injetor' : '')
+    const status = String(prof.status || '').trim() || (isScheduled ? 'Ativo' : '')
+    map.set(prof.name, {
+      ...prof,
+      role,
+      status,
+      units: Array.isArray(prof.units) ? prof.units : [],
+    })
+  })
   scheduleNames.forEach((name) => {
     if (map.has(name)) return
     map.set(name, {
       name,
-      status: 'Sem cadastro',
+      status: 'Ativo',
       units: [],
       role: 'Injetor',
       shift: '',
@@ -397,7 +408,7 @@ function NoAttendanceChip({
   return (
     <div
       className={cn(
-        'inline-flex min-h-8 w-fit max-w-full items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-semibold shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+        'inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
         blocked
           ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
           : 'border-white/10 bg-white/5 text-slate-200/80',
@@ -407,7 +418,6 @@ function NoAttendanceChip({
       title={text}
     >
       <CalendarX2 className="h-3.5 w-3.5" />
-      {label ? <span className="truncate">{text}</span> : null}
     </div>
   )
 }

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -33,7 +33,7 @@ test.describe('escala', () => {
 	        body: JSON.stringify({
 	          ok: true,
 	          data: [
-	            { name: 'Dra. Ana', status: 'Ativo', units: ['novo-hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+	            { name: 'Dra. Ana', status: '', units: ['novo-hamburgo'], role: '', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
 	            { name: 'Bruna', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Consultor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '' },
 	            { name: 'Carla', status: 'Inativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#ef4444' }
 	          ]
@@ -47,7 +47,10 @@ test.describe('escala', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           ok: true,
-          schedule: [{ date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }],
+          schedule: [
+            { date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' },
+            { date: '2026-03-06', unit: 'Novo Hamburgo', professional: 'Dr. Agenda' }
+          ],
           closedDays: [{ date: '2026-03-10', unit: 'Novo Hamburgo', reason: 'Feriado local' }],
           holidays: [{ date: '2026-03-20', unit: 'Novo Hamburgo', name: 'Dia do Cliente' }]
         })
@@ -59,10 +62,12 @@ test.describe('escala', () => {
     await expect(page.getByRole('heading', { name: 'Escala' })).toBeVisible({ timeout: 30000 })
     await expect(page.getByTestId('escala-day-2026-03-05')).toBeVisible()
     await expect(page.getByText('Dra. Ana').first()).toBeVisible()
+    await expect(page.getByText('Dr. Agenda').first()).toBeVisible()
     await expect(page.getByText('Dia do Cliente').first()).toBeVisible()
     await expect(page.getByTestId('escala-no-attendance-icon-2026-03-10')).toBeVisible()
     await expect(page.getByTestId('escala-day-2026-03-10')).not.toContainText('Feriado local')
     await expect(page.getByTestId('escala-team-member-dra-ana')).toBeVisible()
+    await expect(page.getByTestId('escala-team-member-dr-agenda')).toBeVisible()
     await expect(page.getByTestId('escala-team-member-bruna')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-member-carla')).toHaveCount(0)
     await expect(page.getByTestId('escala-team-inactive-toggle')).toContainText('Inativos (1)')
@@ -72,6 +77,7 @@ test.describe('escala', () => {
 
     await page.getByRole('combobox', { name: '' }).nth(3).click()
     await expect(page.getByRole('option', { name: 'Dra. Ana' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Dr. Agenda' })).toBeVisible()
     await expect(page.getByRole('option', { name: 'Bruna' })).toHaveCount(0)
     await expect(page.getByRole('option', { name: 'Carla' })).toHaveCount(0)
   })

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -183,7 +183,7 @@ test.describe('escala', () => {
     await expect.poll(() => closedAddPayloads).toEqual([
       { date: '2026-03-15', unit: 'Novo Hamburgo', reason: 'Manutenção' }
     ])
-    await expect(page.getByTestId('escala-day-2026-03-15')).toContainText('Manutenção')
+    await expect(page.getByTestId('escala-no-attendance-icon-2026-03-15')).toBeVisible()
     await expect(page.getByTestId('escala-day-2026-03-15')).not.toContainText('Dra. Ana')
 
     await page.getByTestId('escala-day-2026-03-15').click()

--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -263,8 +263,10 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                         className="bookingFlow__doctorTooltip unitDoctorsCompact__tooltip"
                                         content={
                                             <>
-                                                <div className="bookingFlow__doctorTooltipName">{fullName}</div>
-                                                <div className="unitDoctorsCompact__tooltipActions" data-single={instagramHandle ? undefined : "true"}>
+                                                <div className="unitDoctorsCompact__tooltipHeader">
+                                                    <div className="bookingFlow__doctorTooltipName">{fullName}</div>
+                                                </div>
+                                                <div className="unitDoctorsCompact__tooltipActions">
                                                     <Link
                                                         className="unitDoctorsCompact__tooltipAction"
                                                         href={bookingHref}
@@ -279,8 +281,8 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                         aria-label={`Agendar com ${fullName}`}
                                                         title="Agendar"
                                                     >
-                                                        <span className="unitDoctorsCompact__tooltipActionIcon">{bookingIcon()}</span>
-                                                        <span className="unitDoctorsCompact__tooltipActionLabel">Agendar</span>
+                                                        {bookingIcon()}
+                                                        <span>Agenda</span>
                                                     </Link>
                                                     {instagramHandle ? (
                                                         <button
@@ -290,10 +292,8 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                             aria-label={`Abrir Instagram de ${fullName}`}
                                                             title="Instagram"
                                                         >
-                                                            <span className="unitDoctorsCompact__tooltipActionIcon">
-                                                                <InstagramIcon size={14} />
-                                                            </span>
-                                                            <span className="unitDoctorsCompact__tooltipActionLabel">Instagram</span>
+                                                            <InstagramIcon size={13} />
+                                                            <span>Insta</span>
                                                         </button>
                                                     ) : null}
                                                 </div>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -4079,62 +4079,62 @@ video.heroMediaEl {
 .unitDoctorsCompact__tooltip {
   display: grid;
   gap: 10px;
-  min-width: 176px;
+  min-width: 128px;
+  padding: 10px 10px 10px;
+}
+
+.unitDoctorsCompact__tooltipHeader {
+  display: grid;
+  justify-items: center;
+  gap: 2px;
 }
 
 .unitDoctorsCompact__tooltip .bookingFlow__doctorTooltipName {
   text-align: center;
+  font-size: 12px;
+  line-height: 1.15;
 }
 
 .unitDoctorsCompact__tooltipActions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  display: flex;
   justify-content: center;
-}
-
-.unitDoctorsCompact__tooltipActions[data-single="true"] {
-  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
 }
 
 .unitDoctorsCompact__tooltipAction {
-  display: grid;
+  display: inline-grid;
   justify-items: center;
   align-content: center;
-  gap: 6px;
-  min-height: 62px;
-  padding: 8px 10px;
+  justify-content: center;
+  width: 52px;
+  height: 48px;
+  min-width: 0;
+  flex: 0 0 auto;
+  gap: 5px;
+  padding: 6px 4px;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
   color: #fff;
   text-decoration: none;
+  font-size: 9.5px;
+  font-weight: 800;
+  line-height: 1;
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
 
-.unitDoctorsCompact__tooltipAction svg,
-.unitDoctorsCompact__tooltipAction path,
+.unitDoctorsCompact__tooltipAction svg {
+  width: 14px;
+  height: 14px;
+}
+
 .unitDoctorsCompact__tooltipAction span {
-  cursor: pointer;
-}
-
-.unitDoctorsCompact__tooltipActionIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-}
-
-.unitDoctorsCompact__tooltipActionLabel {
-  font-size: 10px;
-  font-weight: 800;
-  line-height: 1;
+  letter-spacing: 0.01em;
 }
 
 .unitDoctorsCompact__tooltipAction:hover {
-  background: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.12);
   border-color: rgba(255, 255, 255, 0.28);
   transform: translateY(-1px);
 }


### PR DESCRIPTION
## Resumo
Esta mudança fecha dois problemas visíveis para o usuário final. No módulo `Escala`, doutores/injetores que apareciam na agenda mas vinham com cadastro incompleto deixavam de aparecer tanto no filtro suspenso quanto no box da `Equipe`, o que quebrava a seleção e passava a impressão de que os profissionais haviam sumido. No website, o tooltip compacto dos doutores seguia visualmente pesado: as ações de agenda e Instagram ficavam muito próximas do nome, com botões grandes demais para o espaço disponível.

## Causa Raiz
Na `Escala`, o filtro da interface passou a depender estritamente de `role` contendo `Injetor` e de `status` preenchido com `Ativo` ou `Inativo`. Quando um profissional existia na agenda, mas o cadastro retornava `role` ou `status` em branco, ele era removido da lista derivada usada pelo filtro e pelo painel lateral. No website, a rodada anterior de redesign do tooltip ainda usava um bloco de ações maior, com largura mínima e áreas clicáveis grandes demais para o contexto compacto da grade de doutores.

## Correção
Na `Escala`, o merge entre agenda e cadastro agora trata nomes presentes na agenda como `Injetor` ativo por padrão quando `role` e `status` não vierem preenchidos. Isso faz o profissional continuar visível no filtro e no box da equipe sem depender de metadados completos. Também mantive o chip de `Sem atendimento` somente com ícone, sem texto visível no calendário.

No website, o tooltip compacto dos doutores foi reequilibrado para um layout menor e com mais respiro visual: o nome ficou isolado no topo, e as ações de agenda e Instagram foram miniaturizadas para microbotões com ícone e legenda curta, reduzindo a sensação de sobreposição e excesso de peso visual.

## Impacto para o usuário
Com essa correção, a agenda volta a listar corretamente doutores que já têm escala mesmo quando o cadastro está incompleto, evitando sumiço no filtro e no painel lateral. No site, o tooltip da vitrine de doutores fica mais legível e proporcional ao card, melhorando leitura e clique em desktop.

## Validação
No worktree limpo a partir de `origin/main`, validei com:

- `cd frontend && npm run typecheck`
- `cd frontend && E2E_BASE_URL=http://127.0.0.1:4173 npx playwright test e2e/escala-module.spec.ts --grep "renders overview and schedule from API|edits team member fields from the sidebar next to the calendar|adds a team member from the sidebar using dropdown fields|clicking a professional badge syncs the header filter and highlights matching days"`
- `cd backend/apps/escala-api && npm test`
- `cd website && npm ci`
- `cd website && npm run typecheck`
- `cd website && npm run build`
