### PR TITLE
feat: mature tracking observability and governance

### DIFF
--- a/backend/apps/crm-api/services/trackingDashboardService.js
+++ b/backend/apps/crm-api/services/trackingDashboardService.js
@@ -48,12 +48,13 @@ function readJsonPathString(input, paths) {
     return null
 }
 
-async function fetchWebsiteTrackingOverview({ days, limit }) {
+async function fetchWebsiteTrackingOverview({ days, limit, offsetDays = 0 }) {
     const baseUrl = sanitizeBaseUrl(process.env.TRACKING_WEBSITE_BASE_URL)
     const token = String(process.env.TRACKING_DASHBOARD_TOKEN || '').trim()
     const requestUrl = new URL('/api/tracking/dashboard', baseUrl)
     requestUrl.searchParams.set('days', String(days))
     requestUrl.searchParams.set('limit', String(limit))
+    requestUrl.searchParams.set('offsetDays', String(offsetDays))
 
     const headers = { accept: 'application/json' }
     if (token) headers.authorization = `Bearer ${token}`
@@ -88,6 +89,263 @@ async function fetchWebsiteTrackingOverview({ days, limit }) {
             sourceUrl: requestUrl.toString(),
             error: error instanceof Error ? error.message : 'website_fetch_failed',
         }
+    }
+}
+
+function toNumber(value) {
+    const parsed = Number(value || 0)
+    return Number.isFinite(parsed) ? parsed : 0
+}
+
+function percent(numerator, denominator) {
+    if (!denominator) return 0
+    return Math.max(0, Math.min(100, Math.round((numerator / denominator) * 100)))
+}
+
+function normalizeCapiIssueReason(reason) {
+    return String(reason || '').trim() || 'delivery_failed'
+}
+
+function buildCoverage(summary = {}) {
+    const confirmedBookings = toNumber(summary.confirmedBookings)
+    const whatsappClicks = toNumber(summary.whatsappClicks)
+    const scheduleOk = toNumber(summary.capiScheduleOk)
+    const scheduleFailed = toNumber(summary.capiScheduleFailed)
+    const contactOk = toNumber(summary.capiContactOk)
+    const contactFailed = toNumber(summary.capiContactFailed)
+
+    return {
+        confirmedBookings,
+        whatsappClicks,
+        trackingContext: percent(toNumber(summary.bookingsWithTrackingContext), confirmedBookings),
+        metaEventId: percent(toNumber(summary.bookingsWithMetaEventId), confirmedBookings),
+        facebookIds: percent(toNumber(summary.bookingsWithFacebookIds), confirmedBookings),
+        marketingConsent: percent(toNumber(summary.bookingsWithMarketingConsent), confirmedBookings),
+        analyticsConsent: percent(toNumber(summary.bookingsWithAnalyticsConsent), confirmedBookings),
+        whatsappTracking: percent(toNumber(summary.whatsappClicksWithTrackingContext), whatsappClicks),
+        scheduleDelivery: percent(scheduleOk, scheduleOk + scheduleFailed),
+        contactDelivery: percent(contactOk, contactOk + contactFailed),
+    }
+}
+
+function buildDelta(currentValue, previousValue) {
+    return Math.round((currentValue - previousValue) * 10) / 10
+}
+
+function pushAlert(alerts, alert) {
+    alerts.push({
+        severity: alert.severity,
+        code: alert.code,
+        title: alert.title,
+        message: alert.message,
+    })
+}
+
+function buildOperationalAlerts({
+    website,
+    previousWebsite,
+    coverage,
+    previousCoverage,
+    summary,
+    recentRetryCandidates,
+}) {
+    const alerts = []
+
+    if (!website.available) {
+        pushAlert(alerts, {
+            severity: 'critical',
+            code: 'website_unavailable',
+            title: 'Site indisponível para observabilidade',
+            message: `O CRM não conseguiu ler o dashboard do website: ${website.error || 'unavailable'}.`,
+        })
+        return alerts
+    }
+
+    const config = website.data?.config || {}
+    if (!config.metaPixelConfigured || !config.metaCapiConfigured) {
+        pushAlert(alerts, {
+            severity: 'critical',
+            code: 'meta_runtime_not_configured',
+            title: 'Meta Pixel ou CAPI sem configuração válida',
+            message: 'O runtime do site ainda não está com Pixel e CAPI completos para produção.',
+        })
+    }
+
+    if (coverage.confirmedBookings > 0 && coverage.trackingContext < 80) {
+        pushAlert(alerts, {
+            severity: coverage.trackingContext < 50 ? 'critical' : 'warning',
+            code: 'low_tracking_context_coverage',
+            title: 'Cobertura baixa de tracking_context',
+            message: `${coverage.trackingContext}% dos bookings confirmados chegaram com tracking_context no período atual.`,
+        })
+    }
+
+    if (coverage.confirmedBookings > 0 && coverage.facebookIds < 70) {
+        pushAlert(alerts, {
+            severity: coverage.facebookIds < 30 ? 'critical' : 'warning',
+            code: 'low_facebook_ids_coverage',
+            title: 'Cobertura baixa de identificadores Facebook',
+            message: `${coverage.facebookIds}% dos bookings confirmados chegaram com fbp/fbc/fbclid no período atual.`,
+        })
+    }
+
+    if (coverage.confirmedBookings > 0 && coverage.marketingConsent < 60) {
+        pushAlert(alerts, {
+            severity: coverage.marketingConsent < 30 ? 'critical' : 'warning',
+            code: 'low_marketing_consent',
+            title: 'Consentimento de marketing abaixo do esperado',
+            message: `${coverage.marketingConsent}% dos bookings confirmados tinham consentimento de marketing no período atual.`,
+        })
+    }
+
+    if (toNumber(summary.capiScheduleFailed) > 0) {
+        pushAlert(alerts, {
+            severity: coverage.scheduleDelivery < 70 ? 'critical' : 'warning',
+            code: 'schedule_capi_failures',
+            title: 'Falhas no evento Schedule via CAPI',
+            message: `${toNumber(summary.capiScheduleFailed)} envios de Schedule falharam no período atual.`,
+        })
+    }
+
+    if (toNumber(summary.capiContactFailed) > 0) {
+        pushAlert(alerts, {
+            severity: coverage.contactDelivery < 70 ? 'critical' : 'warning',
+            code: 'contact_capi_failures',
+            title: 'Falhas no evento Contact via CAPI',
+            message: `${toNumber(summary.capiContactFailed)} envios de Contact falharam no período atual.`,
+        })
+    }
+
+    if (recentRetryCandidates.length > 0) {
+        pushAlert(alerts, {
+            severity: 'warning',
+            code: 'meta_retry_candidates',
+            title: 'Falhas retryable aguardando reprocessamento',
+            message: `${recentRetryCandidates.length} falhas recentes parecem transitórias e podem ser reprocessadas com segurança.`,
+        })
+    }
+
+    if (previousWebsite?.available && previousCoverage.confirmedBookings > 0 && coverage.confirmedBookings > 0) {
+        const trackingDrop = buildDelta(coverage.trackingContext, previousCoverage.trackingContext)
+        const facebookDrop = buildDelta(coverage.facebookIds, previousCoverage.facebookIds)
+        const marketingDrop = buildDelta(coverage.marketingConsent, previousCoverage.marketingConsent)
+
+        if (trackingDrop <= -20) {
+            pushAlert(alerts, {
+                severity: 'warning',
+                code: 'tracking_context_drop',
+                title: 'Queda brusca na cobertura de tracking_context',
+                message: `A cobertura caiu ${Math.abs(trackingDrop)} pontos percentuais contra a janela anterior equivalente.`,
+            })
+        }
+
+        if (facebookDrop <= -20) {
+            pushAlert(alerts, {
+                severity: 'warning',
+                code: 'facebook_ids_drop',
+                title: 'Queda brusca na cobertura de fbp/fbc/fbclid',
+                message: `A cobertura de identificadores Facebook caiu ${Math.abs(facebookDrop)} pontos percentuais contra a janela anterior.`,
+            })
+        }
+
+        if (marketingDrop <= -20) {
+            pushAlert(alerts, {
+                severity: 'warning',
+                code: 'marketing_consent_drop',
+                title: 'Queda brusca no consentimento de marketing',
+                message: `A taxa de consentimento caiu ${Math.abs(marketingDrop)} pontos percentuais contra a janela anterior.`,
+            })
+        }
+    }
+
+    return alerts
+}
+
+function buildHealthStatus(alerts) {
+    if (alerts.some((alert) => alert.severity === 'critical')) {
+        return {
+            status: 'critical',
+            label: 'crítico',
+            summary: 'A instrumentação existe, mas há bloqueios sérios de cobertura ou entrega que pedem ação imediata.',
+        }
+    }
+    if (alerts.some((alert) => alert.severity === 'warning')) {
+        return {
+            status: 'degraded',
+            label: 'degradado',
+            summary: 'O tracking está operacional, mas a cobertura e a qualidade ainda precisam de correção ou vigilância.',
+        }
+    }
+    return {
+        status: 'healthy',
+        label: 'saudável',
+        summary: 'A camada de tracking do site está sem alertas críticos no período consultado.',
+    }
+}
+
+function buildReconciliation(websiteData = {}) {
+    const buckets = Array.isArray(websiteData.coverageBuckets) ? websiteData.coverageBuckets : []
+    const total = buckets.reduce((acc, item) => acc + toNumber(item.count), 0)
+    return {
+        buckets: buckets.map((item) => ({
+            bucket: item.bucket,
+            label: item.label,
+            count: toNumber(item.count),
+            percent: percent(toNumber(item.count), total),
+        })),
+        incompleteBookings: Array.isArray(websiteData.recentIncompleteBookings) ? websiteData.recentIncompleteBookings : [],
+        retryCandidates: Array.isArray(websiteData.recentRetryCandidates) ? websiteData.recentRetryCandidates : [],
+    }
+}
+
+function buildGovernance() {
+    return {
+        campaignRule: 'Toda campanha paga com objetivo de booking deve apontar para https://espacofacial.com, sempre com utm_source, utm_medium, utm_campaign e utm_content.',
+        validExamples: [
+            'https://espacofacial.com/agendamento?utm_source=meta&utm_medium=paid_social&utm_campaign=bss_botox&utm_content=video_a',
+            'https://espacofacial.com/novohamburgo?utm_source=meta&utm_medium=paid_social&utm_campaign=nh_avaliacao&utm_content=carrossel_1',
+        ],
+        invalidExamples: [
+            'https://espacofacial.com.br/agendamento?utm_source=meta',
+            'https://wa.me/message/MT7UGL6U6KYWA1',
+            'https://espacofacial.com/agendamento',
+        ],
+        crossDomainAllowlist: [
+            { host: 'espacofacial.com.br', purpose: 'franquia oficial', allowedFromPublicSite: true },
+            { host: 'app.espacofacial.com.br', purpose: 'aplicação oficial externa da franquia', allowedFromPublicSite: true },
+            { host: 'crm.skincos.com.br', purpose: 'CRM interno e observabilidade', allowedFromPublicSite: false },
+            { host: 'orb.skincos.com.br', purpose: 'orquestração/n8n', allowedFromPublicSite: false },
+            { host: 'wa.skincos.com.br', purpose: 'stack técnica de WhatsApp', allowedFromPublicSite: false },
+        ],
+    }
+}
+
+function buildValidationCadence() {
+    return {
+        smoke: 'a cada deploy',
+        functional: 'semanal',
+        coverageAudit: 'quinzenal',
+        recurringChecks: [
+            'entrada com utm_source, utm_medium, utm_campaign e utm_content',
+            'entrada com fbclid',
+            'consentimento aceito e recusado',
+            'booking completo até confirmação',
+            'clique de WhatsApp via /api/whatsapp/redirect',
+            'deduplicação browser/server do Schedule',
+        ],
+    }
+}
+
+function buildWhatsappContract() {
+    return {
+        status: 'pending_n8n_phase',
+        lifecycle: [
+            'conversation_started',
+            'appointment_created',
+            'appointment_confirmed',
+            'sale_closed',
+        ],
+        description: 'Quando a frente n8n voltar a ser prioridade, o CRM deve exibir claramente clique no site, conversa aberta e desfecho final por atendimento.',
     }
 }
 
@@ -303,17 +561,32 @@ export async function getTrackingDashboardOverview(params = {}) {
     }
 
     const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
-    const [website, whatsapp] = await Promise.all([
-        fetchWebsiteTrackingOverview({ days, limit }),
+    const [website, previousWebsite, whatsapp] = await Promise.all([
+        fetchWebsiteTrackingOverview({ days, limit, offsetDays: 0 }),
+        fetchWebsiteTrackingOverview({ days, limit: Math.min(limit, 5), offsetDays: days }),
         fetchWhatsappAttributionOverview({ sinceIso, limit }),
     ])
 
     const warnings = []
     if (!website.available) warnings.push(`website:${website.error || 'unavailable'}`)
+    if (!previousWebsite.available) warnings.push(`website_previous:${previousWebsite.error || 'unavailable'}`)
     if (!whatsapp.available) warnings.push(`whatsapp:${whatsapp.error || 'unavailable'}`)
 
     const websiteSummary = website.available ? website.data?.summary || {} : {}
     const whatsappSummary = whatsapp.available ? whatsapp.data?.summary || {} : {}
+    const previousWebsiteSummary = previousWebsite.available ? previousWebsite.data?.summary || {} : {}
+    const coverage = buildCoverage(websiteSummary)
+    const previousCoverage = buildCoverage(previousWebsiteSummary)
+    const reconciliation = buildReconciliation(website.data || {})
+    const alerts = buildOperationalAlerts({
+        website,
+        previousWebsite,
+        coverage,
+        previousCoverage,
+        summary: websiteSummary,
+        recentRetryCandidates: reconciliation.retryCandidates,
+    })
+    const health = buildHealthStatus(alerts)
 
     const funnel = {
         siteConfirmedBookings: Number(websiteSummary.confirmedBookings || 0),
@@ -329,8 +602,17 @@ export async function getTrackingDashboardOverview(params = {}) {
         partial: warnings.length > 0,
         warnings,
         website,
+        previousWebsite,
         whatsapp,
         funnel,
+        coverage,
+        previousCoverage,
+        alerts,
+        health,
+        reconciliation,
+        governance: buildGovernance(),
+        validationCadence: buildValidationCadence(),
+        whatsappContract: buildWhatsappContract(),
     }
 
     cache = {

--- a/frontend/MetaTrackingDashboard.tsx
+++ b/frontend/MetaTrackingDashboard.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
 import { Progress } from '@/progress'
-import { ArrowRight, ChartBar, CheckCircle, CirclesThreePlus, Funnel, LinkBreak, Spinner, WarningCircle, WhatsappLogo } from '@phosphor-icons/react'
+import { ChartBar, CheckCircle, CirclesThreePlus, Funnel, LinkBreak, Spinner, WarningCircle, WhatsappLogo } from '@phosphor-icons/react'
 
 type TrackingOverviewResponse = {
   ok: boolean
@@ -16,6 +16,89 @@ type TrackingOverviewResponse = {
     siteWhatsappClicks: number
     crmAttributedConversations: number
     crmAttributedAppointments: number
+  }
+  coverage?: {
+    confirmedBookings: number
+    whatsappClicks: number
+    trackingContext: number
+    metaEventId: number
+    facebookIds: number
+    marketingConsent: number
+    analyticsConsent: number
+    whatsappTracking: number
+    scheduleDelivery: number
+    contactDelivery: number
+  }
+  previousCoverage?: {
+    trackingContext: number
+    facebookIds: number
+    marketingConsent: number
+  }
+  alerts?: Array<{
+    severity: 'critical' | 'warning'
+    code: string
+    title: string
+    message: string
+  }>
+  health?: {
+    status: 'healthy' | 'degraded' | 'critical'
+    label: string
+    summary: string
+  }
+  reconciliation?: {
+    buckets?: Array<{
+      bucket: 'sem_origem' | 'origem_first_party' | 'origem_meta_completa'
+      label: string
+      count: number
+      percent: number
+    }>
+    incompleteBookings?: Array<{
+      id: string
+      createdAtMs: number
+      unitSlug: string
+      patient: string | null
+      utmSource: string | null
+      utmCampaign: string | null
+      landingPage: string | null
+      metaEventId: string | null
+      hasFacebookIds: boolean
+      coverageBucket: string
+      incompleteCauses: string[]
+      primaryCause: string
+      scheduleStatus: string | null
+    }>
+    retryCandidates?: Array<{
+      id: string
+      createdAtMs: number
+      eventName: string
+      eventId: string
+      bookingId: string | null
+      waClickId: string | null
+      httpStatus: number | null
+      errorMessage: string | null
+      normalizedReason: string
+    }>
+  }
+  governance?: {
+    campaignRule: string
+    validExamples: string[]
+    invalidExamples: string[]
+    crossDomainAllowlist: Array<{
+      host: string
+      purpose: string
+      allowedFromPublicSite: boolean
+    }>
+  }
+  validationCadence?: {
+    smoke: string
+    functional: string
+    coverageAudit: string
+    recurringChecks: string[]
+  }
+  whatsappContract?: {
+    status: string
+    lifecycle: string[]
+    description: string
   }
   website?: {
     available: boolean
@@ -66,8 +149,14 @@ type TrackingOverviewResponse = {
         waClickId: string | null
         httpStatus: number | null
         errorMessage: string | null
+        normalizedReason?: string
+        retryable?: boolean
       }>
     }
+  }
+  previousWebsite?: {
+    available: boolean
+    error?: string
   }
   whatsapp?: {
     available: boolean
@@ -117,6 +206,11 @@ function formatNumber(value: number | string | null | undefined): string {
 function formatPercent(numerator: number, denominator: number): number {
   if (!denominator) return 0
   return Math.max(0, Math.min(100, Math.round((numerator / denominator) * 100)))
+}
+
+function buildDelta(current: number, previous: number): string {
+  const delta = Math.round((current - previous) * 10) / 10
+  return `${delta >= 0 ? '+' : ''}${delta}`
 }
 
 function formatDateTime(value: number | string | null | undefined): string {
@@ -194,6 +288,49 @@ function SmallList({
   )
 }
 
+function AlertPanel({
+  alerts,
+}: {
+  alerts: Array<{ severity: 'critical' | 'warning'; code: string; title: string; message: string }>
+}) {
+  return (
+    <Card className="glass-card border-white/10">
+      <CardHeader>
+        <CardTitle className="text-white">Alertas operacionais</CardTitle>
+        <CardDescription className="text-blue-100/70">
+          Regras automáticas para cobertura, consentimento e falhas de entrega.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {alerts.length === 0 ? (
+          <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            Nenhum alerta ativo no período consultado.
+          </div>
+        ) : (
+          alerts.map((alert) => (
+            <div
+              key={alert.code}
+              className={`rounded-2xl border p-4 text-sm ${
+                alert.severity === 'critical'
+                  ? 'border-red-400/20 bg-red-500/10 text-red-100'
+                  : 'border-amber-400/20 bg-amber-500/10 text-amber-100'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-medium">{alert.title}</div>
+                <Badge variant="outline" className={alert.severity === 'critical' ? 'border-red-300/30 text-red-100' : 'border-amber-300/30 text-amber-100'}>
+                  {alert.severity === 'critical' ? 'Crítico' : 'Alerta'}
+                </Badge>
+              </div>
+              <div className="mt-2 text-sm opacity-90">{alert.message}</div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
 export function MetaTrackingDashboard() {
   const [days, setDays] = useState(30)
   const [loading, setLoading] = useState(true)
@@ -235,38 +372,54 @@ export function MetaTrackingDashboard() {
 
   const websiteSummary = data?.website?.data?.summary || {}
   const whatsappSummary = data?.whatsapp?.data?.summary || {}
-  const confirmedBookings = Number(websiteSummary.confirmedBookings || 0)
-  const siteWhatsappClicks = Number(websiteSummary.whatsappClicks || 0)
+  const confirmedBookings = Number(data?.coverage?.confirmedBookings ?? websiteSummary.confirmedBookings ?? 0)
+  const siteWhatsappClicks = Number(data?.coverage?.whatsappClicks ?? websiteSummary.whatsappClicks ?? 0)
   const whatsappConversationTotal = Number(whatsappSummary.conversations_total || 0)
   const whatsappAppointmentTotal = Number(whatsappSummary.appointments_total || 0)
 
   const siteCoverage = useMemo(() => {
+    if (data?.coverage) {
+      return {
+        tracking: data.coverage.trackingContext,
+        metaEvent: data.coverage.metaEventId,
+        facebookIds: data.coverage.facebookIds,
+      }
+    }
     return {
       tracking: formatPercent(Number(websiteSummary.bookingsWithTrackingContext || 0), confirmedBookings),
       metaEvent: formatPercent(Number(websiteSummary.bookingsWithMetaEventId || 0), confirmedBookings),
       facebookIds: formatPercent(Number(websiteSummary.bookingsWithFacebookIds || 0), confirmedBookings),
     }
-  }, [websiteSummary, confirmedBookings])
+  }, [data?.coverage, websiteSummary, confirmedBookings])
 
   const siteBehaviorCoverage = useMemo(() => {
+    if (data?.coverage) {
+      return {
+        marketingConsent: data.coverage.marketingConsent,
+        analyticsConsent: data.coverage.analyticsConsent,
+        whatsappTracking: data.coverage.whatsappTracking,
+      }
+    }
     return {
       marketingConsent: formatPercent(Number(websiteSummary.bookingsWithMarketingConsent || 0), confirmedBookings),
       analyticsConsent: formatPercent(Number(websiteSummary.bookingsWithAnalyticsConsent || 0), confirmedBookings),
       whatsappTracking: formatPercent(Number(websiteSummary.whatsappClicksWithTrackingContext || 0), siteWhatsappClicks),
     }
-  }, [websiteSummary, confirmedBookings, siteWhatsappClicks])
+  }, [data?.coverage, websiteSummary, confirmedBookings, siteWhatsappClicks])
 
   const scheduleDeliveryRate = useMemo(() => {
+    if (data?.coverage) return data.coverage.scheduleDelivery
     const ok = Number(websiteSummary.capiScheduleOk || 0)
     const fail = Number(websiteSummary.capiScheduleFailed || 0)
     return formatPercent(ok, ok + fail)
-  }, [websiteSummary])
+  }, [data?.coverage, websiteSummary])
 
   const contactDeliveryRate = useMemo(() => {
+    if (data?.coverage) return data.coverage.contactDelivery
     const ok = Number(websiteSummary.capiContactOk || 0)
     const fail = Number(websiteSummary.capiContactFailed || 0)
     return formatPercent(ok, ok + fail)
-  }, [websiteSummary])
+  }, [data?.coverage, websiteSummary])
 
   const topSourceItems = (data?.website?.data?.topSources || []).map((item) => ({
     label: item.utmSource || 'direto',
@@ -280,6 +433,12 @@ export function MetaTrackingDashboard() {
     label: item.unitSlug || 'sem unidade',
     value: formatNumber(item.count),
   }))
+  const reconciliationBuckets = data?.reconciliation?.buckets || []
+  const incompleteBookings = data?.reconciliation?.incompleteBookings || []
+  const retryCandidates = data?.reconciliation?.retryCandidates || []
+  const previousTracking = Number(data?.previousCoverage?.trackingContext || 0)
+  const previousFacebookIds = Number(data?.previousCoverage?.facebookIds || 0)
+  const previousMarketingConsent = Number(data?.previousCoverage?.marketingConsent || 0)
   const whatsappAttributionReady = whatsappConversationTotal > 0 || whatsappAppointmentTotal > 0
   const siteInsights = useMemo(() => {
     const insights: Array<{ tone: 'success' | 'warning' | 'danger'; text: string }> = []
@@ -387,6 +546,38 @@ export function MetaTrackingDashboard() {
             </div>
           ) : null}
 
+          {data?.health ? (
+            <div
+              className={`rounded-2xl border p-5 ${
+                data.health.status === 'healthy'
+                  ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100'
+                  : data.health.status === 'critical'
+                    ? 'border-red-400/30 bg-red-500/10 text-red-100'
+                    : 'border-amber-400/30 bg-amber-500/10 text-amber-100'
+              }`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2 font-medium">
+                  {data.health.status === 'healthy' ? <CheckCircle className="h-5 w-5" /> : <WarningCircle className="h-5 w-5" />}
+                  Saúde do tracking: {data.health.label}
+                </div>
+                <Badge
+                  variant="outline"
+                  className={
+                    data.health.status === 'healthy'
+                      ? 'border-emerald-300/30 text-emerald-100'
+                      : data.health.status === 'critical'
+                        ? 'border-red-300/30 text-red-100'
+                        : 'border-amber-300/30 text-amber-100'
+                  }
+                >
+                  janela {days}d
+                </Badge>
+              </div>
+              <p className="mt-2 text-sm opacity-90">{data.health.summary}</p>
+            </div>
+          ) : null}
+
           {!whatsappAttributionReady ? (
             <div className="rounded-2xl border border-blue-400/30 bg-blue-500/10 p-5 text-blue-100">
               <div className="flex items-center gap-2 font-medium">
@@ -477,6 +668,29 @@ export function MetaTrackingDashboard() {
           </div>
 
           <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+            <MetricCard
+              title="Tracking_context vs janela anterior"
+              value={`${buildDelta(siteCoverage.tracking, previousTracking)} pp`}
+              hint={`Atual ${siteCoverage.tracking}% • anterior ${previousTracking}%`}
+              tone={siteCoverage.tracking >= previousTracking ? 'success' : 'warning'}
+            />
+            <MetricCard
+              title="FB IDs vs janela anterior"
+              value={`${buildDelta(siteCoverage.facebookIds, previousFacebookIds)} pp`}
+              hint={`Atual ${siteCoverage.facebookIds}% • anterior ${previousFacebookIds}%`}
+              tone={siteCoverage.facebookIds >= previousFacebookIds ? 'success' : 'warning'}
+            />
+            <MetricCard
+              title="Consentimento marketing vs anterior"
+              value={`${buildDelta(siteBehaviorCoverage.marketingConsent, previousMarketingConsent)} pp`}
+              hint={`Atual ${siteBehaviorCoverage.marketingConsent}% • anterior ${previousMarketingConsent}%`}
+              tone={siteBehaviorCoverage.marketingConsent >= previousMarketingConsent ? 'success' : 'warning'}
+            />
+          </div>
+
+          <AlertPanel alerts={data?.alerts || []} />
+
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
             <SmallList title="Top fontes do site" items={topSourceItems} emptyLabel="Sem origem UTM suficiente no periodo." />
             <SmallList title="Top campanhas do site" items={topCampaignItems} emptyLabel="Sem campanhas registradas no periodo." />
             <SmallList title="Unidades com mais bookings" items={unitItems} emptyLabel="Sem unidades registradas no periodo." />
@@ -554,6 +768,22 @@ export function MetaTrackingDashboard() {
                 </div>
               </CardContent>
             </Card>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+            {reconciliationBuckets.map((item) => (
+              <Card key={item.bucket} className="glass-card border-white/10">
+                <CardHeader>
+                  <CardTitle className="text-base text-white">{item.label}</CardTitle>
+                  <CardDescription className="text-blue-100/70">
+                    {item.percent}% dos bookings confirmados na janela atual.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-3xl font-semibold text-white">{formatNumber(item.count)}</div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
 
           <div className={`grid grid-cols-1 gap-4 ${whatsappAttributionReady ? 'xl:grid-cols-2' : ''}`}>
@@ -636,6 +866,76 @@ export function MetaTrackingDashboard() {
             ) : null}
           </div>
 
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <Card className="glass-card border-white/10">
+              <CardHeader>
+                <CardTitle className="text-white">Bookings com tracking incompleto</CardTitle>
+                <CardDescription className="text-blue-100/70">
+                  Lista priorizada por data com a principal causa diagnosticada.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {incompleteBookings.length === 0 ? (
+                  <div className="text-sm text-emerald-200/90">Nenhum booking incompleto na janela consultada.</div>
+                ) : (
+                  incompleteBookings.map((item) => (
+                    <div key={item.id} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <div className="font-medium text-white">{item.patient || 'Paciente oculto'}</div>
+                          <div className="text-sm text-blue-100/65">
+                            {item.unitSlug} • {item.utmSource || 'direto'} • {item.utmCampaign || 'sem campanha'}
+                          </div>
+                        </div>
+                        <Badge variant="outline" className="border-amber-300/30 text-amber-100">
+                          {item.primaryCause}
+                        </Badge>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-2 text-xs text-blue-100/70">
+                        <span>{formatDateTime(item.createdAtMs)}</span>
+                        <span>•</span>
+                        <span>{item.coverageBucket}</span>
+                        <span>•</span>
+                        <span>{item.incompleteCauses.join(', ')}</span>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="glass-card border-white/10">
+              <CardHeader>
+                <CardTitle className="text-white">Falhas retryable para reprocessamento</CardTitle>
+                <CardDescription className="text-blue-100/70">
+                  Eventos server-side com perfil transitório de erro na Meta.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {retryCandidates.length === 0 ? (
+                  <div className="text-sm text-emerald-200/90">Nenhuma falha transitória recente detectada.</div>
+                ) : (
+                  retryCandidates.map((item) => (
+                    <div key={item.id} className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="font-medium text-amber-100">
+                          {item.eventName} • status {item.httpStatus || 'sem HTTP'}
+                        </div>
+                        <Badge variant="outline" className="border-amber-300/30 text-amber-100">
+                          {item.normalizedReason}
+                        </Badge>
+                      </div>
+                      <div className="mt-2 text-sm text-amber-100/85">{item.errorMessage || 'Sem mensagem detalhada.'}</div>
+                      <div className="mt-2 text-xs text-amber-100/70">
+                        {formatDateTime(item.createdAtMs)} • event_id {item.eventId}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
           <Card className="glass-card border-white/10">
             <CardHeader>
               <CardTitle className="text-white">Falhas recentes de entrega server-side</CardTitle>
@@ -664,6 +964,110 @@ export function MetaTrackingDashboard() {
                   </div>
                 ))
               )}
+            </CardContent>
+          </Card>
+
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+            <Card className="glass-card border-white/10 xl:col-span-2">
+              <CardHeader>
+                <CardTitle className="text-white">Governança de campanhas e links</CardTitle>
+                <CardDescription className="text-blue-100/70">
+                  Convenção operacional para manter origem, deduplicação e domínio corretos.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-blue-100/80">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">{data?.governance?.campaignRule}</div>
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <div className="mb-2 font-medium text-white">Exemplos válidos</div>
+                    <div className="space-y-2">
+                      {(data?.governance?.validExamples || []).map((item) => (
+                        <div key={item} className="rounded-xl border border-emerald-400/20 bg-emerald-500/10 p-3 text-emerald-100 break-all">
+                          {item}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="mb-2 font-medium text-white">Exemplos inválidos</div>
+                    <div className="space-y-2">
+                      {(data?.governance?.invalidExamples || []).map((item) => (
+                        <div key={item} className="rounded-xl border border-red-400/20 bg-red-500/10 p-3 text-red-100 break-all">
+                          {item}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div className="mb-2 font-medium text-white">Allowlist cross-domain pública</div>
+                  <div className="space-y-2">
+                    {(data?.governance?.crossDomainAllowlist || []).map((item) => (
+                      <div key={item.host} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                        <div>
+                          <div className="text-white">{item.host}</div>
+                          <div className="text-xs text-blue-100/70">{item.purpose}</div>
+                        </div>
+                        <Badge variant="outline" className={item.allowedFromPublicSite ? 'border-blue-300/30 text-blue-100' : 'border-white/20 text-blue-100/70'}>
+                          {item.allowedFromPublicSite ? 'Saída pública permitida' : 'Uso interno/técnico'}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="glass-card border-white/10">
+              <CardHeader>
+                <CardTitle className="text-white">Rotina contínua</CardTitle>
+                <CardDescription className="text-blue-100/70">
+                  Cadência mínima para manter o tracking auditável.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-blue-100/80">
+                <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                  <div className="font-medium text-white">Smoke</div>
+                  <div>{data?.validationCadence?.smoke}</div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                  <div className="font-medium text-white">Validação funcional</div>
+                  <div>{data?.validationCadence?.functional}</div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                  <div className="font-medium text-white">Auditoria de cobertura</div>
+                  <div>{data?.validationCadence?.coverageAudit}</div>
+                </div>
+                <div className="space-y-2">
+                  {(data?.validationCadence?.recurringChecks || []).map((item) => (
+                    <div key={item} className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card className="glass-card border-white/10">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <WhatsappLogo className="h-5 w-5 text-emerald-300" />
+                Contrato do loop WhatsApp/CRM
+              </CardTitle>
+              <CardDescription className="text-blue-100/70">
+                Preparação do que o CRM deve exibir quando a frente n8n voltar a ser prioridade.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-blue-100/80">
+              <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">{data?.whatsappContract?.description}</div>
+              <div className="flex flex-wrap gap-2">
+                {(data?.whatsappContract?.lifecycle || []).map((step) => (
+                  <Badge key={step} variant="outline" className="border-blue-300/30 text-blue-100">
+                    {step}
+                  </Badge>
+                ))}
+              </div>
             </CardContent>
           </Card>
         </CardContent>

--- a/website/docs/campaign-url-governance.md
+++ b/website/docs/campaign-url-governance.md
@@ -1,0 +1,47 @@
+# Governança de URLs de campanha
+
+## Regra principal
+
+Toda campanha com objetivo de agendamento e otimização por `Schedule` deve apontar para `https://espacofacial.com`, nunca para `espacofacial.com.br`, `app.espacofacial.com.br` ou links diretos de WhatsApp.
+
+## Parâmetros mínimos obrigatórios
+
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `utm_content`
+
+Parâmetro opcional, quando existir:
+
+- `utm_term`
+
+## Exemplos válidos
+
+```text
+https://espacofacial.com/agendamento?utm_source=meta&utm_medium=paid_social&utm_campaign=bss_botox&utm_content=video_a
+https://espacofacial.com/novohamburgo?utm_source=meta&utm_medium=paid_social&utm_campaign=nh_avaliacao&utm_content=carrossel_1
+```
+
+## Exemplos inválidos
+
+```text
+https://espacofacial.com/agendamento
+https://espacofacial.com.br/agendamento?utm_source=meta&utm_medium=paid_social
+https://wa.me/message/MT7UGL6U6KYWA1
+https://api.whatsapp.com/send?phone=5551980882293
+```
+
+## Regras operacionais
+
+1. Qualquer CTA de mídia paga que queira otimizar por conversão deve cair primeiro no site.
+2. O clique para WhatsApp deve acontecer apenas depois da passagem pelo site, para preservar `Contact`, `wa_click_id` e contexto first-party.
+3. Links encurtados, landing pages auxiliares e redirecionamentos devem preservar query string.
+4. O host canônico continua sendo `espacofacial.com`.
+5. Se a campanha depender de stack externa da franquia, isso deve ser uma decisão intencional e fora do funil padrão deste projeto.
+
+## Checklist rápido antes de publicar campanha
+
+1. O domínio é `espacofacial.com`.
+2. A URL contém `utm_source`, `utm_medium`, `utm_campaign` e `utm_content`.
+3. O destino final não é `wa.me`, `api.whatsapp.com` ou `.com.br`.
+4. A oferta/CTA leva o usuário ao site antes de qualquer conversa no WhatsApp.

--- a/website/docs/domain-policy.md
+++ b/website/docs/domain-policy.md
@@ -47,3 +47,16 @@ Esta política define qual domínio pertence a qual stack e como cada host deve 
    - snapshots públicos
    - checklist de validação
    - documentação de tracking
+
+## Allowlist operacional de saídas públicas aceitáveis
+
+1. `espacofacial.com.br`
+   - permitido apenas quando a navegação pública precisar apontar explicitamente para a stack oficial da franquia
+2. `app.espacofacial.com.br`
+   - permitido apenas quando houver necessidade explícita de integração com o app externo da franquia
+3. `crm.skincos.com.br`
+   - não deve ser destino público de campanhas ou CTAs do funil deste site
+4. `orb.skincos.com.br`
+   - uso exclusivamente técnico/interno
+5. `wa.skincos.com.br`
+   - uso exclusivamente técnico/interno

--- a/website/docs/validation-checklist.md
+++ b/website/docs/validation-checklist.md
@@ -1,61 +1,128 @@
-# Checklist final de validação
+# Checklist contínuo de validação
 
-## Comandos
-- Suíte completa (CI):
+## Comandos operacionais
+
+- Suíte completa de qualidade:
   - `npm run quality:ci`
-- Suíte completa (local, sem reinstalar deps):
+- Suíte local sem reinstalar dependências:
   - `npm run quality:check`
-- Smoke isolado (rotas críticas + agenda obrigatório):
+- Smoke isolado do funil público:
   - `npm run smoke:strict`
-  - (equivale a `SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs`)
-- Auditoria 360 (design/ui/ux/seo/perf/a11y):
+- Auditoria de governança de tracking/domínio:
+  - `npm run tracking:governance`
+- Auditoria 360 de UI/UX/SEO/perf/a11y:
   - `npm run audit:360`
 
-## URLs para conferir
-- Home: https://espacofacial.com/
-- Unidades: https://espacofacial.com/unidades
-- Doutores: https://espacofacial.com/doutores
-- Robots: https://espacofacial.com/robots.txt
-- Sitemap: https://espacofacial.com/sitemap.xml
-- 404: https://espacofacial.com/nao-existe
+## Cadência mínima
 
-## Política de domínios
-- `espacofacial.com`:
-  - domínio público canônico deste projeto
-  - usado para mídia paga do site, páginas institucionais deste app e agendamento
-- `www.espacofacial.com`:
-  - deve sempre responder com `308` para `https://espacofacial.com`
-- `espacofacial.com.br`:
-  - domínio oficial separado da franquia
-  - não deve compartilhar sessão/cookies/consentimento com este app
-- `app.espacofacial.com.br`:
-  - app oficial separado da franquia
-  - não deve ser tratado como continuação do funil de tracking deste site
-- `skincos.com.br`, `crm.skincos.com.br`, `orb.skincos.com.br`, `wa.skincos.com.br`:
-  - domínios oficiais da SKINCOS para jurídico, CRM, automação e WhatsApp
-  - não são hosts de navegação pública do funil de booking deste site
+- Smoke por deploy:
+  - rodar `npm run smoke:strict`
+  - validar `x-app-build`
+  - abrir o CRM em `Meta Ads > Tracking`
+- Validação funcional semanal:
+  - percorrer o funil completo do site
+  - validar `Schedule` browser/server
+  - validar clique WhatsApp via `/api/whatsapp/redirect`
+- Auditoria quinzenal de cobertura:
+  - revisar `% tracking_context`
+  - revisar `% meta_event_id`
+  - revisar `% fbp/fbc/fbclid`
+  - revisar `% consentimento marketing`
+  - revisar `Schedule CAPI OK vs failed`
+  - revisar `Contact CAPI OK vs failed`
 
-## Verificações de domínio
-- `curl -sSIL https://www.espacofacial.com/ | head`
-- `curl -sSIL https://espacofacial.com/ | head`
-- `curl -sSIL https://espacofacial.com.br/ | head`
-- `curl -sSIL https://app.espacofacial.com.br/ | head`
-- `curl -sSIL https://crm.skincos.com.br/ | head`
-- Confirmar que campanhas para booking usam `https://espacofacial.com/...`, não `.com.br`.
+## URLs fixas para conferir
 
-## Redirects críticos
-- Shortener:
-  - https://esfa.co/bss/faleconosco
-  - https://esfa.co/nh/faleconsco
-- Domínio principal (vai para WhatsApp):
-  - https://espacofacial.com/barrashoppingsul/faleconosco
-  - https://espacofacial.com/novohamburgo/faleconosco
+- Home:
+  - `https://espacofacial.com/`
+- Agendamento:
+  - `https://espacofacial.com/agendamento`
+- Unidades:
+  - `https://espacofacial.com/unidades`
+- Doutores:
+  - `https://espacofacial.com/doutores`
+- Privacidade:
+  - `https://espacofacial.com/privacidade`
+- Termos:
+  - `https://espacofacial.com/termos`
+- Robots:
+  - `https://espacofacial.com/robots.txt`
+- Sitemap:
+  - `https://espacofacial.com/sitemap.xml`
+- 404:
+  - `https://espacofacial.com/nao-existe`
 
-## Sem loops
-- Rodar:
-  - `curl -sSIL https://esfa.co/bss/faleconosco | head`
-  - `curl -sSIL https://espacofacial.com/barrashoppingsul/faleconosco | head`
+## Bateria manual recorrente
 
-## Operacional (Cloudflare DNS)
-- Registros de e-mail (MX/TXT/DKIM) devem ser **DNS only**.
-- Ideal: não manter A records do Wix no apex.
+### Cenário 1: entrada com UTMs
+
+- Abrir:
+  - `https://espacofacial.com/agendamento?utm_source=meta&utm_medium=paid_social&utm_campaign=teste_tracking&utm_content=criativo_a`
+- Aceitar cookies de marketing e analytics.
+- Concluir um agendamento.
+- Validar no CRM:
+  - booking com `tracking_context`
+  - booking com `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`
+  - booking com `meta_event_id`
+
+### Cenário 2: entrada com fbclid
+
+- Abrir:
+  - `https://espacofacial.com/agendamento?utm_source=meta&utm_medium=paid_social&utm_campaign=teste_fbclid&fbclid=teste-fbclid-validacao`
+- Aceitar cookies de marketing e analytics.
+- Concluir um agendamento.
+- Validar no CRM:
+  - booking com `fbclid`
+  - booking com `fbp/fbc` quando aplicável
+  - `Schedule via CAPI OK`
+
+### Cenário 3: consentimento recusado
+
+- Abrir o site em sessão limpa.
+- Recusar cookies opcionais no banner.
+- Concluir um agendamento.
+- Validar:
+  - booking confirmado normalmente
+  - sem envio indevido de marketing
+  - modal final mostra opt-in opcional de mensuração quando aplicável
+
+### Cenário 4: consentimento previamente aceito
+
+- Abrir o site em sessão com consentimento de marketing já salvo.
+- Avançar até o modal final do agendamento.
+- Validar:
+  - checkbox opcional de mensuração não aparece
+  - agendamento exige apenas o checkbox obrigatório de privacidade
+
+### Cenário 5: clique para WhatsApp
+
+- Abrir qualquer CTA público de WhatsApp do site.
+- Validar:
+  - navegação passa por `/api/whatsapp/redirect`
+  - `Contact` aparece no CRM
+  - `wa_click_id` é gerado
+
+## Redirects e domínio
+
+- `https://www.espacofacial.com/` deve responder `308` para `https://espacofacial.com/`
+- `https://espacofacial.com/barrashoppingsul/faleconosco` deve cair em `/api/whatsapp/redirect` e depois no WhatsApp
+- `https://espacofacial.com/novohamburgo/faleconosco` deve seguir a mesma trilha
+- `npm run tracking:governance` não deve apontar `www.espacofacial.com` em conteúdo canônico
+
+## Leitura esperada no CRM
+
+- O bloco de saúde do tracking deve estar em:
+  - `saudável`, quando não houver alertas
+  - `degradado`, quando houver cobertura insuficiente ou falhas não críticas
+  - `crítico`, quando houver indisponibilidade ou quebra séria de entrega
+- O CRM deve exibir:
+  - buckets de reconciliação
+  - bookings com tracking incompleto
+  - falhas retryable para reprocessamento
+  - governança de campanhas e allowlist cross-domain
+
+## Observações operacionais
+
+- Campanhas de booking devem sempre apontar para `https://espacofacial.com`.
+- `espacofacial.com.br` e `app.espacofacial.com.br` continuam como stacks oficiais separados.
+- `crm.skincos.com.br`, `orb.skincos.com.br` e `wa.skincos.com.br` são domínios internos/técnicos e não devem ser destino público de mídia para este funil.

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "test": "tsx --test tests/*.test.ts",
     "smoke": "node scripts/smoke.mjs",
     "smoke:strict": "SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs",
+    "tracking:governance": "node scripts/audit-tracking-governance.mjs",
     "quality:pr": "npm run audit:360:ci",
     "quality:check": "npm run lint && npm run typecheck && npm run test && npm run build && npm run smoke",
     "quality:ci": "npm ci && npm run quality:check",

--- a/website/scripts/audit-tracking-governance.mjs
+++ b/website/scripts/audit-tracking-governance.mjs
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const WEBSITE_SRC = path.join(ROOT, "src");
+const SNAPSHOT_DIR = path.join(ROOT, "public", "production-snapshot");
+
+const ALLOWED_WHATSAPP_FILES = new Set([
+    path.join(WEBSITE_SRC, "middleware.ts"),
+    path.join(WEBSITE_SRC, "app", "api", "whatsapp", "redirect", "route.ts"),
+    path.join(WEBSITE_SRC, "lib", "whatsappTracking.ts"),
+    path.join(WEBSITE_SRC, "lib", "whatsapp.ts"),
+    path.join(WEBSITE_SRC, "lib", "bookingConfirmationView.ts"),
+    path.join(WEBSITE_SRC, "lib", "faleconoscoRedirect.ts"),
+    path.join(WEBSITE_SRC, "components", "BookingHeroExperience.tsx"),
+]);
+
+const ALLOWED_CANONICAL_REFERENCE_FILES = new Set([
+    path.join(WEBSITE_SRC, "lib", "site-config.ts"),
+]);
+
+const ALLOWED_CROSS_DOMAIN_HOSTS = new Map([
+    ["espacofacial.com.br", "franquia oficial"],
+    ["app.espacofacial.com.br", "app oficial da franquia"],
+    ["crm.skincos.com.br", "crm interno"],
+    ["orb.skincos.com.br", "orquestração/n8n"],
+    ["wa.skincos.com.br", "stack técnica de WhatsApp"],
+]);
+
+const violations = [];
+const notes = [];
+
+function walk(dir) {
+    if (!fs.existsSync(dir)) return [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const absolute = path.join(dir, entry.name);
+        if (entry.isDirectory()) files.push(...walk(absolute));
+        else files.push(absolute);
+    }
+    return files;
+}
+
+function readFile(file) {
+    return fs.readFileSync(file, "utf8");
+}
+
+function relative(file) {
+    return path.relative(ROOT, file);
+}
+
+function addViolation(file, message) {
+    violations.push(`${relative(file)}: ${message}`);
+}
+
+function addNote(file, message) {
+    notes.push(`${relative(file)}: ${message}`);
+}
+
+function auditWhatsappLinks() {
+    const files = walk(WEBSITE_SRC).filter((file) => file.endsWith(".ts") || file.endsWith(".tsx"));
+    const pattern = /https:\/\/(?:wa\.me|api\.whatsapp\.com)/gi;
+
+    for (const file of files) {
+        const content = readFile(file);
+        if (!pattern.test(content)) continue;
+        pattern.lastIndex = 0;
+
+        if (!ALLOWED_WHATSAPP_FILES.has(file)) {
+            addViolation(file, "contém URL direta de WhatsApp fora da allowlist first-party")
+        } else {
+            addNote(file, "usa URL direta de WhatsApp em ponto permitido pela trilha first-party")
+        }
+    }
+}
+
+function auditCanonicalWww() {
+    const files = [...walk(WEBSITE_SRC), ...walk(SNAPSHOT_DIR)];
+    const pattern = /www\.espacofacial\.com/gi;
+
+    for (const file of files) {
+        if (!/\.(ts|tsx|js|mjs|json|html|xml|txt)$/i.test(file)) continue;
+        const content = readFile(file);
+        if (pattern.test(content)) {
+            if (ALLOWED_CANONICAL_REFERENCE_FILES.has(file)) {
+                addNote(file, "referência a www.espacofacial.com permitida para regra de canonicalização")
+            } else {
+                addViolation(file, "aponta para www.espacofacial.com em conteúdo público/canônico")
+            }
+        }
+        pattern.lastIndex = 0;
+    }
+}
+
+function auditCrossDomainReferences() {
+    const files = [...walk(WEBSITE_SRC), ...walk(SNAPSHOT_DIR)];
+    const pattern = /\b(?:espacofacial\.com\.br|app\.espacofacial\.com\.br|crm\.skincos\.com\.br|orb\.skincos\.com\.br|wa\.skincos\.com\.br)\b/gi;
+
+    for (const file of files) {
+        if (!/\.(ts|tsx|js|mjs|json|html|xml|txt)$/i.test(file)) continue;
+        const content = readFile(file);
+        const matches = new Set(content.match(pattern) || []);
+        if (!matches.size) continue;
+
+        for (const host of matches) {
+            if (!ALLOWED_CROSS_DOMAIN_HOSTS.has(host)) {
+                addViolation(file, `referência cross-domain não prevista: ${host}`)
+            } else {
+                addNote(file, `referência cross-domain documentada: ${host} (${ALLOWED_CROSS_DOMAIN_HOSTS.get(host)})`)
+            }
+        }
+    }
+}
+
+function main() {
+    auditWhatsappLinks();
+    auditCanonicalWww();
+    auditCrossDomainReferences();
+
+    if (notes.length > 0) {
+        console.log("Notas de auditoria:")
+        for (const note of notes) console.log(`- ${note}`)
+        console.log("");
+    }
+
+    if (violations.length > 0) {
+        console.error("Falhas de governança encontradas:")
+        for (const violation of violations) console.error(`- ${violation}`)
+        process.exit(1)
+    }
+
+    console.log("OK: governança de tracking/domínio sem violações.")
+}
+
+main();

--- a/website/src/app/api/tracking/dashboard/route.ts
+++ b/website/src/app/api/tracking/dashboard/route.ts
@@ -169,6 +169,68 @@ function sortMapEntries(map: Map<string, number>, valueKey: string) {
         .map(([label, count]) => ({ [valueKey]: label, count }));
 }
 
+function classifyCoverageBucket(params: {
+    hasTrackingContext: boolean;
+    hasMetaEventId: boolean;
+    hasFacebookIds: boolean;
+    marketingConsent: boolean;
+    hasAnyAttribution: boolean;
+}) {
+    if (params.hasTrackingContext && params.hasMetaEventId && params.hasFacebookIds && params.marketingConsent) {
+        return "origem_meta_completa";
+    }
+    if (params.hasAnyAttribution || params.hasTrackingContext || params.hasMetaEventId || params.hasFacebookIds) {
+        return "origem_first_party";
+    }
+    return "sem_origem";
+}
+
+function buildIncompleteTrackingCauses(params: {
+    hasTrackingContext: boolean;
+    hasMetaEventId: boolean;
+    hasFacebookIds: boolean;
+    marketingConsent: boolean;
+    analyticsConsent: boolean;
+    scheduleStatus: string | null;
+}) {
+    const causes: string[] = [];
+    if (!params.hasTrackingContext) causes.push("sem_tracking_context");
+    if (!params.hasMetaEventId) causes.push("sem_meta_event_id");
+    if (!params.hasFacebookIds) causes.push("sem_fb_ids");
+    if (!params.marketingConsent) causes.push("marketing_sem_consentimento");
+    if (!params.analyticsConsent) causes.push("analytics_sem_consentimento");
+    if (params.scheduleStatus === "failed") causes.push("schedule_capi_falhou");
+    if (params.scheduleStatus === "skipped_no_config") causes.push("schedule_capi_sem_config");
+    return causes;
+}
+
+function normalizeMetaFailureReason(message: string | null | undefined, httpStatus: number | null | undefined) {
+    const normalized = (message ?? "").trim().toLowerCase();
+    if (normalized === "missing_meta_capi_config") return "missing_meta_capi_config";
+    if (normalized === "marketing_consent_denied") return "marketing_consent_denied";
+    if (normalized.includes("invalid oauth") || normalized.includes("cannot parse access token")) return "invalid_oauth_token";
+    if (normalized.includes("permission") || normalized.includes("not authorized")) return "meta_permission_denied";
+    if (normalized.includes("timeout") || normalized.includes("timed out")) return "meta_timeout";
+    if (normalized.includes("network") || normalized.includes("fetch failed") || normalized.includes("connection")) return "meta_network_error";
+    if (httpStatus === 429) return "meta_rate_limited";
+    if (httpStatus === 408 || httpStatus === 500 || httpStatus === 502 || httpStatus === 503 || httpStatus === 504) {
+        return "meta_transient_http_error";
+    }
+    if (httpStatus === 400) return "meta_bad_request";
+    if (httpStatus === 401 || httpStatus === 403) return "meta_auth_error";
+    return normalized || "delivery_failed";
+}
+
+function isRetryableMetaFailure(message: string | null | undefined, httpStatus: number | null | undefined) {
+    const reason = normalizeMetaFailureReason(message, httpStatus);
+    return new Set([
+        "meta_timeout",
+        "meta_network_error",
+        "meta_rate_limited",
+        "meta_transient_http_error",
+    ]).has(reason);
+}
+
 async function readMetaConfigStatus() {
     const pixelId =
         ((await getRuntimeSecret("META_PIXEL_ID")) ?? "").trim() ||
@@ -190,8 +252,10 @@ export async function GET(request: Request) {
 
     const url = new URL(request.url);
     const days = Math.min(parsePositiveInt(url.searchParams.get("days"), 30), 90);
+    const offsetDays = Math.min(parsePositiveInt(url.searchParams.get("offsetDays"), 0), 365);
     const limit = Math.min(parsePositiveInt(url.searchParams.get("limit"), 12), 50);
-    const sinceMs = Date.now() - days * 24 * 60 * 60 * 1000;
+    const untilMs = Date.now() - offsetDays * 24 * 60 * 60 * 1000;
+    const sinceMs = untilMs - days * 24 * 60 * 60 * 1000;
 
     const db = await getBookingDb();
     const config = await readMetaConfigStatus();
@@ -203,10 +267,10 @@ export async function GET(request: Request) {
                         tracking_context_json, meta_event_id, marketing_consent, analytics_consent, fbp, fbc, fbclid,
                         landing_page, referrer
                  FROM booking_requests
-                 WHERE created_at_ms >= ? AND status = 'confirmed'
+                 WHERE created_at_ms >= ? AND created_at_ms < ? AND status = 'confirmed'
                  ORDER BY created_at_ms DESC`,
             )
-            .bind(sinceMs)
+            .bind(sinceMs, untilMs)
             .all<BookingRequestRow>()
     ).results ?? [];
 
@@ -216,10 +280,10 @@ export async function GET(request: Request) {
                 `SELECT id, event_id, wa_click_id, placement, source, unit_slug, doctor_name, booking_id,
                         destination_url, redirect_url, page_url, page_path, tracking_context_json, created_at_ms
                  FROM whatsapp_click_events
-                 WHERE created_at_ms >= ?
+                 WHERE created_at_ms >= ? AND created_at_ms < ?
                  ORDER BY created_at_ms DESC`,
             )
-            .bind(sinceMs)
+            .bind(sinceMs, untilMs)
             .all<WhatsappClickRow>()
     ).results ?? [];
 
@@ -229,10 +293,10 @@ export async function GET(request: Request) {
                 `SELECT id, channel, event_name, event_id, endpoint, ok, http_status, response_body, error_message,
                         booking_id, wa_click_id, created_at_ms
                  FROM meta_capi_delivery_logs
-                 WHERE created_at_ms >= ?
+                 WHERE created_at_ms >= ? AND created_at_ms < ?
                  ORDER BY created_at_ms DESC`,
             )
-            .bind(sinceMs)
+            .bind(sinceMs, untilMs)
             .all<MetaDeliveryRow>()
     ).results ?? [];
 
@@ -245,51 +309,12 @@ export async function GET(request: Request) {
     let bookingsWithMarketingConsent = 0;
     let bookingsWithAnalyticsConsent = 0;
     let bookingsWithFbIdentifiers = 0;
-
-    const recentBookings = bookingRows.slice(0, limit).map((row) => {
-        const tracking = normalizeAttribution(safeJsonParse(row.tracking_context_json));
-        const hasTrackingContext = Boolean(row.tracking_context_json);
-        incrementMap(sourceCounts, normalizeDashboardLabel({ value: tracking.utmSource, hasTrackingContext, emptyLabel: "direto" }));
-        incrementMap(campaignCounts, normalizeDashboardLabel({ value: tracking.utmCampaign, hasTrackingContext, emptyLabel: "sem_campanha" }));
-        incrementMap(unitCounts, row.unit_slug);
-
-        if (row.tracking_context_json) bookingsWithTrackingContext += 1;
-        if (row.meta_event_id) bookingsWithMetaEventId += 1;
-        if ((row.marketing_consent ?? 0) === 1) bookingsWithMarketingConsent += 1;
-        if ((row.analytics_consent ?? 0) === 1) bookingsWithAnalyticsConsent += 1;
-        if (row.fbp || row.fbc || row.fbclid || tracking.fbclid || tracking.fbp || tracking.fbc) bookingsWithFbIdentifiers += 1;
-
-        return {
-            id: row.id,
-            createdAtMs: row.created_at_ms,
-            unitSlug: row.unit_slug,
-            doctorSlug: row.doctor_slug,
-            serviceId: row.service_id,
-            patient: maskPersonName(row.patient_name),
-            whatsapp: maskPhone(row.whatsapp),
-            metaEventId: row.meta_event_id ?? null,
-            marketingConsent: (row.marketing_consent ?? 0) === 1,
-            analyticsConsent: (row.analytics_consent ?? 0) === 1,
-            utmSource: normalizeDashboardLabel({ value: tracking.utmSource, hasTrackingContext, emptyLabel: "direto" }),
-            utmCampaign: normalizeDashboardLabel({ value: tracking.utmCampaign, hasTrackingContext, emptyLabel: "sem_campanha" }),
-            utmMedium: tracking.utmMedium,
-            landingPage: row.landing_page ?? tracking.landingPage,
-            hasFacebookIds: Boolean(row.fbp || row.fbc || row.fbclid || tracking.fbclid || tracking.fbp || tracking.fbc),
-        };
-    });
-
-    for (const row of bookingRows.slice(limit)) {
-        const tracking = normalizeAttribution(safeJsonParse(row.tracking_context_json));
-        const hasTrackingContext = Boolean(row.tracking_context_json);
-        incrementMap(sourceCounts, normalizeDashboardLabel({ value: tracking.utmSource, hasTrackingContext, emptyLabel: "direto" }));
-        incrementMap(campaignCounts, normalizeDashboardLabel({ value: tracking.utmCampaign, hasTrackingContext, emptyLabel: "sem_campanha" }));
-        incrementMap(unitCounts, row.unit_slug);
-        if (row.tracking_context_json) bookingsWithTrackingContext += 1;
-        if (row.meta_event_id) bookingsWithMetaEventId += 1;
-        if ((row.marketing_consent ?? 0) === 1) bookingsWithMarketingConsent += 1;
-        if ((row.analytics_consent ?? 0) === 1) bookingsWithAnalyticsConsent += 1;
-        if (row.fbp || row.fbc || row.fbclid || tracking.fbclid || tracking.fbp || tracking.fbc) bookingsWithFbIdentifiers += 1;
-    }
+    const coverageBucketCounts = new Map<string, number>([
+        ["sem_origem", 0],
+        ["origem_first_party", 0],
+        ["origem_meta_completa", 0],
+    ]);
+    const scheduleStatusByBookingId = new Map<string, string>();
 
     let whatsappClicksWithTracking = 0;
     const recentWhatsappClicks = whatsappRows.slice(0, limit).map((row) => {
@@ -322,6 +347,7 @@ export async function GET(request: Request) {
     let capiContactSkippedConsent = 0;
     const capiIssueReasonCounts = new Map<string, number>();
     const recentCapiIssues = [];
+    const recentRetryCandidates = [];
 
     for (const row of capiRows) {
         const ok = row.ok === 1;
@@ -333,6 +359,12 @@ export async function GET(request: Request) {
             else if (skippedNoConfig) capiScheduleSkippedNoConfig += 1;
             else if (skippedConsent) capiScheduleSkippedConsent += 1;
             else capiScheduleFailed += 1;
+            if (row.booking_id && !scheduleStatusByBookingId.has(row.booking_id)) {
+                scheduleStatusByBookingId.set(
+                    row.booking_id,
+                    ok ? "ok" : skippedNoConfig ? "skipped_no_config" : skippedConsent ? "skipped_consent" : "failed",
+                );
+            }
         }
         if (row.event_name === "Contact") {
             if (ok) capiContactOk += 1;
@@ -341,7 +373,7 @@ export async function GET(request: Request) {
             else capiContactFailed += 1;
         }
         if (!ok) {
-            incrementMap(capiIssueReasonCounts, errorReason);
+            incrementMap(capiIssueReasonCounts, normalizeMetaFailureReason(row.error_message, row.http_status));
         }
         if (!ok && recentCapiIssues.length < limit) {
             recentCapiIssues.push({
@@ -353,9 +385,110 @@ export async function GET(request: Request) {
                 waClickId: row.wa_click_id,
                 httpStatus: row.http_status,
                 errorMessage: row.error_message,
+                normalizedReason: normalizeMetaFailureReason(row.error_message, row.http_status),
+                retryable: isRetryableMetaFailure(row.error_message, row.http_status),
+            });
+        }
+        if (!ok && isRetryableMetaFailure(row.error_message, row.http_status) && recentRetryCandidates.length < limit) {
+            recentRetryCandidates.push({
+                id: row.id,
+                createdAtMs: row.created_at_ms,
+                eventName: row.event_name,
+                eventId: row.event_id,
+                bookingId: row.booking_id,
+                waClickId: row.wa_click_id,
+                httpStatus: row.http_status,
+                errorMessage: row.error_message,
+                normalizedReason: normalizeMetaFailureReason(row.error_message, row.http_status),
             });
         }
     }
+
+    const normalizedBookings = bookingRows.map((row) => {
+        const tracking = normalizeAttribution(safeJsonParse(row.tracking_context_json));
+        const hasTrackingContext = Boolean(row.tracking_context_json);
+        const marketingConsent = (row.marketing_consent ?? 0) === 1;
+        const analyticsConsent = (row.analytics_consent ?? 0) === 1;
+        const hasMetaEventId = Boolean(row.meta_event_id);
+        const hasFacebookIds = Boolean(row.fbp || row.fbc || row.fbclid || tracking.fbclid || tracking.fbp || tracking.fbc);
+        const utmSource = normalizeDashboardLabel({ value: tracking.utmSource, hasTrackingContext, emptyLabel: "direto" });
+        const utmCampaign = normalizeDashboardLabel({ value: tracking.utmCampaign, hasTrackingContext, emptyLabel: "sem_campanha" });
+        const utmMedium = tracking.utmMedium;
+        const landingPage = row.landing_page ?? tracking.landingPage;
+        const referrer = row.referrer ?? null;
+        const hasAnyAttribution =
+            hasTrackingContext ||
+            hasMetaEventId ||
+            hasFacebookIds ||
+            Boolean((landingPage ?? "").trim()) ||
+            Boolean((referrer ?? "").trim()) ||
+            (utmSource !== "sem_tracking_context" && utmSource !== "direto") ||
+            (utmCampaign !== "sem_tracking_context" && utmCampaign !== "sem_campanha");
+        const coverageBucket = classifyCoverageBucket({
+            hasTrackingContext,
+            hasMetaEventId,
+            hasFacebookIds,
+            marketingConsent,
+            hasAnyAttribution,
+        });
+        const scheduleStatus = scheduleStatusByBookingId.get(row.id) ?? null;
+        const incompleteCauses = buildIncompleteTrackingCauses({
+            hasTrackingContext,
+            hasMetaEventId,
+            hasFacebookIds,
+            marketingConsent,
+            analyticsConsent,
+            scheduleStatus,
+        });
+
+        incrementMap(sourceCounts, utmSource);
+        incrementMap(campaignCounts, utmCampaign);
+        incrementMap(unitCounts, row.unit_slug);
+
+        if (hasTrackingContext) bookingsWithTrackingContext += 1;
+        if (hasMetaEventId) bookingsWithMetaEventId += 1;
+        if (marketingConsent) bookingsWithMarketingConsent += 1;
+        if (analyticsConsent) bookingsWithAnalyticsConsent += 1;
+        if (hasFacebookIds) bookingsWithFbIdentifiers += 1;
+        coverageBucketCounts.set(coverageBucket, (coverageBucketCounts.get(coverageBucket) ?? 0) + 1);
+
+        return {
+            id: row.id,
+            createdAtMs: row.created_at_ms,
+            unitSlug: row.unit_slug,
+            doctorSlug: row.doctor_slug,
+            serviceId: row.service_id,
+            patient: maskPersonName(row.patient_name),
+            whatsapp: maskPhone(row.whatsapp),
+            metaEventId: row.meta_event_id ?? null,
+            marketingConsent,
+            analyticsConsent,
+            utmSource,
+            utmCampaign,
+            utmMedium,
+            landingPage,
+            referrer,
+            hasFacebookIds,
+            coverageBucket,
+            incompleteCauses,
+            scheduleStatus,
+        };
+    });
+
+    const recentBookings = normalizedBookings.slice(0, limit);
+    const recentIncompleteBookings = normalizedBookings
+        .filter((row) => row.coverageBucket !== "origem_meta_completa" || row.incompleteCauses.length > 0)
+        .slice(0, limit)
+        .map((row) => ({
+            ...row,
+            primaryCause: row.incompleteCauses[0] ?? "sem_causa_normalizada",
+        }));
+
+    const coverageBuckets = [
+        { bucket: "sem_origem", label: "Sem origem", count: coverageBucketCounts.get("sem_origem") ?? 0 },
+        { bucket: "origem_first_party", label: "Origem first-party", count: coverageBucketCounts.get("origem_first_party") ?? 0 },
+        { bucket: "origem_meta_completa", label: "Origem Meta completa", count: coverageBucketCounts.get("origem_meta_completa") ?? 0 },
+    ];
 
     return json({
         ok: true,
@@ -364,6 +497,8 @@ export async function GET(request: Request) {
         window: {
             days,
             sinceMs,
+            untilMs,
+            offsetDays,
         },
         summary: {
             confirmedBookings: bookingRows.length,
@@ -388,8 +523,11 @@ export async function GET(request: Request) {
         topCampaigns: sortMapEntries(campaignCounts, "utmCampaign").slice(0, 6),
         byUnit: sortMapEntries(unitCounts, "unitSlug").slice(0, 6),
         recentBookings,
+        recentIncompleteBookings,
         recentWhatsappClicks,
+        coverageBuckets,
         capiIssueReasons: sortMapEntries(capiIssueReasonCounts, "reason").slice(0, 8),
         recentCapiIssues,
+        recentRetryCandidates,
     });
 }


### PR DESCRIPTION
## Resumo
- expande o dashboard de tracking com saúde semântica, alertas normalizados e buckets de reconciliação
- adiciona governança operacional de campanhas/domínios e auditoria automatizada do website
- prepara o CRM para a futura frente de loop WhatsApp/CRM sem misturar isso com o foco atual no site

## Principais mudanças
- website `/api/tracking/dashboard`
  - suporte a `offsetDays` para comparar janelas equivalentes
  - buckets de cobertura (`sem_origem`, `origem_first_party`, `origem_meta_completa`)
  - lista de bookings com tracking incompleto
  - candidatos de retry para falhas transitórias da Meta
- crm-api `trackingDashboardService`
  - cálculo de cobertura atual e anterior
  - alertas operacionais normalizados
  - estado de saúde (`saudável`, `degradado`, `crítico`)
  - bloco de governança, cadência e contrato futuro do loop WhatsApp/CRM
- frontend `MetaTrackingDashboard`
  - health banner
  - alertas operacionais
  - buckets de reconciliação
  - lista de bookings incompletos
  - retry candidates
  - governança/cadência/contrato WhatsApp
- docs/scripts
  - `website/docs/campaign-url-governance.md`
  - expansão de `website/docs/validation-checklist.md`
  - expansão de `website/docs/domain-policy.md`
  - `npm run tracking:governance`

## Validação
- `npm --prefix website run tracking:governance`
- `npm --prefix website test`
- `npm --prefix website run build`
- `npm --prefix frontend run build`
- `npm --prefix backend/apps/crm-api test`
