### PR TITLE
feat: add authenticated instagram sync primary

### DIFF
--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Forçar sync completo"
+        description: "Forcar sync completo"
         required: false
         default: "false"
       include_stories:
@@ -26,6 +26,15 @@ jobs:
     env:
       INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
       WEBSITE_BASE_URL: https://espacofacial.com
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      INSTAGRAPI_LOGIN_USERNAME: ${{ secrets.INSTAGRAPI_LOGIN_USERNAME }}
+      INSTAGRAPI_LOGIN_PASSWORD: ${{ secrets.INSTAGRAPI_LOGIN_PASSWORD }}
+      INSTAGRAPI_SESSIONID: ${{ secrets.INSTAGRAPI_SESSIONID }}
+      INSTAGRAPI_VERIFICATION_CODE: ${{ secrets.INSTAGRAPI_VERIFICATION_CODE }}
+      INSTAGRAPI_SESSION_JSON: ${{ secrets.INSTAGRAPI_SESSION_JSON }}
+      INSTAGRAPI_SESSION_BUCKET: skincos-espacofacial-instagram-sync
+      INSTAGRAPI_SESSION_OBJECT: production/instagrapi-session.json
 
     steps:
       - name: Guard sync settings
@@ -33,16 +42,110 @@ jobs:
         run: |
           if [[ -z "${INSTAGRAM_SYNC_TOKEN:-}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "INSTAGRAM_SYNC_TOKEN não configurado; pulando sync."
+            echo "INSTAGRAM_SYNC_TOKEN nao configurado; pulando sync."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Trigger website Instagram sync
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Setup Python
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install website dependencies
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        working-directory: website
+        run: npm ci
+
+      - name: Install instagrapi runtime
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          python -m venv .venv-instagram-sync
+          . .venv-instagram-sync/bin/activate
+          pip install -r backend/apps/instagram/instagrapi/requirements.txt
+
+      - name: Restore instagrapi session
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: restore_session
+        run: |
+          set -euo pipefail
+          SESSION_DIR="$RUNNER_TEMP/instagram-sync"
+          SESSION_FILE="$SESSION_DIR/instagrapi-session.json"
+          mkdir -p "$SESSION_DIR"
+
+          if [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            cd website
+            npx wrangler r2 bucket create "${INSTAGRAPI_SESSION_BUCKET}" >/dev/null 2>&1 || true
+            npx wrangler r2 object get "${INSTAGRAPI_SESSION_BUCKET}/${INSTAGRAPI_SESSION_OBJECT}" --remote --file "$SESSION_FILE" >/dev/null 2>&1 || true
+            cd ..
+          fi
+
+          if [[ ! -s "$SESSION_FILE" && -n "${INSTAGRAPI_SESSION_JSON:-}" ]]; then
+            printf "%s" "${INSTAGRAPI_SESSION_JSON}" > "$SESSION_FILE"
+          fi
+
+          echo "session_file=$SESSION_FILE" >> "$GITHUB_OUTPUT"
+          echo "summary_file=$SESSION_DIR/summary.json" >> "$GITHUB_OUTPUT"
+
+      - name: Run primary instagrapi sync
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: primary
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          FORCE_INPUT="${{ github.event.inputs.force || 'false' }}"
+          STORIES_INPUT="${{ github.event.inputs.include_stories || 'true' }}"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            FORCE_INPUT="false"
+            STORIES_INPUT="true"
+          fi
+
+          . .venv-instagram-sync/bin/activate
+          INSTAGRAPI_INCLUDE_STORIES="$STORIES_INPUT" \
+          INSTAGRAPI_MAX_FEED_ITEMS="120" \
+          INSTAGRAPI_SYNC_SUMMARY_FILE="${{ steps.restore_session.outputs.summary_file }}" \
+          INSTAGRAPI_SESSION_FILE="${{ steps.restore_session.outputs.session_file }}" \
+          WEBSITE_BASE_URL="${WEBSITE_BASE_URL}" \
+          PYTHONPATH="backend/apps/instagram/instagrapi" \
+          python backend/apps/instagram/module/instagram_site_sync.py \
+            --summary-file "${{ steps.restore_session.outputs.summary_file }}" \
+            --session-file "${{ steps.restore_session.outputs.session_file }}" \
+            --max-feed-items 120
+
+      - name: Persist instagrapi session
         if: ${{ steps.guard.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
+          SESSION_FILE="${{ steps.restore_session.outputs.session_file }}"
+          if [[ ! -s "$SESSION_FILE" ]]; then
+            exit 0
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            exit 0
+          fi
+          cd website
+          npx wrangler r2 bucket create "${INSTAGRAPI_SESSION_BUCKET}" >/dev/null 2>&1 || true
+          npx wrangler r2 object put "${INSTAGRAPI_SESSION_BUCKET}/${INSTAGRAPI_SESSION_OBJECT}" --remote --file "$SESSION_FILE" --content-type "application/json"
 
+      - name: Fallback to website web sync when needed
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          set -euo pipefail
+          SUMMARY_FILE="${{ steps.restore_session.outputs.summary_file }}"
           FORCE_INPUT="${{ github.event.inputs.force || 'false' }}"
           STORIES_INPUT="${{ github.event.inputs.include_stories || 'true' }}"
 
@@ -60,42 +163,64 @@ jobs:
             0|false|no) stories_bool="false" ;;
           esac
 
-          payload=$(printf '{"force":%s,"includeStories":%s,"maxFeedItems":120,"concurrency":3,"maxHandleRetries":2,"retryDelayMs":1200,"source":"github_actions_schedule_enriched"}' \
-            "${force_bool}" "${stories_bool}")
+          fallback_handles="[]"
+          fallback_reason=""
 
-          max_http_attempts=3
-          http_success="false"
-          status="000"
+          if [[ ! -f "$SUMMARY_FILE" ]]; then
+            fallback_reason="missing_primary_summary"
+          else
+            cat "$SUMMARY_FILE"
+            echo
 
-          for attempt in $(seq 1 "${max_http_attempts}"); do
-            echo "POST ${WEBSITE_BASE_URL}/api/instagram/sync (tentativa ${attempt}/${max_http_attempts})"
-            status=$(curl -sS -o response.json -w "%{http_code}" \
-              -X POST "${WEBSITE_BASE_URL}/api/instagram/sync" \
-              -H "content-type: application/json" \
-              -H "authorization: Bearer ${INSTAGRAM_SYNC_TOKEN}" \
-              --data "$payload" || true)
+            primary_ok=$(jq -r '.ok // false' "$SUMMARY_FILE")
+            configuration_status=$(jq -r '.configurationStatus // ""' "$SUMMARY_FILE")
+            failure_count=$(jq -r '.failureCount // 0' "$SUMMARY_FILE")
 
-            if [[ "$status" -ge 200 && "$status" -lt 300 ]] && jq -e '.ok == true' response.json >/dev/null 2>&1; then
-              http_success="true"
-              break
+            if [[ "$primary_ok" == "true" && "$failure_count" -eq 0 ]]; then
+              echo "Primary instagrapi sync completed without fallback."
+              exit 0
             fi
 
-            if [[ "$attempt" -lt "$max_http_attempts" ]]; then
-              sleep $((attempt * 5))
+            if [[ "$failure_count" -gt 0 ]]; then
+              fallback_handles=$(jq -c '.failedHandles // []' "$SUMMARY_FILE")
+              fallback_reason="primary_partial_failure"
+            else
+              fallback_reason="${configuration_status:-primary_unavailable}"
             fi
-          done
+          fi
+
+          payload=$(jq -cn \
+            --argjson force "$force_bool" \
+            --argjson includeStories "$stories_bool" \
+            --argjson handles "$fallback_handles" \
+            --arg source "github_actions_fallback_after_instagrapi:${fallback_reason}" \
+            '{
+              force: $force,
+              includeStories: $includeStories,
+              maxFeedItems: 120,
+              concurrency: 3,
+              maxHandleRetries: 2,
+              retryDelayMs: 1200,
+              source: $source
+            } + (if ($handles | length) > 0 then {handles: $handles} else {} end)')
+
+          status=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "${WEBSITE_BASE_URL}/api/instagram/sync" \
+            -H "content-type: application/json" \
+            -H "authorization: Bearer ${INSTAGRAM_SYNC_TOKEN}" \
+            --data "$payload")
 
           cat response.json
           echo
 
-          if [[ "$http_success" != "true" ]]; then
-            echo "Sync falhou após ${max_http_attempts} tentativas (último HTTP ${status})"
+          if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
+            echo "Fallback sync failed with HTTP ${status}"
             exit 1
           fi
 
-          failure_count=$(jq -r '.failureCount // 0' response.json)
-          if [[ "$failure_count" -gt 0 ]]; then
-            echo "Sync concluído com ${failure_count} falhas após retries internos por handle."
+          fallback_failure_count=$(jq -r '.failureCount // 0' response.json)
+          if [[ "$fallback_failure_count" -gt 0 ]]; then
+            echo "Fallback sync still has ${fallback_failure_count} hard failures."
             jq -c '.results[] | select(.ok != true) | {handle,error,attempts}' response.json || true
             exit 1
           fi

--- a/backend/apps/instagram/instagrapi/instagrapi/extractors.py
+++ b/backend/apps/instagram/instagrapi/instagrapi/extractors.py
@@ -199,7 +199,8 @@ def extract_user_short(data):
 
 def extract_broadcast_channel(data):
     """ Extract broadcast channel infos """
-    channels = data["pinned_channels_info"]["pinned_channels_list"]
+    pinned_channels_info = data.get("pinned_channels_info") or {}
+    channels = pinned_channels_info.get("pinned_channels_list") or []
     return [Broadcast(**channel) for channel in channels]
 
 

--- a/backend/apps/instagram/instagrapi/instagrapi/mixins/auth.py
+++ b/backend/apps/instagram/instagrapi/instagrapi/mixins/auth.py
@@ -370,10 +370,17 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         }
         try:
             user = self.user_info_v1(int(user_id))
-        except (PrivateError, ValidationError):
-            user = self.user_short_gql(int(user_id))
-        self.username = user.username
-        self.cookie_dict["ds_user_id"] = user.pk
+            self.username = user.username
+            self.cookie_dict["ds_user_id"] = user.pk
+        except Exception:
+            try:
+                current_user = self.private_request("accounts/current_user/?edit=true").get(
+                    "user", {}
+                )
+            except Exception:
+                current_user = {}
+            self.username = current_user.get("username", self.username or "")
+            self.cookie_dict["ds_user_id"] = current_user.get("pk", user_id)
         return True
 
     def login(

--- a/backend/apps/instagram/module/README.md
+++ b/backend/apps/instagram/module/README.md
@@ -5,6 +5,7 @@ Serviço Instagram do SKINCOS: API Node + módulo Python (OSINT/automação/down
 ## Start
 - API Node: `./backend/scripts/dev.sh instagram-module start` (env `INSTAGRAM_PORT`, default 3103)
 - Python (se usado no fluxo): `python3 backend/apps/instagram/module/instagram_main.py`
+- Sync autenticado do site: `python3 backend/apps/instagram/module/instagram_site_sync.py`
 
 ## Config
 - Local (ignorado): `backend/apps/instagram/module/config/config.local.json`
@@ -13,3 +14,8 @@ Serviço Instagram do SKINCOS: API Node + módulo Python (OSINT/automação/down
 
 ## Estado local
 - Preferir `backend/var/instagram-module/` para dados locais (symlinks já apontam para `backend/var/`).
+
+## Sync do site
+- O fluxo principal do site usa `instagrapi` via `backend/apps/instagram/module/instagram_site_sync.py`.
+- Esse script foi desenhado para GitHub Actions, com sessão persistida em arquivo (`INSTAGRAPI_SESSION_FILE`) e ingestão no cache do website via `POST /api/instagram/ingest`.
+- Quando o sync autenticado não está configurado ou falha parcialmente, o website cai para o método web atual como fallback.

--- a/backend/apps/instagram/module/instagram_site_sync.py
+++ b/backend/apps/instagram/module/instagram_site_sync.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""
+Authenticated Instagram sync for the Espaco Facial website.
+
+Runs in GitHub Actions with an optional persisted instagrapi session file and
+pushes normalized profile/media snapshots back into the website cache API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+INSTAGRAPI_ROOT = SCRIPT_DIR.parent / "instagrapi"
+if str(INSTAGRAPI_ROOT) not in sys.path:
+    sys.path.insert(0, str(INSTAGRAPI_ROOT))
+
+
+
+INSTAGRAM_APP_ID = "936619743392459"
+INSTAGRAM_WEB_BASE = "https://www.instagram.com"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def int_env(name: str, default: int, min_value: int, max_value: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(min_value, min(max_value, value))
+
+
+def float_env(name: str, default: float, min_value: float, max_value: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(min_value, min(max_value, value))
+
+
+def normalize_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def normalize_count(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0, parsed)
+
+
+def iso_payload(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        if hasattr(value, "model_dump"):
+            payload = value.model_dump(mode="json")
+        elif hasattr(value, "dict"):
+            payload = value.dict()
+        else:
+            payload = value
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    except Exception:
+        return None
+
+
+@dataclass
+class SyncConfig:
+    website_base_url: str
+    sync_token: str
+    session_file: Path
+    username: str
+    password: str
+    sessionid: str
+    verification_code: str
+    include_stories: bool
+    max_feed_items: int
+    delay_seconds: float
+    request_timeout_seconds: int
+    summary_file: Optional[Path]
+    handles: List[str]
+
+
+@dataclass
+class HandleSummary:
+    handle: str
+    ok: bool
+    error: Optional[str]
+    source: str
+    fetched_items: int
+    fetched_stories: int
+    upserted_items: int
+
+
+class InstagramSessionClient:
+    def __init__(self, *, sessionid: str, request_timeout_seconds: int):
+        self.sessionid = sessionid
+        self.request_timeout_seconds = request_timeout_seconds
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "user-agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "accept": "application/json,text/plain,*/*",
+                "accept-language": "pt-BR,pt;q=0.9,en;q=0.8",
+                "x-ig-app-id": INSTAGRAM_APP_ID,
+                "origin": INSTAGRAM_WEB_BASE,
+                "referer": f"{INSTAGRAM_WEB_BASE}/",
+            }
+        )
+        self.session.cookies.set("sessionid", sessionid, domain=".instagram.com")
+        self.viewer_username: Optional[str] = None
+        self.viewer_user_id: Optional[str] = None
+
+    def _get_json(self, url: str) -> Dict[str, Any]:
+        response = self.session.get(url, timeout=self.request_timeout_seconds)
+        response.raise_for_status()
+        return response.json()
+
+    def bootstrap_viewer(self) -> None:
+        response = self.session.get(f"{INSTAGRAM_WEB_BASE}/", timeout=self.request_timeout_seconds)
+        response.raise_for_status()
+
+        web_profile = self._get_json(f"{INSTAGRAM_WEB_BASE}/api/v1/users/web_profile_info/?username=skincosofficial")
+        user = ((web_profile.get("data") or {}).get("user")) or {}
+        self.viewer_username = normalize_str(user.get("username"))
+        self.viewer_user_id = normalize_str(user.get("id"))
+
+    def fetch_profile(self, handle: str) -> Dict[str, Any]:
+        payload = self._get_json(
+            f"{INSTAGRAM_WEB_BASE}/api/v1/users/web_profile_info/?username={requests.utils.quote(handle)}"
+        )
+        user = ((payload.get("data") or {}).get("user")) or {}
+        if not user:
+            raise RuntimeError(f"profile_not_found:{handle}")
+        return user
+
+    def fetch_feed_page(self, user_id: str, *, cursor: Optional[str], count: int) -> Dict[str, Any]:
+        url = f"{INSTAGRAM_WEB_BASE}/api/v1/feed/user/{requests.utils.quote(user_id)}/?count={count}"
+        if cursor:
+            url += f"&max_id={requests.utils.quote(cursor)}"
+        return self._get_json(url)
+
+    def fetch_feed_items(self, user_id: str, *, amount: int) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        while len(items) < amount:
+            page = self.fetch_feed_page(user_id, cursor=cursor, count=min(33, amount - len(items)))
+            page_items = page.get("items") or []
+            if isinstance(page_items, list):
+                items.extend(item for item in page_items if isinstance(item, dict))
+            more_available = bool(page.get("more_available"))
+            cursor = normalize_str(page.get("next_max_id"))
+            if not more_available or not cursor:
+                break
+        return items[:amount]
+
+    def fetch_story_items(self, user_id: str) -> List[Dict[str, Any]]:
+        try:
+            payload = self._get_json(
+                f"{INSTAGRAM_WEB_BASE}/api/v1/feed/reels_media/?reel_ids={requests.utils.quote(user_id)}"
+            )
+        except Exception:
+            return []
+        reels = payload.get("reels")
+        if not isinstance(reels, dict):
+            return []
+        direct = reels.get(user_id)
+        if isinstance(direct, dict) and isinstance(direct.get("items"), list):
+            return [item for item in direct["items"] if isinstance(item, dict)]
+        for value in reels.values():
+            if isinstance(value, dict) and isinstance(value.get("items"), list):
+                return [item for item in value["items"] if isinstance(item, dict)]
+        return []
+
+
+class WebsiteSyncClient:
+    def __init__(self, config: SyncConfig):
+        self.config = config
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "authorization": f"Bearer {config.sync_token}",
+                "content-type": "application/json",
+                "user-agent": "skincos-instagrapi-sync/1.0",
+            }
+        )
+
+    def _url(self, path: str) -> str:
+        return f"{self.config.website_base_url.rstrip('/')}{path}"
+
+    def fetch_targets(self) -> List[str]:
+        if self.config.handles:
+            return self.config.handles
+        response = self.session.get(
+            self._url("/api/instagram/sync-targets"),
+            timeout=self.config.request_timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        targets = payload.get("targets") or []
+        handles: List[str] = []
+        for target in targets:
+            handle = normalize_str((target or {}).get("handle"))
+            if handle:
+                handles.append(handle.lower())
+        return sorted(set(handles))
+
+    def ingest_snapshot(
+        self,
+        handle: str,
+        profile: Dict[str, Any],
+        items: List[Dict[str, Any]],
+        source: str,
+    ) -> Dict[str, Any]:
+        response = self.session.post(
+            self._url("/api/instagram/ingest"),
+            timeout=self.config.request_timeout_seconds,
+            data=json.dumps(
+                {
+                    "handle": handle,
+                    "source": source,
+                    "profile": profile,
+                    "items": items,
+                },
+                ensure_ascii=False,
+            ),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def build_config(args: argparse.Namespace) -> SyncConfig:
+    base_url = normalize_str(args.base_url or os.getenv("WEBSITE_BASE_URL")) or "https://espacofacial.com"
+    token = normalize_str(os.getenv("INSTAGRAM_SYNC_TOKEN")) or ""
+    session_file = Path(
+        normalize_str(args.session_file or os.getenv("INSTAGRAPI_SESSION_FILE"))
+        or str(SCRIPT_DIR / ".instagrapi-session.json")
+    )
+    summary_file = normalize_str(args.summary_file or os.getenv("INSTAGRAPI_SYNC_SUMMARY_FILE"))
+    handles = [handle.strip().lstrip("@").lower() for handle in (args.handles or "").split(",") if handle.strip()]
+    return SyncConfig(
+        website_base_url=base_url,
+        sync_token=token,
+        session_file=session_file,
+        username=normalize_str(os.getenv("INSTAGRAPI_LOGIN_USERNAME")) or "",
+        password=normalize_str(os.getenv("INSTAGRAPI_LOGIN_PASSWORD")) or "",
+        sessionid=normalize_str(os.getenv("INSTAGRAPI_SESSIONID")) or "",
+        verification_code=normalize_str(os.getenv("INSTAGRAPI_VERIFICATION_CODE")) or "",
+        include_stories=bool_env("INSTAGRAPI_INCLUDE_STORIES", args.include_stories),
+        max_feed_items=int_env("INSTAGRAPI_MAX_FEED_ITEMS", args.max_feed_items, 9, 180),
+        delay_seconds=float_env("INSTAGRAPI_HANDLE_DELAY_SECONDS", args.delay_seconds, 0.0, 15.0),
+        request_timeout_seconds=int_env("INSTAGRAPI_REQUEST_TIMEOUT_SECONDS", 60, 10, 300),
+        summary_file=Path(summary_file) if summary_file else None,
+        handles=handles,
+    )
+
+
+def ensure_session_parent(session_file: Path) -> None:
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_saved_sessionid(session_file: Path) -> str:
+    if not session_file.exists():
+        return ""
+    try:
+        payload = json.loads(session_file.read_text())
+    except Exception:
+        return ""
+    if isinstance(payload, dict):
+        direct = normalize_str(payload.get("sessionid"))
+        if direct:
+            return direct
+        cookies = payload.get("cookies")
+        if isinstance(cookies, dict):
+            return normalize_str(cookies.get("sessionid")) or ""
+    return ""
+
+
+def save_session_state(session_file: Path, *, sessionid: str, viewer_username: Optional[str], viewer_user_id: Optional[str]) -> None:
+    ensure_session_parent(session_file)
+    session_file.write_text(
+        json.dumps(
+            {
+                "sessionid": sessionid,
+                "viewer_username": viewer_username,
+                "viewer_user_id": viewer_user_id,
+                "saved_at": utc_now_iso(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+def authenticate_client(config: SyncConfig) -> tuple[InstagramSessionClient, str]:
+    sessionid = config.sessionid or load_saved_sessionid(config.session_file)
+    if not sessionid:
+        raise RuntimeError("instagrapi_not_configured")
+
+    client = InstagramSessionClient(
+        sessionid=sessionid,
+        request_timeout_seconds=config.request_timeout_seconds,
+    )
+    try:
+        client.bootstrap_viewer()
+    except Exception as exc:
+        raise RuntimeError(f"instagrapi_session_invalid: {exc}") from exc
+
+    save_session_state(
+        config.session_file,
+        sessionid=sessionid,
+        viewer_username=client.viewer_username,
+        viewer_user_id=client.viewer_user_id,
+    )
+    return client, "sessionid"
+
+
+def best_resource_thumbnail(resources: Iterable[Any]) -> Optional[str]:
+    for resource in resources:
+        url = (
+            normalize_str(value_of(resource, "thumbnail_url"))
+            or normalize_str(value_of(resource, "src"))
+            or normalize_str(value_of(resource, "url"))
+            or normalize_str(value_of(resource, "display_url"))
+        )
+        if url:
+            return url
+    return None
+
+
+def best_resource_video(resources: Iterable[Any]) -> Optional[str]:
+    for resource in resources:
+        url = (
+            normalize_str(value_of(resource, "video_url"))
+            or normalize_str(value_of(resource, "src"))
+            or normalize_str(value_of(resource, "url"))
+        )
+        if url:
+            return url
+    return None
+
+
+def value_of(item: Any, key: str, default: Any = None) -> Any:
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+def media_permalink(handle: str, code: Optional[str], is_story: bool, media_type: str, media_pk: str) -> Optional[str]:
+    if is_story:
+        return f"https://www.instagram.com/stories/{handle}/{media_pk}/"
+    if not code:
+        return None
+    if media_type == "video":
+        return f"https://www.instagram.com/reel/{code}/"
+    return f"https://www.instagram.com/p/{code}/"
+
+
+def normalize_media(handle: str, media: Any, *, is_story: bool) -> Optional[Dict[str, Any]]:
+    media_pk = normalize_str(value_of(media, "pk") or value_of(media, "id"))
+    if not media_pk:
+        return None
+
+    media_type_number = int(value_of(media, "media_type", 1) or 1)
+    media_type = "carousel" if media_type_number == 8 else "video" if media_type_number == 2 else "image"
+    carousel = value_of(media, "carousel_media") or value_of(media, "resources") or []
+    resources = list(carousel or [])
+
+    thumbnail_url = (
+        normalize_str(value_of(media, "thumbnail_url"))
+        or normalize_str(value_of(media, "display_url"))
+        or best_resource_thumbnail(value_of(media, "image_versions2", {}).get("candidates", []) if isinstance(value_of(media, "image_versions2"), dict) else [])
+        or best_resource_thumbnail(resources)
+        or normalize_str(value_of(media, "video_url"))
+        or best_resource_video(value_of(media, "video_versions") or [])
+        or best_resource_video(resources)
+    )
+    video_url = (
+        normalize_str(value_of(media, "video_url"))
+        or best_resource_video(value_of(media, "video_versions") or [])
+        or best_resource_video(resources)
+    )
+    if not thumbnail_url:
+        return None
+
+    taken_at = value_of(media, "taken_at")
+    taken_at_ms = None
+    if isinstance(taken_at, datetime):
+        taken_at_ms = int(taken_at.timestamp() * 1000)
+    elif isinstance(taken_at, (int, float)):
+        taken_at_ms = int(float(taken_at) * 1000)
+
+    code = normalize_str(value_of(media, "code"))
+    product_type = normalize_str(value_of(media, "product_type"))
+    location = value_of(media, "location") or {}
+    caption = value_of(media, "caption_text")
+    if caption is None and isinstance(value_of(media, "caption"), dict):
+        caption = value_of(value_of(media, "caption"), "text")
+    resource_count = len(resources) if resources else None
+
+    return {
+        "mediaId": media_pk,
+        "code": code,
+        "mediaType": media_type,
+        "isReel": product_type == "clips",
+        "isStory": is_story,
+        "caption": normalize_str(caption),
+        "likeCount": normalize_count(value_of(media, "like_count")),
+        "commentCount": normalize_count(value_of(media, "comment_count")),
+        "playCount": normalize_count(value_of(media, "play_count")),
+        "viewCount": normalize_count(value_of(media, "view_count") or value_of(media, "video_view_count")),
+        "durationSeconds": value_of(media, "video_duration"),
+        "locationName": normalize_str(value_of(location, "name")),
+        "productType": product_type,
+        "resourcesCount": resource_count,
+        "isPinned": False,
+        "takenAtMs": taken_at_ms,
+        "thumbnailUrl": thumbnail_url,
+        "videoUrl": video_url,
+        "permalink": media_permalink(handle, code, is_story, media_type, media_pk),
+        "payloadJson": iso_payload(media),
+    }
+
+
+def build_profile_payload(user: Any) -> Dict[str, Any]:
+    followers_count = value_of(user, "follower_count")
+    if followers_count is None and isinstance(value_of(user, "edge_followed_by"), dict):
+        followers_count = value_of(value_of(user, "edge_followed_by"), "count")
+
+    following_count = value_of(user, "following_count")
+    if following_count is None and isinstance(value_of(user, "edge_follow"), dict):
+        following_count = value_of(value_of(user, "edge_follow"), "count")
+
+    media_count = value_of(user, "media_count")
+    if media_count is None and isinstance(value_of(user, "edge_owner_to_timeline_media"), dict):
+        media_count = value_of(value_of(user, "edge_owner_to_timeline_media"), "count")
+
+    return {
+        "userId": normalize_str(value_of(user, "pk") or value_of(user, "id")),
+        "username": normalize_str(value_of(user, "username")),
+        "fullName": normalize_str(value_of(user, "full_name")),
+        "biography": normalize_str(value_of(user, "biography")),
+        "avatarUrl": normalize_str(value_of(user, "profile_pic_url_hd"))
+        or normalize_str(value_of(user, "profile_pic_url")),
+        "isVerified": value_of(user, "is_verified"),
+        "isPrivate": value_of(user, "is_private"),
+        "isBusiness": value_of(user, "is_business") or value_of(user, "is_business_account"),
+        "isProfessional": value_of(user, "account_type") in {2, 3} or bool(value_of(user, "is_professional_account")),
+        "externalUrl": normalize_str(value_of(user, "external_url")),
+        "categoryName": normalize_str(value_of(user, "category_name") or value_of(user, "business_category_name")),
+        "publicEmail": normalize_str(value_of(user, "public_email") or value_of(user, "business_email")),
+        "publicPhone": normalize_str(
+            value_of(user, "public_phone_number")
+            or value_of(user, "contact_phone_number")
+            or value_of(user, "business_phone_number")
+        ),
+        "followersCount": normalize_count(followers_count),
+        "followingCount": normalize_count(following_count),
+        "mediaCount": normalize_count(media_count),
+        "payloadJson": iso_payload(user),
+    }
+
+
+def write_summary(config: SyncConfig, payload: Dict[str, Any]) -> None:
+    if not config.summary_file:
+        return
+    config.summary_file.parent.mkdir(parents=True, exist_ok=True)
+    config.summary_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def sync_handle(client: InstagramSessionClient, website: WebsiteSyncClient, handle: str, config: SyncConfig, source: str) -> HandleSummary:
+    try:
+        user = client.fetch_profile(handle)
+        user_id = normalize_str(user.get("id"))
+        if not user_id:
+            raise RuntimeError(f"profile_missing_id:{handle}")
+
+        medias = client.fetch_feed_items(user_id, amount=config.max_feed_items)
+        stories = client.fetch_story_items(user_id) if config.include_stories else []
+        normalized_items = [
+            item
+            for item in [
+                *(normalize_media(handle, media, is_story=False) for media in medias),
+                *(normalize_media(handle, story, is_story=True) for story in stories),
+            ]
+            if item
+        ]
+        ingest_response = website.ingest_snapshot(
+            handle=handle,
+            profile=build_profile_payload(user),
+            items=normalized_items,
+            source=source,
+        )
+        result = ingest_response.get("result") or {}
+        return HandleSummary(
+            handle=handle,
+            ok=bool(ingest_response.get("ok")),
+            error=normalize_str(result.get("error")),
+            source=source,
+            fetched_items=len(medias),
+            fetched_stories=len(stories),
+            upserted_items=normalize_count(result.get("upsertedItems")) or 0,
+        )
+    except Exception as exc:  # pragma: no cover - exercised in live environments
+        return HandleSummary(
+            handle=handle,
+            ok=False,
+            error=str(exc),
+            source=source,
+            fetched_items=0,
+            fetched_stories=0,
+            upserted_items=0,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Authenticated instagrapi sync for the website cache.")
+    parser.add_argument("--base-url", default=None, help="Website base URL. Defaults to WEBSITE_BASE_URL or https://espacofacial.com.")
+    parser.add_argument("--session-file", default=None, help="Path to the instagrapi session settings JSON.")
+    parser.add_argument("--summary-file", default=None, help="Write a JSON summary to this path.")
+    parser.add_argument("--handles", default="", help="Comma-separated handles to sync instead of fetching targets from the website.")
+    parser.add_argument("--max-feed-items", type=int, default=120, help="Maximum number of feed items per handle.")
+    parser.add_argument("--delay-seconds", type=float, default=0.75, help="Delay between handles.")
+    parser.add_argument("--include-stories", action="store_true", default=True, help="Include story sync.")
+    parser.add_argument("--no-include-stories", dest="include_stories", action="store_false", help="Disable story sync.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = build_config(args)
+    summary: Dict[str, Any] = {
+        "ok": False,
+        "startedAt": utc_now_iso(),
+        "mode": "instagrapi_primary",
+        "configurationStatus": "initializing",
+        "authMode": None,
+        "targetsCount": 0,
+        "successCount": 0,
+        "failureCount": 0,
+        "failedHandles": [],
+        "results": [],
+    }
+
+    try:
+        if not config.sync_token:
+            raise RuntimeError("instagram_sync_token_missing")
+
+        client, auth_mode = authenticate_client(config)
+        summary["authMode"] = auth_mode
+        summary["configurationStatus"] = "configured"
+
+        website = WebsiteSyncClient(config)
+        handles = website.fetch_targets()
+        summary["targetsCount"] = len(handles)
+        if not handles:
+            summary["ok"] = True
+            summary["finishedAt"] = utc_now_iso()
+            write_summary(config, summary)
+            print(json.dumps(summary, ensure_ascii=False))
+            return 0
+
+        results: List[HandleSummary] = []
+        for index, handle in enumerate(handles):
+            if index > 0 and config.delay_seconds > 0:
+                time.sleep(config.delay_seconds)
+            results.append(sync_handle(client, website, handle, config, f"instagrapi:{auth_mode}"))
+
+        failed = [result.handle for result in results if not result.ok]
+        summary["results"] = [asdict(result) for result in results]
+        summary["successCount"] = sum(1 for result in results if result.ok)
+        summary["failureCount"] = len(failed)
+        summary["failedHandles"] = failed
+        summary["ok"] = len(failed) == 0
+        summary["finishedAt"] = utc_now_iso()
+
+        if config.session_file.exists():
+            summary["sessionFile"] = str(config.session_file)
+
+        write_summary(config, summary)
+        print(json.dumps(summary, ensure_ascii=False))
+        return 0 if summary["ok"] else 2
+    except Exception as exc:
+        summary["configurationStatus"] = normalize_str(str(exc)) or "error"
+        summary["finishedAt"] = utc_now_iso()
+        write_summary(config, summary)
+        print(json.dumps(summary, ensure_ascii=False))
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/src/app/api/instagram-feed/route.ts
+++ b/website/src/app/api/instagram-feed/route.ts
@@ -7,6 +7,7 @@ import {
     normalizeInstagramHandleInput,
     syncInstagramHandle,
 } from "@/lib/instagramSync";
+import { shouldRefreshInstagramFeed } from "@/lib/instagramFeedRouteShared";
 
 export const dynamic = "force-dynamic";
 
@@ -81,13 +82,18 @@ export async function GET(req: Request) {
 
         const isFirstPage = !cursor;
         const stale = isFirstPage ? await isInstagramProfileStale(handle, INSTAGRAM_SYNC_TTL_MS) : false;
-        const shouldSync = forceRefresh || !page || (isFirstPage && stale && !page?.items?.length);
+        const shouldSync = shouldRefreshInstagramFeed({
+            forceRefresh,
+            isFirstPage,
+            stale,
+            page,
+        });
 
         if (shouldSync) {
             await syncInstagramHandle(handle, {
                 includeStories,
                 maxFeedItems: 72,
-                source: forceRefresh ? "api_refresh" : "api_cache_miss",
+                source: forceRefresh ? "api_refresh" : stale ? "api_stale_refresh" : "api_cache_miss",
             });
 
             page = await getCachedInstagramFeed({

--- a/website/src/app/api/instagram/ingest/route.ts
+++ b/website/src/app/api/instagram/ingest/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import {
+    ingestInstagramHandleSnapshot,
+    normalizeInstagramHandleInput,
+    type InstagramExternalMediaInput,
+    type InstagramExternalProfileInput,
+} from "@/lib/instagramSync";
+import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+
+export const dynamic = "force-dynamic";
+
+type IngestPayload = {
+    handle?: string;
+    source?: string;
+    profile?: InstagramExternalProfileInput;
+    items?: InstagramExternalMediaInput[];
+};
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+    return (request.headers.get("x-instagram-sync-token") ?? "").trim();
+}
+
+async function assertToken(request: Request): Promise<boolean> {
+    const secret = await getRuntimeSecret("INSTAGRAM_SYNC_TOKEN");
+    if (process.env.NODE_ENV === "production" && !secret) return false;
+    if (!secret) return true;
+    return readToken(request) === secret;
+}
+
+export async function POST(request: Request) {
+    if (!(await assertToken(request))) {
+        return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+
+    let payload: IngestPayload = {};
+    try {
+        payload = ((await request.json()) ?? {}) as IngestPayload;
+    } catch {
+        payload = {};
+    }
+
+    const handle = normalizeInstagramHandleInput(payload.handle ?? "");
+    if (!handle) {
+        return NextResponse.json({ ok: false, error: "invalid_handle" }, { status: 400 });
+    }
+
+    const result = await ingestInstagramHandleSnapshot(
+        handle,
+        {
+            profile: payload.profile ?? {},
+            items: Array.isArray(payload.items) ? payload.items : [],
+        },
+        {
+            source: typeof payload.source === "string" && payload.source.trim()
+                ? payload.source.trim().slice(0, 80)
+                : "api_instagram_ingest",
+        },
+    );
+
+    return NextResponse.json({
+        ok: result.ok,
+        result,
+    });
+}

--- a/website/src/app/api/instagram/sync-targets/route.ts
+++ b/website/src/app/api/instagram/sync-targets/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import { resolveInstagramSyncTargets } from "@/lib/instagramSync";
+
+export const dynamic = "force-dynamic";
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+    return (request.headers.get("x-instagram-sync-token") ?? "").trim();
+}
+
+async function assertToken(request: Request): Promise<boolean> {
+    const secret = await getRuntimeSecret("INSTAGRAM_SYNC_TOKEN");
+    if (process.env.NODE_ENV === "production" && !secret) return false;
+    if (!secret) return true;
+    return readToken(request) === secret;
+}
+
+export async function GET(request: Request) {
+    if (!(await assertToken(request))) {
+        return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+
+    const targets = await resolveInstagramSyncTargets();
+    return NextResponse.json({
+        ok: true,
+        count: targets.length,
+        targets,
+    });
+}

--- a/website/src/app/api/instagram/sync/route.ts
+++ b/website/src/app/api/instagram/sync/route.ts
@@ -4,7 +4,7 @@ import {
     INSTAGRAM_SYNC_TTL_MS,
     isInstagramProfileStale,
     normalizeInstagramHandleInput,
-    resolveDoctorInstagramHandles,
+    resolveInstagramSyncHandles,
     type SyncHandleResult,
     syncInstagramHandlesBatch,
 } from "@/lib/instagramSync";
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
         ? payload.handles.map((h) => normalizeInstagramHandleInput(String(h ?? ""))).filter(Boolean)
         : [];
 
-    const discoveredHandles = requestedHandles.length ? requestedHandles : await resolveDoctorInstagramHandles();
+    const discoveredHandles = requestedHandles.length ? requestedHandles : await resolveInstagramSyncHandles();
     const uniqueHandles = [...new Set(discoveredHandles)].sort();
 
     if (!uniqueHandles.length) {

--- a/website/src/lib/instagramFeedRouteShared.ts
+++ b/website/src/lib/instagramFeedRouteShared.ts
@@ -1,0 +1,19 @@
+type CachedInstagramPage = {
+    items?: unknown[] | null;
+};
+
+export function shouldRefreshInstagramFeed(params: {
+    forceRefresh: boolean;
+    isFirstPage: boolean;
+    stale: boolean;
+    page: CachedInstagramPage | null;
+}): boolean {
+    if (params.forceRefresh) return true;
+    if (!params.page) return true;
+    if (!params.isFirstPage) return false;
+    if (!params.stale) return false;
+
+    // Instagram CDN URLs expire even when cached rows still exist, so stale first-page data
+    // must be refreshed before reusing the stored thumbnails/videos.
+    return true;
+}

--- a/website/src/lib/instagramSync.ts
+++ b/website/src/lib/instagramSync.ts
@@ -1,3 +1,4 @@
+import { units } from "@/data/units";
 import { fetchActiveInjectors } from "@/lib/injectorsDirectory";
 import {
     getInstagramCachedProfile,
@@ -71,6 +72,55 @@ export type InstagramFeedPage = {
     items: InstagramApiMedia[];
     hasMore: boolean;
     nextCursor: string | null;
+};
+
+export type InstagramSyncTarget = {
+    handle: string;
+    kind: "doctor" | "unit";
+    label: string | null;
+};
+
+export type InstagramExternalProfileInput = {
+    userId?: string | null;
+    username?: string | null;
+    fullName?: string | null;
+    biography?: string | null;
+    avatarUrl?: string | null;
+    isVerified?: boolean | null;
+    isPrivate?: boolean | null;
+    isBusiness?: boolean | null;
+    isProfessional?: boolean | null;
+    externalUrl?: string | null;
+    categoryName?: string | null;
+    publicEmail?: string | null;
+    publicPhone?: string | null;
+    followersCount?: number | null;
+    followingCount?: number | null;
+    mediaCount?: number | null;
+    payloadJson?: string | null;
+};
+
+export type InstagramExternalMediaInput = {
+    mediaId?: string | null;
+    code?: string | null;
+    mediaType?: "image" | "video" | "carousel" | null;
+    isReel?: boolean | null;
+    isStory?: boolean | null;
+    caption?: string | null;
+    likeCount?: number | null;
+    commentCount?: number | null;
+    playCount?: number | null;
+    viewCount?: number | null;
+    durationSeconds?: number | null;
+    locationName?: string | null;
+    productType?: string | null;
+    resourcesCount?: number | null;
+    isPinned?: boolean | null;
+    takenAtMs?: number | null;
+    thumbnailUrl?: string | null;
+    videoUrl?: string | null;
+    permalink?: string | null;
+    payloadJson?: string | null;
 };
 
 type InstagramProfileResponse = {
@@ -160,6 +210,18 @@ function sanitizeHandle(input: string): string {
         .replace(/^@/, "")
         .replace(/[^a-zA-Z0-9._]/g, "")
         .toLowerCase();
+}
+
+function extractInstagramHandleFromUrl(input: string): string | null {
+    const raw = (input ?? "").trim();
+    if (!raw) return null;
+    try {
+        const url = new URL(raw);
+        const segments = url.pathname.split("/").map((segment) => segment.trim()).filter(Boolean);
+        return sanitizeHandle(segments[0] ?? "") || null;
+    } catch {
+        return null;
+    }
 }
 
 function sanitizeUserId(input: string): string {
@@ -602,6 +664,232 @@ export async function getCachedInstagramFeed(params: {
     };
 }
 
+function normalizeExternalMediaItem(params: {
+    handle: string;
+    item: InstagramExternalMediaInput;
+}): InstagramApiMedia | null {
+    const { handle, item } = params;
+    const mediaId = normalizeText(item.mediaId ?? item.code ?? null);
+    if (!mediaId) return null;
+
+    const mediaType = item.mediaType === "video" || item.mediaType === "carousel" ? item.mediaType : "image";
+    const isStory = item.isStory === true;
+    const thumbnailUrl = normalizeText(item.thumbnailUrl) ?? normalizeText(item.videoUrl) ?? null;
+    if (!thumbnailUrl) return null;
+
+    return {
+        id: `${handle}:${isStory ? "story:" : ""}${mediaId}`,
+        code: normalizeText(item.code),
+        mediaType,
+        isReel: item.isReel === true || normalizeText(item.productType) === "clips",
+        isStory,
+        caption: normalizeText(item.caption),
+        likeCount: normalizeCount(item.likeCount),
+        commentCount: normalizeCount(item.commentCount),
+        playCount: normalizeCount(item.playCount),
+        viewCount: normalizeCount(item.viewCount),
+        durationSeconds: normalizeDuration(item.durationSeconds),
+        locationName: normalizeText(item.locationName),
+        productType: normalizeText(item.productType),
+        resourcesCount: normalizeCount(item.resourcesCount),
+        isPinned: item.isPinned === true,
+        takenAtMs: normalizeCount(item.takenAtMs),
+        thumbnailUrl,
+        videoUrl: normalizeText(item.videoUrl),
+        permalink: normalizeText(item.permalink),
+        payloadJson: item.payloadJson ?? serializePayload(item, MAX_MEDIA_PAYLOAD_CHARS),
+    };
+}
+
+export async function ingestInstagramHandleSnapshot(
+    handleRaw: string,
+    snapshot: {
+        profile: InstagramExternalProfileInput;
+        items: InstagramExternalMediaInput[];
+    },
+    opts?: {
+        source?: string;
+    },
+): Promise<SyncHandleResult> {
+    const handle = sanitizeHandle(handleRaw);
+    const startedAtMs = Date.now();
+    const runId = newInstagramSyncRunId();
+
+    if (!handle) {
+        const error = "invalid_handle";
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle: handleRaw,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: false,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error,
+        });
+        return {
+            handle: handleRaw,
+            ok: false,
+            userId: null,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error,
+        };
+    }
+
+    await markInstagramSyncAttempt({ handle, attemptAtMs: startedAtMs, error: null });
+
+    try {
+        const profile = snapshot.profile ?? {};
+        const userId = sanitizeUserId(profile.userId ?? "");
+        if (!userId) {
+            const error = "invalid_snapshot_profile";
+            await markInstagramSyncAttempt({ handle, attemptAtMs: Date.now(), error });
+            await insertInstagramSyncRun({
+                id: runId,
+                source: opts?.source ?? null,
+                handle,
+                startedAtMs,
+                finishedAtMs: Date.now(),
+                success: false,
+                fetchedItems: 0,
+                fetchedStories: 0,
+                upsertedItems: 0,
+                error,
+            });
+            return {
+                handle,
+                ok: false,
+                userId: null,
+                fetchedItems: 0,
+                fetchedStories: 0,
+                upsertedItems: 0,
+                error,
+            };
+        }
+
+        const normalizedItems = (Array.isArray(snapshot.items) ? snapshot.items : [])
+            .map((item) => normalizeExternalMediaItem({ handle, item }))
+            .filter((item): item is InstagramApiMedia => !!item);
+
+        const syncedAtMs = Date.now();
+        await upsertInstagramCachedProfile({
+            handle,
+            userId,
+            username: sanitizeHandle(profile.username ?? "") || handle,
+            fullName: normalizeText(profile.fullName),
+            biography: normalizeText(profile.biography),
+            avatarUrl: normalizeText(profile.avatarUrl),
+            isVerified: normalizeBool(profile.isVerified) ?? null,
+            isPrivate: normalizeBool(profile.isPrivate) ?? null,
+            isBusiness: normalizeBool(profile.isBusiness) ?? null,
+            isProfessional: normalizeBool(profile.isProfessional) ?? null,
+            externalUrl: normalizeText(profile.externalUrl),
+            categoryName: normalizeText(profile.categoryName),
+            publicEmail: normalizeText(profile.publicEmail),
+            publicPhone: normalizeText(profile.publicPhone),
+            profilePayloadJson: profile.payloadJson ?? serializePayload(profile, MAX_PROFILE_PAYLOAD_CHARS),
+            lastError: null,
+            syncedAtMs,
+        });
+
+        await upsertInstagramCachedProfileStats({
+            handle,
+            followersCount: normalizeCount(profile.followersCount),
+            followingCount: normalizeCount(profile.followingCount),
+            mediaCount: normalizeCount(profile.mediaCount),
+            syncedAtMs,
+        });
+
+        const upsertedItems = await upsertInstagramMediaBatch(
+            normalizedItems.map((item) => ({
+                id: item.id,
+                handle,
+                mediaId: item.id.replace(`${handle}:`, ""),
+                code: item.code,
+                mediaType: item.mediaType,
+                isReel: item.isReel,
+                isStory: item.isStory,
+                caption: item.caption,
+                likeCount: item.likeCount,
+                commentCount: item.commentCount,
+                playCount: item.playCount,
+                viewCount: item.viewCount,
+                durationSeconds: item.durationSeconds,
+                locationName: item.locationName,
+                productType: item.productType,
+                resourcesCount: item.resourcesCount,
+                isPinned: item.isPinned,
+                takenAtMs: item.takenAtMs,
+                thumbnailUrl: item.thumbnailUrl,
+                videoUrl: item.videoUrl,
+                permalink: item.permalink,
+                payloadJson: item.payloadJson ?? null,
+                updatedAtMs: syncedAtMs,
+            })),
+        );
+
+        await pruneInstagramCache({
+            handle,
+            keepPosts: INSTAGRAM_KEEP_POSTS_PER_HANDLE,
+            removeStoriesOlderThanMs: syncedAtMs - INSTAGRAM_STORIES_RETENTION_MS,
+        });
+
+        const fetchedStories = normalizedItems.filter((item) => item.isStory).length;
+        const fetchedItems = normalizedItems.length - fetchedStories;
+
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: true,
+            fetchedItems,
+            fetchedStories,
+            upsertedItems,
+            error: null,
+        });
+
+        return {
+            handle,
+            ok: true,
+            userId,
+            fetchedItems,
+            fetchedStories,
+            upsertedItems,
+            error: null,
+        };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "snapshot_ingest_exception";
+        await markInstagramSyncAttempt({ handle, attemptAtMs: Date.now(), error: message });
+        await insertInstagramSyncRun({
+            id: runId,
+            source: opts?.source ?? null,
+            handle,
+            startedAtMs,
+            finishedAtMs: Date.now(),
+            success: false,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: message,
+        });
+        return {
+            handle,
+            ok: false,
+            userId: null,
+            fetchedItems: 0,
+            fetchedStories: 0,
+            upsertedItems: 0,
+            error: message,
+        };
+    }
+}
+
 export async function fetchLiveInstagramFeedPage(params: {
     handle: string;
     cursor?: string | null;
@@ -883,6 +1171,41 @@ export async function resolveDoctorInstagramHandles(): Promise<string[]> {
     } catch {
         return [];
     }
+}
+
+export async function resolveInstagramSyncTargets(): Promise<InstagramSyncTarget[]> {
+    const unique = new Map<string, InstagramSyncTarget>();
+
+    try {
+        const members = await fetchActiveInjectors();
+        for (const member of members) {
+            const handle = sanitizeHandle(member.instagramHandle ?? "");
+            if (!handle || unique.has(handle)) continue;
+            unique.set(handle, {
+                handle,
+                kind: "doctor",
+                label: normalizeText(member.name),
+            });
+        }
+    } catch {
+        // Best effort: units still provide stable targets even if the directory is unavailable.
+    }
+
+    for (const unit of units) {
+        const handle = extractInstagramHandleFromUrl(unit.instagram ?? "");
+        if (!handle || unique.has(handle)) continue;
+        unique.set(handle, {
+            handle,
+            kind: "unit",
+            label: normalizeText(unit.name),
+        });
+    }
+
+    return [...unique.values()].sort((a, b) => a.handle.localeCompare(b.handle));
+}
+
+export async function resolveInstagramSyncHandles(): Promise<string[]> {
+    return (await resolveInstagramSyncTargets()).map((target) => target.handle);
 }
 
 export async function syncInstagramHandlesBatch(params: {

--- a/website/tests/instagramFeedRoute.test.ts
+++ b/website/tests/instagramFeedRoute.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldRefreshInstagramFeed } from "../src/lib/instagramFeedRouteShared";
+
+test("refreshes when the first page cache is stale even if media rows still exist", () => {
+    assert.equal(
+        shouldRefreshInstagramFeed({
+            forceRefresh: false,
+            isFirstPage: true,
+            stale: true,
+            page: { items: [{ id: "cached-item" }] },
+        }),
+        true,
+    );
+});
+
+test("does not refresh non-stale cached first page without explicit refresh", () => {
+    assert.equal(
+        shouldRefreshInstagramFeed({
+            forceRefresh: false,
+            isFirstPage: true,
+            stale: false,
+            page: { items: [{ id: "cached-item" }] },
+        }),
+        false,
+    );
+});
+
+test("does not refresh later pages just because the profile is stale", () => {
+    assert.equal(
+        shouldRefreshInstagramFeed({
+            forceRefresh: false,
+            isFirstPage: false,
+            stale: true,
+            page: { items: [{ id: "cached-item" }] },
+        }),
+        false,
+    );
+});
+
+test("refreshes when the caller explicitly forces a refresh", () => {
+    assert.equal(
+        shouldRefreshInstagramFeed({
+            forceRefresh: true,
+            isFirstPage: false,
+            stale: false,
+            page: { items: [{ id: "cached-item" }] },
+        }),
+        true,
+    );
+});
+
+test("refreshes when there is no cached page at all", () => {
+    assert.equal(
+        shouldRefreshInstagramFeed({
+            forceRefresh: false,
+            isFirstPage: true,
+            stale: false,
+            page: null,
+        }),
+        true,
+    );
+});


### PR DESCRIPTION
## Summary
- add an authenticated Instagram sync primary path that ingests snapshots into the website cache
- keep the current website sync as an automatic fallback and expand scheduled target discovery to all Instagram profiles shown on the site
- harden the vendored instagrapi session handling and stale first-page refresh support

## Validation
- npm --prefix website test
- npm --prefix website run typecheck
- npm --prefix website run lint
- PYTHONPATH=backend/apps/instagram/instagrapi /tmp/skincos-ig-venv/bin/python -m py_compile backend/apps/instagram/module/instagram_site_sync.py backend/apps/instagram/instagrapi/instagrapi/extractors.py backend/apps/instagram/instagrapi/instagrapi/mixins/auth.py