### PR TITLE
fix(meta-ads): normalize report date in worker output

### DIFF
--- a/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
+++ b/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
@@ -1191,6 +1191,13 @@ function normalizeReportDate(value) {
     return input;
   }
 
+  if (input) {
+    const parsed = new Date(input);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().slice(0, 10);
+    }
+  }
+
   const now = new Date();
   now.setUTCDate(now.getUTCDate() - 1);
   return now.toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary
- fix the worker report date normalization when rows are built from ISO timestamps
- keep report rows aligned with the filtered D1 report_date instead of falling back to yesterday

## Validation
- node --check backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
- verified execution 16201 persisted 2026-05-14 successfully and isolated the remaining issue to worker output formatting
