### PR TITLE
Harden Cloudflare alerting apply workflow

### DIFF
--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -12,7 +12,7 @@ on:
           - "false"
           - "true"
   schedule:
-    - cron: "23 3 * * 1" # weekly drift remediation
+    - cron: "23 3 * * 1" # weekly drift remediation (gated by ENABLE_CLOUDFLARE_ALERTING_APPLY)
 
 permissions:
   contents: read
@@ -24,12 +24,24 @@ jobs:
       - name: Guard Cloudflare alerting secrets
         id: guard
         env:
+          ENABLE_CLOUDFLARE_ALERTING_APPLY: ${{ vars.ENABLE_CLOUDFLARE_ALERTING_APPLY }}
+          CLOUDFLARE_ALERT_ENABLE_EMAILS: ${{ vars.CLOUDFLARE_ALERT_ENABLE_EMAILS || 'false' }}
           CLOUDFLARE_ALERTS_API_TOKEN: ${{ secrets.CLOUDFLARE_ALERTS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ALERT_EMAILS: ${{ vars.CLOUDFLARE_ALERT_EMAILS }}
           CLOUDFLARE_ALERT_WEBHOOK_URL: ${{ secrets.CLOUDFLARE_ALERT_WEBHOOK_URL }}
         run: |
           set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" && "${ENABLE_CLOUDFLARE_ALERTING_APPLY:-false}" != "true" ]]; then
+            echo "Scheduled Cloudflare alerting apply disabled; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${CLOUDFLARE_ALERT_ENABLE_EMAILS:-false}" != "true" ]]; then
+            unset CLOUDFLARE_ALERT_EMAILS
+          fi
+
           if [[ -z "${CLOUDFLARE_ALERTS_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
             echo "Cloudflare alerting secrets not configured; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -56,6 +68,7 @@ jobs:
       - name: Apply Cloudflare alerting policies
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
+          CLOUDFLARE_ALERT_ENABLE_EMAILS: ${{ vars.CLOUDFLARE_ALERT_ENABLE_EMAILS || 'false' }}
           CLOUDFLARE_ALERTS_API_TOKEN: ${{ secrets.CLOUDFLARE_ALERTS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ALERT_EMAILS: ${{ vars.CLOUDFLARE_ALERT_EMAILS }}
@@ -68,6 +81,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${CLOUDFLARE_ALERT_ENABLE_EMAILS:-false}" != "true" ]]; then
+            unset CLOUDFLARE_ALERT_EMAILS
+          fi
           cd /tmp
           bash "$GITHUB_WORKSPACE/backend/scripts/cloudflare-alerting-apply.sh"
           cat cloudflare-alerting-apply.summary.json

--- a/backend/scripts/cloudflare-alerting-apply.sh
+++ b/backend/scripts/cloudflare-alerting-apply.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 #   CLOUDFLARE_ALERTS_API_TOKEN  (preferred) OR CLOUDFLARE_API_TOKEN
 #
 # Destination config (at least one is required):
+#   CLOUDFLARE_ALERT_ENABLE_EMAILS   "true" to allow email destinations from CLOUDFLARE_ALERT_EMAILS
 #   CLOUDFLARE_ALERT_EMAILS          CSV of emails (e.g. "ops@skincos.com.br,dev@skincos.com.br")
 #   CLOUDFLARE_ALERT_WEBHOOK_URL     Webhook URL (Slack/Discord/HTTP receiver)
 #
@@ -27,6 +28,7 @@ acct="${CLOUDFLARE_ACCOUNT_ID:-}"
 token="${CLOUDFLARE_ALERTS_API_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
 
 emails_csv="${CLOUDFLARE_ALERT_EMAILS:-}"
+enable_emails_raw="${CLOUDFLARE_ALERT_ENABLE_EMAILS:-false}"
 webhook_url="${CLOUDFLARE_ALERT_WEBHOOK_URL:-}"
 webhook_name="${CLOUDFLARE_ALERT_WEBHOOK_NAME:-skincos-alerts}"
 
@@ -36,6 +38,16 @@ pages_envs_csv="${CLOUDFLARE_PAGES_ENVIRONMENTS:-production,preview}"
 pages_events_csv="${CLOUDFLARE_PAGES_EVENTS:-}"
 
 dry_run="${CLOUDFLARE_ALERTING_DRY_RUN:-false}"
+
+is_truthy() {
+  local value="${1:-}"
+  value="${value,,}"
+  [[ "${value}" == "1" || "${value}" == "true" || "${value}" == "yes" || "${value}" == "on" ]]
+}
+
+if ! is_truthy "${enable_emails_raw}"; then
+  emails_csv=""
+fi
 
 if [[ -z "${acct}" ]]; then
   echo "[cloudflare-alerting-apply] Missing CLOUDFLARE_ACCOUNT_ID" >&2

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -86,12 +86,15 @@ Configuração (repo → Settings):
   - `CLOUDFLARE_ALERTS_API_TOKEN`
   - (opcional) `CLOUDFLARE_ALERT_WEBHOOK_URL`
 - **Variables → Actions**
-  - `CLOUDFLARE_ALERT_EMAILS` (CSV)
+  - `ENABLE_CLOUDFLARE_ALERTING_APPLY` = `true` para permitir a execução agendada
+  - `CLOUDFLARE_ALERT_ENABLE_EMAILS` = `true` para permitir destinos por e-mail
+  - `CLOUDFLARE_ALERT_EMAILS` (CSV, usado apenas quando `CLOUDFLARE_ALERT_ENABLE_EMAILS=true`)
   - (opcional) `CLOUDFLARE_PAGES_PROJECT_IDS` (CSV)
   - (opcional) `CLOUDFLARE_PAGES_ENVIRONMENTS` (CSV, default sugerido: `production,preview`)
   - (opcional) `CLOUDFLARE_PAGES_EVENTS` (CSV)
 
 Observação: os alertas de **5xx/latência/D1/R2/429** podem depender de produtos/telemetria adicionais (ex.: Workers Observability) e podem não estar disponíveis diretamente via Alerting API v3; mantenha também o `uptime-slo.yml` como monitor sintético.
+Observação 2: por segurança, o agendamento semanal e os destinos de e-mail são opt-in explícitos.
 
 ### Checklist rápido (Cloudflare)
 

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -73,3 +73,6 @@ NOTE: Sheets credentials were removed (Insumos is D1-only). Do not re-add.
 
 ## Notas
 - Para exceções conhecidas, veja `docs/security-exceptions.md`.
+- Variables relacionadas a alerting devem permanecer em modo opt-in:
+  - `ENABLE_CLOUDFLARE_ALERTING_APPLY=true` somente se quiser execução agendada.
+  - `CLOUDFLARE_ALERT_ENABLE_EMAILS=true` somente se quiser destinos por e-mail.


### PR DESCRIPTION
## Summary
- gate scheduled Cloudflare alerting remediation behind an explicit repo variable
- require explicit opt-in before using email alert destinations
- document the new opt-in controls for alerting automation

## Why
The scheduled workflow re-enabled Cloudflare email alerts on March 30, 2026 by consuming the repo variable `CLOUDFLARE_ALERT_EMAILS`. This change prevents scheduled drift remediation and email destinations from being applied unless they are intentionally enabled.