### PR TITLE
[codex] connect Meta Ads manager in CRM

### DIFF
--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -1,14 +1,48 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
-import { Button } from '@/button'
-import { Input } from '@/input'
+import { format, subDays } from 'date-fns'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { toast } from 'sonner'
 import { Badge } from '@/badge'
+import { Button } from '@/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
+import { Input } from '@/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/tabs'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/table'
-import { metaAdsApi, setMetaAdsToken, getMetaAdsToken } from '@/metaAdsApi'
-import { formatCurrency, formatNumber, getStatusColor } from '@/utils'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
-import { format, subDays } from 'date-fns'
+import { Textarea } from '@/textarea'
+import { metaAdsApi, type MetaAdsStatusResponse } from '@/metaAdsApi'
+import { MetaTrackingDashboard } from '@/MetaTrackingDashboard'
+import { CheckCircle, FacebookLogo, FadersHorizontal, Link, PresentationChart, Spinner, Target } from '@phosphor-icons/react'
+
+type MetaAdAccount = {
+  id: string
+  name: string
+  account_status?: string
+  currency?: string
+  timezone_name?: string
+  business_name?: string
+  isSelected?: boolean
+}
+
+type MetaCampaignRow = {
+  id: string
+  name: string
+  status?: string
+  effective_status?: string
+  objective?: string
+  totals?: { adSets: number; ads: number }
+  adSets?: Array<{ id: string; name: string; ads: any[] }>
+}
+
+type MetaInventoryResponse = {
+  ok: boolean
+  accountId: string
+  inventory: {
+    campaigns: MetaCampaignRow[]
+    adSets: any[]
+    ads: any[]
+    creatives: any[]
+  }
+}
 
 const defaultRange = () => {
   const since = format(subDays(new Date(), 6), 'yyyy-MM-dd')
@@ -16,439 +50,577 @@ const defaultRange = () => {
   return { since, until }
 }
 
-export function MetaCampaignControlCenter() {
-  const [token, setToken] = useState<string | null>(getMetaAdsToken())
-  const [loading, setLoading] = useState(false)
-  const [message, setMessage] = useState<string | null>(null)
+function formatCurrency(value: number, currency = 'USD') {
+  try {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: currency || 'USD',
+      maximumFractionDigits: 2,
+    }).format(Number(value || 0))
+  } catch {
+    return `${currency || 'USD'} ${Number(value || 0).toFixed(2)}`
+  }
+}
 
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('pt-BR').format(Number(value || 0))
+}
+
+function statusTone(status?: string) {
+  const normalized = String(status || '').toUpperCase()
+  if (normalized === 'ACTIVE') return 'bg-emerald-500/15 text-emerald-200 border-emerald-500/30'
+  if (normalized === 'PAUSED') return 'bg-amber-500/15 text-amber-200 border-amber-500/30'
+  if (normalized === 'ARCHIVED') return 'bg-slate-500/15 text-slate-200 border-slate-500/30'
+  return 'bg-white/10 text-blue-100 border-white/10'
+}
+
+function emptyState(message: string) {
+  return (
+    <Card className="glass-card border-white/10">
+      <CardContent className="py-10 text-center text-sm text-blue-100/70">
+        {message}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function MetaCampaignControlCenter() {
+  const [status, setStatus] = useState<MetaAdsStatusResponse | null>(null)
+  const [accounts, setAccounts] = useState<MetaAdAccount[]>([])
   const [summary, setSummary] = useState<any | null>(null)
   const [trend, setTrend] = useState<any[]>([])
-  const [campaigns, setCampaigns] = useState<any[]>([])
-  const [accounts, setAccounts] = useState<any[]>([])
-  const [bulkOps, setBulkOps] = useState<any[]>([])
-  const [alerts, setAlerts] = useState<any[]>([])
+  const [inventory, setInventory] = useState<MetaInventoryResponse['inventory'] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [manualToken, setManualToken] = useState('')
+  const [activeTab, setActiveTab] = useState('tracking')
 
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [orgName, setOrgName] = useState('')
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => account.isSelected) || null,
+    [accounts],
+  )
 
-  const [actionType, setActionType] = useState<'pause' | 'resume' | 'budget' | 'rename' | 'duplicate'>('pause')
-  const [budgetMode, setBudgetMode] = useState<'absolute' | 'percent'>('absolute')
-  const [budgetValue, setBudgetValue] = useState(0)
-  const [prefix, setPrefix] = useState('')
-  const [suffix, setSuffix] = useState('')
-  const [deepCopy, setDeepCopy] = useState(false)
-  const [selectedIds, setSelectedIds] = useState<Record<string, boolean>>({})
-  const [preview, setPreview] = useState<any | null>(null)
-  const [nameFilter, setNameFilter] = useState('')
-  const [statusFilter, setStatusFilter] = useState('all')
+  const loadStatus = async () => {
+    const next = await metaAdsApi.status()
+    setStatus(next)
+    return next
+  }
 
-  const refreshDashboard = async () => {
+  const loadAccounts = async () => {
+    const data = await metaAdsApi.listAdAccounts()
+    setAccounts(data.accounts || [])
+    return data
+  }
+
+  const loadOverview = async () => {
     const { since, until } = defaultRange()
-    const [sum, tr] = await Promise.all([metaAdsApi.summary({ since, until }), metaAdsApi.trend({ since, until })])
-    setSummary(sum)
-    setTrend(tr as any[])
+    const [nextSummary, nextTrend] = await Promise.all([
+      metaAdsApi.summary({ since, until }),
+      metaAdsApi.trend({ since, until }),
+    ])
+    setSummary(nextSummary)
+    setTrend(Array.isArray(nextTrend) ? nextTrend : [])
   }
 
-  const refreshCampaigns = async () => {
-    const rows = await metaAdsApi.listCampaigns()
-    setCampaigns(rows as any[])
+  const loadInventory = async () => {
+    const data = await metaAdsApi.inventory()
+    setInventory(data.inventory || null)
   }
 
-  const refreshBulkOps = async () => {
-    const rows = await metaAdsApi.bulkOperations()
-    setBulkOps(rows as any[])
-  }
-
-  const refreshAlerts = async () => {
-    const rows = await metaAdsApi.alerts()
-    setAlerts(rows as any[])
+  const refreshConnectedState = async () => {
+    const nextStatus = await loadStatus()
+    if (!nextStatus.connection.connected) {
+      setAccounts([])
+      setSummary(null)
+      setTrend([])
+      setInventory(null)
+      return
+    }
+    await loadAccounts()
+    if (nextStatus.connection.selectedAdAccountId) {
+      await Promise.all([loadOverview(), loadInventory()])
+    } else {
+      setSummary(null)
+      setTrend([])
+      setInventory(null)
+    }
   }
 
   useEffect(() => {
-    if (!token) return
-    setLoading(true)
-    refreshDashboard()
-      .then(refreshCampaigns)
-      .catch(() => null)
-      .finally(() => setLoading(false))
-  }, [token])
+    let cancelled = false
+    const boot = async () => {
+      setLoading(true)
+      try {
+        if (!cancelled) await refreshConnectedState()
+      } catch (error: any) {
+        if (!cancelled) toast.error(error?.message || 'Falha ao carregar Meta Ads')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    boot()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
-    if (!token) return
-    const interval = setInterval(() => {
-      refreshBulkOps().catch(() => null)
-    }, 5000)
-    return () => clearInterval(interval)
-  }, [token])
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return
+      if (event.data?.type !== 'meta-ads:connected' || !event.data?.ok) return
+      setRefreshing(true)
+      refreshConnectedState()
+        .then(() => toast.success('Conta Meta Ads conectada'))
+        .catch((error: any) => toast.error(error?.message || 'Falha ao concluir conexão'))
+        .finally(() => setRefreshing(false))
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
 
-  const filteredCampaigns = useMemo(() => {
-    return campaigns.filter((row) => {
-      const matchesName = nameFilter ? row.name?.toLowerCase().includes(nameFilter.toLowerCase()) : true
-      const matchesStatus = statusFilter === 'all' ? true : row.status === statusFilter
-      return matchesName && matchesStatus
-    })
-  }, [campaigns, nameFilter, statusFilter])
-
-  const selectedList = Object.entries(selectedIds)
-    .filter(([, v]) => v)
-    .map(([id]) => id)
-
-  const handleRegister = async () => {
-    const res: any = await metaAdsApi.register({ email, password, orgName: orgName || 'Minha Org' })
-    setMetaAdsToken(res.token)
-    setToken(res.token)
-    setMessage('Registrado com sucesso')
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      await refreshConnectedState()
+      toast.success('Meta Ads atualizado')
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao atualizar')
+    } finally {
+      setRefreshing(false)
+    }
   }
 
-  const handleLogin = async () => {
-    const res: any = await metaAdsApi.login({ email, password })
-    setMetaAdsToken(res.token)
-    setToken(res.token)
-    setMessage('Login OK')
-  }
-
-  const handleOAuth = async () => {
-    const res: any = await metaAdsApi.oauthUrl()
-    window.open(res.url, '_blank')
-  }
-
-  const handleLoadAccounts = async () => {
-    const data: any = await metaAdsApi.listAdAccounts()
-    setAccounts(data)
-  }
-
-  const handleSelectAccount = async (id: string) => {
-    await metaAdsApi.selectAdAccount({ adAccountId: id })
-    setMessage('Conta selecionada')
-  }
-
-  const handlePreview = async () => {
-    const payload =
-      actionType === 'budget'
-        ? { mode: budgetMode, value: budgetValue }
-        : actionType === 'rename'
-          ? { prefix, suffix }
-          : actionType === 'duplicate'
-            ? { prefix, suffix, deepCopy }
-            : undefined
-    const res = await metaAdsApi.bulkPreview({ entityType: 'campaign', actionType, ids: selectedList, payload })
-    setPreview(res)
-  }
-
-  const handleExecute = async () => {
-    const payload =
-      actionType === 'budget'
-        ? { mode: budgetMode, value: budgetValue }
-        : actionType === 'rename'
-          ? { prefix, suffix }
-          : actionType === 'duplicate'
-            ? { prefix, suffix, deepCopy }
-            : undefined
-    await metaAdsApi.bulkExecute({ entityType: 'campaign', actionType, ids: selectedList, payload })
-    setPreview(null)
-    refreshBulkOps().catch(() => null)
-  }
-
-  const handleSyncInsights = async () => {
-    const { since, until } = defaultRange()
-    await metaAdsApi.syncInsights({ level: 'campaign', since, until })
-    await refreshDashboard()
-  }
-
-  if (!token) {
-    return (
-      <Card className="border-muted/60">
-        <CardHeader>
-          <CardTitle>Meta Campaign Control Center</CardTitle>
-          <CardDescription>Autenticacao local do subprojeto Meta Ads.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-          <Input placeholder="Senha" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-          <Input placeholder="Org (registro)" value={orgName} onChange={(e) => setOrgName(e.target.value)} />
-          <div className="flex gap-2">
-            <Button onClick={handleRegister}>Registrar</Button>
-            <Button variant="outline" onClick={handleLogin}>Login</Button>
-          </div>
-          {message ? <Badge className="bg-emerald-500/10 text-emerald-200">{message}</Badge> : null}
-        </CardContent>
-      </Card>
+  const handleOpenOAuth = () => {
+    const width = 620
+    const height = 760
+    const left = Math.max(0, Math.round(window.screenX + (window.outerWidth - width) / 2))
+    const top = Math.max(0, Math.round(window.screenY + (window.outerHeight - height) / 2))
+    window.open(
+      metaAdsApi.oauthStartUrl(),
+      'meta-ads-oauth',
+      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
     )
   }
 
+  const handleManualConnect = async () => {
+    if (!manualToken.trim()) {
+      toast.error('Cole um access token válido da Meta.')
+      return
+    }
+    setRefreshing(true)
+    try {
+      await metaAdsApi.connectManual({ accessToken: manualToken.trim() })
+      setManualToken('')
+      await refreshConnectedState()
+      toast.success('Token manual conectado')
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao conectar token manual')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    setRefreshing(true)
+    try {
+      await metaAdsApi.disconnect()
+      await refreshConnectedState()
+      toast.success('Conexão Meta Ads removida')
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao desconectar')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const handleSelectAccount = async (adAccountId: string) => {
+    setRefreshing(true)
+    try {
+      await metaAdsApi.selectAdAccount({ adAccountId })
+      await refreshConnectedState()
+      toast.success('Conta de anúncios selecionada')
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao selecionar conta')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const creativeCount = inventory?.creatives?.length || 0
+  const adCount = inventory?.ads?.length || 0
+  const adSetCount = inventory?.adSets?.length || 0
+  const campaignCount = inventory?.campaigns?.length || 0
+  const missingConfig = status?.missingConfig || []
+
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+    <div className="space-y-6 animate-fade-in">
+      <Card className="glass-card border-white/10">
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <CardTitle>Meta Campaign Control Center</CardTitle>
-            <CardDescription>Operacao e performance de campanhas Meta Ads.</CardDescription>
+            <CardTitle className="flex items-center gap-3 text-white">
+              <div className="flex items-center gap-2">
+                <FacebookLogo className="h-6 w-6 text-blue-400" />
+                <Target className="h-6 w-6 text-pink-400" />
+              </div>
+              Meta Ads
+            </CardTitle>
+            <CardDescription>
+              Conecte o Gerenciador de Anúncios da Meta ao CRM e explore campanhas, conjuntos, anúncios e criativos em tempo real.
+            </CardDescription>
           </div>
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={refreshDashboard} disabled={loading}>Atualizar</Button>
-            <Button onClick={handleSyncInsights}>Sync Insights (7d)</Button>
+          <div className="flex flex-wrap items-center gap-2">
+            {status?.connection.connected ? (
+              <Badge className="bg-emerald-500/15 text-emerald-200 border border-emerald-500/30">
+                <CheckCircle className="mr-1 h-4 w-4" />
+                Conectado
+              </Badge>
+            ) : (
+              <Badge className="bg-amber-500/15 text-amber-200 border border-amber-500/30">
+                <Link className="mr-1 h-4 w-4" />
+                Não conectado
+              </Badge>
+            )}
+            <Button variant="outline" onClick={handleRefresh} disabled={loading || refreshing}>
+              {refreshing ? <Spinner className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Atualizar
+            </Button>
+            {status?.connection.connected ? (
+              <Button variant="outline" onClick={handleDisconnect} disabled={refreshing}>
+                Desconectar
+              </Button>
+            ) : null}
           </div>
         </CardHeader>
       </Card>
 
-      <Tabs defaultValue="dashboard">
-        <TabsList>
-          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
-          <TabsTrigger value="connect">Conectar</TabsTrigger>
-          <TabsTrigger value="campaigns">Campanhas</TabsTrigger>
-          <TabsTrigger value="bulk">Bulk Ops</TabsTrigger>
-          <TabsTrigger value="alerts">Alerts</TabsTrigger>
+      {missingConfig.length ? (
+        <Card className="glass-card border-amber-500/30 bg-amber-500/10">
+          <CardContent className="pt-6 text-sm text-amber-100">
+            Faltam configurações de runtime para OAuth/armazenamento: <span className="font-mono">{missingConfig.join(', ')}</span>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+        <TabsList className="grid w-full max-w-4xl grid-cols-4 glass-morphism p-2 border-white/20">
+          <TabsTrigger value="tracking">Tracking</TabsTrigger>
+          <TabsTrigger value="overview">Visão geral</TabsTrigger>
+          <TabsTrigger value="connect">Conexão</TabsTrigger>
+          <TabsTrigger value="inventory">Inventário</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="dashboard" className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-4">
-            <Card>
-              <CardHeader>
-                <CardDescription>Spend</CardDescription>
-                <CardTitle>{formatCurrency(summary?.spend ?? 0, 'USD')}</CardTitle>
-              </CardHeader>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardDescription>Campanhas ativas</CardDescription>
-                <CardTitle>{summary?.activeCampaigns ?? 0}</CardTitle>
-              </CardHeader>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardDescription>ROAS medio</CardDescription>
-                <CardTitle>{summary?.roas ? `${summary.roas.toFixed(2)}x` : '—'}</CardTitle>
-              </CardHeader>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardDescription>Clicks</CardDescription>
-                <CardTitle>{formatNumber(summary?.clicks ?? 0)}</CardTitle>
-              </CardHeader>
-            </Card>
-          </div>
-          <Card>
-            <CardHeader>
-              <CardTitle>Tendencia de gasto (7 dias)</CardTitle>
-            </CardHeader>
-            <CardContent className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={trend}>
-                  <XAxis dataKey="day" />
-                  <YAxis />
-                  <Tooltip />
-                  <Line type="monotone" dataKey="spend" stroke="#0ea5e9" strokeWidth={2} />
-                </LineChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
+        <TabsContent value="tracking" className="space-y-6">
+          <MetaTrackingDashboard />
         </TabsContent>
 
-        <TabsContent value="connect" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Meta OAuth</CardTitle>
-              <CardDescription>Conecte a conta Meta do usuario.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex gap-2">
-                <Button onClick={handleOAuth}>Abrir OAuth</Button>
-                <Button variant="outline" onClick={handleLoadAccounts}>Listar contas</Button>
-              </div>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Conta</TableHead>
-                    <TableHead>ID</TableHead>
-                    <TableHead></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {accounts.map((acc) => (
-                    <TableRow key={acc.id}>
-                      <TableCell>{acc.name}</TableCell>
-                      <TableCell>{acc.metaAccountId ?? acc.id}</TableCell>
-                      <TableCell>
-                        <Button size="sm" onClick={() => handleSelectAccount(acc.id)}>Selecionar</Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-              {message ? <Badge className="bg-emerald-500/10 text-emerald-200">{message}</Badge> : null}
-            </CardContent>
-          </Card>
+        <TabsContent value="overview" className="space-y-6">
+          {!status?.connection.connected
+            ? emptyState('Conecte uma conta Meta Ads para carregar spend, tendência e inventário.')
+            : !selectedAccount
+              ? emptyState('Escolha uma conta de anúncios na aba Conexão para carregar os dados.')
+              : (
+                <>
+                  <div className="grid gap-4 md:grid-cols-4">
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Spend (7 dias)</CardDescription>
+                        <CardTitle>{formatCurrency(summary?.spend ?? 0, selectedAccount.currency || 'USD')}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Impressões</CardDescription>
+                        <CardTitle>{formatNumber(summary?.impressions ?? 0)}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Clicks</CardDescription>
+                        <CardTitle>{formatNumber(summary?.clicks ?? 0)}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Campanhas ativas</CardDescription>
+                        <CardTitle>{formatNumber(summary?.activeCampaigns ?? 0)}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-4">
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Campanhas</CardDescription>
+                        <CardTitle>{campaignCount}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Conjuntos</CardDescription>
+                        <CardTitle>{adSetCount}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Anúncios</CardDescription>
+                        <CardTitle>{adCount}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardDescription>Criativos</CardDescription>
+                        <CardTitle>{creativeCount}</CardTitle>
+                      </CardHeader>
+                    </Card>
+                  </div>
+
+                  <Card className="glass-card border-white/10">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <PresentationChart className="h-5 w-5 text-blue-300" />
+                        Tendência de gasto
+                      </CardTitle>
+                      <CardDescription>Últimos 7 dias da conta selecionada.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="h-72">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={trend}>
+                          <XAxis dataKey="day" />
+                          <YAxis />
+                          <Tooltip />
+                          <Line type="monotone" dataKey="spend" stroke="#38bdf8" strokeWidth={2} />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </CardContent>
+                  </Card>
+                </>
+              )}
         </TabsContent>
 
-        <TabsContent value="campaigns" className="space-y-4">
-          <Card>
+        <TabsContent value="connect" className="space-y-6">
+          <Card className="glass-card border-white/10">
             <CardHeader>
-              <CardTitle>Bulk Actions</CardTitle>
-              <CardDescription>Selecione campanhas e aplique acoes em lote.</CardDescription>
+              <CardTitle>Conectar com Facebook</CardTitle>
+              <CardDescription>
+                Use OAuth para autorizar leitura e gestão do Gerenciador de Anúncios com os escopos da Meta.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex flex-wrap items-center gap-2">
-                <select
-                  className="border rounded px-2 py-1 text-sm bg-transparent"
-                  value={actionType}
-                  onChange={(e) => setActionType(e.target.value as any)}
-                >
-                  <option value="pause">Pause</option>
-                  <option value="resume">Resume</option>
-                  <option value="budget">Ajustar budget</option>
-                  <option value="rename">Renomear</option>
-                  <option value="duplicate">Duplicar</option>
-                </select>
-                {actionType === 'budget' ? (
-                  <div className="flex items-center gap-2">
-                    <select
-                      className="border rounded px-2 py-1 text-sm bg-transparent"
-                      value={budgetMode}
-                      onChange={(e) => setBudgetMode(e.target.value as any)}
-                    >
-                      <option value="absolute">Valor</option>
-                      <option value="percent">%</option>
-                    </select>
-                    <Input
-                      className="w-24"
-                      type="number"
-                      value={budgetValue}
-                      onChange={(e) => setBudgetValue(Number(e.target.value))}
-                    />
-                  </div>
-                ) : null}
-                {actionType === 'rename' || actionType === 'duplicate' ? (
-                  <div className="flex items-center gap-2">
-                    <Input className="w-28" placeholder="Prefixo" value={prefix} onChange={(e) => setPrefix(e.target.value)} />
-                    <Input className="w-28" placeholder="Sufixo" value={suffix} onChange={(e) => setSuffix(e.target.value)} />
-                  </div>
-                ) : null}
-                {actionType === 'duplicate' ? (
-                  <label className="flex items-center gap-2 text-xs">
-                    <input type="checkbox" checked={deepCopy} onChange={(e) => setDeepCopy(e.target.checked)} />
-                    Deep copy
-                  </label>
-                ) : null}
-                <Button variant="outline" onClick={handlePreview} disabled={selectedList.length === 0}>Preview</Button>
-                <Badge className="bg-white/10">{selectedList.length} selecionadas</Badge>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={handleOpenOAuth} disabled={refreshing || !!missingConfig.length}>
+                  Conectar via Facebook
+                </Button>
+                <Badge className="bg-white/10 text-blue-100 border border-white/10">
+                  Escopos: {status?.connection.scopes?.join(', ') || 'ads_read, ads_management, business_management'}
+                </Badge>
               </div>
-              {preview ? (
-                <div className="border rounded p-3 space-y-2">
-                  <div className="text-sm">{preview.count} itens serao afetados</div>
-                  {preview.previews.map((p: any) => (
-                    <div key={p.id} className="text-xs">
-                      {p.id}: {p.error ? `Erro: ${p.error}` : actionType === 'budget' ? `${p.before.dailyBudget ?? '-'} → ${p.after.dailyBudget ?? '-'}` : actionType === 'rename' || actionType === 'duplicate' ? `${p.before.name} → ${p.after.name}` : `${p.before.status} → ${p.after.status}`}
-                    </div>
-                  ))}
-                  <Button onClick={handleExecute} disabled={preview.previews.some((p: any) => !p.valid)}>Executar</Button>
+              {status?.connection.connected ? (
+                <div className="text-sm text-blue-100/70">
+                  Usuário conectado: <span className="font-medium text-white">{status.connection.metaUserName || status.connection.metaUserId || 'Meta User'}</span>
                 </div>
               ) : null}
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="glass-card border-white/10">
             <CardHeader>
-              <CardTitle>Campanhas</CardTitle>
+              <CardTitle>Conectar por token manual</CardTitle>
+              <CardDescription>
+                Alternativa para tokens de longa duração ou integrações administrativas.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <div className="flex gap-2">
-                <Input placeholder="Filtrar por nome" value={nameFilter} onChange={(e) => setNameFilter(e.target.value)} />
-                <select className="border rounded px-2 py-1 text-sm bg-transparent" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
-                  <option value="all">Status (todos)</option>
-                  <option value="ACTIVE">Active</option>
-                  <option value="PAUSED">Paused</option>
-                </select>
-                <Button variant="outline" onClick={refreshCampaigns}>Recarregar</Button>
+              <Textarea
+                value={manualToken}
+                onChange={(e) => setManualToken(e.target.value)}
+                placeholder="Cole aqui o access token da Meta"
+                className="min-h-28"
+              />
+              <div className="flex justify-end">
+                <Button onClick={handleManualConnect} disabled={refreshing || !manualToken.trim()}>
+                  Validar e conectar token
+                </Button>
               </div>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead></TableHead>
-                    <TableHead>Nome</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Objetivo</TableHead>
-                    <TableHead>Budget diario</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredCampaigns.map((row) => (
-                    <TableRow key={row.metaId || row.id}>
-                      <TableCell>
-                        <input
-                          type="checkbox"
-                          checked={!!selectedIds[row.metaId || row.id]}
-                          onChange={(e) => {
-                            const id = row.metaId || row.id
-                            setSelectedIds((prev) => ({ ...prev, [id]: e.target.checked }))
-                          }}
-                        />
-                      </TableCell>
-                      <TableCell>{row.name}</TableCell>
-                      <TableCell>
-                        <span className={`px-2 py-1 rounded text-xs ${getStatusColor(row.status)}`}>{row.status}</span>
-                      </TableCell>
-                      <TableCell>{row.objective || '—'}</TableCell>
-                      <TableCell>{row.dailyBudget ? formatCurrency(row.dailyBudget / 100, 'USD') : '—'}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
             </CardContent>
           </Card>
-        </TabsContent>
 
-        <TabsContent value="bulk" className="space-y-4">
-          <Card>
+          <Card className="glass-card border-white/10">
             <CardHeader>
-              <CardTitle>Bulk Operations</CardTitle>
-              <CardDescription>Historico e status das operacoes em lote.</CardDescription>
+              <CardTitle>Contas de anúncios</CardTitle>
+              <CardDescription>
+                Depois da conexão, selecione a conta que deve alimentar campanhas, conjuntos, anúncios e criativos no CRM.
+              </CardDescription>
             </CardHeader>
             <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Tipo</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Progresso</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {bulkOps.map((op) => (
-                    <TableRow key={op.id}>
-                      <TableCell>{op.actionType}</TableCell>
-                      <TableCell>
-                        <span className={`px-2 py-1 rounded text-xs ${getStatusColor(op.status)}`}>{op.status}</span>
-                      </TableCell>
-                      <TableCell>
-                        {op.processedItems}/{op.totalItems}
-                      </TableCell>
+              {!status?.connection.connected ? (
+                <div className="text-sm text-blue-100/70">Conecte a Meta primeiro para listar as contas disponíveis.</div>
+              ) : accounts.length === 0 ? (
+                <div className="text-sm text-blue-100/70">Nenhuma conta encontrada para este usuário/token.</div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Conta</TableHead>
+                      <TableHead>Nome</TableHead>
+                      <TableHead>Moeda</TableHead>
+                      <TableHead>Timezone</TableHead>
+                      <TableHead className="text-right">Ação</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {accounts.map((account) => (
+                      <TableRow key={account.id}>
+                        <TableCell className="font-mono">{account.id}</TableCell>
+                        <TableCell>{account.name || '—'}</TableCell>
+                        <TableCell>{account.currency || '—'}</TableCell>
+                        <TableCell>{account.timezone_name || '—'}</TableCell>
+                        <TableCell className="text-right">
+                          {account.isSelected ? (
+                            <Badge className="bg-emerald-500/15 text-emerald-200 border border-emerald-500/30">Selecionada</Badge>
+                          ) : (
+                            <Button size="sm" variant="outline" onClick={() => handleSelectAccount(account.id)} disabled={refreshing}>
+                              Selecionar
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
 
-        <TabsContent value="alerts" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Alerts</CardTitle>
-              <CardDescription>Pacing e anomalias detectadas.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              {alerts.map((alert) => (
-                <div key={alert.id} className="flex items-center justify-between border rounded p-3">
-                  <div>
-                    <div className="font-medium">{alert.type}</div>
-                    <div className="text-xs text-muted-foreground">{alert.message}</div>
-                  </div>
-                  <Button size="sm" onClick={() => metaAdsApi.resolveAlert(alert.id).then(refreshAlerts)}>Resolver</Button>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
+        <TabsContent value="inventory" className="space-y-6">
+          {!status?.connection.connected
+            ? emptyState('Conecte uma conta Meta Ads para liberar o inventário.')
+            : !selectedAccount
+              ? emptyState('Selecione uma conta de anúncios para carregar campanhas, conjuntos, anúncios e criativos.')
+              : !inventory
+                ? emptyState('Ainda não foi possível carregar o inventário desta conta. Clique em Atualizar.')
+                : (
+                  <>
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                          <FadersHorizontal className="h-5 w-5 text-blue-300" />
+                          Campanhas
+                        </CardTitle>
+                        <CardDescription>
+                          Relação da conta selecionada com total de conjuntos e anúncios por campanha.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Campanha</TableHead>
+                              <TableHead>Status</TableHead>
+                              <TableHead>Objetivo</TableHead>
+                              <TableHead>Conjuntos</TableHead>
+                              <TableHead>Anúncios</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {inventory.campaigns.map((campaign) => (
+                              <TableRow key={campaign.id}>
+                                <TableCell>
+                                  <div className="space-y-1">
+                                    <div className="font-medium text-white">{campaign.name || campaign.id}</div>
+                                    <div className="font-mono text-xs text-blue-100/60">{campaign.id}</div>
+                                  </div>
+                                </TableCell>
+                                <TableCell>
+                                  <Badge className={statusTone(campaign.effective_status || campaign.status)}>
+                                    {campaign.effective_status || campaign.status || '—'}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell>{campaign.objective || '—'}</TableCell>
+                                <TableCell>{campaign.totals?.adSets || 0}</TableCell>
+                                <TableCell>{campaign.totals?.ads || 0}</TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </CardContent>
+                    </Card>
+
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardTitle>Anúncios</CardTitle>
+                        <CardDescription>
+                          Mapa direto de anúncios com campanha, conjunto e criativo associados.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Anúncio</TableHead>
+                              <TableHead>Campanha</TableHead>
+                              <TableHead>Conjunto</TableHead>
+                              <TableHead>Criativo</TableHead>
+                              <TableHead>Status</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {inventory.ads.map((ad: any) => (
+                              <TableRow key={ad.id}>
+                                <TableCell>
+                                  <div className="space-y-1">
+                                    <div className="font-medium text-white">{ad.name || ad.id}</div>
+                                    <div className="font-mono text-xs text-blue-100/60">{ad.id}</div>
+                                  </div>
+                                </TableCell>
+                                <TableCell>{ad.campaign_name || ad.campaign_id || '—'}</TableCell>
+                                <TableCell>{ad.adset_name || ad.adset_id || '—'}</TableCell>
+                                <TableCell>{ad.creative?.name || ad.creative?.id || '—'}</TableCell>
+                                <TableCell>
+                                  <Badge className={statusTone(ad.effective_status || ad.status)}>
+                                    {ad.effective_status || ad.status || '—'}
+                                  </Badge>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </CardContent>
+                    </Card>
+
+                    <Card className="glass-card border-white/10">
+                      <CardHeader>
+                        <CardTitle>Criativos</CardTitle>
+                        <CardDescription>
+                          Criativos deduplicados a partir dos anúncios retornados pela Meta para a conta selecionada.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {inventory.creatives.length === 0 ? (
+                          <div className="text-sm text-blue-100/70">Nenhum criativo encontrado.</div>
+                        ) : (
+                          inventory.creatives.map((creative: any) => (
+                            <div key={creative.id} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                              {creative.thumbnailUrl ? (
+                                <img
+                                  src={creative.thumbnailUrl}
+                                  alt={creative.name || creative.id}
+                                  className="mb-3 h-40 w-full rounded-xl object-cover"
+                                />
+                              ) : null}
+                              <div className="space-y-1">
+                                <div className="font-medium text-white">{creative.name || creative.id}</div>
+                                <div className="font-mono text-xs text-blue-100/60">{creative.id}</div>
+                                <div className="text-xs text-blue-100/70">Campanha: {creative.campaignId || '—'}</div>
+                                <div className="text-xs text-blue-100/70">Anúncio: {creative.adName || creative.adId || '—'}</div>
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </CardContent>
+                    </Card>
+                  </>
+                )}
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/functions/_lib/metaAdsGraph.ts
+++ b/frontend/functions/_lib/metaAdsGraph.ts
@@ -1,0 +1,297 @@
+const DEFAULT_GRAPH_VERSION = 'v20.0'
+
+const esc = (value: unknown) => String(value ?? '').trim()
+
+export type MetaAdAccount = {
+  id: string
+  name: string
+  account_status?: string
+  currency?: string
+  timezone_name?: string
+  business_name?: string
+}
+
+export type MetaCampaign = {
+  id: string
+  name: string
+  status?: string
+  effective_status?: string
+  objective?: string
+  daily_budget?: string
+  lifetime_budget?: string
+  start_time?: string
+  stop_time?: string
+}
+
+export type MetaAdSet = {
+  id: string
+  name: string
+  status?: string
+  effective_status?: string
+  campaign_id?: string
+  daily_budget?: string
+  lifetime_budget?: string
+  bid_strategy?: string
+  optimization_goal?: string
+  start_time?: string
+  end_time?: string
+}
+
+export type MetaAd = {
+  id: string
+  name: string
+  status?: string
+  effective_status?: string
+  campaign_id?: string
+  campaign_name?: string
+  adset_id?: string
+  adset_name?: string
+  creative?: {
+    id?: string
+    name?: string
+    thumbnail_url?: string
+    effective_object_story_id?: string
+  }
+}
+
+export type MetaSummary = {
+  spend: number
+  impressions: number
+  clicks: number
+  roas: number
+  activeCampaigns: number
+}
+
+function parseGraphBaseUrl(version?: string) {
+  return `https://graph.facebook.com/${esc(version) || DEFAULT_GRAPH_VERSION}`
+}
+
+function asNumber(value: unknown) {
+  const parsed = Number(value || 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function parseRoas(value: unknown) {
+  if (Array.isArray(value)) {
+    const first = value.find((item) => item && typeof item === 'object' && 'value' in item)
+    return asNumber((first as any)?.value)
+  }
+  return asNumber(value)
+}
+
+function normalizeAccountId(adAccountId: string) {
+  const raw = esc(adAccountId)
+  if (!raw) return raw
+  return raw.startsWith('act_') ? raw : `act_${raw}`
+}
+
+async function graphFetch<T = any>(
+  path: string,
+  params: Record<string, string | number | undefined>,
+  accessToken: string,
+  version?: string,
+): Promise<T> {
+  const qs = new URLSearchParams()
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value == null || value === '') continue
+    qs.set(key, String(value))
+  }
+  qs.set('access_token', accessToken)
+
+  const url = `${parseGraphBaseUrl(version)}${path.startsWith('/') ? '' : '/'}${path}?${qs.toString()}`
+  const res = await fetch(url, { headers: { accept: 'application/json' } })
+  const data = await res.json().catch(() => null)
+  if (!res.ok || data?.error) {
+    throw new Error(data?.error?.message || data?.error_description || `Meta Graph HTTP ${res.status}`)
+  }
+  return data as T
+}
+
+async function collectPaged<T = any>(
+  path: string,
+  params: Record<string, string | number | undefined>,
+  accessToken: string,
+  version?: string,
+): Promise<T[]> {
+  const out: T[] = []
+  let nextUrl: string | null = null
+  let first = true
+
+  while (first || nextUrl) {
+    let data: any
+    if (first) {
+      data = await graphFetch<any>(path, params, accessToken, version)
+      first = false
+    } else {
+      const res = await fetch(String(nextUrl), { headers: { accept: 'application/json' } })
+      data = await res.json().catch(() => null)
+      if (!res.ok || data?.error) {
+        throw new Error(data?.error?.message || data?.error_description || `Meta Graph HTTP ${res.status}`)
+      }
+    }
+
+    if (Array.isArray(data?.data)) out.push(...data.data)
+    nextUrl = esc(data?.paging?.next) || null
+  }
+
+  return out
+}
+
+export async function getMetaProfile(accessToken: string, version?: string) {
+  return graphFetch<{ id: string; name?: string }>(
+    '/me',
+    { fields: 'id,name' },
+    accessToken,
+    version,
+  )
+}
+
+export async function listMetaAdAccounts(accessToken: string, version?: string): Promise<MetaAdAccount[]> {
+  const rows = await collectPaged<any>(
+    '/me/adaccounts',
+    {
+      fields: 'id,name,account_status,currency,timezone_name,business_name',
+      limit: 100,
+    },
+    accessToken,
+    version,
+  )
+  return rows.map((row) => ({
+    id: esc(row?.id),
+    name: esc(row?.name),
+    account_status: esc(row?.account_status),
+    currency: esc(row?.currency),
+    timezone_name: esc(row?.timezone_name),
+    business_name: esc(row?.business_name),
+  })).filter((row) => row.id)
+}
+
+export async function listMetaCampaigns(accessToken: string, adAccountId: string, version?: string): Promise<MetaCampaign[]> {
+  const rows = await collectPaged<any>(
+    `/${normalizeAccountId(adAccountId)}/campaigns`,
+    {
+      fields: 'id,name,status,effective_status,objective,daily_budget,lifetime_budget,start_time,stop_time',
+      limit: 200,
+    },
+    accessToken,
+    version,
+  )
+  return rows.map((row) => ({
+    id: esc(row?.id),
+    name: esc(row?.name),
+    status: esc(row?.status),
+    effective_status: esc(row?.effective_status),
+    objective: esc(row?.objective),
+    daily_budget: esc(row?.daily_budget),
+    lifetime_budget: esc(row?.lifetime_budget),
+    start_time: esc(row?.start_time),
+    stop_time: esc(row?.stop_time),
+  })).filter((row) => row.id)
+}
+
+export async function listMetaAdSets(accessToken: string, adAccountId: string, version?: string): Promise<MetaAdSet[]> {
+  const rows = await collectPaged<any>(
+    `/${normalizeAccountId(adAccountId)}/adsets`,
+    {
+      fields: 'id,name,status,effective_status,campaign_id,daily_budget,lifetime_budget,bid_strategy,optimization_goal,start_time,end_time',
+      limit: 500,
+    },
+    accessToken,
+    version,
+  )
+  return rows.map((row) => ({
+    id: esc(row?.id),
+    name: esc(row?.name),
+    status: esc(row?.status),
+    effective_status: esc(row?.effective_status),
+    campaign_id: esc(row?.campaign_id),
+    daily_budget: esc(row?.daily_budget),
+    lifetime_budget: esc(row?.lifetime_budget),
+    bid_strategy: esc(row?.bid_strategy),
+    optimization_goal: esc(row?.optimization_goal),
+    start_time: esc(row?.start_time),
+    end_time: esc(row?.end_time),
+  })).filter((row) => row.id)
+}
+
+export async function listMetaAds(accessToken: string, adAccountId: string, version?: string): Promise<MetaAd[]> {
+  const rows = await collectPaged<any>(
+    `/${normalizeAccountId(adAccountId)}/ads`,
+    {
+      fields: 'id,name,status,effective_status,campaign{id,name},adset{id,name},creative{id,name,thumbnail_url,effective_object_story_id}',
+      limit: 500,
+    },
+    accessToken,
+    version,
+  )
+  return rows.map((row) => ({
+    id: esc(row?.id),
+    name: esc(row?.name),
+    status: esc(row?.status),
+    effective_status: esc(row?.effective_status),
+    campaign_id: esc(row?.campaign?.id),
+    campaign_name: esc(row?.campaign?.name),
+    adset_id: esc(row?.adset?.id),
+    adset_name: esc(row?.adset?.name),
+    creative: row?.creative
+      ? {
+          id: esc(row.creative.id),
+          name: esc(row.creative.name),
+          thumbnail_url: esc(row.creative.thumbnail_url),
+          effective_object_story_id: esc(row.creative.effective_object_story_id),
+        }
+      : undefined,
+  })).filter((row) => row.id)
+}
+
+export async function getMetaAdsSummary(
+  accessToken: string,
+  adAccountId: string,
+  range: { since: string; until: string },
+  version?: string,
+): Promise<MetaSummary> {
+  const data = await graphFetch<any>(
+    `/${normalizeAccountId(adAccountId)}/insights`,
+    {
+      fields: 'spend,impressions,clicks,purchase_roas',
+      level: 'account',
+      time_range: JSON.stringify({ since: range.since, until: range.until }),
+      limit: 1,
+    },
+    accessToken,
+    version,
+  )
+  const row = Array.isArray(data?.data) ? data.data[0] || {} : {}
+  return {
+    spend: asNumber(row?.spend),
+    impressions: asNumber(row?.impressions),
+    clicks: asNumber(row?.clicks),
+    roas: parseRoas(row?.purchase_roas),
+    activeCampaigns: 0,
+  }
+}
+
+export async function getMetaAdsTrend(
+  accessToken: string,
+  adAccountId: string,
+  range: { since: string; until: string },
+  version?: string,
+) {
+  const data = await graphFetch<any>(
+    `/${normalizeAccountId(adAccountId)}/insights`,
+    {
+      fields: 'date_start,spend',
+      level: 'account',
+      time_range: JSON.stringify({ since: range.since, until: range.until }),
+      time_increment: 1,
+      limit: 100,
+    },
+    accessToken,
+    version,
+  )
+  const rows = Array.isArray(data?.data) ? data.data : []
+  return rows.map((row: any) => ({
+    day: esc(row?.date_start),
+    spend: asNumber(row?.spend),
+  }))
+}

--- a/frontend/functions/_lib/metaAdsStore.ts
+++ b/frontend/functions/_lib/metaAdsStore.ts
@@ -1,0 +1,42 @@
+import { getJson, putJson } from './r2'
+import { decryptTokenIfNeeded, encryptTokenIfNeeded } from './tokenCrypto'
+
+export type MetaAdsConnection = {
+  accessToken: string
+  tokenType: 'manual' | 'oauth'
+  metaUserId?: string
+  metaUserName?: string
+  scopes?: string[]
+  expiresAt?: string
+  selectedAdAccountId?: string
+  updatedAt: string
+}
+
+export function connectionKey(userId: string) {
+  return `internal/integrations/meta-ads/users/${userId}/connection.json`
+}
+
+export async function readMetaAdsConnectionDecrypted(
+  bucket: R2Bucket,
+  userId: string,
+  secret?: string,
+): Promise<MetaAdsConnection | null> {
+  const data = await getJson<MetaAdsConnection>(bucket, connectionKey(userId))
+  if (!data) return null
+  const accessToken = await decryptTokenIfNeeded(data.accessToken, secret)
+  return { ...data, accessToken }
+}
+
+export async function writeMetaAdsConnection(
+  bucket: R2Bucket,
+  userId: string,
+  value: MetaAdsConnection,
+  secret?: string,
+) {
+  const accessToken = await encryptTokenIfNeeded(value.accessToken, secret)
+  await putJson(bucket, connectionKey(userId), { ...value, accessToken })
+}
+
+export async function deleteMetaAdsConnection(bucket: R2Bucket, userId: string) {
+  await bucket.delete(connectionKey(userId))
+}

--- a/frontend/functions/api/meta-ads/[[path]].ts
+++ b/frontend/functions/api/meta-ads/[[path]].ts
@@ -1,0 +1,482 @@
+import { requireSocialAdmin } from '../../_lib/socialAuth'
+import { requireCsrfForMutations } from '../../_lib/csrf'
+import { getShareBucket } from '../../_lib/r2'
+import { getIntegrationsEncryptionSecret, integrationsEncryptionSecretRequired } from '../../_lib/integrationsEncryption'
+import { signState, verifyState } from '../../_lib/oauthState'
+import {
+  deleteMetaAdsConnection,
+  readMetaAdsConnectionDecrypted,
+  writeMetaAdsConnection,
+  type MetaAdsConnection,
+} from '../../_lib/metaAdsStore'
+import {
+  getMetaAdsSummary,
+  getMetaAdsTrend,
+  getMetaProfile,
+  listMetaAdAccounts,
+  listMetaAds,
+  listMetaAdSets,
+  listMetaCampaigns,
+} from '../../_lib/metaAdsGraph'
+
+type OAuthState = { userId: string; nonce: string; iat: number }
+
+const json = (status: number, body: any) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  })
+
+const html = (body: string) =>
+  new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      'x-frame-options': 'DENY',
+      'referrer-policy': 'same-origin',
+      'content-security-policy': [
+        "default-src 'none'",
+        "base-uri 'none'",
+        "frame-ancestors 'none'",
+        "form-action 'self'",
+        "script-src 'unsafe-inline'",
+        "style-src 'unsafe-inline'",
+      ].join('; '),
+    },
+  })
+
+const esc = (value: any) =>
+  String(value || '').replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char] as string))
+
+function runtimeConfig(context: any) {
+  const env = context?.env || {}
+  return {
+    appId: String(env.META_APP_ID || '').trim(),
+    appSecret: String(env.META_APP_SECRET || '').trim(),
+    stateSecret: String(env.META_OAUTH_STATE_SECRET || env.META_APP_SECRET || '').trim(),
+    graphVersion: String(env.META_GRAPH_VERSION || 'v20.0').trim() || 'v20.0',
+    scopes:
+      String(env.META_ADS_OAUTH_SCOPES || '').trim() ||
+      ['ads_read', 'ads_management', 'business_management'].join(','),
+  }
+}
+
+function connectionSummary(connection: MetaAdsConnection | null) {
+  if (!connection) {
+    return {
+      connected: false,
+      tokenType: null,
+      metaUserId: null,
+      metaUserName: null,
+      selectedAdAccountId: null,
+      scopes: [],
+      updatedAt: null,
+      expiresAt: null,
+    }
+  }
+  return {
+    connected: true,
+    tokenType: connection.tokenType,
+    metaUserId: connection.metaUserId || null,
+    metaUserName: connection.metaUserName || null,
+    selectedAdAccountId: connection.selectedAdAccountId || null,
+    scopes: Array.isArray(connection.scopes) ? connection.scopes : [],
+    updatedAt: connection.updatedAt || null,
+    expiresAt: connection.expiresAt || null,
+  }
+}
+
+function resolveMissingConfig(context: any) {
+  const cfg = runtimeConfig(context)
+  const missing: string[] = []
+  if (!cfg.appId) missing.push('META_APP_ID')
+  if (!cfg.appSecret) missing.push('META_APP_SECRET')
+  if (!cfg.stateSecret) missing.push('META_OAUTH_STATE_SECRET')
+  if (integrationsEncryptionSecretRequired(context) && !getIntegrationsEncryptionSecret(context)) {
+    missing.push('INTEGRATIONS_ENCRYPTION_SECRET')
+  }
+  if (!getShareBucket(context)) missing.push('SHARE_BUCKET')
+  return missing
+}
+
+function parseRange(url: URL) {
+  const until = String(url.searchParams.get('until') || '').trim() || new Date().toISOString().slice(0, 10)
+  const since = String(url.searchParams.get('since') || '').trim() || (() => {
+    const date = new Date()
+    date.setDate(date.getDate() - 6)
+    return date.toISOString().slice(0, 10)
+  })()
+  return { since, until }
+}
+
+function buildInventory(campaigns: any[], adsets: any[], ads: any[]) {
+  const adsetsByCampaign = new Map<string, any[]>()
+  const adsByAdset = new Map<string, any[]>()
+  const creativesById = new Map<string, any>()
+
+  for (const adset of adsets) {
+    const list = adsetsByCampaign.get(adset.campaign_id || '') || []
+    list.push({ ...adset, ads: [] as any[] })
+    adsetsByCampaign.set(adset.campaign_id || '', list)
+  }
+
+  for (const ad of ads) {
+    if (ad.creative?.id) {
+      creativesById.set(ad.creative.id, {
+        id: ad.creative.id,
+        name: ad.creative.name || ad.name,
+        thumbnailUrl: ad.creative.thumbnail_url || null,
+        effectiveObjectStoryId: ad.creative.effective_object_story_id || null,
+        adId: ad.id,
+        adName: ad.name,
+        adsetId: ad.adset_id || null,
+        campaignId: ad.campaign_id || null,
+      })
+    }
+    const list = adsByAdset.get(ad.adset_id || '') || []
+    list.push(ad)
+    adsByAdset.set(ad.adset_id || '', list)
+  }
+
+  const campaignsWithChildren = campaigns.map((campaign) => {
+    const campaignAdsets = (adsetsByCampaign.get(campaign.id) || []).map((adset) => ({
+      ...adset,
+      ads: adsByAdset.get(adset.id) || [],
+    }))
+    return {
+      ...campaign,
+      adSets: campaignAdsets,
+      totals: {
+        adSets: campaignAdsets.length,
+        ads: campaignAdsets.reduce((sum, adset) => sum + adset.ads.length, 0),
+      },
+    }
+  })
+
+  return {
+    campaigns: campaignsWithChildren,
+    adSets: adsets,
+    ads,
+    creatives: Array.from(creativesById.values()),
+  }
+}
+
+async function readConnection(context: any, userId: string) {
+  const bucket = getShareBucket(context)
+  if (!bucket) throw new Error('SHARE_BUCKET_NOT_CONFIGURED')
+  const secret = getIntegrationsEncryptionSecret(context)
+  return readMetaAdsConnectionDecrypted(bucket, userId, secret)
+}
+
+async function writeConnection(context: any, userId: string, value: MetaAdsConnection) {
+  const bucket = getShareBucket(context)
+  if (!bucket) throw new Error('SHARE_BUCKET_NOT_CONFIGURED')
+  const secret = getIntegrationsEncryptionSecret(context)
+  await writeMetaAdsConnection(bucket, userId, value, secret)
+}
+
+async function fetchLiveAccounts(context: any, userId: string) {
+  const connection = await readConnection(context, userId)
+  if (!connection?.accessToken) return { connection: null, accounts: [] as any[] }
+  const accounts = await listMetaAdAccounts(connection.accessToken, runtimeConfig(context).graphVersion)
+  return { connection, accounts }
+}
+
+async function handleStatus(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+
+  let connection: MetaAdsConnection | null = null
+  try {
+    connection = await readConnection(context, userOrRes.id)
+  } catch {
+    connection = null
+  }
+
+  return json(200, {
+    ok: true,
+    oauthConfigured: resolveMissingConfig(context).length === 0,
+    missingConfig: resolveMissingConfig(context),
+    connection: connectionSummary(connection),
+  })
+}
+
+async function handleOauthStart(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const cfg = runtimeConfig(context)
+  const missing = resolveMissingConfig(context)
+  if (missing.length) return new Response(`Meta Ads OAuth not configured: ${missing.join(', ')}`, { status: 503, headers: { 'cache-control': 'no-store' } })
+
+  const origin = new URL(context.request.url).origin
+  const redirectUri = `${origin}/api/meta-ads/oauth/callback`
+  const state = await signState({ userId: userOrRes.id, nonce: crypto.randomUUID(), iat: Date.now() }, cfg.stateSecret)
+  const qs = new URLSearchParams({
+    client_id: cfg.appId,
+    redirect_uri: redirectUri,
+    state,
+    scope: cfg.scopes,
+    response_type: 'code',
+  })
+  return Response.redirect(`https://www.facebook.com/${cfg.graphVersion}/dialog/oauth?${qs.toString()}`, 302)
+}
+
+async function fetchJson(url: string) {
+  const res = await fetch(url, { headers: { accept: 'application/json' } })
+  const data = await res.json().catch(() => null)
+  if (!res.ok || data?.error) throw new Error(data?.error?.message || data?.error_description || `HTTP ${res.status}`)
+  return data
+}
+
+async function handleOauthCallback(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const cfg = runtimeConfig(context)
+  const missing = resolveMissingConfig(context)
+  if (missing.length) return html(`<p>Meta Ads OAuth não configurado: ${esc(missing.join(', '))}</p>`)
+
+  const url = new URL(context.request.url)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  const err = url.searchParams.get('error') || url.searchParams.get('error_reason')
+  const errDesc = url.searchParams.get('error_description')
+  if (err) return html(`<p>Erro OAuth: ${esc(err)}<br/>${esc(errDesc)}</p>`)
+  if (!code || !state) return html('<p>Callback inválido (code/state ausentes).</p>')
+
+  const verified = await verifyState<OAuthState>(state, cfg.stateSecret)
+  if (!verified || verified.userId !== userOrRes.id) return html('<p>State inválido. Tente novamente.</p>')
+
+  const origin = new URL(context.request.url).origin
+  const redirectUri = `${origin}/api/meta-ads/oauth/callback`
+
+  try {
+    const tokenData = await fetchJson(
+      `https://graph.facebook.com/${cfg.graphVersion}/oauth/access_token?` +
+        new URLSearchParams({
+          client_id: cfg.appId,
+          client_secret: cfg.appSecret,
+          redirect_uri: redirectUri,
+          code,
+        }).toString(),
+    )
+    const shortToken = String(tokenData?.access_token || '').trim()
+    if (!shortToken) throw new Error('Token ausente no exchange')
+
+    const longData = await fetchJson(
+      `https://graph.facebook.com/${cfg.graphVersion}/oauth/access_token?` +
+        new URLSearchParams({
+          grant_type: 'fb_exchange_token',
+          client_id: cfg.appId,
+          client_secret: cfg.appSecret,
+          fb_exchange_token: shortToken,
+        }).toString(),
+    )
+
+    const accessToken = String(longData?.access_token || '').trim() || shortToken
+    const profile = await getMetaProfile(accessToken, cfg.graphVersion)
+    const scopes = String(cfg.scopes || '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+
+    await writeConnection(context, userOrRes.id, {
+      accessToken,
+      tokenType: 'oauth',
+      metaUserId: String(profile?.id || '').trim() || undefined,
+      metaUserName: String(profile?.name || '').trim() || undefined,
+      scopes,
+      expiresAt: longData?.expires_in ? new Date(Date.now() + Number(longData.expires_in || 0) * 1000).toISOString() : undefined,
+      updatedAt: new Date().toISOString(),
+    })
+
+    return html(`
+      <script>
+        try { if (window.opener) window.opener.postMessage({ type: 'meta-ads:connected', ok: true }, window.location.origin); } catch {}
+        window.close();
+      </script>
+      <p>Conta Meta Ads conectada. Você pode fechar esta janela.</p>
+    `)
+  } catch (error: any) {
+    return html(`<p>Falha ao conectar: ${esc(error?.message || 'Erro')}</p>`)
+  }
+}
+
+async function handleManualConnect(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const csrfRes = requireCsrfForMutations(context)
+  if (csrfRes) return csrfRes
+
+  const body = await context.request.json().catch(() => null)
+  const accessToken = String(body?.accessToken || body?.token || '').trim()
+  if (!accessToken) return json(400, { ok: false, error: 'INVALID_INPUT', hint: 'Informe accessToken.' })
+
+  try {
+    const profile = await getMetaProfile(accessToken, runtimeConfig(context).graphVersion)
+    const accounts = await listMetaAdAccounts(accessToken, runtimeConfig(context).graphVersion)
+    await writeConnection(context, userOrRes.id, {
+      accessToken,
+      tokenType: 'manual',
+      metaUserId: String(profile?.id || '').trim() || undefined,
+      metaUserName: String(profile?.name || '').trim() || undefined,
+      updatedAt: new Date().toISOString(),
+      selectedAdAccountId: accounts[0]?.id || undefined,
+    })
+    return json(200, {
+      ok: true,
+      connected: true,
+      accountCount: accounts.length,
+      connection: connectionSummary(await readConnection(context, userOrRes.id)),
+    })
+  } catch (error: any) {
+    return json(400, { ok: false, error: 'TOKEN_INVALID', message: error?.message || 'Token inválido' })
+  }
+}
+
+async function handleDisconnect(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const csrfRes = requireCsrfForMutations(context)
+  if (csrfRes) return csrfRes
+
+  const bucket = getShareBucket(context)
+  if (!bucket) return json(503, { ok: false, error: 'SHARE_BUCKET_NOT_CONFIGURED' })
+  await deleteMetaAdsConnection(bucket, userOrRes.id)
+  return json(200, { ok: true, disconnected: true })
+}
+
+async function handleListAccounts(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+
+  const { connection, accounts } = await fetchLiveAccounts(context, userOrRes.id)
+  if (!connection?.accessToken) return json(200, { ok: true, connected: false, accounts: [] })
+
+  return json(200, {
+    ok: true,
+    connected: true,
+    selectedAdAccountId: connection.selectedAdAccountId || null,
+    accounts: accounts.map((account) => ({
+      ...account,
+      isSelected: connection.selectedAdAccountId === account.id,
+    })),
+  })
+}
+
+async function handleSelectAccount(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const csrfRes = requireCsrfForMutations(context)
+  if (csrfRes) return csrfRes
+
+  const body = await context.request.json().catch(() => null)
+  const adAccountId = String(body?.adAccountId || '').trim()
+  if (!adAccountId) return json(400, { ok: false, error: 'INVALID_INPUT' })
+
+  const connection = await readConnection(context, userOrRes.id)
+  if (!connection?.accessToken) return json(404, { ok: false, error: 'NOT_CONNECTED' })
+  const accounts = await listMetaAdAccounts(connection.accessToken, runtimeConfig(context).graphVersion)
+  const selected = accounts.find((account) => account.id === adAccountId)
+  if (!selected) return json(404, { ok: false, error: 'ACCOUNT_NOT_FOUND' })
+
+  await writeConnection(context, userOrRes.id, {
+    ...connection,
+    selectedAdAccountId: adAccountId,
+    updatedAt: new Date().toISOString(),
+  })
+  return json(200, { ok: true, selectedAdAccountId: adAccountId })
+}
+
+async function withSelectedAccount(
+  context: any,
+  userId: string,
+): Promise<
+  | { connection: MetaAdsConnection; adAccountId: string }
+  | { error: Response }
+> {
+  const connection = await readConnection(context, userId)
+  if (!connection?.accessToken) {
+    return { error: json(404, { ok: false, error: 'NOT_CONNECTED', hint: 'Conecte a conta Meta primeiro.' }) }
+  }
+  const adAccountId = String(connection.selectedAdAccountId || '').trim()
+  if (!adAccountId) {
+    return { error: json(400, { ok: false, error: 'AD_ACCOUNT_NOT_SELECTED', hint: 'Selecione uma conta de anúncios.' }) }
+  }
+  return { connection, adAccountId }
+}
+
+async function handleSummary(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const selected = await withSelectedAccount(context, userOrRes.id)
+  if ('error' in selected) return selected.error
+
+  const range = parseRange(new URL(context.request.url))
+  const [summary, campaigns] = await Promise.all([
+    getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, runtimeConfig(context).graphVersion),
+    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+  ])
+
+  return json(200, {
+    ...summary,
+    activeCampaigns: campaigns.filter((campaign) => String(campaign.status || '').toUpperCase() === 'ACTIVE').length,
+  })
+}
+
+async function handleTrend(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const selected = await withSelectedAccount(context, userOrRes.id)
+  if ('error' in selected) return selected.error
+
+  const range = parseRange(new URL(context.request.url))
+  const trend = await getMetaAdsTrend(
+    selected.connection.accessToken,
+    selected.adAccountId,
+    range,
+    runtimeConfig(context).graphVersion,
+  )
+  return json(200, trend)
+}
+
+async function handleInventory(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const selected = await withSelectedAccount(context, userOrRes.id)
+  if ('error' in selected) return selected.error
+
+  const [campaigns, adSets, ads] = await Promise.all([
+    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+    listMetaAdSets(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+    listMetaAds(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+  ])
+
+  return json(200, {
+    ok: true,
+    accountId: selected.adAccountId,
+    inventory: buildInventory(campaigns, adSets, ads),
+  })
+}
+
+export async function onRequest(context: any): Promise<Response> {
+  const request: Request = context.request
+  const method = String(request.method || 'GET').toUpperCase()
+  const url = new URL(request.url)
+  const prefix = '/api/meta-ads'
+  const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
+
+  if (method === 'GET' && (rest === '/status' || rest === '/status/')) return handleStatus(context)
+  if (method === 'GET' && (rest === '/oauth/start' || rest === '/oauth/start/')) return handleOauthStart(context)
+  if (method === 'GET' && (rest === '/oauth/callback' || rest === '/oauth/callback/')) return handleOauthCallback(context)
+  if (method === 'POST' && (rest === '/connect/manual' || rest === '/connect/manual/')) return handleManualConnect(context)
+  if (method === 'POST' && (rest === '/disconnect' || rest === '/disconnect/')) return handleDisconnect(context)
+  if (method === 'GET' && (rest === '/ad-accounts' || rest === '/ad-accounts/')) return handleListAccounts(context)
+  if (method === 'POST' && (rest === '/ad-accounts/select' || rest === '/ad-accounts/select/')) return handleSelectAccount(context)
+  if (method === 'GET' && (rest === '/summary' || rest === '/summary/')) return handleSummary(context)
+  if (method === 'GET' && (rest === '/trend' || rest === '/trend/')) return handleTrend(context)
+  if (method === 'GET' && (rest === '/inventory' || rest === '/inventory/')) return handleInventory(context)
+
+  return json(404, { ok: false, error: 'NOT_FOUND' })
+}

--- a/frontend/metaAdsApi.ts
+++ b/frontend/metaAdsApi.ts
@@ -1,26 +1,24 @@
+import { getCsrfToken } from '@/csrf'
+
 const META_ADS_API_URL =
   (import.meta as any).env?.VITE_META_ADS_API_URL || '/api/meta-ads'
 
-const TOKEN_KEY = 'skincos.metaAds.token.v1'
-
-export function setMetaAdsToken(token: string) {
-  localStorage.setItem(TOKEN_KEY, token)
-}
-
-export function getMetaAdsToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY)
-}
-
-export function clearMetaAdsToken() {
-  localStorage.removeItem(TOKEN_KEY)
-}
-
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const token = getMetaAdsToken()
   const headers = new Headers(options.headers || {})
-  headers.set('Content-Type', 'application/json')
-  if (token) headers.set('Authorization', `Bearer ${token}`)
-  const res = await fetch(`${META_ADS_API_URL}${path}`, { ...options, headers })
+  headers.set('Accept', 'application/json')
+  const method = String(options.method || 'GET').toUpperCase()
+  if (options.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+  if (method !== 'GET') {
+    const csrfToken = getCsrfToken()
+    if (csrfToken) headers.set('x-csrf-token', csrfToken)
+  }
+  const res = await fetch(`${META_ADS_API_URL}${path}`, {
+    ...options,
+    headers,
+    credentials: 'include',
+  })
   const text = await res.text()
   let json: any = null
   try {
@@ -34,26 +32,60 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return json as T
 }
 
+export type MetaAdsStatusResponse = {
+  ok: boolean
+  oauthConfigured: boolean
+  missingConfig: string[]
+  connection: {
+    connected: boolean
+    tokenType: 'manual' | 'oauth' | null
+    metaUserId: string | null
+    metaUserName: string | null
+    selectedAdAccountId: string | null
+    scopes: string[]
+    updatedAt: string | null
+    expiresAt: string | null
+  }
+}
+
 export const metaAdsApi = {
-  register: (payload: any) => request('/auth/register', { method: 'POST', body: JSON.stringify(payload) }),
-  login: (payload: any) => request('/auth/login', { method: 'POST', body: JSON.stringify(payload) }),
-  me: () => request('/auth/me'),
-  oauthUrl: () => request('/meta/oauth/url'),
-  listAdAccounts: () => request('/meta/ad-accounts'),
-  selectAdAccount: (payload: any) => request('/meta/ad-accounts/select', { method: 'POST', body: JSON.stringify(payload) }),
-  listCampaigns: () => request('/meta/campaigns'),
-  syncInsights: (payload: any) => request('/meta/insights/sync', { method: 'POST', body: JSON.stringify(payload) }),
-  bulkPreview: (payload: any) => request('/bulk/preview', { method: 'POST', body: JSON.stringify(payload) }),
-  bulkExecute: (payload: any) => request('/bulk/execute', { method: 'POST', body: JSON.stringify(payload) }),
-  bulkOperations: () => request('/bulk/operations'),
-  alerts: () => request('/alerts'),
-  resolveAlert: (id: string) => request(`/alerts/${id}/resolve`, { method: 'POST' }),
+  status: () => request<MetaAdsStatusResponse>('/status'),
+  oauthStartUrl: () => `${META_ADS_API_URL}/oauth/start`,
+  connectManual: (payload: { accessToken: string }) =>
+    request('/connect/manual', { method: 'POST', body: JSON.stringify(payload) }),
+  disconnect: () => request('/disconnect', { method: 'POST' }),
+  listAdAccounts: () => request<{
+    ok: boolean
+    connected: boolean
+    selectedAdAccountId: string | null
+    accounts: Array<{
+      id: string
+      name: string
+      account_status?: string
+      currency?: string
+      timezone_name?: string
+      business_name?: string
+      isSelected?: boolean
+    }>
+  }>('/ad-accounts'),
+  selectAdAccount: (payload: { adAccountId: string }) =>
+    request('/ad-accounts/select', { method: 'POST', body: JSON.stringify(payload) }),
   summary: (params?: { since?: string; until?: string }) => {
     const search = new URLSearchParams(params as any).toString()
-    return request(`/reports/summary${search ? `?${search}` : ''}`)
+    return request(`/summary${search ? `?${search}` : ''}`)
   },
   trend: (params?: { since?: string; until?: string }) => {
     const search = new URLSearchParams(params as any).toString()
-    return request(`/reports/trend${search ? `?${search}` : ''}`)
+    return request(`/trend${search ? `?${search}` : ''}`)
   },
+  inventory: () => request<{
+    ok: boolean
+    accountId: string
+    inventory: {
+      campaigns: any[]
+      adSets: any[]
+      ads: any[]
+      creatives: any[]
+    }
+  }>('/inventory'),
 }

--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -5,6 +5,7 @@
         "/api/auth/*",
         "/api/crm/*",
         "/api/tracking/*",
+        "/api/meta-ads/*",
         "/api/insumos/*",
         "/api/placeholder/*",
         "/api/share/*",


### PR DESCRIPTION
## Resumo
Entrega a integração CRM-native para conectar o gerenciador de anúncios da Meta diretamente na aba `Meta Ads`, sem exigir um segundo login paralelo fora do CRM.

## Problema
A aba publicada hoje expõe bem o tracking, mas não oferece um fluxo real, intuitivo e funcional para conectar uma conta Meta Ads, selecionar a `ad account` ativa e carregar campanhas, conjuntos, anúncios e criativos reais. Na prática, o usuário encontra um módulo parcialmente mockado e sem onboarding operacional completo.

## Causa raiz
O CRM ainda não tinha uma camada própria para:
- iniciar e concluir OAuth da Meta dentro do stack de Pages Functions;
- armazenar a conexão por usuário com criptografia e escopo por conta;
- consultar a Graph API da Meta para `ad accounts`, campanhas, adsets, ads, criativos e insights;
- refletir esse estado na UI da aba `Meta Ads`.

O stack mais avançado de Meta Ads já existia em outros pontos do repositório, mas não estava adaptado ao fluxo autenticado e integrado do CRM.

## O que foi feito
- adiciona `frontend/functions/api/meta-ads/[[path]].ts` com endpoints CRM-native para:
  - `status`
  - `oauth/start`
  - `oauth/callback`
  - `connect/manual`
  - `disconnect`
  - `ad-accounts`
  - `ad-accounts/select`
  - `summary`
  - `trend`
  - `inventory`
- adiciona armazenamento criptografado por usuário em `frontend/functions/_lib/metaAdsStore.ts`
- adiciona cliente Graph da Meta em `frontend/functions/_lib/metaAdsGraph.ts`
- adapta `frontend/metaAdsApi.ts` para usar o backend de Pages Functions do CRM com CSRF/cookies do próprio CRM
- substitui o fluxo antigo do `MetaCampaignControlCenter` por uma UI que:
  - mantém o tab `Tracking`
  - permite `Conectar via Facebook`
  - permite token manual
  - lista e seleciona `ad accounts`
  - carrega inventário real de campanhas, conjuntos, anúncios e criativos
  - mostra `missingConfig` quando o runtime não está completo
- inclui `/api/meta-ads/*` em `frontend/public/_routes.json`

## Impacto para o usuário
A aba `Meta Ads` deixa de ser apenas um painel de tracking parcial e passa a ter um fluxo de conexão utilizável no CRM para trazer a árvore real do Ads Manager da Meta.

## Validação
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `cd frontend && npm test`
- `cd frontend && PAGES_PORT=8791 npm run dev:pages`
- `curl http://127.0.0.1:8791/api/meta-ads/status`
- `curl http://127.0.0.1:8791/api/meta-ads/oauth/start`

## Observações operacionais
Para OAuth e armazenamento funcionarem em produção, o projeto de Cloudflare Pages precisa ter:
- `META_APP_ID`
- `META_APP_SECRET`
- `META_OAUTH_STATE_SECRET`
- `INTEGRATIONS_ENCRYPTION_SECRET`
- `SHARE_BUCKET`

A implementação reutiliza o mesmo padrão de integração já usado pelo fluxo `facebook-review`.
