### PR TITLE
feat: harden website tracking domains and whatsapp flow

### DIFF
--- a/website/docs/domain-policy.md
+++ b/website/docs/domain-policy.md
@@ -1,0 +1,49 @@
+# Política operacional de domínios
+
+## Escopo
+
+Esta política define qual domínio pertence a qual stack e como cada host deve ser usado na operação de mídia, site, agendamento e ferramentas internas.
+
+## Matriz oficial
+
+| Domínio | Papel | Stack | Regra operacional |
+|---|---|---|---|
+| `espacofacial.com` | Site público + agendamento | Este projeto `website/` | Host canônico para navegação, SEO deste app e campanhas com objetivo de booking |
+| `www.espacofacial.com` | Alias de entrada | Este projeto `website/` | Deve redirecionar com `308` para `https://espacofacial.com` |
+| `espacofacial.com.br` | Domínio oficial da franquia | Stack separada | Não deve ser tratado como continuação automática do tracking/cookies deste app |
+| `app.espacofacial.com.br` | App oficial da franquia | Stack separada | Pode existir como integração operacional, mas não como host do funil público deste site |
+| `skincos.com.br` | Hub jurídico/institucional | SKINCOS | Páginas legais e institucionais da SKINCOS |
+| `crm.skincos.com.br` | CRM | SKINCOS | Acompanhamento operacional e visualização de tracking |
+| `orb.skincos.com.br` | Orquestração / n8n | SKINCOS | Automação e fluxos internos |
+| `wa.skincos.com.br` | Stack WhatsApp | SKINCOS | APIs e integrações técnicas de mensagens |
+
+## Regras de atribuição e tracking
+
+1. Campanhas com objetivo de agendamento e otimização por `Schedule` devem apontar para `https://espacofacial.com`.
+2. `espacofacial.com.br` e `app.espacofacial.com.br` devem ser tratados como ambientes oficiais separados.
+3. Não assumir compartilhamento de:
+   - cookies
+   - consentimento
+   - `_fbp`
+   - `_fbc`
+   - UTMs persistidas
+   - sessão
+4. Qualquer navegação do site público para outro domínio oficial deve ser intencional e documentada.
+5. O CRM em `crm.skincos.com.br` é um destino de observabilidade operacional, não de entrada de campanha do funil público.
+
+## Regras de canonicalização
+
+1. `espacofacial.com` é o canônico deste projeto.
+2. `www.espacofacial.com` deve apenas redirecionar para o apex.
+3. URLs públicas, snapshots e metadados deste projeto não devem apontar para `www.espacofacial.com` quando o destino real for o próprio site.
+
+## Regras de operação
+
+1. Se uma campanha tiver como meta booking rastreado neste app, o destino deve ser `espacofacial.com`.
+2. Se um fluxo depender de sistema externo da franquia, isso deve ser modelado como integração entre stacks, não como host equivalente.
+3. Mudanças futuras de domínio devem atualizar:
+   - `site-config.ts`
+   - middleware/redirecionamentos
+   - snapshots públicos
+   - checklist de validação
+   - documentação de tracking

--- a/website/docs/meta-tracking-auditoria-implementacao.md
+++ b/website/docs/meta-tracking-auditoria-implementacao.md
@@ -1,0 +1,298 @@
+# Meta Tracking, Pixel, CAPI e WhatsApp - Espaço Facial
+
+## 1. Diagnóstico atual
+
+- Stack real do site público: `website/` em `Next.js 15 App Router`, deploy via `OpenNext + Cloudflare Workers`, persistência de agendamento em `Cloudflare D1`.
+- O ponto real de conversão confirmada no site é `POST /api/booking/request`. O backend grava o booking e responde com `status = "confirmed"`.
+- Havia consentimento, GTM/GA4 e Meta Pixel no browser, mas o tracking Meta estava incompleto:
+  - sem `Conversions API`;
+  - sem `event_id` para deduplicação browser/server;
+  - sem persistência robusta de atribuição até o backend;
+  - com espelhamento indiscriminado de eventos customizados para `fbq('trackCustom', ...)`.
+- O host canônico deste projeto público é `https://espacofacial.com`. `www.espacofacial.com` continua roteado e redireciona para o apex.
+- `espacofacial.com.br` é um domínio oficial separado da franquia, operado fora deste app.
+- `app.espacofacial.com.br` é um ambiente/aplicação separado, também fora deste app.
+- `skincos.com.br` é o domínio institucional/operacional da SKINCOS, com subdomínios como `orb.skincos.com.br`, `crm.skincos.com.br` e `wa.skincos.com.br`.
+
+## 2. Problemas encontrados
+
+- Ausência de `Conversions API` para o evento final do booking.
+- Ausência de deduplicação `event_id` entre browser e server.
+- `PageView` da Meta dependia da carga inicial do Pixel, sem cobertura explícita de navegação client-side.
+- Contexto de origem (`utm_*`, `fbclid`, `fbp`, `fbc`, landing/referrer) não chegava ao backend do booking.
+- Clique para WhatsApp saía por links externos ou redirects simples, sem `wa_click_id`, sem log server-side e sem `Contact` deduplicado.
+- Parte dos CTAs de agendamento ainda navegava sem `Lead` consistente.
+- Havia referências internas residuais para `www.espacofacial.com`.
+- `espacofacial.com.br` permanece ativo em stack separado, com finalidade própria da franquia. O risco não é “legado”; o risco é haver links, campanhas ou navegação cruzada entre stacks sem política operacional explícita.
+
+## 3. Implementações realizadas
+
+### Tracking e atribuição
+
+- Criei uma camada dedicada de atribuição em first-party com persistência de:
+  - `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`
+  - `gclid`, `gbraid`, `wbraid`, `msclkid`, `fbclid`
+  - `fbp`, `fbc`
+  - `landingUrl`, `landingPath`, `referrer`
+  - `firstTouch` e `lastTouch`
+- A persistência continua condicionada ao consentimento atual do banner.
+- Removi o espelhamento genérico de eventos customizados para a Meta. A Meta agora recebe apenas eventos modelados explicitamente.
+
+### Meta Pixel no browser
+
+- Mantive o carregamento do Pixel condicionado a consentimento de marketing.
+- Separei o `PageView` em um tracker client-side por navegação.
+- Modelei disparos browser-side para:
+  - `PageView`
+  - `ViewContent`
+  - `Lead`
+  - `InitiateCheckout`
+  - `Contact`
+  - `Schedule`
+
+### Conversions API
+
+- Implementei helper server-side de Meta CAPI com:
+  - `event_name`, `event_time`, `event_id`
+  - `action_source = website`
+  - `event_source_url`
+  - `fbp`, `fbc`
+  - `client_ip_address`, `client_user_agent`
+  - `em`, `ph`, `external_id` com hashing
+  - suporte a `META_CAPI_TEST_EVENT_CODE`
+  - flag de debug
+- O evento principal `Schedule` agora é enviado server-side imediatamente após a confirmação do booking.
+- O evento `Contact` de WhatsApp também é enviado server-side pela nova rota first-party.
+
+### Booking / backend
+
+- `POST /api/booking/request` agora aceita:
+  - `trackingContext`
+  - `metaEventId`
+- O booking persistido em D1 agora guarda:
+  - `tracking_context_json`
+  - `attribution_first_touch_json`
+  - `attribution_last_touch_json`
+  - `meta_event_id`
+  - `marketing_consent`
+  - `analytics_consent`
+  - `fbp`, `fbc`, `fbclid`
+  - `landing_page`
+  - `referrer`
+- Adicionei tabela de auditoria `meta_capi_delivery_logs`.
+- O webhook `booking.created` agora leva `metaEventId` e `trackingContext`.
+
+### WhatsApp first-party
+
+- Criei `GET /api/whatsapp/redirect`.
+- Essa rota:
+  - recebe o destino real do WhatsApp;
+  - gera `wa_click_id`;
+  - injeta token curto `Ref:EF-XXXXXXXX` na mensagem;
+  - registra o clique em `whatsapp_click_events`;
+  - dispara `Contact` via CAPI com o mesmo `event_id` usado no browser;
+  - redireciona para `wa.me` / `api.whatsapp.com`.
+- Os atalhos `faleconosco` agora passam pela camada first-party.
+- Atualizei CTAs importantes para usar a nova camada:
+  - confirmação de booking;
+  - modal de mapa/unidade;
+  - atalho de alteração de reserva no hero do agendamento;
+  - CTA do cadastro/roleta.
+
+### Funil / páginas
+
+- Adicionei `ViewContent` nas páginas de unidade e doutor.
+- Adicionei `ViewContent` na primeira seleção de procedimento do fluxo de booking.
+- Adicionei `InitiateCheckout` na abertura do modal final do agendamento.
+- Corrigi CTAs de agendamento sem tracking em pontos relevantes do site.
+
+### CRM / n8n
+
+- Atualizei a migration `db/migrations/20260217_wa_n8n.sql` para suportar:
+  - `external_id` em `wa_n8n.contacts`
+  - `wa_click_id` e `source_tracking` em `wa_n8n.conversations`
+  - `wa_click_id` e `source_tracking` em `wa_n8n.appointments`
+- Atualizei os workflows:
+  - `WORKFLOW_01_INBOUND_TRIAGEM.json` agora reconhece o token `Ref:EF-XXXXXXXX`, persiste `wa_click_id` e carrega `source_tracking`;
+  - `WORKFLOW_02_AGENDAMENTO.json` agora propaga `wa_click_id` e `source_tracking` para `appointments`.
+
+## 4. Arquivos alterados
+
+### Website
+
+- `website/src/lib/attribution.ts`
+- `website/src/lib/campaign.ts`
+- `website/src/lib/metaBrowser.ts`
+- `website/src/lib/metaConversionsApi.ts`
+- `website/src/lib/whatsappTracking.ts`
+- `website/src/lib/analytics.ts`
+- `website/src/lib/conversions.ts`
+- `website/src/lib/bookingDb.ts`
+- `website/src/components/CampaignAttribution.tsx`
+- `website/src/components/MarketingPixels.tsx`
+- `website/src/components/MetaPageTracker.tsx`
+- `website/src/components/MetaMountEvent.tsx`
+- `website/src/components/TrackedWhatsappLink.tsx`
+- `website/src/components/BookingFlow.tsx`
+- `website/src/components/BookingConfirmationCard.tsx`
+- `website/src/components/BookingHeroExperience.tsx`
+- `website/src/components/UnitMapsModal.tsx`
+- `website/src/components/CadastroWheelExperience.tsx`
+- `website/src/components/HeaderMobileMenu.tsx`
+- `website/src/components/AboutUsSection.tsx`
+- `website/src/components/UnitDoctorsGrid.tsx`
+- `website/src/app/api/booking/request/route.ts`
+- `website/src/app/api/whatsapp/redirect/route.ts`
+- `website/src/app/[unit]/faleconosco/route.ts`
+- `website/src/app/faleconosco/[sigla]/route.ts`
+- `website/src/app/[unit]/page.tsx`
+- `website/src/app/unidades/[slug]/page.tsx`
+- `website/src/app/doutores/[slug]/page.tsx`
+- `website/src/data/doctors.ts`
+
+### Testes
+
+- `website/tests/attribution.test.ts`
+- `website/tests/whatsappTracking.test.ts`
+
+### CRM / n8n
+
+- `db/migrations/20260217_wa_n8n.sql`
+- `n8n/workflows/WORKFLOW_01_INBOUND_TRIAGEM.json`
+- `n8n/workflows/WORKFLOW_02_AGENDAMENTO.json`
+
+## 5. Eventos implementados
+
+| Evento | Tipo | Trigger | Origem | Parâmetros principais | Objetivo |
+|---|---|---|---|---|---|
+| `PageView` | Standard | navegação em páginas com consentimento de marketing | browser | `page_path`, `page_query` | base de visita e audiência |
+| `ViewContent` | Standard | página de unidade, página de doutor, seleção de procedimento | browser | `content_type`, `content_name`, `content_ids`, `unit_slug`, `doctor_slug` | qualificar interesse no conteúdo/serviço |
+| `Lead` | Standard | clique de alta intenção para iniciar agendamento | browser | `source`, `placement`, `unitSlug` | otimização de topo/meio de funil |
+| `InitiateCheckout` | Standard | abertura do modal final do booking | browser | `content_type`, `service_id`, `service_name`, `unit_slug`, `doctor_slug`, `date`, `time` | identificar entrada na etapa final |
+| `Contact` | Standard | clique para WhatsApp | browser + server | `placement`, `source`, `unit_slug`, `doctor_name`, `booking_id`, `wa_click_id` | medir saída para atendimento |
+| `Schedule` | Standard | `POST /api/booking/request` concluído com sucesso | browser + server | `booking_id`, `unit_slug`, `doctor_slug`, `service_id`, `service_name`, `date`, `time`, `currency` | evento principal de otimização |
+
+### Evento principal para otimização
+
+- Recomendação atual: `Schedule`
+- Justificativa:
+  - representa a confirmação efetiva do agendamento;
+  - nasce no backend do site;
+  - suporta browser + CAPI com deduplicação;
+  - independe de pagamento online.
+
+## 6. Variáveis de ambiente necessárias
+
+### Browser / site
+
+- `NEXT_PUBLIC_META_PIXEL_ID`
+- `NEXT_PUBLIC_GOOGLE_ADS_ID` (se continuar usando)
+- `NEXT_PUBLIC_GOOGLE_ADS_LEAD_SEND_TO` (opcional)
+- `NEXT_PUBLIC_GOOGLE_ADS_CONTACT_SEND_TO` (opcional)
+- `NEXT_PUBLIC_SITE_URL=https://espacofacial.com`
+
+### Server / CAPI
+
+- `META_ACCESS_TOKEN`
+- `META_PIXEL_ID` (opcional se quiser separar do `NEXT_PUBLIC_META_PIXEL_ID`)
+- `META_API_VERSION` (opcional, default `v22.0`)
+- `META_CAPI_TEST_EVENT_CODE` (opcional, para testes no Events Manager)
+- `META_CAPI_DEBUG=1` (opcional)
+
+### Booking e webhooks
+
+- `BOOKING_DB`
+- `BOOKING_WEBHOOK_URL` (opcional)
+- `BOOKING_WEBHOOK_SECRET` (opcional)
+- `BOOKING_STATUS_SECRET` ou `BOOKING_DECISION_SECRET`
+- `BOOKING_WHATSAPP_WEBHOOK_URL` / `BOOKING_WHATSAPP_WEBHOOK_SECRET` se a operação continuar usando envio transacional atual
+
+## 7. Como publicar em produção
+
+1. Configurar secrets/envs do Worker.
+2. Aplicar a migration do Postgres do stack n8n:
+   - `psql \"$DATABASE_URL\" -f db/migrations/20260217_wa_n8n.sql`
+3. Reimportar/publicar os workflows n8n alterados:
+   - `WORKFLOW_01_INBOUND_TRIAGEM.json`
+   - `WORKFLOW_02_AGENDAMENTO.json`
+4. Fazer deploy do `website/`.
+5. Validar com `META_CAPI_TEST_EVENT_CODE` ativo antes de remover o modo de teste.
+
+## 8. Como validar no Meta Events Manager
+
+### Teste completo
+
+1. Entrar por URL com `utm_*` e `fbclid`.
+2. Aceitar cookies de marketing.
+3. Navegar por home, unidade e doutor.
+4. Abrir `/agendamento`.
+5. Selecionar procedimento, data e horário.
+6. Confirmar o booking.
+7. Verificar no Meta:
+   - `PageView`
+   - `ViewContent`
+   - `Lead`
+   - `InitiateCheckout`
+   - `Schedule`
+8. Confirmar que `Schedule` aparece deduplicado entre browser/server.
+9. Clicar em um CTA de WhatsApp e validar `Contact`.
+10. Confirmar no banco:
+   - `booking_requests.meta_event_id`
+   - `booking_requests.fbp`
+   - `booking_requests.fbc`
+   - `booking_requests.fbclid`
+   - `booking_requests.tracking_context_json`
+   - `whatsapp_click_events.wa_click_id`
+   - `meta_capi_delivery_logs`
+
+### Teste de consentimento
+
+1. Recusar marketing.
+2. Repetir navegação.
+3. Confirmar que Pixel/CAPI não enviam eventos de marketing.
+
+### Teste n8n / WhatsApp
+
+1. Clicar em CTA de WhatsApp do site.
+2. Abrir a conversa e enviar a mensagem com `Ref:EF-XXXXXXXX`.
+3. Disparar o webhook do Evolution no `WORKFLOW_01`.
+4. Confirmar persistência de `wa_click_id` em `wa_n8n.conversations`.
+5. Completar o agendamento via `WORKFLOW_02`.
+6. Confirmar `wa_click_id` também em `wa_n8n.appointments`.
+
+## 9. Pendências externas
+
+- `espacofacial.com.br` e `app.espacofacial.com.br` continuam fora deste app e devem ser tratados como ambientes oficiais separados.
+- O que precisa de decisão operacional não é extinguir o domínio `.com.br`, e sim definir regras claras de:
+  - mídia paga para `espacofacial.com` quando o objetivo for booking/Meta tracking do site;
+  - canonicalização/SEO por stack;
+  - preservação de atribuição quando houver navegação entre stacks.
+- Os redirects legados de shortlinks/atalhos no Worker ainda precisam de migração total para a camada first-party se a operação quiser fechar 100% das saídas antigas de click-to-WhatsApp.
+- Fechamento offline de WhatsApp para Meta além do n8n atual ainda depende de decisão operacional:
+  - usar o próprio n8n para enviar `Schedule` offline/CAPI;
+  - ou integrar CRM final responsável pelo status/venda.
+
+## 10. Recomendação de configuração de campanhas na Meta
+
+- Evento de otimização principal: `Schedule`
+- Janela inicial recomendada:
+  - atribuição padrão da Meta para conversão no site
+  - foco em campanhas para conversão no site, não click-to-WhatsApp
+- Estrutura sugerida:
+  - campanhas com destino `espacofacial.com/agendamento`
+  - conjuntos por unidade ou macro-oferta quando o volume permitir
+  - criativos com CTA para agendamento no site
+  - remarketing usando visitantes de unidade/doutor e iniciadores de booking sem `Schedule`
+- Manter campanhas click-to-WhatsApp apenas como trilha paralela de teste/controlado, agora com `Contact` first-party e correlação por `wa_click_id`.
+
+## 11. Próximos passos prioritários
+
+1. Publicar Worker + envs Meta e validar com `test_event_code`.
+2. Aplicar migration Postgres e republicar os workflows n8n alterados.
+3. Validar `Schedule` deduplicado no Events Manager.
+4. Validar `wa_click_id` no fluxo site -> WhatsApp -> n8n -> agendamento.
+5. Manter a política operacional já definida:
+   - `espacofacial.com` para site público, booking e mídia do funil rastreado;
+   - `espacofacial.com.br` e `app.espacofacial.com.br` como ambientes oficiais separados;
+   - `crm.skincos.com.br`, `orb.skincos.com.br` e `wa.skincos.com.br` como subdomínios operacionais da SKINCOS.
+6. Migrar gradualmente os redirects legados do Worker que ainda levam direto ao WhatsApp para a camada first-party.

--- a/website/docs/validation-checklist.md
+++ b/website/docs/validation-checklist.md
@@ -19,6 +19,30 @@
 - Sitemap: https://espacofacial.com/sitemap.xml
 - 404: https://espacofacial.com/nao-existe
 
+## Política de domínios
+- `espacofacial.com`:
+  - domínio público canônico deste projeto
+  - usado para mídia paga do site, páginas institucionais deste app e agendamento
+- `www.espacofacial.com`:
+  - deve sempre responder com `308` para `https://espacofacial.com`
+- `espacofacial.com.br`:
+  - domínio oficial separado da franquia
+  - não deve compartilhar sessão/cookies/consentimento com este app
+- `app.espacofacial.com.br`:
+  - app oficial separado da franquia
+  - não deve ser tratado como continuação do funil de tracking deste site
+- `skincos.com.br`, `crm.skincos.com.br`, `orb.skincos.com.br`, `wa.skincos.com.br`:
+  - domínios oficiais da SKINCOS para jurídico, CRM, automação e WhatsApp
+  - não são hosts de navegação pública do funil de booking deste site
+
+## Verificações de domínio
+- `curl -sSIL https://www.espacofacial.com/ | head`
+- `curl -sSIL https://espacofacial.com/ | head`
+- `curl -sSIL https://espacofacial.com.br/ | head`
+- `curl -sSIL https://app.espacofacial.com.br/ | head`
+- `curl -sSIL https://crm.skincos.com.br/ | head`
+- Confirmar que campanhas para booking usam `https://espacofacial.com/...`, não `.com.br`.
+
 ## Redirects críticos
 - Shortener:
   - https://esfa.co/bss/faleconosco

--- a/website/public/production-snapshot/places/barrashoppingsul.json
+++ b/website/public/production-snapshot/places/barrashoppingsul.json
@@ -6,7 +6,7 @@
   "rating": 4.6,
   "userRatingsTotal": 61,
   "mapsUrl": "https://maps.google.com/?cid=13110078212665662890",
-  "website": "https://www.espacofacial.com/barrashoppingsul",
+  "website": "https://espacofacial.com/barrashoppingsul",
   "photos": [
     {
       "photoReference": "AU_ZVEHNIkhaJoNYgU1hueClh4heMzCw02scx6S4DKyt711kHdu-mqRClDOUCo05SLUP8X-TEh-5CPY6XK0Wx_tC99q3KFa6mmuLALZSylirBamrsxh1ONQH_zQqvMhnDG4yDA6M_YrsCB2Wsjlw3aHsE83-tLMjKdmzOqtTMnBAwUj7NvbAHFy_Ie0VPi4VyCl6cHUboDFIs_3KMUSsHKbTX6wLg6UdPh647u4I-khEP_bsmS3DWtqE_A1VtR4GMlfhhGoK2aAWYWwMx7q5GiTEnS_-J8FTqUS4sDw3hYp2Gw5AuQ",

--- a/website/public/production-snapshot/places/novo-hamburgo.json
+++ b/website/public/production-snapshot/places/novo-hamburgo.json
@@ -6,7 +6,7 @@
   "rating": 4.8,
   "userRatingsTotal": 150,
   "mapsUrl": "https://maps.google.com/?cid=2591851901279851131",
-  "website": "https://www.espacofacial.com/novohamburgo",
+  "website": "https://espacofacial.com/novohamburgo",
   "photos": [
     {
       "photoReference": "AU_ZVEGQtf09N4YUsFrvt0isRV16WWU6_lwBNjXnSqgzQoEsLeKueo5XPY0YKs66iHllvzSEgFd575iHgsN1Dt5CDomXpmJbxxVhDueYXvAhm313_u1aYtRrd5-bJjCZ6ZGJd0u-61b5LA_TLd3qm53LoAjQS_ebo5oQfk_9idRDlIS9Mb-Ne_GRSiLW9S4gajcxzw9hjnxYqLOS6fvMd2jDcYHHFiNrvUVrgDHUn3PffrnETXcmB06ue1o7Y6NiLQ_RiHyZUQ-vI-wIw9qnM3ZiDp6Gre4y2fKwXSEn-XtfZcDm2A",

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -3,16 +3,19 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getDigitalJourneyUnits, units } from "@/data/units";
 import { services, type Service } from "@/data/services";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { useTeamDirectory } from "@/hooks/useTeamDirectory";
 import { clearBookingDraft, persistBookingDraft, readBookingDraft, type BookingDraftState } from "@/lib/bookingDraft";
+import { COOKIE_CONSENT_EVENT, dispatchConsent, getCookieConsent, setCookieConsent, type CookieConsent } from "@/lib/cookieConsent";
+import { shouldShowBookingMeasurementOptIn } from "@/lib/bookingConsent";
 import { doctorSlugFromTeamMember, doctorSlugMatchesQuery, normalizeDoctorSlug } from "@/lib/doctorSlug";
 import { trackBookingFunnelStep, trackBookingRequestSubmitted } from "@/lib/leadTracking";
 import { setStoredUnitSlug } from "@/lib/unitSelection";
-import { buildTrackingContextFromBrowser } from "@/lib/campaign";
+import { buildTrackingContextFromBrowser, persistAttributionSnapshot } from "@/lib/campaign";
 import { createMetaEventId, trackMetaStandardEvent } from "@/lib/metaBrowser";
 import TurnstileWidget from "@/components/TurnstileWidget";
 import SmoothAnchorLink from "@/components/SmoothAnchorLink";
@@ -387,6 +390,9 @@ export default function BookingFlow() {
 
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
+    const [privacyAccepted, setPrivacyAccepted] = useState(false);
+    const [measurementOptIn, setMeasurementOptIn] = useState(false);
+    const [storedConsent, setStoredConsent] = useState<CookieConsent | null>(() => getCookieConsent());
     const [dateAvailability, setDateAvailability] = useState<Record<string, boolean>>({});
 
     const [submitted, setSubmitted] = useState<SubmittedReservation | null>(null);
@@ -405,6 +411,20 @@ export default function BookingFlow() {
     const isReservationDetailsView = step === "submitted" && !!submitted && bookingIdQuery.length > 0;
 
     const allowedUnitSlugs = useMemo(() => new Set(getDigitalJourneyUnits().map((unit) => unit.slug)), []);
+
+    useEffect(() => {
+        setStoredConsent(getCookieConsent());
+    }, []);
+
+    useEffect(() => {
+        function onConsent(event: Event) {
+            const detail = (event as CustomEvent<CookieConsent>).detail;
+            setStoredConsent(detail ?? getCookieConsent());
+        }
+
+        window.addEventListener(COOKIE_CONSENT_EVENT, onConsent);
+        return () => window.removeEventListener(COOKIE_CONSENT_EVENT, onConsent);
+    }, []);
 
     useEffect(() => {
         const draft = readBookingDraft();
@@ -859,9 +879,30 @@ export default function BookingFlow() {
             trackBookingFunnelStep({ step: "submit_error", errorReason: "missing_whatsapp", unitSlug, doctorSlug: effectiveDoctor.slug, serviceId: primaryService.id, date: dateKey, time: timeKey, detailsStage: "contact" });
             return;
         }
+        if (!privacyAccepted) {
+            setSubmitError("Confirme a Política de Privacidade e os Termos de Uso para concluir o agendamento.");
+            trackBookingFunnelStep({ step: "submit_error", errorReason: "privacy_unchecked", unitSlug, doctorSlug: effectiveDoctor.slug, serviceId: primaryService.id, date: dateKey, time: timeKey, detailsStage: "contact" });
+            return;
+        }
 
         setSubmitting(true);
         try {
+            if (showMeasurementOptIn && measurementOptIn) {
+                const nextConsent: CookieConsent = { analytics: true, marketing: true };
+                setCookieConsent(nextConsent);
+                dispatchConsent(nextConsent);
+                setStoredConsent(nextConsent);
+                if (typeof window !== "undefined") {
+                    persistAttributionSnapshot({
+                        searchParams: new URLSearchParams(window.location.search),
+                        pageUrl: window.location.href,
+                        pagePath: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+                        referrer: document.referrer,
+                        consent: nextConsent,
+                    });
+                }
+            }
+
             const metaEventId = createMetaEventId("schedule");
             const trackingContext = buildTrackingContextFromBrowser({
                 pageUrl: typeof window !== "undefined" ? window.location.href : null,
@@ -1102,12 +1143,14 @@ export default function BookingFlow() {
     const whatsappDigits = whatsapp.replace(/\D/g, "");
     const whatsappSeemsValid = whatsappDigits.length >= 10;
     const hasTurnstileWidget = !!turnstileSiteKey;
+    const showMeasurementOptIn = shouldShowBookingMeasurementOptIn(storedConsent);
     const canSubmit =
         !!selectedSlot &&
         !!patientName.trim() &&
         !!patientGender &&
         emailSeemsValid &&
-        whatsappSeemsValid;
+        whatsappSeemsValid &&
+        privacyAccepted;
 
     const showDetailsModal = step === "details" && !!unitSlug && !!primaryService && !!dateKey && !!timeKey;
 
@@ -1122,6 +1165,9 @@ export default function BookingFlow() {
 
     useEffect(() => {
         if (!showDetailsModal) return;
+        setPrivacyAccepted(false);
+        setMeasurementOptIn(false);
+        setStoredConsent(getCookieConsent());
         const timer = window.setTimeout(() => {
             patientNameInputRef.current?.focus();
         }, 0);
@@ -1780,6 +1826,45 @@ export default function BookingFlow() {
                             {!whatsappSeemsValid && whatsapp.length > 0 ? (
                                 <div className="bookingFlow__fieldError">Informe DDD + número (ex.: (51) 99999-9999).</div>
                             ) : null}
+
+                            <div className="bookingFlow__consentPanel">
+                                <label className="bookingFlow__consentItem bookingFlow__consentItem--required">
+                                    <input
+                                        type="checkbox"
+                                        checked={privacyAccepted}
+                                        onChange={(event) => setPrivacyAccepted(event.target.checked)}
+                                    />
+                                    <span>
+                                        Li e concordo com a{" "}
+                                        <Link href="/privacidade" target="_blank" rel="noreferrer">
+                                            Política de Privacidade
+                                        </Link>{" "}
+                                        e com os{" "}
+                                        <Link href="/termos" target="_blank" rel="noreferrer">
+                                            Termos de Uso
+                                        </Link>{" "}
+                                        para realizar meu agendamento.
+                                    </span>
+                                </label>
+
+                                {showMeasurementOptIn ? (
+                                    <label className="bookingFlow__consentItem">
+                                        <input
+                                            type="checkbox"
+                                            checked={measurementOptIn}
+                                            onChange={(event) => setMeasurementOptIn(event.target.checked)}
+                                        />
+                                        <span>
+                                            Autorizo o uso de cookies e tecnologias de análise e marketing para medir a
+                                            origem desta reserva, avaliar campanhas e melhorar minha experiência.
+                                        </span>
+                                    </label>
+                                ) : null}
+                            </div>
+
+                            <div className="small" style={{ color: "var(--muted)" }}>
+                                O botão de confirmação só é liberado depois do aceite de privacidade.
+                            </div>
 
                             {hasTurnstileWidget ? (
                                 <div style={{ display: "grid", gap: 8 }}>

--- a/website/src/components/LegalContent.tsx
+++ b/website/src/components/LegalContent.tsx
@@ -88,16 +88,17 @@ export function SkincosHubPage() {
           <div className="card" style={{ padding: 18 }}>
             <h2 style={{ marginTop: 0, fontSize: 18 }}>Domínio institucional</h2>
             <p style={{ marginBottom: 0 }}>
-              <strong>skincos.com.br</strong> concentra a apresentação pública e as páginas
-              jurídicas do app.
+              <strong>skincos.com.br</strong> concentra as páginas institucionais e jurídicas da
+              SKINCOS e do app.
             </p>
           </div>
 
           <div className="card" style={{ padding: 18 }}>
             <h2 style={{ marginTop: 0, fontSize: 18 }}>Domínio operacional</h2>
             <p style={{ marginBottom: 0 }}>
-              <strong>orb.skincos.com.br</strong> é usado como subdomínio técnico para o ambiente
-              operacional e integrações em desenvolvimento.
+              <strong>orb.skincos.com.br</strong>, <strong>crm.skincos.com.br</strong> e{" "}
+              <strong>wa.skincos.com.br</strong> são usados como subdomínios técnicos e
+              operacionais da SKINCOS.
             </p>
           </div>
 
@@ -190,9 +191,10 @@ export function SkincosPrivacyContent() {
           Facebook, Instagram, Threads e WhatsApp, quando operadas pela SKINCOS.
         </p>
         <p>
-          O subdomínio <strong>orb.skincos.com.br</strong> pode ser utilizado como ambiente técnico
-          e operacional do app. As páginas jurídicas permanecem vinculadas preferencialmente ao
-          domínio principal.
+          Os subdomínios <strong>orb.skincos.com.br</strong>, <strong>crm.skincos.com.br</strong>{" "}
+          e <strong>wa.skincos.com.br</strong> podem ser utilizados como ambientes técnicos e
+          operacionais. As páginas jurídicas permanecem vinculadas preferencialmente ao domínio
+          principal.
         </p>
 
         <h2>3. Quais dados podem ser tratados</h2>

--- a/website/src/components/UnitsLandingExperience.tsx
+++ b/website/src/components/UnitsLandingExperience.tsx
@@ -3,8 +3,10 @@
 import Link from "next/link";
 import ExperienceTracker from "@/components/ExperienceTracker";
 import TrackedBookingLink from "@/components/TrackedBookingLink";
+import TrackedWhatsappLink from "@/components/TrackedWhatsappLink";
 import { trackExperienceShortcutClick } from "@/lib/leadTracking";
 import { getUnitHref } from "@/lib/unitRoutes";
+import { resolveFaleConoscoDestination } from "@/lib/faleconoscoRedirect";
 
 export type UnitsFeaturedCard = {
     slug: string;
@@ -117,6 +119,7 @@ export default function UnitsLandingExperience({ featuredUnits, unitsByState }: 
                 <div className="decisionCards">
                     {featuredUnits.map((unit) => {
                         const unitHref = getUnitHref(unit.slug);
+                        const whatsappDestination = resolveFaleConoscoDestination(unit.slug);
                         return (
                             <article key={unit.slug} className="decisionCard decisionCard--unit">
                                 <div className="decisionCard__eyebrow">{unit.city || unit.state || "Unidade"}</div>
@@ -163,7 +166,28 @@ export default function UnitsLandingExperience({ featuredUnits, unitsByState }: 
                                         Ver detalhes da unidade
                                     </Link>
 
-                                    {unit.contactUrl ? (
+                                    {whatsappDestination ? (
+                                        <TrackedWhatsappLink
+                                            rawUrl={whatsappDestination}
+                                            className="decisionCard__link"
+                                            placement="units_page"
+                                            unitSlug={unit.slug}
+                                            source="units_page"
+                                            onClick={() =>
+                                                trackExperienceShortcutClick({
+                                                    page: "/unidades",
+                                                    shortcut: `Contato unidade ${unit.slug}`,
+                                                    destination: whatsappDestination,
+                                                    placement: "units_page",
+                                                    unitSlug: unit.slug,
+                                                    experience: EXPERIENCE_KEY,
+                                                    variant: EXPERIENCE_VARIANT,
+                                                })
+                                            }
+                                        >
+                                            Falar com a unidade
+                                        </TrackedWhatsappLink>
+                                    ) : unit.contactUrl ? (
                                         <Link
                                             href={unit.contactUrl}
                                             prefetch={false}

--- a/website/src/lib/bookingConsent.ts
+++ b/website/src/lib/bookingConsent.ts
@@ -1,0 +1,9 @@
+import type { CookieConsent } from "@/lib/cookieConsent";
+
+export function hasFullMeasurementConsent(consent: CookieConsent | null | undefined): boolean {
+    return consent?.analytics === true && consent?.marketing === true;
+}
+
+export function shouldShowBookingMeasurementOptIn(consent: CookieConsent | null | undefined): boolean {
+    return !hasFullMeasurementConsent(consent);
+}

--- a/website/src/lib/site-config.ts
+++ b/website/src/lib/site-config.ts
@@ -1,4 +1,9 @@
 export type SiteKey = "espacofacial" | "skincos";
+export type OfficialHostFamily =
+  | "espacofacial-public"
+  | "espacofacial-external"
+  | "skincos"
+  | "unknown";
 
 export type SiteConfig = {
   key: SiteKey;
@@ -16,7 +21,24 @@ export type SiteConfig = {
   allowedPaths: ReadonlySet<string>;
 };
 
-const SKINCOS_HOSTS = new Set(["skincos.com.br", "www.skincos.com.br"]);
+export const ESPACOFACIAL_PUBLIC_HOSTS = new Set([
+  "espacofacial.com",
+  "www.espacofacial.com",
+]);
+
+export const ESPACOFACIAL_EXTERNAL_HOSTS = new Set([
+  "espacofacial.com.br",
+  "www.espacofacial.com.br",
+  "app.espacofacial.com.br",
+]);
+
+export const SKINCOS_HOSTS = new Set([
+  "skincos.com.br",
+  "www.skincos.com.br",
+  "crm.skincos.com.br",
+  "orb.skincos.com.br",
+  "wa.skincos.com.br",
+]);
 
 const ESPACOFACIAL_ALLOWED_PATHS = new Set<string>(["*"]);
 
@@ -41,6 +63,15 @@ function normalizeHost(host: string | null | undefined): string {
     .trim()
     .toLowerCase()
     .replace(/:\d+$/, "");
+}
+
+export function getOfficialHostFamily(host: string | null | undefined): OfficialHostFamily {
+  const normalizedHost = normalizeHost(host);
+  if (!normalizedHost) return "unknown";
+  if (SKINCOS_HOSTS.has(normalizedHost)) return "skincos";
+  if (ESPACOFACIAL_PUBLIC_HOSTS.has(normalizedHost)) return "espacofacial-public";
+  if (ESPACOFACIAL_EXTERNAL_HOSTS.has(normalizedHost)) return "espacofacial-external";
+  return "unknown";
 }
 
 export function getSiteKeyFromHost(host: string | null | undefined): SiteKey {

--- a/website/src/lib/whatsappTracking.ts
+++ b/website/src/lib/whatsappTracking.ts
@@ -1,4 +1,5 @@
 import { buildWhatsAppUrl } from "@/lib/whatsapp";
+import { mergeCampaignParamsIntoUrl } from "@/lib/mergeCampaignParams";
 import type { TrackingContext } from "@/lib/attribution";
 
 export type WhatsappTrackingPayload = {
@@ -80,6 +81,26 @@ export function buildWhatsappRedirectHref(params: {
     }
 
     return `${url.pathname}${url.search}`;
+}
+
+export function buildWhatsappRedirectHrefFromRequest(params: {
+    requestUrl: string;
+    rawUrl?: string | null;
+    phone?: string | null;
+    text?: string | null;
+    tracking?: WhatsappTrackingPayload;
+}): string | null {
+    const destinationUrl =
+        normalizeUrl(params.rawUrl) ??
+        (params.phone ? buildWhatsAppUrl(params.phone, params.text ?? "") : null);
+    if (!destinationUrl) return null;
+    if (!isSupportedWhatsappUrl(destinationUrl)) return null;
+
+    const mergedDestination = mergeCampaignParamsIntoUrl(destinationUrl, params.requestUrl);
+    return buildWhatsappRedirectHref({
+        rawUrl: mergedDestination,
+        tracking: params.tracking,
+    });
 }
 
 export function buildWhatsappClickToken(waClickId: string): string {

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -1,5 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { isPathAllowedForSite } from "@/lib/site-config";
+import { buildWhatsappRedirectHrefFromRequest, isSupportedWhatsappUrl } from "@/lib/whatsappTracking";
+import { mergeCampaignParamsIntoUrl } from "@/lib/mergeCampaignParams";
 
 function isPublicAsset(pathname: string): boolean {
     return (
@@ -20,6 +22,16 @@ function normalizeRedirectPath(pathname: string): string {
     }
     const trimmed = decoded.replace(/\/+$/, "");
     return (trimmed.length ? trimmed : "/").toLowerCase();
+}
+
+function inferLegacyWhatsappUnitSlug(pathname: string): string | null {
+    if (pathname.startsWith("/barrashoppingsul") || pathname.startsWith("/bss") || pathname.endsWith("/bss")) {
+        return "barrashoppingsul";
+    }
+    if (pathname.startsWith("/novohamburgo") || pathname.startsWith("/novo-hamburgo") || pathname.startsWith("/nh") || pathname.endsWith("/nh")) {
+        return "novo-hamburgo";
+    }
+    return null;
 }
 
 export function middleware(req: NextRequest) {
@@ -179,6 +191,24 @@ export function middleware(req: NextRequest) {
 
         const legacyDest = legacyRedirects[normalizedPath];
         if (legacyDest) {
+            const mergedLegacyDest = mergeCampaignParamsIntoUrl(legacyDest, req.url);
+            if (isSupportedWhatsappUrl(mergedLegacyDest)) {
+                const trackedRedirect = buildWhatsappRedirectHrefFromRequest({
+                    requestUrl: req.url,
+                    rawUrl: legacyDest,
+                    tracking: {
+                        placement: "legacy_redirect",
+                        unitSlug: inferLegacyWhatsappUnitSlug(normalizedPath),
+                        source: `legacy_redirect:${normalizedPath}`,
+                        pageUrl: req.url,
+                    },
+                });
+
+                if (trackedRedirect) {
+                    return NextResponse.redirect(new URL(trackedRedirect, req.url), { status: 301 });
+                }
+            }
+
             const destUrl = new URL(legacyDest);
             if (req.nextUrl.search) {
                 const destParams = new URLSearchParams(destUrl.search);

--- a/website/tests/bookingConsent.test.ts
+++ b/website/tests/bookingConsent.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hasFullMeasurementConsent, shouldShowBookingMeasurementOptIn } from "../src/lib/bookingConsent";
+
+test("full measurement consent requires analytics and marketing together", () => {
+    assert.equal(hasFullMeasurementConsent({ analytics: true, marketing: true }), true);
+    assert.equal(hasFullMeasurementConsent({ analytics: true, marketing: false }), false);
+    assert.equal(hasFullMeasurementConsent({ analytics: false, marketing: true }), false);
+    assert.equal(hasFullMeasurementConsent(null), false);
+});
+
+test("booking measurement opt-in only shows when full consent is still missing", () => {
+    assert.equal(shouldShowBookingMeasurementOptIn({ analytics: true, marketing: true }), false);
+    assert.equal(shouldShowBookingMeasurementOptIn({ analytics: true, marketing: false }), true);
+    assert.equal(shouldShowBookingMeasurementOptIn({ analytics: false, marketing: false }), true);
+    assert.equal(shouldShowBookingMeasurementOptIn(null), true);
+});

--- a/website/tests/siteConfig.test.ts
+++ b/website/tests/siteConfig.test.ts
@@ -1,11 +1,33 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { getSiteConfigFromHost, isPathAllowedForSite } from "../src/lib/site-config";
+import {
+    getOfficialHostFamily,
+    getSiteConfigFromHost,
+    isPathAllowedForSite,
+} from "../src/lib/site-config";
 
 test("site config maps skincos host to legal hub", () => {
     const site = getSiteConfigFromHost("skincos.com.br");
     assert.equal(site.key, "skincos");
     assert.equal(site.siteUrl, "https://skincos.com.br");
+});
+
+test("official host family distinguishes public espacofacial hosts", () => {
+    assert.equal(getOfficialHostFamily("espacofacial.com"), "espacofacial-public");
+    assert.equal(getOfficialHostFamily("www.espacofacial.com"), "espacofacial-public");
+});
+
+test("official host family distinguishes separate franchise and app hosts", () => {
+    assert.equal(getOfficialHostFamily("espacofacial.com.br"), "espacofacial-external");
+    assert.equal(getOfficialHostFamily("www.espacofacial.com.br"), "espacofacial-external");
+    assert.equal(getOfficialHostFamily("app.espacofacial.com.br"), "espacofacial-external");
+});
+
+test("site config maps skincos operational subdomains to the skincos family", () => {
+    assert.equal(getSiteConfigFromHost("crm.skincos.com.br").key, "skincos");
+    assert.equal(getSiteConfigFromHost("orb.skincos.com.br").key, "skincos");
+    assert.equal(getSiteConfigFromHost("wa.skincos.com.br").key, "skincos");
+    assert.equal(getOfficialHostFamily("crm.skincos.com.br"), "skincos");
 });
 
 test("site config keeps espacofacial separate", () => {

--- a/website/tests/whatsappTracking.test.ts
+++ b/website/tests/whatsappTracking.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildWhatsappRedirectHref, buildWhatsappClickToken, injectWhatsappToken, parseWhatsappDestination } from "../src/lib/whatsappTracking";
+import { buildWhatsappRedirectHref, buildWhatsappRedirectHrefFromRequest, buildWhatsappClickToken, injectWhatsappToken, parseWhatsappDestination } from "../src/lib/whatsappTracking";
 
 test("buildWhatsappRedirectHref wraps supported whatsapp destination with tracking params", () => {
     const href = buildWhatsappRedirectHref({
@@ -27,6 +27,23 @@ test("parseWhatsappDestination extracts phone and text from api.whatsapp.com", (
         phone: "5551999999999",
         text: "Oi teste",
     });
+});
+
+test("buildWhatsappRedirectHrefFromRequest preserves attribution params on the destination", () => {
+    const href = buildWhatsappRedirectHrefFromRequest({
+        requestUrl: "https://espacofacial.com/novohamburgo/faleconosco?utm_source=meta&utm_campaign=abril&fbclid=fbclid_123",
+        rawUrl: "https://api.whatsapp.com/send?phone=5551999999999&text=Oi",
+        tracking: {
+            placement: "legacy_redirect",
+            unitSlug: "novo-hamburgo",
+            source: "legacy_redirect:/novohamburgo/faleconosco",
+        },
+    });
+
+    assert.equal(
+        href,
+        "/api/whatsapp/redirect?dest=https%3A%2F%2Fapi.whatsapp.com%2Fsend%3Fphone%3D5551999999999%26text%3DOi%26utm_source%3Dmeta%26utm_campaign%3Dabril%26fbclid%3Dfbclid_123&placement=legacy_redirect&unit_slug=novo-hamburgo&source=legacy_redirect%3A%2Fnovohamburgo%2Ffaleconosco",
+    );
 });
 
 test("injectWhatsappToken appends short token once", () => {


### PR DESCRIPTION
## Resumo
- reforça o uso first-party dos cliques de WhatsApp no site e em redirects legados
- adiciona aceite obrigatório de privacidade no modal final do agendamento e opt-in opcional de mensuração
- formaliza a política de domínios entre espacofacial.com, espacofacial.com.br/app e skincos.com.br

## Validação
- npm --prefix website test
- npm --prefix website run build