### PR TITLE
Unlock Meta Ads tab in CRM

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -351,7 +351,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'escala-profissionais']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'meta-ads', 'escala-profissionais']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@svg-maps/brazil": "^2.0.0",
-        "next": "15.5.15",
+        "next": "^15.5.18",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
@@ -21,7 +21,7 @@
         "@types/react-dom": "18.3.0",
         "cheerio": "^1.1.2",
         "eslint": "8.57.0",
-        "eslint-config-next": "^15.5.14",
+        "eslint-config-next": "^15.5.18",
         "lighthouse": "^13.0.3",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.56.1",
@@ -2871,15 +2871,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.14.tgz",
-      "integrity": "sha512-ogBjgsFrPPz19abP3VwcYSahbkUOMMvJjxCOYWYndw+PydeMuLuB4XrvNkNutFrTjC9St2KFULRdKID8Sd/CMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.18.tgz",
+      "integrity": "sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2887,9 +2887,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -2935,9 +2935,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -2951,9 +2951,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -2967,9 +2967,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -2983,9 +2983,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -7617,13 +7617,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.14.tgz",
-      "integrity": "sha512-lmJ5F8ZgOYogq0qtH4L5SpxuASY2SPdOzqUprN2/56+P3GPsIpXaUWIJC66kYIH+yZdsM4nkHE5MIBP6s1NiBw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.18.tgz",
+      "integrity": "sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.14",
+        "@next/eslint-plugin-next": "15.5.18",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -10363,12 +10363,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10381,14 +10381,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@svg-maps/brazil": "^2.0.0",
-    "next": "15.5.15",
+    "next": "^15.5.18",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
@@ -45,7 +45,7 @@
     "@types/react-dom": "18.3.0",
     "cheerio": "^1.1.2",
     "eslint": "8.57.0",
-    "eslint-config-next": "^15.5.14",
+    "eslint-config-next": "^15.5.18",
     "lighthouse": "^13.0.3",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.56.1",


### PR DESCRIPTION
## Context
The tracking dashboard for influencer/ad click measurement already exists under Meta Ads, but the module was still flagged as locked in the CRM sidebar.

## Change
- unlock  in the CRM sidebar module catalog so gestor users can access the existing tracking surface

## Validation
- 
