### PR TITLE
Align any hover state and time slot cursor

### DIFF
--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -1500,6 +1500,7 @@ export default function BookingFlow() {
                                                     const active = timeKey === s.time;
                                                     const isPast = s.reason === "past";
                                                     const isOccupied = s.reason === "agenda" || s.reason === "booked";
+                                                    const isLocked = isPast || isOccupied;
                                                     const hasTooltip = isPast || isOccupied || s.available;
                                                     const tooltip = isPast ? "passou" : isOccupied ? "ocupado" : s.available ? "disponível" : "";
                                                     const tooltipTone = isPast ? "neutral" : isOccupied ? "occupied" : s.available ? "available" : "neutral";
@@ -1519,7 +1520,7 @@ export default function BookingFlow() {
                                                             disabled={nativeDisabled}
                                                             aria-disabled={ariaDisabled}
                                                             data-reason={s.reason ?? ""}
-                                                            data-locked={hasTooltip ? "true" : "false"}
+                                                            data-locked={isLocked ? "true" : "false"}
                                                             data-tooltip={hasTooltip ? tooltip : undefined}
                                                             data-tooltip-tone={hasTooltip ? tooltipTone : undefined}
                                                             className="bookingFlow__selectItem bookingFlow__timeBtn"

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -2716,6 +2716,7 @@ button:focus-visible {
   border-radius: 12px;
   font-weight: 900;
   text-align: center;
+  cursor: pointer;
 }
 
 .bookingFlow__dateHint {
@@ -6897,18 +6898,14 @@ video.heroMediaEl {
 }
 
 .unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeAvatar,
-.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar,
-.unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeAvatar,
-.unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeAvatar {
+.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar {
   transform: translateY(-2px);
   border-color: rgba(17, 17, 17, 0.88);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
 }
 
 .unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeFallback--all,
-.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeFallback--all,
-.unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeFallback--all,
-.unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeFallback--all {
+.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeFallback--all {
   transform: translateY(-1px);
 }
 


### PR DESCRIPTION
## Summary
- remove the remaining active hover lift from the compact Sem Preferência selector so it matches Outros
- keep available time slots visually clickable with pointer cursor and unlocked state

## Testing
- npm run typecheck