### PR TITLE
feat(meta-ads): improve local launcher and tracking preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Plataforma interna (local) para automações e operações da clínica.
 ## Como rodar (local)
 - Stack principal (recomendado): `./backend/scripts/dev.sh watch`
 - CRM (frontend + API): `./frontend/restart_crm.sh --watch-full`
+- CRM local production-like: `npm run crm:local`
 - Website público: `npm run website:dev` (porta padrão do Next: `http://localhost:3000`)
 - macOS (sem terminal): dê duplo clique em `start-platform.command`
  - Meta Ads (API + worker): `./backend/scripts/meta-ads.sh start`
@@ -63,6 +64,34 @@ Plataforma interna (local) para automações e operações da clínica.
   - `SOCIAL_ADMIN_TOKEN=...`
   - `INTEGRATIONS_ENCRYPTION_SECRET=...`
   - `REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET=true`
+
+### Testar CRM local
+- Launcher recomendado: `npm run crm:local`
+- Atalho direto para o módulo Meta Ads: `npm run crm:local:meta-ads`
+- Atalho macOS: `./start-crm-local.command`
+- Perfil default: `realistic`
+  - sobe o CRM via `Pages Functions` local (`frontend/scripts/dev_pages.sh`)
+  - ativa bypass local de auth apenas em `localhost`
+  - preserva os módulos que já suportam leitura real com segurança, como `Escala`
+- Para testar a sessão real sem bypass: `CRM_PROFILE=session npm run crm:local`
+- Para testar `Insumos` sem tocar a produção:
+  - `CRM_WITH_INSUMOS=1 npm run crm:local`
+  - opcionalmente, use snapshot local:
+    - exportar snapshot remoto: `node backend/scripts/insumos-d1-export.cjs backend/var/local/insumos-snapshot.latest.json`
+    - subir o CRM com seed local: `CRM_WITH_INSUMOS=1 CRM_INSUMOS_SNAPSHOT=backend/var/local/insumos-snapshot.latest.json npm run crm:local`
+- Para testar `Meta Ads` antes de publicar:
+  - fluxo local simplificado e production-like: `npm run crm:local:meta-ads`
+    - abre o CRM já no módulo `Meta Ads`
+    - no perfil `realistic`, usa por padrão o cenário local `connected-ready`
+    - esse cenário simula conexão, seleção de conta, visão geral e inventário apenas em `localhost`
+    - por padrão, o launcher gera `build` do frontend antes de subir, para o shell local refletir a versão mais próxima do online
+    - também suprime preloads globais irrelevantes para esse foco local, como o status do Instagram
+  - para validar o fluxo inicial de setup: `CRM_META_ADS_SCENARIO=disconnected npm run crm:local:meta-ads`
+  - para testar estado de sessão expirada: `CRM_META_ADS_SCENARIO=unauthorized npm run crm:local:meta-ads`
+  - para forçar a integração real publicada no Pages local, sem mock do módulo: `CRM_META_ADS_SCENARIO=live npm run crm:local:meta-ads`
+  - para pular o build prévio quando você só quiser iterar rápido em UI local: `npm run crm:local:meta-ads -- --skip-build`
+  - para rodar uma smoke automatizada do módulo após subir o CRM:
+    - `npm run crm:local:meta-ads -- --smoke`
 
 ## Docs
 - Mapa do backend: `backend/docs/INDEX.md`

--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -8,13 +8,12 @@ import { metaAdsApi } from '@/metaAdsApi'
 import {
   MetaAdsAccountsPanel,
   MetaAdsConnectionPanel,
+  MetaAdsConnectionProgress,
   MetaAdsEmptyState,
   MetaAdsHealthBanner,
   MetaAdsInventoryPanel,
-  MetaAdsManualTokenPanel,
   MetaAdsOverviewPanel,
   MetaAdsPersistentError,
-  MetaAdsSessionFacts,
   MetaAdsStatusHero,
   MetaAdsWorkspaceTabs,
 } from '@/metaAdsPanels'
@@ -171,12 +170,18 @@ export function MetaCampaignControlCenter() {
   }, [])
 
   useEffect(() => {
-    if ((connectionMode === 'disconnected' || connectionMode === 'unauthorized' || connectionMode === 'connected-no-account' || connectionMode === 'forbidden' || connectionMode === 'misconfigured')
-      && (activeTab === 'overview' || activeTab === 'inventory')) {
+    if (
+      (connectionMode === 'disconnected' ||
+        connectionMode === 'unauthorized' ||
+        connectionMode === 'connected-no-account' ||
+        connectionMode === 'forbidden' ||
+        connectionMode === 'misconfigured') &&
+      activeTab !== 'connect'
+    ) {
       setActiveTab('connect')
       return
     }
-    if (connectionMode !== 'connected-ready') {
+    if (connectionMode !== 'connected-ready' && connectionMode !== 'degraded') {
       setDidAutofocusReadyFlow(false)
       return
     }
@@ -220,6 +225,22 @@ export function MetaCampaignControlCenter() {
   }
 
   const handleOpenOAuth = () => {
+    if (metaAdsApi.isLocalMockMode()) {
+      setRefreshing(true)
+      metaAdsApi
+        .simulateOAuthConnect()
+        .then(() => refreshConnectedState())
+        .then(() => {
+          setActiveTab('connect')
+          toast.success('Conexão Meta Ads simulada no ambiente local')
+        })
+        .catch((error: any) => {
+          setStatusError(error)
+          toast.error(error?.message || 'Falha ao iniciar a simulação local do Meta Ads')
+        })
+        .finally(() => setRefreshing(false))
+      return
+    }
     const oauthUrl = metaAdsApi.oauthStartUrl()
     const width = 620
     const height = 760
@@ -300,9 +321,11 @@ export function MetaCampaignControlCenter() {
     connectionMode === 'misconfigured'
   const scopesLabel = status?.connection.scopes?.join(', ') || 'ads_read, ads_management, business_management'
   const connectedUser = status?.connection.metaUserName || status?.connection.metaUserId || null
+  const showWorkspaceTabs = connectionMode === 'connected-ready' || connectionMode === 'degraded'
+  const showAccountSelection = Boolean(status?.connection.connected)
 
   return (
-    <div className="space-y-6 animate-fade-in">
+    <div className="meta-ads-surface space-y-6 animate-fade-in">
       <MetaAdsStatusHero
         connected={Boolean(status?.connection.connected)}
         refreshing={loading || refreshing}
@@ -310,104 +333,137 @@ export function MetaCampaignControlCenter() {
         onDisconnect={handleDisconnect}
       />
 
-      <MetaAdsHealthBanner
-        health={healthState}
-        statusUpdatedAt={status?.connection.updatedAt}
-        selectedAccount={selectedAccount}
-        onNavigate={handleNavigateTab}
-      />
-
       <MetaAdsPersistentError error={statusError} onRetry={handleRefresh} />
 
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as MetaAdsTab)} className="space-y-6">
-        <MetaAdsWorkspaceTabs />
+      {!showWorkspaceTabs ? (
+        <div className="space-y-6">
+          <MetaAdsConnectionProgress
+            connected={Boolean(status?.connection.connected)}
+            hasSelectedAccount={Boolean(selectedAccount)}
+          />
+          <MetaAdsConnectionPanel
+            scopesLabel={scopesLabel}
+            connectedUser={connectedUser}
+            connectDisabled={connectActionsDisabled}
+            onOAuth={handleOpenOAuth}
+            manualToken={manualToken}
+            setManualToken={setManualToken}
+            onManualConnect={handleManualConnect}
+            manualDisabled={refreshing || !manualToken.trim()}
+          />
+          {showAccountSelection ? (
+            <MetaAdsHealthBanner
+              health={healthState}
+              statusUpdatedAt={status?.connection.updatedAt}
+              selectedAccount={selectedAccount}
+              onNavigate={handleNavigateTab}
+            />
+          ) : null}
+          {showAccountSelection ? (
+            <MetaAdsAccountsPanel
+              connected={Boolean(status?.connection.connected)}
+              accounts={accounts}
+              refreshing={refreshing}
+              accountsError={accountsError}
+              onRetry={handleRefresh}
+              onSelectAccount={handleSelectAccount}
+            />
+          ) : null}
+        </div>
+      ) : (
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as MetaAdsTab)} className="space-y-6">
+          <MetaAdsHealthBanner
+            health={healthState}
+            statusUpdatedAt={status?.connection.updatedAt}
+            selectedAccount={selectedAccount}
+            onNavigate={handleNavigateTab}
+          />
+          <MetaAdsWorkspaceTabs />
 
-        <TabsContent value="connect" className="space-y-6">
-          <MetaAdsSessionFacts status={status} selectedAccount={selectedAccount} />
-
-          <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+          <TabsContent value="connect" className="space-y-6">
+            <MetaAdsConnectionProgress
+              connected={Boolean(status?.connection.connected)}
+              hasSelectedAccount={Boolean(selectedAccount)}
+            />
             <MetaAdsConnectionPanel
               scopesLabel={scopesLabel}
               connectedUser={connectedUser}
               connectDisabled={connectActionsDisabled}
               onOAuth={handleOpenOAuth}
-            />
-            <MetaAdsManualTokenPanel
               manualToken={manualToken}
               setManualToken={setManualToken}
-              onConnect={handleManualConnect}
-              disabled={refreshing || !manualToken.trim()}
+              onManualConnect={handleManualConnect}
+              manualDisabled={refreshing || !manualToken.trim()}
             />
-          </div>
-
-          <MetaAdsAccountsPanel
-            connected={Boolean(status?.connection.connected)}
-            accounts={accounts}
-            refreshing={refreshing}
-            accountsError={accountsError}
-            onRetry={handleRefresh}
-            onSelectAccount={handleSelectAccount}
-          />
-        </TabsContent>
-
-        <TabsContent value="overview" className="space-y-6">
-          {!status?.connection.connected ? (
-            <MetaAdsEmptyState
-              message="Conecte uma conta Meta Ads para carregar spend, tendência e inventário."
-              actionLabel="Ir para conexão"
-              onAction={() => setActiveTab('connect')}
-            />
-          ) : !selectedAccount ? (
-            <MetaAdsEmptyState
-              message="Escolha uma conta de anúncios na aba Conexão para liberar a visão geral."
-              actionLabel="Selecionar conta"
-              onAction={() => setActiveTab('connect')}
-            />
-          ) : (
-            <MetaAdsOverviewPanel
-              selectedAccount={selectedAccount}
-              summary={summary}
-              trend={trend}
-              inventory={inventory}
-              overviewError={overviewError}
+            <MetaAdsAccountsPanel
+              connected={Boolean(status?.connection.connected)}
+              accounts={accounts}
+              refreshing={refreshing}
+              accountsError={accountsError}
               onRetry={handleRefresh}
+              onSelectAccount={handleSelectAccount}
             />
-          )}
-        </TabsContent>
+          </TabsContent>
 
-        <TabsContent value="inventory" className="space-y-6">
-          {!status?.connection.connected ? (
-            <MetaAdsEmptyState
-              message="Conecte uma conta Meta Ads para liberar o inventário."
-              actionLabel="Ir para conexão"
-              onAction={() => setActiveTab('connect')}
-            />
-          ) : !selectedAccount ? (
-            <MetaAdsEmptyState
-              message="Selecione uma conta de anúncios para carregar campanhas, conjuntos, anúncios e criativos."
-              actionLabel="Selecionar conta"
-              onAction={() => setActiveTab('connect')}
-            />
-          ) : !inventory ? (
-            <MetaAdsEmptyState
-              message="Ainda não foi possível carregar o inventário desta conta."
-              actionLabel="Atualizar agora"
-              onAction={handleRefresh}
-            />
-          ) : (
-            <MetaAdsInventoryPanel inventory={inventory} inventoryError={inventoryError} onRetry={handleRefresh} />
-          )}
-        </TabsContent>
+          <TabsContent value="overview" className="space-y-6">
+            {!status?.connection.connected ? (
+              <MetaAdsEmptyState
+                message="Conecte uma conta Meta Ads para carregar spend, tendência e inventário."
+                actionLabel="Ir para conexão"
+                onAction={() => setActiveTab('connect')}
+              />
+            ) : !selectedAccount ? (
+              <MetaAdsEmptyState
+                message="Escolha uma conta de anúncios para liberar a visão geral."
+                actionLabel="Selecionar conta"
+                onAction={() => setActiveTab('connect')}
+              />
+            ) : (
+              <MetaAdsOverviewPanel
+                selectedAccount={selectedAccount}
+                summary={summary}
+                trend={trend}
+                inventory={inventory}
+                overviewError={overviewError}
+                onRetry={handleRefresh}
+              />
+            )}
+          </TabsContent>
 
-        <TabsContent value="tracking" className="space-y-6">
-          <Card className="glass-card border-white/10">
-            <CardContent className="pt-6 text-sm text-blue-100/75">
-              Tracking do site e inventário da conta Meta convivem nesta aba, mas são superfícies diferentes: aqui você acompanha os sinais e eventos do site; em Conexão/Inventário você administra a estrutura da conta Meta.
-            </CardContent>
-          </Card>
-          <MetaTrackingDashboard />
-        </TabsContent>
-      </Tabs>
+          <TabsContent value="inventory" className="space-y-6">
+            {!status?.connection.connected ? (
+              <MetaAdsEmptyState
+                message="Conecte uma conta Meta Ads para liberar o inventário."
+                actionLabel="Ir para conexão"
+                onAction={() => setActiveTab('connect')}
+              />
+            ) : !selectedAccount ? (
+              <MetaAdsEmptyState
+                message="Selecione uma conta de anúncios para carregar campanhas, conjuntos, anúncios e criativos."
+                actionLabel="Selecionar conta"
+                onAction={() => setActiveTab('connect')}
+              />
+            ) : !inventory ? (
+              <MetaAdsEmptyState
+                message="Ainda não foi possível carregar o inventário desta conta."
+                actionLabel="Atualizar agora"
+                onAction={handleRefresh}
+              />
+            ) : (
+              <MetaAdsInventoryPanel inventory={inventory} inventoryError={inventoryError} onRetry={handleRefresh} />
+            )}
+          </TabsContent>
+
+          <TabsContent value="tracking" className="space-y-6">
+            <Card className="border-slate-800/80 bg-slate-950/55 shadow-[0_20px_80px_rgba(2,6,23,0.35)] backdrop-blur-xl">
+              <CardContent className="pt-6 text-sm leading-6 text-slate-300">
+                Tracking do site e inventário da conta Meta convivem nesta aba, mas são superfícies diferentes: aqui você acompanha os sinais e eventos do site; nas etapas anteriores você conecta a conta e escolhe qual estrutura da Meta deve alimentar o CRM.
+              </CardContent>
+            </Card>
+            <MetaTrackingDashboard />
+          </TabsContent>
+        </Tabs>
+      )}
     </div>
   )
 }

--- a/frontend/MetaTrackingDashboard.tsx
+++ b/frontend/MetaTrackingDashboard.tsx
@@ -2,200 +2,14 @@ import { useEffect, useMemo, useState } from 'react'
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
+import { getMetaTrackingLocalOverview, isMetaTrackingLocalMockEnabled } from '@/metaTrackingLocalMock'
 import { Progress } from '@/progress'
 import { ChartBar, CheckCircle, CirclesThreePlus, Funnel, LinkBreak, Spinner, WarningCircle, WhatsappLogo } from '@phosphor-icons/react'
-
-type TrackingOverviewResponse = {
-  ok: boolean
-  partial?: boolean
-  warnings?: string[]
-  generatedAt?: number
-  window?: { days: number; sinceIso: string }
-  funnel?: {
-    siteConfirmedBookings: number
-    siteWhatsappClicks: number
-    crmAttributedConversations: number
-    crmAttributedAppointments: number
-  }
-  coverage?: {
-    confirmedBookings: number
-    whatsappClicks: number
-    trackingContext: number
-    metaEventId: number
-    facebookIds: number
-    marketingConsent: number
-    analyticsConsent: number
-    whatsappTracking: number
-    scheduleDelivery: number
-    contactDelivery: number
-  }
-  previousCoverage?: {
-    trackingContext: number
-    facebookIds: number
-    marketingConsent: number
-  }
-  alerts?: Array<{
-    severity: 'critical' | 'warning'
-    code: string
-    title: string
-    message: string
-  }>
-  health?: {
-    status: 'healthy' | 'degraded' | 'critical'
-    label: string
-    summary: string
-  }
-  reconciliation?: {
-    buckets?: Array<{
-      bucket: 'sem_origem' | 'origem_first_party' | 'origem_meta_completa'
-      label: string
-      count: number
-      percent: number
-    }>
-    incompleteBookings?: Array<{
-      id: string
-      createdAtMs: number
-      unitSlug: string
-      patient: string | null
-      utmSource: string | null
-      utmCampaign: string | null
-      landingPage: string | null
-      metaEventId: string | null
-      hasFacebookIds: boolean
-      coverageBucket: string
-      incompleteCauses: string[]
-      primaryCause: string
-      scheduleStatus: string | null
-    }>
-    retryCandidates?: Array<{
-      id: string
-      createdAtMs: number
-      eventName: string
-      eventId: string
-      bookingId: string | null
-      waClickId: string | null
-      httpStatus: number | null
-      errorMessage: string | null
-      normalizedReason: string
-    }>
-  }
-  governance?: {
-    campaignRule: string
-    validExamples: string[]
-    invalidExamples: string[]
-    crossDomainAllowlist: Array<{
-      host: string
-      purpose: string
-      allowedFromPublicSite: boolean
-    }>
-  }
-  validationCadence?: {
-    smoke: string
-    functional: string
-    coverageAudit: string
-    recurringChecks: string[]
-  }
-  whatsappContract?: {
-    status: string
-    lifecycle: string[]
-    description: string
-  }
-  website?: {
-    available: boolean
-    error?: string
-    sourceUrl?: string
-    data?: {
-      summary?: Record<string, number>
-      topSources?: Array<{ utmSource: string; count: number }>
-      topCampaigns?: Array<{ utmCampaign: string; count: number }>
-      byUnit?: Array<{ unitSlug: string; count: number }>
-      recentBookings?: Array<{
-        id: string
-        createdAtMs: number
-        unitSlug: string
-        doctorSlug: string
-        serviceId: string
-        patient: string | null
-        whatsapp: string | null
-        metaEventId: string | null
-        marketingConsent: boolean
-        analyticsConsent: boolean
-        utmSource: string | null
-        utmCampaign: string | null
-        utmMedium: string | null
-        landingPage: string | null
-        hasFacebookIds: boolean
-      }>
-      recentWhatsappClicks?: Array<{
-        id: string
-        createdAtMs: number
-        eventId: string
-        waClickId: string
-        placement: string | null
-        source: string | null
-        unitSlug: string | null
-        doctorName: string | null
-        bookingId: string | null
-        pagePath: string | null
-        utmSource: string | null
-        utmCampaign: string | null
-      }>
-      recentCapiIssues?: Array<{
-        id: string
-        createdAtMs: number
-        eventName: string
-        eventId: string
-        bookingId: string | null
-        waClickId: string | null
-        httpStatus: number | null
-        errorMessage: string | null
-        normalizedReason?: string
-        retryable?: boolean
-      }>
-    }
-  }
-  previousWebsite?: {
-    available: boolean
-    error?: string
-  }
-  whatsapp?: {
-    available: boolean
-    error?: string
-    data?: {
-      summary?: Record<string, number>
-      stages?: Array<{ funnelStatus: string; count: number }>
-      topSources?: Array<{ utmSource: string; count: number }>
-      topCampaigns?: Array<{ utmCampaign: string; count: number }>
-      recentConversations?: Array<{
-        id: string
-        unitSlug: string
-        waClickId: string
-        funnelStatus: string
-        needsHuman: boolean
-        updatedAt: string
-        lastMessageAt: string | null
-        phone: string | null
-        externalId: string | null
-        utmSource: string | null
-        utmCampaign: string | null
-      }>
-      recentAppointments?: Array<{
-        id: string
-        unitSlug: string | null
-        waClickId: string
-        status: string
-        startAt: string | null
-        createdAt: string
-        phone: string | null
-        externalId: string | null
-        utmSource: string | null
-        utmCampaign: string | null
-      }>
-    }
-  }
-}
+import type { TrackingOverviewResponse } from '@/metaTrackingLocalMock'
 
 const WINDOW_OPTIONS = [7, 30, 60]
+const trackingPanelClass = 'glass-card border-slate-800/80 bg-slate-950/65 shadow-[0_20px_80px_rgba(2,6,23,0.35)]'
+const trackingInsetClass = 'rounded-2xl border border-slate-800/80 bg-slate-900/70'
 
 function formatNumber(value: number | string | null | undefined): string {
   const parsed = typeof value === 'number' ? value : Number(value || 0)
@@ -246,12 +60,12 @@ function MetricCard({
           : 'text-white'
 
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={trackingPanelClass}>
       <CardContent className="pt-6">
         <div className="space-y-2">
-          <p className="text-xs uppercase tracking-[0.2em] text-blue-100/60">{title}</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-400/80">{title}</p>
           <div className={`text-3xl font-semibold ${toneClass}`}>{value}</div>
-          <p className="text-sm text-blue-100/70">{hint}</p>
+          <p className="text-sm text-slate-300">{hint}</p>
         </div>
       </CardContent>
     </Card>
@@ -268,17 +82,17 @@ function SmallList({
   emptyLabel: string
 }) {
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={trackingPanelClass}>
       <CardHeader>
         <CardTitle className="text-base text-white">{title}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         {items.length === 0 ? (
-          <div className="text-sm text-blue-100/60">{emptyLabel}</div>
+          <div className="text-sm text-slate-400">{emptyLabel}</div>
         ) : (
           items.map((item) => (
             <div key={`${item.label}-${item.value}`} className="flex items-center justify-between gap-3 text-sm">
-              <span className="truncate text-blue-100/80">{item.label}</span>
+              <span className="truncate text-slate-300">{item.label}</span>
               <span className="font-medium text-white">{item.value}</span>
             </div>
           ))
@@ -294,10 +108,10 @@ function AlertPanel({
   alerts: Array<{ severity: 'critical' | 'warning'; code: string; title: string; message: string }>
 }) {
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={trackingPanelClass}>
       <CardHeader>
         <CardTitle className="text-white">Alertas operacionais</CardTitle>
-        <CardDescription className="text-blue-100/70">
+        <CardDescription className="text-slate-300">
           Regras automáticas para cobertura, consentimento e falhas de entrega.
         </CardDescription>
       </CardHeader>
@@ -345,6 +159,11 @@ export function MetaTrackingDashboard() {
       setLoading(true)
       setError(null)
       try {
+        if (isMetaTrackingLocalMockEnabled()) {
+          const mockData = getMetaTrackingLocalOverview(days)
+          if (!cancelled) setData(mockData)
+          return
+        }
         const res = await fetch(`/api/tracking/overview?days=${days}&limit=10`, {
           credentials: 'include',
           headers: { accept: 'application/json' },
@@ -479,29 +298,29 @@ export function MetaTrackingDashboard() {
 
   return (
     <div className="space-y-6">
-      <Card className="glass-card border-white/10 overflow-hidden">
-        <CardHeader className="border-b border-white/10 bg-white/[0.03]">
+      <Card className={`${trackingPanelClass} overflow-hidden`}>
+        <CardHeader className="border-b border-slate-800/80 bg-slate-950/70">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="space-y-2">
               <CardTitle className="text-2xl text-white flex items-center gap-3">
-                <ChartBar className="h-6 w-6 text-blue-300" />
+                <ChartBar className="h-6 w-6 text-sky-400" />
                 Acompanhamento de Tracking e Conversao
               </CardTitle>
-              <CardDescription className="text-blue-100/70 max-w-3xl">
+              <CardDescription className="max-w-3xl text-slate-300">
                 Painel operacional dos sinais reais do site `espacofacial.com`, com foco em atribuicao, CAPI, booking
                 confirmado e cliques para WhatsApp. A correlacao CRM/n8n fica secundaria enquanto essa camada nao for a
                 prioridade.
               </CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] p-1">
+              <div className="flex items-center gap-2 rounded-full border border-slate-800/80 bg-slate-900/70 p-1">
                 {WINDOW_OPTIONS.map((option) => (
                   <button
                     key={option}
                     type="button"
                     onClick={() => setDays(option)}
                     className={`rounded-full px-3 py-1.5 text-sm transition ${
-                      option === days ? 'bg-white/[0.16] text-white' : 'text-blue-100/70 hover:text-white'
+                      option === days ? 'bg-slate-700 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white'
                     }`}
                   >
                     {option}d
@@ -510,7 +329,7 @@ export function MetaTrackingDashboard() {
               </div>
               <Button
                 variant="outline"
-                className="border-white/15 bg-white/[0.04] text-blue-100 hover:bg-white/[0.08] hover:text-white"
+                className="border-slate-700 bg-slate-900/70 text-slate-100 hover:bg-slate-800"
                 onClick={() => setRefreshTick((value) => value + 1)}
               >
                 {loading ? <Spinner className="mr-2 h-4 w-4 animate-spin" /> : <CirclesThreePlus className="mr-2 h-4 w-4" />}
@@ -531,14 +350,14 @@ export function MetaTrackingDashboard() {
           ) : null}
 
           {data?.warnings && data.warnings.length > 0 ? (
-            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-5 text-amber-100">
+            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/12 p-5 text-amber-100">
               <div className="flex items-center gap-2 font-medium">
                 <WarningCircle className="h-5 w-5" />
                 Painel parcial
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
                 {data.warnings.map((warning) => (
-                  <Badge key={warning} variant="outline" className="border-amber-300/30 text-amber-100">
+                  <Badge key={warning} variant="outline" className="border-amber-300/30 bg-amber-500/10 text-amber-50">
                     {warning}
                   </Badge>
                 ))}
@@ -579,12 +398,12 @@ export function MetaTrackingDashboard() {
           ) : null}
 
           {!whatsappAttributionReady ? (
-            <div className="rounded-2xl border border-blue-400/30 bg-blue-500/10 p-5 text-blue-100">
+            <div className="rounded-2xl border border-sky-500/30 bg-sky-500/10 p-5 text-sky-100">
               <div className="flex items-center gap-2 font-medium">
                 <CheckCircle className="h-5 w-5" />
                 Modo foco site ativo
               </div>
-              <p className="mt-2 text-sm text-blue-100/80">
+              <p className="mt-2 text-sm text-sky-100/85">
                 O dashboard está priorizando leitura do `espacofacial.com`. A parte de conversa/agendamento atribuídos
                 no CRM via WhatsApp permanece disponível, mas ainda sem volume integrado.
               </p>
@@ -592,20 +411,20 @@ export function MetaTrackingDashboard() {
           ) : null}
 
           <div className="grid gap-4 xl:grid-cols-4">
-            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4">
-              <div className="text-xs uppercase tracking-[0.2em] text-blue-100/60">Agendamentos confirmados no site</div>
+            <div className={`${trackingInsetClass} p-4`}>
+              <div className="text-xs uppercase tracking-[0.2em] text-slate-400/80">Agendamentos confirmados no site</div>
               <div className="mt-2 text-2xl font-semibold text-white">{formatNumber(confirmedBookings)}</div>
             </div>
-            <div className="rounded-2xl border border-blue-400/20 bg-blue-500/10 p-4">
-              <div className="text-xs uppercase tracking-[0.2em] text-blue-100/60">Clique WhatsApp no site</div>
+            <div className={`${trackingInsetClass} p-4`}>
+              <div className="text-xs uppercase tracking-[0.2em] text-slate-400/80">Clique WhatsApp no site</div>
               <div className="mt-2 text-2xl font-semibold text-white">{formatNumber(siteWhatsappClicks)}</div>
             </div>
-            <div className="rounded-2xl border border-fuchsia-400/20 bg-fuchsia-500/10 p-4">
-              <div className="text-xs uppercase tracking-[0.2em] text-blue-100/60">Schedule via CAPI OK</div>
+            <div className={`${trackingInsetClass} p-4`}>
+              <div className="text-xs uppercase tracking-[0.2em] text-slate-400/80">Schedule via CAPI OK</div>
               <div className="mt-2 text-2xl font-semibold text-white">{formatNumber(websiteSummary.capiScheduleOk || 0)}</div>
             </div>
-            <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4">
-              <div className="text-xs uppercase tracking-[0.2em] text-blue-100/60">Cobertura tracking_context</div>
+            <div className={`${trackingInsetClass} p-4`}>
+              <div className="text-xs uppercase tracking-[0.2em] text-slate-400/80">Cobertura tracking_context</div>
               <div className="mt-2 text-2xl font-semibold text-white">{siteCoverage.tracking}%</div>
             </div>
           </div>

--- a/frontend/contexts.tsx
+++ b/frontend/contexts.tsx
@@ -8,6 +8,9 @@ import { useWebSocket } from '@/useWebSocket'
 import { useKV } from '@/spark-mock'
 import { csrfHeader } from '@/csrf'
 
+const LOCAL_CRM_FOCUS_MODULE = (import.meta as any).env?.VITE_LOCAL_CRM_FOCUS_MODULE || ''
+const SKIP_INSTAGRAM_PREFLIGHT = LOCAL_CRM_FOCUS_MODULE === 'meta-ads'
+
 // =========================
 // Auth
 // =========================
@@ -402,6 +405,10 @@ export function IntegrationsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!isAuthenticated) {
+      setInstagram({ connected: false })
+      return
+    }
+    if (SKIP_INSTAGRAM_PREFLIGHT) {
       setInstagram({ connected: false })
       return
     }

--- a/frontend/e2e/meta-ads-module.spec.ts
+++ b/frontend/e2e/meta-ads-module.spec.ts
@@ -42,8 +42,10 @@ test.describe('meta ads', () => {
     await openMetaAds(page)
 
     await expect(page.locator('body')).toContainText('Faça login no CRM para continuar', { timeout: 30000 })
-    await expect(page.getByRole('button', { name: 'Conectar via Facebook' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: 'Conectar com Facebook' })).toBeDisabled()
     await expect(page.getByText('UNAUTHORIZED · HTTP 401')).toBeVisible()
+    await expect(page.getByText('Saúde da integração')).toHaveCount(0)
+    await expect(page.getByRole('tab', { name: 'Visão geral' })).toHaveCount(0)
   })
 
   test('surfaces connection health, selected account and inventory in a connected flow', async ({ page }) => {
@@ -167,9 +169,11 @@ test.describe('meta ads', () => {
     await expect(page.getByText('Conta ativa: Conta Principal')).toBeVisible()
     await expect(page.getByText('Tendência de gasto')).toBeVisible()
 
-    await page.getByRole('tab', { name: 'Conexão' }).click()
-    await expect(page.getByText('Saúde da integração')).toBeVisible()
-    await expect(page.getByText('Usuário Meta conectado:')).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Conexão' })).toHaveCount(0)
+    await expect(page.getByRole('tab', { name: 'Visão geral' })).toBeVisible()
+    await page.getByRole('button', { name: 'Gerenciar conexão' }).click()
+    await expect(page.getByText('Escolher a conta de anúncios')).toBeVisible()
+    await expect(page.getByText('Usuário Meta: Jubenito Garcia')).toBeVisible()
 
     await page.getByRole('tab', { name: 'Inventário' }).click()
     await expect(page.locator('body')).toContainText('Criativo 1')

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -541,6 +541,17 @@ body {
   box-shadow: 0 16px 42px rgba(2, 6, 23, 0.35);
 }
 
+.meta-ads-surface .glass-card {
+  background: rgba(10, 15, 29, 0.78);
+  border-color: rgba(51, 65, 85, 0.82);
+  box-shadow: 0 20px 80px rgba(2, 6, 23, 0.4);
+}
+
+.meta-ads-surface .glass-morphism {
+  background: rgba(15, 23, 42, 0.5);
+  border-color: rgba(71, 85, 105, 0.45);
+}
+
 .escala-surface .glass-morphism {
   background: rgba(15, 23, 42, 0.4);
   border-color: rgba(148, 163, 184, 0.25);

--- a/frontend/metaAdsApi.ts
+++ b/frontend/metaAdsApi.ts
@@ -1,4 +1,16 @@
 import { getCsrfToken } from '@/csrf'
+import {
+  connectMetaAdsManualLocal,
+  disconnectMetaAdsLocal,
+  getMetaAdsLocalInventory,
+  getMetaAdsLocalStatus,
+  getMetaAdsLocalSummary,
+  getMetaAdsLocalTrend,
+  isMetaAdsLocalMockEnabled,
+  listMetaAdsLocalAccounts,
+  selectMetaAdsLocalAccount,
+  simulateMetaAdsOAuthConnect,
+} from '@/metaAdsLocalMock'
 import { normalizeMetaAdsApiError } from '@/metaAdsState'
 import type {
   MetaAdAccount,
@@ -44,26 +56,39 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 }
 
 export const metaAdsApi = {
-  status: () => request<MetaAdsStatusResponse>('/status'),
+  isLocalMockMode: () => isMetaAdsLocalMockEnabled(),
+  simulateOAuthConnect: () => simulateMetaAdsOAuthConnect(),
+  status: () => (isMetaAdsLocalMockEnabled() ? getMetaAdsLocalStatus() : request<MetaAdsStatusResponse>('/status')),
   oauthStartUrl: () => `${META_ADS_API_URL}/oauth/start`,
   connectManual: (payload: { accessToken: string }) =>
-    request('/connect/manual', { method: 'POST', body: JSON.stringify(payload) }),
-  disconnect: () => request('/disconnect', { method: 'POST' }),
-  listAdAccounts: () => request<{
-    ok: boolean
-    connected: boolean
-    selectedAdAccountId: string | null
-    accounts: MetaAdAccount[]
-  }>('/ad-accounts'),
+    isMetaAdsLocalMockEnabled()
+      ? connectMetaAdsManualLocal()
+      : request('/connect/manual', { method: 'POST', body: JSON.stringify(payload) }),
+  disconnect: () => (isMetaAdsLocalMockEnabled() ? disconnectMetaAdsLocal() : request('/disconnect', { method: 'POST' })),
+  listAdAccounts: () =>
+    isMetaAdsLocalMockEnabled()
+      ? listMetaAdsLocalAccounts()
+      : request<{
+          ok: boolean
+          connected: boolean
+          selectedAdAccountId: string | null
+          accounts: MetaAdAccount[]
+        }>('/ad-accounts'),
   selectAdAccount: (payload: { adAccountId: string }) =>
-    request('/ad-accounts/select', { method: 'POST', body: JSON.stringify(payload) }),
+    isMetaAdsLocalMockEnabled()
+      ? selectMetaAdsLocalAccount(payload.adAccountId)
+      : request('/ad-accounts/select', { method: 'POST', body: JSON.stringify(payload) }),
   summary: (params?: { since?: string; until?: string }) => {
     const search = new URLSearchParams(params as any).toString()
-    return request<MetaAdsSummaryResponse>(`/summary${search ? `?${search}` : ''}`)
+    return isMetaAdsLocalMockEnabled()
+      ? getMetaAdsLocalSummary()
+      : request<MetaAdsSummaryResponse>(`/summary${search ? `?${search}` : ''}`)
   },
   trend: (params?: { since?: string; until?: string }) => {
     const search = new URLSearchParams(params as any).toString()
-    return request<MetaAdsTrendPoint[]>(`/trend${search ? `?${search}` : ''}`)
+    return isMetaAdsLocalMockEnabled()
+      ? getMetaAdsLocalTrend()
+      : request<MetaAdsTrendPoint[]>(`/trend${search ? `?${search}` : ''}`)
   },
-  inventory: () => request<MetaInventoryResponse>('/inventory'),
+  inventory: () => (isMetaAdsLocalMockEnabled() ? getMetaAdsLocalInventory() : request<MetaInventoryResponse>('/inventory')),
 }

--- a/frontend/metaAdsLocalMock.ts
+++ b/frontend/metaAdsLocalMock.ts
@@ -1,0 +1,417 @@
+import type {
+  MetaAdAccount,
+  MetaAdsApiError,
+  MetaAdsStatusResponse,
+  MetaAdsSummaryResponse,
+  MetaAdsTrendPoint,
+  MetaInventoryResponse,
+} from '@/metaAdsTypes'
+
+export type MetaAdsLocalScenario =
+  | 'live'
+  | 'disconnected'
+  | 'connected-no-account'
+  | 'connected-ready'
+  | 'unauthorized'
+
+type MetaAdsLocalState = {
+  scenario: Exclude<MetaAdsLocalScenario, 'live' | 'unauthorized'>
+  tokenType: 'oauth' | 'manual' | null
+  selectedAdAccountId: string | null
+  updatedAt: string | null
+}
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+const STORAGE_KEY = 'metaAds.localState.v1'
+const SCENARIO_QUERY_KEY = 'metaAdsLocalScenario'
+const DEFAULT_ACCOUNT_ID = 'act_123'
+
+const ACCOUNT_FIXTURES: MetaAdAccount[] = [
+  {
+    id: 'act_123',
+    name: 'Conta Principal',
+    currency: 'BRL',
+    timezone_name: 'America/Sao_Paulo',
+    business_name: 'Skincos',
+  },
+  {
+    id: 'act_456',
+    name: 'Conta Captação',
+    currency: 'BRL',
+    timezone_name: 'America/Sao_Paulo',
+    business_name: 'Skincos',
+  },
+]
+
+function canUseLocalStorage() {
+  return typeof window !== 'undefined' && LOCAL_HOSTS.has(window.location.hostname)
+}
+
+function normalizeScenario(value: unknown): MetaAdsLocalScenario {
+  if (value === 'live' || value === 'disconnected' || value === 'connected-no-account' || value === 'connected-ready' || value === 'unauthorized') {
+    return value
+  }
+  return 'live'
+}
+
+function buildDefaultState(
+  scenario: Exclude<MetaAdsLocalScenario, 'live' | 'unauthorized'> = 'disconnected',
+): MetaAdsLocalState {
+  return {
+    scenario,
+    tokenType: scenario === 'disconnected' ? null : 'oauth',
+    selectedAdAccountId: scenario === 'connected-ready' ? DEFAULT_ACCOUNT_ID : null,
+    updatedAt: scenario === 'disconnected' ? null : new Date().toISOString(),
+  }
+}
+
+function readQueryScenario(): MetaAdsLocalScenario | null {
+  if (!canUseLocalStorage()) return null
+  const params = new URLSearchParams(window.location.search)
+  if (!params.has(SCENARIO_QUERY_KEY)) return null
+  return normalizeScenario(params.get(SCENARIO_QUERY_KEY))
+}
+
+function writeState(next: MetaAdsLocalState | null) {
+  if (!canUseLocalStorage()) return
+  if (!next) {
+    window.localStorage.removeItem(STORAGE_KEY)
+    return
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+}
+
+function syncStateFromUrl() {
+  if (!canUseLocalStorage()) return
+  const scenario = readQueryScenario()
+  if (!scenario) return
+  if (scenario === 'live') {
+    writeState(null)
+    return
+  }
+  if (scenario === 'unauthorized') {
+    writeState(buildDefaultState('disconnected'))
+    return
+  }
+  const current = readState(false)
+  if (!current || current.scenario !== scenario) {
+    writeState(buildDefaultState(scenario))
+  }
+}
+
+function readState(syncFromUrl = true): MetaAdsLocalState | null {
+  if (!canUseLocalStorage()) return null
+  if (syncFromUrl) syncStateFromUrl()
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    const scenario = normalizeScenario(parsed?.scenario)
+    if (scenario === 'live' || scenario === 'unauthorized') return buildDefaultState('disconnected')
+    return {
+      scenario,
+      tokenType: parsed?.tokenType === 'manual' ? 'manual' : parsed?.tokenType === 'oauth' ? 'oauth' : null,
+      selectedAdAccountId: typeof parsed?.selectedAdAccountId === 'string' ? parsed.selectedAdAccountId : null,
+      updatedAt: typeof parsed?.updatedAt === 'string' ? parsed.updatedAt : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+function buildError(input: {
+  code: string
+  message: string
+  hint?: string
+  status?: number
+  retryable?: boolean
+}): MetaAdsApiError {
+  return {
+    code: input.code,
+    message: input.message,
+    hint: input.hint,
+    status: input.status,
+    retryable: input.retryable ?? false,
+  }
+}
+
+function connectedUserName(state: MetaAdsLocalState) {
+  return state.tokenType === 'manual' ? 'Token administrativo local' : 'Jubenito Garcia'
+}
+
+function buildStatus(state: MetaAdsLocalState): MetaAdsStatusResponse {
+  const connected = state.scenario !== 'disconnected'
+  return {
+    ok: true,
+    oauthConfigured: true,
+    missingConfig: [],
+    connection: {
+      connected,
+      tokenType: connected ? state.tokenType : null,
+      metaUserId: connected ? '42' : null,
+      metaUserName: connected ? connectedUserName(state) : null,
+      selectedAdAccountId: connected ? state.selectedAdAccountId : null,
+      scopes: connected ? ['ads_read', 'ads_management', 'business_management'] : [],
+      updatedAt: connected ? state.updatedAt || new Date().toISOString() : null,
+      expiresAt: connected ? '2026-12-31T23:59:59.000Z' : null,
+    },
+  }
+}
+
+function buildAccounts(state: MetaAdsLocalState) {
+  return ACCOUNT_FIXTURES.map((account) => ({
+    ...account,
+    isSelected: account.id === state.selectedAdAccountId,
+  }))
+}
+
+function requireConnectedState(): MetaAdsLocalState {
+  const scenario = getLocalScenario()
+  if (scenario === 'unauthorized') {
+    throw buildError({
+      code: 'UNAUTHORIZED',
+      status: 401,
+      message: 'Faça login no CRM para continuar.',
+      hint: 'No modo local do Meta Ads, escolha um cenário conectado para liberar o inventário.',
+      retryable: false,
+    })
+  }
+  const state = readState()
+  if (!state || state.scenario === 'disconnected') {
+    throw buildError({
+      code: 'META_ADS_NOT_CONNECTED',
+      status: 409,
+      message: 'Conecte uma conta Meta Ads antes de continuar.',
+      hint: 'Use o fluxo local de conexão para simular OAuth ou token manual.',
+      retryable: false,
+    })
+  }
+  return state
+}
+
+function requireSelectedAccount(): MetaAdsLocalState {
+  const state = requireConnectedState()
+  if (!state.selectedAdAccountId) {
+    throw buildError({
+      code: 'META_ADS_ACCOUNT_REQUIRED',
+      status: 409,
+      message: 'Escolha uma conta de anúncios para continuar.',
+      hint: 'Selecione uma conta local para liberar visão geral e inventário.',
+      retryable: false,
+    })
+  }
+  return state
+}
+
+export function getLocalScenario(): MetaAdsLocalScenario {
+  if (!canUseLocalStorage()) return 'live'
+  syncStateFromUrl()
+  const queryScenario = readQueryScenario()
+  if (queryScenario === 'unauthorized') return 'unauthorized'
+  const state = readState(false)
+  return state?.scenario || 'live'
+}
+
+export function isMetaAdsLocalMockEnabled() {
+  const scenario = getLocalScenario()
+  return scenario !== 'live'
+}
+
+export function isMetaAdsLocalMockConnected() {
+  const scenario = getLocalScenario()
+  return scenario === 'connected-no-account' || scenario === 'connected-ready'
+}
+
+export async function simulateMetaAdsOAuthConnect() {
+  if (!canUseLocalStorage()) return
+  writeState({
+    scenario: 'connected-no-account',
+    tokenType: 'oauth',
+    selectedAdAccountId: null,
+    updatedAt: new Date().toISOString(),
+  })
+}
+
+export async function connectMetaAdsManualLocal() {
+  if (!canUseLocalStorage()) return
+  writeState({
+    scenario: 'connected-no-account',
+    tokenType: 'manual',
+    selectedAdAccountId: null,
+    updatedAt: new Date().toISOString(),
+  })
+}
+
+export async function disconnectMetaAdsLocal() {
+  if (!canUseLocalStorage()) return
+  writeState(buildDefaultState('disconnected'))
+}
+
+export async function selectMetaAdsLocalAccount(adAccountId: string) {
+  const account = ACCOUNT_FIXTURES.find((item) => item.id === adAccountId)
+  if (!account) {
+    throw buildError({
+      code: 'META_ADS_ACCOUNT_NOT_FOUND',
+      status: 404,
+      message: 'A conta solicitada não existe no cenário local.',
+      hint: 'Escolha uma das contas simuladas exibidas na tela.',
+      retryable: false,
+    })
+  }
+  const current = readState() || buildDefaultState('connected-no-account')
+  writeState({
+    scenario: 'connected-ready',
+    tokenType: current.tokenType || 'oauth',
+    selectedAdAccountId: adAccountId,
+    updatedAt: new Date().toISOString(),
+  })
+}
+
+export async function getMetaAdsLocalStatus() {
+  const scenario = getLocalScenario()
+  if (scenario === 'unauthorized') {
+    throw buildError({
+      code: 'UNAUTHORIZED',
+      status: 401,
+      message: 'Faça login no CRM para continuar.',
+      hint: 'Para testes locais do Meta Ads, use um cenário conectado ou liberado no launcher.',
+      retryable: false,
+    })
+  }
+  const state = readState() || buildDefaultState('disconnected')
+  return buildStatus(state)
+}
+
+export async function listMetaAdsLocalAccounts() {
+  const state = requireConnectedState()
+  return {
+    ok: true,
+    connected: true,
+    selectedAdAccountId: state.selectedAdAccountId,
+    accounts: buildAccounts(state),
+  }
+}
+
+export async function getMetaAdsLocalSummary(): Promise<MetaAdsSummaryResponse> {
+  const state = requireSelectedAccount()
+  if (state.selectedAdAccountId === 'act_456') {
+    return { spend: 864.12, impressions: 7120, clicks: 214, activeCampaigns: 1 }
+  }
+  return { spend: 1234.56, impressions: 9999, clicks: 321, activeCampaigns: 2 }
+}
+
+export async function getMetaAdsLocalTrend(): Promise<MetaAdsTrendPoint[]> {
+  requireSelectedAccount()
+  return [
+    { day: '2026-05-07', spend: 82 },
+    { day: '2026-05-08', spend: 96 },
+    { day: '2026-05-09', spend: 101 },
+    { day: '2026-05-10', spend: 100 },
+    { day: '2026-05-11', spend: 120 },
+    { day: '2026-05-12', spend: 148 },
+    { day: '2026-05-13', spend: 132 },
+  ]
+}
+
+export async function getMetaAdsLocalInventory(): Promise<MetaInventoryResponse> {
+  const state = requireSelectedAccount()
+  const accountId = state.selectedAdAccountId || DEFAULT_ACCOUNT_ID
+  if (accountId === 'act_456') {
+    return {
+      ok: true,
+      accountId,
+      inventory: {
+        campaigns: [
+          {
+            id: 'cmp_ret_1',
+            name: 'Campanha Remarketing Face',
+            status: 'ACTIVE',
+            effective_status: 'ACTIVE',
+            objective: 'SALES',
+            totals: { adSets: 1, ads: 2 },
+          },
+        ],
+        adSets: [{ id: 'set_ret_1', name: 'Visitantes 30d' }],
+        ads: [
+          {
+            id: 'ad_ret_1',
+            name: 'Anúncio Remarketing 1',
+            campaign_name: 'Campanha Remarketing Face',
+            adset_name: 'Visitantes 30d',
+            creative: { id: 'cr_ret_1', name: 'Criativo Remarketing 1' },
+            effective_status: 'ACTIVE',
+          },
+        ],
+        creatives: [
+          {
+            id: 'cr_ret_1',
+            name: 'Criativo Remarketing 1',
+            campaignId: 'cmp_ret_1',
+            adName: 'Anúncio Remarketing 1',
+          },
+        ],
+      },
+    }
+  }
+
+  return {
+    ok: true,
+    accountId,
+    inventory: {
+      campaigns: [
+        {
+          id: 'cmp_1',
+          name: 'Campanha Primavera',
+          status: 'ACTIVE',
+          effective_status: 'ACTIVE',
+          objective: 'LEADS',
+          totals: { adSets: 1, ads: 1 },
+        },
+        {
+          id: 'cmp_2',
+          name: 'Campanha WhatsApp Facial',
+          status: 'PAUSED',
+          effective_status: 'PAUSED',
+          objective: 'MESSAGES',
+          totals: { adSets: 1, ads: 1 },
+        },
+      ],
+      adSets: [
+        { id: 'set_1', name: 'Conjunto 1' },
+        { id: 'set_2', name: 'Conjunto 2' },
+      ],
+      ads: [
+        {
+          id: 'ad_1',
+          name: 'Anúncio 1',
+          campaign_name: 'Campanha Primavera',
+          adset_name: 'Conjunto 1',
+          creative: { id: 'cr_1', name: 'Criativo 1' },
+          effective_status: 'ACTIVE',
+        },
+        {
+          id: 'ad_2',
+          name: 'Anúncio WhatsApp 1',
+          campaign_name: 'Campanha WhatsApp Facial',
+          adset_name: 'Conjunto 2',
+          creative: { id: 'cr_2', name: 'Criativo WhatsApp 1' },
+          effective_status: 'PAUSED',
+        },
+      ],
+      creatives: [
+        {
+          id: 'cr_1',
+          name: 'Criativo 1',
+          campaignId: 'cmp_1',
+          adName: 'Anúncio 1',
+        },
+        {
+          id: 'cr_2',
+          name: 'Criativo WhatsApp 1',
+          campaignId: 'cmp_2',
+          adName: 'Anúncio WhatsApp 1',
+        },
+      ],
+    },
+  }
+}

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -13,7 +13,6 @@ import type {
   MetaAdsHealthState,
   MetaAdsInventory,
   MetaAdsSummaryResponse,
-  MetaAdsStatusResponse,
   MetaAdsTab,
   MetaAdsTrendPoint,
 } from '@/metaAdsTypes'
@@ -30,14 +29,8 @@ import {
   WarningCircle,
 } from '@phosphor-icons/react'
 
-function formatDateTimeLabel(value?: string | null) {
-  if (!value) return '—'
-  try {
-    return format(new Date(value), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })
-  } catch {
-    return '—'
-  }
-}
+const panelClass = 'border-slate-800/80 bg-slate-950/60 shadow-[0_20px_80px_rgba(2,6,23,0.35)] backdrop-blur-xl'
+const subtlePanelClass = 'border-slate-800/70 bg-slate-950/45 backdrop-blur-xl'
 
 function formatCurrency(value: number, currency = 'USD') {
   try {
@@ -60,13 +53,13 @@ function statusTone(status?: string) {
   if (normalized === 'ACTIVE') return 'bg-emerald-500/15 text-emerald-200 border-emerald-500/30'
   if (normalized === 'PAUSED') return 'bg-amber-500/15 text-amber-200 border-amber-500/30'
   if (normalized === 'ARCHIVED') return 'bg-slate-500/15 text-slate-200 border-slate-500/30'
-  return 'bg-white/10 text-blue-100 border-white/10'
+  return 'border-slate-700 bg-slate-900/70 text-slate-200'
 }
 
 export function MetaAdsEmptyState({ message, actionLabel, onAction }: { message: string; actionLabel?: string; onAction?: () => void }) {
   return (
-    <Card className="glass-card border-white/10">
-      <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-sm text-blue-100/70">
+    <Card className={panelClass}>
+      <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-sm text-slate-300">
         <div>{message}</div>
         {actionLabel && onAction ? <Button variant="outline" onClick={onAction}>{actionLabel}</Button> : null}
       </CardContent>
@@ -86,38 +79,39 @@ export function MetaAdsStatusHero({
   onDisconnect: () => void
 }) {
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={`overflow-hidden ${panelClass}`}>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.18),transparent_36%),radial-gradient(circle_at_top_right,rgba(236,72,153,0.14),transparent_28%)]" />
       <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
+        <div className="relative">
           <CardTitle className="flex items-center gap-3 text-white">
             <div className="flex items-center gap-2">
-              <FacebookLogo className="h-6 w-6 text-blue-400" />
+              <FacebookLogo className="h-6 w-6 text-sky-400" />
               <Target className="h-6 w-6 text-pink-400" />
             </div>
             Meta Ads
           </CardTitle>
-          <CardDescription>
+          <CardDescription className="max-w-3xl text-slate-300">
             Conecte o Gerenciador de Anúncios da Meta ao CRM, escolha a conta certa e acompanhe inventário e tracking sem sair do módulo.
           </CardDescription>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex flex-wrap items-center gap-2">
           {connected ? (
-            <Badge className="bg-emerald-500/15 text-emerald-200 border border-emerald-500/30">
+            <Badge className="border border-emerald-500/30 bg-emerald-500/15 text-emerald-100">
               <CheckCircle className="mr-1 h-4 w-4" />
               Conectado
             </Badge>
           ) : (
-            <Badge className="bg-amber-500/15 text-amber-200 border border-amber-500/30">
+            <Badge className="border border-amber-500/30 bg-amber-500/15 text-amber-100">
               <Link className="mr-1 h-4 w-4" />
               Não conectado
             </Badge>
           )}
-          <Button variant="outline" onClick={onRefresh} disabled={refreshing}>
+          <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={onRefresh} disabled={refreshing}>
             {refreshing ? <Spinner className="mr-2 h-4 w-4 animate-spin" /> : <ArrowClockwise className="mr-2 h-4 w-4" />}
             Atualizar
           </Button>
           {connected ? (
-            <Button variant="outline" onClick={onDisconnect} disabled={refreshing}>
+            <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={onDisconnect} disabled={refreshing}>
               Desconectar
             </Button>
           ) : null}
@@ -142,16 +136,16 @@ export function MetaAdsHealthBanner({
     health.tone === 'success'
       ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
       : health.tone === 'danger'
-        ? 'border-rose-500/30 bg-rose-500/10 text-rose-100'
-        : health.tone === 'warning'
-          ? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
-          : 'border-white/10 bg-white/[0.03] text-blue-100'
+      ? 'border-rose-500/30 bg-rose-500/10 text-rose-100'
+      : health.tone === 'warning'
+        ? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
+          : 'border-slate-700/80 bg-slate-900/60 text-slate-100'
   const updatedLabel = statusUpdatedAt
     ? format(new Date(statusUpdatedAt), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })
     : null
 
   return (
-    <Card className={`glass-card ${toneClass}`}>
+    <Card className={`${panelClass} ${toneClass}`}>
       <CardContent className="flex flex-col gap-4 pt-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -189,7 +183,7 @@ export function MetaAdsPersistentError({
 }) {
   if (!error) return null
   return (
-    <Card className="glass-card border-rose-500/30 bg-rose-500/10">
+    <Card className="border-rose-500/30 bg-rose-500/12 shadow-[0_20px_60px_rgba(136,19,55,0.18)] backdrop-blur-xl">
       <CardContent className="flex flex-col gap-3 pt-6 text-sm text-rose-100 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
           <div className="font-medium">
@@ -216,8 +210,7 @@ export function MetaAdsWorkspaceTabs({
   trackingDisabled?: boolean
 }) {
   return (
-    <TabsList className="grid w-full max-w-5xl grid-cols-4 glass-morphism p-2 border-white/20">
-      <TabsTrigger value="connect">Conexão</TabsTrigger>
+    <TabsList className="grid w-full max-w-4xl grid-cols-3 rounded-3xl border border-slate-800/80 bg-slate-950/65 p-2 backdrop-blur-xl">
       <TabsTrigger value="overview">Visão geral</TabsTrigger>
       <TabsTrigger value="inventory">Inventário</TabsTrigger>
       <TabsTrigger value="tracking" disabled={trackingDisabled}>
@@ -227,125 +220,105 @@ export function MetaAdsWorkspaceTabs({
   )
 }
 
-export function MetaAdsSessionFacts({
-  status,
-  selectedAccount,
-}: {
-  status: MetaAdsStatusResponse | null
-  selectedAccount: MetaAdAccount | null
-}) {
-  const connection = status?.connection
-  const facts = [
-    {
-      label: 'Modo de conexão',
-      value: connection?.connected ? (connection.tokenType === 'oauth' ? 'Facebook OAuth' : 'Token manual') : 'Desconectado',
-    },
-    {
-      label: 'Conta selecionada',
-      value: selectedAccount?.name || selectedAccount?.id || 'Ainda não selecionada',
-    },
-    {
-      label: 'Escopos ativos',
-      value: connection?.scopes?.length ? `${connection.scopes.length} escopos` : 'Nenhum escopo reportado',
-    },
-    {
-      label: 'Expiração do token',
-      value: formatDateTimeLabel(connection?.expiresAt),
-    },
-    {
-      label: 'Última atualização',
-      value: formatDateTimeLabel(connection?.updatedAt),
-    },
-  ]
-
-  return (
-    <Card className="glass-card border-white/10">
-      <CardHeader>
-        <CardTitle>Saúde da integração</CardTitle>
-        <CardDescription>
-          Este resumo mostra se o problema atual é login, permissão, configuração do runtime ou ausência de conta selecionada.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-        {facts.map((fact) => (
-          <div key={fact.label} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <div className="text-xs uppercase tracking-[0.22em] text-blue-100/55">{fact.label}</div>
-            <div className="mt-2 text-sm font-medium text-white">{fact.value}</div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  )
-}
-
 export function MetaAdsConnectionPanel({
   scopesLabel,
   connectedUser,
   connectDisabled,
   onOAuth,
+  manualToken,
+  setManualToken,
+  onManualConnect,
+  manualDisabled,
 }: {
   scopesLabel: string
   connectedUser?: string | null
   connectDisabled: boolean
   onOAuth: () => void
+  manualToken: string
+  setManualToken: (value: string) => void
+  onManualConnect: () => void
+  manualDisabled: boolean
 }) {
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={panelClass}>
       <CardHeader>
-        <CardTitle>1. Autorize o Facebook</CardTitle>
-        <CardDescription>
-          Use OAuth quando quiser uma conexão guiada dentro do CRM. Se o popup for bloqueado, o fluxo cai para a mesma aba.
+        <CardTitle>Conectar a conta Meta</CardTitle>
+        <CardDescription className="text-slate-300">
+          Comece pelo Facebook OAuth. Se preferir, use um token manual como rota secundária no mesmo painel.
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-6">
+        <div className="rounded-3xl border border-slate-800/80 bg-slate-900/65 p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <div className="text-sm font-medium text-white">Fluxo recomendado</div>
+              <div className="text-sm leading-6 text-slate-300">
+                Autorize a Meta dentro do CRM e, se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.
+              </div>
+            </div>
+            <Button className="bg-sky-500 text-slate-950 hover:bg-sky-400" onClick={onOAuth} disabled={connectDisabled}>
+              Conectar com Facebook
+            </Button>
+          </div>
+        </div>
         <div className="flex flex-wrap gap-2">
-          <Button onClick={onOAuth} disabled={connectDisabled}>
-            Conectar via Facebook
-          </Button>
-          <Badge className="bg-white/10 text-blue-100 border border-white/10">
+          <Badge className="border border-slate-700 bg-slate-900/60 text-slate-200">
             Escopos: {scopesLabel}
           </Badge>
+          {connectedUser ? (
+            <Badge className="border border-emerald-500/30 bg-emerald-500/10 text-emerald-100">
+              Usuário Meta: {connectedUser}
+            </Badge>
+          ) : null}
         </div>
-        {connectedUser ? (
-          <div className="text-sm text-blue-100/70">
-            Usuário Meta conectado: <span className="font-medium text-white">{connectedUser}</span>
+        <div className="rounded-3xl border border-slate-800/80 bg-slate-900/45 p-5">
+          <div className="mb-3 text-sm font-medium text-white">Ou conecte por token manual</div>
+          <div className="mb-4 text-sm text-slate-300">
+            Use esta rota apenas para tokens de longa duração ou integrações administrativas.
           </div>
-        ) : null}
+          <Textarea
+            value={manualToken}
+            onChange={(e) => setManualToken(e.target.value)}
+            placeholder="Cole aqui o access token da Meta"
+            className="min-h-28 border-slate-700 bg-slate-950/70 text-slate-100 placeholder:text-slate-500"
+          />
+          <div className="mt-4 flex justify-end">
+            <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={onManualConnect} disabled={manualDisabled}>
+              Validar e conectar token
+            </Button>
+          </div>
+        </div>
       </CardContent>
     </Card>
   )
 }
 
-export function MetaAdsManualTokenPanel({
-  manualToken,
-  setManualToken,
-  onConnect,
-  disabled,
+export function MetaAdsConnectionProgress({
+  connected,
+  hasSelectedAccount,
 }: {
-  manualToken: string
-  setManualToken: (value: string) => void
-  onConnect: () => void
-  disabled: boolean
+  connected: boolean
+  hasSelectedAccount: boolean
 }) {
   return (
-    <Card className="glass-card border-white/10">
-      <CardHeader>
-        <CardTitle>2. Ou conecte por token manual</CardTitle>
-        <CardDescription>
-          Use esta rota para tokens de longa duração ou acessos administrativos em ambientes mais controlados.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <Textarea
-          value={manualToken}
-          onChange={(e) => setManualToken(e.target.value)}
-          placeholder="Cole aqui o access token da Meta"
-          className="min-h-28"
-        />
-        <div className="flex justify-end">
-          <Button onClick={onConnect} disabled={disabled}>
-            Validar e conectar token
-          </Button>
+    <Card className={subtlePanelClass}>
+      <CardContent className="flex flex-col gap-4 pt-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <div className="text-sm font-medium text-white">
+            {connected ? 'Conta Meta conectada.' : 'Comece conectando a Meta ao CRM.'}
+          </div>
+          <div className="text-sm text-slate-300">
+            {connected
+              ? hasSelectedAccount
+                ? 'Conexão concluída. Agora o módulo libera visão geral, inventário e tracking.'
+                : 'Próximo passo: selecione qual conta de anúncios deve alimentar o CRM.'
+              : 'Depois da autorização, escolha a conta de anúncios correta para liberar as demais áreas.'}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.22em] text-slate-400">
+          <span className={connected ? 'text-emerald-300' : ''}>1. Conectar</span>
+          <span className={hasSelectedAccount ? 'text-emerald-300' : ''}>2. Escolher conta</span>
+          <span className={hasSelectedAccount ? 'text-emerald-300' : ''}>3. Operar</span>
         </div>
       </CardContent>
     </Card>
@@ -368,23 +341,23 @@ export function MetaAdsAccountsPanel({
   onSelectAccount: (adAccountId: string) => void
 }) {
   return (
-    <Card className="glass-card border-white/10">
+    <Card className={panelClass}>
       <CardHeader>
-        <CardTitle>3. Escolha a conta de anúncios</CardTitle>
-        <CardDescription>
+        <CardTitle>Escolher a conta de anúncios</CardTitle>
+        <CardDescription className="text-slate-300">
           A conta selecionada define qual inventário e qual visão geral alimentarão o CRM daqui em diante.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <MetaAdsPersistentError error={accountsError} onRetry={onRetry} />
         {!connected ? (
-          <div className="text-sm text-blue-100/70">Conecte a Meta primeiro para listar as contas disponíveis.</div>
+          <div className="text-sm text-slate-300">Conecte a Meta primeiro para listar as contas disponíveis.</div>
         ) : accounts.length === 0 ? (
-          <div className="text-sm text-blue-100/70">Nenhuma conta encontrada para este usuário/token.</div>
+          <div className="text-sm text-slate-300">Nenhuma conta encontrada para este usuário/token.</div>
         ) : (
           <Table>
             <TableHeader>
-              <TableRow>
+              <TableRow className="border-slate-800">
                 <TableHead>Conta</TableHead>
                 <TableHead>Nome</TableHead>
                 <TableHead>Moeda</TableHead>
@@ -394,16 +367,16 @@ export function MetaAdsAccountsPanel({
             </TableHeader>
             <TableBody>
               {accounts.map((account) => (
-                <TableRow key={account.id}>
-                  <TableCell className="font-mono">{account.id}</TableCell>
-                  <TableCell>{account.name || '—'}</TableCell>
-                  <TableCell>{account.currency || '—'}</TableCell>
-                  <TableCell>{account.timezone_name || '—'}</TableCell>
+                <TableRow key={account.id} className="border-slate-800/80">
+                  <TableCell className="font-mono text-slate-200">{account.id}</TableCell>
+                  <TableCell className="text-slate-100">{account.name || '—'}</TableCell>
+                  <TableCell className="text-slate-300">{account.currency || '—'}</TableCell>
+                  <TableCell className="text-slate-300">{account.timezone_name || '—'}</TableCell>
                   <TableCell className="text-right">
                     {account.isSelected ? (
-                      <Badge className="bg-emerald-500/15 text-emerald-200 border border-emerald-500/30">Selecionada</Badge>
+                      <Badge className="border border-emerald-500/30 bg-emerald-500/15 text-emerald-100">Selecionada</Badge>
                     ) : (
-                      <Button size="sm" variant="outline" onClick={() => onSelectAccount(account.id)} disabled={refreshing}>
+                      <Button size="sm" variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={() => onSelectAccount(account.id)} disabled={refreshing}>
                         Selecionar
                       </Button>
                     )}
@@ -442,66 +415,66 @@ export function MetaAdsOverviewPanel({
     <>
       <MetaAdsPersistentError error={overviewError} onRetry={onRetry} />
       <div className="grid gap-4 md:grid-cols-4">
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Spend (7 dias)</CardDescription>
+            <CardDescription className="text-slate-400">Spend (7 dias)</CardDescription>
             <CardTitle>{formatCurrency(summary?.spend ?? 0, selectedAccount.currency || 'USD')}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Impressões</CardDescription>
+            <CardDescription className="text-slate-400">Impressões</CardDescription>
             <CardTitle>{formatNumber(summary?.impressions ?? 0)}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Clicks</CardDescription>
+            <CardDescription className="text-slate-400">Clicks</CardDescription>
             <CardTitle>{formatNumber(summary?.clicks ?? 0)}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Campanhas ativas</CardDescription>
+            <CardDescription className="text-slate-400">Campanhas ativas</CardDescription>
             <CardTitle>{formatNumber(summary?.activeCampaigns ?? 0)}</CardTitle>
           </CardHeader>
         </Card>
       </div>
 
       <div className="grid gap-4 md:grid-cols-4">
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Campanhas</CardDescription>
+            <CardDescription className="text-slate-400">Campanhas</CardDescription>
             <CardTitle>{campaignCount}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Conjuntos</CardDescription>
+            <CardDescription className="text-slate-400">Conjuntos</CardDescription>
             <CardTitle>{adSetCount}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Anúncios</CardDescription>
+            <CardDescription className="text-slate-400">Anúncios</CardDescription>
             <CardTitle>{adCount}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="glass-card border-white/10">
+        <Card className={panelClass}>
           <CardHeader>
-            <CardDescription>Criativos</CardDescription>
+            <CardDescription className="text-slate-400">Criativos</CardDescription>
             <CardTitle>{creativeCount}</CardTitle>
           </CardHeader>
         </Card>
       </div>
 
-      <Card className="glass-card border-white/10">
+      <Card className={panelClass}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <PresentationChart className="h-5 w-5 text-blue-300" />
+            <PresentationChart className="h-5 w-5 text-sky-300" />
             Tendência de gasto
           </CardTitle>
-          <CardDescription>Últimos 7 dias da conta selecionada.</CardDescription>
+          <CardDescription className="text-slate-300">Últimos 7 dias da conta selecionada.</CardDescription>
         </CardHeader>
         <CardContent className="h-72">
           <ResponsiveContainer width="100%" height="100%">
@@ -530,20 +503,20 @@ export function MetaAdsInventoryPanel({
   return (
     <>
       <MetaAdsPersistentError error={inventoryError} onRetry={onRetry} />
-      <Card className="glass-card border-white/10">
+      <Card className={panelClass}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <FadersHorizontal className="h-5 w-5 text-blue-300" />
+            <FadersHorizontal className="h-5 w-5 text-sky-300" />
             Campanhas
           </CardTitle>
-          <CardDescription>
+          <CardDescription className="text-slate-300">
             Relação da conta selecionada com total de conjuntos e anúncios por campanha.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Table>
             <TableHeader>
-              <TableRow>
+              <TableRow className="border-slate-800">
                 <TableHead>Campanha</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Objetivo</TableHead>
@@ -553,7 +526,7 @@ export function MetaAdsInventoryPanel({
             </TableHeader>
             <TableBody>
               {inventory.campaigns.map((campaign) => (
-                <TableRow key={campaign.id}>
+                <TableRow key={campaign.id} className="border-slate-800/80">
                   <TableCell>
                     <div className="space-y-1">
                       <div className="font-medium text-white">{campaign.name || campaign.id}</div>
@@ -575,17 +548,17 @@ export function MetaAdsInventoryPanel({
         </CardContent>
       </Card>
 
-      <Card className="glass-card border-white/10">
+      <Card className={panelClass}>
         <CardHeader>
           <CardTitle>Anúncios</CardTitle>
-          <CardDescription>
+          <CardDescription className="text-slate-300">
             Mapa direto de anúncios com campanha, conjunto e criativo associados.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Table>
             <TableHeader>
-              <TableRow>
+              <TableRow className="border-slate-800">
                 <TableHead>Anúncio</TableHead>
                 <TableHead>Campanha</TableHead>
                 <TableHead>Conjunto</TableHead>
@@ -595,7 +568,7 @@ export function MetaAdsInventoryPanel({
             </TableHeader>
             <TableBody>
               {inventory.ads.map((ad: any) => (
-                <TableRow key={ad.id}>
+                <TableRow key={ad.id} className="border-slate-800/80">
                   <TableCell>
                     <div className="space-y-1">
                       <div className="font-medium text-white">{ad.name || ad.id}</div>
@@ -617,19 +590,19 @@ export function MetaAdsInventoryPanel({
         </CardContent>
       </Card>
 
-      <Card className="glass-card border-white/10">
+      <Card className={panelClass}>
         <CardHeader>
           <CardTitle>Criativos</CardTitle>
-          <CardDescription>
+          <CardDescription className="text-slate-300">
             Criativos deduplicados a partir dos anúncios retornados pela Meta para a conta selecionada.
           </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {inventory.creatives.length === 0 ? (
-            <div className="text-sm text-blue-100/70">Nenhum criativo encontrado.</div>
+            <div className="text-sm text-slate-300">Nenhum criativo encontrado.</div>
           ) : (
             inventory.creatives.map((creative: any) => (
-              <div key={creative.id} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div key={creative.id} className="rounded-2xl border border-slate-800/80 bg-slate-900/55 p-4">
                 {creative.thumbnailUrl ? (
                   <img
                     src={creative.thumbnailUrl}
@@ -639,9 +612,9 @@ export function MetaAdsInventoryPanel({
                 ) : null}
                 <div className="space-y-1">
                   <div className="font-medium text-white">{creative.name || creative.id}</div>
-                  <div className="font-mono text-xs text-blue-100/60">{creative.id}</div>
-                  <div className="text-xs text-blue-100/70">Campanha: {creative.campaignId || '—'}</div>
-                  <div className="text-xs text-blue-100/70">Anúncio: {creative.adName || creative.adId || '—'}</div>
+                  <div className="font-mono text-xs text-slate-400">{creative.id}</div>
+                  <div className="text-xs text-slate-300">Campanha: {creative.campaignId || '—'}</div>
+                  <div className="text-xs text-slate-300">Anúncio: {creative.adName || creative.adId || '—'}</div>
                 </div>
               </div>
             ))

--- a/frontend/metaAdsState.ts
+++ b/frontend/metaAdsState.ts
@@ -138,8 +138,8 @@ export function buildMetaAdsHealthState({
         ? `Conta selecionada: ${selectedAccount.name || selectedAccount.id}. Use Visão geral, Inventário e Tracking para operar.`
         : 'A integração está conectada e pronta para uso.',
       tone: 'success',
-      ctaLabel: 'Ver visão geral',
-      ctaTab: 'overview',
+      ctaLabel: 'Gerenciar conexão',
+      ctaTab: 'connect',
     }
   }
 
@@ -149,17 +149,13 @@ export function buildMetaAdsHealthState({
       title: 'Conexão ativa, mas falta escolher a conta',
       description: 'O login Meta já está válido. Selecione a conta de anúncios que deve alimentar o CRM.',
       tone: 'warning',
-      ctaLabel: 'Selecionar conta',
-      ctaTab: 'connect',
     }
   }
 
   return {
     mode,
     title: 'Conecte a conta Meta para liberar o módulo',
-    description: 'Comece pela aba Conexão, autorize o Facebook e depois selecione a conta de anúncios.',
+    description: 'Autorize o Facebook, depois escolha a conta de anúncios que deve alimentar o CRM.',
     tone: 'neutral',
-    ctaLabel: 'Conectar agora',
-    ctaTab: 'connect',
   }
 }

--- a/frontend/metaTrackingLocalMock.ts
+++ b/frontend/metaTrackingLocalMock.ts
@@ -1,0 +1,343 @@
+import { isMetaAdsLocalMockEnabled } from '@/metaAdsLocalMock'
+
+export type TrackingOverviewResponse = {
+  ok: boolean
+  partial?: boolean
+  warnings?: string[]
+  generatedAt?: number
+  window?: { days: number; sinceIso: string }
+  coverage?: {
+    confirmedBookings: number
+    whatsappClicks: number
+    trackingContext: number
+    metaEventId: number
+    facebookIds: number
+    marketingConsent: number
+    analyticsConsent: number
+    whatsappTracking: number
+    scheduleDelivery: number
+    contactDelivery: number
+  }
+  previousCoverage?: {
+    trackingContext: number
+    facebookIds: number
+    marketingConsent: number
+  }
+  alerts?: Array<{
+    severity: 'critical' | 'warning'
+    code: string
+    title: string
+    message: string
+  }>
+  health?: {
+    status: 'healthy' | 'degraded' | 'critical'
+    label: string
+    summary: string
+  }
+  reconciliation?: {
+    buckets?: Array<{
+      bucket: 'sem_origem' | 'origem_first_party' | 'origem_meta_completa'
+      label: string
+      count: number
+      percent: number
+    }>
+    incompleteBookings?: Array<{
+      id: string
+      createdAtMs: number
+      unitSlug: string
+      patient: string | null
+      utmSource: string | null
+      utmCampaign: string | null
+      landingPage: string | null
+      metaEventId: string | null
+      hasFacebookIds: boolean
+      coverageBucket: string
+      incompleteCauses: string[]
+      primaryCause: string
+      scheduleStatus: string | null
+    }>
+    retryCandidates?: Array<{
+      id: string
+      createdAtMs: number
+      eventName: string
+      eventId: string
+      bookingId: string | null
+      waClickId: string | null
+      httpStatus: number | null
+      errorMessage: string | null
+      normalizedReason: string
+    }>
+  }
+  governance?: {
+    campaignRule: string
+    validExamples: string[]
+    invalidExamples: string[]
+    crossDomainAllowlist: Array<{
+      host: string
+      purpose: string
+      allowedFromPublicSite: boolean
+    }>
+  }
+  validationCadence?: {
+    smoke: string
+    functional: string
+    coverageAudit: string
+    recurringChecks: string[]
+  }
+  whatsappContract?: {
+    status: string
+    lifecycle: string[]
+    description: string
+  }
+  website?: {
+    available: boolean
+    error?: string
+    sourceUrl?: string
+    data?: {
+      summary?: Record<string, number>
+      topSources?: Array<{ utmSource: string; count: number }>
+      topCampaigns?: Array<{ utmCampaign: string; count: number }>
+      byUnit?: Array<{ unitSlug: string; count: number }>
+      recentBookings?: Array<{
+        id: string
+        createdAtMs: number
+        unitSlug: string
+        doctorSlug: string
+        serviceId: string
+        patient: string | null
+        whatsapp: string | null
+        metaEventId: string | null
+        marketingConsent: boolean
+        analyticsConsent: boolean
+        utmSource: string | null
+        utmCampaign: string | null
+        utmMedium: string | null
+        landingPage: string | null
+        hasFacebookIds: boolean
+      }>
+      recentWhatsappClicks?: Array<{
+        id: string
+        createdAtMs: number
+        eventId: string
+        waClickId: string
+        placement: string | null
+        source: string | null
+        unitSlug: string | null
+        doctorName: string | null
+        bookingId: string | null
+        pagePath: string | null
+        utmSource: string | null
+        utmCampaign: string | null
+      }>
+      recentCapiIssues?: Array<{
+        id: string
+        createdAtMs: number
+        eventName: string
+        eventId: string
+        bookingId: string | null
+        waClickId: string | null
+        httpStatus: number | null
+        errorMessage: string | null
+        normalizedReason?: string
+        retryable?: boolean
+      }>
+    }
+  }
+  whatsapp?: {
+    available: boolean
+    error?: string
+    data?: {
+      summary?: Record<string, number>
+      stages?: Array<{ funnelStatus: string; count: number }>
+      topSources?: Array<{ utmSource: string; count: number }>
+      topCampaigns?: Array<{ utmCampaign: string; count: number }>
+      recentConversations?: Array<{
+        id: string
+        unitSlug: string
+        waClickId: string
+        funnelStatus: string
+        needsHuman: boolean
+        updatedAt: string
+        lastMessageAt: string | null
+        phone: string | null
+        externalId: string | null
+        utmSource: string | null
+        utmCampaign: string | null
+      }>
+      recentAppointments?: Array<{
+        id: string
+        unitSlug: string | null
+        waClickId: string
+        status: string
+        startAt: string | null
+        createdAt: string
+        phone: string | null
+        externalId: string | null
+        utmSource: string | null
+        utmCampaign: string | null
+      }>
+    }
+  }
+}
+
+export function isMetaTrackingLocalMockEnabled() {
+  return isMetaAdsLocalMockEnabled()
+}
+
+export function getMetaTrackingLocalOverview(days = 30): TrackingOverviewResponse {
+  const now = Date.now()
+  return {
+    ok: true,
+    generatedAt: now,
+    partial: false,
+    warnings: ['tracking_local_preview'],
+    window: {
+      days,
+      sinceIso: new Date(now - days * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    coverage: {
+      confirmedBookings: 28,
+      whatsappClicks: 63,
+      trackingContext: 96,
+      metaEventId: 93,
+      facebookIds: 89,
+      marketingConsent: 98,
+      analyticsConsent: 95,
+      whatsappTracking: 100,
+      scheduleDelivery: 94,
+      contactDelivery: 97,
+    },
+    previousCoverage: {
+      trackingContext: 88,
+      facebookIds: 81,
+      marketingConsent: 96,
+    },
+    alerts: [
+      {
+        severity: 'warning',
+        code: 'LOCAL_PREVIEW_MODE',
+        title: 'Modo local controlado',
+        message: 'Este painel usa um cenário simulado para validar a experiência do módulo Meta Ads antes do deploy.',
+      },
+    ],
+    health: {
+      status: 'healthy',
+      label: 'Tracking íntegro no preview local',
+      summary: 'Atributos first-party, Schedule via CAPI e cliques WhatsApp estão consistentes neste cenário de teste.',
+    },
+    reconciliation: {
+      buckets: [
+        { bucket: 'origem_meta_completa', label: 'Origem Meta completa', count: 21, percent: 75 },
+        { bucket: 'origem_first_party', label: 'Origem first-party', count: 5, percent: 18 },
+        { bucket: 'sem_origem', label: 'Sem origem', count: 2, percent: 7 },
+      ],
+      incompleteBookings: [
+        {
+          id: 'bk_102',
+          createdAtMs: now - 5 * 60 * 60 * 1000,
+          unitSlug: 'barra-shopping-sul',
+          patient: 'Paciente Preview',
+          utmSource: 'instagram',
+          utmCampaign: 'campanha-whatsapp-facial',
+          landingPage: '/botox-barra',
+          metaEventId: null,
+          hasFacebookIds: true,
+          coverageBucket: 'origem_first_party',
+          incompleteCauses: ['meta_event_id_missing'],
+          primaryCause: 'Meta Event ID ausente no booking confirmado',
+          scheduleStatus: 'sent',
+        },
+      ],
+      retryCandidates: [
+        {
+          id: 'retry_01',
+          createdAtMs: now - 2 * 60 * 60 * 1000,
+          eventName: 'Schedule',
+          eventId: 'sched_preview_01',
+          bookingId: 'bk_102',
+          waClickId: 'wa_preview_01',
+          httpStatus: 500,
+          errorMessage: 'temporary upstream timeout',
+          normalizedReason: 'retryable_timeout',
+        },
+      ],
+    },
+    governance: {
+      campaignRule: 'utm_campaign deve espelhar o identificador operacional da campanha Meta',
+      validExamples: ['meta-whatsapp-botox-barra', 'meta-leads-limpeza-centro'],
+      invalidExamples: ['campanha nova', 'teste', 'ads maio'],
+      crossDomainAllowlist: [
+        { host: 'espacofacial.com', purpose: 'Site institucional', allowedFromPublicSite: true },
+        { host: 'crm.skincos.com.br', purpose: 'CRM interno', allowedFromPublicSite: false },
+      ],
+    },
+    validationCadence: {
+      smoke: 'a cada ajuste de UX do módulo',
+      functional: 'antes de publicar Meta Ads',
+      coverageAudit: 'semanal',
+      recurringChecks: ['tracking_context', 'Schedule CAPI', 'cliques WhatsApp', 'inventory Meta'],
+    },
+    whatsappContract: {
+      status: 'ativo',
+      lifecycle: ['click', 'redirect', 'conversation', 'appointment'],
+      description: 'O fluxo first-party continua sendo a ponte entre clique, conversa e agendamento atribuído.',
+    },
+    website: {
+      available: true,
+      sourceUrl: 'https://espacofacial.com',
+      data: {
+        summary: {
+          confirmedBookings: 28,
+          whatsappClicks: 63,
+          bookingsWithTrackingContext: 27,
+          bookingsWithMetaEventId: 26,
+          bookingsWithFacebookIds: 25,
+          bookingsWithMarketingConsent: 28,
+          bookingsWithAnalyticsConsent: 27,
+          whatsappClicksWithTrackingContext: 63,
+          capiScheduleOk: 17,
+          capiScheduleFailed: 1,
+          capiContactOk: 31,
+          capiContactFailed: 1,
+        },
+        topSources: [
+          { utmSource: 'instagram', count: 16 },
+          { utmSource: 'facebook', count: 7 },
+          { utmSource: 'google', count: 5 },
+        ],
+        topCampaigns: [
+          { utmCampaign: 'meta-whatsapp-botox-barra', count: 11 },
+          { utmCampaign: 'meta-leads-limpeza-centro', count: 8 },
+          { utmCampaign: 'google-institucional-maio', count: 4 },
+        ],
+        byUnit: [
+          { unitSlug: 'barra-shopping-sul', count: 14 },
+          { unitSlug: 'centro', count: 9 },
+          { unitSlug: 'nilo-peçanha', count: 5 },
+        ],
+      },
+    },
+    whatsapp: {
+      available: true,
+      data: {
+        summary: {
+          conversations_total: 19,
+          appointments_total: 7,
+        },
+        stages: [
+          { funnelStatus: 'new', count: 6 },
+          { funnelStatus: 'qualified', count: 8 },
+          { funnelStatus: 'appointment_booked', count: 5 },
+        ],
+        topSources: [
+          { utmSource: 'instagram', count: 12 },
+          { utmSource: 'facebook', count: 4 },
+        ],
+        topCampaigns: [
+          { utmCampaign: 'meta-whatsapp-botox-barra', count: 10 },
+          { utmCampaign: 'meta-leads-limpeza-centro', count: 4 },
+        ],
+      },
+    },
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fetch-face-models": "node ./scripts/fetch-face-models.mjs",
+    "smoke:meta-ads:local": "node ./scripts/meta-ads-local-smoke.cjs",
     "optimize": "vite optimize",
     "preview": "vite preview",
     "test:e2e": "playwright test"

--- a/frontend/scripts/meta-ads-local-smoke.cjs
+++ b/frontend/scripts/meta-ads-local-smoke.cjs
@@ -1,0 +1,66 @@
+/* eslint-disable no-console */
+const fs = require('fs')
+const path = require('path')
+const { chromium } = require('playwright')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const ARTIFACT_DIR = path.join(REPO_ROOT, 'output', 'playwright')
+fs.mkdirSync(ARTIFACT_DIR, { recursive: true })
+
+const SCENARIO = process.env.META_ADS_LOCAL_SCENARIO || 'connected-ready'
+const HEADED = process.env.HEADED === '1' || process.env.HEADED === 'true'
+const TIMEOUT_MS = Math.max(5000, parseInt(String(process.env.TIMEOUT_MS || ''), 10) || 60000)
+const URL =
+  process.env.CRM_URL ||
+  `http://127.0.0.1:8791/?module=meta-ads&metaAdsLocalScenario=${encodeURIComponent(SCENARIO)}`
+
+function nowStamp() {
+  const d = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+}
+
+async function expectVisible(locator, label) {
+  try {
+    await locator.first().waitFor({ state: 'visible', timeout: TIMEOUT_MS })
+  } catch {
+    throw new Error(`Expected visible: ${label}`)
+  }
+}
+
+async function main() {
+  const stamp = nowStamp()
+  const screenshotPath = path.join(ARTIFACT_DIR, `meta-ads-local-${SCENARIO}-${stamp}.png`)
+  const browser = await chromium.launch({ headless: !HEADED })
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    ignoreHTTPSErrors: true,
+  })
+  const page = await context.newPage()
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS })
+  await expectVisible(page.getByRole('heading', { name: 'Meta Ads' }), 'Meta Ads heading')
+
+  if (SCENARIO === 'connected-ready') {
+    await expectVisible(page.getByText('Conta Meta pronta para operar'), 'connected ready banner')
+    await expectVisible(page.getByText('Conta ativa: Conta Principal'), 'selected account')
+    await expectVisible(page.getByRole('tab', { name: 'Visão geral' }), 'overview tab')
+    await page.getByRole('tab', { name: 'Inventário' }).click()
+    await expectVisible(page.getByText('Campanha Primavera'), 'inventory campaign')
+  } else if (SCENARIO === 'unauthorized') {
+    await expectVisible(page.getByText('Faça login no CRM para continuar'), 'unauthorized message')
+    await expectVisible(page.getByText('UNAUTHORIZED · HTTP 401'), 'unauthorized code')
+  } else {
+    await expectVisible(page.getByRole('button', { name: 'Conectar com Facebook' }), 'connect button')
+  }
+
+  await page.screenshot({ path: screenshotPath, fullPage: true })
+  await context.close()
+  await browser.close()
+  console.log(`[meta-ads-local-smoke] OK: ${URL}`)
+}
+
+main().catch((err) => {
+  console.error('[meta-ads-local-smoke] FAIL:', err?.message || err)
+  process.exitCode = 1
+})

--- a/frontend/tests/metaAdsModule.test.ts
+++ b/frontend/tests/metaAdsModule.test.ts
@@ -149,7 +149,6 @@ describe('Meta Ads state helpers', () => {
     expect(health).toMatchObject({
       mode: 'connected-no-account',
       tone: 'warning',
-      ctaTab: 'connect',
     })
     expect(health.description).toContain('Selecione a conta de anúncios')
   })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "scripts": {
+    "crm:local": "bash ./scripts/run-local-crm.sh",
+    "crm:local:meta-ads": "CRM_MODULE=meta-ads bash ./scripts/run-local-crm.sh",
     "quality:frontend": "npm --prefix frontend run lint && npm --prefix frontend run typecheck && npm --prefix frontend run test && npm --prefix frontend run build",
     "quality:website": "npm --prefix website run lint && npm --prefix website run typecheck && npm --prefix website run test && npm --prefix website run build",
     "quality:backend:crm-api": "npm --prefix backend/apps/crm-api test",

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+BACKEND_DIR="$ROOT_DIR/backend"
+INSUMOS_HELPER="$ROOT_DIR/backend/scripts/insumos.sh"
+INSUMOS_EXPORTER="$ROOT_DIR/backend/scripts/insumos-d1-export.cjs"
+INSUMOS_SEEDER="$ROOT_DIR/backend/scripts/insumos-seed.sh"
+
+CRM_HOST="${CRM_HOST:-127.0.0.1}"
+CRM_VITE_PORT="${CRM_VITE_PORT:-5173}"
+CRM_PAGES_PORT="${CRM_PAGES_PORT:-8791}"
+CRM_ROUTE="${CRM_ROUTE:-/}"
+CRM_MODULE="${CRM_MODULE:-}"
+CRM_PROFILE="${CRM_PROFILE:-realistic}"
+CRM_OPEN_BROWSER="${CRM_OPEN_BROWSER:-1}"
+CRM_SMOKE="${CRM_SMOKE:-0}"
+CRM_BUILD_BEFORE_START="${CRM_BUILD_BEFORE_START:-1}"
+CRM_META_ADS_SCENARIO="${CRM_META_ADS_SCENARIO:-}"
+CRM_WITH_INSUMOS="${CRM_WITH_INSUMOS:-0}"
+CRM_INSUMOS_PORT="${CRM_INSUMOS_PORT:-8787}"
+CRM_INSUMOS_SNAPSHOT="${CRM_INSUMOS_SNAPSHOT:-}"
+CRM_REFRESH_INSUMOS_SNAPSHOT="${CRM_REFRESH_INSUMOS_SNAPSHOT:-0}"
+CRM_INSUMOS_SEED_TOKEN="${CRM_INSUMOS_SEED_TOKEN:-dev-seed-token}"
+PID_FILE="${CRM_PID_FILE:-$ROOT_DIR/.crm-local-dev.pid}"
+LOG_FILE="${CRM_LOG_FILE:-$ROOT_DIR/.crm-local-dev.log}"
+SNAPSHOT_DEFAULT_PATH="${CRM_INSUMOS_SNAPSHOT_DEFAULT:-$ROOT_DIR/backend/var/local/insumos-snapshot.latest.json}"
+
+usage() {
+  cat <<EOF
+SKINCOS • Testar CRM local
+
+Uso:
+  $(basename "$0") [rota] [opções]
+
+Perfis:
+  realistic (default)  Bypass local do shell CRM + Pages Functions local + Meta/Escala reais quando configurados.
+                       Se --with-insumos estiver ativo, usa Worker local de Insumos com snapshot opcional.
+  session              Sem bypass local. Exige login manual no localhost para testar a sessão/permite validar auth real.
+
+Opções:
+  --profile NAME                 realistic | session
+  --module NAME                  Abre o CRM já no módulo informado (ex.: meta-ads)
+  --crm-host HOST                Host do Vite (default: 127.0.0.1)
+  --vite-port PORT               Porta do Vite (default: 5173)
+  --pages-port PORT              Porta do Pages local (default: 8791)
+  --meta-ads-scenario NAME       live | disconnected | connected-no-account | connected-ready | unauthorized
+                                 Ativa um cenário local controlado do Meta Ads em localhost.
+  --skip-build                   Não roda build do frontend antes de subir o Pages local
+  --with-insumos                 Sobe Worker local do Insumos e aponta o CRM para ele
+  --insumos-port PORT            Porta do Worker local de Insumos (default: 8787)
+  --insumos-snapshot FILE        Faz seed local do Insumos com este snapshot JSON
+  --refresh-insumos-snapshot     Exporta um snapshot novo do D1 remoto antes do seed
+  --insumos-seed-token TOKEN     Token local usado para /admin/seed (default: dev-seed-token)
+  --smoke                        Roda uma smoke local do módulo após subir o CRM
+  --no-browser                   Não abre o navegador automaticamente
+  --stop                         Encerra a instância atual e sai
+  -h, --help                     Mostrar ajuda
+
+Exemplos:
+  ./scripts/run-local-crm.sh
+  ./scripts/run-local-crm.sh --module meta-ads
+  ./scripts/run-local-crm.sh --module meta-ads --meta-ads-scenario live
+  ./scripts/run-local-crm.sh --module meta-ads --smoke
+  ./scripts/run-local-crm.sh /meta-ads --with-insumos --insumos-snapshot ./tmp/insumos.json
+  ./scripts/run-local-crm.sh --profile session
+EOF
+}
+
+case "$CRM_ROUTE" in
+  /*) ;;
+  *) CRM_ROUTE="/$CRM_ROUTE" ;;
+esac
+
+STOP_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile) shift; CRM_PROFILE="$1" ;;
+    --module) shift; CRM_MODULE="$1" ;;
+    --crm-host) shift; CRM_HOST="$1" ;;
+    --vite-port) shift; CRM_VITE_PORT="$1" ;;
+    --pages-port) shift; CRM_PAGES_PORT="$1" ;;
+    --meta-ads-scenario) shift; CRM_META_ADS_SCENARIO="$1" ;;
+    --skip-build) CRM_BUILD_BEFORE_START=0 ;;
+    --with-insumos) CRM_WITH_INSUMOS=1 ;;
+    --insumos-port) shift; CRM_INSUMOS_PORT="$1" ;;
+    --insumos-snapshot) shift; CRM_INSUMOS_SNAPSHOT="$1" ;;
+    --refresh-insumos-snapshot) CRM_REFRESH_INSUMOS_SNAPSHOT=1 ;;
+    --insumos-seed-token) shift; CRM_INSUMOS_SEED_TOKEN="$1" ;;
+    --smoke) CRM_SMOKE=1 ;;
+    --no-browser) CRM_OPEN_BROWSER=0 ;;
+    --stop) STOP_ONLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      if [[ "$1" == /* && "$CRM_ROUTE" == "/" ]]; then
+        CRM_ROUTE="$1"
+      else
+        echo "Opção desconhecida: $1" >&2
+        usage
+        exit 1
+      fi
+      ;;
+  esac
+  shift || true
+done
+
+append_query_param() {
+  local url="$1"
+  local key="$2"
+  local value="$3"
+  if [[ "$url" == *\?* ]]; then
+    printf '%s&%s=%s' "$url" "$key" "$value"
+  else
+    printf '%s?%s=%s' "$url" "$key" "$value"
+  fi
+}
+
+if [[ -n "$CRM_MODULE" ]]; then
+  CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "module" "$CRM_MODULE")"
+fi
+
+if [[ "$CRM_MODULE" == "meta-ads" && -z "$CRM_META_ADS_SCENARIO" && "$CRM_PROFILE" == "realistic" ]]; then
+  CRM_META_ADS_SCENARIO="connected-ready"
+fi
+
+if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
+  CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "metaAdsLocalScenario" "$CRM_META_ADS_SCENARIO")"
+fi
+
+DEFAULT_URL="http://localhost:${CRM_PAGES_PORT}${CRM_ROUTE}"
+NETWORK_URL="http://${CRM_HOST}:${CRM_PAGES_PORT}${CRM_ROUTE}"
+
+collect_descendants() {
+  local parent_pid="$1"
+  local child_pid
+  if ! command -v pgrep >/dev/null 2>&1; then
+    return 0
+  fi
+  while IFS= read -r child_pid; do
+    [[ -n "$child_pid" ]] || continue
+    collect_descendants "$child_pid"
+    echo "$child_pid"
+  done < <(pgrep -P "$parent_pid" 2>/dev/null || true)
+}
+
+terminate_pid() {
+  local target_pid="$1"
+  local descendant_pids
+  if ! kill -0 "$target_pid" >/dev/null 2>&1; then
+    return 0
+  fi
+  descendant_pids="$(collect_descendants "$target_pid" | tr '\n' ' ')"
+  if [[ -n "$descendant_pids" ]]; then
+    kill -TERM $descendant_pids >/dev/null 2>&1 || true
+  fi
+  kill -TERM "$target_pid" >/dev/null 2>&1 || true
+  sleep 2
+  if [[ -n "$descendant_pids" ]]; then
+    kill -KILL $descendant_pids >/dev/null 2>&1 || true
+  fi
+  kill -KILL "$target_pid" >/dev/null 2>&1 || true
+}
+
+stop_existing() {
+  local existing_pid
+
+  if [[ -f "$PID_FILE" ]]; then
+    existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+      echo "Instância anterior do CRM local detectada (PID $existing_pid). Finalizando..."
+      terminate_pid "$existing_pid"
+    fi
+    rm -f "$PID_FILE"
+  fi
+}
+
+assert_port_free() {
+  local port="$1"
+  local label="$2"
+  local line
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+  line="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | tail -n +2 | head -n 1 || true)"
+  if [[ -n "$line" ]]; then
+    echo "[crm-local] Porta $port já está em uso por outro processo ($label)." >&2
+    echo "$line" >&2
+    echo "Use --${label}-port para outra porta ou finalize manualmente o processo atual." >&2
+    exit 1
+  fi
+}
+
+wait_for_http() {
+  local url="$1"
+  local retries="${2:-90}"
+  while [[ "$retries" -gt 0 ]]; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    retries=$((retries - 1))
+  done
+  return 1
+}
+
+wait_for_crm_api() {
+  local url="$1"
+  local retries="${2:-90}"
+  local body
+  while [[ "$retries" -gt 0 ]]; do
+    body="$(curl -fsS "$url" 2>/dev/null || true)"
+    if [[ "$body" == *'"ok":true'* || "$body" == *'"error":"UNAUTHORIZED"'* || "$body" == *'"error": "UNAUTHORIZED"'* ]]; then
+      return 0
+    fi
+    sleep 1
+    retries=$((retries - 1))
+  done
+  return 1
+}
+
+open_browser() {
+  if command -v open >/dev/null 2>&1; then
+    open "$DEFAULT_URL"
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$DEFAULT_URL" >/dev/null 2>&1 || true
+  fi
+}
+
+ensure_frontend_ready() {
+  if [[ ! -d "$FRONTEND_DIR/node_modules" ]]; then
+    echo "Dependências do frontend não encontradas. Instalando..."
+    npm --prefix "$FRONTEND_DIR" install
+  fi
+}
+
+ensure_insumos_seed_config() {
+  local insumos_dev_vars="$ROOT_DIR/backend/apps/insumos/.dev.vars"
+  if [[ ! -f "$insumos_dev_vars" && -f "$ROOT_DIR/backend/apps/insumos/.dev.vars.example" ]]; then
+    cp "$ROOT_DIR/backend/apps/insumos/.dev.vars.example" "$insumos_dev_vars"
+  fi
+  touch "$insumos_dev_vars"
+  if ! grep -qE '^ALLOW_DEV_SEED=' "$insumos_dev_vars"; then
+    printf '\nALLOW_DEV_SEED=true\n' >> "$insumos_dev_vars"
+  fi
+  if ! grep -qE '^INSUMOS_SEED_TOKEN=' "$insumos_dev_vars"; then
+    printf 'INSUMOS_SEED_TOKEN=%s\n' "$CRM_INSUMOS_SEED_TOKEN" >> "$insumos_dev_vars"
+  fi
+}
+
+refresh_insumos_snapshot_if_needed() {
+  if [[ "$CRM_REFRESH_INSUMOS_SNAPSHOT" != "1" ]]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$SNAPSHOT_DEFAULT_PATH")"
+  local out_path="${CRM_INSUMOS_SNAPSHOT:-$SNAPSHOT_DEFAULT_PATH}"
+  echo "[crm-local] Exportando snapshot remoto de Insumos para $out_path"
+  node "$INSUMOS_EXPORTER" "$out_path"
+  CRM_INSUMOS_SNAPSHOT="$out_path"
+}
+
+start_insumos_local() {
+  ensure_insumos_seed_config
+  echo "[crm-local] Iniciando Worker local do Insumos em :$CRM_INSUMOS_PORT"
+  (
+    cd "$ROOT_DIR"
+    PORT="$CRM_INSUMOS_PORT" ./backend/scripts/insumos.sh dev
+  ) >>"$LOG_FILE" 2>&1 &
+  INSUMOS_PID=$!
+
+  if ! wait_for_http "http://127.0.0.1:${CRM_INSUMOS_PORT}/insumos/health" 90; then
+    echo "[crm-local] Worker local do Insumos não respondeu em tempo hábil." >&2
+    exit 1
+  fi
+
+  if [[ -n "$CRM_INSUMOS_SNAPSHOT" ]]; then
+    if [[ ! -f "$CRM_INSUMOS_SNAPSHOT" ]]; then
+      echo "[crm-local] Snapshot do Insumos não encontrado: $CRM_INSUMOS_SNAPSHOT" >&2
+      exit 1
+    fi
+    echo "[crm-local] Aplicando seed de Insumos com $CRM_INSUMOS_SNAPSHOT"
+    INSUMOS_SEED_TOKEN="$CRM_INSUMOS_SEED_TOKEN" \
+      INSUMOS_API_URL="http://127.0.0.1:${CRM_INSUMOS_PORT}/insumos" \
+      "$INSUMOS_SEEDER" "$CRM_INSUMOS_SNAPSHOT" >>"$LOG_FILE" 2>&1
+  fi
+}
+
+if [[ "$STOP_ONLY" == "1" ]]; then
+  stop_existing
+  echo "CRM local finalizado."
+  exit 0
+fi
+
+if [[ "$CRM_PROFILE" != "realistic" && "$CRM_PROFILE" != "session" ]]; then
+  echo "Perfil inválido: $CRM_PROFILE" >&2
+  usage
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm não encontrado no PATH." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl não encontrado no PATH." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+
+refresh_insumos_snapshot_if_needed
+
+echo ""
+echo "SKINCOS • Testar CRM local"
+echo "Perfil: $CRM_PROFILE"
+echo "Rota inicial: $CRM_ROUTE"
+if [[ -n "$CRM_MODULE" ]]; then
+  echo "Módulo inicial: $CRM_MODULE"
+fi
+if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" ]]; then
+  echo "Cenário Meta Ads: $CRM_META_ADS_SCENARIO"
+fi
+echo "URLs:"
+echo "  Local  : $DEFAULT_URL"
+echo "  Rede   : $NETWORK_URL"
+if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
+  echo "Insumos local: http://127.0.0.1:${CRM_INSUMOS_PORT}/insumos"
+  if [[ -n "$CRM_INSUMOS_SNAPSHOT" ]]; then
+    echo "Snapshot Insumos: $CRM_INSUMOS_SNAPSHOT"
+  fi
+fi
+echo "Log: $LOG_FILE"
+echo ""
+
+stop_existing
+assert_port_free "$CRM_VITE_PORT" "vite"
+assert_port_free "$CRM_PAGES_PORT" "pages"
+ensure_frontend_ready
+
+if [[ "$CRM_BUILD_BEFORE_START" == "1" ]]; then
+  echo "[crm-local] Gerando build do frontend para alinhar o shell local ao online..."
+  npm --prefix "$FRONTEND_DIR" run build
+fi
+
+INSUMOS_PID=""
+if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
+  assert_port_free "$CRM_INSUMOS_PORT" "insumos"
+  start_insumos_local
+fi
+
+export VITE_PORT="$CRM_VITE_PORT"
+export PAGES_PORT="$CRM_PAGES_PORT"
+
+if [[ "$CRM_PROFILE" == "realistic" ]]; then
+  export LOCAL_AUTH_BYPASS=true
+  export LOCAL_AUTH_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
+  export LOCAL_AUTH_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}"
+  export LOCAL_AUTH_NAME="${LOCAL_AUTH_NAME:-Teste CRM Local}"
+else
+  export LOCAL_AUTH_BYPASS=false
+fi
+
+if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
+  export INSUMOS_API_TARGET="http://127.0.0.1:${CRM_INSUMOS_PORT}"
+fi
+
+if [[ -n "$CRM_MODULE" ]]; then
+  export VITE_LOCAL_CRM_FOCUS_MODULE="$CRM_MODULE"
+fi
+
+(
+  cd "$FRONTEND_DIR"
+  npm run dev:pages
+) >>"$LOG_FILE" 2>&1 &
+CRM_PID=$!
+
+echo "$$" > "$PID_FILE"
+
+cleanup() {
+  if [[ -n "${CRM_PID:-}" ]]; then
+    kill "$CRM_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${INSUMOS_PID:-}" ]]; then
+    kill "$INSUMOS_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -f "$PID_FILE" ]]; then
+    local tracked_pid
+    tracked_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [[ "$tracked_pid" == "$$" ]]; then
+      rm -f "$PID_FILE"
+    fi
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+if [[ "$CRM_OPEN_BROWSER" == "1" ]]; then
+  (
+    if wait_for_crm_api "http://127.0.0.1:${CRM_PAGES_PORT}/api/auth/me" 120 && wait_for_http "$DEFAULT_URL" 60; then
+      open_browser
+    else
+      echo "[crm-local] O CRM não respondeu em $DEFAULT_URL dentro do tempo esperado."
+    fi
+  ) &
+fi
+
+if [[ "$CRM_SMOKE" == "1" ]]; then
+  if ! wait_for_crm_api "http://127.0.0.1:${CRM_PAGES_PORT}/api/auth/me" 120; then
+    echo "[crm-local] O CRM não respondeu para a smoke em tempo hábil." >&2
+    exit 1
+  fi
+  if [[ "$CRM_MODULE" == "meta-ads" ]]; then
+    echo "[crm-local] Rodando smoke local do Meta Ads..."
+    (
+      cd "$FRONTEND_DIR"
+      CRM_URL="$DEFAULT_URL" META_ADS_LOCAL_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}" npm run smoke:meta-ads:local
+    )
+  else
+    echo "[crm-local] Rodando smoke local padrão..."
+    (
+      cd "$FRONTEND_DIR"
+      CRM_URL="$DEFAULT_URL" node ./scripts/crm-local-smoke.cjs
+    )
+  fi
+fi
+
+echo "Notas:"
+  echo "  - O shell do CRM local usa Pages Functions reais."
+if [[ "$CRM_PROFILE" == "realistic" ]]; then
+  echo "  - Auth local bypass está ligado apenas para localhost."
+else
+  echo "  - Auth local bypass está desligado; faça login manual no localhost."
+fi
+if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
+  echo "  - Insumos está apontando para o worker local, sem risco de gravar na produção."
+else
+  echo "  - Insumos continua usando o target definido em frontend/.dev.vars ou frontend/wrangler.toml."
+fi
+if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
+  echo "  - Meta Ads está em cenário local controlado; o fluxo de conexão é simulado só em localhost."
+fi
+echo ""
+
+wait "$CRM_PID"

--- a/start-crm-local.command
+++ b/start-crm-local.command
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+export CRM_OPEN_BROWSER="${CRM_OPEN_BROWSER:-1}"
+
+exec ./scripts/run-local-crm.sh "${1:-/}"


### PR DESCRIPTION
## Summary
- improve the Meta Ads UX flow and tracking styling to match the CRM surface
- add a CRM local launcher focused on Meta Ads with controlled scenarios and smoke coverage
- mock the tracking panel locally so connected-ready testing no longer depends on the real tracking database

## Validation
- npm --prefix frontend run typecheck
- npm --prefix frontend test -- tests/metaAdsModule.test.ts
- npm --prefix frontend run build
- npm --prefix frontend run test:e2e -- e2e/meta-ads-module.spec.ts
- cd frontend && CRM_URL="http://127.0.0.1:8791/?module=meta-ads&metaAdsLocalScenario=connected-ready" npm run smoke:meta-ads:local