### PR TITLE
fix(meta-ads): support business login config

### DIFF
--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -320,6 +320,8 @@ export function MetaCampaignControlCenter() {
     connectionMode === 'forbidden' ||
     connectionMode === 'misconfigured'
   const scopesLabel = status?.connection.scopes?.join(', ') || 'ads_read, ads_management, business_management'
+  const oauthMode = status?.oauthMode || 'scopes'
+  const businessLoginConfigId = status?.businessLoginConfigId || null
   const connectedUser = status?.connection.metaUserName || status?.connection.metaUserId || null
   const showWorkspaceTabs = connectionMode === 'connected-ready' || connectionMode === 'degraded'
   const showAccountSelection = Boolean(status?.connection.connected)
@@ -343,6 +345,8 @@ export function MetaCampaignControlCenter() {
           />
           <MetaAdsConnectionPanel
             scopesLabel={scopesLabel}
+            oauthMode={oauthMode}
+            businessLoginConfigId={businessLoginConfigId}
             connectedUser={connectedUser}
             connectDisabled={connectActionsDisabled}
             onOAuth={handleOpenOAuth}
@@ -387,6 +391,8 @@ export function MetaCampaignControlCenter() {
             />
             <MetaAdsConnectionPanel
               scopesLabel={scopesLabel}
+              oauthMode={oauthMode}
+              businessLoginConfigId={businessLoginConfigId}
               connectedUser={connectedUser}
               connectDisabled={connectActionsDisabled}
               onOAuth={handleOpenOAuth}

--- a/frontend/functions/api/meta-ads/[[path]].ts
+++ b/frontend/functions/api/meta-ads/[[path]].ts
@@ -78,6 +78,7 @@ function runtimeConfig(context: any) {
     appSecret: String(env.META_APP_SECRET || '').trim(),
     stateSecret: String(env.META_OAUTH_STATE_SECRET || env.META_APP_SECRET || '').trim(),
     graphVersion: String(env.META_GRAPH_VERSION || 'v20.0').trim() || 'v20.0',
+    configId: String(env.META_ADS_CONFIG_ID || '').trim(),
     scopes:
       String(env.META_ADS_OAUTH_SCOPES || '').trim() ||
       ['ads_read', 'ads_management', 'business_management'].join(','),
@@ -119,6 +120,14 @@ function resolveMissingConfig(context: any) {
     missing.push('INTEGRATIONS_ENCRYPTION_SECRET')
   }
   if (!getShareBucket(context)) missing.push('SHARE_BUCKET')
+  return missing
+}
+
+function resolveOauthStartMissingConfig(context: any) {
+  const cfg = runtimeConfig(context)
+  const missing: string[] = []
+  if (!cfg.appId) missing.push('META_APP_ID')
+  if (!cfg.stateSecret) missing.push('META_OAUTH_STATE_SECRET')
   return missing
 }
 
@@ -208,6 +217,8 @@ async function fetchLiveAccounts(context: any, userId: string) {
 async function handleStatus(context: any) {
   const userOrRes = await requireSocialAdmin(context)
   if (userOrRes instanceof Response) return userOrRes
+  const cfg = runtimeConfig(context)
+  const missingConfig = resolveMissingConfig(context)
 
   let connection: MetaAdsConnection | null = null
   try {
@@ -218,8 +229,10 @@ async function handleStatus(context: any) {
 
   return json(200, {
     ok: true,
-    oauthConfigured: resolveMissingConfig(context).length === 0,
-    missingConfig: resolveMissingConfig(context),
+    oauthConfigured: missingConfig.length === 0,
+    missingConfig,
+    oauthMode: cfg.configId ? 'business-config' : 'scopes',
+    businessLoginConfigId: cfg.configId || null,
     connection: connectionSummary(connection),
   })
 }
@@ -228,7 +241,7 @@ async function handleOauthStart(context: any) {
   const userOrRes = await requireSocialAdmin(context)
   if (userOrRes instanceof Response) return userOrRes
   const cfg = runtimeConfig(context)
-  const missing = resolveMissingConfig(context)
+  const missing = resolveOauthStartMissingConfig(context)
   if (missing.length) {
     return apiError(503, 'META_ADS_OAUTH_NOT_CONFIGURED', {
       message: 'A integração Meta Ads ainda não está configurada neste runtime.',
@@ -245,9 +258,14 @@ async function handleOauthStart(context: any) {
     client_id: cfg.appId,
     redirect_uri: redirectUri,
     state,
-    scope: cfg.scopes,
     response_type: 'code',
   })
+  if (cfg.configId) {
+    qs.set('config_id', cfg.configId)
+    qs.set('override_default_response_type', 'true')
+  } else {
+    qs.set('scope', cfg.scopes)
+  }
   return Response.redirect(`https://www.facebook.com/${cfg.graphVersion}/dialog/oauth?${qs.toString()}`, 302)
 }
 

--- a/frontend/metaAdsLocalMock.ts
+++ b/frontend/metaAdsLocalMock.ts
@@ -145,6 +145,8 @@ function buildStatus(state: MetaAdsLocalState): MetaAdsStatusResponse {
     ok: true,
     oauthConfigured: true,
     missingConfig: [],
+    oauthMode: 'scopes',
+    businessLoginConfigId: null,
     connection: {
       connected,
       tokenType: connected ? state.tokenType : null,

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -222,6 +222,8 @@ export function MetaAdsWorkspaceTabs({
 
 export function MetaAdsConnectionPanel({
   scopesLabel,
+  oauthMode,
+  businessLoginConfigId,
   connectedUser,
   connectDisabled,
   onOAuth,
@@ -231,6 +233,8 @@ export function MetaAdsConnectionPanel({
   manualDisabled,
 }: {
   scopesLabel: string
+  oauthMode: 'scopes' | 'business-config'
+  businessLoginConfigId?: string | null
   connectedUser?: string | null
   connectDisabled: boolean
   onOAuth: () => void
@@ -239,12 +243,15 @@ export function MetaAdsConnectionPanel({
   onManualConnect: () => void
   manualDisabled: boolean
 }) {
+  const isBusinessLogin = oauthMode === 'business-config'
   return (
     <Card className={panelClass}>
       <CardHeader>
         <CardTitle>Conectar a conta Meta</CardTitle>
         <CardDescription className="text-slate-300">
-          Comece pelo Facebook OAuth. Se preferir, use um token manual como rota secundária no mesmo painel.
+          {isBusinessLogin
+            ? 'Use o Facebook Login for Business já configurado no app da Meta. O token manual fica como contingência administrativa.'
+            : 'Comece pelo Facebook OAuth. Se preferir, use um token manual como rota secundária no mesmo painel.'}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -253,7 +260,9 @@ export function MetaAdsConnectionPanel({
             <div className="space-y-2">
               <div className="text-sm font-medium text-white">Fluxo recomendado</div>
               <div className="text-sm leading-6 text-slate-300">
-                Autorize a Meta dentro do CRM e, se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.
+                {isBusinessLogin
+                  ? 'Autorize a Meta com a configuração empresarial do app. Se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.'
+                  : 'Autorize a Meta dentro do CRM e, se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.'}
               </div>
             </div>
             <Button className="bg-sky-500 text-slate-950 hover:bg-sky-400" onClick={onOAuth} disabled={connectDisabled}>
@@ -262,6 +271,14 @@ export function MetaAdsConnectionPanel({
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
+          <Badge className="border border-sky-500/30 bg-sky-500/10 text-sky-100">
+            OAuth: {isBusinessLogin ? 'Facebook Login for Business' : 'Facebook Login clássico'}
+          </Badge>
+          {businessLoginConfigId ? (
+            <Badge className="border border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-100">
+              Config ID: {businessLoginConfigId}
+            </Badge>
+          ) : null}
           <Badge className="border border-slate-700 bg-slate-900/60 text-slate-200">
             Escopos: {scopesLabel}
           </Badge>

--- a/frontend/metaAdsTypes.ts
+++ b/frontend/metaAdsTypes.ts
@@ -23,6 +23,8 @@ export type MetaAdsStatusResponse = {
   ok: boolean
   oauthConfigured: boolean
   missingConfig: string[]
+  oauthMode: 'scopes' | 'business-config'
+  businessLoginConfigId: string | null
   connection: {
     connected: boolean
     tokenType: 'manual' | 'oauth' | null

--- a/frontend/tests/metaAdsModule.test.ts
+++ b/frontend/tests/metaAdsModule.test.ts
@@ -12,6 +12,8 @@ const baseStatus = (overrides: Partial<MetaAdsStatusResponse> = {}): MetaAdsStat
   ok: true,
   oauthConfigured: true,
   missingConfig: [],
+  oauthMode: 'scopes',
+  businessLoginConfigId: null,
   connection: {
     connected: false,
     tokenType: null,


### PR DESCRIPTION
## Summary
- support Facebook Login for Business config_id in the Meta Ads OAuth start flow
- expose the OAuth mode and config id in the Meta Ads status/connection UI
- keep local Meta Ads preview aligned with the new business-config contract

## Validation
- npm --prefix frontend run typecheck
- npm --prefix frontend test -- tests/metaAdsModule.test.ts
- npm --prefix frontend run build
- npm --prefix frontend run test:e2e -- e2e/meta-ads-module.spec.ts
- cd frontend && CRM_URL="http://127.0.0.1:8791/?module=meta-ads&metaAdsLocalScenario=connected-ready" npm run smoke:meta-ads:local