### PR TITLE
fix(auth): stabilize csrf across tabs and proxies

### DIFF
--- a/backend/apps/insumos/src/routes/auth.js
+++ b/backend/apps/insumos/src/routes/auth.js
@@ -351,8 +351,10 @@ export async function handleAuthRoutes({
 	                    allowedUnits: userDb.allowedUnits || [],
 	                    allowedModules: userDb.allowedModules || [],
 	                };
-                const { headers: headersOut, csrf } = await issueAuthCookies({ username: userDb.username });
-                return withCORS(JSON.stringify({ success: true, user, csrfToken: csrf }), { status: 200, headers: headersOut }, appOrigin);
+                // `/auth/me` is read-only. Rotating cookies here invalidates CSRF tokens
+                // cached by other open tabs/modules and causes intermittent mutation failures.
+                const csrfToken = cookies.csrfToken || sessionCsrf || null;
+                return withCORS(JSON.stringify({ success: true, user, csrfToken }), { status: 200 }, appOrigin);
             } catch (err) {
                 return withCORS(JSON.stringify({ error: `Auth error: ${err.message}` }), { status: 500 }, appOrigin);
             }

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { Textarea } from '@/textarea'
 import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { getCsrfToken } from '@/csrf'
 
 type InsumosHealth = {
   ok?: boolean
@@ -966,7 +967,8 @@ async function apiJson<T>(
   const method = String(opts.method || 'GET').toUpperCase()
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (opts.body !== undefined) headers['content-type'] = 'application/json'
-  if (opts.csrfToken) headers['x-csrf-token'] = opts.csrfToken
+  const effectiveCsrfToken = getCsrfToken() || opts.csrfToken || null
+  if (effectiveCsrfToken) headers['x-csrf-token'] = effectiveCsrfToken
   if (opts.idempotencyKey) headers['idempotency-key'] = opts.idempotencyKey
 
   const url = path.startsWith('/api/insumos') ? path : `/api/insumos${path.startsWith('/') ? '' : '/'}${path}`

--- a/frontend/SystemStatusModule.tsx
+++ b/frontend/SystemStatusModule.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/switch'
 import { DEFAULT_UNIT_OPTIONS, useGlobalUnitSelection } from '@/unitSelection'
 import { LoadingPercentButton, LoadingPercentText } from '@/LoadingPattern'
+import { getCsrfToken } from '@/csrf'
 
 type StatusKind = 'ok' | 'warn' | 'error' | 'unknown'
 
@@ -102,7 +103,8 @@ async function apiJson<T>(
   const method = opts.method || 'GET'
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (opts.body !== undefined) headers['content-type'] = 'application/json'
-  if (opts.csrfToken) headers['x-csrf-token'] = opts.csrfToken
+  const effectiveCsrfToken = getCsrfToken() || opts.csrfToken || null
+  if (effectiveCsrfToken) headers['x-csrf-token'] = effectiveCsrfToken
 
   let url = ''
   if (path.startsWith('/api/')) {

--- a/frontend/UsersModule.tsx
+++ b/frontend/UsersModule.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { Button } from '@/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
+import { getCsrfToken } from '@/csrf'
 import { Input } from '@/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { LoadingPercentText } from '@/LoadingPattern'
@@ -61,7 +62,8 @@ async function insumosApiJson<T>(
   const method = (opts.method || 'GET').toUpperCase()
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (opts.body !== undefined) headers['content-type'] = 'application/json'
-  if (opts.csrfToken) headers['x-csrf-token'] = opts.csrfToken
+  const effectiveCsrfToken = getCsrfToken() || opts.csrfToken || null
+  if (effectiveCsrfToken) headers['x-csrf-token'] = effectiveCsrfToken
 
   let url = ''
   if (path.startsWith('/api/')) {

--- a/frontend/functions/api/auth/[[path]].ts
+++ b/frontend/functions/api/auth/[[path]].ts
@@ -76,6 +76,14 @@ export async function onRequest(context: any): Promise<Response> {
         }
         copySetCookieHeaders(upstream.headers, outHeaders, rewriteCookie)
 
+        const hasAuthCookies = (outHeaders.get('set-cookie') || '').includes('session=')
+        if (sharedDomain && hasAuthCookies) {
+            const secureAttr = url.protocol === 'https:' ? '; Secure' : ''
+            const sameSite = url.protocol === 'https:' ? 'None' : 'Lax'
+            outHeaders.append('Set-Cookie', `session=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}; HttpOnly`)
+            outHeaders.append('Set-Cookie', `csrfToken=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}`)
+        }
+
         // Backward-compat: old deployments could have host-only auth cookies.
         // On logout, clear both host-only and shared-domain variants.
         if (rest === '/logout' && method === 'POST') {

--- a/frontend/functions/api/insumos/[[path]].ts
+++ b/frontend/functions/api/insumos/[[path]].ts
@@ -62,15 +62,33 @@ export async function onRequest(context: any): Promise<Response> {
     outHeaders.set('Cache-Control', 'no-store')
 
     try {
+        const host = url.hostname
+        const sharedDomain = host === 'skincos.com.br' || host.endsWith('.skincos.com.br')
+          ? '.skincos.com.br'
+          : ''
         const rewriteCookie = (cookie: string) => {
             if (!cookie) return cookie
             const parts = cookie.split(';').map(part => part.trim()).filter(Boolean)
             if (!parts.length) return cookie
             const [nameValue, ...attrs] = parts
             const filtered = attrs.filter(attr => !attr.toLowerCase().startsWith('domain='))
+            if (sharedDomain) filtered.push(`Domain=${sharedDomain}`)
             return [nameValue, ...filtered].join('; ')
         }
         copySetCookieHeaders(upstream.headers, outHeaders, rewriteCookie)
+
+        // Backward-compat: older proxy behavior could leave host-only auth cookies
+        // alongside the shared-domain cookies. Clear the host-only variants once the
+        // worker refreshes auth cookies to keep session/csrf pairs aligned.
+        const hasAuthCookies =
+          rest.startsWith('/auth/') &&
+          (outHeaders.get('set-cookie') || '').includes('session=')
+        if (sharedDomain && hasAuthCookies) {
+          const secureAttr = url.protocol === 'https:' ? '; Secure' : ''
+          const sameSite = url.protocol === 'https:' ? 'None' : 'Lax'
+          outHeaders.append('Set-Cookie', `session=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}; HttpOnly`)
+          outHeaders.append('Set-Cookie', `csrfToken=deleted; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}`)
+        }
     } catch {
         // ignore
     }

--- a/frontend/tests/insumosProxy.test.ts
+++ b/frontend/tests/insumosProxy.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { onRequest } from '../functions/api/insumos/[[path]].ts'
+
+function createContext(url: string, env: Record<string, unknown> = {}) {
+  return {
+    request: new Request(url, {
+      headers: {
+        accept: 'application/json',
+        cookie: 'session=old-host-cookie; csrfToken=old-host-csrf',
+      },
+    }),
+    env,
+  }
+}
+
+function getSetCookies(response: Response): string[] {
+  const getSetCookie = (response.headers as any).getSetCookie?.bind?.(response.headers)
+  if (typeof getSetCookie === 'function') return getSetCookie() as string[]
+  const raw = response.headers.get('set-cookie')
+  return raw ? [raw] : []
+}
+
+describe('Insumos proxy cookie contract', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('rewrites auth cookies to the shared skincos domain and clears legacy host-only variants', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: true, csrfToken: 'new-csrf' }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'set-cookie': [
+              'session=new-session; Path=/; HttpOnly; Secure; SameSite=None; Domain=api.skincos.com.br; Max-Age=604800',
+              'csrfToken=new-csrf; Path=/; Secure; SameSite=None; Domain=api.skincos.com.br; Max-Age=604800',
+            ].join(', '),
+          },
+        }),
+      ),
+    )
+
+    const response = await onRequest(
+      createContext('https://crm.skincos.com.br/api/insumos/auth/me', {
+        INSUMOS_API_TARGET: 'https://api.skincos.com.br',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const cookies = getSetCookies(response)
+    expect(cookies).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('session=new-session'),
+        expect.stringContaining('csrfToken=new-csrf'),
+        expect.stringContaining('Domain=.skincos.com.br'),
+        expect.stringContaining('session=deleted'),
+        expect.stringContaining('csrfToken=deleted'),
+      ]),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- stop rotating CSRF/session cookies on read-only `/auth/me` calls
- make Insumos frontend mutations prefer the live CSRF cookie over stale in-memory state
- align Pages auth/insumos proxy cookie rewriting and add a regression test for shared-domain cleanup

## Why
Production kept regressing because manual hotfix deploys were later overwritten by automatic deploys from `main` without the patch. This change persists the fix in source control and covers the proxy contract with a test.

## Validation
- `npm test -- tests/insumosProxy.test.ts tests/escalaProxy.test.ts`
