### PR TITLE
Polish hero transitions and booking selection states

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,16 +1,14 @@
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import FloatingContact from "@/components/FloatingContact";
-import UnitsMapSection from "@/components/UnitsMapSection";
-import UnitDoctorsGrid from "@/components/UnitDoctorsGrid";
-import AboutUsSection from "@/components/AboutUsSection";
 import HomeHeroExperience from "@/components/HomeHeroExperience";
 import TrustEvidenceSection from "@/components/TrustEvidenceSection";
-import UnitChooser from "@/components/UnitChooser";
+import HomePageSections from "@/components/HomePageSections";
 import { getHeroMediaItems, heroVariantFromUserAgent } from "@/lib/heroMedia.server";
 import { resolveUnitFromSlug } from "@/lib/unitRoutes";
+import { UNIT_SELECTION_COOKIE_KEY } from "@/lib/unitSelection";
 import type { Metadata } from "next";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { getSiteConfigFromHost } from "@/lib/site-config";
 import { SkincosHubPage } from "@/components/LegalContent";
 
@@ -64,6 +62,7 @@ export default async function HomePage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const requestHeaders = await headers();
+  const requestCookies = await cookies();
   const site = getSiteConfigFromHost(requestHeaders.get("host"));
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
 
@@ -85,7 +84,8 @@ export default async function HomePage({
       : Array.isArray(unitParamRaw)
         ? unitParamRaw[0] ?? ""
         : "";
-  const resolvedUnit = resolveUnitFromSlug(unitParam);
+  const cookieUnitParam = requestCookies.get(UNIT_SELECTION_COOKIE_KEY)?.value ?? "";
+  const resolvedUnit = resolveUnitFromSlug(unitParam || cookieUnitParam);
   const { items: heroItems } = await getHeroMediaItems({ variant, unitSlug: resolvedUnit?.slug ?? null });
 
   return (
@@ -93,68 +93,8 @@ export default async function HomePage({
       <Header />
       <main>
         <HomeHeroExperience heroItems={heroItems} initialMediaVariant={variant} initialUnitSlug={resolvedUnit?.slug ?? null} />
-
-        {resolvedUnit ? (
-          <>
-            <TrustEvidenceSection context="home" />
-
-            <div className="container">
-              <section className="pageSection pageNarrative homeLeadSection">
-                <div className="pageNarrative__intro pageNarrative__intro--extended homeLeadSection__intro">
-                  <h2 className="sectionTitle">Realce sua beleza com equilíbrio, segurança e resultado natural.</h2>
-                  <p className="sectionLead pageNarrative__sub homeLeadSection__sub">
-                    Na Espaço Facial, cada atendimento começa com uma avaliação cuidadosa para indicar o que faz sentido para o seu rosto e/ou corpo, sua rotina e suas expectativas, com segurança, elegância e naturalidade.
-                  </p>
-                </div>
-              </section>
-
-              <AboutUsSection />
-
-              <section id="doutores" className="pageSection homeDoctorsSection">
-                <h2 className="sectionTitle">Conheça a equipe</h2>
-                <div className="sectionCopyPair homeDoctorsLead">
-                  <p className="sectionSub">
-                    Escolher fica mais fácil quando você conhece o profissional.
-                  </p>
-                </div>
-                <UnitDoctorsGrid variant="booking-compact" />
-                <p className="small homeDoctorsAftercopy">
-                  Acompanhe os seus procedimentos em suas redes sociais e agende com confiança com um de nossos doutores especialistas.
-                </p>
-              </section>
-
-              <section id="unidades" className="pageSection">
-                <h2 className="sectionTitle">Nossas Unidades</h2>
-                <p className="sectionSub">
-                  Veja as unidades da Espaço Facial e encontre a mais conveniente para o seu atendimento.
-                </p>
-                <UnitsMapSection />
-              </section>
-            </div>
-          </>
-        ) : (
-          <div className="container">
-            <section className="pageSection pageNarrative pageNarrative--compact" aria-labelledby="home-unit-selector-title">
-              <div className="pageNarrative__intro">
-                <span className="pageNarrative__eyebrow">Escolha sua unidade</span>
-                <h2 id="home-unit-selector-title" className="sectionTitle">
-                  Selecione a unidade para continuar.
-                </h2>
-                <p className="sectionSub pageNarrative__sub">
-                  Para ver informações da unidade, equipe, localização e seguir para a jornada correta, escolha uma unidade no seletor abaixo.
-                </p>
-              </div>
-
-              <div className="bookingFlow__embeddedUnitChooser">
-                <UnitChooser placement="home_empty_state" redirectOnSelect />
-              </div>
-
-              <p className="small pageNarrative__hint">
-                Ao escolher uma unidade, você será redirecionado automaticamente para a página correspondente.
-              </p>
-            </section>
-          </div>
-        )}
+        <TrustEvidenceSection context="home" />
+        <HomePageSections />
       </main>
 
       <Footer />

--- a/website/src/components/HeroMedia.tsx
+++ b/website/src/components/HeroMedia.tsx
@@ -14,6 +14,7 @@ type HeroMediaProps = {
 };
 
 const HERO_AUTOPLAY_MS = 6000;
+const HERO_TRANSITION_MS = 560;
 const HERO_DEFAULT_FRAME_COLOR = "#050505";
 const HERO_LIGHT_TEXT_COLOR = "#f5ead8";
 const HERO_DARK_TEXT_COLOR = "#1f1f1f";
@@ -154,9 +155,11 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
     const unit = useCurrentUnit();
     const [index, setIndex] = useState(0);
     const [prevIndex, setPrevIndex] = useState<number | null>(null);
+    const [queuedIndex, setQueuedIndex] = useState<number | null>(null);
     const [aspectRatio, setAspectRatio] = useState<string>("16 / 9");
     const [frameColors, setFrameColors] = useState<HeroFrameColors>(HERO_DEFAULT_FRAME_COLORS);
     const [pendingFrameColors, setPendingFrameColors] = useState<HeroFrameColors | null>(null);
+    const [readyImageSrcs, setReadyImageSrcs] = useState<Record<string, true>>({});
     const [variant, setVariant] = useState<HeroMediaVariant>(initialVariant ?? "desktop");
     const hasInitialItems = Array.isArray(initialItems) && initialItems.length > 0;
     const topBandTextColor = useMemo(() => pickBandTextColor(frameColors.top), [frameColors.top]);
@@ -201,6 +204,37 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
     const targetCampaignKey = campaignKey(variant, targetUnitSlug);
     const initialCampaignKey = campaignKey(variant, initialUnitSlug ?? null);
     const visibleItems = loadedCampaignKey === targetCampaignKey ? items : EMPTY_HERO_ITEMS;
+
+    const markImageReady = useCallback((src: string) => {
+        if (!src) return;
+        setReadyImageSrcs((current) => {
+            if (current[src]) return current;
+            return {
+                ...current,
+                [src]: true,
+            };
+        });
+    }, []);
+
+    const preloadImage = useCallback(
+        (src: string) => {
+            if (typeof window === "undefined" || !src || readyImageSrcs[src]) return;
+
+            const image = new window.Image();
+            image.decoding = "async";
+            image.onload = () => markImageReady(src);
+            image.onerror = () => markImageReady(src);
+            image.src = src;
+
+            if (typeof image.decode === "function") {
+                void image.decode().then(
+                    () => markImageReady(src),
+                    () => markImageReady(src),
+                );
+            }
+        },
+        [markImageReady, readyImageSrcs],
+    );
 
     useEffect(() => {
         let cancelled = false;
@@ -252,7 +286,15 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
     useEffect(() => {
         setIndex(0);
         setPrevIndex(null);
+        setQueuedIndex(null);
     }, [visibleItems]);
+
+    useEffect(() => {
+        visibleItems.forEach((heroItem) => {
+            if (heroItem.type !== "image") return;
+            preloadImage(heroItem.src);
+        });
+    }, [preloadImage, visibleItems]);
 
     const item = visibleItems[index] ?? visibleItems[0] ?? null;
     const shouldLoopVideo = item?.type === "video" && visibleItems.length === 1;
@@ -265,12 +307,23 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
     const goTo = useCallback(
         (nextIndex: number) => {
             if (visibleItems.length <= 1) return;
+            if (prevIndex !== null) return;
             if (nextIndex === index) return;
             if (nextIndex < 0 || nextIndex >= visibleItems.length) return;
+            const nextItem = visibleItems[nextIndex];
+            if (!nextItem) return;
+
+            if (nextItem.type === "image" && !readyImageSrcs[nextItem.src]) {
+                preloadImage(nextItem.src);
+                setQueuedIndex(nextIndex);
+                return;
+            }
+
+            setQueuedIndex(null);
             setPrevIndex(index);
             setIndex(nextIndex);
         },
-        [index, visibleItems.length],
+        [index, preloadImage, prevIndex, readyImageSrcs, visibleItems],
     );
 
     const goNext = useCallback(() => {
@@ -283,9 +336,26 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
 
     useEffect(() => {
         if (prevIndex === null) return;
-        const t = window.setTimeout(() => setPrevIndex(null), 650);
+        const t = window.setTimeout(() => setPrevIndex(null), HERO_TRANSITION_MS);
         return () => window.clearTimeout(t);
     }, [prevIndex]);
+
+    useEffect(() => {
+        if (queuedIndex === null) return;
+        const queuedItem = visibleItems[queuedIndex];
+        if (!queuedItem) {
+            setQueuedIndex(null);
+            return;
+        }
+        if (queuedItem.type === "image" && !readyImageSrcs[queuedItem.src]) return;
+        if (queuedIndex === index) {
+            setQueuedIndex(null);
+            return;
+        }
+        setPrevIndex(index);
+        setIndex(queuedIndex);
+        setQueuedIndex(null);
+    }, [index, queuedIndex, readyImageSrcs, visibleItems]);
 
     useEffect(() => {
         if (prevIndex !== null || !pendingFrameColors) return;
@@ -344,14 +414,18 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
         root.style.setProperty("--hero-band-bg-bottom-live", frameColors.bottom);
         root.style.setProperty("--hero-band-fg-top-live", topBandTextColor);
         root.style.setProperty("--hero-band-fg-bottom-live", bottomBandTextColor);
+    }, [bottomBandTextColor, frameColors.bottom, frameColors.top, topBandTextColor]);
 
+    useEffect(() => {
+        if (typeof document === "undefined") return undefined;
+        const root = document.documentElement;
         return () => {
             root.style.removeProperty("--hero-band-bg-top-live");
             root.style.removeProperty("--hero-band-bg-bottom-live");
             root.style.removeProperty("--hero-band-fg-top-live");
             root.style.removeProperty("--hero-band-fg-bottom-live");
         };
-    }, [bottomBandTextColor, frameColors.bottom, frameColors.top, topBandTextColor]);
+    }, []);
 
     const style = useMemo<HeroStyle>(() => {
         const hotspot = item?.bookingHotspot;
@@ -368,7 +442,10 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
     }, [aspectRatio, frameColors.bottom, frameColors.top, item?.bookingHotspot]);
 
     const renderLayer = (layerItem: HeroMediaItem, opts: { layerKey: string; kind: "active" | "prev" }) => {
-        const layerClass = opts.kind === "active" ? "heroMediaLayer heroMediaLayer--active" : "heroMediaLayer heroMediaLayer--prev";
+        const layerClass =
+            opts.kind === "active"
+                ? `heroMediaLayer heroMediaLayer--active${prevIndex !== null ? " heroMediaLayer--enter" : ""}`
+                : "heroMediaLayer heroMediaLayer--prev";
 
         return (
             <div key={opts.layerKey} className={layerClass}>
@@ -415,6 +492,7 @@ export default function HeroMedia({ initialItems, initialVariant, initialUnitSlu
                         onLoad={(event) => {
                             if (opts.kind !== "active") return;
                             const img = event.currentTarget;
+                            markImageReady(layerItem.src);
                             if (img.naturalWidth > 0 && img.naturalHeight > 0) {
                                 setAspectRatio(`${img.naturalWidth} / ${img.naturalHeight}`);
                             }

--- a/website/src/components/HomePageSections.tsx
+++ b/website/src/components/HomePageSections.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import UnitsMapSection from "@/components/UnitsMapSection";
+import UnitDoctorsGrid from "@/components/UnitDoctorsGrid";
+import AboutUsSection from "@/components/AboutUsSection";
+import { getDigitalJourneyUnits } from "@/data/units";
+import { useCurrentUnit } from "@/hooks/useCurrentUnit";
+import { trackEvent } from "@/lib/analytics";
+import { setStoredUnitSlug } from "@/lib/unitSelection";
+import { getUnitHref } from "@/lib/unitRoutes";
+
+export default function HomePageSections() {
+    const router = useRouter();
+    const unit = useCurrentUnit();
+    const [hasHydrated, setHasHydrated] = useState(false);
+    const availableUnits = getDigitalJourneyUnits();
+
+    useEffect(() => {
+        setHasHydrated(true);
+    }, []);
+
+    if (!hasHydrated) return null;
+
+    if (!unit) {
+        return (
+            <div className="container">
+                <section className="pageSection pageNarrative pageNarrative--compact homeUnitSelector" aria-labelledby="home-unit-selector-title">
+                    <div className="pageNarrative__intro homeUnitSelector__intro">
+                        <h2 id="home-unit-selector-title" className="sectionTitle">
+                            Selecione a unidade para continuar.
+                        </h2>
+                        <p className="sectionSub pageNarrative__sub">
+                            Para ver informações da unidade, equipe, localização e seguir para a jornada correta, escolha uma das unidades abaixo.
+                        </p>
+                    </div>
+
+                    <div className="homeUnitSelector__actions" role="group" aria-label="Selecionar unidade">
+                        {availableUnits.map((availableUnit) => (
+                            <Link
+                                key={availableUnit.slug}
+                                href={getUnitHref(availableUnit.slug)}
+                                className="homeUnitSelector__button"
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    setStoredUnitSlug(availableUnit.slug);
+                                    trackEvent("unit_select", {
+                                        unitSlug: availableUnit.slug,
+                                        placement: "home_empty_state_unit_buttons",
+                                    });
+                                    router.push(getUnitHref(availableUnit.slug));
+                                }}
+                            >
+                                {availableUnit.name}
+                            </Link>
+                        ))}
+                    </div>
+
+                    <p className="small pageNarrative__hint homeUnitSelector__hint">
+                        Ao escolher uma unidade, você será redirecionado automaticamente para a página correspondente.
+                    </p>
+                </section>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container">
+            <section className="pageSection pageNarrative homeLeadSection">
+                <div className="pageNarrative__intro pageNarrative__intro--extended homeLeadSection__intro">
+                    <h2 className="sectionTitle">Realce sua beleza com equilíbrio, segurança e resultado natural.</h2>
+                    <p className="sectionLead pageNarrative__sub homeLeadSection__sub">
+                        Na Espaço Facial, cada atendimento começa com uma avaliação cuidadosa para indicar o que faz sentido para o seu rosto e/ou corpo, sua rotina e suas expectativas, com segurança, elegância e naturalidade.
+                    </p>
+                </div>
+            </section>
+
+            <AboutUsSection />
+
+            <section id="doutores" className="pageSection homeDoctorsSection">
+                <h2 className="sectionTitle">Conheça a equipe</h2>
+                <div className="sectionCopyPair homeDoctorsLead">
+                    <p className="sectionSub">
+                        Escolher fica mais fácil quando você conhece o profissional.
+                    </p>
+                </div>
+                <UnitDoctorsGrid variant="booking-compact" />
+                <p className="small homeDoctorsAftercopy">
+                    Acompanhe os seus procedimentos em suas redes sociais e agende com confiança com um de nossos doutores especialistas.
+                </p>
+            </section>
+
+            <section id="unidades" className="pageSection">
+                <h2 className="sectionTitle">Nossas Unidades</h2>
+                <p className="sectionSub">
+                    Veja as unidades da Espaço Facial e encontre a mais conveniente para o seu atendimento.
+                </p>
+                <UnitsMapSection />
+            </section>
+        </div>
+    );
+}

--- a/website/src/hooks/useCurrentUnit.ts
+++ b/website/src/hooks/useCurrentUnit.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { units, type Unit } from "@/data/units";
 import { normalizeUnitSlug } from "@/lib/unitRoutes";
 import { getStoredUnitSlug, setStoredUnitSlug } from "@/lib/unitSelection";
@@ -22,6 +22,7 @@ function findUnitBySlugOrAlias(slug: string | null | undefined): Unit | null {
 
 export function useCurrentUnit(): Unit | null {
     const pathname = usePathname();
+    const searchParams = useSearchParams();
 
     const slugFromPath = useMemo(() => {
         if (!pathname) return null;
@@ -32,13 +33,15 @@ export function useCurrentUnit(): Unit | null {
     }, [pathname]);
 
     const unitFromPath = useMemo(() => findUnitBySlugOrAlias(slugFromPath), [slugFromPath]);
+    const slugFromQuery = useMemo(() => searchParams?.get("unit") ?? null, [searchParams]);
+    const unitFromQuery = useMemo(() => findUnitBySlugOrAlias(slugFromQuery), [slugFromQuery]);
 
-    const [storedSlug, setStoredSlug] = useState<string | null>(null);
+    const [storedSlug, setStoredSlug] = useState<string | null>(() => getStoredUnitSlug());
 
     useEffect(() => {
         if (typeof window === "undefined") return;
         setStoredSlug(getStoredUnitSlug());
-    }, [pathname]);
+    }, [pathname, searchParams]);
 
     useEffect(() => {
         function onUnitChange(e: Event) {
@@ -53,11 +56,12 @@ export function useCurrentUnit(): Unit | null {
 
     const unitFromStorage = useMemo(() => findUnitBySlug(storedSlug), [storedSlug]);
 
-    const unit = unitFromPath ?? unitFromStorage;
+    const unit = unitFromPath ?? unitFromQuery ?? unitFromStorage;
 
     useEffect(() => {
-        if (unitFromPath?.slug) setStoredUnitSlug(unitFromPath.slug);
-    }, [unitFromPath?.slug]);
+        const activeSlug = unitFromPath?.slug ?? unitFromQuery?.slug ?? null;
+        if (activeSlug) setStoredUnitSlug(activeSlug);
+    }, [unitFromPath?.slug, unitFromQuery?.slug]);
 
     return unit;
 }

--- a/website/src/lib/unitSelection.ts
+++ b/website/src/lib/unitSelection.ts
@@ -1,21 +1,42 @@
-const STORAGE_KEY = "ef:selectedUnitSlug";
+export const UNIT_SELECTION_STORAGE_KEY = "ef:selectedUnitSlug";
+export const UNIT_SELECTION_COOKIE_KEY = "ef_selected_unit";
+
+function readCookie(name: string): string | null {
+    if (typeof document === "undefined") return null;
+    const cookies = document.cookie
+        .split(";")
+        .map((part) => part.trim())
+        .filter(Boolean);
+    const prefix = `${name}=`;
+    const match = cookies.find((entry) => entry.startsWith(prefix));
+    if (!match) return null;
+    const value = match.slice(prefix.length).trim();
+    return value ? decodeURIComponent(value) : null;
+}
 
 export function getStoredUnitSlug(): string | null {
     if (typeof window === "undefined") return null;
     try {
-        const value = window.localStorage.getItem(STORAGE_KEY);
-        return value && value.trim() ? value : null;
+        const value = window.localStorage.getItem(UNIT_SELECTION_STORAGE_KEY);
+        if (value && value.trim()) return value;
+        return readCookie(UNIT_SELECTION_COOKIE_KEY);
     } catch {
-        return null;
+        return readCookie(UNIT_SELECTION_COOKIE_KEY);
     }
 }
 
 export function setStoredUnitSlug(slug: string): void {
     if (typeof window === "undefined") return;
     try {
-        window.localStorage.setItem(STORAGE_KEY, slug);
+        window.localStorage.setItem(UNIT_SELECTION_STORAGE_KEY, slug);
+        document.cookie = `${UNIT_SELECTION_COOKIE_KEY}=${encodeURIComponent(slug)}; Path=/; Max-Age=31536000; SameSite=Lax`;
         window.dispatchEvent(new CustomEvent("ef:unit-change", { detail: { slug } }));
     } catch {
         // Ignore storage failures (private mode, blocked storage, etc.)
+        try {
+            document.cookie = `${UNIT_SELECTION_COOKIE_KEY}=${encodeURIComponent(slug)}; Path=/; Max-Age=31536000; SameSite=Lax`;
+        } catch {
+            // Ignore cookie failures as well.
+        }
     }
 }

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -2337,8 +2337,8 @@ button:focus-visible {
 }
 
 .bookingFlow__doctorBadgeAvatar--all {
-  background: #fff;
-  border-color: rgba(17, 17, 17, 0.18);
+  background: #111;
+  border-color: rgba(17, 17, 17, 0.92);
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 
@@ -2352,34 +2352,25 @@ button:focus-visible {
   font-size: 10px;
   line-height: 0.95;
   letter-spacing: -0.05em;
-  color: #111;
+  color: #fff;
   text-align: center;
   transition: color 160ms ease;
 }
 
-.bookingFlow__doctorBadge:hover .bookingFlow__doctorBadgeAvatar--all,
-.bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar--all {
-  background: #f3f4f6;
-  border-color: rgba(17, 17, 17, 0.64);
+.bookingFlow__doctorBadgeWrap:not([data-active="true"]) .bookingFlow__doctorBadge:hover .bookingFlow__doctorBadgeAvatar--all,
+.bookingFlow__doctorBadgeWrap:not([data-active="true"]) .bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar--all {
+  background: #000;
+  border-color: #000;
 }
 
 .bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, 0.88);
-  box-shadow: none;
-  transform: none;
+  background: #16a34a;
+  border-color: rgba(17, 17, 17, 0.92);
+  box-shadow: 0 16px 32px rgba(22, 163, 74, .26);
 }
 
 .bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadgeFallback--all {
-  color: #fff;
-}
-
-.bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadge:hover .bookingFlow__doctorBadgeAvatar--all,
-.bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, 0.88);
-  box-shadow: none;
-  transform: none;
+  color: #062814;
 }
 
 .bookingFlow__picker--doctor .bookingFlow__doctorBadgeWrap {
@@ -2599,8 +2590,8 @@ button:focus-visible {
 }
 
 .bookingFlow__procedureBadgeAvatar--all {
-  background: #fff;
-  border-color: rgba(17, 17, 17, 0.18);
+  background: #111;
+  border-color: rgba(17, 17, 17, 0.92);
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 
@@ -2616,43 +2607,27 @@ button:focus-visible {
 }
 
 .bookingFlow__procedureBadgeFallback--all {
-  color: #111;
+  color: #fff;
   font-size: 16px;
   transition: color 160ms ease;
 }
 
-.bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
-.bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar--all {
-  background: #f3f4f6;
-  border-color: rgba(17, 17, 17, 0.64);
+.bookingFlow__procedureBadgeWrap:not([data-active="true"]) .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
+.bookingFlow__procedureBadgeWrap:not([data-active="true"]) .bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar--all {
+  background: #000;
+  border-color: #000;
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeAvatar--all,
 .bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, .84);
-  box-shadow: none;
-  transform: none;
+  background: #16a34a;
+  border-color: rgba(17, 17, 17, 0.92);
+  box-shadow: 0 16px 32px rgba(22, 163, 74, .26);
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeFallback--all,
 .bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeFallback--all {
-  color: #fff;
-}
-
-.bookingFlow__procedureBadge[data-active="true"]:hover:not(:disabled),
-.bookingFlow__procedureBadge[data-active="true"]:focus-visible {
-  transform: none;
-}
-
-.bookingFlow__procedureBadge[data-active="true"]:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
-.bookingFlow__procedureBadge[data-active="true"]:focus-visible .bookingFlow__procedureBadgeAvatar--all,
-.bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
-.bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, .84);
-  box-shadow: none;
-  transform: none;
+  color: #062814;
 }
 
 .bookingFlow__procedureBadgeLabel {
@@ -3242,33 +3217,46 @@ button:focus-visible {
 .heroMediaLayer {
   position: absolute;
   inset: 0;
+  backface-visibility: hidden;
+  transform: translateZ(0);
 }
 
-.heroMediaLayer--fadeIn {
-  animation: heroFadeIn 650ms ease;
+.heroMediaLayer--active {
+  z-index: 1;
+  opacity: 1;
 }
 
-.heroMediaLayer--prev {
-  animation: heroFadeOut 650ms ease forwards;
+.heroMediaLayer--enter {
+  animation: heroFadeIn 560ms cubic-bezier(.22, .61, .36, 1);
 }
 
 @keyframes heroFadeIn {
   from {
     opacity: 0;
+    transform: scale(1.012);
   }
 
   to {
     opacity: 1;
+    transform: scale(1);
   }
+}
+
+.heroMediaLayer--prev {
+  z-index: 2;
+  opacity: 1;
+  animation: heroFadeOut 560ms cubic-bezier(.22, .61, .36, 1) forwards;
 }
 
 @keyframes heroFadeOut {
   from {
     opacity: 1;
+    transform: scale(1);
   }
 
   to {
     opacity: 0;
+    transform: scale(.992);
   }
 }
 
@@ -3277,6 +3265,7 @@ button:focus-visible {
   height: 100%;
   display: block;
   object-fit: contain;
+  transform: translateZ(0);
 }
 
 video.heroMediaEl {
@@ -6952,33 +6941,22 @@ video.heroMediaEl {
   transform: translateY(-1px);
 }
 
-.unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeAvatar--all,
-.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar--all {
-  background: #666;
-  border-color: #666;
+.unitDoctorsCompact__avatarTrigger:not([data-active="true"]):hover .bookingFlow__doctorBadgeAvatar--all,
+.unitDoctorsCompact__avatarTrigger:not([data-active="true"]):focus-visible .bookingFlow__doctorBadgeAvatar--all {
+  background: #000;
+  border-color: #000;
 }
 
 .unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeAvatar--all,
 .unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, .88);
-  box-shadow: none;
-  transform: none;
+  background: #16a34a;
+  border-color: rgba(17, 17, 17, 0.92);
+  box-shadow: 0 16px 32px rgba(22, 163, 74, .26);
 }
 
 .unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeFallback--all,
 .unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeFallback--all {
-  color: #fff;
-}
-
-.unitDoctorsCompact__avatarTrigger--select[data-active="true"]:hover .bookingFlow__doctorBadgeAvatar--all,
-.unitDoctorsCompact__avatarTrigger--select[data-active="true"]:focus-visible .bookingFlow__doctorBadgeAvatar--all,
-.unitDoctorsCompact__item[data-active="true"] .unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeAvatar--all,
-.unitDoctorsCompact__item[data-active="true"] .unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar--all {
-  background: #111;
-  border-color: rgba(17, 17, 17, .88);
-  box-shadow: none;
-  transform: none;
+  color: #062814;
 }
 
 .unitDoctorsCompact__avatarTrigger .bookingFlow__doctorBadgeAvatar {
@@ -7176,6 +7154,66 @@ video.heroMediaEl {
 
 .pageNarrative--compact {
   padding-top: var(--space-5);
+}
+
+.homeUnitSelector {
+  margin-top: 20px;
+}
+
+.homeUnitSelector__intro {
+  transform: translateY(-8px);
+}
+
+.homeUnitSelector__intro .sectionTitle {
+  max-width: min(100%, 1220px);
+}
+
+.homeUnitSelector__intro .sectionSub {
+  max-width: min(100%, 1320px);
+}
+
+.homeUnitSelector__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  width: 100%;
+  margin: 6px auto 0;
+  transform: translateY(-10px);
+}
+
+.homeUnitSelector__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 260px;
+  min-height: 58px;
+  padding: 0 28px;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, .98), rgba(246, 242, 236, .98));
+  box-shadow: 0 18px 34px rgba(17, 17, 17, .08);
+  color: #171717;
+  font-family: var(--font-brand-ui);
+  font-size: 15px;
+  font-weight: 900;
+  letter-spacing: .04em;
+  text-decoration: none;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.homeUnitSelector__button:hover,
+.homeUnitSelector__button:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(138, 95, 42, .28);
+  box-shadow: 0 20px 40px rgba(17, 17, 17, .11);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(250, 244, 235, 1));
+}
+
+.homeUnitSelector__hint {
+  width: 100%;
+  margin-top: 0;
+  text-align: center;
 }
 
 .pageNarrative__intro {
@@ -8229,6 +8267,18 @@ video.heroMediaEl {
   .heroMediaEl {
     object-fit: cover;
   }
+
+  .homeUnitSelector {
+    margin-top: 12px;
+  }
+
+  .homeUnitSelector__intro {
+    transform: none;
+  }
+
+  .homeUnitSelector__actions {
+    transform: none;
+  }
 }
 
 @media (max-width:900px) {
@@ -8344,6 +8394,16 @@ video.heroMediaEl {
   .heroMedia {
     max-height: 380px;
     min-height: 260px;
+  }
+
+  .homeUnitSelector__actions {
+    gap: 12px;
+  }
+
+  .homeUnitSelector__button {
+    width: 100%;
+    min-width: 0;
+    min-height: 54px;
   }
 
   .cookieBannerInner {


### PR DESCRIPTION
## Summary
- stabilize hero banner transitions by preloading slides and keeping band colors steady through the crossfade
- show the unit-picking empty state only when no unit is actually resolved, with two direct unit buttons
- align the booking "Sem Preferência" and "Outros" selection states with the green/black treatment used elsewhere

## Validation
- npm run test
- npm run build