### PR TITLE
[codex] site-update

### DIFF
--- a/backend/apps/insumos/src/d1Store.js
+++ b/backend/apps/insumos/src/d1Store.js
@@ -14,6 +14,14 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+function normalizeDateTimeInput(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toISOString();
+}
+
 // D1/SQLite can reject statements with many bound variables.
 // D1 can reject large IN(...) bind lists on some plans/regions.
 // Keep this low to avoid `too many SQL variables` on overview/insights loads.
@@ -49,7 +57,7 @@ function computeMovementDelta(row) {
   return 0;
 }
 
-async function recomputeMovementLedgerForRegistro({ env, registro, overrides = new Map() }) {
+async function recomputeMovementLedgerForRegistro({ env, registro, overrides = new Map(), removeIds = new Set() }) {
   const reg = String(registro || '').trim();
   if (!reg) throw new Error('Registro inválido');
 
@@ -108,10 +116,23 @@ async function recomputeMovementLedgerForRegistro({ env, registro, overrides = n
     baseStockByUnit.set(unit, current - delta);
   }
 
-  const rowsWithOverrides = rows.map((row) => {
-    const patch = overrides instanceof Map ? overrides.get(String(row.id || '').trim()) : null;
-    return patch ? { ...row, ...patch } : row;
-  });
+  const removeIdSet =
+    removeIds instanceof Set
+      ? new Set(Array.from(removeIds).map((id) => String(id || '').trim()).filter(Boolean))
+      : new Set((Array.isArray(removeIds) ? removeIds : []).map((id) => String(id || '').trim()).filter(Boolean));
+
+  const rowsWithOverrides = rows
+    .filter((row) => !removeIdSet.has(String(row.id || '').trim()))
+    .map((row) => {
+      const patch = overrides instanceof Map ? overrides.get(String(row.id || '').trim()) : null;
+      return patch ? { ...row, ...patch } : row;
+    })
+    .sort((a, b) => {
+      const dateA = String(a?.data_hora || '');
+      const dateB = String(b?.data_hora || '');
+      if (dateA !== dateB) return dateA.localeCompare(dateB);
+      return String(a?.id || '').localeCompare(String(b?.id || ''));
+    });
 
   const nextStockByUnit = new Map(baseStockByUnit);
   const movementUpdates = [];
@@ -135,6 +156,11 @@ async function recomputeMovementLedgerForRegistro({ env, registro, overrides = n
     nextStockByUnit.set(unit, after);
     movementUpdates.push({
       id: String(row.id || '').trim(),
+      dataHora: normalizeDateTimeInput(row?.data_hora) || nowIso(),
+      produto: String(row?.produto || '').trim(),
+      unidade: unit,
+      unidadeOrigem: String(row?.unidade_origem || '').trim(),
+      unidadeDestino: String(row?.unidade_destino || '').trim(),
       quantidade,
       estoqueAnterior: before,
       estoqueNovo: after,
@@ -144,15 +170,43 @@ async function recomputeMovementLedgerForRegistro({ env, registro, overrides = n
   }
 
   const statements = [];
+  for (const id of removeIdSet) {
+    statements.push(
+      env.DB.prepare(
+        `DELETE FROM insumos_movements
+         WHERE id = ?`
+      ).bind(id)
+    );
+  }
   for (const row of movementUpdates) {
     statements.push(
       env.DB.prepare(
         `UPDATE insumos_movements
-         SET quantidade = ?, estoque_anterior = ?, estoque_novo = ?, motivo = ?, observacoes = ?
+         SET data_hora = ?, produto = ?, quantidade = ?, estoque_anterior = ?, estoque_novo = ?,
+             unidade = ?, unidade_origem = ?, unidade_destino = ?, motivo = ?, observacoes = ?
          WHERE id = ?`
-      ).bind(row.quantidade, row.estoqueAnterior, row.estoqueNovo, row.motivo, row.observacoes, row.id)
+      ).bind(
+        row.dataHora,
+        row.produto,
+        row.quantidade,
+        row.estoqueAnterior,
+        row.estoqueNovo,
+        row.unidade,
+        row.unidadeOrigem || null,
+        row.unidadeDestino || null,
+        row.motivo,
+        row.observacoes,
+        row.id
+      )
     );
   }
+
+  statements.push(
+    env.DB.prepare(
+      `DELETE FROM insumos_stocks
+       WHERE registro = ?`
+    ).bind(reg)
+  );
 
   for (const [unit, qty] of nextStockByUnit.entries()) {
     statements.push(
@@ -1570,6 +1624,14 @@ export async function d1UpdateMovimentacao({ env, id, body }) {
 
   const tipo = normalizeTipo(movement?.tipo);
   const overrides = new Map();
+  const produtoProvided = Object.prototype.hasOwnProperty.call(body || {}, 'produto');
+  const dataHoraProvided = Object.prototype.hasOwnProperty.call(body || {}, 'dataHora');
+  const unidadeProvided = Object.prototype.hasOwnProperty.call(body || {}, 'unidade');
+  const produto = produtoProvided ? String(body?.produto || '').trim() : String(movement?.produto || '').trim();
+  const dataHora = dataHoraProvided ? normalizeDateTimeInput(body?.dataHora) : normalizeDateTimeInput(movement?.data_hora);
+
+  if (!produto) return { ok: false, status: 400, error: 'Produto inválido' };
+  if (!dataHora) return { ok: false, status: 400, error: 'Data/hora inválida' };
 
   if (String(movement?.id_transferencia || '').trim()) {
     const transferId = String(movement.id_transferencia || '').trim();
@@ -1594,6 +1656,9 @@ export async function d1UpdateMovimentacao({ env, id, body }) {
     if (!Number.isFinite(quantidade) || quantidade < 1) {
       return { ok: false, status: 400, error: 'Quantidade inválida' };
     }
+    if (unidadeProvided) {
+      return { ok: false, status: 400, error: 'Unidade de transferência não pode ser alterada neste modal' };
+    }
 
     const freeText = Object.prototype.hasOwnProperty.call(body || {}, 'observacoes')
       ? String(body?.observacoes || '').trim()
@@ -1601,6 +1666,8 @@ export async function d1UpdateMovimentacao({ env, id, body }) {
 
     for (const row of pairRows) {
       overrides.set(String(row.id || '').trim(), {
+        data_hora: dataHora,
+        produto,
         quantidade,
         observacoes: buildTransferObservacoes(row?.tipo, row?.unidade_origem, row?.unidade_destino, freeText),
       });
@@ -1612,22 +1679,26 @@ export async function d1UpdateMovimentacao({ env, id, body }) {
     const estoqueNovo = targetProvided ? toInt(body?.estoqueNovo, NaN) : toInt(movement?.estoque_novo, NaN);
     const motivo = motivoProvided ? String(body?.motivo || '').trim() : String(movement?.motivo || '').trim();
     const observacoes = observacoesProvided ? String(body?.observacoes || '').trim() : String(movement?.observacoes || '').trim();
+    const unidade = unidadeProvided ? String(body?.unidade || '').trim() : String(movement?.unidade || '').trim();
 
     if (!Number.isFinite(estoqueNovo) || estoqueNovo < 0) {
       return { ok: false, status: 400, error: 'Novo estoque inválido' };
     }
     if (!motivo) return { ok: false, status: 400, error: 'Motivo é obrigatório' };
+    if (!unidade) return { ok: false, status: 400, error: 'Unidade inválida' };
 
-    overrides.set(movementId, { estoque_novo: estoqueNovo, motivo, observacoes });
+    overrides.set(movementId, { data_hora: dataHora, produto, unidade, estoque_novo: estoqueNovo, motivo, observacoes });
   } else {
     const quantidadeProvided = Object.prototype.hasOwnProperty.call(body || {}, 'quantidade');
     const observacoesProvided = Object.prototype.hasOwnProperty.call(body || {}, 'observacoes');
     const quantidade = quantidadeProvided ? toInt(body?.quantidade, NaN) : toInt(movement?.quantidade, 1);
     const observacoes = observacoesProvided ? String(body?.observacoes || '').trim() : String(movement?.observacoes || '').trim();
+    const unidade = unidadeProvided ? String(body?.unidade || '').trim() : String(movement?.unidade || '').trim();
     if (!Number.isFinite(quantidade) || quantidade < 1) {
       return { ok: false, status: 400, error: 'Quantidade inválida' };
     }
-    overrides.set(movementId, { quantidade, observacoes });
+    if (!unidade) return { ok: false, status: 400, error: 'Unidade inválida' };
+    overrides.set(movementId, { data_hora: dataHora, produto, unidade, quantidade, observacoes });
   }
 
   const recomputed = await recomputeMovementLedgerForRegistro({ env, registro, overrides });
@@ -1662,6 +1733,48 @@ export async function d1UpdateMovimentacao({ env, id, body }) {
     registro,
     transferId: String(movement?.id_transferencia || '').trim() || null,
     movimentos: updatedRowsRes?.results || [],
+    estoqueAtual: recomputed.estoqueAtual,
+  };
+}
+
+export async function d1DeleteMovimentacao({ env, id }) {
+  const movementId = String(id || '').trim();
+  if (!movementId) return { ok: false, status: 400, error: 'Movimentação inválida' };
+
+  const movement = await env.DB.prepare(
+    `SELECT
+        id,
+        registro_insumo,
+        unidade,
+        id_transferencia
+     FROM insumos_movements
+     WHERE id = ?`
+  ).bind(movementId).first();
+  if (!movement) return { ok: false, status: 404, error: 'Movimentação não encontrada' };
+
+  const registro = String(movement?.registro_insumo || '').trim();
+  if (!registro) return { ok: false, status: 400, error: 'Movimentação sem registro de insumo' };
+
+  const removeIds = new Set([movementId]);
+  const transferId = String(movement?.id_transferencia || '').trim();
+  if (transferId) {
+    const pairRows = await env.DB.prepare(
+      `SELECT id
+       FROM insumos_movements
+       WHERE id_transferencia = ?`
+    ).bind(transferId).all();
+    for (const row of pairRows?.results || []) {
+      const idValue = String(row?.id || '').trim();
+      if (idValue) removeIds.add(idValue);
+    }
+  }
+
+  const recomputed = await recomputeMovementLedgerForRegistro({ env, registro, removeIds });
+  return {
+    ok: true,
+    registro,
+    transferId: transferId || null,
+    deletedIds: Array.from(removeIds),
     estoqueAtual: recomputed.estoqueAtual,
   };
 }

--- a/backend/apps/insumos/src/routes/movimentacoes.js
+++ b/backend/apps/insumos/src/routes/movimentacoes.js
@@ -87,6 +87,51 @@ export async function handleMovimentacoesRoutes({
                 return withCORS(JSON.stringify({ success: false, error: err.message || String(err || '') }), { status: 500 }, appOrigin);
             }
         }
+
+        if (url.pathname.startsWith("/movimentacoes/") && request.method === "DELETE") {
+            try {
+                const auth = await requireRoles(['ADMIN', 'GESTOR', 'GERENTE', 'OPERADOR']);
+                if (!auth.ok) return auth.response;
+
+                const id = decodeURIComponent(url.pathname.split('/')[2] || '').trim();
+                if (!id) {
+                    return withCORS(JSON.stringify({ success: false, error: 'Movimentação inválida' }), { status: 400 }, appOrigin);
+                }
+
+                const out = await d1.deleteMovimentacao({ id });
+                if (!out.ok) {
+                    return withCORS(JSON.stringify({ success: false, error: out.error }), { status: out.status || 400 }, appOrigin);
+                }
+
+                await appendAuditLog({
+                    env,
+                    actor: auth.user.username,
+                    role: auth.user.role,
+                    ip,
+                    userAgent,
+                    idempotencyKey,
+                    action: 'DELETE',
+                    entity: 'MOVIMENTACAO',
+                    entityId: id,
+                    unidade: String(url.searchParams.get('unidade') || unidade || '').trim(),
+                    before: { transferId: out.transferId || null, deletedIds: out.deletedIds || [id], registro: out.registro },
+                    after: null
+                });
+
+                if (out?.estoqueAtual && typeof out.estoqueAtual === 'object') {
+                  const units = Array.from(new Set(Object.keys(out.estoqueAtual).map((v) => String(v || '').trim()).filter(Boolean)));
+                  for (const unit of units) {
+                    ctx.waitUntil(enqueueNotificationsRefresh(env, unit));
+                  }
+                } else {
+                  ctx.waitUntil(enqueueNotificationsRefresh(env, String(url.searchParams.get('unidade') || unidade || '').trim()));
+                }
+
+                return withCORS(JSON.stringify({ success: true, data: { deletedIds: out.deletedIds || [id] } }), { status: 200 }, appOrigin);
+            } catch (err) {
+                return withCORS(JSON.stringify({ success: false, error: err.message || String(err || '') }), { status: 500 }, appOrigin);
+            }
+        }
         return null;
     }
 

--- a/backend/apps/insumos/src/worker.js
+++ b/backend/apps/insumos/src/worker.js
@@ -27,6 +27,7 @@ import {
     d1Transfer,
     d1ListMovimentacoes,
     d1UpdateMovimentacao,
+    d1DeleteMovimentacao,
     d1ListInsumosPaged,
     d1ListInsumosOptions,
     d1GetUserByUsername,
@@ -1481,6 +1482,7 @@ export default {
             listMovimentacoes: ({ unidade, tipo, de, ate, pagina, limite, codigoBarras }) =>
                 d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina, limite, codigoBarras }),
             updateMovimentacao: ({ id, body }) => d1UpdateMovimentacao({ env, id, body }),
+            deleteMovimentacao: ({ id }) => d1DeleteMovimentacao({ env, id }),
         };
 
         const movResp = await handleMovimentacoesRoutes({

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -594,6 +594,44 @@ function fmtDateOnlyBR(value?: string | null) {
   return iso ? isoToBrDate(iso) : v
 }
 
+function isoToLocalDateInput(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function isoToLocalTimeInput(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  const hours = String(d.getHours()).padStart(2, '0')
+  const minutes = String(d.getMinutes()).padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+
+function normalizeTimeInput(value?: string | null) {
+  const raw = String(value || '').trim()
+  const match = raw.match(/^(\d{2}):(\d{2})$/)
+  if (!match) return ''
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return ''
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+}
+
+function combineLocalDateTimeToIso(dateValue?: string | null, timeValue?: string | null) {
+  const isoDate = dateInputToIso(dateValue)
+  const isoTime = normalizeTimeInput(timeValue)
+  if (!isoDate || !isoTime) return ''
+  const d = new Date(`${isoDate}T${isoTime}:00`)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toISOString()
+}
+
 function normalizeMovimentacaoTipo(value?: string | null) {
   return String(value || '').toUpperCase().replace('Í', 'I')
 }
@@ -1265,11 +1303,16 @@ export function InsumosModule() {
   const movListContainerRef = React.useRef<HTMLDivElement | null>(null)
   const [editMovOpen, setEditMovOpen] = React.useState(false)
   const [editMovTarget, setEditMovTarget] = React.useState<Movimentacao | null>(null)
+  const [editMovProduto, setEditMovProduto] = React.useState('')
+  const [editMovData, setEditMovData] = React.useState('')
+  const [editMovHora, setEditMovHora] = React.useState('')
+  const [editMovUnidade, setEditMovUnidade] = React.useState('')
   const [editMovQuantidade, setEditMovQuantidade] = React.useState('1')
   const [editMovNovoEstoque, setEditMovNovoEstoque] = React.useState('')
   const [editMovObservacoes, setEditMovObservacoes] = React.useState('')
   const [editMovMotivo, setEditMovMotivo] = React.useState('')
   const [editMovSaving, setEditMovSaving] = React.useState(false)
+  const [editMovDeleting, setEditMovDeleting] = React.useState(false)
 
   // Backups/auditoria foram movidos para o módulo Status do sistema.
 
@@ -3458,13 +3501,17 @@ export function InsumosModule() {
     }
     const tipo = normalizeMovimentacaoTipo(m?.tipo)
     setEditMovTarget(m)
+    setEditMovProduto(String(m?.produto || ''))
+    setEditMovData(isoToLocalDateInput(m?.dataHora))
+    setEditMovHora(isoToLocalTimeInput(m?.dataHora))
+    setEditMovUnidade(String(m?.unidade || unidade))
     setEditMovQuantidade(String(Math.max(1, Number(m?.quantidade) || 1)))
     setEditMovNovoEstoque(String(Number.isFinite(Number(m?.estoqueNovo)) ? Number(m.estoqueNovo) : 0))
     setEditMovObservacoes(m?.transferId ? extractTransferMovementNote(m?.observacoes) : String(m?.observacoes || ''))
     setEditMovMotivo(String(m?.motivo || ''))
     if (tipo !== 'AJUSTE') setEditMovMotivo('')
     setEditMovOpen(true)
-  }, [])
+  }, [unidade])
 
   const openQualityFix = React.useCallback(
     async (issue: QualityIssue) => {
@@ -4193,8 +4240,29 @@ export function InsumosModule() {
     if (!canUseApi || !isAuthed) return
 
     const tipo = normalizeMovimentacaoTipo(target?.tipo)
+    const produto = editMovProduto.trim()
+    if (!produto) {
+      toast.error('Informe o produto.')
+      return
+    }
+    const dataHora = combineLocalDateTimeToIso(editMovData, editMovHora)
+    if (!dataHora) {
+      toast.error('Informe uma data e hora válidas.')
+      return
+    }
     const body: Record<string, unknown> = {
+      produto,
+      dataHora,
       observacoes: editMovObservacoes.trim()
+    }
+
+    if (!String(target?.transferId || '').trim()) {
+      const nextUnidade = String(editMovUnidade || '').trim()
+      if (!nextUnidade) {
+        toast.error('Informe a unidade.')
+        return
+      }
+      body.unidade = nextUnidade
     }
 
     if (String(target?.transferId || '').trim()) {
@@ -4248,10 +4316,56 @@ export function InsumosModule() {
     }
   }, [
     canUseApi,
+    editMovData,
+    editMovHora,
     editMovMotivo,
     editMovNovoEstoque,
     editMovObservacoes,
+    editMovProduto,
     editMovQuantidade,
+    editMovTarget,
+    editMovUnidade,
+    isAuthed,
+    loadMovimentacoes,
+    mutateJson,
+    refreshInsumos,
+    schedulePostMutationRefresh,
+    unidade
+  ])
+
+  const deleteMovementEdit = React.useCallback(async () => {
+    const target = editMovTarget
+    const movementId = String(target?.id || '').trim()
+    if (!movementId) {
+      toast.error('Movimentação inválida.')
+      return
+    }
+    if (!canUseApi || !isAuthed) return
+
+    const confirmed = window.confirm('Excluir este lançamento? Essa ação recalcula o estoque do insumo.')
+    if (!confirmed) return
+
+    setEditMovDeleting(true)
+    try {
+      await mutateJson<{ success?: boolean }>(
+        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(String(target?.unidade || unidade || '').trim() || unidade)}`,
+        {
+          method: 'DELETE',
+          queueLabel: 'Exclusão de movimentação'
+        }
+      )
+      toast.success('Lançamento excluído.')
+      setEditMovOpen(false)
+      setEditMovTarget(null)
+      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+      schedulePostMutationRefresh({ overview: true, insights: true })
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e))
+    } finally {
+      setEditMovDeleting(false)
+    }
+  }, [
+    canUseApi,
     editMovTarget,
     isAuthed,
     loadMovimentacoes,
@@ -4718,6 +4832,12 @@ export function InsumosModule() {
     const fromInsumos = (insumos || []).map((item) => String(item.marca || '').trim()).filter(Boolean)
     return uniqueSortedTextOptions([...fromInsumos, ...insumosOptionsMarcas])
   }, [insumos, insumosOptionsMarcas])
+
+  const insumosProdutos = React.useMemo(() => {
+    const fromInsumos = (insumos || []).map((item) => String(item.produto || '').trim()).filter(Boolean)
+    const fromMovimentacoes = (movimentacoes || []).map((item) => String(item.produto || '').trim()).filter(Boolean)
+    return uniqueSortedTextOptions([...fromInsumos, ...fromMovimentacoes])
+  }, [insumos, movimentacoes])
 
   const insumosTiposUnidade = React.useMemo(() => Array.from(CANONICAL_TIPOS_UNIDADE as readonly string[]), [])
 
@@ -6794,6 +6914,7 @@ export function InsumosModule() {
           if (!open) {
             setEditMovTarget(null)
             setEditMovSaving(false)
+            setEditMovDeleting(false)
           }
         }}
       >
@@ -6815,22 +6936,64 @@ export function InsumosModule() {
           </DialogHeader>
 
           <div className="space-y-3">
-            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-blue-100/80">
-              <div><span className="text-blue-200/60">Produto:</span> {String(editMovTarget?.produto || '-')}</div>
-              <div><span className="text-blue-200/60">Data:</span> {fmtDate(editMovTarget?.dataHora) || '-'}</div>
-              <div>
-                <span className="text-blue-200/60">Unidade:</span>{' '}
-                {String(editMovTarget?.transferId || '').trim()
-                  ? `${unidadeLabel(String(editMovTarget?.unidadeOrigem || ''))} → ${unidadeLabel(String(editMovTarget?.unidadeDestino || ''))}`
-                  : unidadeLabel(String(editMovTarget?.unidade || unidade))}
-              </div>
-              {editMovTarget?.registroInsumo ? (
-                <div><span className="text-blue-200/60">Registro:</span> <span className="font-mono">{String(editMovTarget.registroInsumo)}</span></div>
-              ) : null}
+            <div>
+              <div className="text-xs text-blue-200/70 mb-1">Produto</div>
+              <AutocompleteInput
+                value={editMovProduto}
+                onValueChange={setEditMovProduto}
+                placeholder="Nome do produto"
+                options={insumosProdutos}
+              />
             </div>
 
-            {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <div>
+                <div className="text-xs text-blue-200/70 mb-1">Data</div>
+                <BrDatePickerInput
+                  value={fmtDateOnlyBR(editMovData)}
+                  onChange={(value) => {
+                    const iso = dateInputToIso(value)
+                    setEditMovData(iso || value)
+                  }}
+                  placeholder="DD/MM/AA"
+                  ariaLabel="Data da movimentação"
+                />
+              </div>
+              <div>
+                <div className="text-xs text-blue-200/70 mb-1">Hora</div>
+                <Input
+                  type="time"
+                  value={editMovHora}
+                  onChange={(e) => setEditMovHora(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <div>
+                <div className="text-xs text-blue-200/70 mb-1">Unidade</div>
+                {String(editMovTarget?.transferId || '').trim() ? (
+                  <Input
+                    value={`${unidadeLabel(String(editMovTarget?.unidadeOrigem || ''))} → ${unidadeLabel(String(editMovTarget?.unidadeDestino || ''))}`}
+                    disabled
+                  />
+                ) : (
+                  <Select value={editMovUnidade || undefined} onValueChange={setEditMovUnidade}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Selecione a unidade" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {unidadeOptions.map((u) => (
+                        <SelectItem key={u} value={u}>
+                          {unidadeLabel(u)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+
+              {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
                 <div>
                   <div className="text-xs text-blue-200/70 mb-1">Novo estoque</div>
                   <Input
@@ -6840,48 +7003,56 @@ export function InsumosModule() {
                     onChange={(e) => setEditMovNovoEstoque(e.target.value)}
                   />
                 </div>
+              ) : (
                 <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Motivo</div>
-                  <Input value={editMovMotivo} onChange={(e) => setEditMovMotivo(e.target.value)} />
+                  <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={editMovQuantidade}
+                    onChange={(e) => setEditMovQuantidade(e.target.value)}
+                  />
                 </div>
-              </div>
-            ) : (
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
-                <Input
-                  type="number"
-                  min={1}
-                  value={editMovQuantidade}
-                  onChange={(e) => setEditMovQuantidade(e.target.value)}
-                />
-              </div>
-            )}
-
-            <div>
-              <div className="text-xs text-blue-200/70 mb-1">Observações</div>
-              <Textarea
-                value={editMovObservacoes}
-                onChange={(e) => setEditMovObservacoes(e.target.value)}
-                placeholder="opcional"
-                rows={3}
-              />
+              )}
             </div>
+
+            {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
+              <div>
+                <div className="text-xs text-blue-200/70 mb-1">Motivo</div>
+                <Input value={editMovMotivo} onChange={(e) => setEditMovMotivo(e.target.value)} />
+              </div>
+            ) : null}
+
+            {editMovTarget?.registroInsumo ? (
+              <div className="text-xs text-blue-200/60">
+                Registro: <span className="font-mono">{String(editMovTarget.registroInsumo)}</span>
+              </div>
+            ) : null}
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-between">
+            <Button
+              variant="destructive"
+              onClick={() => void deleteMovementEdit()}
+              disabled={editMovSaving || editMovDeleting || !isAuthed}
+            >
+              {editMovDeleting ? 'Excluindo...' : 'Excluir'}
+            </Button>
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
             <Button
               variant="secondary"
               onClick={() => {
                 setEditMovOpen(false)
                 setEditMovTarget(null)
               }}
-              disabled={editMovSaving}
+              disabled={editMovSaving || editMovDeleting}
             >
               Cancelar
             </Button>
-            <Button onClick={() => void saveMovementEdit()} disabled={editMovSaving || !isAuthed}>
+            <Button onClick={() => void saveMovementEdit()} disabled={editMovSaving || editMovDeleting || !isAuthed}>
               {editMovSaving ? 'Salvando...' : 'Salvar lançamento'}
             </Button>
+            </div>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/website/esfa-redirects/src/index.ts
+++ b/website/esfa-redirects/src/index.ts
@@ -5,12 +5,13 @@ const REDIRECTS: Record<string, string> = {
     "/barrashoppingsul": "https://espacofacial.com/barrashoppingsul",
     "/nh/faleconosco": "https://espacofacial.com/novohamburgo/faleconosco",
     "/bss/faleconosco": "https://espacofacial.com/barrashoppingsul/faleconosco",
+    "/meuespaço": "https://espacofacial.com/MeuEspaço",
 };
 
 function normalizePathname(pathname: string): string {
     // Remove trailing slashes except for root.
     const trimmed = pathname.replace(/\/+$/, "");
-    return trimmed.length ? trimmed : "/";
+    return (trimmed.length ? trimmed : "/").toLowerCase();
 }
 
 function redirect(to: string, status = 301): Response {

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -1217,7 +1217,6 @@ export default function BookingFlow() {
                                                                         </button>
                                                                     ) : null}
                                                                 </div>
-                                                                <div className="bookingFlow__doctorTooltipSub">{unitLabel}</div>
                                                             </>
                                                         }
                                                     >
@@ -1245,6 +1244,28 @@ export default function BookingFlow() {
                                                             </span>
                                                         </button>
                                                     </PortalTooltip>
+                                                    <div className="bookingFlow__doctorMeta">
+                                                        <div className="bookingFlow__doctorNameRow">
+                                                            <span className="bookingFlow__doctorNameLabel">{d.name}</span>
+                                                            {instagramHref ? (
+                                                                <button
+                                                                    type="button"
+                                                                    className="bookingFlow__doctorInstagramBtn"
+                                                                    aria-label={`Abrir Instagram de ${d.name}`}
+                                                                    title="Instagram"
+                                                                    onClick={() =>
+                                                                        openDoctorInstagram({
+                                                                            name: d.name,
+                                                                            handle: d.handle,
+                                                                            instagramUrl: instagramHref,
+                                                                        })
+                                                                    }
+                                                                >
+                                                                    <InstagramIcon size={13} />
+                                                                </button>
+                                                            ) : null}
+                                                        </div>
+                                                    </div>
                                                 </div>
                                             );
                                         })}
@@ -1275,6 +1296,11 @@ export default function BookingFlow() {
                                                     </span>
                                                 </button>
                                             </PortalTooltip>
+                                            <div className="bookingFlow__doctorMeta">
+                                                <div className="bookingFlow__doctorNameRow">
+                                                    <span className="bookingFlow__doctorNameLabel">Sem Preferência</span>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </HoverScrollPicker>

--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { createPortal } from "react-dom";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { doctorSlugFromTeamMember } from "@/lib/doctorSlug";
 import { trackBookingStart, trackDoctorInstagramClick } from "@/lib/leadTracking";
@@ -58,101 +57,6 @@ function extractInstagramHandle(url: string | null): string | null {
 type UnitDoctorsGridProps = {
     variant?: "directory" | "booking-compact";
 };
-
-function PortalTooltip(props: { content: ReactNode; children: ReactNode; className: string; disabled?: boolean }) {
-    const anchorRef = useRef<HTMLDivElement | null>(null);
-    const tooltipRef = useRef<HTMLDivElement | null>(null);
-    const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const [open, setOpen] = useState(false);
-    const [position, setPosition] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
-
-    const clearCloseTimer = useCallback(() => {
-        if (!closeTimerRef.current) return;
-        clearTimeout(closeTimerRef.current);
-        closeTimerRef.current = null;
-    }, []);
-
-    const openTooltip = useCallback(() => {
-        if (props.disabled) return;
-        clearCloseTimer();
-        setOpen(true);
-    }, [clearCloseTimer, props.disabled]);
-
-    const scheduleClose = useCallback(() => {
-        clearCloseTimer();
-        closeTimerRef.current = setTimeout(() => setOpen(false), 120);
-    }, [clearCloseTimer]);
-
-    const updatePosition = useCallback(() => {
-        const anchor = anchorRef.current;
-        const tooltip = tooltipRef.current;
-        if (!anchor || !tooltip) return;
-        const anchorRect = anchor.getBoundingClientRect();
-        const tooltipRect = tooltip.getBoundingClientRect();
-        const viewportPadding = 8;
-        let left = anchorRect.left + anchorRect.width / 2;
-        const minLeft = viewportPadding + tooltipRect.width / 2;
-        const maxLeft = window.innerWidth - viewportPadding - tooltipRect.width / 2;
-        left = Math.max(minLeft, Math.min(maxLeft, left));
-        const top = anchorRect.bottom + 4;
-        setPosition({ left, top });
-    }, []);
-
-    useLayoutEffect(() => {
-        if (!open) return;
-        updatePosition();
-    }, [open, updatePosition, props.content]);
-
-    useEffect(() => {
-        if (!open) return;
-        const onWindowChange = () => updatePosition();
-        window.addEventListener("resize", onWindowChange);
-        window.addEventListener("scroll", onWindowChange, true);
-        return () => {
-            window.removeEventListener("resize", onWindowChange);
-            window.removeEventListener("scroll", onWindowChange, true);
-        };
-    }, [open, updatePosition]);
-
-    useEffect(() => {
-        return () => clearCloseTimer();
-    }, [clearCloseTimer]);
-
-    return (
-        <div
-            ref={anchorRef}
-            className="bookingFlow__tooltipAnchor"
-            onMouseEnter={openTooltip}
-            onMouseLeave={scheduleClose}
-            onFocusCapture={openTooltip}
-            onBlurCapture={scheduleClose}
-        >
-            {props.children}
-            {open && typeof document !== "undefined"
-                ? createPortal(
-                      <div
-                          ref={tooltipRef}
-                          className={props.className}
-                          role="tooltip"
-                          style={{
-                              position: "fixed",
-                              left: position.left,
-                              top: position.top,
-                              transform: "translateX(-50%)",
-                              display: "block",
-                              zIndex: 5000,
-                          }}
-                          onMouseEnter={openTooltip}
-                          onMouseLeave={scheduleClose}
-                      >
-                          {props.content}
-                      </div>,
-                      document.body,
-                  )
-                : null}
-        </div>
-    );
-}
 
 export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGridProps) {
     const unit = useCurrentUnit();
@@ -259,49 +163,46 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
 
                             return (
                                 <article key={`${fullName}-${href ?? "noinsta"}`} className="unitDoctorsCompact__item" role="listitem">
-                                    <PortalTooltip
-                                        className="bookingFlow__doctorTooltip unitDoctorsCompact__tooltip"
-                                        content={
-                                            <>
-                                                <div className="unitDoctorsCompact__tooltipHeader">
-                                                    <div className="bookingFlow__doctorTooltipName">{fullName}</div>
-                                                </div>
-                                                <div className="unitDoctorsCompact__tooltipActions">
-                                                    <Link
-                                                        className="unitDoctorsCompact__tooltipAction"
-                                                        href={bookingHref}
-                                                        onClick={() =>
-                                                            trackBookingStart({
-                                                                placement: "doctor_grid",
-                                                                unitSlug: unit?.slug ?? null,
-                                                                doctorName: fullName,
-                                                                bookingUrl: bookingHref,
-                                                            })
-                                                        }
-                                                        aria-label={`Agendar com ${fullName}`}
-                                                        title="Agendar"
-                                                    >
-                                                        {bookingIcon()}
-                                                        <span>Agenda</span>
-                                                    </Link>
-                                                    {instagramHandle ? (
-                                                        <button
-                                                            type="button"
-                                                            className="unitDoctorsCompact__tooltipAction"
-                                                            onClick={openInstagram}
-                                                            aria-label={`Abrir Instagram de ${fullName}`}
-                                                            title="Instagram"
-                                                        >
-                                                            <InstagramIcon size={13} />
-                                                            <span>Insta</span>
-                                                        </button>
-                                                    ) : null}
-                                                </div>
-                                            </>
+                                    <Link
+                                        className="bookingFlow__doctorBadge unitDoctorsCompact__badgeLink"
+                                        href={bookingHref}
+                                        onClick={() =>
+                                            trackBookingStart({
+                                                placement: "doctor_grid",
+                                                unitSlug: unit?.slug ?? null,
+                                                doctorName: fullName,
+                                                bookingUrl: bookingHref,
+                                            })
                                         }
+                                        aria-label={`Agendar com ${fullName}`}
                                     >
+                                        <span className="bookingFlow__doctorBadgeAvatar">
+                                            {instagramHandle ? (
+                                                <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={76} height={76} unoptimized />
+                                            ) : (
+                                                <span className="bookingFlow__doctorBadgeFallback">{fullName.charAt(0).toUpperCase()}</span>
+                                            )}
+                                        </span>
+                                    </Link>
+
+                                    <div className="unitDoctorsCompact__meta">
+                                        <div className="unitDoctorsCompact__nameRow">
+                                            <div className="unitDoctorsCompact__name">{fullName}</div>
+                                            {instagramHandle ? (
+                                                <button
+                                                    type="button"
+                                                    className="unitDoctorsCompact__instagramBtn"
+                                                    onClick={openInstagram}
+                                                    aria-label={`Abrir Instagram de ${fullName}`}
+                                                    title="Instagram"
+                                                >
+                                                    <InstagramIcon size={14} />
+                                                </button>
+                                            ) : null}
+                                        </div>
+
                                         <Link
-                                            className="bookingFlow__doctorBadge unitDoctorsCompact__badgeLink"
+                                            className="cta cta--agende unitDoctorsCompact__bookBtn"
                                             href={bookingHref}
                                             onClick={() =>
                                                 trackBookingStart({
@@ -311,19 +212,10 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                                     bookingUrl: bookingHref,
                                                 })
                                             }
-                                            aria-label={`Agendar com ${fullName}`}
                                         >
-                                            <span className="bookingFlow__doctorBadgeAvatar">
-                                                {instagramHandle ? (
-                                                    <Image src={avatarUrl(instagramHandle, fullName)} alt={fullName} width={76} height={76} unoptimized />
-                                                ) : (
-                                                    <span className="bookingFlow__doctorBadgeFallback">{fullName.charAt(0).toUpperCase()}</span>
-                                                )}
-                                            </span>
+                                            AGENDE
                                         </Link>
-                                    </PortalTooltip>
-
-                                    <div className="unitDoctorsCompact__name">{fullName}</div>
+                                    </div>
                                 </article>
                             );
                         })}

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -30,17 +30,22 @@ export function middleware(req: NextRequest) {
 
     // esfa.co short links -> main site routes
     if (!isPublicAsset(url.pathname) && (host === "esfa.co" || host === "www.esfa.co")) {
-        const pathname = url.pathname.replace(/\/+$/, "") || "/";
+        const pathname = (url.pathname.replace(/\/+$/, "") || "/").toLowerCase();
         const map: Record<string, string> = {
             "/nh": "https://espacofacial.com/novohamburgo",
             "/bss": "https://espacofacial.com/barrashoppingsul",
             "/nh/faleconosco": "https://espacofacial.com/novohamburgo/faleconosco",
             "/bss/faleconosco": "https://espacofacial.com/barrashoppingsul/faleconosco",
+            "/meuespaço": "https://espacofacial.com/MeuEspaço",
         };
 
         const dest = map[pathname];
         if (dest) {
-            return NextResponse.redirect(dest, { status: 301 });
+            const destUrl = new URL(dest);
+            if (req.nextUrl.search) {
+                destUrl.search = req.nextUrl.search;
+            }
+            return NextResponse.redirect(destUrl, { status: 301 });
         }
     }
 

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1421,6 +1421,10 @@ button:focus-visible {
 .bookingFlow__doctorBadgeWrap {
   position: relative;
   flex: 0 0 auto;
+  width: 108px;
+  display: grid;
+  justify-items: center;
+  gap: 8px;
 }
 
 .bookingFlow__doctorBadgeWrap::after {
@@ -1438,6 +1442,9 @@ button:focus-visible {
   padding: 0;
   background: transparent;
   cursor: pointer;
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
 }
 
 .bookingFlow__doctorBadgeAvatar {
@@ -1501,7 +1508,7 @@ button:focus-visible {
 }
 
 .bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap {
-  padding-top: 6px;
+  padding-top: 0;
 }
 
 .bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap:hover,
@@ -1542,6 +1549,49 @@ button:focus-visible {
   font-weight: 900;
   line-height: 1.1;
   font-size: 11px;
+}
+
+.bookingFlow__doctorMeta {
+  width: 100%;
+}
+
+.bookingFlow__doctorNameRow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 30px;
+  min-width: 0;
+}
+
+.bookingFlow__doctorNameLabel {
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1.08;
+  text-align: center;
+  text-wrap: balance;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.bookingFlow__doctorInstagramBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #111;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.bookingFlow__doctorInstagramBtn:hover {
+  background: rgba(17, 17, 17, 0.06);
 }
 
 .bookingFlow__doctorTooltipSub {
@@ -1806,6 +1856,7 @@ button:focus-visible {
 
 .bookingFlow__picker {
   --picker-arrow-zone: 46px;
+  --picker-arrow-inset: 6px;
   --picker-edge-height: 84px;
   position: relative;
   margin-top: 4px;
@@ -1829,16 +1880,16 @@ button:focus-visible {
   margin-left: 0;
   margin-right: 0;
   margin-top: 0;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 24px;
+  padding-right: 24px;
   padding-top: 8px;
   padding-bottom: 10px;
-  scroll-padding-left: 0;
-  scroll-padding-right: 0;
+  scroll-padding-left: 24px;
+  scroll-padding-right: 24px;
 }
 
 .bookingFlow__scrollWindow--doctor {
-  padding-top: 8px !important;
+  padding-top: 18px !important;
   padding-bottom: 16px !important;
 }
 
@@ -1873,12 +1924,12 @@ button:focus-visible {
 }
 
 .bookingFlow__hoverZone--left {
-  left: calc(var(--picker-arrow-zone) * -1);
+  left: var(--picker-arrow-inset);
   justify-content: center;
 }
 
 .bookingFlow__hoverZone--right {
-  right: calc(var(--picker-arrow-zone) * -1);
+  right: var(--picker-arrow-inset);
   justify-content: center;
 }
 
@@ -4046,15 +4097,22 @@ video.heroMediaEl {
 
 .unitDoctorsCompact__item {
   flex: 0 0 auto;
-  width: 96px;
+  width: 148px;
   display: grid;
   justify-items: center;
-  gap: 8px;
+  gap: 10px;
   text-align: center;
 }
 
 .unitDoctorsCompact__badgeLink {
   text-decoration: none;
+}
+
+.unitDoctorsCompact__badgeLink:hover .bookingFlow__doctorBadgeAvatar,
+.unitDoctorsCompact__badgeLink:focus-visible .bookingFlow__doctorBadgeAvatar {
+  transform: translateY(-2px);
+  border-color: rgba(17, 17, 17, 0.88);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
 }
 
 .unitDoctorsCompact__badgeLink .bookingFlow__doctorBadgeAvatar {
@@ -4068,75 +4126,59 @@ video.heroMediaEl {
   object-fit: cover;
 }
 
+.unitDoctorsCompact__meta {
+  display: grid;
+  gap: 8px;
+  width: 100%;
+}
+
+.unitDoctorsCompact__nameRow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 36px;
+  width: 100%;
+  min-width: 0;
+}
+
 .unitDoctorsCompact__name {
   font-size: 13px;
   font-weight: 900;
   line-height: 1.15;
   letter-spacing: -.03em;
   text-wrap: balance;
-}
-
-.unitDoctorsCompact__tooltip {
-  display: grid;
-  gap: 10px;
-  min-width: 128px;
-  padding: 10px 10px 10px;
-}
-
-.unitDoctorsCompact__tooltipHeader {
-  display: grid;
-  justify-items: center;
-  gap: 2px;
-}
-
-.unitDoctorsCompact__tooltip .bookingFlow__doctorTooltipName {
-  text-align: center;
-  font-size: 12px;
-  line-height: 1.15;
-}
-
-.unitDoctorsCompact__tooltipActions {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-}
-
-.unitDoctorsCompact__tooltipAction {
-  display: inline-grid;
-  justify-items: center;
-  align-content: center;
-  justify-content: center;
-  width: 52px;
-  height: 48px;
+  overflow-wrap: anywhere;
   min-width: 0;
-  flex: 0 0 auto;
-  gap: 5px;
-  padding: 6px 4px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.06);
-  color: #fff;
-  text-decoration: none;
-  font-size: 9.5px;
-  font-weight: 800;
-  line-height: 1;
+}
+
+.unitDoctorsCompact__instagramBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #111;
   cursor: pointer;
-  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+  flex: 0 0 auto;
 }
 
-.unitDoctorsCompact__tooltipAction svg {
-  width: 14px;
-  height: 14px;
+.unitDoctorsCompact__instagramBtn:hover {
+  background: rgba(17, 17, 17, 0.06);
 }
 
-.unitDoctorsCompact__tooltipAction span {
-  letter-spacing: 0.01em;
-}
-
-.unitDoctorsCompact__tooltipAction:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.28);
-  transform: translateY(-1px);
+.unitDoctorsCompact__bookBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 42px;
+  padding: 10px 16px;
+  text-decoration: none;
 }
 
 .pageNarrative {

--- a/website/workers/esfa-redirector/worker.ts
+++ b/website/workers/esfa-redirector/worker.ts
@@ -32,6 +32,7 @@ const REDIRECTS: Record<string, string> = {
 
   // Interno
   "/sugereaqui": "https://espacofacial.com/sugereaqui",
+  "/meuespaço": "https://espacofacial.com/MeuEspaço",
 
   // Doutores - BSS
   "/bss/dragabrielamenegat": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Gabriela%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",


### PR DESCRIPTION
This branch updates the doctor presentation on the website and the booking flow UI.

User-facing changes:
- On the booking page, doctor avatars now show the doctor name underneath, with Instagram kept beside the name.
- Doctor tooltips on booking now show only the doctor name and Instagram action, removing the unit subtitle.
- The home page doctor rail now uses the same visual language as booking: name + Instagram inline, plus the green `AGENDE` CTA styled like the header button.
- The doctor carousel arrows were moved inward and the doctor rail spacing was adjusted to keep the arrows from overlapping the procedures rail.

The branch also carries the other work already present in the workspace for Insumos/Escala-related modules, so the PR reflects the full current state of the tree.

Validation:
- `npm --prefix website run build`
