### PR TITLE
feat: finalize escala workflow + meta-ads ingestion improvements

### DIFF
--- a/backend/apps/meta-ads/apps/report-ingest-worker/README.md
+++ b/backend/apps/meta-ads/apps/report-ingest-worker/README.md
@@ -2,10 +2,13 @@
 
 Worker Cloudflare responsável por receber o payload do workflow `Meta Ads - Performance Report` no n8n e persistir em D1/R2.
 
+Também expõe um endpoint de inventário incremental para o workflow reaproveitar ads já persistidos e evitar redescobrir `campaigns -> adsets -> ads` em toda execução.
+
 ## Endpoints
 
 - `GET /health`
 - `GET /contract/meta-ads-performance-report`
+- `GET /inventory/meta-ads-performance-report?account_id=...&freshness_hours=...&limit=...`
 - `POST /ingest/meta-ads-performance-report`
 
 ## Bindings
@@ -38,6 +41,15 @@ wrangler deploy --env staging
 
 ## Contrato
 
+Inventário:
+
+- método `GET`
+- autenticação bearer idêntica ao endpoint de ingestão
+- query `account_id` obrigatória
+- query `freshness_hours` opcional
+- query `limit` opcional
+- resposta com `count` + `items`
+
 Headers:
 
 - `Content-Type: application/json`
@@ -56,3 +68,23 @@ Body opcional:
 
 - `compatibility_exports`
 - `duplication_report`
+
+## Idempotência e fases
+
+- O Worker usa `Idempotency-Key` como chave primária de reconciliação em `ingestion_runs`.
+- Se receber novamente um payload já concluído com a mesma chave, responde `200` com `idempotentReplay: true`.
+- Se receber a mesma chave enquanto uma ingestão ainda está em andamento e a tentativa anterior não está stale, responde `202` com `inProgress: true`.
+- O progresso operacional fica explícito em `ingestion_runs`:
+  - `phase`
+  - `last_successful_phase`
+  - `attempt_count`
+  - `last_request_id`
+  - `r2_status`
+  - `d1_status`
+  - `processing_warnings_json`
+
+## Resiliência
+
+- O upload de payload bruto para R2 ocorre antes do commit dos índices em D1.
+- As escritas em D1 seguem fases explícitas para `entities`, `metric_snapshots`, `ingestion_audit`, `metric_duplication_audit` e `raw_payloads`.
+- Em falha parcial, uma nova tentativa com a mesma `Idempotency-Key` reconcilia o estado usando `upsert`, sem duplicar a camada analítica principal.

--- a/backend/apps/meta-ads/apps/report-ingest-worker/migrations/0002_ingestion_run_phases.sql
+++ b/backend/apps/meta-ads/apps/report-ingest-worker/migrations/0002_ingestion_run_phases.sql
@@ -1,0 +1,13 @@
+ALTER TABLE ingestion_runs ADD COLUMN phase TEXT NOT NULL DEFAULT 'received';
+ALTER TABLE ingestion_runs ADD COLUMN last_successful_phase TEXT NOT NULL DEFAULT '';
+ALTER TABLE ingestion_runs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ingestion_runs ADD COLUMN last_request_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE ingestion_runs ADD COLUMN r2_status TEXT NOT NULL DEFAULT 'not_started';
+ALTER TABLE ingestion_runs ADD COLUMN d1_status TEXT NOT NULL DEFAULT 'not_started';
+ALTER TABLE ingestion_runs ADD COLUMN processing_warnings_json TEXT NOT NULL DEFAULT '[]';
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_runs_idempotency_status
+  ON ingestion_runs(idempotency_key, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_runs_phase
+  ON ingestion_runs(status, phase, last_successful_phase, updated_at);

--- a/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
+++ b/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
@@ -14,6 +14,14 @@ export default {
       return jsonResponse(200, buildContractResponse(env));
     }
 
+    if (request.method === 'GET' && url.pathname === '/inventory/meta-ads-performance-report') {
+      return handleInventoryRequest(request, env, url);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/report/meta-ads-performance-report') {
+      return handleReportRequest(request, env, url);
+    }
+
     if (request.method === 'POST' && url.pathname === '/ingest/meta-ads-performance-report') {
       return handleIngestion(request, env);
     }
@@ -25,6 +33,102 @@ export default {
     });
   },
 };
+
+async function handleInventoryRequest(request, env, url) {
+  const requestId = crypto.randomUUID();
+  const authResult = await authorizeRequest(request, env);
+
+  if (!authResult.ok) {
+    log(env, 'warn', 'inventory_auth_failed', {
+      requestId,
+      reason: authResult.reason,
+    });
+
+    return jsonResponse(authResult.status, {
+      ok: false,
+      error: 'unauthorized',
+      message: authResult.message,
+      requestId,
+    });
+  }
+
+  if (!env.META_ADS_DB) {
+    return jsonResponse(500, {
+      ok: false,
+      error: 'missing_binding',
+      message: 'META_ADS_DB binding missing.',
+      requestId,
+    });
+  }
+
+  const accountId = safeString(url.searchParams.get('account_id'));
+  const freshnessHours = positiveInteger(url.searchParams.get('freshness_hours'), 168);
+  const limit = positiveInteger(url.searchParams.get('limit'), 500);
+
+  if (!accountId) {
+    return jsonResponse(400, {
+      ok: false,
+      error: 'invalid_query',
+      message: 'account_id query parameter is required.',
+      requestId,
+    });
+  }
+
+  const freshnessCutoffIso = new Date(Date.now() - freshnessHours * 60 * 60 * 1000).toISOString();
+
+  const rows = await env.META_ADS_DB.prepare(`
+    SELECT
+      entity_id,
+      entity_name,
+      account_id,
+      campaign_id,
+      campaign_name,
+      adset_id,
+      adset_name,
+      ad_id,
+      ad_name,
+      creative_id,
+      creative_name,
+      status,
+      effective_status,
+      configured_status,
+      source_json,
+      last_seen_at
+    FROM entities
+    WHERE entity_kind = 'ad'
+      AND account_id = ?
+      AND last_seen_at >= ?
+    ORDER BY last_seen_at DESC
+    LIMIT ?
+  `).bind(accountId, freshnessCutoffIso, limit).all();
+
+  const items = asArray(rows?.results)
+    .map((row) => buildInventoryItem(row))
+    .filter(Boolean);
+
+  log(env, 'info', 'inventory_lookup_completed', {
+    requestId,
+    accountId,
+    freshnessHours,
+    freshnessCutoffIso,
+    count: items.length,
+  });
+
+  return jsonResponse(200, {
+    ok: true,
+    requestId,
+    count: items.length,
+    inventory: {
+      source: 'd1',
+      entity_kind: 'ad',
+      account_id: accountId,
+      freshness_hours: freshnessHours,
+      freshness_cutoff_iso: freshnessCutoffIso,
+      limit,
+    },
+    items,
+  });
+}
 
 async function handleIngestion(request, env) {
   const requestId = crypto.randomUUID();
@@ -99,9 +203,18 @@ async function handleIngestion(request, env) {
     request.headers.get('Idempotency-Key') ||
     `${safeString(run.run_id)}:${safeString(run.metrics_group_key)}`
   );
+  const requestHeadersJson = JSON.stringify(redactHeaders(request.headers, env));
 
   const existingRun = await env.META_ADS_DB.prepare(`
-    SELECT summary_json, status
+    SELECT
+      summary_json,
+      status,
+      phase,
+      last_successful_phase,
+      attempt_count,
+      created_at,
+      updated_at,
+      last_request_id
     FROM ingestion_runs
     WHERE idempotency_key = ?
     LIMIT 1
@@ -125,6 +238,33 @@ async function handleIngestion(request, env) {
     });
   }
 
+  if (
+    existingRun?.status === 'in_progress' &&
+    !isStaleRun(existingRun.updated_at)
+  ) {
+    const inProgressSummary = safeJsonParse(existingRun.summary_json, {});
+
+    log(env, 'info', 'idempotent_in_progress', {
+      requestId,
+      idempotencyKey,
+      runId: safeString(run.run_id),
+      metricsGroupKey: safeString(run.metrics_group_key),
+      phase: safeString(existingRun.phase),
+      previousRequestId: safeString(existingRun.last_request_id),
+    });
+
+    return jsonResponse(202, {
+      ok: true,
+      inProgress: true,
+      requestId,
+      idempotencyKey,
+      phase: safeString(existingRun.phase),
+      lastSuccessfulPhase: safeString(existingRun.last_successful_phase),
+      previousRequestId: safeString(existingRun.last_request_id),
+      results: inProgressSummary,
+    });
+  }
+
   const requestMeta = {
     requestId,
     runId: safeString(run.run_id),
@@ -139,34 +279,58 @@ async function handleIngestion(request, env) {
     compatibilitySummaryRows: asArray(compatibilityExports.summary_rows).length,
     compatibilityBreakdownRows: asArray(compatibilityExports.breakdown_rows).length,
   };
+  const createdAt = safeString(existingRun?.created_at || startedAt);
+  const attemptCount = Math.max(1, safeInteger(existingRun?.attempt_count) + 1);
+  const runRowBase = {
+    run_id: safeString(run.run_id || idempotencyKey),
+    workflow_name: safeString(run.workflow_name || 'Meta Ads - Performance Report'),
+    report_mode: safeString(run.report_mode),
+    report_date: safeString(run.report_date),
+    requested_at: safeString(run.requested_at || startedAt),
+    account_id: safeString(run.account_id),
+    metrics_group_key: safeString(run.metrics_group_key),
+    idempotency_key: idempotencyKey,
+    request_headers_json: requestHeadersJson,
+    created_at: createdAt,
+  };
+  const progress = {
+    status: 'in_progress',
+    phase: 'accepted',
+    last_successful_phase: safeString(existingRun?.last_successful_phase),
+    attempt_count: attemptCount,
+    last_request_id: requestId,
+    entities_upserted: 0,
+    metric_snapshots_inserted: 0,
+    audit_rows_inserted: 0,
+    raw_payloads_written: 0,
+    raw_payload_rows_upserted: 0,
+    duplication_rows_upserted: 0,
+    warnings_count: 0,
+    duplication_count: duplicationReport.length,
+    last_error: '',
+    r2_status: 'not_started',
+    d1_status: 'not_started',
+    processing_warnings_json: '[]',
+    summary_json: JSON.stringify({
+      status: 'in_progress',
+      phase: 'accepted',
+      attempt_count: attemptCount,
+    }),
+    updated_at: startedAt,
+  };
+
+  async function syncRunProgress(overrides = {}) {
+    Object.assign(progress, overrides);
+    await upsertIngestionRun(env, {
+      ...runRowBase,
+      ...progress,
+    });
+  }
 
   log(env, 'info', 'ingestion_started', requestMeta);
 
   try {
-    await upsertIngestionRun(env, {
-      run_id: safeString(run.run_id || idempotencyKey),
-      workflow_name: safeString(run.workflow_name || 'Meta Ads - Performance Report'),
-      report_mode: safeString(run.report_mode),
-      report_date: safeString(run.report_date),
-      requested_at: safeString(run.requested_at || startedAt),
-      account_id: safeString(run.account_id),
-      metrics_group_key: safeString(run.metrics_group_key),
-      idempotency_key: idempotencyKey,
-      status: 'started',
-      entities_upserted: 0,
-      metric_snapshots_inserted: 0,
-      audit_rows_inserted: 0,
-      raw_payloads_written: 0,
-      raw_payload_rows_upserted: 0,
-      duplication_rows_upserted: 0,
-      warnings_count: 0,
-      duplication_count: duplicationReport.length,
-      last_error: '',
-      request_headers_json: JSON.stringify(redactHeaders(request.headers, env)),
-      summary_json: JSON.stringify({ status: 'started' }),
-      created_at: startedAt,
-      updated_at: startedAt,
-    });
+    await syncRunProgress();
 
     const entityStatements = entities.map((entity) => buildEntityStatement(env, entity));
     const metricStatements = metricSnapshots.map((snapshot) => buildMetricSnapshotStatement(env, snapshot));
@@ -174,15 +338,107 @@ async function handleIngestion(request, env) {
     const rawPayloadStatements = rawPayloads.map((payload) => buildRawPayloadStatement(env, payload));
     const duplicationStatements = duplicationReport.map((entry) => buildDuplicationStatement(env, entry, run));
 
-    await runStatementsInChunks(env.META_ADS_DB, entityStatements);
-    await runStatementsInChunks(env.META_ADS_DB, metricStatements);
-    await runStatementsInChunks(env.META_ADS_DB, auditStatements);
-    await runStatementsInChunks(env.META_ADS_DB, duplicationStatements);
+    await syncRunProgress({
+      phase: 'raw_payload_sync_started',
+      updated_at: new Date().toISOString(),
+      summary_json: JSON.stringify({
+        status: progress.status,
+        phase: 'raw_payload_sync_started',
+        attempt_count: progress.attempt_count,
+      }),
+      r2_status: 'in_progress',
+    });
 
     const rawPayloadWrite = await persistRawPayloads(env, rawPayloads, requestMeta);
-    await runStatementsInChunks(env.META_ADS_DB, rawPayloadStatements);
-
     const warningsCount = countWarnings(metricSnapshots, ingestionAudit) + rawPayloadWrite.warnings.length;
+
+    await syncRunProgress({
+      phase: rawPayloadWrite.status === 'completed' ? 'raw_payload_sync_completed' : 'raw_payload_sync_partial',
+      last_successful_phase: 'raw_payload_sync',
+      raw_payloads_written: rawPayloadWrite.written,
+      warnings_count: warningsCount,
+      r2_status: rawPayloadWrite.status,
+      processing_warnings_json: JSON.stringify(rawPayloadWrite.warnings),
+      updated_at: new Date().toISOString(),
+      summary_json: JSON.stringify({
+        status: progress.status,
+        phase: rawPayloadWrite.status === 'completed' ? 'raw_payload_sync_completed' : 'raw_payload_sync_partial',
+        last_successful_phase: 'raw_payload_sync',
+        warnings_count: warningsCount,
+        processing_warnings: rawPayloadWrite.warnings,
+        attempt_count: progress.attempt_count,
+      }),
+    });
+
+    await syncRunProgress({
+      phase: 'd1_entities_started',
+      d1_status: 'in_progress',
+      updated_at: new Date().toISOString(),
+      summary_json: JSON.stringify({
+        status: progress.status,
+        phase: 'd1_entities_started',
+        last_successful_phase: progress.last_successful_phase,
+        warnings_count: progress.warnings_count,
+        attempt_count: progress.attempt_count,
+      }),
+    });
+    await runStatementsInChunks(env.META_ADS_DB, entityStatements);
+    await syncRunProgress({
+      phase: 'd1_entities_completed',
+      last_successful_phase: 'd1_entities',
+      entities_upserted: entities.length,
+      updated_at: new Date().toISOString(),
+    });
+
+    await syncRunProgress({
+      phase: 'd1_metric_snapshots_started',
+      updated_at: new Date().toISOString(),
+    });
+    await runStatementsInChunks(env.META_ADS_DB, metricStatements);
+    await syncRunProgress({
+      phase: 'd1_metric_snapshots_completed',
+      last_successful_phase: 'd1_metric_snapshots',
+      metric_snapshots_inserted: metricSnapshots.length,
+      updated_at: new Date().toISOString(),
+    });
+
+    await syncRunProgress({
+      phase: 'd1_ingestion_audit_started',
+      updated_at: new Date().toISOString(),
+    });
+    await runStatementsInChunks(env.META_ADS_DB, auditStatements);
+    await syncRunProgress({
+      phase: 'd1_ingestion_audit_completed',
+      last_successful_phase: 'd1_ingestion_audit',
+      audit_rows_inserted: ingestionAudit.length,
+      updated_at: new Date().toISOString(),
+    });
+
+    await syncRunProgress({
+      phase: 'd1_duplication_audit_started',
+      updated_at: new Date().toISOString(),
+    });
+    await runStatementsInChunks(env.META_ADS_DB, duplicationStatements);
+    await syncRunProgress({
+      phase: 'd1_duplication_audit_completed',
+      last_successful_phase: 'd1_duplication_audit',
+      duplication_rows_upserted: duplicationReport.length,
+      updated_at: new Date().toISOString(),
+    });
+
+    await syncRunProgress({
+      phase: 'd1_raw_payload_index_started',
+      updated_at: new Date().toISOString(),
+    });
+    await runStatementsInChunks(env.META_ADS_DB, rawPayloadStatements);
+    await syncRunProgress({
+      phase: 'd1_raw_payload_index_completed',
+      last_successful_phase: 'd1_raw_payload_index',
+      raw_payload_rows_upserted: rawPayloads.length,
+      d1_status: 'committed',
+      updated_at: new Date().toISOString(),
+    });
+
     const summary = {
       entities_upserted: entities.length,
       metric_snapshots_inserted: metricSnapshots.length,
@@ -197,16 +453,10 @@ async function handleIngestion(request, env) {
       processing_warnings: rawPayloadWrite.warnings,
     };
 
-    await upsertIngestionRun(env, {
-      run_id: safeString(run.run_id || idempotencyKey),
-      workflow_name: safeString(run.workflow_name || 'Meta Ads - Performance Report'),
-      report_mode: safeString(run.report_mode),
-      report_date: safeString(run.report_date),
-      requested_at: safeString(run.requested_at || startedAt),
-      account_id: safeString(run.account_id),
-      metrics_group_key: safeString(run.metrics_group_key),
-      idempotency_key: idempotencyKey,
+    await syncRunProgress({
       status: 'completed',
+      phase: 'completed',
+      last_successful_phase: 'completed',
       entities_upserted: summary.entities_upserted,
       metric_snapshots_inserted: summary.metric_snapshots_inserted,
       audit_rows_inserted: summary.audit_rows_inserted,
@@ -216,9 +466,10 @@ async function handleIngestion(request, env) {
       warnings_count: summary.warnings_count,
       duplication_count: summary.duplication_count,
       last_error: '',
-      request_headers_json: JSON.stringify(redactHeaders(request.headers, env)),
+      r2_status: rawPayloadWrite.status,
+      d1_status: 'completed',
+      processing_warnings_json: JSON.stringify(rawPayloadWrite.warnings),
       summary_json: JSON.stringify(summary),
-      created_at: startedAt,
       updated_at: new Date().toISOString(),
     });
 
@@ -236,28 +487,26 @@ async function handleIngestion(request, env) {
     const message = String(error?.message || error);
 
     try {
-      await upsertIngestionRun(env, {
-        run_id: safeString(run.run_id || idempotencyKey),
-        workflow_name: safeString(run.workflow_name || 'Meta Ads - Performance Report'),
-        report_mode: safeString(run.report_mode),
-        report_date: safeString(run.report_date),
-        requested_at: safeString(run.requested_at || startedAt),
-        account_id: safeString(run.account_id),
-        metrics_group_key: safeString(run.metrics_group_key),
-        idempotency_key: idempotencyKey,
+      await syncRunProgress({
         status: 'failed',
-        entities_upserted: 0,
-        metric_snapshots_inserted: 0,
-        audit_rows_inserted: 0,
-        raw_payloads_written: 0,
-        raw_payload_rows_upserted: 0,
-        duplication_rows_upserted: 0,
-        warnings_count: 0,
-        duplication_count: duplicationReport.length,
+        phase: `${safeString(progress.phase || 'unknown')}_failed`,
         last_error: message,
-        request_headers_json: JSON.stringify(redactHeaders(request.headers, env)),
-        summary_json: JSON.stringify({ status: 'failed', error: message }),
-        created_at: startedAt,
+        summary_json: JSON.stringify({
+          status: 'failed',
+          error: message,
+          phase: progress.phase,
+          last_successful_phase: progress.last_successful_phase,
+          entities_upserted: progress.entities_upserted,
+          metric_snapshots_inserted: progress.metric_snapshots_inserted,
+          audit_rows_inserted: progress.audit_rows_inserted,
+          raw_payloads_written: progress.raw_payloads_written,
+          raw_payload_rows_upserted: progress.raw_payload_rows_upserted,
+          duplication_rows_upserted: progress.duplication_rows_upserted,
+          warnings_count: progress.warnings_count,
+          duplication_count: progress.duplication_count,
+          processing_warnings: safeJsonParse(progress.processing_warnings_json, []),
+          attempt_count: progress.attempt_count,
+        }),
         updated_at: new Date().toISOString(),
       });
     } catch (secondaryError) {
@@ -277,8 +526,713 @@ async function handleIngestion(request, env) {
       error: 'ingestion_failed',
       message,
       requestId,
+      phase: safeString(progress.phase),
+      lastSuccessfulPhase: safeString(progress.last_successful_phase),
     });
   }
+}
+
+const REPORT_WINDOWS = ['last_24h', 'last_7d', 'last_30d'];
+
+const SUMMARY_SCALAR_ALIAS = {
+  spend: 'scalar_spend',
+  clicks: 'scalar_clicks',
+  reach: 'scalar_reach',
+  impressions: 'scalar_impressions',
+  ctr: 'scalar_ctr',
+  cpc: 'scalar_cpc',
+  cpm: 'scalar_cpm',
+  cpp: 'scalar_cpp',
+  frequency: 'scalar_frequency',
+  inline_link_clicks: 'scalar_inline_link_clicks',
+  inline_link_click_ctr: 'scalar_inline_link_click_ctr',
+  cost_per_inline_link_click: 'scalar_cost_per_inline_link_click',
+  unique_clicks: 'scalar_unique_clicks',
+  unique_inline_link_clicks: 'scalar_unique_inline_link_clicks',
+  outbound_clicks: 'scalar_outbound_clicks',
+  outbound_clicks_ctr: 'scalar_outbound_clicks_ctr',
+  cost_per_outbound_click: 'scalar_cost_per_outbound_click',
+  website_ctr: 'scalar_website_ctr',
+  social_spend: 'scalar_social_spend',
+  instagram_profile_visits: 'scalar_instagram_profile_visits',
+  inline_post_engagement: 'scalar_inline_post_engagement',
+  cost_per_inline_post_engagement: 'scalar_cost_per_inline_post_engagement',
+  quality_ranking: 'scalar_quality_ranking',
+  engagement_rate_ranking: 'scalar_engagement_rate_ranking',
+  conversion_rate_ranking: 'scalar_conversion_rate_ranking',
+};
+
+const ACTION_ALIAS = {
+  conversation_started: 'onsite_conversion_messaging_conversation_started_7d',
+  total_messaging_connection: 'onsite_conversion_total_messaging_connection',
+  first_reply: 'onsite_conversion_messaging_first_reply',
+  conversation_replied: 'onsite_conversion_messaging_conversation_replied_7d',
+  messaging_depth_2: 'onsite_conversion_messaging_user_depth_2_message_send',
+  messaging_depth_3: 'onsite_conversion_messaging_user_depth_3_message_send',
+  messaging_depth_5: 'onsite_conversion_messaging_user_depth_5_message_send',
+  outbound_clicks: 'outbound_clicks',
+  inline_link_clicks: 'link_click',
+  post_reaction: 'post_reaction',
+  comments: 'comment',
+  posts: 'post',
+};
+
+const DIMENSION_FIELDS = new Set([
+  'age',
+  'gender',
+  'country',
+  'region',
+  'dma',
+  'impression_device',
+  'device_platform',
+  'publisher_platform',
+  'platform_position',
+]);
+
+async function handleReportRequest(request, env, url) {
+  const requestId = crypto.randomUUID();
+  const authResult = await authorizeRequest(request, env);
+
+  if (!authResult.ok) {
+    log(env, 'warn', 'report_auth_failed', {
+      requestId,
+      reason: authResult.reason,
+    });
+
+    return jsonResponse(authResult.status, {
+      ok: false,
+      error: 'unauthorized',
+      message: authResult.message,
+      requestId,
+    });
+  }
+
+  if (!env.META_ADS_DB) {
+    return jsonResponse(500, {
+      ok: false,
+      error: 'missing_binding',
+      message: 'META_ADS_DB binding missing.',
+      requestId,
+    });
+  }
+
+  const accountId = safeString(url.searchParams.get('account_id'));
+  const reportDate = normalizeReportDate(url.searchParams.get('report_date'));
+  const windows = parseReportWindows(url.searchParams.get('windows'));
+  const limit = positiveInteger(url.searchParams.get('limit'), 200);
+  const include = normalizeInclude(url.searchParams.get('include'));
+
+  if (!accountId) {
+    return jsonResponse(400, {
+      ok: false,
+      error: 'invalid_query',
+      message: 'account_id query parameter is required.',
+      requestId,
+    });
+  }
+
+  const latestRuns = await fetchLatestAdRuns(env.META_ADS_DB, accountId, reportDate, limit);
+  if (!latestRuns.length) {
+    return jsonResponse(200, {
+      ok: true,
+      requestId,
+      metadata: {
+        source: 'd1',
+        account_id: accountId,
+        report_date: reportDate,
+        windows,
+        include,
+        runs_count: 0,
+        reason: 'no_data_for_filters',
+      },
+      summary_rows: [],
+      breakdown_rows: [],
+    });
+  }
+
+  const adIds = dedupeStrings(latestRuns.map((row) => row.ad_id));
+  const groupKeys = dedupeStrings(latestRuns.map((row) => row.metrics_group_key));
+  const adEntityRows = await fetchAdEntities(env.META_ADS_DB, accountId, adIds);
+  const metricRows = await fetchMetricSnapshots(env.META_ADS_DB, reportDate, groupKeys, windows);
+  const auditRows = await fetchIngestionAudit(env.META_ADS_DB, reportDate, groupKeys, windows);
+
+  const adEntityById = new Map(adEntityRows.map((row) => [safeString(row.entity_id), row]));
+  const latestByGroup = new Map(latestRuns.map((row) => [safeString(row.metrics_group_key), row]));
+  const auditIndex = buildAuditIndex(auditRows);
+  const metricIndex = buildMetricIndexes(metricRows);
+
+  const summaryRows = include === 'breakdown'
+    ? []
+    : buildReportSummaryRows(latestRuns, adEntityById, metricIndex.summary, auditIndex, windows);
+  const breakdownRows = include === 'summary'
+    ? []
+    : buildReportBreakdownRows(metricIndex.breakdown, latestByGroup, adEntityById, auditIndex);
+
+  log(env, 'info', 'report_lookup_completed', {
+    requestId,
+    accountId,
+    reportDate,
+    include,
+    windows,
+    runsCount: latestRuns.length,
+    summaryRows: summaryRows.length,
+    breakdownRows: breakdownRows.length,
+  });
+
+  return jsonResponse(200, {
+    ok: true,
+    requestId,
+    metadata: {
+      source: 'd1',
+      account_id: accountId,
+      report_date: reportDate,
+      windows,
+      include,
+      runs_count: latestRuns.length,
+      ad_entities_count: adEntityRows.length,
+    },
+    summary_rows: summaryRows,
+    breakdown_rows: breakdownRows,
+  });
+}
+
+async function fetchLatestAdRuns(db, accountId, reportDate, limit) {
+  const rows = await db.prepare(`
+    WITH ranked AS (
+      SELECT
+        ia.entity_id AS ad_id,
+        ia.metrics_group_key,
+        ia.requested_at,
+        ia.updated_at,
+        ia.api_version,
+        ia.schedule_mode,
+        ROW_NUMBER() OVER (
+          PARTITION BY ia.entity_id
+          ORDER BY ia.requested_at DESC, ia.updated_at DESC
+        ) AS rn
+      FROM ingestion_audit ia
+      JOIN entities e
+        ON e.entity_kind = 'ad'
+       AND e.entity_id = ia.entity_id
+      WHERE ia.report_date = ?
+        AND ia.entity_level = 'ad'
+        AND e.account_id = ?
+    )
+    SELECT
+      ad_id,
+      metrics_group_key,
+      requested_at,
+      updated_at,
+      api_version,
+      schedule_mode
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY requested_at DESC
+    LIMIT ?
+  `).bind(reportDate, accountId, limit).all();
+
+  return asArray(rows?.results).map((row) => ({
+    ad_id: safeString(row.ad_id),
+    metrics_group_key: safeString(row.metrics_group_key),
+    requested_at: safeString(row.requested_at),
+    updated_at: safeString(row.updated_at),
+    api_version: safeString(row.api_version),
+    schedule_mode: safeString(row.schedule_mode),
+  })).filter((row) => row.ad_id && row.metrics_group_key);
+}
+
+async function fetchAdEntities(db, accountId, adIds) {
+  if (!adIds.length) return [];
+
+  const placeholders = buildPlaceholders(adIds.length);
+  const rows = await db.prepare(`
+    SELECT
+      entity_id,
+      entity_name,
+      account_id,
+      campaign_id,
+      campaign_name,
+      adset_id,
+      adset_name,
+      ad_id,
+      ad_name,
+      creative_id,
+      creative_name,
+      page_id,
+      instagram_user_id,
+      campaign_objective,
+      optimization_goal,
+      destination_type,
+      bid_strategy,
+      billing_event,
+      buying_type,
+      status,
+      effective_status,
+      configured_status,
+      source_json,
+      last_seen_at
+    FROM entities
+    WHERE entity_kind = 'ad'
+      AND account_id = ?
+      AND entity_id IN (${placeholders})
+  `).bind(accountId, ...adIds).all();
+
+  return asArray(rows?.results);
+}
+
+async function fetchMetricSnapshots(db, reportDate, groupKeys, windows) {
+  if (!groupKeys.length || !windows.length) return [];
+
+  const keyPlaceholders = buildPlaceholders(groupKeys.length);
+  const windowPlaceholders = buildPlaceholders(windows.length);
+
+  const rows = await db.prepare(`
+    SELECT
+      metrics_group_key,
+      report_date,
+      entity_level,
+      entity_id,
+      metrics_window,
+      metric_name,
+      metric_value,
+      source_kind,
+      source_metric_name,
+      dimension_key,
+      dimensions_json,
+      recorded_at
+    FROM metric_snapshots
+    WHERE report_date = ?
+      AND metrics_group_key IN (${keyPlaceholders})
+      AND metrics_window IN (${windowPlaceholders})
+      AND entity_level IN ('ad', 'adset', 'campaign')
+  `).bind(reportDate, ...groupKeys, ...windows).all();
+
+  return asArray(rows?.results);
+}
+
+async function fetchIngestionAudit(db, reportDate, groupKeys, windows) {
+  if (!groupKeys.length || !windows.length) return [];
+
+  const keyPlaceholders = buildPlaceholders(groupKeys.length);
+  const windowPlaceholders = buildPlaceholders(windows.length);
+
+  const rows = await db.prepare(`
+    SELECT
+      metrics_group_key,
+      entity_level,
+      entity_id,
+      metrics_window,
+      requested_at,
+      api_version,
+      schedule_mode,
+      fetch_status_summary,
+      fetch_status_hourly,
+      row_count_summary,
+      row_count_hourly,
+      row_count_breakdown,
+      warning_count,
+      low_confidence_count,
+      processing_notes_json,
+      warning_codes_json,
+      updated_at
+    FROM ingestion_audit
+    WHERE report_date = ?
+      AND metrics_group_key IN (${keyPlaceholders})
+      AND metrics_window IN (${windowPlaceholders})
+      AND entity_level IN ('ad', 'adset', 'campaign')
+  `).bind(reportDate, ...groupKeys, ...windows).all();
+
+  return asArray(rows?.results);
+}
+
+function buildAuditIndex(auditRows) {
+  const index = new Map();
+
+  for (const row of auditRows) {
+    const key = makeScopeWindowKey(
+      row.metrics_group_key,
+      row.entity_level,
+      row.entity_id,
+      row.metrics_window,
+    );
+    index.set(key, row);
+  }
+
+  return index;
+}
+
+function buildMetricIndexes(metricRows) {
+  const summary = new Map();
+  const breakdown = new Map();
+
+  for (const row of metricRows) {
+    const metricName = safeString(row.metric_name);
+    if (!metricName) continue;
+
+    const scopeKey = makeScopeWindowKey(
+      row.metrics_group_key,
+      row.entity_level,
+      row.entity_id,
+      row.metrics_window,
+    );
+
+    if (!safeString(row.dimension_key)) {
+      if (!summary.has(scopeKey)) summary.set(scopeKey, []);
+      summary.get(scopeKey).push(row);
+      continue;
+    }
+
+    const breakdownKey = [
+      scopeKey,
+      safeString(row.dimension_key),
+      safeString(row.dimensions_json || '{}'),
+    ].join('|');
+
+    if (!breakdown.has(breakdownKey)) breakdown.set(breakdownKey, []);
+    breakdown.get(breakdownKey).push(row);
+  }
+
+  return { summary, breakdown };
+}
+
+function buildReportSummaryRows(latestRuns, adEntityById, summaryMetricIndex, auditIndex, windows) {
+  const rows = [];
+
+  for (const run of latestRuns) {
+    const adEntity = adEntityById.get(run.ad_id);
+    if (!adEntity) continue;
+
+    const row = buildSummaryBaseRow(run, adEntity);
+
+    for (const entityLevel of ['ad', 'adset', 'campaign']) {
+      const entityId = resolveScopeEntityId(adEntity, entityLevel);
+      if (!entityId) continue;
+
+      for (const windowKey of windows) {
+        const prefix = `${entityLevel}_${windowKey}_`;
+        const scopeWindowKey = makeScopeWindowKey(run.metrics_group_key, entityLevel, entityId, windowKey);
+        const metrics = summaryMetricIndex.get(scopeWindowKey) || [];
+        const audit = auditIndex.get(scopeWindowKey);
+
+        applyAuditToSummaryRow(row, prefix, audit);
+
+        for (const metric of metrics) {
+          applyMetricToSummaryRow(row, prefix, metric);
+        }
+
+        synthesizeEngagementFields(row, prefix);
+      }
+    }
+
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function buildSummaryBaseRow(run, adEntity) {
+  const source = safeJsonParse(adEntity.source_json, {});
+
+  return {
+    report_date: normalizeReportDate(run.requested_at),
+    row_type: 'summary',
+    sheet_target: 'metrics_summary',
+    row_key: [normalizeReportDate(run.requested_at), safeString(adEntity.entity_id), safeString(run.metrics_group_key)].join('|'),
+    metrics_group_key: safeString(run.metrics_group_key),
+    schedule_mode: safeString(run.schedule_mode || 'manual'),
+    report_mode: 'cloudflare_d1',
+    requested_at: safeString(run.requested_at),
+    account_id: safeString(adEntity.account_id),
+    api_version: safeString(run.api_version || source.api_version || 'v24.0'),
+    ad_id: safeString(adEntity.ad_id || adEntity.entity_id),
+    ad_name: safeString(adEntity.ad_name || adEntity.entity_name),
+    adset_id: safeString(adEntity.adset_id),
+    adset_name: safeString(adEntity.adset_name),
+    campaign_id: safeString(adEntity.campaign_id),
+    campaign_name: safeString(adEntity.campaign_name),
+    creative_id: safeString(adEntity.creative_id || source.creative_id),
+    creative_name: safeString(adEntity.creative_name || source.creative_name),
+    page_id: safeString(adEntity.page_id || source.page_id),
+    instagram_user_id: safeString(adEntity.instagram_user_id || source.instagram_user_id),
+    optimization_goal: safeString(adEntity.optimization_goal || source.optimization_goal),
+    destination_type: safeString(adEntity.destination_type || source.destination_type),
+    bid_strategy: safeString(adEntity.bid_strategy || source.bid_strategy),
+    billing_event: safeString(adEntity.billing_event || source.billing_event),
+    buying_type: safeString(adEntity.buying_type || source.buying_type),
+    campaign_objective: safeString(adEntity.campaign_objective || source.campaign_objective),
+    ad_status: safeString(source.ad_status || adEntity.status),
+    ad_effective_status: safeString(source.ad_effective_status || adEntity.effective_status),
+    campaign_status: safeString(source.campaign_status),
+    campaign_effective_status: safeString(source.campaign_effective_status),
+    effective_instagram_media_id: safeString(source.effective_instagram_media_id),
+    instagram_permalink_url: safeString(source.instagram_permalink_url),
+    effective_object_story_id: safeString(source.effective_object_story_id),
+  };
+}
+
+function buildReportBreakdownRows(breakdownMetricIndex, latestByGroup, adEntityById, auditIndex) {
+  const output = [];
+
+  for (const [breakdownGroupKey, metrics] of breakdownMetricIndex.entries()) {
+    const first = metrics[0];
+    if (!first) continue;
+
+    const scopeWindowKey = makeScopeWindowKey(
+      first.metrics_group_key,
+      first.entity_level,
+      first.entity_id,
+      first.metrics_window,
+    );
+    const run = latestByGroup.get(safeString(first.metrics_group_key));
+    const adEntity = run ? adEntityById.get(run.ad_id) : null;
+    if (!run || !adEntity) continue;
+
+    const dimensions = safeJsonParse(first.dimensions_json, {});
+    const row = {
+      report_date: normalizeReportDate(run.requested_at),
+      row_type: 'breakdown',
+      sheet_target: 'metrics_breakdowns',
+      row_key: [
+        normalizeReportDate(run.requested_at),
+        safeString(first.metrics_group_key),
+        safeString(first.entity_level),
+        safeString(first.entity_id),
+        safeString(first.metrics_window),
+        safeString(first.dimension_key),
+      ].join('|'),
+      metrics_group_key: safeString(first.metrics_group_key),
+      account_id: safeString(adEntity.account_id),
+      scope_type: safeString(first.entity_level),
+      ad_id: safeString(adEntity.ad_id || adEntity.entity_id),
+      adset_id: safeString(adEntity.adset_id),
+      campaign_id: safeString(adEntity.campaign_id),
+      window: safeString(first.metrics_window),
+      breakdown_key: safeString(first.dimension_key),
+      row_count: 1,
+    };
+
+    applyDimensionsToBreakdownRow(row, dimensions);
+
+    const audit = auditIndex.get(scopeWindowKey);
+    applyAuditToBreakdownRow(row, audit);
+
+    for (const metric of metrics) {
+      applyMetricToBreakdownRow(row, metric);
+    }
+
+    synthesizeBreakdownEngagement(row);
+    output.push(row);
+  }
+
+  return output;
+}
+
+function applyAuditToSummaryRow(row, prefix, audit) {
+  row[`${prefix}fetch_status_summary`] = safeString(audit?.fetch_status_summary);
+  row[`${prefix}fetch_status_hourly`] = safeString(audit?.fetch_status_hourly);
+  row[`${prefix}fetch_error_summary_message`] = '';
+  row[`${prefix}fetch_error_summary_code`] = '';
+  row[`${prefix}fetch_error_hourly_message`] = '';
+  row[`${prefix}fetch_error_hourly_code`] = '';
+  row[`${prefix}row_count_summary`] = safeInteger(audit?.row_count_summary);
+  row[`${prefix}row_count_hourly`] = safeInteger(audit?.row_count_hourly);
+}
+
+function applyMetricToSummaryRow(row, prefix, metric) {
+  const metricName = safeString(metric.metric_name);
+  if (!metricName) return;
+
+  const value = normalizeMetricValue(metric.metric_value);
+  if (value === null) return;
+
+  row[`${prefix}${metricName}`] = value;
+
+  const scalarAlias = SUMMARY_SCALAR_ALIAS[metricName];
+  if (scalarAlias) {
+    row[`${prefix}${scalarAlias}`] = value;
+    row[`${prefix}${scalarAlias}_source`] = safeString(metric.source_kind || 'summary');
+  }
+
+  if (metricName === 'conversation_started') {
+    row[`${prefix}whatsapp_conversations_started`] = value;
+  }
+  if (metricName === 'cost_per_conversation_started' && row[`${prefix}avg_cost_per_conversation`] == null) {
+    row[`${prefix}avg_cost_per_conversation`] = value;
+  }
+
+  applyActionListFields(row, prefix, metricName, value);
+}
+
+function applyActionListFields(row, prefix, metricName, value) {
+  const directAlias = ACTION_ALIAS[metricName];
+  if (directAlias) {
+    row[`${prefix}list_actions_${directAlias}`] = value;
+    return;
+  }
+
+  if (metricName.startsWith('unique_')) {
+    const baseMetric = metricName.slice('unique_'.length);
+    const alias = ACTION_ALIAS[baseMetric];
+    if (alias) row[`${prefix}list_unique_actions_${alias}`] = value;
+    return;
+  }
+
+  if (metricName.startsWith('cost_per_unique_')) {
+    const baseMetric = metricName.slice('cost_per_unique_'.length);
+    const alias = ACTION_ALIAS[baseMetric];
+    if (alias) row[`${prefix}list_cost_per_unique_action_type_${alias}`] = value;
+    return;
+  }
+
+  if (metricName.startsWith('cost_per_')) {
+    const baseMetric = metricName.slice('cost_per_'.length);
+    const alias = ACTION_ALIAS[baseMetric];
+    if (alias) row[`${prefix}list_cost_per_action_type_${alias}`] = value;
+  }
+}
+
+function synthesizeEngagementFields(row, prefix) {
+  if (row[`${prefix}engagement_general`] != null) return;
+
+  const postReaction = toNumberOrNull(row[`${prefix}post_reaction`]) || 0;
+  const comments = toNumberOrNull(row[`${prefix}comments`]) || 0;
+  const posts = toNumberOrNull(row[`${prefix}posts`]) || 0;
+  const computed = postReaction + comments + posts;
+
+  if (computed > 0) {
+    row[`${prefix}engagement_general`] = computed;
+  }
+}
+
+function applyDimensionsToBreakdownRow(row, dimensions) {
+  for (const [key, rawValue] of Object.entries(isObject(dimensions) ? dimensions : {})) {
+    const normalizedKey = safeString(key);
+    if (!DIMENSION_FIELDS.has(normalizedKey)) continue;
+    const value = safeString(rawValue);
+    if (!value) continue;
+    row[`dimension_${normalizedKey}`] = value;
+  }
+}
+
+function applyAuditToBreakdownRow(row, audit) {
+  row.metric_fetch_status_summary = safeString(audit?.fetch_status_summary);
+  row.metric_fetch_status_hourly = safeString(audit?.fetch_status_hourly);
+  row.metric_fetch_error_summary_message = '';
+  row.metric_fetch_error_summary_code = '';
+  row.metric_fetch_error_hourly_message = '';
+  row.metric_fetch_error_hourly_code = '';
+  row.metric_row_count_summary = safeInteger(audit?.row_count_summary);
+  row.metric_row_count_hourly = safeInteger(audit?.row_count_hourly);
+}
+
+function applyMetricToBreakdownRow(row, metric) {
+  const metricName = safeString(metric.metric_name);
+  if (!metricName) return;
+
+  const value = normalizeMetricValue(metric.metric_value);
+  if (value === null) return;
+
+  row[metricName] = value;
+
+  const scalarAlias = SUMMARY_SCALAR_ALIAS[metricName];
+  if (scalarAlias) {
+    row[`metric_${scalarAlias}`] = value;
+  }
+
+  if (metricName === 'conversation_started') {
+    row.whatsapp_conversations_started = value;
+  }
+  if (metricName === 'cost_per_conversation_started' && row.avg_cost_per_conversation == null) {
+    row.avg_cost_per_conversation = value;
+  }
+}
+
+function synthesizeBreakdownEngagement(row) {
+  if (row.engagement_general != null) return;
+
+  const postReaction = toNumberOrNull(row.post_reaction) || 0;
+  const comments = toNumberOrNull(row.comments) || 0;
+  const posts = toNumberOrNull(row.posts) || 0;
+  const computed = postReaction + comments + posts;
+
+  if (computed > 0) {
+    row.engagement_general = computed;
+  }
+}
+
+function resolveScopeEntityId(adEntity, scopeType) {
+  if (scopeType === 'ad') return safeString(adEntity.ad_id || adEntity.entity_id);
+  if (scopeType === 'adset') return safeString(adEntity.adset_id);
+  if (scopeType === 'campaign') return safeString(adEntity.campaign_id);
+  return '';
+}
+
+function normalizeMetricValue(value) {
+  const numeric = toNumberOrNull(value);
+  return numeric === null ? null : numeric;
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function normalizeInclude(value) {
+  const normalized = safeString(value).toLowerCase();
+  if (normalized === 'summary') return 'summary';
+  if (normalized === 'breakdown' || normalized === 'breakdowns') return 'breakdown';
+  return 'both';
+}
+
+function normalizeReportDate(value) {
+  const input = safeString(value);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    return input;
+  }
+
+  const now = new Date();
+  now.setUTCDate(now.getUTCDate() - 1);
+  return now.toISOString().slice(0, 10);
+}
+
+function parseReportWindows(raw) {
+  const values = safeString(raw)
+    .split(',')
+    .map((entry) => safeString(entry))
+    .filter(Boolean);
+
+  if (!values.length) return [...REPORT_WINDOWS];
+
+  const unique = dedupeStrings(values.filter((windowKey) => REPORT_WINDOWS.includes(windowKey)));
+  return unique.length ? unique : [...REPORT_WINDOWS];
+}
+
+function dedupeStrings(values) {
+  const seen = new Set();
+  const output = [];
+
+  for (const value of values) {
+    const normalized = safeString(value);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    output.push(normalized);
+  }
+
+  return output;
+}
+
+function makeScopeWindowKey(metricsGroupKey, entityLevel, entityId, windowKey) {
+  return [
+    safeString(metricsGroupKey),
+    safeString(entityLevel),
+    safeString(entityId),
+    safeString(windowKey),
+  ].join('|');
+}
+
+function buildPlaceholders(count) {
+  return new Array(count).fill('?').join(',');
 }
 
 function buildContractResponse(env) {
@@ -286,6 +1240,37 @@ function buildContractResponse(env) {
     ok: true,
     environment: safeString(env.ENVIRONMENT || 'unknown'),
     contract: {
+      report: {
+        method: 'GET',
+        endpoint: '/report/meta-ads-performance-report',
+        query: {
+          account_id: 'required',
+          report_date: 'optional (YYYY-MM-DD, default yesterday UTC)',
+          windows: 'optional (csv: last_24h,last_7d,last_30d)',
+          include: 'optional (summary|breakdown|both)',
+          limit: 'optional',
+        },
+        success_response: {
+          ok: true,
+          summary_rows: 'array',
+          breakdown_rows: 'array',
+          metadata: 'object',
+        },
+      },
+      inventory: {
+        method: 'GET',
+        endpoint: '/inventory/meta-ads-performance-report',
+        query: {
+          account_id: 'required',
+          freshness_hours: 'optional',
+          limit: 'optional',
+        },
+        success_response: {
+          ok: true,
+          count: 'number',
+          items: 'array',
+        },
+      },
       method: 'POST',
       endpoint: '/ingest/meta-ads-performance-report',
       auth: {
@@ -324,6 +1309,12 @@ function buildContractResponse(env) {
         error: 'string',
         message: 'string',
         requestId: 'string',
+      },
+      in_progress_response: {
+        ok: true,
+        inProgress: true,
+        phase: 'string',
+        lastSuccessfulPhase: 'string',
       },
       retries: {
         safe: true,
@@ -492,10 +1483,7 @@ function buildMetricSnapshotStatement(env, snapshot) {
       dimensions_json, confidence_status, confidence_score, warning_codes_json, warning_messages_json,
       duplicate_source_kinds_json, is_primary, recorded_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(
-      metrics_group_key, entity_level, entity_id, report_date, metrics_window, metric_name, dimension_key, dimensions_json
-    ) DO UPDATE SET
-      snapshot_key = excluded.snapshot_key,
+    ON CONFLICT(snapshot_key) DO UPDATE SET
       audit_key = excluded.audit_key,
       entity_name = excluded.entity_name,
       metric_value = excluded.metric_value,
@@ -673,6 +1661,10 @@ async function persistRawPayloads(env, rawPayloads, requestMeta) {
   const warnings = [];
   let written = 0;
 
+  if (!rawPayloads.length) {
+    return { written, warnings, status: 'skipped' };
+  }
+
   for (const payload of rawPayloads) {
     const reference = safeString(payload.raw_payload_reference || payload.raw_payload_key || payload.payload_hash);
     const body = safeString(payload.raw_payload_body);
@@ -702,7 +1694,11 @@ async function persistRawPayloads(env, rawPayloads, requestMeta) {
     });
   }
 
-  return { written, warnings };
+  return {
+    written,
+    warnings,
+    status: warnings.length ? 'partial' : 'completed',
+  };
 }
 
 async function upsertIngestionRun(env, row) {
@@ -712,9 +1708,17 @@ async function upsertIngestionRun(env, row) {
       metrics_group_key, idempotency_key, status, entities_upserted, metric_snapshots_inserted,
       audit_rows_inserted, raw_payloads_written, raw_payload_rows_upserted,
       duplication_rows_upserted, warnings_count, duplication_count, last_error,
-      request_headers_json, summary_json, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      request_headers_json, summary_json, phase, last_successful_phase, attempt_count,
+      last_request_id, r2_status, d1_status, processing_warnings_json, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(idempotency_key) DO UPDATE SET
+      run_id = excluded.run_id,
+      workflow_name = excluded.workflow_name,
+      report_mode = excluded.report_mode,
+      report_date = excluded.report_date,
+      requested_at = excluded.requested_at,
+      account_id = excluded.account_id,
+      metrics_group_key = excluded.metrics_group_key,
       status = excluded.status,
       entities_upserted = excluded.entities_upserted,
       metric_snapshots_inserted = excluded.metric_snapshots_inserted,
@@ -727,6 +1731,13 @@ async function upsertIngestionRun(env, row) {
       last_error = excluded.last_error,
       request_headers_json = excluded.request_headers_json,
       summary_json = excluded.summary_json,
+      phase = excluded.phase,
+      last_successful_phase = excluded.last_successful_phase,
+      attempt_count = excluded.attempt_count,
+      last_request_id = excluded.last_request_id,
+      r2_status = excluded.r2_status,
+      d1_status = excluded.d1_status,
+      processing_warnings_json = excluded.processing_warnings_json,
       updated_at = excluded.updated_at
   `).bind(
     safeString(row.run_id),
@@ -749,6 +1760,13 @@ async function upsertIngestionRun(env, row) {
     safeString(row.last_error),
     safeJsonString(row.request_headers_json, '{}'),
     safeJsonString(row.summary_json, '{}'),
+    safeString(row.phase || 'received'),
+    safeString(row.last_successful_phase),
+    Math.max(1, safeInteger(row.attempt_count || 1)),
+    safeString(row.last_request_id),
+    safeString(row.r2_status || 'not_started'),
+    safeString(row.d1_status || 'not_started'),
+    safeJsonString(row.processing_warnings_json, '[]'),
     safeString(row.created_at || new Date().toISOString()),
     safeString(row.updated_at || new Date().toISOString())
   ).run();
@@ -806,6 +1824,45 @@ function safeJsonString(value, fallback) {
   }
 }
 
+function buildInventoryItem(row) {
+  const source = safeJsonParse(row.source_json, {});
+  const campaign = isObject(source.campaign) ? source.campaign : {};
+  const creative = isObject(source.creative) ? source.creative : {};
+  const adset = isObject(source.adset) ? source.adset : {};
+  const adId = firstIdentifier(source.ad_id, row.ad_id, row.entity_id);
+  const adsetId = firstIdentifier(source.adset_id, adset.id, row.adset_id);
+  const creativeId = firstIdentifier(source.creative_id, creative.id, row.creative_id);
+
+  if (!adId || !adsetId || !creativeId) {
+    return null;
+  }
+
+  const inventoryItem = {
+    id: adId,
+    ad_id: adId,
+    ad_name: safeString(source.ad_name || row.ad_name || row.entity_name),
+    campaign_id: firstIdentifier(source.campaign_id, campaign.id, row.campaign_id),
+    campaign_name: safeString(source.campaign_name || row.campaign_name || campaign.name),
+    adset_id: adsetId,
+    adset_name: safeString(source.adset_name || row.adset_name || adset.name),
+    creative_id: creativeId,
+    creative_name: safeString(source.creative_name || row.creative_name || creative.name),
+    account_id: firstIdentifier(source.account_id, row.account_id),
+    status: safeString(source.ad_status || row.status),
+    effective_status: safeString(source.ad_effective_status || row.effective_status),
+    configured_status: safeString(source.ad_configured_status || row.configured_status),
+    creative: {
+      id: creativeId,
+      name: safeString(source.creative_name || row.creative_name || creative.name),
+    },
+    inventory_source: 'd1',
+    inventory_last_seen_at: safeString(row.last_seen_at),
+    inventory_snapshot: source,
+  };
+
+  return inventoryItem.id ? inventoryItem : null;
+}
+
 function jsonResponse(status, body) {
   return Response.json(body, { status });
 }
@@ -820,6 +1877,17 @@ function isObject(value) {
 
 function safeString(value) {
   return value == null ? '' : String(value).trim();
+}
+
+function firstIdentifier(...values) {
+  for (const value of values) {
+    const normalized = safeString(value);
+    if (normalized && normalized !== '0') {
+      return normalized;
+    }
+  }
+
+  return '';
 }
 
 function nullableString(value) {
@@ -838,6 +1906,19 @@ function nullableNumber(value) {
 
 function safeInteger(value) {
   return Math.trunc(safeNumber(value, 0));
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Math.trunc(Number(value));
+  return parsed > 0 ? parsed : fallback;
+}
+
+function isStaleRun(value, thresholdMs = 10 * 60 * 1000) {
+  const timestamp = Date.parse(safeString(value));
+  if (!Number.isFinite(timestamp)) {
+    return true;
+  }
+  return Date.now() - timestamp > thresholdMs;
 }
 
 function timingSafeEqual(left, right) {

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -46,6 +46,7 @@ type EscalaProfessional = {
 type EscalaScheduleEntry = { date: string; unit: string; professional: string }
 type EscalaClosedDay = { date: string; unit: string; reason: string }
 type EscalaHoliday = { date: string; unit: string; name: string }
+type WeekdayDefaultMap = Partial<Record<0 | 1 | 2 | 3 | 4 | 5 | 6, string>>
 const MONTH_LABELS = new Map<string, string>()
 const DEFAULT_DATE = new Date()
 const DEFAULT_MONTH_NUMBER = String(DEFAULT_DATE.getMonth() + 1).padStart(2, '0')
@@ -236,9 +237,57 @@ function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional
   return Array.from(map.values())
 }
 
+function getWeekdayFromIsoDate(value: string) {
+  const [year, month, day] = String(value || '').split('-').map(Number)
+  if (!year || !month || !day) return -1
+  return new Date(year, month - 1, day).getDay()
+}
+
+function buildPreviousMonthKeys(monthValue: string, count = 3) {
+  const [year, month] = monthValue.split('-').map(Number)
+  if (!year || !month || count <= 0) return [] as string[]
+  const keys: string[] = []
+  for (let index = 1; index <= count; index += 1) {
+    const date = new Date(year, month - 1 - index, 1)
+    keys.push(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`)
+  }
+  return keys
+}
+
+function deriveWeekdayDefaultProfessionals(entries: EscalaScheduleEntry[]): WeekdayDefaultMap {
+  const byWeekday = new Map<number, Map<string, number>>()
+  entries.forEach((entry) => {
+    const professional = String(entry?.professional || '').trim()
+    const weekday = getWeekdayFromIsoDate(String(entry?.date || ''))
+    if (!professional || weekday < 0) return
+    const currentMap = byWeekday.get(weekday) || new Map<string, number>()
+    currentMap.set(professional, (currentMap.get(professional) || 0) + 1)
+    byWeekday.set(weekday, currentMap)
+  })
+
+  const defaults: WeekdayDefaultMap = {}
+  byWeekday.forEach((countByProfessional, weekday) => {
+    const winner = Array.from(countByProfessional.entries())
+      .sort((left, right) => {
+        if (right[1] !== left[1]) return right[1] - left[1]
+        return left[0].localeCompare(right[0])
+      })[0]
+    if (!winner) return
+    defaults[weekday as 0 | 1 | 2 | 3 | 4 | 5 | 6] = winner[0]
+  })
+
+  return defaults
+}
+
+function toLocalIsoDate(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
 export const __testables = {
   mergeProfessionals,
   resolveVisibleMonth,
+  buildPreviousMonthKeys,
+  deriveWeekdayDefaultProfessionals,
 }
 
 function uniqueNames(values: string[]) {
@@ -537,6 +586,9 @@ export function EscalaProfissionaisModule() {
   const [dayActionKey, setDayActionKey] = useState<string | null>(null)
   const [activeDate, setActiveDate] = useState<string | null>(null)
   const [selectedDates, setSelectedDates] = useState<string[]>([])
+  const [isDayAssignModalOpen, setIsDayAssignModalOpen] = useState(false)
+  const [isBulkSelectionMode, setIsBulkSelectionMode] = useState(false)
+  const [isBulkAssignModalOpen, setIsBulkAssignModalOpen] = useState(false)
   const [highlightMode, setHighlightMode] = useState<'scheduled' | 'blocked' | 'empty' | null>(null)
   const [multiDateBlockReason, setMultiDateBlockReason] = useState('')
   const [selectedTeamMember, setSelectedTeamMember] = useState<string>('')
@@ -546,6 +598,8 @@ export function EscalaProfissionaisModule() {
   const [showInactiveTeamMembers, setShowInactiveTeamMembers] = useState(false)
   const activeDateRef = useRef<string | null>(null)
   const selectedDatesRef = useRef<string[]>([])
+  const autoPrefillRunningRef = useRef(false)
+  const autoPrefilledMonthKeysRef = useRef(new Set<string>())
   const teamPanelExpanded = teamFormMode !== 'idle'
   const selectedMonth = useMemo(
     () => (selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : ''),
@@ -614,6 +668,9 @@ export function EscalaProfissionaisModule() {
     setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
     setSelectedDates([])
     setActiveDate(null)
+    setIsDayAssignModalOpen(false)
+    setIsBulkSelectionMode(false)
+    setIsBulkAssignModalOpen(false)
     setHighlightMode(null)
     setMultiDateBlockReason('')
   }, [])
@@ -640,16 +697,12 @@ export function EscalaProfissionaisModule() {
   }, [refreshSchedule, selectedMonthNumber, selectedUnit, selectedYear])
 
   useEffect(() => {
-    const next = resolveVisibleMonth(availableMonths, selectedYear, selectedMonthNumber)
-    if (next.year !== selectedYear) setSelectedYear(next.year)
-    if (next.monthNumber !== selectedMonthNumber) setSelectedMonthNumber(next.monthNumber)
-  }, [availableMonths, selectedMonthNumber, selectedYear])
-
-  useEffect(() => {
     const activeMonth = selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : ''
     if (!activeMonth) return
     setActiveDate((prev) => (prev && prev.startsWith(`${activeMonth}-`) ? prev : null))
     setSelectedDates((prev) => prev.filter((date) => date.startsWith(`${activeMonth}-`)))
+    setIsDayAssignModalOpen(false)
+    setIsBulkAssignModalOpen(false)
   }, [selectedMonthNumber, selectedYear])
 
   useEffect(() => {
@@ -703,6 +756,7 @@ export function EscalaProfissionaisModule() {
     setTeamMemberDrafts({})
     setTeamFormMode('idle')
     setShowInactiveTeamMembers(false)
+    autoPrefilledMonthKeysRef.current.clear()
   }, [selectedUnit])
 
   const scheduleForMonth = schedule
@@ -790,6 +844,81 @@ export function EscalaProfissionaisModule() {
     return map
   }, [closedDaysForMonth])
   const closedDateSet = useMemo(() => new Set(closedDaysForMonth.map((entry) => entry.date)), [closedDaysForMonth])
+  const calendarCells = useMemo(() => (selectedMonth ? buildCalendarCells(selectedMonth) : []), [selectedMonth])
+
+  const autoPrefillFutureDatesFromHistory = useCallback(async () => {
+    if (!selectedUnit || !selectedMonth) return
+    if (autoPrefillRunningRef.current) return
+
+    const prefillKey = `${selectedUnit}__${selectedMonth}`
+    if (autoPrefilledMonthKeysRef.current.has(prefillKey)) return
+
+    const todayIso = toLocalIsoDate(new Date())
+    const emptyFutureDates = calendarCells
+      .filter((cell) => cell.monthOffset === 0 && cell.date >= todayIso)
+      .map((cell) => cell.date)
+      .filter((date) => !closedDateSet.has(date) && (scheduleByDate.get(date) || []).length === 0)
+
+    if (!emptyFutureDates.length) {
+      autoPrefilledMonthKeysRef.current.add(prefillKey)
+      return
+    }
+
+    autoPrefillRunningRef.current = true
+    try {
+      const previousMonths = buildPreviousMonthKeys(selectedMonth, 3)
+      const historyResponses = await Promise.all(
+        previousMonths.map((monthKey) => fetchEscalaSchedule(selectedUnit, monthKey)),
+      )
+      const historicalEntries = historyResponses
+        .filter((response) => response.ok)
+        .flatMap((response) => (Array.isArray(response.schedule) ? response.schedule : [])) as EscalaScheduleEntry[]
+
+      const weekdayDefaults = deriveWeekdayDefaultProfessionals(historicalEntries)
+      const targetUpdates = emptyFutureDates
+        .map((date) => {
+          const weekday = getWeekdayFromIsoDate(date)
+          const professional = weekdayDefaults[weekday as 0 | 1 | 2 | 3 | 4 | 5 | 6]
+          if (!professional) return null
+          return { date, professional }
+        })
+        .filter((item): item is { date: string; professional: string } => Boolean(item))
+
+      if (!targetUpdates.length) {
+        autoPrefilledMonthKeysRef.current.add(prefillKey)
+        return
+      }
+
+      let successCount = 0
+      for (const update of targetUpdates) {
+        const result = await replaceScheduleEntries({
+          date: update.date,
+          unit: selectedUnit,
+          professionals: [update.professional],
+        })
+        if (result.ok) successCount += 1
+      }
+
+      autoPrefilledMonthKeysRef.current.add(prefillKey)
+      if (!successCount) return
+
+      toast.success(
+        successCount === 1
+          ? '1 data futura foi pré-preenchida com o doutor padrão.'
+          : `${successCount} datas futuras foram pré-preenchidas com os doutores padrão.`,
+      )
+      await refreshSchedule(selectedUnit, selectedMonth)
+      await refreshOverview()
+    } finally {
+      autoPrefillRunningRef.current = false
+    }
+  }, [calendarCells, closedDateSet, refreshOverview, refreshSchedule, scheduleByDate, selectedMonth, selectedUnit])
+
+  useEffect(() => {
+    if (loadingSchedule) return
+    if (!selectedUnit || !selectedMonth) return
+    void autoPrefillFutureDatesFromHistory()
+  }, [autoPrefillFutureDatesFromHistory, loadingSchedule, selectedMonth, selectedUnit])
 
   useEffect(() => {
     if (selectedDates.length <= 1) {
@@ -805,7 +934,6 @@ export function EscalaProfissionaisModule() {
     setMultiDateBlockReason(nextReason)
   }, [closedReasonByDate, dayBlockReasons, selectedDates])
 
-  const calendarCells = useMemo(() => (selectedMonth ? buildCalendarCells(selectedMonth) : []), [selectedMonth])
   const selectedDateSet = useMemo(() => new Set(selectedDates), [selectedDates])
   const selectedDatesLabel = useMemo(() => {
     if (!selectedDates.length) return ''
@@ -969,11 +1097,11 @@ export function EscalaProfissionaisModule() {
   const handleApplyDayProfessionals = useCallback(async (dates: string[]) => {
     if (!selectedUnit) {
       toast.error('Selecione uma unidade antes de alterar a agenda.')
-      return false
+      return { ok: false, changed: false }
     }
 
     const targetDates = uniqueNames(dates).filter((date) => !closedBlockedDates.has(date))
-    if (!targetDates.length) return true
+    if (!targetDates.length) return { ok: true, changed: false }
 
     setDayActionKey(targetDates.length === 1 ? `assign:${targetDates[0]}` : 'assign:multi')
     const changedDates: string[] = []
@@ -990,7 +1118,7 @@ export function EscalaProfissionaisModule() {
       if (!res.ok) {
         setDayActionKey(null)
         toast.error(res.error || `Falha ao atualizar a agenda de ${formatDisplayDate(date)}.`)
-        return false
+        return { ok: false, changed: false }
       }
       changedDates.push(date)
     }
@@ -1012,24 +1140,92 @@ export function EscalaProfissionaisModule() {
     })
     await refreshSchedule()
     await refreshOverview()
-    return true
+    return { ok: true, changed: changedDates.length > 0 }
   }, [closedBlockedDates, getDayDraft, refreshOverview, refreshSchedule, scheduleByDate, selectedUnit])
 
   const closeActiveDateWithSave = useCallback(async () => {
     const dates = uniqueNames(selectedDatesRef.current)
     if (!dates.length) {
+      setIsDayAssignModalOpen(false)
       setSelectedDates([])
       setActiveDate(null)
       setMultiDateBlockReason('')
+      setIsBulkAssignModalOpen(false)
       return
     }
 
-    const saved = await handleApplyDayProfessionals(dates)
-    if (!saved) return
+    const result = await handleApplyDayProfessionals(dates)
+    if (!result.ok) return
+
+    if (isBulkSelectionMode) {
+      setIsBulkAssignModalOpen(false)
+      if (result.changed) {
+        setIsBulkSelectionMode(false)
+        setIsDayAssignModalOpen(false)
+        setSelectedDates([])
+        setActiveDate(null)
+        setMultiDateBlockReason('')
+      }
+      return
+    }
+
+    setIsDayAssignModalOpen(false)
     setSelectedDates([])
     setActiveDate(null)
     setMultiDateBlockReason('')
-  }, [handleApplyDayProfessionals])
+    setIsBulkAssignModalOpen(false)
+  }, [handleApplyDayProfessionals, isBulkSelectionMode])
+
+  const closeAssignModalWithoutSave = useCallback(() => {
+    const dates = uniqueNames(selectedDatesRef.current)
+    setDayProfessionalDrafts((prev) => {
+      if (!dates.length) return prev
+      const next = { ...prev }
+      dates.forEach((date) => {
+        delete next[date]
+      })
+      return next
+    })
+
+    if (isBulkSelectionMode) {
+      setIsBulkAssignModalOpen(false)
+      return
+    }
+
+    setIsDayAssignModalOpen(false)
+    setSelectedDates([])
+    setActiveDate(null)
+    setMultiDateBlockReason('')
+  }, [isBulkSelectionMode])
+
+  const enableBulkSelectionMode = useCallback(() => {
+    setIsBulkSelectionMode(true)
+    setIsBulkAssignModalOpen(false)
+    setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
+    setHighlightMode(null)
+    setSelectedDates([])
+    setActiveDate(null)
+    setMultiDateBlockReason('')
+  }, [])
+
+  const confirmBulkSelectionMode = useCallback(() => {
+    const dates = uniqueNames(selectedDatesRef.current).sort()
+    if (!dates.length) {
+      toast.error('Selecione pelo menos uma data para continuar.')
+      return
+    }
+    setSelectedDates(dates)
+    setActiveDate(dates[dates.length - 1] || null)
+    setIsBulkAssignModalOpen(true)
+  }, [])
+
+  const cancelBulkSelectionMode = useCallback(() => {
+    setIsBulkSelectionMode(false)
+    setIsBulkAssignModalOpen(false)
+    setSelectedDates([])
+    setActiveDate(null)
+    setMultiDateBlockReason('')
+  }, [])
 
   const shiftSelectedMonth = useCallback((offset: number) => {
     const next = shiftMonthValue(selectedMonth, offset)
@@ -1062,6 +1258,8 @@ export function EscalaProfissionaisModule() {
       setSelectedDates([])
       setActiveDate(null)
       setMultiDateBlockReason('')
+      if (isBulkSelectionMode) setIsBulkSelectionMode(false)
+      setIsBulkAssignModalOpen(false)
       await refreshSchedule()
       await refreshOverview()
       return
@@ -1090,9 +1288,11 @@ export function EscalaProfissionaisModule() {
     setSelectedDates([])
     setActiveDate(null)
     setMultiDateBlockReason('')
+    if (isBulkSelectionMode) setIsBulkSelectionMode(false)
+    setIsBulkAssignModalOpen(false)
     await refreshSchedule()
     await refreshOverview()
-  }, [closedDateSet, closedReasonByDate, dayBlockReasons, refreshOverview, refreshSchedule, selectedUnit])
+  }, [closedDateSet, closedReasonByDate, dayBlockReasons, isBulkSelectionMode, refreshOverview, refreshSchedule, selectedUnit])
 
   const handleToggleSelectedDatesBlock = useCallback(async () => {
     if (!selectedUnit) {
@@ -1131,6 +1331,8 @@ export function EscalaProfissionaisModule() {
       setSelectedDates([])
       setActiveDate(null)
       setMultiDateBlockReason('')
+      if (isBulkSelectionMode) setIsBulkSelectionMode(false)
+      setIsBulkAssignModalOpen(false)
       await refreshSchedule()
       await refreshOverview()
       return
@@ -1169,9 +1371,11 @@ export function EscalaProfissionaisModule() {
     setSelectedDates([])
     setActiveDate(null)
     setMultiDateBlockReason('')
+    if (isBulkSelectionMode) setIsBulkSelectionMode(false)
+    setIsBulkAssignModalOpen(false)
     await refreshSchedule()
     await refreshOverview()
-  }, [closedDateSet, closedReasonByDate, dayBlockReasons, handleToggleDayBlock, multiDateBlockReason, refreshOverview, refreshSchedule, selectedUnit])
+  }, [closedDateSet, closedReasonByDate, dayBlockReasons, handleToggleDayBlock, isBulkSelectionMode, multiDateBlockReason, refreshOverview, refreshSchedule, selectedUnit])
 
   const updateSelectedTeamMemberField = useCallback((field: keyof EscalaProfessional, value: string) => {
     const draftKey = teamFormMode === 'add' ? NEW_TEAM_MEMBER_KEY : selectedTeamMemberBase?.name
@@ -1293,9 +1497,9 @@ export function EscalaProfissionaisModule() {
     const res = teamFormMode === 'add'
       ? await addEscalaProfessional(payload)
       : await updateEscalaProfessional({
-          currentName: selectedTeamMemberBase?.name || '',
-          ...payload,
-        })
+        currentName: selectedTeamMemberBase?.name || '',
+        ...payload,
+      })
     setSavingTeamMember(false)
 
     if (!res.ok) {
@@ -1371,349 +1575,362 @@ export function EscalaProfissionaisModule() {
                 </div>
                 <div className="grid flex-1 grid-cols-7 gap-1.5">
                   {calendarCells.map((cell, index) => {
-                const entries = scheduleByDate.get(cell.date) || []
-                const entryNames = uniqueNames(entries.map((entry) => entry.professional))
-                const isBlocked = closedBlockedDates.has(cell.date)
-                const holidayLabels = holidayByDate.get(cell.date) || []
-                const displayEntryNames = isBlocked ? [] : entryNames
-                const isWithinSelectedMonth = cell.monthOffset === 0
-                const matchesSelectedProfessional = selectedProfessional !== ALL_PROFESSIONALS_OPTION && displayEntryNames.includes(selectedProfessional)
-                const matchesHighlightMode = highlightMode === 'scheduled'
-                  ? isWithinSelectedMonth && !isBlocked && entryNames.length > 0
-                  : highlightMode === 'empty'
-                    ? isWithinSelectedMonth && (isBlocked || entryNames.length === 0)
-                    : false
-                const hasTrackedFilter = selectedProfessional !== ALL_PROFESSIONALS_OPTION || highlightMode !== null
-                const isTracked = matchesSelectedProfessional || matchesHighlightMode
-                const isSelectedDate = selectedDateSet.has(cell.date)
-                const isPrimarySelectedDate = activeDate === cell.date
-                const dimmedByActiveDate = selectedDates.length > 0 && !isSelectedDate
-                const dimmedByTrackedFilter = hasTrackedFilter && !isTracked
-                const isEmptyDay = isWithinSelectedMonth && !isBlocked && entryNames.length === 0
-                const isAdjacentMonth = cell.monthOffset !== 0
-                const isPrevMonthShortcut = index === firstCurrentMonthIndex - 1
-                const isNextMonthShortcut = cell.monthOffset === 1 && cell.day === 1
-                const selectedProfessionalColor = selectedProfessional !== ALL_PROFESSIONALS_OPTION
-                  ? professionalMap.get(selectedProfessional)?.color
-                  : ''
-                const adjacentPosition = cell.monthOffset === -1
-                  ? index + 1
-                  : cell.monthOffset === 1
-                    ? cell.day
-                    : 0
-                const adjacentTotal = cell.monthOffset === -1 ? previousMonthCellsCount : nextMonthCellsCount
-                const localBlockReason = String(dayBlockReasons[cell.date] || '').trim()
-                const blockReason = localBlockReason || closedReasonByDate.get(cell.date) || ''
-                const blockBadgeLabel = String(blockReason || '').trim() || 'Sem atendimento'
-                const trackedCardStyle = matchesSelectedProfessional
-                  ? getProfessionalCardHighlightStyle(selectedProfessional, selectedProfessionalColor)
-                  : matchesHighlightMode && highlightMode === 'scheduled'
-                    ? {
-                        borderColor: 'rgba(125, 211, 252, 0.68)',
-                        background: 'linear-gradient(180deg, rgba(56, 189, 248, 0.13), rgba(15, 23, 42, 0.32))',
-                        boxShadow: '0 0 0 1px rgba(125, 211, 252, 0.18), 0 14px 28px rgba(2, 132, 199, 0.16), inset 0 1px 0 rgba(255,255,255,0.05)',
-                      } as React.CSSProperties
-                    : matchesHighlightMode && highlightMode === 'empty'
-                      ? {
-                          borderColor: isBlocked ? 'rgba(251, 113, 133, 0.7)' : 'rgba(250, 204, 21, 0.6)',
-                          background: isBlocked
-                            ? 'linear-gradient(180deg, rgba(244, 63, 94, 0.14), rgba(15, 23, 42, 0.34))'
-                            : 'linear-gradient(180deg, rgba(250, 204, 21, 0.1), rgba(15, 23, 42, 0.32))',
-                          boxShadow: isBlocked
-                            ? '0 0 0 1px rgba(251, 113, 133, 0.18), 0 14px 28px rgba(159, 18, 57, 0.16), inset 0 1px 0 rgba(255,255,255,0.04)'
-                            : '0 0 0 1px rgba(250, 204, 21, 0.16), 0 14px 28px rgba(120, 53, 15, 0.14), inset 0 1px 0 rgba(255,255,255,0.04)',
+                    const entries = scheduleByDate.get(cell.date) || []
+                    const entryNames = uniqueNames(entries.map((entry) => entry.professional))
+                    const isBlocked = closedBlockedDates.has(cell.date)
+                    const holidayLabels = holidayByDate.get(cell.date) || []
+                    const displayEntryNames = isBlocked ? [] : entryNames
+                    const isWithinSelectedMonth = cell.monthOffset === 0
+                    const matchesSelectedProfessional = selectedProfessional !== ALL_PROFESSIONALS_OPTION && displayEntryNames.includes(selectedProfessional)
+                    const matchesHighlightMode = highlightMode === 'scheduled'
+                      ? isWithinSelectedMonth && !isBlocked && entryNames.length > 0
+                      : highlightMode === 'empty'
+                        ? isWithinSelectedMonth && (isBlocked || entryNames.length === 0)
+                        : false
+                    const hasTrackedFilter = selectedProfessional !== ALL_PROFESSIONALS_OPTION || highlightMode !== null
+                    const isTracked = matchesSelectedProfessional || matchesHighlightMode
+                    const isSelectedDate = selectedDateSet.has(cell.date)
+                    const isPrimarySelectedDate = activeDate === cell.date
+                    const dimmedByActiveDate = selectedDates.length > 0 && !isSelectedDate
+                    const dimmedByTrackedFilter = hasTrackedFilter && !isTracked
+                    const isEmptyDay = isWithinSelectedMonth && !isBlocked && entryNames.length === 0
+                    const isAdjacentMonth = cell.monthOffset !== 0
+                    const isPrevMonthShortcut = index === firstCurrentMonthIndex - 1
+                    const isNextMonthShortcut = cell.monthOffset === 1 && cell.day === 1
+                    const selectedProfessionalColor = selectedProfessional !== ALL_PROFESSIONALS_OPTION
+                      ? professionalMap.get(selectedProfessional)?.color
+                      : ''
+                    const adjacentPosition = cell.monthOffset === -1
+                      ? index + 1
+                      : cell.monthOffset === 1
+                        ? cell.day
+                        : 0
+                    const adjacentTotal = cell.monthOffset === -1 ? previousMonthCellsCount : nextMonthCellsCount
+                    const localBlockReason = String(dayBlockReasons[cell.date] || '').trim()
+                    const blockReason = localBlockReason || closedReasonByDate.get(cell.date) || ''
+                    const blockBadgeLabel = String(blockReason || '').trim() || 'Sem atendimento'
+                    const trackedCardStyle = matchesSelectedProfessional
+                      ? getProfessionalCardHighlightStyle(selectedProfessional, selectedProfessionalColor)
+                      : matchesHighlightMode && highlightMode === 'scheduled'
+                        ? {
+                          borderColor: 'rgba(125, 211, 252, 0.68)',
+                          background: 'linear-gradient(180deg, rgba(56, 189, 248, 0.13), rgba(15, 23, 42, 0.32))',
+                          boxShadow: '0 0 0 1px rgba(125, 211, 252, 0.18), 0 14px 28px rgba(2, 132, 199, 0.16), inset 0 1px 0 rgba(255,255,255,0.05)',
                         } as React.CSSProperties
-                      : undefined
-                const cardStyle = isAdjacentMonth
-                  ? getAdjacentMonthCardStyle(cell.monthOffset === -1 ? 'previous-month' : 'next-month', adjacentPosition, adjacentTotal)
-                  : trackedCardStyle
-                const handleOpenDate = (event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
-                  if (selectedProfessional !== ALL_PROFESSIONALS_OPTION) {
-                    setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
-                    setHighlightMode(null)
-                    return
-                  }
-                  if (highlightMode) {
-                    setHighlightMode(null)
-                    return
-                  }
-                  const multiSelect = Boolean((event as React.MouseEvent<HTMLDivElement> | undefined)?.metaKey || (event as React.MouseEvent<HTMLDivElement> | undefined)?.ctrlKey)
-                  if (multiSelect) {
-                    const alreadySelected = selectedDateSet.has(cell.date)
-                    const next = alreadySelected
-                      ? selectedDates.filter((date) => date !== cell.date)
-                      : uniqueNames([...selectedDates, cell.date]).sort()
-                    setSelectedDates(next)
-                    setActiveDate(next.length ? (alreadySelected ? next[next.length - 1] : cell.date) : null)
-                    if (!next.length) setMultiDateBlockReason('')
-                    return
-                  }
-                  setSelectedDates([cell.date])
-                  setActiveDate(cell.date)
-                }
+                        : matchesHighlightMode && highlightMode === 'empty'
+                          ? {
+                            borderColor: isBlocked ? 'rgba(251, 113, 133, 0.7)' : 'rgba(250, 204, 21, 0.6)',
+                            background: isBlocked
+                              ? 'linear-gradient(180deg, rgba(244, 63, 94, 0.14), rgba(15, 23, 42, 0.34))'
+                              : 'linear-gradient(180deg, rgba(250, 204, 21, 0.1), rgba(15, 23, 42, 0.32))',
+                            boxShadow: isBlocked
+                              ? '0 0 0 1px rgba(251, 113, 133, 0.18), 0 14px 28px rgba(159, 18, 57, 0.16), inset 0 1px 0 rgba(255,255,255,0.04)'
+                              : '0 0 0 1px rgba(250, 204, 21, 0.16), 0 14px 28px rgba(120, 53, 15, 0.14), inset 0 1px 0 rgba(255,255,255,0.04)',
+                          } as React.CSSProperties
+                          : undefined
+                    const cardStyle = isAdjacentMonth
+                      ? getAdjacentMonthCardStyle(cell.monthOffset === -1 ? 'previous-month' : 'next-month', adjacentPosition, adjacentTotal)
+                      : trackedCardStyle
+                    const handleOpenDate = (event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
+                      if (isBulkSelectionMode) {
+                        const alreadySelected = selectedDateSet.has(cell.date)
+                        const next = alreadySelected
+                          ? selectedDates.filter((date) => date !== cell.date)
+                          : uniqueNames([...selectedDates, cell.date]).sort()
+                        setSelectedDates(next)
+                        setActiveDate(next.length ? (alreadySelected ? next[next.length - 1] : cell.date) : null)
+                        if (!next.length) setMultiDateBlockReason('')
+                        setIsBulkAssignModalOpen(false)
+                        return
+                      }
+                      if (selectedProfessional !== ALL_PROFESSIONALS_OPTION) {
+                        setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
+                        setHighlightMode(null)
+                        return
+                      }
+                      if (highlightMode) {
+                        setHighlightMode(null)
+                        return
+                      }
+                      const multiSelect = Boolean((event as React.MouseEvent<HTMLDivElement> | undefined)?.metaKey || (event as React.MouseEvent<HTMLDivElement> | undefined)?.ctrlKey)
+                      if (multiSelect) {
+                        const alreadySelected = selectedDateSet.has(cell.date)
+                        const next = alreadySelected
+                          ? selectedDates.filter((date) => date !== cell.date)
+                          : uniqueNames([...selectedDates, cell.date]).sort()
+                        setSelectedDates(next)
+                        setActiveDate(next.length ? (alreadySelected ? next[next.length - 1] : cell.date) : null)
+                        if (!next.length) setMultiDateBlockReason('')
+                        return
+                      }
+                      setSelectedDates([cell.date])
+                      setActiveDate(cell.date)
+                      setIsDayAssignModalOpen(true)
+                    }
 
-                  return (
-                    <div
-                      key={cell.date}
-                      role={isAdjacentMonth ? undefined : 'button'}
-                      tabIndex={isAdjacentMonth ? undefined : 0}
-                      data-testid={`escala-day-${cell.date}`}
-                      data-escala-preserve-filter="true"
-                      onClick={isAdjacentMonth ? undefined : (event) => handleOpenDate(event)}
-                      onKeyDown={isAdjacentMonth ? undefined : (event) => {
-                        if (event.key === 'Enter' || event.key === ' ') {
-                          event.preventDefault()
-                          handleOpenDate(event)
-                        }
-                      }}
-                      className={cn(
-                        'escala-day-card grid h-full min-h-[76px] content-start gap-1 rounded-xl border border-white/10 bg-white/[0.045] px-2 py-1.5 text-left text-[11px] text-slate-100/90 transition-all',
-                        isAdjacentMonth ? 'place-items-center border-slate-400/8 bg-slate-400/[0.03] text-center text-slate-500/65 saturate-50' : 'hover:border-white/30',
-                        isBlocked && 'border-rose-300/45 bg-rose-500/12 text-rose-50/95',
-                        isTracked && 'escala-day-card--tracked',
-                        isSelectedDate && 'escala-day-card--selected border-sky-200/80 bg-sky-300/14',
-                        isPrimarySelectedDate && 'ring-2 ring-sky-300/32',
-                        (dimmedByActiveDate || dimmedByTrackedFilter) && 'opacity-45 saturate-75'
-                      )}
-                      style={cardStyle}
-                    >
-                      <div className={cn(
-                        'flex min-h-[1.2rem] w-full items-start justify-between gap-2',
-                        isAdjacentMonth && 'justify-center'
-                      )}>
+                    return (
+                      <div
+                        key={cell.date}
+                        role={isAdjacentMonth ? undefined : 'button'}
+                        tabIndex={isAdjacentMonth ? undefined : 0}
+                        data-testid={`escala-day-${cell.date}`}
+                        data-escala-preserve-filter="true"
+                        onClick={isAdjacentMonth ? undefined : (event) => handleOpenDate(event)}
+                        onKeyDown={isAdjacentMonth ? undefined : (event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault()
+                            handleOpenDate(event)
+                          }
+                        }}
+                        className={cn(
+                          'escala-day-card grid h-full min-h-[76px] content-start gap-1 rounded-xl border border-white/10 bg-white/[0.045] px-2 py-1.5 text-left text-[11px] text-slate-100/90 transition-all',
+                          isAdjacentMonth ? 'place-items-center border-slate-400/8 bg-slate-400/[0.03] text-center text-slate-500/65 saturate-50' : 'hover:border-white/30',
+                          isBlocked && 'border-rose-300/45 bg-rose-500/12 text-rose-50/95',
+                          isTracked && 'escala-day-card--tracked',
+                          isSelectedDate && 'escala-day-card--selected border-sky-200/80 bg-sky-300/14',
+                          isPrimarySelectedDate && 'ring-2 ring-sky-300/32',
+                          (dimmedByActiveDate || dimmedByTrackedFilter) && 'opacity-45 saturate-75'
+                        )}
+                        style={cardStyle}
+                      >
                         <div className={cn(
-                          'flex min-w-[1.4rem] items-start gap-1 pt-0.5 text-[13px] font-semibold leading-none text-white/92',
-                          isAdjacentMonth && 'min-w-0 justify-center pt-0 text-slate-500/60'
+                          'flex min-h-[1.2rem] w-full items-start justify-between gap-2',
+                          isAdjacentMonth && 'justify-center'
                         )}>
-                          <span className={cn(isAdjacentMonth && 'text-slate-400/60')}>{cell.day}</span>
+                          <div className={cn(
+                            'flex min-w-[1.4rem] items-start gap-1 pt-0.5 text-[13px] font-semibold leading-none text-white/92',
+                            isAdjacentMonth && 'min-w-0 justify-center pt-0 text-slate-500/60'
+                          )}>
+                            <span className={cn(isAdjacentMonth && 'text-slate-400/60')}>{cell.day}</span>
+                          </div>
+                        </div>
+
+                        <div
+                          className={cn(
+                            'flex min-h-[34px] min-w-0 flex-wrap items-start justify-center gap-1 text-center',
+                            isAdjacentMonth && 'min-h-[42px]'
+                          )}
+                        >
+                          {isAdjacentMonth ? (
+                            <>
+                              {isPrevMonthShortcut ? (
+                                <button
+                                  type="button"
+                                  className="flex size-10 items-center justify-center rounded-full border border-white/14 bg-white/[0.07] text-slate-200/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition hover:border-white/25 hover:bg-white/[0.12] hover:text-white"
+                                  data-escala-preserve-filter="true"
+                                  aria-label="Mês anterior"
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    shiftSelectedMonth(-1)
+                                  }}
+                                >
+                                  <ChevronLeft className="size-5" />
+                                </button>
+                              ) : null}
+                              {isNextMonthShortcut ? (
+                                <button
+                                  type="button"
+                                  className="flex size-10 items-center justify-center rounded-full border border-white/14 bg-white/[0.07] text-slate-200/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition hover:border-white/25 hover:bg-white/[0.12] hover:text-white"
+                                  data-escala-preserve-filter="true"
+                                  aria-label="Próximo mês"
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    shiftSelectedMonth(1)
+                                  }}
+                                >
+                                  <ChevronRight className="size-5" />
+                                </button>
+                              ) : null}
+                            </>
+                          ) : displayEntryNames.length ? (
+                            displayEntryNames.map((name) => {
+                              const isActiveSelection = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name === selectedProfessional
+                              const isMuted = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name !== selectedProfessional
+                              const accentColor = professionalMap.get(name)?.color
+                              return (
+                                <button
+                                  key={`${cell.date}__${name}`}
+                                  type="button"
+                                  data-testid={`escala-pill-${cell.date}-${slugifySegment(name)}`}
+                                  data-escala-preserve-filter="true"
+                                  className={cn(
+                                    'escala-entry-pill rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-tight transition-all',
+                                    isActiveSelection && 'escala-entry-pill--active',
+                                    isMuted && 'escala-entry-pill--muted',
+                                  )}
+                                  style={getProfessionalBadgeStyle(name, isActiveSelection ? 'active' : (isMuted ? 'muted' : 'default'), accentColor)}
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    focusProfessional(name)
+                                  }}
+                                  aria-pressed={isActiveSelection}
+                                >
+                                  {name}
+                                </button>
+                              )
+                            })
+                          ) : null}
+                        </div>
+
+                        <div className="flex min-h-[22px] flex-col gap-1">
+                          {!isAdjacentMonth && !displayEntryNames.length && isBlocked ? (
+                            <NoAttendanceChip
+                              date={cell.date}
+                              blocked
+                              label={localBlockReason ? blockBadgeLabel : undefined}
+                            />
+                          ) : null}
+                          {!isAdjacentMonth && !displayEntryNames.length && !isBlocked && (
+                            <div className={cn(highlightMode === 'empty' && isEmptyDay && '[&_div]:border-amber-300/35 [&_div]:bg-amber-400/12 [&_div]:text-amber-50')}>
+                              <NoAttendanceChip date={cell.date} label="Sem atendimento" />
+                            </div>
+                          )}
+                          {!isAdjacentMonth && holidayLabels.length ? (
+                            <Badge variant="warning" className="max-w-full px-1.5 py-0.5 text-[10px]">
+                              {holidayLabels[0]}
+                            </Badge>
+                          ) : null}
                         </div>
                       </div>
-
-                      <div
-                        className={cn(
-                          'flex min-h-[34px] min-w-0 flex-wrap items-start justify-center gap-1 text-center',
-                          isAdjacentMonth && 'min-h-[42px]'
-                        )}
-                      >
-                        {isAdjacentMonth ? (
-                          <>
-                            {isPrevMonthShortcut ? (
-                              <button
-                                type="button"
-                                className="flex size-10 items-center justify-center rounded-full border border-white/14 bg-white/[0.07] text-slate-200/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition hover:border-white/25 hover:bg-white/[0.12] hover:text-white"
-                                data-escala-preserve-filter="true"
-                                aria-label="Mês anterior"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  shiftSelectedMonth(-1)
-                                }}
-                              >
-                                <ChevronLeft className="size-5" />
-                              </button>
-                            ) : null}
-                            {isNextMonthShortcut ? (
-                              <button
-                                type="button"
-                                className="flex size-10 items-center justify-center rounded-full border border-white/14 bg-white/[0.07] text-slate-200/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition hover:border-white/25 hover:bg-white/[0.12] hover:text-white"
-                                data-escala-preserve-filter="true"
-                                aria-label="Próximo mês"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  shiftSelectedMonth(1)
-                                }}
-                              >
-                                <ChevronRight className="size-5" />
-                              </button>
-                            ) : null}
-                          </>
-                        ) : displayEntryNames.length ? (
-                          displayEntryNames.map((name) => {
-                            const isActiveSelection = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name === selectedProfessional
-                            const isMuted = selectedProfessional !== ALL_PROFESSIONALS_OPTION && name !== selectedProfessional
-                            const accentColor = professionalMap.get(name)?.color
-                            return (
-                              <button
-                                key={`${cell.date}__${name}`}
-                                type="button"
-                                data-testid={`escala-pill-${cell.date}-${slugifySegment(name)}`}
-                                data-escala-preserve-filter="true"
-                                className={cn(
-                                  'escala-entry-pill rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-tight transition-all',
-                                  isActiveSelection && 'escala-entry-pill--active',
-                                  isMuted && 'escala-entry-pill--muted',
-                                )}
-                                style={getProfessionalBadgeStyle(name, isActiveSelection ? 'active' : (isMuted ? 'muted' : 'default'), accentColor)}
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  focusProfessional(name)
-                                }}
-                                aria-pressed={isActiveSelection}
-                              >
-                                {name}
-                              </button>
-                            )
-                          })
-                        ) : null}
-                      </div>
-
-                      <div className="flex min-h-[22px] flex-col gap-1">
-                        {!isAdjacentMonth && !displayEntryNames.length && isBlocked ? (
-                          <NoAttendanceChip
-                            date={cell.date}
-                            blocked
-                            label={localBlockReason ? blockBadgeLabel : undefined}
-                          />
-                        ) : null}
-                        {!isAdjacentMonth && !displayEntryNames.length && !isBlocked && (
-                          <div className={cn(highlightMode === 'empty' && isEmptyDay && '[&_div]:border-amber-300/35 [&_div]:bg-amber-400/12 [&_div]:text-amber-50')}>
-                            <NoAttendanceChip date={cell.date} label="Sem atendimento" />
-                          </div>
-                        )}
-                        {!isAdjacentMonth && holidayLabels.length ? (
-                          <Badge variant="warning" className="max-w-full px-1.5 py-0.5 text-[10px]">
-                            {holidayLabels[0]}
-                          </Badge>
-                        ) : null}
-                      </div>
-                    </div>
-                  )
-                })}
+                    )
+                  })}
                 </div>
               </div>
 
-              <div
-                className="escala-team-panel flex flex-col self-start overflow-hidden rounded-2xl border border-white/10 bg-slate-950/45 xl:w-[360px] xl:justify-self-end"
-                data-testid="escala-team-panel"
-              >
-                <div className="border-b border-white/10 px-3 py-2.5">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-[11px] uppercase tracking-[0.22em] text-slate-300/60">Equipe</div>
-                      <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <Button
-                        type="button"
-                        size="icon"
-                        variant={teamFormMode === 'add' ? 'premium' : 'outline'}
-                        onClick={beginAddTeamMember}
-                        disabled={!!teamLoadError}
-                        aria-label="Adicionar injetor"
-                        title="Adicionar"
-                        data-testid="escala-team-add"
-                      >
-                        <Plus className="h-4 w-4" />
-                      </Button>
-                      {teamPanelExpanded ? (
-                        <>
-                          <Button
-                            type="button"
-                            size="icon"
-                            variant="premium"
-                            onClick={() => void handleSaveTeamMember()}
-                            disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
-                            aria-label="Salvar cadastro do injetor"
-                            title="Salvar"
-                            data-testid="escala-team-save"
-                          >
-                            <Save className="h-4 w-4" />
-                          </Button>
+              <div className="flex flex-col gap-2 xl:w-[360px] xl:justify-self-end">
+                <div
+                  className="escala-team-panel flex flex-col self-start overflow-hidden rounded-2xl border border-white/10 bg-slate-950/45"
+                  data-testid="escala-team-panel"
+                >
+                  <div className="border-b border-white/10 px-3 py-2.5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[11px] uppercase tracking-[0.22em] text-slate-300/60">Equipe</div>
+                        <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant={teamFormMode === 'add' ? 'premium' : 'outline'}
+                          onClick={beginAddTeamMember}
+                          disabled={!!teamLoadError}
+                          aria-label="Adicionar injetor"
+                          title="Adicionar"
+                          data-testid="escala-team-add"
+                        >
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                        {teamPanelExpanded ? (
+                          <>
+                            <Button
+                              type="button"
+                              size="icon"
+                              variant="premium"
+                              onClick={() => void handleSaveTeamMember()}
+                              disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
+                              aria-label="Salvar cadastro do injetor"
+                              title="Salvar"
+                              data-testid="escala-team-save"
+                            >
+                              <Save className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              type="button"
+                              size="icon"
+                              variant="outline"
+                              onClick={closeTeamPanel}
+                              aria-label="Fechar cadastro da equipe"
+                              title="Fechar"
+                              data-testid="escala-team-close"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : (
                           <Button
                             type="button"
                             size="icon"
                             variant="outline"
-                            onClick={closeTeamPanel}
-                            aria-label="Fechar cadastro da equipe"
-                            title="Fechar"
-                            data-testid="escala-team-close"
+                            onClick={() => beginEditTeamMember(selectedTeamMember)}
+                            disabled={!selectedTeamMember || !!teamLoadError}
+                            aria-label="Editar injetor"
+                            title="Editar"
+                            data-testid="escala-team-edit"
                           >
-                            <X className="h-4 w-4" />
+                            <Pencil className="h-4 w-4" />
                           </Button>
-                        </>
-                      ) : (
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="outline"
-                          onClick={() => beginEditTeamMember(selectedTeamMember)}
-                          disabled={!selectedTeamMember || !!teamLoadError}
-                          aria-label="Editar injetor"
-                          title="Editar"
-                          data-testid="escala-team-edit"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {teamLoadError ? (
-                      <div
-                        className="w-full rounded-xl border border-amber-300/30 bg-amber-500/10 px-3 py-3 text-xs text-amber-50/90"
-                        data-testid="escala-team-error"
-                      >
-                        <div className="font-medium text-amber-50">Falha ao carregar a equipe do cadastro.</div>
-                        <div className="mt-1 text-amber-50/80">
-                          A agenda pode continuar visível, mas a lateral da equipe não está confiável até recarregar os profissionais.
-                        </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          className="mt-3 border-amber-200/35 bg-amber-50/8 text-amber-50 hover:bg-amber-50/14"
-                          onClick={() => void refreshProfessionals(selectedUnit)}
-                          data-testid="escala-team-retry"
-                        >
-                          Tentar novamente
-                        </Button>
+                        )}
                       </div>
-                    ) : activeInjectors.length || inactiveInjectors.length ? (
-                      <>
-                        {activeInjectors.map((prof) => {
-                      const isCurrent = prof.name === selectedTeamMember
-                      return (
-                        <button
-                          key={prof.name}
-                          type="button"
-                          className={cn(
-                            'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
-                            isCurrent ? 'text-white shadow-[0_14px_26px_rgba(15,23,42,0.24)]' : 'text-slate-200/80 hover:text-white'
-                          )}
-                          style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default', prof.color)}
-                          onClick={() => selectTeamMember(prof.name)}
-                          data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
+                    </div>
+
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {teamLoadError ? (
+                        <div
+                          className="w-full rounded-xl border border-amber-300/30 bg-amber-500/10 px-3 py-3 text-xs text-amber-50/90"
+                          data-testid="escala-team-error"
                         >
-                          {prof.name}
-                        </button>
-                      )
-                        })}
-                        {inactiveInjectors.length ? (
-                          <>
-                            <button
-                              type="button"
-                              className={cn(
-                                'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
-                                showInactiveTeamMembers ? 'text-white' : 'text-rose-100/90 hover:text-white'
-                              )}
-                              style={{
-                                background: showInactiveTeamMembers
-                                  ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.38), rgba(190, 24, 93, 0.28))'
-                                  : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
-                                borderColor: showInactiveTeamMembers ? 'rgba(254, 202, 202, 0.85)' : 'rgba(252, 165, 165, 0.45)',
-                                boxShadow: showInactiveTeamMembers
-                                  ? '0 14px 26px rgba(69, 10, 10, 0.26), inset 0 1px 0 rgba(255,255,255,0.16)'
-                                  : 'inset 0 1px 0 rgba(255,255,255,0.05)',
-                              }}
-                              onClick={() => setShowInactiveTeamMembers((prev) => !prev)}
-                              data-testid="escala-team-inactive-toggle"
-                              aria-expanded={showInactiveTeamMembers}
-                            >
-                              Inativos ({inactiveInjectors.length})
-                            </button>
-                            {showInactiveTeamMembers ? inactiveInjectors.map((prof) => {
-                              const isCurrent = prof.name === selectedTeamMember
-                              return (
+                          <div className="font-medium text-amber-50">Falha ao carregar a equipe do cadastro.</div>
+                          <div className="mt-1 text-amber-50/80">
+                            A agenda pode continuar visível, mas a lateral da equipe não está confiável até recarregar os profissionais.
+                          </div>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="mt-3 border-amber-200/35 bg-amber-50/8 text-amber-50 hover:bg-amber-50/14"
+                            onClick={() => void refreshProfessionals(selectedUnit)}
+                            data-testid="escala-team-retry"
+                          >
+                            Tentar novamente
+                          </Button>
+                        </div>
+                      ) : activeInjectors.length || inactiveInjectors.length ? (
+                        <>
+                          {activeInjectors.map((prof) => {
+                            const isCurrent = prof.name === selectedTeamMember
+                            return (
+                              <button
+                                key={prof.name}
+                                type="button"
+                                className={cn(
+                                  'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
+                                  isCurrent ? 'text-white shadow-[0_14px_26px_rgba(15,23,42,0.24)]' : 'text-slate-200/80 hover:text-white'
+                                )}
+                                style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default', prof.color)}
+                                onClick={() => selectTeamMember(prof.name)}
+                                data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
+                              >
+                                {prof.name}
+                              </button>
+                            )
+                          })}
+                          {inactiveInjectors.length ? (
+                            <>
+                              <button
+                                type="button"
+                                className={cn(
+                                  'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
+                                  showInactiveTeamMembers ? 'text-white' : 'text-rose-100/90 hover:text-white'
+                                )}
+                                style={{
+                                  background: showInactiveTeamMembers
+                                    ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.38), rgba(190, 24, 93, 0.28))'
+                                    : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
+                                  borderColor: showInactiveTeamMembers ? 'rgba(254, 202, 202, 0.85)' : 'rgba(252, 165, 165, 0.45)',
+                                  boxShadow: showInactiveTeamMembers
+                                    ? '0 14px 26px rgba(69, 10, 10, 0.26), inset 0 1px 0 rgba(255,255,255,0.16)'
+                                    : 'inset 0 1px 0 rgba(255,255,255,0.05)',
+                                }}
+                                onClick={() => setShowInactiveTeamMembers((prev) => !prev)}
+                                data-testid="escala-team-inactive-toggle"
+                                aria-expanded={showInactiveTeamMembers}
+                              >
+                                Inativos ({inactiveInjectors.length})
+                              </button>
+                              {showInactiveTeamMembers ? inactiveInjectors.map((prof) => {
+                                const isCurrent = prof.name === selectedTeamMember
+                                return (
                                   <button
                                     key={prof.name}
                                     type="button"
@@ -1721,159 +1938,197 @@ export function EscalaProfissionaisModule() {
                                       'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
                                       isCurrent ? 'text-white shadow-[0_14px_26px_rgba(69,10,10,0.28)]' : 'text-rose-100/90 hover:text-white'
                                     )}
-                                  style={{
-                                    background: isCurrent
-                                      ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.42), rgba(190, 24, 93, 0.3))'
-                                      : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
-                                    borderColor: isCurrent ? 'rgba(254, 202, 202, 0.9)' : 'rgba(252, 165, 165, 0.45)',
-                                    boxShadow: isCurrent
-                                      ? '0 14px 26px rgba(69,10,10,0.3), inset 0 1px 0 rgba(255,255,255,0.18)'
-                                      : 'inset 0 1px 0 rgba(255,255,255,0.05)',
-                                  }}
-                                  onClick={() => selectTeamMember(prof.name)}
-                                  data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
-                                >
-                                  {prof.name}
-                                </button>
-                              )
-                            }) : null}
-                          </>
-                        ) : null}
-                      </>
-                    ) : (
-                      <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-xs text-slate-300/70">
-                        Nenhum injetor encontrado para a unidade selecionada.
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {teamPanelExpanded ? (
-                  <>
-                <div className="px-3 py-3">
-                  {selectedTeamMemberDraft ? (
-                    <div className="grid content-start gap-2.5 sm:grid-cols-2">
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          NOME
-                        </span>
-                        <Input
-                          value={selectedTeamMemberDraft.name}
-                          onChange={(event) => updateSelectedTeamMemberField('name', event.target.value)}
-                          className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                          data-testid="escala-team-field-name"
-                        />
-                      </label>
-
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          SITUAÇÃO
-                        </span>
-                        <Select
-                          value={selectedTeamMemberDraft.status || STATUS_OPTIONS[0]}
-                          onValueChange={(value) => updateSelectedTeamMemberField('status', value)}
-                        >
-                          <SelectTrigger className="h-9 w-full border-white/10 bg-white/[0.05] text-white" data-testid="escala-team-field-status">
-                            <SelectValue placeholder="Selecione" />
-                          </SelectTrigger>
-                          <SelectContent className="border-white/15 bg-slate-900 text-slate-100">
-                            {STATUS_OPTIONS.map((option) => (
-                              <SelectItem key={option} value={option}>{option}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </label>
-
-                      <MultiSelectField
-                        label="CARGO"
-                        placeholder="Selecione os cargos"
-                        options={ROLE_OPTIONS}
-                        values={parseDelimitedValues(selectedTeamMemberDraft.role)}
-                        onToggle={(option) => toggleSelectedTeamMemberOption('role', option)}
-                        testId="escala-team-field-role"
-                      />
-
-                      <MultiSelectField
-                        label="UNIDADE"
-                        placeholder="Selecione as unidades"
-                        options={UNIT_OPTIONS}
-                        values={selectedTeamMemberDraft.units}
-                        onToggle={(option) => toggleSelectedTeamMemberOption('units', option)}
-                        testId="escala-team-field-units"
-                      />
-
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          EMAIL
-                        </span>
-                        <Input
-                          value={selectedTeamMemberDraft.email}
-                          onChange={(event) => updateSelectedTeamMemberField('email', event.target.value)}
-                          className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                          data-testid="escala-team-field-email"
-                        />
-                      </label>
-
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          TELEFONE
-                        </span>
-                        <Input
-                          value={selectedTeamMemberDraft.phone}
-                          onChange={(event) => updateSelectedTeamMemberField('phone', event.target.value)}
-                          placeholder="+55 (51) 99999-9999"
-                          className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                          data-testid="escala-team-field-phone"
-                        />
-                      </label>
-
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          INSTAGRAM
-                        </span>
-                        <Input
-                          value={selectedTeamMemberDraft.instagram}
-                          onChange={(event) => updateSelectedTeamMemberField('instagram', event.target.value)}
-                          className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                          data-testid="escala-team-field-instagram"
-                        />
-                      </label>
-
-                      <label className="space-y-1.5">
-                        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                          COR
-                        </span>
-                        <div className="flex h-9 items-center gap-3 rounded-md border border-white/10 bg-white/[0.05] px-3">
-                          <input
-                            type="color"
-                            value={normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
-                            onChange={(event) => updateSelectedTeamMemberField('color', event.target.value)}
-                            className="h-6 w-9 cursor-pointer rounded border-0 bg-transparent p-0"
-                            data-testid="escala-team-field-color"
-                            aria-label="Escolher cor do injetor"
-                          />
-                          <div
-                            className="h-[18px] w-[18px] rounded-full border border-white/20"
-                            style={{ background: normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR }}
-                            aria-hidden="true"
-                          />
-                          <span className="text-xs text-slate-300/75">
-                            {normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
-                          </span>
+                                    style={{
+                                      background: isCurrent
+                                        ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.42), rgba(190, 24, 93, 0.3))'
+                                        : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
+                                      borderColor: isCurrent ? 'rgba(254, 202, 202, 0.9)' : 'rgba(252, 165, 165, 0.45)',
+                                      boxShadow: isCurrent
+                                        ? '0 14px 26px rgba(69,10,10,0.3), inset 0 1px 0 rgba(255,255,255,0.18)'
+                                        : 'inset 0 1px 0 rgba(255,255,255,0.05)',
+                                    }}
+                                    onClick={() => selectTeamMember(prof.name)}
+                                    data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
+                                  >
+                                    {prof.name}
+                                  </button>
+                                )
+                              }) : null}
+                            </>
+                          ) : null}
+                        </>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-xs text-slate-300/70">
+                          Nenhum injetor encontrado para a unidade selecionada.
                         </div>
-                      </label>
+                      )}
+                    </div>
+                  </div>
 
-                    </div>
-                  ) : (
-                    <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-sm text-slate-300/70">
-                      {selectedTeamMember
-                        ? 'Clique em Editar para abrir os campos do injetor selecionado.'
-                        : 'Selecione um injetor e clique em Editar para abrir os campos.'}
-                    </div>
-                  )}
+                  {teamPanelExpanded ? (
+                    <>
+                      <div className="px-3 py-3">
+                        {selectedTeamMemberDraft ? (
+                          <div className="grid content-start gap-2.5 sm:grid-cols-2">
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                NOME
+                              </span>
+                              <Input
+                                value={selectedTeamMemberDraft.name}
+                                onChange={(event) => updateSelectedTeamMemberField('name', event.target.value)}
+                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                                data-testid="escala-team-field-name"
+                              />
+                            </label>
+
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                SITUAÇÃO
+                              </span>
+                              <Select
+                                value={selectedTeamMemberDraft.status || STATUS_OPTIONS[0]}
+                                onValueChange={(value) => updateSelectedTeamMemberField('status', value)}
+                              >
+                                <SelectTrigger className="h-9 w-full border-white/10 bg-white/[0.05] text-white" data-testid="escala-team-field-status">
+                                  <SelectValue placeholder="Selecione" />
+                                </SelectTrigger>
+                                <SelectContent className="border-white/15 bg-slate-900 text-slate-100">
+                                  {STATUS_OPTIONS.map((option) => (
+                                    <SelectItem key={option} value={option}>{option}</SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </label>
+
+                            <MultiSelectField
+                              label="CARGO"
+                              placeholder="Selecione os cargos"
+                              options={ROLE_OPTIONS}
+                              values={parseDelimitedValues(selectedTeamMemberDraft.role)}
+                              onToggle={(option) => toggleSelectedTeamMemberOption('role', option)}
+                              testId="escala-team-field-role"
+                            />
+
+                            <MultiSelectField
+                              label="UNIDADE"
+                              placeholder="Selecione as unidades"
+                              options={UNIT_OPTIONS}
+                              values={selectedTeamMemberDraft.units}
+                              onToggle={(option) => toggleSelectedTeamMemberOption('units', option)}
+                              testId="escala-team-field-units"
+                            />
+
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                EMAIL
+                              </span>
+                              <Input
+                                value={selectedTeamMemberDraft.email}
+                                onChange={(event) => updateSelectedTeamMemberField('email', event.target.value)}
+                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                                data-testid="escala-team-field-email"
+                              />
+                            </label>
+
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                TELEFONE
+                              </span>
+                              <Input
+                                value={selectedTeamMemberDraft.phone}
+                                onChange={(event) => updateSelectedTeamMemberField('phone', event.target.value)}
+                                placeholder="+55 (51) 99999-9999"
+                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                                data-testid="escala-team-field-phone"
+                              />
+                            </label>
+
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                INSTAGRAM
+                              </span>
+                              <Input
+                                value={selectedTeamMemberDraft.instagram}
+                                onChange={(event) => updateSelectedTeamMemberField('instagram', event.target.value)}
+                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                                data-testid="escala-team-field-instagram"
+                              />
+                            </label>
+
+                            <label className="space-y-1.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+                                COR
+                              </span>
+                              <div className="flex h-9 items-center gap-3 rounded-md border border-white/10 bg-white/[0.05] px-3">
+                                <input
+                                  type="color"
+                                  value={normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                                  onChange={(event) => updateSelectedTeamMemberField('color', event.target.value)}
+                                  className="h-6 w-9 cursor-pointer rounded border-0 bg-transparent p-0"
+                                  data-testid="escala-team-field-color"
+                                  aria-label="Escolher cor do injetor"
+                                />
+                                <div
+                                  className="h-[18px] w-[18px] rounded-full border border-white/20"
+                                  style={{ background: normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR }}
+                                  aria-hidden="true"
+                                />
+                                <span className="text-xs text-slate-300/75">
+                                  {normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                                </span>
+                              </div>
+                            </label>
+
+                          </div>
+                        ) : (
+                          <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-sm text-slate-300/70">
+                            {selectedTeamMember
+                              ? 'Clique em Editar para abrir os campos do injetor selecionado.'
+                              : 'Selecione um injetor e clique em Editar para abrir os campos.'}
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  ) : null}
                 </div>
-                  </>
-                ) : null}
+
+                <div className="rounded-2xl border border-white/10 bg-slate-950/45 px-3 py-3" data-testid="escala-bulk-select-panel">
+                  <Button
+                    type="button"
+                    variant={isBulkSelectionMode ? 'premium' : 'outline'}
+                    className="w-full"
+                    onClick={enableBulkSelectionMode}
+                    data-testid="escala-multi-select-toggle"
+                  >
+                    Seleção múltipla
+                  </Button>
+                  {isBulkSelectionMode ? (
+                    <>
+                      <div className="mt-2 text-[11px] text-slate-300/80">
+                        Clique nas datas do calendário para selecionar.
+                      </div>
+                      <div className="mt-2 grid grid-cols-2 gap-2">
+                        <Button
+                          type="button"
+                          variant="premium"
+                          onClick={confirmBulkSelectionMode}
+                          data-testid="escala-multi-select-ok"
+                        >
+                          OK
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={cancelBulkSelectionMode}
+                          data-testid="escala-multi-select-close"
+                        >
+                          Fechar
+                        </Button>
+                      </div>
+                    </>
+                  ) : null}
+                </div>
               </div>
             </div>
           </CardContent>
@@ -1881,13 +2136,29 @@ export function EscalaProfissionaisModule() {
       </div>
 
       <Dialog
-        open={selectedDates.length > 0}
+        open={isBulkSelectionMode ? (isBulkAssignModalOpen && selectedDates.length > 0) : (isDayAssignModalOpen && selectedDates.length > 0)}
         onOpenChange={(open) => {
-          if (open) return
-          void closeActiveDateWithSave()
+          if (open) {
+            if (isBulkSelectionMode) {
+              setIsBulkAssignModalOpen(true)
+            } else {
+              setIsDayAssignModalOpen(true)
+            }
+            return
+          }
+          closeAssignModalWithoutSave()
         }}
       >
         <DialogContent className="max-w-sm border-white/10 bg-slate-950/96 text-slate-100" data-escala-preserve-filter="true">
+          <button
+            type="button"
+            className="absolute right-10 top-3 rounded-xs border border-emerald-300/35 bg-emerald-500/16 px-2 py-1 text-[11px] font-semibold text-emerald-50 transition hover:bg-emerald-500/24 focus:outline-none focus:ring-2 focus:ring-emerald-300/45 sm:right-11 sm:top-4"
+            onClick={() => void closeActiveDateWithSave()}
+            data-testid="escala-modal-confirm"
+            aria-label="Confirmar alterações"
+          >
+            V
+          </button>
           {selectedDates.length ? (
             <>
               <DialogHeader className="space-y-1">
@@ -1977,10 +2248,10 @@ export function EscalaProfissionaisModule() {
                   const targetDates = selectedDates.filter((date) => !closedBlockedDates.has(date))
                   const checked = selectedDates.length === 1 && activeDate
                     ? (
-                        closedBlockedDates.has(activeDate)
-                          ? false
-                          : getDayDraft(activeDate, scheduleByDate.get(activeDate) || []).includes(name)
-                      )
+                      closedBlockedDates.has(activeDate)
+                        ? false
+                        : getDayDraft(activeDate, scheduleByDate.get(activeDate) || []).includes(name)
+                    )
                     : getDatesSelectionState(targetDates, name)
                   return (
                     <label

--- a/frontend/tests/escalaModule.test.ts
+++ b/frontend/tests/escalaModule.test.ts
@@ -35,4 +35,26 @@ describe('Escala module helpers', () => {
       monthNumber: '03',
     })
   })
+
+  it('builds the previous 3 month keys based on the selected month', () => {
+    expect(__testables.buildPreviousMonthKeys('2026-04', 3)).toEqual([
+      '2026-03',
+      '2026-02',
+      '2026-01',
+    ])
+  })
+
+  it('derives weekday defaults by most frequent doctor in the last months', () => {
+    const defaults = __testables.deriveWeekdayDefaultProfessionals([
+      { date: '2026-01-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }, // Monday
+      { date: '2026-01-12', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }, // Monday
+      { date: '2026-02-02', unit: 'Novo Hamburgo', professional: 'Dr. Bruno' }, // Monday
+      { date: '2026-02-03', unit: 'Novo Hamburgo', professional: 'Dr. Caio' }, // Tuesday
+      { date: '2026-03-03', unit: 'Novo Hamburgo', professional: 'Dr. Caio' }, // Tuesday
+      { date: '2026-03-10', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }, // Tuesday
+    ])
+
+    expect(defaults[1]).toBe('Dra. Ana')
+    expect(defaults[2]).toBe('Dr. Caio')
+  })
 })

--- a/website/scripts/smoke.mjs
+++ b/website/scripts/smoke.mjs
@@ -167,7 +167,11 @@ async function run() {
         const { res, text } = await fetchText("/");
         assert(res.status === 200, `/ expected 200, got ${res.status}`);
         assert(text.includes('href="/#sobre-nos"'), `Home HTML should include header link to /#sobre-nos`);
-        assert(text.includes('aria-label="Instagram"'), `Home HTML should include Instagram button (aria-label)`);
+        // Validate a stable SSR marker for social presence.
+        assert(
+            /https:\/\/www\.instagram\.com\/espacofacial_/i.test(text),
+            `Home HTML should include Instagram references for official unit profiles`,
+        );
     }
 
     {


### PR DESCRIPTION
## Summary\n- finalize Escala UX flow (multi-select, explicit modal confirm/discard, month selection stability)\n- add automatic future prefill by weekday defaults based on last 3 months\n- add helper tests for Escala prefill logic\n- improve meta-ads ingest worker with phase/idempotency progress and report/inventory endpoints\n- add ingestion run migration and update smoke assertion\n\n## Validation\n- frontend: npm run -s test -- tests/escalaModule.test.ts\n- repo sanity: ./backend/scripts/doctor.sh\n