### PR TITLE
Fix Escala professionals schema drift

### DIFF
--- a/.github/workflows/deploy-escala-api-reconcile.yml
+++ b/.github/workflows/deploy-escala-api-reconcile.yml
@@ -110,6 +110,15 @@ jobs:
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for production."
 
+      - name: Apply Escala D1 migrations (production)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config backend/apps/escala-api/wrangler.toml
+
       - name: Deploy Escala worker (production)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         env:
@@ -129,6 +138,15 @@ jobs:
           set -euo pipefail
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml --env staging >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for staging."
+
+      - name: Apply Escala D1 migrations (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config backend/apps/escala-api/wrangler.toml --env staging
 
       - name: Deploy Escala worker (staging)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') && steps.guard.outputs.deploy_staging == 'true' }}
@@ -158,4 +176,3 @@ jobs:
         with:
           key: escala-api-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
-

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -66,6 +66,15 @@ jobs:
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for production."
 
+      - name: Apply Escala D1 migrations (production)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config backend/apps/escala-api/wrangler.toml
+
       - name: Deploy Escala worker (production)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -86,6 +95,15 @@ jobs:
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config backend/apps/escala-api/wrangler.toml --env staging >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for staging."
 
+      - name: Apply Escala D1 migrations (staging)
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.deploy_staging == 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config backend/apps/escala-api/wrangler.toml --env staging
+
       - name: Deploy Escala worker (staging)
         if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.deploy_staging == 'true' }}
         env:
@@ -100,4 +118,3 @@ jobs:
         run: |
           set -euo pipefail
           curl -fsS -H 'User-Agent: EscalaWorkerSmoke/1.0' https://escala-api.skincos.com.br/api/escala/health >/dev/null
-

--- a/backend/apps/escala-api/worker.js
+++ b/backend/apps/escala-api/worker.js
@@ -146,6 +146,32 @@ function normalizeUnitKey(value) {
     .trim()
 }
 
+async function getTableColumns(env, tableName) {
+  if (!globalThis.__escalaSchemaCache) {
+    globalThis.__escalaSchemaCache = new WeakMap()
+  }
+  const dbCache = globalThis.__escalaSchemaCache
+  let tableCache = dbCache.get(env.DB)
+  if (!tableCache) {
+    tableCache = new Map()
+    dbCache.set(env.DB, tableCache)
+  }
+  if (!tableCache.has(tableName)) {
+    tableCache.set(
+      tableName,
+      env.DB.prepare(`pragma table_info(${tableName})`).all()
+        .then((res) => new Set((res.results || []).map((row) => String(row.name || '').trim()).filter(Boolean)))
+        .catch(() => new Set())
+    )
+  }
+  return tableCache.get(tableName)
+}
+
+async function tableHasColumn(env, tableName, columnName) {
+  const columns = await getTableColumns(env, tableName)
+  return columns.has(String(columnName || '').trim())
+}
+
 function isUnitVisibleForActor(actor, unit) {
   const key = normalizeUnitKey(unit)
   if (!key) return true
@@ -187,8 +213,9 @@ async function handleOverview(env, actor) {
 }
 
 async function handleProfessionals(env, unit, actor) {
+  const hasColorColumn = await tableHasColumn(env, 'professionals', 'color')
   const res = await env.DB.prepare(
-    `select name, status, role, shift, nickname, phone, email, instagram, color, units_json
+    `select name, status, role, shift, nickname, phone, email, instagram, ${hasColorColumn ? 'color' : 'null as color'}, units_json
      from professionals
      order by name`
   ).all()
@@ -286,6 +313,7 @@ async function listKnownProfessionals(env, names) {
 }
 
 async function handleProfessionalPut(env, actor, body) {
+  const hasColorColumn = await tableHasColumn(env, 'professionals', 'color')
   const currentName = normalizeName(body?.currentName)
   const nextName = normalizeName(body?.name)
   const status = normalizeName(body?.status)
@@ -324,34 +352,63 @@ async function handleProfessionalPut(env, actor, body) {
   }
 
   const now = new Date().toISOString()
-  await env.DB.prepare(
-    `update professionals
-     set name = ?1,
-         status = ?2,
-         role = ?3,
-         shift = ?4,
-         nickname = ?5,
-         phone = ?6,
-         email = ?7,
-         instagram = ?8,
-         color = ?9,
-         units_json = ?10,
-         updated_at = ?11
-     where name = ?12`
-  ).bind(
-    nextName,
-    status || null,
-    role || null,
-    shift || null,
-    nickname || null,
-    phone || null,
-    email || null,
-    instagram || null,
-    color || null,
-    JSON.stringify(units),
-    now,
-    currentName,
-  ).run()
+  if (hasColorColumn) {
+    await env.DB.prepare(
+      `update professionals
+       set name = ?1,
+           status = ?2,
+           role = ?3,
+           shift = ?4,
+           nickname = ?5,
+           phone = ?6,
+           email = ?7,
+           instagram = ?8,
+           color = ?9,
+           units_json = ?10,
+           updated_at = ?11
+       where name = ?12`
+    ).bind(
+      nextName,
+      status || null,
+      role || null,
+      shift || null,
+      nickname || null,
+      phone || null,
+      email || null,
+      instagram || null,
+      color || null,
+      JSON.stringify(units),
+      now,
+      currentName,
+    ).run()
+  } else {
+    await env.DB.prepare(
+      `update professionals
+       set name = ?1,
+           status = ?2,
+           role = ?3,
+           shift = ?4,
+           nickname = ?5,
+           phone = ?6,
+           email = ?7,
+           instagram = ?8,
+           units_json = ?9,
+           updated_at = ?10
+       where name = ?11`
+    ).bind(
+      nextName,
+      status || null,
+      role || null,
+      shift || null,
+      nickname || null,
+      phone || null,
+      email || null,
+      instagram || null,
+      JSON.stringify(units),
+      now,
+      currentName,
+    ).run()
+  }
 
   if (currentName !== nextName) {
     await env.DB.prepare(
@@ -367,6 +424,7 @@ async function handleProfessionalPut(env, actor, body) {
 }
 
 async function handleProfessionalPost(env, actor, body) {
+  const hasColorColumn = await tableHasColumn(env, 'professionals', 'color')
   const name = normalizeName(body?.name)
   const status = normalizeName(body?.status)
   const role = normalizeName(body?.role)
@@ -395,25 +453,46 @@ async function handleProfessionalPost(env, actor, body) {
   }
 
   const now = new Date().toISOString()
-  await env.DB.prepare(
-    `insert into professionals
-     (id, name, status, role, shift, nickname, phone, email, instagram, color, units_json, created_at, updated_at)
-     values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)`
-  ).bind(
-    crypto.randomUUID(),
-    name,
-    status || null,
-    role || null,
-    shift || null,
-    nickname || null,
-    phone || null,
-    email || null,
-    instagram || null,
-    color || null,
-    JSON.stringify(units),
-    now,
-    now,
-  ).run()
+  if (hasColorColumn) {
+    await env.DB.prepare(
+      `insert into professionals
+       (id, name, status, role, shift, nickname, phone, email, instagram, color, units_json, created_at, updated_at)
+       values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)`
+    ).bind(
+      crypto.randomUUID(),
+      name,
+      status || null,
+      role || null,
+      shift || null,
+      nickname || null,
+      phone || null,
+      email || null,
+      instagram || null,
+      color || null,
+      JSON.stringify(units),
+      now,
+      now,
+    ).run()
+  } else {
+    await env.DB.prepare(
+      `insert into professionals
+       (id, name, status, role, shift, nickname, phone, email, instagram, units_json, created_at, updated_at)
+       values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)`
+    ).bind(
+      crypto.randomUUID(),
+      name,
+      status || null,
+      role || null,
+      shift || null,
+      nickname || null,
+      phone || null,
+      email || null,
+      instagram || null,
+      JSON.stringify(units),
+      now,
+      now,
+    ).run()
+  }
 
   return { ok: true, status: 200, body: { ok: true } }
 }
@@ -620,7 +699,8 @@ export default {
           return jsonResponse(unitAllowed.body, { status: unitAllowed.status, headers: { ...corsHeaders, 'x-request-id': requestId } })
         }
         const data = await handleProfessionals(env, unit, actor)
-        console.log(JSON.stringify({ event: 'escala.professionals', requestId, actor: actor.id, unit }))
+        const hasColorColumn = await tableHasColumn(env, 'professionals', 'color')
+        console.log(JSON.stringify({ event: 'escala.professionals', requestId, actor: actor.id, unit, total: data.data.length, hasColorColumn }))
         return jsonResponse({ ok: true, ...data }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
       }
 

--- a/backend/apps/escala-api/worker.test.js
+++ b/backend/apps/escala-api/worker.test.js
@@ -39,6 +39,21 @@ class FakeD1 {
     this.scheduleEntries = []
     this.closedDays = []
     this.holidays = []
+    this.professionalColumns = new Set([
+      'id',
+      'name',
+      'status',
+      'role',
+      'shift',
+      'nickname',
+      'phone',
+      'email',
+      'instagram',
+      'units_json',
+      'created_at',
+      'updated_at',
+      'color',
+    ])
   }
 
   prepare(sql) {
@@ -60,10 +75,17 @@ class FakeD1 {
   all(sql, params) {
     const query = normalizeSql(sql)
 
-    if (query.includes('select name, status, role, shift, nickname, phone, email, instagram, color, units_json from professionals')) {
+    if (query.startsWith('pragma table_info(professionals)')) {
+      return Array.from(this.professionalColumns).map((name, index) => ({ cid: index, name }))
+    }
+
+    if (
+      query.includes('select name, status, role, shift, nickname, phone, email, instagram, color, units_json from professionals')
+      || query.includes('select name, status, role, shift, nickname, phone, email, instagram, null as color, units_json from professionals')
+    ) {
       return [...this.professionals]
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((prof) => ({ ...prof }))
+        .map((prof) => ({ ...prof, color: this.professionalColumns.has('color') ? prof.color ?? null : null }))
     }
 
     if (query.startsWith('select name from professionals where name in (')) {
@@ -100,6 +122,7 @@ class FakeD1 {
     const query = normalizeSql(sql)
 
     if (query.startsWith('insert into professionals')) {
+      const hasColor = query.includes('(id, name, status, role, shift, nickname, phone, email, instagram, color, units_json, created_at, updated_at)')
       this.professionals.push({
         id: params[0],
         name: params[1],
@@ -110,16 +133,17 @@ class FakeD1 {
         phone: params[6],
         email: params[7],
         instagram: params[8],
-        color: params[9],
-        units_json: params[10],
-        created_at: params[11],
-        updated_at: params[12],
+        color: hasColor ? params[9] : null,
+        units_json: hasColor ? params[10] : params[9],
+        created_at: hasColor ? params[11] : params[10],
+        updated_at: hasColor ? params[12] : params[11],
       })
       return
     }
 
     if (query.startsWith('update professionals set name = ?1')) {
-      const index = this.professionals.findIndex((prof) => prof.name === params[11])
+      const hasColor = query.includes('color = ?9')
+      const index = this.professionals.findIndex((prof) => prof.name === params[hasColor ? 11 : 10])
       if (index >= 0) {
         this.professionals[index] = {
           ...this.professionals[index],
@@ -131,9 +155,9 @@ class FakeD1 {
           phone: params[5],
           email: params[6],
           instagram: params[7],
-          color: params[8],
-          units_json: params[9],
-          updated_at: params[10],
+          color: hasColor ? params[8] : this.professionals[index].color ?? null,
+          units_json: hasColor ? params[9] : params[8],
+          updated_at: hasColor ? params[10] : params[9],
         }
       }
       return
@@ -318,4 +342,72 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
       professional: 'Dra. Anita',
     },
   ])
+})
+
+test('Escala professionals GET/POST/PUT tolerate legacy schema without color column', async () => {
+  const db = new FakeD1()
+  db.professionalColumns.delete('color')
+  const env = {
+    DB: db,
+    APP_ORIGIN: 'https://crm.local',
+    ESCALA_ACTOR_HMAC_KEY: 'test-secret',
+  }
+  const actor = {
+    id: 'gestor-1',
+    email: 'gestor@local.test',
+    role: 'GESTOR',
+    allowedUnits: [],
+  }
+
+  const createResponse = await worker.fetch(
+    await signedRequest('https://escala.local/api/escala/professionals', {
+      method: 'POST',
+      secret: env.ESCALA_ACTOR_HMAC_KEY,
+      actor,
+      body: {
+        name: 'Dra. Marina',
+        status: 'Ativo',
+        units: ['BarraShoppingSul'],
+        role: 'Injetor',
+        color: '#22c55e',
+      },
+    }),
+    env,
+  )
+  assert.equal(createResponse.status, 200)
+  assert.equal(db.professionals.length, 1)
+  assert.equal(db.professionals[0].name, 'Dra. Marina')
+  assert.equal(db.professionals[0].color, null)
+
+  const updateResponse = await worker.fetch(
+    await signedRequest('https://escala.local/api/escala/professionals', {
+      method: 'PUT',
+      secret: env.ESCALA_ACTOR_HMAC_KEY,
+      actor,
+      body: {
+        currentName: 'Dra. Marina',
+        name: 'Dra. Marina Lima',
+        status: 'Ativo',
+        units: ['BarraShoppingSul'],
+        role: 'Injetor',
+        color: '#0ea5e9',
+      },
+    }),
+    env,
+  )
+  assert.equal(updateResponse.status, 200)
+
+  const professionalsResponse = await worker.fetch(
+    await signedRequest('https://escala.local/api/escala/professionals?unit=BarraShoppingSul', {
+      secret: env.ESCALA_ACTOR_HMAC_KEY,
+      actor,
+    }),
+    env,
+  )
+  assert.equal(professionalsResponse.status, 200)
+  const professionalsJson = await professionalsResponse.json()
+  assert.equal(professionalsJson.data.length, 1)
+  assert.equal(professionalsJson.data[0].name, 'Dra. Marina Lima')
+  assert.equal(professionalsJson.data[0].color, null)
+  assert.deepEqual(professionalsJson.data[0].units, ['BarraShoppingSul'])
 })


### PR DESCRIPTION
## Summary
- make Escala professionals endpoints tolerate legacy D1 schemas without the  column
- add regression coverage for legacy  tables
- apply Escala D1 migrations during both push and reconcile deploy workflows

## Validation
- node --test backend/apps/escala-api/worker.test.js
- npm run typecheck
- manually applied  to production D1 and revalidated 
