### PR TITLE
booking: simplify emailed reservation details view

### DIFF
--- a/website/src/components/BookingConfirmationCard.tsx
+++ b/website/src/components/BookingConfirmationCard.tsx
@@ -16,6 +16,7 @@ type BookingConfirmationCardProps = {
         email?: NotificationResult;
         whatsapp?: NotificationResult;
     };
+    variant?: "default" | "details_link";
 };
 
 function notificationLabel(result?: NotificationResult): string {
@@ -39,6 +40,7 @@ export default function BookingConfirmationCard(props: BookingConfirmationCardPr
         siteUrl: resolveBookingSiteUrl(),
     });
     const hasNotificationStatuses = !!props.notifications?.email || !!props.notifications?.whatsapp;
+    const isDetailsLinkVariant = props.variant === "details_link";
 
     return (
         <section className="bookingConfirmation" aria-label="Resumo da reserva confirmada">
@@ -94,6 +96,19 @@ export default function BookingConfirmationCard(props: BookingConfirmationCardPr
                                 <div className="bookingConfirmation__detailValue">{model.customerEmail}</div>
                             </div>
                         </div>
+
+                        {isDetailsLinkVariant ? (
+                            <div className="bookingConfirmation__detailSupplement">
+                                <div className="bookingConfirmation__detailLabel">Próximos passos</div>
+                                <div className="bookingConfirmation__nextSteps bookingConfirmation__nextSteps--embedded">
+                                    {model.nextSteps.map((step) => (
+                                        <div key={step} className="bookingConfirmation__nextStep">
+                                            {step}
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        ) : null}
                     </div>
 
                     <div className="bookingConfirmation__ambassadorWrap">
@@ -128,52 +143,56 @@ export default function BookingConfirmationCard(props: BookingConfirmationCardPr
                 </div>
             ) : null}
 
-            <div className="bookingConfirmation__supportCard">
-                <div>
-                    <div className="bookingConfirmation__sectionTitle">Próximos passos</div>
-                    <div className="bookingConfirmation__nextSteps">
-                        {model.nextSteps.map((step) => (
-                            <div key={step} className="bookingConfirmation__nextStep">
-                                {step}
+            {!isDetailsLinkVariant ? (
+                <>
+                    <div className="bookingConfirmation__supportCard">
+                        <div>
+                            <div className="bookingConfirmation__sectionTitle">Próximos passos</div>
+                            <div className="bookingConfirmation__nextSteps">
+                                {model.nextSteps.map((step) => (
+                                    <div key={step} className="bookingConfirmation__nextStep">
+                                        {step}
+                                    </div>
+                                ))}
                             </div>
-                        ))}
+                        </div>
+
+                        <div className="bookingConfirmation__actions">
+                            <a href={model.teamContactUrl} className="bookingConfirmation__cta bookingConfirmation__cta--secondary">
+                                Falar com a equipe
+                            </a>
+                            <a href={model.unitWhatsappUrl} className="bookingConfirmation__cta">
+                                Abrir WhatsApp da unidade
+                            </a>
+                        </div>
                     </div>
-                </div>
 
-                <div className="bookingConfirmation__actions">
-                    <a href={model.teamContactUrl} className="bookingConfirmation__cta bookingConfirmation__cta--secondary">
-                        Falar com a equipe
-                    </a>
-                    <a href={model.unitWhatsappUrl} className="bookingConfirmation__cta">
-                        Abrir WhatsApp da unidade
-                    </a>
-                </div>
-            </div>
-
-            <div className="bookingConfirmation__footer">
-                <div className="bookingConfirmation__footerCol">
-                    <div className="bookingConfirmation__detailLabel">Instagram</div>
-                    <a href={model.unitInstagramUrl} className="bookingConfirmation__footerLink">
-                        {model.unitInstagramLabel}
-                    </a>
-                </div>
-                <div className="bookingConfirmation__footerCol">
-                    <div className="bookingConfirmation__detailLabel">Facebook</div>
-                    <a href={model.unitFacebookUrl} className="bookingConfirmation__footerLink">
-                        {model.unitFacebookLabel}
-                    </a>
-                </div>
-                <div className="bookingConfirmation__footerCol">
-                    <div className="bookingConfirmation__detailLabel">WhatsApp</div>
-                    <a href={model.unitWhatsappUrl} className="bookingConfirmation__footerLink">
-                        {model.unitWhatsappLabel}
-                    </a>
-                </div>
-                <div className="bookingConfirmation__footerAddress">
-                    <div className="bookingConfirmation__detailLabel">Endereço da unidade</div>
-                    <div className="bookingConfirmation__footerText">{model.unitAddress}</div>
-                </div>
-            </div>
+                    <div className="bookingConfirmation__footer">
+                        <div className="bookingConfirmation__footerCol">
+                            <div className="bookingConfirmation__detailLabel">Instagram</div>
+                            <a href={model.unitInstagramUrl} className="bookingConfirmation__footerLink">
+                                {model.unitInstagramLabel}
+                            </a>
+                        </div>
+                        <div className="bookingConfirmation__footerCol">
+                            <div className="bookingConfirmation__detailLabel">Facebook</div>
+                            <a href={model.unitFacebookUrl} className="bookingConfirmation__footerLink">
+                                {model.unitFacebookLabel}
+                            </a>
+                        </div>
+                        <div className="bookingConfirmation__footerCol">
+                            <div className="bookingConfirmation__detailLabel">WhatsApp</div>
+                            <a href={model.unitWhatsappUrl} className="bookingConfirmation__footerLink">
+                                {model.unitWhatsappLabel}
+                            </a>
+                        </div>
+                        <div className="bookingConfirmation__footerAddress">
+                            <div className="bookingConfirmation__detailLabel">Endereço da unidade</div>
+                            <div className="bookingConfirmation__footerText">{model.unitAddress}</div>
+                        </div>
+                    </div>
+                </>
+            ) : null}
         </section>
     );
 }

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -399,6 +399,7 @@ export default function BookingFlow() {
     }, [searchParams]);
     const bookingIdQuery = useMemo(() => (searchParams?.get("booking") ?? "").trim(), [searchParams]);
     const bookingTokenQuery = useMemo(() => (searchParams?.get("statusToken") ?? "").trim(), [searchParams]);
+    const isReservationDetailsView = step === "submitted" && !!submitted && bookingIdQuery.length > 0;
 
     const allowedUnitSlugs = useMemo(() => new Set(getDigitalJourneyUnits().map((unit) => unit.slug)), []);
 
@@ -1581,69 +1582,75 @@ export default function BookingFlow() {
                 <div className="bookingFlow__grid">
                     <div className="bookingFlow__cardFull">
                         {submitted ? (
-                            <BookingConfirmationCard reservation={submitted.reservation} notifications={submitted.notifications} />
+                            <BookingConfirmationCard
+                                reservation={submitted.reservation}
+                                notifications={submitted.notifications}
+                                variant={isReservationDetailsView ? "details_link" : "default"}
+                            />
                         ) : null}
                     </div>
 
-                    <div className="card bookingFlow__cardFull bookingFlow__submittedStatusCard" style={{ padding: 18 }}>
-                        <div style={{ fontWeight: 900, fontSize: 18 }}>
-                            {submitted?.status === "confirmed" ? "Status do agendamento" : "Status do pedido"}
-                        </div>
-
-                        {status ? (
-                            <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px solid var(--border)" }}>
-                                <div style={{ fontWeight: 900 }}>Status</div>
-                                <div style={{ marginTop: 6 }}>
-                                    {status.status === "confirmed" ? (
-                                        <span style={{ fontWeight: 900, color: "#16a34a" }}>Confirmado</span>
-                                    ) : status.status === "declined" ? (
-                                        <span style={{ fontWeight: 900, color: "#b91c1c" }}>Não confirmado</span>
-                                    ) : status.status === "expired" ? (
-                                        <span style={{ fontWeight: 900, color: "#b45309" }}>Expirado</span>
-                                    ) : status.status === "needs_approval" ? (
-                                        <span style={{ fontWeight: 900, color: "#b45309" }}>Em análise</span>
-                                    ) : (
-                                        <span style={{ fontWeight: 900 }}>Pendente</span>
-                                    )}
-                                </div>
-                                <div className="small" style={{ marginTop: 6 }}>
-                                    Atualiza automaticamente.
-                                </div>
+                    {!isReservationDetailsView ? (
+                        <div className="card bookingFlow__cardFull bookingFlow__submittedStatusCard" style={{ padding: 18 }}>
+                            <div style={{ fontWeight: 900, fontSize: 18 }}>
+                                {submitted?.status === "confirmed" ? "Status do agendamento" : "Status do pedido"}
                             </div>
-                        ) : null}
 
-                        <div style={{ marginTop: 16, display: "flex", gap: 10, flexWrap: "wrap" }}>
-                            <button
-                                type="button"
-                                className="pill"
-                                onClick={() => {
-                                    // restart
-                                    setStep("pick");
-                                    setDoctor(null);
-                                    setSelectedServices([]);
-                                    setDateKey(null);
-                                    setDateTouched(false);
-                                    setTimeKey(null);
-                                    setPatientName("");
-                                    setPatientGender("");
-                                    setEmail("");
-                                    setWhatsapp("");
-                                    setNotes("");
-                                    setSlots(null);
-                                    setSubmitted(null);
-                                    setStatus(null);
-                                    setSubmitError(null);
-                                    setDetailsStartedAtMs(null);
-                                    setTurnstileToken(null);
-                                    setTurnstileHadError(false);
-                                    clearBookingDraft();
-                                }}
-                                style={{ cursor: "pointer" }}
-                            >
-                                Fazer outro pedido
-                            </button>
+                            {status ? (
+                                <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px solid var(--border)" }}>
+                                    <div style={{ fontWeight: 900 }}>Status</div>
+                                    <div style={{ marginTop: 6 }}>
+                                        {status.status === "confirmed" ? (
+                                            <span style={{ fontWeight: 900, color: "#16a34a" }}>Confirmado</span>
+                                        ) : status.status === "declined" ? (
+                                            <span style={{ fontWeight: 900, color: "#b91c1c" }}>Não confirmado</span>
+                                        ) : status.status === "expired" ? (
+                                            <span style={{ fontWeight: 900, color: "#b45309" }}>Expirado</span>
+                                        ) : status.status === "needs_approval" ? (
+                                            <span style={{ fontWeight: 900, color: "#b45309" }}>Em análise</span>
+                                        ) : (
+                                            <span style={{ fontWeight: 900 }}>Pendente</span>
+                                        )}
+                                    </div>
+                                    <div className="small" style={{ marginTop: 6 }}>
+                                        Atualiza automaticamente.
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            <div style={{ marginTop: 16, display: "flex", gap: 10, flexWrap: "wrap" }}>
+                                <button
+                                    type="button"
+                                    className="pill"
+                                    onClick={() => {
+                                        // restart
+                                        setStep("pick");
+                                        setDoctor(null);
+                                        setSelectedServices([]);
+                                        setDateKey(null);
+                                        setDateTouched(false);
+                                        setTimeKey(null);
+                                        setPatientName("");
+                                        setPatientGender("");
+                                        setEmail("");
+                                        setWhatsapp("");
+                                        setNotes("");
+                                        setSlots(null);
+                                        setSubmitted(null);
+                                        setStatus(null);
+                                        setSubmitError(null);
+                                        setDetailsStartedAtMs(null);
+                                        setTurnstileToken(null);
+                                        setTurnstileHadError(false);
+                                        clearBookingDraft();
+                                    }}
+                                    style={{ cursor: "pointer" }}
+                                >
+                                    Fazer outro pedido
+                                </button>
+                            </div>
                         </div>
-                    </div>
+                    ) : null}
                 </div>
             )}
             {showDetailsModal && unitSlug && primaryService && dateKey && timeKey ? (

--- a/website/src/components/BookingHeroExperience.tsx
+++ b/website/src/components/BookingHeroExperience.tsx
@@ -4,15 +4,35 @@ import { useSearchParams } from "next/navigation";
 import ExperienceTracker from "@/components/ExperienceTracker";
 import PageTitleBand from "@/components/PageTitleBand";
 import SmoothAnchorLink from "@/components/SmoothAnchorLink";
+import { units } from "@/data/units";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { trackExperienceShortcutClick } from "@/lib/leadTracking";
 
 const EXPERIENCE_KEY = "booking_public_v1";
 const EXPERIENCE_VARIANT = "canonical";
 
+type HeroShortcut = {
+    title: string;
+    href: string;
+    kind: "primary" | "secondary";
+    description?: string;
+    external?: boolean;
+};
+
 export default function BookingHeroExperience() {
     const unit = useCurrentUnit();
     const searchParams = useSearchParams();
+    const bookingId = (searchParams?.get("booking") ?? "").trim();
+    const unitFromQuery = (searchParams?.get("unit") ?? "").trim();
+    const confirmationMode = bookingId.length > 0;
+
+    const resolvedUnit =
+        units.find((item) => item.slug === unitFromQuery) ??
+        units.find((item) => item.slug === unit?.slug) ??
+        null;
+    const unitWhatsappDigits = (resolvedUnit?.whatsappPhone ?? "").replace(/\D/g, "");
+    const unitWhatsappUrl = unitWhatsappDigits ? `https://api.whatsapp.com/send?phone=${unitWhatsappDigits}` : "/agendamento#booking-flow";
+    const scheduleAnotherHref = resolvedUnit?.slug ? `/agendamento?unit=${resolvedUnit.slug}#booking-flow` : "/agendamento#booking-flow";
 
     const bookingQuery = new URLSearchParams({
         doctor: "any",
@@ -21,7 +41,7 @@ export default function BookingHeroExperience() {
     });
     if (unit?.slug) bookingQuery.set("unit", unit.slug);
 
-    const shortcuts = [
+    const shortcuts: HeroShortcut[] = [
         {
             title: "Primeiro Horário Disponível",
             description: "Sem preferência por especialista e indicação de procedimento.",
@@ -33,6 +53,20 @@ export default function BookingHeroExperience() {
             description: "Conheça a equipe e veja seus procedimentos.",
             href: "/#doutores",
             kind: "secondary" as const,
+        },
+    ];
+    const confirmationActions: HeroShortcut[] = [
+        {
+            title: "Agendar Outra Reserva",
+            href: scheduleAnotherHref,
+            kind: "primary" as const,
+            external: false,
+        },
+        {
+            title: "Alterar Reserva",
+            href: unitWhatsappUrl,
+            kind: "secondary" as const,
+            external: true,
         },
     ];
 
@@ -48,34 +82,59 @@ export default function BookingHeroExperience() {
                 <div className="container">
                     <div className="bookingHero__shell bookingHero__shell--stacked">
                         <div className="bookingHero__copy bookingHero__copy--experience">
-                            <h1 className="sectionTitle">Escolha a unidade, o especialista e o melhor horário para você.</h1>
+                            <h1 className="sectionTitle">
+                                {confirmationMode ? "Confira os detalhes da sua reserva." : "Escolha a unidade, o especialista e o melhor horário para você."}
+                            </h1>
                             <p className="sectionSub bookingHero__lede">
-                                Reserve a sua avaliação em poucos passos.
+                                {confirmationMode
+                                    ? "Se quiser iniciar um novo agendamento ou falar com a unidade, use os atalhos abaixo."
+                                    : "Reserve a sua avaliação em poucos passos."}
                             </p>
                         </div>
 
-                        <div className="bookingHero__panel" role="group" aria-label="Atalhos do agendamento">
+                        <div className="bookingHero__panel" role="group" aria-label={confirmationMode ? "Ações da reserva" : "Atalhos do agendamento"}>
                             <div className="bookingHero__shortcutGrid bookingHero__shortcutGrid--inline">
-                                {shortcuts.map((item) => (
+                                {(confirmationMode ? confirmationActions : shortcuts).map((item) => (
                                     <div key={item.title} className="bookingHero__shortcutItem">
-                                        <SmoothAnchorLink
-                                            href={item.href}
-                                            className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
-                                            data-selected={item.kind === "primary" && firstSlotSelected ? "true" : "false"}
-                                            onClick={() =>
-                                                trackExperienceShortcutClick({
-                                                    page: "/agendamento",
-                                                    shortcut: item.title,
-                                                    destination: item.href,
-                                                    placement: "booking_page",
-                                                    experience: EXPERIENCE_KEY,
-                                                    variant: EXPERIENCE_VARIANT,
-                                                })
-                                            }
-                                        >
-                                            <strong>{item.title}</strong>
-                                        </SmoothAnchorLink>
-                                        <p className="bookingHero__shortcutNote">{item.description}</p>
+                                        {item.external ? (
+                                            <a
+                                                href={item.href}
+                                                className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                onClick={() =>
+                                                    trackExperienceShortcutClick({
+                                                        page: "/agendamento",
+                                                        shortcut: item.title,
+                                                        destination: item.href,
+                                                        placement: "booking_page",
+                                                        experience: EXPERIENCE_KEY,
+                                                        variant: EXPERIENCE_VARIANT,
+                                                    })
+                                                }
+                                            >
+                                                <strong>{item.title}</strong>
+                                            </a>
+                                        ) : (
+                                            <SmoothAnchorLink
+                                                href={item.href}
+                                                className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
+                                                data-selected={!confirmationMode && item.kind === "primary" && firstSlotSelected ? "true" : "false"}
+                                                onClick={() =>
+                                                    trackExperienceShortcutClick({
+                                                        page: "/agendamento",
+                                                        shortcut: item.title,
+                                                        destination: item.href,
+                                                        placement: "booking_page",
+                                                        experience: EXPERIENCE_KEY,
+                                                        variant: EXPERIENCE_VARIANT,
+                                                    })
+                                                }
+                                            >
+                                                <strong>{item.title}</strong>
+                                            </SmoothAnchorLink>
+                                        )}
+                                        {!confirmationMode && item.description ? <p className="bookingHero__shortcutNote">{item.description}</p> : null}
                                     </div>
                                 ))}
                             </div>

--- a/website/src/lib/bookingNotifications.ts
+++ b/website/src/lib/bookingNotifications.ts
@@ -83,9 +83,12 @@ function resolveSiteUrl(): string {
     return raw.replace(/\/$/, "");
 }
 
-function buildReservationDetailsUrl(siteUrl: string, payload: Pick<BookingNotificationPayload, "id" | "statusToken">): string {
+function buildReservationDetailsUrl(siteUrl: string, payload: Pick<BookingNotificationPayload, "id" | "statusToken" | "unitSlug">): string {
     const url = new URL("/agendamento", siteUrl);
     url.searchParams.set("booking", payload.id);
+    if (payload.unitSlug) {
+        url.searchParams.set("unit", payload.unitSlug);
+    }
     if (payload.statusToken) {
         url.searchParams.set("statusToken", payload.statusToken);
     }

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1849,6 +1849,10 @@ button:focus-visible {
   margin-top: 16px;
 }
 
+.bookingConfirmation__detailSupplement {
+  margin-top: 18px;
+}
+
 .bookingConfirmation__detailLabel {
   font-size: 11px;
   line-height: 1.2;
@@ -1936,6 +1940,10 @@ button:focus-visible {
   display: grid;
   gap: 10px;
   margin-top: 16px;
+}
+
+.bookingConfirmation__nextSteps--embedded {
+  margin-top: 12px;
 }
 
 .bookingConfirmation__nextStep {


### PR DESCRIPTION
## Summary
- tailor the booking hero for reservation links opened from confirmation emails
- show only "Agendar Outra Reserva" and "Alterar Reserva" in that mode
- move next steps into the reservation details card and remove the lower status/footer blocks for the linked details view
- preserve the selected unit in the email details URL

## Validation
- npm run lint -- --file src/components/BookingFlow.tsx --file src/components/BookingConfirmationCard.tsx --file src/components/BookingHeroExperience.tsx --file src/lib/bookingNotifications.ts
- npm run typecheck
