### PR TITLE
Fix Meta Ads report runtime sync

### DIFF
--- a/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
+++ b/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
@@ -1,0 +1,78 @@
+name: Sync Meta Ads Report Secret (Cloudflare Pages)
+
+on:
+  schedule:
+    # Keep the CRM Pages runtime aligned with the GitHub source of truth.
+    - cron: "37 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      force_redeploy:
+        description: "Force CRM Pages redeploy after syncing the secret"
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard Cloudflare credentials + Meta Ads report secret
+        id: guard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+          META_ADS_REPORT_WORKER_API_TOKEN: ${{ secrets.META_ADS_REPORT_WORKER_API_TOKEN }}
+          FORCE_REDEPLOY: ${{ github.event.inputs.force_redeploy || 'true' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare secrets missing; cannot sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${META_ADS_REPORT_WORKER_API_TOKEN:-}" ]]; then
+            echo "Missing GitHub secret META_ADS_REPORT_WORKER_API_TOKEN; cannot sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "project=${PAGES_PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
+          echo "force_redeploy=${FORCE_REDEPLOY:-true}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Sync Meta Ads report token to Cloudflare Pages
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+          META_ADS_REPORT_WORKER_API_TOKEN: ${{ secrets.META_ADS_REPORT_WORKER_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          for env_name in production preview; do
+            printf "%s" "$META_ADS_REPORT_WORKER_API_TOKEN" | npx --yes wrangler@4 pages secret put META_ADS_REPORT_WORKER_API_TOKEN --project-name "$PROJECT" --env "$env_name" >/dev/null
+            echo "Set Pages secret META_ADS_REPORT_WORKER_API_TOKEN for env=$env_name."
+          done
+
+      - name: Force redeploy CRM Pages
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.force_redeploy == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "deploy-crm-pages-reconcile.yml",
+              ref: "main",
+              inputs: { force: "true" },
+            })
+            core.info("Dispatched deploy-crm-pages-reconcile.yml with force=true")

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -22,7 +22,7 @@ import { dispatchInsumosHeaderAction, subscribeInsumosHeaderState } from '@/insu
 import type { InsumosHeaderState, InsumosOverviewPeriod } from '@/insumosTypes'
 import { dispatchMetaAdsHeaderAction, subscribeMetaAdsHeaderState } from '@/metaAdsHeaderBridge'
 import type { MetaAdsHeaderState } from '@/metaAdsTypes'
-import { CalendarX2, CheckCircle2, Circle, CircleDot, Clock3, Download, Pencil, RefreshCw, Settings2, Shield, Sparkles } from 'lucide-react'
+import { CalendarX2, CheckCircle2, Circle, CircleDot, Download, Pencil, RefreshCw, Settings2, Shield, Sparkles } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
@@ -1400,20 +1400,6 @@ export default function AppFunctionalNeatlab() {
                                                     </TooltipContent>
                                                 </Tooltip>
                                             </div>
-                                            {metaAdsHeaderState?.sessionUpdatedAt ? (
-                                                <Tooltip>
-                                                    <TooltipTrigger asChild>
-                                                        <span
-                                                            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/15 bg-white/[0.06] text-blue-50"
-                                                        >
-                                                            <Clock3 className="size-3.5" aria-hidden="true" />
-                                                        </span>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent>
-                                                        Ultima atualizacao de sessao: {new Date(metaAdsHeaderState.sessionUpdatedAt).toLocaleString('pt-BR')}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                            ) : null}
                                             <Tooltip>
                                                 <TooltipTrigger asChild>
                                                     <Button
@@ -1444,7 +1430,14 @@ export default function AppFunctionalNeatlab() {
                                                     </Button>
                                                 </TooltipTrigger>
                                                 <TooltipContent>
-                                                    Atualizar
+                                                    <div className="space-y-0.5">
+                                                        <div>Atualizar painel</div>
+                                                        <div className="text-[11px] text-slate-300">
+                                                            {metaAdsHeaderState?.sessionUpdatedAt
+                                                                ? `Última atualização: ${new Date(metaAdsHeaderState.sessionUpdatedAt).toLocaleString('pt-BR')}`
+                                                                : 'Sem atualização registrada nesta sessão.'}
+                                                        </div>
+                                                    </div>
                                                 </TooltipContent>
                                             </Tooltip>
                                         </div>

--- a/frontend/MetaTrackingDashboard.tsx
+++ b/frontend/MetaTrackingDashboard.tsx
@@ -5,27 +5,27 @@ import { LinkBreak, WarningCircle } from '@phosphor-icons/react'
 function describeFallbackReason(report: MetaAdsReportResponse | null) {
   const reason = report?.fallbackReason
   if (reason === 'worker_unconfigured') {
-    return 'O consolidado do workflow ainda não está configurado neste runtime do CRM. O módulo caiu para o Graph para não ficar vazio.'
+    return 'As métricas consolidadas ainda não estão disponíveis nesta leitura. O painel está usando dados parciais da Meta para não ficar vazio.'
   }
   if (reason === 'worker_unauthorized') {
-    return 'O CRM não conseguiu autenticar a leitura do worker consolidado. O módulo caiu para o Graph enquanto a credencial do worker não é corrigida.'
+    return 'O CRM não conseguiu acessar a fonte consolidada de métricas. O painel está usando dados parciais da Meta enquanto a credencial é normalizada.'
   }
   if (reason === 'worker_unavailable') {
-    return 'O worker consolidado ficou indisponível nesta leitura. O CRM caiu para o Graph até o consolidado voltar a responder.'
+    return 'A fonte consolidada de métricas não respondeu nesta leitura. O painel está usando dados parciais da Meta até o serviço voltar.'
   }
   if (reason === 'worker_invalid_response') {
-    return 'O worker consolidado respondeu em formato inválido para esta tela. O CRM caiu para o Graph para preservar a operação.'
+    return 'A fonte consolidada retornou dados incompletos para esta tela. O painel está usando dados parciais da Meta para preservar a operação.'
   }
-  return 'O consolidado do workflow não respondeu neste momento. O CRM caiu para o Graph da Meta para não deixar o módulo vazio.'
+  return 'As métricas consolidadas não responderam neste momento. O painel está usando dados parciais da Meta para não ficar vazio.'
 }
 
 function describeWarning(warning: string) {
   if (warning === 'empty_report') return 'Sem consolidado diário para a janela consultada'
-  if (warning === 'graph_fallback') return 'Leitura degradada via Graph'
-  if (warning === 'worker_unconfigured') return 'Worker não configurado'
-  if (warning === 'worker_unauthorized') return 'Worker sem autorização'
-  if (warning === 'worker_unavailable') return 'Worker indisponível'
-  if (warning === 'worker_invalid_response') return 'Worker retornou payload inválido'
+  if (warning === 'graph_fallback') return 'Dados parciais da Meta'
+  if (warning === 'worker_unconfigured') return 'Fonte consolidada indisponível'
+  if (warning === 'worker_unauthorized') return 'Credencial pendente'
+  if (warning === 'worker_unavailable') return 'Fonte consolidada temporariamente indisponível'
+  if (warning === 'worker_invalid_response') return 'Fonte consolidada incompleta'
   return warning
 }
 
@@ -58,7 +58,7 @@ export function MetaTrackingDashboard({
         <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-amber-100">
           <div className="flex items-center gap-2 font-medium">
             <WarningCircle className="h-5 w-5" />
-            Avisos de leitura
+            Métricas parciais
           </div>
           {data?.source === 'graph-fallback' ? (
             <p className="mt-2 text-sm text-amber-100/90">{describeFallbackReason(data)}</p>


### PR DESCRIPTION
## Summary
- move Meta Ads last-session timestamp into the refresh tooltip and remove the redundant header clock badge
- replace technical report fallback wording with product-facing partial-metrics copy
- add a Cloudflare Pages secret sync workflow for META_ADS_REPORT_WORKER_API_TOKEN so production can read the consolidated report worker

## Validation
- npm run typecheck
- npm run build
- git diff --check