### PR TITLE
fix(website): eliminar flicker de campanha antiga no hero

### DIFF
--- a/backend/apps/crm-api/package.json
+++ b/backend/apps/crm-api/package.json
@@ -10,7 +10,7 @@
     "test": "node --test server/harmonia/__tests__/*.test.js"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "googleapis": "^148.0.0",

--- a/backend/apps/whatsapp/official-module/package.json
+++ b/backend/apps/whatsapp/official-module/package.json
@@ -8,7 +8,7 @@
     "dev": "node official-whatsapp.js"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
     "express": "^4.22.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
       "express@4.21.2>path-to-regexp": "0.1.13",
       "express@4.22.1>path-to-regexp": "0.1.13",
       "router@2.2.0>path-to-regexp": "8.4.0",
+      "axios": "1.15.0",
       "qs@>=6.7.0 <=6.14.1": ">=6.14.2",
       "express-rate-limit@>=8.2.0 <8.2.2": ">=8.2.2",
       "tar-fs@>=2.0.0 <2.1.4": ">=2.1.4",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   express@4.21.2>path-to-regexp: 0.1.13
   express@4.22.1>path-to-regexp: 0.1.13
   router@2.2.0>path-to-regexp: 8.4.0
+  axios: 1.15.0
   qs@>=6.7.0 <=6.14.1: '>=6.14.2'
   express-rate-limit@>=8.2.0 <8.2.2: '>=8.2.2'
   tar-fs@>=2.0.0 <2.1.4: '>=2.1.4'
@@ -42,8 +43,8 @@ importers:
   apps/crm-api:
     dependencies:
       axios:
-        specifier: ^1.13.5
-        version: 1.13.5
+        specifier: 1.15.0
+        version: 1.15.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -157,8 +158,8 @@ importers:
   apps/whatsapp/official-module:
     dependencies:
       axios:
-        specifier: ^1.13.5
-        version: 1.13.5
+        specifier: 1.15.0
+        version: 1.15.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -755,8 +756,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -2065,6 +2066,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
@@ -3035,11 +3040,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.13.5:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -4514,6 +4519,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   pstree.remy@1.1.8: {}
 

--- a/website/src/app/[unit]/page.tsx
+++ b/website/src/app/[unit]/page.tsx
@@ -159,7 +159,7 @@ export default async function UnitHomePage({
             <h1 className="srOnly">Espaço Facial</h1>
 
             <section className="hero" aria-label="Destaque">
-                <HeroMedia initialItems={heroItems} initialVariant={variant} />
+                <HeroMedia initialItems={heroItems} initialVariant={variant} initialUnitSlug={unit.slug} />
                 <div className="heroOverlay" />
             </section>
 

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -91,7 +91,7 @@ export default async function HomePage({
     <>
       <Header />
       <main>
-        <HomeHeroExperience heroItems={heroItems} initialMediaVariant={variant} />
+        <HomeHeroExperience heroItems={heroItems} initialMediaVariant={variant} initialUnitSlug={resolvedUnit?.slug ?? null} />
         <TrustEvidenceSection context="home" />
 
         <div className="container">

--- a/website/src/components/HeroMedia.tsx
+++ b/website/src/components/HeroMedia.tsx
@@ -2,27 +2,168 @@
 
 import TrackedBookingLink from "@/components/TrackedBookingLink";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
-import { getLocalHeroItems, type HeroMediaItem, type HeroMediaVariant } from "@/lib/heroMediaShared";
+import { getLocalHeroItems, normalizeHeroUnitSlug, type HeroMediaItem, type HeroMediaVariant } from "@/lib/heroMediaShared";
+import { getStoredUnitSlug } from "@/lib/unitSelection";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
 
 type HeroMediaProps = {
     initialItems?: HeroMediaItem[];
     initialVariant?: HeroMediaVariant;
+    initialUnitSlug?: string | null;
 };
 
 const HERO_AUTOPLAY_MS = 6000;
+const HERO_DEFAULT_FRAME_COLOR = "#050505";
+const HERO_LIGHT_TEXT_COLOR = "#f5ead8";
+const HERO_DARK_TEXT_COLOR = "#1f1f1f";
+const HERO_DEFAULT_FRAME_COLORS = {
+    top: HERO_DEFAULT_FRAME_COLOR,
+    bottom: HERO_DEFAULT_FRAME_COLOR,
+} as const;
+const EMPTY_HERO_ITEMS: HeroMediaItem[] = [];
 
-export default function HeroMedia({ initialItems, initialVariant }: HeroMediaProps) {
+type HeroFrameColors = {
+    top: string;
+    bottom: string;
+};
+
+function clampColorChannel(value: number): number {
+    return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function toHexColor(r: number, g: number, b: number): string {
+    const toHex = (value: number) => clampColorChannel(value).toString(16).padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function parseHexColor(value: string): { r: number; g: number; b: number } | null {
+    const raw = (value ?? "").trim().replace("#", "");
+    if (!/^[0-9a-fA-F]{6}$/.test(raw)) return null;
+    return {
+        r: Number.parseInt(raw.slice(0, 2), 16),
+        g: Number.parseInt(raw.slice(2, 4), 16),
+        b: Number.parseInt(raw.slice(4, 6), 16),
+    };
+}
+
+function relativeLuminance(colorHex: string): number {
+    const parsed = parseHexColor(colorHex);
+    if (!parsed) return 0;
+
+    const toLinear = (channel: number) => {
+        const c = channel / 255;
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+
+    const r = toLinear(parsed.r);
+    const g = toLinear(parsed.g);
+    const b = toLinear(parsed.b);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function pickBandTextColor(backgroundHex: string): string {
+    return relativeLuminance(backgroundHex) > 0.42 ? HERO_DARK_TEXT_COLOR : HERO_LIGHT_TEXT_COLOR;
+}
+
+function campaignKey(variant: HeroMediaVariant, unitSlug: string | null | undefined): string {
+    const normalizedUnit = normalizeHeroUnitSlug(unitSlug);
+    return `${variant}:${normalizedUnit || "default"}`;
+}
+
+function extractTopBottomEdgeColorsFromImage(src: string): Promise<HeroFrameColors | null> {
+    return new Promise((resolve) => {
+        if (typeof window === "undefined") {
+            resolve(null);
+            return;
+        }
+
+        const image = new window.Image();
+        image.decoding = "async";
+        image.crossOrigin = "anonymous";
+
+        image.onload = () => {
+            try {
+                const sampleSize = 24;
+                const canvas = document.createElement("canvas");
+                canvas.width = sampleSize;
+                canvas.height = sampleSize;
+
+                const ctx = canvas.getContext("2d", { willReadFrequently: true });
+                if (!ctx) {
+                    resolve(null);
+                    return;
+                }
+
+                ctx.drawImage(image, 0, 0, sampleSize, sampleSize);
+                const data = ctx.getImageData(0, 0, sampleSize, sampleSize).data;
+
+                let topR = 0;
+                let topG = 0;
+                let topB = 0;
+                let topWeight = 0;
+                let bottomR = 0;
+                let bottomG = 0;
+                let bottomB = 0;
+                let bottomWeight = 0;
+
+                const edgeBand = 3;
+
+                for (let y = 0; y < sampleSize; y += 1) {
+                    for (let x = 0; x < sampleSize; x += 1) {
+                        const idx = (y * sampleSize + x) * 4;
+                        const alpha = data[idx + 3] / 255;
+                        if (alpha < 0.14) continue;
+
+                        if (y < edgeBand) {
+                            topR += data[idx] * alpha;
+                            topG += data[idx + 1] * alpha;
+                            topB += data[idx + 2] * alpha;
+                            topWeight += alpha;
+                        }
+
+                        if (y >= sampleSize - edgeBand) {
+                            bottomR += data[idx] * alpha;
+                            bottomG += data[idx + 1] * alpha;
+                            bottomB += data[idx + 2] * alpha;
+                            bottomWeight += alpha;
+                        }
+                    }
+                }
+
+                if (topWeight <= 0 || bottomWeight <= 0) {
+                    resolve(null);
+                    return;
+                }
+
+                resolve({
+                    top: toHexColor(topR / topWeight, topG / topWeight, topB / topWeight),
+                    bottom: toHexColor(bottomR / bottomWeight, bottomG / bottomWeight, bottomB / bottomWeight),
+                });
+            } catch {
+                resolve(null);
+            }
+        };
+
+        image.onerror = () => resolve(null);
+        image.src = src;
+    });
+}
+
+export default function HeroMedia({ initialItems, initialVariant, initialUnitSlug = null }: HeroMediaProps) {
     const unit = useCurrentUnit();
     const [index, setIndex] = useState(0);
     const [prevIndex, setPrevIndex] = useState<number | null>(null);
     const [aspectRatio, setAspectRatio] = useState<string>("16 / 9");
+    const [frameColors, setFrameColors] = useState<HeroFrameColors>(HERO_DEFAULT_FRAME_COLORS);
     const [variant, setVariant] = useState<HeroMediaVariant>(initialVariant ?? "desktop");
+    const hasInitialItems = Array.isArray(initialItems) && initialItems.length > 0;
+    const topBandTextColor = useMemo(() => pickBandTextColor(frameColors.top), [frameColors.top]);
+    const bottomBandTextColor = useMemo(() => pickBandTextColor(frameColors.bottom), [frameColors.bottom]);
 
     type HeroStyle = CSSProperties &
         Record<
-            "--hero-ar" | "--hero-cta-left" | "--hero-cta-top" | "--hero-cta-width" | "--hero-cta-height",
+            "--hero-ar" | "--hero-band-bg" | "--hero-band-bg-top" | "--hero-band-bg-bottom" | "--hero-cta-left" | "--hero-cta-top" | "--hero-cta-width" | "--hero-cta-height",
             string
         >;
     useEffect(() => {
@@ -39,19 +180,81 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
         return () => mql.removeListener(update);
     }, [initialItems]);
 
-    const items = useMemo(() => {
-        if (Array.isArray(initialItems) && initialItems.length) return initialItems;
-        return getLocalHeroItems(variant);
-    }, [initialItems, variant]);
+    const [items, setItems] = useState<HeroMediaItem[]>(() => {
+        const startupStoredUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
+        const startupTargetUnitSlug = startupStoredUnitSlug ?? initialUnitSlug ?? null;
+        const startupCampaignKey = campaignKey(variant, startupTargetUnitSlug);
+        const initialCampaignKey = campaignKey(variant, initialUnitSlug ?? null);
+        const canHydrateInitialItems = hasInitialItems && startupCampaignKey === initialCampaignKey;
+        if (canHydrateInitialItems) return initialItems;
+        return getLocalHeroItems(variant, { unitSlug: startupTargetUnitSlug });
+    });
+    const [loadedCampaignKey, setLoadedCampaignKey] = useState<string>(() => {
+        const startupStoredUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
+        const startupTargetUnitSlug = startupStoredUnitSlug ?? initialUnitSlug ?? null;
+        return campaignKey(variant, startupTargetUnitSlug);
+    });
+
+    const storedUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
+    const targetUnitSlug = unit?.slug ?? storedUnitSlug ?? initialUnitSlug ?? null;
+    const targetCampaignKey = campaignKey(variant, targetUnitSlug);
+    const initialCampaignKey = campaignKey(variant, initialUnitSlug ?? null);
+    const visibleItems = loadedCampaignKey === targetCampaignKey ? items : EMPTY_HERO_ITEMS;
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const shouldUseInitialItems = hasInitialItems && targetCampaignKey === initialCampaignKey;
+
+        if (shouldUseInitialItems) {
+            setItems(initialItems);
+            setLoadedCampaignKey(targetCampaignKey);
+            return;
+        }
+
+        const fallbackItems = getLocalHeroItems(variant, { unitSlug: targetUnitSlug });
+
+        // Avoid flashing stale campaign while the new one is loading.
+        setItems([]);
+        setLoadedCampaignKey("");
+
+        async function loadItemsByUnit() {
+            try {
+                const query = new URLSearchParams({ variant });
+                if (targetUnitSlug) query.set("unit", targetUnitSlug);
+                const response = await fetch(`/api/hero-media?${query.toString()}`, { cache: "no-store" });
+                if (!response.ok) throw new Error(`hero_media_http_${response.status}`);
+
+                const payload = (await response.json()) as { items?: HeroMediaItem[] };
+                const nextItems = Array.isArray(payload.items) && payload.items.length > 0 ? payload.items : fallbackItems;
+                if (!cancelled) {
+                    setItems(nextItems);
+                    setLoadedCampaignKey(targetCampaignKey);
+                }
+            } catch {
+                if (!cancelled) {
+                    setItems(fallbackItems);
+                    setLoadedCampaignKey(targetCampaignKey);
+                }
+            }
+        }
+
+        void loadItemsByUnit();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [hasInitialItems, initialCampaignKey, initialItems, targetCampaignKey, targetUnitSlug, variant]);
+
     const effectiveVariant = initialVariant ?? variant;
 
     useEffect(() => {
         setIndex(0);
         setPrevIndex(null);
-    }, [items]);
+    }, [visibleItems]);
 
-    const item = items[index] ?? items[0]!;
-    const shouldLoopVideo = item.type === "video" && items.length === 1;
+    const item = visibleItems[index] ?? visibleItems[0] ?? null;
+    const shouldLoopVideo = item?.type === "video" && visibleItems.length === 1;
     const imageFit = effectiveVariant === "mobile" ? "cover" : "contain";
     const bookingHref = useMemo(() => {
         if (!unit?.slug) return "/agendamento?doctor=none#booking-flow";
@@ -60,22 +263,22 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
 
     const goTo = useCallback(
         (nextIndex: number) => {
-            if (items.length <= 1) return;
+            if (visibleItems.length <= 1) return;
             if (nextIndex === index) return;
-            if (nextIndex < 0 || nextIndex >= items.length) return;
+            if (nextIndex < 0 || nextIndex >= visibleItems.length) return;
             setPrevIndex(index);
             setIndex(nextIndex);
         },
-        [index, items.length],
+        [index, visibleItems.length],
     );
 
     const goNext = useCallback(() => {
-        goTo((index + 1) % items.length);
-    }, [goTo, index, items.length]);
+        goTo((index + 1) % visibleItems.length);
+    }, [goTo, index, visibleItems.length]);
 
     const goPrev = useCallback(() => {
-        goTo((index - 1 + items.length) % items.length);
-    }, [goTo, index, items.length]);
+        goTo((index - 1 + visibleItems.length) % visibleItems.length);
+    }, [goTo, index, visibleItems.length]);
 
     useEffect(() => {
         if (prevIndex === null) return;
@@ -84,7 +287,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
     }, [prevIndex]);
 
     useEffect(() => {
-        const canAutoAdvance = items.length > 1 && item.type === "image" && effectiveVariant !== "mobile";
+        const canAutoAdvance = visibleItems.length > 1 && item?.type === "image" && effectiveVariant !== "mobile";
         if (!canAutoAdvance) return;
 
         const t = window.setTimeout(() => {
@@ -92,20 +295,59 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
         }, HERO_AUTOPLAY_MS);
 
         return () => window.clearTimeout(t);
-    }, [effectiveVariant, goNext, items.length, item.type]);
+    }, [effectiveVariant, goNext, visibleItems.length, item?.type]);
 
-    const canAutoAdvance = items.length > 1 && item.type === "image" && effectiveVariant !== "mobile";
+    const canAutoAdvance = visibleItems.length > 1 && item?.type === "image" && effectiveVariant !== "mobile";
+
+    useEffect(() => {
+        let cancelled = false;
+
+        if (!item || item.type !== "image") {
+            setFrameColors(HERO_DEFAULT_FRAME_COLORS);
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        void extractTopBottomEdgeColorsFromImage(item.src).then((nextColors) => {
+            if (cancelled) return;
+            setFrameColors(nextColors ?? HERO_DEFAULT_FRAME_COLORS);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [item]);
+
+    useEffect(() => {
+        if (typeof document === "undefined") return;
+        const root = document.documentElement;
+        root.style.setProperty("--hero-band-bg-top-live", frameColors.top);
+        root.style.setProperty("--hero-band-bg-bottom-live", frameColors.bottom);
+        root.style.setProperty("--hero-band-fg-top-live", topBandTextColor);
+        root.style.setProperty("--hero-band-fg-bottom-live", bottomBandTextColor);
+
+        return () => {
+            root.style.removeProperty("--hero-band-bg-top-live");
+            root.style.removeProperty("--hero-band-bg-bottom-live");
+            root.style.removeProperty("--hero-band-fg-top-live");
+            root.style.removeProperty("--hero-band-fg-bottom-live");
+        };
+    }, [bottomBandTextColor, frameColors.bottom, frameColors.top, topBandTextColor]);
 
     const style = useMemo<HeroStyle>(() => {
-        const hotspot = item.bookingHotspot;
+        const hotspot = item?.bookingHotspot;
         return {
             "--hero-ar": aspectRatio,
+            "--hero-band-bg": frameColors.top,
+            "--hero-band-bg-top": frameColors.top,
+            "--hero-band-bg-bottom": frameColors.bottom,
             "--hero-cta-left": hotspot ? `${hotspot.leftPct}%` : "0%",
             "--hero-cta-top": hotspot ? `${hotspot.topPct}%` : "0%",
             "--hero-cta-width": hotspot ? `${hotspot.widthPct}%` : "0%",
             "--hero-cta-height": hotspot ? `${hotspot.heightPct}%` : "0%",
         };
-    }, [aspectRatio, item.bookingHotspot]);
+    }, [aspectRatio, frameColors.bottom, frameColors.top, item?.bookingHotspot]);
 
     const shouldAnimateIn = prevIndex !== null;
 
@@ -127,7 +369,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                         playsInline
                         preload="metadata"
                         onError={() => {
-                            if (items.length <= 1) return;
+                            if (visibleItems.length <= 1) return;
                             if (opts.kind !== "active") return;
                             goNext();
                         }}
@@ -139,7 +381,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                             }
                         }}
                         onEnded={() => {
-                            if (items.length <= 1) return;
+                            if (visibleItems.length <= 1) return;
                             if (opts.kind !== "active") return;
                             goNext();
                         }}
@@ -153,7 +395,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                         priority={opts.kind === "active"}
                         sizes="100vw"
                         onError={() => {
-                            if (items.length <= 1) return;
+                            if (visibleItems.length <= 1) return;
                             if (opts.kind !== "active") return;
                             goNext();
                         }}
@@ -164,7 +406,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                                 setAspectRatio(`${img.naturalWidth} / ${img.naturalHeight}`);
                             }
                         }}
-                        style={{ objectFit: imageFit, backgroundColor: "#050505" }}
+                        style={{ objectFit: imageFit, background: `linear-gradient(180deg, ${frameColors.top}, ${frameColors.bottom})` }}
                     />
                 )}
             </div>
@@ -173,7 +415,7 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
 
     return (
         <div className="heroMedia" style={style}>
-            {items.length > 1 ? (
+            {visibleItems.length > 1 ? (
                 <>
                     <div className="heroHoverZone heroHoverZone--left" aria-hidden="true" />
                     <button type="button" className="heroArrow carouselNavChrome heroArrow--left" aria-label="Anterior" onClick={goPrev}>
@@ -190,10 +432,10 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                 </>
             ) : null}
 
-            {renderLayer(item, { layerKey: `active:${item.src}`, kind: "active" })}
-            {prevIndex !== null && items[prevIndex] ? renderLayer(items[prevIndex]!, { layerKey: `prev:${items[prevIndex]!.src}:${prevIndex}`, kind: "prev" }) : null}
+            {item ? renderLayer(item, { layerKey: `active:${item.src}`, kind: "active" }) : null}
+            {prevIndex !== null && visibleItems[prevIndex] ? renderLayer(visibleItems[prevIndex]!, { layerKey: `prev:${visibleItems[prevIndex]!.src}:${prevIndex}`, kind: "prev" }) : null}
 
-            {item.bookingHotspot ? (
+            {item?.bookingHotspot ? (
                 <TrackedBookingLink
                     href={bookingHref}
                     className="heroBannerCtaHotspot"
@@ -207,16 +449,16 @@ export default function HeroMedia({ initialItems, initialVariant }: HeroMediaPro
                 </TrackedBookingLink>
             ) : null}
 
-            {items.length > 1 ? (
+            {visibleItems.length > 1 ? (
                 <div className="heroMediaNav" aria-label="Selecionar mídia do banner">
-                    {items.map((_, i) => {
+                    {visibleItems.map((_, i) => {
                         const active = i === index;
                         return (
                             <button
                                 key={i}
                                 type="button"
                                 className={`heroDot${active ? " heroDot--active" : ""}`}
-                                aria-label={`Ir para ${i + 1} de ${items.length}`}
+                                aria-label={`Ir para ${i + 1} de ${visibleItems.length}`}
                                 aria-pressed={active}
                                 onClick={() => goTo(i)}
                             >

--- a/website/src/components/HomeHeroExperience.tsx
+++ b/website/src/components/HomeHeroExperience.tsx
@@ -8,12 +8,13 @@ import type { HeroMediaItem, HeroMediaVariant } from "@/lib/heroMediaShared";
 type HomeHeroExperienceProps = {
     heroItems: HeroMediaItem[];
     initialMediaVariant: HeroMediaVariant;
+    initialUnitSlug?: string | null;
 };
 
 const EXPERIENCE_KEY = "home_public_v1";
 const EXPERIENCE_VARIANT = "canonical";
 
-export default function HomeHeroExperience({ heroItems, initialMediaVariant }: HomeHeroExperienceProps) {
+export default function HomeHeroExperience({ heroItems, initialMediaVariant, initialUnitSlug = null }: HomeHeroExperienceProps) {
     return (
         <>
             <ExperienceTracker page="/" experience={EXPERIENCE_KEY} variant={EXPERIENCE_VARIANT} />
@@ -21,7 +22,7 @@ export default function HomeHeroExperience({ heroItems, initialMediaVariant }: H
             <PageTitleBand title="Harmonização facial com naturalidade" ariaLabel="Título da página inicial" />
 
             <section className="hero hero--experience hero--value-led" aria-label="Destaque">
-                <HeroMedia initialItems={heroItems} initialVariant={initialMediaVariant} />
+                <HeroMedia initialItems={heroItems} initialVariant={initialMediaVariant} initialUnitSlug={initialUnitSlug} />
             </section>
         </>
     );

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -2839,14 +2839,18 @@ button:focus-visible {
   height: auto;
   border-bottom: 1px solid var(--border);
   overflow: hidden;
-  background: #050505;
+  background: linear-gradient(180deg, var(--hero-band-bg-top-live, #050505), var(--hero-band-bg-bottom-live, #050505));
 }
 
 .hero--experience,
-.heroTitleBand,
+.heroTitleBand {
+  --hero-band-bg: var(--hero-band-bg-top-live, #050505);
+  --hero-band-fg: var(--hero-band-fg-top-live, #f5ead8);
+}
+
 .trustEvidenceBand {
-  --hero-band-bg: #050505;
-  --hero-band-fg: #f5ead8;
+  --hero-band-bg: var(--hero-band-bg-bottom-live, #050505);
+  --hero-band-fg: var(--hero-band-fg-bottom-live, #f5ead8);
 }
 
 .heroMedia {
@@ -2855,7 +2859,7 @@ button:focus-visible {
   min-height: 320px;
   position: relative;
   z-index: 1;
-  background: var(--hero-band-bg, #050505);
+  background: linear-gradient(180deg, var(--hero-band-bg-top, var(--hero-band-bg, #050505)), var(--hero-band-bg-bottom, var(--hero-band-bg, #050505)));
 }
 
 .heroMediaLayer {


### PR DESCRIPTION
## Resumo\n- impede render de campanha stale durante troca de unidade/campanha\n- mantém tarjas dinâmicas topo/base por pixels das bordas do banner ativo\n\n## Validação\n- npm run -s typecheck\n- npm run -s build