### PR TITLE
feat(crm): publish escala and insumos module refactors

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -16,6 +16,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/tooltip'
 import { useKV } from '@/spark-mock'
 import { DEFAULT_UNIT_OPTIONS, useGlobalUnitSelection } from '@/unitSelection'
+import { dispatchEscalaHeaderAction, subscribeEscalaHeaderState } from '@/escalaHeaderBridge'
+import type { EscalaHeaderState, EscalaHighlightMode } from '@/escalaTypes'
+import { dispatchInsumosHeaderAction, subscribeInsumosHeaderState } from '@/insumosBridge'
+import type { InsumosHeaderState, InsumosOverviewPeriod } from '@/insumosTypes'
 import { CalendarX2, CheckCircle2, Download, Pencil, Shield, Sparkles } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
@@ -44,26 +48,6 @@ function formatMonthLabelHeader(value: string) {
     return label.charAt(0).toUpperCase() + label.slice(1)
 }
 
-function hashEscalaValue(value: string) {
-    let hash = 0
-    for (let index = 0; index < value.length; index += 1) {
-        hash = value.charCodeAt(index) + ((hash << 5) - hash)
-    }
-    return Math.abs(hash)
-}
-
-function getEscalaProfessionalTriggerStyle(name: string) {
-    const hue = hashEscalaValue(name) % 360
-    return {
-        background: `linear-gradient(135deg, hsla(${hue}, 78%, 56%, 0.2), hsla(${(hue + 24) % 360}, 78%, 58%, 0.1))`,
-        borderColor: `hsla(${hue}, 84%, 72%, 0.42)`,
-        color: `hsl(${hue} 88% 92%)`,
-        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.05)',
-    } as React.CSSProperties
-}
-
-type InsumosOverviewPeriod = '7d' | '30d' | '1y' | 'custom'
-
 type ApiError = {
     error?: string
     message?: string
@@ -90,29 +74,6 @@ type AtendimentoHeaderState = {
     }
     ticketFilter: 'total' | 'open' | 'overdue' | 'resolved'
     paused: boolean
-}
-
-type EscalaHeaderState = {
-    units: string[]
-    monthOptions: string[]
-    yearOptions: string[]
-    selectedUnit: string
-    selectedMonth: string
-    selectedMonthNumber: string
-    selectedYear: string
-    selectedProfessional: string
-    professionalOptions: string[]
-    totalScheduledDays: number
-    unavailableDaysCount?: number
-    manualDays?: number
-    autoDays?: number
-    blockedDays?: number
-    emptyDays?: number
-    coveredDays?: number
-    activeInjectors: number
-    selectedDatesCount: number
-    highlightMode?: 'manual' | 'auto' | 'blocked' | 'empty' | null
-    loadingOverview: boolean
 }
 
 async function insumosApiJson<T>(
@@ -351,7 +312,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'escala-profissionais']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'atendimento', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'meta-ads', 'escala-profissionais']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)
@@ -403,20 +364,8 @@ export default function AppFunctionalNeatlab() {
 	    const [search, setSearch] = useState('')
         const [atendimentoHeaderState, setAtendimentoHeaderState] = useState<AtendimentoHeaderState | null>(null)
         const [escalaHeaderState, setEscalaHeaderState] = useState<EscalaHeaderState | null>(null)
-				    const [insumosHeaderStatus, setInsumosHeaderStatus] = useState<{
-			        online: boolean | null
-			        authed: boolean | null
-			        integrated: boolean | null
-			        unidades: string[]
-			        allowedUnits: string[]
-			    } | null>(null)
-				    const [insumosHeaderEstoque, setInsumosHeaderEstoque] = useState<{
-                        value: number | null
-                        loading: boolean
-                        percent: number | null
-                        entradaValor?: number | null
-                        saidaValor?: number | null
-                    } | null>(null)
+				    const [insumosHeaderStatus, setInsumosHeaderStatus] = useState<InsumosHeaderState['status']>(null)
+				    const [insumosHeaderEstoque, setInsumosHeaderEstoque] = useState<InsumosHeaderState['stock']>(null)
                     const defaultEstoqueThresholds = React.useMemo(() => ({ warning: 50000, critical: 20000 }), [])
                     const [estoqueThresholds, setEstoqueThresholds] = useState<{ warning: number; critical: number }>(() => {
                         try {
@@ -448,7 +397,6 @@ export default function AppFunctionalNeatlab() {
 				    React.useEffect(() => {
 				        effectiveUnitRef.current = effectiveUnit
 				    }, [effectiveUnit])
-				    const insumosHeaderFetchRef = React.useRef<{ lastAt: number; inflight: boolean }>({ lastAt: 0, inflight: false })
 				    const canonicalUnitValues = useMemo(() => unitOptions.map((o) => o.value), [unitOptions])
 				    const insumosUnitsForHeaderSelect = useMemo(() => {
 				        const fromApi = insumosHeaderStatus?.unidades?.length ? insumosHeaderStatus.unidades : canonicalUnitValues
@@ -540,28 +488,17 @@ export default function AppFunctionalNeatlab() {
 			        if (!insumosMounted) return
 			        if (lastInsumosUnitRef.current === effectiveUnit) return
 			        lastInsumosUnitRef.current = effectiveUnit
-			        try {
-			            window.dispatchEvent(new CustomEvent('skincos:insumos:unidade', { detail: { unidade: effectiveUnit } }))
-			        } catch { /* ignore */ }
+			        dispatchInsumosHeaderAction({ type: 'set-unit', value: effectiveUnit })
 			    }, [effectiveUnit, insumosMounted])
 
                 React.useEffect(() => {
-                    const handler = (event: Event) => {
-                        const detail = (event as CustomEvent)?.detail || {}
-                        const rawValue = detail?.value
-                        const value = rawValue == null || Number.isNaN(Number(rawValue)) ? null : Number(rawValue)
-                        const entradaValor = Number.isFinite(Number(detail?.entradaValor)) ? Number(detail?.entradaValor) : null
-                        const saidaValor = Number.isFinite(Number(detail?.saidaValor)) ? Number(detail?.saidaValor) : null
-                        setInsumosHeaderEstoque({
-                            value,
-                            loading: Boolean(detail?.loading),
-                            percent: typeof detail?.percent === 'number' ? detail.percent : null,
-                            entradaValor,
-                            saidaValor
-                        })
-                    }
-                    window.addEventListener('skincos:insumos:estoque', handler)
-                    return () => window.removeEventListener('skincos:insumos:estoque', handler)
+                    return subscribeInsumosHeaderState((detail) => {
+                        setInsumosHeaderStatus(detail?.status || null)
+                        setInsumosHeaderEstoque(detail?.stock || null)
+                        if (detail?.selectedUnit && detail.selectedUnit !== effectiveUnitRef.current) {
+                            setSelectedUnitRef.current(detail.selectedUnit)
+                        }
+                    })
                 }, [])
 
                 React.useEffect(() => {
@@ -584,16 +521,9 @@ export default function AppFunctionalNeatlab() {
                 }, [])
 
                 React.useEffect(() => {
-                    const handler = (event: Event) => {
-                        const detail = (event as CustomEvent<EscalaHeaderState | null>)?.detail || null
-                        if (!detail || typeof detail !== 'object') {
-                            setEscalaHeaderState(null)
-                            return
-                        }
+                    return subscribeEscalaHeaderState((detail) => {
                         setEscalaHeaderState(detail)
-                    }
-                    window.addEventListener('skincos:escala:header', handler as EventListener)
-                    return () => window.removeEventListener('skincos:escala:header', handler as EventListener)
+                    })
                 }, [])
 
 	    // Allow forcing a module via URL, e.g. http://localhost:5173/?module=capabilities
@@ -628,66 +558,9 @@ export default function AppFunctionalNeatlab() {
 				    React.useEffect(() => {
 				        if (active !== 'insumos' || !isAuthenticated) {
 				            setInsumosHeaderStatus(null)
-				            return
+				            setInsumosHeaderEstoque(null)
 				        }
-
-		        const ac = new AbortController()
-		        const now = Date.now()
-		        if (insumosHeaderFetchRef.current.inflight) return () => ac.abort()
-		        if (now - insumosHeaderFetchRef.current.lastAt < 2500) return () => ac.abort()
-		        insumosHeaderFetchRef.current.inflight = true
-		        insumosHeaderFetchRef.current.lastAt = now
-
-		        ;(async () => {
-		            try {
-		                const healthRes = await fetch('/api/insumos/health', { credentials: 'include', signal: ac.signal }).catch(() => null)
-
-                let online: boolean | null = null
-                let integrated: boolean | null = null
-                let unidades: string[] = []
-                if (healthRes?.ok) {
-                    const h: any = await healthRes.json().catch(() => null)
-                    const ready =
-                        typeof h?.ready === 'boolean'
-                            ? h.ready
-                            : (typeof h?.dbConfigured === 'boolean' ? h.dbConfigured : Boolean(h?.ok))
-                    online = true
-                    integrated = typeof ready === 'boolean' ? Boolean(ready) : null
-                    unidades = Array.isArray(h?.unidades) ? h.unidades.filter(Boolean).map((x: any) => String(x)) : []
-                } else if (healthRes) {
-                    online = false
-                }
-
-		                const authed: boolean | null = Boolean(user?.username)
-		                const allowedUnits: string[] = Array.isArray(user?.allowedUnits)
-		                    ? user.allowedUnits.filter(Boolean).map((x: any) => String(x))
-		                    : []
-
-	                const candidateUnits = unidades.length ? unidades : ['novo-hamburgo', 'barra-shopping-sul']
-	                const filteredUnits = allowedUnits.length
-	                    ? candidateUnits.filter((u) => allowedUnits.includes(u))
-	                    : candidateUnits
-	                const options = filteredUnits.length ? filteredUnits : candidateUnits
-
-		                const currentUnit = effectiveUnitRef.current
-		                let nextUnit = currentUnit
-		                try {
-		                    const saved = localStorage.getItem(INSUMOS_UNIT_KEY)
-		                    if (saved) nextUnit = saved
-		                } catch { /* ignore */ }
-			                if (!options.includes(nextUnit)) nextUnit = options[0]
-			                if (nextUnit && nextUnit !== currentUnit) setSelectedUnitRef.current(nextUnit)
-
-			                setInsumosHeaderStatus({ online, authed, integrated, unidades: options, allowedUnits })
-			            } catch {
-			                setInsumosHeaderStatus({ online: false, authed: false, integrated: null, unidades: [], allowedUnits: [] })
-			            } finally {
-			                insumosHeaderFetchRef.current.inflight = false
-			            }
-		        })()
-
-				        return () => ac.abort()
-						    }, [active, isAuthenticated, user?.allowedUnits?.join('|'), user?.username])
+				    }, [active, isAuthenticated])
 
 		    const lastInsumosOverviewRef = React.useRef<string | null>(null)
 		    React.useEffect(() => {
@@ -695,13 +568,10 @@ export default function AppFunctionalNeatlab() {
 		        const nextKey = `${insumosOverviewPeriod}|${insumosOverviewFrom}|${insumosOverviewTo}`
 		        if (lastInsumosOverviewRef.current === nextKey) return
 		        lastInsumosOverviewRef.current = nextKey
-		        try {
-		            window.dispatchEvent(
-		                new CustomEvent('skincos:insumos:overview', {
-		                    detail: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: insumosOverviewTo }
-		                })
-		            )
-		        } catch { /* ignore */ }
+		        dispatchInsumosHeaderAction({
+		            type: 'set-overview',
+		            value: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: insumosOverviewTo },
+		        })
 		    }, [insumosMounted, insumosOverviewFrom, insumosOverviewPeriod, insumosOverviewTo])
 
     const modulesSorted = useMemo(() => {
@@ -1146,9 +1016,7 @@ export default function AppFunctionalNeatlab() {
 				                                                            const next = (v as any) as InsumosOverviewPeriod
 				                                                            setInsumosOverviewPeriod(next)
 				                                                            try { localStorage.setItem(INSUMOS_OVERVIEW_PERIOD_KEY, next) } catch { /* ignore */ }
-				                                                            try {
-				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: next, from: insumosOverviewFrom, to: insumosOverviewTo } }))
-				                                                            } catch { /* ignore */ }
+				                                                            dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: next, from: insumosOverviewFrom, to: insumosOverviewTo } })
 				                                                        }}
 				                                                    >
 					                                                    <SelectTrigger className="h-8 w-40 bg-white/[0.06] border-white/20 text-white">
@@ -1169,9 +1037,7 @@ export default function AppFunctionalNeatlab() {
 				                                                                onChange={(next) => {
 				                                                                    setInsumosOverviewFrom(next)
 				                                                                    try { localStorage.setItem(INSUMOS_OVERVIEW_FROM_KEY, next) } catch { /* ignore */ }
-				                                                                    try {
-				                                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: insumosOverviewPeriod, from: next, to: insumosOverviewTo } }))
-				                                                                    } catch { /* ignore */ }
+				                                                                    dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: insumosOverviewPeriod, from: next, to: insumosOverviewTo } })
 					                                                                }}
 					                                                                placeholder="De (DD/MM/AA)"
 					                                                                className="h-8 w-36 bg-white/[0.06] border-white/20 text-white placeholder:text-blue-200/40"
@@ -1182,9 +1048,7 @@ export default function AppFunctionalNeatlab() {
 				                                                                onChange={(next) => {
 				                                                                    setInsumosOverviewTo(next)
 				                                                                    try { localStorage.setItem(INSUMOS_OVERVIEW_TO_KEY, next) } catch { /* ignore */ }
-				                                                                    try {
-				                                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: next } }))
-				                                                                    } catch { /* ignore */ }
+				                                                                    dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: next } })
 					                                                                }}
 					                                                                placeholder="Até (DD/MM/AA)"
 					                                                                className="h-8 w-36 bg-white/[0.06] border-white/20 text-white placeholder:text-blue-200/40"
@@ -1198,9 +1062,7 @@ export default function AppFunctionalNeatlab() {
 						                                                        variant="ghost"
 						                                                        className="h-9 w-9 rounded-md bg-emerald-500/25 text-emerald-100 hover:bg-emerald-500/35"
 					                                                        onClick={() => {
-				                                                            try {
-				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'ENTRADA' } }))
-				                                                            } catch { /* ignore */ }
+				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
 	                                                        }}
 			                                                        title="Entrada"
 			                                                        aria-label="Entrada"
@@ -1212,9 +1074,7 @@ export default function AppFunctionalNeatlab() {
 						                                                        variant="ghost"
 						                                                        className="h-9 w-9 rounded-md bg-rose-500/30 text-rose-100 hover:bg-rose-500/40"
 					                                                        onClick={() => {
-				                                                            try {
-				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'BAIXA' } }))
-				                                                            } catch { /* ignore */ }
+				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
 	                                                        }}
 			                                                        title="Saída"
 			                                                        aria-label="Saída"
@@ -1226,9 +1086,7 @@ export default function AppFunctionalNeatlab() {
 				                                                        variant="ghost"
 				                                                        className="h-9 w-9 rounded-md bg-sky-500/30 text-sky-100 hover:bg-sky-500/40"
 				                                                        onClick={() => {
-				                                                            try {
-				                                                                window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'TRANSFERENCIA' } }))
-				                                                            } catch { /* ignore */ }
+				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
 	                                                        }}
 			                                                        title="Transferência"
 			                                                        aria-label="Transferência"
@@ -1310,9 +1168,7 @@ export default function AppFunctionalNeatlab() {
 					                                                <Select
 					                                                    value={escalaHeaderState?.selectedUnit || ''}
 				                                                    onValueChange={(value) => {
-				                                                        try {
-				                                                            window.dispatchEvent(new CustomEvent('skincos:escala:action', { detail: { action: 'set-unit', value } }))
-				                                                        } catch { /* ignore */ }
+                                                                        dispatchEscalaHeaderAction({ type: 'set-unit', value })
 				                                                    }}
 				                                                >
 					                                                    <SelectTrigger className="h-8 w-48 bg-white/[0.06] border-white/20 text-white" data-escala-preserve-filter="true">
@@ -1329,9 +1185,7 @@ export default function AppFunctionalNeatlab() {
 					                                                <Select
 					                                                    value={escalaHeaderState?.selectedMonthNumber || ''}
 					                                                    onValueChange={(value) => {
-					                                                        try {
-					                                                            window.dispatchEvent(new CustomEvent('skincos:escala:action', { detail: { action: 'set-month', value } }))
-					                                                        } catch { /* ignore */ }
+                                                                        dispatchEscalaHeaderAction({ type: 'set-month', value })
 					                                                    }}
 					                                                >
 					                                                    <SelectTrigger className="h-8 w-36 bg-white/[0.06] border-white/20 text-white" data-escala-preserve-filter="true">
@@ -1348,9 +1202,7 @@ export default function AppFunctionalNeatlab() {
 					                                                <Select
 					                                                    value={escalaHeaderState?.selectedYear || ''}
 					                                                    onValueChange={(value) => {
-					                                                        try {
-					                                                            window.dispatchEvent(new CustomEvent('skincos:escala:action', { detail: { action: 'set-year', value } }))
-					                                                        } catch { /* ignore */ }
+                                                                        dispatchEscalaHeaderAction({ type: 'set-year', value })
 					                                                    }}
 					                                                >
 					                                                    <SelectTrigger className="h-8 w-28 bg-white/[0.06] border-white/20 text-white" data-escala-preserve-filter="true">
@@ -1364,34 +1216,6 @@ export default function AppFunctionalNeatlab() {
 					                                                        ))}
 					                                                    </SelectContent>
 					                                                </Select>
-					                                                <Select
-					                                                    value={escalaHeaderState?.selectedProfessional || '–'}
-				                                                    onValueChange={(value) => {
-				                                                        try {
-				                                                            window.dispatchEvent(new CustomEvent('skincos:escala:action', { detail: { action: 'set-professional', value } }))
-				                                                        } catch { /* ignore */ }
-				                                                    }}
-				                                                >
-					                                                    <SelectTrigger
-                                                                            className="h-8 w-48 bg-white/[0.06] border-white/20 text-white"
-                                                                            data-escala-preserve-filter="true"
-                                                                            style={
-                                                                                escalaHeaderState?.selectedProfessional && escalaHeaderState.selectedProfessional !== '–'
-                                                                                    ? getEscalaProfessionalTriggerStyle(escalaHeaderState.selectedProfessional)
-                                                                                    : undefined
-                                                                            }
-                                                                        >
-					                                                        <SelectValue placeholder="Profissional" />
-					                                                    </SelectTrigger>
-					                                                    <SelectContent data-escala-preserve-filter="true">
-					                                                        <SelectItem value="–">–</SelectItem>
-				                                                        {(escalaHeaderState?.professionalOptions || []).map((name) => (
-				                                                            <SelectItem key={name} value={name}>
-				                                                                {name}
-				                                                            </SelectItem>
-				                                                        ))}
-				                                                    </SelectContent>
-				                                                </Select>
 				                                            </div>
 				                                        ) : null}
 		                                    </div>
@@ -1402,28 +1226,28 @@ export default function AppFunctionalNeatlab() {
 		                                        <div className="flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" data-escala-preserve-filter="true">
                                                     {[
                                                         {
-                                                            key: 'manual',
+                                                            key: 'manual' as EscalaHighlightMode,
                                                             label: 'Manual',
                                                             icon: <Pencil className="size-3.5" aria-hidden="true" />,
                                                             value: escalaHeaderState?.manualDays ?? escalaHeaderState?.totalScheduledDays ?? 0,
                                                             activeClass: 'border-sky-300/55 bg-sky-300/16 text-sky-50 shadow-[0_0_0_1px_rgba(125,211,252,0.16)]',
                                                         },
                                                         {
-                                                            key: 'auto',
+                                                            key: 'auto' as EscalaHighlightMode,
                                                             label: 'Auto',
                                                             icon: <Sparkles className="size-3.5" aria-hidden="true" />,
                                                             value: escalaHeaderState?.autoDays ?? 0,
                                                             activeClass: 'border-emerald-300/55 bg-emerald-300/16 text-emerald-50 shadow-[0_0_0_1px_rgba(110,231,183,0.16)]',
                                                         },
                                                         {
-                                                            key: 'blocked',
+                                                            key: 'blocked' as EscalaHighlightMode,
                                                             label: 'Bloqueado',
                                                             icon: <Shield className="size-3.5" aria-hidden="true" />,
                                                             value: escalaHeaderState?.blockedDays ?? 0,
                                                             activeClass: 'border-rose-300/55 bg-rose-300/16 text-rose-50 shadow-[0_0_0_1px_rgba(253,164,175,0.16)]',
                                                         },
                                                         {
-                                                            key: 'empty',
+                                                            key: 'empty' as EscalaHighlightMode,
                                                             label: 'Vazio',
                                                             icon: <CalendarX2 className="size-3.5" aria-hidden="true" />,
                                                             value: escalaHeaderState?.emptyDays ?? escalaHeaderState?.unavailableDaysCount ?? 0,
@@ -1439,9 +1263,7 @@ export default function AppFunctionalNeatlab() {
                                                                     data-testid={`escala-highlight-${item.key}`}
                                                                     aria-label={`Destacar dias ${item.label.toLowerCase()}`}
                                                                     onClick={() => {
-                                                                        try {
-                                                                            window.dispatchEvent(new CustomEvent('skincos:escala:action', { detail: { action: 'toggle-highlight-mode', value: item.key } }))
-                                                                        } catch { /* ignore */ }
+                                                                        dispatchEscalaHeaderAction({ type: 'toggle-highlight', value: item.key })
                                                                     }}
                                                                 >
                                                                     {item.icon}
@@ -1594,9 +1416,7 @@ export default function AppFunctionalNeatlab() {
 		                                                variant="ghost"
 		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
-		                                                    try {
-		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'expandAll' } }))
-		                                                    } catch { /* ignore */ }
+		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'expandAll' })
 	                                                }}
 		                                                title="Expandir tudo"
 		                                                aria-label="Expandir tudo"
@@ -1611,9 +1431,7 @@ export default function AppFunctionalNeatlab() {
 		                                                variant="ghost"
 		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
-		                                                    try {
-		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'collapseAll' } }))
-		                                                    } catch { /* ignore */ }
+		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'collapseAll' })
 	                                                }}
 		                                                title="Contrair tudo"
 		                                                aria-label="Contrair tudo"
@@ -1628,9 +1446,7 @@ export default function AppFunctionalNeatlab() {
 		                                                variant="ghost"
 		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
 		                                                onClick={() => {
-		                                                    try {
-		                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:layout', { detail: { action: 'reset' } }))
-		                                                    } catch { /* ignore */ }
+		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'reset' })
 	                                                }}
 		                                                title="Resetar layout"
 		                                                aria-label="Resetar layout"
@@ -1677,9 +1493,7 @@ export default function AppFunctionalNeatlab() {
 	                                                const next = (v as any) as InsumosOverviewPeriod
 	                                                setInsumosOverviewPeriod(next)
 	                                                try { localStorage.setItem(INSUMOS_OVERVIEW_PERIOD_KEY, next) } catch { /* ignore */ }
-	                                                try {
-	                                                    window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: next, from: insumosOverviewFrom, to: insumosOverviewTo } }))
-	                                                } catch { /* ignore */ }
+	                                                dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: next, from: insumosOverviewFrom, to: insumosOverviewTo } })
 	                                            }}
 	                                        >
 	                                            <SelectTrigger className="h-10 w-full bg-white/[0.06] border-white/20 text-white">
@@ -1702,9 +1516,7 @@ export default function AppFunctionalNeatlab() {
 	                                                    const next = e.target.value
 	                                                    setInsumosOverviewFrom(next)
 	                                                    try { localStorage.setItem(INSUMOS_OVERVIEW_FROM_KEY, next) } catch { /* ignore */ }
-	                                                    try {
-	                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: insumosOverviewPeriod, from: next, to: insumosOverviewTo } }))
-	                                                    } catch { /* ignore */ }
+	                                                    dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: insumosOverviewPeriod, from: next, to: insumosOverviewTo } })
 	                                                }}
 	                                                placeholder="De (DD/MM/AAAA)"
 	                                                className="h-10 bg-white/[0.06] border-white/20 text-white placeholder:text-blue-200/40"
@@ -1715,9 +1527,7 @@ export default function AppFunctionalNeatlab() {
 	                                                    const next = e.target.value
 	                                                    setInsumosOverviewTo(next)
 	                                                    try { localStorage.setItem(INSUMOS_OVERVIEW_TO_KEY, next) } catch { /* ignore */ }
-	                                                    try {
-	                                                        window.dispatchEvent(new CustomEvent('skincos:insumos:overview', { detail: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: next } }))
-	                                                    } catch { /* ignore */ }
+	                                                    dispatchInsumosHeaderAction({ type: 'set-overview', value: { period: insumosOverviewPeriod, from: insumosOverviewFrom, to: next } })
 	                                                }}
 	                                                placeholder="Até (DD/MM/AAAA)"
 	                                                className="h-10 bg-white/[0.06] border-white/20 text-white placeholder:text-blue-200/40"
@@ -1746,9 +1556,7 @@ export default function AppFunctionalNeatlab() {
 	                                                    variant="ghost"
                                                     className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
                                                     onClick={() => {
-                                                        try {
-                                                            window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'ENTRADA' } }))
-                                                        } catch { /* ignore */ }
+                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
                                                     }}
                                                     title="Entrada"
                                                     aria-label="Entrada"
@@ -1760,9 +1568,7 @@ export default function AppFunctionalNeatlab() {
                                                     variant="ghost"
                                                     className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
                                                     onClick={() => {
-                                                        try {
-                                                            window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'BAIXA' } }))
-                                                        } catch { /* ignore */ }
+                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
                                                     }}
                                                     title="Saída"
                                                     aria-label="Saída"
@@ -1774,9 +1580,7 @@ export default function AppFunctionalNeatlab() {
                                                     variant="ghost"
                                                     className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
                                                     onClick={() => {
-                                                        try {
-                                                            window.dispatchEvent(new CustomEvent('skincos:insumos:op', { detail: { op: 'TRANSFERENCIA' } }))
-                                                        } catch { /* ignore */ }
+                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
                                                     }}
                                                     title="Transferência"
                                                     aria-label="Transferência"

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -1,318 +1,75 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { CalendarX2, ChevronLeft, ChevronRight, Pencil, Plus, Save, Shield, X } from 'lucide-react'
+import { CalendarX2, ChevronLeft, ChevronRight, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { Badge } from '@/badge'
-import { Button } from '@/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
-import { Checkbox } from '@/checkbox'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/dialog'
-import { Input } from '@/input'
 import { LoadingPercentText } from '@/LoadingPattern'
-import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
-import { Progress } from '@/progress'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
+import { EscalaDaySourceBadge, NoAttendanceChip } from '@/escalaComponents'
+import {
+  EscalaAssignDialog,
+  EscalaPlanningAssistantModal,
+  EscalaTeamPanel,
+} from '@/escalaPanels'
 import { useAuth } from '@/contexts'
 import { cn } from '@/utils'
-import { buildMonthPlanMetrics, buildScheduleVersion, resolveDayPlanSource } from '@/escalaDomain'
+import { emitEscalaHeaderState, subscribeEscalaHeaderAction } from '@/escalaHeaderBridge'
+import {
+  applyPrefillUpdatesToSchedule,
+  buildCalendarCells,
+  buildMonthPlanMetrics,
+  buildPreviousMonthKeys,
+  buildScheduleVersion,
+  buildWeekdayPrefillAssignments,
+  deriveWeekdayDefaultProfessionals,
+  resolveDayPlanSource,
+} from '@/escalaDomain'
+import {
+  ALL_PROFESSIONALS_OPTION,
+  createEmptyProfessional,
+  DEFAULT_MONTH_NUMBER,
+  DEFAULT_YEAR,
+  formatBrazilPhone,
+  formatDelimitedValues,
+  formatDisplayDate,
+  getAdjacentMonthCardStyle,
+  getProfessionalBadgeStyle,
+  getProfessionalCardHighlightStyle,
+  hexToRgba,
+  isActiveInjector,
+  isInactiveInjector,
+  isVisibleInjector,
+  mergeProfessionals,
+  MONTH_OPTIONS,
+  NEW_TEAM_MEMBER_KEY,
+  normalizeHexColor,
+  normalizeProfessionalForCompare,
+  normalizeText,
+  parseDelimitedValues,
+  parseUnitsInput,
+  resolveVisibleMonth,
+  shiftMonthValue,
+  slugifySegment,
+  uniqueNames,
+  unitsMatch,
+} from '@/escalaShared'
+import { buildSelectedDatesLabel, buildSelectionScopeLabel, filterDatesToMonth, resolveNextActiveDate, toggleDateSelection } from '@/escalaSelection'
+import type {
+  EscalaActionResult,
+  EscalaHeaderAction,
+  EscalaHighlightMode,
+  EscalaProfessional,
+  EscalaTeamFormMode,
+} from '@/escalaTypes'
+import { useEscalaDataController } from '@/useEscalaDataController'
 import { useEscalaPrefill } from '@/useEscalaPrefill'
 import {
   addClosedDay,
   addEscalaProfessional,
-  fetchEscalaOverview,
-  fetchEscalaProfessionals,
-  fetchEscalaSchedule,
   removeScheduleEntry,
   removeClosedDay,
   replaceScheduleEntries,
   updateEscalaProfessional
 } from '@/escalaApi'
-
-type CalendarCell = {
-  date: string
-  day: number
-  monthOffset: -1 | 0 | 1
-}
-
-type EscalaProfessional = {
-  name: string
-  status: string
-  units: string[]
-  role: string
-  shift: string
-  nickname: string
-  phone: string
-  email: string
-  instagram: string
-  color: string
-}
-
-type EscalaScheduleEntry = { date: string; unit: string; professional: string }
-type EscalaClosedDay = { date: string; unit: string; reason: string }
-type EscalaHoliday = { date: string; unit: string; name: string }
-type WeekdayDefaultMap = Partial<Record<0 | 1 | 2 | 3 | 4 | 5 | 6, string>>
-const MONTH_LABELS = new Map<string, string>()
-const DEFAULT_DATE = new Date()
-const DEFAULT_MONTH_NUMBER = String(DEFAULT_DATE.getMonth() + 1).padStart(2, '0')
-const DEFAULT_YEAR = String(DEFAULT_DATE.getFullYear())
-const MONTH_OPTIONS = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, '0'))
-const ALL_PROFESSIONALS_OPTION = '–'
-const NEW_TEAM_MEMBER_KEY = '__new__'
-const STATUS_OPTIONS = ['Ativo', 'Inativo']
-const UNIT_OPTIONS = ['BarraShoppingSul', 'Novo Hamburgo']
-const ROLE_OPTIONS = ['Diretor', 'Gerente', 'Coordenador', 'Responsável Técnico', 'Injetor', 'Consultor']
-const DEFAULT_TEAM_COLOR = '#ec4899'
-
-function formatMonthLabel(value: string) {
-  if (MONTH_LABELS.has(value)) return MONTH_LABELS.get(value) as string
-  const [year, month] = value.split('-').map(Number)
-  const date = new Date(year, month - 1, 1)
-  let label = date.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })
-  label = label.charAt(0).toUpperCase() + label.slice(1)
-  MONTH_LABELS.set(value, label)
-  return label
-}
-
-function formatMonthName(value: string) {
-  const month = Number(value)
-  if (!month) return value
-  const date = new Date(2000, month - 1, 1)
-  const label = date.toLocaleDateString('pt-BR', { month: 'long' })
-  return label.charAt(0).toUpperCase() + label.slice(1)
-}
-
-function formatDisplayDate(value: string) {
-  const [year, month, day] = String(value || '').split('-')
-  if (!year || !month || !day) return value
-  return `${day}/${month}/${year}`
-}
-
-function shiftMonthValue(monthValue: string, offset: number) {
-  const [year, month] = monthValue.split('-').map(Number)
-  const date = new Date(year, month - 1 + offset, 1)
-  return {
-    year: String(date.getFullYear()),
-    monthNumber: String(date.getMonth() + 1).padStart(2, '0'),
-  }
-}
-
-function buildCalendarCells(monthValue: string): CalendarCell[] {
-  const [year, month] = monthValue.split('-').map(Number)
-  const firstDay = new Date(year, month - 1, 1)
-  const daysInMonth = new Date(year, month, 0).getDate()
-  const mondayIndex = (firstDay.getDay() + 6) % 7
-  const pad = (value: number) => String(value).padStart(2, '0')
-  const cells: CalendarCell[] = []
-  const previousMonthDate = new Date(year, month - 2, 1)
-  const previousMonthDays = new Date(year, month - 1, 0).getDate()
-  const previousMonthYear = previousMonthDate.getFullYear()
-  const previousMonthNumber = previousMonthDate.getMonth() + 1
-  for (let i = 0; i < mondayIndex; i += 1) {
-    const day = previousMonthDays - mondayIndex + i + 1
-    cells.push({
-      date: `${previousMonthYear}-${pad(previousMonthNumber)}-${pad(day)}`,
-      day,
-      monthOffset: -1,
-    })
-  }
-  for (let day = 1; day <= daysInMonth; day += 1) {
-    const iso = `${year}-${pad(month)}-${pad(day)}`
-    cells.push({ date: iso, day, monthOffset: 0 })
-  }
-  const trailingCount = (7 - (cells.length % 7)) % 7
-  const nextMonthDate = new Date(year, month, 1)
-  const nextMonthYear = nextMonthDate.getFullYear()
-  const nextMonthNumber = nextMonthDate.getMonth() + 1
-  for (let day = 1; day <= trailingCount; day += 1) {
-    cells.push({
-      date: `${nextMonthYear}-${pad(nextMonthNumber)}-${pad(day)}`,
-      day,
-      monthOffset: 1,
-    })
-  }
-  return cells
-}
-
-function normalizeText(value: string) {
-  return String(value || '').trim().toLowerCase()
-}
-
-function normalizeHexColor(value: string) {
-  const raw = String(value || '').trim().toLowerCase()
-  if (!raw) return ''
-  const normalized = raw.startsWith('#') ? raw : `#${raw}`
-  if (/^#[0-9a-f]{6}$/.test(normalized)) return normalized
-  if (/^#[0-9a-f]{3}$/.test(normalized)) {
-    const [, r, g, b] = normalized
-    return `#${r}${r}${g}${g}${b}${b}`
-  }
-  return ''
-}
-
-function hexToRgba(value: string, alpha: number) {
-  const hex = normalizeHexColor(value)
-  if (!hex) return `rgba(236, 72, 153, ${alpha})`
-  const red = Number.parseInt(hex.slice(1, 3), 16)
-  const green = Number.parseInt(hex.slice(3, 5), 16)
-  const blue = Number.parseInt(hex.slice(5, 7), 16)
-  return `rgba(${red}, ${green}, ${blue}, ${alpha})`
-}
-
-function formatBrazilPhone(value: string) {
-  const digits = String(value || '').replace(/\D/g, '')
-  if (!digits) return ''
-  const normalized = (digits.startsWith('55') ? digits : `55${digits}`).slice(0, 13)
-  const country = normalized.slice(0, 2)
-  const area = normalized.slice(2, 4)
-  const subscriber = normalized.slice(4)
-  let formatted = `+${country}`
-  if (area) {
-    formatted += ` (${area}`
-    if (area.length === 2) formatted += ')'
-  }
-  if (subscriber) {
-    const prefixLength = subscriber.length > 8 ? 5 : Math.min(4, subscriber.length)
-    const prefix = subscriber.slice(0, prefixLength)
-    const suffix = subscriber.slice(prefixLength)
-    formatted += ` ${prefix}`
-    if (suffix) formatted += `-${suffix}`
-  }
-  return formatted
-}
-
-function normalizeUnitKey(value: string) {
-  return String(value || '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '')
-    .trim()
-}
-
-function unitsMatch(left: string, right: string) {
-  return normalizeUnitKey(left) === normalizeUnitKey(right)
-}
-
-function isActiveInjector(prof: EscalaProfessional) {
-  const role = normalizeText(prof.role)
-  const status = normalizeText(prof.status)
-  return role.includes('injetor') && status === 'ativo'
-}
-
-function isInactiveInjector(prof: EscalaProfessional) {
-  const role = normalizeText(prof.role)
-  const status = normalizeText(prof.status)
-  return role.includes('injetor') && status === 'inativo'
-}
-
-function isVisibleInjector(prof: EscalaProfessional) {
-  return isActiveInjector(prof) || isInactiveInjector(prof)
-}
-
-function normalizeProfessionalRecord(prof: EscalaProfessional) {
-  return {
-    ...prof,
-    role: String(prof.role || '').trim() || 'Injetor',
-    status: String(prof.status || '').trim() || 'Ativo',
-    units: Array.isArray(prof.units) ? prof.units : [],
-  }
-}
-
-function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional[]) {
-  const map = new Map<string, EscalaProfessional>()
-  base.forEach((prof) => {
-    map.set(prof.name, normalizeProfessionalRecord(prof))
-  })
-  scheduleNames.forEach((name) => {
-    if (map.has(name)) return
-    map.set(name, normalizeProfessionalRecord({
-      name,
-      status: 'Ativo',
-      units: [],
-      role: 'Injetor',
-      shift: '',
-      nickname: '',
-      phone: '',
-      email: '',
-      instagram: '',
-      color: '',
-    }))
-  })
-  return Array.from(map.values())
-}
-
-function getWeekdayFromIsoDate(value: string) {
-  const [year, month, day] = String(value || '').split('-').map(Number)
-  if (!year || !month || !day) return -1
-  return new Date(year, month - 1, day).getDay()
-}
-
-function buildPreviousMonthKeys(monthValue: string, count = 3) {
-  const [year, month] = monthValue.split('-').map(Number)
-  if (!year || !month || count <= 0) return [] as string[]
-  const keys: string[] = []
-  for (let index = 1; index <= count; index += 1) {
-    const date = new Date(year, month - 1 - index, 1)
-    keys.push(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`)
-  }
-  return keys
-}
-
-function deriveWeekdayDefaultProfessionals(entries: EscalaScheduleEntry[]): WeekdayDefaultMap {
-  const byWeekday = new Map<number, Map<string, number>>()
-  entries.forEach((entry) => {
-    const professional = String(entry?.professional || '').trim()
-    const weekday = getWeekdayFromIsoDate(String(entry?.date || ''))
-    if (!professional || weekday < 0) return
-    const currentMap = byWeekday.get(weekday) || new Map<string, number>()
-    currentMap.set(professional, (currentMap.get(professional) || 0) + 1)
-    byWeekday.set(weekday, currentMap)
-  })
-
-  const defaults: WeekdayDefaultMap = {}
-  byWeekday.forEach((countByProfessional, weekday) => {
-    const winner = Array.from(countByProfessional.entries())
-      .sort((left, right) => {
-        if (right[1] !== left[1]) return right[1] - left[1]
-        return left[0].localeCompare(right[0])
-      })[0]
-    if (!winner) return
-    defaults[weekday as 0 | 1 | 2 | 3 | 4 | 5 | 6] = winner[0]
-  })
-
-  return defaults
-}
-
-function buildWeekdayPrefillAssignments(dates: string[], historicalEntries: EscalaScheduleEntry[]) {
-  const weekdayDefaults = deriveWeekdayDefaultProfessionals(historicalEntries)
-  return dates
-    .map((date) => {
-      const weekday = getWeekdayFromIsoDate(date)
-      const professional = weekdayDefaults[weekday as 0 | 1 | 2 | 3 | 4 | 5 | 6]
-      if (!professional) return null
-      return { date, professional }
-    })
-    .filter((item): item is { date: string; professional: string } => Boolean(item))
-}
-
-function applyPrefillUpdatesToSchedule(entries: EscalaScheduleEntry[], unit: string, updates: Array<{ date: string; professional: string }>) {
-  const updateMap = new Map(updates.map((update) => [update.date, update.professional]))
-  const preserved = entries.filter((entry) => !updateMap.has(entry.date))
-  const inserted = updates.map((update) => ({
-    date: update.date,
-    unit,
-    professional: update.professional,
-  }))
-  return [...preserved, ...inserted].sort((left, right) => {
-    const dateCompare = left.date.localeCompare(right.date)
-    if (dateCompare !== 0) return dateCompare
-    return left.professional.localeCompare(right.professional)
-  })
-}
-
-function toLocalIsoDate(date: Date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-}
-
 export const __testables = {
   mergeProfessionals,
   resolveVisibleMonth,
@@ -322,297 +79,35 @@ export const __testables = {
   applyPrefillUpdatesToSchedule,
 }
 
-function uniqueNames(values: string[]) {
-  return Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean)))
-}
-
-function parseDelimitedValues(value: string) {
-  return uniqueNames(String(value || '').split(',').map((item) => item.trim()))
-}
-
-function formatDelimitedValues(values: string[]) {
-  return uniqueNames(values).join(', ')
-}
-
-function parseUnitsInput(value: string) {
-  return parseDelimitedValues(value)
-}
-
-function normalizeProfessionalForCompare(prof: EscalaProfessional | null) {
-  if (!prof) return null
-  return {
-    name: String(prof.name || '').trim(),
-    status: String(prof.status || '').trim(),
-    units: uniqueNames(prof.units || []),
-    role: String(prof.role || '').trim(),
-    shift: String(prof.shift || '').trim(),
-    nickname: String(prof.nickname || '').trim(),
-    phone: String(prof.phone || '').trim(),
-    email: String(prof.email || '').trim(),
-    instagram: String(prof.instagram || '').trim(),
-    color: normalizeHexColor(prof.color),
-  }
-}
-
-function buildYearOptions(monthKeys: string[]) {
-  const currentYear = Number(DEFAULT_YEAR)
-  const years = new Set<string>([String(currentYear - 1), DEFAULT_YEAR, String(currentYear + 1), String(currentYear + 2)])
-  monthKeys.forEach((value) => {
-    const year = String(value || '').slice(0, 4)
-    if (/^\d{4}$/.test(year)) years.add(year)
-  })
-  return Array.from(years).sort((a, b) => Number(a) - Number(b))
-}
-
-function normalizeMonthKey(value: string) {
-  return /^\d{4}-\d{2}$/.test(String(value || '')) ? String(value) : ''
-}
-
-function resolveVisibleMonth(monthKeys: string[], year: string, monthNumber: string) {
-  const available = Array.from(new Set(monthKeys.map(normalizeMonthKey).filter(Boolean))).sort()
-  const selected = normalizeMonthKey(`${year}-${monthNumber}`)
-  const fallback = available.length ? available[available.length - 1] : (selected || `${DEFAULT_YEAR}-${DEFAULT_MONTH_NUMBER}`)
-  const next = selected && available.includes(selected) ? selected : fallback
-  return {
-    year: next.slice(0, 4),
-    monthNumber: next.slice(5, 7),
-  }
-}
-
-function hashString(value: string) {
-  let hash = 0
-  for (let index = 0; index < value.length; index += 1) {
-    hash = value.charCodeAt(index) + ((hash << 5) - hash)
-  }
-  return Math.abs(hash)
-}
-
-function getProfessionalBadgeStyle(
-  name: string,
-  mode: 'default' | 'active' | 'muted' = 'default',
-  accentColor?: string,
-) {
-  const color = normalizeHexColor(accentColor || '')
-  const hash = hashString(name)
-  const hue = hash % 360
-  const baseText = color ? 'white' : `hsl(${hue} 88% 92%)`
-
-  if (mode === 'active') {
-    return {
-      background: color
-        ? `linear-gradient(135deg, ${hexToRgba(color, 0.55)}, ${hexToRgba(color, 0.28)})`
-        : `linear-gradient(135deg, hsla(${hue}, 82%, 56%, 0.38), hsla(${(hue + 28) % 360}, 82%, 58%, 0.26))`,
-      borderColor: color ? hexToRgba(color, 0.92) : `hsla(${hue}, 88%, 74%, 0.9)`,
-      color: 'white',
-      boxShadow: color
-        ? `0 0 0 1px ${hexToRgba(color, 0.45)}, 0 16px 28px ${hexToRgba(color, 0.28)}, inset 0 1px 0 rgba(255,255,255,0.18)`
-        : `0 0 0 1px hsla(${hue}, 90%, 74%, 0.45), 0 16px 28px hsla(${hue}, 90%, 20%, 0.28), inset 0 1px 0 rgba(255,255,255,0.18)`,
-      opacity: 1,
-    } as React.CSSProperties
-  }
-
-  if (mode === 'muted') {
-    return {
-      background: 'rgba(15, 23, 42, 0.28)',
-      borderColor: 'rgba(148, 163, 184, 0.18)',
-      color: 'rgba(226, 232, 240, 0.58)',
-      boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.02)',
-      opacity: 0.72,
-    } as React.CSSProperties
-  }
-
-  return {
-    background: color
-      ? `linear-gradient(135deg, ${hexToRgba(color, 0.28)}, ${hexToRgba(color, 0.16)})`
-      : `linear-gradient(135deg, hsla(${hue}, 78%, 56%, 0.22), hsla(${(hue + 24) % 360}, 78%, 58%, 0.14))`,
-    borderColor: color ? hexToRgba(color, 0.5) : `hsla(${hue}, 84%, 72%, 0.4)`,
-    color: baseText,
-    boxShadow: color
-      ? `inset 0 1px 0 rgba(255,255,255,0.08), 0 0 0 1px ${hexToRgba(color, 0.12)}`
-      : 'inset 0 1px 0 rgba(255,255,255,0.05)',
-    opacity: 1,
-  } as React.CSSProperties
-}
-
-function getProfessionalCardHighlightStyle(name: string, accentColor?: string) {
-  const color = normalizeHexColor(accentColor || '')
-  const hue = hashString(name) % 360
-  return {
-    borderColor: color ? hexToRgba(color, 0.78) : `hsla(${hue}, 88%, 74%, 0.72)`,
-    background: color
-      ? `linear-gradient(180deg, ${hexToRgba(color, 0.18)}, rgba(15, 23, 42, 0.34))`
-      : `linear-gradient(180deg, hsla(${hue}, 86%, 54%, 0.12), rgba(15, 23, 42, 0.34))`,
-    boxShadow: color
-      ? `0 0 0 1px ${hexToRgba(color, 0.24)}, 0 18px 34px ${hexToRgba(color, 0.24)}, inset 0 1px 0 rgba(255,255,255,0.06)`
-      : `0 0 0 1px hsla(${hue}, 88%, 74%, 0.25), 0 18px 34px hsla(${hue}, 90%, 18%, 0.24), inset 0 1px 0 rgba(255,255,255,0.06)`,
-  } as React.CSSProperties
-}
-
-function getAdjacentMonthCardStyle(type: 'previous-month' | 'next-month', position: number, total: number) {
-  if (!total || !position) return {} as React.CSSProperties
-  const step = 0.8 / total
-  const transparency = type === 'previous-month'
-    ? Math.min(0.9, 0.1 + step * (total - position + 1))
-    : Math.min(0.9, 0.1 + step * (position - 1))
-  const opacity = 1 - transparency * 0.58
-  const blur = 8 + transparency * 10
-  const saturation = 0.84 - transparency * 0.36
-  const grayscale = 0.12 + transparency * 0.52
-  const borderAlpha = 0.08 + transparency * 0.18
-  const topAlpha = 0.025 + transparency * 0.07
-  const bottomAlpha = 0.045 + transparency * 0.12
-  return {
-    opacity: Number(opacity.toFixed(3)),
-    borderColor: `rgba(148, 163, 184, ${borderAlpha.toFixed(3)})`,
-    background: `linear-gradient(180deg, rgba(255,255,255,${topAlpha.toFixed(3)}), rgba(148,163,184,${bottomAlpha.toFixed(3)}))`,
-    boxShadow: `inset 0 1px 0 rgba(255,255,255,${(0.03 + transparency * 0.06).toFixed(3)}), 0 10px 24px rgba(15,23,42,${(0.05 + transparency * 0.08).toFixed(3)})`,
-    filter: `grayscale(${grayscale.toFixed(2)}) saturate(${saturation.toFixed(2)})`,
-    backdropFilter: `blur(${blur.toFixed(1)}px) saturate(${(0.9 - transparency * 0.18).toFixed(2)})`,
-    WebkitBackdropFilter: `blur(${blur.toFixed(1)}px) saturate(${(0.9 - transparency * 0.18).toFixed(2)})`,
-  } as React.CSSProperties
-}
-
-function slugifySegment(value: string) {
-  return String(value || '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-}
-
-function createEmptyProfessional(selectedUnit?: string): EscalaProfessional {
-  return {
-    name: '',
-    status: 'Ativo',
-    units: selectedUnit ? [selectedUnit] : [],
-    role: '',
-    shift: '',
-    nickname: '',
-    phone: '',
-    email: '',
-    instagram: '',
-    color: '',
-  }
-}
-
-function NoAttendanceChip({
-  date,
-  blocked,
-  label,
-}: {
-  date: string
-  blocked?: boolean
-  label?: string
-}) {
-  const text = String(label || 'Sem atendimento').trim() || 'Sem atendimento'
-
-  return (
-    <div
-      className={cn(
-        'inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
-        blocked
-          ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
-          : 'border-white/10 bg-white/5 text-slate-200/80',
-      )}
-      data-testid={`escala-no-attendance-icon-${date}`}
-      aria-label={text}
-      title={text}
-    >
-      <CalendarX2 className="h-3.5 w-3.5" />
-    </div>
-  )
-}
-
-type MultiSelectFieldProps = {
-  label: string
-  placeholder: string
-  options: string[]
-  values: string[]
-  onToggle: (option: string) => void
-  testId: string
-  full?: boolean
-}
-
-function MultiSelectField({
-  label,
-  placeholder,
-  options,
-  values,
-  onToggle,
-  testId,
-  full,
-}: MultiSelectFieldProps) {
-  const displayValue = values.length ? values.join(', ') : placeholder
-
-  return (
-    <label className={cn('space-y-1.5', full && 'sm:col-span-2')}>
-      <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-        {label}
-      </span>
-      <Popover>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              'flex h-10 w-full items-center justify-between rounded-md border border-white/10 bg-white/[0.05] px-3 text-left text-sm transition hover:border-white/20',
-              values.length ? 'text-white' : 'text-slate-400'
-            )}
-            data-testid={testId}
-          >
-            <span className="truncate">{displayValue}</span>
-            <span className="ml-3 text-[10px] uppercase tracking-[0.14em] text-slate-400">
-              {values.length || 0}
-            </span>
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[320px] border-white/15 bg-slate-900/95 p-2 text-slate-100" align="start">
-          <div className="space-y-1">
-            {options.map((option) => {
-              const checked = values.includes(option)
-              return (
-                <label
-                  key={option}
-                  className={cn(
-                    'flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 text-sm transition hover:bg-white/[0.06]',
-                    checked && 'bg-white/[0.08]'
-                  )}
-                >
-                  <Checkbox
-                    checked={checked}
-                    onCheckedChange={() => onToggle(option)}
-                    data-testid={`${testId}-${slugifySegment(option)}`}
-                  />
-                  <span>{option}</span>
-                </label>
-              )
-            })}
-          </div>
-        </PopoverContent>
-      </Popover>
-    </label>
-  )
-}
-
 export function EscalaProfissionaisModule() {
   const { user } = useAuth()
   const roleKey = String(user?.role || '').trim().toUpperCase()
   const canAccess = roleKey === 'GESTOR' || roleKey === 'GERENTE'
 
-  const [units, setUnits] = useState<string[]>([])
-  const [availableMonths, setAvailableMonths] = useState<string[]>([])
-  const [selectedUnit, setSelectedUnit] = useState<string>('')
-  const [selectedMonthNumber, setSelectedMonthNumber] = useState<string>(DEFAULT_MONTH_NUMBER)
-  const [selectedYear, setSelectedYear] = useState<string>(DEFAULT_YEAR)
+  const {
+    units,
+    selectedUnit,
+    selectedMonth,
+    selectedMonthNumber,
+    selectedYear,
+    professionals,
+    schedule,
+    closedDays,
+    holidays,
+    loadingSchedule,
+    error,
+    teamLoadError,
+    yearOptions,
+    setSelectedUnit,
+    setSelectedMonthNumber,
+    setSelectedYear,
+    setSchedule,
+    refreshOverview,
+    refreshProfessionals,
+    refreshSchedule,
+    markMonthSelectionTouched,
+  } = useEscalaDataController()
   const [selectedProfessional, setSelectedProfessional] = useState<string>(ALL_PROFESSIONALS_OPTION)
-  const [professionals, setProfessionals] = useState<EscalaProfessional[]>([])
-  const [schedule, setSchedule] = useState<EscalaScheduleEntry[]>([])
-  const [closedDays, setClosedDays] = useState<EscalaClosedDay[]>([])
-  const [holidays, setHolidays] = useState<EscalaHoliday[]>([])
-  const [loadingOverview, setLoadingOverview] = useState(true)
-  const [loadingSchedule, setLoadingSchedule] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [teamLoadError, setTeamLoadError] = useState<string | null>(null)
   const [dayProfessionalDrafts, setDayProfessionalDrafts] = useState<Record<string, string[]>>({})
   const [dayBlockReasons, setDayBlockReasons] = useState<Record<string, string>>({})
   const [dayActionKey, setDayActionKey] = useState<string | null>(null)
@@ -622,23 +117,16 @@ export function EscalaProfissionaisModule() {
   const [isBulkSelectionMode, setIsBulkSelectionMode] = useState(false)
   const [isBulkAssignModalOpen, setIsBulkAssignModalOpen] = useState(false)
   const [isPlanningAssistantModalOpen, setIsPlanningAssistantModalOpen] = useState(false)
-  const [highlightMode, setHighlightMode] = useState<'manual' | 'auto' | 'blocked' | 'empty' | null>(null)
+  const [highlightMode, setHighlightMode] = useState<EscalaHighlightMode | null>(null)
   const [multiDateBlockReason, setMultiDateBlockReason] = useState('')
   const [selectedTeamMember, setSelectedTeamMember] = useState<string>('')
   const [teamMemberDrafts, setTeamMemberDrafts] = useState<Record<string, EscalaProfessional>>({})
   const [savingTeamMember, setSavingTeamMember] = useState(false)
-  const [teamFormMode, setTeamFormMode] = useState<'idle' | 'edit' | 'add'>('idle')
+  const [teamFormMode, setTeamFormMode] = useState<EscalaTeamFormMode>('idle')
   const [showInactiveTeamMembers, setShowInactiveTeamMembers] = useState(false)
   const activeDateRef = useRef<string | null>(null)
   const selectedDatesRef = useRef<string[]>([])
-  const selectedPeriodRef = useRef<{ year: string; monthNumber: string }>({ year: DEFAULT_YEAR, monthNumber: DEFAULT_MONTH_NUMBER })
-  const monthSelectionTouchedRef = useRef(false)
   const dismissedPlanningAssistantRef = useRef(new Set<string>())
-  const teamPanelExpanded = teamFormMode !== 'idle'
-  const selectedMonth = useMemo(
-    () => (selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : ''),
-    [selectedMonthNumber, selectedYear],
-  )
 
   useEffect(() => {
     activeDateRef.current = activeDate
@@ -647,73 +135,6 @@ export function EscalaProfissionaisModule() {
   useEffect(() => {
     selectedDatesRef.current = selectedDates
   }, [selectedDates])
-
-  useEffect(() => {
-    selectedPeriodRef.current = {
-      year: selectedYear || DEFAULT_YEAR,
-      monthNumber: selectedMonthNumber || DEFAULT_MONTH_NUMBER,
-    }
-  }, [selectedMonthNumber, selectedYear])
-
-  const refreshOverview = useCallback(async () => {
-    setLoadingOverview(true)
-    const res = await fetchEscalaOverview()
-    if (!res.ok) {
-      setError(res.error || 'Não foi possível carregar a escala.')
-      setLoadingOverview(false)
-      return
-    }
-    const nextUnits = Array.isArray(res.units) ? res.units : []
-    const nextMonths = Array.isArray(res.months) ? res.months : []
-    setUnits(nextUnits)
-    setAvailableMonths(nextMonths)
-    setSelectedUnit((prev) => (prev || nextUnits[0] || prev))
-    if (!monthSelectionTouchedRef.current && nextMonths.length) {
-      const resolvedMonth = resolveVisibleMonth(
-        nextMonths,
-        selectedPeriodRef.current.year,
-        selectedPeriodRef.current.monthNumber,
-      )
-      setSelectedYear(resolvedMonth.year)
-      setSelectedMonthNumber(resolvedMonth.monthNumber)
-    } else {
-      setSelectedMonthNumber((prev) => prev || DEFAULT_MONTH_NUMBER)
-      setSelectedYear((prev) => prev || DEFAULT_YEAR)
-    }
-    setError(null)
-    setLoadingOverview(false)
-  }, [])
-
-  const refreshProfessionals = useCallback(async (unitOverride?: string) => {
-    const unit = unitOverride || selectedUnit
-    if (!unit) return
-    const res = await fetchEscalaProfessionals(unit)
-    if (!res.ok) {
-      setProfessionals([])
-      setTeamLoadError(res.error || 'Falha ao carregar a equipe do cadastro.')
-      return
-    }
-    setProfessionals(Array.isArray(res.data) ? res.data : [])
-    setTeamLoadError(null)
-  }, [selectedUnit])
-
-  const refreshSchedule = useCallback(async (unitOverride?: string, monthOverride?: string) => {
-    const unit = unitOverride || selectedUnit
-    const month = monthOverride || (selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : '')
-    if (!unit || !month) return
-    setLoadingSchedule(true)
-    const res = await fetchEscalaSchedule(unit, month)
-    if (!res.ok) {
-      setError(res.error || 'Não foi possível carregar a agenda.')
-      setLoadingSchedule(false)
-      return
-    }
-    setSchedule(Array.isArray(res.schedule) ? res.schedule : [])
-    setClosedDays(Array.isArray(res.closedDays) ? res.closedDays : [])
-    setHolidays(Array.isArray(res.holidays) ? res.holidays : [])
-    setError(null)
-    setLoadingSchedule(false)
-  }, [selectedMonthNumber, selectedUnit, selectedYear])
 
   const clearInteractiveState = useCallback(() => {
     setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
@@ -734,24 +155,10 @@ export function EscalaProfissionaisModule() {
   }, [])
 
   useEffect(() => {
-    void refreshOverview()
-  }, [refreshOverview])
-
-  useEffect(() => {
-    if (!selectedUnit) return
-    void refreshProfessionals(selectedUnit)
-  }, [selectedUnit, refreshProfessionals])
-
-  useEffect(() => {
-    if (!selectedUnit || !selectedMonth) return
-    void refreshSchedule(selectedUnit, selectedMonth)
-  }, [refreshSchedule, selectedMonthNumber, selectedUnit, selectedYear])
-
-  useEffect(() => {
     const activeMonth = selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : ''
     if (!activeMonth) return
     setActiveDate((prev) => (prev && prev.startsWith(`${activeMonth}-`) ? prev : null))
-    setSelectedDates((prev) => prev.filter((date) => date.startsWith(`${activeMonth}-`)))
+    setSelectedDates((prev) => filterDatesToMonth(prev, activeMonth))
     setIsDayAssignModalOpen(false)
     setIsBulkAssignModalOpen(false)
   }, [selectedMonthNumber, selectedYear])
@@ -782,22 +189,17 @@ export function EscalaProfissionaisModule() {
     [mergedProfessionals],
   )
   const professionalOptions = useMemo(() => uniqueNames(activeInjectors.map((prof) => prof.name)), [activeInjectors])
-  const headerProfessionalOptions = useMemo(
-    () => uniqueNames(selectedProfessional !== ALL_PROFESSIONALS_OPTION ? [...professionalOptions, selectedProfessional] : professionalOptions),
-    [professionalOptions, selectedProfessional],
-  )
   const assignableProfessionalOptions = useMemo(
     () => uniqueNames([...professionalOptions, ...schedule.map((entry) => entry.professional)]),
     [professionalOptions, schedule],
   )
-  const yearOptions = useMemo(() => buildYearOptions(availableMonths), [availableMonths])
 
   useEffect(() => {
     if (selectedProfessional === ALL_PROFESSIONALS_OPTION) return
-    if (!headerProfessionalOptions.includes(selectedProfessional)) {
+    if (!professionalOptions.includes(selectedProfessional)) {
       setSelectedProfessional(ALL_PROFESSIONALS_OPTION)
     }
-  }, [headerProfessionalOptions, selectedProfessional])
+  }, [professionalOptions, selectedProfessional])
 
   useEffect(() => {
     setDayProfessionalDrafts({})
@@ -941,14 +343,10 @@ export function EscalaProfissionaisModule() {
   }, [closedReasonByDate, dayBlockReasons, selectedDates])
 
   const selectedDateSet = useMemo(() => new Set(selectedDates), [selectedDates])
-  const selectedDatesLabel = useMemo(() => {
-    if (!selectedDates.length) return ''
-    if (selectedDates.length === 1) return formatDisplayDate(selectedDates[0])
-    const ordered = [...selectedDates].sort()
-    const preview = ordered.slice(0, 3).map(formatDisplayDate)
-    const suffix = ordered.length > 3 ? ` +${ordered.length - 3}` : ''
-    return `${preview.join(', ')}${suffix}`
-  }, [selectedDates])
+  const selectedDatesLabel = useMemo(
+    () => buildSelectedDatesLabel(selectedDates, formatDisplayDate),
+    [selectedDates],
+  )
 
   const monthPlanMetrics = useMemo(
     () => buildMonthPlanMetrics(calendarCells, scheduleByDate, closedBlockedDates, appliedSuggestionMap),
@@ -973,16 +371,10 @@ export function EscalaProfissionaisModule() {
   const firstCurrentMonthIndex = useMemo(() => calendarCells.findIndex((cell) => cell.monthOffset === 0), [calendarCells])
   const previousMonthCellsCount = useMemo(() => calendarCells.filter((cell) => cell.monthOffset === -1).length, [calendarCells])
   const nextMonthCellsCount = useMemo(() => calendarCells.filter((cell) => cell.monthOffset === 1).length, [calendarCells])
-  const prefillWindowLabel = useMemo(
-    () => autoPrefillState.windowMonths.map(formatMonthLabel).join(', '),
-    [autoPrefillState.windowMonths],
+  const selectionScopeLabel = useMemo(
+    () => buildSelectionScopeLabel(selectedDatesLabel, selectedDates.length),
+    [selectedDates.length, selectedDatesLabel],
   )
-  const selectionScopeLabel = useMemo(() => {
-    if (!selectedDates.length) return 'Nenhuma data selecionada'
-    return selectedDates.length === 1
-      ? `1 data selecionada: ${selectedDatesLabel}`
-      : `${selectedDates.length} datas selecionadas: ${selectedDatesLabel}`
-  }, [selectedDates.length, selectedDatesLabel])
   const planningAssistantTitle = useMemo(() => {
     if (autoPrefillState.status === 'analyzing') return 'Analisando histórico'
     if (autoPrefillState.status === 'ready') return 'Sugestões prontas para aplicar'
@@ -1021,42 +413,24 @@ export function EscalaProfissionaisModule() {
   }, [planningAssistantSessionKey])
 
   useEffect(() => {
-    try {
-      window.dispatchEvent(new CustomEvent('skincos:escala:header', {
-        detail: {
-          units,
-          monthOptions: MONTH_OPTIONS,
-          yearOptions,
-          selectedUnit,
-          selectedMonth,
-          selectedMonthNumber,
-          selectedYear,
-          selectedProfessional,
-          professionalOptions: headerProfessionalOptions,
-          totalScheduledDays,
-          unavailableDaysCount,
-          manualDays: monthPlanMetrics.manual,
-          autoDays: monthPlanMetrics.auto,
-          blockedDays: monthPlanMetrics.blocked,
-          emptyDays: monthPlanMetrics.empty,
-          coveredDays: monthPlanMetrics.covered,
-          activeInjectors: professionalOptions.length,
-          selectedDatesCount: selectedDates.length,
-          highlightMode,
-          loadingOverview
-        }
-      }))
-    } catch {
-      // ignore header sync errors
-    }
+    emitEscalaHeaderState({
+      units,
+      monthOptions: MONTH_OPTIONS,
+      yearOptions,
+      selectedUnit,
+      selectedMonthNumber,
+      selectedYear,
+      totalScheduledDays,
+      unavailableDaysCount,
+      manualDays: monthPlanMetrics.manual,
+      autoDays: monthPlanMetrics.auto,
+      blockedDays: monthPlanMetrics.blocked,
+      emptyDays: monthPlanMetrics.empty,
+      coveredDays: monthPlanMetrics.covered,
+      highlightMode,
+    })
   }, [
-    headerProfessionalOptions,
-    loadingOverview,
-    professionalOptions,
     selectedMonthNumber,
-    selectedMonth,
-    selectedProfessional,
-    selectedDates.length,
     selectedUnit,
     selectedYear,
     totalScheduledDays,
@@ -1064,48 +438,34 @@ export function EscalaProfissionaisModule() {
     monthPlanMetrics,
     units,
     yearOptions,
-    highlightMode
+    highlightMode,
   ])
 
-  useEffect(() => {
-    return () => {
-      try {
-        window.dispatchEvent(new CustomEvent('skincos:escala:header', { detail: null }))
-      } catch {
-        // ignore cleanup errors
-      }
-    }
-  }, [])
+  useEffect(() => () => emitEscalaHeaderState(null), [])
 
   useEffect(() => {
-    const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ action?: string; value?: string }>)?.detail || {}
-      const action = String(detail?.action || '')
-      if (!action) return
-
-      if (action === 'set-unit' && detail.value != null) setSelectedUnit(String(detail.value))
-      if (action === 'set-month' && detail.value != null) {
-        monthSelectionTouchedRef.current = true
-        setSelectedMonthNumber(String(detail.value))
+    return subscribeEscalaHeaderAction((action: EscalaHeaderAction) => {
+      if (action.type === 'set-unit') {
+        setSelectedUnit(action.value)
+        return
       }
-      if (action === 'set-year' && detail.value != null) {
-        monthSelectionTouchedRef.current = true
-        setSelectedYear(String(detail.value))
+      if (action.type === 'set-month') {
+        markMonthSelectionTouched()
+        setSelectedMonthNumber(action.value)
+        return
       }
-      if (action === 'set-professional' && detail.value != null) setSelectedProfessional(String(detail.value))
-      if (action === 'toggle-highlight-mode' && detail.value != null) {
-        const next = String(detail.value)
-        const normalized = next === 'scheduled' ? 'manual' : next
-        if (normalized === 'manual' || normalized === 'auto' || normalized === 'blocked' || normalized === 'empty') {
-          setHighlightMode((prev) => (prev === normalized ? null : normalized))
-        }
+      if (action.type === 'set-year') {
+        markMonthSelectionTouched()
+        setSelectedYear(action.value)
+        return
       }
-      if (action === 'clear-selection') clearInteractiveState()
-    }
-
-    window.addEventListener('skincos:escala:action', handler as EventListener)
-    return () => window.removeEventListener('skincos:escala:action', handler as EventListener)
-  }, [clearInteractiveState])
+      if (action.type === 'toggle-highlight') {
+        setHighlightMode((prev) => (prev === action.value ? null : action.value))
+        return
+      }
+      clearInteractiveState()
+    })
+  }, [clearInteractiveState, markMonthSelectionTouched, setSelectedMonthNumber, setSelectedUnit, setSelectedYear])
 
   useEffect(() => {
     if ((selectedProfessional === ALL_PROFESSIONALS_OPTION && !highlightMode) || activeDate) return
@@ -1168,7 +528,7 @@ export function EscalaProfissionaisModule() {
     })
   }, [closedBlockedDates, scheduleByDate])
 
-  const handleApplyDayProfessionals = useCallback(async (dates: string[]) => {
+  const handleApplyDayProfessionals = useCallback(async (dates: string[]): Promise<EscalaActionResult> => {
     if (!selectedUnit) {
       toast.error('Selecione uma unidade antes de alterar a agenda.')
       return { ok: false, changed: false }
@@ -1272,6 +632,19 @@ export function EscalaProfissionaisModule() {
     setMultiDateBlockReason('')
   }, [isBulkSelectionMode])
 
+  useEffect(() => {
+    if (!isDayAssignModalOpen && !isBulkAssignModalOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      closeAssignModalWithoutSave()
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [closeAssignModalWithoutSave, isBulkAssignModalOpen, isDayAssignModalOpen])
+
   const enableBulkSelectionMode = useCallback(() => {
     setIsBulkSelectionMode(true)
     setIsBulkAssignModalOpen(false)
@@ -1301,17 +674,61 @@ export function EscalaProfissionaisModule() {
     setMultiDateBlockReason('')
   }, [])
 
+  useEffect(() => {
+    if (!isBulkSelectionMode) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null
+      if (!target) return
+      if (target.closest('[data-escala-bulk-preserve="true"]')) return
+      event.preventDefault()
+      event.stopPropagation()
+      cancelBulkSelectionMode()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [cancelBulkSelectionMode, isBulkSelectionMode])
+
+  useEffect(() => {
+    const hasInteractiveSelection = isBulkSelectionMode || selectedProfessional !== ALL_PROFESSIONALS_OPTION || highlightMode !== null
+    if (!hasInteractiveSelection) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      if (isDayAssignModalOpen || isBulkAssignModalOpen || isPlanningAssistantModalOpen) return
+      event.preventDefault()
+      if (isBulkSelectionMode) {
+        cancelBulkSelectionMode()
+        return
+      }
+      clearInteractiveState()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [
+    cancelBulkSelectionMode,
+    clearInteractiveState,
+    highlightMode,
+    isBulkAssignModalOpen,
+    isBulkSelectionMode,
+    isDayAssignModalOpen,
+    isPlanningAssistantModalOpen,
+    selectedProfessional,
+  ])
+
   const shiftSelectedMonth = useCallback((offset: number) => {
-    monthSelectionTouchedRef.current = true
+    markMonthSelectionTouched()
     const next = shiftMonthValue(selectedMonth, offset)
     setSelectedYear(next.year)
     setSelectedMonthNumber(next.monthNumber)
-  }, [selectedMonth])
+  }, [markMonthSelectionTouched, selectedMonth, setSelectedMonthNumber, setSelectedYear])
 
-  const handleToggleDayBlock = useCallback(async (date: string) => {
+  const handleToggleDayBlock = useCallback(async (date: string): Promise<EscalaActionResult> => {
     if (!selectedUnit) {
       toast.error('Selecione uma unidade antes de bloquear uma data.')
-      return
+      return { ok: false, changed: false, error: 'Selecione uma unidade antes de bloquear uma data.' }
     }
 
     const isDirectlyBlocked = closedDateSet.has(date)
@@ -1322,7 +739,7 @@ export function EscalaProfissionaisModule() {
       setDayActionKey(null)
       if (!res.ok) {
         toast.error(res.error || 'Falha ao remover bloqueio do dia.')
-        return
+        return { ok: false, changed: false, error: res.error || 'Falha ao remover bloqueio do dia.' }
       }
       toast.success('Bloqueio removido.')
       setDayBlockReasons((prev) => {
@@ -1337,7 +754,7 @@ export function EscalaProfissionaisModule() {
       setIsBulkAssignModalOpen(false)
       await refreshSchedule()
       await refreshOverview()
-      return
+      return { ok: true, changed: true }
     }
 
     const reason = String(dayBlockReasons[date] || closedReasonByDate.get(date) || '').trim()
@@ -1345,14 +762,14 @@ export function EscalaProfissionaisModule() {
     if (!clearDayRes.ok) {
       setDayActionKey(null)
       toast.error(clearDayRes.error || 'Falha ao limpar a agenda antes do bloqueio.')
-      return
+      return { ok: false, changed: false, error: clearDayRes.error || 'Falha ao limpar a agenda antes do bloqueio.' }
     }
 
     const res = await addClosedDay({ date, unit: selectedUnit, reason: reason || undefined })
     setDayActionKey(null)
     if (!res.ok) {
       toast.error(res.error || 'Falha ao bloquear o dia.')
-      return
+      return { ok: false, changed: false, error: res.error || 'Falha ao bloquear o dia.' }
     }
     toast.success('Data bloqueada.')
     setDayProfessionalDrafts((prev) => {
@@ -1367,19 +784,19 @@ export function EscalaProfissionaisModule() {
     setIsBulkAssignModalOpen(false)
     await refreshSchedule()
     await refreshOverview()
+    return { ok: true, changed: true }
   }, [closedDateSet, closedReasonByDate, dayBlockReasons, isBulkSelectionMode, refreshOverview, refreshSchedule, selectedUnit])
 
-  const handleToggleSelectedDatesBlock = useCallback(async () => {
+  const handleToggleSelectedDatesBlock = useCallback(async (): Promise<EscalaActionResult> => {
     if (!selectedUnit) {
       toast.error('Selecione uma unidade antes de bloquear datas.')
-      return
+      return { ok: false, changed: false, error: 'Selecione uma unidade antes de bloquear datas.' }
     }
 
     const dates = uniqueNames(selectedDatesRef.current)
-    if (!dates.length) return
+    if (!dates.length) return { ok: true, changed: false }
     if (dates.length === 1) {
-      await handleToggleDayBlock(dates[0])
-      return
+      return handleToggleDayBlock(dates[0])
     }
 
     const allDirectlyBlocked = dates.every((date) => closedDateSet.has(date))
@@ -1391,7 +808,7 @@ export function EscalaProfissionaisModule() {
         if (!res.ok) {
           setDayActionKey(null)
           toast.error(res.error || `Falha ao remover bloqueio de ${formatDisplayDate(date)}.`)
-          return
+          return { ok: false, changed: false, error: res.error || `Falha ao remover bloqueio de ${formatDisplayDate(date)}.` }
         }
       }
       setDayActionKey(null)
@@ -1410,7 +827,7 @@ export function EscalaProfissionaisModule() {
       setIsBulkAssignModalOpen(false)
       await refreshSchedule()
       await refreshOverview()
-      return
+      return { ok: true, changed: true }
     }
 
     for (const date of dates) {
@@ -1419,7 +836,7 @@ export function EscalaProfissionaisModule() {
       if (!clearDayRes.ok) {
         setDayActionKey(null)
         toast.error(clearDayRes.error || `Falha ao limpar a agenda de ${formatDisplayDate(date)} antes do bloqueio.`)
-        return
+        return { ok: false, changed: false, error: clearDayRes.error || `Falha ao limpar a agenda de ${formatDisplayDate(date)} antes do bloqueio.` }
       }
       const reason = String(
         (dates.length > 1 ? multiDateBlockReason : dayBlockReasons[date]) ||
@@ -1430,7 +847,7 @@ export function EscalaProfissionaisModule() {
       if (!res.ok) {
         setDayActionKey(null)
         toast.error(res.error || `Falha ao bloquear ${formatDisplayDate(date)}.`)
-        return
+        return { ok: false, changed: false, error: res.error || `Falha ao bloquear ${formatDisplayDate(date)}.` }
       }
     }
 
@@ -1450,6 +867,7 @@ export function EscalaProfissionaisModule() {
     setIsBulkAssignModalOpen(false)
     await refreshSchedule()
     await refreshOverview()
+    return { ok: true, changed: true }
   }, [closedDateSet, closedReasonByDate, dayBlockReasons, handleToggleDayBlock, isBulkSelectionMode, multiDateBlockReason, refreshOverview, refreshSchedule, selectedUnit])
 
   const updateSelectedTeamMemberField = useCallback((field: keyof EscalaProfessional, value: string) => {
@@ -1633,7 +1051,7 @@ export function EscalaProfissionaisModule() {
         <Card className="glass-card flex flex-col">
           <CardContent className="flex flex-col gap-2 pt-3">
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_344px]">
-              <div className="flex flex-col gap-2" data-testid="escala-calendar-panel">
+              <div className="flex flex-col gap-2" data-testid="escala-calendar-panel" data-escala-bulk-preserve="true">
                 <div className="flex flex-wrap items-start justify-end gap-2 pb-1">
                   {loadingSchedule ? (
                     <div className="text-[11px] text-slate-300/75">
@@ -1733,13 +1151,10 @@ export function EscalaProfissionaisModule() {
                       : trackedCardStyle
                     const handleOpenDate = (event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
                       if (isBulkSelectionMode) {
-                        const alreadySelected = selectedDateSet.has(cell.date)
-                        const next = alreadySelected
-                          ? selectedDates.filter((date) => date !== cell.date)
-                          : uniqueNames([...selectedDates, cell.date]).sort()
-                        setSelectedDates(next)
-                        setActiveDate(next.length ? (alreadySelected ? next[next.length - 1] : cell.date) : null)
-                        if (!next.length) setMultiDateBlockReason('')
+                        const { alreadySelected, nextDates } = toggleDateSelection(selectedDates, cell.date)
+                        setSelectedDates(nextDates)
+                        setActiveDate(resolveNextActiveDate(nextDates, cell.date, alreadySelected))
+                        if (!nextDates.length) setMultiDateBlockReason('')
                         setIsBulkAssignModalOpen(false)
                         return
                       }
@@ -1754,13 +1169,10 @@ export function EscalaProfissionaisModule() {
                       }
                       const multiSelect = Boolean((event as React.MouseEvent<HTMLDivElement> | undefined)?.metaKey || (event as React.MouseEvent<HTMLDivElement> | undefined)?.ctrlKey)
                       if (multiSelect) {
-                        const alreadySelected = selectedDateSet.has(cell.date)
-                        const next = alreadySelected
-                          ? selectedDates.filter((date) => date !== cell.date)
-                          : uniqueNames([...selectedDates, cell.date]).sort()
-                        setSelectedDates(next)
-                        setActiveDate(next.length ? (alreadySelected ? next[next.length - 1] : cell.date) : null)
-                        if (!next.length) setMultiDateBlockReason('')
+                        const { alreadySelected, nextDates } = toggleDateSelection(selectedDates, cell.date)
+                        setSelectedDates(nextDates)
+                        setActiveDate(resolveNextActiveDate(nextDates, cell.date, alreadySelected))
+                        if (!nextDates.length) setMultiDateBlockReason('')
                         return
                       }
                       setSelectedDates([cell.date])
@@ -1892,23 +1304,11 @@ export function EscalaProfissionaisModule() {
                             </Badge>
                           ) : null}
                           {!isAdjacentMonth ? (
-                            <div
-                              className={cn(
-                                'inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em]',
-                                daySource === 'manual' && 'border-sky-300/22 bg-sky-500/10 text-sky-100/85',
-                                daySource === 'auto' && 'border-emerald-300/22 bg-emerald-500/10 text-emerald-100/85',
-                                daySource === 'blocked' && 'border-rose-300/22 bg-rose-500/10 text-rose-100/85',
-                                daySource === 'empty' && 'border-amber-300/22 bg-amber-500/10 text-amber-100/85',
-                              )}
-                              title={daySource === 'auto' && appliedSuggestion
-                                ? `${appliedSuggestion.professional} • ${Math.round(appliedSuggestion.confidence * 100)}% • ${appliedSuggestion.sampleSize} ocorrências`
-                                : undefined}
-                            >
-                              {daySource === 'manual' && 'Manual'}
-                              {daySource === 'auto' && 'Auto'}
-                              {daySource === 'blocked' && 'Bloqueado'}
-                              {daySource === 'empty' && 'Vazio'}
-                            </div>
+                            <EscalaDaySourceBadge
+                              date={cell.date}
+                              daySource={daySource}
+                              appliedSuggestion={appliedSuggestion}
+                            />
                           ) : null}
                         </div>
                       </div>
@@ -1917,582 +1317,76 @@ export function EscalaProfissionaisModule() {
                 </div>
               </div>
 
-              <div className="flex flex-col gap-2 xl:w-[360px] xl:justify-self-end">
-                <div
-                  className="escala-team-panel flex flex-col self-start overflow-hidden rounded-2xl border border-white/10 bg-slate-950/45"
-                  data-testid="escala-team-panel"
-                >
-                  <div className="border-b border-white/10 px-3 py-2.5">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="text-[11px] uppercase tracking-[0.22em] text-slate-300/60">Equipe</div>
-                        <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-2">
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant={teamFormMode === 'add' ? 'premium' : 'outline'}
-                          onClick={beginAddTeamMember}
-                          disabled={!!teamLoadError}
-                          aria-label="Adicionar injetor"
-                          title="Adicionar"
-                          data-testid="escala-team-add"
-                        >
-                          <Plus className="h-4 w-4" />
-                        </Button>
-                        {teamPanelExpanded ? (
-                          <>
-                            <Button
-                              type="button"
-                              size="icon"
-                              variant="premium"
-                              onClick={() => void handleSaveTeamMember()}
-                              disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
-                              aria-label="Salvar cadastro do injetor"
-                              title="Salvar"
-                              data-testid="escala-team-save"
-                            >
-                              <Save className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              type="button"
-                              size="icon"
-                              variant="outline"
-                              onClick={closeTeamPanel}
-                              aria-label="Fechar cadastro da equipe"
-                              title="Fechar"
-                              data-testid="escala-team-close"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </>
-                        ) : (
-                          <Button
-                            type="button"
-                            size="icon"
-                            variant="outline"
-                            onClick={() => beginEditTeamMember(selectedTeamMember)}
-                            disabled={!selectedTeamMember || !!teamLoadError}
-                            aria-label="Editar injetor"
-                            title="Editar"
-                            data-testid="escala-team-edit"
-                          >
-                            <Pencil className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="mt-2 flex flex-wrap gap-1.5">
-                      {teamLoadError ? (
-                        <div
-                          className="w-full rounded-xl border border-amber-300/30 bg-amber-500/10 px-3 py-3 text-xs text-amber-50/90"
-                          data-testid="escala-team-error"
-                        >
-                          <div className="font-medium text-amber-50">Falha ao carregar a equipe do cadastro.</div>
-                          <div className="mt-1 text-amber-50/80">
-                            A agenda pode continuar visível, mas a lateral da equipe não está confiável até recarregar os profissionais.
-                          </div>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            className="mt-3 border-amber-200/35 bg-amber-50/8 text-amber-50 hover:bg-amber-50/14"
-                            onClick={() => void refreshProfessionals(selectedUnit)}
-                            data-testid="escala-team-retry"
-                          >
-                            Tentar novamente
-                          </Button>
-                        </div>
-                      ) : activeInjectors.length || inactiveInjectors.length ? (
-                        <>
-                          {activeInjectors.map((prof) => {
-                            const isCurrent = prof.name === selectedTeamMember
-                            return (
-                              <button
-                                key={prof.name}
-                                type="button"
-                                className={cn(
-                                  'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
-                                  isCurrent ? 'text-white shadow-[0_14px_26px_rgba(15,23,42,0.24)]' : 'text-slate-200/80 hover:text-white'
-                                )}
-                                style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default', prof.color)}
-                                onClick={() => selectTeamMember(prof.name)}
-                                data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
-                              >
-                                {prof.name}
-                              </button>
-                            )
-                          })}
-                          {inactiveInjectors.length ? (
-                            <>
-                              <button
-                                type="button"
-                                className={cn(
-                                  'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
-                                  showInactiveTeamMembers ? 'text-white' : 'text-rose-100/90 hover:text-white'
-                                )}
-                                style={{
-                                  background: showInactiveTeamMembers
-                                    ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.38), rgba(190, 24, 93, 0.28))'
-                                    : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
-                                  borderColor: showInactiveTeamMembers ? 'rgba(254, 202, 202, 0.85)' : 'rgba(252, 165, 165, 0.45)',
-                                  boxShadow: showInactiveTeamMembers
-                                    ? '0 14px 26px rgba(69, 10, 10, 0.26), inset 0 1px 0 rgba(255,255,255,0.16)'
-                                    : 'inset 0 1px 0 rgba(255,255,255,0.05)',
-                                }}
-                                onClick={() => setShowInactiveTeamMembers((prev) => !prev)}
-                                data-testid="escala-team-inactive-toggle"
-                                aria-expanded={showInactiveTeamMembers}
-                              >
-                                Inativos ({inactiveInjectors.length})
-                              </button>
-                              {showInactiveTeamMembers ? inactiveInjectors.map((prof) => {
-                                const isCurrent = prof.name === selectedTeamMember
-                                return (
-                                  <button
-                                    key={prof.name}
-                                    type="button"
-                                    className={cn(
-                                      'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
-                                      isCurrent ? 'text-white shadow-[0_14px_26px_rgba(69,10,10,0.28)]' : 'text-rose-100/90 hover:text-white'
-                                    )}
-                                    style={{
-                                      background: isCurrent
-                                        ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.42), rgba(190, 24, 93, 0.3))'
-                                        : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
-                                      borderColor: isCurrent ? 'rgba(254, 202, 202, 0.9)' : 'rgba(252, 165, 165, 0.45)',
-                                      boxShadow: isCurrent
-                                        ? '0 14px 26px rgba(69,10,10,0.3), inset 0 1px 0 rgba(255,255,255,0.18)'
-                                        : 'inset 0 1px 0 rgba(255,255,255,0.05)',
-                                    }}
-                                    onClick={() => selectTeamMember(prof.name)}
-                                    data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
-                                  >
-                                    {prof.name}
-                                  </button>
-                                )
-                              }) : null}
-                            </>
-                          ) : null}
-                        </>
-                      ) : (
-                        <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-xs text-slate-300/70">
-                          Nenhum injetor encontrado para a unidade selecionada.
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  {teamPanelExpanded ? (
-                    <>
-                      <div className="px-3 py-3">
-                        {selectedTeamMemberDraft ? (
-                          <div className="grid content-start gap-2.5 sm:grid-cols-2">
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                NOME
-                              </span>
-                              <Input
-                                value={selectedTeamMemberDraft.name}
-                                onChange={(event) => updateSelectedTeamMemberField('name', event.target.value)}
-                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                                data-testid="escala-team-field-name"
-                              />
-                            </label>
-
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                SITUAÇÃO
-                              </span>
-                              <Select
-                                value={selectedTeamMemberDraft.status || STATUS_OPTIONS[0]}
-                                onValueChange={(value) => updateSelectedTeamMemberField('status', value)}
-                              >
-                                <SelectTrigger className="h-9 w-full border-white/10 bg-white/[0.05] text-white" data-testid="escala-team-field-status">
-                                  <SelectValue placeholder="Selecione" />
-                                </SelectTrigger>
-                                <SelectContent className="border-white/15 bg-slate-900 text-slate-100">
-                                  {STATUS_OPTIONS.map((option) => (
-                                    <SelectItem key={option} value={option}>{option}</SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </label>
-
-                            <MultiSelectField
-                              label="CARGO"
-                              placeholder="Selecione os cargos"
-                              options={ROLE_OPTIONS}
-                              values={parseDelimitedValues(selectedTeamMemberDraft.role)}
-                              onToggle={(option) => toggleSelectedTeamMemberOption('role', option)}
-                              testId="escala-team-field-role"
-                            />
-
-                            <MultiSelectField
-                              label="UNIDADE"
-                              placeholder="Selecione as unidades"
-                              options={UNIT_OPTIONS}
-                              values={selectedTeamMemberDraft.units}
-                              onToggle={(option) => toggleSelectedTeamMemberOption('units', option)}
-                              testId="escala-team-field-units"
-                            />
-
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                EMAIL
-                              </span>
-                              <Input
-                                value={selectedTeamMemberDraft.email}
-                                onChange={(event) => updateSelectedTeamMemberField('email', event.target.value)}
-                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                                data-testid="escala-team-field-email"
-                              />
-                            </label>
-
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                TELEFONE
-                              </span>
-                              <Input
-                                value={selectedTeamMemberDraft.phone}
-                                onChange={(event) => updateSelectedTeamMemberField('phone', event.target.value)}
-                                placeholder="+55 (51) 99999-9999"
-                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                                data-testid="escala-team-field-phone"
-                              />
-                            </label>
-
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                INSTAGRAM
-                              </span>
-                              <Input
-                                value={selectedTeamMemberDraft.instagram}
-                                onChange={(event) => updateSelectedTeamMemberField('instagram', event.target.value)}
-                                className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
-                                data-testid="escala-team-field-instagram"
-                              />
-                            </label>
-
-                            <label className="space-y-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
-                                COR
-                              </span>
-                              <div className="flex h-9 items-center gap-3 rounded-md border border-white/10 bg-white/[0.05] px-3">
-                                <input
-                                  type="color"
-                                  value={normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
-                                  onChange={(event) => updateSelectedTeamMemberField('color', event.target.value)}
-                                  className="h-6 w-9 cursor-pointer rounded border-0 bg-transparent p-0"
-                                  data-testid="escala-team-field-color"
-                                  aria-label="Escolher cor do injetor"
-                                />
-                                <div
-                                  className="h-[18px] w-[18px] rounded-full border border-white/20"
-                                  style={{ background: normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR }}
-                                  aria-hidden="true"
-                                />
-                                <span className="text-xs text-slate-300/75">
-                                  {normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
-                                </span>
-                              </div>
-                            </label>
-
-                          </div>
-                        ) : (
-                          <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-sm text-slate-300/70">
-                            {selectedTeamMember
-                              ? 'Clique em Editar para abrir os campos do injetor selecionado.'
-                              : 'Selecione um injetor e clique em Editar para abrir os campos.'}
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  ) : null}
-                </div>
-
-                <div className="rounded-2xl border border-white/10 bg-slate-950/45 px-3 py-3" data-testid="escala-bulk-select-panel">
-                  <Button
-                    type="button"
-                    variant={isBulkSelectionMode ? 'premium' : 'outline'}
-                    className="w-full"
-                    onClick={enableBulkSelectionMode}
-                    data-testid="escala-multi-select-toggle"
-                  >
-                    Seleção múltipla
-                  </Button>
-                  {isBulkSelectionMode ? (
-                    <>
-                      <div className="mt-2 text-[11px] text-slate-300/80">
-                        Clique nas datas do calendário para selecionar.
-                      </div>
-                      <div className="mt-2 grid grid-cols-2 gap-2">
-                        <Button
-                          type="button"
-                          variant="premium"
-                          onClick={confirmBulkSelectionMode}
-                          data-testid="escala-multi-select-ok"
-                        >
-                          OK
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={cancelBulkSelectionMode}
-                          data-testid="escala-multi-select-close"
-                        >
-                          Fechar
-                        </Button>
-                      </div>
-                    </>
-                  ) : null}
-                </div>
-              </div>
+              <EscalaTeamPanel
+                activeInjectors={activeInjectors}
+                inactiveInjectors={inactiveInjectors}
+                isBulkSelectionMode={isBulkSelectionMode}
+                savingTeamMember={savingTeamMember}
+                selectedTeamMember={selectedTeamMember}
+                selectedTeamMemberDirty={selectedTeamMemberDirty}
+                selectedTeamMemberDraft={selectedTeamMemberDraft}
+                showInactiveTeamMembers={showInactiveTeamMembers}
+                teamFormMode={teamFormMode}
+                teamLoadError={teamLoadError}
+                onBeginAddTeamMember={beginAddTeamMember}
+                onBeginEditTeamMember={beginEditTeamMember}
+                onCancelBulkSelectionMode={cancelBulkSelectionMode}
+                onCloseTeamPanel={closeTeamPanel}
+                onConfirmBulkSelectionMode={confirmBulkSelectionMode}
+                onEnableBulkSelectionMode={enableBulkSelectionMode}
+                onRetryProfessionals={() => void refreshProfessionals(selectedUnit)}
+                onSaveTeamMember={() => void handleSaveTeamMember()}
+                onSelectTeamMember={selectTeamMember}
+                onToggleInactiveTeamMembers={() => setShowInactiveTeamMembers((prev) => !prev)}
+                onToggleSelectedTeamMemberOption={toggleSelectedTeamMemberOption}
+                onUpdateSelectedTeamMemberField={updateSelectedTeamMemberField}
+              />
             </div>
           </CardContent>
         </Card>
       </div>
 
-      <Dialog
-        open={isBulkSelectionMode ? (isBulkAssignModalOpen && selectedDates.length > 0) : (isDayAssignModalOpen && selectedDates.length > 0)}
-        onOpenChange={(open) => {
-          if (open) {
-            if (isBulkSelectionMode) {
-              setIsBulkAssignModalOpen(true)
-            } else {
-              setIsDayAssignModalOpen(true)
-            }
-            return
-          }
-          closeAssignModalWithoutSave()
-        }}
-      >
-        <DialogContent className="max-w-sm border-white/10 bg-slate-950/96 text-slate-100" data-escala-preserve-filter="true">
-          <button
-            type="button"
-            className="absolute right-10 top-3 rounded-xs border border-emerald-300/35 bg-emerald-500/16 px-2 py-1 text-[11px] font-semibold text-emerald-50 transition hover:bg-emerald-500/24 focus:outline-none focus:ring-2 focus:ring-emerald-300/45 sm:right-11 sm:top-4"
-            onClick={() => void closeActiveDateWithSave()}
-            data-testid="escala-modal-confirm"
-            aria-label="Confirmar alterações"
-          >
-            V
-          </button>
-          {selectedDates.length ? (
-            <>
-              <DialogHeader className="space-y-1">
-                <div className="flex items-start justify-between gap-3 pr-8">
-                  <div className="flex items-center gap-2">
-                    <DialogTitle className="text-base">
-                      {selectedDates.length === 1 ? 'Injetores do dia' : 'Injetores das datas'}
-                    </DialogTitle>
-                    <DialogDescription className="text-xs text-slate-300/75">
-                      {selectedDates.length === 1 ? selectedDatesLabel : `${selectedDates.length} datas selecionadas`}
-                    </DialogDescription>
-                  </div>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        data-testid={selectedDates.length === 1 && activeDate ? `escala-block-${activeDate}` : 'escala-block-multi'}
-                        className={cn(
-                          'escala-card-action rounded-full border p-2 hover:bg-white/[0.12]',
-                          selectedDates.every((date) => closedBlockedDates.has(date))
-                            ? 'border-rose-300/40 bg-rose-500/15 text-rose-100'
-                            : 'border-white/15 bg-white/[0.06] text-white/85'
-                        )}
-                        aria-label={selectedDates.length === 1 && activeDate ? `Bloquear data ${activeDate}` : 'Bloquear datas selecionadas'}
-                      >
-                        <Shield className="size-4.5" />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-72 border-white/15 bg-slate-900/95 text-slate-100"
-                      align="end"
-                      data-escala-preserve-filter="true"
-                    >
-                      <div className="space-y-3 text-xs">
-                        <div>
-                          <div className="text-[11px] uppercase tracking-[0.2em] text-slate-300/70">
-                            {selectedDates.length === 1 ? 'Bloqueio de data' : 'Bloqueio de datas'}
-                          </div>
-                          <div className="text-sm text-white">
-                            {selectedDates.length === 1 ? activeDate : selectedDatesLabel}
-                          </div>
-                        </div>
-                        <Input
-                          value={
-                            selectedDates.length === 1 && activeDate
-                              ? (dayBlockReasons[activeDate] || closedReasonByDate.get(activeDate) || '')
-                              : multiDateBlockReason
-                          }
-                          onChange={(event) => {
-                            if (selectedDates.length === 1 && activeDate) {
-                              setDayBlockReasons((prev) => ({ ...prev, [activeDate]: event.target.value }))
-                              return
-                            }
-                            setMultiDateBlockReason(event.target.value)
-                          }}
-                          placeholder="escreva o motivo"
-                          className="h-9 bg-white/5"
-                          data-testid={selectedDates.length === 1 && activeDate ? `escala-block-reason-${activeDate}` : 'escala-block-reason-multi'}
-                          disabled={selectedDates.length === 1 && !!activeDate && closedBlockedDates.has(activeDate) && !closedDateSet.has(activeDate)}
-                        />
-                        <Button
-                          variant={selectedDates.every((date) => closedDateSet.has(date)) ? 'outline' : 'premium'}
-                          size="sm"
-                          className="w-full"
-                          data-testid={selectedDates.length === 1 && activeDate ? `escala-toggle-block-${activeDate}` : 'escala-toggle-block-multi'}
-                          onClick={() => void handleToggleSelectedDatesBlock()}
-                          disabled={dayActionKey === (selectedDates.length === 1 && activeDate ? `block:${activeDate}` : 'block:multi')}
-                        >
-                          {selectedDates.every((date) => closedDateSet.has(date))
-                            ? (selectedDates.length === 1 ? 'Remover bloqueio' : 'Remover bloqueio das datas')
-                            : (selectedDates.length === 1 ? 'Bloquear data' : 'Bloquear datas')}
-                        </Button>
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              </DialogHeader>
+      <EscalaAssignDialog
+        activeDate={activeDate}
+        assignableProfessionalOptions={assignableProfessionalOptions}
+        closedBlockedDates={closedBlockedDates}
+        closedDateSet={closedDateSet}
+        closedReasonByDate={closedReasonByDate}
+        dayActionKey={dayActionKey}
+        dayBlockReasons={dayBlockReasons}
+        getDatesSelectionState={getDatesSelectionState}
+        getDayDraft={getDayDraft}
+        isBulkAssignModalOpen={isBulkAssignModalOpen}
+        isBulkSelectionMode={isBulkSelectionMode}
+        isDayAssignModalOpen={isDayAssignModalOpen}
+        multiDateBlockReason={multiDateBlockReason}
+        professionalMap={professionalMap}
+        scheduleByDate={scheduleByDate}
+        selectedDates={selectedDates}
+        selectedDatesLabel={selectedDatesLabel}
+        setDayBlockReasons={setDayBlockReasons}
+        setIsBulkAssignModalOpen={setIsBulkAssignModalOpen}
+        setIsDayAssignModalOpen={setIsDayAssignModalOpen}
+        setMultiDateBlockReason={setMultiDateBlockReason}
+        toggleDayProfessional={toggleDayProfessional}
+        toggleSelectedDatesProfessional={toggleSelectedDatesProfessional}
+        onCloseAssignModalWithoutSave={closeAssignModalWithoutSave}
+        onCloseActiveDateWithSave={() => void closeActiveDateWithSave()}
+        onToggleSelectedDatesBlock={() => void handleToggleSelectedDatesBlock()}
+      />
 
-              {selectedDates.length > 1 ? (
-                <div className="rounded-xl border border-sky-300/16 bg-sky-400/8 px-3 py-2 text-[11px] text-sky-100/78">
-                  Seleção múltipla ativa. As alterações de injetores e bloqueio serão aplicadas em todas as datas selecionadas.
-                </div>
-              ) : null}
-
-              <div className="grid grid-cols-2 gap-2">
-                {assignableProfessionalOptions.length ? assignableProfessionalOptions.map((name) => {
-                  const targetDates = selectedDates.filter((date) => !closedBlockedDates.has(date))
-                  const checked = selectedDates.length === 1 && activeDate
-                    ? (
-                      closedBlockedDates.has(activeDate)
-                        ? false
-                        : getDayDraft(activeDate, scheduleByDate.get(activeDate) || []).includes(name)
-                    )
-                    : getDatesSelectionState(targetDates, name)
-                  return (
-                    <label
-                      key={`${selectedDates.join('|')}-${name}`}
-                      className={cn(
-                        'flex min-w-0 cursor-pointer items-center gap-2 rounded-xl border px-2 py-1.5 text-xs transition-all',
-                        checked ? 'shadow-[0_10px_24px_rgba(15,23,42,0.18)]' : 'bg-white/[0.03]',
-                      )}
-                      style={getProfessionalBadgeStyle(name, checked ? 'active' : 'default', professionalMap.get(name)?.color)}
-                    >
-                      <Checkbox
-                        checked={checked}
-                        onCheckedChange={() => {
-                          if (selectedDates.length === 1 && activeDate) {
-                            toggleDayProfessional(activeDate, name, scheduleByDate.get(activeDate) || [])
-                            return
-                          }
-                          toggleSelectedDatesProfessional(name)
-                        }}
-                        disabled={selectedDates.length === 1 && !!activeDate ? closedBlockedDates.has(activeDate) : selectedDates.every((date) => closedBlockedDates.has(date))}
-                      />
-                      <span className="truncate font-medium">{name}</span>
-                    </label>
-                  )
-                }) : (
-                  <div className="col-span-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-slate-300/80">
-                    Nenhum injetor ativo disponível.
-                  </div>
-                )}
-              </div>
-            </>
-          ) : null}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={isPlanningAssistantModalOpen} onOpenChange={handlePlanningAssistantOpenChange}>
-        <DialogContent
-          className="border-white/14 bg-[#121a2d]/96 text-white shadow-2xl shadow-slate-950/60 backdrop-blur-xl sm:max-w-lg"
-          data-testid="escala-planning-assistant-modal"
-        >
-          <div
-            data-testid="escala-autoprefill-status"
-            className={cn(
-              'rounded-2xl border px-4 py-4',
-              autoPrefillState.status === 'error'
-                ? 'border-rose-300/35 bg-rose-500/10'
-                : autoPrefillState.status === 'done'
-                  ? 'border-emerald-300/28 bg-emerald-500/10'
-                  : autoPrefillState.status === 'ignored'
-                    ? 'border-slate-300/20 bg-white/[0.04]'
-                    : 'border-sky-300/25 bg-sky-500/10',
-            )}
-          >
-            <DialogHeader className="space-y-2 text-left">
-              <div className="text-[10px] uppercase tracking-[0.18em] text-slate-300/65">
-                Assistente de planejamento
-              </div>
-              <DialogTitle className="text-base text-slate-50">
-                {planningAssistantTitle}
-              </DialogTitle>
-              <DialogDescription className="text-[11px] leading-5 text-slate-100/88">
-                {autoPrefillState.message}
-              </DialogDescription>
-            </DialogHeader>
-
-            {prefillWindowLabel ? (
-              <div className="mt-3 text-[10px] text-slate-300/72">
-                Base histórica: {prefillWindowLabel}
-              </div>
-            ) : null}
-
-            {autoPrefillState.status !== 'error' ? (
-              <div className="mt-4 space-y-1.5">
-                <Progress value={autoPrefillProgress} className="h-1.5 bg-white/10 [&_[data-slot=progress-indicator]]:bg-sky-300" />
-                <div className="flex items-center justify-between text-[10px] text-slate-300/70">
-                  <span>{formatMonthLabel(selectedMonth)}</span>
-                  <span>{planningAssistantProgressLabel}</span>
-                </div>
-              </div>
-            ) : null}
-
-            {(autoPrefillState.status === 'ready' || autoPrefillState.status === 'error') ? (
-              <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-                {autoPrefillState.status === 'ready' ? (
-                  <>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={ignoreSuggestions}
-                      data-testid="escala-prefill-ignore"
-                    >
-                      Ignorar neste mês
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="premium"
-                      onClick={() => void applySuggestions()}
-                      data-testid="escala-prefill-apply"
-                    >
-                      Aplicar sugestões
-                    </Button>
-                  </>
-                ) : null}
-                {autoPrefillState.status === 'error' ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={retryAnalysis}
-                    data-testid="escala-prefill-retry"
-                  >
-                    Tentar novamente
-                  </Button>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <EscalaPlanningAssistantModal
+        autoPrefillProgress={autoPrefillProgress}
+        autoPrefillState={autoPrefillState}
+        onApplySuggestions={applySuggestions}
+        onIgnoreSuggestions={ignoreSuggestions}
+        onOpenChange={handlePlanningAssistantOpenChange}
+        onRetryAnalysis={retryAnalysis}
+        open={isPlanningAssistantModalOpen}
+        planningAssistantProgressLabel={planningAssistantProgressLabel}
+        planningAssistantTitle={planningAssistantTitle}
+        selectedMonth={selectedMonth}
+      />
     </div>
   )
 }

--- a/frontend/EscalaProfissionaisModule.tsx
+++ b/frontend/EscalaProfissionaisModule.tsx
@@ -57,6 +57,7 @@ import type {
   EscalaActionResult,
   EscalaHeaderAction,
   EscalaHighlightMode,
+  EscalaScheduleEntry,
   EscalaProfessional,
   EscalaTeamFormMode,
 } from '@/escalaTypes'
@@ -1378,7 +1379,9 @@ export function EscalaProfissionaisModule() {
       <EscalaPlanningAssistantModal
         autoPrefillProgress={autoPrefillProgress}
         autoPrefillState={autoPrefillState}
-        onApplySuggestions={applySuggestions}
+        onApplySuggestions={async () => {
+          await applySuggestions()
+        }}
         onIgnoreSuggestions={ignoreSuggestions}
         onOpenChange={handlePlanningAssistantOpenChange}
         onRetryAnalysis={retryAnalysis}

--- a/frontend/InsumosBarcodeScannerInline.tsx
+++ b/frontend/InsumosBarcodeScannerInline.tsx
@@ -1,0 +1,289 @@
+import React from 'react'
+import { Button } from '@/button'
+
+export function InsumosBarcodeScannerInline({
+  onDetected,
+  onClose,
+}: {
+  onDetected: (code: string) => void
+  onClose: () => void
+}) {
+  const videoRef = React.useRef<HTMLVideoElement | null>(null)
+  const rafRef = React.useRef<number | null>(null)
+  const streamRef = React.useRef<MediaStream | null>(null)
+  const zxingReaderRef = React.useRef<any>(null)
+  const zxingControlsRef = React.useRef<any>(null)
+  const runTokenRef = React.useRef(0)
+  const mountedRef = React.useRef(true)
+  const [error, setError] = React.useState<string | null>(null)
+  const [supported, setSupported] = React.useState(true)
+  const [starting, setStarting] = React.useState(false)
+  const [running, setRunning] = React.useState(false)
+  const [needsGesture, setNeedsGesture] = React.useState(false)
+  const [mode, setMode] = React.useState<'BARCODE_DETECTOR' | 'ZXING' | 'NONE'>('BARCODE_DETECTOR')
+  const [facingMode, setFacingMode] = React.useState<'user' | 'environment'>('environment')
+  const [activeFacingMode, setActiveFacingMode] = React.useState<'user' | 'environment' | null>(null)
+
+  const stop = React.useCallback(() => {
+    runTokenRef.current += 1
+    if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    rafRef.current = null
+    try {
+      zxingControlsRef.current?.stop?.()
+    } catch {
+      // ignore
+    }
+    zxingControlsRef.current = null
+    try {
+      zxingReaderRef.current?.reset?.()
+    } catch {
+      // ignore
+    }
+    zxingReaderRef.current = null
+    if (streamRef.current) {
+      for (const t of streamRef.current.getTracks()) t.stop()
+    }
+    streamRef.current = null
+    if (mountedRef.current) {
+      setRunning(false)
+      setStarting(false)
+      setActiveFacingMode(null)
+    }
+  }, [])
+
+  const start = React.useCallback(async (origin: 'auto' | 'gesture', preferredFacing?: 'user' | 'environment') => {
+    stop()
+    setError(null)
+    setNeedsGesture(false)
+    setStarting(true)
+    setSupported(true)
+
+    if (!navigator?.mediaDevices?.getUserMedia) {
+      setSupported(false)
+      setMode('NONE')
+      if (mountedRef.current) setStarting(false)
+      return
+    }
+
+    const token = runTokenRef.current
+    const targetFacingMode = preferredFacing || facingMode
+    const facingAttempts: Array<'user' | 'environment'> =
+      targetFacingMode === 'user' ? ['user', 'environment'] : ['environment', 'user']
+
+    const getStreamWithFallback = async () => {
+      let lastError: any = null
+      for (const currentFacingMode of facingAttempts) {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: currentFacingMode } as any },
+            audio: false,
+          })
+          return { stream, currentFacingMode }
+        } catch (e: any) {
+          lastError = e
+          const name = String(e?.name || '')
+          if (name === 'NotAllowedError' || name === 'SecurityError') break
+        }
+      }
+      throw lastError || new Error('Não foi possível abrir a câmera.')
+    }
+
+    const tickBarcodeDetector = async (detector: any, tickToken: number) => {
+      if (tickToken !== runTokenRef.current) return
+      const video = videoRef.current
+      if (!video) return
+      try {
+        const results = await detector.detect(video)
+        const raw = results?.[0]?.rawValue ? String(results[0].rawValue) : ''
+        if (raw) {
+          stop()
+          onDetected(raw)
+          return
+        }
+      } catch {
+        // ignore detection errors and keep trying
+      }
+      rafRef.current = requestAnimationFrame(() => {
+        void tickBarcodeDetector(detector, tickToken)
+      })
+    }
+
+    const Detector = (globalThis as any).BarcodeDetector
+    try {
+      if (Detector) {
+        setMode('BARCODE_DETECTOR')
+        const detector = new Detector({
+          formats: ['ean_13', 'ean_8', 'code_128', 'code_39', 'qr_code', 'upc_a', 'upc_e'],
+        })
+        const { stream, currentFacingMode } = await getStreamWithFallback()
+        if (token !== runTokenRef.current) {
+          for (const t of stream.getTracks()) t.stop()
+          return
+        }
+        streamRef.current = stream
+        const video = videoRef.current
+        if (!video) throw new Error('Pré-visualização indisponível.')
+        video.srcObject = stream
+        await video.play()
+        if (token !== runTokenRef.current) return
+        setRunning(true)
+        setActiveFacingMode(currentFacingMode)
+        rafRef.current = requestAnimationFrame(() => {
+          void tickBarcodeDetector(detector, token)
+        })
+        return
+      }
+
+      setMode('ZXING')
+      const mod: any = await import('@zxing/browser')
+      const Reader = mod?.BrowserMultiFormatReader
+      if (!Reader) throw new Error('Scanner indisponível.')
+      const reader = new Reader()
+      zxingReaderRef.current = reader
+
+      const video = videoRef.current
+      if (!video) throw new Error('Pré-visualização indisponível.')
+
+      let controls: any = null
+      let usedFacingMode: 'user' | 'environment' | null = null
+      let lastDecodeError: any = null
+      for (const currentFacingMode of facingAttempts) {
+        try {
+          controls = await reader.decodeFromConstraints(
+            { video: { facingMode: { ideal: currentFacingMode } } } as any,
+            video,
+            (result: any) => {
+              if (token !== runTokenRef.current) return
+              const raw = result?.getText ? String(result.getText() || '') : ''
+              if (!raw) return
+              stop()
+              onDetected(raw)
+            },
+          )
+          usedFacingMode = currentFacingMode
+          break
+        } catch (e: any) {
+          lastDecodeError = e
+          const name = String(e?.name || '')
+          if (name === 'NotAllowedError' || name === 'SecurityError') break
+        }
+      }
+      if (!controls) {
+        throw lastDecodeError || new Error('Não foi possível iniciar o scanner de câmera.')
+      }
+      if (!usedFacingMode) {
+        usedFacingMode = targetFacingMode
+      }
+      if (token !== runTokenRef.current) {
+        try {
+          controls?.stop?.()
+        } catch {
+          // ignore
+        }
+        return
+      }
+      zxingControlsRef.current = controls
+      setRunning(true)
+      setActiveFacingMode(usedFacingMode)
+    } catch (e: any) {
+      const name = String(e?.name || '')
+      const message = String(e?.message || '')
+
+      if (origin === 'auto' && (name === 'NotAllowedError' || name === 'SecurityError')) {
+        setNeedsGesture(true)
+      }
+
+      if (name === 'NotFoundError') {
+        setSupported(false)
+        setMode('NONE')
+        setError('Nenhuma câmera foi encontrada neste dispositivo.')
+      } else if (!location?.protocol?.startsWith('https') && location?.hostname !== 'localhost') {
+        setSupported(false)
+        setMode('NONE')
+        setError('O scanner precisa de HTTPS para acessar a câmera.')
+      } else {
+        setError(message || 'Não foi possível iniciar o scanner. Verifique a permissão de câmera no navegador.')
+      }
+    } finally {
+      if (mountedRef.current && token === runTokenRef.current) setStarting(false)
+    }
+  }, [facingMode, onDetected, stop])
+
+  React.useEffect(() => {
+    void start('auto')
+    return () => {
+      mountedRef.current = false
+      stop()
+    }
+  }, [start, stop])
+
+  if (!supported) {
+    return (
+      <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-semibold text-blue-50">Scanner indisponível</div>
+          <Button variant="secondary" onClick={onClose}>Fechar</Button>
+        </div>
+        <div className="text-sm text-blue-100/70">
+          Este navegador não suporta leitura automática de códigos. Digite o código manualmente ou use Chrome/Edge.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm text-blue-100/80">
+          {mode === 'ZXING' ? 'Scanner (compatível)' : 'Scanner (rápido)'} • {activeFacingMode === 'user' ? 'câmera frontal' : 'câmera traseira'}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            type="button"
+            onClick={() => {
+              const next = facingMode === 'user' ? 'environment' : 'user'
+              setFacingMode(next)
+              void start('gesture', next)
+            }}
+            disabled={starting}
+          >
+            Inverter câmera
+          </Button>
+          {!running ? (
+            <Button
+              variant="outline"
+              onClick={() => void start('gesture')}
+              disabled={starting}
+              title={needsGesture ? 'Clique para solicitar permissão de câmera' : 'Tentar novamente'}
+            >
+              {starting ? 'Iniciando…' : needsGesture ? 'Ativar câmera' : 'Tentar novamente'}
+            </Button>
+          ) : null}
+          <Button variant="secondary" onClick={() => { stop(); onClose() }}>Fechar</Button>
+        </div>
+      </div>
+      {error ? <div className="text-sm text-red-200">{error}</div> : null}
+      <div className="relative w-full max-w-xl">
+        <video
+          ref={videoRef}
+          className="w-full rounded-lg border border-white/10 bg-black"
+          style={{ transform: activeFacingMode === 'user' ? 'scaleX(-1)' : 'none' }}
+          playsInline
+          muted
+        />
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="relative h-[28%] w-[78%] rounded-xl border-2 border-emerald-300/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.24)]">
+            <div className="absolute -left-2 -top-2 h-6 w-6 rounded-tl-md border-l-2 border-t-2 border-white/90" />
+            <div className="absolute -right-2 -top-2 h-6 w-6 rounded-tr-md border-r-2 border-t-2 border-white/90" />
+            <div className="absolute -bottom-2 -left-2 h-6 w-6 rounded-bl-md border-b-2 border-l-2 border-white/90" />
+            <div className="absolute -bottom-2 -right-2 h-6 w-6 rounded-br-md border-b-2 border-r-2 border-white/90" />
+          </div>
+        </div>
+      </div>
+      <div className="text-xs text-blue-200/60">
+        Posicione o código dentro da moldura verde. Se não detectar, aumente a luz e aproxime o produto.
+      </div>
+    </div>
+  )
+}

--- a/frontend/InsumosModule.tsx
+++ b/frontend/InsumosModule.tsx
@@ -3,955 +3,126 @@ import { toast } from 'sonner'
 import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd'
 import { Badge } from '@/badge'
 import { Button } from '@/button'
-import { BrDatePickerInput } from '@/br-date-picker'
-import { AutocompleteInput } from '@/autocomplete-input'
-import { Card, CardContent, CardHeader, CardTitle } from '@/card'
-import { Checkbox } from '@/checkbox'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
-import { Input } from '@/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
-import { Textarea } from '@/textarea'
 import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { getCsrfToken } from '@/csrf'
-
-type InsumosHealth = {
-  ok?: boolean
-  ready?: boolean
-  service?: string
-  runtime?: string
-  storage?: string
-  dbConfigured?: boolean
-  unidades?: string[]
-}
-
-type InsumosUser = {
-  username?: string
-  displayName?: string
-  name?: string
-  email?: string
-  role?: string
-  photoUrl?: string
-  allowedUnits?: string[]
-}
-
-type Insumo = {
-  registro?: string
-  codigoBarras?: string
-  codigosBarras?: string[]
-  categoria?: string
-  marca?: string
-  produto?: string
-  especificacao?: string
-  concentracao?: string
-  volume?: string
-  tipoUnidade?: string
-  fonte?: string
-  calibre?: string
-  policyRequiresLot?: boolean | null
-  policyRequiresExpiry?: boolean | null
-  policyFefo?: boolean | null
-  lote?: string
-  precoCusto?: number
-  estoqueAtual?: number
-  estoqueMinimo?: number
-  dataValidade?: string | null
-  statusValidade?: { status?: string; dias?: number | null }
-  estoques?: Record<string, number>
-}
-
-type Movimentacao = {
-  id?: string
-  dataHora?: string
-  tipo?: string
-  codigoBarras?: string
-  produto?: string
-  categoria?: string
-  marca?: string
-  quantidade?: number
-  estoqueAnterior?: number
-  estoqueNovo?: number
-  preco?: number
-  unidade?: string
-  unidadeOrigem?: string
-  unidadeDestino?: string
-  transferId?: string
-  usuario?: string
-  motivo?: string
-  registroInsumo?: string
-  lote?: string
-  dataValidade?: string
-  observacoes?: string
-}
-
-type NotificationsSummary = {
-  generatedAt?: string
-  unidade?: string
-  counts?: { lowStock?: number; expiringSoon?: number; expiredWithStock?: number }
-  lowStock?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; estoqueMinimo?: number; categoria?: string }>
-  expiringSoon?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; dataValidade?: string; dias?: number; categoria?: string }>
-  expiredWithStock?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; dataValidade?: string; categoria?: string }>
-}
-
-type EstoqueResumo = {
-  totalInsumos?: number
-  valorEstoqueTotal?: number
-  criticos?: number
-}
-
-type Actionables = {
-  unidade?: string
-  reposicao?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueAtual?: number; estoqueMinimo?: number; suggestedPurchaseQty?: number; estimatedValue?: number }>
-  transferencias?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; from?: string; to?: string; qty?: number; estimatedValue?: number }>
-  perdasValidade?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueAtual?: number; dataValidade?: string; lossValue?: number }>
-  rupturas?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueMinimo?: number; estimatedImpact?: number }>
-}
-
-type EstoqueAlerta = {
-  codigoBarras?: string
-  produto?: string
-  categoria?: string
-  estoqueAtual?: number
-  estoqueMinimo?: number
-  diferenca?: number
-  percentual?: number | null
-  tipoAlerta?: string
-  statusAlerta?: 'URGENTE' | 'ATENCAO' | string
-}
-
-type RoiInsights = {
-  unidade?: string
-  perdas?: {
-    valorExpirado?: number
-    valorRiscoVencendo?: number
-    itensExpirados?: number
-    itensVencendo?: number
-  }
-  ruptura?: { itensRuptura?: number }
-  produtividade?: { entrada?: number | null; baixa?: number | null }
-}
-
-type QualityIssue = {
-  severity?: 'CRITICAL' | 'WARN' | 'INFO' | string
-  code?: string
-  message?: string
-  registro?: string
-  codigoBarras?: string
-  produto?: string
-  unidade?: string
-  suggestion?: string
-}
-
-type QualityReport = {
-  generatedAt?: string
-  unidade?: string
-  summary?: { total?: number; bySeverity?: Record<string, number> }
-  issues?: QualityIssue[]
-}
-
-type OverviewBundleData = {
-  resumo?: EstoqueResumo | null
-  itens?: Insumo[] | null
-  notifications?: NotificationsSummary | null
-  actionables?: Actionables | null
-  roi?: RoiInsights | null
-  quality?: QualityReport | null
-  movResumo?: {
-    entradaQtd?: number
-    saidaQtd?: number
-    entradaValor?: number
-    saidaValor?: number
-    saldoLiquido?: number
-  } | null
-  movSeries?: Array<{ day?: string; entrada?: number; saida?: number; entradaValor?: number; saidaValor?: number }>
-}
-
-type InsightsBundleData = {
-  alertas?: EstoqueAlerta[] | null
-  trends?: any
-  turnover?: {
-    saida?: any
-    entrada?: any
-  } | null
-}
-
-type InsumosProxyStatus = {
-  ok?: boolean
-  localDirect?: boolean
-  target?: string
-  isProductionTarget?: boolean
-  localSafeMode?: boolean
-  mutationsBlocked?: boolean
-}
-
-type ShareFile = {
-  name: string
-  size?: number
-  contentType?: string
-  url?: string
-}
-
-type SharePayload = {
-  title?: string
-  text?: string
-  url?: string
-  files?: ShareFile[]
-}
-
-type ShareHistoryItem = SharePayload & {
-  id: string
-  createdAt: string
-}
-
-type CategoryPolicy = {
-  slug: string
-  label?: string
-  requiresLot?: boolean
-  requiresExpiry?: boolean
-  fefo?: boolean
-  createdAt?: string | null
-  updatedAt?: string | null
-}
-
-type CategoryPolicySuggestion = {
-  slug: string
-  label: string
-}
-
-type ApiError = {
-  error?: string
-  message?: string
-  success?: boolean
-  code?: string
-  registros?: string[]
-  candidates?: Array<{
-    registro?: string
-    lote?: string
-    dataValidade?: string | null
-    estoque?: number
-    categoria?: string
-  }>
-}
-
-type UserPrefs = {
-  overviewPanelOrder?: string[]
-  mainPanelOrder?: string[]
-  detailsOpen?: Record<string, boolean>
-}
-
-type OfflineQueueItem = {
-  id: string
-  ts: number
-  path: string
-  method: string
-  body?: unknown
-}
-
-const CANONICAL_TIPOS_UNIDADE = ['unidade', 'frasco', 'seringa', 'caixa', 'ampola', 'pacote', 'rolo'] as const
-const CANONICAL_TIPOS_UNIDADE_SET = new Set<string>(CANONICAL_TIPOS_UNIDADE as readonly string[])
-
-function normalizeTipoUnidadeToCanonical(raw: string): string {
-  const normalized = String(raw || '')
-    .trim()
-    .toLowerCase()
-    .replace(/\s*\(s\)\s*/g, '')
-    .trim()
-  if (!normalized) return ''
-  if (normalized === 'flaconete') return 'frasco'
-  return CANONICAL_TIPOS_UNIDADE_SET.has(normalized) ? normalized : ''
-}
-
-function parseBarcodeInput(value: string): string[] {
-  return String(value || '')
-    .split(/[\n,;]+/g)
-    .map((v) => String(v || '').trim())
-    .filter(Boolean);
-}
-
-function getInsumoBarcodes(item: Insumo | null | undefined): string[] {
-  const codes = new Set<string>();
-  const add = (v?: string) => {
-    const value = String(v || '').trim();
-    if (value) codes.add(value);
-  };
-  add(item?.codigoBarras);
-  if (Array.isArray(item?.codigosBarras)) {
-    for (const v of item?.codigosBarras || []) add(String(v || ''));
-  }
-  return Array.from(codes);
-}
-
-function fmtMoneyBRL(value: number) {
-  try {
-    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value)
-  } catch {
-    return `R$ ${value.toFixed(2)}`
-  }
-}
-
-function fmtMoneyBRL0(value: number) {
-  try {
-    return new Intl.NumberFormat('pt-BR', {
-      style: 'currency',
-      currency: 'BRL',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0
-    }).format(value)
-  } catch {
-    return `R$ ${Math.round(value)}`
-  }
-}
-
-function fmtMoneyBRLCompact(value: number) {
-  if (!Number.isFinite(value)) return '-'
-  const abs = Math.abs(value)
-  if (abs >= 1000) {
-    const rounded = Math.round(value / 1000)
-    return `R$ ${rounded}k`
-  }
-  return fmtMoneyBRL0(value)
-}
-
-const CATEGORIA_CORES: Record<string, string> = {
-  toxina: '#1e3a8a',
-  'toxina botulínica': '#1e3a8a',
-  'toxina botulinica': '#1e3a8a',
-  preenchedor: '#bfdbfe',
-  bioestimulador: '#ec4899',
-  fio: '#7c3aed',
-  'fio pdo': '#1f2937',
-  descartável: '#6b7280',
-  descartavel: '#6b7280',
-  peeling: '#ea580c',
-  skinbooster: '#ec4899',
-  anestésico: '#be123c',
-  anestesico: '#be123c',
-  medicamento: '#14b8a6',
-  limpeza: '#06b6d4',
-  cosmético: '#10b981',
-  cosmetico: '#10b981',
-  intradermoterapia: '#86efac',
-  perfurocortante: '#f87171',
-  higiene: '#8b5cf6',
-  recepção: '#c026d3',
-  recepcao: '#c026d3'
-}
-
-const CATEGORIA_PALETA = ['#60a5fa', '#a78bfa', '#34d399', '#f87171', '#fbbf24', '#22d3ee', '#fb7185', '#c084fc', '#4ade80', '#f472b6']
-const MARCA_PALETA = ['#0891b2', '#2563eb', '#7c3aed', '#db2777', '#16a34a', '#ea580c', '#475569', '#be123c']
-
-function hashToIndex(value: string, mod: number) {
-  let h = 0
-  for (let i = 0; i < value.length; i++) {
-    h = (h * 31 + value.charCodeAt(i)) >>> 0
-  }
-  return mod > 0 ? h % mod : 0
-}
-
-function getCategoriaBgColor(categoria?: string | null) {
-  const key = String(categoria || '').trim().toLowerCase()
-  const mapped = CATEGORIA_CORES[key]
-  if (mapped) return mapped
-  if (!key) return '#0ea5e9'
-  return CATEGORIA_PALETA[hashToIndex(key, CATEGORIA_PALETA.length)] || '#0ea5e9'
-}
-
-function getMarcaBgColor(marca?: string | null) {
-  const key = String(marca || '').trim().toLowerCase()
-  if (!key) return '#334155'
-  return MARCA_PALETA[hashToIndex(key, MARCA_PALETA.length)] || '#334155'
-}
-
-function getContrastColor(hexColor?: string | null) {
-  const raw = String(hexColor || '').trim()
-  const hex = raw.startsWith('#') ? raw.slice(1) : raw
-  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return '#ffffff'
-  const r = parseInt(hex.slice(0, 2), 16)
-  const g = parseInt(hex.slice(2, 4), 16)
-  const b = parseInt(hex.slice(4, 6), 16)
-  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-  return luminance > 140 ? '#0f172a' : '#ffffff'
-}
-
-function buildTagStyle(bgColor?: string | null): React.CSSProperties {
-  const bg = String(bgColor || '').trim() || '#334155'
-  return {
-    backgroundColor: bg,
-    color: getContrastColor(bg),
-    borderColor: 'rgba(255,255,255,0.25)'
-  }
-}
-
-function buildInsumoDescriptor(item?: Insumo | null) {
-  if (!item) return []
-  const produto = String(item.produto || '').trim()
-  const produtoKey = normalizeText(produto)
-  const rawParts = [item.especificacao, item.concentracao, item.volume, item.calibre, item.tipoUnidade]
-  const out: string[] = []
-  const seen = new Set<string>()
-  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  for (const raw of rawParts) {
-    let v = String(raw || '').trim()
-    if (!v) continue
-    if (produtoKey) {
-      const vNorm = normalizeText(v)
-      if (vNorm.includes(produtoKey)) {
-        const prodRegex = new RegExp(escapeRegExp(produto), 'ig')
-        v = v.replace(prodRegex, '').trim()
-      }
-    }
-    const key = normalizeText(v)
-    if (!key || seen.has(key)) continue
-    seen.add(key)
-    out.push(v)
-    if (out.length >= 3) break
-  }
-  return out
-}
-
-function formatInsumoDescriptor(item?: Insumo | null) {
-  const parts = buildInsumoDescriptor(item)
-  if (!parts.length) return ''
-  return parts.slice(0, 3).join(' • ')
-}
-
-function useViewportSize() {
-  const [size, setSize] = React.useState({ width: 0, height: 0 })
-  React.useEffect(() => {
-    const update = () => setSize({ width: window.innerWidth, height: window.innerHeight })
-    update()
-    window.addEventListener('resize', update)
-    return () => window.removeEventListener('resize', update)
-  }, [])
-  return size
-}
-function slugifyCategoria(value?: string | null) {
-  const s0 = String(value || '').trim().toLowerCase()
-  if (!s0) return ''
-  return s0
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-function normalizeText(value?: string | null) {
-  return String(value || '')
-    .trim()
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/\s+/g, ' ')
-}
-
-function uniqueSortedTextOptions(values: Array<string | null | undefined>) {
-  const out: string[] = []
-  const seen = new Set<string>()
-  for (const raw of values || []) {
-    const value = String(raw || '').trim()
-    if (!value) continue
-    const key = normalizeText(value)
-    if (!key || seen.has(key)) continue
-    seen.add(key)
-    out.push(value)
-  }
-  return out.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }))
-}
-
-type EstoqueStatus = 'OK' | 'ATENCAO' | 'URGENTE'
-
-function calcularStatusEstoque(estoqueAtual?: number, estoqueMinimo?: number): EstoqueStatus {
-  const atual = Number(estoqueAtual) || 0
-  const minimo = Number(estoqueMinimo) || 0
-  if (atual < 0) return 'URGENTE'
-  if (minimo <= 0) return 'OK'
-  // "Critico" means strictly below the configured minimum.
-  if (atual < minimo) return 'URGENTE'
-  // "Atencao" is only at the limit (not below it).
-  if (atual === minimo) return 'ATENCAO'
-  return 'OK'
-}
-
-function estoqueStatusLabel(status: EstoqueStatus) {
-  if (status === 'URGENTE') return 'Crítico'
-  if (status === 'ATENCAO') return 'Atenção'
-  return 'Ok'
-}
-
-function estoqueStatusBadgeVariant(status: EstoqueStatus): 'default' | 'secondary' | 'destructive' {
-  if (status === 'URGENTE') return 'destructive'
-  if (status === 'ATENCAO') return 'secondary'
-  return 'default'
-}
-
-type AlertaStatusTag = 'URGENTE' | 'ATENCAO' | 'VENCENDO' | 'EXPIRADO' | 'INFO'
-
-function alertaTagLabel(tag: AlertaStatusTag) {
-  if (tag === 'URGENTE') return 'Crítico'
-  if (tag === 'ATENCAO') return 'Atenção'
-  if (tag === 'VENCENDO') return 'Vencendo'
-  if (tag === 'INFO') return 'Info'
-  return 'Expirado'
-}
-
-function alertaTagVariant(tag: AlertaStatusTag): 'default' | 'secondary' | 'destructive' {
-  if (tag === 'URGENTE') return 'destructive'
-  if (tag === 'EXPIRADO') return 'destructive'
-  if (tag === 'VENCENDO') return 'secondary'
-  if (tag === 'ATENCAO') return 'secondary'
-  return 'default'
-}
-
-function normalizeAlertTags(tags: Set<AlertaStatusTag>): AlertaStatusTag[] {
-  const out = new Set(tags)
-  if (out.has('URGENTE')) out.delete('ATENCAO')
-  if (out.has('EXPIRADO')) out.delete('VENCENDO')
-  const order: Record<AlertaStatusTag, number> = { URGENTE: 0, EXPIRADO: 1, VENCENDO: 2, ATENCAO: 3, INFO: 4 }
-  return Array.from(out).sort((a, b) => order[a] - order[b])
-}
-
-function fmtDate(value?: string | null) {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return String(value)
-  return d.toLocaleString('pt-BR')
-}
-
-function fmtMovDateShort(value?: string | null) {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return String(value)
-  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' })
-}
-
-function fmtMovTimeShort(value?: string | null) {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
-}
-
-function fmtDayShort(isoDay?: string) {
-  if (!isoDay) return ''
-  const d = new Date(`${isoDay}T00:00:00.000Z`)
-  if (Number.isNaN(d.getTime())) return String(isoDay)
-  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
-}
-
-function isoDayWeekStart(isoDay?: string) {
-  const v = String(isoDay || '').trim()
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return ''
-  const d = new Date(`${v}T00:00:00.000Z`)
-  if (Number.isNaN(d.getTime())) return ''
-  const dow = d.getUTCDay() // 0=Sun
-  const diff = (dow + 6) % 7 // days since Monday
-  const start = new Date(d)
-  start.setUTCDate(start.getUTCDate() - diff)
-  return start.toISOString().slice(0, 10)
-}
-
-function isoToBrDate(value?: string | null) {
-  const v = String(value || '').trim()
-  if (!v) return ''
-  const m = v.match(/^(\d{4})-(\d{2})-(\d{2})/)
-  if (!m) return v
-  return `${m[3]}/${m[2]}/${m[1]}`
-}
-
-function brToIsoDate(value?: string | null) {
-  const v = String(value || '').trim()
-  if (!v) return ''
-  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v
-
-  const m = v.match(/^(\d{2})\/(\d{2})\/(\d{2}|\d{4})$/)
-  if (!m) return ''
-  const day = parseInt(m[1], 10)
-  const month = parseInt(m[2], 10)
-  const yearRaw = m[3]
-  const year =
-    yearRaw.length === 2
-      ? 2000 + parseInt(yearRaw, 10)
-      : parseInt(yearRaw, 10)
-  const d = new Date(Date.UTC(year, month - 1, day))
-  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return ''
-  const yyyy = String(year).padStart(4, '0')
-  const mm = String(month).padStart(2, '0')
-  const dd = String(day).padStart(2, '0')
-  return `${yyyy}-${mm}-${dd}`
-}
-
-function dateInputToIso(value?: string | null) {
-  const v = String(value || '').trim()
-  if (!v) return ''
-  if (/^\d{4}-\d{2}-\d{2}/.test(v)) return v.slice(0, 10)
-  const iso = brToIsoDate(v)
-  return iso || ''
-}
-
-function fmtDateOnlyBR(value?: string | null) {
-  const v = String(value || '').trim()
-  if (!v) return ''
-  if (/^\d{2}\/\d{2}\/\d{4}$/.test(v)) return v
-  const iso = dateInputToIso(v)
-  return iso ? isoToBrDate(iso) : v
-}
-
-function isoToLocalDateInput(value?: string | null) {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return ''
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function isoToLocalTimeInput(value?: string | null) {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return ''
-  const hours = String(d.getHours()).padStart(2, '0')
-  const minutes = String(d.getMinutes()).padStart(2, '0')
-  return `${hours}:${minutes}`
-}
-
-function normalizeTimeInput(value?: string | null) {
-  const raw = String(value || '').trim()
-  const match = raw.match(/^(\d{2}):(\d{2})$/)
-  if (!match) return ''
-  const hour = Number(match[1])
-  const minute = Number(match[2])
-  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return ''
-  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
-}
-
-function combineLocalDateTimeToIso(dateValue?: string | null, timeValue?: string | null) {
-  const isoDate = dateInputToIso(dateValue)
-  const isoTime = normalizeTimeInput(timeValue)
-  if (!isoDate || !isoTime) return ''
-  const d = new Date(`${isoDate}T${isoTime}:00`)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toISOString()
-}
-
-function normalizeMovimentacaoTipo(value?: string | null) {
-  return String(value || '').toUpperCase().replace('Í', 'I')
-}
-
-function extractTransferMovementNote(value?: string | null) {
-  const raw = String(value || '').trim()
-  if (!raw) return ''
-  const sep = raw.indexOf(' | ')
-  return sep >= 0 ? raw.slice(sep + 3).trim() : ''
-}
-
-function statusBadgeVariant(status?: string): 'default' | 'secondary' | 'destructive' {
-  const s = String(status || '').toUpperCase()
-  if (s === 'EXPIRADO') return 'destructive'
-  if (s === 'VENCENDO') return 'secondary'
-  return 'default'
-}
-
-function severityBadgeVariant(severity?: string): 'default' | 'secondary' | 'destructive' {
-  const s = String(severity || '').toUpperCase()
-  if (s === 'CRITICAL') return 'destructive'
-  if (s === 'WARN' || s === 'WARNING') return 'secondary'
-  return 'default'
-}
-
-function severityLabel(severity?: string) {
-  const key = normalizeText(severity).toUpperCase()
-  if (!key) return 'Info'
-  if (key === 'CRITICAL' || key === 'CRITICO') return 'Crítico'
-  if (key === 'WARN' || key === 'WARNING' || key === 'ATENCAO') return 'Atenção'
-  if (key === 'INFO') return 'Info'
-  const raw = String(severity || '').trim()
-  if (!raw) return 'Info'
-  return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase()
-}
-
-function BarcodeScannerInline({
-  onDetected,
-  onClose
-}: {
-  onDetected: (code: string) => void
-  onClose: () => void
-}) {
-  const videoRef = React.useRef<HTMLVideoElement | null>(null)
-  const rafRef = React.useRef<number | null>(null)
-  const streamRef = React.useRef<MediaStream | null>(null)
-  const zxingReaderRef = React.useRef<any>(null)
-  const zxingControlsRef = React.useRef<any>(null)
-  const runTokenRef = React.useRef(0)
-  const mountedRef = React.useRef(true)
-  const [error, setError] = React.useState<string | null>(null)
-  const [supported, setSupported] = React.useState(true)
-  const [starting, setStarting] = React.useState(false)
-  const [running, setRunning] = React.useState(false)
-  const [needsGesture, setNeedsGesture] = React.useState(false)
-  const [mode, setMode] = React.useState<'BARCODE_DETECTOR' | 'ZXING' | 'NONE'>('BARCODE_DETECTOR')
-  const [facingMode, setFacingMode] = React.useState<'user' | 'environment'>('environment')
-  const [activeFacingMode, setActiveFacingMode] = React.useState<'user' | 'environment' | null>(null)
-
-  const stop = React.useCallback(() => {
-    runTokenRef.current += 1
-    if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
-    rafRef.current = null
-    try {
-      zxingControlsRef.current?.stop?.()
-    } catch {
-      // ignore
-    }
-    zxingControlsRef.current = null
-    try {
-      zxingReaderRef.current?.reset?.()
-    } catch {
-      // ignore
-    }
-    zxingReaderRef.current = null
-    if (streamRef.current) {
-      for (const t of streamRef.current.getTracks()) t.stop()
-    }
-    streamRef.current = null
-    if (mountedRef.current) {
-      setRunning(false)
-      setStarting(false)
-      setActiveFacingMode(null)
-    }
-  }, [])
-
-  const start = React.useCallback(async (origin: 'auto' | 'gesture', preferredFacing?: 'user' | 'environment') => {
-    stop()
-    setError(null)
-    setNeedsGesture(false)
-    setStarting(true)
-    setSupported(true)
-
-    if (!navigator?.mediaDevices?.getUserMedia) {
-      setSupported(false)
-      setMode('NONE')
-      if (mountedRef.current) setStarting(false)
-      return
-    }
-
-    const token = runTokenRef.current
-    const targetFacingMode = preferredFacing || facingMode
-    const facingAttempts: Array<'user' | 'environment'> =
-      targetFacingMode === 'user' ? ['user', 'environment'] : ['environment', 'user']
-
-    const getStreamWithFallback = async () => {
-      let lastError: any = null
-      for (const currentFacingMode of facingAttempts) {
-        try {
-          const stream = await navigator.mediaDevices.getUserMedia({
-            video: { facingMode: { ideal: currentFacingMode } as any },
-            audio: false
-          })
-          return { stream, currentFacingMode }
-        } catch (e: any) {
-          lastError = e
-          const name = String(e?.name || '')
-          if (name === 'NotAllowedError' || name === 'SecurityError') break
-        }
-      }
-      throw lastError || new Error('Não foi possível abrir a câmera.')
-    }
-
-    const tickBarcodeDetector = async (detector: any, tickToken: number) => {
-      if (tickToken !== runTokenRef.current) return
-      const video = videoRef.current
-      if (!video) return
-      try {
-        const results = await detector.detect(video)
-        const raw = results?.[0]?.rawValue ? String(results[0].rawValue) : ''
-        if (raw) {
-          stop()
-          onDetected(raw)
-          return
-        }
-      } catch {
-        // ignore detection errors and keep trying
-      }
-      rafRef.current = requestAnimationFrame(() => { void tickBarcodeDetector(detector, tickToken) })
-    }
-
-    const Detector = (globalThis as any).BarcodeDetector
-    try {
-      if (Detector) {
-        setMode('BARCODE_DETECTOR')
-        const detector = new Detector({
-          formats: ['ean_13', 'ean_8', 'code_128', 'code_39', 'qr_code', 'upc_a', 'upc_e']
-        })
-        const { stream, currentFacingMode } = await getStreamWithFallback()
-        if (token !== runTokenRef.current) {
-          for (const t of stream.getTracks()) t.stop()
-          return
-        }
-        streamRef.current = stream
-        const video = videoRef.current
-        if (!video) throw new Error('Pré-visualização indisponível.')
-        video.srcObject = stream
-        await video.play()
-        if (token !== runTokenRef.current) return
-        setRunning(true)
-        setActiveFacingMode(currentFacingMode)
-        rafRef.current = requestAnimationFrame(() => { void tickBarcodeDetector(detector, token) })
-        return
-      }
-
-      setMode('ZXING')
-      const mod: any = await import('@zxing/browser')
-      const Reader = mod?.BrowserMultiFormatReader
-      if (!Reader) throw new Error('Scanner indisponível.')
-      const reader = new Reader()
-      zxingReaderRef.current = reader
-
-      const video = videoRef.current
-      if (!video) throw new Error('Pré-visualização indisponível.')
-
-      let controls: any = null
-      let usedFacingMode: 'user' | 'environment' | null = null
-      let lastDecodeError: any = null
-      for (const currentFacingMode of facingAttempts) {
-        try {
-          controls = await reader.decodeFromConstraints(
-            { video: { facingMode: { ideal: currentFacingMode } } } as any,
-            video,
-            (result: any) => {
-              if (token !== runTokenRef.current) return
-              const raw = result?.getText ? String(result.getText() || '') : ''
-              if (!raw) return
-              stop()
-              onDetected(raw)
-            }
-          )
-          usedFacingMode = currentFacingMode
-          break
-        } catch (e: any) {
-          lastDecodeError = e
-          const name = String(e?.name || '')
-          if (name === 'NotAllowedError' || name === 'SecurityError') break
-        }
-      }
-      if (!controls) {
-        throw lastDecodeError || new Error('Não foi possível iniciar o scanner de câmera.')
-      }
-      if (!usedFacingMode) {
-        usedFacingMode = targetFacingMode
-      }
-      if (token !== runTokenRef.current) {
-        try {
-          controls?.stop?.()
-        } catch {
-          // ignore
-        }
-        return
-      }
-      zxingControlsRef.current = controls
-      setRunning(true)
-      setActiveFacingMode(usedFacingMode)
-    } catch (e: any) {
-      const name = String(e?.name || '')
-      const message = String(e?.message || '')
-
-      // Safari/iOS: algumas versões exigem gesto explícito para pedir permissão de câmera.
-      if (origin === 'auto' && (name === 'NotAllowedError' || name === 'SecurityError')) {
-        setNeedsGesture(true)
-      }
-
-      if (name === 'NotFoundError') {
-        setSupported(false)
-        setMode('NONE')
-        setError('Nenhuma câmera foi encontrada neste dispositivo.')
-      } else if (!location?.protocol?.startsWith('https') && location?.hostname !== 'localhost') {
-        setSupported(false)
-        setMode('NONE')
-        setError('O scanner precisa de HTTPS para acessar a câmera.')
-      } else {
-        setError(message || 'Não foi possível iniciar o scanner. Verifique a permissão de câmera no navegador.')
-      }
-    } finally {
-      if (mountedRef.current && token === runTokenRef.current) setStarting(false)
-    }
-  }, [facingMode, onDetected, stop])
-
-  React.useEffect(() => {
-    void start('auto')
-    return () => {
-      mountedRef.current = false
-      stop()
-    }
-  }, [start, stop])
-
-  if (!supported) {
-    return (
-      <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-2">
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-sm text-blue-50 font-semibold">Scanner indisponível</div>
-          <Button variant="secondary" onClick={onClose}>Fechar</Button>
-        </div>
-        <div className="text-sm text-blue-100/70">
-          Este navegador não suporta leitura automática de códigos. Digite o código manualmente ou use Chrome/Edge.
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-sm text-blue-100/80">
-          {mode === 'ZXING' ? 'Scanner (compatível)' : 'Scanner (rápido)'} • {activeFacingMode === 'user' ? 'câmera frontal' : 'câmera traseira'}
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            type="button"
-            onClick={() => {
-              const next = facingMode === 'user' ? 'environment' : 'user'
-              setFacingMode(next)
-              void start('gesture', next)
-            }}
-            disabled={starting}
-          >
-            Inverter câmera
-          </Button>
-          {!running ? (
-            <Button
-              variant="outline"
-              onClick={() => void start('gesture')}
-              disabled={starting}
-              title={needsGesture ? 'Clique para solicitar permissão de câmera' : 'Tentar novamente'}
-            >
-              {starting ? 'Iniciando…' : (needsGesture ? 'Ativar câmera' : 'Tentar novamente')}
-            </Button>
-          ) : null}
-          <Button variant="secondary" onClick={() => { stop(); onClose() }}>Fechar</Button>
-        </div>
-      </div>
-      {error ? <div className="text-sm text-red-200">{error}</div> : null}
-      <div className="relative w-full max-w-xl">
-        <video
-          ref={videoRef}
-          className="w-full rounded-lg border border-white/10 bg-black"
-          style={{ transform: activeFacingMode === 'user' ? 'scaleX(-1)' : 'none' }}
-          playsInline
-          muted
-        />
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="relative h-[28%] w-[78%] rounded-xl border-2 border-emerald-300/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.24)]">
-            <div className="absolute -top-2 -left-2 h-6 w-6 border-l-2 border-t-2 border-white/90 rounded-tl-md" />
-            <div className="absolute -top-2 -right-2 h-6 w-6 border-r-2 border-t-2 border-white/90 rounded-tr-md" />
-            <div className="absolute -bottom-2 -left-2 h-6 w-6 border-l-2 border-b-2 border-white/90 rounded-bl-md" />
-            <div className="absolute -bottom-2 -right-2 h-6 w-6 border-r-2 border-b-2 border-white/90 rounded-br-md" />
-          </div>
-        </div>
-      </div>
-      <div className="text-xs text-blue-200/60">
-        Posicione o código dentro da moldura verde. Se não detectar, aumente a luz e aproxime o produto.
-      </div>
-    </div>
-  )
-}
+import {
+  InsumosAutoSyncBanner,
+  InsumosAlertsPanel,
+  InsumosChartsPanel,
+  InsumosCategoryPoliciesPanel,
+  InsumosEditDialog,
+  InsumosLotDialog,
+  InsumosMovementEditDialog,
+  InsumosMovementsPanel,
+  InsumosOfflineQueueDialog,
+  InsumosInventoryDialog,
+  InsumosPurchaseDialog,
+  InsumosQualityMatchesDialog,
+  InsumosQuickOperationDialog,
+  InsumosSafeModeBanner,
+} from '@/insumosPanels'
+import {
+  CHART_PRESETS,
+  CHARTS_SLOTS_KEY,
+  DEFAULT_CHART_SLOTS,
+  MAX_CHARTS,
+  filterChartSlotsView,
+  getChartIndexFromKey,
+  getNextChartPresetPatch,
+  getNextDistributionGroupByPatch,
+  getNextMovementsGroupByPatch,
+  getNextMovementsModePatch,
+  normalizeChartTopN,
+  parseChartSlots,
+  resolveChartPreset,
+  resolveChartSlot,
+  resolveChartViewOptions,
+  type ChartFilterTipo,
+  type ChartFilterTop,
+  type ChartFilterView,
+  type ChartFilterX,
+  type ChartFilterY,
+  type ChartGroupBy,
+  type ChartMetric,
+  type ChartPresetId,
+  type ChartSlotConfig,
+  type ChartView,
+  type MovementsMode,
+  updateChartSlotAt,
+} from '@/insumosCharts'
+import {
+  buildMovementRows,
+  buildMovimentacoesView,
+  type MovementSortKey,
+} from '@/insumosDerivations'
+import { useInsumosDashboardController } from '@/insumosDashboardController'
+import { useInsumosCreateLookupController } from '@/useInsumosCreateLookupController'
+import { useInsumosInventoryMutationsController } from '@/useInsumosInventoryMutationsController'
+import { useInsumosMovementsController } from '@/useInsumosMovementsController'
+import { useInsumosQuickLookupController } from '@/useInsumosQuickLookupController'
+import { useInsumosQuickOperationsController } from '@/useInsumosQuickOperationsController'
+import {
+  CANONICAL_TIPOS_UNIDADE,
+  brToIsoDate,
+  buildTagStyle,
+  calcularStatusEstoque,
+  combineLocalDateTimeToIso,
+  dateInputToIso,
+  estoqueStatusBadgeVariant,
+  estoqueStatusLabel,
+  extractTransferMovementNote,
+  fmtDateOnlyBR,
+  fmtDayShort,
+  fmtMoneyBRL,
+  fmtMoneyBRL0,
+  fmtMoneyBRLCompact,
+  fmtMovDateShort,
+  fmtMovTimeShort,
+  formatInsumoDescriptor,
+  getCategoriaBgColor,
+  getInsumoBarcodes,
+  getMarcaBgColor,
+  isoDayWeekStart,
+  isoToBrDate,
+  isoToLocalDateInput,
+  isoToLocalTimeInput,
+  normalizeAlertTags,
+  normalizeMovimentacaoTipo,
+  normalizeText,
+  normalizeTimeInput,
+  normalizeTipoUnidadeToCanonical,
+  parseBarcodeInput,
+  slugifyCategoria,
+  statusBadgeVariant,
+  uniqueSortedTextOptions,
+  useViewportSize,
+} from '@/insumosShared'
+import type { AlertaStatusTag } from '@/insumosShared'
+import type {
+  Actionables,
+  ApiError,
+  CategoryPolicy,
+  CategoryPolicySuggestion,
+  EstoqueAlerta,
+  EstoqueResumo,
+  Insumo,
+  InsumosHealth,
+  InsumosProxyStatus,
+  InsumosQuickOperation,
+  InsumosUser,
+  Movimentacao,
+  NotificationsSummary,
+  OfflineQueueItem,
+  QuickActionFeedback,
+  QuickCandidate,
+  QualityIssue,
+  QualityReport,
+  RoiInsights,
+  ShareHistoryItem,
+  SharePayload,
+  UserPrefs,
+} from '@/insumosTypes'
+import { useInsumosHeaderBridge } from '@/useInsumosHeaderBridge'
 
 async function apiJson<T>(
   path: string,
@@ -1107,12 +278,12 @@ export function InsumosModule() {
   const [movLoaded, setMovLoaded] = React.useState(false)
   const [insightsLoaded, setInsightsLoaded] = React.useState(false)
 
-  const [quickOp, setQuickOp] = React.useState<'ENTRADA' | 'BAIXA' | 'TRANSFERENCIA' | null>(null)
+  const [quickOp, setQuickOp] = React.useState<InsumosQuickOperation | null>(null)
   const [quickCodigo, setQuickCodigo] = React.useState('')
   const [quickSearch, setQuickSearch] = React.useState('')
   const [quickRegistro, setQuickRegistro] = React.useState('')
   const [quickRegistros, setQuickRegistros] = React.useState<string[]>([])
-  const [quickCandidates, setQuickCandidates] = React.useState<Array<{ registro: string; lote: string; dataValidade: string | null; estoque: number }>>([])
+  const [quickCandidates, setQuickCandidates] = React.useState<QuickCandidate[]>([])
   const [quickAutoFefo, setQuickAutoFefo] = React.useState(true)
   const [quickScanOpen, setQuickScanOpen] = React.useState(false)
   const [quickQuantidade, setQuickQuantidade] = React.useState('1')
@@ -1120,7 +291,7 @@ export function InsumosModule() {
   const [quickObs, setQuickObs] = React.useState('')
   const [quickMotivo, setQuickMotivo] = React.useState('Ajuste manual')
   const [quickActionLoading, setQuickActionLoading] = React.useState(false)
-  const [quickActionFeedback, setQuickActionFeedback] = React.useState<{ type: 'success' | 'error'; message: string } | null>(null)
+  const [quickActionFeedback, setQuickActionFeedback] = React.useState<QuickActionFeedback | null>(null)
   const [quickLookupLoading, setQuickLookupLoading] = React.useState(false)
   const [quickLookupError, setQuickLookupError] = React.useState<string | null>(null)
   const [quickLookupCtxUnidade, setQuickLookupCtxUnidade] = React.useState<string | null>(null)
@@ -1130,15 +301,8 @@ export function InsumosModule() {
   const [quickSearchRemote, setQuickSearchRemote] = React.useState<Insumo[]>([])
   const [quickSearchRemoteLoading, setQuickSearchRemoteLoading] = React.useState(false)
   const [quickSearchRemoteError, setQuickSearchRemoteError] = React.useState<string | null>(null)
-  const quickLookupTokenRef = React.useRef(0)
-  const quickSearchRemoteTokenRef = React.useRef(0)
   const overviewSectionRef = React.useRef<HTMLDivElement | null>(null)
   const movSectionRef = React.useRef<HTMLDivElement | null>(null)
-  const overviewAbortRef = React.useRef<AbortController | null>(null)
-  const insightsAbortRef = React.useRef<AbortController | null>(null)
-  const overviewFullAttemptRef = React.useRef<number>(0)
-  const apiFailureTimestampsRef = React.useRef<number[]>([])
-  const [autoSyncSuspendedUntil, setAutoSyncSuspendedUntil] = React.useState<number>(0)
   const [overviewVisible, setOverviewVisible] = React.useState(false)
   const [overviewEverVisible, setOverviewEverVisible] = React.useState(false)
   const [sharePayload, setSharePayload] = React.useState<SharePayload | null>(null)
@@ -1237,7 +401,6 @@ export function InsumosModule() {
   const [createLookupLoading, setCreateLookupLoading] = React.useState(false)
   const [createLookupError, setCreateLookupError] = React.useState<string | null>(null)
   const [createLookupItems, setCreateLookupItems] = React.useState<Insumo[]>([])
-  const createLookupTokenRef = React.useRef(0)
 
   const [editOpen, setEditOpen] = React.useState(false)
   const [editTarget, setEditTarget] = React.useState<Insumo | null>(null)
@@ -1298,9 +461,7 @@ export function InsumosModule() {
   const [movFilterCategoria, setMovFilterCategoria] = React.useState('')
   const [movFilterMarca, setMovFilterMarca] = React.useState('')
   const [movSearch, setMovSearch] = React.useState('')
-  const [movSortKey, setMovSortKey] = React.useState<
-    'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'
-  >('dataHora')
+  const [movSortKey, setMovSortKey] = React.useState<MovementSortKey>('dataHora')
   const [movSortDir, setMovSortDir] = React.useState<'asc' | 'desc'>('desc')
   const movListContainerRef = React.useRef<HTMLDivElement | null>(null)
   const [editMovOpen, setEditMovOpen] = React.useState(false)
@@ -1506,89 +667,8 @@ export function InsumosModule() {
   )
   const isAuthed = !!user?.username
   const allowedUnits = Array.isArray(user?.allowedUnits) ? user!.allowedUnits!.filter(Boolean) : []
-  const autoSyncSuspended = autoSyncSuspendedUntil > Date.now()
-  const autoSyncRemainingSeconds = autoSyncSuspended ? Math.max(1, Math.ceil((autoSyncSuspendedUntil - Date.now()) / 1000)) : 0
 
   const isManagerRole = ['GESTOR', 'GERENTE'].includes(String(user?.role || '').toUpperCase())
-
-  const markAutoSyncFailure = React.useCallback(
-    (error: unknown) => {
-      const status = Number((error as any)?.status || 0)
-      const rawMessage = String((error as any)?.message || '')
-      const message = rawMessage.toLowerCase()
-      const isNetworkError =
-        status <= 0 ||
-        String((error as any)?.name || '') === 'TypeError' ||
-        message.includes('network') ||
-        message.includes('failed to fetch') ||
-        message.includes('conex')
-      const isRecoverableServerFailure = status >= 500 || status === 429 || isNetworkError
-      if (!isRecoverableServerFailure) return
-
-      const now = Date.now()
-      const failureWindowMs = 30_000
-      const cooldownMs = 60_000
-
-      apiFailureTimestampsRef.current = apiFailureTimestampsRef.current.filter((ts) => now - ts <= failureWindowMs)
-      apiFailureTimestampsRef.current.push(now)
-
-      if (apiFailureTimestampsRef.current.length < 5) return
-      if (autoSyncSuspendedUntil > now) return
-
-      setAutoSyncSuspendedUntil(now + cooldownMs)
-      toast.warning('API instável: sincronização automática reduzida por 60 segundos.')
-    },
-    [autoSyncSuspendedUntil]
-  )
-
-  React.useEffect(() => {
-    if (!isAuthed || !canUseApi) {
-      setOverviewLoaded(false)
-      setInsumosLoaded(false)
-      setMovLoaded(false)
-      setInsightsLoaded(false)
-    }
-  }, [isAuthed, canUseApi])
-
-  React.useEffect(() => {
-    if (!autoSyncSuspendedUntil) return
-    const remainingMs = autoSyncSuspendedUntil - Date.now()
-    if (remainingMs <= 0) {
-      apiFailureTimestampsRef.current = []
-      setAutoSyncSuspendedUntil(0)
-      return
-    }
-    const timeoutId = window.setTimeout(() => {
-      apiFailureTimestampsRef.current = []
-      setAutoSyncSuspendedUntil(0)
-    }, remainingMs + 20)
-    return () => window.clearTimeout(timeoutId)
-  }, [autoSyncSuspendedUntil])
-
-  React.useEffect(() => {
-    if (autoSyncSuspendedUntil) return
-    overviewFullAttemptRef.current = 0
-  }, [autoSyncSuspendedUntil])
-
-  const dashboardProgress = React.useMemo(() => {
-    const steps = [
-      healthLoaded,
-      authLoaded,
-      ...(canUseApi && isAuthed ? [overviewLoaded, insumosLoaded, movLoaded, insightsLoaded] : [])
-    ]
-    const total = steps.length || 1
-    const done = steps.filter(Boolean).length
-    return Math.max(0, Math.min(100, Math.round((done / total) * 100)))
-  }, [authLoaded, canUseApi, healthLoaded, insumosLoaded, insightsLoaded, isAuthed, movLoaded, overviewLoaded])
-
-  const loadingPercent = Math.max(0, Math.min(100, Math.round(dashboardProgress)))
-
-  const isDashboardLoading =
-    authLoading || healthLoading || (canUseApi && isAuthed && dashboardProgress < 100)
-  const shouldShowDashboardLoading =
-    isDashboardLoading || !authLoaded || !healthLoaded
-  const showOverviewLoadingProgress =
-    overviewLoading || (canUseApi && isAuthed && shouldShowDashboardLoading)
 
   const overviewCriticosCount = React.useMemo(() => {
     const criticos = Number(overviewResumo?.criticos ?? NaN)
@@ -1603,82 +683,6 @@ export function InsumosModule() {
     if (Number.isNaN(baixo) && Number.isNaN(vencendo)) return null
     return (Number.isNaN(baixo) ? 0 : baixo) + (Number.isNaN(vencendo) ? 0 : vencendo)
   }, [overviewNotifications?.counts?.expiringSoon, overviewNotifications?.counts?.lowStock])
-
-  React.useEffect(() => {
-    try {
-      const entradaValor = Number.isFinite(Number(overviewMovResumo?.entradaValor))
-        ? Number(overviewMovResumo?.entradaValor)
-        : null
-      const saidaValor = Number.isFinite(Number(overviewMovResumo?.saidaValor))
-        ? Number(overviewMovResumo?.saidaValor)
-        : null
-      window.dispatchEvent(
-        new CustomEvent('skincos:insumos:estoque', {
-          detail: {
-            value: overviewResumo?.valorEstoqueTotal ?? null,
-            loading: showOverviewLoadingProgress,
-            percent: loadingPercent,
-            entradaValor,
-            saidaValor
-          }
-        })
-      )
-    } catch {
-      // ignore
-    }
-  }, [
-    loadingPercent,
-    overviewMovResumo?.entradaValor,
-    overviewMovResumo?.saidaValor,
-    overviewResumo?.valorEstoqueTotal,
-    showOverviewLoadingProgress
-  ])
-  const renderInlinePercent = React.useCallback(
-    (active: boolean, className = '') => {
-      if (!active) return null
-      return (
-        <div className={`inline-flex items-center gap-2 text-xs text-blue-200/70 ${className}`.trim()}>
-          <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
-          <span className="font-mono">{loadingPercent}%</span>
-        </div>
-      )
-    },
-    [loadingPercent]
-  )
-
-  const renderLoadingText = React.useCallback(
-    (loading: boolean, emptyLabel: string) => {
-      if (loading || shouldShowDashboardLoading) {
-        return (
-          <span className="inline-flex items-center gap-2 text-blue-100/70">
-            <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
-            {`Carregando ${loadingPercent}%`}
-          </span>
-        )
-      }
-      return <span>{emptyLabel}</span>
-    },
-    [loadingPercent, shouldShowDashboardLoading]
-  )
-
-  const DashboardLoadingButton = React.useCallback(
-    ({ size = 'sm', className = '' }: { size?: 'sm' | 'default' | 'lg'; className?: string } = {}) => (
-      <Button variant="secondary" size={size} disabled className={`gap-2 ${className}`.trim()}>
-        <span className="animate-pulse">⏳</span>
-        {`Carregando dados ${dashboardProgress}%`}
-      </Button>
-    ),
-    [dashboardProgress]
-  )
-
-  const renderListPlaceholder = React.useCallback(
-    (loading: boolean, emptyLabel: string) => {
-      if (loading || shouldShowDashboardLoading) return <div className="text-sm text-blue-100/70">{renderLoadingText(true, emptyLabel)}</div>
-      if (isAuthed) return emptyLabel
-      return 'Faça login para carregar.'
-    },
-    [DashboardLoadingButton, isAuthed, renderLoadingText, shouldShowDashboardLoading]
-  )
 
   const upsertInsumosCache = React.useCallback((items: Insumo[]) => {
     if (!Array.isArray(items) || !items.length) return
@@ -1753,6 +757,107 @@ export function InsumosModule() {
 
   const chartsPanelOpen = detailsOpen[OVERVIEW_PANEL_OPEN_KEYS.charts] ?? true
   const chartsPanelVisible = visibleOverviewPanels.includes('charts')
+
+  const {
+    autoSyncRemainingSeconds,
+    autoSyncSuspended,
+    dashboardProgress,
+    loadInsights,
+    loadOverview,
+    loadingPercent,
+    resumeAutoSync,
+    schedulePostMutationRefresh,
+    shouldShowDashboardLoading,
+    showOverviewLoadingProgress,
+  } = useInsumosDashboardController({
+    apiJson,
+    authLoaded,
+    authLoading,
+    canUseApi,
+    chartsPanelOpen,
+    chartsPanelVisible,
+    healthLoaded,
+    healthLoading,
+    insightsLoaded,
+    insumosLoaded,
+    isAuthed,
+    movLoaded,
+    overviewCustomFrom,
+    overviewCustomTo,
+    overviewEverVisible,
+    overviewInsumos,
+    overviewLoaded,
+    overviewLoading,
+    overviewPeriod,
+    overviewSectionRef,
+    overviewVisible,
+    setInsightsAlertas,
+    setInsightsLoaded,
+    setInsightsLoading,
+    setInsightsTrends,
+    setInsightsTurnover,
+    setInsumosLoaded,
+    setMovLoaded,
+    setOverviewActionables,
+    setOverviewEverVisible,
+    setOverviewInsumos,
+    setOverviewLoaded,
+    setOverviewLoading,
+    setOverviewMovResumo,
+    setOverviewMovSeries,
+    setOverviewNotifications,
+    setOverviewQuality,
+    setOverviewResumo,
+    setOverviewRoi,
+    unidade,
+  })
+
+  const renderInlinePercent = React.useCallback(
+    (active: boolean, className = '') => {
+      if (!active) return null
+      return (
+        <div className={`inline-flex items-center gap-2 text-xs text-blue-200/70 ${className}`.trim()}>
+          <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
+          <span className="font-mono">{loadingPercent}%</span>
+        </div>
+      )
+    },
+    [loadingPercent]
+  )
+
+  const renderLoadingText = React.useCallback(
+    (loading: boolean, emptyLabel: string) => {
+      if (loading || shouldShowDashboardLoading) {
+        return (
+          <span className="inline-flex items-center gap-2 text-blue-100/70">
+            <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
+            {`Carregando ${loadingPercent}%`}
+          </span>
+        )
+      }
+      return <span>{emptyLabel}</span>
+    },
+    [loadingPercent, shouldShowDashboardLoading]
+  )
+
+  const DashboardLoadingButton = React.useCallback(
+    ({ size = 'sm', className = '' }: { size?: 'sm' | 'default' | 'lg'; className?: string } = {}) => (
+      <Button variant="secondary" size={size} disabled className={`gap-2 ${className}`.trim()}>
+        <span className="animate-pulse">⏳</span>
+        {`Carregando dados ${dashboardProgress}%`}
+      </Button>
+    ),
+    [dashboardProgress]
+  )
+
+  const renderListPlaceholder = React.useCallback(
+    (loading: boolean, emptyLabel: string) => {
+      if (loading || shouldShowDashboardLoading) return <div className="text-sm text-blue-100/70">{renderLoadingText(true, emptyLabel)}</div>
+      if (isAuthed) return emptyLabel
+      return 'Faça login para carregar.'
+    },
+    [DashboardLoadingButton, isAuthed, renderLoadingText, shouldShowDashboardLoading]
+  )
 
   const persistMainPanels = React.useCallback((next: MainPanelId[]) => {
     setMainPanelOrder(next)
@@ -2166,302 +1271,6 @@ export function InsumosModule() {
     return list.sort(sortByValidade)
   }, [insumos, quickCodigo, quickOp, quickLookupCode, quickLookupCtxUnidade, quickLookupItems, transferFrom, unidade])
 
-  const quickSearchMatches = React.useMemo(() => {
-    const query = quickSearch.trim().toLowerCase()
-    if (!query) return []
-    const looksLikeCode = /^[0-9]{4,}$/.test(query)
-    const remoteActive = canUseApi && isAuthed && !looksLikeCode && query.length >= 2
-    const baseList = remoteActive
-      ? (quickSearchRemoteError ? (Array.isArray(insumos) ? insumos : []) : quickSearchRemote)
-      : (Array.isArray(insumos) ? insumos : [])
-    const selected: Insumo[] = []
-    if (Array.isArray(quickLookupItems) && quickLookupItems.length) selected.push(...quickLookupItems)
-    else if (quickSelectedSnapshot) selected.push(quickSelectedSnapshot)
-    const primarySelected = quickSelectedSnapshot || (quickLookupItems.length ? quickLookupItems[0] : null)
-    const allowSelectedWhileLoading = !!(quickLookupLoading && primarySelected)
-    const selectedSignatures = selected.map((s) => ({
-      registro: normalizeText(s?.registro || ''),
-      codes: getInsumoBarcodes(s).map((c) => normalizeText(c)),
-      produto: normalizeText(s?.produto || ''),
-      categoria: normalizeText(s?.categoria || ''),
-      marca: normalizeText(s?.marca || '')
-    }))
-    const isSelected = (item: Insumo) => {
-      const registro = normalizeText(item?.registro || '')
-      if (registro && selectedSignatures.some((s) => s.registro && s.registro === registro)) return true
-      const codes = getInsumoBarcodes(item).map((c) => normalizeText(c))
-      const produto = normalizeText(item?.produto || '')
-      const categoria = normalizeText(item?.categoria || '')
-      const marca = normalizeText(item?.marca || '')
-      return selectedSignatures.some((s) => {
-        const sameCore =
-          (!!produto || !!categoria || !!marca) &&
-          produto === s.produto &&
-          categoria === s.categoria &&
-          marca === s.marca
-        if (!sameCore) return false
-        if (!codes.length || !s.codes.length) return true
-        return s.codes.some((c) => codes.includes(c))
-      })
-    }
-    const scored: Array<{ item: Insumo; matchedCode: string; score: number }> = []
-    const normQuery = normalizeText(query)
-    const scoreMatch = (item: Insumo, matchedCode: string) => {
-      let score = 0
-      const produto = normalizeText(item?.produto || '')
-      const categoria = normalizeText(item?.categoria || '')
-      const marca = normalizeText(item?.marca || '')
-      const extras = [
-        normalizeText((item as any)?.especificacao || ''),
-        normalizeText((item as any)?.concentracao || ''),
-        normalizeText((item as any)?.volume || ''),
-        normalizeText((item as any)?.calibre || ''),
-        normalizeText((item as any)?.tipoUnidade || '')
-      ]
-      const codes = getInsumoBarcodes(item).map((c) => normalizeText(c))
-      if (matchedCode) score += 20
-      if (codes.includes(normQuery)) score += 80
-      if (produto === normQuery) score += 70
-      else if (produto.startsWith(normQuery)) score += 40
-      else if (produto.includes(normQuery)) score += 25
-      if (marca === normQuery) score += 30
-      else if (marca.includes(normQuery)) score += 12
-      if (categoria === normQuery) score += 25
-      else if (categoria.includes(normQuery)) score += 10
-      if (extras.some((e) => e && e === normQuery)) score += 15
-      else if (extras.some((e) => e && e.includes(normQuery))) score += 8
-      return score
-    }
-    for (const item of baseList) {
-      if (isSelected(item) && !(allowSelectedWhileLoading && isSameInsumo(item, primarySelected))) continue
-      const codes = getInsumoBarcodes(item)
-      const produto = String(item?.produto || '').toLowerCase()
-      const categoria = String(item?.categoria || '').toLowerCase()
-      const marca = String(item?.marca || '').toLowerCase()
-      const extras = [
-        String((item as any)?.especificacao || '').toLowerCase(),
-        String((item as any)?.concentracao || '').toLowerCase(),
-        String((item as any)?.volume || '').toLowerCase(),
-        String((item as any)?.calibre || '').toLowerCase(),
-        String((item as any)?.tipoUnidade || '').toLowerCase()
-      ]
-      const hay = [produto, categoria, marca, ...extras, ...codes].filter(Boolean).join(' ')
-      if (!hay.includes(query)) continue
-      const matchedCode = codes.find((c) => String(c || '').toLowerCase().includes(query)) || codes[0] || ''
-      scored.push({ item, matchedCode, score: scoreMatch(item, matchedCode) })
-    }
-    return scored
-      .sort((a, b) => {
-        if (b.score !== a.score) return b.score - a.score
-        return String(a.item?.produto || '').localeCompare(String(b.item?.produto || ''), 'pt-BR', { sensitivity: 'base' })
-      })
-      .slice(0, 8)
-  }, [canUseApi, insumos, isAuthed, isSameInsumo, quickLookupItems, quickLookupLoading, quickSearch, quickSearchRemote, quickSearchRemoteError, quickSelectedSnapshot])
-
-  const hasQuickSelection = !!quickSelectedSnapshot || quickLookupItems.length > 0
-
-  const selectQuickCodigo = React.useCallback(
-    (code: string, opts?: { setSearch?: boolean; snapshot?: Insumo | null }) => {
-      const value = String(code || '').trim()
-      if (!value) return false
-      setQuickCodigo(value)
-      if (opts?.setSearch) setQuickSearch(value)
-      if (opts && Object.prototype.hasOwnProperty.call(opts, 'snapshot')) {
-        setQuickSelectedSnapshot(opts?.snapshot ?? null)
-      }
-      setQuickLookupError(null)
-      return true
-    },
-    []
-  )
-
-  const clearQuickSelection = React.useCallback(() => {
-    setQuickCodigo('')
-    setQuickSelectedSnapshot(null)
-    setQuickRegistro('')
-    setQuickRegistros([])
-    setQuickCandidates([])
-    setQuickLookupError(null)
-    setQuickLookupCtxUnidade(null)
-    setQuickLookupCode(null)
-    setQuickLookupItems([])
-  }, [])
-
-  const applyQuickSelection = React.useCallback((item: Insumo, preferredCode?: string) => {
-    const codes = getInsumoBarcodes(item)
-    if (!codes.length) {
-      const message = 'Este item não possui código de barras cadastrado.'
-      setQuickLookupError(message)
-      toast.error(message)
-      return
-    }
-    const code = preferredCode && codes.includes(preferredCode) ? preferredCode : codes[0] || ''
-    if (!code) return
-    selectQuickCodigo(code, { setSearch: false, snapshot: item })
-  }, [selectQuickCodigo])
-
-  React.useEffect(() => {
-    if (!quickLookupItems.length) return
-    setQuickSelectedSnapshot(quickLookupItems[0])
-  }, [quickLookupItems])
-
-  React.useEffect(() => {
-    if (!quickOp) return
-    if (!canUseApi || !isAuthed) {
-      setQuickSearchRemote([])
-      setQuickSearchRemoteLoading(false)
-      setQuickSearchRemoteError(null)
-      return
-    }
-    const query = quickSearch.trim()
-    const looksLikeCode = /^[0-9]{4,}$/.test(query)
-    if (!query || looksLikeCode || query.length < 2) {
-      setQuickSearchRemote([])
-      setQuickSearchRemoteLoading(false)
-      setQuickSearchRemoteError(null)
-      return
-    }
-    const ctxUnidade = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
-    const token = ++quickSearchRemoteTokenRef.current
-    setQuickSearchRemoteLoading(true)
-    setQuickSearchRemoteError(null)
-    const t = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const params = new URLSearchParams({
-            unidade: ctxUnidade,
-            q: query,
-            pagina: '1',
-            limite: '30'
-          })
-          const out = await apiJson<{ success?: boolean; data?: Insumo[] }>(`/insumos?${params.toString()}`)
-          if (token !== quickSearchRemoteTokenRef.current) return
-          const items = Array.isArray(out?.data) ? out.data : []
-          if (items.length) upsertInsumosCache(items)
-          setQuickSearchRemote(items)
-        } catch (e: any) {
-          if (token !== quickSearchRemoteTokenRef.current) return
-          const message = e?.message || 'Falha ao buscar insumos.'
-          setQuickSearchRemoteError(message)
-          setQuickSearchRemote([])
-          console.warn('[insumos][quick-search]', {
-            unit: ctxUnidade,
-            query,
-            status: e?.status || 0,
-            code: e?.code || null
-          })
-        } finally {
-          if (token === quickSearchRemoteTokenRef.current) setQuickSearchRemoteLoading(false)
-        }
-      })()
-    }, 250)
-    return () => window.clearTimeout(t)
-  }, [apiJson, canUseApi, isAuthed, quickOp, quickSearch, transferFrom, unidade, upsertInsumosCache])
-
-  React.useEffect(() => {
-    const query = quickSearch.trim()
-    const hasSelection = !!quickSelectedSnapshot || quickLookupItems.length > 0
-    if (!query) {
-      if (!hasSelection && quickCodigo) setQuickCodigo('')
-      return
-    }
-    if (query === quickCodigo) return
-    const looksLikeCode = /^[0-9]{4,}$/.test(query)
-    if (looksLikeCode) {
-      if (query !== quickCodigo) {
-        setQuickSelectedSnapshot(null)
-        setQuickCodigo(query)
-      }
-      return
-    }
-    if (!hasSelection && quickCodigo) setQuickCodigo('')
-  }, [quickSearch, quickCodigo, quickLookupItems.length, quickSelectedSnapshot])
-
-  React.useEffect(() => {
-    if (quickCodigo) return
-    const selected = quickLookupItems[0] || quickSelectedSnapshot
-    if (!selected) return
-    const codes = getInsumoBarcodes(selected)
-    if (!codes.length) return
-    setQuickCodigo(codes[0])
-  }, [quickCodigo, quickLookupItems, quickSelectedSnapshot])
-
-  const quickLoteNeedsPick = (quickCandidates.length > 1) || (quickRegistros.length > 1) || (quickLotes.length > 1)
-  const quickLotesForPicker = React.useMemo(() => {
-    if (quickCandidates.length) return quickCandidates
-    if (quickRegistros.length) {
-      const set = new Set(quickRegistros)
-      const filtered = quickLotes.filter((l) => set.has(l.registro))
-      if (filtered.length) return filtered
-      return quickRegistros.map((registro) => ({ registro, lote: '', dataValidade: null as any, estoque: 0 }))
-    }
-    return quickLotes
-  }, [quickCandidates, quickLotes, quickRegistros.join('|')])
-
-  const resetQuickOperationState = React.useCallback((opts?: { keepFeedback?: boolean }) => {
-    setQuickSearch('')
-    setQuickCodigo('')
-    setQuickSelectedSnapshot(null)
-    setQuickRegistro('')
-    setQuickRegistros([])
-    setQuickCandidates([])
-    setQuickAutoFefo(true)
-    setQuickQuantidade('1')
-    setQuickNovoEstoque('')
-    setQuickObs('')
-    setQuickMotivo('Ajuste manual')
-    setQuickScanOpen(false)
-    setQuickLookupLoading(false)
-    setQuickLookupError(null)
-    setQuickLookupCtxUnidade(null)
-    setQuickLookupCode(null)
-    setQuickLookupItems([])
-    setQuickSearchRemote([])
-    setQuickSearchRemoteLoading(false)
-    setQuickSearchRemoteError(null)
-    setQuickActionLoading(false)
-    if (!opts?.keepFeedback) setQuickActionFeedback(null)
-  }, [])
-
-  const openQuickOperation = React.useCallback(
-    (
-      op: 'ENTRADA' | 'BAIXA' | 'TRANSFERENCIA',
-      prefill?: {
-        codigoBarras?: string | null
-        quantidade?: number | string | null
-        obs?: string | null
-        fromUnidade?: string | null
-        toUnidade?: string | null
-      }
-    ) => {
-      resetQuickOperationState()
-      if (prefill?.codigoBarras) {
-        const code = String(prefill.codigoBarras).trim()
-        selectQuickCodigo(code, { setSearch: true, snapshot: null })
-      }
-      if (prefill?.quantidade != null) setQuickQuantidade(String(prefill.quantidade))
-      if (prefill?.obs) setQuickObs(String(prefill.obs))
-      if (prefill?.fromUnidade) setTransferFrom(String(prefill.fromUnidade))
-      if (prefill?.toUnidade) setTransferTo(String(prefill.toUnidade))
-      setQuickOp(op)
-    },
-    [resetQuickOperationState, selectQuickCodigo]
-  )
-
-  React.useEffect(() => {
-    if (!quickOp) return
-    setQuickRegistros([])
-    setQuickCandidates([])
-    setQuickRegistro('')
-  }, [quickOp])
-
-  React.useEffect(() => {
-    if (!quickOp) return
-    setQuickRegistros([])
-    setQuickCandidates([])
-    setQuickRegistro('')
-  }, [quickCodigo])
-
   const lookupInsumosByCodigo = React.useCallback(
     async ({ codigoBarras, ctxUnidade }: { codigoBarras: string; ctxUnidade: string }) => {
       const codigo = String(codigoBarras || '').trim()
@@ -2510,136 +1319,156 @@ export function InsumosModule() {
     [apiJson, readCachedInsumosByCodigo, upsertInsumosCache]
   )
 
+  const {
+    applyQuickSelection,
+    clearQuickSelection,
+    hasQuickSelection,
+    quickLoteNeedsPick,
+    quickLotesForPicker,
+    quickSearchMatches,
+    selectQuickCodigo,
+  } = useInsumosQuickLookupController({
+    apiJson,
+    canUseApi,
+    insumos,
+    isAuthed,
+    isSameInsumo,
+    lookupInsumosByCodigo,
+    normalizeText,
+    quickCandidates,
+    quickCodigo,
+    quickLookupCode,
+    quickLookupCtxUnidade,
+    quickLookupItems,
+    quickLotes,
+    quickOp,
+    quickRegistros,
+    quickSearch,
+    quickSearchRemote,
+    quickSearchRemoteError,
+    quickSearchRemoteLoading,
+    quickSelectedSnapshot,
+    readCachedInsumosByCodigo,
+    transferFrom,
+    unidade,
+    upsertInsumosCache,
+    setQuickCandidates,
+    setQuickCodigo,
+    setQuickLookupCode,
+    setQuickLookupCtxUnidade,
+    setQuickLookupError,
+    setQuickLookupItems,
+    setQuickLookupLoading,
+    setQuickRegistros,
+    setQuickRegistro,
+    setQuickSearch,
+    setQuickSearchRemote,
+    setQuickSearchRemoteError,
+    setQuickSearchRemoteLoading,
+    setQuickSelectedSnapshot,
+  })
+
+  const resetQuickOperationState = React.useCallback((opts?: { keepFeedback?: boolean }) => {
+    setQuickSearch('')
+    setQuickCodigo('')
+    setQuickSelectedSnapshot(null)
+    setQuickRegistro('')
+    setQuickRegistros([])
+    setQuickCandidates([])
+    setQuickAutoFefo(true)
+    setQuickQuantidade('1')
+    setQuickNovoEstoque('')
+    setQuickObs('')
+    setQuickMotivo('Ajuste manual')
+    setQuickScanOpen(false)
+    setQuickLookupLoading(false)
+    setQuickLookupError(null)
+    setQuickLookupCtxUnidade(null)
+    setQuickLookupCode(null)
+    setQuickLookupItems([])
+    setQuickSearchRemote([])
+    setQuickSearchRemoteLoading(false)
+    setQuickSearchRemoteError(null)
+    setQuickActionLoading(false)
+    if (!opts?.keepFeedback) setQuickActionFeedback(null)
+  }, [])
+
+  const openQuickOperation = React.useCallback(
+    (
+      op: InsumosQuickOperation,
+      prefill?: {
+        codigoBarras?: string | null
+        quantidade?: number | string | null
+        obs?: string | null
+        fromUnidade?: string | null
+        toUnidade?: string | null
+      }
+    ) => {
+      resetQuickOperationState()
+      if (prefill?.codigoBarras) {
+        const code = String(prefill.codigoBarras).trim()
+        selectQuickCodigo(code, { setSearch: true, snapshot: null })
+      }
+      if (prefill?.quantidade != null) setQuickQuantidade(String(prefill.quantidade))
+      if (prefill?.obs) setQuickObs(String(prefill.obs))
+      if (prefill?.fromUnidade) setTransferFrom(String(prefill.fromUnidade))
+      if (prefill?.toUnidade) setTransferTo(String(prefill.toUnidade))
+      setQuickOp(op)
+    },
+    [resetQuickOperationState, selectQuickCodigo]
+  )
+
   React.useEffect(() => {
     if (!quickOp) return
-    if (!canUseApi || !isAuthed) return
-    const codigo = quickCodigo.trim()
-    if (!codigo) {
-      setQuickLookupLoading(false)
-      setQuickLookupError(null)
-      setQuickLookupItems([])
-      setQuickLookupCode(null)
-      setQuickLookupCtxUnidade(null)
-      return
-    }
-    const ctxUnidade = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
-    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
-    if (cached.length) {
-      setQuickLookupLoading(false)
-      setQuickLookupError(null)
-      setQuickLookupItems(cached)
-      setQuickLookupCode(codigo)
-      setQuickLookupCtxUnidade(ctxUnidade)
-      return
-    }
-    const token = ++quickLookupTokenRef.current
-    setQuickLookupLoading(true)
-    setQuickLookupError(null)
-    const t = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const items = await lookupInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
-          if (token !== quickLookupTokenRef.current) return
-          setQuickLookupItems(items)
-          setQuickLookupCode(codigo)
-          setQuickLookupCtxUnidade(ctxUnidade)
-          if (!items.length) setQuickLookupError('Nenhum insumo encontrado para este código.')
-        } catch (e: any) {
-          if (token !== quickLookupTokenRef.current) return
-          setQuickLookupError(e?.message || 'Falha ao buscar o insumo.')
-          setQuickLookupItems([])
-          setQuickLookupCode(codigo)
-          setQuickLookupCtxUnidade(ctxUnidade)
-          console.warn('[insumos][quick-lookup]', {
-            unit: ctxUnidade,
-            codigo,
-            status: e?.status || 0,
-            code: e?.code || null
-          })
-        } finally {
-	          if (token === quickLookupTokenRef.current) setQuickLookupLoading(false)
-	        }
-	      })()
-	    }, 250)
+    setQuickRegistros([])
+    setQuickCandidates([])
+    setQuickRegistro('')
+  }, [quickOp])
 
-    return () => window.clearTimeout(t)
-  }, [canUseApi, isAuthed, lookupInsumosByCodigo, quickCodigo, quickOp, readCachedInsumosByCodigo, transferFrom, unidade])
+  React.useEffect(() => {
+    if (!quickOp) return
+    setQuickRegistros([])
+    setQuickCandidates([])
+    setQuickRegistro('')
+  }, [quickCodigo])
 
-  const createLookupApplyPrefill = React.useCallback((items: Insumo[]) => {
-    const it = Array.isArray(items) && items.length ? items[0] : null
-    if (!it) return
-    if (!createProduto.trim() && it.produto) setCreateProduto(String(it.produto))
-    if (!createCategoria.trim() && it.categoria) setCreateCategoria(String(it.categoria))
-    if (!createMarca.trim() && it.marca) setCreateMarca(String(it.marca))
-    if (!createTipoUnidade.trim() && it.tipoUnidade) setCreateTipoUnidade(normalizeTipoUnidadeToCanonical(String(it.tipoUnidade)) || '')
-    if (!createEspecificacao.trim() && (it as any).especificacao) setCreateEspecificacao(String((it as any).especificacao))
-    if (!createConcentracao.trim() && (it as any).concentracao) setCreateConcentracao(String((it as any).concentracao))
-    if (!createVolume.trim() && (it as any).volume) setCreateVolume(String((it as any).volume))
-    if (!createHomologado && /homologad/i.test(String((it as any).fonte || '').trim())) setCreateHomologado(true)
-    if (!createCalibre.trim() && (it as any).calibre) setCreateCalibre(String((it as any).calibre))
-    if (!createPrecoCusto.trim() && (it as any).precoCusto) setCreatePrecoCusto(String((it as any).precoCusto))
-    if (!createPolicyTouched) {
-      const policy = getPolicyForItem(it)
-      setCreateCategoriaRequiresLot(!!policy.requiresLot)
-      setCreateCategoriaRequiresExpiry(!!policy.requiresExpiry)
-      setCreateCategoriaFefo(!!policy.fefo)
-    }
-  }, [
+  useInsumosCreateLookupController({
+    canUseApi,
     createCalibre,
     createCategoria,
+    createCodigo,
     createConcentracao,
     createEspecificacao,
     createHomologado,
     createMarca,
+    createOpen,
     createPolicyTouched,
     createPrecoCusto,
     createProduto,
     createTipoUnidade,
     createVolume,
     getPolicyForItem,
-    normalizeTipoUnidadeToCanonical
-  ])
-
-  React.useEffect(() => {
-    if (!createOpen) return
-    if (!canUseApi || !isAuthed) return
-    const codigo = createCodigo.trim()
-    if (!codigo) {
-      setCreateLookupLoading(false)
-      setCreateLookupError(null)
-      setCreateLookupItems([])
-      return
-    }
-    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade: unidade })
-    if (cached.length) {
-      setCreateLookupLoading(false)
-      setCreateLookupError(null)
-      setCreateLookupItems(cached)
-      createLookupApplyPrefill(cached)
-      return
-    }
-    const token = ++createLookupTokenRef.current
-    setCreateLookupLoading(true)
-    setCreateLookupError(null)
-    const t = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const items = await lookupInsumosByCodigo({ codigoBarras: codigo, ctxUnidade: unidade })
-          if (token !== createLookupTokenRef.current) return
-          setCreateLookupItems(items)
-          if (!items.length) setCreateLookupError('Nenhum insumo encontrado para este código.')
-          createLookupApplyPrefill(items)
-	        } catch (e: any) {
-	          if (token !== createLookupTokenRef.current) return
-	          setCreateLookupError(e?.message || 'Falha ao buscar o insumo.')
-	          setCreateLookupItems([])
-	        } finally {
-	          if (token === createLookupTokenRef.current) setCreateLookupLoading(false)
-	        }
-	      })()
-	    }, 250)
-    return () => window.clearTimeout(t)
-  }, [canUseApi, createCodigo, createLookupApplyPrefill, createOpen, isAuthed, lookupInsumosByCodigo, readCachedInsumosByCodigo, unidade])
+    isAuthed,
+    lookupInsumosByCodigo,
+    readCachedInsumosByCodigo,
+    unidade,
+    setCreateCalibre,
+    setCreateCategoria,
+    setCreateCategoriaFefo,
+    setCreateCategoriaRequiresExpiry,
+    setCreateCategoriaRequiresLot,
+    setCreateConcentracao,
+    setCreateEspecificacao,
+    setCreateHomologado,
+    setCreateLookupError,
+    setCreateLookupItems,
+    setCreateLookupLoading,
+    setCreateMarca,
+    setCreatePrecoCusto,
+    setCreateProduto,
+    setCreateTipoUnidade,
+    setCreateVolume,
+  })
 
   React.useEffect(() => {
     if (!quickOp) return
@@ -2875,6 +1704,7 @@ export function InsumosModule() {
       if (wantsQuickAction) {
         if (actionLabel === 'Entrada') openQuickOperation('ENTRADA')
         else if (actionLabel === 'Saída') openQuickOperation('BAIXA')
+        else if (actionLabel === 'Ajuste') openQuickOperation('AJUSTE')
         else if (actionLabel === 'Transferência') openQuickOperation('TRANSFERENCIA')
         setTimeout(() => {
           window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -2984,60 +1814,6 @@ export function InsumosModule() {
 	      setCreateEspecificacao((prev) => (prev ? prev : filesSummary))
 	    }
 	  }, [])
-
-  React.useEffect(() => {
-    try {
-      window.localStorage.setItem(INSUMOS_UNIT_KEY, unidade)
-    } catch {
-      // ignore
-    }
-  }, [INSUMOS_UNIT_KEY, unidade])
-
-  React.useEffect(() => {
-    const onUnit = (evt: Event) => {
-      const next = String((evt as any)?.detail?.unidade || '').trim()
-      if (!next) return
-      setUnidade(next)
-    }
-    window.addEventListener('skincos:insumos:unidade', onUnit as any)
-    return () => window.removeEventListener('skincos:insumos:unidade', onUnit as any)
-  }, [])
-
-  React.useEffect(() => {
-    if (!allowedUnits.length) return
-    if (allowedUnits.includes(unidade)) return
-    const next = allowedUnits[0]
-    setUnidade(next)
-    try {
-      window.localStorage.setItem(INSUMOS_UNIT_KEY, next)
-    } catch {
-      // ignore
-    }
-    try {
-      window.dispatchEvent(new CustomEvent('skincos:insumos:unidade', { detail: { unidade: next } }))
-    } catch {
-      // ignore
-    }
-  }, [allowedUnits.join('|'), unidade])
-
-  React.useEffect(() => {
-    const allowed = allUnidades || []
-    if (!allowed.length) return
-    if (allowed.includes(unidade)) return
-    const next = allowed[0]
-    if (!next) return
-    setUnidade(next)
-    try {
-      window.localStorage.setItem(INSUMOS_UNIT_KEY, next)
-    } catch {
-      // ignore
-    }
-    try {
-      window.dispatchEvent(new CustomEvent('skincos:insumos:unidade', { detail: { unidade: next } }))
-    } catch {
-      // ignore
-    }
-  }, [INSUMOS_UNIT_KEY, allUnidades.join('|'), unidade])
 
   React.useEffect(() => {
     setTransferFrom(unidade)
@@ -3725,598 +2501,12 @@ export function InsumosModule() {
     if (el.scrollHeight <= el.clientHeight + 80) loadMoreInsumos()
   }, [insumosHasMore, insumosLoading, insumos.length, loadMoreInsumos, insumosListModalOpen])
 
-  const loadMovimentacoes = React.useCallback(async () => {
-    if (!canUseApi || !isAuthed) return
-    setMovLoading(true)
-    try {
-      const limite = 200
-      let pagina = 1
-      let merged: Movimentacao[] = []
-      let totalOut: number | null = null
-      while (true) {
-        const params = new URLSearchParams()
-        params.set('unidade', unidade)
-        params.set('limite', String(limite))
-        params.set('pagina', String(pagina))
-        if (movTipo !== 'TODOS') params.set('tipo', movTipo)
-        const codigo = selectedCodigoBarras.trim()
-        if (codigo) params.set('codigoBarras', codigo)
-        const deIso = dateInputToIso(movDe)
-        const ateIso = dateInputToIso(movAte)
-        if (deIso) params.set('de', deIso)
-        if (ateIso) params.set('ate', ateIso)
-        const out = await apiJson<{ success?: boolean; data?: Movimentacao[]; movimentos?: Movimentacao[]; resumo?: any }>(
-          `/movimentacoes?${params.toString()}`
-        )
-        const list = (out as any)?.movimentos ?? out?.data
-        const items = Array.isArray(list) ? list : []
-        merged = [...merged, ...items]
-        const total = Number((out as any)?.resumo?.totalMovimentacoes)
-        if (Number.isFinite(total)) totalOut = total
-        if (items.length < limite) break
-        if (totalOut != null && merged.length >= totalOut) break
-        pagina += 1
-      }
-      setMovimentacoes(merged)
-      setMovLoadError(null)
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
-      setMovLoadError({
-        message: e instanceof Error ? e.message : String(e),
-        status: Number((e as any)?.status || 0) || 0,
-        code: (e as any)?.code ? String((e as any).code) : undefined
-      })
-      setMovimentacoes([])
-    } finally {
-      setMovLoaded(true)
-      setMovLoading(false)
-    }
-  }, [canUseApi, isAuthed, movAte, movDe, movTipo, selectedCodigoBarras, unidade])
-
-  React.useEffect(() => {
-    try {
-      movListContainerRef.current?.scrollTo?.({ top: 0 })
-    } catch {
-      // ignore
-    }
-  }, [unidade, movAte, movDe, movTipo, selectedCodigoBarras, movFilterCategoria, movFilterMarca])
-
-  React.useEffect(() => {
-    if (!canUseApi || !isAuthed) return
-    const deIso = movDe.trim() ? dateInputToIso(movDe) : ''
-    const ateIso = movAte.trim() ? dateInputToIso(movAte) : ''
-    if (movDe.trim() && !deIso) return
-    if (movAte.trim() && !ateIso) return
-    const t = window.setTimeout(() => {
-      void loadMovimentacoes()
-    }, 250)
-    return () => window.clearTimeout(t)
-  }, [canUseApi, isAuthed, loadMovimentacoes, movAte, movDe, movTipo, selectedCodigoBarras, unidade])
-
-  const loadOverview = React.useCallback(async (opts?: { force?: boolean; lite?: boolean }) => {
-    if (!canUseApi || !isAuthed) return
-    // If the user triggered analytics loads (or they are visible), unlock subsequent auto-refreshes.
-    setOverviewEverVisible(true)
-    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
-    try {
-      overviewAbortRef.current?.abort()
-    } catch {
-      // ignore
-    }
-    const ac = new AbortController()
-    overviewAbortRef.current = ac
-    setOverviewLoading(true)
-    try {
-      const now = new Date()
-      const yyyyMmDd = (d: Date) => d.toISOString().slice(0, 10)
-      let de = ''
-      let ate = yyyyMmDd(now)
-      let days = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : 365
-      const isLite = opts?.lite !== false
-
-      if (overviewPeriod === 'custom') {
-        const deIso = dateInputToIso(overviewCustomFrom)
-        const ateIso = dateInputToIso(overviewCustomTo)
-        if (deIso && ateIso) {
-          de = deIso
-          ate = ateIso
-          const fromMs = new Date(deIso).getTime()
-          const toMs = new Date(ateIso).getTime()
-          const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
-          days = Math.max(1, Math.min(365, diffDays))
-        }
-      }
-
-      if (!de) {
-        const start = new Date(now)
-        if (overviewPeriod === '7d') start.setDate(start.getDate() - 7)
-        else if (overviewPeriod === '30d') start.setDate(start.getDate() - 30)
-        else start.setFullYear(start.getFullYear() - 1)
-        de = yyyyMmDd(start)
-      }
-
-      const params = new URLSearchParams({
-        unidade,
-        de,
-        ate,
-        days: String(days),
-        limitIssues: '120'
-      })
-      if (isLite) params.set('lite', '1')
-      const out = await apiJson<{ success?: boolean; data?: OverviewBundleData }>(`/analytics/overview?${params.toString()}`, { signal: ac.signal })
-
-      if (overviewAbortRef.current !== ac) return
-      const data = out?.data || null
-      setOverviewResumo(data?.resumo || null)
-      if (Array.isArray(data?.itens)) {
-        setOverviewInsumos(data?.itens as any)
-      } else if (!isLite) {
-        setOverviewInsumos(null)
-      }
-      setOverviewNotifications(data?.notifications || null)
-      setOverviewActionables(data?.actionables || null)
-      setOverviewRoi(data?.roi || null)
-      setOverviewQuality(data?.quality || null)
-      setOverviewMovResumo((data?.movResumo as any) || null)
-      setOverviewMovSeries(
-        Array.isArray(data?.movSeries)
-          ? data.movSeries
-              .map((item) => ({
-                day: String(item?.day || ''),
-                entrada: Number(item?.entrada ?? 0) || 0,
-                saida: Number(item?.saida ?? 0) || 0,
-                entradaValor: Number.isFinite(Number(item?.entradaValor)) ? Number(item?.entradaValor) : undefined,
-                saidaValor: Number.isFinite(Number(item?.saidaValor)) ? Number(item?.saidaValor) : undefined
-              }))
-              .filter((item) => item.day)
-          : []
-      )
-    } catch (e) {
-      if ((e as any)?.name === 'AbortError') return
-      if (overviewAbortRef.current !== ac) return
-      markAutoSyncFailure(e)
-      toast.error(e instanceof Error ? e.message : String(e))
-      setOverviewResumo(null)
-      setOverviewNotifications(null)
-      setOverviewActionables(null)
-      setOverviewRoi(null)
-      setOverviewQuality(null)
-      setOverviewMovResumo(null)
-      setOverviewMovSeries([])
-    } finally {
-      if (overviewAbortRef.current === ac) {
-        setOverviewLoaded(true)
-        setOverviewLoading(false)
-        overviewAbortRef.current = null
-      }
-    }
-  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, overviewCustomFrom, overviewCustomTo, overviewPeriod, unidade])
-
-  React.useEffect(() => {
-    if (!canUseApi || !isAuthed) return
-    if (!chartsPanelVisible || !chartsPanelOpen) return
-    if (overviewInsumos && overviewInsumos.length) return
-    if (overviewLoading) return
-    if (autoSyncSuspendedUntil > Date.now()) return
-    const now = Date.now()
-    if (now - overviewFullAttemptRef.current < 15_000) return
-    overviewFullAttemptRef.current = now
-    void loadOverview({ force: true, lite: false })
-  }, [
-    autoSyncSuspendedUntil,
-    canUseApi,
-    chartsPanelOpen,
-    chartsPanelVisible,
-    isAuthed,
-    loadOverview,
-    overviewInsumos,
-    overviewLoading
-  ])
-
-  const saveLot = React.useCallback(async () => {
-    if (!lotSelecionado?.registro) {
-      toast.error('Registro do insumo ausente.')
-      return
-    }
-    if (!canUseApi || !isAuthed) return
-    setLotSaving(true)
-    try {
-      const dataValidade = dateInputToIso(lotEditValidade)
-      await mutateJson<{ success?: boolean }>(`/insumos/${encodeURIComponent(lotSelecionado.registro)}?unidade=${encodeURIComponent(unidade)}`, {
-        method: 'PUT',
-        body: { lote: lotEditLote.trim(), dataValidade },
-        queueLabel: 'Atualização de lote/validade'
-      })
-      toast.success('Lote/validade atualizados.')
-      setLotDialogOpen(false)
-      await Promise.allSettled([refreshInsumos(), loadOverview({ force: true })])
-    } catch (e) {
-      if (policyErrorToast(e)) return
-      toast.error(e instanceof Error ? e.message : String(e))
-    } finally {
-      setLotSaving(false)
-    }
-  }, [canUseApi, isAuthed, loadOverview, lotEditLote, lotEditValidade, lotSelecionado?.registro, mutateJson, refreshInsumos, unidade])
-
-  const saveEdit = React.useCallback(async () => {
-    const registro = String(editTarget?.registro || '').trim()
-    if (!registro) {
-      setEditSaveError('Registro do insumo ausente.')
-      toast.error('Registro do insumo ausente.')
-      return
-    }
-    if (!isAuthed) {
-      setEditSaveError('Nao autenticado.')
-      toast.error('Nao autenticado.')
-      return
-    }
-    if (!canUseApi) {
-      setEditSaveError('API indisponivel ou nao pronta. Aguarde carregar e tente novamente.')
-      toast.error('API indisponivel ou nao pronta. Aguarde carregar e tente novamente.')
-      return
-    }
-    const codigoBarras = editCodigo.trim()
-    const extraCodes = parseBarcodeInput(editCodigosExtras)
-    const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
-    const produto = editProduto.trim()
-    if (!codigoBarras) {
-      setEditValidationErrors({ codigoBarras: 'Obrigatorio.' })
-      setEditSaveError('Informe o código de barras para salvar.')
-      return toast.error('Informe o código de barras')
-    }
-    if (!produto) {
-      setEditValidationErrors({ produto: 'Obrigatorio.' })
-      setEditSaveError('Informe o produto para salvar.')
-      return toast.error('Informe o produto')
-    }
-
-    setEditSaving(true)
-    try {
-      setEditSaveError(null)
-      setEditValidationErrors({})
-      const categoria = editCategoria.trim()
-      const policy = {
-        requiresLot: !!editCategoriaRequiresLot,
-        requiresExpiry: !!editCategoriaRequiresExpiry,
-        fefo: !!editCategoriaFefo
-      }
-      const lote = editLote.trim()
-      const dataValidade = dateInputToIso(editDataValidade)
-      const tipoUnidade = normalizeTipoUnidadeToCanonical(editTipoUnidade)
-
-      if (!tipoUnidade) {
-        setEditValidationErrors({ tipoUnidade: 'Selecione a unidade (medida).' })
-        setEditSaveError('Informe a unidade (medida) para salvar.')
-        toast.error('Informe a unidade (medida) para salvar.')
-        return
-      }
-
-      if (policy.fefo && !policy.requiresExpiry) {
-        setEditValidationErrors({ policy: 'FEFO exige validade obrigatoria.' })
-        setEditSaveError('FEFO exige validade obrigatoria.')
-        toast.error('FEFO exige validade obrigatória')
-        return
-      }
-      if (policy.requiresLot && !lote) {
-        setEditValidationErrors({
-          policy: 'Lote obrigatorio pela politica.',
-          lote: 'Obrigatorio (pela politica do item).'
-        })
-        setEditSaveError('Este item exige Lote. Preencha o campo lote para salvar.')
-        toast.error('Este item exige Lote. Preencha o campo lote para salvar.')
-        return
-      }
-      if (policy.requiresExpiry && !dataValidade) {
-        setEditValidationErrors({
-          policy: 'Validade obrigatoria pela politica.',
-          dataValidade: 'Obrigatorio (pela politica do item).'
-        })
-        setEditSaveError('Este item exige Data de validade. Preencha o campo validade para salvar.')
-        toast.error('Este item exige Data de validade. Preencha o campo validade para salvar.')
-        return
-      }
-
-      await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
-        method: 'PUT',
-        queueLabel: 'Edição de insumo',
-        body: {
-          codigoBarras,
-          codigosBarras,
-          produto,
-          categoria,
-          marca: editMarca.trim(),
-          tipoUnidade,
-          especificacao: editEspecificacao.trim(),
-          concentracao: editConcentracao.trim(),
-          volume: editVolume.trim(),
-          fonte: editHomologado ? 'Homologado' : '',
-          calibre: editCalibre.trim(),
-          precoCusto: editPrecoCusto.trim(),
-          estoqueMinimo: Number(editEstoqueMinimo) || 0,
-          lote,
-          dataValidade,
-          policyRequiresLot: policy.requiresLot,
-          policyRequiresExpiry: policy.requiresExpiry,
-          policyFefo: policy.fefo
-        }
-      })
-      toast.success('Insumo atualizado')
-      setEditOpen(false)
-      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
-    } catch (e) {
-      const policyCode = getPolicyErrorCode(e)
-      if (policyCode) {
-        setEditSaveError(e instanceof Error ? e.message : String(e))
-        policyErrorToast(e)
-        if (policyCode === 'POLICY_REQUIRES_LOT') {
-          setEditValidationErrors({
-            policy: 'Lote obrigatorio pela politica.',
-            lote: 'Obrigatorio (pela politica do item).'
-          })
-        } else {
-          setEditValidationErrors({
-            policy: 'Validade obrigatoria pela politica.',
-            dataValidade: 'Obrigatorio (pela politica do item).'
-          })
-        }
-        return
-      }
-      setEditSaveError(e instanceof Error ? e.message : String(e))
-      toast.error(e instanceof Error ? e.message : String(e))
-    } finally {
-      setEditSaving(false)
-    }
-  }, [
-    canUseApi,
-    clearEditValidationError,
-    editCalibre,
-    editCategoria,
-    editCategoriaFefo,
-    editCategoriaRequiresExpiry,
-    editCategoriaRequiresLot,
-    editCodigo,
-    editConcentracao,
-    editDataValidade,
-    editEspecificacao,
-    editEstoqueMinimo,
-    editHomologado,
-    editLote,
-    editMarca,
-    editPrecoCusto,
-    editProduto,
-    editTarget?.registro,
-    editTipoUnidade,
-    editVolume,
-    isAuthed,
-    loadInsumosOptions,
-    loadOverview,
-    mutateJson,
-    refreshInsumos,
-    getPolicyErrorCode,
-    unidade
-  ])
-
-  const deleteEdit = React.useCallback(async () => {
-    const registro = String(editTarget?.registro || '').trim()
-    if (!registro) return
-    if (!canUseApi || !isAuthed) return
-    if (!window.confirm('Excluir este insumo? Esta ação não pode ser desfeita.')) return
-    setEditSaving(true)
-    try {
-      await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
-        method: 'DELETE',
-        queueLabel: 'Exclusão de insumo'
-      })
-      toast.success('Insumo excluído')
-      setEditOpen(false)
-      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
-    } finally {
-      setEditSaving(false)
-    }
-  }, [canUseApi, editTarget?.registro, isAuthed, loadInsumosOptions, loadOverview, mutateJson, refreshInsumos, unidade])
-
-  const deleteInsumoByRegistro = React.useCallback(
-    async (registroRaw: string) => {
-      const registro = String(registroRaw || '').trim()
-      if (!registro || !canUseApi || !isAuthed) return
-      if (!window.confirm('Excluir este insumo? Esta ação não pode ser desfeita.')) return
-      setQualityMatchesSavingRegistro(registro)
-      try {
-        await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
-          method: 'DELETE',
-          queueLabel: 'Exclusão de insumo'
-        })
-        toast.success('Insumo excluído')
-        setQualityMatchesItems((prev) => prev.filter((it) => String(it?.registro || '').trim() !== registro))
-        await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
-      } catch (e) {
-        toast.error(e instanceof Error ? e.message : String(e))
-      } finally {
-        setQualityMatchesSavingRegistro('')
-      }
-    },
-    [canUseApi, isAuthed, loadInsumosOptions, loadOverview, mutateJson, refreshInsumos, unidade]
-  )
-
-  const loadInsights = React.useCallback(async (opts?: { force?: boolean }) => {
-    if (!canUseApi || !isAuthed) return
-    // If the user triggered analytics loads (or they are visible), unlock subsequent auto-refreshes.
-    setOverviewEverVisible(true)
-    if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
-    try {
-      insightsAbortRef.current?.abort()
-    } catch {
-      // ignore
-    }
-    const ac = new AbortController()
-    insightsAbortRef.current = ac
-    setInsightsLoading(true)
-    try {
-      const params = new URLSearchParams()
-      params.set('unidade', unidade)
-      params.set('groupBy', 'day')
-
-      let days = overviewPeriod === '7d' ? 7 : overviewPeriod === '30d' ? 30 : 365
-      const customFromIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomFrom) : ''
-      const customToIso = overviewPeriod === 'custom' ? dateInputToIso(overviewCustomTo) : ''
-      if (overviewPeriod === 'custom' && customFromIso && customToIso) {
-        const fromMs = new Date(customFromIso).getTime()
-        const toMs = new Date(customToIso).getTime()
-        const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
-        days = Math.max(1, Math.min(365, diffDays))
-        params.set('from', customFromIso)
-        params.set('to', customToIso)
-      }
-      params.set('days', String(days))
-
-      const out = await apiJson<{ success?: boolean; data?: InsightsBundleData }>(`/analytics/insights?${params.toString()}`, { signal: ac.signal })
-      if (insightsAbortRef.current !== ac) return
-      const data = out?.data || null
-      setInsightsAlertas(Array.isArray(data?.alertas) ? data.alertas : [])
-      setInsightsTrends(data?.trends || null)
-      setInsightsTurnover(data?.turnover || null)
-    } catch (e) {
-      if ((e as any)?.name === 'AbortError') return
-      if (insightsAbortRef.current !== ac) return
-      markAutoSyncFailure(e)
-      toast.error(e instanceof Error ? e.message : String(e))
-      setInsightsAlertas([])
-      setInsightsTrends(null)
-      setInsightsTurnover(null)
-    } finally {
-      if (insightsAbortRef.current === ac) {
-        setInsightsLoaded(true)
-        setInsightsLoading(false)
-        insightsAbortRef.current = null
-      }
-    }
-  }, [autoSyncSuspendedUntil, canUseApi, isAuthed, markAutoSyncFailure, overviewCustomFrom, overviewCustomTo, overviewPeriod, unidade])
-
-  const postMutationRefreshTimerRef = React.useRef<number | null>(null)
-	  const schedulePostMutationRefresh = React.useCallback(
-	    (opts?: { overview?: boolean; insights?: boolean }) => {
-	      const wantsOverview = opts?.overview !== false
-	      const wantsInsights = opts?.insights !== false
-	      if (!wantsOverview && !wantsInsights) return
-	      if (autoSyncSuspendedUntil > Date.now()) return
-
-	      if (postMutationRefreshTimerRef.current) {
-	        window.clearTimeout(postMutationRefreshTimerRef.current)
-	        postMutationRefreshTimerRef.current = null
-	      }
-
-      postMutationRefreshTimerRef.current = window.setTimeout(() => {
-        const isOverviewVisible = (() => {
-          try {
-            const el = overviewSectionRef.current
-            if (!el) return true
-            const rect = el.getBoundingClientRect()
-            const vh = window.innerHeight || 0
-            if (!vh) return true
-            const topOk = rect.top < vh * 0.85
-            const bottomOk = rect.bottom > vh * 0.15
-            return topOk && bottomOk
-          } catch {
-            return true
-          }
-        })()
-
-        const tasks: Promise<any>[] = []
-        if (wantsOverview && overviewLoaded && isOverviewVisible) tasks.push(Promise.resolve(loadOverview()))
-        if (wantsInsights && insightsLoaded && isOverviewVisible) tasks.push(Promise.resolve(loadInsights()))
-	        if (tasks.length) void Promise.allSettled(tasks)
-	      }, 2500)
-	    },
-	    [autoSyncSuspendedUntil, insightsLoaded, loadInsights, loadOverview, overviewLoaded]
-	  )
-
-  const saveMovementEdit = React.useCallback(async () => {
-    const target = editMovTarget
-    const movementId = String(target?.id || '').trim()
-    if (!movementId) {
-      toast.error('Movimentação inválida.')
-      return
-    }
-    if (!canUseApi || !isAuthed) return
-
-    const tipo = normalizeMovimentacaoTipo(target?.tipo)
-    const produto = editMovProduto.trim()
-    if (!produto) {
-      toast.error('Informe o produto.')
-      return
-    }
-    const dataHora = combineLocalDateTimeToIso(editMovData, editMovHora)
-    if (!dataHora) {
-      toast.error('Informe uma data e hora válidas.')
-      return
-    }
-    const body: Record<string, unknown> = {
-      produto,
-      dataHora,
-      observacoes: editMovObservacoes.trim()
-    }
-
-    if (!String(target?.transferId || '').trim()) {
-      const nextUnidade = String(editMovUnidade || '').trim()
-      if (!nextUnidade) {
-        toast.error('Informe a unidade.')
-        return
-      }
-      body.unidade = nextUnidade
-    }
-
-    if (String(target?.transferId || '').trim()) {
-      const quantidade = parseInt(editMovQuantidade, 10)
-      if (!Number.isFinite(quantidade) || quantidade < 1) {
-        toast.error('Informe uma quantidade válida.')
-        return
-      }
-      body.quantidade = quantidade
-    } else if (tipo === 'AJUSTE') {
-      const estoqueNovo = parseInt(editMovNovoEstoque, 10)
-      if (!Number.isFinite(estoqueNovo) || estoqueNovo < 0) {
-        toast.error('Informe o novo estoque.')
-        return
-      }
-      const motivo = editMovMotivo.trim()
-      if (!motivo) {
-        toast.error('Informe o motivo do ajuste.')
-        return
-      }
-      body.estoqueNovo = estoqueNovo
-      body.motivo = motivo
-    } else {
-      const quantidade = parseInt(editMovQuantidade, 10)
-      if (!Number.isFinite(quantidade) || quantidade < 1) {
-        toast.error('Informe uma quantidade válida.')
-        return
-      }
-      body.quantidade = quantidade
-    }
-
-    setEditMovSaving(true)
-    try {
-      await mutateJson<{ success?: boolean }>(
-        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(String(target?.unidade || unidade || '').trim() || unidade)}`,
-        {
-          method: 'PUT',
-          body,
-          queueLabel: 'Edição de movimentação'
-        }
-      )
-      toast.success('Lançamento atualizado.')
-      setEditMovOpen(false)
-      setEditMovTarget(null)
-      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
-      schedulePostMutationRefresh({ overview: true, insights: true })
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
-    } finally {
-      setEditMovSaving(false)
-    }
-  }, [
+  const {
+    deleteMovementEdit,
+    loadMovimentacoes,
+    saveMovementEdit,
+  } = useInsumosMovementsController({
+    apiJson,
     canUseApi,
     editMovData,
     editMovHora,
@@ -4328,370 +2518,184 @@ export function InsumosModule() {
     editMovTarget,
     editMovUnidade,
     isAuthed,
-    loadMovimentacoes,
+    movAte,
+    movDe,
+    movFilterCategoria,
+    movFilterMarca,
+    movListContainerRef,
+    movTipo,
     mutateJson,
     refreshInsumos,
     schedulePostMutationRefresh,
-    unidade
-  ])
-
-  const deleteMovementEdit = React.useCallback(async () => {
-    const target = editMovTarget
-    const movementId = String(target?.id || '').trim()
-    if (!movementId) {
-      toast.error('Movimentação inválida.')
-      return
-    }
-    if (!canUseApi || !isAuthed) return
-
-    const confirmed = window.confirm('Excluir este lançamento? Essa ação recalcula o estoque do insumo.')
-    if (!confirmed) return
-
-    setEditMovDeleting(true)
-    try {
-      await mutateJson<{ success?: boolean }>(
-        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(String(target?.unidade || unidade || '').trim() || unidade)}`,
-        {
-          method: 'DELETE',
-          queueLabel: 'Exclusão de movimentação'
-        }
-      )
-      toast.success('Lançamento excluído.')
-      setEditMovOpen(false)
-      setEditMovTarget(null)
-      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
-      schedulePostMutationRefresh({ overview: true, insights: true })
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
-    } finally {
-      setEditMovDeleting(false)
-    }
-  }, [
+    selectedCodigoBarras,
+    setEditMovDeleting,
+    setEditMovOpen,
+    setEditMovSaving,
+    setEditMovTarget,
+    setMovLoaded,
+    setMovLoading,
+    setMovLoadError,
+    setMovimentacoes,
+    unidade,
+  })
+  const {
+    deleteEdit,
+    deleteInsumoByRegistro,
+    saveCreateFromModal,
+    saveCreateInline,
+    saveEdit,
+    saveLot,
+  } = useInsumosInventoryMutationsController({
     canUseApi,
-    editMovTarget,
+    createCalibre,
+    createCategoria,
+    createCategoriaFefo,
+    createCategoriaRequiresExpiry,
+    createCategoriaRequiresLot,
+    createCodigo,
+    createCodigosExtras,
+    createConcentracao,
+    createDataValidade,
+    createEspecificacao,
+    createEstoqueInicial,
+    createEstoqueMinimo,
+    createHomologado,
+    createLote,
+    createMarca,
+    createNovoLote,
+    createPrecoCusto,
+    createProduto,
+    createTipoUnidade,
+    createVolume,
+    editCalibre,
+    editCategoria,
+    editCategoriaFefo,
+    editCategoriaRequiresExpiry,
+    editCategoriaRequiresLot,
+    editCodigo,
+    editCodigosExtras,
+    editConcentracao,
+    editDataValidade,
+    editEspecificacao,
+    editEstoqueMinimo,
+    editHomologado,
+    editLote,
+    editMarca,
+    editPrecoCusto,
+    editProduto,
+    editTarget,
+    editTipoUnidade,
+    editVolume,
+    getPolicyErrorCode,
+    insumos,
     isAuthed,
-    loadMovimentacoes,
+    loadInsumosOptions,
+    loadOverview,
+    lotEditLote,
+    lotEditValidade,
+    lotSelecionado,
     mutateJson,
+    policyErrorToast,
     refreshInsumos,
-    schedulePostMutationRefresh,
-    unidade
-  ])
+    setCreateCalibre,
+    setCreateCategoria,
+    setCreateCodigosExtras,
+    setCreateCodigo,
+    setCreateConcentracao,
+    setCreateDataValidade,
+    setCreateEspecificacao,
+    setCreateEstoqueInicial,
+    setCreateEstoqueMinimo,
+    setCreateHomologado,
+    setCreateLoading,
+    setCreateLote,
+    setCreateMarca,
+    setCreateNovoLote,
+    setCreateOpen,
+    setCreatePrecoCusto,
+    setCreateProduto,
+    setCreateTipoUnidade,
+    setCreateVolume,
+    setEditOpen,
+    setEditSaveError,
+    setEditSaving,
+    setEditValidationErrors,
+    setLotDialogOpen,
+    setLotSaving,
+    setQualityMatchesItems,
+    setQualityMatchesSavingRegistro,
+    unidade,
+  })
 
-  const runQuickAction = React.useCallback(
-    async (kind: 'ENTRADA' | 'BAIXA' | 'AJUSTE'): Promise<boolean> => {
-      if (!canUseApi || !isAuthed) return false
-      setQuickActionFeedback(null)
-      const codigoBarras = quickCodigo.trim()
-      if (!codigoBarras) {
-        const message = 'Informe o código de barras'
-        setQuickActionFeedback({ type: 'error', message })
-        return false
-      }
-
-      setQuickActionLoading(true)
-      try {
-        if (kind === 'AJUSTE') {
-          const novoEstoque = Number.isFinite(Number(quickNovoEstoque)) ? Number(quickNovoEstoque) : null
-          if (novoEstoque === null) {
-            const message = 'Informe o novo estoque'
-            setQuickActionFeedback({ type: 'error', message })
-            return false
-          }
-          const registro = quickRegistro.trim()
-          await mutateJson(`/insumos/ajuste?unidade=${encodeURIComponent(unidade)}`, {
-            method: 'POST',
-            body: { codigoBarras, registro: registro || undefined, novoEstoque, motivo: quickMotivo, observacoes: quickObs },
-            queueLabel: 'Ajuste'
-          })
-          const message = 'Ajuste registrado'
-          setQuickActionFeedback({ type: 'success', message })
-        } else {
-          const quantidade = Math.max(1, parseInt(quickQuantidade, 10) || 0)
-          const path = kind === 'ENTRADA' ? '/insumos/entrada' : '/insumos/baixa'
-          const registro = quickRegistro.trim()
-          if (quickLoteNeedsPick && !registro) {
-            const message = 'Selecione o lote/registro'
-            setQuickActionFeedback({ type: 'error', message })
-            return false
-          }
-          const out = await mutateJson<{ success?: boolean; novoEstoque?: number; quebraEstoque?: boolean; deficit?: number }>(
-            `${path}?unidade=${encodeURIComponent(unidade)}`,
-            {
-              method: 'POST',
-              body: { codigoBarras, registro: registro || undefined, quantidade, observacoes: quickObs },
-              queueLabel: kind === 'ENTRADA' ? 'Entrada' : 'Baixa'
-            }
-          )
-
-          const novoEstoque = Number((out as any)?.novoEstoque)
-          const quebraEstoque = kind === 'BAIXA' && (
-            (out as any)?.quebraEstoque === true ||
-            (Number.isFinite(novoEstoque) && novoEstoque < 0)
-          )
-          const message =
-            quebraEstoque
-              ? `Baixa registrada com quebra de estoque (saldo: ${Number.isFinite(novoEstoque) ? novoEstoque : '-'})`
-              : (kind === 'ENTRADA' ? 'Entrada registrada' : 'Baixa registrada')
-          setQuickActionFeedback({ type: 'success', message })
-          if (quebraEstoque) {
-            const deficit = Number((out as any)?.deficit)
-            toast.warning(
-              `Quebra de estoque detectada${Number.isFinite(deficit) ? `: déficit de ${deficit}` : ''}. Confira os alertas.`
-            )
-          }
-        }
-
-        await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
-        schedulePostMutationRefresh({ overview: true, insights: true })
-        return true
-      } catch (e) {
-        const code = (e as any)?.code
-        const registros = Array.isArray((e as any)?.registros) ? (e as any).registros : []
-        const candidatesRaw = Array.isArray((e as any)?.candidates) ? (e as any).candidates : []
-        if (String(code || '').toUpperCase() === 'AMBIGUOUS') {
-          if (candidatesRaw.length) {
-            const candidates = candidatesRaw
-              .map((c: any) => ({
-                registro: String(c?.registro || '').trim(),
-                lote: String(c?.lote || '').trim(),
-                dataValidade: c?.dataValidade ? String(c.dataValidade) : null,
-                estoque: Number.isFinite(Number(c?.estoque)) ? Number(c.estoque) : 0
-              }))
-              .filter((c: any) => c.registro)
-              .sort((a: any, b: any) => {
-                const sa = (Number(a.estoque) || 0) > 0 ? 0 : 1
-                const sb = (Number(b.estoque) || 0) > 0 ? 0 : 1
-                if (sa !== sb) return sa - sb
-                const da = a?.dataValidade ? new Date(a.dataValidade).getTime() : Number.POSITIVE_INFINITY
-                const db = b?.dataValidade ? new Date(b.dataValidade).getTime() : Number.POSITIVE_INFINITY
-                if (da !== db) return da - db
-                return String(a.registro).localeCompare(String(b.registro))
-              })
-            setQuickCandidates(candidates)
-            setQuickRegistros(candidates.map((c: any) => c.registro))
-          } else {
-            setQuickCandidates([])
-            setQuickRegistros(registros)
-          }
-          const message = 'Este código possui múltiplos lotes. Selecione o lote/registro.'
-          setQuickActionFeedback({ type: 'error', message })
-          return false
-        }
-        if (policyErrorToast(e)) {
-          setQuickActionFeedback({ type: 'error', message: e instanceof Error ? e.message : String(e) })
-          return false
-        }
-        const message = e instanceof Error ? e.message : String(e)
-        setQuickActionFeedback({ type: 'error', message })
-        return false
-      } finally {
-        setQuickActionLoading(false)
-      }
-    },
-    [
-      canUseApi,
-      isAuthed,
-      quickLoteNeedsPick,
-      loadMovimentacoes,
-      mutateJson,
-      quickCodigo,
-      quickMotivo,
-      quickNovoEstoque,
-      quickObs,
-      quickQuantidade,
-      quickRegistro,
-      refreshInsumos,
-      schedulePostMutationRefresh,
-      setQuickActionFeedback,
-      unidade
-    ]
+  const headerStatus = React.useMemo(
+    () => ({
+      online: healthLoaded ? Boolean(health) : null,
+      authed: authLoaded ? isAuthed : null,
+      integrated: healthLoaded
+        ? (typeof health?.ready === 'boolean'
+            ? health.ready
+            : (typeof health?.dbConfigured === 'boolean' ? health.dbConfigured : (health?.ok == null ? null : Boolean(health.ok))))
+        : null,
+      unidades: unidadeOptions,
+      allowedUnits,
+    }),
+    [allowedUnits, authLoaded, health, healthLoaded, isAuthed, unidadeOptions],
   )
 
-  const runTransfer = React.useCallback(async (): Promise<boolean> => {
-    if (!canUseApi || !isAuthed) return false
-    setQuickActionFeedback(null)
-    const codigoBarras = quickCodigo.trim()
-    if (!codigoBarras) {
-      const message = 'Informe o código de barras'
-      setQuickActionFeedback({ type: 'error', message })
-      return false
-    }
+  useInsumosHeaderBridge({
+    allUnidades,
+    allowedUnits,
+    loadInsights,
+    loadOverview,
+    loadingPercent,
+    openQuickOperation,
+    overviewCustomFrom,
+    overviewCustomTo,
+    overviewMovResumo,
+    overviewPeriod,
+    overviewResumo,
+    refreshInsumos,
+    resetUserLayoutPrefs,
+    selectedUnit: unidade,
+    setAllDetailsOpen,
+    setOverviewCustomFrom,
+    setOverviewCustomTo,
+    setOverviewPeriod,
+    setSelectedUnit: setUnidade,
+    showOverviewLoadingProgress,
+    status: headerStatus,
+    storageKey: INSUMOS_UNIT_KEY,
+  })
 
-    if (transferFrom === transferTo) {
-      const message = 'Origem e destino devem ser diferentes'
-      setQuickActionFeedback({ type: 'error', message })
-      return false
-    }
-    const registro = quickRegistro.trim()
-    if (quickLoteNeedsPick && !registro) {
-      const message = 'Selecione o lote/registro'
-      setQuickActionFeedback({ type: 'error', message })
-      return false
-    }
-
-    setQuickActionLoading(true)
-    try {
-      const quantidade = Math.max(1, parseInt(quickQuantidade, 10) || 0)
-      const out = await mutateJson<{
-        success?: boolean
-        estoqueNovoOrigem?: number
-        quebraEstoqueOrigem?: boolean
-        deficitOrigem?: number
-      }>(`/insumos/transferir?unidade=${encodeURIComponent(transferFrom)}`, {
-        method: 'POST',
-        body: {
-          codigoBarras,
-          registro: registro || undefined,
-          quantidade,
-          fromUnidade: transferFrom,
-          toUnidade: transferTo,
-          observacoes: quickObs
-        },
-        queueLabel: 'Transferência'
-      })
-      const novoOrigem = Number((out as any)?.estoqueNovoOrigem)
-      const quebraEstoque = (out as any)?.quebraEstoqueOrigem === true || (Number.isFinite(novoOrigem) && novoOrigem < 0)
-      const message = quebraEstoque
-        ? `Transferência registrada com quebra de estoque (origem: ${Number.isFinite(novoOrigem) ? novoOrigem : '-'})`
-        : 'Transferência registrada'
-      setQuickActionFeedback({ type: 'success', message })
-      if (quebraEstoque) {
-        const deficit = Number((out as any)?.deficitOrigem)
-        toast.warning(
-          `Quebra de estoque detectada na origem${Number.isFinite(deficit) ? `: déficit de ${deficit}` : ''}. Confira os alertas.`
-        )
-      }
-
-      // Refresh what the user is seeing (estoque + movimentações)
-      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
-      schedulePostMutationRefresh({ overview: true, insights: true })
-      return true
-    } catch (e) {
-      const code = (e as any)?.code
-      const registros = Array.isArray((e as any)?.registros) ? (e as any).registros : []
-      const candidatesRaw = Array.isArray((e as any)?.candidates) ? (e as any).candidates : []
-      if (String(code || '').toUpperCase() === 'AMBIGUOUS') {
-        if (candidatesRaw.length) {
-          const candidates = candidatesRaw
-            .map((c: any) => ({
-              registro: String(c?.registro || '').trim(),
-              lote: String(c?.lote || '').trim(),
-              dataValidade: c?.dataValidade ? String(c.dataValidade) : null,
-              estoque: Number.isFinite(Number(c?.estoque)) ? Number(c.estoque) : 0
-            }))
-            .filter((c: any) => c.registro)
-            .sort((a: any, b: any) => {
-              const sa = (Number(a.estoque) || 0) > 0 ? 0 : 1
-              const sb = (Number(b.estoque) || 0) > 0 ? 0 : 1
-              if (sa !== sb) return sa - sb
-              const da = a?.dataValidade ? new Date(a.dataValidade).getTime() : Number.POSITIVE_INFINITY
-              const db = b?.dataValidade ? new Date(b.dataValidade).getTime() : Number.POSITIVE_INFINITY
-              if (da !== db) return da - db
-              return String(a.registro).localeCompare(String(b.registro))
-            })
-          setQuickCandidates(candidates)
-          setQuickRegistros(candidates.map((c: any) => c.registro))
-        } else {
-          setQuickCandidates([])
-          setQuickRegistros(registros)
-        }
-        const message = 'Este código possui múltiplos lotes. Selecione o lote/registro.'
-        setQuickActionFeedback({ type: 'error', message })
-        return false
-      }
-      if (policyErrorToast(e)) {
-        setQuickActionFeedback({ type: 'error', message: e instanceof Error ? e.message : String(e) })
-        return false
-      }
-      const message = e instanceof Error ? e.message : String(e)
-      setQuickActionFeedback({ type: 'error', message })
-      return false
-    } finally {
-      setQuickActionLoading(false)
-    }
-  }, [
+  const { runQuickOperation, runTransfer } = useInsumosQuickOperationsController({
     canUseApi,
     isAuthed,
-    quickLoteNeedsPick,
     loadMovimentacoes,
     mutateJson,
+    policyErrorToast,
     quickCodigo,
+    quickLoteNeedsPick,
+    quickMotivo,
+    quickNovoEstoque,
     quickObs,
     quickQuantidade,
     quickRegistro,
     refreshInsumos,
     schedulePostMutationRefresh,
     setQuickActionFeedback,
+    setQuickActionLoading,
+    setQuickCandidates,
+    setQuickRegistros,
     transferFrom,
-    transferTo
-  ])
+    transferTo,
+    unidade,
+  })
 
   React.useEffect(() => {
     void loadHealth()
     void loadMe()
     void loadProxyStatus()
   }, [loadHealth, loadMe, loadProxyStatus])
-
-  React.useEffect(() => {
-    if (!canUseApi || !isAuthed) return
-    if (!overviewVisible && !overviewEverVisible) return
-    const t = window.setTimeout(() => {
-      void loadOverview()
-    }, 250)
-    return () => window.clearTimeout(t)
-  }, [canUseApi, isAuthed, loadOverview, overviewEverVisible, overviewVisible])
-
-  React.useEffect(() => {
-    if (!canUseApi || !isAuthed) return
-    if (!overviewVisible && !overviewEverVisible) return
-    const t = window.setTimeout(() => {
-      void loadInsights()
-    }, 450)
-    return () => window.clearTimeout(t)
-  }, [canUseApi, isAuthed, loadInsights, overviewEverVisible, overviewVisible])
-
-  React.useEffect(() => {
-      const onOp = (event: Event) => {
-        const e = event as CustomEvent<{ op?: 'ENTRADA' | 'BAIXA' | 'TRANSFERENCIA' }>
-        const op = e.detail?.op
-        if (!op) return
-      openQuickOperation(op)
-      try {
-        window.scrollTo({ top: 0, behavior: 'smooth' })
-      } catch {
-        // ignore
-      }
-    }
-    window.addEventListener('skincos:insumos:op', onOp as EventListener)
-    return () => window.removeEventListener('skincos:insumos:op', onOp as EventListener)
-  }, [openQuickOperation])
-
-  React.useEffect(() => {
-    const onLayout = (event: Event) => {
-      const e = event as CustomEvent<{ action?: 'expandAll' | 'collapseAll' | 'reset' }>
-      const action = e.detail?.action
-      if (action === 'expandAll') setAllDetailsOpen(true)
-      if (action === 'collapseAll') setAllDetailsOpen(false)
-      if (action === 'reset') void resetUserLayoutPrefs()
-    }
-    window.addEventListener('skincos:insumos:layout', onLayout as EventListener)
-    return () => window.removeEventListener('skincos:insumos:layout', onLayout as EventListener)
-  }, [resetUserLayoutPrefs, setAllDetailsOpen])
-
-  React.useEffect(() => {
-    const onOverview = (event: Event) => {
-      const e = event as CustomEvent<{ action?: 'reload'; period?: '7d' | '30d' | '1y' | 'custom'; from?: string; to?: string }>
-      const nextPeriod = e.detail?.period
-      if (nextPeriod) setOverviewPeriod(nextPeriod)
-	      if (typeof e.detail?.from === 'string') setOverviewCustomFrom(e.detail.from)
-	      if (typeof e.detail?.to === 'string') setOverviewCustomTo(e.detail.to)
-	      if (e.detail?.action === 'reload') {
-	        void Promise.allSettled([loadOverview({ force: true }), loadInsights({ force: true }), refreshInsumos()])
-	      }
-	    }
-    window.addEventListener('skincos:insumos:overview', onOverview as EventListener)
-    return () => window.removeEventListener('skincos:insumos:overview', onOverview as EventListener)
-  }, [loadInsights, loadOverview, refreshInsumos])
 
   React.useEffect(() => {
     if (!canUseApi || !isAuthed) return
@@ -4843,123 +2847,20 @@ export function InsumosModule() {
 
   const insumosTiposUnidade = React.useMemo(() => Array.from(CANONICAL_TIPOS_UNIDADE as readonly string[]), [])
 
-	  type ChartPresetId = 'distribution' | 'movements' | 'roi_risk'
-
-	  type ChartMetric = 'qtd' | 'valor'
-	  type ChartView = 'bar' | 'line' | 'pie'
-	  type ChartLayout = 'square' | 'wide' | 'tall'
-	  type ChartGroupBy = 'categoria' | 'marca' | 'item' | 'tempo'
-	  type MovementsMode = 'inout' | 'saldo' | 'entrada' | 'saida'
-	  type ChartSlotConfig = {
-	    presetId: ChartPresetId
-	    metric?: ChartMetric
-	    view?: ChartView
-	    topN?: number
-	    groupBy?: ChartGroupBy
-	    mode?: MovementsMode
-	  }
-
-	  const CHARTS_SLOTS_KEY = 'skincos.insumos.charts.slots.v1'
-	  const DEFAULT_CHART_SLOTS: ChartSlotConfig[] = [
-	    { presetId: 'distribution', groupBy: 'categoria', metric: 'qtd', view: 'pie', topN: 8 }
-	  ]
-	  const MAX_CHARTS = 9
-
-	  const CHART_PRESETS: Array<{
-	    id: ChartPresetId
-	    label: string
-	    supportsMetric?: boolean
-	    supportsView?: boolean
-	    supportsTopN?: boolean
-	    defaultMetric?: ChartMetric
-	    defaultView?: ChartView
-	    layout?: ChartLayout
-	  }> = [
-	      { id: 'distribution', label: 'Distribuição', supportsMetric: true, supportsView: true, supportsTopN: true, defaultView: 'pie', layout: 'square' },
-	      { id: 'movements', label: 'Movimentações', supportsMetric: true, supportsView: true, supportsTopN: true, defaultView: 'bar', layout: 'wide' },
-	      { id: 'roi_risk', label: 'ROI (perdas & risco)', supportsMetric: true, supportsView: true, defaultView: 'bar', layout: 'square' }
-	    ]
-
   const [chartSlots, setChartSlots] = React.useState<ChartSlotConfig[]>(() => {
-	    try {
-	      const raw = window.localStorage.getItem(CHARTS_SLOTS_KEY)
-	      if (!raw) return DEFAULT_CHART_SLOTS
-	      const parsed = JSON.parse(raw)
-	      const slots = Array.isArray(parsed) ? parsed : []
-	      const validIds = new Set<ChartPresetId>(CHART_PRESETS.map((p) => p.id))
-	      const cleaned: ChartSlotConfig[] = slots
-	        .slice(0, MAX_CHARTS)
-	        .map((s: any, idx: number) => {
-	          const fallback = DEFAULT_CHART_SLOTS[0]
-	          const presetIdRaw = String(s?.presetId || '')
-	          let presetId: ChartPresetId = fallback.presetId
-	          let groupBy: ChartGroupBy | undefined = undefined
-	          let mode: MovementsMode | undefined = undefined
-
-	          if (presetIdRaw === 'stock_category') {
-	            presetId = 'distribution'
-	            groupBy = 'categoria'
-	          } else if (presetIdRaw === 'stock_brand') {
-	            presetId = 'distribution'
-	            groupBy = 'marca'
-	          } else if (presetIdRaw === 'stock_top') {
-	            presetId = 'distribution'
-	            groupBy = 'item'
-	          } else if (presetIdRaw === 'mov_inout') {
-	            presetId = 'movements'
-	            groupBy = 'tempo'
-	            mode = 'inout'
-	          } else if (presetIdRaw === 'mov_saldo') {
-	            presetId = 'movements'
-	            groupBy = 'tempo'
-	            mode = 'saldo'
-	          } else if (presetIdRaw === 'trends_inout') {
-	            presetId = 'movements'
-	            groupBy = 'tempo'
-	            mode = 'inout'
-	          } else if (presetIdRaw === 'turnover_category') {
-	            presetId = 'movements'
-	            groupBy = 'categoria'
-	            mode = 'saida'
-	          } else if (validIds.has(presetIdRaw as any)) {
-	            presetId = presetIdRaw as ChartPresetId
-	            groupBy = (s?.groupBy as any) || undefined
-	            mode = (s?.mode as any) || undefined
-	          }
-
-	          if (!validIds.has(presetId)) presetId = fallback.presetId
-	          const preset = CHART_PRESETS.find((p) => p.id === presetId)
-	          const metric: ChartMetric | undefined = s?.metric === 'valor' || s?.metric === 'qtd' ? s.metric : preset?.defaultMetric
-	          const view: ChartView | undefined = s?.view === 'bar' || s?.view === 'line' || s?.view === 'pie' ? s.view : preset?.defaultView
-	          const topN = Math.max(5, Math.min(15, parseInt(String(s?.topN ?? ''), 10) || 0)) || fallback.topN
-	          const groupByFixed: ChartGroupBy | undefined = (() => {
-	            const v = String(groupBy || s?.groupBy || '').trim()
-	            if (v === 'categoria' || v === 'marca' || v === 'item' || v === 'tempo') return v
-	            if (presetId === 'distribution') return 'categoria'
-	            if (presetId === 'movements') return 'tempo'
-	            return undefined
-	          })()
-	          const modeFixed: MovementsMode | undefined = (() => {
-	            const v = String(mode || s?.mode || '').trim()
-	            if (v === 'inout' || v === 'saldo' || v === 'entrada' || v === 'saida') return v
-	            if (presetId === 'movements') return groupByFixed === 'categoria' ? 'saida' : 'inout'
-	            return undefined
-	          })()
-	          return { presetId, groupBy: groupByFixed, mode: modeFixed, metric, view, topN }
-	        })
-	      if (!cleaned.length) return DEFAULT_CHART_SLOTS
-	      return cleaned
-	    } catch {
-	      return DEFAULT_CHART_SLOTS
+    try {
+      return parseChartSlots(window.localStorage.getItem(CHARTS_SLOTS_KEY))
+    } catch {
+      return DEFAULT_CHART_SLOTS
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   })
 
-  const [chartsFilterTipo, setChartsFilterTipo] = React.useState<ChartPresetId | '__ALL__'>('__ALL__')
-  const [chartsFilterY, setChartsFilterY] = React.useState<ChartGroupBy | '__ALL__'>('__ALL__')
-  const [chartsFilterX, setChartsFilterX] = React.useState<ChartMetric | '__ALL__'>('__ALL__')
-  const [chartsFilterView, setChartsFilterView] = React.useState<ChartView | '__ALL__'>('__ALL__')
-  const [chartsFilterTop, setChartsFilterTop] = React.useState<'5' | '8' | '10' | '15' | '__ALL__'>('__ALL__')
+  const [chartsFilterTipo, setChartsFilterTipo] = React.useState<ChartFilterTipo>('__ALL__')
+  const [chartsFilterY, setChartsFilterY] = React.useState<ChartFilterY>('__ALL__')
+  const [chartsFilterX, setChartsFilterX] = React.useState<ChartFilterX>('__ALL__')
+  const [chartsFilterView, setChartsFilterView] = React.useState<ChartFilterView>('__ALL__')
+  const [chartsFilterTop, setChartsFilterTop] = React.useState<ChartFilterTop>('__ALL__')
   const [chartsSearch, setChartsSearch] = React.useState('')
 
   React.useEffect(() => {
@@ -4970,32 +2871,9 @@ export function InsumosModule() {
     }
   }, [chartSlots])
 
-	  const setChartSlot = React.useCallback((idx: number, next: Partial<ChartSlotConfig>) => {
-	    setChartSlots((prev) => {
-	      const copy = [...prev]
-	      const cur = copy[idx] || DEFAULT_CHART_SLOTS[0]
-	      const presetId = (next.presetId ?? cur.presetId) as ChartPresetId
-	      const preset = CHART_PRESETS.find((p) => p.id === presetId)
-	      const metric = next.metric ?? cur.metric ?? preset?.defaultMetric
-	      const groupBy: ChartGroupBy | undefined = (() => {
-	        const v = String(next.groupBy ?? cur.groupBy ?? '').trim()
-	        if (v === 'categoria' || v === 'marca' || v === 'item' || v === 'tempo') return v
-	        if (presetId === 'distribution') return 'categoria'
-	        if (presetId === 'movements') return 'tempo'
-	        return undefined
-	      })()
-	      const mode: MovementsMode | undefined = (() => {
-	        const v = String(next.mode ?? cur.mode ?? '').trim()
-	        if (v === 'inout' || v === 'saldo' || v === 'entrada' || v === 'saida') return v
-	        if (presetId === 'movements') return groupBy === 'categoria' ? 'saida' : 'inout'
-	        return undefined
-	      })()
-	      const view = next.view ?? cur.view ?? preset?.defaultView
-	      const topN = next.topN ?? cur.topN
-	      copy[idx] = { ...cur, ...next, presetId, groupBy, mode, metric, view, topN }
-	      return copy
-	    })
-	  }, [])
+  const setChartSlot = React.useCallback((idx: number, next: Partial<ChartSlotConfig>) => {
+    setChartSlots((prev) => updateChartSlotAt(prev, idx, next))
+  }, [])
 
   const fmtChartValue = React.useCallback(
     (metric: ChartMetric, v: any) => {
@@ -5096,90 +2974,16 @@ export function InsumosModule() {
     return Array.from(byWeek.values()).sort((a, b) => String(a.bucket).localeCompare(String(b.bucket))).slice(-60)
   }, [overviewPeriod, trendsSeriesRaw])
 
-	  const presetSupports = React.useCallback(
-	    (id: ChartPresetId) =>
-	      CHART_PRESETS.find((p) => p.id === id) || {
-	        id,
-        label: String(id),
-        supportsMetric: false,
-        supportsView: false,
-        supportsTopN: false,
-        defaultView: 'bar' as any,
-        layout: 'square' as any
-      },
-    []
-  )
-
-  const presetViewOptions = React.useCallback((slot: ChartSlotConfig): ChartView[] => {
-    if (slot.presetId === 'distribution') {
-      const gb = slot.groupBy === 'item' ? 'item' : slot.groupBy === 'marca' ? 'marca' : 'categoria'
-      return gb === 'item' ? ['bar'] : ['pie', 'bar']
-    }
-	    if (slot.presetId === 'movements') {
-	      const gb = slot.groupBy === 'categoria' ? 'categoria' : 'tempo'
-	      return gb === 'tempo' ? ['bar', 'line'] : ['bar', 'pie']
-	    }
-    if (slot.presetId === 'roi_risk') return ['bar', 'pie']
-    return ['bar', 'line']
-  }, [])
-
-  const resolveChartSlot = React.useCallback(
-    (slot: ChartSlotConfig) => {
-      const preset = presetSupports(slot.presetId)
-      const groupBy: ChartGroupBy | undefined =
-        slot.presetId === 'distribution'
-          ? slot.groupBy === 'marca' || slot.groupBy === 'item'
-            ? slot.groupBy
-            : 'categoria'
-          : slot.presetId === 'movements'
-            ? slot.groupBy === 'categoria'
-              ? 'categoria'
-              : 'tempo'
-            : undefined
-      const mode: MovementsMode | undefined =
-        slot.presetId === 'movements'
-          ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
-            ? slot.mode
-            : groupBy === 'categoria'
-              ? 'saida'
-              : 'inout'
-          : undefined
-      const viewOptions = presetViewOptions({ ...slot, groupBy, mode })
-      const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as ChartView
-      const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
-      const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as ChartMetric
-      const topN = Math.max(5, Math.min(15, Number(slot.topN) || 8))
-      const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
-      const layout = (preset as any).layout as ChartLayout | undefined
-      return { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout }
-    },
-    [presetSupports, presetViewOptions]
-  )
-
   const chartSlotsView = React.useMemo(() => {
-    const search = chartsSearch.trim().toLowerCase()
-    return chartSlots
-      .map((slot, idx) => ({ slot, idx, meta: resolveChartSlot(slot) }))
-      .filter(({ slot, meta }) => {
-        if (chartsFilterTipo !== '__ALL__' && slot.presetId !== chartsFilterTipo) return false
-        if (chartsFilterY !== '__ALL__' && meta.groupBy !== chartsFilterY) return false
-        if (chartsFilterX !== '__ALL__' && meta.metric !== chartsFilterX) return false
-        if (chartsFilterView !== '__ALL__' && meta.view !== chartsFilterView) return false
-        if (chartsFilterTop !== '__ALL__' && String(meta.topN) !== String(chartsFilterTop)) return false
-        if (!search) return true
-        const hay = [
-          meta.preset.label,
-          slot.presetId,
-          meta.groupBy || '',
-          meta.metric,
-          meta.view,
-          meta.mode || '',
-          String(meta.topN)
-        ]
-          .join(' ')
-          .toLowerCase()
-        return hay.includes(search)
-      })
+    return filterChartSlotsView({
+      chartSlots,
+      chartsFilterTipo,
+      chartsFilterY,
+      chartsFilterX,
+      chartsFilterView,
+      chartsFilterTop,
+      chartsSearch,
+    })
   }, [
     chartSlots,
     chartsFilterTipo,
@@ -5188,7 +2992,6 @@ export function InsumosModule() {
     chartsFilterView,
     chartsFilterTop,
     chartsSearch,
-    resolveChartSlot
   ])
 
   const renderChart = React.useCallback(
@@ -5520,6 +3323,119 @@ export function InsumosModule() {
 	    },
 	    [fmtBucketLabel, fmtChartValue, insightsLoading, insightsTurnover, overviewLoading, overviewRoi, stockAgg, trendsSeries]
 	  )
+
+  const chartPresetOptions = React.useMemo(
+    () => CHART_PRESETS.map((preset) => ({ id: preset.id, label: preset.label })),
+    []
+  )
+
+  const chartCards = React.useMemo(
+    () =>
+      chartSlotsView.map(({ slot, idx, meta }) => {
+        const { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout } = meta
+        const baseHeight = chartSlotsView.length === 1 ? 360 : chartSlotsView.length === 2 ? 300 : 260
+        const height = layout === 'tall' ? baseHeight + (chartSlotsView.length === 1 ? 180 : 120) : baseHeight
+        return {
+          key: String(idx),
+          presetId: slot.presetId,
+          presetLabel: preset.label,
+          groupBy,
+          mode,
+          metric,
+          topN,
+          view,
+          viewOptions,
+          supportsMetric: !!preset.supportsMetric,
+          supportsView: !!preset.supportsView,
+          showTopN,
+          controlsKind: slot.presetId === 'distribution' ? 'distribution' : slot.presetId === 'movements' ? 'movements' : 'none',
+          canRemove: chartSlots.length > 1,
+          cardSpanClass: chartSlotsView.length >= 3 && layout === 'wide' ? 'xl:col-span-2' : '',
+          renderNode: renderChart({ ...slot, view, metric, topN }, { height }),
+        } as const
+      }),
+    [chartSlots.length, chartSlotsView, renderChart]
+  )
+
+  const getChartIndexFromKey = React.useCallback((cardKey: string) => {
+    const idx = Number.parseInt(String(cardKey), 10)
+    return Number.isInteger(idx) && idx >= 0 ? idx : -1
+  }, [])
+
+  const handleChartPresetChange = React.useCallback(
+    (cardKey: string, value: string) => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      const slot = chartSlots[idx] || DEFAULT_CHART_SLOTS[0]
+      setChartSlot(idx, getNextChartPresetPatch(slot, value))
+    },
+    [chartSlots, getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleRemoveChart = React.useCallback(
+    (cardKey: string) => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      setChartSlots((prev) => prev.filter((_, currentIdx) => currentIdx !== idx))
+    },
+    [getChartIndexFromKey]
+  )
+
+  const handleDistributionGroupByChange = React.useCallback(
+    (cardKey: string, value: 'categoria' | 'marca' | 'item') => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      const slot = chartSlots[idx] || DEFAULT_CHART_SLOTS[0]
+      setChartSlot(idx, getNextDistributionGroupByPatch(slot, value))
+    },
+    [chartSlots, getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleMovementsGroupByChange = React.useCallback(
+    (cardKey: string, value: 'tempo' | 'categoria') => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      const slot = chartSlots[idx] || DEFAULT_CHART_SLOTS[0]
+      setChartSlot(idx, getNextMovementsGroupByPatch(slot, value))
+    },
+    [chartSlots, getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleMovementsModeChange = React.useCallback(
+    (cardKey: string, value: 'inout' | 'saldo' | 'entrada' | 'saida') => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      setChartSlot(idx, getNextMovementsModePatch(value))
+    },
+    [getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleChartMetricChange = React.useCallback(
+    (cardKey: string, value: 'qtd' | 'valor') => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      setChartSlot(idx, { metric: value })
+    },
+    [getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleChartViewChange = React.useCallback(
+    (cardKey: string, value: 'pie' | 'bar' | 'line') => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      setChartSlot(idx, { view: value })
+    },
+    [getChartIndexFromKey, setChartSlot]
+  )
+
+  const handleChartTopNChange = React.useCallback(
+    (cardKey: string, value: number) => {
+      const idx = getChartIndexFromKey(cardKey)
+      if (idx < 0) return
+      setChartSlot(idx, { topN: normalizeChartTopN(value) })
+    },
+    [getChartIndexFromKey, setChartSlot]
+  )
 
   type AlertasLinha = {
     key: string
@@ -5870,1047 +3786,269 @@ export function InsumosModule() {
     return `${h}h`
   }, [])
 
-  const movimentacoesView = React.useMemo(() => {
-    const list = Array.isArray(movimentacoes) ? movimentacoes : []
-    const selectedCode = selectedCodigoBarras.trim()
-    const filterCategoria = normalizeText(movFilterCategoria)
-    const filterMarca = normalizeText(movFilterMarca)
-    const filterSearch = normalizeText(movSearch)
+  const movimentacoesView = React.useMemo(
+    () =>
+      buildMovimentacoesView({
+        movGroupTransfers,
+        movSortDir,
+        movSortKey,
+        movTipo,
+        movFilterCategoria,
+        movFilterMarca,
+        movSearch,
+        movimentacoes,
+        pickInsumoForMov,
+        selectedCodigoBarras,
+        normalizeText,
+      }),
+    [movGroupTransfers, movSortDir, movSortKey, movTipo, movFilterCategoria, movFilterMarca, movSearch, movimentacoes, pickInsumoForMov, selectedCodigoBarras]
+  )
 
-    const applyFiltersAndSort = (base: Movimentacao[]) => {
-      const filtered = base.filter((m) => {
-        if (selectedCode) {
-          if (String(m?.codigoBarras || '').trim() !== selectedCode) return false
-        } else if (filterSearch) {
-          const insumo = pickInsumoForMov(m)
-          const produtoNome = normalizeText(String(insumo?.produto || m?.produto || '').trim())
-          const categoriaNome = normalizeText(insumo?.categoria || '')
-          const marcaNome = normalizeText(insumo?.marca || m?.marca || '')
-          const codigoBarras = normalizeText(String(m?.codigoBarras || insumo?.codigoBarras || '').trim())
-          if (
-            !(
-              (produtoNome && produtoNome.includes(filterSearch)) ||
-              (categoriaNome && categoriaNome.includes(filterSearch)) ||
-              (marcaNome && marcaNome.includes(filterSearch)) ||
-              (codigoBarras && codigoBarras.includes(filterSearch))
-            )
-          ) {
-            return false
-          }
-        }
-
-        if (filterCategoria) {
-          const insumo = pickInsumoForMov(m)
-          const categoriaNome = normalizeText(insumo?.categoria || '')
-          if (!categoriaNome || categoriaNome !== filterCategoria) return false
-        }
-
-        if (filterMarca) {
-          const insumo = pickInsumoForMov(m)
-          const marcaNome = normalizeText(insumo?.marca || '')
-          if (!marcaNome || marcaNome !== filterMarca) return false
-        }
-        return true
-      })
-
-      const dir = movSortDir === 'asc' ? 1 : -1
-      const getSortValue = (m: Movimentacao) => {
-        if (movSortKey === 'dataHora') return new Date(m?.dataHora || 0).getTime() || 0
-        if (movSortKey === 'usuario') return String(m?.usuario || '').trim().toLowerCase()
-        if (movSortKey === 'observacao') {
-          const v = m?.transferId
-            ? `transferencia ${String(m?.unidadeOrigem || '')}->${String(m?.unidadeDestino || '')}`
-            : String(m?.motivo || m?.observacoes || '').trim()
-          return v.toLowerCase()
-        }
-
-        const insumo = pickInsumoForMov(m)
-        if (movSortKey === 'produto') return String(insumo?.produto || m?.produto || '').trim().toLowerCase()
-        if (movSortKey === 'categoria') return String(insumo?.categoria || '').trim().toLowerCase()
-        if (movSortKey === 'marca') return String(insumo?.marca || '').trim().toLowerCase()
-        if (movSortKey === 'estoque') return Number(m?.estoqueNovo ?? m?.estoqueAnterior ?? 0) || 0
-        if (movSortKey === 'valor') {
-          const preco = Number(m?.preco) || Number(insumo?.precoCusto) || 0
-          const qtd = Number(m?.quantidade) || 0
-          return preco * qtd
-        }
-        return 0
-      }
-
-      filtered.sort((a, b) => {
-        const av = getSortValue(a) as any
-        const bv = getSortValue(b) as any
-        if (typeof av === 'number' && typeof bv === 'number') {
-          if (av !== bv) return (av - bv) * dir
-          return (new Date(a?.dataHora || 0).getTime() - new Date(b?.dataHora || 0).getTime()) * dir
-        }
-        const cmp = String(av).localeCompare(String(bv), 'pt-BR', { sensitivity: 'base' })
-        if (cmp !== 0) return cmp * dir
-        return (new Date(a?.dataHora || 0).getTime() - new Date(b?.dataHora || 0).getTime()) * dir
-      })
-
-      return filtered
-    }
-
-    if (!movGroupTransfers || movTipo !== 'TODOS') return applyFiltersAndSort(list)
-
-    const byTransfer = new Map<string, Movimentacao[]>()
-    for (const m of list) {
-      const id = String((m as any)?.transferId || '').trim()
-      if (!id) continue
-      const arr = byTransfer.get(id) || []
-      arr.push(m)
-      byTransfer.set(id, arr)
-    }
-
-    const seen = new Set<string>()
-    const out: Movimentacao[] = []
-    for (const m of list) {
-      const id = String((m as any)?.transferId || '').trim()
-      if (!id) {
-        out.push(m)
-        continue
-      }
-      if (seen.has(id)) continue
-      seen.add(id)
-
-      const group = byTransfer.get(id) || [m]
-      if (group.length < 2) {
-        out.push(m)
-        continue
-      }
-
-      const pick = group.reduce((best, cur) => {
-        const bt = new Date(best?.dataHora || 0).getTime()
-        const ct = new Date(cur?.dataHora || 0).getTime()
-        return ct > bt ? cur : best
-      }, group[0])
-
-      const quantidade = group.reduce((acc, cur) => Math.max(acc, Number(cur?.quantidade) || 0), 0)
-      const unidadeOrigem = String((pick as any)?.unidadeOrigem || '').trim()
-      const unidadeDestino = String((pick as any)?.unidadeDestino || '').trim()
-
-      out.push({
-        ...pick,
-        tipo: 'TRANSFERÊNCIA',
-        quantidade,
-        unidadeOrigem,
-        unidadeDestino,
-        transferId: id
-      } as any)
-    }
-    return applyFiltersAndSort(out)
-  }, [
-    movGroupTransfers,
-    movSortDir,
-    movSortKey,
-    movTipo,
-    movFilterCategoria,
-    movFilterMarca,
-    movSearch,
-    movimentacoes,
-    pickInsumoForMov,
-    selectedCodigoBarras
-  ])
+  const movementRows = React.useMemo(
+    () =>
+      buildMovementRows({
+        movimentacoesView,
+        pickInsumoForMov,
+        selectedCodigoBarras,
+        movFilterCategoria,
+        movFilterMarca,
+        movSearch,
+        unidade,
+        isAuthed,
+        unidadeLabel,
+        normalizeText,
+        fmtMovDateShort,
+        fmtMovTimeShort,
+        fmtDateOnlyBR,
+        fmtMoneyBRL,
+        fmtMoneyBRL0,
+      }),
+    [isAuthed, movFilterCategoria, movFilterMarca, movSearch, movimentacoesView, pickInsumoForMov, selectedCodigoBarras, unidade, unidadeLabel]
+  )
 
   return (
     <div ref={rootRef} className="px-3 py-4 sm:p-6 space-y-4 sm:space-y-6">
       {autoSyncSuspended ? (
-        <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-amber-100 flex flex-wrap items-center gap-3">
-          <div className="text-sm">
-            API instável detectada. Sincronização automática de Overview/Insights pausada por {autoSyncRemainingSeconds}s.
-          </div>
-          <div className="ml-auto flex items-center gap-2">
-            <Button
-              variant="outline"
-              className="border-amber-300/50 text-amber-100 hover:bg-amber-500/20"
-              onClick={() => {
-                apiFailureTimestampsRef.current = []
-                setAutoSyncSuspendedUntil(0)
-              }}
-            >
-              Retomar auto-sync
-            </Button>
-            <Button
-              className="!bg-amber-600 hover:!bg-amber-700 !text-white"
-              onClick={() => {
-                apiFailureTimestampsRef.current = []
-                setAutoSyncSuspendedUntil(0)
-                void Promise.allSettled([loadOverview({ force: true }), loadInsights({ force: true }), refreshInsumos()])
-              }}
-            >
-              Atualizar agora
-            </Button>
-          </div>
-        </div>
+        <InsumosAutoSyncBanner
+          autoSyncRemainingSeconds={autoSyncRemainingSeconds}
+          onResume={resumeAutoSync}
+          onRefreshNow={() => {
+            resumeAutoSync()
+            void Promise.allSettled([loadOverview({ force: true }), loadInsights({ force: true }), refreshInsumos()])
+          }}
+        />
       ) : null}
       <DragDropContext onDragStart={onDragStartLayout} onDragEnd={onDragEndLayout}>
-      <Dialog open={insumosListModalOpen} onOpenChange={setInsumosListModalOpen}>
-        <DialogContent size="wideTable" className={dialogWideClass}>
-          <DialogHeader className="space-y-2">
-            <div className="flex flex-nowrap items-center gap-2 min-w-0 w-full overflow-x-auto">
-              <DialogTitle className="text-white">Insumos</DialogTitle>
-              <Input
-                value={insumosQuery}
-                onChange={(e) => setInsumosQuery(e.target.value)}
-                placeholder="Buscar por código, produto, categoria…"
-                className="h-8 flex-1 min-w-[160px] md:min-w-0 ml-auto"
-              />
-              <Button
-                variant="outline"
-                className="h-8 px-3"
-                onClick={() => window.open(`/api/insumos/export/insumos.csv?unidade=${encodeURIComponent(unidade)}`, '_blank', 'noopener,noreferrer')}
-                disabled={!isAuthed}
-                title="Exportar CSV"
-              >
-                Exportar
-              </Button>
-              <Button variant="outline" className="h-8 px-3" onClick={() => setCreateOpen((v) => !v)} disabled={!isAuthed}>
-                {createOpen ? 'Fechar' : 'Adicionar'}
-              </Button>
-            </div>
-            <DialogDescription>Lista e cadastro de insumos da unidade selecionada.</DialogDescription>
-          </DialogHeader>
+      <InsumosInventoryDialog
+        open={insumosListModalOpen}
+        dialogClassName={dialogWideClass}
+        isAuthed={isAuthed}
+        unit={unidade}
+        unitLabel={unidadeLabel}
+        query={insumosQuery}
+        onQueryChange={setInsumosQuery}
+        onOpenChange={setInsumosListModalOpen}
+        onExport={() => window.open(`/api/insumos/export/insumos.csv?unidade=${encodeURIComponent(unidade)}`, '_blank', 'noopener,noreferrer')}
+        createOpen={createOpen}
+        onToggleCreate={() => setCreateOpen((value) => !value)}
+        onCancelCreate={() => setCreateOpen(false)}
+        createLookupLoading={createLookupLoading}
+        createLookupError={createLookupError}
+        createLookupCount={createLookupItems?.length || 0}
+        createScanOpen={createScanOpen}
+        onToggleCreateScan={() => setCreateScanOpen((value) => !value)}
+        onCloseCreateScan={() => setCreateScanOpen(false)}
+        onCreateBarcodeDetected={(code) => {
+          setCreateCodigo(code)
+          setCreateScanOpen(false)
+          toast.success('Código detectado')
+        }}
+        createCodigo={createCodigo}
+        onCreateCodigoChange={setCreateCodigo}
+        createCodigosExtras={createCodigosExtras}
+        onCreateCodigosExtrasChange={setCreateCodigosExtras}
+        createProduto={createProduto}
+        onCreateProdutoChange={setCreateProduto}
+        createCategoria={createCategoria}
+        onCreateCategoriaChange={setCreateCategoria}
+        createMarca={createMarca}
+        onCreateMarcaChange={setCreateMarca}
+        createTipoUnidade={normalizeTipoUnidadeToCanonical(createTipoUnidade) || ''}
+        onCreateTipoUnidadeChange={setCreateTipoUnidade}
+        createPrecoCusto={createPrecoCusto}
+        onCreatePrecoCustoChange={setCreatePrecoCusto}
+        createEstoqueMinimo={createEstoqueMinimo}
+        onCreateEstoqueMinimoChange={setCreateEstoqueMinimo}
+        createEstoqueInicial={createEstoqueInicial}
+        onCreateEstoqueInicialChange={setCreateEstoqueInicial}
+        createLote={createLote}
+        onCreateLoteChange={setCreateLote}
+        createDataValidade={createDataValidade}
+        onCreateDataValidadeChange={setCreateDataValidade}
+        createNovoLote={createNovoLote}
+        onToggleCreateNovoLote={() => setCreateNovoLote((value) => !value)}
+        createCategoriaRequiresLot={createCategoriaRequiresLot}
+        onCreateCategoriaRequiresLotChange={(value) => {
+          setCreatePolicyTouched(true)
+          setCreateCategoriaRequiresLot(value)
+        }}
+        createCategoriaRequiresExpiry={createCategoriaRequiresExpiry}
+        onCreateCategoriaRequiresExpiryChange={(value) => {
+          setCreatePolicyTouched(true)
+          setCreateCategoriaRequiresExpiry(value)
+          if (!value) setCreateCategoriaFefo(false)
+        }}
+        createCategoriaFefo={createCategoriaFefo}
+        onCreateCategoriaFefoChange={(value) => {
+          setCreatePolicyTouched(true)
+          setCreateCategoriaFefo(value)
+          if (value) setCreateCategoriaRequiresExpiry(true)
+        }}
+        isManagerRole={isManagerRole}
+        lotCategorias={lotCategorias}
+        insumosMarcas={insumosMarcas}
+        insumosTiposUnidade={insumosTiposUnidade}
+        createLoading={createLoading}
+        onSaveCreate={() => void saveCreateFromModal()}
+        filteredInsumos={filteredInsumos}
+        listContainerRef={insumosModalListContainerRef}
+        onListScroll={onInsumosModalScroll}
+        insumosLoading={insumosLoading}
+        insumosLoadError={insumosLoadError}
+        emptyContent={renderListPlaceholder(insumosLoading, 'Sem itens.')}
+        onEditItem={openEditDialog}
+      />
+      <InsumosOfflineQueueDialog
+        open={offlineDialogOpen}
+        dialogClassName={dialogSmallClass}
+        items={offlineItems}
+        debugUi={debugUi}
+        isAuthed={isAuthed}
+        fmtAge={fmtAge}
+        onOpenChange={setOfflineDialogOpen}
+        onSync={() => void syncOfflineQueue()}
+        onClear={() => {
+          if (!offlineItems.length) return
+          if (!window.confirm('Limpar a fila offline? Você perderá as operações pendentes.')) return
+          try {
+            window.localStorage.removeItem(OFFLINE_QUEUE_KEY)
+          } catch {
+            // ignore
+          }
+          setOfflineItems([])
+          setOfflineQueueCount(0)
+          toast.success('Fila limpa.')
+        }}
+        onToggleDebug={toggleDebugUi}
+        onCopyItem={async (item) => {
+          try {
+            await navigator.clipboard.writeText(JSON.stringify(item, null, 2))
+            toast.success('Copiado.')
+          } catch (error: any) {
+            toast.error(error?.message || 'Não foi possível copiar.')
+          }
+        }}
+      />
 
-          <div className="space-y-3">
-            {createOpen ? (
-              <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-3">
-                <div className="text-sm text-blue-100/70">
-                  Cadastro rápido (campos mínimos) + detalhes opcionais.
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-                  <div>
-                    <div className="text-xs text-blue-200/70 mb-1">Código de barras</div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input value={createCodigo} onChange={(e) => setCreateCodigo(e.target.value)} placeholder="789..." />
-                      <Button variant="secondary" type="button" onClick={() => setCreateScanOpen((v) => !v)}>
-                        {createScanOpen ? 'Fechar' : 'Escanear'}
-                      </Button>
-                    </div>
-                    <div className="mt-2">
-                      {createLookupLoading ? (
-                        <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
-                      ) : createLookupError ? (
-                        <div className="text-xs text-red-200">{createLookupError}</div>
-                      ) : createLookupItems?.length ? (
-                        <div className="text-xs text-blue-200/70">
-                          Encontrado no histórico: <span className="font-mono">{createLookupItems.length}</span> variação(ões)
-                        </div>
-                      ) : null}
-                    </div>
-                    <div className="mt-2">
-                      <div className="text-xs text-blue-200/70 mb-1">Códigos adicionais</div>
-                      <Textarea
-                        value={createCodigosExtras}
-                        onChange={(e) => setCreateCodigosExtras(e.target.value)}
-                        placeholder="um por linha"
-                        rows={3}
-                        className="bg-white/[0.06] border-white/20 text-white"
-                      />
-                      <div className="mt-1 text-[10px] text-blue-200/50">
-                        Opcional. Use para variações de código do mesmo produto.
-                      </div>
-                    </div>
-                  </div>
-                  <div className="md:col-span-2">
-                    <div className="text-xs text-blue-200/70 mb-1">Produto</div>
-                    <Input value={createProduto} onChange={(e) => setCreateProduto(e.target.value)} placeholder="ex: Toxina botulínica" />
-                  </div>
-	                  <div>
-	                    <div className="text-xs text-blue-200/70 mb-1">Categoria</div>
-	                    <Input
-	                      value={createCategoria}
-	                      onChange={(e) => setCreateCategoria(e.target.value)}
-	                      placeholder="ex: toxina"
-	                      list="insumos-categorias"
-	                    />
-	                    <datalist id="insumos-categorias">
-	                      {lotCategorias.map((c) => (
-	                        <option key={c} value={c} />
-	                      ))}
-	                    </datalist>
-	                  </div>
-                  <div className="md:col-span-2 rounded-xl border border-white/10 bg-black/10 p-3">
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div className="text-xs text-blue-200/70">Política do item</div>
-                      <div className="text-xs text-blue-200/60">Defina as regras para este insumo.</div>
-                    </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
-                      <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                        <Checkbox
-                          checked={createCategoriaRequiresLot}
-                          onCheckedChange={(v) => {
-                            setCreatePolicyTouched(true)
-                            setCreateCategoriaRequiresLot(!!v)
-                          }}
-                          disabled={!isManagerRole}
-                        />
-                        Lote obrigatório
-                      </label>
-                      <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                        <Checkbox
-                          checked={createCategoriaRequiresExpiry}
-                          onCheckedChange={(v) => {
-                            setCreatePolicyTouched(true)
-                            const next = !!v
-                            setCreateCategoriaRequiresExpiry(next)
-                            if (!next) setCreateCategoriaFefo(false)
-                          }}
-                          disabled={!isManagerRole}
-                        />
-                        Validade obrigatória
-                      </label>
-                      <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                        <Checkbox
-                          checked={createCategoriaFefo}
-                          onCheckedChange={(v) => {
-                            setCreatePolicyTouched(true)
-                            const next = !!v
-                            setCreateCategoriaFefo(next)
-                            if (next) setCreateCategoriaRequiresExpiry(true)
-                          }}
-                          disabled={!isManagerRole}
-                        />
-                        FEFO
-                      </label>
-                      {!isManagerRole ? <span className="text-xs text-blue-200/60">Somente gestores alteram.</span> : null}
-                    </div>
-                  </div>
-	                  <div>
-	                    <div className="text-xs text-blue-200/70 mb-1">Marca</div>
-	                    <Input
-	                      value={createMarca}
-	                      onChange={(e) => setCreateMarca(e.target.value)}
-	                      placeholder="ex: Allergan"
-	                      list="insumos-marcas"
-	                    />
-	                    <datalist id="insumos-marcas">
-	                      {insumosMarcas.map((m) => (
-	                        <option key={m} value={m} />
-	                      ))}
-	                    </datalist>
-	                  </div>
-	                  <div>
-	                    <div className="text-xs text-blue-200/70 mb-1">Tipo (unidade)</div>
-	                    <Select
-	                      value={normalizeTipoUnidadeToCanonical(createTipoUnidade) || undefined}
-	                      onValueChange={setCreateTipoUnidade}
-	                    >
-	                      <SelectTrigger>
-	                        <SelectValue placeholder="Selecione a unidade" />
-	                      </SelectTrigger>
-	                      <SelectContent>
-	                        {insumosTiposUnidade.map((u) => (
-	                          <SelectItem key={u} value={u}>
-	                            {u}
-	                          </SelectItem>
-	                        ))}
-	                      </SelectContent>
-	                    </Select>
-	                  </div>
-                  <div>
-                    <div className="text-xs text-blue-200/70 mb-1">Preço (custo)</div>
-                    <Input value={createPrecoCusto} onChange={(e) => setCreatePrecoCusto(e.target.value)} placeholder="ex: 1200" />
-                  </div>
-                  <div>
-                    <div className="text-xs text-blue-200/70 mb-1">Estoque mínimo</div>
-                    <Input value={createEstoqueMinimo} onChange={(e) => setCreateEstoqueMinimo(e.target.value)} placeholder="ex: 5" />
-                  </div>
-	                  <div>
-	                    <div className="text-xs text-blue-200/70 mb-1">Estoque inicial</div>
-	                    <Input value={createEstoqueInicial} onChange={(e) => setCreateEstoqueInicial(e.target.value)} placeholder="ex: 0" />
-	                  </div>
-	                  <div>
-	                    <div className="flex items-center justify-between gap-2 mb-1">
-	                      <div className="text-xs text-blue-200/70">Lote</div>
-	                      <Button
-	                        variant={createNovoLote ? 'secondary' : 'outline'}
-	                        size="sm"
-	                        type="button"
-	                        onClick={() => setCreateNovoLote((v) => !v)}
-	                        title="Ative quando estiver cadastrando um lote adicional para um código já existente."
-	                      >
-	                        {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
-	                      </Button>
-	                    </div>
-	                    <Input
-	                      value={createLote}
-	                      onChange={(e) => setCreateLote(e.target.value)}
-	                      placeholder={createNovoLote ? 'obrigatório (ex: L2026-01)' : 'opcional'}
-	                    />
-	                  </div>
-	                  <div>
-	                    <div className="text-xs text-blue-200/70 mb-1">Validade</div>
-                      <BrDatePickerInput value={createDataValidade} onChange={setCreateDataValidade} placeholder="DD/MM/AA" ariaLabel="Validade" />
-	                  </div>
-	                </div>
-
-                {createScanOpen ? (
-                  <BarcodeScannerInline
-                    onDetected={(code) => {
-                      setCreateCodigo(code)
-                      setCreateScanOpen(false)
-                      toast.success('Código detectado')
-                    }}
-                    onClose={() => setCreateScanOpen(false)}
-                  />
-                ) : null}
-
-                <div className="flex items-center justify-end gap-2">
-                  <Button variant="secondary" onClick={() => setCreateOpen(false)}>
-                    Cancelar
-                  </Button>
-                  <Button
-                    onClick={async () => {
-                      const codigoBarras = createCodigo.trim()
-                      if (!codigoBarras) return toast.error('Informe o código de barras')
-                      const extraCodes = parseBarcodeInput(createCodigosExtras)
-                      const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
-                      const existing = (insumos || []).find((i) => getInsumoBarcodes(i).includes(codigoBarras))
-                      const categoria = createCategoria.trim() || String(existing?.categoria || '').trim()
-                      const policy = {
-                        requiresLot: !!createCategoriaRequiresLot,
-                        requiresExpiry: !!createCategoriaRequiresExpiry,
-                        fefo: !!createCategoriaFefo
-                      }
-                      const validadeIso = dateInputToIso(createDataValidade)
-
-                      const allowDuplicateLot = createNovoLote || (!!existing && policy.requiresLot)
-                      if (!createNovoLote && allowDuplicateLot) setCreateNovoLote(true)
-
-                      if ((policy.requiresLot || allowDuplicateLot) && !createLote.trim()) {
-                        return toast.error(policy.requiresLot ? 'Informe o lote (obrigatório pelo item)' : 'Informe o lote (Novo lote: on)')
-                      }
-                      if (policy.requiresExpiry && !validadeIso) {
-                        return toast.error('Informe a data de validade (obrigatória pelo item)')
-                      }
-                      if (policy.fefo && !policy.requiresExpiry) {
-                        return toast.error('FEFO exige validade obrigatória')
-                      }
-
-                      const produto = createProduto.trim() || (allowDuplicateLot ? String(existing?.produto || '').trim() : '')
-                      if (!produto) return toast.error('Informe o produto')
-                      const tipoUnidade = normalizeTipoUnidadeToCanonical(createTipoUnidade)
-                      if (!tipoUnidade) return toast.error('Informe a unidade (medida)')
-
-                      setCreateLoading(true)
-                      try {
-                        await mutateJson(`/insumos?unidade=${encodeURIComponent(unidade)}`, {
-                          method: 'POST',
-                          queueLabel: 'Cadastro de insumo',
-                          body: {
-                            codigoBarras,
-                            codigosBarras,
-                            produto,
-                            allowDuplicateLot,
-                            categoria,
-                            marca: createMarca.trim(),
-                            tipoUnidade,
-                            especificacao: createEspecificacao.trim(),
-                            concentracao: createConcentracao.trim(),
-                            volume: createVolume.trim(),
-                            fonte: createHomologado ? 'Homologado' : '',
-                            calibre: createCalibre.trim(),
-                            precoCusto: createPrecoCusto ? Number(createPrecoCusto) : undefined,
-                            estoqueInicial: createEstoqueInicial ? Number(createEstoqueInicial) : undefined,
-                            estoqueMinimo: createEstoqueMinimo ? Number(createEstoqueMinimo) : undefined,
-                            lote: createLote.trim(),
-                            dataValidade: validadeIso || undefined,
-                            policyRequiresLot: policy.requiresLot,
-                            policyRequiresExpiry: policy.requiresExpiry,
-                            policyFefo: policy.fefo
-                          }
-                        })
-                        toast.success('Insumo cadastrado.')
-                        setCreateCodigosExtras('')
-                        setCreateOpen(false)
-                        await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
-                      } catch (e) {
-                        if (policyErrorToast(e)) return
-                        toast.error(e instanceof Error ? e.message : String(e))
-                      } finally {
-                        setCreateLoading(false)
-                      }
-                    }}
-                    disabled={!isAuthed || createLoading}
-                  >
-                    {createLoading ? 'Salvando…' : 'Salvar'}
-                  </Button>
-                </div>
-              </div>
-            ) : null}
-
-            <div
-              ref={insumosModalListContainerRef}
-              onScroll={onInsumosModalScroll}
-              className="overflow-auto max-h-[60vh] rounded-xl border border-white/10"
-            >
-              <table className="w-full min-w-[880px] table-auto text-sm">
-                <thead className="bg-black/30 text-blue-100/80">
-                  <tr>
-                    <th className="text-left p-3 w-[30%]">Produto</th>
-                    <th className="text-left p-3 hidden md:table-cell w-[20%]">Categoria</th>
-                    <th className="text-left p-3 hidden lg:table-cell w-[18%]">Código</th>
-                    <th className="text-right p-3 w-[6rem] whitespace-nowrap">Estoque</th>
-                    <th className="text-right p-3 hidden sm:table-cell w-[5rem] whitespace-nowrap">Mín</th>
-                    <th className="text-left p-3 hidden xl:table-cell w-[7rem] whitespace-nowrap">Validade</th>
-                    <th className="text-right p-3 hidden xl:table-cell w-[7.5rem] whitespace-nowrap">Valor</th>
-                    <th className="text-right p-3 w-[6.5rem] whitespace-nowrap">Ações</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-white/5">
-                  {filteredInsumos.map((i, idx) => {
-                    const codigoBarras = String(i.codigoBarras || '').trim()
-                    const estoque = unidade && i?.estoques ? Number(i.estoques?.[unidade] ?? 0) : Number(i.estoqueAtual ?? 0)
-                    const min = Number(i.estoqueMinimo) || 0
-                    const valor = (Number(i.precoCusto) || 0) * (Number.isFinite(estoque) ? estoque : 0)
-                    return (
-                      <tr key={`${i.registro || ''}-${idx}`} className="hover:bg-white/5">
-                        <td className="p-3 text-blue-50 align-top">
-                          <div className="min-w-0">
-                            <div className="font-medium break-words">{i.produto || '-'}</div>
-                            <div className="mt-1 space-y-0.5">
-                              <div className="text-xs text-blue-200/60 md:hidden break-words">{i.categoria || '-'}</div>
-                              <div className="text-xs text-blue-200/60 lg:hidden font-mono break-all">{i.codigoBarras || '-'}</div>
-                              <div className="text-xs text-blue-200/60 xl:hidden">{fmtDateOnlyBR(i.dataValidade || '') || '-'}</div>
-                              <div className="text-xs text-blue-200/60 xl:hidden">{fmtMoneyBRL(valor)}</div>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="p-3 text-blue-100/80 hidden md:table-cell align-middle">
-                          <div className="break-words">{i.categoria || '-'}</div>
-                        </td>
-                        <td className="p-3 font-mono text-blue-100/70 hidden lg:table-cell align-middle break-all">{i.codigoBarras || '-'}</td>
-                        <td className="p-3 text-right text-blue-100/80 font-mono align-middle whitespace-nowrap">{Number.isFinite(estoque) ? estoque : '-'}</td>
-                        <td className="p-3 text-right text-blue-100/70 font-mono hidden sm:table-cell align-middle whitespace-nowrap">{min || '-'}</td>
-                        <td className="p-3 text-blue-100/70 hidden xl:table-cell align-middle whitespace-nowrap">{fmtDateOnlyBR(i.dataValidade || '')}</td>
-                        <td className="p-3 text-right text-blue-100/80 hidden xl:table-cell align-middle whitespace-nowrap">{fmtMoneyBRL(valor)}</td>
-                        <td className="p-3 text-right align-middle whitespace-nowrap">
-                          <div className="flex items-center justify-end">
-                            <Button variant="outline" size="sm" className="h-8 px-3 text-xs" onClick={() => openEditDialog(i)} disabled={!isAuthed}>
-                              Editar
-                            </Button>
-                          </div>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                  {!filteredInsumos.length ? (
-                    <tr>
-                      <td className="p-3 text-blue-100/70" colSpan={8}>
-                        {insumosLoadError && !insumosLoading && isAuthed ? (
-                          <span className="text-red-200">
-                            Erro ao carregar insumos ({insumosLoadError.status || 'erro'}
-                            {insumosLoadError.code ? `/${insumosLoadError.code}` : ''}): {insumosLoadError.message}
-                          </span>
-                        ) : (
-                          renderListPlaceholder(insumosLoading, 'Sem itens.')
-                        )}
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={offlineDialogOpen} onOpenChange={setOfflineDialogOpen}>
-        <DialogContent className={dialogSmallClass}>
-          <DialogHeader>
-            <DialogTitle>Pendências de sincronização</DialogTitle>
-            <DialogDescription>
-              Operações salvas localmente quando a rede cai. Ao reconectar, clique em “Sincronizar”.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="text-sm text-muted-foreground">
-              Itens: <span className="font-mono">{offlineItems.length}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button variant="secondary" onClick={() => void syncOfflineQueue()} disabled={!isAuthed || !offlineItems.length}>
-                Sincronizar
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => {
-                  if (!offlineItems.length) return
-                  if (!window.confirm('Limpar a fila offline? Você perderá as operações pendentes.')) return
-                  try {
-                    window.localStorage.removeItem(OFFLINE_QUEUE_KEY)
-                  } catch {
-                    // ignore
-                  }
-                  setOfflineItems([])
-                  setOfflineQueueCount(0)
-                  toast.success('Fila limpa.')
-                }}
-                disabled={!offlineItems.length}
-              >
-                Limpar
-              </Button>
-            </div>
-          </div>
-
-          {debugUi ? (
-            <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
-              <table className="min-w-full text-sm">
-                <thead className="bg-black/30 text-blue-100/80">
-                  <tr>
-                    <th className="text-left p-3">Quando</th>
-                    <th className="text-left p-3">Método</th>
-                    <th className="text-left p-3">Endpoint</th>
-                    <th className="text-right p-3">Ações</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-white/5">
-                  {offlineItems.map((it) => (
-                    <tr key={it.id} className="hover:bg-white/5">
-                      <td className="p-3 text-blue-100/70">{fmtAge(it.ts)}</td>
-                      <td className="p-3 text-blue-100/80 font-mono">{it.method}</td>
-                      <td className="p-3 text-blue-50 font-mono">{it.path}</td>
-                      <td className="p-3 text-right">
-                        <Button
-                          variant="outline"
-                          onClick={async () => {
-                            try {
-                              await navigator.clipboard.writeText(JSON.stringify(it, null, 2))
-                              toast.success('Copiado.')
-                            } catch (e: any) {
-                              toast.error(e?.message || 'Não foi possível copiar.')
-                            }
-                          }}
-                        >
-                          Copiar
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                  {!offlineItems.length ? (
-                    <tr>
-                      <td className="p-3 text-blue-100/70" colSpan={4}>
-                        Sem itens pendentes.
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-blue-100/70">
-              {offlineItems.length ? (
-                <div>
-                  Existem <span className="font-semibold text-blue-100">{offlineItems.length}</span> operações pendentes. Clique em
-                  “Sincronizar” quando estiver online.
-                </div>
-              ) : (
-                <div>Sem pendências.</div>
-              )}
-              <div className="mt-2">
-                <Button variant="outline" size="sm" onClick={toggleDebugUi}>
-                  Ver detalhes técnicos
-                </Button>
-              </div>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
+      <InsumosQuickOperationDialog
         open={quickOp != null}
+        operation={quickOp}
+        dialogClassName={dialogLargeClass}
+        isAuthed={isAuthed}
+        shouldShowDashboardLoading={shouldShowDashboardLoading}
+        renderDashboardLoadingButton={() => <DashboardLoadingButton size="sm" />}
+        unit={unidade}
+        transferFrom={transferFrom}
+        transferTo={transferTo}
+        unitOptions={unidadeOptions}
+        unitLabel={unidadeLabel}
+        search={quickSearch}
+        onSearchChange={setQuickSearch}
+        scanOpen={quickScanOpen}
+        onScanToggle={() => setQuickScanOpen((value) => !value)}
+        onScanClose={() => setQuickScanOpen(false)}
+        onBarcodeDetected={(code) => {
+          selectQuickCodigo(code, { setSearch: true, snapshot: null })
+          setQuickScanOpen(false)
+          toast.success('Código detectado')
+        }}
+        searchRemoteLoading={quickSearchRemoteLoading}
+        searchRemoteError={quickSearchRemoteError}
+        searchMatches={quickSearchMatches}
+        hasSelection={hasQuickSelection}
+        lookupLoading={quickLookupLoading}
+        lookupError={quickLookupError}
+        lookupItems={quickLookupItems}
+        selectedSnapshot={quickSelectedSnapshot}
+        quickCode={quickCodigo}
+        onClearSelection={clearQuickSelection}
+        onApplySelection={applyQuickSelection}
+        isSameInsumo={isSameInsumo}
+        onSelectCode={(value, item) => selectQuickCodigo(value, { snapshot: item ?? null })}
+        loteNeedsPick={quickLoteNeedsPick}
+        lotesForPicker={quickLotesForPicker}
+        selectedRegistro={quickRegistro}
+        onRegistroChange={(value) => {
+          setQuickRegistro(value)
+          setQuickAutoFefo(false)
+        }}
+        showFefoToggle={
+          (quickOp === 'BAIXA' || quickOp === 'TRANSFERENCIA') &&
+          quickLotesForPicker.length > 1 &&
+          getPolicyForItem(quickLookupItems?.[0] || null).fefo
+        }
+        autoFefo={quickAutoFefo}
+        onToggleAutoFefo={() => setQuickAutoFefo((value) => !value)}
+        quantity={quickQuantidade}
+        onQuantityChange={setQuickQuantidade}
+        adjustmentStock={quickNovoEstoque}
+        onAdjustmentStockChange={setQuickNovoEstoque}
+        adjustmentReason={quickMotivo}
+        onAdjustmentReasonChange={setQuickMotivo}
+        obs={quickObs}
+        onObsChange={setQuickObs}
+        onTransferFromChange={setTransferFrom}
+        onTransferToChange={setTransferTo}
+        feedback={quickActionFeedback}
+        loading={quickActionLoading}
         onOpenChange={(open) => {
           if (open) return
           resetQuickOperationState()
           setQuickOp(null)
         }}
-      >
-      <DialogContent className={`${dialogLargeClass} dark bg-corporate-900 border-white/10 text-white`}>
-          <DialogHeader>
-            <DialogTitle className="text-white">
-              {quickOp === 'ENTRADA'
-                ? 'Entrada'
-                : quickOp === 'BAIXA'
-                  ? 'Saída'
-                  : quickOp === 'TRANSFERENCIA'
-                    ? 'Transferência'
-                    : 'Operação'}
-            </DialogTitle>
-            <DialogDescription className="text-blue-100/70">
-              Preencha os dados para registrar a operação na unidade selecionada.
-            </DialogDescription>
-          </DialogHeader>
+        onCancel={() => {
+          resetQuickOperationState()
+          setQuickOp(null)
+        }}
+        onConfirmTransfer={async () => {
+          const ok = await runTransfer()
+          if (ok) resetQuickOperationState({ keepFeedback: true })
+        }}
+        onConfirmOperation={async () => {
+          const operation = quickOp === 'AJUSTE' ? 'AJUSTE' : quickOp === 'ENTRADA' ? 'ENTRADA' : 'BAIXA'
+          const ok = await runQuickOperation(operation)
+          if (ok) resetQuickOperationState({ keepFeedback: true })
+        }}
+        onEditItem={openEditDialog}
+      />
 
-          {!isAuthed ? (
-            shouldShowDashboardLoading ? (
-              <DashboardLoadingButton size="sm" />
-            ) : (
-              <div className="text-sm text-blue-100/80">Faça login no CRM para usar as operações de Insumos.</div>
-            )
-          ) : null}
-
-          <div className="rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2 text-xs text-blue-100">
-            {quickOp === 'TRANSFERENCIA'
-              ? `Unidade da operação: ${unidadeLabel(transferFrom)} → ${unidadeLabel(transferTo)}`
-              : `Unidade da operação: ${unidadeLabel(unidade)}`}
-          </div>
-
-          <div className="space-y-3">
-            <div>
-              <div className="text-xs text-blue-200/70 mb-1">Buscar por produto, marca, categoria ou código</div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Input
-                  value={quickSearch}
-                  onChange={(e) => setQuickSearch(e.target.value)}
-                  placeholder="ex: Rennova, preenchedor, 789..."
-                  className="w-full sm:flex-1 sm:min-w-[240px]"
-                />
-                <Button variant="secondary" type="button" onClick={() => setQuickScanOpen((v) => !v)}>
-                  {quickScanOpen ? 'Fechar' : 'Escanear'}
-                </Button>
-              </div>
-              <div className="mt-2">
-                {quickSearchRemoteLoading ? (
-                  <div className="text-xs text-blue-200/70">Buscando no servidor…</div>
-                ) : quickSearchRemoteError ? (
-                  <div className="text-xs text-amber-200">{quickSearchRemoteError} (mostrando cache local).</div>
-                ) : null}
-                {quickSearchMatches.length && (!hasQuickSelection || quickLookupLoading) ? (
-                  <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
-                    <div className="text-[11px] text-blue-200/60 mb-2">Selecione o produto para lançar a operação:</div>
-                    <div className="space-y-2">
-                      {quickSearchMatches.map(({ item, matchedCode }) => {
-                        const codes = getInsumoBarcodes(item)
-                        const code = matchedCode && codes.includes(matchedCode) ? matchedCode : codes[0] || ''
-                        const hasCode = !!code
-                        const descriptor = formatInsumoDescriptor(item)
-                        const primarySelected = quickSelectedSnapshot || (quickLookupItems.length ? quickLookupItems[0] : null)
-                        const isLoadingSelection = !!(quickLookupLoading && primarySelected && isSameInsumo(item, primarySelected))
-                        return (
-                          <div
-                            key={`${item.registro || ''}-${code || 'nocode'}`}
-                            className="w-full min-w-0 rounded-md border border-white/5 bg-white/5 px-2 py-2"
-                          >
-                            <button
-                              type="button"
-                              onClick={() => applyQuickSelection(item, code)}
-                              disabled={!hasCode || isLoadingSelection}
-                              className={`w-full text-left ${(!hasCode || isLoadingSelection) ? 'cursor-not-allowed' : 'hover:bg-white/10'} rounded-md px-1 py-1`}
-                              aria-busy={isLoadingSelection}
-                            >
-                              <div className="flex flex-wrap items-center justify-between gap-2">
-                                <div className="text-sm text-blue-50 font-semibold break-words">{String(item.produto || 'Insumo')}</div>
-                                <div className="flex items-center gap-2 text-xs text-blue-200/60 font-mono break-all">
-                                  {code || '—'}
-                                  {isLoadingSelection ? (
-                                    <span className="inline-flex items-center gap-1 text-blue-200/70 font-sans">
-                                      <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
-                                      Carregando…
-                                    </span>
-                                  ) : null}
-                                </div>
-                              </div>
-                              {descriptor ? (
-                                <div className="text-xs text-blue-200/70 mt-0.5 break-words">{descriptor}</div>
-                              ) : null}
-                              {!hasCode ? (
-                                <div className="text-xs text-amber-200 mt-1">Sem código de barras cadastrado</div>
-                              ) : null}
-                              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
-                                {item.categoria ? (
-                                  <Badge style={buildTagStyle(getCategoriaBgColor(String(item.categoria)))} className="border">
-                                    {String(item.categoria)}
-                                  </Badge>
-                                ) : null}
-                                {item.marca ? (
-                                  <Badge style={buildTagStyle(getMarcaBgColor(String(item.marca)))} className="border">
-                                    {String(item.marca)}
-                                  </Badge>
-                                ) : null}
-                              </div>
-                            </button>
-                            {!hasCode ? (
-                              <div className="mt-2 flex justify-end">
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  onClick={() => openEditDialog(item)}
-                                  disabled={!isAuthed}
-                                >
-                                  Editar cadastro
-                                </Button>
-                              </div>
-                            ) : null}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </div>
-                ) : null}
-                {quickLookupLoading ? (
-                  <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
-                ) : quickLookupError ? (
-                  <div className="text-xs text-red-200">{quickLookupError}</div>
-                ) : (quickLookupItems.length || quickSelectedSnapshot) ? (
-                  (() => {
-                    const selected = quickLookupItems[0] || quickSelectedSnapshot
-                    if (!selected) return null
-                    const selectedCodes = getInsumoBarcodes(selected)
-                    const activeCode = quickCodigo.trim() || selectedCodes[0] || ''
-                    const resumoBase = quickLookupItems.length ? quickLookupItems : [selected]
-                    return (
-                      <div className="rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2">
-                        <div className="flex flex-wrap items-start justify-between gap-2">
-                          <div>
-                            <div className="text-xs uppercase tracking-wide text-blue-200/70">Selecionado</div>
-                            <div className="text-sm text-blue-50 font-semibold">
-                              {String(selected?.produto || '').trim() || 'Insumo'}
-                            </div>
-                            {formatInsumoDescriptor(selected) ? (
-                              <div className="text-xs text-blue-200/70 mt-0.5">
-                                {formatInsumoDescriptor(selected)}
-                              </div>
-                            ) : null}
-                          </div>
-                          <div className="flex flex-col items-end gap-2 text-xs text-blue-200/70">
-                            <Button variant="outline" size="sm" onClick={clearQuickSelection}>
-                              Trocar seleção
-                            </Button>
-                            <div className="text-right">
-                              {(() => {
-                                const ctx = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
-                                const total = resumoBase.reduce((acc, it) => {
-                                  const v = ctx && (it as any)?.estoques ? Number((it as any).estoques?.[ctx] ?? 0) : Number((it as any).estoqueAtual ?? 0)
-                                  return acc + (Number.isFinite(v) ? v : 0)
-                                }, 0)
-                                return `Estoque: ${total}`
-                              })()}
-                              {' • '}
-                              {Array.from(new Set(resumoBase.map((it) => String((it as any)?.registro || '').trim()).filter(Boolean))).length} registros
-                            </div>
-                          </div>
-                        </div>
-                        {selectedCodes.length > 1 ? (
-                          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
-                            <span className="uppercase tracking-wide">Código</span>
-                            <Select value={activeCode} onValueChange={(v) => selectQuickCodigo(v, { snapshot: selected })}>
-                              <SelectTrigger className="h-8">
-                                <SelectValue placeholder="Selecione o código" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {selectedCodes.map((c) => (
-                                  <SelectItem key={c} value={c}>
-                                    <span className="font-mono">{c}</span>
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </div>
-                        ) : null}
-                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-blue-200/70">
-                          {selected?.categoria ? (
-                            <Badge style={buildTagStyle(getCategoriaBgColor(String(selected.categoria)))} className="border">
-                              {String(selected.categoria)}
-                            </Badge>
-                          ) : null}
-                          {selected?.marca ? (
-                            <Badge style={buildTagStyle(getMarcaBgColor(String(selected.marca)))} className="border">
-                              {String(selected.marca)}
-                            </Badge>
-                          ) : null}
-                        </div>
-                      </div>
-                    )
-                  })()
-                ) : null}
-              </div>
-            </div>
-
-            {quickLoteNeedsPick ? (
-              <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="text-xs text-blue-200/70">Lote/registro</div>
-                    {(quickOp === 'BAIXA' || quickOp === 'TRANSFERENCIA') &&
-                      quickLotesForPicker.length > 1 &&
-                      getPolicyForItem(quickLookupItems?.[0] || null).fefo ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      type="button"
-                      onClick={() => setQuickAutoFefo((v) => !v)}
-                      title="FEFO (First-Expire, First-Out): prioriza o lote com validade mais próxima"
-                    >
-                      FEFO {quickAutoFefo ? 'auto' : 'manual'}
-                    </Button>
-                  ) : null}
-                </div>
-                <Select
-                  value={quickRegistro}
-                  onValueChange={(v) => {
-                    setQuickRegistro(v)
-                    setQuickAutoFefo(false)
-                  }}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Selecione o lote/registro" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {quickLotesForPicker.map((l) => (
-                      <SelectItem key={l.registro} value={l.registro}>
-                        <span className="flex w-full items-center justify-between gap-3">
-                          <span className="font-mono">{l.registro}</span>
-                          <span className="flex items-center gap-2 text-xs text-blue-100/70">
-                            {l.lote ? <span>Lote {l.lote}</span> : null}
-                            {l.dataValidade ? <span>Vence {fmtDateOnlyBR(l.dataValidade)}</span> : null}
-                            {Number.isFinite(Number(l.estoque)) ? <span>Estoque {Number(l.estoque)}</span> : null}
-                          </span>
-                        </span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <div className="text-xs text-blue-200/60">
-                  Se o produto tiver múltiplos lotes, selecione qual registro deve ser movimentado.
-                </div>
-              </div>
-            ) : null}
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
-                <Input value={quickQuantidade} onChange={(e) => setQuickQuantidade(e.target.value)} type="number" min={1} />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Observações</div>
-                <Input value={quickObs} onChange={(e) => setQuickObs(e.target.value)} placeholder="opcional" />
-              </div>
-            </div>
-
-            {quickOp === 'TRANSFERENCIA' ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Origem</div>
-                  <Select value={transferFrom} onValueChange={setTransferFrom}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {unidadeOptions.map((u) => (
-                        <SelectItem key={u} value={u}>
-                          {unidadeLabel(u)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Destino</div>
-                  <Select value={transferTo} onValueChange={setTransferTo}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {unidadeOptions.map((u) => (
-                        <SelectItem key={u} value={u}>
-                          {unidadeLabel(u)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            ) : null}
-
-            {quickScanOpen ? (
-              <BarcodeScannerInline
-                onDetected={(code) => {
-                  selectQuickCodigo(code, { setSearch: true, snapshot: null })
-                  setQuickScanOpen(false)
-                  toast.success('Código detectado')
-                }}
-                onClose={() => setQuickScanOpen(false)}
-              />
-            ) : null}
-
-            {quickActionFeedback ? (
-              <div
-                className={`rounded-lg border px-3 py-2 text-sm ${
-                  quickActionFeedback.type === 'success'
-                    ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
-                    : 'border-red-400/40 bg-red-500/10 text-red-100'
-                }`}
-              >
-                {quickActionFeedback.message}
-              </div>
-            ) : null}
-          </div>
-
-          <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  resetQuickOperationState()
-                  setQuickOp(null)
-                }}
-              >
-                Cancelar
-              </Button>
-            {quickOp === 'TRANSFERENCIA' ? (
-              <Button
-                className="!bg-blue-600 hover:!bg-blue-700 !text-white"
-                onClick={async () => {
-                  const ok = await runTransfer()
-                  if (ok) {
-                    resetQuickOperationState({ keepFeedback: true })
-                  }
-                }}
-                disabled={quickActionLoading || !isAuthed}
-              >
-                <span className="flex items-center gap-2">
-                  {quickActionLoading ? (
-                    <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
-                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
-                      <path d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-                    </svg>
-                  ) : null}
-                  {quickActionLoading ? 'Processando...' : 'Confirmar transferência'}
-                </span>
-              </Button>
-            ) : (
-              <Button
-                className={
-                  quickOp === 'ENTRADA'
-                    ? '!bg-green-600 hover:!bg-green-700 !text-white'
-                    : quickOp === 'BAIXA'
-                      ? ''
-                      : ''
-                }
-                variant={quickOp === 'BAIXA' ? 'destructive' : 'default'}
-                onClick={async () => {
-                  const ok = await runQuickAction(quickOp === 'ENTRADA' ? 'ENTRADA' : 'BAIXA')
-                  if (ok) {
-                    resetQuickOperationState({ keepFeedback: true })
-                  }
-                }}
-                disabled={quickActionLoading || !isAuthed}
-              >
-                <span className="flex items-center gap-2">
-                  {quickActionLoading ? (
-                    <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
-                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
-                      <path d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-                    </svg>
-                  ) : null}
-                  {quickActionLoading ? 'Processando...' : (quickOp === 'ENTRADA' ? 'Confirmar entrada' : 'Confirmar saída')}
-                </span>
-              </Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
+      <InsumosMovementEditDialog
         open={editMovOpen}
+        dialogClassName={dialogSmallClass}
+        target={editMovTarget}
+        isAuthed={isAuthed}
+        saving={editMovSaving}
+        deleting={editMovDeleting}
+        produto={editMovProduto}
+        data={editMovData}
+        hora={editMovHora}
+        unidade={editMovUnidade}
+        quantidade={editMovQuantidade}
+        novoEstoque={editMovNovoEstoque}
+        motivo={editMovMotivo}
+        unitOptions={unidadeOptions}
+        insumosProdutos={insumosProdutos}
+        unitLabel={unidadeLabel}
         onOpenChange={(open) => {
           setEditMovOpen(open)
           if (!open) {
@@ -6919,307 +4057,39 @@ export function InsumosModule() {
             setEditMovDeleting(false)
           }
         }}
-      >
-        <DialogContent className={`${dialogSmallClass} dark bg-corporate-900 border-white/10 text-white`}>
-          <DialogHeader>
-            <DialogTitle className="text-white">
-              {(() => {
-                const tipo = normalizeMovimentacaoTipo(editMovTarget?.tipo)
-                if (String(editMovTarget?.transferId || '').trim()) return 'Editar transferência'
-                if (tipo === 'AJUSTE') return 'Editar ajuste'
-                if (tipo.includes('ENTRADA')) return 'Editar entrada'
-                if (tipo.includes('SAIDA')) return 'Editar saída'
-                return 'Editar lançamento'
-              })()}
-            </DialogTitle>
-            <DialogDescription className="text-blue-100/70">
-              Edite os dados do lançamento sem abrir o cadastro do insumo.
-            </DialogDescription>
-          </DialogHeader>
+        onProdutoChange={setEditMovProduto}
+        onDataChange={(value) => {
+          const iso = dateInputToIso(value)
+          setEditMovData(iso || value)
+        }}
+        onHoraChange={setEditMovHora}
+        onUnidadeChange={setEditMovUnidade}
+        onQuantidadeChange={setEditMovQuantidade}
+        onNovoEstoqueChange={setEditMovNovoEstoque}
+        onMotivoChange={setEditMovMotivo}
+        onCancel={() => {
+          setEditMovOpen(false)
+          setEditMovTarget(null)
+        }}
+        onSave={() => void saveMovementEdit()}
+        onDelete={() => void deleteMovementEdit()}
+      />
 
-          <div className="space-y-3">
-            <div>
-              <div className="text-xs text-blue-200/70 mb-1">Produto</div>
-              <AutocompleteInput
-                value={editMovProduto}
-                onValueChange={setEditMovProduto}
-                placeholder="Nome do produto"
-                options={insumosProdutos}
-              />
-            </div>
+      <InsumosPurchaseDialog
+        actionables={overviewActionables}
+        dialogClassName={dialogMediumClass}
+        isAuthed={isAuthed}
+        loading={overviewLoading}
+        open={purchaseDialogOpen}
+        onOpenChange={setPurchaseDialogOpen}
+        onOpenQuickOperation={openQuickOperation}
+        onClose={() => setPurchaseDialogOpen(false)}
+        renderLoadingText={renderLoadingText}
+        unit={unidade}
+        unitLabel={unidadeLabel}
+      />
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Data</div>
-                <BrDatePickerInput
-                  value={fmtDateOnlyBR(editMovData)}
-                  onChange={(value) => {
-                    const iso = dateInputToIso(value)
-                    setEditMovData(iso || value)
-                  }}
-                  placeholder="DD/MM/AA"
-                  ariaLabel="Data da movimentação"
-                />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Hora</div>
-                <Input
-                  type="time"
-                  value={editMovHora}
-                  onChange={(e) => setEditMovHora(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Unidade</div>
-                {String(editMovTarget?.transferId || '').trim() ? (
-                  <Input
-                    value={`${unidadeLabel(String(editMovTarget?.unidadeOrigem || ''))} → ${unidadeLabel(String(editMovTarget?.unidadeDestino || ''))}`}
-                    disabled
-                  />
-                ) : (
-                  <Select value={editMovUnidade || undefined} onValueChange={setEditMovUnidade}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Selecione a unidade" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {unidadeOptions.map((u) => (
-                        <SelectItem key={u} value={u}>
-                          {unidadeLabel(u)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
-
-              {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Novo estoque</div>
-                  <Input
-                    type="number"
-                    min={0}
-                    value={editMovNovoEstoque}
-                    onChange={(e) => setEditMovNovoEstoque(e.target.value)}
-                  />
-                </div>
-              ) : (
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Quantidade</div>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={editMovQuantidade}
-                    onChange={(e) => setEditMovQuantidade(e.target.value)}
-                  />
-                </div>
-              )}
-            </div>
-
-            {normalizeMovimentacaoTipo(editMovTarget?.tipo) === 'AJUSTE' ? (
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Motivo</div>
-                <Input value={editMovMotivo} onChange={(e) => setEditMovMotivo(e.target.value)} />
-              </div>
-            ) : null}
-
-            {editMovTarget?.registroInsumo ? (
-              <div className="text-xs text-blue-200/60">
-                Registro: <span className="font-mono">{String(editMovTarget.registroInsumo)}</span>
-              </div>
-            ) : null}
-          </div>
-
-          <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-between">
-            <Button
-              variant="destructive"
-              onClick={() => void deleteMovementEdit()}
-              disabled={editMovSaving || editMovDeleting || !isAuthed}
-            >
-              {editMovDeleting ? 'Excluindo...' : 'Excluir'}
-            </Button>
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-            <Button
-              variant="secondary"
-              onClick={() => {
-                setEditMovOpen(false)
-                setEditMovTarget(null)
-              }}
-              disabled={editMovSaving || editMovDeleting}
-            >
-              Cancelar
-            </Button>
-            <Button onClick={() => void saveMovementEdit()} disabled={editMovSaving || editMovDeleting || !isAuthed}>
-              {editMovSaving ? 'Salvando...' : 'Salvar lançamento'}
-            </Button>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={purchaseDialogOpen} onOpenChange={setPurchaseDialogOpen}>
-        <DialogContent size="wideTable" className={`${dialogMediumClass} dark bg-corporate-900 border-white/10 text-white`}>
-          <DialogHeader>
-            <DialogTitle className="text-white">Lista de compra</DialogTitle>
-            <DialogDescription className="text-blue-100/70">
-              Sugestões de reposição para {unidadeLabel(unidade)} (baseado em estoque mínimo).
-            </DialogDescription>
-          </DialogHeader>
-
-          {(() => {
-            const items = (overviewActionables?.reposicao || []).slice()
-            const totalValue = items.reduce((acc, it) => acc + (Number(it.estimatedValue) || 0), 0)
-            const totalQty = items.reduce((acc, it) => acc + (Number(it.suggestedPurchaseQty) || 0), 0)
-
-            const byCat = new Map<string, any[]>()
-            for (const it of items) {
-              const cat = String(it.categoria || 'Outros').trim() || 'Outros'
-              const prev = byCat.get(cat) || []
-              prev.push(it)
-              byCat.set(cat, prev)
-            }
-            const cats = Array.from(byCat.entries()).sort((a, b) => a[0].localeCompare(b[0]))
-
-	            const escapeCsv = (v: any) => {
-	              const s = String(v ?? '')
-	              if (/[";\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
-	              return s
-	            }
-            const toCsv = () => {
-              const header = ['Categoria', 'Produto', 'Código', 'Qtd sugerida', 'Valor estimado (R$)']
-              const rows = items.map((it) => [
-                it.categoria || '',
-                it.produto || '',
-                it.codigoBarras || '',
-                Number(it.suggestedPurchaseQty) || 0,
-                Number(it.estimatedValue) || 0
-              ])
-              return [header, ...rows].map((r) => r.map(escapeCsv).join(';')).join('\n')
-            }
-
-            return (
-              <div className="space-y-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="text-sm text-blue-100/80">
-                    <span className="font-mono">{items.length}</span> itens •{' '}
-                    <span className="font-mono">{totalQty}</span> unidades sugeridas •{' '}
-                    <span className="font-mono">{fmtMoneyBRL(totalValue)}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(toCsv())
-                          toast.success('Lista copiada (CSV)')
-                        } catch {
-                          toast.error('Não foi possível copiar')
-                        }
-                      }}
-                      disabled={!items.length}
-                    >
-                      Copiar CSV
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        const csv = toCsv()
-                        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
-                        const url = URL.createObjectURL(blob)
-                        const a = document.createElement('a')
-                        a.href = url
-                        a.download = `lista-compra-${unidade}-${new Date().toISOString().slice(0, 10)}.csv`
-                        document.body.appendChild(a)
-                        a.click()
-                        a.remove()
-                        setTimeout(() => URL.revokeObjectURL(url), 2000)
-                      }}
-                      disabled={!items.length}
-                    >
-                      Baixar CSV
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
-                  <table className="min-w-full text-sm">
-                    <thead className="bg-black/30 text-blue-100/80">
-                      <tr>
-                        <th className="text-left p-3">Produto</th>
-                        <th className="text-left p-3 hidden md:table-cell">Categoria</th>
-                        <th className="text-left p-3 hidden sm:table-cell">Código</th>
-                        <th className="text-right p-3">Qtd sugerida</th>
-                        <th className="text-right p-3">Valor</th>
-                        <th className="text-right p-3">Ação</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-white/5">
-                      {cats.flatMap(([cat, list]) => {
-                        const rows = list.map((it, idx) => (
-                          <tr key={`${String(it.codigoBarras || '')}-${idx}`} className="hover:bg-white/5">
-                            <td className="p-3 text-blue-50">
-                              <div className="font-medium">{it.produto || '-'}</div>
-                            </td>
-                            <td className="p-3 text-blue-100/80 hidden md:table-cell">{it.categoria || cat}</td>
-                            <td className="p-3 font-mono text-blue-100/80 hidden sm:table-cell break-all">{it.codigoBarras || ''}</td>
-                            <td className="p-3 text-right font-mono text-blue-100/80">{it.suggestedPurchaseQty ?? 0}</td>
-                            <td className="p-3 text-right font-mono text-blue-100/80">
-                              {fmtMoneyBRL(Number(it.estimatedValue) || 0)}
-                            </td>
-                            <td className="p-3 text-right">
-                              <Button
-                                variant="outline"
-                                className="h-8 px-2 text-xs"
-                                onClick={() => {
-                                  openQuickOperation('ENTRADA', {
-                                    codigoBarras: String(it.codigoBarras || ''),
-                                    quantidade: it.suggestedPurchaseQty ?? 1,
-                                    obs: 'Reposição sugerida'
-                                  })
-                                  setPurchaseDialogOpen(false)
-                                }}
-                                disabled={!isAuthed}
-                              >
-                                Registrar entrada
-                              </Button>
-                            </td>
-                          </tr>
-                        ))
-                        return rows
-                      })}
-                      {!items.length ? (
-                        <tr>
-                          <td className="p-3 text-blue-100/70" colSpan={6}>
-                            {renderLoadingText(overviewLoading, 'Sem recomendações de compra.')}
-                          </td>
-                        </tr>
-                      ) : null}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            )
-          })()}
-
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setPurchaseDialogOpen(false)}>
-              Fechar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {proxyStatus?.mutationsBlocked ? (
-        <div className="max-w-6xl mx-auto mb-3 rounded-xl border border-amber-400/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-          <div className="font-semibold">Modo local seguro ativo</div>
-          <div className="text-amber-100/80">
-            Mutações para o backend de produção estão bloqueadas. Para liberar, rode com
-            <span className="font-mono"> LOCAL_ALLOW_UPSTREAM_MUTATIONS=1</span>.
-          </div>
-        </div>
-      ) : null}
+      <InsumosSafeModeBanner visible={!!proxyStatus?.mutationsBlocked} />
 
       <div ref={overviewSectionRef} className="max-w-6xl mx-auto space-y-3 pt-1">
         <div className="flex flex-col gap-3">
@@ -7236,238 +4106,51 @@ export function InsumosModule() {
                         if (!isManagerRole) return <div key={panelId} />
                         return (
                           <div ref={dragProvided.innerRef} {...dragProvided.draggableProps}>
-	                            <Card className="bg-black/20 border border-white/10">
-	                              <CardHeader className="relative pr-24">
-	                                <CardTitle className="text-white text-base">Políticas por categoria</CardTitle>
-	                                <div className="absolute top-2 right-2 flex items-center gap-1">
-                                  <div
-                                    {...handleProps}
-                                    className="h-9 w-9 flex items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] cursor-grab active:cursor-grabbing"
-                                    title="Arraste para mover"
-                                    aria-label="Mover"
-                                    role="button"
-                                    tabIndex={0}
-                                  >
-                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                      <path
-                                        d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01"
-                                        stroke="currentColor"
-                                        strokeWidth="3"
-                                        strokeLinecap="round"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                                    onClick={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.policies, !panelOpen)}
-                                    title={panelOpen ? 'Contrair' : 'Expandir'}
-                                    aria-label={panelOpen ? 'Contrair' : 'Expandir'}
-                                  >
-                                    {panelOpen ? (
-                                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                      </svg>
-                                    ) : (
-                                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                      </svg>
-                                    )}
-                                  </Button>
-	                                </div>
-	                              </CardHeader>
-                              {panelOpen ? (
-                                <CardContent className="space-y-3">
-              <div className="text-xs text-blue-200/60">
-                Configure quais categorias exigem <span className="font-medium text-blue-100/80">lote</span> e/ou <span className="font-medium text-blue-100/80">validade</span>, e habilite <span className="font-medium text-blue-100/80">FEFO</span> quando aplicável.
-              </div>
-
-              <div className="rounded-xl border border-white/10 bg-black/10 p-3 space-y-3">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-2 items-end">
-                  <div className="md:col-span-2">
-                    <div className="text-xs text-blue-200/70 mb-1">Categoria (nome)</div>
-                    <Input
-                      value={policyFormLabel}
-                      onChange={(e) => {
-                        const next = e.target.value
-                        setPolicyFormLabel(next)
-                      }}
-                      placeholder="Ex: Toxina botulínica"
-                      disabled={!isAuthed}
-                    />
-                  </div>
-                  <div>
-                    <div className="text-xs text-blue-200/70 mb-1">Slug (opcional)</div>
-                    <Input
-                      value={policyFormSlug}
-                      onChange={(e) => {
-                        setPolicyFormSlugTouched(true)
-                        setPolicyFormSlug(e.target.value)
-                      }}
-                      placeholder={slugifyCategoria(policyFormLabel) || 'ex: toxina-botulinica'}
-                      disabled={!isAuthed}
-                    />
-                  </div>
-                </div>
-
-                {adminCategorySuggestions.length ? (
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2 items-end">
-                    <div className="md:col-span-2">
-                      <div className="text-xs text-blue-200/70 mb-1">Sugestões (já usadas em itens)</div>
-                      <Select
-                        value={policyFormSuggestion}
-                        onValueChange={(v) => {
-                          const next = String(v)
-                          setPolicyFormSuggestion(next)
-                          if (next === '__NONE__') return
-                          const hit = adminCategorySuggestions.find((s) => s.slug === next)
-                          if (!hit) return
-                          setPolicyFormLabel(hit.label)
-                          setPolicyFormSlugTouched(true)
-                          setPolicyFormSlug(hit.slug)
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Escolher…" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__NONE__">(nenhuma)</SelectItem>
-                          {adminCategorySuggestions.map((s) => (
-                            <SelectItem key={s.slug} value={s.slug}>
-                              {s.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="text-xs text-blue-200/60">
-                      {policyFormEditingSlug ? (
-                        <Badge variant="secondary">Editando: {policyFormEditingSlug}</Badge>
-                      ) : (
-                        <Badge variant="secondary">Nova política</Badge>
-                      )}
-                    </div>
-                  </div>
-                ) : policyFormEditingSlug ? (
-                  <div className="text-xs text-blue-200/60">
-                    <Badge variant="secondary">Editando: {policyFormEditingSlug}</Badge>
-                  </div>
-                ) : null}
-
-                <div className="flex flex-wrap gap-4">
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="policy-requires-lot"
-                      checked={policyFormRequiresLot}
-                      onCheckedChange={(checked) => setPolicyFormRequiresLot(!!checked)}
-                    />
-                    <label htmlFor="policy-requires-lot" className="text-sm text-blue-100/80 cursor-pointer">
-                      Lote obrigatório
-                    </label>
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="policy-requires-expiry"
-                      checked={policyFormRequiresExpiry}
-                      onCheckedChange={(checked) => {
-                        const next = !!checked
-                        setPolicyFormRequiresExpiry(next)
-                        if (!next) setPolicyFormFefo(false)
-                      }}
-                    />
-                    <label htmlFor="policy-requires-expiry" className="text-sm text-blue-100/80 cursor-pointer">
-                      Validade obrigatória
-                    </label>
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="policy-fefo"
-                      checked={policyFormFefo}
-                      onCheckedChange={(checked) => {
-                        const next = !!checked
-                        setPolicyFormFefo(next)
-                        if (next) setPolicyFormRequiresExpiry(true)
-                      }}
-                    />
-                    <label htmlFor="policy-fefo" className="text-sm text-blue-100/80 cursor-pointer">
-                      FEFO (sugere lote por validade)
-                    </label>
-                  </div>
-                </div>
-
-                <div className="flex items-center justify-between gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={() => resetPolicyForm()}
-                    disabled={!isAuthed}
-                  >
-                    Limpar
-                  </Button>
-                  <Button
-                    className="!bg-blue-600 hover:!bg-blue-700 !text-white"
-                    onClick={() => void saveCategoryPolicy()}
-                    disabled={!isAuthed}
-                  >
-                    {policyFormEditingSlug ? 'Salvar alterações' : 'Criar política'}
-                  </Button>
-                </div>
-              </div>
-
-              <div className="overflow-auto rounded-xl border border-white/10">
-                <table className="min-w-full text-sm">
-                      <thead className="bg-black/30 text-blue-100/80">
-                        <tr>
-                          <th className="text-left p-3 w-[34%]">Categoria</th>
-                          <th className="text-left p-3 w-[46%]">Regras</th>
-                          <th className="text-right p-3 w-[20%]">Ações</th>
-                        </tr>
-                      </thead>
-                  <tbody className="divide-y divide-white/5">
-                    {(adminCategoryPolicies || []).map((p) => (
-                      <tr key={p.slug} className="hover:bg-white/5">
-                        <td className="p-3 text-blue-50">
-                          <div className="text-blue-50">{p.label || p.slug}</div>
-                          <div className="text-xs text-blue-200/60 font-mono">{p.slug}</div>
-                        </td>
-                        <td className="p-3">
-                          <div className="flex flex-wrap gap-2">
-                            {p.requiresLot ? <Badge variant="secondary">lote</Badge> : <Badge variant="secondary">lote opcional</Badge>}
-                            {p.requiresExpiry ? <Badge variant="secondary">validade</Badge> : <Badge variant="secondary">validade opcional</Badge>}
-                            {p.fefo ? <Badge>FEFO</Badge> : <Badge variant="secondary">sem FEFO</Badge>}
-                          </div>
-                        </td>
-                        <td className="p-3 text-right">
-                          <div className="flex justify-end gap-2">
-                            <Button variant="outline" className="h-8 px-2" onClick={() => startEditPolicyForm(p)}>
-                              Editar
-                            </Button>
-                            <Button
-                              variant="destructive"
-                              className="h-8 px-2"
-                              onClick={() => void deleteCategoryPolicy(p.slug)}
-                            >
-                              Remover
-                            </Button>
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                    {!adminCategoryPoliciesLoading && !(adminCategoryPolicies || []).length ? (
-                      <tr>
-                        <td className="p-3 text-blue-100/70" colSpan={3}>
-                          Sem políticas cadastradas.
-                        </td>
-                      </tr>
-                    ) : null}
-                  </tbody>
-                </table>
-              </div>
-                                </CardContent>
-                              ) : null}
-                            </Card>
+                            <InsumosCategoryPoliciesPanel
+                              panelOpen={panelOpen}
+                              isAuthed={isAuthed}
+                              policyFormLabel={policyFormLabel}
+                              policyFormSlug={policyFormSlug}
+                              policyFormSlugPlaceholder={slugifyCategoria(policyFormLabel) || 'ex: toxina-botulinica'}
+                              policyFormSuggestion={policyFormSuggestion}
+                              policyFormEditingSlug={policyFormEditingSlug}
+                              policyFormRequiresLot={policyFormRequiresLot}
+                              policyFormRequiresExpiry={policyFormRequiresExpiry}
+                              policyFormFefo={policyFormFefo}
+                              adminCategorySuggestions={adminCategorySuggestions}
+                              adminCategoryPolicies={adminCategoryPolicies}
+                              adminCategoryPoliciesLoading={adminCategoryPoliciesLoading}
+                              dragHandleProps={handleProps || undefined}
+                              onToggleOpen={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.policies, !panelOpen)}
+                              onPolicyFormLabelChange={setPolicyFormLabel}
+                              onPolicyFormSlugChange={(value) => {
+                                setPolicyFormSlugTouched(true)
+                                setPolicyFormSlug(value)
+                              }}
+                              onPolicyFormSuggestionChange={(value) => {
+                                const next = String(value)
+                                setPolicyFormSuggestion(next)
+                                if (next === '__NONE__') return
+                                const hit = adminCategorySuggestions.find((suggestion) => suggestion.slug === next)
+                                if (!hit) return
+                                setPolicyFormLabel(hit.label)
+                                setPolicyFormSlugTouched(true)
+                                setPolicyFormSlug(hit.slug)
+                              }}
+                              onPolicyFormRequiresLotChange={setPolicyFormRequiresLot}
+                              onPolicyFormRequiresExpiryChange={(value) => {
+                                setPolicyFormRequiresExpiry(value)
+                                if (!value) setPolicyFormFefo(false)
+                              }}
+                              onPolicyFormFefoChange={(value) => {
+                                setPolicyFormFefo(value)
+                                if (value) setPolicyFormRequiresExpiry(true)
+                              }}
+                              onResetPolicyForm={resetPolicyForm}
+                              onSaveCategoryPolicy={() => void saveCategoryPolicy()}
+                              onStartEditPolicyForm={startEditPolicyForm}
+                              onDeleteCategoryPolicy={(slug) => void deleteCategoryPolicy(slug)}
+                            />
                           </div>
                         )
                       }
@@ -7475,820 +4158,98 @@ export function InsumosModule() {
                       if (panelId === 'alerts') {
                         return (
                           <div ref={dragProvided.innerRef} {...dragProvided.draggableProps}>
-		                            <Card className="bg-black/20 border border-white/10">
-                              <CardHeader className="flex flex-col gap-2">
-                                <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:gap-3">
-                                  <div className="flex items-center gap-3 min-w-0">
-                                    <button
-                                      type="button"
-                                      {...handleProps}
-                                      className="mt-0.5 h-9 w-9 flex items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] cursor-grab active:cursor-grabbing"
-                                      title="Arraste para mover"
-                                      aria-label="Mover"
-                                    >
-                                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path
-                                          d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01"
-                                          stroke="currentColor"
-                                          strokeWidth="3"
-                                          strokeLinecap="round"
-                                        />
-                                      </svg>
-                                    </button>
-                                    <CardTitle className="text-white text-base">Avisos</CardTitle>
-                                    <div className="hidden sm:flex items-center gap-3 text-xs text-blue-200/70">
-                                      <span className="inline-flex items-center gap-1">
-                                        <span
-                                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/40 text-red-50"
-                                          title="Crítico"
-                                          aria-label="Crítico"
-                                        >
-                                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                            <path d="M12 7v7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                                            <circle cx="12" cy="17" r="1.5" fill="currentColor" />
-                                          </svg>
-                                        </span>
-                                        <span className="font-mono text-blue-50">
-                                          {showOverviewLoadingProgress ? (
-                                            <span className="inline-flex items-center gap-2">
-                                              <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
-                                              {loadingPercent}%
-                                            </span>
-                                          ) : (
-                                            overviewCriticosCount ?? '-'
-                                          )}
-                                        </span>
-                                      </span>
-                                      <span className="inline-flex items-center gap-1">
-                                        <span
-                                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500/35 text-amber-100"
-                                          title="Atenção"
-                                          aria-label="Atenção"
-                                        >
-                                          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                            <path
-                                              d="M12 3l9 16H3l9-16z"
-                                              fill="currentColor"
-                                              fillOpacity="0.45"
-                                              stroke="currentColor"
-                                              strokeWidth="1.4"
-                                              strokeLinejoin="round"
-                                            />
-                                            <path d="M12 9v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                                            <circle cx="12" cy="16.5" r="1.2" fill="currentColor" />
-                                          </svg>
-                                        </span>
-                                        <span className="font-mono text-blue-50">
-                                          {showOverviewLoadingProgress ? (
-                                            <span className="inline-flex items-center gap-2">
-                                              <span className="inline-flex h-3 w-3 rounded-full border border-blue-200/70 border-t-transparent animate-spin" />
-                                              {loadingPercent}%
-                                            </span>
-                                          ) : (
-                                            overviewAtencaoCount ?? '-'
-                                          )}
-                                        </span>
-                                      </span>
-                                    </div>
-                                  </div>
-                                  <div className="flex flex-1 flex-nowrap items-center gap-2 min-w-0 justify-end overflow-x-auto">
-                                    <Select value={alertasStatus} onValueChange={(v) => setAlertasStatus(v as any)}>
-                                      <SelectTrigger className="h-8 w-24 shrink-0">
-                                        <SelectValue placeholder="Status" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="TODOS">–</SelectItem>
-                                        <SelectItem value="ATENCAO">Atenção</SelectItem>
-                                        <SelectItem value="URGENTE">Crítico</SelectItem>
-                                        <SelectItem value="INFO">Info</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Select
-                                      value={alertasCategoria || '__ALL__'}
-                                      onValueChange={(v) => setAlertasCategoria(v === '__ALL__' ? '' : String(v))}
-                                    >
-                                      <SelectTrigger className="h-8 w-36 shrink-0">
-                                        <SelectValue placeholder="Categoria" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        {alertasCategorias.map((c) => (
-                                          <SelectItem key={c} value={c}>
-                                            {c}
-                                          </SelectItem>
-                                        ))}
-                                      </SelectContent>
-                                    </Select>
-                                    <Select value={alertasFluxo} onValueChange={(v) => setAlertasFluxo(v as any)}>
-                                      <SelectTrigger className="h-8 w-28 shrink-0">
-                                        <SelectValue placeholder="Fluxo" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="TODOS">–</SelectItem>
-                                        <SelectItem value="ENTRADA">Entrada</SelectItem>
-                                        <SelectItem value="SAIDA">Saída</SelectItem>
-                                        <SelectItem value="DESCARTE">Descarte</SelectItem>
-                                        <SelectItem value="TRANSFERENCIA">Transferência</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Input
-                                      value={alertasBusca}
-                                      onChange={(e) => setAlertasBusca(e.target.value)}
-                                      placeholder="Buscar"
-                                      className="h-8 flex-1 min-w-[120px] md:min-w-0 ml-auto"
-                                    />
-                                    <div className="flex items-center gap-2 shrink-0">
-                                      <Button
-                                        size="icon"
-                                        variant="ghost"
-                                        className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                                        onClick={() => setPurchaseDialogOpen(true)}
-                                        disabled={!isAuthed || !(overviewActionables?.reposicao || []).length}
-                                        title="Lista de compra"
-                                        aria-label="Lista de compra"
-                                      >
-                                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                          <path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.6a2 2 0 0 0 2-1.6L21 8H7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                          <circle cx="9" cy="20" r="1.6" fill="currentColor" />
-                                          <circle cx="17" cy="20" r="1.6" fill="currentColor" />
-                                        </svg>
-                                      </Button>
-                                      <Button
-	                                    size="icon"
-	                                    variant="ghost"
-	                                    className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-	                                    onClick={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.alerts, !panelOpen)}
-                                        title={panelOpen ? 'Contrair' : 'Expandir'}
-                                        aria-label={panelOpen ? 'Contrair' : 'Expandir'}
-                                      >
-                                        {panelOpen ? (
-                                          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                            <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                          </svg>
-                                        ) : (
-                                          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                            <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                          </svg>
-                                        )}
-                                      </Button>
-                                    </div>
-                                  </div>
-                                </div>
-                              </CardHeader>
-                              {panelOpen ? (
-                                <CardContent className="space-y-2">
-                                  <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
-                                    <table className="w-full table-fixed text-sm">
-                                      <thead className="bg-black/30 text-blue-100/80">
-                                        <tr>
-                                          {(
-                                            [
-                                              { key: 'produto', label: 'Produto', align: 'text-left', widthClass: 'w-[24%]' },
-                                              { key: 'categoria', label: 'Categoria', align: 'text-left', widthClass: 'w-[14%]' },
-                                              { key: 'status', label: 'Status', align: 'text-left', widthClass: 'w-[14%]' },
-                                              { key: 'acao', label: 'Ação recomendada', align: 'text-left', widthClass: 'w-[20%]' },
-                                              { key: 'atual', label: 'Atual', align: 'text-right', widthClass: 'w-[8%]' },
-                                              { key: 'min', label: 'Mín', align: 'text-right hidden sm:table-cell', widthClass: 'w-[6%]' },
-                                              { key: 'dif', label: 'Dif', align: 'text-right hidden lg:table-cell', widthClass: 'w-[7%]' },
-                                              { key: 'percentual', label: '%', align: 'text-right hidden lg:table-cell', widthClass: 'w-[7%]' }
-                                            ] as Array<{ key: AlertasSortKey; label: string; align: string; widthClass?: string }>
-                                          ).map((col) => {
-                                            const isActive = alertasSortKey === col.key
-                                            return (
-                                              <th
-                                                key={col.label}
-                                                className={`p-3 ${col.align} ${col.widthClass || ''} sticky top-0 z-10 bg-black/40 backdrop-blur`}
-                                              >
-                                                <button
-                                                  type="button"
-                                                  className={`w-full inline-flex items-center ${col.align.includes('right') ? 'justify-end' : 'justify-start'} gap-2 cursor-pointer select-none ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 rounded-sm px-0.5`}
-                                                  onClick={() => {
-                                                    if (alertasSortKey === col.key) {
-                                                      setAlertasSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
-                                                      return
-                                                    }
-                                                    setAlertasSortKey(col.key)
-                                                    setAlertasSortDir(col.key === 'status' ? 'asc' : 'desc')
-                                                  }}
-                                                  aria-label={`Ordenar ${col.label}`}
-                                                  title={`Ordenar ${col.label}`}
-                                                >
-                                                  <span>{col.label}</span>
-                                                  <span className={`inline-flex items-center justify-center ${isActive ? 'text-white' : 'text-blue-100/30'}`} aria-hidden>
-                                                    {isActive && alertasSortDir === 'asc' ? (
-                                                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                                        <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                                      </svg>
-                                                    ) : (
-                                                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                                        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                                      </svg>
-                                                    )}
-                                                  </span>
-                                                </button>
-                                              </th>
-                                            )
-                                          })}
-                                        </tr>
-                                      </thead>
-                    <tbody className="divide-y divide-white/5">
-                      {alertasLinhasOrdenadas.slice(0, 120).map((a, idx) => {
-                        const code = String(a.codigoBarras || '').trim()
-                        const rec = code ? alertasRecommendationByCode.get(code) || null : null
-                        const canQuick = !!code && isAuthed
-                        const qualityIssue = a.qualityIssue
-                        const qualityMessage = String(a.qualityMessage || '').trim()
-                        const qualitySeverity = a.qualitySeverity || (qualityIssue as any)?.severity
-                        const canQualityEdit = !!qualityIssue && isAuthed && (!!qualityIssue.registro || !!qualityIssue.codigoBarras || !!qualityIssue.produto)
-                        const hasQualityAction = !!qualityIssue
-                        const isVencendo = a.tags.includes('VENCENDO')
-                        const isExpirado = a.tags.includes('EXPIRADO')
-                        const hasExpiringAction = !rec && (isExpirado || isVencendo)
-                        const hasAnyAction = !!rec || hasExpiringAction || hasQualityAction
-                        const displayTagsSet = new Set<AlertaStatusTag>()
-                        if (a.tags.includes('URGENTE') || isExpirado) displayTagsSet.add('URGENTE')
-                        if (a.tags.includes('ATENCAO') || isVencendo) displayTagsSet.add('ATENCAO')
-                        if (a.tags.includes('INFO')) displayTagsSet.add('INFO')
-                        const displayTags = Array.from(displayTagsSet)
-                        return (
-                          <tr
-                            key={`${a.key}-${idx}`}
-                            className={`hover:bg-white/5 ${a.codigoBarras ? 'cursor-pointer' : ''}`}
-                            onClick={() => {
-                              if (code) {
-                                selectQuickCodigo(code, { setSearch: true, snapshot: null })
-                              }
-                            }}
-                            title={a.codigoBarras ? 'Clique para usar este código de barras' : undefined}
-                          >
-                            <td className="p-3 text-blue-50 align-top">
-                              <div className="flex flex-wrap items-center gap-2 text-blue-50 break-words">
-                                <span>{a.produto || '-'}</span>
-                                {isVencendo ? (
-                                  <Badge variant="secondary" className="border text-[10px] px-1 py-0 h-4 leading-4">
-                                    Venc.
-                                  </Badge>
-                                ) : null}
-                                {isExpirado ? (
-                                  <Badge variant="destructive" className="border text-[10px] px-1 py-0 h-4 leading-4">
-                                    Exp.
-                                  </Badge>
-                                ) : null}
-                              </div>
-                              <div className="hidden md:block text-xs text-blue-200/60 font-mono break-all">{a.codigoBarras || '-'}</div>
-                              {a.marca ? (
-                                <div className="mt-1">
-                                  <Badge
-                                    style={buildTagStyle(getMarcaBgColor(a.marca))}
-                                    className="border cursor-pointer hover:opacity-80"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      const value = String(a.marca || '')
-                                      if (!value) return
-                                      setAlertasMarca((prev) => (prev === value ? '' : value))
-                                    }}
-                                    title="Filtrar por marca"
-                                  >
-                                    {a.marca}
-                                  </Badge>
-                                </div>
-                              ) : null}
-                              {a.dataValidade ? (
-                                <div className="mt-1 text-xs text-blue-200/60">
-                                  validade: <span className="font-mono">{fmtDateOnlyBR(String(a.dataValidade))}</span>
-                                  {a.dias != null ? (
-                                    <>
-                                      {' '}
-                                      <span className="font-mono">({Number(a.dias)}d)</span>
-                                    </>
-                                  ) : null}
-                                </div>
-                              ) : null}
-                            </td>
-                            <td className="p-3 text-blue-100/80 hidden sm:table-cell">
-                              <Badge
-                                style={buildTagStyle(getCategoriaBgColor(a.categoria || 'Outros'))}
-                                className="border cursor-pointer hover:opacity-80"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  const value = String(a.categoria || 'Outros')
-                                  setAlertasCategoria((prev) => (prev === value ? '' : value))
-                                }}
-                                title="Filtrar por categoria"
-                              >
-                                {a.categoria || 'Outros'}
-                              </Badge>
-                            </td>
-                            <td className="p-3">
-                              <div className="flex flex-wrap gap-1">
-                                {displayTags.map((t) => (
-                                  <Badge
-                                    key={t}
-                                    variant={alertaTagVariant(t)}
-                                    className="cursor-pointer hover:opacity-80"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      setAlertasStatus((prev) => (prev === t ? 'TODOS' : (t as AlertasStatusFilter)))
-                                    }}
-                                    title="Filtrar por status"
-                                  >
-                                    {alertaTagLabel(t)}
-                                  </Badge>
-                                ))}
-                              </div>
-                            </td>
-                            <td className="p-3">
-                              <div className="flex flex-wrap gap-2">
-                                {rec?.kind === 'TRANSFERENCIA' ? (
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-8 w-8 bg-sky-500/30 text-sky-100 hover:bg-sky-500/45"
-                                    disabled={!canQuick}
-                                    title="Transferir"
-                                    aria-label="Transferir"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      openQuickOperation('TRANSFERENCIA', {
-                                        codigoBarras: code,
-                                        quantidade: rec.qty ?? 1,
-                                        fromUnidade: rec.fromUnidade ?? null,
-                                        toUnidade: rec.toUnidade ?? null,
-                                        obs: 'Transferência sugerida'
-                                      })
-                                    }}
-                                  >
-                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                      <path
-                                        d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                      />
-                                    </svg>
-                                  </Button>
-                                ) : null}
-                                {rec?.kind === 'ENTRADA' ? (
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-8 w-8 bg-emerald-500/30 text-emerald-100 hover:bg-emerald-500/45"
-                                    disabled={!canQuick}
-                                    title="Entrada"
-                                    aria-label="Entrada"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      openQuickOperation('ENTRADA', {
-                                        codigoBarras: code,
-                                        quantidade: rec.qty ?? 1,
-                                        obs: 'Reposição sugerida'
-                                      })
-                                    }}
-                                  >
-                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                      <path
-                                        d="M12 5v10m0 0-4-4m4 4 4-4M5 19h14"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                      />
-                                    </svg>
-                                  </Button>
-                                ) : null}
-                                {hasExpiringAction ? (
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-8 w-8 bg-rose-500/35 text-rose-100 hover:bg-rose-500/50"
-                                    disabled={!canQuick}
-                                    title={a.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
-                                    aria-label={a.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      openQuickOperation('BAIXA', {
-                                        codigoBarras: code,
-                                        quantidade: 1,
-                                        obs: a.tags.includes('EXPIRADO') ? 'Descarte (expirado)' : 'Saída (vencendo)'
-                                      })
-                                    }}
-                                  >
-                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                      <path
-                                        d="M12 19V9m0 0-4 4m4-4 4 4M5 5h14"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                      />
-                                    </svg>
-                                  </Button>
-                                ) : null}
-                                {hasQualityAction ? (
-                                  <Button
-                                    variant="outline"
-                                    className="h-8 px-2 text-xs"
-                                    disabled={!canQualityEdit}
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      if (qualityIssue) openQualityFix(qualityIssue)
-                                    }}
-                                  >
-                                    Editar
-                                  </Button>
-                                ) : null}
-                                {!hasAnyAction ? (
-                                  <span className="text-xs text-blue-200/60">-</span>
-                                ) : null}
-                              </div>
-                              {qualityMessage ? (
-                                <div className="mt-2 text-xs text-blue-200/70">
-                                  <div className="inline-flex items-center gap-2">
-                                    <Badge variant={severityBadgeVariant(qualitySeverity) as any} className="border">
-                                      {severityLabel(qualitySeverity)}
-                                    </Badge>
-                                  </div>
-                                  <div className="mt-1 break-words">{qualityMessage}</div>
-                                </div>
-                              ) : null}
-                            </td>
-                            <td className="p-3 text-right text-blue-100/80">{a.estoqueAtual ?? '-'}</td>
-                            <td className="p-3 text-right text-blue-100/70 hidden sm:table-cell">{a.estoqueMinimo ?? '-'}</td>
-                            <td className="hidden lg:table-cell p-3 text-right text-blue-100/70">{a.diferenca ?? '-'}</td>
-                            <td className="hidden lg:table-cell p-3 text-right text-blue-100/70">{a.percentual != null ? `${a.percentual}%` : '-'}</td>
-                          </tr>
-                        )
-                      })}
-                      {!alertasLinhasOrdenadas.length ? (
-                        <tr>
-                          <td className="p-3 text-blue-100/70" colSpan={8}>
-                            {renderListPlaceholder(insightsLoading, 'Sem alertas.')}
-                          </td>
-                        </tr>
-                      ) : null}
-                                </tbody>
-                              </table>
-                            </div>
-                          </CardContent>
-                              ) : null}
-                            </Card>
+                            <InsumosAlertsPanel
+                              panelOpen={panelOpen}
+                              dragHandleProps={handleProps || undefined}
+                              showOverviewLoadingProgress={showOverviewLoadingProgress}
+                              loadingPercent={loadingPercent}
+                              overviewCriticosCount={overviewCriticosCount}
+                              overviewAtencaoCount={overviewAtencaoCount}
+                              alertasStatus={alertasStatus}
+                              alertasCategoria={alertasCategoria}
+                              alertasFluxo={alertasFluxo}
+                              alertasBusca={alertasBusca}
+                              alertasCategorias={alertasCategorias}
+                              alertasSortKey={alertasSortKey}
+                              alertasSortDir={alertasSortDir}
+                              rows={alertasLinhasOrdenadas}
+                              recommendationByCode={alertasRecommendationByCode}
+                              purchaseDisabled={!isAuthed || !(overviewActionables?.reposicao || []).length}
+                              isAuthed={isAuthed}
+                              emptyContent={renderListPlaceholder(insightsLoading, 'Sem alertas.')}
+                              onToggleOpen={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.alerts, !panelOpen)}
+                              onOpenPurchaseDialog={() => setPurchaseDialogOpen(true)}
+                              onAlertasStatusChange={setAlertasStatus}
+                              onAlertasCategoriaChange={setAlertasCategoria}
+                              onAlertasFluxoChange={setAlertasFluxo}
+                              onAlertasBuscaChange={setAlertasBusca}
+                              onSortChange={(key) => {
+                                if (alertasSortKey === key) {
+                                  setAlertasSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))
+                                  return
+                                }
+                                setAlertasSortKey(key)
+                                setAlertasSortDir(key === 'status' ? 'asc' : 'desc')
+                              }}
+                              onSelectBarcode={(code) => selectQuickCodigo(code, { setSearch: true, snapshot: null })}
+                              onToggleMarcaFilter={(value) => {
+                                if (!value) return
+                                setAlertasMarca((prev) => (prev === value ? '' : value))
+                              }}
+                              onToggleCategoriaFilter={(value) => setAlertasCategoria((prev) => (prev === value ? '' : value))}
+                              onToggleStatusFilter={(value) => setAlertasStatus((prev) => (prev === value ? 'TODOS' : (value as AlertasStatusFilter)))}
+                              onOpenQuickOperation={openQuickOperation}
+                              onOpenQualityFix={openQualityFix}
+                            />
                           </div>
                         )
                       }
 
-	                      return (
-	                        <div ref={dragProvided.innerRef} {...dragProvided.draggableProps}>
-		                          <Card className="bg-black/20 border border-white/10">
-                              <CardHeader className="flex flex-col gap-2">
-                                <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:gap-3">
-                                  <div className="flex items-center gap-3 min-w-0">
-                                    <button
-                                      type="button"
-                                      {...handleProps}
-                                      className="mt-0.5 h-9 w-9 flex items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] cursor-grab active:cursor-grabbing"
-                                      title="Arraste para mover"
-                                      aria-label="Mover"
-                                    >
-                                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-                                      </svg>
-                                    </button>
-                                    <CardTitle className="text-white text-base">Gráficos</CardTitle>
-                                  </div>
-                                  <div className="flex flex-1 flex-nowrap items-center gap-2 min-w-0 justify-end overflow-x-auto">
-                                    <Select value={chartsFilterTipo} onValueChange={(v) => setChartsFilterTipo(v as any)}>
-                                      <SelectTrigger className="h-8 w-32 shrink-0">
-                                        <SelectValue placeholder="Tipo" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        <SelectItem value="distribution">Distribuição</SelectItem>
-                                        <SelectItem value="movements">Movimentações</SelectItem>
-                                        <SelectItem value="roi_risk">ROI</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Select value={chartsFilterY} onValueChange={(v) => setChartsFilterY(v as any)}>
-                                      <SelectTrigger className="h-8 w-28 shrink-0">
-                                        <SelectValue placeholder="Eixo Y" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        <SelectItem value="categoria">Categoria</SelectItem>
-                                        <SelectItem value="marca">Marca</SelectItem>
-                                        <SelectItem value="item">Item</SelectItem>
-                                        <SelectItem value="tempo">Tempo</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Select value={chartsFilterX} onValueChange={(v) => setChartsFilterX(v as any)}>
-                                      <SelectTrigger className="h-8 w-24 shrink-0">
-                                        <SelectValue placeholder="Eixo X" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        <SelectItem value="qtd">Qtd</SelectItem>
-                                        <SelectItem value="valor">R$</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Select value={chartsFilterView} onValueChange={(v) => setChartsFilterView(v as any)}>
-                                      <SelectTrigger className="h-8 w-32 shrink-0">
-                                        <SelectValue placeholder="Representação" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        <SelectItem value="pie">Pizza</SelectItem>
-                                        <SelectItem value="bar">Barras</SelectItem>
-                                        <SelectItem value="line">Linhas</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Select value={chartsFilterTop} onValueChange={(v) => setChartsFilterTop(v as any)}>
-                                      <SelectTrigger className="h-8 w-24 shrink-0">
-                                        <SelectValue placeholder="Top" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="__ALL__">–</SelectItem>
-                                        <SelectItem value="5">Top 5</SelectItem>
-                                        <SelectItem value="8">Top 8</SelectItem>
-                                        <SelectItem value="10">Top 10</SelectItem>
-                                        <SelectItem value="15">Top 15</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                    <Input
-                                      value={chartsSearch}
-                                      onChange={(e) => setChartsSearch(e.target.value)}
-                                      placeholder="Buscar"
-                                      className="h-8 flex-1 min-w-[120px] md:min-w-0 ml-auto"
-                                    />
-                                    <div className="flex items-center gap-2 shrink-0">
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                                      onClick={() => {
-                                        if (chartSlots.length >= MAX_CHARTS) return
-                                        setChartSlots((prev) => [
-                                          ...prev,
-                                          { presetId: 'movements', groupBy: 'tempo', mode: 'inout', metric: 'qtd', view: 'bar', topN: 8 }
-                                        ])
-                                      }}
-                                      disabled={overviewLoading || insightsLoading || chartSlots.length >= MAX_CHARTS}
-                                      title="Adicionar gráfico"
-                                      aria-label="Adicionar gráfico"
-                                    >
-                                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                                      </svg>
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                                      onClick={() => setChartSlots(DEFAULT_CHART_SLOTS)}
-                                      disabled={overviewLoading || insightsLoading}
-                                      title="Resetar gráficos"
-                                      aria-label="Resetar gráficos"
-                                    >
-                                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                        <path
-                                          d="M20 12a8 8 0 1 1-2.34-5.66"
-                                          stroke="currentColor"
-                                          strokeWidth="2.2"
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                        />
-                                        <path d="M20 4v6h-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                      </svg>
-                                    </Button>
-                                    <Button
-                                      size="icon"
-                                      variant="ghost"
-                                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                                      onClick={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.charts, !panelOpen)}
-                                      title={panelOpen ? 'Contrair' : 'Expandir'}
-                                      aria-label={panelOpen ? 'Contrair' : 'Expandir'}
-                                    >
-                                      {panelOpen ? (
-                                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                          <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                        </svg>
-                                      ) : (
-                                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                          <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                                        </svg>
-                                      )}
-                                    </Button>
-                                    </div>
-                                  </div>
-                                </div>
-                              </CardHeader>
-                            {panelOpen ? (
-                              <CardContent className="space-y-3">
-              <div
-                className={`grid gap-3 ${chartSlotsView.length <= 1
-                  ? 'grid-cols-1'
-                  : chartSlotsView.length === 2
-                    ? 'grid-cols-1 lg:grid-cols-2'
-                    : 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3 xl:grid-flow-dense'
-                  }`}
-              >
-	                {chartSlotsView.length ? (
-                    chartSlotsView.map(({ slot, idx, meta }) => {
-                      const { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout } = meta
-                      const baseH = chartSlotsView.length === 1 ? 360 : chartSlotsView.length === 2 ? 300 : 260
-                      const height = layout === 'tall' ? baseH + (chartSlotsView.length === 1 ? 180 : 120) : baseH
-                      const cardSpan = chartSlotsView.length >= 3 && layout === 'wide' ? 'xl:col-span-2' : ''
-
                       return (
-                        <Card key={`${slot.presetId}-${idx}`} className={`bg-black/20 border border-white/10 ${cardSpan}`}>
-	                      <CardHeader className="space-y-2">
-	                        <div className="flex items-center gap-2">
-	                          <Select
-	                            value={slot.presetId}
-	                            onValueChange={(v) => {
-	                              const nextId = v as any
-	                              const nextPreset = presetSupports(nextId)
-	                              const baseNext: ChartSlotConfig = {
-	                                ...slot,
-	                                presetId: nextId,
-	                                groupBy: nextId === 'distribution' ? 'categoria' : nextId === 'movements' ? 'tempo' : undefined,
-	                                mode: nextId === 'movements' ? 'inout' : undefined
-	                              }
-	                              const nextViewOptions = presetViewOptions(baseNext)
-	                              const presetDefault = (nextPreset as any)?.defaultView as any
-	                              const nextView = nextViewOptions.includes(presetDefault) ? presetDefault : nextViewOptions[0]
-	                              setChartSlot(idx, { presetId: nextId, groupBy: baseNext.groupBy, mode: baseNext.mode, view: nextView as any })
-	                            }}
-	                          >
-                            <SelectTrigger className="h-8 w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {CHART_PRESETS.map((p) => (
-                                <SelectItem key={p.id} value={p.id}>
-                                  {p.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                          {chartSlots.length > 1 ? (
-                            <Button
-                              variant="outline"
-                              className="h-8 w-8 p-0"
-                              title="Remover gráfico"
-                              aria-label="Remover gráfico"
-                              onClick={() => {
-                                setChartSlots((prev) => prev.filter((_, i) => i !== idx))
-                              }}
-                            >
-                              ×
-                            </Button>
-                          ) : null}
+                        <div ref={dragProvided.innerRef} {...dragProvided.draggableProps}>
+                          <InsumosChartsPanel
+                            panelOpen={panelOpen}
+                            dragHandleProps={handleProps || undefined}
+                            chartsFilterTipo={chartsFilterTipo}
+                            chartsFilterY={chartsFilterY}
+                            chartsFilterX={chartsFilterX}
+                            chartsFilterView={chartsFilterView}
+                            chartsFilterTop={chartsFilterTop}
+                            chartsSearch={chartsSearch}
+                            canAddChart={!overviewLoading && !insightsLoading && chartSlots.length < MAX_CHARTS}
+                            canResetCharts={!overviewLoading && !insightsLoading}
+                            chartCards={chartCards}
+                            presetOptions={chartPresetOptions}
+                            emptyContent={
+                              <div className="rounded-xl border border-white/10 bg-black/10 p-6 text-sm text-blue-100/70">
+                                Nenhum gráfico encontrado para esses filtros.
+                              </div>
+                            }
+                            onToggleOpen={() => setDetailsKeyOpen(OVERVIEW_PANEL_OPEN_KEYS.charts, !panelOpen)}
+                            onChartsFilterTipoChange={setChartsFilterTipo}
+                            onChartsFilterYChange={setChartsFilterY}
+                            onChartsFilterXChange={setChartsFilterX}
+                            onChartsFilterViewChange={setChartsFilterView}
+                            onChartsFilterTopChange={setChartsFilterTop}
+                            onChartsSearchChange={setChartsSearch}
+                            onAddChart={() => {
+                              if (chartSlots.length >= MAX_CHARTS) return
+                              setChartSlots((prev) => [
+                                ...prev,
+                                { presetId: 'movements', groupBy: 'tempo', mode: 'inout', metric: 'qtd', view: 'bar', topN: 8 },
+                              ])
+                            }}
+                            onResetCharts={() => setChartSlots(DEFAULT_CHART_SLOTS)}
+                            onPresetChange={handleChartPresetChange}
+                            onRemoveChart={handleRemoveChart}
+                            onDistributionGroupByChange={handleDistributionGroupByChange}
+                            onMovementsGroupByChange={handleMovementsGroupByChange}
+                            onMovementsModeChange={handleMovementsModeChange}
+                            onMetricChange={handleChartMetricChange}
+                            onViewChange={handleChartViewChange}
+                            onTopNChange={handleChartTopNChange}
+                          />
                         </div>
-
-                        <div className="flex flex-wrap items-center gap-2">
-                          {slot.presetId === 'distribution' ? (
-                            <Select
-                              value={groupBy || 'categoria'}
-                              onValueChange={(v) => {
-                                const nextGroupBy = (v === 'marca' || v === 'item' || v === 'categoria' ? v : 'categoria') as ChartGroupBy
-                                const baseNext: ChartSlotConfig = { ...slot, groupBy: nextGroupBy }
-                                const nextViewOptions = presetViewOptions(baseNext)
-                                const nextView = nextViewOptions.includes(view) ? view : nextViewOptions[0]
-                                setChartSlot(idx, { groupBy: nextGroupBy, view: nextView as any })
-                              }}
-                            >
-                              <SelectTrigger className="h-8 w-32">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="categoria">Categoria</SelectItem>
-                                <SelectItem value="marca">Marca</SelectItem>
-                                <SelectItem value="item">Item</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          ) : null}
-
-                          {slot.presetId === 'movements' ? (
-                            <>
-                              <Select
-                                value={groupBy === 'categoria' ? 'categoria' : 'tempo'}
-                                onValueChange={(v) => {
-                                  const nextGroupBy = v === 'categoria' ? ('categoria' as ChartGroupBy) : ('tempo' as ChartGroupBy)
-                                  const nextMode: MovementsMode = nextGroupBy === 'categoria' ? 'saida' : 'inout'
-                                  const baseNext: ChartSlotConfig = { ...slot, groupBy: nextGroupBy, mode: nextMode }
-                                  const nextViewOptions = presetViewOptions(baseNext)
-                                  const nextView = nextViewOptions.includes(view) ? view : nextViewOptions[0]
-                                  setChartSlot(idx, { groupBy: nextGroupBy, mode: nextMode, view: nextView as any })
-                                }}
-                              >
-                                <SelectTrigger className="h-8 w-28">
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="tempo">Tempo</SelectItem>
-                                  <SelectItem value="categoria">Categoria</SelectItem>
-                                </SelectContent>
-                              </Select>
-
-                              {groupBy === 'categoria' ? (
-                                <Select
-                                  value={mode === 'entrada' ? 'entrada' : 'saida'}
-                                  onValueChange={(v) => {
-                                    const nextMode = v === 'entrada' ? ('entrada' as MovementsMode) : ('saida' as MovementsMode)
-                                    setChartSlot(idx, { mode: nextMode })
-                                  }}
-                                >
-                                  <SelectTrigger className="h-8 w-28">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    <SelectItem value="saida">Saídas</SelectItem>
-                                    <SelectItem value="entrada">Entradas</SelectItem>
-                                  </SelectContent>
-                                </Select>
-                              ) : (
-                                <Select
-                                  value={mode || 'inout'}
-                                  onValueChange={(v) => {
-                                    const nextMode =
-                                      v === 'saldo' || v === 'entrada' || v === 'saida' || v === 'inout' ? (v as MovementsMode) : ('inout' as MovementsMode)
-                                    setChartSlot(idx, { mode: nextMode })
-                                  }}
-                                >
-                                  <SelectTrigger className="h-8 w-36">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    <SelectItem value="inout">Entradas vs Saídas</SelectItem>
-                                    <SelectItem value="saldo">Saldo</SelectItem>
-                                    <SelectItem value="entrada">Entradas</SelectItem>
-                                    <SelectItem value="saida">Saídas</SelectItem>
-                                  </SelectContent>
-                                </Select>
-                              )}
-                            </>
-                          ) : null}
-
-                          {preset.supportsMetric ? (
-                            <Select value={metric} onValueChange={(v) => setChartSlot(idx, { metric: v as any })}>
-                              <SelectTrigger className="h-8 w-24">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="qtd">Qtd</SelectItem>
-                                <SelectItem value="valor">R$</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          ) : null}
-
-                          {preset.supportsView && viewOptions.length > 1 ? (
-                            <Select value={view} onValueChange={(v) => setChartSlot(idx, { view: v as any })}>
-                              <SelectTrigger className="h-8 w-28">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {viewOptions.map((vv) => (
-                                  <SelectItem key={vv} value={vv}>
-                                    {vv === 'bar' ? 'Barras' : vv === 'line' ? 'Linhas' : 'Pizza'}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          ) : null}
-
-                          {showTopN ? (
-                            <Select value={String(topN)} onValueChange={(v) => setChartSlot(idx, { topN: parseInt(String(v), 10) || 8 })}>
-                              <SelectTrigger className="h-8 w-20">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="5">Top 5</SelectItem>
-                                <SelectItem value="8">Top 8</SelectItem>
-                                <SelectItem value="10">Top 10</SelectItem>
-                                <SelectItem value="15">Top 15</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          ) : null}
-                        </div>
-                        <div className="flex justify-end" />
-                      </CardHeader>
-                      <CardContent>
-                        {renderChart({ ...slot, view, metric, topN }, { height })}
-                      </CardContent>
-                    </Card>
-                      )
-                    })
-                  ) : (
-                    <div className="rounded-xl border border-white/10 bg-black/10 p-6 text-sm text-blue-100/70">
-                      Nenhum gráfico encontrado para esses filtros.
-                    </div>
-                  )}
-              </div>
-
-	                              </CardContent>
-	                            ) : null}
-	                          </Card>
-	                        </div>
                       )
                     }}
                   </Draggable>
@@ -8300,8 +4261,15 @@ export function InsumosModule() {
         </div>
       </div>
 
-      <Dialog
+      <InsumosQualityMatchesDialog
         open={qualityMatchesOpen}
+        dialogClassName={dialogMediumClass}
+        issue={qualityMatchesIssue}
+        items={qualityMatchesItems}
+        savingRegistro={qualityMatchesSavingRegistro}
+        isAuthed={isAuthed}
+        unit={unidade}
+        unitLabel={unidadeLabel}
         onOpenChange={(next) => {
           setQualityMatchesOpen(next)
           if (!next) {
@@ -8310,444 +4278,93 @@ export function InsumosModule() {
             setQualityMatchesSavingRegistro('')
           }
         }}
-      >
-        <DialogContent size="wideTable" className={dialogMediumClass}>
-          <DialogHeader>
-            <DialogTitle>Duplicidade de código de barras</DialogTitle>
-            <DialogDescription>
-              {qualityMatchesIssue?.codigoBarras ? (
-                <>
-                  Selecione qual registro editar ou excluir para o código <span className="font-mono">#{qualityMatchesIssue.codigoBarras}</span>.
-                  {' '}
-                  ({qualityMatchesItems.length} correspondências)
-                </>
-              ) : (
-                <>Selecione qual registro editar ou excluir para resolver a duplicidade.</>
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
-            <table className="min-w-full text-sm">
-                      <thead className="bg-black/30 text-blue-100/80">
-                        <tr>
-                          <th className="text-left p-3 w-[20%]">Registro</th>
-                          <th className="text-left p-3 w-[32%]">Produto</th>
-                          <th className="text-left p-3 hidden md:table-cell w-[18%]">Lote</th>
-                          <th className="text-left p-3 hidden sm:table-cell w-[14%]">Estoque ({unidadeLabel(unidade)})</th>
-                          <th className="text-left p-3 w-[16%]">Ações</th>
-                        </tr>
-                      </thead>
-              <tbody className="divide-y divide-white/5">
-                {qualityMatchesItems.map((item) => {
-                  const registro = String(item?.registro || '').trim()
-                  const isDeleting = qualityMatchesSavingRegistro === registro
-                  return (
-                    <tr key={registro || String(item?.codigoBarras || '')} className="hover:bg-white/5">
-                      <td className="p-3 font-mono text-blue-100/80">{registro || '-'}</td>
-                      <td className="p-3 text-blue-50">{String(item?.produto || '-')}</td>
-                      <td className="p-3 text-blue-100/70 hidden md:table-cell">{String(item?.lote || '-')}</td>
-                      <td className="p-3 text-blue-100/70 hidden sm:table-cell">{Number(item?.estoqueAtual || 0)}</td>
-                      <td className="p-3">
-                        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => {
-                              setQualityMatchesOpen(false)
-                              openEditDialog(item)
-                            }}
-                            disabled={!isAuthed || isDeleting}
-                          >
-                            Editar
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => void deleteInsumoByRegistro(registro)}
-                            disabled={!isAuthed || !registro || isDeleting}
-                          >
-                            {isDeleting ? 'Excluindo…' : 'Excluir'}
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-                {!qualityMatchesItems.length ? (
-                  <tr>
-                    <td className="p-3 text-blue-100/70" colSpan={5}>Nenhuma correspondência encontrada.</td>
-                  </tr>
-                ) : null}
-              </tbody>
-            </table>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editOpen}
-        onOpenChange={(v) => {
-          setEditOpen(v)
-          if (!v) setEditTarget(null)
+        onEditItem={(item) => {
+          setQualityMatchesOpen(false)
+          openEditDialog(item)
         }}
-      >
-        <DialogContent className={dialogLargeClass}>
-          <DialogHeader>
-            <DialogTitle>Editar insumo</DialogTitle>
-            <DialogDescription className="break-words">
-              {editTarget?.produto || '-'} • <span className="font-mono break-all">{editTarget?.codigoBarras || '-'}</span>
-              {editTarget?.registro ? <span className="break-all"> • Reg {editTarget.registro}</span> : null}
-            </DialogDescription>
-          </DialogHeader>
+        onDeleteRegistro={(registro) => void deleteInsumoByRegistro(registro)}
+      />
 
-          {editSaveError ? (
-            <div className="mt-2 rounded-lg border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-100">
-              {editSaveError}
-            </div>
-          ) : null}
+      <InsumosEditDialog
+        open={editOpen}
+        dialogClassName={dialogLargeClass}
+        target={editTarget}
+        isAuthed={isAuthed}
+        canUseApi={canUseApi}
+        isManagerRole={isManagerRole}
+        saving={editSaving}
+        saveError={editSaveError}
+        validationErrors={editValidationErrors}
+        codigo={editCodigo}
+        codigosExtras={editCodigosExtras}
+        produto={editProduto}
+        categoria={editCategoria}
+        categoriaRequiresLot={editCategoriaRequiresLot}
+        categoriaRequiresExpiry={editCategoriaRequiresExpiry}
+        categoriaFefo={editCategoriaFefo}
+        marca={editMarca}
+        tipoUnidade={editTipoUnidade}
+        especificacao={editEspecificacao}
+        concentracao={editConcentracao}
+        volume={editVolume}
+        homologado={editHomologado}
+        calibre={editCalibre}
+        precoCusto={editPrecoCusto}
+        estoqueMinimo={editEstoqueMinimo}
+        lote={editLote}
+        dataValidade={editDataValidade}
+        optionalDetailsOpen={detailsOpen['insumos.details.edit.optional'] ?? true}
+        lotCategorias={lotCategorias}
+        insumosMarcas={insumosMarcas}
+        insumosTiposUnidade={insumosTiposUnidade}
+        onOpenChange={(open) => {
+          setEditOpen(open)
+          if (!open) setEditTarget(null)
+        }}
+        onClearValidationError={clearEditValidationError}
+        onCodigoChange={setEditCodigo}
+        onCodigosExtrasChange={setEditCodigosExtras}
+        onProdutoChange={setEditProduto}
+        onCategoriaChange={setEditCategoria}
+        onCategoriaRequiresLotChange={setEditCategoriaRequiresLot}
+        onCategoriaRequiresExpiryChange={(value) => {
+          setEditCategoriaRequiresExpiry(value)
+          if (!value) setEditCategoriaFefo(false)
+        }}
+        onCategoriaFefoChange={(value) => {
+          setEditCategoriaFefo(value)
+          if (value) setEditCategoriaRequiresExpiry(true)
+        }}
+        onMarcaChange={setEditMarca}
+        onTipoUnidadeChange={setEditTipoUnidade}
+        onEspecificacaoChange={setEditEspecificacao}
+        onConcentracaoChange={setEditConcentracao}
+        onVolumeChange={setEditVolume}
+        onHomologadoChange={setEditHomologado}
+        onCalibreChange={setEditCalibre}
+        onPrecoCustoChange={setEditPrecoCusto}
+        onEstoqueMinimoChange={setEditEstoqueMinimo}
+        onLoteChange={setEditLote}
+        onDataValidadeChange={setEditDataValidade}
+        onOptionalDetailsToggle={(open) => setDetailsKeyOpen('insumos.details.edit.optional', open)}
+        onCancel={() => setEditOpen(false)}
+        onDelete={deleteEdit}
+        onSave={saveEdit}
+      />
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Código de barras</div>
-              <Input
-                value={editCodigo}
-                onChange={(e) => {
-                  setEditCodigo(e.target.value)
-                  clearEditValidationError('codigoBarras')
-                }}
-                placeholder="789..."
-                aria-invalid={editValidationErrors.codigoBarras ? true : undefined}
-                className={
-                  editValidationErrors.codigoBarras
-                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
-                    : undefined
-                }
-              />
-              {editValidationErrors.codigoBarras ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.codigoBarras}</div>
-              ) : null}
-            </div>
-            <div className="md:col-span-2">
-              <div className="text-xs text-muted-foreground mb-1">Códigos adicionais</div>
-              <Textarea
-                value={editCodigosExtras}
-                onChange={(e) => setEditCodigosExtras(e.target.value)}
-                placeholder="um por linha"
-                rows={3}
-                className="bg-white/[0.06] border-white/20 text-white"
-              />
-              <div className="mt-1 text-[10px] text-muted-foreground">
-                Opcional. Use para variações de código do mesmo produto.
-              </div>
-            </div>
-            <div className="md:col-span-2">
-              <div className="text-xs text-muted-foreground mb-1">Produto</div>
-              <Input
-                value={editProduto}
-                onChange={(e) => {
-                  setEditProduto(e.target.value)
-                  clearEditValidationError('produto')
-                }}
-                placeholder="Nome do produto"
-                aria-invalid={editValidationErrors.produto ? true : undefined}
-                className={
-                  editValidationErrors.produto
-                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
-                    : undefined
-                }
-              />
-              {editValidationErrors.produto ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.produto}</div>
-              ) : null}
-            </div>
-	            <div>
-	              <div className="text-xs text-muted-foreground mb-1">Categoria</div>
-	              <AutocompleteInput
-	                value={editCategoria}
-	                onValueChange={(next) => {
-	                  setEditCategoria(next)
-	                  clearEditValidationError('categoria')
-	                }}
-	                placeholder="ex: toxina"
-	                options={lotCategorias}
-	                inputTestId="insumos-edit-categoria"
-	                ariaInvalid={editValidationErrors.categoria ? true : undefined}
-	                inputClassName={
-	                  editValidationErrors.categoria
-	                    ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25'
-	                    : undefined
-	                }
-	              />
-	              {editValidationErrors.categoria ? (
-	                <div className="mt-1 text-xs text-red-300">{editValidationErrors.categoria}</div>
-	              ) : null}
-            </div>
-            <div
-              className={`md:col-span-2 rounded-xl border p-3 ${
-                editValidationErrors.policy ? 'border-red-500/50 bg-red-500/5' : 'border-white/10 bg-black/10'
-              }`}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="text-xs text-muted-foreground">Política do item</div>
-                <div className="text-xs text-muted-foreground">Defina as regras para este insumo.</div>
-              </div>
-              <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
-                <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                  <Checkbox
-                    checked={editCategoriaRequiresLot}
-                    onCheckedChange={(v) => {
-                      setEditCategoriaRequiresLot(!!v)
-                      clearEditValidationError('policy')
-                      clearEditValidationError('lote')
-                    }}
-                    disabled={!isManagerRole}
-                  />
-                  Lote obrigatório
-                </label>
-                <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                  <Checkbox
-                    checked={editCategoriaRequiresExpiry}
-                    onCheckedChange={(v) => {
-                      const next = !!v
-                      setEditCategoriaRequiresExpiry(next)
-                      if (!next) setEditCategoriaFefo(false)
-                      clearEditValidationError('policy')
-                      clearEditValidationError('dataValidade')
-                    }}
-                    disabled={!isManagerRole}
-                  />
-                  Validade obrigatória
-                </label>
-                <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                  <Checkbox
-                    checked={editCategoriaFefo}
-                    onCheckedChange={(v) => {
-                      const next = !!v
-                      setEditCategoriaFefo(next)
-                      if (next) setEditCategoriaRequiresExpiry(true)
-                      clearEditValidationError('policy')
-                    }}
-                    disabled={!isManagerRole}
-                  />
-                  FEFO
-                </label>
-                {!isManagerRole ? <span className="text-xs text-muted-foreground">Somente gestores alteram.</span> : null}
-              </div>
-              {editValidationErrors.policy ? (
-                <div className="mt-2 text-xs text-red-300">{editValidationErrors.policy}</div>
-              ) : null}
-            </div>
-	            <div>
-	              <div className="text-xs text-muted-foreground mb-1">Marca</div>
-	              <AutocompleteInput
-	                value={editMarca}
-	                onValueChange={(next) => {
-	                  setEditMarca(next)
-	                  clearEditValidationError('marca')
-	                }}
-	                placeholder="ex: Allergan"
-	                options={insumosMarcas}
-	                inputTestId="insumos-edit-marca"
-	                ariaInvalid={editValidationErrors.marca ? true : undefined}
-	                inputClassName={
-	                  editValidationErrors.marca ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined
-	                }
-	              />
-	              {editValidationErrors.marca ? (
-	                <div className="mt-1 text-xs text-red-300">{editValidationErrors.marca}</div>
-	              ) : null}
-	            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Unidade (medida)</div>
-              <Select
-                value={normalizeTipoUnidadeToCanonical(editTipoUnidade) || undefined}
-                onValueChange={(v) => {
-                  setEditTipoUnidade(v)
-                  clearEditValidationError('tipoUnidade')
-                }}
-              >
-                <SelectTrigger
-                  aria-invalid={editValidationErrors.tipoUnidade ? true : undefined}
-                  className={
-                    editValidationErrors.tipoUnidade ? 'border-red-500/60 ring-2 ring-red-500/15' : undefined
-                  }
-                >
-                  <SelectValue placeholder="Selecione a unidade" />
-                </SelectTrigger>
-                <SelectContent>
-                  {insumosTiposUnidade.map((t) => (
-                    <SelectItem key={t} value={t}>
-                      {t}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {editValidationErrors.tipoUnidade ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.tipoUnidade}</div>
-              ) : null}
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Preço custo (R$)</div>
-              <Input value={editPrecoCusto} onChange={(e) => setEditPrecoCusto(e.target.value)} placeholder="ex: 120,00" />
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Estoque mínimo</div>
-              <Input value={editEstoqueMinimo} onChange={(e) => setEditEstoqueMinimo(e.target.value)} placeholder="ex: 5" />
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Lote</div>
-              <Input
-                value={editLote}
-                onChange={(e) => {
-                  setEditLote(e.target.value)
-                  clearEditValidationError('lote')
-                }}
-                placeholder="ex: L2026-01"
-                aria-invalid={editValidationErrors.lote ? true : undefined}
-                className={editValidationErrors.lote ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
-              />
-              {editValidationErrors.lote ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.lote}</div>
-              ) : null}
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Validade</div>
-              <BrDatePickerInput
-                value={editDataValidade}
-                onChange={(v) => {
-                  setEditDataValidade(v)
-                  clearEditValidationError('dataValidade')
-                }}
-                placeholder="DD/MM/AA"
-                ariaLabel="Validade"
-                className={editValidationErrors.dataValidade ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
-              />
-              {editValidationErrors.dataValidade ? (
-                <div className="mt-1 text-xs text-red-300">{editValidationErrors.dataValidade}</div>
-              ) : null}
-            </div>
-          </div>
-
-          <details
-            data-pref-key="insumos.details.edit.optional"
-            open={detailsOpen['insumos.details.edit.optional'] ?? true}
-            onToggle={(e) => setDetailsKeyOpen('insumos.details.edit.optional', (e.currentTarget as HTMLDetailsElement).open)}
-            className="mt-2 rounded-lg border border-white/10 bg-black/10 p-3"
-          >
-            <summary className="cursor-pointer select-none text-sm text-blue-100/80">Detalhes (opcional)</summary>
-            <div className="mt-3 grid grid-cols-1 md:grid-cols-3 gap-2">
-              <div className="md:col-span-2">
-                <div className="text-xs text-muted-foreground mb-1">Especificação / Modelo</div>
-                <Input value={editEspecificacao} onChange={(e) => setEditEspecificacao(e.target.value)} placeholder="ex: Base, Lidocaine" />
-              </div>
-              <div>
-                <div className="text-xs text-muted-foreground mb-1">Concentração</div>
-                <Input value={editConcentracao} onChange={(e) => setEditConcentracao(e.target.value)} placeholder="ex: 300U" />
-              </div>
-              <div>
-                <div className="text-xs text-muted-foreground mb-1">Volume</div>
-                <Input value={editVolume} onChange={(e) => setEditVolume(e.target.value)} placeholder="ex: 1ml" />
-              </div>
-              <div>
-                <div className="text-xs text-muted-foreground mb-1">Calibre / Bitola</div>
-                <Input value={editCalibre} onChange={(e) => setEditCalibre(e.target.value)} placeholder="ex: 30G" />
-              </div>
-              <div className="md:col-span-2">
-                <div className="text-xs text-muted-foreground mb-1">Homologado</div>
-                <label className="flex items-center gap-2 text-sm text-blue-100/80 select-none">
-                  <Checkbox checked={editHomologado} onCheckedChange={(v) => setEditHomologado(!!v)} />
-                  Produto homologado
-                </label>
-              </div>
-            </div>
-          </details>
-
-          <DialogFooter>
-            {!canUseApi ? (
-              <span className="mr-auto text-xs text-muted-foreground">API indisponivel. Aguarde o carregamento.</span>
-            ) : null}
-            <Button variant="secondary" onClick={() => setEditOpen(false)} disabled={editSaving}>
-              Cancelar
-            </Button>
-            <Button variant="destructive" onClick={deleteEdit} disabled={editSaving || !isAuthed}>
-              Excluir
-            </Button>
-            <Button onClick={saveEdit} disabled={editSaving || !isAuthed || !canUseApi}>
-              {editSaving ? 'Salvando…' : 'Salvar'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={lotDialogOpen} onOpenChange={setLotDialogOpen}>
-        <DialogContent className={dialogSmallClass}>
-          <DialogHeader>
-            <DialogTitle>Editar lote/validade</DialogTitle>
-            <DialogDescription>
-              {lotSelecionado?.produto || '-'} • <span className="font-mono">{lotSelecionado?.codigoBarras || '-'}</span>
-            </DialogDescription>
-          </DialogHeader>
-
-          {lotSelecionado ? (
-            <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-blue-100/70">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                <div>
-                  <div className="text-xs text-muted-foreground">Categoria</div>
-                  <div className="text-blue-100/80">{lotSelecionado.categoria || '-'}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-muted-foreground">Marca</div>
-                  <div className="text-blue-100/80">{lotSelecionado.marca || '-'}</div>
-                </div>
-                {lotSelecionado.concentracao ? (
-                  <div>
-                    <div className="text-xs text-muted-foreground">Concentração</div>
-                    <div className="text-blue-100/80">{lotSelecionado.concentracao}</div>
-                  </div>
-                ) : null}
-                {lotSelecionado.volume ? (
-                  <div>
-                    <div className="text-xs text-muted-foreground">Volume</div>
-                    <div className="text-blue-100/80">{lotSelecionado.volume}</div>
-                  </div>
-                ) : null}
-                {lotSelecionado.calibre ? (
-                  <div>
-                    <div className="text-xs text-muted-foreground">Calibre</div>
-                    <div className="text-blue-100/80">{lotSelecionado.calibre}</div>
-                  </div>
-                ) : null}
-                <div>
-                  <div className="text-xs text-muted-foreground">Homologado</div>
-                  <div className="text-blue-100/80">
-                    {/homologad/i.test(String(lotSelecionado.fonte || '').trim()) ? 'Sim' : 'Não'}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : null}
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Lote</div>
-              <Input value={lotEditLote} onChange={(e) => setLotEditLote(e.target.value)} placeholder="ex: 2026-01A" />
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Validade</div>
-              <BrDatePickerInput value={lotEditValidade} onChange={setLotEditValidade} placeholder="DD/MM/AA" ariaLabel="Validade do lote" />
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setLotDialogOpen(false)}>
-              Cancelar
-            </Button>
-            <Button onClick={saveLot} disabled={lotSaving || !isAuthed}>
-              {lotSaving ? 'Salvando…' : 'Salvar'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <InsumosLotDialog
+        open={lotDialogOpen}
+        dialogClassName={dialogSmallClass}
+        item={lotSelecionado}
+        lotValue={lotEditLote}
+        expiryValue={lotEditValidade}
+        onOpenChange={setLotDialogOpen}
+        onLotChange={setLotEditLote}
+        onExpiryChange={setLotEditValidade}
+        onSave={saveLot}
+        saving={lotSaving}
+        isAuthed={isAuthed}
+      />
 
         <Droppable droppableId="main-panels" direction={mainPanelsDirection}>
           {(dropProvided) => (
@@ -8756,686 +4373,6 @@ export function InsumosModule() {
               {...dropProvided.droppableProps}
               className="max-w-6xl mx-auto flex flex-col lg:flex-row gap-3"
             >
-              {/*
-              <Draggable draggableId="main-insumos" index={mainOrderIndex.get('insumos') ?? 0}>
-                {(dragProvided) => (
-                  <div
-                    ref={(el) => {
-                      dragProvided.innerRef(el)
-                      insumosSectionRef.current = el
-                    }}
-                    {...dragProvided.draggableProps}
-                    style={{ ...(dragProvided.draggableProps.style || {}), order: mainOrderIndex.get('insumos') ?? 0 }}
-                    className="space-y-3 flex-1 min-w-0"
-                  >
-	          <Card className="bg-black/20 border border-white/10">
-	            <CardHeader className="flex flex-col gap-2">
-	              <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:gap-3">
-	                <div className="flex items-center gap-3 min-w-0">
-	                  <button
-	                    type="button"
-	                    {...dragProvided.dragHandleProps}
-	                    className="mt-0.5 h-9 w-9 flex items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] cursor-grab active:cursor-grabbing"
-	                    title="Arraste para mover"
-	                    aria-label="Mover"
-	                  >
-	                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-	                      <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-	                    </svg>
-	                  </button>
-	                  <div className="min-w-0">
-	                    <div className="text-white text-lg font-semibold">Insumos</div>
-	                    <div className="text-sm text-blue-100/70">Cadastro, estoque e ações rápidas.</div>
-	                  </div>
-	                </div>
-	                <div className="flex flex-1 flex-nowrap items-center gap-2 min-w-0 justify-end overflow-x-auto">
-	                  <Input
-	                    value={insumosQuery}
-	                    onChange={(e) => setInsumosQuery(e.target.value)}
-	                    placeholder="Buscar por código, produto, categoria…"
-	                    className="h-8 flex-1 min-w-[160px] md:min-w-0 ml-auto"
-	                  />
-	                  <Button
-	                    variant="outline"
-	                    className="h-8 px-3"
-	                    onClick={() => window.open(`/api/insumos/export/insumos.csv?unidade=${encodeURIComponent(unidade)}`, '_blank', 'noopener,noreferrer')}
-	                    disabled={!isAuthed}
-	                    title="Exportar CSV"
-	                  >
-	                    Exportar
-	                  </Button>
-	                  <Button variant="outline" className="h-8 px-3" onClick={() => setCreateOpen((v) => !v)} disabled={!isAuthed}>
-	                    {createOpen ? 'Fechar' : 'Adicionar'}
-	                  </Button>
-	                  <Button
-	                    size="icon"
-	                    variant="ghost"
-	                    className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-	                    onClick={() => setDetailsKeyOpen(MAIN_PANEL_OPEN_KEYS.insumos, !insumosPanelOpen)}
-	                    title={insumosPanelOpen ? 'Contrair' : 'Expandir'}
-	                    aria-label={insumosPanelOpen ? 'Contrair' : 'Expandir'}
-	                  >
-	                    {insumosPanelOpen ? (
-	                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-	                        <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-	                      </svg>
-	                    ) : (
-	                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-	                        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-	                      </svg>
-	                    )}
-	                  </Button>
-	                </div>
-	              </div>
-	              {offlineQueueCount > 0 ? (
-	                <div>
-	                  <Button variant="outline" size="sm" onClick={() => setOfflineDialogOpen(true)} disabled={!isAuthed}>
-	                    Pendências <span className="ml-2 font-mono">{offlineQueueCount}</span>
-	                  </Button>
-	                </div>
-	              ) : null}
-	            </CardHeader>
-            {insumosPanelOpen ? (
-              <CardContent className="space-y-3">
-
-        {sharePayload && !shareHidden ? (
-          <div className="rounded-xl border border-white/10 bg-black/30 p-3 text-sm text-blue-100/80">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-blue-50 font-semibold">Compartilhamento recebido</div>
-              <Button variant="secondary" size="sm" onClick={() => setShareHidden(true)}>
-                Fechar
-              </Button>
-            </div>
-            {shareLoading ? <div className="mt-2 text-xs text-blue-200/60">Carregando anexos…</div> : null}
-            <div className="mt-2 space-y-1">
-              {sharePayload.title ? (
-                <div>
-                  <span className="text-blue-200/70">Título:</span> {sharePayload.title}
-                </div>
-              ) : null}
-              {sharePayload.text ? (
-                <div>
-                  <span className="text-blue-200/70">Texto:</span> {sharePayload.text}
-                </div>
-              ) : null}
-              {sharePayload.url ? (
-                <div className="break-words">
-                  <span className="text-blue-200/70">Link:</span>{' '}
-                  <a className="underline" href={sharePayload.url} target="_blank" rel="noreferrer">
-                    {sharePayload.url}
-                  </a>
-                </div>
-              ) : null}
-              {sharePayload.files && sharePayload.files.length ? (
-                <div className="space-y-1">
-                  <div className="text-blue-200/70">Arquivos:</div>
-                  <div className="flex flex-wrap gap-2">
-                    {sharePayload.files.map((f, idx) => (
-                      <span key={`${f.name}-${idx}`} className="text-xs">
-                        {f.url ? (
-                          <a className="underline" href={f.url} target="_blank" rel="noreferrer">
-                            {f.name}
-                          </a>
-                        ) : (
-                          f.name
-                        )}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </div>
-            <div className="mt-2 text-xs text-blue-200/60">
-              Preenchi o cadastro com os dados compartilhados. Revise antes de salvar.
-            </div>
-          </div>
-        ) : null}
-        {shareHistory.length ? (
-          <Card className="bg-black/20 border border-white/10">
-            <CardHeader className="flex flex-row items-center justify-between gap-2">
-              <CardTitle className="text-white text-sm">Importações recentes</CardTitle>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-blue-200/60">{shareHistory.length} itens</span>
-                <Button variant="secondary" size="sm" onClick={clearShareHistory}>
-                  Limpar
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              {shareHistoryLoading ? <div className="text-xs text-blue-200/60">Sincronizando…</div> : null}
-              {shareHistory.slice(0, 6).map((item) => (
-                <div key={item.id} className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div className="text-sm text-blue-50">
-                      {item.title || item.url || 'Conteúdo compartilhado'}
-                    </div>
-                    <div className="text-xs text-blue-200/60">{fmtDate(item.createdAt)}</div>
-                  </div>
-                  {item.text ? <div className="text-xs text-blue-200/70 mt-1">{item.text}</div> : null}
-                  {item.files && item.files.length ? (
-                    <div className="mt-1 flex flex-wrap gap-2 text-xs text-blue-200/70">
-                      {item.files.map((f, idx) => (
-                      <span key={`${item.id}-${idx}`} className="break-words">
-                        {f.url ? (
-                          <a className="underline" href={f.url} target="_blank" rel="noreferrer">
-                            {f.name}
-                          </a>
-                          ) : (
-                            f.name
-                          )}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <Button variant="secondary" size="sm" onClick={() => applyShareToForm(item)}>
-                      Usar no cadastro
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={() => removeShareHistory(item.id)}>
-                      Remover
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        ) : null}
-
-        {createOpen ? (
-          <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-3">
-            <div className="text-sm text-blue-100/70">
-              Cadastro rápido (campos mínimos) + detalhes opcionais (como no app antigo de Insumos).
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Código de barras</div>
-                <div className="flex items-center gap-2">
-                  <Input value={createCodigo} onChange={(e) => setCreateCodigo(e.target.value)} placeholder="789..." />
-                  <Button variant="secondary" type="button" onClick={() => setCreateScanOpen((v) => !v)}>
-                    {createScanOpen ? 'Fechar' : 'Escanear'}
-                  </Button>
-                </div>
-                <div className="mt-2">
-                  {createLookupLoading ? (
-                    <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
-                  ) : createLookupError ? (
-                    <div className="text-xs text-red-200">{createLookupError}</div>
-                  ) : createLookupItems.length ? (
-                    <div className="text-xs text-blue-200/70">
-                      Encontramos um cadastro para este código e pré-preenchemos alguns campos (produto/categoria/marca). Se quiser, você pode cadastrar um novo lote.
-                    </div>
-                  ) : null}
-                </div>
-                <div className="mt-2">
-                  <div className="text-xs text-blue-200/70 mb-1">Códigos adicionais</div>
-                  <Textarea
-                    value={createCodigosExtras}
-                    onChange={(e) => setCreateCodigosExtras(e.target.value)}
-                    placeholder="um por linha"
-                    rows={3}
-                    className="bg-white/[0.06] border-white/20 text-white"
-                  />
-                  <div className="mt-1 text-[10px] text-blue-200/50">
-                    Opcional. Use para variações de código do mesmo produto.
-                  </div>
-                </div>
-              </div>
-              <div className="md:col-span-2">
-                <div className="text-xs text-blue-200/70 mb-1">Produto</div>
-                <Input value={createProduto} onChange={(e) => setCreateProduto(e.target.value)} placeholder="Nome do produto" />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Categoria</div>
-                <Input
-                  value={createCategoria}
-                  onChange={(e) => setCreateCategoria(e.target.value)}
-                  placeholder="ex: Anestésicos"
-                  list="insumos-categorias"
-                />
-                <datalist id="insumos-categorias">
-                  {lotCategorias.map((c) => (
-                    <option key={c} value={c} />
-                  ))}
-                </datalist>
-              </div>
-              <div className="md:col-span-2 rounded-xl border border-white/10 bg-black/10 p-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="text-xs text-blue-200/70">Política do item</div>
-                  <div className="text-xs text-blue-200/60">Defina as regras para este insumo.</div>
-                </div>
-                <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
-                  <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                    <Checkbox
-                      checked={createCategoriaRequiresLot}
-                      onCheckedChange={(v) => {
-                        setCreatePolicyTouched(true)
-                        setCreateCategoriaRequiresLot(!!v)
-                      }}
-                      disabled={!isManagerRole}
-                    />
-                    Lote obrigatório
-                  </label>
-                  <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                    <Checkbox
-                      checked={createCategoriaRequiresExpiry}
-                      onCheckedChange={(v) => {
-                        setCreatePolicyTouched(true)
-                        const next = !!v
-                        setCreateCategoriaRequiresExpiry(next)
-                        if (!next) setCreateCategoriaFefo(false)
-                      }}
-                      disabled={!isManagerRole}
-                    />
-                    Validade obrigatória
-                  </label>
-                  <label className={`flex items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'} select-none`}>
-                    <Checkbox
-                      checked={createCategoriaFefo}
-                      onCheckedChange={(v) => {
-                        setCreatePolicyTouched(true)
-                        const next = !!v
-                        setCreateCategoriaFefo(next)
-                        if (next) setCreateCategoriaRequiresExpiry(true)
-                      }}
-                      disabled={!isManagerRole}
-                    />
-                    FEFO
-                  </label>
-                  {!isManagerRole ? <span className="text-xs text-blue-200/60">Somente gestores alteram.</span> : null}
-                </div>
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Marca</div>
-                <Input
-                  value={createMarca}
-                  onChange={(e) => setCreateMarca(e.target.value)}
-                  placeholder="ex: Galderma"
-                  list="insumos-marcas"
-                />
-                <datalist id="insumos-marcas">
-                  {insumosMarcas.map((m) => (
-                    <option key={m} value={m} />
-                  ))}
-                </datalist>
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Unidade (medida)</div>
-                <Select
-                  value={normalizeTipoUnidadeToCanonical(createTipoUnidade) || undefined}
-                  onValueChange={setCreateTipoUnidade}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione a unidade" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {insumosTiposUnidade.map((u) => (
-                      <SelectItem key={u} value={u}>
-                        {u}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Preço custo</div>
-                <Input value={createPrecoCusto} onChange={(e) => setCreatePrecoCusto(e.target.value)} placeholder="R$ 0,00" />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Estoque inicial ({unidadeLabel(unidade)})</div>
-                <Input value={createEstoqueInicial} onChange={(e) => setCreateEstoqueInicial(e.target.value)} type="number" min={0} />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Estoque mínimo</div>
-                <Input value={createEstoqueMinimo} onChange={(e) => setCreateEstoqueMinimo(e.target.value)} type="number" min={0} />
-              </div>
-              <div>
-                <div className="flex items-center justify-between gap-2 mb-1">
-                  <div className="text-xs text-blue-200/70">Lote</div>
-                  <Button
-                    variant={createNovoLote ? 'secondary' : 'outline'}
-                    size="sm"
-                    type="button"
-                    onClick={() => setCreateNovoLote((v) => !v)}
-                    title="Ative quando estiver cadastrando um lote adicional para um código já existente."
-                  >
-                    {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
-                  </Button>
-                </div>
-                <Input
-                  value={createLote}
-                  onChange={(e) => setCreateLote(e.target.value)}
-                  placeholder={createNovoLote ? 'obrigatório (ex: L2026-01)' : 'opcional'}
-                />
-              </div>
-              <div>
-                <div className="text-xs text-blue-200/70 mb-1">Validade</div>
-                <BrDatePickerInput value={createDataValidade} onChange={setCreateDataValidade} placeholder="DD/MM/AA" ariaLabel="Validade" />
-              </div>
-            </div>
-
-            <details
-              data-pref-key="insumos.details.create.optional"
-              open={detailsOpen['insumos.details.create.optional'] ?? true}
-              onToggle={(e) => setDetailsKeyOpen('insumos.details.create.optional', (e.currentTarget as HTMLDetailsElement).open)}
-              className="rounded-lg border border-white/10 bg-black/10 p-3"
-            >
-              <summary className="cursor-pointer select-none text-sm text-blue-100/80">
-                Detalhes (opcional)
-              </summary>
-              <div className="mt-3 grid grid-cols-1 md:grid-cols-3 gap-2">
-                <div className="md:col-span-2">
-                  <div className="text-xs text-blue-200/70 mb-1">Especificação / Modelo</div>
-                  <Input
-                    value={createEspecificacao}
-                    onChange={(e) => setCreateEspecificacao(e.target.value)}
-                    placeholder="ex: Base, Lidocaine"
-                  />
-                </div>
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Concentração</div>
-                  <Input
-                    value={createConcentracao}
-                    onChange={(e) => setCreateConcentracao(e.target.value)}
-                    placeholder="ex: 300U"
-                  />
-                </div>
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Volume</div>
-                  <Input
-                    value={createVolume}
-                    onChange={(e) => setCreateVolume(e.target.value)}
-                    placeholder="ex: 1ml"
-                  />
-                </div>
-                <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Calibre / Bitola</div>
-                  <Input
-                    value={createCalibre}
-                    onChange={(e) => setCreateCalibre(e.target.value)}
-                    placeholder="ex: 30G"
-                  />
-                </div>
-                <div className="md:col-span-2">
-                  <div className="text-xs text-blue-200/70 mb-1">Homologado</div>
-                  <label className="flex items-center gap-2 text-sm text-blue-100/80 select-none">
-                    <Checkbox checked={createHomologado} onCheckedChange={(v) => setCreateHomologado(!!v)} />
-                    Produto homologado
-                  </label>
-                </div>
-              </div>
-            </details>
-
-            {createScanOpen ? (
-              <BarcodeScannerInline
-                onDetected={(code) => {
-                  setCreateCodigo(code)
-                  setCreateScanOpen(false)
-                  toast.success('Código detectado')
-                }}
-                onClose={() => setCreateScanOpen(false)}
-              />
-            ) : null}
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-xs text-blue-200/60">
-                Dica: preencha só o essencial agora e complete os detalhes depois (categoria, lote, validade, etc.).
-              </div>
-              <Button
-                onClick={async () => {
-                  const codigoBarras = createCodigo.trim()
-                  if (!codigoBarras) return toast.error('Informe o código de barras')
-                  const extraCodes = parseBarcodeInput(createCodigosExtras)
-                  const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((v) => String(v || '').trim()).filter(Boolean)))
-                  const existing = (insumos || []).find((i) => getInsumoBarcodes(i).includes(codigoBarras))
-                  const categoria = createCategoria.trim() || String(existing?.categoria || '').trim()
-                  const policy = {
-                    requiresLot: !!createCategoriaRequiresLot,
-                    requiresExpiry: !!createCategoriaRequiresExpiry,
-                    fefo: !!createCategoriaFefo
-                  }
-                  const validadeIso = dateInputToIso(createDataValidade)
-
-                  const allowDuplicateLot = createNovoLote || (!!existing && policy.requiresLot)
-                  if (!createNovoLote && allowDuplicateLot) setCreateNovoLote(true)
-
-                  if ((policy.requiresLot || allowDuplicateLot) && !createLote.trim()) {
-                    return toast.error(policy.requiresLot ? 'Informe o lote (obrigatório pelo item)' : 'Informe o lote (Novo lote: on)')
-                  }
-                  if (policy.requiresExpiry && !validadeIso) {
-                    return toast.error('Informe a data de validade (obrigatória pelo item)')
-                  }
-                  if (policy.fefo && !policy.requiresExpiry) {
-                    return toast.error('FEFO exige validade obrigatória')
-                  }
-
-                  const produto = createProduto.trim() || (allowDuplicateLot ? String(existing?.produto || '').trim() : '')
-                  if (!produto) return toast.error('Informe o produto')
-                  const tipoUnidade = normalizeTipoUnidadeToCanonical(createTipoUnidade)
-                  if (!tipoUnidade) return toast.error('Informe a unidade (medida)')
-
-                  setCreateLoading(true)
-                  try {
-                    await mutateJson(`/insumos?unidade=${encodeURIComponent(unidade)}`, {
-                      method: 'POST',
-                      queueLabel: 'Cadastro de insumo',
-                      body: {
-                        codigoBarras,
-                        codigosBarras,
-                        produto,
-                        allowDuplicateLot,
-                        categoria,
-                        marca: createMarca.trim(),
-                        tipoUnidade,
-                        especificacao: createEspecificacao.trim(),
-                        concentracao: createConcentracao.trim(),
-                        volume: createVolume.trim(),
-                        fonte: createHomologado ? 'Homologado' : '',
-                        calibre: createCalibre.trim(),
-                        precoCusto: createPrecoCusto.trim(),
-                        estoqueInicial: Number(createEstoqueInicial) || 0,
-                        estoqueMinimo: Number(createEstoqueMinimo) || 0,
-                        lote: createLote.trim(),
-                        dataValidade: validadeIso,
-                        policyRequiresLot: policy.requiresLot,
-                        policyRequiresExpiry: policy.requiresExpiry,
-                        policyFefo: policy.fefo
-                      }
-                    })
-                    toast.success('Insumo cadastrado')
-                    setCreateCodigo('')
-                    setCreateCodigosExtras('')
-                    setCreateProduto('')
-                    setCreateCategoria('')
-                    setCreateMarca('')
-                    setCreateTipoUnidade('')
-                    setCreateEspecificacao('')
-                    setCreateConcentracao('')
-                    setCreateVolume('')
-                    setCreateHomologado(false)
-                    setCreateCalibre('')
-                    setCreatePrecoCusto('')
-                    setCreateEstoqueInicial('0')
-                    setCreateEstoqueMinimo('5')
-                    setCreateLote('')
-                    setCreateDataValidade('')
-                    setCreateNovoLote(false)
-                    setCreateOpen(false)
-                    await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadInsumosOptions()])
-                  } catch (e) {
-                    const status = (e as any)?.status
-                    const msg = e instanceof Error ? e.message : String(e)
-                    if (status === 409 && /código de barras já cadastrado/i.test(msg)) {
-                      setCreateNovoLote(true)
-                      toast.error('Código já existe. Ative “Novo lote” e informe Lote/Validade para cadastrar um lote adicional.')
-                      return
-                    }
-                    if (policyErrorToast(e)) return
-                    toast.error(msg)
-                  } finally {
-                    setCreateLoading(false)
-                  }
-                }}
-                disabled={createLoading || !isAuthed}
-              >
-                {createLoading ? 'Salvando…' : 'Salvar'}
-              </Button>
-            </div>
-          </div>
-        ) : null}
-
-        <div ref={insumosListContainerRef} onScroll={onInsumosScroll} className="overflow-auto max-h-[70vh] rounded-xl border border-white/10">
-          <table className="w-full table-fixed text-sm">
-            <thead className="bg-black/30 text-blue-100/80">
-              <tr>
-                <th className="text-left p-3 w-[28%]">Produto</th>
-                <th className="text-left p-3 w-[16%]">Categoria</th>
-                <th className="hidden lg:table-cell text-left p-3 w-[16%]">Código</th>
-                <th className="text-right p-3 w-[7%]">Estoque</th>
-                <th className="text-right p-3 w-[7%]">Mín</th>
-                <th className="hidden md:table-cell text-left p-3 w-[10%]">Validade</th>
-                <th className="hidden xl:table-cell text-right p-3 w-[8%]">Valor</th>
-                <th className="text-right p-3 w-[8%]">Ações</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-white/5">
-              {filteredInsumos.map((i) => {
-                const codigoBarras = String(i.codigoBarras || '').trim()
-                const isSelected = !!codigoBarras && selectedCodigoBarras.trim() === codigoBarras
-                const estoque = Number(i.estoqueAtual) || 0
-                const min = Number(i.estoqueMinimo) || 0
-                const stockStatus = calcularStatusEstoque(estoque, min)
-                const isCritico = stockStatus === 'URGENTE'
-                const isLowStock = stockStatus === 'ATENCAO'
-                const validadeStatus = String(i.statusValidade?.status || '').toUpperCase()
-                const isVencendo = validadeStatus === 'VENCENDO'
-                const isExpirado = validadeStatus === 'EXPIRADO'
-                const valor = (Number(i.precoCusto) || 0) * estoque
-                const otherStocks = i.estoques
-                  ? Object.entries(i.estoques)
-                    .filter(([u, v]) => u !== unidade && (Number(v) || 0) > 0)
-                    .sort((a, b) => (Number(b[1]) || 0) - (Number(a[1]) || 0))
-                  : []
-                const otherSummary = otherStocks.length
-                  ? `${otherStocks
-                    .slice(0, 2)
-                    .map(([u, v]) => `${unidadeLabel(u)}: ${Number(v) || 0}`)
-                    .join(' • ')}${otherStocks.length > 2 ? ` • +${otherStocks.length - 2}` : ''}`
-                  : ''
-
-                return (
-                  <tr
-                    key={`${i.registro || ''}-${i.codigoBarras || ''}`}
-                    className={isSelected ? 'bg-white/5 hover:bg-white/10' : 'hover:bg-white/5'}
-                  >
-                    <td className="p-3 min-w-0 align-top">
-                      <button
-                        type="button"
-                        className="w-full text-left rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 cursor-pointer group"
-                        onClick={() => {
-                          if (!codigoBarras) return
-                          setSelectedCodigoBarras((prev) => (prev.trim() === codigoBarras ? '' : codigoBarras))
-                          try {
-                            movSectionRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' })
-                          } catch {
-                            // ignore
-                          }
-                        }}
-                        title={codigoBarras ? 'Ver movimentações deste insumo' : undefined}
-                        aria-pressed={isSelected}
-                      >
-                        <div className="flex items-center justify-between gap-2 min-w-0">
-                          <div className="text-blue-50 group-hover:underline break-words line-clamp-2">{i.produto || '-'}</div>
-                          {isSelected ? <div className="text-xs text-blue-200/60">Filtrando</div> : null}
-                        </div>
-                        {i.marca ? (
-                          <div className="mt-1 flex flex-wrap gap-1">
-                            <Badge style={buildTagStyle(getMarcaBgColor(String(i.marca)))} className="border">
-                              {String(i.marca)}
-                            </Badge>
-                          </div>
-                        ) : null}
-                        {isCritico || isLowStock || isVencendo || isExpirado ? (
-                          <div className="mt-1 flex flex-wrap gap-1">
-                            {isCritico ? <Badge variant="destructive">Crítico</Badge> : null}
-                            {isLowStock ? <Badge variant="secondary">Atenção</Badge> : null}
-                            {isVencendo ? <Badge variant="secondary">Vencendo</Badge> : null}
-                            {isExpirado ? <Badge variant="destructive">Expirado</Badge> : null}
-                          </div>
-                        ) : null}
-                      </button>
-                    </td>
-                    <td className="p-3 text-blue-100/80 align-top">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <Badge style={buildTagStyle(getCategoriaBgColor(i.categoria || 'Outros'))} className="border">
-                          {i.categoria || '-'}
-                        </Badge>
-                      </div>
-                    </td>
-                    <td className="hidden lg:table-cell p-3 align-top">
-                      <div className="font-mono text-blue-100/80 break-all">{i.codigoBarras || '-'}</div>
-                    </td>
-                    <td className={`p-3 text-right align-top ${isCritico ? 'text-red-200' : 'text-blue-100/80'}`}>
-                      <div className="flex items-center justify-end gap-2">
-                        <span className="font-mono">{estoque}</span>
-                      </div>
-                      {otherSummary ? <div className="mt-1 text-[11px] text-blue-200/50">{otherSummary}</div> : null}
-                    </td>
-                    <td className="p-3 text-right text-blue-100/70 align-top">{min || '-'}</td>
-                    <td className="hidden md:table-cell p-3 align-top">
-                      <span className="text-blue-100/70">{fmtDateOnlyBR(i.dataValidade || '')}</span>
-                    </td>
-                    <td className="hidden xl:table-cell p-3 text-right text-blue-100/80 align-top">{fmtMoneyBRL(valor)}</td>
-                    <td className="p-3 text-right align-top">
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="secondary"
-                          className="h-8 px-2 text-xs"
-                          onClick={() => {
-                            if (i.codigoBarras) {
-                              selectQuickCodigo(i.codigoBarras, { setSearch: true, snapshot: i })
-                            }
-                          }}
-                        >
-                          Usar
-                        </Button>
-                        <Button
-                          variant="outline"
-                          className="h-8 px-2 text-xs"
-                          onClick={() => openEditDialog(i)}
-                          disabled={!isAuthed}
-                        >
-                          Editar
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-              {!filteredInsumos.length ? (
-                <tr>
-                  <td className="p-3 text-blue-100/70" colSpan={8}>
-                    {insumosLoadError && !insumosLoading && isAuthed ? (
-                      <span className="text-red-200">
-                        Erro ao carregar insumos ({insumosLoadError.status || 'erro'}
-                        {insumosLoadError.code ? `/${insumosLoadError.code}` : ''}): {insumosLoadError.message}
-                      </span>
-                    ) : (
-                      renderListPlaceholder(insumosLoading, 'Sem itens.')
-                    )}
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-        </div>
-              </CardContent>
-            ) : null}
-	        </Card>
-	      </div>
-
-	    )}
-	  </Draggable>
-              */}
-
 		  <Draggable draggableId="main-mov" index={mainOrderIndex.get('mov') ?? 0}>
 		    {(dragProvided) => (
 		      <div
@@ -9447,387 +4384,80 @@ export function InsumosModule() {
 	        style={{ ...(dragProvided.draggableProps.style || {}), order: mainOrderIndex.get('mov') ?? 0 }}
 	        className="space-y-3 flex-1 min-w-0"
 		      >
-		        <Card className="bg-black/20 border border-white/10">
-                <CardHeader className="flex flex-col gap-2">
-                  <div className="flex flex-col gap-2 min-w-0 w-full md:flex-row md:items-center md:gap-3">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <button
-                        type="button"
-                        {...dragProvided.dragHandleProps}
-			                className="mt-0.5 h-9 w-9 flex items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] cursor-grab active:cursor-grabbing"
-			                title="Arraste para mover"
-			                aria-label="Mover"
-		              >
-		                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-		                  <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-		                </svg>
-                      </button>
-                      <CardTitle className="text-white text-lg">Movimentações</CardTitle>
-                    </div>
-                    <div className="flex flex-1 flex-nowrap items-center gap-2 min-w-0 justify-end overflow-x-auto">
-                      <Select value={movTipo} onValueChange={(v) => setMovTipo(v as any)}>
-                        <SelectTrigger className="h-8 w-28 shrink-0">
-                          <SelectValue placeholder="Fluxo" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="TODOS">–</SelectItem>
-                          <SelectItem value="ENTRADA">Entrada</SelectItem>
-                          <SelectItem value="SAÍDA">Saída</SelectItem>
-                          <SelectItem value="AJUSTE">Ajuste</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Select
-                        value={movFilterCategoria || '__ALL__'}
-                        onValueChange={(v) => setMovFilterCategoria(v === '__ALL__' ? '' : String(v))}
-                      >
-                        <SelectTrigger className="h-8 w-36 shrink-0">
-                          <SelectValue placeholder="Categoria" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__ALL__">–</SelectItem>
-                          {lotCategorias.map((c) => (
-                            <SelectItem key={c} value={c}>
-                              {c}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select value={movFilterMarca || '__ALL__'} onValueChange={(v) => setMovFilterMarca(v === '__ALL__' ? '' : String(v))}>
-                        <SelectTrigger className="h-8 w-32 shrink-0">
-                          <SelectValue placeholder="Marca" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__ALL__">–</SelectItem>
-                          {insumosMarcas.map((m) => (
-                            <SelectItem key={m} value={m}>
-                              {m}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        value={movSearch}
-                        onChange={(e) => setMovSearch(e.target.value)}
-                        placeholder="Buscar"
-                        className="h-8 flex-1 min-w-[120px] md:min-w-0 ml-auto"
-                      />
-                      <div className="flex items-center gap-2 shrink-0">
-		                <Button
-		                  size="icon"
-		                  variant="ghost"
-		                  className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-		                  onClick={() => openInsumosListModal()}
-                      title="Abrir lista de insumos"
-                      aria-label="Abrir lista de insumos"
-                    >
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                        <path d="M8 6h12M8 12h12M8 18h12" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                        <circle cx="5" cy="6" r="1.5" fill="currentColor" />
-                        <circle cx="5" cy="12" r="1.5" fill="currentColor" />
-                        <circle cx="5" cy="18" r="1.5" fill="currentColor" />
-                      </svg>
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                      onClick={() => {
-                        const deIso = dateInputToIso(movDe)
-                        const ateIso = dateInputToIso(movAte)
-                        const params = new URLSearchParams({
-                          unidade,
-                          ...(selectedCodigoBarras.trim() ? { codigoBarras: selectedCodigoBarras.trim() } : {}),
-                          ...(movTipo !== 'TODOS' ? { tipo: movTipo } : {}),
-                          ...(deIso ? { de: deIso } : {}),
-                          ...(ateIso ? { ate: ateIso } : {})
-                        })
-                        window.open(`/api/insumos/export/movimentacoes.csv?${params.toString()}`, '_blank', 'noopener,noreferrer')
-                      }}
-                      disabled={!isAuthed}
-                      title="Exportar CSV"
-                      aria-label="Exportar CSV"
-                    >
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                        <path
-                          d="M12 16V4m0 12-4-4m4 4 4-4M4 20h16"
-                          stroke="currentColor"
-                          strokeWidth="2.2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                      onClick={() => setDetailsKeyOpen(MAIN_PANEL_OPEN_KEYS.mov, !movPanelOpen)}
-                    title={movPanelOpen ? 'Contrair' : 'Expandir'}
-                    aria-label={movPanelOpen ? 'Contrair' : 'Expandir'}
-                  >
-                    {movPanelOpen ? (
-                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                        <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    ) : (
-                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-		                )}
-		              </Button>
-                      </div>
-                    </div>
-                  </div>
-		          </CardHeader>
-          {movPanelOpen ? (
-            <CardContent className="space-y-3">
-
-        <div ref={movListContainerRef} className="overflow-auto max-h-[60vh] rounded-xl border border-white/10">
-          <table className="w-full table-fixed text-sm">
-            <thead className="bg-black/30 text-blue-100/80">
-              <tr>
-                  {(
-                    [
-                      { key: 'dataHora', label: 'Data', compact: true, className: '', widthClass: 'w-[8%]' },
-                      { key: 'produto', label: 'Produto', widthClass: 'w-[22%]' },
-                      { key: 'categoria', label: 'Categoria', compact: true, className: 'hidden md:table-cell', widthClass: 'w-[12%]' },
-                      { key: 'marca', label: 'Marca', compact: true, className: 'hidden lg:table-cell', widthClass: 'w-[10%]' },
-                      { key: 'estoque', label: 'Estoque', compact: true, widthClass: 'w-[10%]' },
-                      { key: 'valor', label: 'Valor', compact: true, widthClass: 'w-[10%]' },
-                      { key: 'usuario', label: 'Usuário', compact: true, className: 'hidden xl:table-cell', widthClass: 'w-[10%]' },
-                      { key: 'observacao', label: 'Observação', className: 'hidden md:table-cell', widthClass: 'w-[16%]' },
-                      { key: null, label: 'Ações', compact: true, widthClass: 'w-[6%]' }
-                    ] as Array<{ key: null | 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'; label: string; compact?: boolean; className?: string; widthClass?: string }>
-                  ).map((col) => {
-                    const isActive = !!col.key && movSortKey === col.key
-                    return (
-                      <th
-                        key={col.label}
-                        className={`p-3 text-center align-middle ${col.compact ? 'whitespace-nowrap' : ''} ${col.widthClass || ''} ${col.className || ''} sticky top-0 z-10 bg-black/40 backdrop-blur`}
-                      >
-	                        <div className="flex items-center justify-center gap-2">
-                            {col.key ? (
-                              <button
-                                type="button"
-                                className={`cursor-pointer select-none ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 rounded-sm px-0.5`}
-                                onClick={() => {
-                                  if (movSortKey === col.key) {
-                                    setMovSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
-                                    return
-                                  }
-                                  setMovSortKey(col.key!)
-                                  setMovSortDir(col.key === 'dataHora' ? 'desc' : 'asc')
-                                }}
-                                aria-label={`Ordenar ${col.label}`}
-                                title={`Ordenar ${col.label}`}
-                              >
-                                {col.label}
-                              </button>
-                            ) : (
-                              <span>{col.label}</span>
-                            )}
-                            {col.key ? (
-                              <span className={`inline-flex items-center justify-center ${isActive ? 'text-white' : 'text-blue-100/30'}`} aria-hidden>
-                                {isActive && movSortDir === 'asc' ? (
-                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                  </svg>
-                                ) : (
-                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                                  </svg>
-                                )}
-                              </span>
-                            ) : null}
-	                        </div>
-	                      </th>
-                    )
-                  })}
-	              </tr>
-	            </thead>
-	            <tbody className="divide-y divide-white/5">
-	              {movimentacoesView.map((m, idx) => {
-	                const codigoBarras = String(m.codigoBarras || '').trim()
-                  const insumo = pickInsumoForMov(m)
-                  const ctxUnit = String(m.unidade || unidade || '').trim()
-                  const estoqueAtual = insumo
-                    ? (ctxUnit && insumo?.estoques ? Number(insumo.estoques?.[ctxUnit] ?? 0) : Number(insumo.estoqueAtual ?? 0))
-                    : null
-                  const tipoNorm = String(m.tipo || '').toUpperCase().replace('Í', 'I')
-                  const isEntrada = tipoNorm.includes('ENTRADA')
-                  const isSaida = tipoNorm.includes('SAIDA')
-                  const preco = Number(m.preco) || Number(insumo?.precoCusto) || 0
-                  const qtd = Number(m.quantidade) || 0
-                  const valorMov = preco * qtd
-                  const estoqueDepois = Number.isFinite(Number(m.estoqueNovo)) ? Number(m.estoqueNovo) : (estoqueAtual != null ? estoqueAtual : null)
-                  const estoqueAntes = Number.isFinite(Number(m.estoqueAnterior))
-                    ? Number(m.estoqueAnterior)
-                    : (Number.isFinite(Number(estoqueDepois)) && Number.isFinite(qtd) && (isEntrada || isSaida)
-                      ? (isEntrada ? Number(estoqueDepois) - qtd : Number(estoqueDepois) + qtd)
-                      : null)
-                  const valorEstoqueTotal = preco && estoqueDepois != null && Number.isFinite(Number(estoqueDepois)) ? preco * Number(estoqueDepois) : null
-                  const produtoNome = String(insumo?.produto || m.produto || '').trim() || '-'
-                  const categoriaNome = String(insumo?.categoria || '').trim() || '-'
-                  const marcaNome = String(insumo?.marca || m.marca || '').trim() || '-'
-		                const isSelected = !!codigoBarras && selectedCodigoBarras.trim() === codigoBarras
-
-                  const rowTone = isEntrada
-                    ? 'bg-emerald-400/10 hover:bg-emerald-400/15'
-                    : isSaida
-                      ? 'bg-rose-400/10 hover:bg-rose-400/15'
-                      : 'hover:bg-white/5'
-                  const rowClass = `${rowTone} ${isSelected ? 'ring-1 ring-white/10' : ''}`
-
-		                return (
-		                  <tr key={`${m.dataHora || ''}-${idx}`} className={rowClass}>
-                    <td className="p-3 text-center align-top text-blue-100/70 whitespace-nowrap">
-                          <div className="text-blue-50">{fmtMovDateShort(m.dataHora) || '-'}</div>
-                          <div className="text-xs text-blue-200/60">{fmtMovTimeShort(m.dataHora) || ''}</div>
-                        </td>
-                    <td className="p-3 text-center align-top">
-                      <button
-                        type="button"
-                        className="w-full text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 rounded-sm cursor-pointer break-words"
-                        onClick={() => {
-                          const p = String(produtoNome || '').trim()
-                          if (!p || p === '-') return
-                          setSelectedCodigoBarras('')
-                          setMovFilterCategoria('')
-                          setMovFilterMarca('')
-                          setMovSearch((prev) => (normalizeText(prev) === normalizeText(p) ? '' : p))
-                        }}
-                        title="Filtrar por produto"
-                        aria-pressed={normalizeText(movSearch) === normalizeText(produtoNome)}
-                      >
-                        <span className="line-clamp-2">{produtoNome}</span>
-                      </button>
-                      {marcaNome && marcaNome !== '-' ? (
-                        <div className="mt-1 flex flex-wrap justify-center gap-1 lg:hidden">
-                          <Badge style={buildTagStyle(getMarcaBgColor(marcaNome))} className="border">
-                            {marcaNome}
-                          </Badge>
-                        </div>
-                      ) : null}
-                    </td>
-                      <td className="p-3 text-center align-top whitespace-nowrap hidden md:table-cell">
-                        {categoriaNome && categoriaNome !== '-' ? (
-                          <button
-                            type="button"
-                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                            onClick={() => {
-                              const c = String(categoriaNome || '').trim()
-                              if (!c || c === '-') return
-                              setSelectedCodigoBarras('')
-                              setMovSearch('')
-                              setMovFilterCategoria((prev) => (normalizeText(prev) === normalizeText(c) ? '' : c))
-                            }}
-                            title="Filtrar por categoria"
-                            aria-pressed={normalizeText(movFilterCategoria) === normalizeText(categoriaNome)}
-                          >
-                            <Badge style={buildTagStyle(getCategoriaBgColor(categoriaNome))} className="border">
-                              {categoriaNome}
-                            </Badge>
-                          </button>
-                        ) : (
-                          <span className="text-blue-100/70">-</span>
-                        )}
-                      </td>
-                      <td className="p-3 text-center align-top whitespace-nowrap hidden lg:table-cell">
-                        {marcaNome && marcaNome !== '-' ? (
-                          <button
-                            type="button"
-                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                            onClick={() => {
-                              const b = String(marcaNome || '').trim()
-                              if (!b || b === '-') return
-                              setSelectedCodigoBarras('')
-                              setMovSearch('')
-                              setMovFilterMarca((prev) => (normalizeText(prev) === normalizeText(b) ? '' : b))
-                            }}
-                            title="Filtrar por marca"
-                            aria-pressed={normalizeText(movFilterMarca) === normalizeText(marcaNome)}
-                          >
-                            <Badge style={buildTagStyle(getMarcaBgColor(marcaNome))} className="border">
-                              {marcaNome}
-                            </Badge>
-                          </button>
-                        ) : (
-                          <span className="text-blue-100/70">-</span>
-                        )}
-                      </td>
-                      <td className="p-3 text-center align-top whitespace-nowrap">
-                        {estoqueAntes != null && estoqueDepois != null && Number.isFinite(estoqueAntes) && Number.isFinite(estoqueDepois) ? (
-                          <span className="font-mono text-blue-50">{estoqueAntes} → {estoqueDepois}</span>
-                        ) : (
-                          <span className="font-mono text-blue-100/70">-</span>
-                        )}
-                      </td>
-                      <td className="p-3 text-center align-top whitespace-nowrap w-[1%]">
-                        <div className="text-blue-50">{preco ? fmtMoneyBRL(valorMov) : '-'}</div>
-                        <div className="text-xs text-blue-200/60">
-                          {valorEstoqueTotal != null ? fmtMoneyBRL0(valorEstoqueTotal) : ''}
-                        </div>
-                      </td>
-                    <td className="p-3 text-center align-top text-blue-100/70 whitespace-nowrap hidden xl:table-cell">{m.usuario || '-'}</td>
-                    <td className="p-3 text-left align-top text-blue-100/60 hidden md:table-cell">
-                      <div className="space-y-1 break-words">
-                        {m.transferId ? (
-                          <div>
-                            <div>
-                              Transferência {m.unidadeOrigem ? unidadeLabel(m.unidadeOrigem) : '-'} →{' '}
-                              {m.unidadeDestino ? unidadeLabel(m.unidadeDestino) : '-'}
-                            </div>
-                            <div className="font-mono text-xs">{m.transferId}</div>
-                          </div>
-                        ) : m.motivo ? (
-                          <span>Motivo: {m.motivo}</span>
-                        ) : (
-                          <span>{m.observacoes || '-'}</span>
-                        )}
-                          {m.registroInsumo || m.lote || m.dataValidade ? (
-                            <div className="text-xs text-blue-200/60">
-                              {m.registroInsumo ? <span className="font-mono">Reg {m.registroInsumo}</span> : null}
-                              {m.lote ? <span>{m.registroInsumo ? ' • ' : ''}Lote {m.lote}</span> : null}
-                              {m.dataValidade ? <span>{(m.registroInsumo || m.lote) ? ' • ' : ''}Val {fmtDateOnlyBR(m.dataValidade)}</span> : null}
-                            </div>
-                          ) : null}
-                        </div>
-                      </td>
-                      <td className="p-3 text-center align-top whitespace-nowrap">
-                        <div className="flex justify-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => openMovementEditDialog(m)}
-                            disabled={!isAuthed || !String(m.id || '').trim()}
-                          >
-                            Editar
-                          </Button>
-                        </div>
-                      </td>
-		                  </tr>
-		                )
-	              })}
-	              {!movimentacoesView.length ? (
-	                <tr>
-	                  <td className="p-3 text-blue-100/70 text-center" colSpan={9}>
-	                    {movLoadError && !movLoading && isAuthed ? (
-                        <span className="text-red-200">
-                          Erro ao carregar movimentações ({movLoadError.status || 'erro'}
-                          {movLoadError.code ? `/${movLoadError.code}` : ''}): {movLoadError.message}
-                        </span>
-                      ) : (
-                        renderListPlaceholder(movLoading, 'Sem movimentações.')
-                      )}
-	                  </td>
-	                </tr>
-	              ) : null}
-            </tbody>
-          </table>
-        </div>
-            </CardContent>
-          ) : null}
-	        </Card>
+            <InsumosMovementsPanel
+              panelOpen={movPanelOpen}
+              dragHandleProps={dragProvided.dragHandleProps || undefined}
+              movTipo={movTipo}
+              movFilterCategoria={movFilterCategoria}
+              movFilterMarca={movFilterMarca}
+              movSearch={movSearch}
+              movSortKey={movSortKey}
+              movSortDir={movSortDir}
+              lotCategorias={lotCategorias}
+              insumosMarcas={insumosMarcas}
+              isAuthed={isAuthed}
+              rows={movementRows}
+              emptyContent={
+                movLoadError && !movLoading && isAuthed ? (
+                  <span className="text-red-200">
+                    Erro ao carregar movimentações ({movLoadError.status || 'erro'}
+                    {movLoadError.code ? `/${movLoadError.code}` : ''}): {movLoadError.message}
+                  </span>
+                ) : (
+                  renderListPlaceholder(movLoading, 'Sem movimentações.')
+                )
+              }
+              listContainerRef={movListContainerRef}
+              onToggleOpen={() => setDetailsKeyOpen(MAIN_PANEL_OPEN_KEYS.mov, !movPanelOpen)}
+              onTipoChange={setMovTipo}
+              onCategoriaChange={setMovFilterCategoria}
+              onMarcaChange={setMovFilterMarca}
+              onSearchChange={setMovSearch}
+              onOpenInventoryList={() => openInsumosListModal()}
+              onExportCsv={() => {
+                const deIso = dateInputToIso(movDe)
+                const ateIso = dateInputToIso(movAte)
+                const params = new URLSearchParams({
+                  unidade,
+                  ...(selectedCodigoBarras.trim() ? { codigoBarras: selectedCodigoBarras.trim() } : {}),
+                  ...(movTipo !== 'TODOS' ? { tipo: movTipo } : {}),
+                  ...(deIso ? { de: deIso } : {}),
+                  ...(ateIso ? { ate: ateIso } : {}),
+                })
+                window.open(`/api/insumos/export/movimentacoes.csv?${params.toString()}`, '_blank', 'noopener,noreferrer')
+              }}
+              onSortChange={(key) => {
+                if (movSortKey === key) {
+                  setMovSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))
+                  return
+                }
+                setMovSortKey(key)
+                setMovSortDir(key === 'dataHora' ? 'desc' : 'asc')
+              }}
+              onProductClick={(productName) => {
+                const product = String(productName || '').trim()
+                if (!product || product === '-') return
+                setSelectedCodigoBarras('')
+                setMovFilterCategoria('')
+                setMovFilterMarca('')
+                setMovSearch((prev) => (normalizeText(prev) === normalizeText(product) ? '' : product))
+              }}
+              onCategoryClick={(categoryName) => {
+                const category = String(categoryName || '').trim()
+                if (!category || category === '-') return
+                setSelectedCodigoBarras('')
+                setMovSearch('')
+                setMovFilterCategoria((prev) => (normalizeText(prev) === normalizeText(category) ? '' : category))
+              }}
+              onBrandClick={(brandName) => {
+                const brand = String(brandName || '').trim()
+                if (!brand || brand === '-') return
+                setSelectedCodigoBarras('')
+                setMovSearch('')
+                setMovFilterMarca((prev) => (normalizeText(prev) === normalizeText(brand) ? '' : brand))
+              }}
+              onEditMovement={openMovementEditDialog}
+            />
 	      </div>
 	    )}
 	  </Draggable>

--- a/frontend/e2e/escala-module.spec.ts
+++ b/frontend/e2e/escala-module.spec.ts
@@ -49,11 +49,9 @@ async function openEscalaModule(page: Page) {
 
 async function dismissPlanningAssistantIfVisible(page: Page) {
   const modal = page.getByTestId('escala-planning-assistant-modal')
-  if (!(await modal.isVisible().catch(() => false))) {
-    await modal.waitFor({ state: 'visible', timeout: 1500 }).catch(() => {})
-  }
+  await modal.waitFor({ state: 'visible', timeout: 2000 }).catch(() => null)
   if (!(await modal.isVisible().catch(() => false))) return
-  await modal.getByRole('button', { name: 'Close' }).click()
+  await page.keyboard.press('Escape')
   await expect(modal).not.toBeVisible()
 }
 
@@ -128,11 +126,10 @@ test.describe('escala', () => {
     await expect(page.getByTestId('escala-team-member-carla')).toBeVisible()
     await expect(page.getByTestId('escala-no-attendance-icon-2026-03-01')).toBeVisible()
 
-    await page.getByRole('combobox', { name: '' }).nth(3).click()
-    await expect(page.getByRole('option', { name: 'Dra. Ana' })).toBeVisible()
-    await expect(page.getByRole('option', { name: 'Dr. Agenda' })).toBeVisible()
-    await expect(page.getByRole('option', { name: 'Bruna' })).toHaveCount(0)
-    await expect(page.getByRole('option', { name: 'Carla' })).toHaveCount(0)
+    await page.getByTestId('escala-pill-2026-03-05-dra-ana').click()
+    await expect(page.getByTestId('escala-pill-2026-03-05-dra-ana')).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
+    await expect(page.getByTestId('escala-day-2026-03-06')).not.toHaveClass(/escala-day-card--tracked/)
   })
 
   test('keeps team members visible when the selected month has no schedule entries', async ({ page }) => {
@@ -181,9 +178,10 @@ test.describe('escala', () => {
     await dismissPlanningAssistantIfVisible(page)
     await expect(page.getByTestId('escala-team-member-dra-ana')).toBeVisible()
     await expect(page.getByTestId('escala-team-member-dr-bruno')).toBeVisible()
-    await page.getByRole('combobox', { name: '' }).nth(3).click()
-    await expect(page.getByRole('option', { name: 'Dra. Ana' })).toBeVisible()
-    await expect(page.getByRole('option', { name: 'Dr. Bruno' })).toBeVisible()
+    await page.getByTestId('escala-team-member-dra-ana').click()
+    await expect(page.getByTestId('escala-day-2026-04-01')).not.toHaveClass(/escala-day-card--tracked/)
+    await page.getByTestId('escala-team-member-dra-ana').click()
+    await expect(page.getByTestId('escala-team-member-dr-bruno')).toBeVisible()
   })
 
   test('shows team load failure as an error state instead of an empty team', async ({ page }) => {
@@ -305,8 +303,10 @@ test.describe('escala', () => {
       ],
     })
 
-    await expect(page.getByTestId('escala-day-2026-04-14')).toContainText('Auto')
-    await expect(page.getByTestId('escala-day-2026-04-15')).toContainText('Auto')
+    await expect(page.getByTestId('escala-day-source-2026-04-14')).toBeVisible()
+    await page.getByTestId('escala-day-source-2026-04-14').hover()
+    await expect(page.getByRole('tooltip')).toContainText('Automático')
+    await expect(page.getByTestId('escala-day-source-2026-04-15')).toBeVisible()
     await expect(page.getByTestId('escala-highlight-auto')).toContainText('2')
   })
 
@@ -523,12 +523,12 @@ test.describe('escala', () => {
 
     await page.getByTestId('escala-pill-2026-03-05-dra-ana').click()
 
-    await expect(page.getByRole('combobox', { name: '' }).nth(3)).toContainText('Dra. Ana')
+    await expect(page.getByTestId('escala-pill-2026-03-05-dra-ana')).toHaveAttribute('aria-pressed', 'true')
     await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
     await expect(page.getByTestId('escala-day-2026-03-12')).toHaveClass(/escala-day-card--tracked/)
     await expect(page.getByTestId('escala-day-2026-03-18')).not.toHaveClass(/escala-day-card--tracked/)
     await page.getByTestId('escala-day-2026-03-18').click()
-    await expect(page.getByRole('combobox', { name: '' }).nth(3)).toContainText('–')
+    await expect(page.getByTestId('escala-pill-2026-03-05-dra-ana')).toHaveAttribute('aria-pressed', 'false')
     await expect(page.getByText('Injetores do dia')).toHaveCount(0)
 
     await page.getByRole('button', { name: 'Destacar dias manual' }).click({ force: true })
@@ -637,14 +637,13 @@ test.describe('escala', () => {
 
     await expect(page.getByTestId('escala-team-field-name')).toHaveCount(0)
     await page.getByTestId('escala-team-member-dra-ana').click()
-    await expect(page.getByRole('combobox', { name: '' }).nth(3)).toContainText('Dra. Ana')
+    await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
     await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
     await page.getByTestId('escala-team-member-dra-ana').click()
-    await expect(page.getByRole('combobox', { name: '' }).nth(3)).toContainText('–')
     await expect(page.getByTestId('escala-day-2026-03-05')).not.toHaveClass(/escala-day-card--tracked/)
     await expect(page.getByTestId('escala-team-edit')).toBeDisabled()
     await page.getByTestId('escala-team-member-dra-ana').click()
-    await expect(page.getByRole('combobox', { name: '' }).nth(3)).toContainText('Dra. Ana')
+    await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
     await page.getByTestId('escala-team-edit').click()
     await expect(page.getByTestId('escala-team-field-name')).toHaveValue('Dra. Ana')
     await expect(page.getByTestId('escala-team-edit')).toHaveCount(0)
@@ -797,5 +796,201 @@ test.describe('escala', () => {
     }
     await expect(page.getByTestId('escala-team-member-paula-nova')).toBeVisible()
     await expect(page.getByTestId('escala-team-field-name')).toHaveCount(0)
+  })
+
+  test('fecha a seleção múltipla ao clicar fora do calendário', async ({ page }) => {
+    await mockEscalaAuth(page)
+    await mockEscalaPrefill(page)
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [{ date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }],
+          closedDays: [],
+          holidays: []
+        })
+      })
+    })
+
+    await openEscalaModule(page)
+
+    await page.getByTestId('escala-multi-select-toggle').click()
+    await expect(page.getByTestId('escala-multi-select-close')).toBeVisible()
+    await page.getByTestId('escala-day-2026-03-05').click()
+    await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--selected/)
+    await page.getByTestId('escala-team-panel').click({ position: { x: 20, y: 20 } })
+    await expect(page.getByTestId('escala-multi-select-close')).toHaveCount(0)
+    await expect(page.getByTestId('escala-day-2026-03-05')).not.toHaveClass(/escala-day-card--selected/)
+  })
+
+  test('limpa filtro ativo com Escape quando não há modal aberta', async ({ page }) => {
+    await mockEscalaAuth(page)
+    await mockEscalaPrefill(page)
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [
+            { date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' },
+            { date: '2026-03-12', unit: 'Novo Hamburgo', professional: 'Dr. Lucas' },
+          ],
+          closedDays: [],
+          holidays: []
+        })
+      })
+    })
+
+    await openEscalaModule(page)
+
+    await page.getByTestId('escala-pill-2026-03-05-dra-ana').click()
+    await expect(page.getByTestId('escala-day-2026-03-05')).toHaveClass(/escala-day-card--tracked/)
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('escala-day-2026-03-05')).not.toHaveClass(/escala-day-card--tracked/)
+  })
+
+  test('abre a edição do dia pelo teclado e fecha com Escape', async ({ page }) => {
+    await mockEscalaAuth(page)
+    await mockEscalaPrefill(page)
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [{ date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }],
+          closedDays: [],
+          holidays: []
+        })
+      })
+    })
+
+    await openEscalaModule(page)
+
+    const targetDay = page.getByTestId('escala-day-2026-03-05')
+    await targetDay.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('escala-modal-confirm')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('escala-modal-confirm')).toHaveCount(0)
+  })
+
+  test('mantém os controles principais acessíveis em viewport mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockEscalaAuth(page)
+    await mockEscalaPrefill(page)
+
+    await page.route('**/api/escala/overview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, units: ['Novo Hamburgo'], months: ['2026-03'] })
+      })
+    })
+
+    await page.route('**/api/escala/professionals**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: [
+            { name: 'Dra. Ana', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#22c55e' },
+            { name: 'Dr. Lucas', status: 'Ativo', units: ['Novo Hamburgo'], role: 'Injetor', shift: '', nickname: '', phone: '', email: '', instagram: '', color: '#0ea5e9' }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/escala/schedule**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          schedule: [{ date: '2026-03-05', unit: 'Novo Hamburgo', professional: 'Dra. Ana' }],
+          closedDays: [],
+          holidays: []
+        })
+      })
+    })
+
+    await openEscalaModule(page)
+
+    await expect(page.getByTestId('escala-calendar-panel')).toBeVisible()
+    await page.getByTestId('escala-team-panel').scrollIntoViewIfNeeded()
+    await expect(page.getByTestId('escala-team-panel')).toBeVisible()
+    await expect(page.getByTestId('escala-multi-select-toggle')).toBeVisible()
   })
 })

--- a/frontend/escalaApi.ts
+++ b/frontend/escalaApi.ts
@@ -1,4 +1,4 @@
-import type { PrefillSuggestion } from '@/escalaDomain'
+import type { PrefillSuggestion } from '@/escalaTypes'
 
 const DEFAULT_ESCALA_API_BASE = '/api/escala'
 

--- a/frontend/escalaComponents.tsx
+++ b/frontend/escalaComponents.tsx
@@ -1,0 +1,212 @@
+import { CalendarX2, Pencil, Shield, Sparkles } from 'lucide-react'
+
+import { Button } from '@/button'
+import { Checkbox } from '@/checkbox'
+import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/tooltip'
+import { cn } from '@/utils'
+import { slugifySegment } from '@/escalaShared'
+import type { DayPlanSource, PrefillSuggestion } from '@/escalaTypes'
+
+export function NoAttendanceChip({
+  date,
+  blocked,
+  label,
+}: {
+  date: string
+  blocked?: boolean
+  label?: string
+}) {
+  const text = String(label || 'Sem atendimento').trim() || 'Sem atendimento'
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+        blocked
+          ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
+          : 'border-white/10 bg-white/5 text-slate-200/80',
+      )}
+      data-testid={`escala-no-attendance-icon-${date}`}
+      aria-label={text}
+      title={text}
+    >
+      <CalendarX2 className="h-3.5 w-3.5" />
+    </div>
+  )
+}
+
+type MultiSelectFieldProps = {
+  label: string
+  placeholder: string
+  options: string[]
+  values: string[]
+  onToggle: (option: string) => void
+  testId: string
+  full?: boolean
+}
+
+export function MultiSelectField({
+  label,
+  placeholder,
+  options,
+  values,
+  onToggle,
+  testId,
+  full,
+}: MultiSelectFieldProps) {
+  const displayValue = values.length ? values.join(', ') : placeholder
+
+  return (
+    <label className={cn('space-y-1.5', full && 'sm:col-span-2')}>
+      <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300/65">
+        {label}
+      </span>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              'flex h-10 w-full items-center justify-between rounded-md border border-white/10 bg-white/[0.05] px-3 text-left text-sm transition hover:border-white/20',
+              values.length ? 'text-white' : 'text-slate-400'
+            )}
+            data-testid={testId}
+          >
+            <span className="truncate">{displayValue}</span>
+            <span className="ml-3 text-[10px] uppercase tracking-[0.14em] text-slate-400">
+              {values.length || 0}
+            </span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[320px] border-white/15 bg-slate-900/95 p-2 text-slate-100" align="start">
+          <div className="space-y-1">
+            {options.map((option) => {
+              const checked = values.includes(option)
+              return (
+                <label
+                  key={option}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 text-sm transition hover:bg-white/[0.06]',
+                    checked && 'bg-white/[0.08]'
+                  )}
+                >
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={() => onToggle(option)}
+                    data-testid={`${testId}-${slugifySegment(option)}`}
+                  />
+                  <span>{option}</span>
+                </label>
+              )
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </label>
+  )
+}
+
+export function EscalaDaySourceBadge({
+  date,
+  daySource,
+  appliedSuggestion,
+}: {
+  date: string
+  daySource: DayPlanSource
+  appliedSuggestion?: PrefillSuggestion | null
+}) {
+  const label = daySource === 'manual'
+    ? 'Manual'
+    : daySource === 'auto'
+      ? 'Automático'
+      : daySource === 'blocked'
+        ? 'Bloqueado'
+        : 'Vazio'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={cn(
+            'inline-flex size-7 items-center justify-center rounded-full border',
+            daySource === 'manual' && 'border-sky-300/22 bg-sky-500/10 text-sky-100/85',
+            daySource === 'auto' && 'border-emerald-300/22 bg-emerald-500/10 text-emerald-100/85',
+            daySource === 'blocked' && 'border-rose-300/22 bg-rose-500/10 text-rose-100/85',
+            daySource === 'empty' && 'border-amber-300/22 bg-amber-500/10 text-amber-100/85',
+          )}
+          data-testid={`escala-day-source-${date}`}
+          aria-label={label}
+        >
+          {daySource === 'manual' ? <Pencil className="size-3.5" aria-hidden="true" /> : null}
+          {daySource === 'auto' ? <Sparkles className="size-3.5" aria-hidden="true" /> : null}
+          {daySource === 'blocked' ? <Shield className="size-3.5" aria-hidden="true" /> : null}
+          {daySource === 'empty' ? <CalendarX2 className="size-3.5" aria-hidden="true" /> : null}
+          <span className="sr-only">{label}</span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="text-xs font-medium">{label}</div>
+        {daySource === 'auto' && appliedSuggestion ? (
+          <div className="mt-1 text-[11px] text-slate-300/85">
+            {`${appliedSuggestion.professional} • ${Math.round(appliedSuggestion.confidence * 100)}% • ${appliedSuggestion.sampleSize} ocorrências`}
+          </div>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function EscalaBulkSelectionPanel({
+  isBulkSelectionMode,
+  onEnable,
+  onConfirm,
+  onCancel,
+}: {
+  isBulkSelectionMode: boolean
+  onEnable: () => void
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div
+      className="rounded-2xl border border-white/10 bg-slate-950/45 px-3 py-3"
+      data-testid="escala-bulk-select-panel"
+      data-escala-bulk-preserve="true"
+    >
+      <Button
+        type="button"
+        variant={isBulkSelectionMode ? 'premium' : 'outline'}
+        className="w-full"
+        onClick={onEnable}
+        data-testid="escala-multi-select-toggle"
+      >
+        Seleção múltipla
+      </Button>
+      {isBulkSelectionMode ? (
+        <>
+          <div className="mt-2 text-[11px] text-slate-300/80">
+            Clique nas datas do calendário para selecionar.
+          </div>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant="default"
+              onClick={onConfirm}
+              data-testid="escala-multi-select-ok"
+            >
+              OK
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              data-testid="escala-multi-select-close"
+            >
+              Fechar
+            </Button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/escalaDomain.ts
+++ b/frontend/escalaDomain.ts
@@ -1,35 +1,11 @@
-export type CalendarCell = {
-  date: string
-  day: number
-  monthOffset: -1 | 0 | 1
-}
-
-export type EscalaProfessional = {
-  name: string
-  status: string
-  units: string[]
-  role: string
-  shift: string
-  nickname: string
-  phone: string
-  email: string
-  instagram: string
-  color: string
-}
-
-export type EscalaScheduleEntry = { date: string; unit: string; professional: string }
-export type EscalaClosedDay = { date: string; unit: string; reason: string }
-export type EscalaHoliday = { date: string; unit: string; name: string }
-export type WeekdayDefaultMap = Partial<Record<0 | 1 | 2 | 3 | 4 | 5 | 6, string>>
-
-export type PrefillSuggestion = {
-  date: string
-  professional: string
-  confidence: number
-  sampleSize: number
-}
-
-export type DayPlanSource = 'manual' | 'auto' | 'blocked' | 'empty'
+import type {
+  CalendarCell,
+  DayPlanSource,
+  EscalaClosedDay,
+  EscalaScheduleEntry,
+  PrefillSuggestion,
+  WeekdayDefaultMap,
+} from '@/escalaTypes'
 
 export function buildCalendarCells(monthValue: string): CalendarCell[] {
   const [year, month] = monthValue.split('-').map(Number)

--- a/frontend/escalaHeaderBridge.ts
+++ b/frontend/escalaHeaderBridge.ts
@@ -1,0 +1,92 @@
+import type { EscalaHeaderAction, EscalaHeaderState, EscalaHighlightMode } from '@/escalaTypes'
+
+const ESCALA_HEADER_EVENT = 'skincos:escala:header'
+const ESCALA_ACTION_EVENT = 'skincos:escala:action'
+
+function isHighlightMode(value: unknown): value is EscalaHighlightMode {
+  return value === 'manual' || value === 'auto' || value === 'blocked' || value === 'empty'
+}
+
+export function normalizeEscalaHeaderState(detail: unknown): EscalaHeaderState | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as Partial<EscalaHeaderState>
+  if (!Array.isArray(payload.units) || !Array.isArray(payload.monthOptions) || !Array.isArray(payload.yearOptions)) {
+    return null
+  }
+  return {
+    units: payload.units.map((item) => String(item)),
+    monthOptions: payload.monthOptions.map((item) => String(item)),
+    yearOptions: payload.yearOptions.map((item) => String(item)),
+    selectedUnit: String(payload.selectedUnit || ''),
+    selectedMonthNumber: String(payload.selectedMonthNumber || ''),
+    selectedYear: String(payload.selectedYear || ''),
+    totalScheduledDays: Number(payload.totalScheduledDays || 0),
+    unavailableDaysCount: payload.unavailableDaysCount == null ? undefined : Number(payload.unavailableDaysCount),
+    manualDays: payload.manualDays == null ? undefined : Number(payload.manualDays),
+    autoDays: payload.autoDays == null ? undefined : Number(payload.autoDays),
+    blockedDays: payload.blockedDays == null ? undefined : Number(payload.blockedDays),
+    emptyDays: payload.emptyDays == null ? undefined : Number(payload.emptyDays),
+    coveredDays: payload.coveredDays == null ? undefined : Number(payload.coveredDays),
+    highlightMode: isHighlightMode(payload.highlightMode) ? payload.highlightMode : null,
+  }
+}
+
+export function normalizeEscalaHeaderAction(detail: unknown): EscalaHeaderAction | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as { action?: unknown; type?: unknown; value?: unknown }
+  const rawType = String(payload.type || payload.action || '').trim()
+  if (!rawType) return null
+
+  if (rawType === 'clear-selection') {
+    return { type: 'clear-selection' }
+  }
+
+  if (rawType === 'set-unit' || rawType === 'set-month' || rawType === 'set-year') {
+    return {
+      type: rawType,
+      value: String(payload.value || ''),
+    }
+  }
+
+  if (rawType === 'toggle-highlight' || rawType === 'toggle-highlight-mode') {
+    const value = payload.value === 'scheduled' ? 'manual' : payload.value
+    if (!isHighlightMode(value)) return null
+    return { type: 'toggle-highlight', value }
+  }
+
+  return null
+}
+
+export function emitEscalaHeaderState(detail: EscalaHeaderState | null) {
+  try {
+    window.dispatchEvent(new CustomEvent<EscalaHeaderState | null>(ESCALA_HEADER_EVENT, { detail }))
+  } catch {
+    // ignore browser event bridge errors
+  }
+}
+
+export function dispatchEscalaHeaderAction(action: EscalaHeaderAction) {
+  try {
+    window.dispatchEvent(new CustomEvent<EscalaHeaderAction>(ESCALA_ACTION_EVENT, { detail: action }))
+  } catch {
+    // ignore browser event bridge errors
+  }
+}
+
+export function subscribeEscalaHeaderState(callback: (state: EscalaHeaderState | null) => void) {
+  const handler = (event: Event) => {
+    callback(normalizeEscalaHeaderState((event as CustomEvent<unknown>).detail))
+  }
+  window.addEventListener(ESCALA_HEADER_EVENT, handler as EventListener)
+  return () => window.removeEventListener(ESCALA_HEADER_EVENT, handler as EventListener)
+}
+
+export function subscribeEscalaHeaderAction(callback: (action: EscalaHeaderAction) => void) {
+  const handler = (event: Event) => {
+    const action = normalizeEscalaHeaderAction((event as CustomEvent<unknown>).detail)
+    if (!action) return
+    callback(action)
+  }
+  window.addEventListener(ESCALA_ACTION_EVENT, handler as EventListener)
+  return () => window.removeEventListener(ESCALA_ACTION_EVENT, handler as EventListener)
+}

--- a/frontend/escalaPanels.tsx
+++ b/frontend/escalaPanels.tsx
@@ -1,0 +1,745 @@
+import React from 'react'
+import {
+  ChevronDown,
+  ChevronUp,
+  Pencil,
+  Plus,
+  Save,
+  Shield,
+  X,
+} from 'lucide-react'
+import { Button } from '@/button'
+import { Checkbox } from '@/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/dialog'
+import { Input } from '@/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
+import { Progress } from '@/progress'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/select'
+import {
+  EscalaBulkSelectionPanel,
+  MultiSelectField,
+} from '@/escalaComponents'
+import {
+  DEFAULT_TEAM_COLOR,
+  formatMonthLabel,
+  getProfessionalBadgeStyle,
+  normalizeHexColor,
+  parseDelimitedValues,
+  ROLE_OPTIONS,
+  slugifySegment,
+  STATUS_OPTIONS,
+  UNIT_OPTIONS,
+} from '@/escalaShared'
+import type {
+  EscalaProfessional,
+  EscalaScheduleEntry,
+  EscalaTeamFormMode,
+} from '@/escalaTypes'
+import { cn } from '@/utils'
+
+type EscalaTeamPanelProps = {
+  activeInjectors: EscalaProfessional[]
+  inactiveInjectors: EscalaProfessional[]
+  isBulkSelectionMode: boolean
+  savingTeamMember: boolean
+  selectedTeamMember: string
+  selectedTeamMemberDirty: boolean
+  selectedTeamMemberDraft: EscalaProfessional | null
+  showInactiveTeamMembers: boolean
+  teamFormMode: EscalaTeamFormMode
+  teamLoadError: string | null
+  onBeginAddTeamMember: () => void
+  onBeginEditTeamMember: (name?: string) => void
+  onCancelBulkSelectionMode: () => void
+  onCloseTeamPanel: () => void
+  onConfirmBulkSelectionMode: () => void
+  onEnableBulkSelectionMode: () => void
+  onRetryProfessionals: () => void
+  onSaveTeamMember: () => void
+  onSelectTeamMember: (name: string) => void
+  onToggleInactiveTeamMembers: () => void
+  onToggleSelectedTeamMemberOption: (field: 'units' | 'role', option: string) => void
+  onUpdateSelectedTeamMemberField: (field: keyof EscalaProfessional, value: string) => void
+}
+
+type EscalaAssignDialogProps = {
+  activeDate: string | null
+  assignableProfessionalOptions: string[]
+  closedBlockedDates: Set<string>
+  closedDateSet: Set<string>
+  closedReasonByDate: Map<string, string>
+  dayActionKey: string | null
+  dayBlockReasons: Record<string, string>
+  getDatesSelectionState: (dates: string[], name: string) => boolean | 'indeterminate'
+  getDayDraft: (date: string, entries: EscalaScheduleEntry[]) => string[]
+  isBulkAssignModalOpen: boolean
+  isBulkSelectionMode: boolean
+  isDayAssignModalOpen: boolean
+  multiDateBlockReason: string
+  professionalMap: Map<string, EscalaProfessional>
+  scheduleByDate: Map<string, EscalaScheduleEntry[]>
+  selectedDates: string[]
+  selectedDatesLabel: string
+  setDayBlockReasons: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  setIsBulkAssignModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setIsDayAssignModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setMultiDateBlockReason: React.Dispatch<React.SetStateAction<string>>
+  toggleDayProfessional: (date: string, name: string, entries: EscalaScheduleEntry[]) => void
+  toggleSelectedDatesProfessional: (name: string) => void
+  onCloseAssignModalWithoutSave: () => void
+  onCloseActiveDateWithSave: () => void
+  onToggleSelectedDatesBlock: () => void
+}
+
+type EscalaPlanningAssistantModalProps = {
+  autoPrefillProgress: number
+  autoPrefillState: {
+    status: string
+    message: string
+    windowMonths: string[]
+    completed: number
+    total: number
+  }
+  onApplySuggestions: () => Promise<void>
+  onIgnoreSuggestions: () => void
+  onOpenChange: (open: boolean) => void
+  onRetryAnalysis: () => void
+  open: boolean
+  planningAssistantProgressLabel: string
+  planningAssistantTitle: string
+  selectedMonth: string
+}
+
+export function EscalaTeamPanel({
+  activeInjectors,
+  inactiveInjectors,
+  isBulkSelectionMode,
+  savingTeamMember,
+  selectedTeamMember,
+  selectedTeamMemberDirty,
+  selectedTeamMemberDraft,
+  showInactiveTeamMembers,
+  teamFormMode,
+  teamLoadError,
+  onBeginAddTeamMember,
+  onBeginEditTeamMember,
+  onCancelBulkSelectionMode,
+  onCloseTeamPanel,
+  onConfirmBulkSelectionMode,
+  onEnableBulkSelectionMode,
+  onRetryProfessionals,
+  onSaveTeamMember,
+  onSelectTeamMember,
+  onToggleInactiveTeamMembers,
+  onToggleSelectedTeamMemberOption,
+  onUpdateSelectedTeamMemberField,
+}: EscalaTeamPanelProps) {
+  const teamPanelExpanded = teamFormMode !== 'idle'
+
+  return (
+    <div className="flex flex-col gap-2 xl:w-[360px] xl:justify-self-end">
+      <div
+        className="escala-team-panel flex flex-col self-start overflow-hidden rounded-2xl border border-white/10 bg-slate-950/45"
+        data-testid="escala-team-panel"
+      >
+        <div className="border-b border-white/10 px-3 py-2.5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-[11px] uppercase tracking-[0.22em] text-slate-300/60">Equipe</div>
+              <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                size="icon"
+                variant={teamFormMode === 'add' ? 'premium' : 'outline'}
+                onClick={onBeginAddTeamMember}
+                disabled={!!teamLoadError}
+                aria-label="Adicionar injetor"
+                title="Adicionar"
+                data-testid="escala-team-add"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+              {teamPanelExpanded ? (
+                <>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="premium"
+                    onClick={() => void onSaveTeamMember()}
+                    disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
+                    aria-label="Salvar cadastro do injetor"
+                    title="Salvar"
+                    data-testid="escala-team-save"
+                  >
+                    <Save className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    onClick={onCloseTeamPanel}
+                    aria-label="Fechar cadastro da equipe"
+                    title="Fechar"
+                    data-testid="escala-team-close"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  onClick={() => onBeginEditTeamMember(selectedTeamMember)}
+                  disabled={!selectedTeamMember || !!teamLoadError}
+                  aria-label="Editar injetor"
+                  title="Editar"
+                  data-testid="escala-team-edit"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {teamLoadError ? (
+              <div
+                className="w-full rounded-xl border border-amber-300/30 bg-amber-500/10 px-3 py-3 text-xs text-amber-50/90"
+                data-testid="escala-team-error"
+              >
+                <div className="font-medium text-amber-50">Falha ao carregar a equipe do cadastro.</div>
+                <div className="mt-1 text-amber-50/80">
+                  A agenda pode continuar visível, mas a lateral da equipe não está confiável até recarregar os profissionais.
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="mt-3 border-amber-200/35 bg-amber-50/8 text-amber-50 hover:bg-amber-50/14"
+                  onClick={() => void onRetryProfessionals()}
+                  data-testid="escala-team-retry"
+                >
+                  Tentar novamente
+                </Button>
+              </div>
+            ) : activeInjectors.length || inactiveInjectors.length ? (
+              <>
+                {activeInjectors.map((prof) => {
+                  const isCurrent = prof.name === selectedTeamMember
+                  return (
+                    <button
+                      key={prof.name}
+                      type="button"
+                      className={cn(
+                        'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
+                        isCurrent ? 'text-white shadow-[0_14px_26px_rgba(15,23,42,0.24)]' : 'text-slate-200/80 hover:text-white',
+                      )}
+                      style={getProfessionalBadgeStyle(prof.name, isCurrent ? 'active' : 'default', prof.color)}
+                      onClick={() => onSelectTeamMember(prof.name)}
+                      data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
+                    >
+                      {prof.name}
+                    </button>
+                  )
+                })}
+                {inactiveInjectors.length ? (
+                  <>
+                    <button
+                      type="button"
+                      className={cn(
+                        'inline-flex min-h-[30px] items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
+                        showInactiveTeamMembers ? 'text-white' : 'text-rose-100/90 hover:text-white',
+                      )}
+                      style={{
+                        background: showInactiveTeamMembers
+                          ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.38), rgba(190, 24, 93, 0.28))'
+                          : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
+                        borderColor: showInactiveTeamMembers ? 'rgba(254, 202, 202, 0.85)' : 'rgba(252, 165, 165, 0.45)',
+                        boxShadow: showInactiveTeamMembers
+                          ? '0 14px 26px rgba(69, 10, 10, 0.26), inset 0 1px 0 rgba(255,255,255,0.16)'
+                          : 'inset 0 1px 0 rgba(255,255,255,0.05)',
+                      }}
+                      onClick={onToggleInactiveTeamMembers}
+                      data-testid="escala-team-inactive-toggle"
+                      aria-expanded={showInactiveTeamMembers}
+                    >
+                      <span>{`Inativos (${inactiveInjectors.length})`}</span>
+                      {showInactiveTeamMembers ? (
+                        <ChevronUp className="size-3.5" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown className="size-3.5" aria-hidden="true" />
+                      )}
+                    </button>
+                    {showInactiveTeamMembers ? inactiveInjectors.map((prof) => {
+                      const isCurrent = prof.name === selectedTeamMember
+                      return (
+                        <button
+                          key={prof.name}
+                          type="button"
+                          className={cn(
+                            'min-h-[30px] rounded-full border px-2.5 py-1 text-[10px] font-medium leading-tight transition-all',
+                            isCurrent ? 'text-white shadow-[0_14px_26px_rgba(69,10,10,0.28)]' : 'text-rose-100/90 hover:text-white',
+                          )}
+                          style={{
+                            background: isCurrent
+                              ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.42), rgba(190, 24, 93, 0.3))'
+                              : 'linear-gradient(135deg, rgba(239, 68, 68, 0.22), rgba(190, 24, 93, 0.16))',
+                            borderColor: isCurrent ? 'rgba(254, 202, 202, 0.9)' : 'rgba(252, 165, 165, 0.45)',
+                            boxShadow: isCurrent
+                              ? '0 14px 26px rgba(69,10,10,0.3), inset 0 1px 0 rgba(255,255,255,0.18)'
+                              : 'inset 0 1px 0 rgba(255,255,255,0.05)',
+                          }}
+                          onClick={() => onSelectTeamMember(prof.name)}
+                          data-testid={`escala-team-member-${slugifySegment(prof.name)}`}
+                        >
+                          {prof.name}
+                        </button>
+                      )
+                    }) : null}
+                  </>
+                ) : null}
+              </>
+            ) : (
+              <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-xs text-slate-300/70">
+                Nenhum injetor encontrado para a unidade selecionada.
+              </div>
+            )}
+          </div>
+        </div>
+
+        {teamPanelExpanded ? (
+          <div className="px-3 py-3">
+            {selectedTeamMemberDraft ? (
+              <div className="grid content-start gap-2.5 sm:grid-cols-2">
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">NOME</span>
+                  <Input
+                    value={selectedTeamMemberDraft.name}
+                    onChange={(event) => onUpdateSelectedTeamMemberField('name', event.target.value)}
+                    className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                    data-testid="escala-team-field-name"
+                  />
+                </label>
+
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">SITUAÇÃO</span>
+                  <Select
+                    value={selectedTeamMemberDraft.status || STATUS_OPTIONS[0]}
+                    onValueChange={(value) => onUpdateSelectedTeamMemberField('status', value)}
+                  >
+                    <SelectTrigger className="h-9 w-full border-white/10 bg-white/[0.05] text-white" data-testid="escala-team-field-status">
+                      <SelectValue placeholder="Selecione" />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/15 bg-slate-900 text-slate-100">
+                      {STATUS_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>{option}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+
+                <MultiSelectField
+                  label="CARGO"
+                  placeholder="Selecione os cargos"
+                  options={ROLE_OPTIONS}
+                  values={parseDelimitedValues(selectedTeamMemberDraft.role)}
+                  onToggle={(option) => onToggleSelectedTeamMemberOption('role', option)}
+                  testId="escala-team-field-role"
+                />
+
+                <MultiSelectField
+                  label="UNIDADE"
+                  placeholder="Selecione as unidades"
+                  options={UNIT_OPTIONS}
+                  values={selectedTeamMemberDraft.units}
+                  onToggle={(option) => onToggleSelectedTeamMemberOption('units', option)}
+                  testId="escala-team-field-units"
+                />
+
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">EMAIL</span>
+                  <Input
+                    value={selectedTeamMemberDraft.email}
+                    onChange={(event) => onUpdateSelectedTeamMemberField('email', event.target.value)}
+                    className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                    data-testid="escala-team-field-email"
+                  />
+                </label>
+
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">TELEFONE</span>
+                  <Input
+                    value={selectedTeamMemberDraft.phone}
+                    onChange={(event) => onUpdateSelectedTeamMemberField('phone', event.target.value)}
+                    placeholder="+55 (51) 99999-9999"
+                    className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                    data-testid="escala-team-field-phone"
+                  />
+                </label>
+
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">INSTAGRAM</span>
+                  <Input
+                    value={selectedTeamMemberDraft.instagram}
+                    onChange={(event) => onUpdateSelectedTeamMemberField('instagram', event.target.value)}
+                    className="h-9 border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-slate-500"
+                    data-testid="escala-team-field-instagram"
+                  />
+                </label>
+
+                <label className="space-y-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-300/65">COR</span>
+                  <div className="flex h-9 items-center gap-3 rounded-md border border-white/10 bg-white/[0.05] px-3">
+                    <input
+                      type="color"
+                      value={normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                      onChange={(event) => onUpdateSelectedTeamMemberField('color', event.target.value)}
+                      className="h-6 w-9 cursor-pointer rounded border-0 bg-transparent p-0"
+                      data-testid="escala-team-field-color"
+                      aria-label="Escolher cor do injetor"
+                    />
+                    <div
+                      className="h-[18px] w-[18px] rounded-full border border-white/20"
+                      style={{ background: normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR }}
+                      aria-hidden="true"
+                    />
+                    <span className="text-xs text-slate-300/75">
+                      {normalizeHexColor(selectedTeamMemberDraft.color) || DEFAULT_TEAM_COLOR}
+                    </span>
+                  </div>
+                </label>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-white/10 px-3 py-4 text-sm text-slate-300/70">
+                {selectedTeamMember
+                  ? 'Clique em Editar para abrir os campos do injetor selecionado.'
+                  : 'Selecione um injetor e clique em Editar para abrir os campos.'}
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      <EscalaBulkSelectionPanel
+        isBulkSelectionMode={isBulkSelectionMode}
+        onEnable={onEnableBulkSelectionMode}
+        onConfirm={onConfirmBulkSelectionMode}
+        onCancel={onCancelBulkSelectionMode}
+      />
+    </div>
+  )
+}
+
+export function EscalaAssignDialog({
+  activeDate,
+  assignableProfessionalOptions,
+  closedBlockedDates,
+  closedDateSet,
+  closedReasonByDate,
+  dayActionKey,
+  dayBlockReasons,
+  getDatesSelectionState,
+  getDayDraft,
+  isBulkAssignModalOpen,
+  isBulkSelectionMode,
+  isDayAssignModalOpen,
+  multiDateBlockReason,
+  professionalMap,
+  scheduleByDate,
+  selectedDates,
+  selectedDatesLabel,
+  setDayBlockReasons,
+  setIsBulkAssignModalOpen,
+  setIsDayAssignModalOpen,
+  setMultiDateBlockReason,
+  toggleDayProfessional,
+  toggleSelectedDatesProfessional,
+  onCloseAssignModalWithoutSave,
+  onCloseActiveDateWithSave,
+  onToggleSelectedDatesBlock,
+}: EscalaAssignDialogProps) {
+  const isOpen = isBulkSelectionMode
+    ? (isBulkAssignModalOpen && selectedDates.length > 0)
+    : (isDayAssignModalOpen && selectedDates.length > 0)
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (open) {
+          if (isBulkSelectionMode) {
+            setIsBulkAssignModalOpen(true)
+          } else {
+            setIsDayAssignModalOpen(true)
+          }
+          return
+        }
+        onCloseAssignModalWithoutSave()
+      }}
+    >
+      <DialogContent
+        className="max-w-sm border-white/10 bg-slate-950/96 text-slate-100"
+        data-escala-preserve-filter="true"
+        data-escala-bulk-preserve="true"
+        onEscapeKeyDown={(event) => {
+          event.preventDefault()
+          onCloseAssignModalWithoutSave()
+        }}
+      >
+        <button
+          type="button"
+          className="absolute right-10 top-3 rounded-xs border border-emerald-300/35 bg-emerald-500/16 px-2 py-1 text-[11px] font-semibold text-emerald-50 transition hover:bg-emerald-500/24 focus:outline-none focus:ring-2 focus:ring-emerald-300/45 sm:right-11 sm:top-4"
+          onClick={() => void onCloseActiveDateWithSave()}
+          data-testid="escala-modal-confirm"
+          aria-label="Confirmar alterações"
+        >
+          V
+        </button>
+        {selectedDates.length ? (
+          <>
+            <DialogHeader className="space-y-1">
+              <div className="flex items-start justify-between gap-3 pr-8">
+                <div className="flex items-center gap-2">
+                  <DialogTitle className="text-base">
+                    {selectedDates.length === 1 ? 'Injetores do dia' : 'Injetores das datas'}
+                  </DialogTitle>
+                  <DialogDescription className="text-xs text-slate-300/75">
+                    {selectedDates.length === 1 ? selectedDatesLabel : `${selectedDates.length} datas selecionadas`}
+                  </DialogDescription>
+                </div>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      data-testid={selectedDates.length === 1 && activeDate ? `escala-block-${activeDate}` : 'escala-block-multi'}
+                      className={cn(
+                        'escala-card-action rounded-full border p-2 hover:bg-white/[0.12]',
+                        selectedDates.every((date) => closedBlockedDates.has(date))
+                          ? 'border-rose-300/40 bg-rose-500/15 text-rose-100'
+                          : 'border-white/15 bg-white/[0.06] text-white/85',
+                      )}
+                      aria-label={selectedDates.length === 1 && activeDate ? `Bloquear data ${activeDate}` : 'Bloquear datas selecionadas'}
+                    >
+                      <Shield className="size-4.5" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-72 border-white/15 bg-slate-900/95 text-slate-100"
+                    align="end"
+                    data-escala-preserve-filter="true"
+                  >
+                    <div className="space-y-3 text-xs">
+                      <div>
+                        <div className="text-[11px] uppercase tracking-[0.2em] text-slate-300/70">
+                          {selectedDates.length === 1 ? 'Bloqueio de data' : 'Bloqueio de datas'}
+                        </div>
+                        <div className="text-sm text-white">
+                          {selectedDates.length === 1 ? activeDate : selectedDatesLabel}
+                        </div>
+                      </div>
+                      <Input
+                        value={
+                          selectedDates.length === 1 && activeDate
+                            ? (dayBlockReasons[activeDate] || closedReasonByDate.get(activeDate) || '')
+                            : multiDateBlockReason
+                        }
+                        onChange={(event) => {
+                          if (selectedDates.length === 1 && activeDate) {
+                            setDayBlockReasons((prev) => ({ ...prev, [activeDate]: event.target.value }))
+                            return
+                          }
+                          setMultiDateBlockReason(event.target.value)
+                        }}
+                        placeholder="escreva o motivo"
+                        className="h-9 bg-white/5"
+                        data-testid={selectedDates.length === 1 && activeDate ? `escala-block-reason-${activeDate}` : 'escala-block-reason-multi'}
+                        disabled={selectedDates.length === 1 && !!activeDate && closedBlockedDates.has(activeDate) && !closedDateSet.has(activeDate)}
+                      />
+                      <Button
+                        variant={selectedDates.every((date) => closedDateSet.has(date)) ? 'outline' : 'premium'}
+                        size="sm"
+                        className="w-full"
+                        data-testid={selectedDates.length === 1 && activeDate ? `escala-toggle-block-${activeDate}` : 'escala-toggle-block-multi'}
+                        onClick={() => void onToggleSelectedDatesBlock()}
+                        disabled={dayActionKey === (selectedDates.length === 1 && activeDate ? `block:${activeDate}` : 'block:multi')}
+                      >
+                        {selectedDates.every((date) => closedDateSet.has(date))
+                          ? (selectedDates.length === 1 ? 'Remover bloqueio' : 'Remover bloqueio das datas')
+                          : (selectedDates.length === 1 ? 'Bloquear data' : 'Bloquear datas')}
+                      </Button>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            </DialogHeader>
+
+            {selectedDates.length > 1 ? (
+              <div className="rounded-xl border border-sky-300/16 bg-sky-400/8 px-3 py-2 text-[11px] text-sky-100/78">
+                Seleção múltipla ativa. As alterações de injetores e bloqueio serão aplicadas em todas as datas selecionadas.
+              </div>
+            ) : null}
+
+            <div className="grid grid-cols-2 gap-2">
+              {assignableProfessionalOptions.length ? assignableProfessionalOptions.map((name) => {
+                const targetDates = selectedDates.filter((date) => !closedBlockedDates.has(date))
+                const checked = selectedDates.length === 1 && activeDate
+                  ? (
+                    closedBlockedDates.has(activeDate)
+                      ? false
+                      : getDayDraft(activeDate, scheduleByDate.get(activeDate) || []).includes(name)
+                  )
+                  : getDatesSelectionState(targetDates, name)
+                return (
+                  <label
+                    key={`${selectedDates.join('|')}-${name}`}
+                    className={cn(
+                      'flex min-w-0 cursor-pointer items-center gap-2 rounded-xl border px-2 py-1.5 text-xs transition-all',
+                      checked ? 'shadow-[0_10px_24px_rgba(15,23,42,0.18)]' : 'bg-white/[0.03]',
+                    )}
+                    style={getProfessionalBadgeStyle(name, checked ? 'active' : 'default', professionalMap.get(name)?.color)}
+                  >
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={() => {
+                        if (selectedDates.length === 1 && activeDate) {
+                          toggleDayProfessional(activeDate, name, scheduleByDate.get(activeDate) || [])
+                          return
+                        }
+                        toggleSelectedDatesProfessional(name)
+                      }}
+                      disabled={selectedDates.length === 1 && !!activeDate ? closedBlockedDates.has(activeDate) : selectedDates.every((date) => closedBlockedDates.has(date))}
+                    />
+                    <span className="truncate font-medium">{name}</span>
+                  </label>
+                )
+              }) : (
+                <div className="col-span-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-slate-300/80">
+                  Nenhum injetor ativo disponível.
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function EscalaPlanningAssistantModal({
+  autoPrefillProgress,
+  autoPrefillState,
+  onApplySuggestions,
+  onIgnoreSuggestions,
+  onOpenChange,
+  onRetryAnalysis,
+  open,
+  planningAssistantProgressLabel,
+  planningAssistantTitle,
+  selectedMonth,
+}: EscalaPlanningAssistantModalProps) {
+  const prefillWindowLabel = autoPrefillState.windowMonths.map(formatMonthLabel).join(', ')
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="border-white/14 bg-[#121a2d]/96 text-white shadow-2xl shadow-slate-950/60 backdrop-blur-xl sm:max-w-lg"
+        data-testid="escala-planning-assistant-modal"
+      >
+        <div
+          data-testid="escala-autoprefill-status"
+          className={cn(
+            'rounded-2xl border px-4 py-4',
+            autoPrefillState.status === 'error'
+              ? 'border-rose-300/35 bg-rose-500/10'
+              : autoPrefillState.status === 'done'
+                ? 'border-emerald-300/28 bg-emerald-500/10'
+                : autoPrefillState.status === 'ignored'
+                  ? 'border-slate-300/20 bg-white/[0.04]'
+                  : 'border-sky-300/25 bg-sky-500/10',
+          )}
+        >
+          <DialogHeader className="space-y-2 text-left">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-slate-300/65">
+              Assistente de planejamento
+            </div>
+            <DialogTitle className="text-base text-slate-50">
+              {planningAssistantTitle}
+            </DialogTitle>
+            <DialogDescription className="text-[11px] leading-5 text-slate-100/88">
+              {autoPrefillState.message}
+            </DialogDescription>
+          </DialogHeader>
+
+          {prefillWindowLabel ? (
+            <div className="mt-3 text-[10px] text-slate-300/72">
+              Base histórica: {prefillWindowLabel}
+            </div>
+          ) : null}
+
+          {autoPrefillState.status !== 'error' ? (
+            <div className="mt-4 space-y-1.5">
+              <Progress value={autoPrefillProgress} className="h-1.5 bg-white/10 [&_[data-slot=progress-indicator]]:bg-sky-300" />
+              <div className="flex items-center justify-between text-[10px] text-slate-300/70">
+                <span>{formatMonthLabel(selectedMonth)}</span>
+                <span>{planningAssistantProgressLabel}</span>
+              </div>
+            </div>
+          ) : null}
+
+          {(autoPrefillState.status === 'ready' || autoPrefillState.status === 'error') ? (
+            <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+              {autoPrefillState.status === 'ready' ? (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={onIgnoreSuggestions}
+                    data-testid="escala-prefill-ignore"
+                  >
+                    Ignorar neste mês
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="premium"
+                    onClick={() => void onApplySuggestions()}
+                    data-testid="escala-prefill-apply"
+                  >
+                    Aplicar sugestões
+                  </Button>
+                </>
+              ) : null}
+              {autoPrefillState.status === 'error' ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={onRetryAnalysis}
+                  data-testid="escala-prefill-retry"
+                >
+                  Tentar novamente
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/escalaPanels.tsx
+++ b/frontend/escalaPanels.tsx
@@ -112,7 +112,7 @@ type EscalaPlanningAssistantModalProps = {
     completed: number
     total: number
   }
-  onApplySuggestions: () => Promise<void>
+  onApplySuggestions: () => Promise<unknown>
   onIgnoreSuggestions: () => void
   onOpenChange: (open: boolean) => void
   onRetryAnalysis: () => void

--- a/frontend/escalaSelection.ts
+++ b/frontend/escalaSelection.ts
@@ -1,0 +1,35 @@
+export function toggleDateSelection(selectedDates: string[], date: string) {
+  const alreadySelected = selectedDates.includes(date)
+  const nextDates = alreadySelected
+    ? selectedDates.filter((item) => item !== date)
+    : Array.from(new Set([...selectedDates, date])).sort()
+  return {
+    alreadySelected,
+    nextDates,
+  }
+}
+
+export function resolveNextActiveDate(nextDates: string[], date: string, alreadySelected: boolean) {
+  if (!nextDates.length) return null
+  return alreadySelected ? nextDates[nextDates.length - 1] || null : date
+}
+
+export function filterDatesToMonth(selectedDates: string[], monthKey: string) {
+  return selectedDates.filter((date) => date.startsWith(`${monthKey}-`))
+}
+
+export function buildSelectedDatesLabel(selectedDates: string[], formatDisplayDate: (value: string) => string) {
+  if (!selectedDates.length) return ''
+  if (selectedDates.length === 1) return formatDisplayDate(selectedDates[0])
+  const ordered = [...selectedDates].sort()
+  const preview = ordered.slice(0, 3).map(formatDisplayDate)
+  const suffix = ordered.length > 3 ? ` +${ordered.length - 3}` : ''
+  return `${preview.join(', ')}${suffix}`
+}
+
+export function buildSelectionScopeLabel(selectedDatesLabel: string, selectedDatesCount: number) {
+  if (!selectedDatesCount) return 'Nenhuma data selecionada'
+  return selectedDatesCount === 1
+    ? `1 data selecionada: ${selectedDatesLabel}`
+    : `${selectedDatesCount} datas selecionadas: ${selectedDatesLabel}`
+}

--- a/frontend/escalaShared.ts
+++ b/frontend/escalaShared.ts
@@ -1,0 +1,334 @@
+import type { CSSProperties } from 'react'
+
+import type { EscalaProfessional } from '@/escalaTypes'
+
+export const MONTH_LABELS = new Map<string, string>()
+export const DEFAULT_DATE = new Date()
+export const DEFAULT_MONTH_NUMBER = String(DEFAULT_DATE.getMonth() + 1).padStart(2, '0')
+export const DEFAULT_YEAR = String(DEFAULT_DATE.getFullYear())
+export const MONTH_OPTIONS = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, '0'))
+export const ALL_PROFESSIONALS_OPTION = '–'
+export const NEW_TEAM_MEMBER_KEY = '__new__'
+export const STATUS_OPTIONS = ['Ativo', 'Inativo']
+export const UNIT_OPTIONS = ['BarraShoppingSul', 'Novo Hamburgo']
+export const ROLE_OPTIONS = ['Diretor', 'Gerente', 'Coordenador', 'Responsável Técnico', 'Injetor', 'Consultor']
+export const DEFAULT_TEAM_COLOR = '#ec4899'
+
+export function formatMonthLabel(value: string) {
+  if (MONTH_LABELS.has(value)) return MONTH_LABELS.get(value) as string
+  const [year, month] = value.split('-').map(Number)
+  const date = new Date(year, month - 1, 1)
+  let label = date.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })
+  label = label.charAt(0).toUpperCase() + label.slice(1)
+  MONTH_LABELS.set(value, label)
+  return label
+}
+
+export function formatMonthName(value: string) {
+  const month = Number(value)
+  if (!month) return value
+  const date = new Date(2000, month - 1, 1)
+  const label = date.toLocaleDateString('pt-BR', { month: 'long' })
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+export function formatDisplayDate(value: string) {
+  const [year, month, day] = String(value || '').split('-')
+  if (!year || !month || !day) return value
+  return `${day}/${month}/${year}`
+}
+
+export function shiftMonthValue(monthValue: string, offset: number) {
+  const [year, month] = monthValue.split('-').map(Number)
+  const date = new Date(year, month - 1 + offset, 1)
+  return {
+    year: String(date.getFullYear()),
+    monthNumber: String(date.getMonth() + 1).padStart(2, '0'),
+  }
+}
+
+export function uniqueNames(values: string[]) {
+  return Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean)))
+}
+
+export function normalizeText(value: string) {
+  return String(value || '').trim().toLowerCase()
+}
+
+export function normalizeHexColor(value: string) {
+  const raw = String(value || '').trim().toLowerCase()
+  if (!raw) return ''
+  const normalized = raw.startsWith('#') ? raw : `#${raw}`
+  if (/^#[0-9a-f]{6}$/.test(normalized)) return normalized
+  if (/^#[0-9a-f]{3}$/.test(normalized)) {
+    const [, r, g, b] = normalized
+    return `#${r}${r}${g}${g}${b}${b}`
+  }
+  return ''
+}
+
+export function hexToRgba(value: string, alpha: number) {
+  const hex = normalizeHexColor(value)
+  if (!hex) return `rgba(236, 72, 153, ${alpha})`
+  const red = Number.parseInt(hex.slice(1, 3), 16)
+  const green = Number.parseInt(hex.slice(3, 5), 16)
+  const blue = Number.parseInt(hex.slice(5, 7), 16)
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+}
+
+export function formatBrazilPhone(value: string) {
+  const digits = String(value || '').replace(/\D/g, '')
+  if (!digits) return ''
+  const normalized = (digits.startsWith('55') ? digits : `55${digits}`).slice(0, 13)
+  const country = normalized.slice(0, 2)
+  const area = normalized.slice(2, 4)
+  const subscriber = normalized.slice(4)
+  let formatted = `+${country}`
+  if (area) {
+    formatted += ` (${area}`
+    if (area.length === 2) formatted += ')'
+  }
+  if (subscriber) {
+    const prefixLength = subscriber.length > 8 ? 5 : Math.min(4, subscriber.length)
+    const prefix = subscriber.slice(0, prefixLength)
+    const suffix = subscriber.slice(prefixLength)
+    formatted += ` ${prefix}`
+    if (suffix) formatted += `-${suffix}`
+  }
+  return formatted
+}
+
+export function normalizeUnitKey(value: string) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .trim()
+}
+
+export function unitsMatch(left: string, right: string) {
+  return normalizeUnitKey(left) === normalizeUnitKey(right)
+}
+
+export function isActiveInjector(prof: EscalaProfessional) {
+  const role = normalizeText(prof.role)
+  const status = normalizeText(prof.status)
+  return role.includes('injetor') && status === 'ativo'
+}
+
+export function isInactiveInjector(prof: EscalaProfessional) {
+  const role = normalizeText(prof.role)
+  const status = normalizeText(prof.status)
+  return role.includes('injetor') && status === 'inativo'
+}
+
+export function isVisibleInjector(prof: EscalaProfessional) {
+  return isActiveInjector(prof) || isInactiveInjector(prof)
+}
+
+export function normalizeProfessionalRecord(prof: EscalaProfessional) {
+  return {
+    ...prof,
+    role: String(prof.role || '').trim() || 'Injetor',
+    status: String(prof.status || '').trim() || 'Ativo',
+    units: Array.isArray(prof.units) ? prof.units : [],
+  }
+}
+
+export function mergeProfessionals(scheduleNames: Set<string>, base: EscalaProfessional[]) {
+  const map = new Map<string, EscalaProfessional>()
+  base.forEach((prof) => {
+    map.set(prof.name, normalizeProfessionalRecord(prof))
+  })
+  scheduleNames.forEach((name) => {
+    if (map.has(name)) return
+    map.set(name, normalizeProfessionalRecord({
+      name,
+      status: 'Ativo',
+      units: [],
+      role: 'Injetor',
+      shift: '',
+      nickname: '',
+      phone: '',
+      email: '',
+      instagram: '',
+      color: '',
+    }))
+  })
+  return Array.from(map.values())
+}
+
+export function parseDelimitedValues(value: string) {
+  return uniqueNames(String(value || '').split(',').map((item) => item.trim()))
+}
+
+export function formatDelimitedValues(values: string[]) {
+  return uniqueNames(values).join(', ')
+}
+
+export function parseUnitsInput(value: string) {
+  return parseDelimitedValues(value)
+}
+
+export function normalizeProfessionalForCompare(prof: EscalaProfessional | null) {
+  if (!prof) return null
+  return {
+    name: String(prof.name || '').trim(),
+    status: String(prof.status || '').trim(),
+    units: uniqueNames(prof.units || []),
+    role: String(prof.role || '').trim(),
+    shift: String(prof.shift || '').trim(),
+    nickname: String(prof.nickname || '').trim(),
+    phone: String(prof.phone || '').trim(),
+    email: String(prof.email || '').trim(),
+    instagram: String(prof.instagram || '').trim(),
+    color: normalizeHexColor(prof.color),
+  }
+}
+
+export function buildYearOptions(monthKeys: string[]) {
+  const currentYear = Number(DEFAULT_YEAR)
+  const years = new Set<string>([String(currentYear - 1), DEFAULT_YEAR, String(currentYear + 1), String(currentYear + 2)])
+  monthKeys.forEach((value) => {
+    const year = String(value || '').slice(0, 4)
+    if (/^\d{4}$/.test(year)) years.add(year)
+  })
+  return Array.from(years).sort((a, b) => Number(a) - Number(b))
+}
+
+export function normalizeMonthKey(value: string) {
+  return /^\d{4}-\d{2}$/.test(String(value || '')) ? String(value) : ''
+}
+
+export function resolveVisibleMonth(monthKeys: string[], year: string, monthNumber: string) {
+  const available = Array.from(new Set(monthKeys.map(normalizeMonthKey).filter(Boolean))).sort()
+  const selected = normalizeMonthKey(`${year}-${monthNumber}`)
+  const fallback = available.length ? available[available.length - 1] : (selected || `${DEFAULT_YEAR}-${DEFAULT_MONTH_NUMBER}`)
+  const next = selected && available.includes(selected) ? selected : fallback
+  return {
+    year: next.slice(0, 4),
+    monthNumber: next.slice(5, 7),
+  }
+}
+
+export function hashString(value: string) {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = value.charCodeAt(index) + ((hash << 5) - hash)
+  }
+  return Math.abs(hash)
+}
+
+export function getProfessionalBadgeStyle(
+  name: string,
+  mode: 'default' | 'active' | 'muted' = 'default',
+  accentColor?: string,
+) {
+  const color = normalizeHexColor(accentColor || '')
+  const hash = hashString(name)
+  const hue = hash % 360
+  const baseText = color ? 'white' : `hsl(${hue} 88% 92%)`
+
+  if (mode === 'active') {
+    return {
+      background: color
+        ? `linear-gradient(135deg, ${hexToRgba(color, 0.55)}, ${hexToRgba(color, 0.28)})`
+        : `linear-gradient(135deg, hsla(${hue}, 82%, 56%, 0.38), hsla(${(hue + 28) % 360}, 82%, 58%, 0.26))`,
+      borderColor: color ? hexToRgba(color, 0.92) : `hsla(${hue}, 88%, 74%, 0.9)`,
+      color: 'white',
+      boxShadow: color
+        ? `0 0 0 1px ${hexToRgba(color, 0.45)}, 0 16px 28px ${hexToRgba(color, 0.28)}, inset 0 1px 0 rgba(255,255,255,0.18)`
+        : `0 0 0 1px hsla(${hue}, 90%, 74%, 0.45), 0 16px 28px hsla(${hue}, 90%, 20%, 0.28), inset 0 1px 0 rgba(255,255,255,0.18)`,
+      opacity: 1,
+    } as CSSProperties
+  }
+
+  if (mode === 'muted') {
+    return {
+      background: 'rgba(15, 23, 42, 0.28)',
+      borderColor: 'rgba(148, 163, 184, 0.18)',
+      color: 'rgba(226, 232, 240, 0.58)',
+      boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.02)',
+      opacity: 0.72,
+    } as CSSProperties
+  }
+
+  return {
+    background: color
+      ? `linear-gradient(135deg, ${hexToRgba(color, 0.28)}, ${hexToRgba(color, 0.16)})`
+      : `linear-gradient(135deg, hsla(${hue}, 78%, 56%, 0.22), hsla(${(hue + 24) % 360}, 78%, 58%, 0.14))`,
+    borderColor: color ? hexToRgba(color, 0.5) : `hsla(${hue}, 84%, 72%, 0.4)`,
+    color: baseText,
+    boxShadow: color
+      ? `inset 0 1px 0 rgba(255,255,255,0.08), 0 0 0 1px ${hexToRgba(color, 0.12)}`
+      : 'inset 0 1px 0 rgba(255,255,255,0.05)',
+    opacity: 1,
+  } as CSSProperties
+}
+
+export function getProfessionalCardHighlightStyle(name: string, accentColor?: string) {
+  const color = normalizeHexColor(accentColor || '')
+  const hue = hashString(name) % 360
+  return {
+    borderColor: color ? hexToRgba(color, 0.78) : `hsla(${hue}, 88%, 74%, 0.72)`,
+    background: color
+      ? `linear-gradient(180deg, ${hexToRgba(color, 0.18)}, rgba(15, 23, 42, 0.34))`
+      : `linear-gradient(180deg, hsla(${hue}, 86%, 54%, 0.12), rgba(15, 23, 42, 0.34))`,
+    boxShadow: color
+      ? `0 0 0 1px ${hexToRgba(color, 0.24)}, 0 18px 34px ${hexToRgba(color, 0.24)}, inset 0 1px 0 rgba(255,255,255,0.06)`
+      : `0 0 0 1px hsla(${hue}, 88%, 74%, 0.25), 0 18px 34px hsla(${hue}, 90%, 18%, 0.24), inset 0 1px 0 rgba(255,255,255,0.06)`,
+  } as CSSProperties
+}
+
+export function getAdjacentMonthCardStyle(type: 'previous-month' | 'next-month', position: number, total: number) {
+  if (!total || !position) return {} as CSSProperties
+  const step = 0.8 / total
+  const transparency = type === 'previous-month'
+    ? Math.min(0.9, 0.1 + step * (total - position + 1))
+    : Math.min(0.9, 0.1 + step * (position - 1))
+  const opacity = 1 - transparency * 0.58
+  const blur = 8 + transparency * 10
+  const saturation = 0.84 - transparency * 0.36
+  const grayscale = 0.12 + transparency * 0.52
+  const borderAlpha = 0.08 + transparency * 0.18
+  const topAlpha = 0.025 + transparency * 0.07
+  const bottomAlpha = 0.045 + transparency * 0.12
+  return {
+    opacity: Number(opacity.toFixed(3)),
+    borderColor: `rgba(148, 163, 184, ${borderAlpha.toFixed(3)})`,
+    background: `linear-gradient(180deg, rgba(255,255,255,${topAlpha.toFixed(3)}), rgba(148,163,184,${bottomAlpha.toFixed(3)}))`,
+    boxShadow: `inset 0 1px 0 rgba(255,255,255,${(0.03 + transparency * 0.06).toFixed(3)}), 0 10px 24px rgba(15,23,42,${(0.05 + transparency * 0.08).toFixed(3)})`,
+    filter: `grayscale(${grayscale.toFixed(2)}) saturate(${saturation.toFixed(2)})`,
+    backdropFilter: `blur(${blur.toFixed(1)}px) saturate(${(0.9 - transparency * 0.18).toFixed(2)})`,
+    WebkitBackdropFilter: `blur(${blur.toFixed(1)}px) saturate(${(0.9 - transparency * 0.18).toFixed(2)})`,
+  } as CSSProperties
+}
+
+export function slugifySegment(value: string) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+export function createEmptyProfessional(selectedUnit?: string): EscalaProfessional {
+  return {
+    name: '',
+    status: 'Ativo',
+    units: selectedUnit ? [selectedUnit] : [],
+    role: '',
+    shift: '',
+    nickname: '',
+    phone: '',
+    email: '',
+    instagram: '',
+    color: '',
+  }
+}
+
+export function toLocalIsoDate(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}

--- a/frontend/escalaTypes.ts
+++ b/frontend/escalaTypes.ts
@@ -1,0 +1,81 @@
+export type CalendarCell = {
+  date: string
+  day: number
+  monthOffset: -1 | 0 | 1
+}
+
+export type EscalaProfessional = {
+  name: string
+  status: string
+  units: string[]
+  role: string
+  shift: string
+  nickname: string
+  phone: string
+  email: string
+  instagram: string
+  color: string
+}
+
+export type EscalaScheduleEntry = {
+  date: string
+  unit: string
+  professional: string
+}
+
+export type EscalaClosedDay = {
+  date: string
+  unit: string
+  reason: string
+}
+
+export type EscalaHoliday = {
+  date: string
+  unit: string
+  name: string
+}
+
+export type WeekdayDefaultMap = Partial<Record<0 | 1 | 2 | 3 | 4 | 5 | 6, string>>
+
+export type PrefillSuggestion = {
+  date: string
+  professional: string
+  confidence: number
+  sampleSize: number
+}
+
+export type DayPlanSource = 'manual' | 'auto' | 'blocked' | 'empty'
+
+export type EscalaHighlightMode = Extract<DayPlanSource, 'manual' | 'auto' | 'blocked' | 'empty'>
+
+export type EscalaHeaderState = {
+  units: string[]
+  monthOptions: string[]
+  yearOptions: string[]
+  selectedUnit: string
+  selectedMonthNumber: string
+  selectedYear: string
+  totalScheduledDays: number
+  unavailableDaysCount?: number
+  manualDays?: number
+  autoDays?: number
+  blockedDays?: number
+  emptyDays?: number
+  coveredDays?: number
+  highlightMode?: EscalaHighlightMode | null
+}
+
+export type EscalaHeaderAction =
+  | { type: 'set-unit'; value: string }
+  | { type: 'set-month'; value: string }
+  | { type: 'set-year'; value: string }
+  | { type: 'toggle-highlight'; value: EscalaHighlightMode }
+  | { type: 'clear-selection' }
+
+export type EscalaActionResult = {
+  ok: boolean
+  changed: boolean
+  error?: string
+}
+
+export type EscalaTeamFormMode = 'idle' | 'edit' | 'add'

--- a/frontend/insumosBridge.ts
+++ b/frontend/insumosBridge.ts
@@ -1,0 +1,194 @@
+import type {
+  InsumosHeaderAction,
+  InsumosHeaderState,
+  InsumosLayoutAction,
+  InsumosOverviewPeriod,
+  InsumosOverviewQuery,
+  InsumosQuickOperation,
+} from '@/insumosTypes'
+
+const INSUMOS_HEADER_EVENT = 'skincos:insumos:header'
+const INSUMOS_ACTION_EVENT = 'skincos:insumos:action'
+const INSUMOS_LEGACY_UNIT_EVENT = 'skincos:insumos:unidade'
+const INSUMOS_LEGACY_OVERVIEW_EVENT = 'skincos:insumos:overview'
+const INSUMOS_LEGACY_OP_EVENT = 'skincos:insumos:op'
+const INSUMOS_LEGACY_LAYOUT_EVENT = 'skincos:insumos:layout'
+const INSUMOS_LEGACY_STOCK_EVENT = 'skincos:insumos:estoque'
+
+function isOverviewPeriod(value: unknown): value is InsumosOverviewPeriod {
+  return value === '7d' || value === '30d' || value === '1y' || value === 'custom'
+}
+
+function isQuickOperation(value: unknown): value is InsumosQuickOperation {
+  return value === 'ENTRADA' || value === 'BAIXA' || value === 'AJUSTE' || value === 'TRANSFERENCIA'
+}
+
+function isLayoutAction(value: unknown): value is InsumosLayoutAction {
+  return value === 'expandAll' || value === 'collapseAll' || value === 'reset'
+}
+
+function normalizeOverviewQuery(detail: unknown): InsumosOverviewQuery | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as Partial<InsumosOverviewQuery>
+  const period = isOverviewPeriod(payload.period) ? payload.period : undefined
+  const from = typeof payload.from === 'string' ? payload.from : undefined
+  const to = typeof payload.to === 'string' ? payload.to : undefined
+  const action = payload.action === 'reload' ? 'reload' : undefined
+  if (!period && !from && !to && !action) return null
+  return { period, from, to, action }
+}
+
+export function normalizeInsumosHeaderState(detail: unknown): InsumosHeaderState | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as Partial<InsumosHeaderState>
+  const stock = payload.stock && typeof payload.stock === 'object'
+    ? {
+        value: payload.stock.value == null ? null : Number(payload.stock.value),
+        loading: Boolean(payload.stock.loading),
+        percent: payload.stock.percent == null ? null : Number(payload.stock.percent),
+        entradaValor: payload.stock.entradaValor == null ? null : Number(payload.stock.entradaValor),
+        saidaValor: payload.stock.saidaValor == null ? null : Number(payload.stock.saidaValor),
+      }
+    : null
+  const status = payload.status && typeof payload.status === 'object'
+    ? {
+        online: payload.status.online == null ? null : Boolean(payload.status.online),
+        authed: payload.status.authed == null ? null : Boolean(payload.status.authed),
+        integrated: payload.status.integrated == null ? null : Boolean(payload.status.integrated),
+        unidades: Array.isArray(payload.status.unidades) ? payload.status.unidades.map((item) => String(item)) : [],
+        allowedUnits: Array.isArray(payload.status.allowedUnits) ? payload.status.allowedUnits.map((item) => String(item)) : [],
+      }
+    : null
+  const overview = normalizeOverviewQuery(payload.overview) || { period: '30d' as const }
+  if (!isOverviewPeriod(overview.period)) {
+    overview.period = '30d'
+  }
+  return {
+    status,
+    stock,
+    selectedUnit: String(payload.selectedUnit || ''),
+    overview: {
+      period: overview.period,
+      from: overview.from,
+      to: overview.to,
+    },
+  }
+}
+
+export function normalizeInsumosHeaderAction(detail: unknown): InsumosHeaderAction | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as Record<string, unknown>
+  const rawType = String(payload.type || payload.action || '').trim()
+
+  if (rawType === 'set-unit' || Object.prototype.hasOwnProperty.call(payload, 'unidade')) {
+    const value = String(payload.value || payload.unidade || '').trim()
+    return value ? { type: 'set-unit', value } : null
+  }
+
+  if (rawType === 'quick-op' || Object.prototype.hasOwnProperty.call(payload, 'op')) {
+    const op = payload.value || payload.op
+    return isQuickOperation(op) ? { type: 'quick-op', value: op } : null
+  }
+
+  if (rawType === 'layout') {
+    return isLayoutAction(payload.value) ? { type: 'layout', value: payload.value } : null
+  }
+
+  if (isLayoutAction(payload.action)) {
+    return { type: 'layout', value: payload.action }
+  }
+
+  if (rawType === 'reload-overview') {
+    return { type: 'reload-overview' }
+  }
+
+  if (rawType === 'set-overview' || rawType === 'reload' || payload.period || payload.from || payload.to) {
+    const overview = normalizeOverviewQuery(rawType === 'reload' ? { ...payload, action: 'reload' } : payload)
+    return overview ? { type: 'set-overview', value: overview } : null
+  }
+
+  return null
+}
+
+function dispatchLegacyAction(action: InsumosHeaderAction) {
+  try {
+    if (action.type === 'set-unit') {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_UNIT_EVENT, { detail: { unidade: action.value } }))
+      return
+    }
+    if (action.type === 'set-overview') {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_OVERVIEW_EVENT, { detail: action.value }))
+      return
+    }
+    if (action.type === 'reload-overview') {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_OVERVIEW_EVENT, { detail: { action: 'reload' } }))
+      return
+    }
+    if (action.type === 'quick-op') {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_OP_EVENT, { detail: { op: action.value } }))
+      return
+    }
+    if (action.type === 'layout') {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_LAYOUT_EVENT, { detail: { action: action.value } }))
+    }
+  } catch {
+    // ignore legacy bridge errors
+  }
+}
+
+export function emitInsumosHeaderState(detail: InsumosHeaderState | null) {
+  try {
+    window.dispatchEvent(new CustomEvent<InsumosHeaderState | null>(INSUMOS_HEADER_EVENT, { detail }))
+  } catch {
+    // ignore
+  }
+  if (detail?.stock) {
+    try {
+      window.dispatchEvent(new CustomEvent(INSUMOS_LEGACY_STOCK_EVENT, { detail: detail.stock }))
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function dispatchInsumosHeaderAction(action: InsumosHeaderAction) {
+  try {
+    window.dispatchEvent(new CustomEvent<InsumosHeaderAction>(INSUMOS_ACTION_EVENT, { detail: action }))
+  } catch {
+    // ignore
+  }
+  dispatchLegacyAction(action)
+}
+
+export function subscribeInsumosHeaderState(callback: (state: InsumosHeaderState | null) => void) {
+  const handler = (event: Event) => {
+    callback(normalizeInsumosHeaderState((event as CustomEvent<unknown>).detail))
+  }
+  window.addEventListener(INSUMOS_HEADER_EVENT, handler as EventListener)
+  return () => window.removeEventListener(INSUMOS_HEADER_EVENT, handler as EventListener)
+}
+
+export function subscribeInsumosHeaderAction(callback: (action: InsumosHeaderAction) => void) {
+  const typedHandler = (event: Event) => {
+    const action = normalizeInsumosHeaderAction((event as CustomEvent<unknown>).detail)
+    if (action) callback(action)
+  }
+  const legacyHandler = (event: Event) => {
+    const action = normalizeInsumosHeaderAction((event as CustomEvent<unknown>).detail)
+    if (action) callback(action)
+  }
+
+  window.addEventListener(INSUMOS_ACTION_EVENT, typedHandler as EventListener)
+  window.addEventListener(INSUMOS_LEGACY_UNIT_EVENT, legacyHandler as EventListener)
+  window.addEventListener(INSUMOS_LEGACY_OVERVIEW_EVENT, legacyHandler as EventListener)
+  window.addEventListener(INSUMOS_LEGACY_OP_EVENT, legacyHandler as EventListener)
+  window.addEventListener(INSUMOS_LEGACY_LAYOUT_EVENT, legacyHandler as EventListener)
+
+  return () => {
+    window.removeEventListener(INSUMOS_ACTION_EVENT, typedHandler as EventListener)
+    window.removeEventListener(INSUMOS_LEGACY_UNIT_EVENT, legacyHandler as EventListener)
+    window.removeEventListener(INSUMOS_LEGACY_OVERVIEW_EVENT, legacyHandler as EventListener)
+    window.removeEventListener(INSUMOS_LEGACY_OP_EVENT, legacyHandler as EventListener)
+    window.removeEventListener(INSUMOS_LEGACY_LAYOUT_EVENT, legacyHandler as EventListener)
+  }
+}

--- a/frontend/insumosCharts.ts
+++ b/frontend/insumosCharts.ts
@@ -1,0 +1,290 @@
+export type ChartPresetId = 'distribution' | 'movements' | 'roi_risk'
+export type ChartMetric = 'qtd' | 'valor'
+export type ChartView = 'bar' | 'line' | 'pie'
+export type ChartLayout = 'square' | 'wide' | 'tall'
+export type ChartGroupBy = 'categoria' | 'marca' | 'item' | 'tempo'
+export type MovementsMode = 'inout' | 'saldo' | 'entrada' | 'saida'
+export type ChartSlotConfig = {
+  presetId: ChartPresetId
+  metric?: ChartMetric
+  view?: ChartView
+  topN?: number
+  groupBy?: ChartGroupBy
+  mode?: MovementsMode
+}
+
+export type ChartPreset = {
+  id: ChartPresetId
+  label: string
+  supportsMetric?: boolean
+  supportsView?: boolean
+  supportsTopN?: boolean
+  defaultMetric?: ChartMetric
+  defaultView?: ChartView
+  layout?: ChartLayout
+}
+
+export type ChartSlotMeta = {
+  preset: ChartPreset
+  groupBy?: ChartGroupBy
+  mode?: MovementsMode
+  viewOptions: ChartView[]
+  view: ChartView
+  metric: ChartMetric
+  topN: number
+  showTopN: boolean
+  layout?: ChartLayout
+}
+
+export type ChartFilterTipo = ChartPresetId | '__ALL__'
+export type ChartFilterY = ChartGroupBy | '__ALL__'
+export type ChartFilterX = ChartMetric | '__ALL__'
+export type ChartFilterView = ChartView | '__ALL__'
+export type ChartFilterTop = '5' | '8' | '10' | '15' | '__ALL__'
+
+export const CHARTS_SLOTS_KEY = 'skincos.insumos.charts.slots.v1'
+export const DEFAULT_CHART_SLOTS: ChartSlotConfig[] = [
+  { presetId: 'distribution', groupBy: 'categoria', metric: 'qtd', view: 'pie', topN: 8 },
+]
+export const MAX_CHARTS = 9
+
+export const CHART_PRESETS: ChartPreset[] = [
+  { id: 'distribution', label: 'Distribuição', supportsMetric: true, supportsView: true, supportsTopN: true, defaultView: 'pie', layout: 'square' },
+  { id: 'movements', label: 'Movimentações', supportsMetric: true, supportsView: true, supportsTopN: true, defaultView: 'bar', layout: 'wide' },
+  { id: 'roi_risk', label: 'ROI (perdas & risco)', supportsMetric: true, supportsView: true, defaultView: 'bar', layout: 'square' },
+]
+
+export function normalizeChartTopN(value: unknown): number {
+  return Math.max(5, Math.min(15, Number.parseInt(String(value ?? ''), 10) || 0)) || DEFAULT_CHART_SLOTS[0].topN || 8
+}
+
+export function resolveChartPreset(id: ChartPresetId): ChartPreset {
+  return (
+    CHART_PRESETS.find((preset) => preset.id === id) || {
+      id,
+      label: String(id),
+      supportsMetric: false,
+      supportsView: false,
+      supportsTopN: false,
+      defaultView: 'bar',
+      layout: 'square',
+    }
+  )
+}
+
+export function resolveChartViewOptions(slot: ChartSlotConfig): ChartView[] {
+  if (slot.presetId === 'distribution') {
+    const groupBy = slot.groupBy === 'item' ? 'item' : slot.groupBy === 'marca' ? 'marca' : 'categoria'
+    return groupBy === 'item' ? ['bar'] : ['pie', 'bar']
+  }
+  if (slot.presetId === 'movements') {
+    const groupBy = slot.groupBy === 'categoria' ? 'categoria' : 'tempo'
+    return groupBy === 'tempo' ? ['bar', 'line'] : ['bar', 'pie']
+  }
+  if (slot.presetId === 'roi_risk') return ['bar', 'pie']
+  return ['bar', 'line']
+}
+
+export function resolveChartSlot(slot: ChartSlotConfig): ChartSlotMeta {
+  const preset = resolveChartPreset(slot.presetId)
+  const groupBy: ChartGroupBy | undefined =
+    slot.presetId === 'distribution'
+      ? slot.groupBy === 'marca' || slot.groupBy === 'item'
+        ? slot.groupBy
+        : 'categoria'
+      : slot.presetId === 'movements'
+        ? slot.groupBy === 'categoria'
+          ? 'categoria'
+          : 'tempo'
+        : undefined
+  const mode: MovementsMode | undefined =
+    slot.presetId === 'movements'
+      ? slot.mode === 'saldo' || slot.mode === 'entrada' || slot.mode === 'saida' || slot.mode === 'inout'
+        ? slot.mode
+        : groupBy === 'categoria'
+          ? 'saida'
+          : 'inout'
+      : undefined
+  const viewOptions = resolveChartViewOptions({ ...slot, groupBy, mode })
+  const rawView = (slot.view || preset.defaultView || viewOptions[0] || 'bar') as ChartView
+  const view = viewOptions.includes(rawView) ? rawView : viewOptions[0]
+  const metric = (slot.metric === 'valor' ? 'valor' : 'qtd') as ChartMetric
+  const topN = normalizeChartTopN(slot.topN)
+  const showTopN = !!preset.supportsTopN && (slot.presetId === 'distribution' || (slot.presetId === 'movements' && groupBy === 'categoria'))
+  return { preset, groupBy, mode, viewOptions, view, metric, topN, showTopN, layout: preset.layout }
+}
+
+export function parseChartSlots(raw: string | null | undefined): ChartSlotConfig[] {
+  try {
+    if (!raw) return DEFAULT_CHART_SLOTS
+    const parsed = JSON.parse(raw)
+    const slots = Array.isArray(parsed) ? parsed : []
+    const validIds = new Set<ChartPresetId>(CHART_PRESETS.map((preset) => preset.id))
+    const cleaned: ChartSlotConfig[] = slots
+      .slice(0, MAX_CHARTS)
+      .map((slotLike: any) => {
+        const fallback = DEFAULT_CHART_SLOTS[0]
+        const presetIdRaw = String(slotLike?.presetId || '')
+        let presetId: ChartPresetId = fallback.presetId
+        let groupBy: ChartGroupBy | undefined
+        let mode: MovementsMode | undefined
+
+        if (presetIdRaw === 'stock_category') {
+          presetId = 'distribution'
+          groupBy = 'categoria'
+        } else if (presetIdRaw === 'stock_brand') {
+          presetId = 'distribution'
+          groupBy = 'marca'
+        } else if (presetIdRaw === 'stock_top') {
+          presetId = 'distribution'
+          groupBy = 'item'
+        } else if (presetIdRaw === 'mov_inout') {
+          presetId = 'movements'
+          groupBy = 'tempo'
+          mode = 'inout'
+        } else if (presetIdRaw === 'mov_saldo') {
+          presetId = 'movements'
+          groupBy = 'tempo'
+          mode = 'saldo'
+        } else if (presetIdRaw === 'trends_inout') {
+          presetId = 'movements'
+          groupBy = 'tempo'
+          mode = 'inout'
+        } else if (presetIdRaw === 'turnover_category') {
+          presetId = 'movements'
+          groupBy = 'categoria'
+          mode = 'saida'
+        } else if (validIds.has(presetIdRaw as ChartPresetId)) {
+          presetId = presetIdRaw as ChartPresetId
+          groupBy = slotLike?.groupBy || undefined
+          mode = slotLike?.mode || undefined
+        }
+
+        if (!validIds.has(presetId)) presetId = fallback.presetId
+        const preset = resolveChartPreset(presetId)
+        const metric: ChartMetric | undefined = slotLike?.metric === 'valor' || slotLike?.metric === 'qtd' ? slotLike.metric : preset.defaultMetric
+        const view: ChartView | undefined = slotLike?.view === 'bar' || slotLike?.view === 'line' || slotLike?.view === 'pie' ? slotLike.view : preset.defaultView
+        const groupByFixed: ChartGroupBy | undefined = (() => {
+          const value = String(groupBy || slotLike?.groupBy || '').trim()
+          if (value === 'categoria' || value === 'marca' || value === 'item' || value === 'tempo') return value
+          if (presetId === 'distribution') return 'categoria'
+          if (presetId === 'movements') return 'tempo'
+          return undefined
+        })()
+        const modeFixed: MovementsMode | undefined = (() => {
+          const value = String(mode || slotLike?.mode || '').trim()
+          if (value === 'inout' || value === 'saldo' || value === 'entrada' || value === 'saida') return value
+          if (presetId === 'movements') return groupByFixed === 'categoria' ? 'saida' : 'inout'
+          return undefined
+        })()
+
+        return {
+          presetId,
+          groupBy: groupByFixed,
+          mode: modeFixed,
+          metric,
+          view,
+          topN: normalizeChartTopN(slotLike?.topN),
+        }
+      })
+    return cleaned.length ? cleaned : DEFAULT_CHART_SLOTS
+  } catch {
+    return DEFAULT_CHART_SLOTS
+  }
+}
+
+export function updateChartSlotAt(prev: ChartSlotConfig[], idx: number, next: Partial<ChartSlotConfig>): ChartSlotConfig[] {
+  const copy = [...prev]
+  const current = copy[idx] || DEFAULT_CHART_SLOTS[0]
+  const presetId = (next.presetId ?? current.presetId) as ChartPresetId
+  const preset = resolveChartPreset(presetId)
+  const metric = next.metric ?? current.metric ?? preset.defaultMetric
+  const groupBy: ChartGroupBy | undefined = (() => {
+    const value = String(next.groupBy ?? current.groupBy ?? '').trim()
+    if (value === 'categoria' || value === 'marca' || value === 'item' || value === 'tempo') return value
+    if (presetId === 'distribution') return 'categoria'
+    if (presetId === 'movements') return 'tempo'
+    return undefined
+  })()
+  const mode: MovementsMode | undefined = (() => {
+    const value = String(next.mode ?? current.mode ?? '').trim()
+    if (value === 'inout' || value === 'saldo' || value === 'entrada' || value === 'saida') return value
+    if (presetId === 'movements') return groupBy === 'categoria' ? 'saida' : 'inout'
+    return undefined
+  })()
+  const view = next.view ?? current.view ?? preset.defaultView
+  const topN = next.topN ?? current.topN
+  copy[idx] = { ...current, ...next, presetId, groupBy, mode, metric, view, topN }
+  return copy
+}
+
+export function filterChartSlotsView(args: {
+  chartSlots: ChartSlotConfig[]
+  chartsFilterTipo: ChartFilterTipo
+  chartsFilterY: ChartFilterY
+  chartsFilterX: ChartFilterX
+  chartsFilterView: ChartFilterView
+  chartsFilterTop: ChartFilterTop
+  chartsSearch: string
+}) {
+  const { chartSlots, chartsFilterTipo, chartsFilterY, chartsFilterX, chartsFilterView, chartsFilterTop, chartsSearch } = args
+  const search = chartsSearch.trim().toLowerCase()
+  return chartSlots
+    .map((slot, idx) => ({ slot, idx, meta: resolveChartSlot(slot) }))
+    .filter(({ slot, meta }) => {
+      if (chartsFilterTipo !== '__ALL__' && slot.presetId !== chartsFilterTipo) return false
+      if (chartsFilterY !== '__ALL__' && meta.groupBy !== chartsFilterY) return false
+      if (chartsFilterX !== '__ALL__' && meta.metric !== chartsFilterX) return false
+      if (chartsFilterView !== '__ALL__' && meta.view !== chartsFilterView) return false
+      if (chartsFilterTop !== '__ALL__' && String(meta.topN) !== String(chartsFilterTop)) return false
+      if (!search) return true
+      const hay = [meta.preset.label, slot.presetId, meta.groupBy || '', meta.metric, meta.view, meta.mode || '', String(meta.topN)]
+        .join(' ')
+        .toLowerCase()
+      return hay.includes(search)
+    })
+}
+
+export function getChartIndexFromKey(cardKey: string): number {
+  const idx = Number.parseInt(String(cardKey), 10)
+  return Number.isInteger(idx) && idx >= 0 ? idx : -1
+}
+
+export function getNextChartPresetPatch(slot: ChartSlotConfig, value: string): Partial<ChartSlotConfig> {
+  const nextId = value as ChartPresetId
+  const nextPreset = resolveChartPreset(nextId)
+  const baseNext: ChartSlotConfig = {
+    ...slot,
+    presetId: nextId,
+    groupBy: nextId === 'distribution' ? 'categoria' : nextId === 'movements' ? 'tempo' : undefined,
+    mode: nextId === 'movements' ? 'inout' : undefined,
+  }
+  const nextViewOptions = resolveChartViewOptions(baseNext)
+  const presetDefault = nextPreset.defaultView as ChartView | undefined
+  const nextView = nextViewOptions.includes(presetDefault || 'bar') ? (presetDefault as ChartView) : nextViewOptions[0]
+  return { presetId: nextId, groupBy: baseNext.groupBy, mode: baseNext.mode, view: nextView }
+}
+
+export function getNextDistributionGroupByPatch(slot: ChartSlotConfig, value: 'categoria' | 'marca' | 'item'): Partial<ChartSlotConfig> {
+  const nextGroupBy = value as ChartGroupBy
+  const baseNext: ChartSlotConfig = { ...slot, groupBy: nextGroupBy }
+  const nextViewOptions = resolveChartViewOptions(baseNext)
+  const currentView = resolveChartSlot(slot).view
+  const nextView = nextViewOptions.includes(currentView) ? currentView : nextViewOptions[0]
+  return { groupBy: nextGroupBy, view: nextView }
+}
+
+export function getNextMovementsGroupByPatch(slot: ChartSlotConfig, value: 'tempo' | 'categoria'): Partial<ChartSlotConfig> {
+  const nextGroupBy = value === 'categoria' ? ('categoria' as ChartGroupBy) : ('tempo' as ChartGroupBy)
+  const nextMode: MovementsMode = nextGroupBy === 'categoria' ? 'saida' : 'inout'
+  const baseNext: ChartSlotConfig = { ...slot, groupBy: nextGroupBy, mode: nextMode }
+  const nextViewOptions = resolveChartViewOptions(baseNext)
+  const currentView = resolveChartSlot(slot).view
+  const nextView = nextViewOptions.includes(currentView) ? currentView : nextViewOptions[0]
+  return { groupBy: nextGroupBy, mode: nextMode, view: nextView }
+}
+
+export function getNextMovementsModePatch(value: 'inout' | 'saldo' | 'entrada' | 'saida'): Partial<ChartSlotConfig> {
+  const nextMode: MovementsMode = value === 'saldo' || value === 'entrada' || value === 'saida' || value === 'inout' ? value : 'inout'
+  return { mode: nextMode }
+}

--- a/frontend/insumosDashboardController.ts
+++ b/frontend/insumosDashboardController.ts
@@ -1,0 +1,536 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import { dateInputToIso } from '@/insumosShared'
+import type {
+  Actionables,
+  EstoqueAlerta,
+  EstoqueResumo,
+  InsightsBundleData,
+  Insumo,
+  InsumosOverviewPeriod,
+  NotificationsSummary,
+  OverviewBundleData,
+  QualityReport,
+  RoiInsights,
+} from '@/insumosTypes'
+
+type OverviewMovResumo = {
+  entradaQtd: number
+  saidaQtd: number
+  entradaValor: number
+  saidaValor: number
+  saldoLiquido: number
+} | null
+
+type OverviewMovSeriesItem = {
+  day: string
+  entrada: number
+  saida: number
+  entradaValor?: number
+  saidaValor?: number
+}
+
+type ApiJsonFn = <T>(path: string, opts?: { signal?: AbortSignal }) => Promise<T>
+
+type DashboardStateSetters = {
+  setOverviewLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  setInsumosLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  setMovLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  setInsightsLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  setOverviewLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setOverviewResumo: React.Dispatch<React.SetStateAction<EstoqueResumo | null>>
+  setOverviewInsumos: React.Dispatch<React.SetStateAction<Insumo[] | null>>
+  setOverviewNotifications: React.Dispatch<React.SetStateAction<NotificationsSummary | null>>
+  setOverviewActionables: React.Dispatch<React.SetStateAction<Actionables | null>>
+  setOverviewRoi: React.Dispatch<React.SetStateAction<RoiInsights | null>>
+  setOverviewQuality: React.Dispatch<React.SetStateAction<QualityReport | null>>
+  setOverviewMovResumo: React.Dispatch<React.SetStateAction<OverviewMovResumo>>
+  setOverviewMovSeries: React.Dispatch<React.SetStateAction<OverviewMovSeriesItem[]>>
+  setInsightsLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setInsightsAlertas: React.Dispatch<React.SetStateAction<EstoqueAlerta[]>>
+  setInsightsTrends: React.Dispatch<React.SetStateAction<any | null>>
+  setInsightsTurnover: React.Dispatch<React.SetStateAction<{ saida?: any; entrada?: any } | null>>
+  setOverviewEverVisible: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type UseInsumosDashboardControllerArgs = DashboardStateSetters & {
+  apiJson: ApiJsonFn
+  authLoaded: boolean
+  authLoading: boolean
+  canUseApi: boolean
+  chartsPanelOpen: boolean
+  chartsPanelVisible: boolean
+  healthLoaded: boolean
+  healthLoading: boolean
+  insightsLoaded: boolean
+  insumosLoaded: boolean
+  isAuthed: boolean
+  movLoaded: boolean
+  overviewCustomFrom: string
+  overviewCustomTo: string
+  overviewEverVisible: boolean
+  overviewInsumos: Insumo[] | null
+  overviewLoaded: boolean
+  overviewLoading: boolean
+  overviewPeriod: InsumosOverviewPeriod
+  overviewSectionRef: React.RefObject<HTMLDivElement | null>
+  overviewVisible: boolean
+  unidade: string
+}
+
+type LoadOverviewOptions = { force?: boolean; lite?: boolean }
+type LoadInsightsOptions = { force?: boolean }
+type PostMutationRefreshOptions = { overview?: boolean; insights?: boolean }
+
+export function resolveOverviewDateRange(args: {
+  period: InsumosOverviewPeriod
+  customFrom: string
+  customTo: string
+  now?: Date
+}) {
+  const now = args.now ?? new Date()
+  const yyyyMmDd = (value: Date) => value.toISOString().slice(0, 10)
+
+  let de = ''
+  let ate = yyyyMmDd(now)
+  let days = args.period === '7d' ? 7 : args.period === '30d' ? 30 : 365
+
+  if (args.period === 'custom') {
+    const deIso = dateInputToIso(args.customFrom)
+    const ateIso = dateInputToIso(args.customTo)
+    if (deIso && ateIso) {
+      de = deIso
+      ate = ateIso
+      const fromMs = new Date(deIso).getTime()
+      const toMs = new Date(ateIso).getTime()
+      const diffDays = Math.max(1, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)))
+      days = Math.max(1, Math.min(365, diffDays))
+    }
+  }
+
+  if (!de) {
+    const start = new Date(now)
+    if (args.period === '7d') start.setDate(start.getDate() - 7)
+    else if (args.period === '30d') start.setDate(start.getDate() - 30)
+    else start.setFullYear(start.getFullYear() - 1)
+    de = yyyyMmDd(start)
+  }
+
+  return { de, ate, days }
+}
+
+function isOverviewViewportVisible(sectionRef: React.RefObject<HTMLDivElement | null>) {
+  try {
+    const el = sectionRef.current
+    if (!el) return true
+    const rect = el.getBoundingClientRect()
+    const viewportHeight = window.innerHeight || 0
+    if (!viewportHeight) return true
+    const topOk = rect.top < viewportHeight * 0.85
+    const bottomOk = rect.bottom > viewportHeight * 0.15
+    return topOk && bottomOk
+  } catch {
+    return true
+  }
+}
+
+export function useInsumosDashboardController({
+  apiJson,
+  authLoaded,
+  authLoading,
+  canUseApi,
+  chartsPanelOpen,
+  chartsPanelVisible,
+  healthLoaded,
+  healthLoading,
+  insightsLoaded,
+  insumosLoaded,
+  isAuthed,
+  movLoaded,
+  overviewCustomFrom,
+  overviewCustomTo,
+  overviewEverVisible,
+  overviewInsumos,
+  overviewLoaded,
+  overviewLoading,
+  overviewPeriod,
+  overviewSectionRef,
+  overviewVisible,
+  setInsightsAlertas,
+  setInsightsLoaded,
+  setInsightsLoading,
+  setInsightsTrends,
+  setInsightsTurnover,
+  setInsumosLoaded,
+  setMovLoaded,
+  setOverviewActionables,
+  setOverviewEverVisible,
+  setOverviewInsumos,
+  setOverviewLoaded,
+  setOverviewLoading,
+  setOverviewMovResumo,
+  setOverviewMovSeries,
+  setOverviewNotifications,
+  setOverviewQuality,
+  setOverviewResumo,
+  setOverviewRoi,
+  unidade,
+}: UseInsumosDashboardControllerArgs) {
+  const overviewAbortRef = React.useRef<AbortController | null>(null)
+  const insightsAbortRef = React.useRef<AbortController | null>(null)
+  const overviewFullAttemptRef = React.useRef<number>(0)
+  const apiFailureTimestampsRef = React.useRef<number[]>([])
+  const postMutationRefreshTimerRef = React.useRef<number | null>(null)
+  const [autoSyncSuspendedUntil, setAutoSyncSuspendedUntil] = React.useState(0)
+
+  const autoSyncSuspended = autoSyncSuspendedUntil > Date.now()
+  const autoSyncRemainingSeconds = autoSyncSuspended
+    ? Math.max(1, Math.ceil((autoSyncSuspendedUntil - Date.now()) / 1000))
+    : 0
+
+  const markAutoSyncFailure = React.useCallback(
+    (error: unknown) => {
+      const status = Number((error as any)?.status || 0)
+      const rawMessage = String((error as any)?.message || '')
+      const message = rawMessage.toLowerCase()
+      const isNetworkError =
+        status <= 0 ||
+        String((error as any)?.name || '') === 'TypeError' ||
+        message.includes('network') ||
+        message.includes('failed to fetch') ||
+        message.includes('conex')
+      const isRecoverableServerFailure = status >= 500 || status === 429 || isNetworkError
+      if (!isRecoverableServerFailure) return
+
+      const now = Date.now()
+      const failureWindowMs = 30_000
+      const cooldownMs = 60_000
+
+      apiFailureTimestampsRef.current = apiFailureTimestampsRef.current.filter((ts) => now - ts <= failureWindowMs)
+      apiFailureTimestampsRef.current.push(now)
+
+      if (apiFailureTimestampsRef.current.length < 5) return
+      if (autoSyncSuspendedUntil > now) return
+
+      setAutoSyncSuspendedUntil(now + cooldownMs)
+      toast.warning('API instável: sincronização automática reduzida por 60 segundos.')
+    },
+    [autoSyncSuspendedUntil]
+  )
+
+  React.useEffect(() => {
+    if (!isAuthed || !canUseApi) {
+      setOverviewLoaded(false)
+      setInsumosLoaded(false)
+      setMovLoaded(false)
+      setInsightsLoaded(false)
+    }
+  }, [canUseApi, isAuthed, setInsightsLoaded, setInsumosLoaded, setMovLoaded, setOverviewLoaded])
+
+  React.useEffect(() => {
+    if (!autoSyncSuspendedUntil) return
+    const remainingMs = autoSyncSuspendedUntil - Date.now()
+    if (remainingMs <= 0) {
+      apiFailureTimestampsRef.current = []
+      setAutoSyncSuspendedUntil(0)
+      return
+    }
+    const timeoutId = window.setTimeout(() => {
+      apiFailureTimestampsRef.current = []
+      setAutoSyncSuspendedUntil(0)
+    }, remainingMs + 20)
+    return () => window.clearTimeout(timeoutId)
+  }, [autoSyncSuspendedUntil])
+
+  React.useEffect(() => {
+    if (autoSyncSuspendedUntil) return
+    overviewFullAttemptRef.current = 0
+  }, [autoSyncSuspendedUntil])
+
+  const dashboardProgress = React.useMemo(() => {
+    const steps = [
+      healthLoaded,
+      authLoaded,
+      ...(canUseApi && isAuthed ? [overviewLoaded, insumosLoaded, movLoaded, insightsLoaded] : []),
+    ]
+    const total = steps.length || 1
+    const done = steps.filter(Boolean).length
+    return Math.max(0, Math.min(100, Math.round((done / total) * 100)))
+  }, [authLoaded, canUseApi, healthLoaded, insightsLoaded, insumosLoaded, isAuthed, movLoaded, overviewLoaded])
+
+  const loadingPercent = Math.max(0, Math.min(100, Math.round(dashboardProgress)))
+  const isDashboardLoading = authLoading || healthLoading || (canUseApi && isAuthed && dashboardProgress < 100)
+  const shouldShowDashboardLoading = isDashboardLoading || !authLoaded || !healthLoaded
+  const showOverviewLoadingProgress = overviewLoading || (canUseApi && isAuthed && shouldShowDashboardLoading)
+
+  const loadOverview = React.useCallback(
+    async (opts?: LoadOverviewOptions) => {
+      if (!canUseApi || !isAuthed) return
+      setOverviewEverVisible(true)
+      if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
+      try {
+        overviewAbortRef.current?.abort()
+      } catch {
+        // ignore
+      }
+      const ac = new AbortController()
+      overviewAbortRef.current = ac
+      setOverviewLoading(true)
+      try {
+        const { de, ate, days } = resolveOverviewDateRange({
+          period: overviewPeriod,
+          customFrom: overviewCustomFrom,
+          customTo: overviewCustomTo,
+        })
+        const params = new URLSearchParams({
+          unidade,
+          de,
+          ate,
+          days: String(days),
+          limitIssues: '120',
+        })
+        const isLite = opts?.lite !== false
+        if (isLite) params.set('lite', '1')
+        const out = await apiJson<{ success?: boolean; data?: OverviewBundleData }>(
+          `/analytics/overview?${params.toString()}`,
+          { signal: ac.signal }
+        )
+        if (overviewAbortRef.current !== ac) return
+        const data = out?.data || null
+        setOverviewResumo(data?.resumo || null)
+        if (Array.isArray(data?.itens)) {
+          setOverviewInsumos(data.itens as Insumo[])
+        } else if (!isLite) {
+          setOverviewInsumos(null)
+        }
+        setOverviewNotifications(data?.notifications || null)
+        setOverviewActionables(data?.actionables || null)
+        setOverviewRoi(data?.roi || null)
+        setOverviewQuality(data?.quality || null)
+        setOverviewMovResumo((data?.movResumo as any) || null)
+        setOverviewMovSeries(
+          Array.isArray(data?.movSeries)
+            ? data.movSeries
+                .map((item) => ({
+                  day: String(item?.day || ''),
+                  entrada: Number(item?.entrada ?? 0) || 0,
+                  saida: Number(item?.saida ?? 0) || 0,
+                  entradaValor: Number.isFinite(Number(item?.entradaValor)) ? Number(item?.entradaValor) : undefined,
+                  saidaValor: Number.isFinite(Number(item?.saidaValor)) ? Number(item?.saidaValor) : undefined,
+                }))
+                .filter((item) => item.day)
+            : []
+        )
+      } catch (error) {
+        if ((error as any)?.name === 'AbortError') return
+        if (overviewAbortRef.current !== ac) return
+        markAutoSyncFailure(error)
+        toast.error(error instanceof Error ? error.message : String(error))
+        setOverviewResumo(null)
+        setOverviewNotifications(null)
+        setOverviewActionables(null)
+        setOverviewRoi(null)
+        setOverviewQuality(null)
+        setOverviewMovResumo(null)
+        setOverviewMovSeries([])
+      } finally {
+        if (overviewAbortRef.current === ac) {
+          setOverviewLoaded(true)
+          setOverviewLoading(false)
+          overviewAbortRef.current = null
+        }
+      }
+    },
+    [
+      apiJson,
+      autoSyncSuspendedUntil,
+      canUseApi,
+      isAuthed,
+      markAutoSyncFailure,
+      overviewCustomFrom,
+      overviewCustomTo,
+      overviewPeriod,
+      setOverviewActionables,
+      setOverviewEverVisible,
+      setOverviewInsumos,
+      setOverviewLoaded,
+      setOverviewLoading,
+      setOverviewMovResumo,
+      setOverviewMovSeries,
+      setOverviewNotifications,
+      setOverviewQuality,
+      setOverviewResumo,
+      setOverviewRoi,
+      unidade,
+    ]
+  )
+
+  const loadInsights = React.useCallback(
+    async (opts?: LoadInsightsOptions) => {
+      if (!canUseApi || !isAuthed) return
+      setOverviewEverVisible(true)
+      if (!opts?.force && autoSyncSuspendedUntil > Date.now()) return
+      try {
+        insightsAbortRef.current?.abort()
+      } catch {
+        // ignore
+      }
+      const ac = new AbortController()
+      insightsAbortRef.current = ac
+      setInsightsLoading(true)
+      try {
+        const { days } = resolveOverviewDateRange({
+          period: overviewPeriod,
+          customFrom: overviewCustomFrom,
+          customTo: overviewCustomTo,
+        })
+        const params = new URLSearchParams()
+        params.set('unidade', unidade)
+        params.set('groupBy', 'day')
+        if (overviewPeriod === 'custom') {
+          const from = dateInputToIso(overviewCustomFrom)
+          const to = dateInputToIso(overviewCustomTo)
+          if (from && to) {
+            params.set('from', from)
+            params.set('to', to)
+          }
+        }
+        params.set('days', String(days))
+
+        const out = await apiJson<{ success?: boolean; data?: InsightsBundleData }>(
+          `/analytics/insights?${params.toString()}`,
+          { signal: ac.signal }
+        )
+        if (insightsAbortRef.current !== ac) return
+        const data = out?.data || null
+        setInsightsAlertas(Array.isArray(data?.alertas) ? data.alertas : [])
+        setInsightsTrends(data?.trends || null)
+        setInsightsTurnover(data?.turnover || null)
+      } catch (error) {
+        if ((error as any)?.name === 'AbortError') return
+        if (insightsAbortRef.current !== ac) return
+        markAutoSyncFailure(error)
+        toast.error(error instanceof Error ? error.message : String(error))
+        setInsightsAlertas([])
+        setInsightsTrends(null)
+        setInsightsTurnover(null)
+      } finally {
+        if (insightsAbortRef.current === ac) {
+          setInsightsLoaded(true)
+          setInsightsLoading(false)
+          insightsAbortRef.current = null
+        }
+      }
+    },
+    [
+      apiJson,
+      autoSyncSuspendedUntil,
+      canUseApi,
+      isAuthed,
+      markAutoSyncFailure,
+      overviewCustomFrom,
+      overviewCustomTo,
+      overviewPeriod,
+      setInsightsAlertas,
+      setInsightsLoaded,
+      setInsightsLoading,
+      setInsightsTrends,
+      setInsightsTurnover,
+      setOverviewEverVisible,
+      unidade,
+    ]
+  )
+
+  const schedulePostMutationRefresh = React.useCallback(
+    (opts?: PostMutationRefreshOptions) => {
+      const wantsOverview = opts?.overview !== false
+      const wantsInsights = opts?.insights !== false
+      if (!wantsOverview && !wantsInsights) return
+      if (autoSyncSuspendedUntil > Date.now()) return
+
+      if (postMutationRefreshTimerRef.current) {
+        window.clearTimeout(postMutationRefreshTimerRef.current)
+        postMutationRefreshTimerRef.current = null
+      }
+
+      postMutationRefreshTimerRef.current = window.setTimeout(() => {
+        const tasks: Promise<unknown>[] = []
+        const isVisible = isOverviewViewportVisible(overviewSectionRef)
+        if (wantsOverview && overviewLoaded && isVisible) tasks.push(Promise.resolve(loadOverview()))
+        if (wantsInsights && insightsLoaded && isVisible) tasks.push(Promise.resolve(loadInsights()))
+        if (tasks.length) void Promise.allSettled(tasks)
+      }, 2500)
+    },
+    [autoSyncSuspendedUntil, insightsLoaded, loadInsights, loadOverview, overviewLoaded, overviewSectionRef]
+  )
+
+  const resumeAutoSync = React.useCallback(() => {
+    apiFailureTimestampsRef.current = []
+    setAutoSyncSuspendedUntil(0)
+  }, [])
+
+  React.useEffect(() => {
+    if (!canUseApi || !isAuthed) return
+    if (!chartsPanelVisible || !chartsPanelOpen) return
+    if (overviewInsumos && overviewInsumos.length) return
+    if (overviewLoading) return
+    if (autoSyncSuspendedUntil > Date.now()) return
+    const now = Date.now()
+    if (now - overviewFullAttemptRef.current < 15_000) return
+    overviewFullAttemptRef.current = now
+    void loadOverview({ force: true, lite: false })
+  }, [
+    autoSyncSuspendedUntil,
+    canUseApi,
+    chartsPanelOpen,
+    chartsPanelVisible,
+    isAuthed,
+    loadOverview,
+    overviewInsumos,
+    overviewLoading,
+  ])
+
+  React.useEffect(() => {
+    if (!canUseApi || !isAuthed) return
+    if (!overviewVisible && !overviewEverVisible) return
+    const timeoutId = window.setTimeout(() => {
+      void loadOverview()
+    }, 250)
+    return () => window.clearTimeout(timeoutId)
+  }, [canUseApi, isAuthed, loadOverview, overviewEverVisible, overviewVisible])
+
+  React.useEffect(() => {
+    if (!canUseApi || !isAuthed) return
+    if (!overviewVisible && !overviewEverVisible) return
+    const timeoutId = window.setTimeout(() => {
+      void loadInsights()
+    }, 450)
+    return () => window.clearTimeout(timeoutId)
+  }, [canUseApi, isAuthed, loadInsights, overviewEverVisible, overviewVisible])
+
+  React.useEffect(() => {
+    return () => {
+      if (postMutationRefreshTimerRef.current) window.clearTimeout(postMutationRefreshTimerRef.current)
+      try {
+        overviewAbortRef.current?.abort()
+        insightsAbortRef.current?.abort()
+      } catch {
+        // ignore
+      }
+    }
+  }, [])
+
+  return {
+    autoSyncRemainingSeconds,
+    autoSyncSuspended,
+    dashboardProgress,
+    loadInsights,
+    loadOverview,
+    loadingPercent,
+    resumeAutoSync,
+    schedulePostMutationRefresh,
+    shouldShowDashboardLoading,
+    showOverviewLoadingProgress,
+  }
+}

--- a/frontend/insumosDerivations.ts
+++ b/frontend/insumosDerivations.ts
@@ -1,0 +1,292 @@
+import type { Insumo, Movimentacao } from './insumosTypes'
+
+export type MovementSortKey = 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'
+export type MovementSortDir = 'asc' | 'desc'
+export type MovementTipoFilter = 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE'
+
+export type MovementRowView = {
+  key: string
+  movement: Movimentacao
+  rowClass: string
+  productName: string
+  categoryName: string
+  brandName: string
+  dateLabel: string
+  timeLabel: string
+  stockLabel: string
+  movementValueLabel: string
+  stockValueLabel: string
+  userLabel: string
+  notePrimary: string
+  noteSecondary?: string | null
+  noteMeta?: string | null
+  productPressed: boolean
+  categoryPressed: boolean
+  brandPressed: boolean
+  canEdit: boolean
+}
+
+type BuildMovimentacoesViewArgs = {
+  movGroupTransfers: boolean
+  movSortDir: MovementSortDir
+  movSortKey: MovementSortKey
+  movTipo: MovementTipoFilter
+  movFilterCategoria: string
+  movFilterMarca: string
+  movSearch: string
+  movimentacoes: Movimentacao[]
+  pickInsumoForMov: (movement: Movimentacao) => Insumo | null | undefined
+  selectedCodigoBarras: string
+  normalizeText: (value: string) => string
+}
+
+export function buildMovimentacoesView({
+  movGroupTransfers,
+  movSortDir,
+  movSortKey,
+  movTipo,
+  movFilterCategoria,
+  movFilterMarca,
+  movSearch,
+  movimentacoes,
+  pickInsumoForMov,
+  selectedCodigoBarras,
+  normalizeText,
+}: BuildMovimentacoesViewArgs): Movimentacao[] {
+  const list = Array.isArray(movimentacoes) ? movimentacoes : []
+  const selectedCode = selectedCodigoBarras.trim()
+  const filterCategoria = normalizeText(movFilterCategoria)
+  const filterMarca = normalizeText(movFilterMarca)
+  const filterSearch = normalizeText(movSearch)
+
+  const applyFiltersAndSort = (base: Movimentacao[]) => {
+    const filtered = base.filter((movement) => {
+      if (selectedCode) {
+        if (String(movement?.codigoBarras || '').trim() !== selectedCode) return false
+      } else if (filterSearch) {
+        const insumo = pickInsumoForMov(movement)
+        const productName = normalizeText(String(insumo?.produto || movement?.produto || '').trim())
+        const categoryName = normalizeText(insumo?.categoria || '')
+        const brandName = normalizeText(insumo?.marca || movement?.marca || '')
+        const barcode = normalizeText(String(movement?.codigoBarras || insumo?.codigoBarras || '').trim())
+        if (
+          !(
+            (productName && productName.includes(filterSearch)) ||
+            (categoryName && categoryName.includes(filterSearch)) ||
+            (brandName && brandName.includes(filterSearch)) ||
+            (barcode && barcode.includes(filterSearch))
+          )
+        ) {
+          return false
+        }
+      }
+
+      if (filterCategoria) {
+        const insumo = pickInsumoForMov(movement)
+        const categoryName = normalizeText(insumo?.categoria || '')
+        if (!categoryName || categoryName !== filterCategoria) return false
+      }
+
+      if (filterMarca) {
+        const insumo = pickInsumoForMov(movement)
+        const brandName = normalizeText(insumo?.marca || '')
+        if (!brandName || brandName !== filterMarca) return false
+      }
+
+      return true
+    })
+
+    const dir = movSortDir === 'asc' ? 1 : -1
+    const getSortValue = (movement: Movimentacao) => {
+      if (movSortKey === 'dataHora') return new Date(movement?.dataHora || 0).getTime() || 0
+      if (movSortKey === 'usuario') return String(movement?.usuario || '').trim().toLowerCase()
+      if (movSortKey === 'observacao') {
+        const value = movement?.transferId
+          ? `transferencia ${String(movement?.unidadeOrigem || '')}->${String(movement?.unidadeDestino || '')}`
+          : String(movement?.motivo || movement?.observacoes || '').trim()
+        return value.toLowerCase()
+      }
+
+      const insumo = pickInsumoForMov(movement)
+      if (movSortKey === 'produto') return String(insumo?.produto || movement?.produto || '').trim().toLowerCase()
+      if (movSortKey === 'categoria') return String(insumo?.categoria || '').trim().toLowerCase()
+      if (movSortKey === 'marca') return String(insumo?.marca || '').trim().toLowerCase()
+      if (movSortKey === 'estoque') return Number(movement?.estoqueNovo ?? movement?.estoqueAnterior ?? 0) || 0
+      if (movSortKey === 'valor') {
+        const price = Number(movement?.preco) || Number(insumo?.precoCusto) || 0
+        const quantity = Number(movement?.quantidade) || 0
+        return price * quantity
+      }
+      return 0
+    }
+
+    filtered.sort((left, right) => {
+      const leftValue = getSortValue(left) as any
+      const rightValue = getSortValue(right) as any
+      if (typeof leftValue === 'number' && typeof rightValue === 'number') {
+        if (leftValue !== rightValue) return (leftValue - rightValue) * dir
+        return (new Date(left?.dataHora || 0).getTime() - new Date(right?.dataHora || 0).getTime()) * dir
+      }
+      const compare = String(leftValue).localeCompare(String(rightValue), 'pt-BR', { sensitivity: 'base' })
+      if (compare !== 0) return compare * dir
+      return (new Date(left?.dataHora || 0).getTime() - new Date(right?.dataHora || 0).getTime()) * dir
+    })
+
+    return filtered
+  }
+
+  if (!movGroupTransfers || movTipo !== 'TODOS') return applyFiltersAndSort(list)
+
+  const byTransfer = new Map<string, Movimentacao[]>()
+  for (const movement of list) {
+    const transferId = String((movement as any)?.transferId || '').trim()
+    if (!transferId) continue
+    const grouped = byTransfer.get(transferId) || []
+    grouped.push(movement)
+    byTransfer.set(transferId, grouped)
+  }
+
+  const seen = new Set<string>()
+  const merged: Movimentacao[] = []
+  for (const movement of list) {
+    const transferId = String((movement as any)?.transferId || '').trim()
+    if (!transferId) {
+      merged.push(movement)
+      continue
+    }
+    if (seen.has(transferId)) continue
+    seen.add(transferId)
+
+    const group = byTransfer.get(transferId) || [movement]
+    if (group.length < 2) {
+      merged.push(movement)
+      continue
+    }
+
+    const picked = group.reduce((best, current) => {
+      const bestTs = new Date(best?.dataHora || 0).getTime()
+      const currentTs = new Date(current?.dataHora || 0).getTime()
+      return currentTs > bestTs ? current : best
+    }, group[0])
+
+    const quantity = group.reduce((acc, current) => Math.max(acc, Number(current?.quantidade) || 0), 0)
+    const fromUnit = String((picked as any)?.unidadeOrigem || '').trim()
+    const toUnit = String((picked as any)?.unidadeDestino || '').trim()
+
+    merged.push({
+      ...picked,
+      tipo: 'TRANSFERÊNCIA',
+      quantidade: quantity,
+      unidadeOrigem: fromUnit,
+      unidadeDestino: toUnit,
+      transferId,
+    } as any)
+  }
+
+  return applyFiltersAndSort(merged)
+}
+
+type BuildMovementRowsArgs = {
+  movimentacoesView: Movimentacao[]
+  pickInsumoForMov: (movement: Movimentacao) => Insumo | null | undefined
+  selectedCodigoBarras: string
+  movFilterCategoria: string
+  movFilterMarca: string
+  movSearch: string
+  unidade: string
+  isAuthed: boolean
+  unidadeLabel: (unit: string) => string
+  normalizeText: (value: string) => string
+  fmtMovDateShort: (value?: string | null) => string
+  fmtMovTimeShort: (value?: string | null) => string
+  fmtDateOnlyBR: (value?: string | null) => string
+  fmtMoneyBRL: (value: number) => string
+  fmtMoneyBRL0: (value: number) => string
+}
+
+export function buildMovementRows({
+  movimentacoesView,
+  pickInsumoForMov,
+  selectedCodigoBarras,
+  movFilterCategoria,
+  movFilterMarca,
+  movSearch,
+  unidade,
+  isAuthed,
+  unidadeLabel,
+  normalizeText,
+  fmtMovDateShort,
+  fmtMovTimeShort,
+  fmtDateOnlyBR,
+  fmtMoneyBRL,
+  fmtMoneyBRL0,
+}: BuildMovementRowsArgs): MovementRowView[] {
+  return movimentacoesView.map((movement, idx) => {
+    const codigoBarras = String(movement.codigoBarras || '').trim()
+    const insumo = pickInsumoForMov(movement)
+    const ctxUnit = String(movement.unidade || unidade || '').trim()
+    const estoqueAtual = insumo
+      ? ctxUnit && insumo?.estoques
+        ? Number(insumo.estoques?.[ctxUnit] ?? 0)
+        : Number(insumo.estoqueAtual ?? 0)
+      : null
+    const tipoNorm = String(movement.tipo || '').toUpperCase().replace('Í', 'I')
+    const isEntrada = tipoNorm.includes('ENTRADA')
+    const isSaida = tipoNorm.includes('SAIDA')
+    const preco = Number(movement.preco) || Number(insumo?.precoCusto) || 0
+    const quantidade = Number(movement.quantidade) || 0
+    const valorMov = preco * quantidade
+    const estoqueDepois = Number.isFinite(Number(movement.estoqueNovo)) ? Number(movement.estoqueNovo) : estoqueAtual != null ? estoqueAtual : null
+    const estoqueAntes = Number.isFinite(Number(movement.estoqueAnterior))
+      ? Number(movement.estoqueAnterior)
+      : Number.isFinite(Number(estoqueDepois)) && Number.isFinite(quantidade) && (isEntrada || isSaida)
+        ? isEntrada
+          ? Number(estoqueDepois) - quantidade
+          : Number(estoqueDepois) + quantidade
+        : null
+    const valorEstoqueTotal =
+      preco && estoqueDepois != null && Number.isFinite(Number(estoqueDepois)) ? preco * Number(estoqueDepois) : null
+    const productName = String(insumo?.produto || movement.produto || '').trim() || '-'
+    const categoryName = String(insumo?.categoria || '').trim() || '-'
+    const brandName = String(insumo?.marca || movement.marca || '').trim() || '-'
+    const isSelected = !!codigoBarras && selectedCodigoBarras.trim() === codigoBarras
+    const rowTone = isEntrada
+      ? 'bg-emerald-400/10 hover:bg-emerald-400/15'
+      : isSaida
+        ? 'bg-rose-400/10 hover:bg-rose-400/15'
+        : 'hover:bg-white/5'
+    const metaParts: string[] = []
+    if (movement.registroInsumo) metaParts.push(`Reg ${movement.registroInsumo}`)
+    if (movement.lote) metaParts.push(`Lote ${movement.lote}`)
+    if (movement.dataValidade) metaParts.push(`Val ${fmtDateOnlyBR(movement.dataValidade)}`)
+
+    return {
+      key: `${movement.dataHora || ''}-${idx}`,
+      movement,
+      rowClass: `${rowTone} ${isSelected ? 'ring-1 ring-white/10' : ''}`,
+      productName,
+      categoryName,
+      brandName,
+      dateLabel: fmtMovDateShort(movement.dataHora) || '-',
+      timeLabel: fmtMovTimeShort(movement.dataHora) || '',
+      stockLabel:
+        estoqueAntes != null && estoqueDepois != null && Number.isFinite(estoqueAntes) && Number.isFinite(estoqueDepois)
+          ? `${estoqueAntes} → ${estoqueDepois}`
+          : '-',
+      movementValueLabel: preco ? fmtMoneyBRL(valorMov) : '-',
+      stockValueLabel: valorEstoqueTotal != null ? fmtMoneyBRL0(valorEstoqueTotal) : '',
+      userLabel: movement.usuario || '-',
+      notePrimary: movement.transferId
+        ? `Transferência ${movement.unidadeOrigem ? unidadeLabel(movement.unidadeOrigem) : '-'} → ${movement.unidadeDestino ? unidadeLabel(movement.unidadeDestino) : '-'}`
+        : movement.motivo
+          ? `Motivo: ${movement.motivo}`
+          : movement.observacoes || '-',
+      noteSecondary: movement.transferId ? String(movement.transferId) : null,
+      noteMeta: metaParts.length ? metaParts.join(' • ') : null,
+      productPressed: normalizeText(movSearch) === normalizeText(productName),
+      categoryPressed: normalizeText(movFilterCategoria) === normalizeText(categoryName),
+      brandPressed: normalizeText(movFilterMarca) === normalizeText(brandName),
+      canEdit: !!isAuthed && !!String(movement.id || '').trim(),
+    }
+  })
+}

--- a/frontend/insumosPanels.tsx
+++ b/frontend/insumosPanels.tsx
@@ -1,0 +1,3909 @@
+import React from 'react'
+import { AutocompleteInput } from '@/autocomplete-input'
+import { Badge } from '@/badge'
+import { BrDatePickerInput } from '@/br-date-picker'
+import { Button } from '@/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/card'
+import { Checkbox } from '@/checkbox'
+import { Input } from '@/input'
+import { InsumosBarcodeScannerInline } from '@/InsumosBarcodeScannerInline'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
+import { Textarea } from '@/textarea'
+import {
+  alertaTagLabel,
+  alertaTagVariant,
+  buildTagStyle,
+  calcularStatusEstoque,
+  fmtDateOnlyBR,
+  fmtDate,
+  fmtMoneyBRL,
+  formatInsumoDescriptor,
+  getCategoriaBgColor,
+  getInsumoBarcodes,
+  getMarcaBgColor,
+  normalizeMovimentacaoTipo,
+  normalizeTipoUnidadeToCanonical,
+  severityBadgeVariant,
+  severityLabel,
+} from '@/insumosShared'
+import type { MovementRowView } from '@/insumosDerivations'
+import type { AlertaStatusTag } from '@/insumosShared'
+import type {
+  Actionables,
+  CategoryPolicy,
+  CategoryPolicySuggestion,
+  Insumo,
+  InsumosQuickOperation,
+  Movimentacao,
+  OfflineQueueItem,
+  QuickActionFeedback,
+  QuickCandidate,
+  QualityIssue,
+  ShareHistoryItem,
+  SharePayload,
+} from '@/insumosTypes'
+
+type InsumosAutoSyncBannerProps = {
+  autoSyncRemainingSeconds: number
+  onRefreshNow: () => void
+  onResume: () => void
+}
+
+export function InsumosAutoSyncBanner({
+  autoSyncRemainingSeconds,
+  onRefreshNow,
+  onResume,
+}: InsumosAutoSyncBannerProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-amber-100">
+      <div className="text-sm">
+        API instável detectada. Sincronização automática de Overview/Insights pausada por {autoSyncRemainingSeconds}s.
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <Button
+          variant="outline"
+          className="border-amber-300/50 text-amber-100 hover:bg-amber-500/20"
+          onClick={onResume}
+        >
+          Retomar auto-sync
+        </Button>
+        <Button className="!bg-amber-600 hover:!bg-amber-700 !text-white" onClick={onRefreshNow}>
+          Atualizar agora
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type InsumosSafeModeBannerProps = {
+  visible: boolean
+}
+
+export function InsumosSafeModeBanner({ visible }: InsumosSafeModeBannerProps) {
+  if (!visible) return null
+  return (
+    <div className="mx-auto mb-3 max-w-6xl rounded-xl border border-amber-400/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+      <div className="font-semibold">Modo local seguro ativo</div>
+      <div className="text-amber-100/80">
+        Mutações para o backend de produção estão bloqueadas. Para liberar, rode com
+        <span className="font-mono"> LOCAL_ALLOW_UPSTREAM_MUTATIONS=1</span>.
+      </div>
+    </div>
+  )
+}
+
+type InsumosPurchaseDialogProps = {
+  actionables: Actionables | null
+  dialogClassName: string
+  isAuthed: boolean
+  loading: boolean
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onOpenQuickOperation: (op: InsumosQuickOperation, prefill?: { codigoBarras?: string; quantidade?: number; obs?: string }) => void
+  onClose: () => void
+  renderLoadingText: (loading: boolean, emptyLabel: string) => React.ReactNode
+  unit: string
+  unitLabel: (unit: string) => string
+}
+
+type InventoryLoadError = {
+  message: string
+  status?: number
+  code?: string
+}
+
+type InsumosInventoryDialogProps = {
+  open: boolean
+  dialogClassName: string
+  isAuthed: boolean
+  unit: string
+  unitLabel: (unit: string) => string
+  query: string
+  onQueryChange: (value: string) => void
+  onOpenChange: (open: boolean) => void
+  onExport: () => void
+  createOpen: boolean
+  onToggleCreate: () => void
+  onCancelCreate: () => void
+  createLookupLoading: boolean
+  createLookupError: string | null
+  createLookupCount: number
+  createScanOpen: boolean
+  onToggleCreateScan: () => void
+  onCloseCreateScan: () => void
+  onCreateBarcodeDetected: (code: string) => void
+  createCodigo: string
+  onCreateCodigoChange: (value: string) => void
+  createCodigosExtras: string
+  onCreateCodigosExtrasChange: (value: string) => void
+  createProduto: string
+  onCreateProdutoChange: (value: string) => void
+  createCategoria: string
+  onCreateCategoriaChange: (value: string) => void
+  createMarca: string
+  onCreateMarcaChange: (value: string) => void
+  createTipoUnidade: string
+  onCreateTipoUnidadeChange: (value: string) => void
+  createPrecoCusto: string
+  onCreatePrecoCustoChange: (value: string) => void
+  createEstoqueMinimo: string
+  onCreateEstoqueMinimoChange: (value: string) => void
+  createEstoqueInicial: string
+  onCreateEstoqueInicialChange: (value: string) => void
+  createLote: string
+  onCreateLoteChange: (value: string) => void
+  createDataValidade: string
+  onCreateDataValidadeChange: (value: string) => void
+  createNovoLote: boolean
+  onToggleCreateNovoLote: () => void
+  createCategoriaRequiresLot: boolean
+  onCreateCategoriaRequiresLotChange: (value: boolean) => void
+  createCategoriaRequiresExpiry: boolean
+  onCreateCategoriaRequiresExpiryChange: (value: boolean) => void
+  createCategoriaFefo: boolean
+  onCreateCategoriaFefoChange: (value: boolean) => void
+  isManagerRole: boolean
+  lotCategorias: string[]
+  insumosMarcas: string[]
+  insumosTiposUnidade: string[]
+  createLoading: boolean
+  onSaveCreate: () => void
+  filteredInsumos: Insumo[]
+  listContainerRef: React.RefObject<HTMLDivElement | null>
+  onListScroll: (event: React.UIEvent<HTMLDivElement>) => void
+  insumosLoading: boolean
+  insumosLoadError: InventoryLoadError | null
+  emptyContent: React.ReactNode
+  onEditItem: (item: Insumo) => void
+}
+
+export function InsumosInventoryDialog({
+  open,
+  dialogClassName,
+  isAuthed,
+  unit,
+  unitLabel,
+  query,
+  onQueryChange,
+  onOpenChange,
+  onExport,
+  createOpen,
+  onToggleCreate,
+  onCancelCreate,
+  createLookupLoading,
+  createLookupError,
+  createLookupCount,
+  createScanOpen,
+  onToggleCreateScan,
+  onCloseCreateScan,
+  onCreateBarcodeDetected,
+  createCodigo,
+  onCreateCodigoChange,
+  createCodigosExtras,
+  onCreateCodigosExtrasChange,
+  createProduto,
+  onCreateProdutoChange,
+  createCategoria,
+  onCreateCategoriaChange,
+  createMarca,
+  onCreateMarcaChange,
+  createTipoUnidade,
+  onCreateTipoUnidadeChange,
+  createPrecoCusto,
+  onCreatePrecoCustoChange,
+  createEstoqueMinimo,
+  onCreateEstoqueMinimoChange,
+  createEstoqueInicial,
+  onCreateEstoqueInicialChange,
+  createLote,
+  onCreateLoteChange,
+  createDataValidade,
+  onCreateDataValidadeChange,
+  createNovoLote,
+  onToggleCreateNovoLote,
+  createCategoriaRequiresLot,
+  onCreateCategoriaRequiresLotChange,
+  createCategoriaRequiresExpiry,
+  onCreateCategoriaRequiresExpiryChange,
+  createCategoriaFefo,
+  onCreateCategoriaFefoChange,
+  isManagerRole,
+  lotCategorias,
+  insumosMarcas,
+  insumosTiposUnidade,
+  createLoading,
+  onSaveCreate,
+  filteredInsumos,
+  listContainerRef,
+  onListScroll,
+  insumosLoading,
+  insumosLoadError,
+  emptyContent,
+  onEditItem,
+}: InsumosInventoryDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="wideTable" className={dialogClassName}>
+        <DialogHeader className="space-y-2">
+          <div className="flex min-w-0 w-full flex-nowrap items-center gap-2 overflow-x-auto">
+            <DialogTitle className="text-white">Insumos</DialogTitle>
+            <Input
+              value={query}
+              onChange={(e) => onQueryChange(e.target.value)}
+              placeholder="Buscar por código, produto, categoria…"
+              className="ml-auto h-8 min-w-[160px] flex-1 md:min-w-0"
+            />
+            <Button variant="outline" className="h-8 px-3" onClick={onExport} disabled={!isAuthed} title="Exportar CSV">
+              Exportar
+            </Button>
+            <Button variant="outline" className="h-8 px-3" onClick={onToggleCreate} disabled={!isAuthed}>
+              {createOpen ? 'Fechar' : 'Adicionar'}
+            </Button>
+          </div>
+          <DialogDescription>Lista e cadastro de insumos da unidade selecionada.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {createOpen ? (
+            <div className="space-y-3 rounded-xl border border-white/10 bg-black/20 p-3">
+              <div className="text-sm text-blue-100/70">Cadastro rápido (campos mínimos) + detalhes opcionais.</div>
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Código de barras</div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Input value={createCodigo} onChange={(e) => onCreateCodigoChange(e.target.value)} placeholder="789..." />
+                    <Button variant="secondary" type="button" onClick={onToggleCreateScan}>
+                      {createScanOpen ? 'Fechar' : 'Escanear'}
+                    </Button>
+                  </div>
+                  <div className="mt-2">
+                    {createLookupLoading ? (
+                      <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
+                    ) : createLookupError ? (
+                      <div className="text-xs text-red-200">{createLookupError}</div>
+                    ) : createLookupCount ? (
+                      <div className="text-xs text-blue-200/70">
+                        Encontrado no histórico: <span className="font-mono">{createLookupCount}</span> variação(ões)
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="mt-2">
+                    <div className="mb-1 text-xs text-blue-200/70">Códigos adicionais</div>
+                    <Textarea
+                      value={createCodigosExtras}
+                      onChange={(e) => onCreateCodigosExtrasChange(e.target.value)}
+                      placeholder="um por linha"
+                      rows={3}
+                      className="border-white/20 bg-white/[0.06] text-white"
+                    />
+                    <div className="mt-1 text-[10px] text-blue-200/50">Opcional. Use para variações de código do mesmo produto.</div>
+                  </div>
+                </div>
+                <div className="md:col-span-2">
+                  <div className="mb-1 text-xs text-blue-200/70">Produto</div>
+                  <Input value={createProduto} onChange={(e) => onCreateProdutoChange(e.target.value)} placeholder="ex: Toxina botulínica" />
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Categoria</div>
+                  <Input
+                    value={createCategoria}
+                    onChange={(e) => onCreateCategoriaChange(e.target.value)}
+                    placeholder="ex: toxina"
+                    list="insumos-categorias"
+                  />
+                  <datalist id="insumos-categorias">
+                    {lotCategorias.map((categoria) => (
+                      <option key={categoria} value={categoria} />
+                    ))}
+                  </datalist>
+                </div>
+                <div className="md:col-span-2 rounded-xl border border-white/10 bg-black/10 p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-xs text-blue-200/70">Política do item</div>
+                    <div className="text-xs text-blue-200/60">Defina as regras para este insumo.</div>
+                  </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
+                    <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                      <Checkbox checked={createCategoriaRequiresLot} onCheckedChange={(value) => onCreateCategoriaRequiresLotChange(!!value)} disabled={!isManagerRole} />
+                      Lote obrigatório
+                    </label>
+                    <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                      <Checkbox
+                        checked={createCategoriaRequiresExpiry}
+                        onCheckedChange={(value) => onCreateCategoriaRequiresExpiryChange(!!value)}
+                        disabled={!isManagerRole}
+                      />
+                      Validade obrigatória
+                    </label>
+                    <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                      <Checkbox checked={createCategoriaFefo} onCheckedChange={(value) => onCreateCategoriaFefoChange(!!value)} disabled={!isManagerRole} />
+                      FEFO
+                    </label>
+                    {!isManagerRole ? <span className="text-xs text-blue-200/60">Somente gestores alteram.</span> : null}
+                  </div>
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Marca</div>
+                  <Input
+                    value={createMarca}
+                    onChange={(e) => onCreateMarcaChange(e.target.value)}
+                    placeholder="ex: Allergan"
+                    list="insumos-marcas"
+                  />
+                  <datalist id="insumos-marcas">
+                    {insumosMarcas.map((marca) => (
+                      <option key={marca} value={marca} />
+                    ))}
+                  </datalist>
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Tipo (unidade)</div>
+                  <Select value={createTipoUnidade || undefined} onValueChange={onCreateTipoUnidadeChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Selecione a unidade" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {insumosTiposUnidade.map((tipo) => (
+                        <SelectItem key={tipo} value={tipo}>
+                          {tipo}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Preço (custo)</div>
+                  <Input value={createPrecoCusto} onChange={(e) => onCreatePrecoCustoChange(e.target.value)} placeholder="ex: 1200" />
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Estoque mínimo</div>
+                  <Input value={createEstoqueMinimo} onChange={(e) => onCreateEstoqueMinimoChange(e.target.value)} placeholder="ex: 5" />
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Estoque inicial</div>
+                  <Input value={createEstoqueInicial} onChange={(e) => onCreateEstoqueInicialChange(e.target.value)} placeholder="ex: 0" />
+                </div>
+                <div>
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="text-xs text-blue-200/70">Lote</div>
+                    <Button
+                      variant={createNovoLote ? 'secondary' : 'outline'}
+                      size="sm"
+                      type="button"
+                      onClick={onToggleCreateNovoLote}
+                      title="Ative quando estiver cadastrando um lote adicional para um código já existente."
+                    >
+                      {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
+                    </Button>
+                  </div>
+                  <Input
+                    value={createLote}
+                    onChange={(e) => onCreateLoteChange(e.target.value)}
+                    placeholder={createNovoLote ? 'obrigatório (ex: L2026-01)' : 'opcional'}
+                  />
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Validade</div>
+                  <BrDatePickerInput value={createDataValidade} onChange={onCreateDataValidadeChange} placeholder="DD/MM/AA" ariaLabel="Validade" />
+                </div>
+              </div>
+
+              {createScanOpen ? <InsumosBarcodeScannerInline onDetected={onCreateBarcodeDetected} onClose={onCloseCreateScan} /> : null}
+
+              <div className="flex items-center justify-end gap-2">
+                <Button variant="secondary" onClick={onCancelCreate}>
+                  Cancelar
+                </Button>
+                <Button onClick={onSaveCreate} disabled={!isAuthed || createLoading}>
+                  {createLoading ? 'Salvando…' : 'Salvar'}
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          <div ref={listContainerRef as React.RefObject<HTMLDivElement>} onScroll={onListScroll} className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+            <table className="w-full min-w-[880px] table-auto text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  <th className="w-[30%] p-3 text-left">Produto</th>
+                  <th className="hidden w-[20%] p-3 text-left md:table-cell">Categoria</th>
+                  <th className="hidden w-[18%] p-3 text-left lg:table-cell">Código</th>
+                  <th className="w-[6rem] p-3 text-right whitespace-nowrap">Estoque</th>
+                  <th className="hidden w-[5rem] p-3 text-right whitespace-nowrap sm:table-cell">Mín</th>
+                  <th className="hidden w-[7rem] p-3 text-left whitespace-nowrap xl:table-cell">Validade</th>
+                  <th className="hidden w-[7.5rem] p-3 text-right whitespace-nowrap xl:table-cell">Valor</th>
+                  <th className="w-[6.5rem] p-3 text-right whitespace-nowrap">Ações</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {filteredInsumos.map((item, idx) => {
+                  const estoque = unit && item?.estoques ? Number(item.estoques?.[unit] ?? 0) : Number(item.estoqueAtual ?? 0)
+                  const min = Number(item.estoqueMinimo) || 0
+                  const valor = (Number(item.precoCusto) || 0) * (Number.isFinite(estoque) ? estoque : 0)
+                  return (
+                    <tr key={`${item.registro || ''}-${idx}`} className="hover:bg-white/5">
+                      <td className="p-3 align-top text-blue-50">
+                        <div className="min-w-0">
+                          <div className="break-words font-medium">{item.produto || '-'}</div>
+                          <div className="mt-1 space-y-0.5">
+                            <div className="break-words text-xs text-blue-200/60 md:hidden">{item.categoria || '-'}</div>
+                            <div className="break-all font-mono text-xs text-blue-200/60 lg:hidden">{item.codigoBarras || '-'}</div>
+                            <div className="text-xs text-blue-200/60 xl:hidden">{fmtDateOnlyBR(item.dataValidade || '') || '-'}</div>
+                            <div className="text-xs text-blue-200/60 xl:hidden">{fmtMoneyBRL(valor)}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="hidden p-3 align-middle text-blue-100/80 md:table-cell">
+                        <div className="break-words">{item.categoria || '-'}</div>
+                      </td>
+                      <td className="hidden break-all p-3 align-middle font-mono text-blue-100/70 lg:table-cell">{item.codigoBarras || '-'}</td>
+                      <td className="p-3 align-middle text-right font-mono text-blue-100/80 whitespace-nowrap">{Number.isFinite(estoque) ? estoque : '-'}</td>
+                      <td className="hidden p-3 align-middle text-right font-mono text-blue-100/70 whitespace-nowrap sm:table-cell">{min || '-'}</td>
+                      <td className="hidden p-3 align-middle text-blue-100/70 whitespace-nowrap xl:table-cell">{fmtDateOnlyBR(item.dataValidade || '')}</td>
+                      <td className="hidden p-3 align-middle text-right text-blue-100/80 whitespace-nowrap xl:table-cell">{fmtMoneyBRL(valor)}</td>
+                      <td className="p-3 align-middle text-right whitespace-nowrap">
+                        <div className="flex items-center justify-end">
+                          <Button variant="outline" size="sm" className="h-8 px-3 text-xs" onClick={() => onEditItem(item)} disabled={!isAuthed}>
+                            Editar
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+                {!filteredInsumos.length ? (
+                  <tr>
+                    <td className="p-3 text-blue-100/70" colSpan={8}>
+                      {insumosLoadError && !insumosLoading ? (
+                        <span className="text-red-200">
+                          Erro ao carregar insumos ({insumosLoadError.status || 'erro'}
+                          {insumosLoadError.code ? `/${insumosLoadError.code}` : ''}): {insumosLoadError.message}
+                        </span>
+                      ) : (
+                        emptyContent
+                      )}
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function InsumosPurchaseDialog({
+  actionables,
+  dialogClassName,
+  isAuthed,
+  loading,
+  open,
+  onOpenChange,
+  onOpenQuickOperation,
+  onClose,
+  renderLoadingText,
+  unit,
+  unitLabel,
+}: InsumosPurchaseDialogProps) {
+  const items = React.useMemo(() => (actionables?.reposicao || []).slice(), [actionables?.reposicao])
+  const totalValue = React.useMemo(
+    () => items.reduce((acc, it) => acc + (Number(it.estimatedValue) || 0), 0),
+    [items],
+  )
+  const totalQty = React.useMemo(
+    () => items.reduce((acc, it) => acc + (Number(it.suggestedPurchaseQty) || 0), 0),
+    [items],
+  )
+  const categories = React.useMemo(() => {
+    const byCat = new Map<string, typeof items>()
+    for (const it of items) {
+      const cat = String(it.categoria || 'Outros').trim() || 'Outros'
+      const prev = byCat.get(cat) || []
+      prev.push(it)
+      byCat.set(cat, prev)
+    }
+    return Array.from(byCat.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+  }, [items])
+
+  const escapeCsv = React.useCallback((value: unknown) => {
+    const out = String(value ?? '')
+    if (/[";\n\r]/.test(out)) return `"${out.replace(/"/g, '""')}"`
+    return out
+  }, [])
+
+  const toCsv = React.useCallback(() => {
+    const header = ['Categoria', 'Produto', 'Código', 'Qtd sugerida', 'Valor estimado (R$)']
+    const rows = items.map((it) => [
+      it.categoria || '',
+      it.produto || '',
+      it.codigoBarras || '',
+      Number(it.suggestedPurchaseQty) || 0,
+      Number(it.estimatedValue) || 0,
+    ])
+    return [header, ...rows].map((row) => row.map(escapeCsv).join(';')).join('\n')
+  }, [escapeCsv, items])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="wideTable" className={`${dialogClassName} dark bg-corporate-900 border-white/10 text-white`}>
+        <DialogHeader>
+          <DialogTitle className="text-white">Lista de compra</DialogTitle>
+          <DialogDescription className="text-blue-100/70">
+            Sugestões de reposição para {unitLabel(unit)} (baseado em estoque mínimo).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm text-blue-100/80">
+              <span className="font-mono">{items.length}</span> itens • <span className="font-mono">{totalQty}</span> unidades sugeridas •{' '}
+              <span className="font-mono">{fmtMoneyBRL(totalValue)}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(toCsv())
+                  } catch {
+                    // ignore clipboard errors
+                  }
+                }}
+                disabled={!items.length}
+              >
+                Copiar CSV
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const csv = toCsv()
+                  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+                  const url = URL.createObjectURL(blob)
+                  const link = document.createElement('a')
+                  link.href = url
+                  link.download = `lista-compra-${unit}-${new Date().toISOString().slice(0, 10)}.csv`
+                  document.body.appendChild(link)
+                  link.click()
+                  link.remove()
+                  setTimeout(() => URL.revokeObjectURL(url), 2000)
+                }}
+                disabled={!items.length}
+              >
+                Baixar CSV
+              </Button>
+            </div>
+          </div>
+
+          <div className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  <th className="p-3 text-left">Produto</th>
+                  <th className="hidden p-3 text-left md:table-cell">Categoria</th>
+                  <th className="hidden p-3 text-left sm:table-cell">Código</th>
+                  <th className="p-3 text-right">Qtd sugerida</th>
+                  <th className="p-3 text-right">Valor</th>
+                  <th className="p-3 text-right">Ação</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {categories.flatMap(([category, list]) =>
+                  list.map((it, idx) => (
+                    <tr key={`${String(it.codigoBarras || '')}-${idx}`} className="hover:bg-white/5">
+                      <td className="p-3 text-blue-50">
+                        <div className="font-medium">{it.produto || '-'}</div>
+                      </td>
+                      <td className="hidden p-3 text-blue-100/80 md:table-cell">{it.categoria || category}</td>
+                      <td className="hidden break-all p-3 font-mono text-blue-100/80 sm:table-cell">{it.codigoBarras || ''}</td>
+                      <td className="p-3 text-right font-mono text-blue-100/80">{it.suggestedPurchaseQty ?? 0}</td>
+                      <td className="p-3 text-right font-mono text-blue-100/80">
+                        {fmtMoneyBRL(Number(it.estimatedValue) || 0)}
+                      </td>
+                      <td className="p-3 text-right">
+                        <Button
+                          variant="outline"
+                          className="h-8 px-2 text-xs"
+                          onClick={() => {
+                            onOpenQuickOperation('ENTRADA', {
+                              codigoBarras: String(it.codigoBarras || ''),
+                              quantidade: it.suggestedPurchaseQty ?? 1,
+                              obs: 'Reposição sugerida',
+                            })
+                            onClose()
+                          }}
+                          disabled={!isAuthed}
+                        >
+                          Registrar entrada
+                        </Button>
+                      </td>
+                    </tr>
+                  )),
+                )}
+                {!items.length ? (
+                  <tr>
+                    <td className="p-3 text-blue-100/70" colSpan={6}>
+                      {renderLoadingText(loading, 'Sem recomendações de compra.')}
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>
+            Fechar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type QuickSearchMatch = {
+  item: Insumo
+  matchedCode: string
+  score: number
+}
+
+type InsumosQuickOperationDialogProps = {
+  open: boolean
+  operation: InsumosQuickOperation | null
+  dialogClassName: string
+  isAuthed: boolean
+  shouldShowDashboardLoading: boolean
+  renderDashboardLoadingButton: () => React.ReactNode
+  unit: string
+  transferFrom: string
+  transferTo: string
+  unitOptions: string[]
+  unitLabel: (unit: string) => string
+  search: string
+  onSearchChange: (value: string) => void
+  scanOpen: boolean
+  onScanToggle: () => void
+  onScanClose: () => void
+  onBarcodeDetected: (code: string) => void
+  searchRemoteLoading: boolean
+  searchRemoteError: string | null
+  searchMatches: QuickSearchMatch[]
+  hasSelection: boolean
+  lookupLoading: boolean
+  lookupError: string | null
+  lookupItems: Insumo[]
+  selectedSnapshot: Insumo | null
+  quickCode: string
+  onClearSelection: () => void
+  onApplySelection: (item: Insumo, preferredCode?: string) => void
+  isSameInsumo: (item: Insumo, target: Insumo | null) => boolean
+  onSelectCode: (value: string, item?: Insumo | null) => void
+  loteNeedsPick: boolean
+  lotesForPicker: QuickCandidate[]
+  selectedRegistro: string
+  onRegistroChange: (value: string) => void
+  showFefoToggle: boolean
+  autoFefo: boolean
+  onToggleAutoFefo: () => void
+  quantity: string
+  onQuantityChange: (value: string) => void
+  adjustmentStock: string
+  onAdjustmentStockChange: (value: string) => void
+  adjustmentReason: string
+  onAdjustmentReasonChange: (value: string) => void
+  obs: string
+  onObsChange: (value: string) => void
+  onTransferFromChange: (value: string) => void
+  onTransferToChange: (value: string) => void
+  feedback: QuickActionFeedback | null
+  loading: boolean
+  onOpenChange: (open: boolean) => void
+  onCancel: () => void
+  onConfirmTransfer: () => Promise<void>
+  onConfirmOperation: () => Promise<void>
+  onEditItem: (item: Insumo) => void
+}
+
+export function InsumosQuickOperationDialog({
+  open,
+  operation,
+  dialogClassName,
+  isAuthed,
+  shouldShowDashboardLoading,
+  renderDashboardLoadingButton,
+  unit,
+  transferFrom,
+  transferTo,
+  unitOptions,
+  unitLabel,
+  search,
+  onSearchChange,
+  scanOpen,
+  onScanToggle,
+  onScanClose,
+  onBarcodeDetected,
+  searchRemoteLoading,
+  searchRemoteError,
+  searchMatches,
+  hasSelection,
+  lookupLoading,
+  lookupError,
+  lookupItems,
+  selectedSnapshot,
+  quickCode,
+  onClearSelection,
+  onApplySelection,
+  isSameInsumo,
+  onSelectCode,
+  loteNeedsPick,
+  lotesForPicker,
+  selectedRegistro,
+  onRegistroChange,
+  showFefoToggle,
+  autoFefo,
+  onToggleAutoFefo,
+  quantity,
+  onQuantityChange,
+  adjustmentStock,
+  onAdjustmentStockChange,
+  adjustmentReason,
+  onAdjustmentReasonChange,
+  obs,
+  onObsChange,
+  onTransferFromChange,
+  onTransferToChange,
+  feedback,
+  loading,
+  onOpenChange,
+  onCancel,
+  onConfirmTransfer,
+  onConfirmOperation,
+  onEditItem,
+}: InsumosQuickOperationDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={`${dialogClassName} dark bg-corporate-900 border-white/10 text-white`}>
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {operation === 'ENTRADA'
+              ? 'Entrada'
+              : operation === 'BAIXA'
+                ? 'Saída'
+                : operation === 'AJUSTE'
+                  ? 'Ajuste'
+                : operation === 'TRANSFERENCIA'
+                  ? 'Transferência'
+                  : 'Operação'}
+          </DialogTitle>
+          <DialogDescription className="text-blue-100/70">
+            Preencha os dados para registrar a operação na unidade selecionada.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!isAuthed ? (
+          shouldShowDashboardLoading ? (
+            renderDashboardLoadingButton()
+          ) : (
+            <div className="text-sm text-blue-100/80">Faça login no CRM para usar as operações de Insumos.</div>
+          )
+        ) : null}
+
+        <div className="rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2 text-xs text-blue-100">
+          {operation === 'TRANSFERENCIA'
+            ? `Unidade da operação: ${unitLabel(transferFrom)} → ${unitLabel(transferTo)}`
+            : `Unidade da operação: ${unitLabel(unit)}`}
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <div className="mb-1 text-xs text-blue-200/70">Buscar por produto, marca, categoria ou código</div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Input
+                value={search}
+                onChange={(e) => onSearchChange(e.target.value)}
+                placeholder="ex: Rennova, preenchedor, 789..."
+                className="w-full sm:min-w-[240px] sm:flex-1"
+              />
+              <Button variant="secondary" type="button" onClick={onScanToggle}>
+                {scanOpen ? 'Fechar' : 'Escanear'}
+              </Button>
+            </div>
+            <div className="mt-2">
+              {searchRemoteLoading ? (
+                <div className="text-xs text-blue-200/70">Buscando no servidor…</div>
+              ) : searchRemoteError ? (
+                <div className="text-xs text-amber-200">{searchRemoteError} (mostrando cache local).</div>
+              ) : null}
+              {searchMatches.length && (!hasSelection || lookupLoading) ? (
+                <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+                  <div className="mb-2 text-[11px] text-blue-200/60">Selecione o produto para lançar a operação:</div>
+                  <div className="space-y-2">
+                    {searchMatches.map(({ item, matchedCode }) => {
+                      const codes = getInsumoBarcodes(item)
+                      const code = matchedCode && codes.includes(matchedCode) ? matchedCode : codes[0] || ''
+                      const hasCode = !!code
+                      const descriptor = formatInsumoDescriptor(item)
+                      const primarySelected = selectedSnapshot || (lookupItems.length ? lookupItems[0] : null)
+                      const isLoadingSelection = !!(lookupLoading && primarySelected && isSameInsumo(item, primarySelected))
+                      return (
+                        <div
+                          key={`${item.registro || ''}-${code || 'nocode'}`}
+                          className="w-full min-w-0 rounded-md border border-white/5 bg-white/5 px-2 py-2"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => onApplySelection(item, code)}
+                            disabled={!hasCode || isLoadingSelection}
+                            className={`w-full rounded-md px-1 py-1 text-left ${!hasCode || isLoadingSelection ? 'cursor-not-allowed' : 'hover:bg-white/10'}`}
+                            aria-busy={isLoadingSelection}
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="break-words text-sm font-semibold text-blue-50">{String(item.produto || 'Insumo')}</div>
+                              <div className="flex items-center gap-2 break-all font-mono text-xs text-blue-200/60">
+                                {code || '—'}
+                                {isLoadingSelection ? (
+                                  <span className="inline-flex items-center gap-1 font-sans text-blue-200/70">
+                                    <span className="inline-flex h-3 w-3 animate-spin rounded-full border border-blue-200/70 border-t-transparent" />
+                                    Carregando…
+                                  </span>
+                                ) : null}
+                              </div>
+                            </div>
+                            {descriptor ? (
+                              <div className="mt-0.5 break-words text-xs text-blue-200/70">{descriptor}</div>
+                            ) : null}
+                            {!hasCode ? (
+                              <div className="mt-1 text-xs text-amber-200">Sem código de barras cadastrado</div>
+                            ) : null}
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
+                              {item.categoria ? (
+                                <Badge style={buildTagStyle(getCategoriaBgColor(String(item.categoria)))} className="border">
+                                  {String(item.categoria)}
+                                </Badge>
+                              ) : null}
+                              {item.marca ? (
+                                <Badge style={buildTagStyle(getMarcaBgColor(String(item.marca)))} className="border">
+                                  {String(item.marca)}
+                                </Badge>
+                              ) : null}
+                            </div>
+                          </button>
+                          {!hasCode ? (
+                            <div className="mt-2 flex justify-end">
+                              <Button variant="outline" size="sm" onClick={() => onEditItem(item)} disabled={!isAuthed}>
+                                Editar cadastro
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              {lookupLoading ? (
+                <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
+              ) : lookupError ? (
+                <div className="text-xs text-red-200">{lookupError}</div>
+              ) : lookupItems.length || selectedSnapshot ? (
+                (() => {
+                  const selected = lookupItems[0] || selectedSnapshot
+                  if (!selected) return null
+                  const selectedCodes = getInsumoBarcodes(selected)
+                  const activeCode = quickCode.trim() || selectedCodes[0] || ''
+                  const resumoBase = lookupItems.length ? lookupItems : [selected]
+                  return (
+                    <div className="rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-blue-200/70">Selecionado</div>
+                          <div className="text-sm font-semibold text-blue-50">
+                            {String(selected?.produto || '').trim() || 'Insumo'}
+                          </div>
+                          {formatInsumoDescriptor(selected) ? (
+                            <div className="mt-0.5 text-xs text-blue-200/70">{formatInsumoDescriptor(selected)}</div>
+                          ) : null}
+                        </div>
+                        <div className="flex flex-col items-end gap-2 text-xs text-blue-200/70">
+                          <Button variant="outline" size="sm" onClick={onClearSelection}>
+                            Trocar seleção
+                          </Button>
+                          <div className="text-right">
+                            {(() => {
+                              const ctx = operation === 'TRANSFERENCIA' ? transferFrom : unit
+                              const total = resumoBase.reduce((acc, it) => {
+                                const value =
+                                  ctx && (it as any)?.estoques
+                                    ? Number((it as any).estoques?.[ctx] ?? 0)
+                                    : Number((it as any).estoqueAtual ?? 0)
+                                return acc + (Number.isFinite(value) ? value : 0)
+                              }, 0)
+                              return `Estoque: ${total}`
+                            })()}
+                            {' • '}
+                            {
+                              Array.from(
+                                new Set(resumoBase.map((it) => String((it as any)?.registro || '').trim()).filter(Boolean)),
+                              ).length
+                            }{' '}
+                            registros
+                          </div>
+                        </div>
+                      </div>
+                      {selectedCodes.length > 1 ? (
+                        <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-blue-200/70">
+                          <span className="uppercase tracking-wide">Código</span>
+                          <Select value={activeCode} onValueChange={(value) => onSelectCode(value, selected)}>
+                            <SelectTrigger className="h-8">
+                              <SelectValue placeholder="Selecione o código" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {selectedCodes.map((code) => (
+                                <SelectItem key={code} value={code}>
+                                  <span className="font-mono">{code}</span>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      ) : null}
+                      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-blue-200/70">
+                        {selected?.categoria ? (
+                          <Badge style={buildTagStyle(getCategoriaBgColor(String(selected.categoria)))} className="border">
+                            {String(selected.categoria)}
+                          </Badge>
+                        ) : null}
+                        {selected?.marca ? (
+                          <Badge style={buildTagStyle(getMarcaBgColor(String(selected.marca)))} className="border">
+                            {String(selected.marca)}
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </div>
+                  )
+                })()
+              ) : null}
+            </div>
+          </div>
+
+          {loteNeedsPick ? (
+            <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs text-blue-200/70">Lote/registro</div>
+                {showFefoToggle ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    type="button"
+                    onClick={onToggleAutoFefo}
+                    title="FEFO (First-Expire, First-Out): prioriza o lote com validade mais próxima"
+                  >
+                    FEFO {autoFefo ? 'auto' : 'manual'}
+                  </Button>
+                ) : null}
+              </div>
+              <Select value={selectedRegistro} onValueChange={onRegistroChange}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Selecione o lote/registro" />
+                </SelectTrigger>
+                <SelectContent>
+                  {lotesForPicker.map((lote) => (
+                    <SelectItem key={lote.registro} value={lote.registro}>
+                      <span className="flex w-full items-center justify-between gap-3">
+                        <span className="font-mono">{lote.registro}</span>
+                        <span className="flex items-center gap-2 text-xs text-blue-100/70">
+                          {lote.lote ? <span>Lote {lote.lote}</span> : null}
+                          {lote.dataValidade ? <span>Vence {fmtDateOnlyBR(lote.dataValidade)}</span> : null}
+                          {Number.isFinite(Number(lote.estoque)) ? <span>Estoque {Number(lote.estoque)}</span> : null}
+                        </span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="text-xs text-blue-200/60">
+                Se o produto tiver múltiplos lotes, selecione qual registro deve ser movimentado.
+              </div>
+            </div>
+          ) : null}
+
+          {operation === 'AJUSTE' ? (
+            <>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Novo estoque</div>
+                  <Input value={adjustmentStock} onChange={(e) => onAdjustmentStockChange(e.target.value)} type="number" min={0} />
+                </div>
+                <div>
+                  <div className="mb-1 text-xs text-blue-200/70">Motivo</div>
+                  <Input value={adjustmentReason} onChange={(e) => onAdjustmentReasonChange(e.target.value)} placeholder="Ajuste manual" />
+                </div>
+              </div>
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Observações</div>
+                <Input value={obs} onChange={(e) => onObsChange(e.target.value)} placeholder="opcional" />
+              </div>
+            </>
+          ) : (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Quantidade</div>
+                <Input value={quantity} onChange={(e) => onQuantityChange(e.target.value)} type="number" min={1} />
+              </div>
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Observações</div>
+                <Input value={obs} onChange={(e) => onObsChange(e.target.value)} placeholder="opcional" />
+              </div>
+            </div>
+          )}
+
+          {operation === 'TRANSFERENCIA' ? (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Origem</div>
+                <Select value={transferFrom} onValueChange={onTransferFromChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {unitOptions.map((unitOption) => (
+                      <SelectItem key={unitOption} value={unitOption}>
+                        {unitLabel(unitOption)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Destino</div>
+                <Select value={transferTo} onValueChange={onTransferToChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {unitOptions.map((unitOption) => (
+                      <SelectItem key={unitOption} value={unitOption}>
+                        {unitLabel(unitOption)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          ) : null}
+
+          {scanOpen ? (
+            <InsumosBarcodeScannerInline onDetected={onBarcodeDetected} onClose={onScanClose} />
+          ) : null}
+
+          {feedback ? (
+            <div
+              className={`rounded-lg border px-3 py-2 text-sm ${
+                feedback.type === 'success'
+                  ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                  : 'border-red-400/40 bg-red-500/10 text-red-100'
+              }`}
+            >
+              {feedback.message}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancelar
+          </Button>
+          {operation === 'TRANSFERENCIA' ? (
+            <Button
+              className="!bg-blue-600 hover:!bg-blue-700 !text-white"
+              onClick={() => void onConfirmTransfer()}
+              disabled={loading || !isAuthed}
+            >
+              <span className="flex items-center gap-2">
+                {loading ? (
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
+                    <path d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                  </svg>
+                ) : null}
+                {loading ? 'Processando...' : 'Confirmar transferência'}
+              </span>
+            </Button>
+          ) : (
+            <Button
+              className={
+                operation === 'ENTRADA'
+                  ? '!bg-green-600 hover:!bg-green-700 !text-white'
+                  : operation === 'AJUSTE'
+                    ? '!bg-amber-500 hover:!bg-amber-600 !text-white'
+                    : ''
+              }
+              variant={operation === 'BAIXA' ? 'destructive' : 'default'}
+              onClick={() => void onConfirmOperation()}
+              disabled={loading || !isAuthed}
+            >
+              <span className="flex items-center gap-2">
+                {loading ? (
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
+                    <path d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                  </svg>
+                ) : null}
+                {loading
+                  ? 'Processando...'
+                  : operation === 'ENTRADA'
+                    ? 'Confirmar entrada'
+                    : operation === 'AJUSTE'
+                      ? 'Confirmar ajuste'
+                      : 'Confirmar saída'}
+              </span>
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosLotDialogProps = {
+  open: boolean
+  dialogClassName: string
+  item: Insumo | null
+  lotValue: string
+  expiryValue: string
+  onOpenChange: (open: boolean) => void
+  onLotChange: (value: string) => void
+  onExpiryChange: (value: string) => void
+  onSave: () => void
+  saving: boolean
+  isAuthed: boolean
+}
+
+export function InsumosLotDialog({
+  open,
+  dialogClassName,
+  item,
+  lotValue,
+  expiryValue,
+  onOpenChange,
+  onLotChange,
+  onExpiryChange,
+  onSave,
+  saving,
+  isAuthed,
+}: InsumosLotDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={dialogClassName}>
+        <DialogHeader>
+          <DialogTitle>Editar lote/validade</DialogTitle>
+          <DialogDescription>
+            {item?.produto || '-'} • <span className="font-mono">{item?.codigoBarras || '-'}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {item ? (
+          <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-blue-100/70">
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              <div>
+                <div className="text-xs text-muted-foreground">Categoria</div>
+                <div className="text-blue-100/80">{item.categoria || '-'}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Marca</div>
+                <div className="text-blue-100/80">{item.marca || '-'}</div>
+              </div>
+              {item.concentracao ? (
+                <div>
+                  <div className="text-xs text-muted-foreground">Concentração</div>
+                  <div className="text-blue-100/80">{item.concentracao}</div>
+                </div>
+              ) : null}
+              {item.volume ? (
+                <div>
+                  <div className="text-xs text-muted-foreground">Volume</div>
+                  <div className="text-blue-100/80">{item.volume}</div>
+                </div>
+              ) : null}
+              {item.calibre ? (
+                <div>
+                  <div className="text-xs text-muted-foreground">Calibre</div>
+                  <div className="text-blue-100/80">{item.calibre}</div>
+                </div>
+              ) : null}
+              <div>
+                <div className="text-xs text-muted-foreground">Homologado</div>
+                <div className="text-blue-100/80">{/homologad/i.test(String(item.fonte || '').trim()) ? 'Sim' : 'Não'}</div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Lote</div>
+            <Input value={lotValue} onChange={(e) => onLotChange(e.target.value)} placeholder="ex: 2026-01A" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Validade</div>
+            <BrDatePickerInput
+              value={expiryValue}
+              onChange={onExpiryChange}
+              placeholder="DD/MM/AA"
+              ariaLabel="Validade do lote"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={onSave} disabled={saving || !isAuthed}>
+            {saving ? 'Salvando…' : 'Salvar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosOfflineQueueDialogProps = {
+  open: boolean
+  dialogClassName: string
+  items: OfflineQueueItem[]
+  debugUi: boolean
+  isAuthed: boolean
+  fmtAge: (ts?: number) => string
+  onOpenChange: (open: boolean) => void
+  onSync: () => void
+  onClear: () => void
+  onToggleDebug: () => void
+  onCopyItem: (item: OfflineQueueItem) => void
+}
+
+export function InsumosOfflineQueueDialog({
+  open,
+  dialogClassName,
+  items,
+  debugUi,
+  isAuthed,
+  fmtAge,
+  onOpenChange,
+  onSync,
+  onClear,
+  onToggleDebug,
+  onCopyItem,
+}: InsumosOfflineQueueDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={dialogClassName}>
+        <DialogHeader>
+          <DialogTitle>Pendências de sincronização</DialogTitle>
+          <DialogDescription>
+            Operações salvas localmente quando a rede cai. Ao reconectar, clique em “Sincronizar”.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm text-muted-foreground">
+            Itens: <span className="font-mono">{items.length}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="secondary" onClick={onSync} disabled={!isAuthed || !items.length}>
+              Sincronizar
+            </Button>
+            <Button variant="destructive" onClick={onClear} disabled={!items.length}>
+              Limpar
+            </Button>
+          </div>
+        </div>
+
+        {debugUi ? (
+          <div className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  <th className="p-3 text-left">Quando</th>
+                  <th className="p-3 text-left">Método</th>
+                  <th className="p-3 text-left">Endpoint</th>
+                  <th className="p-3 text-right">Ações</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {items.map((item) => (
+                  <tr key={item.id} className="hover:bg-white/5">
+                    <td className="p-3 text-blue-100/70">{fmtAge(item.ts)}</td>
+                    <td className="p-3 font-mono text-blue-100/80">{item.method}</td>
+                    <td className="p-3 font-mono text-blue-50">{item.path}</td>
+                    <td className="p-3 text-right">
+                      <Button variant="outline" onClick={() => onCopyItem(item)}>
+                        Copiar
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+                {!items.length ? (
+                  <tr>
+                    <td className="p-3 text-blue-100/70" colSpan={4}>
+                      Sem itens pendentes.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-blue-100/70">
+            {items.length ? (
+              <div>
+                Existem <span className="font-semibold text-blue-100">{items.length}</span> operações pendentes. Clique em
+                “Sincronizar” quando estiver online.
+              </div>
+            ) : (
+              <div>Sem pendências.</div>
+            )}
+            <div className="mt-2">
+              <Button variant="outline" size="sm" onClick={onToggleDebug}>
+                Ver detalhes técnicos
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosMovementEditDialogProps = {
+  open: boolean
+  dialogClassName: string
+  target: Movimentacao | null
+  isAuthed: boolean
+  saving: boolean
+  deleting: boolean
+  produto: string
+  data: string
+  hora: string
+  unidade: string
+  quantidade: string
+  novoEstoque: string
+  motivo: string
+  unitOptions: string[]
+  insumosProdutos: string[]
+  unitLabel: (value: string) => string
+  onOpenChange: (open: boolean) => void
+  onProdutoChange: (value: string) => void
+  onDataChange: (value: string) => void
+  onHoraChange: (value: string) => void
+  onUnidadeChange: (value: string) => void
+  onQuantidadeChange: (value: string) => void
+  onNovoEstoqueChange: (value: string) => void
+  onMotivoChange: (value: string) => void
+  onCancel: () => void
+  onSave: () => void
+  onDelete: () => void
+}
+
+export function InsumosMovementEditDialog({
+  open,
+  dialogClassName,
+  target,
+  isAuthed,
+  saving,
+  deleting,
+  produto,
+  data,
+  hora,
+  unidade,
+  quantidade,
+  novoEstoque,
+  motivo,
+  unitOptions,
+  insumosProdutos,
+  unitLabel,
+  onOpenChange,
+  onProdutoChange,
+  onDataChange,
+  onHoraChange,
+  onUnidadeChange,
+  onQuantidadeChange,
+  onNovoEstoqueChange,
+  onMotivoChange,
+  onCancel,
+  onSave,
+  onDelete,
+}: InsumosMovementEditDialogProps) {
+  const tipo = normalizeMovimentacaoTipo(target?.tipo)
+  const isTransfer = !!String(target?.transferId || '').trim()
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={`${dialogClassName} dark bg-corporate-900 border-white/10 text-white`}>
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {isTransfer
+              ? 'Editar transferência'
+              : tipo === 'AJUSTE'
+                ? 'Editar ajuste'
+                : tipo.includes('ENTRADA')
+                  ? 'Editar entrada'
+                  : tipo.includes('SAIDA')
+                    ? 'Editar saída'
+                    : 'Editar lançamento'}
+          </DialogTitle>
+          <DialogDescription className="text-blue-100/70">
+            Edite os dados do lançamento sem abrir o cadastro do insumo.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <div className="mb-1 text-xs text-blue-200/70">Produto</div>
+            <AutocompleteInput
+              value={produto}
+              onValueChange={onProdutoChange}
+              placeholder="Nome do produto"
+              options={insumosProdutos}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-xs text-blue-200/70">Data</div>
+              <BrDatePickerInput
+                value={fmtDateOnlyBR(data)}
+                onChange={onDataChange}
+                placeholder="DD/MM/AA"
+                ariaLabel="Data da movimentação"
+              />
+            </div>
+            <div>
+              <div className="mb-1 text-xs text-blue-200/70">Hora</div>
+              <Input type="time" value={hora} onChange={(e) => onHoraChange(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-xs text-blue-200/70">Unidade</div>
+              {isTransfer ? (
+                <Input
+                  value={`${unitLabel(String(target?.unidadeOrigem || ''))} → ${unitLabel(String(target?.unidadeDestino || ''))}`}
+                  disabled
+                />
+              ) : (
+                <Select value={unidade || undefined} onValueChange={onUnidadeChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione a unidade" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {unitOptions.map((unitOption) => (
+                      <SelectItem key={unitOption} value={unitOption}>
+                        {unitLabel(unitOption)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            {tipo === 'AJUSTE' ? (
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Novo estoque</div>
+                <Input type="number" min={0} value={novoEstoque} onChange={(e) => onNovoEstoqueChange(e.target.value)} />
+              </div>
+            ) : (
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Quantidade</div>
+                <Input type="number" min={1} value={quantidade} onChange={(e) => onQuantidadeChange(e.target.value)} />
+              </div>
+            )}
+          </div>
+
+          {tipo === 'AJUSTE' ? (
+            <div>
+              <div className="mb-1 text-xs text-blue-200/70">Motivo</div>
+              <Input value={motivo} onChange={(e) => onMotivoChange(e.target.value)} />
+            </div>
+          ) : null}
+
+          {target?.registroInsumo ? (
+            <div className="text-xs text-blue-200/60">
+              Registro: <span className="font-mono">{String(target.registroInsumo)}</span>
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-between">
+          <Button variant="destructive" onClick={onDelete} disabled={saving || deleting || !isAuthed}>
+            {deleting ? 'Excluindo...' : 'Excluir'}
+          </Button>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row">
+            <Button variant="secondary" onClick={onCancel} disabled={saving || deleting}>
+              Cancelar
+            </Button>
+            <Button onClick={onSave} disabled={saving || deleting || !isAuthed}>
+              {saving ? 'Salvando...' : 'Salvar lançamento'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosQualityMatchesDialogProps = {
+  open: boolean
+  dialogClassName: string
+  issue: QualityIssue | null
+  items: Insumo[]
+  savingRegistro: string
+  isAuthed: boolean
+  unit: string
+  unitLabel: (unit: string) => string
+  onOpenChange: (open: boolean) => void
+  onEditItem: (item: Insumo) => void
+  onDeleteRegistro: (registro: string) => void
+}
+
+export function InsumosQualityMatchesDialog({
+  open,
+  dialogClassName,
+  issue,
+  items,
+  savingRegistro,
+  isAuthed,
+  unit,
+  unitLabel,
+  onOpenChange,
+  onEditItem,
+  onDeleteRegistro,
+}: InsumosQualityMatchesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="wideTable" className={dialogClassName}>
+        <DialogHeader>
+          <DialogTitle>Duplicidade de código de barras</DialogTitle>
+          <DialogDescription>
+            {issue?.codigoBarras ? (
+              <>
+                Selecione qual registro editar ou excluir para o código <span className="font-mono">#{issue.codigoBarras}</span>. ({items.length}{' '}
+                correspondências)
+              </>
+            ) : (
+              <>Selecione qual registro editar ou excluir para resolver a duplicidade.</>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+          <table className="min-w-full text-sm">
+            <thead className="bg-black/30 text-blue-100/80">
+              <tr>
+                <th className="w-[20%] p-3 text-left">Registro</th>
+                <th className="w-[32%] p-3 text-left">Produto</th>
+                <th className="hidden w-[18%] p-3 text-left md:table-cell">Lote</th>
+                <th className="hidden w-[14%] p-3 text-left sm:table-cell">Estoque ({unitLabel(unit)})</th>
+                <th className="w-[16%] p-3 text-left">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {items.map((item) => {
+                const registro = String(item?.registro || '').trim()
+                const isDeleting = savingRegistro === registro
+                return (
+                  <tr key={registro || String(item?.codigoBarras || '')} className="hover:bg-white/5">
+                    <td className="p-3 font-mono text-blue-100/80">{registro || '-'}</td>
+                    <td className="p-3 text-blue-50">{String(item?.produto || '-')}</td>
+                    <td className="hidden p-3 text-blue-100/70 md:table-cell">{String(item?.lote || '-')}</td>
+                    <td className="hidden p-3 text-blue-100/70 sm:table-cell">{Number(item?.estoqueAtual || 0)}</td>
+                    <td className="p-3">
+                      <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+                        <Button size="sm" variant="outline" onClick={() => onEditItem(item)} disabled={!isAuthed || isDeleting}>
+                          Editar
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => onDeleteRegistro(registro)}
+                          disabled={!isAuthed || !registro || isDeleting}
+                        >
+                          {isDeleting ? 'Excluindo…' : 'Excluir'}
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+              {!items.length ? (
+                <tr>
+                  <td className="p-3 text-blue-100/70" colSpan={5}>
+                    Nenhuma correspondência encontrada.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosShareReceivedPanelProps = {
+  payload: SharePayload
+  loading: boolean
+  onClose: () => void
+}
+
+export function InsumosShareReceivedPanel({ payload, loading, onClose }: InsumosShareReceivedPanelProps) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3 text-sm text-blue-100/80">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="font-semibold text-blue-50">Compartilhamento recebido</div>
+        <Button variant="secondary" size="sm" onClick={onClose}>
+          Fechar
+        </Button>
+      </div>
+      {loading ? <div className="mt-2 text-xs text-blue-200/60">Carregando anexos…</div> : null}
+      <div className="mt-2 space-y-1">
+        {payload.title ? (
+          <div>
+            <span className="text-blue-200/70">Título:</span> {payload.title}
+          </div>
+        ) : null}
+        {payload.text ? (
+          <div>
+            <span className="text-blue-200/70">Texto:</span> {payload.text}
+          </div>
+        ) : null}
+        {payload.url ? (
+          <div className="break-words">
+            <span className="text-blue-200/70">Link:</span>{' '}
+            <a className="underline" href={payload.url} target="_blank" rel="noreferrer">
+              {payload.url}
+            </a>
+          </div>
+        ) : null}
+        {payload.files && payload.files.length ? (
+          <div className="space-y-1">
+            <div className="text-blue-200/70">Arquivos:</div>
+            <div className="flex flex-wrap gap-2">
+              {payload.files.map((file, idx) => (
+                <span key={`${file.name}-${idx}`} className="text-xs">
+                  {file.url ? (
+                    <a className="underline" href={file.url} target="_blank" rel="noreferrer">
+                      {file.name}
+                    </a>
+                  ) : (
+                    file.name
+                  )}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <div className="mt-2 text-xs text-blue-200/60">Preenchi o cadastro com os dados compartilhados. Revise antes de salvar.</div>
+    </div>
+  )
+}
+
+type InsumosShareHistoryPanelProps = {
+  items: ShareHistoryItem[]
+  loading: boolean
+  onClear: () => void
+  onUseItem: (item: ShareHistoryItem) => void
+  onRemoveItem: (id: string) => void
+}
+
+export function InsumosShareHistoryPanel({
+  items,
+  loading,
+  onClear,
+  onUseItem,
+  onRemoveItem,
+}: InsumosShareHistoryPanelProps) {
+  if (!items.length) return null
+  return (
+    <Card className="border border-white/10 bg-black/20">
+      <CardHeader className="flex flex-row items-center justify-between gap-2">
+        <CardTitle className="text-sm text-white">Importações recentes</CardTitle>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-blue-200/60">{items.length} itens</span>
+          <Button variant="secondary" size="sm" onClick={onClear}>
+            Limpar
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {loading ? <div className="text-xs text-blue-200/60">Sincronizando…</div> : null}
+        {items.slice(0, 6).map((item) => (
+          <div key={item.id} className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-sm text-blue-50">{item.title || item.url || 'Conteúdo compartilhado'}</div>
+              <div className="text-xs text-blue-200/60">{fmtDate(item.createdAt)}</div>
+            </div>
+            {item.text ? <div className="mt-1 text-xs text-blue-200/70">{item.text}</div> : null}
+            {item.files && item.files.length ? (
+              <div className="mt-1 flex flex-wrap gap-2 text-xs text-blue-200/70">
+                {item.files.map((file, idx) => (
+                  <span key={`${item.id}-${idx}`} className="break-words">
+                    {file.url ? (
+                      <a className="underline" href={file.url} target="_blank" rel="noreferrer">
+                        {file.name}
+                      </a>
+                    ) : (
+                      file.name
+                    )}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <Button variant="secondary" size="sm" onClick={() => onUseItem(item)}>
+                Usar no cadastro
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => onRemoveItem(item.id)}>
+                Remover
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+type InsumosCreateInlinePanelProps = Omit<
+  InsumosInventoryDialogProps,
+  'open' | 'dialogClassName' | 'query' | 'onQueryChange' | 'onOpenChange' | 'onExport' | 'filteredInsumos' | 'listContainerRef' | 'onListScroll' | 'insumosLoading' | 'insumosLoadError' | 'emptyContent' | 'onEditItem'
+> & {
+  hint: string
+  optionalDetailsOpen: boolean
+  onOptionalDetailsToggle: (open: boolean) => void
+  createEspecificacao: string
+  onCreateEspecificacaoChange: (value: string) => void
+  createConcentracao: string
+  onCreateConcentracaoChange: (value: string) => void
+  createVolume: string
+  onCreateVolumeChange: (value: string) => void
+  createCalibre: string
+  onCreateCalibreChange: (value: string) => void
+  createHomologado: boolean
+  onCreateHomologadoChange: (value: boolean) => void
+}
+
+export function InsumosCreateInlinePanel({
+  createOpen,
+  unit,
+  unitLabel,
+  isAuthed,
+  createLookupLoading,
+  createLookupError,
+  createLookupCount,
+  createScanOpen,
+  onToggleCreateScan,
+  onCloseCreateScan,
+  onCreateBarcodeDetected,
+  createCodigo,
+  onCreateCodigoChange,
+  createCodigosExtras,
+  onCreateCodigosExtrasChange,
+  createProduto,
+  onCreateProdutoChange,
+  createCategoria,
+  onCreateCategoriaChange,
+  createMarca,
+  onCreateMarcaChange,
+  createTipoUnidade,
+  onCreateTipoUnidadeChange,
+  createPrecoCusto,
+  onCreatePrecoCustoChange,
+  createEstoqueMinimo,
+  onCreateEstoqueMinimoChange,
+  createEstoqueInicial,
+  onCreateEstoqueInicialChange,
+  createLote,
+  onCreateLoteChange,
+  createDataValidade,
+  onCreateDataValidadeChange,
+  createNovoLote,
+  onToggleCreateNovoLote,
+  createCategoriaRequiresLot,
+  onCreateCategoriaRequiresLotChange,
+  createCategoriaRequiresExpiry,
+  onCreateCategoriaRequiresExpiryChange,
+  createCategoriaFefo,
+  onCreateCategoriaFefoChange,
+  isManagerRole,
+  lotCategorias,
+  insumosMarcas,
+  insumosTiposUnidade,
+  createLoading,
+  onSaveCreate,
+  onCancelCreate,
+  hint,
+  optionalDetailsOpen,
+  onOptionalDetailsToggle,
+  createEspecificacao,
+  onCreateEspecificacaoChange,
+  createConcentracao,
+  onCreateConcentracaoChange,
+  createVolume,
+  onCreateVolumeChange,
+  createCalibre,
+  onCreateCalibreChange,
+  createHomologado,
+  onCreateHomologadoChange,
+}: InsumosCreateInlinePanelProps) {
+  if (!createOpen) return null
+  return (
+    <div className="space-y-3 rounded-xl border border-white/10 bg-black/20 p-3">
+      <div className="text-sm text-blue-100/70">Cadastro rápido (campos mínimos) + detalhes opcionais (como no app antigo de Insumos).</div>
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Código de barras</div>
+          <div className="flex items-center gap-2">
+            <Input value={createCodigo} onChange={(e) => onCreateCodigoChange(e.target.value)} placeholder="789..." />
+            <Button variant="secondary" type="button" onClick={onToggleCreateScan}>
+              {createScanOpen ? 'Fechar' : 'Escanear'}
+            </Button>
+          </div>
+          <div className="mt-2">
+            {createLookupLoading ? (
+              <div className="text-xs text-blue-200/70">Buscando informações do insumo…</div>
+            ) : createLookupError ? (
+              <div className="text-xs text-red-200">{createLookupError}</div>
+            ) : createLookupCount ? (
+              <div className="text-xs text-blue-200/70">
+                Encontramos um cadastro para este código e pré-preenchemos alguns campos (produto/categoria/marca). Se quiser, você pode cadastrar um novo lote.
+              </div>
+            ) : null}
+          </div>
+          <div className="mt-2">
+            <div className="mb-1 text-xs text-blue-200/70">Códigos adicionais</div>
+            <Textarea
+              value={createCodigosExtras}
+              onChange={(e) => onCreateCodigosExtrasChange(e.target.value)}
+              placeholder="um por linha"
+              rows={3}
+              className="border-white/20 bg-white/[0.06] text-white"
+            />
+            <div className="mt-1 text-[10px] text-blue-200/50">Opcional. Use para variações de código do mesmo produto.</div>
+          </div>
+        </div>
+        <div className="md:col-span-2">
+          <div className="mb-1 text-xs text-blue-200/70">Produto</div>
+          <Input value={createProduto} onChange={(e) => onCreateProdutoChange(e.target.value)} placeholder="Nome do produto" />
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Categoria</div>
+          <Input value={createCategoria} onChange={(e) => onCreateCategoriaChange(e.target.value)} placeholder="ex: Anestésicos" list="insumos-categorias-inline" />
+          <datalist id="insumos-categorias-inline">
+            {lotCategorias.map((categoria) => (
+              <option key={categoria} value={categoria} />
+            ))}
+          </datalist>
+        </div>
+        <div className="md:col-span-2 rounded-xl border border-white/10 bg-black/10 p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-xs text-blue-200/70">Política do item</div>
+            <div className="text-xs text-blue-200/60">Defina as regras para este insumo.</div>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
+            <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+              <Checkbox checked={createCategoriaRequiresLot} onCheckedChange={(value) => onCreateCategoriaRequiresLotChange(!!value)} disabled={!isManagerRole} />
+              Lote obrigatório
+            </label>
+            <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+              <Checkbox checked={createCategoriaRequiresExpiry} onCheckedChange={(value) => onCreateCategoriaRequiresExpiryChange(!!value)} disabled={!isManagerRole} />
+              Validade obrigatória
+            </label>
+            <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+              <Checkbox checked={createCategoriaFefo} onCheckedChange={(value) => onCreateCategoriaFefoChange(!!value)} disabled={!isManagerRole} />
+              FEFO
+            </label>
+            {!isManagerRole ? <span className="text-xs text-blue-200/60">Somente gestores alteram.</span> : null}
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Marca</div>
+          <Input value={createMarca} onChange={(e) => onCreateMarcaChange(e.target.value)} placeholder="ex: Galderma" list="insumos-marcas-inline" />
+          <datalist id="insumos-marcas-inline">
+            {insumosMarcas.map((marca) => (
+              <option key={marca} value={marca} />
+            ))}
+          </datalist>
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Unidade (medida)</div>
+          <Select value={createTipoUnidade || undefined} onValueChange={onCreateTipoUnidadeChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione a unidade" />
+            </SelectTrigger>
+            <SelectContent>
+              {insumosTiposUnidade.map((tipo) => (
+                <SelectItem key={tipo} value={tipo}>
+                  {tipo}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Preço custo</div>
+          <Input value={createPrecoCusto} onChange={(e) => onCreatePrecoCustoChange(e.target.value)} placeholder="R$ 0,00" />
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Estoque inicial ({unitLabel(unit)})</div>
+          <Input value={createEstoqueInicial} onChange={(e) => onCreateEstoqueInicialChange(e.target.value)} type="number" min={0} />
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Estoque mínimo</div>
+          <Input value={createEstoqueMinimo} onChange={(e) => onCreateEstoqueMinimoChange(e.target.value)} type="number" min={0} />
+        </div>
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <div className="text-xs text-blue-200/70">Lote</div>
+            <Button variant={createNovoLote ? 'secondary' : 'outline'} size="sm" type="button" onClick={onToggleCreateNovoLote} title="Ative quando estiver cadastrando um lote adicional para um código já existente.">
+              {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
+            </Button>
+          </div>
+          <Input value={createLote} onChange={(e) => onCreateLoteChange(e.target.value)} placeholder={createNovoLote ? 'obrigatório (ex: L2026-01)' : 'opcional'} />
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-blue-200/70">Validade</div>
+          <BrDatePickerInput value={createDataValidade} onChange={onCreateDataValidadeChange} placeholder="DD/MM/AA" ariaLabel="Validade" />
+        </div>
+      </div>
+
+      {createScanOpen ? <InsumosBarcodeScannerInline onDetected={onCreateBarcodeDetected} onClose={onCloseCreateScan} /> : null}
+      <details
+        open={optionalDetailsOpen}
+        onToggle={(event) => onOptionalDetailsToggle((event.currentTarget as HTMLDetailsElement).open)}
+        className="rounded-lg border border-white/10 bg-black/10 p-3"
+      >
+        <summary className="cursor-pointer select-none text-sm text-blue-100/80">Detalhes (opcional)</summary>
+        <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-3">
+          <div className="md:col-span-2">
+            <div className="mb-1 text-xs text-blue-200/70">Especificação / Modelo</div>
+            <Input value={createEspecificacao} onChange={(e) => onCreateEspecificacaoChange(e.target.value)} placeholder="ex: Base, Lidocaine" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-blue-200/70">Concentração</div>
+            <Input value={createConcentracao} onChange={(e) => onCreateConcentracaoChange(e.target.value)} placeholder="ex: 300U" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-blue-200/70">Volume</div>
+            <Input value={createVolume} onChange={(e) => onCreateVolumeChange(e.target.value)} placeholder="ex: 1ml" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-blue-200/70">Calibre / Bitola</div>
+            <Input value={createCalibre} onChange={(e) => onCreateCalibreChange(e.target.value)} placeholder="ex: 30G" />
+          </div>
+          <div className="md:col-span-2">
+            <div className="mb-1 text-xs text-blue-200/70">Homologado</div>
+            <label className="flex select-none items-center gap-2 text-sm text-blue-100/80">
+              <Checkbox checked={createHomologado} onCheckedChange={(value) => onCreateHomologadoChange(!!value)} />
+              Produto homologado
+            </label>
+          </div>
+        </div>
+      </details>
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs text-blue-200/60">{hint}</div>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={onCancelCreate}>
+            Cancelar
+          </Button>
+          <Button onClick={onSaveCreate} disabled={createLoading || !isAuthed}>
+            {createLoading ? 'Salvando…' : 'Salvar'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type InsumosInventoryWorkspaceTableProps = {
+  items: Insumo[]
+  unit: string
+  unitLabel: (unit: string) => string
+  selectedBarcode: string
+  isAuthed: boolean
+  listContainerRef: React.RefObject<HTMLDivElement | null>
+  onListScroll: (event: React.UIEvent<HTMLDivElement>) => void
+  onSelectBarcode: (barcode: string) => void
+  onEditItem: (item: Insumo) => void
+  onUseItem: (item: Insumo) => void
+  emptyContent: React.ReactNode
+}
+
+export function InsumosInventoryWorkspaceTable({
+  items,
+  unit,
+  unitLabel,
+  selectedBarcode,
+  isAuthed,
+  listContainerRef,
+  onListScroll,
+  onSelectBarcode,
+  onEditItem,
+  onUseItem,
+  emptyContent,
+}: InsumosInventoryWorkspaceTableProps) {
+  return (
+    <div ref={listContainerRef as React.RefObject<HTMLDivElement>} onScroll={onListScroll} className="max-h-[70vh] overflow-auto rounded-xl border border-white/10">
+      <table className="w-full table-fixed text-sm">
+        <thead className="bg-black/30 text-blue-100/80">
+          <tr>
+            <th className="w-[28%] p-3 text-left">Produto</th>
+            <th className="w-[16%] p-3 text-left">Categoria</th>
+            <th className="hidden w-[16%] p-3 text-left lg:table-cell">Código</th>
+            <th className="w-[7%] p-3 text-right">Estoque</th>
+            <th className="w-[7%] p-3 text-right">Mín</th>
+            <th className="hidden w-[10%] p-3 text-left md:table-cell">Validade</th>
+            <th className="hidden w-[8%] p-3 text-right xl:table-cell">Valor</th>
+            <th className="w-[8%] p-3 text-right">Ações</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/5">
+          {items.map((item) => {
+            const codigoBarras = String(item.codigoBarras || '').trim()
+            const isSelected = !!codigoBarras && selectedBarcode.trim() === codigoBarras
+            const estoque = Number(item.estoqueAtual) || 0
+            const min = Number(item.estoqueMinimo) || 0
+            const stockStatus = calcularStatusEstoque(estoque, min)
+            const isCritico = stockStatus === 'URGENTE'
+            const isLowStock = stockStatus === 'ATENCAO'
+            const validadeStatus = String(item.statusValidade?.status || '').toUpperCase()
+            const isVencendo = validadeStatus === 'VENCENDO'
+            const isExpirado = validadeStatus === 'EXPIRADO'
+            const valor = (Number(item.precoCusto) || 0) * estoque
+            const otherStocks = item.estoques
+              ? Object.entries(item.estoques)
+                  .filter(([u, v]) => u !== unit && (Number(v) || 0) > 0)
+                  .sort((a, b) => (Number(b[1]) || 0) - (Number(a[1]) || 0))
+              : []
+            const otherSummary = otherStocks.length
+              ? `${otherStocks
+                  .slice(0, 2)
+                  .map(([u, v]) => `${unitLabel(u)}: ${Number(v) || 0}`)
+                  .join(' • ')}${otherStocks.length > 2 ? ` • +${otherStocks.length - 2}` : ''}`
+              : ''
+            return (
+              <tr key={`${item.registro || ''}-${item.codigoBarras || ''}`} className={isSelected ? 'bg-white/5 hover:bg-white/10' : 'hover:bg-white/5'}>
+                <td className="min-w-0 p-3 align-top">
+                  <button
+                    type="button"
+                    className="group w-full cursor-pointer rounded-sm text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                    onClick={() => {
+                      if (!codigoBarras) return
+                      onSelectBarcode(codigoBarras)
+                    }}
+                    title={codigoBarras ? 'Ver movimentações deste insumo' : undefined}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="flex min-w-0 items-center justify-between gap-2">
+                      <div className="line-clamp-2 break-words text-blue-50 group-hover:underline">{item.produto || '-'}</div>
+                      {isSelected ? <div className="text-xs text-blue-200/60">Filtrando</div> : null}
+                    </div>
+                    {item.marca ? (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        <Badge style={buildTagStyle(getMarcaBgColor(String(item.marca)))} className="border">
+                          {String(item.marca)}
+                        </Badge>
+                      </div>
+                    ) : null}
+                    {isCritico || isLowStock || isVencendo || isExpirado ? (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {isCritico ? <Badge variant="destructive">Crítico</Badge> : null}
+                        {isLowStock ? <Badge variant="secondary">Atenção</Badge> : null}
+                        {isVencendo ? <Badge variant="secondary">Vencendo</Badge> : null}
+                        {isExpirado ? <Badge variant="destructive">Expirado</Badge> : null}
+                      </div>
+                    ) : null}
+                  </button>
+                </td>
+                <td className="p-3 align-top text-blue-100/80">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Badge style={buildTagStyle(getCategoriaBgColor(item.categoria || 'Outros'))} className="border">
+                      {item.categoria || '-'}
+                    </Badge>
+                  </div>
+                </td>
+                <td className="hidden p-3 align-top lg:table-cell">
+                  <div className="break-all font-mono text-blue-100/80">{item.codigoBarras || '-'}</div>
+                </td>
+                <td className={`p-3 align-top text-right ${isCritico ? 'text-red-200' : 'text-blue-100/80'}`}>
+                  <div className="flex items-center justify-end gap-2">
+                    <span className="font-mono">{estoque}</span>
+                  </div>
+                  {otherSummary ? <div className="mt-1 text-[11px] text-blue-200/50">{otherSummary}</div> : null}
+                </td>
+                <td className="p-3 align-top text-right text-blue-100/70">{min || '-'}</td>
+                <td className="hidden p-3 align-top text-blue-100/70 md:table-cell">
+                  <span>{fmtDateOnlyBR(item.dataValidade || '')}</span>
+                </td>
+                <td className="hidden p-3 align-top text-right text-blue-100/80 xl:table-cell">{fmtMoneyBRL(valor)}</td>
+                <td className="p-3 align-top text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button variant="secondary" className="h-8 px-2 text-xs" onClick={() => onUseItem(item)}>
+                      Usar
+                    </Button>
+                    <Button variant="outline" className="h-8 px-2 text-xs" onClick={() => onEditItem(item)} disabled={!isAuthed}>
+                      Editar
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+          {!items.length ? (
+            <tr>
+              <td className="p-3 text-blue-100/70" colSpan={8}>
+                {emptyContent}
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+type InsumosEditValidationKey =
+  | 'codigoBarras'
+  | 'produto'
+  | 'categoria'
+  | 'marca'
+  | 'tipoUnidade'
+  | 'lote'
+  | 'dataValidade'
+  | 'policy'
+
+type InsumosEditValidationErrors = Partial<Record<InsumosEditValidationKey, string>>
+
+type InsumosEditDialogProps = {
+  open: boolean
+  dialogClassName: string
+  target: Insumo | null
+  isAuthed: boolean
+  canUseApi: boolean
+  isManagerRole: boolean
+  saving: boolean
+  saveError: string | null
+  validationErrors: InsumosEditValidationErrors
+  codigo: string
+  codigosExtras: string
+  produto: string
+  categoria: string
+  categoriaRequiresLot: boolean
+  categoriaRequiresExpiry: boolean
+  categoriaFefo: boolean
+  marca: string
+  tipoUnidade: string
+  especificacao: string
+  concentracao: string
+  volume: string
+  homologado: boolean
+  calibre: string
+  precoCusto: string
+  estoqueMinimo: string
+  lote: string
+  dataValidade: string
+  optionalDetailsOpen: boolean
+  lotCategorias: string[]
+  insumosMarcas: string[]
+  insumosTiposUnidade: string[]
+  onOpenChange: (open: boolean) => void
+  onClearValidationError: (key: InsumosEditValidationKey) => void
+  onCodigoChange: (value: string) => void
+  onCodigosExtrasChange: (value: string) => void
+  onProdutoChange: (value: string) => void
+  onCategoriaChange: (value: string) => void
+  onCategoriaRequiresLotChange: (value: boolean) => void
+  onCategoriaRequiresExpiryChange: (value: boolean) => void
+  onCategoriaFefoChange: (value: boolean) => void
+  onMarcaChange: (value: string) => void
+  onTipoUnidadeChange: (value: string) => void
+  onEspecificacaoChange: (value: string) => void
+  onConcentracaoChange: (value: string) => void
+  onVolumeChange: (value: string) => void
+  onHomologadoChange: (value: boolean) => void
+  onCalibreChange: (value: string) => void
+  onPrecoCustoChange: (value: string) => void
+  onEstoqueMinimoChange: (value: string) => void
+  onLoteChange: (value: string) => void
+  onDataValidadeChange: (value: string) => void
+  onOptionalDetailsToggle: (open: boolean) => void
+  onCancel: () => void
+  onDelete: () => void
+  onSave: () => void
+}
+
+export function InsumosEditDialog({
+  open,
+  dialogClassName,
+  target,
+  isAuthed,
+  canUseApi,
+  isManagerRole,
+  saving,
+  saveError,
+  validationErrors,
+  codigo,
+  codigosExtras,
+  produto,
+  categoria,
+  categoriaRequiresLot,
+  categoriaRequiresExpiry,
+  categoriaFefo,
+  marca,
+  tipoUnidade,
+  especificacao,
+  concentracao,
+  volume,
+  homologado,
+  calibre,
+  precoCusto,
+  estoqueMinimo,
+  lote,
+  dataValidade,
+  optionalDetailsOpen,
+  lotCategorias,
+  insumosMarcas,
+  insumosTiposUnidade,
+  onOpenChange,
+  onClearValidationError,
+  onCodigoChange,
+  onCodigosExtrasChange,
+  onProdutoChange,
+  onCategoriaChange,
+  onCategoriaRequiresLotChange,
+  onCategoriaRequiresExpiryChange,
+  onCategoriaFefoChange,
+  onMarcaChange,
+  onTipoUnidadeChange,
+  onEspecificacaoChange,
+  onConcentracaoChange,
+  onVolumeChange,
+  onHomologadoChange,
+  onCalibreChange,
+  onPrecoCustoChange,
+  onEstoqueMinimoChange,
+  onLoteChange,
+  onDataValidadeChange,
+  onOptionalDetailsToggle,
+  onCancel,
+  onDelete,
+  onSave,
+}: InsumosEditDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={dialogClassName}>
+        <DialogHeader>
+          <DialogTitle>Editar insumo</DialogTitle>
+          <DialogDescription className="break-words">
+            {target?.produto || '-'} • <span className="font-mono break-all">{target?.codigoBarras || '-'}</span>
+            {target?.registro ? <span className="break-all"> • Reg {target.registro}</span> : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {saveError ? <div className="mt-2 rounded-lg border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-100">{saveError}</div> : null}
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Código de barras</div>
+            <Input
+              value={codigo}
+              onChange={(event) => {
+                onCodigoChange(event.target.value)
+                onClearValidationError('codigoBarras')
+              }}
+              placeholder="789..."
+              aria-invalid={validationErrors.codigoBarras ? true : undefined}
+              className={validationErrors.codigoBarras ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.codigoBarras ? <div className="mt-1 text-xs text-red-300">{validationErrors.codigoBarras}</div> : null}
+          </div>
+          <div className="md:col-span-2">
+            <div className="mb-1 text-xs text-muted-foreground">Códigos adicionais</div>
+            <Textarea
+              value={codigosExtras}
+              onChange={(event) => onCodigosExtrasChange(event.target.value)}
+              placeholder="um por linha"
+              rows={3}
+              className="border-white/20 bg-white/[0.06] text-white"
+            />
+            <div className="mt-1 text-[10px] text-muted-foreground">Opcional. Use para variações de código do mesmo produto.</div>
+          </div>
+          <div className="md:col-span-2">
+            <div className="mb-1 text-xs text-muted-foreground">Produto</div>
+            <Input
+              value={produto}
+              onChange={(event) => {
+                onProdutoChange(event.target.value)
+                onClearValidationError('produto')
+              }}
+              placeholder="Nome do produto"
+              aria-invalid={validationErrors.produto ? true : undefined}
+              className={validationErrors.produto ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.produto ? <div className="mt-1 text-xs text-red-300">{validationErrors.produto}</div> : null}
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Categoria</div>
+            <AutocompleteInput
+              value={categoria}
+              onValueChange={(value) => {
+                onCategoriaChange(value)
+                onClearValidationError('categoria')
+              }}
+              placeholder="ex: toxina"
+              options={lotCategorias}
+              inputTestId="insumos-edit-categoria"
+              ariaInvalid={validationErrors.categoria ? true : undefined}
+              inputClassName={validationErrors.categoria ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.categoria ? <div className="mt-1 text-xs text-red-300">{validationErrors.categoria}</div> : null}
+          </div>
+          <div className={`rounded-xl border p-3 md:col-span-2 ${validationErrors.policy ? 'border-red-500/50 bg-red-500/5' : 'border-white/10 bg-black/10'}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground">Política do item</div>
+              <div className="text-xs text-muted-foreground">Defina as regras para este insumo.</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-blue-100/80">
+              <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                <Checkbox
+                  checked={categoriaRequiresLot}
+                  onCheckedChange={(value) => {
+                    onCategoriaRequiresLotChange(!!value)
+                    onClearValidationError('policy')
+                    onClearValidationError('lote')
+                  }}
+                  disabled={!isManagerRole}
+                />
+                Lote obrigatório
+              </label>
+              <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                <Checkbox
+                  checked={categoriaRequiresExpiry}
+                  onCheckedChange={(value) => {
+                    onCategoriaRequiresExpiryChange(!!value)
+                    onClearValidationError('policy')
+                    onClearValidationError('dataValidade')
+                  }}
+                  disabled={!isManagerRole}
+                />
+                Validade obrigatória
+              </label>
+              <label className={`flex select-none items-center gap-2 ${isManagerRole ? 'cursor-pointer' : 'cursor-default'}`}>
+                <Checkbox
+                  checked={categoriaFefo}
+                  onCheckedChange={(value) => {
+                    onCategoriaFefoChange(!!value)
+                    onClearValidationError('policy')
+                  }}
+                  disabled={!isManagerRole}
+                />
+                FEFO
+              </label>
+              {!isManagerRole ? <span className="text-xs text-muted-foreground">Somente gestores alteram.</span> : null}
+            </div>
+            {validationErrors.policy ? <div className="mt-2 text-xs text-red-300">{validationErrors.policy}</div> : null}
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Marca</div>
+            <AutocompleteInput
+              value={marca}
+              onValueChange={(value) => {
+                onMarcaChange(value)
+                onClearValidationError('marca')
+              }}
+              placeholder="ex: Allergan"
+              options={insumosMarcas}
+              inputTestId="insumos-edit-marca"
+              ariaInvalid={validationErrors.marca ? true : undefined}
+              inputClassName={validationErrors.marca ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.marca ? <div className="mt-1 text-xs text-red-300">{validationErrors.marca}</div> : null}
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Unidade (medida)</div>
+            <Select
+              value={normalizeTipoUnidadeToCanonical(tipoUnidade) || undefined}
+              onValueChange={(value) => {
+                onTipoUnidadeChange(value)
+                onClearValidationError('tipoUnidade')
+              }}
+            >
+              <SelectTrigger aria-invalid={validationErrors.tipoUnidade ? true : undefined} className={validationErrors.tipoUnidade ? 'border-red-500/60 ring-2 ring-red-500/15' : undefined}>
+                <SelectValue placeholder="Selecione a unidade" />
+              </SelectTrigger>
+              <SelectContent>
+                {insumosTiposUnidade.map((tipo) => (
+                  <SelectItem key={tipo} value={tipo}>
+                    {tipo}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {validationErrors.tipoUnidade ? <div className="mt-1 text-xs text-red-300">{validationErrors.tipoUnidade}</div> : null}
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Preço custo (R$)</div>
+            <Input value={precoCusto} onChange={(event) => onPrecoCustoChange(event.target.value)} placeholder="ex: 120,00" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Estoque mínimo</div>
+            <Input value={estoqueMinimo} onChange={(event) => onEstoqueMinimoChange(event.target.value)} placeholder="ex: 5" />
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Lote</div>
+            <Input
+              value={lote}
+              onChange={(event) => {
+                onLoteChange(event.target.value)
+                onClearValidationError('lote')
+              }}
+              placeholder="ex: L2026-01"
+              aria-invalid={validationErrors.lote ? true : undefined}
+              className={validationErrors.lote ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.lote ? <div className="mt-1 text-xs text-red-300">{validationErrors.lote}</div> : null}
+          </div>
+          <div>
+            <div className="mb-1 text-xs text-muted-foreground">Validade</div>
+            <BrDatePickerInput
+              value={dataValidade}
+              onChange={(value) => {
+                onDataValidadeChange(value)
+                onClearValidationError('dataValidade')
+              }}
+              placeholder="DD/MM/AA"
+              ariaLabel="Validade"
+              className={validationErrors.dataValidade ? 'border-red-500/60 focus:border-red-500/60 focus:ring-red-500/25' : undefined}
+            />
+            {validationErrors.dataValidade ? <div className="mt-1 text-xs text-red-300">{validationErrors.dataValidade}</div> : null}
+          </div>
+        </div>
+
+        <details
+          open={optionalDetailsOpen}
+          onToggle={(event) => onOptionalDetailsToggle((event.currentTarget as HTMLDetailsElement).open)}
+          className="mt-2 rounded-lg border border-white/10 bg-black/10 p-3"
+        >
+          <summary className="cursor-pointer select-none text-sm text-blue-100/80">Detalhes (opcional)</summary>
+          <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-3">
+            <div className="md:col-span-2">
+              <div className="mb-1 text-xs text-muted-foreground">Especificação / Modelo</div>
+              <Input value={especificacao} onChange={(event) => onEspecificacaoChange(event.target.value)} placeholder="ex: Base, Lidocaine" />
+            </div>
+            <div>
+              <div className="mb-1 text-xs text-muted-foreground">Concentração</div>
+              <Input value={concentracao} onChange={(event) => onConcentracaoChange(event.target.value)} placeholder="ex: 300U" />
+            </div>
+            <div>
+              <div className="mb-1 text-xs text-muted-foreground">Volume</div>
+              <Input value={volume} onChange={(event) => onVolumeChange(event.target.value)} placeholder="ex: 1ml" />
+            </div>
+            <div>
+              <div className="mb-1 text-xs text-muted-foreground">Calibre / Bitola</div>
+              <Input value={calibre} onChange={(event) => onCalibreChange(event.target.value)} placeholder="ex: 30G" />
+            </div>
+            <div className="md:col-span-2">
+              <div className="mb-1 text-xs text-muted-foreground">Homologado</div>
+              <label className="flex select-none items-center gap-2 text-sm text-blue-100/80">
+                <Checkbox checked={homologado} onCheckedChange={(value) => onHomologadoChange(!!value)} />
+                Produto homologado
+              </label>
+            </div>
+          </div>
+        </details>
+
+        <DialogFooter>
+          {!canUseApi ? <span className="mr-auto text-xs text-muted-foreground">API indisponivel. Aguarde o carregamento.</span> : null}
+          <Button variant="secondary" onClick={onCancel} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button variant="destructive" onClick={onDelete} disabled={saving || !isAuthed}>
+            Excluir
+          </Button>
+          <Button onClick={onSave} disabled={saving || !isAuthed || !canUseApi}>
+            {saving ? 'Salvando…' : 'Salvar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type InsumosCategoryPoliciesPanelProps = {
+  panelOpen: boolean
+  isAuthed: boolean
+  policyFormLabel: string
+  policyFormSlug: string
+  policyFormSlugPlaceholder: string
+  policyFormSuggestion: string
+  policyFormEditingSlug: string | null
+  policyFormRequiresLot: boolean
+  policyFormRequiresExpiry: boolean
+  policyFormFefo: boolean
+  adminCategorySuggestions: CategoryPolicySuggestion[]
+  adminCategoryPolicies: CategoryPolicy[]
+  adminCategoryPoliciesLoading: boolean
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>
+  onToggleOpen: () => void
+  onPolicyFormLabelChange: (value: string) => void
+  onPolicyFormSlugChange: (value: string) => void
+  onPolicyFormSuggestionChange: (value: string) => void
+  onPolicyFormRequiresLotChange: (value: boolean) => void
+  onPolicyFormRequiresExpiryChange: (value: boolean) => void
+  onPolicyFormFefoChange: (value: boolean) => void
+  onResetPolicyForm: () => void
+  onSaveCategoryPolicy: () => void
+  onStartEditPolicyForm: (policy: CategoryPolicy) => void
+  onDeleteCategoryPolicy: (slug: string) => void
+}
+
+export function InsumosCategoryPoliciesPanel({
+  panelOpen,
+  isAuthed,
+  policyFormLabel,
+  policyFormSlug,
+  policyFormSlugPlaceholder,
+  policyFormSuggestion,
+  policyFormEditingSlug,
+  policyFormRequiresLot,
+  policyFormRequiresExpiry,
+  policyFormFefo,
+  adminCategorySuggestions,
+  adminCategoryPolicies,
+  adminCategoryPoliciesLoading,
+  dragHandleProps,
+  onToggleOpen,
+  onPolicyFormLabelChange,
+  onPolicyFormSlugChange,
+  onPolicyFormSuggestionChange,
+  onPolicyFormRequiresLotChange,
+  onPolicyFormRequiresExpiryChange,
+  onPolicyFormFefoChange,
+  onResetPolicyForm,
+  onSaveCategoryPolicy,
+  onStartEditPolicyForm,
+  onDeleteCategoryPolicy,
+}: InsumosCategoryPoliciesPanelProps) {
+  return (
+    <Card className="border border-white/10 bg-black/20">
+      <CardHeader className="relative pr-24">
+        <CardTitle className="text-base text-white">Políticas por categoria</CardTitle>
+        <div className="absolute right-2 top-2 flex items-center gap-1">
+          <div
+            {...dragHandleProps}
+            className="flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+            title="Arraste para mover"
+            aria-label="Mover"
+            role="button"
+            tabIndex={0}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+            </svg>
+          </div>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+            onClick={onToggleOpen}
+            title={panelOpen ? 'Contrair' : 'Expandir'}
+            aria-label={panelOpen ? 'Contrair' : 'Expandir'}
+          >
+            {panelOpen ? (
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            ) : (
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </Button>
+        </div>
+      </CardHeader>
+      {panelOpen ? (
+        <CardContent className="space-y-3">
+          <div className="text-xs text-blue-200/60">
+            Configure quais categorias exigem <span className="font-medium text-blue-100/80">lote</span> e/ou <span className="font-medium text-blue-100/80">validade</span>, e habilite <span className="font-medium text-blue-100/80">FEFO</span> quando aplicável.
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-white/10 bg-black/10 p-3">
+            <div className="grid grid-cols-1 items-end gap-2 md:grid-cols-3">
+              <div className="md:col-span-2">
+                <div className="mb-1 text-xs text-blue-200/70">Categoria (nome)</div>
+                <Input value={policyFormLabel} onChange={(event) => onPolicyFormLabelChange(event.target.value)} placeholder="Ex: Toxina botulínica" disabled={!isAuthed} />
+              </div>
+              <div>
+                <div className="mb-1 text-xs text-blue-200/70">Slug (opcional)</div>
+                <Input value={policyFormSlug} onChange={(event) => onPolicyFormSlugChange(event.target.value)} placeholder={policyFormSlugPlaceholder} disabled={!isAuthed} />
+              </div>
+            </div>
+
+            {adminCategorySuggestions.length ? (
+              <div className="grid grid-cols-1 items-end gap-2 md:grid-cols-3">
+                <div className="md:col-span-2">
+                  <div className="mb-1 text-xs text-blue-200/70">Sugestões (já usadas em itens)</div>
+                  <Select value={policyFormSuggestion} onValueChange={onPolicyFormSuggestionChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Escolher…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__NONE__">(nenhuma)</SelectItem>
+                      {adminCategorySuggestions.map((suggestion) => (
+                        <SelectItem key={suggestion.slug} value={suggestion.slug}>
+                          {suggestion.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="text-xs text-blue-200/60">
+                  {policyFormEditingSlug ? <Badge variant="secondary">Editando: {policyFormEditingSlug}</Badge> : <Badge variant="secondary">Nova política</Badge>}
+                </div>
+              </div>
+            ) : policyFormEditingSlug ? (
+              <div className="text-xs text-blue-200/60">
+                <Badge variant="secondary">Editando: {policyFormEditingSlug}</Badge>
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-4">
+              <div className="flex items-center gap-2">
+                <Checkbox id="policy-requires-lot" checked={policyFormRequiresLot} onCheckedChange={(checked) => onPolicyFormRequiresLotChange(!!checked)} />
+                <label htmlFor="policy-requires-lot" className="cursor-pointer text-sm text-blue-100/80">
+                  Lote obrigatório
+                </label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox id="policy-requires-expiry" checked={policyFormRequiresExpiry} onCheckedChange={(checked) => onPolicyFormRequiresExpiryChange(!!checked)} />
+                <label htmlFor="policy-requires-expiry" className="cursor-pointer text-sm text-blue-100/80">
+                  Validade obrigatória
+                </label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox id="policy-fefo" checked={policyFormFefo} onCheckedChange={(checked) => onPolicyFormFefoChange(!!checked)} />
+                <label htmlFor="policy-fefo" className="cursor-pointer text-sm text-blue-100/80">
+                  FEFO (sugere lote por validade)
+                </label>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-2">
+              <Button variant="outline" onClick={onResetPolicyForm} disabled={!isAuthed}>
+                Limpar
+              </Button>
+              <Button className="!bg-blue-600 !text-white hover:!bg-blue-700" onClick={onSaveCategoryPolicy} disabled={!isAuthed}>
+                {policyFormEditingSlug ? 'Salvar alterações' : 'Criar política'}
+              </Button>
+            </div>
+          </div>
+
+          <div className="overflow-auto rounded-xl border border-white/10">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  <th className="w-[34%] p-3 text-left">Categoria</th>
+                  <th className="w-[46%] p-3 text-left">Regras</th>
+                  <th className="w-[20%] p-3 text-right">Ações</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {adminCategoryPolicies.map((policy) => (
+                  <tr key={policy.slug} className="hover:bg-white/5">
+                    <td className="p-3 text-blue-50">
+                      <div className="text-blue-50">{policy.label || policy.slug}</div>
+                      <div className="font-mono text-xs text-blue-200/60">{policy.slug}</div>
+                    </td>
+                    <td className="p-3">
+                      <div className="flex flex-wrap gap-2">
+                        {policy.requiresLot ? <Badge variant="secondary">lote</Badge> : <Badge variant="secondary">lote opcional</Badge>}
+                        {policy.requiresExpiry ? <Badge variant="secondary">validade</Badge> : <Badge variant="secondary">validade opcional</Badge>}
+                        {policy.fefo ? <Badge>FEFO</Badge> : <Badge variant="secondary">sem FEFO</Badge>}
+                      </div>
+                    </td>
+                    <td className="p-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button variant="outline" className="h-8 px-2" onClick={() => onStartEditPolicyForm(policy)}>
+                          Editar
+                        </Button>
+                        <Button variant="destructive" className="h-8 px-2" onClick={() => onDeleteCategoryPolicy(policy.slug)}>
+                          Remover
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {!adminCategoryPoliciesLoading && !adminCategoryPolicies.length ? (
+                  <tr>
+                    <td className="p-3 text-blue-100/70" colSpan={3}>
+                      Sem políticas cadastradas.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}
+
+type AlertasStatusFilter = 'TODOS' | 'ATENCAO' | 'URGENTE' | 'VENCENDO' | 'EXPIRADO' | 'INFO'
+type AlertasFluxoFilter = 'TODOS' | 'ENTRADA' | 'SAIDA' | 'DESCARTE' | 'TRANSFERENCIA'
+type AlertasSortKey = 'produto' | 'categoria' | 'status' | 'acao' | 'atual' | 'min' | 'dif' | 'percentual'
+
+type AlertasLinha = {
+  key: string
+  codigoBarras?: string
+  produto?: string
+  categoria?: string
+  marca?: string
+  qualityIssue?: QualityIssue
+  qualityMessage?: string
+  qualitySeverity?: string
+  estoqueAtual?: number
+  estoqueMinimo?: number
+  diferenca?: number
+  percentual?: number | null
+  dataValidade?: string | null
+  dias?: number | null
+  tags: AlertaStatusTag[]
+}
+
+type AlertasRecommendation =
+  | { kind: 'TRANSFERENCIA'; fromUnidade?: string | null; toUnidade?: string | null; qty?: number | null }
+  | { kind: 'ENTRADA'; qty?: number | null }
+
+type InsumosAlertsPanelProps = {
+  panelOpen: boolean
+  dragHandleProps?: Record<string, any>
+  showOverviewLoadingProgress: boolean
+  loadingPercent: number
+  overviewCriticosCount: number | null
+  overviewAtencaoCount: number | null
+  alertasStatus: AlertasStatusFilter
+  alertasCategoria: string
+  alertasFluxo: AlertasFluxoFilter
+  alertasBusca: string
+  alertasCategorias: string[]
+  alertasSortKey: AlertasSortKey
+  alertasSortDir: 'asc' | 'desc'
+  rows: AlertasLinha[]
+  recommendationByCode: Map<string, AlertasRecommendation>
+  purchaseDisabled: boolean
+  isAuthed: boolean
+  emptyContent: React.ReactNode
+  onToggleOpen: () => void
+  onOpenPurchaseDialog: () => void
+  onAlertasStatusChange: (value: AlertasStatusFilter) => void
+  onAlertasCategoriaChange: (value: string) => void
+  onAlertasFluxoChange: (value: AlertasFluxoFilter) => void
+  onAlertasBuscaChange: (value: string) => void
+  onSortChange: (key: AlertasSortKey) => void
+  onSelectBarcode: (code: string) => void
+  onToggleMarcaFilter: (value: string) => void
+  onToggleCategoriaFilter: (value: string) => void
+  onToggleStatusFilter: (value: AlertaStatusTag) => void
+  onOpenQuickOperation: (
+    op: InsumosQuickOperation,
+    prefill?: { codigoBarras?: string | null; quantidade?: number | string | null; obs?: string | null; fromUnidade?: string | null; toUnidade?: string | null }
+  ) => void
+  onOpenQualityFix: (issue: QualityIssue) => void
+}
+
+export function InsumosAlertsPanel({
+  panelOpen,
+  dragHandleProps,
+  showOverviewLoadingProgress,
+  loadingPercent,
+  overviewCriticosCount,
+  overviewAtencaoCount,
+  alertasStatus,
+  alertasCategoria,
+  alertasFluxo,
+  alertasBusca,
+  alertasCategorias,
+  alertasSortKey,
+  alertasSortDir,
+  rows,
+  recommendationByCode,
+  purchaseDisabled,
+  isAuthed,
+  emptyContent,
+  onToggleOpen,
+  onOpenPurchaseDialog,
+  onAlertasStatusChange,
+  onAlertasCategoriaChange,
+  onAlertasFluxoChange,
+  onAlertasBuscaChange,
+  onSortChange,
+  onSelectBarcode,
+  onToggleMarcaFilter,
+  onToggleCategoriaFilter,
+  onToggleStatusFilter,
+  onOpenQuickOperation,
+  onOpenQualityFix,
+}: InsumosAlertsPanelProps) {
+  const columns: Array<{ key: AlertasSortKey; label: string; align: string; widthClass?: string }> = [
+    { key: 'produto', label: 'Produto', align: 'text-left', widthClass: 'w-[24%]' },
+    { key: 'categoria', label: 'Categoria', align: 'text-left', widthClass: 'w-[14%]' },
+    { key: 'status', label: 'Status', align: 'text-left', widthClass: 'w-[14%]' },
+    { key: 'acao', label: 'Ação recomendada', align: 'text-left', widthClass: 'w-[20%]' },
+    { key: 'atual', label: 'Atual', align: 'text-right', widthClass: 'w-[8%]' },
+    { key: 'min', label: 'Mín', align: 'text-right hidden sm:table-cell', widthClass: 'w-[6%]' },
+    { key: 'dif', label: 'Dif', align: 'text-right hidden lg:table-cell', widthClass: 'w-[7%]' },
+    { key: 'percentual', label: '%', align: 'text-right hidden lg:table-cell', widthClass: 'w-[7%]' },
+  ]
+
+  return (
+    <Card className="border border-white/10 bg-black/20">
+      <CardHeader className="flex flex-col gap-2">
+        <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              {...dragHandleProps}
+              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+              title="Arraste para mover"
+              aria-label="Mover"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+              </svg>
+            </button>
+            <CardTitle className="text-base text-white">Avisos</CardTitle>
+            <div className="hidden items-center gap-3 text-xs text-blue-200/70 sm:flex">
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/40 text-red-50" title="Crítico" aria-label="Crítico">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M12 7v7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                    <circle cx="12" cy="17" r="1.5" fill="currentColor" />
+                  </svg>
+                </span>
+                <span className="font-mono text-blue-50">
+                  {showOverviewLoadingProgress ? (
+                    <span className="inline-flex items-center gap-2">
+                      <span className="inline-flex h-3 w-3 animate-spin rounded-full border border-blue-200/70 border-t-transparent" />
+                      {loadingPercent}%
+                    </span>
+                  ) : (
+                    overviewCriticosCount ?? '-'
+                  )}
+                </span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500/35 text-amber-100" title="Atenção" aria-label="Atenção">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M12 3l9 16H3l9-16z" fill="currentColor" fillOpacity="0.45" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+                    <path d="M12 9v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <circle cx="12" cy="16.5" r="1.2" fill="currentColor" />
+                  </svg>
+                </span>
+                <span className="font-mono text-blue-50">
+                  {showOverviewLoadingProgress ? (
+                    <span className="inline-flex items-center gap-2">
+                      <span className="inline-flex h-3 w-3 animate-spin rounded-full border border-blue-200/70 border-t-transparent" />
+                      {loadingPercent}%
+                    </span>
+                  ) : (
+                    overviewAtencaoCount ?? '-'
+                  )}
+                </span>
+              </span>
+            </div>
+          </div>
+          <div className="ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
+            <Select value={alertasStatus} onValueChange={(value) => onAlertasStatusChange(value as AlertasStatusFilter)}>
+              <SelectTrigger className="h-8 w-24 shrink-0">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="TODOS">–</SelectItem>
+                <SelectItem value="ATENCAO">Atenção</SelectItem>
+                <SelectItem value="URGENTE">Crítico</SelectItem>
+                <SelectItem value="INFO">Info</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={alertasCategoria || '__ALL__'} onValueChange={(value) => onAlertasCategoriaChange(value === '__ALL__' ? '' : String(value))}>
+              <SelectTrigger className="h-8 w-36 shrink-0">
+                <SelectValue placeholder="Categoria" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                {alertasCategorias.map((categoria) => (
+                  <SelectItem key={categoria} value={categoria}>
+                    {categoria}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={alertasFluxo} onValueChange={(value) => onAlertasFluxoChange(value as AlertasFluxoFilter)}>
+              <SelectTrigger className="h-8 w-28 shrink-0">
+                <SelectValue placeholder="Fluxo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="TODOS">–</SelectItem>
+                <SelectItem value="ENTRADA">Entrada</SelectItem>
+                <SelectItem value="SAIDA">Saída</SelectItem>
+                <SelectItem value="DESCARTE">Descarte</SelectItem>
+                <SelectItem value="TRANSFERENCIA">Transferência</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input value={alertasBusca} onChange={(event) => onAlertasBuscaChange(event.target.value)} placeholder="Buscar" className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0" />
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                onClick={onOpenPurchaseDialog}
+                disabled={purchaseDisabled}
+                title="Lista de compra"
+                aria-label="Lista de compra"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.6a2 2 0 0 0 2-1.6L21 8H7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                  <circle cx="9" cy="20" r="1.6" fill="currentColor" />
+                  <circle cx="17" cy="20" r="1.6" fill="currentColor" />
+                </svg>
+              </Button>
+              <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} title={panelOpen ? 'Contrair' : 'Expandir'} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
+                {panelOpen ? (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                ) : (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {panelOpen ? (
+        <CardContent className="space-y-2">
+          <div className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+            <table className="w-full table-fixed text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  {columns.map((column) => {
+                    const isActive = alertasSortKey === column.key
+                    return (
+                      <th key={column.label} className={`sticky top-0 z-10 bg-black/40 p-3 backdrop-blur ${column.align} ${column.widthClass || ''}`}>
+                        <button
+                          type="button"
+                          className={`inline-flex w-full items-center gap-2 rounded-sm px-0.5 ${column.align.includes('right') ? 'justify-end' : 'justify-start'} cursor-pointer select-none ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40`}
+                          onClick={() => onSortChange(column.key)}
+                          aria-label={`Ordenar ${column.label}`}
+                          title={`Ordenar ${column.label}`}
+                        >
+                          <span>{column.label}</span>
+                          <span className={`inline-flex items-center justify-center ${isActive ? 'text-white' : 'text-blue-100/30'}`} aria-hidden>
+                            {isActive && alertasSortDir === 'asc' ? (
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            ) : (
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            )}
+                          </span>
+                        </button>
+                      </th>
+                    )
+                  })}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {rows.slice(0, 120).map((row, index) => {
+                  const code = String(row.codigoBarras || '').trim()
+                  const recommendation = code ? recommendationByCode.get(code) || null : null
+                  const canQuick = !!code && isAuthed
+                  const qualityIssue = row.qualityIssue
+                  const qualityMessage = String(row.qualityMessage || '').trim()
+                  const qualitySeverity = row.qualitySeverity || (qualityIssue as any)?.severity
+                  const canQualityEdit = !!qualityIssue && isAuthed && (!!qualityIssue.registro || !!qualityIssue.codigoBarras || !!qualityIssue.produto)
+                  const hasQualityAction = !!qualityIssue
+                  const isVencendo = row.tags.includes('VENCENDO')
+                  const isExpirado = row.tags.includes('EXPIRADO')
+                  const hasExpiringAction = !recommendation && (isExpirado || isVencendo)
+                  const hasAnyAction = !!recommendation || hasExpiringAction || hasQualityAction
+                  const displayTagsSet = new Set<AlertaStatusTag>()
+                  if (row.tags.includes('URGENTE') || isExpirado) displayTagsSet.add('URGENTE')
+                  if (row.tags.includes('ATENCAO') || isVencendo) displayTagsSet.add('ATENCAO')
+                  if (row.tags.includes('INFO')) displayTagsSet.add('INFO')
+                  const displayTags = Array.from(displayTagsSet)
+
+                  return (
+                    <tr
+                      key={`${row.key}-${index}`}
+                      className={`hover:bg-white/5 ${row.codigoBarras ? 'cursor-pointer' : ''}`}
+                      onClick={() => {
+                        if (code) onSelectBarcode(code)
+                      }}
+                      title={row.codigoBarras ? 'Clique para usar este código de barras' : undefined}
+                    >
+                      <td className="p-3 align-top text-blue-50">
+                        <div className="flex flex-wrap items-center gap-2 break-words text-blue-50">
+                          <span>{row.produto || '-'}</span>
+                          {isVencendo ? <Badge variant="secondary" className="h-4 border px-1 py-0 text-[10px] leading-4">Venc.</Badge> : null}
+                          {isExpirado ? <Badge variant="destructive" className="h-4 border px-1 py-0 text-[10px] leading-4">Exp.</Badge> : null}
+                        </div>
+                        <div className="hidden break-all font-mono text-xs text-blue-200/60 md:block">{row.codigoBarras || '-'}</div>
+                        {row.marca ? (
+                          <div className="mt-1">
+                            <Badge
+                              style={buildTagStyle(getMarcaBgColor(row.marca))}
+                              className="cursor-pointer border hover:opacity-80"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onToggleMarcaFilter(String(row.marca || ''))
+                              }}
+                              title="Filtrar por marca"
+                            >
+                              {row.marca}
+                            </Badge>
+                          </div>
+                        ) : null}
+                        {row.dataValidade ? (
+                          <div className="mt-1 text-xs text-blue-200/60">
+                            validade: <span className="font-mono">{fmtDateOnlyBR(String(row.dataValidade))}</span>
+                            {row.dias != null ? <><span>{' '}</span><span className="font-mono">({Number(row.dias)}d)</span></> : null}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="hidden p-3 text-blue-100/80 sm:table-cell">
+                        <Badge
+                          style={buildTagStyle(getCategoriaBgColor(row.categoria || 'Outros'))}
+                          className="cursor-pointer border hover:opacity-80"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            onToggleCategoriaFilter(String(row.categoria || 'Outros'))
+                          }}
+                          title="Filtrar por categoria"
+                        >
+                          {row.categoria || 'Outros'}
+                        </Badge>
+                      </td>
+                      <td className="p-3">
+                        <div className="flex flex-wrap gap-1">
+                          {displayTags.map((tag) => (
+                            <Badge
+                              key={tag}
+                              variant={alertaTagVariant(tag)}
+                              className="cursor-pointer hover:opacity-80"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onToggleStatusFilter(tag)
+                              }}
+                              title="Filtrar por status"
+                            >
+                              {alertaTagLabel(tag)}
+                            </Badge>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="p-3">
+                        <div className="flex flex-wrap gap-2">
+                          {recommendation?.kind === 'TRANSFERENCIA' ? (
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 bg-sky-500/30 text-sky-100 hover:bg-sky-500/45"
+                              disabled={!canQuick}
+                              title="Transferir"
+                              aria-label="Transferir"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onOpenQuickOperation('TRANSFERENCIA', {
+                                  codigoBarras: code,
+                                  quantidade: recommendation.qty ?? 1,
+                                  fromUnidade: recommendation.fromUnidade ?? null,
+                                  toUnidade: recommendation.toUnidade ?? null,
+                                  obs: 'Transferência sugerida',
+                                })
+                              }}
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                <path d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            </Button>
+                          ) : null}
+                          {recommendation?.kind === 'ENTRADA' ? (
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 bg-emerald-500/30 text-emerald-100 hover:bg-emerald-500/45"
+                              disabled={!canQuick}
+                              title="Entrada"
+                              aria-label="Entrada"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onOpenQuickOperation('ENTRADA', {
+                                  codigoBarras: code,
+                                  quantidade: recommendation.qty ?? 1,
+                                  obs: 'Reposição sugerida',
+                                })
+                              }}
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                <path d="M12 5v10m0 0-4-4m4 4 4-4M5 19h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            </Button>
+                          ) : null}
+                          {hasExpiringAction ? (
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 bg-rose-500/35 text-rose-100 hover:bg-rose-500/50"
+                              disabled={!canQuick}
+                              title={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
+                              aria-label={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onOpenQuickOperation('BAIXA', {
+                                  codigoBarras: code,
+                                  quantidade: 1,
+                                  obs: row.tags.includes('EXPIRADO') ? 'Descarte (expirado)' : 'Saída (vencendo)',
+                                })
+                              }}
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                <path d="M12 19V9m0 0-4 4m4-4 4 4M5 5h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            </Button>
+                          ) : null}
+                          {hasQualityAction ? (
+                            <Button
+                              variant="outline"
+                              className="h-8 px-2 text-xs"
+                              disabled={!canQualityEdit}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                if (qualityIssue) onOpenQualityFix(qualityIssue)
+                              }}
+                            >
+                              Editar
+                            </Button>
+                          ) : null}
+                          {!hasAnyAction ? <span className="text-xs text-blue-200/60">-</span> : null}
+                        </div>
+                        {qualityMessage ? (
+                          <div className="mt-2 text-xs text-blue-200/70">
+                            <div className="inline-flex items-center gap-2">
+                              <Badge variant={severityBadgeVariant(qualitySeverity) as any} className="border">
+                                {severityLabel(qualitySeverity)}
+                              </Badge>
+                            </div>
+                            <div className="mt-1 break-words">{qualityMessage}</div>
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="p-3 text-right text-blue-100/80">{row.estoqueAtual ?? '-'}</td>
+                      <td className="hidden p-3 text-right text-blue-100/70 sm:table-cell">{row.estoqueMinimo ?? '-'}</td>
+                      <td className="hidden p-3 text-right text-blue-100/70 lg:table-cell">{row.diferenca ?? '-'}</td>
+                      <td className="hidden p-3 text-right text-blue-100/70 lg:table-cell">{row.percentual != null ? `${row.percentual}%` : '-'}</td>
+                    </tr>
+                  )
+                })}
+                {!rows.length ? (
+                  <tr>
+                    <td className="p-3 text-blue-100/70" colSpan={8}>
+                      {emptyContent}
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}
+
+type ChartsFilterTipo = 'distribution' | 'movements' | 'roi_risk' | '__ALL__'
+type ChartsFilterY = 'categoria' | 'marca' | 'item' | 'tempo' | '__ALL__'
+type ChartsFilterX = 'qtd' | 'valor' | '__ALL__'
+type ChartsFilterView = 'pie' | 'bar' | 'line' | '__ALL__'
+type ChartsFilterTop = '5' | '8' | '10' | '15' | '__ALL__'
+
+type InsumosChartCardView = {
+  key: string
+  presetId: string
+  presetLabel: string
+  groupBy?: string
+  mode?: string
+  metric: 'qtd' | 'valor'
+  topN: number
+  view: 'pie' | 'bar' | 'line'
+  viewOptions: Array<'pie' | 'bar' | 'line'>
+  supportsMetric: boolean
+  supportsView: boolean
+  showTopN: boolean
+  controlsKind: 'distribution' | 'movements' | 'none'
+  canRemove: boolean
+  cardSpanClass: string
+  renderNode: React.ReactNode
+}
+
+type InsumosChartsPanelProps = {
+  panelOpen: boolean
+  dragHandleProps?: Record<string, any>
+  chartsFilterTipo: ChartsFilterTipo
+  chartsFilterY: ChartsFilterY
+  chartsFilterX: ChartsFilterX
+  chartsFilterView: ChartsFilterView
+  chartsFilterTop: ChartsFilterTop
+  chartsSearch: string
+  canAddChart: boolean
+  canResetCharts: boolean
+  chartCards: InsumosChartCardView[]
+  presetOptions: Array<{ id: string; label: string }>
+  emptyContent: React.ReactNode
+  onToggleOpen: () => void
+  onChartsFilterTipoChange: (value: ChartsFilterTipo) => void
+  onChartsFilterYChange: (value: ChartsFilterY) => void
+  onChartsFilterXChange: (value: ChartsFilterX) => void
+  onChartsFilterViewChange: (value: ChartsFilterView) => void
+  onChartsFilterTopChange: (value: ChartsFilterTop) => void
+  onChartsSearchChange: (value: string) => void
+  onAddChart: () => void
+  onResetCharts: () => void
+  onPresetChange: (cardKey: string, value: string) => void
+  onRemoveChart: (cardKey: string) => void
+  onDistributionGroupByChange: (cardKey: string, value: 'categoria' | 'marca' | 'item') => void
+  onMovementsGroupByChange: (cardKey: string, value: 'tempo' | 'categoria') => void
+  onMovementsModeChange: (cardKey: string, value: 'inout' | 'saldo' | 'entrada' | 'saida') => void
+  onMetricChange: (cardKey: string, value: 'qtd' | 'valor') => void
+  onViewChange: (cardKey: string, value: 'pie' | 'bar' | 'line') => void
+  onTopNChange: (cardKey: string, value: number) => void
+}
+
+export function InsumosChartsPanel({
+  panelOpen,
+  dragHandleProps,
+  chartsFilterTipo,
+  chartsFilterY,
+  chartsFilterX,
+  chartsFilterView,
+  chartsFilterTop,
+  chartsSearch,
+  canAddChart,
+  canResetCharts,
+  chartCards,
+  presetOptions,
+  emptyContent,
+  onToggleOpen,
+  onChartsFilterTipoChange,
+  onChartsFilterYChange,
+  onChartsFilterXChange,
+  onChartsFilterViewChange,
+  onChartsFilterTopChange,
+  onChartsSearchChange,
+  onAddChart,
+  onResetCharts,
+  onPresetChange,
+  onRemoveChart,
+  onDistributionGroupByChange,
+  onMovementsGroupByChange,
+  onMovementsModeChange,
+  onMetricChange,
+  onViewChange,
+  onTopNChange,
+}: InsumosChartsPanelProps) {
+  return (
+    <Card className="border border-white/10 bg-black/20">
+      <CardHeader className="flex flex-col gap-2">
+        <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              {...dragHandleProps}
+              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+              title="Arraste para mover"
+              aria-label="Mover"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+              </svg>
+            </button>
+            <CardTitle className="text-base text-white">Gráficos</CardTitle>
+          </div>
+          <div className="ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
+            <Select value={chartsFilterTipo} onValueChange={(value) => onChartsFilterTipoChange(value as ChartsFilterTipo)}>
+              <SelectTrigger className="h-8 w-32 shrink-0">
+                <SelectValue placeholder="Tipo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                <SelectItem value="distribution">Distribuição</SelectItem>
+                <SelectItem value="movements">Movimentações</SelectItem>
+                <SelectItem value="roi_risk">ROI</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={chartsFilterY} onValueChange={(value) => onChartsFilterYChange(value as ChartsFilterY)}>
+              <SelectTrigger className="h-8 w-28 shrink-0">
+                <SelectValue placeholder="Eixo Y" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                <SelectItem value="categoria">Categoria</SelectItem>
+                <SelectItem value="marca">Marca</SelectItem>
+                <SelectItem value="item">Item</SelectItem>
+                <SelectItem value="tempo">Tempo</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={chartsFilterX} onValueChange={(value) => onChartsFilterXChange(value as ChartsFilterX)}>
+              <SelectTrigger className="h-8 w-24 shrink-0">
+                <SelectValue placeholder="Eixo X" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                <SelectItem value="qtd">Qtd</SelectItem>
+                <SelectItem value="valor">R$</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={chartsFilterView} onValueChange={(value) => onChartsFilterViewChange(value as ChartsFilterView)}>
+              <SelectTrigger className="h-8 w-32 shrink-0">
+                <SelectValue placeholder="Representação" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                <SelectItem value="pie">Pizza</SelectItem>
+                <SelectItem value="bar">Barras</SelectItem>
+                <SelectItem value="line">Linhas</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={chartsFilterTop} onValueChange={(value) => onChartsFilterTopChange(value as ChartsFilterTop)}>
+              <SelectTrigger className="h-8 w-24 shrink-0">
+                <SelectValue placeholder="Top" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                <SelectItem value="5">Top 5</SelectItem>
+                <SelectItem value="8">Top 8</SelectItem>
+                <SelectItem value="10">Top 10</SelectItem>
+                <SelectItem value="15">Top 15</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input value={chartsSearch} onChange={(event) => onChartsSearchChange(event.target.value)} placeholder="Buscar" className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0" />
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onAddChart} disabled={!canAddChart} title="Adicionar gráfico" aria-label="Adicionar gráfico">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                </svg>
+              </Button>
+              <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onResetCharts} disabled={!canResetCharts} title="Resetar gráficos" aria-label="Resetar gráficos">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M20 12a8 8 0 1 1-2.34-5.66" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M20 4v6h-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </Button>
+              <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} title={panelOpen ? 'Contrair' : 'Expandir'} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
+                {panelOpen ? (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                ) : (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {panelOpen ? (
+        <CardContent className="space-y-3">
+          <div
+            className={`grid gap-3 ${
+              chartCards.length <= 1
+                ? 'grid-cols-1'
+                : chartCards.length === 2
+                  ? 'grid-cols-1 lg:grid-cols-2'
+                  : 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3 xl:grid-flow-dense'
+            }`}
+          >
+            {chartCards.length ? (
+              chartCards.map((card) => (
+                <Card key={card.key} className={`border border-white/10 bg-black/20 ${card.cardSpanClass}`}>
+                  <CardHeader className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Select value={card.presetId} onValueChange={(value) => onPresetChange(card.key, value)}>
+                        <SelectTrigger className="h-8 w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {presetOptions.map((preset) => (
+                            <SelectItem key={preset.id} value={preset.id}>
+                              {preset.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {card.canRemove ? (
+                        <Button variant="outline" className="h-8 w-8 p-0" title="Remover gráfico" aria-label="Remover gráfico" onClick={() => onRemoveChart(card.key)}>
+                          ×
+                        </Button>
+                      ) : null}
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {card.controlsKind === 'distribution' ? (
+                        <Select value={(card.groupBy as 'categoria' | 'marca' | 'item' | undefined) || 'categoria'} onValueChange={(value) => onDistributionGroupByChange(card.key, value as 'categoria' | 'marca' | 'item')}>
+                          <SelectTrigger className="h-8 w-32">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="categoria">Categoria</SelectItem>
+                            <SelectItem value="marca">Marca</SelectItem>
+                            <SelectItem value="item">Item</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      ) : null}
+
+                      {card.controlsKind === 'movements' ? (
+                        <>
+                          <Select value={card.groupBy === 'categoria' ? 'categoria' : 'tempo'} onValueChange={(value) => onMovementsGroupByChange(card.key, value as 'tempo' | 'categoria')}>
+                            <SelectTrigger className="h-8 w-28">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="tempo">Tempo</SelectItem>
+                              <SelectItem value="categoria">Categoria</SelectItem>
+                            </SelectContent>
+                          </Select>
+
+                          {card.groupBy === 'categoria' ? (
+                            <Select value={card.mode === 'entrada' ? 'entrada' : 'saida'} onValueChange={(value) => onMovementsModeChange(card.key, value as 'entrada' | 'saida')}>
+                              <SelectTrigger className="h-8 w-28">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="saida">Saídas</SelectItem>
+                                <SelectItem value="entrada">Entradas</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          ) : (
+                            <Select value={(card.mode as 'inout' | 'saldo' | 'entrada' | 'saida' | undefined) || 'inout'} onValueChange={(value) => onMovementsModeChange(card.key, value as 'inout' | 'saldo' | 'entrada' | 'saida')}>
+                              <SelectTrigger className="h-8 w-36">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="inout">Entradas vs Saídas</SelectItem>
+                                <SelectItem value="saldo">Saldo</SelectItem>
+                                <SelectItem value="entrada">Entradas</SelectItem>
+                                <SelectItem value="saida">Saídas</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </>
+                      ) : null}
+
+                      {card.supportsMetric ? (
+                        <Select value={card.metric} onValueChange={(value) => onMetricChange(card.key, value as 'qtd' | 'valor')}>
+                          <SelectTrigger className="h-8 w-24">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="qtd">Qtd</SelectItem>
+                            <SelectItem value="valor">R$</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      ) : null}
+
+                      {card.supportsView && card.viewOptions.length > 1 ? (
+                        <Select value={card.view} onValueChange={(value) => onViewChange(card.key, value as 'pie' | 'bar' | 'line')}>
+                          <SelectTrigger className="h-8 w-28">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {card.viewOptions.map((viewOption) => (
+                              <SelectItem key={viewOption} value={viewOption}>
+                                {viewOption === 'bar' ? 'Barras' : viewOption === 'line' ? 'Linhas' : 'Pizza'}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : null}
+
+                      {card.showTopN ? (
+                        <Select value={String(card.topN)} onValueChange={(value) => onTopNChange(card.key, parseInt(String(value), 10) || 8)}>
+                          <SelectTrigger className="h-8 w-20">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="5">Top 5</SelectItem>
+                            <SelectItem value="8">Top 8</SelectItem>
+                            <SelectItem value="10">Top 10</SelectItem>
+                            <SelectItem value="15">Top 15</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      ) : null}
+                    </div>
+                    <div className="flex justify-end" />
+                  </CardHeader>
+                  <CardContent>{card.renderNode}</CardContent>
+                </Card>
+              ))
+            ) : (
+              emptyContent
+            )}
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}
+
+type InsumosMovementsPanelProps = {
+  panelOpen: boolean
+  dragHandleProps?: Record<string, any>
+  movTipo: 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE'
+  movFilterCategoria: string
+  movFilterMarca: string
+  movSearch: string
+  movSortKey: 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'
+  movSortDir: 'asc' | 'desc'
+  lotCategorias: string[]
+  insumosMarcas: string[]
+  isAuthed: boolean
+  rows: MovementRowView[]
+  emptyContent: React.ReactNode
+  listContainerRef: React.RefObject<HTMLDivElement | null>
+  onToggleOpen: () => void
+  onTipoChange: (value: 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE') => void
+  onCategoriaChange: (value: string) => void
+  onMarcaChange: (value: string) => void
+  onSearchChange: (value: string) => void
+  onOpenInventoryList: () => void
+  onExportCsv: () => void
+  onSortChange: (value: 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao') => void
+  onProductClick: (productName: string) => void
+  onCategoryClick: (categoryName: string) => void
+  onBrandClick: (brandName: string) => void
+  onEditMovement: (movement: Movimentacao) => void
+}
+
+export function InsumosMovementsPanel({
+  panelOpen,
+  dragHandleProps,
+  movTipo,
+  movFilterCategoria,
+  movFilterMarca,
+  movSearch,
+  movSortKey,
+  movSortDir,
+  lotCategorias,
+  insumosMarcas,
+  isAuthed,
+  rows,
+  emptyContent,
+  listContainerRef,
+  onToggleOpen,
+  onTipoChange,
+  onCategoriaChange,
+  onMarcaChange,
+  onSearchChange,
+  onOpenInventoryList,
+  onExportCsv,
+  onSortChange,
+  onProductClick,
+  onCategoryClick,
+  onBrandClick,
+  onEditMovement,
+}: InsumosMovementsPanelProps) {
+  const columns: Array<{
+    key: null | 'dataHora' | 'produto' | 'categoria' | 'marca' | 'estoque' | 'valor' | 'usuario' | 'observacao'
+    label: string
+    compact?: boolean
+    className?: string
+    widthClass?: string
+  }> = [
+    { key: 'dataHora', label: 'Data', compact: true, className: '', widthClass: 'w-[8%]' },
+    { key: 'produto', label: 'Produto', widthClass: 'w-[22%]' },
+    { key: 'categoria', label: 'Categoria', compact: true, className: 'hidden md:table-cell', widthClass: 'w-[12%]' },
+    { key: 'marca', label: 'Marca', compact: true, className: 'hidden lg:table-cell', widthClass: 'w-[10%]' },
+    { key: 'estoque', label: 'Estoque', compact: true, widthClass: 'w-[10%]' },
+    { key: 'valor', label: 'Valor', compact: true, widthClass: 'w-[10%]' },
+    { key: 'usuario', label: 'Usuário', compact: true, className: 'hidden xl:table-cell', widthClass: 'w-[10%]' },
+    { key: 'observacao', label: 'Observação', className: 'hidden md:table-cell', widthClass: 'w-[16%]' },
+    { key: null, label: 'Ações', compact: true, widthClass: 'w-[6%]' },
+  ]
+
+  return (
+    <Card className="border border-white/10 bg-black/20">
+      <CardHeader className="flex flex-col gap-2">
+        <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              {...dragHandleProps}
+              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+              title="Arraste para mover"
+              aria-label="Mover"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+              </svg>
+            </button>
+            <CardTitle className="text-lg text-white">Movimentações</CardTitle>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
+            <Select value={movTipo} onValueChange={(value) => onTipoChange(value as 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE')}>
+              <SelectTrigger className="h-8 w-28 shrink-0">
+                <SelectValue placeholder="Fluxo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="TODOS">–</SelectItem>
+                <SelectItem value="ENTRADA">Entrada</SelectItem>
+                <SelectItem value="SAÍDA">Saída</SelectItem>
+                <SelectItem value="AJUSTE">Ajuste</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={movFilterCategoria || '__ALL__'} onValueChange={(value) => onCategoriaChange(value === '__ALL__' ? '' : String(value))}>
+              <SelectTrigger className="h-8 w-36 shrink-0">
+                <SelectValue placeholder="Categoria" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                {lotCategorias.map((categoria) => (
+                  <SelectItem key={categoria} value={categoria}>
+                    {categoria}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={movFilterMarca || '__ALL__'} onValueChange={(value) => onMarcaChange(value === '__ALL__' ? '' : String(value))}>
+              <SelectTrigger className="h-8 w-32 shrink-0">
+                <SelectValue placeholder="Marca" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__ALL__">–</SelectItem>
+                {insumosMarcas.map((marca) => (
+                  <SelectItem key={marca} value={marca}>
+                    {marca}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              value={movSearch}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Buscar"
+              className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0"
+            />
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                onClick={onOpenInventoryList}
+                title="Abrir lista de insumos"
+                aria-label="Abrir lista de insumos"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M8 6h12M8 12h12M8 18h12" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                  <circle cx="5" cy="6" r="1.5" fill="currentColor" />
+                  <circle cx="5" cy="12" r="1.5" fill="currentColor" />
+                  <circle cx="5" cy="18" r="1.5" fill="currentColor" />
+                </svg>
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                onClick={onExportCsv}
+                disabled={!isAuthed}
+                title="Exportar CSV"
+                aria-label="Exportar CSV"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M12 16V4m0 12-4-4m4 4 4-4M4 20h16" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                onClick={onToggleOpen}
+                title={panelOpen ? 'Contrair' : 'Expandir'}
+                aria-label={panelOpen ? 'Contrair' : 'Expandir'}
+              >
+                {panelOpen ? (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                ) : (
+                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {panelOpen ? (
+        <CardContent className="space-y-3">
+          <div ref={listContainerRef} className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+            <table className="w-full table-fixed text-sm">
+              <thead className="bg-black/30 text-blue-100/80">
+                <tr>
+                  {columns.map((column) => {
+                    const isActive = !!column.key && movSortKey === column.key
+                    return (
+                      <th
+                        key={column.label}
+                        className={`sticky top-0 z-10 bg-black/40 p-3 text-center align-middle backdrop-blur ${column.compact ? 'whitespace-nowrap' : ''} ${column.widthClass || ''} ${column.className || ''}`}
+                      >
+                        <div className="flex items-center justify-center gap-2">
+                          {column.key ? (
+                            <button
+                              type="button"
+                              className={`cursor-pointer select-none rounded-sm px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline`}
+                              onClick={() => onSortChange(column.key)}
+                              aria-label={`Ordenar ${column.label}`}
+                              title={`Ordenar ${column.label}`}
+                            >
+                              {column.label}
+                            </button>
+                          ) : (
+                            <span>{column.label}</span>
+                          )}
+                          {column.key ? (
+                            <span className={`inline-flex items-center justify-center ${isActive ? 'text-white' : 'text-blue-100/30'}`} aria-hidden>
+                              {isActive && movSortDir === 'asc' ? (
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                  <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              ) : (
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                  <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              )}
+                            </span>
+                          ) : null}
+                        </div>
+                      </th>
+                    )
+                  })}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {rows.length ? (
+                  rows.map((row) => (
+                    <tr key={row.key} className={row.rowClass}>
+                      <td className="whitespace-nowrap p-3 text-center align-top text-blue-100/70">
+                        <div className="text-blue-50">{row.dateLabel}</div>
+                        <div className="text-xs text-blue-200/60">{row.timeLabel}</div>
+                      </td>
+                      <td className="p-3 text-center align-top">
+                        <button
+                          type="button"
+                          className="w-full cursor-pointer break-words rounded-sm text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                          onClick={() => onProductClick(row.productName)}
+                          title="Filtrar por produto"
+                          aria-pressed={row.productPressed}
+                        >
+                          <span className="line-clamp-2">{row.productName}</span>
+                        </button>
+                        {row.brandName && row.brandName !== '-' ? (
+                          <div className="mt-1 flex flex-wrap justify-center gap-1 lg:hidden">
+                            <Badge style={buildTagStyle(getMarcaBgColor(row.brandName))} className="border">
+                              {row.brandName}
+                            </Badge>
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="hidden whitespace-nowrap p-3 text-center align-top md:table-cell">
+                        {row.categoryName && row.categoryName !== '-' ? (
+                          <button
+                            type="button"
+                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                            onClick={() => onCategoryClick(row.categoryName)}
+                            title="Filtrar por categoria"
+                            aria-pressed={row.categoryPressed}
+                          >
+                            <Badge style={buildTagStyle(getCategoriaBgColor(row.categoryName))} className="border">
+                              {row.categoryName}
+                            </Badge>
+                          </button>
+                        ) : (
+                          <span className="text-blue-100/70">-</span>
+                        )}
+                      </td>
+                      <td className="hidden whitespace-nowrap p-3 text-center align-top lg:table-cell">
+                        {row.brandName && row.brandName !== '-' ? (
+                          <button
+                            type="button"
+                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                            onClick={() => onBrandClick(row.brandName)}
+                            title="Filtrar por marca"
+                            aria-pressed={row.brandPressed}
+                          >
+                            <Badge style={buildTagStyle(getMarcaBgColor(row.brandName))} className="border">
+                              {row.brandName}
+                            </Badge>
+                          </button>
+                        ) : (
+                          <span className="text-blue-100/70">-</span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap p-3 text-center align-top">
+                        <span className={`font-mono ${row.stockLabel === '-' ? 'text-blue-100/70' : 'text-blue-50'}`}>{row.stockLabel}</span>
+                      </td>
+                      <td className="w-[1%] whitespace-nowrap p-3 text-center align-top">
+                        <div className="text-blue-50">{row.movementValueLabel}</div>
+                        <div className="text-xs text-blue-200/60">{row.stockValueLabel}</div>
+                      </td>
+                      <td className="hidden whitespace-nowrap p-3 text-center align-top text-blue-100/70 xl:table-cell">{row.userLabel}</td>
+                      <td className="hidden p-3 text-left align-top text-blue-100/60 md:table-cell">
+                        <div className="space-y-1 break-words">
+                          <div>{row.notePrimary}</div>
+                          {row.noteSecondary ? <div className="font-mono text-xs">{row.noteSecondary}</div> : null}
+                          {row.noteMeta ? <div className="text-xs text-blue-200/60">{row.noteMeta}</div> : null}
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap p-3 text-center align-top">
+                        <div className="flex justify-center gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditMovement(row.movement)} disabled={!row.canEdit}>
+                            Editar
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td className="p-3 text-center text-blue-100/70" colSpan={9}>
+                      {emptyContent}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}

--- a/frontend/insumosPanels.tsx
+++ b/frontend/insumosPanels.tsx
@@ -3764,7 +3764,7 @@ export function InsumosMovementsPanel({
       </CardHeader>
       {panelOpen ? (
         <CardContent className="space-y-3">
-          <div ref={listContainerRef} className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
+          <div ref={listContainerRef as React.RefObject<HTMLDivElement>} className="max-h-[60vh] overflow-auto rounded-xl border border-white/10">
             <table className="w-full table-fixed text-sm">
               <thead className="bg-black/30 text-blue-100/80">
                 <tr>
@@ -3780,7 +3780,7 @@ export function InsumosMovementsPanel({
                             <button
                               type="button"
                               className={`cursor-pointer select-none rounded-sm px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline`}
-                              onClick={() => onSortChange(column.key)}
+                              onClick={() => onSortChange(column.key!)}
                               aria-label={`Ordenar ${column.label}`}
                               title={`Ordenar ${column.label}`}
                             >

--- a/frontend/insumosShared.ts
+++ b/frontend/insumosShared.ts
@@ -1,0 +1,421 @@
+import React from 'react'
+import type { Insumo } from '@/insumosTypes'
+
+export const CANONICAL_TIPOS_UNIDADE = ['unidade', 'frasco', 'seringa', 'caixa', 'ampola', 'pacote', 'rolo'] as const
+const CANONICAL_TIPOS_UNIDADE_SET = new Set<string>(CANONICAL_TIPOS_UNIDADE as readonly string[])
+
+export function normalizeTipoUnidadeToCanonical(raw: string): string {
+  const normalized = String(raw || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s*\(s\)\s*/g, '')
+    .trim()
+  if (!normalized) return ''
+  if (normalized === 'flaconete') return 'frasco'
+  return CANONICAL_TIPOS_UNIDADE_SET.has(normalized) ? normalized : ''
+}
+
+export function parseBarcodeInput(value: string): string[] {
+  return String(value || '')
+    .split(/[\n,;]+/g)
+    .map((v) => String(v || '').trim())
+    .filter(Boolean)
+}
+
+export function getInsumoBarcodes(item: Insumo | null | undefined): string[] {
+  const codes = new Set<string>()
+  const add = (v?: string) => {
+    const value = String(v || '').trim()
+    if (value) codes.add(value)
+  }
+  add(item?.codigoBarras)
+  if (Array.isArray(item?.codigosBarras)) {
+    for (const v of item?.codigosBarras || []) add(String(v || ''))
+  }
+  return Array.from(codes)
+}
+
+export function fmtMoneyBRL(value: number) {
+  try {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value)
+  } catch {
+    return `R$ ${value.toFixed(2)}`
+  }
+}
+
+export function fmtMoneyBRL0(value: number) {
+  try {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value)
+  } catch {
+    return `R$ ${Math.round(value)}`
+  }
+}
+
+export function fmtMoneyBRLCompact(value: number) {
+  if (!Number.isFinite(value)) return '-'
+  const abs = Math.abs(value)
+  if (abs >= 1000) {
+    const rounded = Math.round(value / 1000)
+    return `R$ ${rounded}k`
+  }
+  return fmtMoneyBRL0(value)
+}
+
+const CATEGORIA_CORES: Record<string, string> = {
+  toxina: '#1e3a8a',
+  'toxina botulínica': '#1e3a8a',
+  'toxina botulinica': '#1e3a8a',
+  preenchedor: '#bfdbfe',
+  bioestimulador: '#ec4899',
+  fio: '#7c3aed',
+  'fio pdo': '#1f2937',
+  descartável: '#6b7280',
+  descartavel: '#6b7280',
+  peeling: '#ea580c',
+  skinbooster: '#ec4899',
+  anestésico: '#be123c',
+  anestesico: '#be123c',
+  medicamento: '#14b8a6',
+  limpeza: '#06b6d4',
+  cosmético: '#10b981',
+  cosmetico: '#10b981',
+  intradermoterapia: '#86efac',
+  perfurocortante: '#f87171',
+  higiene: '#8b5cf6',
+  recepção: '#c026d3',
+  recepcao: '#c026d3',
+}
+
+const CATEGORIA_PALETA = ['#60a5fa', '#a78bfa', '#34d399', '#f87171', '#fbbf24', '#22d3ee', '#fb7185', '#c084fc', '#4ade80', '#f472b6']
+const MARCA_PALETA = ['#0891b2', '#2563eb', '#7c3aed', '#db2777', '#16a34a', '#ea580c', '#475569', '#be123c']
+
+function hashToIndex(value: string, mod: number) {
+  let h = 0
+  for (let i = 0; i < value.length; i++) {
+    h = (h * 31 + value.charCodeAt(i)) >>> 0
+  }
+  return mod > 0 ? h % mod : 0
+}
+
+export function getCategoriaBgColor(categoria?: string | null) {
+  const key = String(categoria || '').trim().toLowerCase()
+  const mapped = CATEGORIA_CORES[key]
+  if (mapped) return mapped
+  if (!key) return '#0ea5e9'
+  return CATEGORIA_PALETA[hashToIndex(key, CATEGORIA_PALETA.length)] || '#0ea5e9'
+}
+
+export function getMarcaBgColor(marca?: string | null) {
+  const key = String(marca || '').trim().toLowerCase()
+  if (!key) return '#334155'
+  return MARCA_PALETA[hashToIndex(key, MARCA_PALETA.length)] || '#334155'
+}
+
+export function getContrastColor(hexColor?: string | null) {
+  const raw = String(hexColor || '').trim()
+  const hex = raw.startsWith('#') ? raw.slice(1) : raw
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return '#ffffff'
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+  return luminance > 140 ? '#0f172a' : '#ffffff'
+}
+
+export function buildTagStyle(bgColor?: string | null): React.CSSProperties {
+  const bg = String(bgColor || '').trim() || '#334155'
+  return {
+    backgroundColor: bg,
+    color: getContrastColor(bg),
+    borderColor: 'rgba(255,255,255,0.25)',
+  }
+}
+
+export function normalizeText(value?: string | null) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+}
+
+export function buildInsumoDescriptor(item?: Insumo | null) {
+  if (!item) return []
+  const produto = String(item.produto || '').trim()
+  const produtoKey = normalizeText(produto)
+  const rawParts = [item.especificacao, item.concentracao, item.volume, item.calibre, item.tipoUnidade]
+  const out: string[] = []
+  const seen = new Set<string>()
+  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  for (const raw of rawParts) {
+    let v = String(raw || '').trim()
+    if (!v) continue
+    if (produtoKey) {
+      const vNorm = normalizeText(v)
+      if (vNorm.includes(produtoKey)) {
+        const prodRegex = new RegExp(escapeRegExp(produto), 'ig')
+        v = v.replace(prodRegex, '').trim()
+      }
+    }
+    const key = normalizeText(v)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(v)
+    if (out.length >= 3) break
+  }
+  return out
+}
+
+export function formatInsumoDescriptor(item?: Insumo | null) {
+  const parts = buildInsumoDescriptor(item)
+  if (!parts.length) return ''
+  return parts.slice(0, 3).join(' • ')
+}
+
+export function useViewportSize() {
+  const [size, setSize] = React.useState({ width: 0, height: 0 })
+  React.useEffect(() => {
+    const update = () => setSize({ width: window.innerWidth, height: window.innerHeight })
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+  return size
+}
+
+export function slugifyCategoria(value?: string | null) {
+  const s0 = String(value || '').trim().toLowerCase()
+  if (!s0) return ''
+  return s0
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function uniqueSortedTextOptions(values: Array<string | null | undefined>) {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const raw of values || []) {
+    const value = String(raw || '').trim()
+    if (!value) continue
+    const key = normalizeText(value)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(value)
+  }
+  return out.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }))
+}
+
+export type EstoqueStatus = 'OK' | 'ATENCAO' | 'URGENTE'
+
+export function calcularStatusEstoque(estoqueAtual?: number, estoqueMinimo?: number): EstoqueStatus {
+  const atual = Number(estoqueAtual) || 0
+  const minimo = Number(estoqueMinimo) || 0
+  if (atual < 0) return 'URGENTE'
+  if (minimo <= 0) return 'OK'
+  if (atual < minimo) return 'URGENTE'
+  if (atual === minimo) return 'ATENCAO'
+  return 'OK'
+}
+
+export function estoqueStatusLabel(status: EstoqueStatus) {
+  if (status === 'URGENTE') return 'Crítico'
+  if (status === 'ATENCAO') return 'Atenção'
+  return 'Ok'
+}
+
+export function estoqueStatusBadgeVariant(status: EstoqueStatus): 'default' | 'secondary' | 'destructive' {
+  if (status === 'URGENTE') return 'destructive'
+  if (status === 'ATENCAO') return 'secondary'
+  return 'default'
+}
+
+export type AlertaStatusTag = 'URGENTE' | 'ATENCAO' | 'VENCENDO' | 'EXPIRADO' | 'INFO'
+
+export function alertaTagLabel(tag: AlertaStatusTag) {
+  if (tag === 'URGENTE') return 'Crítico'
+  if (tag === 'ATENCAO') return 'Atenção'
+  if (tag === 'VENCENDO') return 'Vencendo'
+  if (tag === 'INFO') return 'Info'
+  return 'Expirado'
+}
+
+export function alertaTagVariant(tag: AlertaStatusTag): 'default' | 'secondary' | 'destructive' {
+  if (tag === 'URGENTE') return 'destructive'
+  if (tag === 'EXPIRADO') return 'destructive'
+  if (tag === 'VENCENDO') return 'secondary'
+  if (tag === 'ATENCAO') return 'secondary'
+  return 'default'
+}
+
+export function normalizeAlertTags(tags: Set<AlertaStatusTag>): AlertaStatusTag[] {
+  const out = new Set(tags)
+  if (out.has('URGENTE')) out.delete('ATENCAO')
+  if (out.has('EXPIRADO')) out.delete('VENCENDO')
+  const order: Record<AlertaStatusTag, number> = { URGENTE: 0, EXPIRADO: 1, VENCENDO: 2, ATENCAO: 3, INFO: 4 }
+  return Array.from(out).sort((a, b) => order[a] - order[b])
+}
+
+export function fmtDate(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return String(value)
+  return d.toLocaleString('pt-BR')
+}
+
+export function fmtMovDateShort(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return String(value)
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' })
+}
+
+export function fmtMovTimeShort(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+}
+
+export function fmtDayShort(isoDay?: string) {
+  if (!isoDay) return ''
+  const d = new Date(`${isoDay}T00:00:00.000Z`)
+  if (Number.isNaN(d.getTime())) return String(isoDay)
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+}
+
+export function isoDayWeekStart(isoDay?: string) {
+  const v = String(isoDay || '').trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return ''
+  const d = new Date(`${v}T00:00:00.000Z`)
+  if (Number.isNaN(d.getTime())) return ''
+  const dow = d.getUTCDay()
+  const diff = (dow + 6) % 7
+  const start = new Date(d)
+  start.setUTCDate(start.getUTCDate() - diff)
+  return start.toISOString().slice(0, 10)
+}
+
+export function isoToBrDate(value?: string | null) {
+  const v = String(value || '').trim()
+  if (!v) return ''
+  const m = v.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return v
+  return `${m[3]}/${m[2]}/${m[1]}`
+}
+
+export function brToIsoDate(value?: string | null) {
+  const v = String(value || '').trim()
+  if (!v) return ''
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v
+
+  const m = v.match(/^(\d{2})\/(\d{2})\/(\d{2}|\d{4})$/)
+  if (!m) return ''
+  const day = parseInt(m[1], 10)
+  const month = parseInt(m[2], 10)
+  const yearRaw = m[3]
+  const year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10)
+  const d = new Date(Date.UTC(year, month - 1, day))
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return ''
+  const yyyy = String(year).padStart(4, '0')
+  const mm = String(month).padStart(2, '0')
+  const dd = String(day).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+export function dateInputToIso(value?: string | null) {
+  const v = String(value || '').trim()
+  if (!v) return ''
+  if (/^\d{4}-\d{2}-\d{2}/.test(v)) return v.slice(0, 10)
+  const iso = brToIsoDate(v)
+  return iso || ''
+}
+
+export function fmtDateOnlyBR(value?: string | null) {
+  const v = String(value || '').trim()
+  if (!v) return ''
+  if (/^\d{2}\/\d{2}\/\d{4}$/.test(v)) return v
+  const iso = dateInputToIso(v)
+  return iso ? isoToBrDate(iso) : v
+}
+
+export function isoToLocalDateInput(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function isoToLocalTimeInput(value?: string | null) {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  const hours = String(d.getHours()).padStart(2, '0')
+  const minutes = String(d.getMinutes()).padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+
+export function normalizeTimeInput(value?: string | null) {
+  const raw = String(value || '').trim()
+  const match = raw.match(/^(\d{2}):(\d{2})$/)
+  if (!match) return ''
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return ''
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+}
+
+export function combineLocalDateTimeToIso(dateValue?: string | null, timeValue?: string | null) {
+  const isoDate = dateInputToIso(dateValue)
+  const isoTime = normalizeTimeInput(timeValue)
+  if (!isoDate || !isoTime) return ''
+  const d = new Date(`${isoDate}T${isoTime}:00`)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toISOString()
+}
+
+export function normalizeMovimentacaoTipo(value?: string | null) {
+  return String(value || '').toUpperCase().replace('Í', 'I')
+}
+
+export function extractTransferMovementNote(value?: string | null) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+  const sep = raw.indexOf(' | ')
+  return sep >= 0 ? raw.slice(sep + 3).trim() : ''
+}
+
+export function statusBadgeVariant(status?: string): 'default' | 'secondary' | 'destructive' {
+  const s = String(status || '').toUpperCase()
+  if (s === 'EXPIRADO') return 'destructive'
+  if (s === 'VENCENDO') return 'secondary'
+  return 'default'
+}
+
+export function severityBadgeVariant(severity?: string): 'default' | 'secondary' | 'destructive' {
+  const s = String(severity || '').toUpperCase()
+  if (s === 'CRITICAL') return 'destructive'
+  if (s === 'WARN' || s === 'WARNING') return 'secondary'
+  return 'default'
+}
+
+export function severityLabel(severity?: string) {
+  const key = normalizeText(severity).toUpperCase()
+  if (!key) return 'Info'
+  if (key === 'CRITICAL' || key === 'CRITICO') return 'Crítico'
+  if (key === 'WARN' || key === 'WARNING' || key === 'ATENCAO') return 'Atenção'
+  if (key === 'INFO') return 'Info'
+  const raw = String(severity || '').trim()
+  if (!raw) return 'Info'
+  return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase()
+}

--- a/frontend/insumosTypes.ts
+++ b/frontend/insumosTypes.ts
@@ -1,0 +1,308 @@
+export type InsumosHealth = {
+  ok?: boolean
+  ready?: boolean
+  service?: string
+  runtime?: string
+  storage?: string
+  dbConfigured?: boolean
+  unidades?: string[]
+}
+
+export type InsumosUser = {
+  username?: string
+  displayName?: string
+  name?: string
+  email?: string
+  role?: string
+  photoUrl?: string
+  allowedUnits?: string[]
+}
+
+export type Insumo = {
+  registro?: string
+  codigoBarras?: string
+  codigosBarras?: string[]
+  categoria?: string
+  marca?: string
+  produto?: string
+  especificacao?: string
+  concentracao?: string
+  volume?: string
+  tipoUnidade?: string
+  fonte?: string
+  calibre?: string
+  policyRequiresLot?: boolean | null
+  policyRequiresExpiry?: boolean | null
+  policyFefo?: boolean | null
+  lote?: string
+  precoCusto?: number
+  estoqueAtual?: number
+  estoqueMinimo?: number
+  dataValidade?: string | null
+  statusValidade?: { status?: string; dias?: number | null }
+  estoques?: Record<string, number>
+}
+
+export type Movimentacao = {
+  id?: string
+  dataHora?: string
+  tipo?: string
+  codigoBarras?: string
+  produto?: string
+  categoria?: string
+  marca?: string
+  quantidade?: number
+  estoqueAnterior?: number
+  estoqueNovo?: number
+  preco?: number
+  unidade?: string
+  unidadeOrigem?: string
+  unidadeDestino?: string
+  transferId?: string
+  usuario?: string
+  motivo?: string
+  registroInsumo?: string
+  lote?: string
+  dataValidade?: string
+  observacoes?: string
+}
+
+export type NotificationsSummary = {
+  generatedAt?: string
+  unidade?: string
+  counts?: { lowStock?: number; expiringSoon?: number; expiredWithStock?: number }
+  lowStock?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; estoqueMinimo?: number; categoria?: string }>
+  expiringSoon?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; dataValidade?: string; dias?: number; categoria?: string }>
+  expiredWithStock?: Array<{ codigoBarras?: string; produto?: string; estoqueAtual?: number; dataValidade?: string; categoria?: string }>
+}
+
+export type EstoqueResumo = {
+  totalInsumos?: number
+  valorEstoqueTotal?: number
+  criticos?: number
+}
+
+export type Actionables = {
+  unidade?: string
+  reposicao?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueAtual?: number; estoqueMinimo?: number; suggestedPurchaseQty?: number; estimatedValue?: number }>
+  transferencias?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; from?: string; to?: string; qty?: number; estimatedValue?: number }>
+  perdasValidade?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueAtual?: number; dataValidade?: string; lossValue?: number }>
+  rupturas?: Array<{ codigoBarras?: string; produto?: string; categoria?: string; estoqueMinimo?: number; estimatedImpact?: number }>
+}
+
+export type EstoqueAlerta = {
+  codigoBarras?: string
+  produto?: string
+  categoria?: string
+  estoqueAtual?: number
+  estoqueMinimo?: number
+  diferenca?: number
+  percentual?: number | null
+  tipoAlerta?: string
+  statusAlerta?: 'URGENTE' | 'ATENCAO' | string
+}
+
+export type RoiInsights = {
+  unidade?: string
+  perdas?: {
+    valorExpirado?: number
+    valorRiscoVencendo?: number
+    itensExpirados?: number
+    itensVencendo?: number
+  }
+  ruptura?: { itensRuptura?: number }
+  produtividade?: { entrada?: number | null; baixa?: number | null }
+}
+
+export type QualityIssue = {
+  severity?: 'CRITICAL' | 'WARN' | 'INFO' | string
+  code?: string
+  message?: string
+  registro?: string
+  codigoBarras?: string
+  produto?: string
+  unidade?: string
+  suggestion?: string
+}
+
+export type QualityReport = {
+  generatedAt?: string
+  unidade?: string
+  summary?: { total?: number; bySeverity?: Record<string, number> }
+  issues?: QualityIssue[]
+}
+
+export type OverviewBundleData = {
+  resumo?: EstoqueResumo | null
+  itens?: Insumo[] | null
+  notifications?: NotificationsSummary | null
+  actionables?: Actionables | null
+  roi?: RoiInsights | null
+  quality?: QualityReport | null
+  movResumo?: {
+    entradaQtd?: number
+    saidaQtd?: number
+    entradaValor?: number
+    saidaValor?: number
+    saldoLiquido?: number
+  } | null
+  movSeries?: Array<{ day?: string; entrada?: number; saida?: number; entradaValor?: number; saidaValor?: number }>
+}
+
+export type InsightsBundleData = {
+  alertas?: EstoqueAlerta[] | null
+  trends?: unknown
+  turnover?: {
+    saida?: unknown
+    entrada?: unknown
+  } | null
+}
+
+export type InsumosProxyStatus = {
+  ok?: boolean
+  localDirect?: boolean
+  target?: string
+  isProductionTarget?: boolean
+  localSafeMode?: boolean
+  mutationsBlocked?: boolean
+}
+
+export type ShareFile = {
+  name: string
+  size?: number
+  contentType?: string
+  url?: string
+}
+
+export type SharePayload = {
+  title?: string
+  text?: string
+  url?: string
+  files?: ShareFile[]
+}
+
+export type ShareHistoryItem = SharePayload & {
+  id: string
+  createdAt: string
+}
+
+export type CategoryPolicy = {
+  slug: string
+  label?: string
+  requiresLot?: boolean
+  requiresExpiry?: boolean
+  fefo?: boolean
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+export type CategoryPolicySuggestion = {
+  slug: string
+  label: string
+}
+
+export type ApiError = {
+  error?: string
+  message?: string
+  success?: boolean
+  code?: string
+  registros?: string[]
+  candidates?: Array<{
+    registro?: string
+    lote?: string
+    dataValidade?: string | null
+    estoque?: number
+    categoria?: string
+  }>
+}
+
+export type UserPrefs = {
+  overviewPanelOrder?: string[]
+  mainPanelOrder?: string[]
+  detailsOpen?: Record<string, boolean>
+}
+
+export type OfflineQueueItem = {
+  id: string
+  ts: number
+  path: string
+  method: string
+  body?: unknown
+}
+
+export type InsumosOverviewPeriod = '7d' | '30d' | '1y' | 'custom'
+export type InsumosQuickOperation = 'ENTRADA' | 'BAIXA' | 'AJUSTE' | 'TRANSFERENCIA'
+export type InsumosLayoutAction = 'expandAll' | 'collapseAll' | 'reset'
+export type InsumosUiSection =
+  | 'context'
+  | 'workspace'
+  | 'overview'
+  | 'inventory'
+  | 'quick-operations'
+  | 'movements'
+  | 'policies'
+  | 'history'
+  | 'governance'
+export type InsumosWorkspaceMode = 'inventory' | 'movements' | 'analytics' | 'governance'
+
+export type InsumosOverviewQuery = {
+  action?: 'reload'
+  period?: InsumosOverviewPeriod
+  from?: string
+  to?: string
+}
+
+export type InsumosLoadState<T> = {
+  data: T
+  loading: boolean
+  loaded: boolean
+  error: string | null
+}
+
+export type InsumosMutationResult = {
+  ok: boolean
+  changed: boolean
+  error?: string
+}
+
+export type QuickCandidate = {
+  registro: string
+  lote: string
+  dataValidade: string | null
+  estoque: number
+}
+
+export type QuickActionFeedback = {
+  type: 'success' | 'error'
+  message: string
+}
+
+export type InsumosHeaderStatus = {
+  online: boolean | null
+  authed: boolean | null
+  integrated: boolean | null
+  unidades: string[]
+  allowedUnits: string[]
+}
+
+export type InsumosHeaderStockState = {
+  value: number | null
+  loading: boolean
+  percent: number | null
+  entradaValor?: number | null
+  saidaValor?: number | null
+}
+
+export type InsumosHeaderState = {
+  status: InsumosHeaderStatus | null
+  stock: InsumosHeaderStockState | null
+  selectedUnit: string
+  overview: Required<Pick<InsumosOverviewQuery, 'period'>> & Pick<InsumosOverviewQuery, 'from' | 'to'>
+}
+
+export type InsumosHeaderAction =
+  | { type: 'set-unit'; value: string }
+  | { type: 'set-overview'; value: InsumosOverviewQuery }
+  | { type: 'reload-overview' }
+  | { type: 'quick-op'; value: InsumosQuickOperation }
+  | { type: 'layout'; value: InsumosLayoutAction }

--- a/frontend/tests/escalaModule.test.ts
+++ b/frontend/tests/escalaModule.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { normalizeEscalaHeaderAction, normalizeEscalaHeaderState } from '../escalaHeaderBridge'
+import { buildSelectedDatesLabel, buildSelectionScopeLabel, resolveNextActiveDate, toggleDateSelection } from '../escalaSelection'
 import { __testables } from '../EscalaProfissionaisModule'
 import { buildMonthPlanMetrics, resolveDayPlanSource } from '../escalaDomain'
 
@@ -147,5 +149,79 @@ describe('Escala module helpers', () => {
       manual: 1,
       auto: 1,
     })
+  })
+
+  it('normalizes typed header actions and legacy highlight payloads', () => {
+    expect(normalizeEscalaHeaderAction({ type: 'set-unit', value: 'Novo Hamburgo' })).toEqual({
+      type: 'set-unit',
+      value: 'Novo Hamburgo',
+    })
+
+    expect(normalizeEscalaHeaderAction({ action: 'toggle-highlight-mode', value: 'scheduled' })).toEqual({
+      type: 'toggle-highlight',
+      value: 'manual',
+    })
+
+    expect(normalizeEscalaHeaderAction({ action: 'clear-selection' })).toEqual({
+      type: 'clear-selection',
+    })
+  })
+
+  it('normalizes the header state contract before syncing with App', () => {
+    expect(normalizeEscalaHeaderState({
+      units: ['Novo Hamburgo'],
+      monthOptions: ['03', '04'],
+      yearOptions: ['2026'],
+      selectedUnit: 'Novo Hamburgo',
+      selectedMonthNumber: '04',
+      selectedYear: '2026',
+      totalScheduledDays: 12,
+      manualDays: 10,
+      autoDays: 1,
+      blockedDays: 1,
+      emptyDays: 2,
+      coveredDays: 11,
+      highlightMode: 'manual',
+    })).toEqual({
+      units: ['Novo Hamburgo'],
+      monthOptions: ['03', '04'],
+      yearOptions: ['2026'],
+      selectedUnit: 'Novo Hamburgo',
+      selectedMonthNumber: '04',
+      selectedYear: '2026',
+      totalScheduledDays: 12,
+      manualDays: 10,
+      autoDays: 1,
+      blockedDays: 1,
+      emptyDays: 2,
+      coveredDays: 11,
+      unavailableDaysCount: undefined,
+      highlightMode: 'manual',
+    })
+  })
+
+  it('toggles multi-date selection and resolves the next active date predictably', () => {
+    const added = toggleDateSelection(['2026-03-05'], '2026-03-12')
+    expect(added).toEqual({
+      alreadySelected: false,
+      nextDates: ['2026-03-05', '2026-03-12'],
+    })
+    expect(resolveNextActiveDate(added.nextDates, '2026-03-12', added.alreadySelected)).toBe('2026-03-12')
+
+    const removed = toggleDateSelection(['2026-03-05', '2026-03-12'], '2026-03-12')
+    expect(removed).toEqual({
+      alreadySelected: true,
+      nextDates: ['2026-03-05'],
+    })
+    expect(resolveNextActiveDate(removed.nextDates, '2026-03-12', removed.alreadySelected)).toBe('2026-03-05')
+  })
+
+  it('builds readable labels for selected dates', () => {
+    const label = buildSelectedDatesLabel(
+      ['2026-03-05', '2026-03-12', '2026-03-19', '2026-03-26'],
+      (value) => value,
+    )
+    expect(label).toBe('2026-03-05, 2026-03-12, 2026-03-19 +1')
+    expect(buildSelectionScopeLabel(label, 4)).toBe('4 datas selecionadas: 2026-03-05, 2026-03-12, 2026-03-19 +1')
   })
 })

--- a/frontend/tests/insumosModule.test.ts
+++ b/frontend/tests/insumosModule.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeInsumosHeaderAction, normalizeInsumosHeaderState } from '../insumosBridge'
+import { getNextChartPresetPatch, getNextMovementsGroupByPatch, parseChartSlots } from '../insumosCharts'
+import { resolveOverviewDateRange } from '../insumosDashboardController'
+import { buildMovimentacoesView } from '../insumosDerivations'
+import { brToIsoDate, calcularStatusEstoque, normalizeTipoUnidadeToCanonical, parseBarcodeInput } from '../insumosShared'
+import { buildMovimentacoesQuery } from '../useInsumosMovementsController'
+
+describe('Insumos module helpers', () => {
+  it('normalizes typed and legacy header actions', () => {
+    expect(normalizeInsumosHeaderAction({ type: 'set-unit', value: 'novo-hamburgo' })).toEqual({
+      type: 'set-unit',
+      value: 'novo-hamburgo',
+    })
+
+    expect(normalizeInsumosHeaderAction({ op: 'BAIXA' })).toEqual({
+      type: 'quick-op',
+      value: 'BAIXA',
+    })
+
+    expect(normalizeInsumosHeaderAction({ op: 'AJUSTE' })).toEqual({
+      type: 'quick-op',
+      value: 'AJUSTE',
+    })
+
+    expect(normalizeInsumosHeaderAction({ action: 'expandAll' })).toEqual({
+      type: 'layout',
+      value: 'expandAll',
+    })
+
+    expect(normalizeInsumosHeaderAction({ action: 'reload', period: '30d' })).toEqual({
+      type: 'set-overview',
+      value: { action: 'reload', period: '30d' },
+    })
+  })
+
+  it('normalizes the header state emitted to App', () => {
+    expect(normalizeInsumosHeaderState({
+      status: {
+        online: true,
+        authed: true,
+        integrated: false,
+        unidades: ['novo-hamburgo'],
+        allowedUnits: ['novo-hamburgo'],
+      },
+      stock: {
+        value: 1234,
+        loading: true,
+        percent: 82,
+        entradaValor: 500,
+        saidaValor: 120,
+      },
+      selectedUnit: 'novo-hamburgo',
+      overview: { period: 'custom', from: '01/05/2026', to: '10/05/2026' },
+    })).toEqual({
+      status: {
+        online: true,
+        authed: true,
+        integrated: false,
+        unidades: ['novo-hamburgo'],
+        allowedUnits: ['novo-hamburgo'],
+      },
+      stock: {
+        value: 1234,
+        loading: true,
+        percent: 82,
+        entradaValor: 500,
+        saidaValor: 120,
+      },
+      selectedUnit: 'novo-hamburgo',
+      overview: { period: 'custom', from: '01/05/2026', to: '10/05/2026' },
+    })
+  })
+
+  it('keeps barcode parsing, unit normalization and stock severity predictable', () => {
+    expect(parseBarcodeInput('789\n 123 ; 456,789')).toEqual(['789', '123', '456', '789'])
+    expect(normalizeTipoUnidadeToCanonical('Flaconete')).toBe('frasco')
+    expect(calcularStatusEstoque(2, 3)).toBe('URGENTE')
+    expect(calcularStatusEstoque(3, 3)).toBe('ATENCAO')
+    expect(calcularStatusEstoque(4, 3)).toBe('OK')
+  })
+
+  it('converts Brazilian dates to ISO safely', () => {
+    expect(brToIsoDate('10/05/2026')).toBe('2026-05-10')
+    expect(brToIsoDate('10/05/26')).toBe('2026-05-10')
+    expect(brToIsoDate('31/02/2026')).toBe('')
+  })
+
+  it('groups duplicate transfer movements and keeps sorting deterministic', () => {
+    const insumos = {
+      '111': { codigoBarras: '111', produto: 'Seringa', categoria: 'Descartáveis', marca: 'Marca A', precoCusto: 10 },
+      '222': { codigoBarras: '222', produto: 'Luva', categoria: 'EPIs', marca: 'Marca B', precoCusto: 4 },
+    }
+
+    const view = buildMovimentacoesView({
+      movGroupTransfers: true,
+      movSortDir: 'desc',
+      movSortKey: 'dataHora',
+      movTipo: 'TODOS',
+      movFilterCategoria: '',
+      movFilterMarca: '',
+      movSearch: '',
+      movimentacoes: [
+        {
+          id: '1',
+          dataHora: '2026-05-10T10:00:00.000Z',
+          tipo: 'SAÍDA',
+          codigoBarras: '111',
+          quantidade: 2,
+          transferId: 'tx-1',
+          unidadeOrigem: 'novo-hamburgo',
+          unidadeDestino: 'barra-shopping-sul',
+        },
+        {
+          id: '2',
+          dataHora: '2026-05-10T10:01:00.000Z',
+          tipo: 'ENTRADA',
+          codigoBarras: '111',
+          quantidade: 2,
+          transferId: 'tx-1',
+          unidadeOrigem: 'novo-hamburgo',
+          unidadeDestino: 'barra-shopping-sul',
+        },
+        {
+          id: '3',
+          dataHora: '2026-05-09T09:00:00.000Z',
+          tipo: 'ENTRADA',
+          codigoBarras: '222',
+          quantidade: 1,
+        },
+      ],
+      pickInsumoForMov: (movement) => insumos[String(movement.codigoBarras || '') as '111' | '222'] || null,
+      selectedCodigoBarras: '',
+      normalizeText: (value) => String(value || '').trim().toLowerCase(),
+    })
+
+    expect(view).toHaveLength(2)
+    expect(view[0]).toMatchObject({
+      transferId: 'tx-1',
+      tipo: 'TRANSFERÊNCIA',
+      quantidade: 2,
+      unidadeOrigem: 'novo-hamburgo',
+      unidadeDestino: 'barra-shopping-sul',
+    })
+    expect(view[1]).toMatchObject({
+      id: '3',
+      codigoBarras: '222',
+    })
+  })
+
+  it('normalizes legacy chart slots and clamps invalid values', () => {
+    const slots = parseChartSlots(
+      JSON.stringify([
+        { presetId: 'stock_brand', metric: 'valor', view: 'pie', topN: 99 },
+        { presetId: 'mov_saldo', topN: 2, view: 'line' },
+      ])
+    )
+
+    expect(slots).toEqual([
+      { presetId: 'distribution', groupBy: 'marca', metric: 'valor', view: 'pie', topN: 15 },
+      { presetId: 'movements', groupBy: 'tempo', mode: 'saldo', metric: undefined, view: 'line', topN: 5 },
+    ])
+  })
+
+  it('recomputes chart mode and view when moving movement charts to categoria', () => {
+    expect(
+      getNextMovementsGroupByPatch(
+        { presetId: 'movements', groupBy: 'tempo', mode: 'inout', metric: 'qtd', view: 'line', topN: 8 },
+        'categoria'
+      )
+    ).toEqual({
+      groupBy: 'categoria',
+      mode: 'saida',
+      view: 'bar',
+    })
+
+    expect(
+      getNextChartPresetPatch(
+        { presetId: 'distribution', groupBy: 'item', metric: 'qtd', view: 'bar', topN: 8 },
+        'movements'
+      )
+    ).toEqual({
+      presetId: 'movements',
+      groupBy: 'tempo',
+      mode: 'inout',
+      view: 'bar',
+    })
+  })
+
+  it('derives stable overview date ranges for rolling and custom periods', () => {
+    expect(
+      resolveOverviewDateRange({
+        period: '30d',
+        customFrom: '',
+        customTo: '',
+        now: new Date('2026-05-10T12:00:00.000Z'),
+      })
+    ).toEqual({
+      de: '2026-04-10',
+      ate: '2026-05-10',
+      days: 30,
+    })
+
+    expect(
+      resolveOverviewDateRange({
+        period: 'custom',
+        customFrom: '01/05/2026',
+        customTo: '10/05/2026',
+        now: new Date('2026-05-10T12:00:00.000Z'),
+      })
+    ).toEqual({
+      de: '2026-05-01',
+      ate: '2026-05-10',
+      days: 9,
+    })
+  })
+
+  it('builds movement queries with normalized filters and dates', () => {
+    expect(
+      buildMovimentacoesQuery({
+        unidade: 'novo-hamburgo',
+        limite: 200,
+        pagina: 2,
+        movTipo: 'SAÍDA',
+        selectedCodigoBarras: '789',
+        movDe: '01/05/2026',
+        movAte: '10/05/2026',
+      }).toString()
+    ).toBe(
+      'unidade=novo-hamburgo&limite=200&pagina=2&tipo=SA%C3%8DDA&codigoBarras=789&de=2026-05-01&ate=2026-05-10'
+    )
+  })
+})

--- a/frontend/useEscalaDataController.ts
+++ b/frontend/useEscalaDataController.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  fetchEscalaOverview,
+  fetchEscalaProfessionals,
+  fetchEscalaSchedule,
+} from '@/escalaApi'
+import {
+  buildYearOptions,
+  DEFAULT_MONTH_NUMBER,
+  DEFAULT_YEAR,
+  resolveVisibleMonth,
+} from '@/escalaShared'
+import type {
+  EscalaClosedDay,
+  EscalaHoliday,
+  EscalaProfessional,
+  EscalaScheduleEntry,
+} from '@/escalaTypes'
+
+type EscalaDataControllerResult = {
+  units: string[]
+  availableMonths: string[]
+  selectedUnit: string
+  selectedMonth: string
+  selectedMonthNumber: string
+  selectedYear: string
+  professionals: EscalaProfessional[]
+  schedule: EscalaScheduleEntry[]
+  closedDays: EscalaClosedDay[]
+  holidays: EscalaHoliday[]
+  loadingSchedule: boolean
+  error: string | null
+  teamLoadError: string | null
+  yearOptions: string[]
+  setError: React.Dispatch<React.SetStateAction<string | null>>
+  setSelectedUnit: React.Dispatch<React.SetStateAction<string>>
+  setSelectedMonthNumber: React.Dispatch<React.SetStateAction<string>>
+  setSelectedYear: React.Dispatch<React.SetStateAction<string>>
+  setSchedule: React.Dispatch<React.SetStateAction<EscalaScheduleEntry[]>>
+  setProfessionals: React.Dispatch<React.SetStateAction<EscalaProfessional[]>>
+  setClosedDays: React.Dispatch<React.SetStateAction<EscalaClosedDay[]>>
+  setHolidays: React.Dispatch<React.SetStateAction<EscalaHoliday[]>>
+  setTeamLoadError: React.Dispatch<React.SetStateAction<string | null>>
+  markMonthSelectionTouched: () => void
+  refreshOverview: () => Promise<void>
+  refreshProfessionals: (unitOverride?: string) => Promise<void>
+  refreshSchedule: (unitOverride?: string, monthOverride?: string) => Promise<void>
+}
+
+export function useEscalaDataController(): EscalaDataControllerResult {
+  const [units, setUnits] = useState<string[]>([])
+  const [availableMonths, setAvailableMonths] = useState<string[]>([])
+  const [selectedUnit, setSelectedUnit] = useState<string>('')
+  const [selectedMonthNumber, setSelectedMonthNumber] = useState<string>(DEFAULT_MONTH_NUMBER)
+  const [selectedYear, setSelectedYear] = useState<string>(DEFAULT_YEAR)
+  const [professionals, setProfessionals] = useState<EscalaProfessional[]>([])
+  const [schedule, setSchedule] = useState<EscalaScheduleEntry[]>([])
+  const [closedDays, setClosedDays] = useState<EscalaClosedDay[]>([])
+  const [holidays, setHolidays] = useState<EscalaHoliday[]>([])
+  const [loadingSchedule, setLoadingSchedule] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [teamLoadError, setTeamLoadError] = useState<string | null>(null)
+
+  const selectedPeriodRef = useRef<{ year: string; monthNumber: string }>({
+    year: DEFAULT_YEAR,
+    monthNumber: DEFAULT_MONTH_NUMBER,
+  })
+  const monthSelectionTouchedRef = useRef(false)
+  const overviewRequestRef = useRef(0)
+  const professionalsRequestRef = useRef(0)
+  const scheduleRequestRef = useRef(0)
+
+  const selectedMonth = useMemo(
+    () => (selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : ''),
+    [selectedMonthNumber, selectedYear],
+  )
+  const yearOptions = useMemo(() => buildYearOptions(availableMonths), [availableMonths])
+
+  useEffect(() => {
+    selectedPeriodRef.current = {
+      year: selectedYear || DEFAULT_YEAR,
+      monthNumber: selectedMonthNumber || DEFAULT_MONTH_NUMBER,
+    }
+  }, [selectedMonthNumber, selectedYear])
+
+  const refreshOverview = useCallback(async () => {
+    const requestId = overviewRequestRef.current + 1
+    overviewRequestRef.current = requestId
+    const res = await fetchEscalaOverview()
+    if (overviewRequestRef.current !== requestId) return
+    if (!res.ok) {
+      setError(res.error || 'Não foi possível carregar a escala.')
+      return
+    }
+
+    const nextUnits = Array.isArray(res.units) ? res.units : []
+    const nextMonths = Array.isArray(res.months) ? res.months : []
+    setUnits(nextUnits)
+    setAvailableMonths(nextMonths)
+    setSelectedUnit((prev) => (prev || nextUnits[0] || prev))
+
+    if (!monthSelectionTouchedRef.current && nextMonths.length) {
+      const resolvedMonth = resolveVisibleMonth(
+        nextMonths,
+        selectedPeriodRef.current.year,
+        selectedPeriodRef.current.monthNumber,
+      )
+      setSelectedYear(resolvedMonth.year)
+      setSelectedMonthNumber(resolvedMonth.monthNumber)
+    } else {
+      setSelectedMonthNumber((prev) => prev || DEFAULT_MONTH_NUMBER)
+      setSelectedYear((prev) => prev || DEFAULT_YEAR)
+    }
+    setError(null)
+  }, [])
+
+  const refreshProfessionals = useCallback(async (unitOverride?: string) => {
+    const unit = unitOverride || selectedUnit
+    if (!unit) return
+    const requestId = professionalsRequestRef.current + 1
+    professionalsRequestRef.current = requestId
+    const res = await fetchEscalaProfessionals(unit)
+    if (professionalsRequestRef.current !== requestId) return
+    if (!res.ok) {
+      setProfessionals([])
+      setTeamLoadError(res.error || 'Falha ao carregar a equipe do cadastro.')
+      return
+    }
+    setProfessionals(Array.isArray(res.data) ? res.data : [])
+    setTeamLoadError(null)
+  }, [selectedUnit])
+
+  const refreshSchedule = useCallback(async (unitOverride?: string, monthOverride?: string) => {
+    const unit = unitOverride || selectedUnit
+    const month = monthOverride || (selectedYear && selectedMonthNumber ? `${selectedYear}-${selectedMonthNumber}` : '')
+    if (!unit || !month) return
+    const requestId = scheduleRequestRef.current + 1
+    scheduleRequestRef.current = requestId
+    setLoadingSchedule(true)
+    const res = await fetchEscalaSchedule(unit, month)
+    if (scheduleRequestRef.current !== requestId) return
+    if (!res.ok) {
+      setError(res.error || 'Não foi possível carregar a agenda.')
+      setLoadingSchedule(false)
+      return
+    }
+    setSchedule(Array.isArray(res.schedule) ? res.schedule : [])
+    setClosedDays(Array.isArray(res.closedDays) ? res.closedDays : [])
+    setHolidays(Array.isArray(res.holidays) ? res.holidays : [])
+    setError(null)
+    setLoadingSchedule(false)
+  }, [selectedMonthNumber, selectedUnit, selectedYear])
+
+  useEffect(() => {
+    void refreshOverview()
+  }, [refreshOverview])
+
+  useEffect(() => {
+    if (!selectedUnit) return
+    void refreshProfessionals(selectedUnit)
+  }, [refreshProfessionals, selectedUnit])
+
+  useEffect(() => {
+    if (!selectedUnit || !selectedMonth) return
+    void refreshSchedule(selectedUnit, selectedMonth)
+  }, [refreshSchedule, selectedMonth, selectedUnit])
+
+  const markMonthSelectionTouched = useCallback(() => {
+    monthSelectionTouchedRef.current = true
+  }, [])
+
+  return {
+    units,
+    availableMonths,
+    selectedUnit,
+    selectedMonth,
+    selectedMonthNumber,
+    selectedYear,
+    professionals,
+    schedule,
+    closedDays,
+    holidays,
+    loadingSchedule,
+    error,
+    teamLoadError,
+    yearOptions,
+    setError,
+    setSelectedUnit,
+    setSelectedMonthNumber,
+    setSelectedYear,
+    setSchedule,
+    setProfessionals,
+    setClosedDays,
+    setHolidays,
+    setTeamLoadError,
+    markMonthSelectionTouched,
+    refreshOverview,
+    refreshProfessionals,
+    refreshSchedule,
+  }
+}

--- a/frontend/useEscalaPrefill.ts
+++ b/frontend/useEscalaPrefill.ts
@@ -4,11 +4,13 @@ import { toast } from 'sonner'
 import { fetchEscalaPrefill, replaceScheduleEntriesBatch } from '@/escalaApi'
 import {
   applyPrefillUpdatesToSchedule,
-  type CalendarCell,
-  type EscalaClosedDay,
-  type EscalaScheduleEntry,
-  type PrefillSuggestion,
 } from '@/escalaDomain'
+import type {
+  CalendarCell,
+  EscalaClosedDay,
+  EscalaScheduleEntry,
+  PrefillSuggestion,
+} from '@/escalaTypes'
 
 type PrefillUiStatus = 'idle' | 'analyzing' | 'ready' | 'applying' | 'done' | 'error' | 'ignored'
 

--- a/frontend/useInsumosCreateLookupController.ts
+++ b/frontend/useInsumosCreateLookupController.ts
@@ -1,0 +1,187 @@
+import React from 'react'
+
+import { normalizeTipoUnidadeToCanonical } from '@/insumosShared'
+import type { Insumo } from '@/insumosTypes'
+
+type LookupByCodigoFn = (args: { codigoBarras: string; ctxUnidade: string }) => Promise<Insumo[]>
+type ReadCachedByCodigoFn = (args: { codigoBarras: string; ctxUnidade: string }) => Insumo[]
+
+type UseInsumosCreateLookupControllerArgs = {
+  canUseApi: boolean
+  createCalibre: string
+  createCategoria: string
+  createCodigo: string
+  createConcentracao: string
+  createEspecificacao: string
+  createHomologado: boolean
+  createMarca: string
+  createOpen: boolean
+  createPolicyTouched: boolean
+  createPrecoCusto: string
+  createProduto: string
+  createTipoUnidade: string
+  createVolume: string
+  getPolicyForItem: (item?: Insumo | null) => { requiresLot: boolean; requiresExpiry: boolean; fefo: boolean }
+  isAuthed: boolean
+  lookupInsumosByCodigo: LookupByCodigoFn
+  readCachedInsumosByCodigo: ReadCachedByCodigoFn
+  unidade: string
+  setCreateCalibre: React.Dispatch<React.SetStateAction<string>>
+  setCreateCategoria: React.Dispatch<React.SetStateAction<string>>
+  setCreateCategoriaFefo: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateCategoriaRequiresExpiry: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateCategoriaRequiresLot: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateConcentracao: React.Dispatch<React.SetStateAction<string>>
+  setCreateEspecificacao: React.Dispatch<React.SetStateAction<string>>
+  setCreateHomologado: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateLookupError: React.Dispatch<React.SetStateAction<string | null>>
+  setCreateLookupItems: React.Dispatch<React.SetStateAction<Insumo[]>>
+  setCreateLookupLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateMarca: React.Dispatch<React.SetStateAction<string>>
+  setCreatePrecoCusto: React.Dispatch<React.SetStateAction<string>>
+  setCreateProduto: React.Dispatch<React.SetStateAction<string>>
+  setCreateTipoUnidade: React.Dispatch<React.SetStateAction<string>>
+  setCreateVolume: React.Dispatch<React.SetStateAction<string>>
+}
+
+export function useInsumosCreateLookupController({
+  canUseApi,
+  createCalibre,
+  createCategoria,
+  createCodigo,
+  createConcentracao,
+  createEspecificacao,
+  createHomologado,
+  createMarca,
+  createOpen,
+  createPolicyTouched,
+  createPrecoCusto,
+  createProduto,
+  createTipoUnidade,
+  createVolume,
+  getPolicyForItem,
+  isAuthed,
+  lookupInsumosByCodigo,
+  readCachedInsumosByCodigo,
+  unidade,
+  setCreateCalibre,
+  setCreateCategoria,
+  setCreateCategoriaFefo,
+  setCreateCategoriaRequiresExpiry,
+  setCreateCategoriaRequiresLot,
+  setCreateConcentracao,
+  setCreateEspecificacao,
+  setCreateHomologado,
+  setCreateLookupError,
+  setCreateLookupItems,
+  setCreateLookupLoading,
+  setCreateMarca,
+  setCreatePrecoCusto,
+  setCreateProduto,
+  setCreateTipoUnidade,
+  setCreateVolume,
+}: UseInsumosCreateLookupControllerArgs) {
+  const createLookupTokenRef = React.useRef(0)
+
+  const applyCreateLookupPrefill = React.useCallback((items: Insumo[]) => {
+    const item = Array.isArray(items) && items.length ? items[0] : null
+    if (!item) return
+    if (!createProduto.trim() && item.produto) setCreateProduto(String(item.produto))
+    if (!createCategoria.trim() && item.categoria) setCreateCategoria(String(item.categoria))
+    if (!createMarca.trim() && item.marca) setCreateMarca(String(item.marca))
+    if (!createEspecificacao.trim() && (item as any).especificacao) setCreateEspecificacao(String((item as any).especificacao))
+    if (!createConcentracao.trim() && (item as any).concentracao) setCreateConcentracao(String((item as any).concentracao))
+    if (!createVolume.trim() && (item as any).volume) setCreateVolume(String((item as any).volume))
+    if (!createHomologado && /homologad/i.test(String((item as any).fonte || '').trim())) setCreateHomologado(true)
+    if (!createCalibre.trim() && (item as any).calibre) setCreateCalibre(String((item as any).calibre))
+    if (!createPrecoCusto.trim() && (item as any).precoCusto) setCreatePrecoCusto(String((item as any).precoCusto))
+    if (!createTipoUnidade.trim() && item.tipoUnidade) {
+      setCreateTipoUnidade(normalizeTipoUnidadeToCanonical(String(item.tipoUnidade)) || '')
+    }
+    if (!createPolicyTouched) {
+      const policy = getPolicyForItem(item)
+      setCreateCategoriaRequiresLot(!!policy.requiresLot)
+      setCreateCategoriaRequiresExpiry(!!policy.requiresExpiry)
+      setCreateCategoriaFefo(!!policy.fefo)
+    }
+  }, [
+    createCalibre,
+    createCategoria,
+    createConcentracao,
+    createEspecificacao,
+    createHomologado,
+    createMarca,
+    createPolicyTouched,
+    createPrecoCusto,
+    createProduto,
+    createTipoUnidade,
+    createVolume,
+    getPolicyForItem,
+    setCreateCalibre,
+    setCreateCategoria,
+    setCreateCategoriaFefo,
+    setCreateCategoriaRequiresExpiry,
+    setCreateCategoriaRequiresLot,
+    setCreateConcentracao,
+    setCreateEspecificacao,
+    setCreateHomologado,
+    setCreateMarca,
+    setCreatePrecoCusto,
+    setCreateProduto,
+    setCreateTipoUnidade,
+    setCreateVolume,
+  ])
+
+  React.useEffect(() => {
+    if (!createOpen) return
+    if (!canUseApi || !isAuthed) return
+    const codigo = createCodigo.trim()
+    if (!codigo) {
+      setCreateLookupLoading(false)
+      setCreateLookupError(null)
+      setCreateLookupItems([])
+      return
+    }
+    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade: unidade })
+    if (cached.length) {
+      setCreateLookupLoading(false)
+      setCreateLookupError(null)
+      setCreateLookupItems(cached)
+      applyCreateLookupPrefill(cached)
+      return
+    }
+    const token = ++createLookupTokenRef.current
+    setCreateLookupLoading(true)
+    setCreateLookupError(null)
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const items = await lookupInsumosByCodigo({ codigoBarras: codigo, ctxUnidade: unidade })
+          if (token !== createLookupTokenRef.current) return
+          setCreateLookupItems(items)
+          if (!items.length) setCreateLookupError('Nenhum insumo encontrado para este código.')
+          applyCreateLookupPrefill(items)
+        } catch (error: any) {
+          if (token !== createLookupTokenRef.current) return
+          setCreateLookupError(error?.message || 'Falha ao buscar o insumo.')
+          setCreateLookupItems([])
+        } finally {
+          if (token === createLookupTokenRef.current) setCreateLookupLoading(false)
+        }
+      })()
+    }, 250)
+    return () => window.clearTimeout(timer)
+  }, [
+    applyCreateLookupPrefill,
+    canUseApi,
+    createCodigo,
+    createOpen,
+    isAuthed,
+    lookupInsumosByCodigo,
+    readCachedInsumosByCodigo,
+    setCreateLookupError,
+    setCreateLookupItems,
+    setCreateLookupLoading,
+    unidade,
+  ])
+}

--- a/frontend/useInsumosHeaderBridge.ts
+++ b/frontend/useInsumosHeaderBridge.ts
@@ -1,0 +1,161 @@
+import React from 'react'
+import { dispatchInsumosHeaderAction, emitInsumosHeaderState, subscribeInsumosHeaderAction } from '@/insumosBridge'
+import type {
+  InsumosHeaderState,
+  InsumosLayoutAction,
+  InsumosOverviewPeriod,
+  InsumosQuickOperation,
+} from '@/insumosTypes'
+
+type UseInsumosHeaderBridgeArgs = {
+  allUnidades: string[]
+  allowedUnits: string[]
+  loadInsights: (opts?: { force?: boolean }) => Promise<void>
+  loadOverview: (opts?: { force?: boolean }) => Promise<void>
+  loadingPercent: number
+  openQuickOperation: (op: InsumosQuickOperation) => void
+  overviewCustomFrom: string
+  overviewCustomTo: string
+  overviewMovResumo: { entradaValor?: number | null; saidaValor?: number | null } | null
+  overviewPeriod: InsumosOverviewPeriod
+  overviewResumo: { valorEstoqueTotal?: number | null } | null
+  refreshInsumos: () => Promise<void>
+  resetUserLayoutPrefs: () => Promise<void>
+  selectedUnit: string
+  setAllDetailsOpen: (value: boolean) => void
+  setOverviewCustomFrom: React.Dispatch<React.SetStateAction<string>>
+  setOverviewCustomTo: React.Dispatch<React.SetStateAction<string>>
+  setOverviewPeriod: React.Dispatch<React.SetStateAction<InsumosOverviewPeriod>>
+  setSelectedUnit: React.Dispatch<React.SetStateAction<string>>
+  showOverviewLoadingProgress: boolean
+  status: InsumosHeaderState['status']
+  storageKey: string
+}
+
+export function useInsumosHeaderBridge({
+  allUnidades,
+  allowedUnits,
+  loadInsights,
+  loadOverview,
+  loadingPercent,
+  openQuickOperation,
+  overviewCustomFrom,
+  overviewCustomTo,
+  overviewMovResumo,
+  overviewPeriod,
+  overviewResumo,
+  refreshInsumos,
+  resetUserLayoutPrefs,
+  selectedUnit,
+  setAllDetailsOpen,
+  setOverviewCustomFrom,
+  setOverviewCustomTo,
+  setOverviewPeriod,
+  setSelectedUnit,
+  showOverviewLoadingProgress,
+  status,
+  storageKey,
+}: UseInsumosHeaderBridgeArgs) {
+  React.useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, selectedUnit)
+    } catch {
+      // ignore
+    }
+  }, [selectedUnit, storageKey])
+
+  React.useEffect(() => {
+    if (!allowedUnits.length) return
+    if (allowedUnits.includes(selectedUnit)) return
+    const next = allowedUnits[0]
+    setSelectedUnit(next)
+    dispatchInsumosHeaderAction({ type: 'set-unit', value: next })
+  }, [allowedUnits, selectedUnit, setSelectedUnit])
+
+  React.useEffect(() => {
+    if (!allUnidades.length) return
+    if (allUnidades.includes(selectedUnit)) return
+    const next = allUnidades[0]
+    if (!next) return
+    setSelectedUnit(next)
+    dispatchInsumosHeaderAction({ type: 'set-unit', value: next })
+  }, [allUnidades, selectedUnit, setSelectedUnit])
+
+  React.useEffect(() => {
+    emitInsumosHeaderState({
+      status,
+      stock: {
+        value: overviewResumo?.valorEstoqueTotal == null ? null : Number(overviewResumo.valorEstoqueTotal),
+        loading: showOverviewLoadingProgress,
+        percent: loadingPercent,
+        entradaValor: Number.isFinite(Number(overviewMovResumo?.entradaValor)) ? Number(overviewMovResumo?.entradaValor) : null,
+        saidaValor: Number.isFinite(Number(overviewMovResumo?.saidaValor)) ? Number(overviewMovResumo?.saidaValor) : null,
+      },
+      selectedUnit,
+      overview: {
+        period: overviewPeriod,
+        from: overviewCustomFrom,
+        to: overviewCustomTo,
+      },
+    })
+  }, [
+    loadingPercent,
+    overviewCustomFrom,
+    overviewCustomTo,
+    overviewMovResumo?.entradaValor,
+    overviewMovResumo?.saidaValor,
+    overviewPeriod,
+    overviewResumo?.valorEstoqueTotal,
+    selectedUnit,
+    showOverviewLoadingProgress,
+    status,
+  ])
+
+  React.useEffect(() => {
+    return subscribeInsumosHeaderAction((action) => {
+      if (action.type === 'set-unit') {
+        setSelectedUnit(action.value)
+        return
+      }
+      if (action.type === 'set-overview') {
+        if (action.value.period) setOverviewPeriod(action.value.period)
+        if (typeof action.value.from === 'string') setOverviewCustomFrom(action.value.from)
+        if (typeof action.value.to === 'string') setOverviewCustomTo(action.value.to)
+        if (action.value.action === 'reload') {
+          void Promise.allSettled([loadOverview({ force: true }), loadInsights({ force: true }), refreshInsumos()])
+        }
+        return
+      }
+      if (action.type === 'reload-overview') {
+        void Promise.allSettled([loadOverview({ force: true }), loadInsights({ force: true }), refreshInsumos()])
+        return
+      }
+      if (action.type === 'quick-op') {
+        openQuickOperation(action.value)
+        try {
+          window.scrollTo({ top: 0, behavior: 'smooth' })
+        } catch {
+          // ignore
+        }
+        return
+      }
+      if (action.type === 'layout') {
+        const layoutAction: InsumosLayoutAction = action.value
+        if (layoutAction === 'expandAll') setAllDetailsOpen(true)
+        if (layoutAction === 'collapseAll') setAllDetailsOpen(false)
+        if (layoutAction === 'reset') void resetUserLayoutPrefs()
+      }
+    })
+  }, [
+    loadInsights,
+    loadOverview,
+    openQuickOperation,
+    refreshInsumos,
+    resetUserLayoutPrefs,
+    setAllDetailsOpen,
+    setOverviewCustomFrom,
+    setOverviewCustomTo,
+    setOverviewPeriod,
+    setSelectedUnit,
+  ])
+}

--- a/frontend/useInsumosInventoryMutationsController.ts
+++ b/frontend/useInsumosInventoryMutationsController.ts
@@ -11,7 +11,7 @@ type MutateJsonFn = <T>(
     body?: unknown
     queueLabel?: string
   }
-) => Promise<T>
+) => Promise<T | { queued: true }>
 
 type PolicyErrorCode = 'POLICY_REQUIRES_LOT' | 'POLICY_REQUIRES_EXPIRY' | null
 type EditValidationErrors = Partial<Record<'codigoBarras' | 'produto' | 'categoria' | 'marca' | 'tipoUnidade' | 'lote' | 'dataValidade' | 'policy', string>>

--- a/frontend/useInsumosInventoryMutationsController.ts
+++ b/frontend/useInsumosInventoryMutationsController.ts
@@ -1,0 +1,728 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import { dateInputToIso, getInsumoBarcodes, normalizeTipoUnidadeToCanonical, parseBarcodeInput } from '@/insumosShared'
+import type { Insumo } from '@/insumosTypes'
+
+type MutateJsonFn = <T>(
+  path: string,
+  opts: {
+    method?: string
+    body?: unknown
+    queueLabel?: string
+  }
+) => Promise<T>
+
+type PolicyErrorCode = 'POLICY_REQUIRES_LOT' | 'POLICY_REQUIRES_EXPIRY' | null
+type EditValidationErrors = Partial<Record<'codigoBarras' | 'produto' | 'categoria' | 'marca' | 'tipoUnidade' | 'lote' | 'dataValidade' | 'policy', string>>
+
+type UseInsumosInventoryMutationsControllerArgs = {
+  canUseApi: boolean
+  createCalibre: string
+  createCategoria: string
+  createCategoriaFefo: boolean
+  createCategoriaRequiresExpiry: boolean
+  createCategoriaRequiresLot: boolean
+  createCodigo: string
+  createCodigosExtras: string
+  createConcentracao: string
+  createDataValidade: string
+  createEspecificacao: string
+  createEstoqueInicial: string
+  createEstoqueMinimo: string
+  createHomologado: boolean
+  createLote: string
+  createMarca: string
+  createNovoLote: boolean
+  createPrecoCusto: string
+  createProduto: string
+  createTipoUnidade: string
+  createVolume: string
+  editCalibre: string
+  editCategoria: string
+  editCategoriaFefo: boolean
+  editCategoriaRequiresExpiry: boolean
+  editCategoriaRequiresLot: boolean
+  editCodigo: string
+  editCodigosExtras: string
+  editConcentracao: string
+  editDataValidade: string
+  editEspecificacao: string
+  editEstoqueMinimo: string
+  editHomologado: boolean
+  editLote: string
+  editMarca: string
+  editPrecoCusto: string
+  editProduto: string
+  editTarget: Insumo | null
+  editTipoUnidade: string
+  editVolume: string
+  getPolicyErrorCode: (error: unknown) => PolicyErrorCode
+  insumos: Insumo[]
+  isAuthed: boolean
+  loadInsumosOptions: () => Promise<void>
+  loadOverview: (opts?: { force?: boolean; lite?: boolean }) => Promise<void>
+  lotEditLote: string
+  lotEditValidade: string
+  lotSelecionado: Insumo | null
+  mutateJson: MutateJsonFn
+  policyErrorToast: (error: unknown) => boolean
+  refreshInsumos: (opts?: { pagina?: number }) => Promise<void>
+  setCreateCalibre: React.Dispatch<React.SetStateAction<string>>
+  setCreateCategoria: React.Dispatch<React.SetStateAction<string>>
+  setCreateCodigosExtras: React.Dispatch<React.SetStateAction<string>>
+  setCreateCodigo: React.Dispatch<React.SetStateAction<string>>
+  setCreateConcentracao: React.Dispatch<React.SetStateAction<string>>
+  setCreateDataValidade: React.Dispatch<React.SetStateAction<string>>
+  setCreateEspecificacao: React.Dispatch<React.SetStateAction<string>>
+  setCreateEstoqueInicial: React.Dispatch<React.SetStateAction<string>>
+  setCreateEstoqueMinimo: React.Dispatch<React.SetStateAction<string>>
+  setCreateHomologado: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateLote: React.Dispatch<React.SetStateAction<string>>
+  setCreateMarca: React.Dispatch<React.SetStateAction<string>>
+  setCreateNovoLote: React.Dispatch<React.SetStateAction<boolean>>
+  setCreateOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setCreatePrecoCusto: React.Dispatch<React.SetStateAction<string>>
+  setCreateProduto: React.Dispatch<React.SetStateAction<string>>
+  setCreateTipoUnidade: React.Dispatch<React.SetStateAction<string>>
+  setCreateVolume: React.Dispatch<React.SetStateAction<string>>
+  setEditOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setEditSaveError: React.Dispatch<React.SetStateAction<string | null>>
+  setEditSaving: React.Dispatch<React.SetStateAction<boolean>>
+  setEditValidationErrors: React.Dispatch<React.SetStateAction<EditValidationErrors>>
+  setLotDialogOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setLotSaving: React.Dispatch<React.SetStateAction<boolean>>
+  setQualityMatchesItems: React.Dispatch<React.SetStateAction<Insumo[]>>
+  setQualityMatchesSavingRegistro: React.Dispatch<React.SetStateAction<string>>
+  unidade: string
+}
+
+function resolveCreateDraft(args: {
+  createCalibre: string
+  createCategoria: string
+  createCategoriaFefo: boolean
+  createCategoriaRequiresExpiry: boolean
+  createCategoriaRequiresLot: boolean
+  createCodigo: string
+  createCodigosExtras: string
+  createConcentracao: string
+  createDataValidade: string
+  createEspecificacao: string
+  createEstoqueInicial: string
+  createEstoqueMinimo: string
+  createHomologado: boolean
+  createLote: string
+  createMarca: string
+  createNovoLote: boolean
+  createPrecoCusto: string
+  createProduto: string
+  createTipoUnidade: string
+  createVolume: string
+  insumos: Insumo[]
+}) {
+  const codigoBarras = args.createCodigo.trim()
+  if (!codigoBarras) return { error: 'Informe o código de barras' as const }
+
+  const extraCodes = parseBarcodeInput(args.createCodigosExtras)
+  const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((value) => String(value || '').trim()).filter(Boolean)))
+  const existing = (args.insumos || []).find((item) => getInsumoBarcodes(item).includes(codigoBarras))
+  const categoria = args.createCategoria.trim() || String(existing?.categoria || '').trim()
+  const policy = {
+    requiresLot: !!args.createCategoriaRequiresLot,
+    requiresExpiry: !!args.createCategoriaRequiresExpiry,
+    fefo: !!args.createCategoriaFefo,
+  }
+  const validadeIso = dateInputToIso(args.createDataValidade)
+  const allowDuplicateLot = args.createNovoLote || (!!existing && policy.requiresLot)
+
+  if ((policy.requiresLot || allowDuplicateLot) && !args.createLote.trim()) {
+    return {
+      allowDuplicateLot,
+      error: policy.requiresLot ? 'Informe o lote (obrigatório pelo item)' : 'Informe o lote (Novo lote: on)' as const,
+    }
+  }
+  if (policy.requiresExpiry && !validadeIso) return { allowDuplicateLot, error: 'Informe a data de validade (obrigatória pelo item)' as const }
+  if (policy.fefo && !policy.requiresExpiry) return { allowDuplicateLot, error: 'FEFO exige validade obrigatória' as const }
+
+  const produto = args.createProduto.trim() || (allowDuplicateLot ? String(existing?.produto || '').trim() : '')
+  if (!produto) return { allowDuplicateLot, error: 'Informe o produto' as const }
+
+  const tipoUnidade = normalizeTipoUnidadeToCanonical(args.createTipoUnidade)
+  if (!tipoUnidade) return { allowDuplicateLot, error: 'Informe a unidade (medida)' as const }
+
+  return {
+    allowDuplicateLot,
+    body: {
+      codigoBarras,
+      codigosBarras,
+      produto,
+      allowDuplicateLot,
+      categoria,
+      marca: args.createMarca.trim(),
+      tipoUnidade,
+      especificacao: args.createEspecificacao.trim(),
+      concentracao: args.createConcentracao.trim(),
+      volume: args.createVolume.trim(),
+      fonte: args.createHomologado ? 'Homologado' : '',
+      calibre: args.createCalibre.trim(),
+      precoCusto: args.createPrecoCusto ? Number(args.createPrecoCusto) : undefined,
+      estoqueInicial: args.createEstoqueInicial ? Number(args.createEstoqueInicial) : undefined,
+      estoqueMinimo: args.createEstoqueMinimo ? Number(args.createEstoqueMinimo) : undefined,
+      lote: args.createLote.trim(),
+      dataValidade: validadeIso || undefined,
+      policyRequiresLot: policy.requiresLot,
+      policyRequiresExpiry: policy.requiresExpiry,
+      policyFefo: policy.fefo,
+    },
+    existing,
+    codigoBarras,
+  }
+}
+
+export function useInsumosInventoryMutationsController({
+  canUseApi,
+  createCalibre,
+  createCategoria,
+  createCategoriaFefo,
+  createCategoriaRequiresExpiry,
+  createCategoriaRequiresLot,
+  createCodigo,
+  createCodigosExtras,
+  createConcentracao,
+  createDataValidade,
+  createEspecificacao,
+  createEstoqueInicial,
+  createEstoqueMinimo,
+  createHomologado,
+  createLote,
+  createMarca,
+  createNovoLote,
+  createPrecoCusto,
+  createProduto,
+  createTipoUnidade,
+  createVolume,
+  editCalibre,
+  editCategoria,
+  editCategoriaFefo,
+  editCategoriaRequiresExpiry,
+  editCategoriaRequiresLot,
+  editCodigo,
+  editCodigosExtras,
+  editConcentracao,
+  editDataValidade,
+  editEspecificacao,
+  editEstoqueMinimo,
+  editHomologado,
+  editLote,
+  editMarca,
+  editPrecoCusto,
+  editProduto,
+  editTarget,
+  editTipoUnidade,
+  editVolume,
+  getPolicyErrorCode,
+  insumos,
+  isAuthed,
+  loadInsumosOptions,
+  loadOverview,
+  lotEditLote,
+  lotEditValidade,
+  lotSelecionado,
+  mutateJson,
+  policyErrorToast,
+  refreshInsumos,
+  setCreateCalibre,
+  setCreateCategoria,
+  setCreateCodigosExtras,
+  setCreateCodigo,
+  setCreateConcentracao,
+  setCreateDataValidade,
+  setCreateEspecificacao,
+  setCreateEstoqueInicial,
+  setCreateEstoqueMinimo,
+  setCreateHomologado,
+  setCreateLoading,
+  setCreateLote,
+  setCreateMarca,
+  setCreateNovoLote,
+  setCreateOpen,
+  setCreatePrecoCusto,
+  setCreateProduto,
+  setCreateTipoUnidade,
+  setCreateVolume,
+  setEditOpen,
+  setEditSaveError,
+  setEditSaving,
+  setEditValidationErrors,
+  setLotDialogOpen,
+  setLotSaving,
+  setQualityMatchesItems,
+  setQualityMatchesSavingRegistro,
+  unidade,
+}: UseInsumosInventoryMutationsControllerArgs) {
+  const resetCreateInlineForm = React.useCallback(() => {
+    setCreateCodigo('')
+    setCreateCodigosExtras('')
+    setCreateProduto('')
+    setCreateCategoria('')
+    setCreateMarca('')
+    setCreateTipoUnidade('')
+    setCreateEspecificacao('')
+    setCreateConcentracao('')
+    setCreateVolume('')
+    setCreateHomologado(false)
+    setCreateCalibre('')
+    setCreatePrecoCusto('')
+    setCreateEstoqueInicial('0')
+    setCreateEstoqueMinimo('5')
+    setCreateLote('')
+    setCreateDataValidade('')
+    setCreateNovoLote(false)
+    setCreateOpen(false)
+  }, [
+    setCreateCalibre,
+    setCreateCategoria,
+    setCreateCodigosExtras,
+    setCreateCodigo,
+    setCreateConcentracao,
+    setCreateDataValidade,
+    setCreateEspecificacao,
+    setCreateEstoqueInicial,
+    setCreateEstoqueMinimo,
+    setCreateHomologado,
+    setCreateLote,
+    setCreateMarca,
+    setCreateNovoLote,
+    setCreateOpen,
+    setCreatePrecoCusto,
+    setCreateProduto,
+    setCreateTipoUnidade,
+    setCreateVolume,
+  ])
+
+  const saveCreateFromModal = React.useCallback(async () => {
+    const draft = resolveCreateDraft({
+      createCalibre,
+      createCategoria,
+      createCategoriaFefo,
+      createCategoriaRequiresExpiry,
+      createCategoriaRequiresLot,
+      createCodigo,
+      createCodigosExtras,
+      createConcentracao,
+      createDataValidade,
+      createEspecificacao,
+      createEstoqueInicial,
+      createEstoqueMinimo,
+      createHomologado,
+      createLote,
+      createMarca,
+      createNovoLote,
+      createPrecoCusto,
+      createProduto,
+      createTipoUnidade,
+      createVolume,
+      insumos,
+    })
+    if ('allowDuplicateLot' in draft && draft.allowDuplicateLot && !createNovoLote) setCreateNovoLote(true)
+    if ('error' in draft) return toast.error(draft.error)
+
+    setCreateLoading(true)
+    try {
+      await mutateJson(`/insumos?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'POST',
+        queueLabel: 'Cadastro de insumo',
+        body: draft.body,
+      })
+      toast.success('Insumo cadastrado.')
+      setCreateCodigosExtras('')
+      setCreateOpen(false)
+      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
+    } catch (error) {
+      if (policyErrorToast(error)) return
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setCreateLoading(false)
+    }
+  }, [
+    createCalibre,
+    createCategoria,
+    createCategoriaFefo,
+    createCategoriaRequiresExpiry,
+    createCategoriaRequiresLot,
+    createCodigo,
+    createCodigosExtras,
+    createConcentracao,
+    createDataValidade,
+    createEspecificacao,
+    createEstoqueInicial,
+    createEstoqueMinimo,
+    createHomologado,
+    createLote,
+    createMarca,
+    createNovoLote,
+    createPrecoCusto,
+    createProduto,
+    createTipoUnidade,
+    createVolume,
+    insumos,
+    loadInsumosOptions,
+    loadOverview,
+    mutateJson,
+    policyErrorToast,
+    refreshInsumos,
+    setCreateCodigosExtras,
+    setCreateLoading,
+    setCreateNovoLote,
+    setCreateOpen,
+    unidade,
+  ])
+
+  const saveCreateInline = React.useCallback(async () => {
+    const draft = resolveCreateDraft({
+      createCalibre,
+      createCategoria,
+      createCategoriaFefo,
+      createCategoriaRequiresExpiry,
+      createCategoriaRequiresLot,
+      createCodigo,
+      createCodigosExtras,
+      createConcentracao,
+      createDataValidade,
+      createEspecificacao,
+      createEstoqueInicial,
+      createEstoqueMinimo,
+      createHomologado,
+      createLote,
+      createMarca,
+      createNovoLote,
+      createPrecoCusto,
+      createProduto,
+      createTipoUnidade,
+      createVolume,
+      insumos,
+    })
+    if ('allowDuplicateLot' in draft && draft.allowDuplicateLot && !createNovoLote) setCreateNovoLote(true)
+    if ('error' in draft) return toast.error(draft.error)
+
+    setCreateLoading(true)
+    try {
+      await mutateJson(`/insumos?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'POST',
+        queueLabel: 'Cadastro de insumo',
+        body: {
+          ...draft.body,
+          precoCusto: createPrecoCusto.trim(),
+          estoqueInicial: Number(createEstoqueInicial) || 0,
+          estoqueMinimo: Number(createEstoqueMinimo) || 0,
+          dataValidade: dateInputToIso(createDataValidade),
+        },
+      })
+      toast.success('Insumo cadastrado')
+      resetCreateInlineForm()
+      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadInsumosOptions()])
+    } catch (error) {
+      const status = (error as any)?.status
+      const message = error instanceof Error ? error.message : String(error)
+      if (status === 409 && /código de barras já cadastrado/i.test(message)) {
+        setCreateNovoLote(true)
+        toast.error('Código já existe. Ative “Novo lote” e informe Lote/Validade para cadastrar um lote adicional.')
+        return
+      }
+      if (policyErrorToast(error)) return
+      toast.error(message)
+    } finally {
+      setCreateLoading(false)
+    }
+  }, [
+    createCalibre,
+    createCategoria,
+    createCategoriaFefo,
+    createCategoriaRequiresExpiry,
+    createCategoriaRequiresLot,
+    createCodigo,
+    createCodigosExtras,
+    createConcentracao,
+    createDataValidade,
+    createEspecificacao,
+    createEstoqueInicial,
+    createEstoqueMinimo,
+    createHomologado,
+    createLote,
+    createMarca,
+    createNovoLote,
+    createPrecoCusto,
+    createProduto,
+    createTipoUnidade,
+    createVolume,
+    insumos,
+    loadInsumosOptions,
+    mutateJson,
+    policyErrorToast,
+    refreshInsumos,
+    resetCreateInlineForm,
+    setCreateLoading,
+    setCreateNovoLote,
+    unidade,
+  ])
+
+  const saveLot = React.useCallback(async () => {
+    if (!lotSelecionado?.registro) {
+      toast.error('Registro do insumo ausente.')
+      return
+    }
+    if (!canUseApi || !isAuthed) return
+    setLotSaving(true)
+    try {
+      const dataValidade = dateInputToIso(lotEditValidade)
+      await mutateJson<{ success?: boolean }>(`/insumos/${encodeURIComponent(lotSelecionado.registro)}?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'PUT',
+        body: { lote: lotEditLote.trim(), dataValidade },
+        queueLabel: 'Atualização de lote/validade',
+      })
+      toast.success('Lote/validade atualizados.')
+      setLotDialogOpen(false)
+      await Promise.allSettled([refreshInsumos(), loadOverview({ force: true })])
+    } catch (error) {
+      if (policyErrorToast(error)) return
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setLotSaving(false)
+    }
+  }, [
+    canUseApi,
+    isAuthed,
+    loadOverview,
+    lotEditLote,
+    lotEditValidade,
+    lotSelecionado?.registro,
+    mutateJson,
+    policyErrorToast,
+    refreshInsumos,
+    setLotDialogOpen,
+    setLotSaving,
+    unidade,
+  ])
+
+  const saveEdit = React.useCallback(async () => {
+    const registro = String(editTarget?.registro || '').trim()
+    if (!registro) {
+      setEditSaveError('Registro do insumo ausente.')
+      toast.error('Registro do insumo ausente.')
+      return
+    }
+    if (!isAuthed) {
+      setEditSaveError('Nao autenticado.')
+      toast.error('Nao autenticado.')
+      return
+    }
+    if (!canUseApi) {
+      setEditSaveError('API indisponivel ou nao pronta. Aguarde carregar e tente novamente.')
+      toast.error('API indisponivel ou nao pronta. Aguarde carregar e tente novamente.')
+      return
+    }
+
+    const codigoBarras = editCodigo.trim()
+    const extraCodes = parseBarcodeInput(editCodigosExtras)
+    const codigosBarras = Array.from(new Set([codigoBarras, ...extraCodes].map((value) => String(value || '').trim()).filter(Boolean)))
+    const produto = editProduto.trim()
+    if (!codigoBarras) {
+      setEditValidationErrors({ codigoBarras: 'Obrigatorio.' })
+      setEditSaveError('Informe o código de barras para salvar.')
+      return toast.error('Informe o código de barras')
+    }
+    if (!produto) {
+      setEditValidationErrors({ produto: 'Obrigatorio.' })
+      setEditSaveError('Informe o produto para salvar.')
+      return toast.error('Informe o produto')
+    }
+
+    setEditSaving(true)
+    try {
+      setEditSaveError(null)
+      setEditValidationErrors({})
+      const categoria = editCategoria.trim()
+      const policy = {
+        requiresLot: !!editCategoriaRequiresLot,
+        requiresExpiry: !!editCategoriaRequiresExpiry,
+        fefo: !!editCategoriaFefo,
+      }
+      const lote = editLote.trim()
+      const dataValidade = dateInputToIso(editDataValidade)
+      const tipoUnidade = normalizeTipoUnidadeToCanonical(editTipoUnidade)
+
+      if (!tipoUnidade) {
+        setEditValidationErrors({ tipoUnidade: 'Selecione a unidade (medida).' })
+        setEditSaveError('Informe a unidade (medida) para salvar.')
+        toast.error('Informe a unidade (medida) para salvar.')
+        return
+      }
+      if (policy.fefo && !policy.requiresExpiry) {
+        setEditValidationErrors({ policy: 'FEFO exige validade obrigatoria.' })
+        setEditSaveError('FEFO exige validade obrigatoria.')
+        toast.error('FEFO exige validade obrigatória')
+        return
+      }
+      if (policy.requiresLot && !lote) {
+        setEditValidationErrors({ policy: 'Lote obrigatorio pela politica.', lote: 'Obrigatorio (pela politica do item).' })
+        setEditSaveError('Este item exige Lote. Preencha o campo lote para salvar.')
+        toast.error('Este item exige Lote. Preencha o campo lote para salvar.')
+        return
+      }
+      if (policy.requiresExpiry && !dataValidade) {
+        setEditValidationErrors({ policy: 'Validade obrigatoria pela politica.', dataValidade: 'Obrigatorio (pela politica do item).' })
+        setEditSaveError('Este item exige Data de validade. Preencha o campo validade para salvar.')
+        toast.error('Este item exige Data de validade. Preencha o campo validade para salvar.')
+        return
+      }
+
+      await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'PUT',
+        queueLabel: 'Edição de insumo',
+        body: {
+          codigoBarras,
+          codigosBarras,
+          produto,
+          categoria,
+          marca: editMarca.trim(),
+          tipoUnidade,
+          especificacao: editEspecificacao.trim(),
+          concentracao: editConcentracao.trim(),
+          volume: editVolume.trim(),
+          fonte: editHomologado ? 'Homologado' : '',
+          calibre: editCalibre.trim(),
+          precoCusto: editPrecoCusto.trim(),
+          estoqueMinimo: Number(editEstoqueMinimo) || 0,
+          lote,
+          dataValidade,
+          policyRequiresLot: policy.requiresLot,
+          policyRequiresExpiry: policy.requiresExpiry,
+          policyFefo: policy.fefo,
+        },
+      })
+      toast.success('Insumo atualizado')
+      setEditOpen(false)
+      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
+    } catch (error) {
+      const policyCode = getPolicyErrorCode(error)
+      if (policyCode) {
+        setEditSaveError(error instanceof Error ? error.message : String(error))
+        policyErrorToast(error)
+        if (policyCode === 'POLICY_REQUIRES_LOT') {
+          setEditValidationErrors({ policy: 'Lote obrigatorio pela politica.', lote: 'Obrigatorio (pela politica do item).' })
+        } else {
+          setEditValidationErrors({ policy: 'Validade obrigatoria pela politica.', dataValidade: 'Obrigatorio (pela politica do item).' })
+        }
+        return
+      }
+      setEditSaveError(error instanceof Error ? error.message : String(error))
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setEditSaving(false)
+    }
+  }, [
+    canUseApi,
+    editCalibre,
+    editCategoria,
+    editCategoriaFefo,
+    editCategoriaRequiresExpiry,
+    editCategoriaRequiresLot,
+    editCodigo,
+    editCodigosExtras,
+    editConcentracao,
+    editDataValidade,
+    editEspecificacao,
+    editEstoqueMinimo,
+    editHomologado,
+    editLote,
+    editMarca,
+    editPrecoCusto,
+    editProduto,
+    editTarget?.registro,
+    editTipoUnidade,
+    editVolume,
+    getPolicyErrorCode,
+    isAuthed,
+    loadInsumosOptions,
+    loadOverview,
+    mutateJson,
+    policyErrorToast,
+    refreshInsumos,
+    setEditOpen,
+    setEditSaveError,
+    setEditSaving,
+    setEditValidationErrors,
+    unidade,
+  ])
+
+  const deleteEdit = React.useCallback(async () => {
+    const registro = String(editTarget?.registro || '').trim()
+    if (!registro || !canUseApi || !isAuthed) return
+    if (!window.confirm('Excluir este insumo? Esta ação não pode ser desfeita.')) return
+    setEditSaving(true)
+    try {
+      await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'DELETE',
+        queueLabel: 'Exclusão de insumo',
+      })
+      toast.success('Insumo excluído')
+      setEditOpen(false)
+      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setEditSaving(false)
+    }
+  }, [
+    canUseApi,
+    editTarget?.registro,
+    isAuthed,
+    loadInsumosOptions,
+    loadOverview,
+    mutateJson,
+    refreshInsumos,
+    setEditOpen,
+    setEditSaving,
+    unidade,
+  ])
+
+  const deleteInsumoByRegistro = React.useCallback(async (registroRaw: string) => {
+    const registro = String(registroRaw || '').trim()
+    if (!registro || !canUseApi || !isAuthed) return
+    if (!window.confirm('Excluir este insumo? Esta ação não pode ser desfeita.')) return
+    setQualityMatchesSavingRegistro(registro)
+    try {
+      await mutateJson(`/insumos/${encodeURIComponent(registro)}?unidade=${encodeURIComponent(unidade)}`, {
+        method: 'DELETE',
+        queueLabel: 'Exclusão de insumo',
+      })
+      toast.success('Insumo excluído')
+      setQualityMatchesItems((prev) => prev.filter((item) => String(item?.registro || '').trim() !== registro))
+      await Promise.allSettled([refreshInsumos({ pagina: 1 }), loadOverview({ force: true }), loadInsumosOptions()])
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setQualityMatchesSavingRegistro('')
+    }
+  }, [
+    canUseApi,
+    isAuthed,
+    loadInsumosOptions,
+    loadOverview,
+    mutateJson,
+    refreshInsumos,
+    setQualityMatchesItems,
+    setQualityMatchesSavingRegistro,
+    unidade,
+  ])
+
+  return {
+    deleteEdit,
+    deleteInsumoByRegistro,
+    saveCreateFromModal,
+    saveCreateInline,
+    saveEdit,
+    saveLot,
+  }
+}

--- a/frontend/useInsumosMovementsController.ts
+++ b/frontend/useInsumosMovementsController.ts
@@ -12,7 +12,7 @@ type MutateJsonFn = <T>(
     body?: unknown
     queueLabel?: string
   }
-) => Promise<T>
+) => Promise<T | { queued: true }>
 
 type MovementLoadError = { message: string; status: number; code?: string } | null
 

--- a/frontend/useInsumosMovementsController.ts
+++ b/frontend/useInsumosMovementsController.ts
@@ -1,0 +1,353 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import { combineLocalDateTimeToIso, dateInputToIso, normalizeMovimentacaoTipo } from '@/insumosShared'
+import type { Movimentacao } from '@/insumosTypes'
+
+type ApiJsonFn = <T>(path: string, opts?: { signal?: AbortSignal }) => Promise<T>
+type MutateJsonFn = <T>(
+  path: string,
+  opts: {
+    method?: string
+    body?: unknown
+    queueLabel?: string
+  }
+) => Promise<T>
+
+type MovementLoadError = { message: string; status: number; code?: string } | null
+
+type UseInsumosMovementsControllerArgs = {
+  apiJson: ApiJsonFn
+  canUseApi: boolean
+  editMovData: string
+  editMovHora: string
+  editMovMotivo: string
+  editMovNovoEstoque: string
+  editMovObservacoes: string
+  editMovProduto: string
+  editMovQuantidade: string
+  editMovTarget: Movimentacao | null
+  editMovUnidade: string
+  isAuthed: boolean
+  movAte: string
+  movDe: string
+  movFilterCategoria: string
+  movFilterMarca: string
+  movListContainerRef: React.RefObject<HTMLDivElement | null>
+  movTipo: 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE'
+  mutateJson: MutateJsonFn
+  refreshInsumos: () => Promise<void>
+  schedulePostMutationRefresh: (opts?: { overview?: boolean; insights?: boolean }) => void
+  selectedCodigoBarras: string
+  setEditMovDeleting: React.Dispatch<React.SetStateAction<boolean>>
+  setEditMovOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setEditMovSaving: React.Dispatch<React.SetStateAction<boolean>>
+  setEditMovTarget: React.Dispatch<React.SetStateAction<Movimentacao | null>>
+  setMovLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  setMovLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setMovLoadError: React.Dispatch<React.SetStateAction<MovementLoadError>>
+  setMovimentacoes: React.Dispatch<React.SetStateAction<Movimentacao[]>>
+  unidade: string
+}
+
+export function buildMovimentacoesQuery(args: {
+  unidade: string
+  limite: number
+  pagina: number
+  movTipo: 'TODOS' | 'ENTRADA' | 'SAÍDA' | 'AJUSTE'
+  selectedCodigoBarras: string
+  movDe: string
+  movAte: string
+}) {
+  const params = new URLSearchParams()
+  params.set('unidade', args.unidade)
+  params.set('limite', String(args.limite))
+  params.set('pagina', String(args.pagina))
+  if (args.movTipo !== 'TODOS') params.set('tipo', args.movTipo)
+
+  const codigo = String(args.selectedCodigoBarras || '').trim()
+  if (codigo) params.set('codigoBarras', codigo)
+
+  const deIso = dateInputToIso(args.movDe)
+  const ateIso = dateInputToIso(args.movAte)
+  if (deIso) params.set('de', deIso)
+  if (ateIso) params.set('ate', ateIso)
+  return params
+}
+
+export function useInsumosMovementsController({
+  apiJson,
+  canUseApi,
+  editMovData,
+  editMovHora,
+  editMovMotivo,
+  editMovNovoEstoque,
+  editMovObservacoes,
+  editMovProduto,
+  editMovQuantidade,
+  editMovTarget,
+  editMovUnidade,
+  isAuthed,
+  movAte,
+  movDe,
+  movFilterCategoria,
+  movFilterMarca,
+  movListContainerRef,
+  movTipo,
+  mutateJson,
+  refreshInsumos,
+  schedulePostMutationRefresh,
+  selectedCodigoBarras,
+  setEditMovDeleting,
+  setEditMovOpen,
+  setEditMovSaving,
+  setEditMovTarget,
+  setMovLoaded,
+  setMovLoading,
+  setMovLoadError,
+  setMovimentacoes,
+  unidade,
+}: UseInsumosMovementsControllerArgs) {
+  const loadMovimentacoes = React.useCallback(async () => {
+    if (!canUseApi || !isAuthed) return
+    setMovLoading(true)
+    try {
+      const limite = 200
+      let pagina = 1
+      let merged: Movimentacao[] = []
+      let totalOut: number | null = null
+
+      while (true) {
+        const params = buildMovimentacoesQuery({
+          unidade,
+          limite,
+          pagina,
+          movTipo,
+          selectedCodigoBarras,
+          movDe,
+          movAte,
+        })
+        const out = await apiJson<{ success?: boolean; data?: Movimentacao[]; movimentos?: Movimentacao[]; resumo?: any }>(
+          `/movimentacoes?${params.toString()}`
+        )
+        const list = (out as any)?.movimentos ?? out?.data
+        const items = Array.isArray(list) ? list : []
+        merged = [...merged, ...items]
+        const total = Number((out as any)?.resumo?.totalMovimentacoes)
+        if (Number.isFinite(total)) totalOut = total
+        if (items.length < limite) break
+        if (totalOut != null && merged.length >= totalOut) break
+        pagina += 1
+      }
+
+      setMovimentacoes(merged)
+      setMovLoadError(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setMovLoadError({
+        message: error instanceof Error ? error.message : String(error),
+        status: Number((error as any)?.status || 0) || 0,
+        code: (error as any)?.code ? String((error as any).code) : undefined,
+      })
+      setMovimentacoes([])
+    } finally {
+      setMovLoaded(true)
+      setMovLoading(false)
+    }
+  }, [
+    apiJson,
+    canUseApi,
+    isAuthed,
+    movAte,
+    movDe,
+    movTipo,
+    selectedCodigoBarras,
+    setMovLoaded,
+    setMovLoading,
+    setMovLoadError,
+    setMovimentacoes,
+    unidade,
+  ])
+
+  React.useEffect(() => {
+    try {
+      movListContainerRef.current?.scrollTo?.({ top: 0 })
+    } catch {
+      // ignore
+    }
+  }, [movAte, movDe, movFilterCategoria, movFilterMarca, movListContainerRef, movTipo, selectedCodigoBarras, unidade])
+
+  React.useEffect(() => {
+    if (!canUseApi || !isAuthed) return
+    const deIso = movDe.trim() ? dateInputToIso(movDe) : ''
+    const ateIso = movAte.trim() ? dateInputToIso(movAte) : ''
+    if (movDe.trim() && !deIso) return
+    if (movAte.trim() && !ateIso) return
+    const timeoutId = window.setTimeout(() => {
+      void loadMovimentacoes()
+    }, 250)
+    return () => window.clearTimeout(timeoutId)
+  }, [canUseApi, isAuthed, loadMovimentacoes, movAte, movDe, movTipo, selectedCodigoBarras, unidade])
+
+  const saveMovementEdit = React.useCallback(async () => {
+    const target = editMovTarget
+    const movementId = String(target?.id || '').trim()
+    if (!movementId) {
+      toast.error('Movimentação inválida.')
+      return
+    }
+    if (!canUseApi || !isAuthed) return
+
+    const tipo = normalizeMovimentacaoTipo(target?.tipo)
+    const produto = editMovProduto.trim()
+    if (!produto) {
+      toast.error('Informe o produto.')
+      return
+    }
+    const dataHora = combineLocalDateTimeToIso(editMovData, editMovHora)
+    if (!dataHora) {
+      toast.error('Informe uma data e hora válidas.')
+      return
+    }
+
+    const body: Record<string, unknown> = {
+      produto,
+      dataHora,
+      observacoes: editMovObservacoes.trim(),
+    }
+
+    if (!String(target?.transferId || '').trim()) {
+      const nextUnidade = String(editMovUnidade || '').trim()
+      if (!nextUnidade) {
+        toast.error('Informe a unidade.')
+        return
+      }
+      body.unidade = nextUnidade
+    }
+
+    if (String(target?.transferId || '').trim()) {
+      const quantidade = parseInt(editMovQuantidade, 10)
+      if (!Number.isFinite(quantidade) || quantidade < 1) {
+        toast.error('Informe uma quantidade válida.')
+        return
+      }
+      body.quantidade = quantidade
+    } else if (tipo === 'AJUSTE') {
+      const estoqueNovo = parseInt(editMovNovoEstoque, 10)
+      if (!Number.isFinite(estoqueNovo) || estoqueNovo < 0) {
+        toast.error('Informe o novo estoque.')
+        return
+      }
+      const motivo = editMovMotivo.trim()
+      if (!motivo) {
+        toast.error('Informe o motivo do ajuste.')
+        return
+      }
+      body.estoqueNovo = estoqueNovo
+      body.motivo = motivo
+    } else {
+      const quantidade = parseInt(editMovQuantidade, 10)
+      if (!Number.isFinite(quantidade) || quantidade < 1) {
+        toast.error('Informe uma quantidade válida.')
+        return
+      }
+      body.quantidade = quantidade
+    }
+
+    setEditMovSaving(true)
+    try {
+      await mutateJson<{ success?: boolean }>(
+        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(
+          String(target?.unidade || unidade || '').trim() || unidade
+        )}`,
+        {
+          method: 'PUT',
+          body,
+          queueLabel: 'Edição de movimentação',
+        }
+      )
+      toast.success('Lançamento atualizado.')
+      setEditMovOpen(false)
+      setEditMovTarget(null)
+      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+      schedulePostMutationRefresh({ overview: true, insights: true })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setEditMovSaving(false)
+    }
+  }, [
+    canUseApi,
+    editMovData,
+    editMovHora,
+    editMovMotivo,
+    editMovNovoEstoque,
+    editMovObservacoes,
+    editMovProduto,
+    editMovQuantidade,
+    editMovTarget,
+    editMovUnidade,
+    isAuthed,
+    loadMovimentacoes,
+    mutateJson,
+    refreshInsumos,
+    schedulePostMutationRefresh,
+    setEditMovOpen,
+    setEditMovSaving,
+    setEditMovTarget,
+    unidade,
+  ])
+
+  const deleteMovementEdit = React.useCallback(async () => {
+    const target = editMovTarget
+    const movementId = String(target?.id || '').trim()
+    if (!movementId) {
+      toast.error('Movimentação inválida.')
+      return
+    }
+    if (!canUseApi || !isAuthed) return
+
+    const confirmed = window.confirm('Excluir este lançamento? Essa ação recalcula o estoque do insumo.')
+    if (!confirmed) return
+
+    setEditMovDeleting(true)
+    try {
+      await mutateJson<{ success?: boolean }>(
+        `/movimentacoes/${encodeURIComponent(movementId)}?unidade=${encodeURIComponent(
+          String(target?.unidade || unidade || '').trim() || unidade
+        )}`,
+        {
+          method: 'DELETE',
+          queueLabel: 'Exclusão de movimentação',
+        }
+      )
+      toast.success('Lançamento excluído.')
+      setEditMovOpen(false)
+      setEditMovTarget(null)
+      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+      schedulePostMutationRefresh({ overview: true, insights: true })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setEditMovDeleting(false)
+    }
+  }, [
+    canUseApi,
+    editMovTarget,
+    isAuthed,
+    loadMovimentacoes,
+    mutateJson,
+    refreshInsumos,
+    schedulePostMutationRefresh,
+    setEditMovDeleting,
+    setEditMovOpen,
+    setEditMovTarget,
+    unidade,
+  ])
+
+  return {
+    deleteMovementEdit,
+    loadMovimentacoes,
+    saveMovementEdit,
+  }
+}

--- a/frontend/useInsumosQuickLookupController.ts
+++ b/frontend/useInsumosQuickLookupController.ts
@@ -1,0 +1,453 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import { getInsumoBarcodes } from '@/insumosShared'
+import type { Insumo, InsumosQuickOperation, QuickCandidate } from '@/insumosTypes'
+
+type ApiJsonFn = <T>(path: string, init?: { method?: string; body?: unknown }) => Promise<T>
+
+type LookupByCodigoFn = (args: { codigoBarras: string; ctxUnidade: string }) => Promise<Insumo[]>
+type ReadCachedByCodigoFn = (args: { codigoBarras: string; ctxUnidade: string }) => Insumo[]
+type UpsertInsumosCacheFn = (items: Insumo[]) => void
+type NormalizeTextFn = (value: unknown) => string
+type IsSameInsumoFn = (item: Insumo, target: Insumo | null) => boolean
+
+type QuickSearchMatch = {
+  item: Insumo
+  matchedCode: string
+  score: number
+}
+
+type UseInsumosQuickLookupControllerArgs = {
+  apiJson: ApiJsonFn
+  canUseApi: boolean
+  insumos: Insumo[]
+  isAuthed: boolean
+  isSameInsumo: IsSameInsumoFn
+  lookupInsumosByCodigo: LookupByCodigoFn
+  normalizeText: NormalizeTextFn
+  quickCandidates: QuickCandidate[]
+  quickCodigo: string
+  quickLookupCode: string | null
+  quickLookupCtxUnidade: string | null
+  quickLookupItems: Insumo[]
+  quickLotes: QuickCandidate[]
+  quickOp: InsumosQuickOperation | null
+  quickRegistros: string[]
+  quickSearch: string
+  quickSearchRemote: Insumo[]
+  quickSearchRemoteError: string | null
+  quickSearchRemoteLoading: boolean
+  quickSelectedSnapshot: Insumo | null
+  readCachedInsumosByCodigo: ReadCachedByCodigoFn
+  transferFrom: string
+  unidade: string
+  upsertInsumosCache: UpsertInsumosCacheFn
+  setQuickCandidates: React.Dispatch<React.SetStateAction<QuickCandidate[]>>
+  setQuickCodigo: React.Dispatch<React.SetStateAction<string>>
+  setQuickLookupCode: React.Dispatch<React.SetStateAction<string | null>>
+  setQuickLookupCtxUnidade: React.Dispatch<React.SetStateAction<string | null>>
+  setQuickLookupError: React.Dispatch<React.SetStateAction<string | null>>
+  setQuickLookupItems: React.Dispatch<React.SetStateAction<Insumo[]>>
+  setQuickLookupLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setQuickRegistros: React.Dispatch<React.SetStateAction<string[]>>
+  setQuickRegistro: React.Dispatch<React.SetStateAction<string>>
+  setQuickSearch: React.Dispatch<React.SetStateAction<string>>
+  setQuickSearchRemote: React.Dispatch<React.SetStateAction<Insumo[]>>
+  setQuickSearchRemoteError: React.Dispatch<React.SetStateAction<string | null>>
+  setQuickSearchRemoteLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setQuickSelectedSnapshot: React.Dispatch<React.SetStateAction<Insumo | null>>
+}
+
+export function useInsumosQuickLookupController({
+  apiJson,
+  canUseApi,
+  insumos,
+  isAuthed,
+  isSameInsumo,
+  lookupInsumosByCodigo,
+  normalizeText,
+  quickCandidates,
+  quickCodigo,
+  quickLookupCode,
+  quickLookupCtxUnidade,
+  quickLookupItems,
+  quickLotes,
+  quickOp,
+  quickRegistros,
+  quickSearch,
+  quickSearchRemote,
+  quickSearchRemoteError,
+  quickSearchRemoteLoading,
+  quickSelectedSnapshot,
+  readCachedInsumosByCodigo,
+  transferFrom,
+  unidade,
+  upsertInsumosCache,
+  setQuickCandidates,
+  setQuickCodigo,
+  setQuickLookupCode,
+  setQuickLookupCtxUnidade,
+  setQuickLookupError,
+  setQuickLookupItems,
+  setQuickLookupLoading,
+  setQuickRegistros,
+  setQuickRegistro,
+  setQuickSearch,
+  setQuickSearchRemote,
+  setQuickSearchRemoteError,
+  setQuickSearchRemoteLoading,
+  setQuickSelectedSnapshot,
+}: UseInsumosQuickLookupControllerArgs) {
+  const quickLookupTokenRef = React.useRef(0)
+  const quickSearchRemoteTokenRef = React.useRef(0)
+
+  const quickSearchMatches = React.useMemo(() => {
+    const query = quickSearch.trim().toLowerCase()
+    if (!query) return [] as QuickSearchMatch[]
+    const looksLikeCode = /^[0-9]{4,}$/.test(query)
+    const remoteActive = canUseApi && isAuthed && !looksLikeCode && query.length >= 2
+    const baseList = remoteActive
+      ? (quickSearchRemoteError ? (Array.isArray(insumos) ? insumos : []) : quickSearchRemote)
+      : (Array.isArray(insumos) ? insumos : [])
+    const selected: Insumo[] = []
+    if (Array.isArray(quickLookupItems) && quickLookupItems.length) selected.push(...quickLookupItems)
+    else if (quickSelectedSnapshot) selected.push(quickSelectedSnapshot)
+    const primarySelected = quickSelectedSnapshot || (quickLookupItems.length ? quickLookupItems[0] : null)
+    const allowSelectedWhileLoading = !!(quickSearchRemoteLoading && primarySelected)
+    const selectedSignatures = selected.map((selectedItem) => ({
+      registro: normalizeText(selectedItem?.registro || ''),
+      codes: getInsumoBarcodes(selectedItem).map((code) => normalizeText(code)),
+      produto: normalizeText(selectedItem?.produto || ''),
+      categoria: normalizeText(selectedItem?.categoria || ''),
+      marca: normalizeText(selectedItem?.marca || ''),
+    }))
+    const isSelected = (item: Insumo) => {
+      const registro = normalizeText(item?.registro || '')
+      if (registro && selectedSignatures.some((signature) => signature.registro && signature.registro === registro)) return true
+      const codes = getInsumoBarcodes(item).map((code) => normalizeText(code))
+      const produto = normalizeText(item?.produto || '')
+      const categoria = normalizeText(item?.categoria || '')
+      const marca = normalizeText(item?.marca || '')
+      return selectedSignatures.some((signature) => {
+        const sameCore =
+          (!!produto || !!categoria || !!marca) &&
+          produto === signature.produto &&
+          categoria === signature.categoria &&
+          marca === signature.marca
+        if (!sameCore) return false
+        if (!codes.length || !signature.codes.length) return true
+        return signature.codes.some((code) => codes.includes(code))
+      })
+    }
+    const scoreMatch = (item: Insumo, matchedCode: string) => {
+      let score = 0
+      const produto = normalizeText(item?.produto || '')
+      const categoria = normalizeText(item?.categoria || '')
+      const marca = normalizeText(item?.marca || '')
+      const extras = [
+        normalizeText((item as any)?.especificacao || ''),
+        normalizeText((item as any)?.concentracao || ''),
+        normalizeText((item as any)?.volume || ''),
+        normalizeText((item as any)?.calibre || ''),
+        normalizeText((item as any)?.tipoUnidade || ''),
+      ]
+      const codes = getInsumoBarcodes(item).map((code) => normalizeText(code))
+      const normalizedQuery = normalizeText(query)
+      if (matchedCode) score += 20
+      if (codes.includes(normalizedQuery)) score += 80
+      if (produto === normalizedQuery) score += 70
+      else if (produto.startsWith(normalizedQuery)) score += 40
+      else if (produto.includes(normalizedQuery)) score += 25
+      if (marca === normalizedQuery) score += 30
+      else if (marca.includes(normalizedQuery)) score += 12
+      if (categoria === normalizedQuery) score += 25
+      else if (categoria.includes(normalizedQuery)) score += 10
+      if (extras.some((extra) => extra && extra === normalizedQuery)) score += 15
+      else if (extras.some((extra) => extra && extra.includes(normalizedQuery))) score += 8
+      return score
+    }
+
+    const scored: QuickSearchMatch[] = []
+    for (const item of baseList) {
+      if (isSelected(item) && !(allowSelectedWhileLoading && isSameInsumo(item, primarySelected))) continue
+      const codes = getInsumoBarcodes(item)
+      const produto = String(item?.produto || '').toLowerCase()
+      const categoria = String(item?.categoria || '').toLowerCase()
+      const marca = String(item?.marca || '').toLowerCase()
+      const extras = [
+        String((item as any)?.especificacao || '').toLowerCase(),
+        String((item as any)?.concentracao || '').toLowerCase(),
+        String((item as any)?.volume || '').toLowerCase(),
+        String((item as any)?.calibre || '').toLowerCase(),
+        String((item as any)?.tipoUnidade || '').toLowerCase(),
+      ]
+      const haystack = [produto, categoria, marca, ...extras, ...codes].filter(Boolean).join(' ')
+      if (!haystack.includes(query)) continue
+      const matchedCode = codes.find((code) => String(code || '').toLowerCase().includes(query)) || codes[0] || ''
+      scored.push({ item, matchedCode, score: scoreMatch(item, matchedCode) })
+    }
+
+    return scored
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score
+        return String(a.item?.produto || '').localeCompare(String(b.item?.produto || ''), 'pt-BR', { sensitivity: 'base' })
+      })
+      .slice(0, 8)
+  }, [
+    canUseApi,
+    insumos,
+    isAuthed,
+    isSameInsumo,
+    normalizeText,
+    quickLookupItems,
+    quickSearch,
+    quickSearchRemote,
+    quickSearchRemoteError,
+    quickSearchRemoteLoading,
+    quickSelectedSnapshot,
+  ])
+
+  const hasQuickSelection = !!quickSelectedSnapshot || quickLookupItems.length > 0
+
+  const selectQuickCodigo = React.useCallback(
+    (code: string, opts?: { setSearch?: boolean; snapshot?: Insumo | null }) => {
+      const value = String(code || '').trim()
+      if (!value) return false
+      setQuickCodigo(value)
+      if (opts?.setSearch) setQuickSearch(value)
+      if (opts && Object.prototype.hasOwnProperty.call(opts, 'snapshot')) {
+        setQuickSelectedSnapshot(opts?.snapshot ?? null)
+      }
+      setQuickLookupError(null)
+      return true
+    },
+    [setQuickCodigo, setQuickLookupError, setQuickSearch, setQuickSelectedSnapshot],
+  )
+
+  const clearQuickSelection = React.useCallback(() => {
+    setQuickCodigo('')
+    setQuickSelectedSnapshot(null)
+    setQuickRegistro('')
+    setQuickRegistros([])
+    setQuickCandidates([])
+    setQuickLookupError(null)
+    setQuickLookupCtxUnidade(null)
+    setQuickLookupCode(null)
+    setQuickLookupItems([])
+  }, [
+    setQuickCandidates,
+    setQuickCodigo,
+    setQuickLookupCode,
+    setQuickLookupCtxUnidade,
+    setQuickLookupError,
+    setQuickLookupItems,
+    setQuickRegistro,
+    setQuickRegistros,
+    setQuickSelectedSnapshot,
+  ])
+
+  const applyQuickSelection = React.useCallback(
+    (item: Insumo, preferredCode?: string) => {
+      const codes = getInsumoBarcodes(item)
+      if (!codes.length) {
+        const message = 'Este item não possui código de barras cadastrado.'
+        setQuickLookupError(message)
+        toast.error(message)
+        return
+      }
+      const code = preferredCode && codes.includes(preferredCode) ? preferredCode : codes[0] || ''
+      if (!code) return
+      selectQuickCodigo(code, { setSearch: false, snapshot: item })
+    },
+    [selectQuickCodigo, setQuickLookupError],
+  )
+
+  React.useEffect(() => {
+    if (!quickLookupItems.length) return
+    setQuickSelectedSnapshot(quickLookupItems[0])
+  }, [quickLookupItems, setQuickSelectedSnapshot])
+
+  React.useEffect(() => {
+    if (!quickOp) return
+    if (!canUseApi || !isAuthed) {
+      setQuickSearchRemote([])
+      setQuickSearchRemoteLoading(false)
+      setQuickSearchRemoteError(null)
+      return
+    }
+    const query = quickSearch.trim()
+    const looksLikeCode = /^[0-9]{4,}$/.test(query)
+    if (!query || looksLikeCode || query.length < 2) {
+      setQuickSearchRemote([])
+      setQuickSearchRemoteLoading(false)
+      setQuickSearchRemoteError(null)
+      return
+    }
+    const ctxUnidade = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
+    const token = ++quickSearchRemoteTokenRef.current
+    setQuickSearchRemoteLoading(true)
+    setQuickSearchRemoteError(null)
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const params = new URLSearchParams({
+            unidade: ctxUnidade,
+            q: query,
+            pagina: '1',
+            limite: '30',
+          })
+          const out = await apiJson<{ success?: boolean; data?: Insumo[] }>(`/insumos?${params.toString()}`)
+          if (token !== quickSearchRemoteTokenRef.current) return
+          const items = Array.isArray(out?.data) ? out.data : []
+          if (items.length) upsertInsumosCache(items)
+          setQuickSearchRemote(items)
+        } catch (error: any) {
+          if (token !== quickSearchRemoteTokenRef.current) return
+          setQuickSearchRemoteError(error?.message || 'Falha ao buscar insumos.')
+          setQuickSearchRemote([])
+          console.warn('[insumos][quick-search]', {
+            unit: ctxUnidade,
+            query,
+            status: error?.status || 0,
+            code: error?.code || null,
+          })
+        } finally {
+          if (token === quickSearchRemoteTokenRef.current) setQuickSearchRemoteLoading(false)
+        }
+      })()
+    }, 250)
+    return () => window.clearTimeout(timer)
+  }, [
+    apiJson,
+    canUseApi,
+    isAuthed,
+    quickOp,
+    quickSearch,
+    setQuickSearchRemote,
+    setQuickSearchRemoteError,
+    setQuickSearchRemoteLoading,
+    transferFrom,
+    unidade,
+    upsertInsumosCache,
+  ])
+
+  React.useEffect(() => {
+    const query = quickSearch.trim()
+    const hasSelection = !!quickSelectedSnapshot || quickLookupItems.length > 0
+    if (!query) {
+      if (!hasSelection && quickCodigo) setQuickCodigo('')
+      return
+    }
+    if (query === quickCodigo) return
+    const looksLikeCode = /^[0-9]{4,}$/.test(query)
+    if (looksLikeCode) {
+      if (query !== quickCodigo) {
+        setQuickSelectedSnapshot(null)
+        setQuickCodigo(query)
+      }
+      return
+    }
+    if (!hasSelection && quickCodigo) setQuickCodigo('')
+  }, [quickSearch, quickCodigo, quickLookupItems.length, quickSelectedSnapshot, setQuickCodigo, setQuickSelectedSnapshot])
+
+  React.useEffect(() => {
+    if (quickCodigo) return
+    const selected = quickLookupItems[0] || quickSelectedSnapshot
+    if (!selected) return
+    const codes = getInsumoBarcodes(selected)
+    if (!codes.length) return
+    setQuickCodigo(codes[0])
+  }, [quickCodigo, quickLookupItems, quickSelectedSnapshot, setQuickCodigo])
+
+  const quickLoteNeedsPick = quickCandidates.length > 1 || quickRegistros.length > 1 || quickLotes.length > 1
+  const quickLotesForPicker = React.useMemo(() => {
+    if (quickCandidates.length) return quickCandidates
+    if (quickRegistros.length) {
+      const registrosSet = new Set(quickRegistros)
+      const filtered = quickLotes.filter((lote) => registrosSet.has(lote.registro))
+      if (filtered.length) return filtered
+      return quickRegistros.map((registro) => ({ registro, lote: '', dataValidade: null, estoque: 0 }))
+    }
+    return quickLotes
+  }, [quickCandidates, quickLotes, quickRegistros])
+
+  React.useEffect(() => {
+    if (!quickOp) return
+    if (!canUseApi || !isAuthed) return
+    const codigo = quickCodigo.trim()
+    if (!codigo) {
+      setQuickLookupLoading(false)
+      setQuickLookupError(null)
+      setQuickLookupItems([])
+      setQuickLookupCode(null)
+      setQuickLookupCtxUnidade(null)
+      return
+    }
+    const ctxUnidade = quickOp === 'TRANSFERENCIA' ? transferFrom : unidade
+    const cached = readCachedInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
+    if (cached.length) {
+      setQuickLookupLoading(false)
+      setQuickLookupError(null)
+      setQuickLookupItems(cached)
+      setQuickLookupCode(codigo)
+      setQuickLookupCtxUnidade(ctxUnidade)
+      return
+    }
+    const token = ++quickLookupTokenRef.current
+    setQuickLookupLoading(true)
+    setQuickLookupError(null)
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const items = await lookupInsumosByCodigo({ codigoBarras: codigo, ctxUnidade })
+          if (token !== quickLookupTokenRef.current) return
+          setQuickLookupItems(items)
+          setQuickLookupCode(codigo)
+          setQuickLookupCtxUnidade(ctxUnidade)
+          if (!items.length) setQuickLookupError('Nenhum insumo encontrado para este código.')
+        } catch (error: any) {
+          if (token !== quickLookupTokenRef.current) return
+          setQuickLookupError(error?.message || 'Falha ao buscar o insumo.')
+          setQuickLookupItems([])
+          setQuickLookupCode(codigo)
+          setQuickLookupCtxUnidade(ctxUnidade)
+          console.warn('[insumos][quick-lookup]', {
+            unit: ctxUnidade,
+            codigo,
+            status: error?.status || 0,
+            code: error?.code || null,
+          })
+        } finally {
+          if (token === quickLookupTokenRef.current) setQuickLookupLoading(false)
+        }
+      })()
+    }, 250)
+
+    return () => window.clearTimeout(timer)
+  }, [
+    canUseApi,
+    isAuthed,
+    lookupInsumosByCodigo,
+    quickCodigo,
+    quickOp,
+    readCachedInsumosByCodigo,
+    setQuickLookupCode,
+    setQuickLookupCtxUnidade,
+    setQuickLookupError,
+    setQuickLookupItems,
+    setQuickLookupLoading,
+    transferFrom,
+    unidade,
+  ])
+
+  return {
+    applyQuickSelection,
+    clearQuickSelection,
+    hasQuickSelection,
+    quickLoteNeedsPick,
+    quickLotesForPicker,
+    quickSearchMatches,
+    selectQuickCodigo,
+  }
+}

--- a/frontend/useInsumosQuickOperationsController.ts
+++ b/frontend/useInsumosQuickOperationsController.ts
@@ -1,0 +1,320 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import type { InsumosQuickOperation, QuickActionFeedback, QuickCandidate } from '@/insumosTypes'
+
+type MutateJsonFn = <T>(
+  path: string,
+  opts: {
+    method?: string
+    body?: unknown
+    queueLabel?: string
+  }
+) => Promise<T>
+
+type SchedulePostMutationRefreshFn = (opts?: { overview?: boolean; insights?: boolean }) => void
+
+type UseInsumosQuickOperationsControllerArgs = {
+  canUseApi: boolean
+  isAuthed: boolean
+  loadMovimentacoes: () => Promise<void>
+  mutateJson: MutateJsonFn
+  policyErrorToast: (error: unknown) => boolean
+  quickCodigo: string
+  quickLoteNeedsPick: boolean
+  quickMotivo: string
+  quickNovoEstoque: string
+  quickObs: string
+  quickQuantidade: string
+  quickRegistro: string
+  refreshInsumos: () => Promise<void>
+  schedulePostMutationRefresh: SchedulePostMutationRefreshFn
+  setQuickActionFeedback: React.Dispatch<React.SetStateAction<QuickActionFeedback | null>>
+  setQuickActionLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setQuickCandidates: React.Dispatch<React.SetStateAction<QuickCandidate[]>>
+  setQuickRegistros: React.Dispatch<React.SetStateAction<string[]>>
+  transferFrom: string
+  transferTo: string
+  unidade: string
+}
+
+function normalizeAmbiguousCandidates(raw: unknown): QuickCandidate[] {
+  const list = Array.isArray(raw) ? raw : []
+  return list
+    .map((candidate: any) => ({
+      registro: String(candidate?.registro || '').trim(),
+      lote: String(candidate?.lote || '').trim(),
+      dataValidade: candidate?.dataValidade ? String(candidate.dataValidade) : null,
+      estoque: Number.isFinite(Number(candidate?.estoque)) ? Number(candidate.estoque) : 0,
+    }))
+    .filter((candidate) => candidate.registro)
+    .sort((a, b) => {
+      const sa = (Number(a.estoque) || 0) > 0 ? 0 : 1
+      const sb = (Number(b.estoque) || 0) > 0 ? 0 : 1
+      if (sa !== sb) return sa - sb
+      const da = a.dataValidade ? new Date(a.dataValidade).getTime() : Number.POSITIVE_INFINITY
+      const db = b.dataValidade ? new Date(b.dataValidade).getTime() : Number.POSITIVE_INFINITY
+      if (da !== db) return da - db
+      return String(a.registro).localeCompare(String(b.registro))
+    })
+}
+
+function applyAmbiguousSelection(args: {
+  error: unknown
+  setQuickActionFeedback: React.Dispatch<React.SetStateAction<QuickActionFeedback | null>>
+  setQuickCandidates: React.Dispatch<React.SetStateAction<QuickCandidate[]>>
+  setQuickRegistros: React.Dispatch<React.SetStateAction<string[]>>
+}) {
+  const code = String((args.error as any)?.code || '').toUpperCase()
+  if (code !== 'AMBIGUOUS') return false
+
+  const registros = Array.isArray((args.error as any)?.registros) ? (args.error as any).registros : []
+  const candidates = normalizeAmbiguousCandidates((args.error as any)?.candidates)
+  if (candidates.length) {
+    args.setQuickCandidates(candidates)
+    args.setQuickRegistros(candidates.map((candidate) => candidate.registro))
+  } else {
+    args.setQuickCandidates([])
+    args.setQuickRegistros(registros)
+  }
+  args.setQuickActionFeedback({
+    type: 'error',
+    message: 'Este código possui múltiplos lotes. Selecione o lote/registro.',
+  })
+  return true
+}
+
+export function useInsumosQuickOperationsController({
+  canUseApi,
+  isAuthed,
+  loadMovimentacoes,
+  mutateJson,
+  policyErrorToast,
+  quickCodigo,
+  quickLoteNeedsPick,
+  quickMotivo,
+  quickNovoEstoque,
+  quickObs,
+  quickQuantidade,
+  quickRegistro,
+  refreshInsumos,
+  schedulePostMutationRefresh,
+  setQuickActionFeedback,
+  setQuickActionLoading,
+  setQuickCandidates,
+  setQuickRegistros,
+  transferFrom,
+  transferTo,
+  unidade,
+}: UseInsumosQuickOperationsControllerArgs) {
+  const runQuickOperation = React.useCallback(
+    async (operation: Exclude<InsumosQuickOperation, 'TRANSFERENCIA'>): Promise<boolean> => {
+      if (!canUseApi || !isAuthed) return false
+      setQuickActionFeedback(null)
+      const codigoBarras = quickCodigo.trim()
+      if (!codigoBarras) {
+        setQuickActionFeedback({ type: 'error', message: 'Informe o código de barras' })
+        return false
+      }
+
+      setQuickActionLoading(true)
+      try {
+        if (operation === 'AJUSTE') {
+          const novoEstoque = Number.isFinite(Number(quickNovoEstoque)) ? Number(quickNovoEstoque) : null
+          if (novoEstoque === null) {
+            setQuickActionFeedback({ type: 'error', message: 'Informe o novo estoque' })
+            return false
+          }
+          const registro = quickRegistro.trim()
+          await mutateJson(`/insumos/ajuste?unidade=${encodeURIComponent(unidade)}`, {
+            method: 'POST',
+            body: {
+              codigoBarras,
+              registro: registro || undefined,
+              novoEstoque,
+              motivo: quickMotivo,
+              observacoes: quickObs,
+            },
+            queueLabel: 'Ajuste',
+          })
+          setQuickActionFeedback({ type: 'success', message: 'Ajuste registrado' })
+        } else {
+          const quantidade = Math.max(1, parseInt(quickQuantidade, 10) || 0)
+          const path = operation === 'ENTRADA' ? '/insumos/entrada' : '/insumos/baixa'
+          const registro = quickRegistro.trim()
+          if (quickLoteNeedsPick && !registro) {
+            setQuickActionFeedback({ type: 'error', message: 'Selecione o lote/registro' })
+            return false
+          }
+          const out = await mutateJson<{ success?: boolean; novoEstoque?: number; quebraEstoque?: boolean; deficit?: number }>(
+            `${path}?unidade=${encodeURIComponent(unidade)}`,
+            {
+              method: 'POST',
+              body: { codigoBarras, registro: registro || undefined, quantidade, observacoes: quickObs },
+              queueLabel: operation === 'ENTRADA' ? 'Entrada' : 'Baixa',
+            },
+          )
+          const novoEstoque = Number((out as any)?.novoEstoque)
+          const quebraEstoque =
+            operation === 'BAIXA' && ((out as any)?.quebraEstoque === true || (Number.isFinite(novoEstoque) && novoEstoque < 0))
+          const message = quebraEstoque
+            ? `Baixa registrada com quebra de estoque (saldo: ${Number.isFinite(novoEstoque) ? novoEstoque : '-'})`
+            : operation === 'ENTRADA'
+              ? 'Entrada registrada'
+              : 'Baixa registrada'
+          setQuickActionFeedback({ type: 'success', message })
+          if (quebraEstoque) {
+            const deficit = Number((out as any)?.deficit)
+            toast.warning(`Quebra de estoque detectada${Number.isFinite(deficit) ? `: déficit de ${deficit}` : ''}. Confira os alertas.`)
+          }
+        }
+
+        await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+        schedulePostMutationRefresh({ overview: true, insights: true })
+        return true
+      } catch (error) {
+        if (
+          applyAmbiguousSelection({
+            error,
+            setQuickActionFeedback,
+            setQuickCandidates,
+            setQuickRegistros,
+          })
+        ) {
+          return false
+        }
+        if (policyErrorToast(error)) {
+          setQuickActionFeedback({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+          return false
+        }
+        setQuickActionFeedback({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+        return false
+      } finally {
+        setQuickActionLoading(false)
+      }
+    },
+    [
+      canUseApi,
+      isAuthed,
+      loadMovimentacoes,
+      mutateJson,
+      policyErrorToast,
+      quickCodigo,
+      quickLoteNeedsPick,
+      quickMotivo,
+      quickNovoEstoque,
+      quickObs,
+      quickQuantidade,
+      quickRegistro,
+      refreshInsumos,
+      schedulePostMutationRefresh,
+      setQuickActionFeedback,
+      setQuickActionLoading,
+      setQuickCandidates,
+      setQuickRegistros,
+      unidade,
+    ],
+  )
+
+  const runTransfer = React.useCallback(async (): Promise<boolean> => {
+    if (!canUseApi || !isAuthed) return false
+    setQuickActionFeedback(null)
+    const codigoBarras = quickCodigo.trim()
+    if (!codigoBarras) {
+      setQuickActionFeedback({ type: 'error', message: 'Informe o código de barras' })
+      return false
+    }
+    if (transferFrom === transferTo) {
+      setQuickActionFeedback({ type: 'error', message: 'Origem e destino devem ser diferentes' })
+      return false
+    }
+
+    const registro = quickRegistro.trim()
+    if (quickLoteNeedsPick && !registro) {
+      setQuickActionFeedback({ type: 'error', message: 'Selecione o lote/registro' })
+      return false
+    }
+
+    setQuickActionLoading(true)
+    try {
+      const quantidade = Math.max(1, parseInt(quickQuantidade, 10) || 0)
+      const out = await mutateJson<{
+        success?: boolean
+        estoqueNovoOrigem?: number
+        quebraEstoqueOrigem?: boolean
+        deficitOrigem?: number
+      }>(`/insumos/transferir?unidade=${encodeURIComponent(transferFrom)}`, {
+        method: 'POST',
+        body: {
+          codigoBarras,
+          registro: registro || undefined,
+          quantidade,
+          fromUnidade: transferFrom,
+          toUnidade: transferTo,
+          observacoes: quickObs,
+        },
+        queueLabel: 'Transferência',
+      })
+
+      const novoOrigem = Number((out as any)?.estoqueNovoOrigem)
+      const quebraEstoque = (out as any)?.quebraEstoqueOrigem === true || (Number.isFinite(novoOrigem) && novoOrigem < 0)
+      const message = quebraEstoque
+        ? `Transferência registrada com quebra de estoque (origem: ${Number.isFinite(novoOrigem) ? novoOrigem : '-'})`
+        : 'Transferência registrada'
+      setQuickActionFeedback({ type: 'success', message })
+      if (quebraEstoque) {
+        const deficit = Number((out as any)?.deficitOrigem)
+        toast.warning(
+          `Quebra de estoque detectada na origem${Number.isFinite(deficit) ? `: déficit de ${deficit}` : ''}. Confira os alertas.`,
+        )
+      }
+
+      await Promise.allSettled([refreshInsumos(), loadMovimentacoes()])
+      schedulePostMutationRefresh({ overview: true, insights: true })
+      return true
+    } catch (error) {
+      if (
+        applyAmbiguousSelection({
+          error,
+          setQuickActionFeedback,
+          setQuickCandidates,
+          setQuickRegistros,
+        })
+      ) {
+        return false
+      }
+      if (policyErrorToast(error)) {
+        setQuickActionFeedback({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+        return false
+      }
+      setQuickActionFeedback({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+      return false
+    } finally {
+      setQuickActionLoading(false)
+    }
+  }, [
+    canUseApi,
+    isAuthed,
+    loadMovimentacoes,
+    mutateJson,
+    policyErrorToast,
+    quickCodigo,
+    quickLoteNeedsPick,
+    quickObs,
+    quickQuantidade,
+    quickRegistro,
+    refreshInsumos,
+    schedulePostMutationRefresh,
+    setQuickActionFeedback,
+    setQuickActionLoading,
+    setQuickCandidates,
+    setQuickRegistros,
+    transferFrom,
+    transferTo,
+  ])
+
+  return {
+    runQuickOperation,
+    runTransfer,
+  }
+}

--- a/frontend/useInsumosQuickOperationsController.ts
+++ b/frontend/useInsumosQuickOperationsController.ts
@@ -10,7 +10,7 @@ type MutateJsonFn = <T>(
     body?: unknown
     queueLabel?: string
   }
-) => Promise<T>
+) => Promise<T | { queued: true }>
 
 type SchedulePostMutationRefreshFn = (opts?: { overview?: boolean; insights?: boolean }) => void
 


### PR DESCRIPTION
## Summary
- publish the completed Escala refactor with typed header bridge, extracted panels/components, and stronger keyboard/multi-select behavior
- publish the Insumos refactor with typed header state, extracted dialogs/panels, and dedicated controllers for dashboard, movements, inventory, and quick operations
- keep the release scoped to CRM frontend changes only, excluding stale local website deltas that would regress main

## Validation
- `cd frontend && node ./node_modules/vitest/vitest.mjs run tests/escalaModule.test.ts tests/insumosModule.test.ts tests/insumosProxy.test.ts`
- `cd frontend && node ./node_modules/vite/bin/vite.js build`
- `cd frontend && node ./node_modules/playwright/cli.js test e2e/escala-module.spec.ts`
- `cd frontend && node ./node_modules/playwright/cli.js test e2e/insumos-edit-modal-policy.spec.ts e2e/insumos-no-request-storm.spec.ts`
