### PR TITLE
fix: restore first-party WhatsApp faleconosco redirects

### DIFF
--- a/website/src/app/[unit]/faleconosco/route.ts
+++ b/website/src/app/[unit]/faleconosco/route.ts
@@ -18,5 +18,5 @@ export async function GET(req: Request, { params }: { params: Promise<{ unit: st
         },
     });
     if (!redirectUrl) return NextResponse.redirect(mergedDestination, { status: 301 });
-    return NextResponse.redirect(redirectUrl, { status: 301 });
+    return NextResponse.redirect(new URL(redirectUrl, req.url), { status: 301 });
 }

--- a/website/src/app/faleconosco/[sigla]/route.ts
+++ b/website/src/app/faleconosco/[sigla]/route.ts
@@ -18,5 +18,5 @@ export async function GET(req: Request, { params }: { params: Promise<{ sigla: s
         },
     });
     if (!redirectUrl) return NextResponse.redirect(mergedDestination, { status: 301 });
-    return NextResponse.redirect(redirectUrl, { status: 301 });
+    return NextResponse.redirect(new URL(redirectUrl, req.url), { status: 301 });
 }


### PR DESCRIPTION
## Summary
- fix the `faleconosco` app routes to redirect to an absolute `/api/whatsapp/redirect` URL
- restore the first-party WhatsApp tracking path used by the site and CRM dashboard
- remove the production `HTTP 500` seen on `/faleconosco/bss` and equivalent unit routes

## Validation
- reproduced live `HTTP 500` on `https://espacofacial.com/faleconosco/bss`
- confirmed `https://espacofacial.com/api/whatsapp/redirect?...` was healthy (`302`)
- local `next build` in isolated worktree was blocked by disk space (`ENOSPC`), so runtime validation will be done after deploy
