### PR TITLE
[codex] align booking flow with system agenda

### DIFF
--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -121,22 +121,6 @@ async function tryPostWebhook(payload: unknown) {
     }
 }
 
-async function expireStaleOverlaps(db: Awaited<ReturnType<typeof getBookingDb>>, overlaps: Array<{ id: string; status: string; confirm_by_ms: number }>) {
-    const now = nowMs();
-    for (const o of overlaps) {
-        const status = (o.status ?? "").toString();
-        if (status !== "pending" && status !== "needs_approval") continue;
-        const confirmBy = Number(o.confirm_by_ms ?? 0);
-        if (now <= confirmBy) continue;
-        await db
-            .prepare(
-                "UPDATE booking_requests SET status = 'expired', decided_at_ms = ?, decision_note = COALESCE(decision_note, 'auto_expired') WHERE id = ? AND (status = 'pending' OR status = 'needs_approval')",
-            )
-            .bind(now, o.id)
-            .run();
-    }
-}
-
 async function upsertCustomer(
     db: Awaited<ReturnType<typeof getBookingDb>>,
     params: { name: string; email: string; whatsapp: string; cpf: string | null; address: string | null; now: number },
@@ -401,44 +385,13 @@ export async function POST(request: Request) {
     }
     const agendaRanges = await listAgendaRanges({ unitSlug, date });
 
-    const db = await getBookingDb();
-
     // If the user has no preference, pick a free doctor for that unit+slot.
     let effectiveDoctorSlug = doctorSlug;
     let safeDoctorName = clampText(selectedDoctor?.name || doctorName || doctorSlug, 120);
     if (wantsAnyDoctor) {
         const doctorsForSelection = daySchedule ? doctorsAvailableBySchedule : doctors;
 
-        const placeholders = doctorsForSelection.map(() => "?").join(", ");
-        const overlapsRes = await db
-            .prepare(
-                `SELECT id, doctor_slug, status, confirm_by_ms, start_at_ms, end_at_ms FROM booking_requests WHERE unit_slug = ? AND doctor_slug IN (${placeholders}) AND start_at_ms < ? AND end_at_ms > ?`,
-            )
-            .bind(unitSlug, ...doctorsForSelection.map((doctor) => doctor.slug), endAtMs, startAtMs)
-            .all<{ id: string; doctor_slug: string; status: string; confirm_by_ms: number; start_at_ms: number; end_at_ms: number }>();
-
-        await expireStaleOverlaps(db, overlapsRes.results);
-
-        const now = nowMs();
-        const activeByDoctor = new Map<string, { hasConfirmed: boolean; hasPending: boolean }>();
-
-        for (const o of overlapsRes.results) {
-            const status = (o.status ?? "").toString();
-            const isConfirmed = status === "confirmed";
-            const isPending = status === "pending" || status === "needs_approval";
-            if (!isConfirmed && !isPending) continue;
-
-            if (isPending && now > Number(o.confirm_by_ms ?? 0)) continue;
-
-            const slug = (o.doctor_slug ?? "").toString();
-            const cur = activeByDoctor.get(slug) ?? { hasConfirmed: false, hasPending: false };
-            if (isConfirmed) cur.hasConfirmed = true;
-            if (isPending) cur.hasPending = true;
-            activeByDoctor.set(slug, cur);
-        }
-
-        const pick = doctorsForSelection.find((doctor) => {
-            if (activeByDoctor.has(doctor.slug)) return false;
+        const pick = doctorsForSelection.find(() => {
             return !hasAgendaConflictForDoctor({
                 agendaRanges,
                 startAtMs,
@@ -446,8 +399,7 @@ export async function POST(request: Request) {
             });
         }) ?? null;
         if (!pick) {
-            const anyPending = Array.from(activeByDoctor.values()).some((v) => v.hasPending);
-            return json({ ok: false, error: anyPending ? "slot_in_review" : "no_availability" }, { status: 409 });
+            return json({ ok: false, error: "no_availability" }, { status: 409 });
         }
 
         effectiveDoctorSlug = pick.slug;
@@ -463,39 +415,9 @@ export async function POST(request: Request) {
         return json({ ok: false, error: "no_availability" }, { status: 409 });
     }
 
-    // Check overlaps for the same unit+doctor.
-    const overlapsRes = await db
-        .prepare(
-            "SELECT id, status, confirm_by_ms, start_at_ms, end_at_ms FROM booking_requests WHERE unit_slug = ? AND doctor_slug = ? AND start_at_ms < ? AND end_at_ms > ?",
-        )
-        .bind(unitSlug, effectiveDoctorSlug, endAtMs, startAtMs)
-        .all<{ id: string; status: string; confirm_by_ms: number; start_at_ms: number; end_at_ms: number }>();
-
-    await expireStaleOverlaps(db, overlapsRes.results);
-
-    const now = nowMs();
-    const activeOverlaps = overlapsRes.results.filter((o) => {
-        const status = (o.status ?? "").toString();
-        if (status === "confirmed") return true;
-        if (status === "pending" || status === "needs_approval") {
-            return now <= Number(o.confirm_by_ms ?? 0);
-        }
-        return false;
-    });
-
-    const hasConfirmedConflict = activeOverlaps.some((o) => (o.status ?? "").toString() === "confirmed");
-    const hasPendingConflict = activeOverlaps.some((o) => {
-        const status = (o.status ?? "").toString();
-        return status === "pending" || status === "needs_approval";
-    });
-
-    if (hasPendingConflict) {
-        return json({ ok: false, error: "slot_in_review" }, { status: 409 });
-    }
-
-    if (hasConfirmedConflict) {
-        return json({ ok: false, error: "no_availability" }, { status: 409 });
-    }
+    // Persist the website request for protocol/automation, but do not let local booking_requests
+    // become a scheduling lock. Slot blocking must mirror agenda_appointments from the system only.
+    const db = await getBookingDb();
 
     const status = "confirmed";
 

--- a/website/src/app/api/booking/slots/route.ts
+++ b/website/src/app/api/booking/slots/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getBookingDb, nowMs, addMinutes, isValidDateKey, isValidTimeKey, toSaoPauloIso } from "@/lib/bookingDb";
+import { nowMs, addMinutes, isValidDateKey, isValidTimeKey, toSaoPauloIso } from "@/lib/bookingDb";
 import { getAgendaDb } from "@/lib/agendaDb";
 import { getServiceById } from "@/data/services";
 import { getUnitDoctorsResult } from "@/lib/injectorsDirectory";
@@ -86,28 +86,6 @@ function buildUnavailableSlots(params: { date: string; durationMinutes: number; 
     });
 }
 
-async function expireIfNeeded(db: Awaited<ReturnType<typeof getBookingDb>>, id: string) {
-    // Best-effort: mark pending approvals as expired after confirm_by.
-    const row = await db
-        .prepare("SELECT id, status, confirm_by_ms FROM booking_requests WHERE id = ?")
-        .bind(id)
-        .first<{ id: string; status: string; confirm_by_ms: number }>();
-
-    if (!row) return;
-    const status = (row.status ?? "").toString();
-    if (status !== "pending" && status !== "needs_approval") return;
-
-    const now = nowMs();
-    if (now <= Number(row.confirm_by_ms)) return;
-
-    await db
-        .prepare(
-            "UPDATE booking_requests SET status = 'expired', decided_at_ms = ?, decision_note = COALESCE(decision_note, 'auto_expired') WHERE id = ? AND (status = 'pending' OR status = 'needs_approval')",
-        )
-        .bind(now, id)
-        .run();
-}
-
 export async function GET(req: Request) {
     const url = new URL(req.url);
 
@@ -145,7 +123,6 @@ export async function GET(req: Request) {
     }
     const daySlots = buildDaySlots(unitSlug, date, durationMinutes);
 
-    const db = await getBookingDb();
     const wantsAnyDoctor = doctorSlug === "any";
     const unitDoctorsResult = await getUnitDoctorsResult(unitSlug);
     if (wantsAnyDoctor && !unitDoctorsResult.ok) {
@@ -230,55 +207,11 @@ export async function GET(req: Request) {
         });
     }
 
-    // Fetch existing bookings for that day (unit + doctor(s))
-    const dayStartIso = toSaoPauloIso(date, "00:00");
-    const dayStartMs = Date.parse(dayStartIso);
-    const dayEndMs = addMinutes(dayStartMs, 24 * 60);
-
-    const inPlaceholders = doctorSlugs.map(() => "?").join(", ");
-    const existing = await db
-        .prepare(
-            `SELECT id, doctor_slug, start_at_ms, end_at_ms, status, confirm_by_ms FROM booking_requests WHERE unit_slug = ? AND doctor_slug IN (${inPlaceholders}) AND start_at_ms < ? AND end_at_ms > ?`,
-        )
-        .bind(unitSlug, ...doctorSlugs, dayEndMs, dayStartMs)
-        .all<{ id: string; doctor_slug: string; start_at_ms: number; end_at_ms: number; status: string; confirm_by_ms: number }>();
-
-    // Expire stale rows we just loaded.
-    for (const row of existing.results) {
-        await expireIfNeeded(db, row.id);
-    }
-
     const now = nowMs();
-
-    const normalizedExisting = existing.results
-        .map((r) => {
-            const status = (r.status ?? "").toString();
-            const confirmBy = Number(r.confirm_by_ms ?? 0);
-            const activePending = (status === "pending" || status === "needs_approval") && now <= confirmBy;
-            const activeConfirmed = status === "confirmed";
-            return {
-                id: r.id,
-                doctorSlug: (r.doctor_slug ?? "").toString(),
-                start: Number(r.start_at_ms),
-                end: Number(r.end_at_ms),
-                status,
-                active: activeConfirmed || activePending,
-                isConfirmed: activeConfirmed,
-            };
-        })
-        .filter((r) => r.active);
-
-    const byDoctor = new Map<string, Array<{ start: number; end: number; isConfirmed: boolean }>>();
-    for (const e of normalizedExisting) {
-        const key = e.doctorSlug;
-        const list = byDoctor.get(key) ?? [];
-        list.push({ start: e.start, end: e.end, isConfirmed: e.isConfirmed });
-        if (!byDoctor.has(key)) byDoctor.set(key, list);
-    }
-
     let agendaBlockedCount = 0;
     const overlapsAgendaForDoctor = (startMs: number, endMs: number) => {
-        // Business rule: agenda slots from scraper block by unit+day+time regardless of "profissional".
+        // The site agenda must mirror the system agenda only.
+        // Local website booking requests do not reserve slots until the automation creates them in app.espacofacial.com.br.
         return agendaRanges.some((r) => r.start < endMs && r.end > startMs);
     };
     const out = daySlots.map((s) => {
@@ -304,37 +237,12 @@ export async function GET(req: Request) {
             return { time, available: false, reason: "agenda" };
         }
 
-        if (!wantsAnyDoctor) {
-            for (const e of normalizedExisting) {
-                const overlaps = e.start < endMs && e.end > startMs;
-                if (!overlaps) continue;
+        if (wantsAnyDoctor) {
+            const hasAgendaConflict = doctorSlugs.length > 0 && overlapsAgendaForDoctor(startMs, endMs);
+            if (hasAgendaConflict) {
                 available = false;
-                reason = e.isConfirmed ? "booked" : "in_review";
-                break;
-            }
-        } else {
-            let hasPending = false;
-            let hasConfirmed = false;
-            let hasAgendaConflict = false;
-            let anyFree = false;
-
-            for (const slug of doctorSlugs) {
-                const agendaOverlap = overlapsAgendaForDoctor(startMs, endMs);
-                const ranges = byDoctor.get(slug) ?? [];
-                const overlap = ranges.some((e) => e.start < endMs && e.end > startMs);
-                if (!agendaOverlap && !overlap) {
-                    anyFree = true;
-                    break;
-                }
-                if (agendaOverlap) hasAgendaConflict = true;
-                if (ranges.some((e) => e.start < endMs && e.end > startMs && e.isConfirmed)) hasConfirmed = true;
-                if (ranges.some((e) => e.start < endMs && e.end > startMs && !e.isConfirmed)) hasPending = true;
-            }
-
-            if (!anyFree) {
-                available = false;
-                reason = hasPending ? "in_review" : hasConfirmed ? "booked" : hasAgendaConflict ? "agenda" : "booked";
-                if (reason === "agenda") agendaBlockedCount += 1;
+                reason = "agenda";
+                agendaBlockedCount += 1;
             }
         }
 

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -386,7 +386,6 @@ export default function BookingFlow() {
     const [dateAvailability, setDateAvailability] = useState<Record<string, boolean>>({});
 
     const [submitted, setSubmitted] = useState<SubmittedReservation | null>(null);
-    const [status, setStatus] = useState<BookingStatus | null>(null);
     const procedureScrollWindowRef = useRef<HTMLDivElement | null>(null);
     const autoPickMotionDoneRef = useRef(false);
     const patientNameInputRef = useRef<HTMLInputElement | null>(null);
@@ -474,7 +473,6 @@ export default function BookingFlow() {
                     statusToken: token,
                     reservation,
                 });
-                setStatus(booking);
                 setStep("submitted");
 
                 if (bookingTokenQuery && typeof window !== "undefined") {
@@ -990,41 +988,6 @@ export default function BookingFlow() {
         }
     }
 
-    // Poll status after submit
-    useEffect(() => {
-        if (!submitted) return;
-        const bookingId = submitted.id;
-        const statusToken = submitted.statusToken;
-        if (typeof statusToken !== "string" || statusToken.length === 0) return;
-        const safeStatusToken: string = statusToken;
-        let cancelled = false;
-        let timer: ReturnType<typeof setTimeout> | null = null;
-
-        async function tick() {
-            try {
-                const res = await fetch(`/api/booking/status?id=${encodeURIComponent(bookingId)}`, {
-                    cache: "no-store",
-                    headers: { "x-booking-status-token": safeStatusToken },
-                });
-                const json = (await res.json().catch(() => null)) as StatusResponse | null;
-                if (cancelled) return;
-                if (res.ok && json && isOkResponse(json)) {
-                    setStatus((json as { ok: true; booking: BookingStatus }).booking);
-                }
-            } catch {
-                // ignore
-            } finally {
-                if (!cancelled) timer = setTimeout(tick, 25_000);
-            }
-        }
-
-        tick();
-        return () => {
-            cancelled = true;
-            if (timer) clearTimeout(timer);
-        };
-    }, [submitted]);
-
     const canPickProcedure = !!unitSlug;
     const canPick = !!unitSlug;
     const hasResolvedDateAvailability = upcomingDays.every((day) => typeof dateAvailability[day] === "boolean");
@@ -1137,14 +1100,14 @@ export default function BookingFlow() {
     }, [dateKey, effectiveDoctorSlug, effectiveServiceId, showDetailsModal, timeKey, unitSlug]);
 
     function selectDoctor(nextDoctor: DoctorSelection | null) {
-        const nextSelection = doctor?.slug === nextDoctor?.slug ? null : nextDoctor;
-        if (!doctor && !nextSelection) return;
+        if (!nextDoctor) return;
+        if (doctor?.slug === nextDoctor.slug) return;
         trackBookingFunnelStep({
-            step: nextSelection ? "doctor_selected" : "doctor_cleared",
+            step: "doctor_selected",
             unitSlug,
-            doctorSlug: nextSelection?.slug ?? null,
+            doctorSlug: nextDoctor.slug,
         });
-        setDoctor(nextSelection);
+        setDoctor(nextDoctor);
         setDateKey(null);
         setDateTouched(false);
         setTimeKey(null);
@@ -1153,11 +1116,13 @@ export default function BookingFlow() {
 
     function toggleProcedure(nextService: Service) {
         setSelectedServices((current) => {
-            const exists = current.some((item) => item.id === nextService.id);
             if (nextService.id === OTHER_SERVICE.id) {
-                const nextSelection = exists ? [] : [OTHER_SERVICE];
+                const alreadySelected = current.some((item) => item.id === OTHER_SERVICE.id);
+                if (alreadySelected) return current;
+
+                const nextSelection = [OTHER_SERVICE];
                 trackBookingFunnelStep({
-                    step: nextSelection.length ? "service_selected" : "service_cleared",
+                    step: "service_selected",
                     unitSlug,
                     doctorSlug: effectiveDoctorSlug,
                     serviceId: nextSelection[0]?.id ?? null,
@@ -1167,9 +1132,12 @@ export default function BookingFlow() {
             }
 
             const withoutOther = current.filter((item) => item.id !== OTHER_SERVICE.id);
-            const nextSelection = exists ? withoutOther.filter((item) => item.id !== nextService.id) : [...withoutOther, nextService];
+            const alreadySelected = withoutOther.some((item) => item.id === nextService.id);
+            if (alreadySelected) return current;
+
+            const nextSelection = [...withoutOther, nextService];
             trackBookingFunnelStep({
-                step: nextSelection.length ? "service_selected" : "service_cleared",
+                step: "service_selected",
                 unitSlug,
                 doctorSlug: effectiveDoctorSlug,
                 serviceId: nextService.id,
@@ -1500,7 +1468,6 @@ export default function BookingFlow() {
                                                     const active = timeKey === s.time;
                                                     const isPast = s.reason === "past";
                                                     const isOccupied = s.reason === "agenda" || s.reason === "booked";
-                                                    const isLocked = isPast || isOccupied;
                                                     const hasTooltip = isPast || isOccupied || s.available;
                                                     const tooltip = isPast ? "passou" : isOccupied ? "ocupado" : s.available ? "disponível" : "";
                                                     const tooltipTone = isPast ? "neutral" : isOccupied ? "occupied" : s.available ? "available" : "neutral";
@@ -1520,7 +1487,7 @@ export default function BookingFlow() {
                                                             disabled={nativeDisabled}
                                                             aria-disabled={ariaDisabled}
                                                             data-reason={s.reason ?? ""}
-                                                            data-locked={isLocked ? "true" : "false"}
+                                                            data-locked={hasTooltip ? "true" : "false"}
                                                             data-tooltip={hasTooltip ? tooltip : undefined}
                                                             data-tooltip-tone={hasTooltip ? tooltipTone : undefined}
                                                             className="bookingFlow__selectItem bookingFlow__timeBtn"
@@ -1583,81 +1550,19 @@ export default function BookingFlow() {
                         )}
                     </div>
                 </div>
-            ) : (
-                <div className="bookingFlow__grid">
-                    <div className="bookingFlow__cardFull">
-                        {submitted ? (
-                            <BookingConfirmationCard
-                                reservation={submitted.reservation}
-                                notifications={submitted.notifications}
-                                variant={isReservationDetailsView ? "details_link" : "default"}
-                            />
-                        ) : null}
-                    </div>
-
-                    {!isReservationDetailsView ? (
-                        <div className="card bookingFlow__cardFull bookingFlow__submittedStatusCard" style={{ padding: 18 }}>
-                            <div style={{ fontWeight: 900, fontSize: 18 }}>
-                                {submitted?.status === "confirmed" ? "Status do agendamento" : "Status do pedido"}
-                            </div>
-
-                            {status ? (
-                                <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px solid var(--border)" }}>
-                                    <div style={{ fontWeight: 900 }}>Status</div>
-                                    <div style={{ marginTop: 6 }}>
-                                        {status.status === "confirmed" ? (
-                                            <span style={{ fontWeight: 900, color: "#16a34a" }}>Confirmado</span>
-                                        ) : status.status === "declined" ? (
-                                            <span style={{ fontWeight: 900, color: "#b91c1c" }}>Não confirmado</span>
-                                        ) : status.status === "expired" ? (
-                                            <span style={{ fontWeight: 900, color: "#b45309" }}>Expirado</span>
-                                        ) : status.status === "needs_approval" ? (
-                                            <span style={{ fontWeight: 900, color: "#b45309" }}>Em análise</span>
-                                        ) : (
-                                            <span style={{ fontWeight: 900 }}>Pendente</span>
-                                        )}
-                                    </div>
-                                    <div className="small" style={{ marginTop: 6 }}>
-                                        Atualiza automaticamente.
-                                    </div>
-                                </div>
-                            ) : null}
-
-                            <div style={{ marginTop: 16, display: "flex", gap: 10, flexWrap: "wrap" }}>
-                                <button
-                                    type="button"
-                                    className="pill"
-                                    onClick={() => {
-                                        // restart
-                                        setStep("pick");
-                                        setDoctor(null);
-                                        setSelectedServices([]);
-                                        setDateKey(null);
-                                        setDateTouched(false);
-                                        setTimeKey(null);
-                                        setPatientName("");
-                                        setPatientGender("");
-                                        setEmail("");
-                                        setWhatsapp("");
-                                        setNotes("");
-                                        setSlots(null);
-                                        setSubmitted(null);
-                                        setStatus(null);
-                                        setSubmitError(null);
-                                        setDetailsStartedAtMs(null);
-                                        setTurnstileToken(null);
-                                        setTurnstileHadError(false);
-                                        clearBookingDraft();
-                                    }}
-                                    style={{ cursor: "pointer" }}
-                                >
-                                    Fazer outro pedido
-                                </button>
-                            </div>
-                        </div>
-                    ) : null}
-                </div>
-            )}
+	            ) : (
+	                <div className="bookingFlow__grid">
+	                    <div className="bookingFlow__cardFull">
+	                        {submitted ? (
+	                            <BookingConfirmationCard
+                                    reservation={submitted.reservation}
+                                    notifications={submitted.notifications}
+                                    variant={isReservationDetailsView ? "details_link" : "default"}
+                                />
+	                        ) : null}
+	                    </div>
+	                </div>
+	            )}
             {showDetailsModal && unitSlug && primaryService && dateKey && timeKey ? (
                 <div
                     className="bookingFlow__modalBackdrop"

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -1782,8 +1782,8 @@ button:focus-visible {
 .bookingConfirmation__hero {
   display: grid;
   justify-items: center;
-  gap: 12px;
-  padding: 28px 24px;
+  gap: 8px;
+  padding: 22px 24px 24px;
   text-align: center;
   background:
     radial-gradient(circle at top right, rgba(197, 186, 171, 0.28), rgba(255, 255, 255, 0) 30%),
@@ -1810,20 +1810,6 @@ button:focus-visible {
   color: #fff;
   font-size: 28px;
   font-weight: 900;
-}
-
-.bookingConfirmation__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  min-height: 32px;
-  padding: 0 14px;
-  border-radius: 999px;
-  background: #f3f3f3;
-  color: #505050;
-  font-size: 11px;
-  font-weight: 900;
-  letter-spacing: .16em;
-  text-transform: uppercase;
 }
 
 .bookingConfirmation__title {
@@ -1953,8 +1939,10 @@ button:focus-visible {
 }
 
 .bookingConfirmation__nextSteps {
-  display: grid;
-  gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
   margin-top: 16px;
 }
 
@@ -1963,13 +1951,19 @@ button:focus-visible {
 }
 
 .bookingConfirmation__nextStep {
-  padding: 14px 16px;
-  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  max-width: 100%;
+  padding: 10px 16px;
+  border-radius: 999px;
   border: 1px solid rgba(17, 17, 17, 0.08);
-  background: rgba(248, 246, 244, 0.92);
-  color: rgba(17, 17, 17, 0.78);
-  font-size: 14px;
-  line-height: 1.55;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 241, 237, 0.94));
+  color: rgba(17, 17, 17, 0.82);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  box-shadow: 0 8px 18px rgba(31, 24, 18, 0.06);
 }
 
 .bookingConfirmation__actions {
@@ -2314,7 +2308,8 @@ button:focus-visible {
 }
 
 .bookingFlow__doctorBadge:hover .bookingFlow__doctorBadgeAvatar,
-.bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar {
+.bookingFlow__doctorBadge:focus-visible .bookingFlow__doctorBadgeAvatar,
+.bookingFlow__doctorBadgeWrap[data-active="true"] .bookingFlow__doctorBadgeAvatar {
   transform: translateY(-2px);
   border-color: rgba(17, 17, 17, 0.88);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
@@ -2566,12 +2561,19 @@ button:focus-visible {
 .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar,
 .bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar {
   transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
+}
+
+.bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeAvatar,
+.bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeAvatar {
+  transform: translateY(-2px);
   border-color: rgba(17, 17, 17, 0.88);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
 }
 
 .bookingFlow__procedureBadge:hover:not(:disabled),
-.bookingFlow__procedureBadge:focus-visible {
+.bookingFlow__procedureBadge:focus-visible,
+.bookingFlow__procedureBadge[data-active="true"] {
   transform: translateY(-1px);
 }
 
@@ -2584,7 +2586,9 @@ button:focus-visible {
 }
 
 .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar img,
-.bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar img {
+.bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar img,
+.bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeAvatar img,
+.bookingFlow__procedureBadgeWrap[data-active="true"] .bookingFlow__procedureBadgeAvatar img {
   filter: saturate(1) grayscale(0);
   transform: scale(1.03);
 }
@@ -2614,8 +2618,8 @@ button:focus-visible {
 
 .bookingFlow__procedureBadgeWrap:not([data-active="true"]) .bookingFlow__procedureBadge:hover:not(:disabled) .bookingFlow__procedureBadgeAvatar--all,
 .bookingFlow__procedureBadgeWrap:not([data-active="true"]) .bookingFlow__procedureBadge:focus-visible .bookingFlow__procedureBadgeAvatar--all {
-  background: #000;
-  border-color: #000;
+  background: #16a34a;
+  border-color: rgba(22, 163, 74, 0.72);
 }
 
 .bookingFlow__procedureBadge[data-active="true"] .bookingFlow__procedureBadgeAvatar--all,
@@ -2723,7 +2727,6 @@ button:focus-visible {
   border-radius: 12px;
   font-weight: 900;
   text-align: center;
-  cursor: pointer;
 }
 
 .bookingFlow__dateHint {
@@ -6930,21 +6933,28 @@ video.heroMediaEl {
 }
 
 .unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeAvatar,
-.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar {
+.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeAvatar,
+.unitDoctorsCompact__item:hover .bookingFlow__doctorBadgeAvatar {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
+}
+
+.unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeAvatar,
+.unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeAvatar {
   transform: translateY(-2px);
   border-color: rgba(17, 17, 17, 0.88);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
 }
 
-.unitDoctorsCompact__avatarTrigger:hover .bookingFlow__doctorBadgeFallback--all,
-.unitDoctorsCompact__avatarTrigger:focus-visible .bookingFlow__doctorBadgeFallback--all {
-  transform: translateY(-1px);
+.unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeFallback--all,
+.unitDoctorsCompact__item[data-active="true"] .bookingFlow__doctorBadgeFallback--all {
+  transform: none;
 }
 
 .unitDoctorsCompact__avatarTrigger:not([data-active="true"]):hover .bookingFlow__doctorBadgeAvatar--all,
 .unitDoctorsCompact__avatarTrigger:not([data-active="true"]):focus-visible .bookingFlow__doctorBadgeAvatar--all {
-  background: #000;
-  border-color: #000;
+  background: #16a34a;
+  border-color: rgba(22, 163, 74, 0.72);
 }
 
 .unitDoctorsCompact__avatarTrigger--select[data-active="true"] .bookingFlow__doctorBadgeAvatar--all,


### PR DESCRIPTION
## Summary
This changes the website booking flow so the site agenda mirrors only the real schedule coming from the system sync, instead of self-blocking from local website booking records.

## Problem
The booking flow was treating `booking_requests` created by the website itself as scheduling locks. That meant a booking created on the site could immediately occupy a slot in the website agenda even before the downstream automation actually created the appointment in `app.espacofacial.com.br`.

That behavior breaks the source-of-truth model. If the automation later changes the appointment in the system, or fails to create it there, the site can remain blocked by stale local state that no longer matches the real agenda.

## Root cause
Two API paths were using `booking_requests` as if they were confirmed schedule occupancy:

- `GET /api/booking/slots` combined scraped agenda data with local booking request records and marked slots as unavailable from website-side requests.
- `POST /api/booking/request` also rejected new requests based on overlapping `booking_requests`, including pending and confirmed local records.

This made the website act as its own scheduler instead of reflecting the synced system agenda.

## Fix
The scheduling rule is now:

- Website requests are persisted for protocol, notifications, and automation handoff.
- Slot blocking is driven only by `agenda_appointments`, which is the synced reflection of the real system agenda.
- A website request does not reserve a slot by itself.
- The slot becomes unavailable on the site only after the automation creates the appointment in the system and that occupancy appears in the synced agenda.

Concretely:

- Removed `booking_requests` overlap blocking from `website/src/app/api/booking/slots/route.ts`.
- Removed `booking_requests` conflict blocking from `website/src/app/api/booking/request/route.ts`.
- Kept persistence of website requests intact for protocol and automation payloads.
- Included the booking flow UI changes from this thread in the same branch so the procedure and doctor selections remain visually stable and explicit.

## Validation
I validated the isolated branch in a clean worktree with:

- `npx tsc -p tsconfig.json --noEmit`
- `npm test`
- `npm run build`

All passed before pushing this branch.
