### PR TITLE
fix(meta-ads): harden facebook login flow

### DIFF
--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { format, subDays } from 'date-fns'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/card'
@@ -8,10 +8,10 @@ import { metaAdsApi } from '@/metaAdsApi'
 import {
   MetaAdsAccountsPanel,
   MetaAdsConnectionPanel,
-  MetaAdsConnectionProgress,
   MetaAdsEmptyState,
   MetaAdsHealthBanner,
   MetaAdsInventoryPanel,
+  MetaAdsOAuthDialog,
   MetaAdsOverviewPanel,
   MetaAdsPersistentError,
   MetaAdsStatusHero,
@@ -49,6 +49,11 @@ export function MetaCampaignControlCenter() {
   const [manualToken, setManualToken] = useState('')
   const [activeTab, setActiveTab] = useState<MetaAdsTab>('connect')
   const [didAutofocusReadyFlow, setDidAutofocusReadyFlow] = useState(false)
+  const [oauthDialogOpen, setOauthDialogOpen] = useState(false)
+  const [oauthDialogState, setOauthDialogState] = useState<'opening' | 'opened' | 'blocked' | 'closed' | 'error'>('opening')
+  const [oauthDialogError, setOauthDialogError] = useState<MetaAdsApiError | null>(null)
+  const oauthPopupRef = useRef<Window | null>(null)
+  const oauthPollRef = useRef<number | null>(null)
 
   const selectedAccount = useMemo(
     () => accounts.find((account) => account.isSelected) || null,
@@ -73,6 +78,32 @@ export function MetaCampaignControlCenter() {
     setOverviewError(null)
     setInventory(null)
     setInventoryError(null)
+  }
+
+  const clearOAuthWatcher = () => {
+    if (oauthPollRef.current) {
+      window.clearInterval(oauthPollRef.current)
+      oauthPollRef.current = null
+    }
+  }
+
+  const finalizeOAuthSuccess = () => {
+    cleanupOAuthPopup(true)
+    setOauthDialogError(null)
+    setOauthDialogOpen(false)
+    setOauthDialogState('opening')
+  }
+
+  const cleanupOAuthPopup = (closeWindow = false) => {
+    clearOAuthWatcher()
+    if (closeWindow) {
+      try {
+        oauthPopupRef.current?.close()
+      } catch {
+        // no-op
+      }
+    }
+    oauthPopupRef.current = null
   }
 
   const loadStatus = async () => {
@@ -194,7 +225,29 @@ export function MetaCampaignControlCenter() {
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return
-      if (event.data?.type !== 'meta-ads:connected' || !event.data?.ok) return
+      if (event.data?.type !== 'meta-ads:connected') return
+      if (!event.data?.ok) {
+        const error = event.data?.error && typeof event.data.error === 'object'
+          ? {
+              code: String(event.data.error.code || 'META_OAUTH_CONNECT_FAILED'),
+              message: String(event.data.error.message || 'Falha ao concluir o login da Meta.'),
+              hint: event.data.error.hint ? String(event.data.error.hint) : undefined,
+              retryable: false,
+            }
+          : {
+              code: 'META_OAUTH_CONNECT_FAILED',
+              message: 'Falha ao concluir o login da Meta.',
+              retryable: false,
+            }
+        cleanupOAuthPopup(true)
+        setOauthDialogError(error)
+        setOauthDialogState('error')
+        setOauthDialogOpen(true)
+        setStatusError(error)
+        toast.error(error.message)
+        return
+      }
+      finalizeOAuthSuccess()
       setRefreshing(true)
       refreshConnectedState()
         .then(() => {
@@ -211,6 +264,10 @@ export function MetaCampaignControlCenter() {
     return () => window.removeEventListener('message', onMessage)
   }, [])
 
+  useEffect(() => {
+    return () => cleanupOAuthPopup(true)
+  }, [])
+
   const handleRefresh = async () => {
     setRefreshing(true)
     try {
@@ -222,6 +279,62 @@ export function MetaCampaignControlCenter() {
     } finally {
       setRefreshing(false)
     }
+  }
+
+  const openOAuthPopup = () => {
+    const oauthUrl = metaAdsApi.oauthStartUrl()
+    const width = 620
+    const height = 760
+    const left = Math.max(0, Math.round(window.screenX + (window.outerWidth - width) / 2))
+    const top = Math.max(0, Math.round(window.screenY + (window.outerHeight - height) / 2))
+    const popup = window.open(
+      oauthUrl,
+      'meta-ads-oauth',
+      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
+    )
+    if (!popup) {
+      setOauthDialogError(null)
+      setOauthDialogState('blocked')
+      return false
+    }
+    popup.focus?.()
+    oauthPopupRef.current = popup
+    setOauthDialogError(null)
+    setOauthDialogState('opened')
+    clearOAuthWatcher()
+    oauthPollRef.current = window.setInterval(() => {
+      const currentPopup = oauthPopupRef.current
+      if (!currentPopup) {
+        clearOAuthWatcher()
+        return
+      }
+      if (currentPopup.closed) {
+        cleanupOAuthPopup()
+        setRefreshing(true)
+        refreshConnectedState()
+          .then((nextStatus) => {
+            if (nextStatus.connection.connected) {
+              finalizeOAuthSuccess()
+              setActiveTab('connect')
+              toast.success('Conta Meta Ads conectada')
+              return
+            }
+            setOauthDialogState('closed')
+          })
+          .catch(() => {
+            setOauthDialogState('closed')
+          })
+          .finally(() => setRefreshing(false))
+      }
+    }, 500)
+    return true
+  }
+
+  const handleRetryOAuth = () => {
+    setOauthDialogError(null)
+    setOauthDialogState('opening')
+    setOauthDialogOpen(true)
+    openOAuthPopup()
   }
 
   const handleOpenOAuth = () => {
@@ -241,22 +354,10 @@ export function MetaCampaignControlCenter() {
         .finally(() => setRefreshing(false))
       return
     }
-    const oauthUrl = metaAdsApi.oauthStartUrl()
-    const width = 620
-    const height = 760
-    const left = Math.max(0, Math.round(window.screenX + (window.outerWidth - width) / 2))
-    const top = Math.max(0, Math.round(window.screenY + (window.outerHeight - height) / 2))
-    const popup = window.open(
-      oauthUrl,
-      'meta-ads-oauth',
-      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
-    )
-    if (popup) {
-      popup.focus?.()
-      return
-    }
-    toast.info('O navegador bloqueou a janela pop-up. A autenticação será aberta nesta mesma aba.')
-    window.location.assign(oauthUrl)
+    setOauthDialogOpen(true)
+    setOauthDialogError(null)
+    setOauthDialogState('opening')
+    openOAuthPopup()
   }
 
   const handleManualConnect = async () => {
@@ -319,35 +420,29 @@ export function MetaCampaignControlCenter() {
     connectionMode === 'unauthorized' ||
     connectionMode === 'forbidden' ||
     connectionMode === 'misconfigured'
-  const scopesLabel = status?.connection.scopes?.join(', ') || 'ads_read, ads_management, business_management'
-  const oauthMode = status?.oauthMode || 'scopes'
-  const businessLoginConfigId = status?.businessLoginConfigId || null
-  const connectedUser = status?.connection.metaUserName || status?.connection.metaUserId || null
   const showWorkspaceTabs = connectionMode === 'connected-ready' || connectionMode === 'degraded'
   const showAccountSelection = Boolean(status?.connection.connected)
 
   return (
     <div className="meta-ads-surface space-y-6 animate-fade-in">
-      <MetaAdsStatusHero
-        connected={Boolean(status?.connection.connected)}
-        refreshing={loading || refreshing}
-        onRefresh={handleRefresh}
-        onDisconnect={handleDisconnect}
-      />
+      {showWorkspaceTabs ? (
+        <MetaAdsStatusHero
+          connected={Boolean(status?.connection.connected)}
+          refreshing={loading || refreshing}
+          onRefresh={handleRefresh}
+          onDisconnect={handleDisconnect}
+        />
+      ) : null}
 
       <MetaAdsPersistentError error={statusError} onRetry={handleRefresh} />
 
       {!showWorkspaceTabs ? (
         <div className="space-y-6">
-          <MetaAdsConnectionProgress
-            connected={Boolean(status?.connection.connected)}
-            hasSelectedAccount={Boolean(selectedAccount)}
-          />
           <MetaAdsConnectionPanel
-            scopesLabel={scopesLabel}
-            oauthMode={oauthMode}
-            businessLoginConfigId={businessLoginConfigId}
-            connectedUser={connectedUser}
+            connected={Boolean(status?.connection.connected)}
+            refreshing={loading || refreshing}
+            onRefresh={handleRefresh}
+            onDisconnect={status?.connection.connected ? handleDisconnect : undefined}
             connectDisabled={connectActionsDisabled}
             onOAuth={handleOpenOAuth}
             manualToken={manualToken}
@@ -385,15 +480,11 @@ export function MetaCampaignControlCenter() {
           <MetaAdsWorkspaceTabs />
 
           <TabsContent value="connect" className="space-y-6">
-            <MetaAdsConnectionProgress
-              connected={Boolean(status?.connection.connected)}
-              hasSelectedAccount={Boolean(selectedAccount)}
-            />
             <MetaAdsConnectionPanel
-              scopesLabel={scopesLabel}
-              oauthMode={oauthMode}
-              businessLoginConfigId={businessLoginConfigId}
-              connectedUser={connectedUser}
+              connected={Boolean(status?.connection.connected)}
+              refreshing={loading || refreshing}
+              onRefresh={handleRefresh}
+              onDisconnect={status?.connection.connected ? handleDisconnect : undefined}
               connectDisabled={connectActionsDisabled}
               onOAuth={handleOpenOAuth}
               manualToken={manualToken}
@@ -470,6 +561,20 @@ export function MetaCampaignControlCenter() {
           </TabsContent>
         </Tabs>
       )}
+      <MetaAdsOAuthDialog
+        open={oauthDialogOpen}
+        state={oauthDialogState}
+        error={oauthDialogError}
+        onOpenChange={(open) => {
+          setOauthDialogOpen(open)
+          if (!open) {
+            cleanupOAuthPopup(true)
+            setOauthDialogError(null)
+            setOauthDialogState('opening')
+          }
+        }}
+        onRetry={handleRetryOAuth}
+      />
     </div>
   )
 }

--- a/frontend/e2e/meta-ads-module.spec.ts
+++ b/frontend/e2e/meta-ads-module.spec.ts
@@ -172,13 +172,51 @@ test.describe('meta ads', () => {
     await expect(page.getByRole('tab', { name: 'Conexão' })).toHaveCount(0)
     await expect(page.getByRole('tab', { name: 'Visão geral' })).toBeVisible()
     await page.getByRole('button', { name: 'Gerenciar conexão' }).click()
-    await expect(page.getByText('Escolher a conta de anúncios')).toBeVisible()
-    await expect(page.getByText('Usuário Meta: Jubenito Garcia')).toBeVisible()
+    await expect(page.getByText('Conectar a conta Meta')).toBeVisible()
+    await expect(page.getByText('Escolher a conta de anúncios', { exact: true })).toBeVisible()
+    await expect(page.getByText('Comece conectando a Meta ao CRM.')).toHaveCount(0)
+    await expect(page.getByText('OAuth:')).toHaveCount(0)
 
     await page.getByRole('tab', { name: 'Inventário' }).click()
     await expect(page.locator('body')).toContainText('Criativo 1')
 
     await page.getByRole('tab', { name: 'Tracking' }).click()
     await expect(page.getByText('Tracking do site e inventário da conta Meta convivem nesta aba')).toBeVisible()
+  })
+
+  test('keeps the oauth flow inside CRM with a modal when the popup is blocked', async ({ page }) => {
+    await mockCrmUser(page)
+
+    await page.route('**/api/meta-ads/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          oauthConfigured: true,
+          missingConfig: [],
+          connection: {
+            connected: false,
+            tokenType: null,
+            metaUserId: null,
+            metaUserName: null,
+            selectedAdAccountId: null,
+            scopes: [],
+            updatedAt: null,
+            expiresAt: null,
+          },
+        }),
+      })
+    })
+
+    await openMetaAds(page)
+
+    await page.evaluate(() => {
+      window.open = () => null
+    })
+
+    await page.getByRole('button', { name: 'Conectar com Facebook' }).click()
+    await expect(page.getByRole('dialog')).toContainText('Permita a janela do Facebook')
+    await expect(page.locator('body')).not.toContainText('A autenticação será aberta nesta mesma aba.')
   })
 })

--- a/frontend/functions/_lib/metaAdsGraph.ts
+++ b/frontend/functions/_lib/metaAdsGraph.ts
@@ -85,11 +85,26 @@ function normalizeAccountId(adAccountId: string) {
   return raw.startsWith('act_') ? raw : `act_${raw}`
 }
 
+async function buildAppSecretProof(accessToken: string, appSecret?: string) {
+  const secret = esc(appSecret)
+  if (!secret) return ''
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(accessToken))
+  return Array.from(new Uint8Array(sig)).map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
 async function graphFetch<T = any>(
   path: string,
   params: Record<string, string | number | undefined>,
   accessToken: string,
   version?: string,
+  appSecret?: string,
 ): Promise<T> {
   const qs = new URLSearchParams()
   for (const [key, value] of Object.entries(params || {})) {
@@ -97,6 +112,8 @@ async function graphFetch<T = any>(
     qs.set(key, String(value))
   }
   qs.set('access_token', accessToken)
+  const appSecretProof = await buildAppSecretProof(accessToken, appSecret)
+  if (appSecretProof) qs.set('appsecret_proof', appSecretProof)
 
   const url = `${parseGraphBaseUrl(version)}${path.startsWith('/') ? '' : '/'}${path}?${qs.toString()}`
   const res = await fetch(url, { headers: { accept: 'application/json' } })
@@ -112,6 +129,7 @@ async function collectPaged<T = any>(
   params: Record<string, string | number | undefined>,
   accessToken: string,
   version?: string,
+  appSecret?: string,
 ): Promise<T[]> {
   const out: T[] = []
   let nextUrl: string | null = null
@@ -120,10 +138,15 @@ async function collectPaged<T = any>(
   while (first || nextUrl) {
     let data: any
     if (first) {
-      data = await graphFetch<any>(path, params, accessToken, version)
+      data = await graphFetch<any>(path, params, accessToken, version, appSecret)
       first = false
     } else {
-      const res = await fetch(String(nextUrl), { headers: { accept: 'application/json' } })
+      const next = new URL(String(nextUrl))
+      const appSecretProof = await buildAppSecretProof(accessToken, appSecret)
+      if (appSecretProof && !next.searchParams.has('appsecret_proof')) {
+        next.searchParams.set('appsecret_proof', appSecretProof)
+      }
+      const res = await fetch(String(next), { headers: { accept: 'application/json' } })
       data = await res.json().catch(() => null)
       if (!res.ok || data?.error) {
         throw new Error(data?.error?.message || data?.error_description || `Meta Graph HTTP ${res.status}`)
@@ -137,16 +160,17 @@ async function collectPaged<T = any>(
   return out
 }
 
-export async function getMetaProfile(accessToken: string, version?: string) {
+export async function getMetaProfile(accessToken: string, version?: string, appSecret?: string) {
   return graphFetch<{ id: string; name?: string }>(
     '/me',
     { fields: 'id,name' },
     accessToken,
     version,
+    appSecret,
   )
 }
 
-export async function listMetaAdAccounts(accessToken: string, version?: string): Promise<MetaAdAccount[]> {
+export async function listMetaAdAccounts(accessToken: string, version?: string, appSecret?: string): Promise<MetaAdAccount[]> {
   const rows = await collectPaged<any>(
     '/me/adaccounts',
     {
@@ -155,6 +179,7 @@ export async function listMetaAdAccounts(accessToken: string, version?: string):
     },
     accessToken,
     version,
+    appSecret,
   )
   return rows.map((row) => ({
     id: esc(row?.id),
@@ -166,7 +191,7 @@ export async function listMetaAdAccounts(accessToken: string, version?: string):
   })).filter((row) => row.id)
 }
 
-export async function listMetaCampaigns(accessToken: string, adAccountId: string, version?: string): Promise<MetaCampaign[]> {
+export async function listMetaCampaigns(accessToken: string, adAccountId: string, version?: string, appSecret?: string): Promise<MetaCampaign[]> {
   const rows = await collectPaged<any>(
     `/${normalizeAccountId(adAccountId)}/campaigns`,
     {
@@ -175,6 +200,7 @@ export async function listMetaCampaigns(accessToken: string, adAccountId: string
     },
     accessToken,
     version,
+    appSecret,
   )
   return rows.map((row) => ({
     id: esc(row?.id),
@@ -189,7 +215,7 @@ export async function listMetaCampaigns(accessToken: string, adAccountId: string
   })).filter((row) => row.id)
 }
 
-export async function listMetaAdSets(accessToken: string, adAccountId: string, version?: string): Promise<MetaAdSet[]> {
+export async function listMetaAdSets(accessToken: string, adAccountId: string, version?: string, appSecret?: string): Promise<MetaAdSet[]> {
   const rows = await collectPaged<any>(
     `/${normalizeAccountId(adAccountId)}/adsets`,
     {
@@ -198,6 +224,7 @@ export async function listMetaAdSets(accessToken: string, adAccountId: string, v
     },
     accessToken,
     version,
+    appSecret,
   )
   return rows.map((row) => ({
     id: esc(row?.id),
@@ -214,7 +241,7 @@ export async function listMetaAdSets(accessToken: string, adAccountId: string, v
   })).filter((row) => row.id)
 }
 
-export async function listMetaAds(accessToken: string, adAccountId: string, version?: string): Promise<MetaAd[]> {
+export async function listMetaAds(accessToken: string, adAccountId: string, version?: string, appSecret?: string): Promise<MetaAd[]> {
   const rows = await collectPaged<any>(
     `/${normalizeAccountId(adAccountId)}/ads`,
     {
@@ -223,6 +250,7 @@ export async function listMetaAds(accessToken: string, adAccountId: string, vers
     },
     accessToken,
     version,
+    appSecret,
   )
   return rows.map((row) => ({
     id: esc(row?.id),
@@ -249,6 +277,7 @@ export async function getMetaAdsSummary(
   adAccountId: string,
   range: { since: string; until: string },
   version?: string,
+  appSecret?: string,
 ): Promise<MetaSummary> {
   const data = await graphFetch<any>(
     `/${normalizeAccountId(adAccountId)}/insights`,
@@ -260,6 +289,7 @@ export async function getMetaAdsSummary(
     },
     accessToken,
     version,
+    appSecret,
   )
   const row = Array.isArray(data?.data) ? data.data[0] || {} : {}
   return {
@@ -276,6 +306,7 @@ export async function getMetaAdsTrend(
   adAccountId: string,
   range: { since: string; until: string },
   version?: string,
+  appSecret?: string,
 ) {
   const data = await graphFetch<any>(
     `/${normalizeAccountId(adAccountId)}/insights`,
@@ -288,10 +319,29 @@ export async function getMetaAdsTrend(
     },
     accessToken,
     version,
+    appSecret,
   )
   const rows = Array.isArray(data?.data) ? data.data : []
   return rows.map((row: any) => ({
     day: esc(row?.date_start),
     spend: asNumber(row?.spend),
   }))
+}
+
+export async function debugMetaAccessToken(
+  inputToken: string,
+  appId: string,
+  appSecret: string,
+  version?: string,
+) {
+  const appAccessToken = `${esc(appId)}|${esc(appSecret)}`
+  return graphFetch<any>(
+    '/debug_token',
+    {
+      input_token: inputToken,
+    },
+    appAccessToken,
+    version,
+    appSecret,
+  )
 }

--- a/frontend/functions/_lib/metaAdsStore.ts
+++ b/frontend/functions/_lib/metaAdsStore.ts
@@ -7,7 +7,10 @@ export type MetaAdsConnection = {
   metaUserId?: string
   metaUserName?: string
   scopes?: string[]
+  grantedScopes?: string[]
   expiresAt?: string
+  dataAccessExpiresAt?: string
+  lastValidatedAt?: string
   selectedAdAccountId?: string
   updatedAt: string
 }

--- a/frontend/functions/api/meta-ads/[[path]].ts
+++ b/frontend/functions/api/meta-ads/[[path]].ts
@@ -10,6 +10,7 @@ import {
   type MetaAdsConnection,
 } from '../../_lib/metaAdsStore'
 import {
+  debugMetaAccessToken,
   getMetaAdsSummary,
   getMetaAdsTrend,
   getMetaProfile,
@@ -20,12 +21,30 @@ import {
 } from '../../_lib/metaAdsGraph'
 
 type OAuthState = { userId: string; nonce: string; iat: number }
+type OAuthPopupMessage = {
+  type: 'meta-ads:connected'
+  ok: boolean
+  error?: {
+    code: string
+    message: string
+    hint?: string | null
+  }
+}
 type MetaAdsApiErrorInit = {
   message?: string
   hint?: string
   retryable?: boolean
   extra?: Record<string, unknown>
 }
+type MetaTokenValidation = {
+  grantedScopes: string[]
+  expiresAt?: string
+  dataAccessExpiresAt?: string
+  lastValidatedAt: string
+}
+
+const OAUTH_STATE_MAX_AGE_MS = 15 * 60 * 1000
+const CONNECTION_REVALIDATE_INTERVAL_MS = 60 * 60 * 1000
 
 const json = (status: number, body: any) =>
   new Response(JSON.stringify(body), {
@@ -71,6 +90,23 @@ const apiError = (
     ...(extra || {}),
   })
 
+class MetaAdsRouteError extends Error {
+  status: number
+  code: string
+  hint?: string
+  retryable: boolean
+  extra?: Record<string, unknown>
+
+  constructor(status: number, code: string, { message, hint, retryable = status >= 500, extra }: MetaAdsApiErrorInit = {}) {
+    super(message || code)
+    this.status = status
+    this.code = code
+    this.hint = hint
+    this.retryable = retryable
+    this.extra = extra
+  }
+}
+
 function runtimeConfig(context: any) {
   const env = context?.env || {}
   return {
@@ -83,6 +119,123 @@ function runtimeConfig(context: any) {
       String(env.META_ADS_OAUTH_SCOPES || '').trim() ||
       ['ads_read', 'ads_management', 'business_management'].join(','),
   }
+}
+
+function requiredScopes(cfg: ReturnType<typeof runtimeConfig>) {
+  return String(cfg.scopes || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function normalizeScopes(values: unknown[]) {
+  return Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean)))
+}
+
+function epochSecondsToIso(value: unknown) {
+  const raw = Number(value || 0)
+  if (!Number.isFinite(raw) || raw <= 0) return undefined
+  return new Date(raw * 1000).toISOString()
+}
+
+function extractDebugScopes(data: any) {
+  const direct = Array.isArray(data?.scopes) ? data.scopes : []
+  const granular = Array.isArray(data?.granular_scopes)
+    ? data.granular_scopes.map((item: any) => item?.scope)
+    : []
+  return normalizeScopes([...direct, ...granular])
+}
+
+function shouldRevalidateConnection(connection: MetaAdsConnection | null) {
+  if (!connection?.accessToken) return false
+  if (!connection.lastValidatedAt) return true
+  const timestamp = Date.parse(connection.lastValidatedAt)
+  if (!Number.isFinite(timestamp)) return true
+  return Date.now() - timestamp >= CONNECTION_REVALIDATE_INTERVAL_MS
+}
+
+function normalizeUnhandledMetaError(error: any) {
+  const message = String(error?.message || '').toLowerCase()
+  if (!message) return null
+  if (message.includes('invalid oauth access token') || message.includes('session has been invalidated')) {
+    return new MetaAdsRouteError(401, 'META_TOKEN_INVALID', {
+      message: 'A sessão da Meta expirou ou foi revogada.',
+      hint: 'Conecte novamente a conta Meta pelo Facebook ou valide um novo token manual.',
+      retryable: false,
+    })
+  }
+  if (message.includes('permissions error') || message.includes('missing permissions')) {
+    return new MetaAdsRouteError(403, 'META_PERMISSIONS_ERROR', {
+      message: 'A Meta negou parte das permissões necessárias para esta operação.',
+      hint: 'Refaça o login e confirme as permissões do Gerenciador de Anúncios.',
+      retryable: false,
+    })
+  }
+  return null
+}
+
+async function validateMetaAccessToken(
+  accessToken: string,
+  cfg: ReturnType<typeof runtimeConfig>,
+): Promise<MetaTokenValidation> {
+  if (!cfg.appId || !cfg.appSecret) {
+    return {
+      grantedScopes: requiredScopes(cfg),
+      lastValidatedAt: new Date().toISOString(),
+    }
+  }
+
+  const debug = await debugMetaAccessToken(accessToken, cfg.appId, cfg.appSecret, cfg.graphVersion)
+  const debugData = debug?.data || {}
+  if (!debugData?.is_valid) {
+    throw new MetaAdsRouteError(401, 'META_TOKEN_INVALID', {
+      message: 'A Meta rejeitou o access token desta conexão.',
+      hint: 'Refaça a autenticação com Facebook ou gere um token manual válido.',
+      retryable: false,
+    })
+  }
+
+  const tokenAppId = String(debugData?.app_id || '').trim()
+  if (tokenAppId && cfg.appId && tokenAppId !== cfg.appId) {
+    throw new MetaAdsRouteError(400, 'META_TOKEN_APP_MISMATCH', {
+      message: 'O token retornado pertence a outro app Meta.',
+      hint: 'Confirme que o app do Meta Developer usado no CRM é o mesmo da autenticação.',
+      retryable: false,
+    })
+  }
+
+  const grantedScopes = extractDebugScopes(debugData)
+  const missingScopes = requiredScopes(cfg).filter((scope) => !grantedScopes.includes(scope))
+  if (missingScopes.length) {
+    throw new MetaAdsRouteError(400, 'META_SCOPES_INCOMPLETE', {
+      message: 'A autenticação não concedeu todos os acessos exigidos pelo Meta Ads.',
+      hint: `Escopos ausentes: ${missingScopes.join(', ')}.`,
+      retryable: false,
+      extra: { missingScopes, grantedScopes },
+    })
+  }
+
+  return {
+    grantedScopes,
+    expiresAt: epochSecondsToIso(debugData?.expires_at),
+    dataAccessExpiresAt: epochSecondsToIso(debugData?.data_access_expires_at),
+    lastValidatedAt: new Date().toISOString(),
+  }
+}
+
+function buildOauthPopupResponse(payload: OAuthPopupMessage, body: string) {
+  const safePayload = JSON.stringify(payload).replace(/</g, '\\u003c')
+  return html(`
+      <script>
+        try {
+          if (window.opener) {
+            window.opener.postMessage(${safePayload}, window.location.origin);
+          }
+        } catch {}
+        try { window.close(); } catch {}
+      </script>
+      <p>${esc(body)}</p>
+    `)
 }
 
 function connectionSummary(connection: MetaAdsConnection | null) {
@@ -208,9 +361,10 @@ async function writeConnection(context: any, userId: string, value: MetaAdsConne
 }
 
 async function fetchLiveAccounts(context: any, userId: string) {
+  const cfg = runtimeConfig(context)
   const connection = await readConnection(context, userId)
   if (!connection?.accessToken) return { connection: null, accounts: [] as any[] }
-  const accounts = await listMetaAdAccounts(connection.accessToken, runtimeConfig(context).graphVersion)
+  const accounts = await listMetaAdAccounts(connection.accessToken, cfg.graphVersion, cfg.appSecret)
   return { connection, accounts }
 }
 
@@ -223,6 +377,28 @@ async function handleStatus(context: any) {
   let connection: MetaAdsConnection | null = null
   try {
     connection = await readConnection(context, userOrRes.id)
+    if (connection && shouldRevalidateConnection(connection)) {
+      try {
+        const tokenValidation = await validateMetaAccessToken(connection.accessToken, cfg)
+        connection = {
+          ...connection,
+          scopes: tokenValidation.grantedScopes,
+          grantedScopes: tokenValidation.grantedScopes,
+          expiresAt: tokenValidation.expiresAt || connection.expiresAt,
+          dataAccessExpiresAt: tokenValidation.dataAccessExpiresAt || connection.dataAccessExpiresAt,
+          lastValidatedAt: tokenValidation.lastValidatedAt,
+        }
+        await writeConnection(context, userOrRes.id, connection)
+      } catch (error: any) {
+        if (error instanceof MetaAdsRouteError && error.code === 'META_TOKEN_INVALID') {
+          const bucket = getShareBucket(context)
+          if (bucket) await deleteMetaAdsConnection(bucket, userOrRes.id)
+          connection = null
+        } else {
+          throw error
+        }
+      }
+    }
   } catch {
     connection = null
   }
@@ -259,6 +435,7 @@ async function handleOauthStart(context: any) {
     redirect_uri: redirectUri,
     state,
     response_type: 'code',
+    display: 'popup',
   })
   if (cfg.configId) {
     qs.set('config_id', cfg.configId)
@@ -281,18 +458,84 @@ async function handleOauthCallback(context: any) {
   if (userOrRes instanceof Response) return userOrRes
   const cfg = runtimeConfig(context)
   const missing = resolveMissingConfig(context)
-  if (missing.length) return html(`<p>Meta Ads OAuth não configurado: ${esc(missing.join(', '))}</p>`)
+  if (missing.length) {
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: 'META_ADS_OAUTH_NOT_CONFIGURED',
+          message: 'A integração Meta Ads ainda não está pronta neste runtime.',
+          hint: `Faltam bindings/segredos obrigatórios: ${missing.join(', ')}`,
+        },
+      },
+      `Meta Ads OAuth não configurado: ${esc(missing.join(', '))}`,
+    )
+  }
 
   const url = new URL(context.request.url)
   const code = url.searchParams.get('code')
   const state = url.searchParams.get('state')
   const err = url.searchParams.get('error') || url.searchParams.get('error_reason')
   const errDesc = url.searchParams.get('error_description')
-  if (err) return html(`<p>Erro OAuth: ${esc(err)}<br/>${esc(errDesc)}</p>`)
-  if (!code || !state) return html('<p>Callback inválido (code/state ausentes).</p>')
+  if (err) {
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: String(err || 'OAUTH_DENIED'),
+          message: 'A Meta não concluiu a autorização da conta.',
+          hint: String(errDesc || 'Conclua a autorização no Facebook e tente novamente.'),
+        },
+      },
+      `Erro OAuth: ${esc(err)}${errDesc ? `<br/>${esc(errDesc)}` : ''}`,
+    )
+  }
+  if (!code || !state) {
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: 'OAUTH_CALLBACK_INVALID',
+          message: 'A Meta retornou uma resposta incompleta para o CRM.',
+          hint: 'Refaça a autenticação e confirme o login no Facebook.',
+        },
+      },
+      'Callback inválido (code/state ausentes).',
+    )
+  }
 
   const verified = await verifyState<OAuthState>(state, cfg.stateSecret)
-  if (!verified || verified.userId !== userOrRes.id) return html('<p>State inválido. Tente novamente.</p>')
+  if (!verified || verified.userId !== userOrRes.id) {
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: 'OAUTH_STATE_INVALID',
+          message: 'A resposta de autenticação da Meta não corresponde à sessão atual.',
+          hint: 'Feche a janela e reinicie o login pelo CRM.',
+        },
+      },
+      'State inválido. Tente novamente.',
+    )
+  }
+  if (Date.now() - Number(verified.iat || 0) > OAUTH_STATE_MAX_AGE_MS) {
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: 'OAUTH_STATE_EXPIRED',
+          message: 'A tentativa de login expirou antes de concluir a autorização.',
+          hint: 'Reinicie a conexão do Meta Ads pelo CRM.',
+        },
+      },
+      'A tentativa de login expirou. Reinicie a conexão pelo CRM.',
+    )
+  }
 
   const origin = new URL(context.request.url).origin
   const redirectUri = `${origin}/api/meta-ads/oauth/callback`
@@ -321,31 +564,47 @@ async function handleOauthCallback(context: any) {
     )
 
     const accessToken = String(longData?.access_token || '').trim() || shortToken
-    const profile = await getMetaProfile(accessToken, cfg.graphVersion)
-    const scopes = String(cfg.scopes || '')
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean)
+    const [profile, tokenValidation] = await Promise.all([
+      getMetaProfile(accessToken, cfg.graphVersion, cfg.appSecret),
+      validateMetaAccessToken(accessToken, cfg),
+    ])
 
     await writeConnection(context, userOrRes.id, {
       accessToken,
       tokenType: 'oauth',
       metaUserId: String(profile?.id || '').trim() || undefined,
       metaUserName: String(profile?.name || '').trim() || undefined,
-      scopes,
-      expiresAt: longData?.expires_in ? new Date(Date.now() + Number(longData.expires_in || 0) * 1000).toISOString() : undefined,
+      scopes: tokenValidation.grantedScopes,
+      grantedScopes: tokenValidation.grantedScopes,
+      expiresAt:
+        tokenValidation.expiresAt ||
+        (longData?.expires_in ? new Date(Date.now() + Number(longData.expires_in || 0) * 1000).toISOString() : undefined),
+      dataAccessExpiresAt: tokenValidation.dataAccessExpiresAt,
+      lastValidatedAt: tokenValidation.lastValidatedAt,
       updatedAt: new Date().toISOString(),
     })
 
-    return html(`
-      <script>
-        try { if (window.opener) window.opener.postMessage({ type: 'meta-ads:connected', ok: true }, window.location.origin); } catch {}
-        window.close();
-      </script>
-      <p>Conta Meta Ads conectada. Você pode fechar esta janela.</p>
-    `)
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: true,
+      },
+      'Conta Meta Ads conectada. Você pode fechar esta janela.',
+    )
   } catch (error: any) {
-    return html(`<p>Falha ao conectar: ${esc(error?.message || 'Erro')}</p>`)
+    const routeError = error instanceof MetaAdsRouteError ? error : null
+    return buildOauthPopupResponse(
+      {
+        type: 'meta-ads:connected',
+        ok: false,
+        error: {
+          code: routeError?.code || 'META_OAUTH_CONNECT_FAILED',
+          message: routeError?.message || 'Falha ao conectar a conta Meta.',
+          hint: routeError?.hint || error?.message || 'Tente novamente e revise o app Meta configurado no CRM.',
+        },
+      },
+      `Falha ao conectar: ${esc(routeError?.message || error?.message || 'Erro')}`,
+    )
   }
 }
 
@@ -366,13 +625,22 @@ async function handleManualConnect(context: any) {
   }
 
   try {
-    const profile = await getMetaProfile(accessToken, runtimeConfig(context).graphVersion)
-    const accounts = await listMetaAdAccounts(accessToken, runtimeConfig(context).graphVersion)
+    const cfg = runtimeConfig(context)
+    const [profile, tokenValidation, accounts] = await Promise.all([
+      getMetaProfile(accessToken, cfg.graphVersion, cfg.appSecret),
+      validateMetaAccessToken(accessToken, cfg),
+      listMetaAdAccounts(accessToken, cfg.graphVersion, cfg.appSecret),
+    ])
     await writeConnection(context, userOrRes.id, {
       accessToken,
       tokenType: 'manual',
       metaUserId: String(profile?.id || '').trim() || undefined,
       metaUserName: String(profile?.name || '').trim() || undefined,
+      scopes: tokenValidation.grantedScopes,
+      grantedScopes: tokenValidation.grantedScopes,
+      expiresAt: tokenValidation.expiresAt,
+      dataAccessExpiresAt: tokenValidation.dataAccessExpiresAt,
+      lastValidatedAt: tokenValidation.lastValidatedAt,
       updatedAt: new Date().toISOString(),
       selectedAdAccountId: accounts[0]?.id || undefined,
     })
@@ -451,7 +719,8 @@ async function handleSelectAccount(context: any) {
       retryable: false,
     })
   }
-  const accounts = await listMetaAdAccounts(connection.accessToken, runtimeConfig(context).graphVersion)
+  const cfg = runtimeConfig(context)
+  const accounts = await listMetaAdAccounts(connection.accessToken, cfg.graphVersion, cfg.appSecret)
   const selected = accounts.find((account) => account.id === adAccountId)
   if (!selected) {
     return apiError(404, 'ACCOUNT_NOT_FOUND', {
@@ -505,10 +774,11 @@ async function handleSummary(context: any) {
   const selected = await withSelectedAccount(context, userOrRes.id)
   if ('error' in selected) return selected.error
 
+  const cfg = runtimeConfig(context)
   const range = parseRange(new URL(context.request.url))
   const [summary, campaigns] = await Promise.all([
-    getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, runtimeConfig(context).graphVersion),
-    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+    getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, cfg.graphVersion, cfg.appSecret),
+    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
   ])
 
   return json(200, {
@@ -523,12 +793,14 @@ async function handleTrend(context: any) {
   const selected = await withSelectedAccount(context, userOrRes.id)
   if ('error' in selected) return selected.error
 
+  const cfg = runtimeConfig(context)
   const range = parseRange(new URL(context.request.url))
   const trend = await getMetaAdsTrend(
     selected.connection.accessToken,
     selected.adAccountId,
     range,
-    runtimeConfig(context).graphVersion,
+    cfg.graphVersion,
+    cfg.appSecret,
   )
   return json(200, trend)
 }
@@ -539,10 +811,11 @@ async function handleInventory(context: any) {
   const selected = await withSelectedAccount(context, userOrRes.id)
   if ('error' in selected) return selected.error
 
+  const cfg = runtimeConfig(context)
   const [campaigns, adSets, ads] = await Promise.all([
-    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
-    listMetaAdSets(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
-    listMetaAds(selected.connection.accessToken, selected.adAccountId, runtimeConfig(context).graphVersion),
+    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
+    listMetaAdSets(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
+    listMetaAds(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
   ])
 
   return json(200, {
@@ -577,6 +850,23 @@ export async function onRequest(context: any): Promise<Response> {
       retryable: false,
     })
   } catch (error: any) {
+    const mapped = normalizeUnhandledMetaError(error)
+    if (mapped) {
+      return apiError(mapped.status, mapped.code, {
+        message: mapped.message,
+        hint: mapped.hint,
+        retryable: mapped.retryable,
+        extra: mapped.extra,
+      })
+    }
+    if (error instanceof MetaAdsRouteError) {
+      return apiError(error.status, error.code, {
+        message: error.message,
+        hint: error.hint,
+        retryable: error.retryable,
+        extra: error.extra,
+      })
+    }
     return apiError(500, 'META_ADS_INTERNAL_ERROR', {
       message: 'A API Meta Ads encontrou um erro inesperado.',
       hint: error?.message || 'Erro interno.',

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -4,6 +4,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import { TabsList, TabsTrigger } from '@/tabs'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/table'
 import { Textarea } from '@/textarea'
@@ -30,7 +31,6 @@ import {
 } from '@phosphor-icons/react'
 
 const panelClass = 'border-slate-800/80 bg-slate-950/60 shadow-[0_20px_80px_rgba(2,6,23,0.35)] backdrop-blur-xl'
-const subtlePanelClass = 'border-slate-800/70 bg-slate-950/45 backdrop-blur-xl'
 
 function formatCurrency(value: number, currency = 'USD') {
   try {
@@ -221,10 +221,10 @@ export function MetaAdsWorkspaceTabs({
 }
 
 export function MetaAdsConnectionPanel({
-  scopesLabel,
-  oauthMode,
-  businessLoginConfigId,
-  connectedUser,
+  connected,
+  refreshing,
+  onRefresh,
+  onDisconnect,
   connectDisabled,
   onOAuth,
   manualToken,
@@ -232,10 +232,10 @@ export function MetaAdsConnectionPanel({
   onManualConnect,
   manualDisabled,
 }: {
-  scopesLabel: string
-  oauthMode: 'scopes' | 'business-config'
-  businessLoginConfigId?: string | null
-  connectedUser?: string | null
+  connected: boolean
+  refreshing: boolean
+  onRefresh: () => void
+  onDisconnect?: () => void
   connectDisabled: boolean
   onOAuth: () => void
   manualToken: string
@@ -243,50 +243,66 @@ export function MetaAdsConnectionPanel({
   onManualConnect: () => void
   manualDisabled: boolean
 }) {
-  const isBusinessLogin = oauthMode === 'business-config'
   return (
-    <Card className={panelClass}>
-      <CardHeader>
-        <CardTitle>Conectar a conta Meta</CardTitle>
-        <CardDescription className="text-slate-300">
-          {isBusinessLogin
-            ? 'Use o Facebook Login for Business já configurado no app da Meta. O token manual fica como contingência administrativa.'
-            : 'Comece pelo Facebook OAuth. Se preferir, use um token manual como rota secundária no mesmo painel.'}
-        </CardDescription>
+    <Card className={`overflow-hidden ${panelClass}`}>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.18),transparent_36%),radial-gradient(circle_at_top_right,rgba(236,72,153,0.14),transparent_28%)]" />
+      <CardHeader className="relative gap-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-3 text-white">
+              <div className="flex items-center gap-2">
+                <FacebookLogo className="h-6 w-6 text-sky-400" />
+                <Target className="h-6 w-6 text-pink-400" />
+              </div>
+              Meta Ads
+            </CardTitle>
+            <CardDescription className="max-w-3xl text-slate-300">
+              Conecte o Gerenciador de Anúncios da Meta ao CRM, escolha a conta certa e acompanhe inventário e tracking sem sair do módulo.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {connected ? (
+              <Badge className="border border-emerald-500/30 bg-emerald-500/15 text-emerald-100">
+                <CheckCircle className="mr-1 h-4 w-4" />
+                Conectado
+              </Badge>
+            ) : (
+              <Badge className="border border-amber-500/30 bg-amber-500/15 text-amber-100">
+                <Link className="mr-1 h-4 w-4" />
+                Não conectado
+              </Badge>
+            )}
+            <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={onRefresh} disabled={refreshing}>
+              {refreshing ? <Spinner className="mr-2 h-4 w-4 animate-spin" /> : <ArrowClockwise className="mr-2 h-4 w-4" />}
+              Atualizar
+            </Button>
+            {connected && onDisconnect ? (
+              <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={onDisconnect} disabled={refreshing}>
+                Desconectar
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        <div className="space-y-2 border-t border-slate-800/80 pt-6">
+          <CardTitle>Conectar a conta Meta</CardTitle>
+          <CardDescription className="text-slate-300">
+            Autorize com Facebook no fluxo principal. O token manual permanece apenas como contingência administrativa.
+          </CardDescription>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent className="relative space-y-6">
         <div className="rounded-3xl border border-slate-800/80 bg-slate-900/65 p-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-4">
             <div className="space-y-2">
               <div className="text-sm font-medium text-white">Fluxo recomendado</div>
               <div className="text-sm leading-6 text-slate-300">
-                {isBusinessLogin
-                  ? 'Autorize a Meta com a configuração empresarial do app. Se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.'
-                  : 'Autorize a Meta dentro do CRM e, se o navegador bloquear pop-up, o processo continua automaticamente nesta mesma aba.'}
+                O login do Facebook abre em uma janela segura sobre o CRM. Depois da autorização, basta escolher a conta de anúncios correta para liberar as demais áreas.
               </div>
             </div>
             <Button className="bg-sky-500 text-slate-950 hover:bg-sky-400" onClick={onOAuth} disabled={connectDisabled}>
               Conectar com Facebook
             </Button>
           </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Badge className="border border-sky-500/30 bg-sky-500/10 text-sky-100">
-            OAuth: {isBusinessLogin ? 'Facebook Login for Business' : 'Facebook Login clássico'}
-          </Badge>
-          {businessLoginConfigId ? (
-            <Badge className="border border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-100">
-              Config ID: {businessLoginConfigId}
-            </Badge>
-          ) : null}
-          <Badge className="border border-slate-700 bg-slate-900/60 text-slate-200">
-            Escopos: {scopesLabel}
-          </Badge>
-          {connectedUser ? (
-            <Badge className="border border-emerald-500/30 bg-emerald-500/10 text-emerald-100">
-              Usuário Meta: {connectedUser}
-            </Badge>
-          ) : null}
         </div>
         <div className="rounded-3xl border border-slate-800/80 bg-slate-900/45 p-5">
           <div className="mb-3 text-sm font-medium text-white">Ou conecte por token manual</div>
@@ -310,35 +326,78 @@ export function MetaAdsConnectionPanel({
   )
 }
 
-export function MetaAdsConnectionProgress({
-  connected,
-  hasSelectedAccount,
+export function MetaAdsOAuthDialog({
+  open,
+  state,
+  error,
+  onOpenChange,
+  onRetry,
 }: {
-  connected: boolean
-  hasSelectedAccount: boolean
+  open: boolean
+  state: 'opening' | 'opened' | 'blocked' | 'closed' | 'error'
+  error?: MetaAdsApiError | null
+  onOpenChange: (open: boolean) => void
+  onRetry: () => void
 }) {
+  const title =
+    state === 'blocked'
+      ? 'Permita a janela do Facebook'
+      : state === 'closed'
+        ? 'Continue a conexão com Facebook'
+        : state === 'error'
+          ? 'Falha ao concluir o login da Meta'
+        : 'Conectar com Facebook'
+
+  const description =
+    state === 'blocked'
+      ? 'O navegador bloqueou a janela de autenticação. Libere pop-ups para o CRM e tente abrir novamente.'
+      : state === 'closed'
+        ? 'A janela foi fechada antes de concluir a autorização. Reabra o login do Facebook para continuar.'
+        : state === 'error'
+          ? error?.hint || error?.message || 'O Facebook retornou um erro antes de concluir a conexão no CRM.'
+        : 'O Facebook foi aberto em uma janela segura para concluir a autenticação da conta Meta sem sair desta página.'
+
   return (
-    <Card className={subtlePanelClass}>
-      <CardContent className="flex flex-col gap-4 pt-6 lg:flex-row lg:items-center lg:justify-between">
-        <div className="space-y-1">
-          <div className="text-sm font-medium text-white">
-            {connected ? 'Conta Meta conectada.' : 'Comece conectando a Meta ao CRM.'}
-          </div>
-          <div className="text-sm text-slate-300">
-            {connected
-              ? hasSelectedAccount
-                ? 'Conexão concluída. Agora o módulo libera visão geral, inventário e tracking.'
-                : 'Próximo passo: selecione qual conta de anúncios deve alimentar o CRM.'
-              : 'Depois da autorização, escolha a conta de anúncios correta para liberar as demais áreas.'}
-          </div>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg border-slate-800/80 bg-slate-950 text-slate-100">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription className="text-slate-300">{description}</DialogDescription>
+        </DialogHeader>
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-4 text-sm text-slate-300">
+          {state === 'blocked' ? (
+            <div>
+              Se o pop-up não aparecer, permita janelas para <span className="font-medium text-white">crm.skincos.com.br</span> e clique em <span className="font-medium text-white">Abrir login novamente</span>.
+            </div>
+          ) : state === 'closed' ? (
+            <div>
+              A autenticação precisa ser concluída na janela do Facebook. Se você finalizou o login e nada mudou, reabra a janela para tentar novamente.
+            </div>
+          ) : state === 'error' ? (
+            <div className="space-y-2">
+              <div className="font-medium text-white">{error?.message || 'O login da Meta falhou.'}</div>
+              {error?.hint ? <div>{error.hint}</div> : null}
+              {error?.code ? <div className="font-mono text-xs text-slate-400">{error.code}</div> : null}
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <Spinner className="h-4 w-4 animate-spin text-sky-300" />
+              <span>Aguardando autorização do Facebook...</span>
+            </div>
+          )}
         </div>
-        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.22em] text-slate-400">
-          <span className={connected ? 'text-emerald-300' : ''}>1. Conectar</span>
-          <span className={hasSelectedAccount ? 'text-emerald-300' : ''}>2. Escolher conta</span>
-          <span className={hasSelectedAccount ? 'text-emerald-300' : ''}>3. Operar</span>
-        </div>
-      </CardContent>
-    </Card>
+        <DialogFooter>
+          <Button variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80" onClick={() => onOpenChange(false)}>
+            Fechar
+          </Button>
+          {(state === 'blocked' || state === 'closed' || state === 'error') ? (
+            <Button className="bg-sky-500 text-slate-950 hover:bg-sky-400" onClick={onRetry}>
+              Abrir login novamente
+            </Button>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -13,6 +13,7 @@ ESCALA_API_TARGET = "https://escala-api.skincos.com.br"
 REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET = "true"
 R2_KEY_PREFIX = ""
 R2_PRODUCTION_BRANCH = "main"
+META_ADS_CONFIG_ID = "1608208000506752"
 
 [[env.preview.r2_buckets]]
 binding = "SHARE_BUCKET"
@@ -24,3 +25,4 @@ ESCALA_API_TARGET = "https://escala-api-staging.skincos.com.br"
 REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET = "false"
 R2_KEY_PREFIX = "preview/"
 R2_PRODUCTION_BRANCH = "main"
+META_ADS_CONFIG_ID = "1608208000506752"


### PR DESCRIPTION
## Summary\n- harden the Meta Ads OAuth flow with structured popup callback handling\n- validate Meta tokens and granted scopes before saving the connection\n- enable business login config on Pages runtime and add appsecret_proof on Graph calls\n\n## Validation\n- npm --prefix frontend run typecheck\n- npm --prefix frontend test -- tests/metaAdsModule.test.ts\n- npm --prefix frontend run build\n- npm --prefix frontend run test:e2e -- e2e/meta-ads-module.spec.ts