### PR TITLE
[codex] refresh places snapshot cache

### DIFF
--- a/website/src/app/api/places/details/route.ts
+++ b/website/src/app/api/places/details/route.ts
@@ -33,7 +33,7 @@ export async function GET(req: Request) {
 
     const cache = getCloudflareCache();
     const cacheKey = new Request(
-        `https://espacofacial.com/__cache/places/details?v=4&src=snapshot&placeId=${encodeURIComponent(placeIdParam)}&query=${encodeURIComponent(queryParam)}`,
+        `https://espacofacial.com/__cache/places/details?v=5&src=snapshot&placeId=${encodeURIComponent(placeIdParam)}&query=${encodeURIComponent(queryParam)}`,
     );
 
     if (cache) {
@@ -58,8 +58,6 @@ export async function GET(req: Request) {
         placeId: placeIdParam || null,
         query: queryParam || null,
     };
-
-    if (cache) void cache.put(cacheKey, new Response(JSON.stringify(payload), { headers: { "content-type": "application/json" } }));
 
     return jsonOk(payload, { "x-places": "snapshot_missing" });
 }


### PR DESCRIPTION
## Summary
This hotfix refreshes the cache key for `website/src/app/api/places/details/route.ts` and stops caching `snapshot_not_found` payloads.

## Why
The first fix published the snapshot assets correctly, but production was still serving an old cached miss from the worker cache. The `Sobre Nós` section depends on `/api/places/details`, so the page continued to see `snapshot_not_found` even after the snapshot became available under `/production-snapshot/...`.

## Fix
- bump the route cache key version so the worker stops reading the stale cached miss
- stop writing `snapshot_not_found` responses into the cache, so future snapshot availability changes do not get pinned by a miss cache entry

## Validation
- `cd website && npm run typecheck`
- `cd website && npm run build`
