### PR TITLE
[codex] fix escala team db fallback

### DIFF
--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -204,22 +204,23 @@ function isVisibleInjector(prof: EscalaProfessional) {
   return isActiveInjector(prof) || isInactiveInjector(prof)
 }
 
+function normalizeProfessionalRecord(prof: EscalaProfessional) {
+  return {
+    ...prof,
+    role: String(prof.role || '').trim() || 'Injetor',
+    status: String(prof.status || '').trim() || 'Ativo',
+    units: Array.isArray(prof.units) ? prof.units : [],
+  }
+}
+
 function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional[]) {
   const map = new Map<string, EscalaProfessional>()
   base.forEach((prof) => {
-    const isScheduled = scheduleNames.has(prof.name)
-    const role = String(prof.role || '').trim() || (isScheduled ? 'Injetor' : '')
-    const status = String(prof.status || '').trim() || (isScheduled ? 'Ativo' : '')
-    map.set(prof.name, {
-      ...prof,
-      role,
-      status,
-      units: Array.isArray(prof.units) ? prof.units : [],
-    })
+    map.set(prof.name, normalizeProfessionalRecord(prof))
   })
   scheduleNames.forEach((name) => {
     if (map.has(name)) return
-    map.set(name, {
+    map.set(name, normalizeProfessionalRecord({
       name,
       status: 'Ativo',
       units: [],
@@ -230,9 +231,13 @@ function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional
       email: '',
       instagram: '',
       color: '',
-    })
+    }))
   })
   return Array.from(map.values())
+}
+
+export const __testables = {
+  mergeProfessionals,
 }
 
 function uniqueNames(values: string[]) {

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -84,6 +84,68 @@ test.describe('escala', () => {
     await expect(page.getByRole('option', { name: 'Carla' })).toHaveCount(0)
   })
 
+  test('keeps team members visible when the selected month has no schedule entries', async ({ page }) => {
+    await page.route('**/api/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
+      })
+    })
+
+    await page.route('**/api/insumos/auth/me**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] }, csrfToken: 'e2e' })
+      })
+    })
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-04'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: '', units: ['Novo Hamburgo'], role: '', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Bruno', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' },
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [],
+          closedDays: [],
+          holidays: []
+        })
+      })
+    })
+
+    await page.goto('/?module=escala-profissionais')
+
+    await expect(page.getByRole('heading', { name: 'Escala' })).toBeVisible({ timeout: 30000 })
+    await expect(page.getByTestId('escala-team-member-dra-ana')).toBeVisible()
+    await expect(page.getByTestId('escala-team-member-dr-bruno')).toBeVisible()
+    await page.getByRole('combobox', { name: '' }).nth(3).click()
+    await expect(page.getByRole('option', { name: 'Dra. Ana' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Dr. Bruno' })).toBeVisible()
+  })
+
   test('edits schedule entries directly from the day card modal', async ({ page }) => {
     const replacePayloads: any[] = []
     const closedAddPayloads: any[] = []

--- a/frontend/tests/escalaModule.test.ts
+++ b/frontend/tests/escalaModule.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { __testables } from '../EscalaProfissionaisModule'
+
+describe('Escala module helpers', () => {
+  it('keeps db professionals visible even when the selected month has no schedule', () => {
+    const professionals = __testables.mergeProfessionals(new Set(), [
+      {
+        name: 'Dra. Ana',
+        status: '',
+        units: ['Novo Hamburgo'],
+        role: '',
+        shift: '',
+        nickname: '',
+        phone: '',
+        email: '',
+        instagram: '',
+        color: '#22c55e',
+      },
+    ])
+
+    expect(professionals).toEqual([
+      expect.objectContaining({
+        name: 'Dra. Ana',
+        status: 'Ativo',
+        role: 'Injetor',
+        units: ['Novo Hamburgo'],
+      }),
+    ])
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '.'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
## Problema

No módulo `Escala`, a seção `Equipe` ficava vazia em meses sem agenda cadastrada, como abril. Na prática isso fazia a tela parecer sem injetores ativos mesmo quando os profissionais já existiam no banco de dados. O efeito para o usuário era incorreto: a equipe parecia depender de relançamento mensal da escala.

## Causa raiz

O frontend carregava corretamente o cadastro pelo endpoint de profissionais, mas a derivação local dos itens visíveis tratava registros legados sem `role` e `status` preenchidos como injetores apenas quando eles apareciam na agenda do mês selecionado. Em um mês sem entradas de `schedule`, esses mesmos registros deixavam de ser reconhecidos como parte da equipe e sumiam do painel lateral e das opções de atribuição.

## Correção

Ajustei a normalização dos profissionais no módulo `Escala` para que o cadastro vindo do banco seja considerado a fonte principal da equipe, independentemente do mês selecionado. Registros legados sem `role` e `status` agora recebem fallback consistente para `Injetor` e `Ativo` durante a derivação local, sem depender de haver entradas na agenda do mês. A lógica que complementa nomes vindos apenas da escala foi preservada, mas deixou de ser o gatilho para exibir profissionais já cadastrados.

Também adicionei cobertura automatizada para impedir regressão:

- teste unitário para o helper que mescla profissionais e agenda, validando o comportamento com mês vazio;
- teste E2E cobrindo o cenário em que `schedule` retorna vazio e a seção `Equipe` continua exibindo os injetores do banco;
- ajuste no `vitest` para resolver o alias `@/` usado pelo frontend, mantendo o runner coerente com a configuração do app.

## Validação

Validei a mudança com:

- `npm run typecheck`
- `npx vitest run tests/escalaModule.test.ts tests/escalaApi.test.ts`
- `E2E_BASE_URL=http://127.0.0.1:5173 npx playwright test e2e/escala-module.spec.ts --grep "keeps team members visible when the selected month has no schedule entries"`

