### PR TITLE
fix: unlock Meta Ads module for gestores

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -351,7 +351,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'escala-profissionais']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'escala-profissionais', 'meta-ads']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)


### PR DESCRIPTION
## Contexto\nO módulo `Meta Ads` já estava implementado e o perfil `GESTOR` já passava no filtro de acesso, mas a UI ainda o marcava como bloqueado via `UNLOCKED_MODULE_KEYS`.\n\n## Mudança\n- adiciona `meta-ads` à lista de módulos liberados no frontend do CRM\n\n## Validação\n- `npm --prefix frontend run build`