### PR TITLE
fix: route CRM Meta Ads to tracking dashboard

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -153,7 +153,7 @@ const NotificationCenter = lazy(() => import('@/NotificationCenter').then(m => (
 const ReportsDashboard = lazy(() => import('@/ReportsDashboard').then(m => ({ default: m.ReportsDashboard })))
 const AccountingModule = lazy(() => import('@/AccountingModule').then(m => ({ default: m.AccountingModule })))
 const AtendimentoModule = lazy(() => import('@/AtendimentoModule').then(m => ({ default: m.AtendimentoModule })))
-const MetaAdsManager = lazy(() => import('@/MetaCampaignControlCenter').then(m => ({ default: m.MetaCampaignControlCenter })))
+const MetaAdsManager = lazy(() => import('@/MetaAdsManager').then(m => ({ default: m.MetaAdsManager })))
 const MetaCommandCenter = lazy(() => import('@/MetaCommandCenter').then(m => ({ default: m.MetaCommandCenter })))
 const MetaSyncMonitor = lazy(() => import('@/MetaSyncMonitor').then(m => ({ default: m.MetaSyncMonitor })))
 const MetaSentimentMonitor = lazy(() => import('@/MetaSentimentMonitor').then(m => ({ default: m.MetaSentimentMonitor })))


### PR DESCRIPTION
## Contexto
O módulo `Meta Ads` já estava liberado no menu, mas o roteamento do CRM ainda lazy-loadava `MetaCampaignControlCenter`, que é a interface antiga de autenticação do subprojeto.

## Mudança
- troca o import lazy do módulo `meta-ads` para `MetaAdsManager`

## Validação
- `npm --prefix frontend ci`
- `npm --prefix frontend run build`
