### PR TITLE
[codex] tooltip dos doutores na home

### DIFF
--- a/website/src/components/UnitDoctorsGrid.tsx
+++ b/website/src/components/UnitDoctorsGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
@@ -52,6 +53,189 @@ function extractInstagramHandle(url: string | null): string | null {
     } catch {
         return null;
     }
+}
+
+type CompactDoctorTooltipProps = {
+    fullName: string;
+    bookingHref: string;
+    unitSlug: string | null;
+    onOpenInstagram: () => void;
+};
+
+function CompactDoctorTooltip({
+    fullName,
+    bookingHref,
+    unitSlug,
+    onOpenInstagram,
+}: CompactDoctorTooltipProps) {
+    const [open, setOpen] = useState(false);
+    const [ready, setReady] = useState(false);
+    const [position, setPosition] = useState({ left: 0, top: 0 });
+    const triggerRef = useRef<HTMLButtonElement | null>(null);
+    const tooltipRef = useRef<HTMLDivElement | null>(null);
+    const closeTimerRef = useRef<number | null>(null);
+
+    const clearCloseTimer = useCallback(() => {
+        if (!closeTimerRef.current) return;
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+    }, []);
+
+    const scheduleClose = useCallback(() => {
+        clearCloseTimer();
+        closeTimerRef.current = window.setTimeout(() => {
+            setOpen(false);
+        }, 120);
+    }, [clearCloseTimer]);
+
+    const updatePosition = useCallback(() => {
+        const trigger = triggerRef.current;
+        const tooltip = tooltipRef.current;
+        if (!trigger || !tooltip) return;
+
+        const triggerRect = trigger.getBoundingClientRect();
+        const tooltipRect = tooltip.getBoundingClientRect();
+        const viewportPadding = 12;
+        const gap = 12;
+
+        const centerX = triggerRect.left + triggerRect.width / 2;
+        const halfWidth = tooltipRect.width / 2;
+        const left = Math.min(
+            window.innerWidth - viewportPadding - halfWidth,
+            Math.max(viewportPadding + halfWidth, centerX),
+        );
+
+        const spaceBelow = window.innerHeight - triggerRect.bottom;
+        const spaceAbove = triggerRect.top;
+        const openBelow = spaceBelow >= tooltipRect.height + gap || spaceBelow >= spaceAbove;
+        const top = openBelow
+            ? Math.min(window.innerHeight - viewportPadding - tooltipRect.height, triggerRect.bottom + gap)
+            : Math.max(viewportPadding, triggerRect.top - tooltipRect.height - gap);
+
+        setPosition({ left, top });
+        setReady(true);
+    }, []);
+
+    useEffect(() => {
+        if (!open) {
+            setReady(false);
+            clearCloseTimer();
+            return;
+        }
+
+        const onUpdate = () => updatePosition();
+        const raf = window.requestAnimationFrame(onUpdate);
+        window.addEventListener("resize", onUpdate);
+        window.addEventListener("scroll", onUpdate, true);
+
+        return () => {
+            window.cancelAnimationFrame(raf);
+            window.removeEventListener("resize", onUpdate);
+            window.removeEventListener("scroll", onUpdate, true);
+        };
+    }, [clearCloseTimer, open, updatePosition]);
+
+    useEffect(() => () => clearCloseTimer(), [clearCloseTimer]);
+
+    return (
+        <div
+            className="unitDoctorsCompact__tooltipAnchor"
+            onMouseEnter={() => {
+                clearCloseTimer();
+                setOpen(true);
+            }}
+            onMouseLeave={scheduleClose}
+            onFocusCapture={() => {
+                clearCloseTimer();
+                setOpen(true);
+            }}
+            onBlurCapture={(event) => {
+                const next = event.relatedTarget as Node | null;
+                const trigger = triggerRef.current;
+                const tooltip = tooltipRef.current;
+                if (next && ((trigger && trigger.contains(next)) || (tooltip && tooltip.contains(next)))) return;
+                scheduleClose();
+            }}
+        >
+            <button
+                ref={triggerRef}
+                type="button"
+                className="unitDoctorsCompact__triggerBtn"
+                onMouseEnter={() => {
+                    clearCloseTimer();
+                    setOpen(true);
+                }}
+                onClick={() => {
+                    clearCloseTimer();
+                    setOpen((current) => !current);
+                }}
+                aria-haspopup="true"
+                aria-expanded={open}
+                aria-label={`Abrir ações de ${fullName}`}
+                title="Abrir ações"
+            >
+                <InstagramIcon size={14} />
+            </button>
+
+            {open && typeof document !== "undefined"
+                ? createPortal(
+                      <div
+                          ref={tooltipRef}
+                          className="bookingFlow__doctorTooltip unitDoctorsCompact__tooltip"
+                          role="tooltip"
+                          style={{
+                              position: "fixed",
+                              left: position.left,
+                              top: position.top,
+                              transform: "translateX(-50%)",
+                              display: "block",
+                              zIndex: 5000,
+                              opacity: ready ? 1 : 0,
+                          }}
+                          onMouseEnter={() => {
+                              clearCloseTimer();
+                              setOpen(true);
+                          }}
+                          onMouseLeave={scheduleClose}
+                      >
+                          <div className="unitDoctorsCompact__tooltipNameRow">
+                              <div className="unitDoctorsCompact__tooltipName">{fullName}</div>
+                              <button
+                                  type="button"
+                                  className="unitDoctorsCompact__tooltipInstagramBtn"
+                                  onClick={() => {
+                                      clearCloseTimer();
+                                      setOpen(false);
+                                      onOpenInstagram();
+                                  }}
+                                  aria-label={`Abrir Instagram de ${fullName}`}
+                                  title="Instagram"
+                              >
+                                  <InstagramIcon size={14} />
+                              </button>
+                          </div>
+
+                          <Link
+                              className="cta cta--agende unitDoctorsCompact__tooltipBookBtn"
+                              href={bookingHref}
+                              onClick={() =>
+                                  trackBookingStart({
+                                      placement: "doctor_grid",
+                                      unitSlug,
+                                      doctorName: fullName,
+                                      bookingUrl: bookingHref,
+                                  })
+                              }
+                              onMouseEnter={() => clearCloseTimer()}
+                          >
+                              AGENDE
+                          </Link>
+                      </div>,
+                      document.body,
+                  )
+                : null}
+        </div>
+    );
 }
 
 type UnitDoctorsGridProps = {
@@ -189,32 +373,14 @@ export default function UnitDoctorsGrid({ variant = "directory" }: UnitDoctorsGr
                                         <div className="unitDoctorsCompact__nameRow">
                                             <div className="unitDoctorsCompact__name">{fullName}</div>
                                             {instagramHandle ? (
-                                                <button
-                                                    type="button"
-                                                    className="unitDoctorsCompact__instagramBtn"
-                                                    onClick={openInstagram}
-                                                    aria-label={`Abrir Instagram de ${fullName}`}
-                                                    title="Instagram"
-                                                >
-                                                    <InstagramIcon size={14} />
-                                                </button>
+                                                <CompactDoctorTooltip
+                                                    fullName={fullName}
+                                                    bookingHref={bookingHref}
+                                                    unitSlug={unit?.slug ?? null}
+                                                    onOpenInstagram={openInstagram}
+                                                />
                                             ) : null}
                                         </div>
-
-                                        <Link
-                                            className="cta cta--agende unitDoctorsCompact__bookBtn"
-                                            href={bookingHref}
-                                            onClick={() =>
-                                                trackBookingStart({
-                                                    placement: "doctor_grid",
-                                                    unitSlug: unit?.slug ?? null,
-                                                    doctorName: fullName,
-                                                    bookingUrl: bookingHref,
-                                                })
-                                            }
-                                        >
-                                            AGENDE
-                                        </Link>
                                     </div>
                                 </article>
                             );

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -4142,6 +4142,101 @@ video.heroMediaEl {
   min-width: 0;
 }
 
+.unitDoctorsCompact__tooltipAnchor {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.unitDoctorsCompact__triggerBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #111;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.unitDoctorsCompact__triggerBtn:hover,
+.unitDoctorsCompact__triggerBtn:focus-visible {
+  background: rgba(17, 17, 17, 0.06);
+  transform: translateY(-1px);
+}
+
+.unitDoctorsCompact__tooltip {
+  display: grid;
+  gap: 10px;
+  min-width: 176px;
+  padding: 10px 12px 12px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.3);
+}
+
+.unitDoctorsCompact__tooltipNameRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+
+.unitDoctorsCompact__tooltipName {
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.unitDoctorsCompact__tooltipInstagramBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: background 160ms ease, transform 160ms ease, opacity 160ms ease;
+}
+
+.unitDoctorsCompact__tooltipInstagramBtn:hover,
+.unitDoctorsCompact__tooltipInstagramBtn:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  opacity: 1;
+}
+
+.unitDoctorsCompact__tooltipBookBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+.unitDoctorsCompact__tooltipBookBtn:hover,
+.unitDoctorsCompact__tooltipBookBtn:focus-visible {
+  background: #18b14c;
+  box-shadow: 0 10px 26px rgba(22, 163, 74, 0.28);
+}
+
 .unitDoctorsCompact__name {
   font-size: 13px;
   font-weight: 900;


### PR DESCRIPTION
A seção "Nossos Doutores" na home exibia o botão de Instagram e o CTA de agendamento na linha principal do card. Isso competia com o nome do doutor e não seguia a referência visual desejada.

A correção moveu essas ações para uma tooltip acionada pelo ícone ao lado do nome. Agora o card compacto mostra apenas o nome do doutor como conteúdo principal, enquanto o botão do Instagram e o botão "AGENDE" aparecem no hover/foco do ícone. Para evitar que a tooltip seja cortada pela faixa horizontal, ela é renderizada via portal e posicionada com `position: fixed`.

Validação realizada:
- `npm run typecheck`

