### PR TITLE
Fix Escala workflow safety and E2E timeout

### DIFF
--- a/.github/workflows/escala-api-smoke.yml
+++ b/.github/workflows/escala-api-smoke.yml
@@ -39,9 +39,11 @@ jobs:
 
       - name: Resolve target
         id: target
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'production' }}
         run: |
           set -euo pipefail
-          ENVIRONMENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'production' }}"
+          ENVIRONMENT="${INPUT_ENVIRONMENT}"
           if [[ "$ENVIRONMENT" == "staging" ]]; then
             echo "base_url=https://escala-api-staging.skincos.com.br" >> "$GITHUB_OUTPUT"
           else
@@ -53,7 +55,8 @@ jobs:
         env:
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
           ESCALA_SMOKE_BASE_URL: ${{ steps.target.outputs.base_url }}
+          ESCALA_SMOKE_ENVIRONMENT: ${{ steps.target.outputs.environment }}
         run: |
           set -euo pipefail
-          echo "Running Escala smoke for environment=${{ steps.target.outputs.environment }}"
+          echo "Running Escala smoke for environment=${ESCALA_SMOKE_ENVIRONMENT}"
           node backend/apps/escala-api/scripts/smoke.mjs

--- a/.github/workflows/escala-ui-e2e.yml
+++ b/.github/workflows/escala-ui-e2e.yml
@@ -19,6 +19,7 @@ jobs:
   e2e:
     name: Escala UI E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -45,7 +46,7 @@ jobs:
         run: |
           set -euxo pipefail
           cd frontend
-          npx playwright install --with-deps chromium
+          npx --yes playwright install --with-deps chromium
 
       - name: Start frontend
         run: |


### PR DESCRIPTION
## Summary
- move GitHub context values into env before shell execution in Escala smoke workflow
- add an explicit timeout to the Escala UI E2E job
- align the Playwright install command with the passing Pages smoke workflow

## Validation
- python3 YAML parse for both updated workflows
- cancelled the stuck Escala UI E2E run from PR #469 so future runs use the timeout-protected workflow
