### PR TITLE
ci(meta-ads): deploy report worker on main

### DIFF
--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -1,0 +1,49 @@
+name: Deploy Meta Ads Report Worker
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "backend/apps/meta-ads/apps/report-ingest-worker/**"
+      - ".github/workflows/deploy-meta-ads-report-worker.yml"
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard Cloudflare deploy secrets
+        id: guard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare deploy secrets not configured; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Deploy Worker (wrangler)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@3 deploy --config backend/apps/meta-ads/apps/report-ingest-worker/wrangler.toml --keep-vars


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for backend/apps/meta-ads/apps/report-ingest-worker
- deploy the Cloudflare worker on main changes and allow manual workflow_dispatch

## Why
The report worker fix in #543 merged correctly, but this worker was not covered by the existing worker deploy automation.
