### PR TITLE
Tune booking shortcut and availability tooltips

### DIFF
--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -610,7 +610,7 @@ export default function BookingFlow() {
     const doctorQuery = useMemo(() => normalizeDoctorSlug(searchParams?.get("doctor") ?? ""), [searchParams]);
     const serviceQuery = useMemo(() => normalizeDoctorSlug(searchParams?.get("service") ?? ""), [searchParams]);
     const autoPickQuery = useMemo(() => normalizeDoctorSlug(searchParams?.get("autopick") ?? ""), [searchParams]);
-    const autoPickConsumedRef = useRef(false);
+    const autoPickNonceQuery = useMemo(() => (searchParams?.get("autopick_nonce") ?? "").trim(), [searchParams]);
 
     useEffect(() => {
         if (!unitSlug || !doctorsForUnit || doctorsForUnit.length === 0) return;
@@ -639,7 +639,7 @@ export default function BookingFlow() {
         if (!match) return;
         setDoctor({ slug: match.slug, name: match.name, handle: match.handle });
         appliedDoctorQueryRef.current = doctorQuery;
-    }, [doctorQuery, doctorsForUnit, unitSlug]);
+    }, [autoPickNonceQuery, doctorQuery, doctorsForUnit, unitSlug]);
 
     useEffect(() => {
         if (!unitSlug || !serviceQuery) return;
@@ -658,12 +658,25 @@ export default function BookingFlow() {
         if (!match) return;
         setSelectedServices([match]);
         appliedServiceQueryRef.current = serviceQuery;
-    }, [serviceQuery, unitSlug]);
+    }, [autoPickNonceQuery, serviceQuery, unitSlug]);
 
     useEffect(() => {
-        autoPickConsumedRef.current = false;
         autoPickMotionDoneRef.current = false;
-    }, [autoPickQuery, unitSlug]);
+        if (autoPickQuery !== "first" || !unitSlug) return;
+
+        appliedDoctorQueryRef.current = null;
+        appliedServiceQueryRef.current = null;
+        setDoctor(ANY_DOCTOR);
+        setSelectedServices([OTHER_SERVICE]);
+        setDateKey(null);
+        setDateTouched(false);
+        setTimeKey(null);
+        setStep("pick");
+        setDetailsStartedAtMs(null);
+        setTurnstileToken(null);
+        setTurnstileHadError(false);
+        setSubmitError(null);
+    }, [autoPickNonceQuery, autoPickQuery, unitSlug]);
 
     useEffect(() => {
         if (autoPickQuery !== "first") return;
@@ -693,7 +706,7 @@ export default function BookingFlow() {
             block: "nearest",
             inline: "center",
         });
-    }, [autoPickQuery, selectedServiceIds, unitSlug]);
+    }, [autoPickNonceQuery, autoPickQuery, selectedServiceIds, unitSlug]);
 
     const upcomingWeeks = useMemo(() => {
         const out: string[][] = [];
@@ -1071,19 +1084,6 @@ export default function BookingFlow() {
         });
     }, [dateKey, effectiveDoctorSlug, effectiveServiceId, ensureDefaultSelections, unitSlug]);
 
-    useEffect(() => {
-        if (autoPickQuery !== "first") return;
-        if (autoPickConsumedRef.current) return;
-        if (!unitSlug || !dateKey || step !== "pick" || slotsLoading) return;
-        if (!slots?.slots?.length) return;
-
-        const firstAvailableSlot = slots.slots.find((slot) => slot.available);
-        if (!firstAvailableSlot) return;
-
-        autoPickConsumedRef.current = true;
-        openDetailsModal(firstAvailableSlot.time);
-    }, [autoPickQuery, dateKey, openDetailsModal, slots?.slots, slotsLoading, step, unitSlug]);
-
     const emailValue = email.trim().toLowerCase();
     const emailSeemsValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue);
     const whatsappDigits = whatsapp.replace(/\D/g, "");
@@ -1422,6 +1422,7 @@ export default function BookingFlow() {
                                                     const isOccupiedDate = canPick && hasResolvedDateAvailability && !isPastDate && dateAvailability[d] === false;
                                                     const isLockedDate = isPastDate || isOccupiedDate;
                                                     const dateTooltip = isPastDate ? "passou" : isOccupiedDate ? "ocupado" : "disponível";
+                                                    const dateTooltipTone = isPastDate ? "neutral" : isOccupiedDate ? "occupied" : "available";
                                                     const dateReason = isPastDate ? "past" : isOccupiedDate ? "agenda" : "available";
                                                     const ariaDisabled = !canPick || isLockedDate;
                                                     return (
@@ -1435,6 +1436,7 @@ export default function BookingFlow() {
                                                             data-locked={isLockedDate ? "true" : "false"}
                                                             data-reason={dateReason}
                                                             data-tooltip={dateTooltip}
+                                                            data-tooltip-tone={dateTooltipTone}
                                                             onClick={() => {
                                                                 if (ariaDisabled) return;
                                                                 ensureDefaultSelections();
@@ -1498,8 +1500,9 @@ export default function BookingFlow() {
                                                     const active = timeKey === s.time;
                                                     const isPast = s.reason === "past";
                                                     const isOccupied = s.reason === "agenda" || s.reason === "booked";
-                                                    const hasTooltip = isPast || isOccupied;
-                                                    const tooltip = isPast ? "horário já passou" : isOccupied ? "horário ocupado" : "";
+                                                    const hasTooltip = isPast || isOccupied || s.available;
+                                                    const tooltip = isPast ? "passou" : isOccupied ? "ocupado" : s.available ? "disponível" : "";
+                                                    const tooltipTone = isPast ? "neutral" : isOccupied ? "occupied" : s.available ? "available" : "neutral";
                                                     const ariaDisabled = !s.available;
                                                     const nativeDisabled = !s.available && !hasTooltip;
                                                     const label =
@@ -1518,6 +1521,7 @@ export default function BookingFlow() {
                                                             data-reason={s.reason ?? ""}
                                                             data-locked={hasTooltip ? "true" : "false"}
                                                             data-tooltip={hasTooltip ? tooltip : undefined}
+                                                            data-tooltip-tone={hasTooltip ? tooltipTone : undefined}
                                                             className="bookingFlow__selectItem bookingFlow__timeBtn"
                                                             data-active={active ? "true" : "false"}
                                                             onClick={() => {

--- a/website/src/components/BookingHeroExperience.tsx
+++ b/website/src/components/BookingHeroExperience.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ExperienceTracker from "@/components/ExperienceTracker";
 import PageTitleBand from "@/components/PageTitleBand";
 import SmoothAnchorLink from "@/components/SmoothAnchorLink";
@@ -17,9 +17,11 @@ type HeroShortcut = {
     kind: "primary" | "secondary";
     description?: string;
     external?: boolean;
+    action?: "first_available";
 };
 
 export default function BookingHeroExperience() {
+    const router = useRouter();
     const unit = useCurrentUnit();
     const searchParams = useSearchParams();
     const bookingId = (searchParams?.get("booking") ?? "").trim();
@@ -33,20 +35,15 @@ export default function BookingHeroExperience() {
     const unitWhatsappDigits = (resolvedUnit?.whatsappPhone ?? "").replace(/\D/g, "");
     const unitWhatsappUrl = unitWhatsappDigits ? `https://api.whatsapp.com/send?phone=${unitWhatsappDigits}` : "/agendamento#booking-flow";
     const scheduleAnotherHref = resolvedUnit?.slug ? `/agendamento?unit=${resolvedUnit.slug}#booking-flow` : "/agendamento#booking-flow";
-
-    const bookingQuery = new URLSearchParams({
-        doctor: "any",
-        service: "any",
-        autopick: "first",
-    });
-    if (unit?.slug) bookingQuery.set("unit", unit.slug);
+    const preferredUnitSlug = resolvedUnit?.slug ?? unit?.slug ?? null;
 
     const shortcuts: HeroShortcut[] = [
         {
             title: "Primeiro Horário Disponível",
             description: "Sem preferência por especialista e indicação de procedimento.",
-            href: `/agendamento?${bookingQuery.toString()}#booking-flow`,
+            href: "/agendamento#booking-flow",
             kind: "primary" as const,
+            action: "first_available",
         },
         {
             title: "Ver Especialistas",
@@ -70,7 +67,16 @@ export default function BookingHeroExperience() {
         },
     ];
 
-    const firstSlotSelected = (searchParams?.get("autopick") ?? "").toLowerCase() === "first";
+    function activateFirstAvailableShortcut() {
+        const params = new URLSearchParams({
+            doctor: "any",
+            service: "any",
+            autopick: "first",
+            autopick_nonce: `${Date.now()}`,
+        });
+        if (preferredUnitSlug) params.set("unit", preferredUnitSlug);
+        router.push(`/agendamento?${params.toString()}#booking-flow`, { scroll: false });
+    }
 
     return (
         <>
@@ -96,7 +102,25 @@ export default function BookingHeroExperience() {
                             <div className="bookingHero__shortcutGrid bookingHero__shortcutGrid--inline">
                                 {(confirmationMode ? confirmationActions : shortcuts).map((item) => (
                                     <div key={item.title} className="bookingHero__shortcutItem">
-                                        {item.external ? (
+                                        {item.action === "first_available" ? (
+                                            <button
+                                                type="button"
+                                                className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
+                                                onClick={() => {
+                                                    trackExperienceShortcutClick({
+                                                        page: "/agendamento",
+                                                        shortcut: item.title,
+                                                        destination: "/agendamento?doctor=any&service=any&autopick=first#booking-flow",
+                                                        placement: "booking_page",
+                                                        experience: EXPERIENCE_KEY,
+                                                        variant: EXPERIENCE_VARIANT,
+                                                    });
+                                                    activateFirstAvailableShortcut();
+                                                }}
+                                            >
+                                                <strong>{item.title}</strong>
+                                            </button>
+                                        ) : item.external ? (
                                             <a
                                                 href={item.href}
                                                 className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
@@ -119,7 +143,6 @@ export default function BookingHeroExperience() {
                                             <SmoothAnchorLink
                                                 href={item.href}
                                                 className={`bookingHero__shortcut bookingHero__shortcut--${item.kind}`.trim()}
-                                                data-selected={!confirmationMode && item.kind === "primary" && firstSlotSelected ? "true" : "false"}
                                                 onClick={() =>
                                                     trackExperienceShortcutClick({
                                                         page: "/agendamento",

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -902,22 +902,6 @@ button:focus-visible {
   color: #fff;
 }
 
-.bookingHero__shortcut--primary:active,
-.bookingHero__shortcut--primary[data-selected="true"],
-.bookingHero__shortcut--primary[data-selected="true"]:hover,
-.bookingHero__shortcut--primary[data-selected="true"]:focus-visible {
-  background: #fff;
-  border-color: rgba(17, 17, 17, .78);
-  color: #111;
-}
-
-.bookingHero__shortcut--primary:active strong,
-.bookingHero__shortcut--primary[data-selected="true"] strong,
-.bookingHero__shortcut--primary[data-selected="true"]:hover strong,
-.bookingHero__shortcut--primary[data-selected="true"]:focus-visible strong {
-  color: #111;
-}
-
 .bookingHero__story {
   display: inline-flex;
   align-items: center;
@@ -2322,7 +2306,8 @@ button:focus-visible {
 }
 
 .bookingFlow__doctorBadgeAvatar--all {
-  background: #111;
+  background: #fff;
+  border-color: rgba(17, 17, 17, 0.18);
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 
@@ -2336,9 +2321,24 @@ button:focus-visible {
   font-size: 10px;
   line-height: 0.95;
   letter-spacing: -0.05em;
-  color: #fff;
+  color: #111;
   text-align: center;
   transition: color 160ms ease;
+}
+
+.bookingFlow__doctorBadge:hover .bookingFlow__doctorBadgeAvatar--all,
+.bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar--all {
+  background: #f3f4f6;
+  border-color: rgba(17, 17, 17, 0.64);
+}
+
+.bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadgeAvatar--all {
+  background: #111;
+  border-color: rgba(17, 17, 17, 0.88);
+}
+
+.bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadgeFallback--all {
+  color: #fff;
 }
 
 .bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap {
@@ -2563,7 +2563,8 @@ button:focus-visible {
 }
 
 .bookingFlow__procedureBadgeAvatar--all {
-  background: #111;
+  background: #fff;
+  border-color: rgba(17, 17, 17, 0.18);
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 
@@ -2579,26 +2580,26 @@ button:focus-visible {
 }
 
 .bookingFlow__procedureBadgeFallback--all {
-  color: #fff;
+  color: #111;
   font-size: 16px;
   transition: color 160ms ease;
 }
 
 .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
 .bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar--all {
-  background: #666;
-  border-color: #666;
+  background: #f3f4f6;
+  border-color: rgba(17, 17, 17, 0.64);
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeAvatar--all,
 .bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeAvatar--all {
-  background: #fff;
+  background: #111;
   border-color: rgba(17, 17, 17, .84);
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeFallback--all,
 .bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeFallback--all {
-  color: #111;
+  color: #fff;
 }
 
 .bookingFlow__procedureBadgeLabel {
@@ -2771,6 +2772,13 @@ button:focus-visible {
   z-index: 2;
 }
 
+.bookingFlow__timeBtn[data-tooltip-tone="available"]::after,
+.bookingFlow__dateBtn[data-tooltip-tone="available"]::after {
+  background: #16a34a;
+  color: #111;
+  border-color: rgba(17, 17, 17, 0.14);
+}
+
 .bookingFlow__timeBtn[data-tooltip]::before,
 .bookingFlow__dateBtn[data-tooltip]::before {
   content: "";
@@ -2786,6 +2794,11 @@ button:focus-visible {
   opacity: 0;
   transition: opacity 220ms cubic-bezier(.22, 1, .36, 1), transform 260ms cubic-bezier(.22, 1, .36, 1);
   z-index: 1;
+}
+
+.bookingFlow__timeBtn[data-tooltip-tone="available"]::before,
+.bookingFlow__dateBtn[data-tooltip-tone="available"]::before {
+  background: #16a34a;
 }
 
 .bookingFlow__timeBtn[data-tooltip]:hover::after,


### PR DESCRIPTION
## Summary
- add available tooltips to time slots and align occupied copy with date states
- keep Primeiro Horário Disponível as a shortcut that resets doctor/service/date without auto-selecting a time
- invert the visual treatment for Sem Preferência and Outros to make selected state read more clearly

## Testing
- npm run typecheck
- npm run lint -- --file src/components/BookingFlow.tsx --file src/components/BookingHeroExperience.tsx