### PR TITLE
[codex] Harden Meta Ads CRM module and tooltips

### DIFF
--- a/.github/security/pip-audit-path-exceptions.csv
+++ b/.github/security/pip-audit-path-exceptions.csv
@@ -2,10 +2,10 @@
 backend/apps/agent-zero/requirements.txt,2026-06-30,openai-whisper dependency resolution currently fails pip-audit build metadata
 backend/apps/agent-zero/requirements.unified.txt,2026-06-30,openai-whisper dependency resolution currently fails pip-audit build metadata
 backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt,2026-06-30,crawl4ai vendor stack triggers lxml source build in pip-audit and GitHub runner lacks libxml2/libxslt development packages
-backend/apps/automations/scraper/requirements.txt,2026-05-15,python dependency remediation for scraper stack will be handled in a dedicated security update batch
-backend/apps/automations/sprinta/legacy/requirements.txt,2026-05-15,legacy sprinta stack requires coordinated dependency remediation outside this public-site release
-backend/apps/automations/sprinta/v2/requirements.txt,2026-05-15,sprinta v2 python stack requires coordinated dependency remediation outside this public-site release
-backend/apps/instagram/instagrapi/requirements.txt,2026-05-15,instagrapi stack requires dedicated dependency review outside this public-site release
-backend/archive/tools/repo_checks/requirements.txt,2026-05-15,archived tooling dependency remediation is deferred to a separate maintenance pass
-backend/requirements.txt,2026-05-15,backend shared python requirements carry pre-existing vulnerabilities and need a dedicated upgrade pass separate from this release
-backend/tools/scripts/xiaomi/requirements.txt,2026-05-15,xiaomi tooling dependency remediation is deferred to a separate maintenance pass
+backend/apps/automations/scraper/requirements.txt,2026-06-30,python dependency remediation for scraper stack will be handled in a dedicated security update batch
+backend/apps/automations/sprinta/legacy/requirements.txt,2026-06-30,legacy sprinta stack requires coordinated dependency remediation outside this public-site release
+backend/apps/automations/sprinta/v2/requirements.txt,2026-06-30,sprinta v2 python stack requires coordinated dependency remediation outside this public-site release
+backend/apps/instagram/instagrapi/requirements.txt,2026-06-30,instagrapi stack requires dedicated dependency review outside this public-site release
+backend/archive/tools/repo_checks/requirements.txt,2026-06-30,archived tooling dependency remediation is deferred to a separate maintenance pass
+backend/requirements.txt,2026-06-30,backend shared python requirements carry pre-existing vulnerabilities and need a dedicated upgrade pass separate from this release
+backend/tools/scripts/xiaomi/requirements.txt,2026-06-30,xiaomi tooling dependency remediation is deferred to a separate maintenance pass

--- a/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
+++ b/backend/apps/meta-ads/apps/report-ingest-worker/src/index.js
@@ -632,6 +632,7 @@ async function handleReportRequest(request, env, url) {
   }
 
   const latestRuns = await fetchLatestAdRuns(env.META_ADS_DB, accountId, reportDate, limit);
+  const effectiveReportDate = safeString(latestRuns[0]?.report_date) || reportDate;
   if (!latestRuns.length) {
     return jsonResponse(200, {
       ok: true,
@@ -640,6 +641,7 @@ async function handleReportRequest(request, env, url) {
         source: 'd1',
         account_id: accountId,
         report_date: reportDate,
+        requested_report_date: reportDate,
         windows,
         include,
         runs_count: 0,
@@ -653,8 +655,8 @@ async function handleReportRequest(request, env, url) {
   const adIds = dedupeStrings(latestRuns.map((row) => row.ad_id));
   const groupKeys = dedupeStrings(latestRuns.map((row) => row.metrics_group_key));
   const adEntityRows = await fetchAdEntities(env.META_ADS_DB, accountId, adIds);
-  const metricRows = await fetchMetricSnapshots(env.META_ADS_DB, reportDate, groupKeys, windows);
-  const auditRows = await fetchIngestionAudit(env.META_ADS_DB, reportDate, groupKeys, windows);
+  const metricRows = await fetchMetricSnapshots(env.META_ADS_DB, effectiveReportDate, groupKeys, windows);
+  const auditRows = await fetchIngestionAudit(env.META_ADS_DB, effectiveReportDate, groupKeys, windows);
 
   const adEntityById = new Map(adEntityRows.map((row) => [safeString(row.entity_id), row]));
   const latestByGroup = new Map(latestRuns.map((row) => [safeString(row.metrics_group_key), row]));
@@ -671,7 +673,8 @@ async function handleReportRequest(request, env, url) {
   log(env, 'info', 'report_lookup_completed', {
     requestId,
     accountId,
-    reportDate,
+    reportDate: effectiveReportDate,
+    requestedReportDate: reportDate,
     include,
     windows,
     runsCount: latestRuns.length,
@@ -685,7 +688,8 @@ async function handleReportRequest(request, env, url) {
     metadata: {
       source: 'd1',
       account_id: accountId,
-      report_date: reportDate,
+      report_date: effectiveReportDate,
+      requested_report_date: reportDate,
       windows,
       include,
       runs_count: latestRuns.length,
@@ -698,8 +702,19 @@ async function handleReportRequest(request, env, url) {
 
 async function fetchLatestAdRuns(db, accountId, reportDate, limit) {
   const rows = await db.prepare(`
-    WITH ranked AS (
+    WITH effective_report AS (
+      SELECT MAX(ia.report_date) AS report_date
+      FROM ingestion_audit ia
+      JOIN entities e
+        ON e.entity_kind = 'ad'
+       AND e.entity_id = ia.entity_id
+      WHERE ia.report_date <= ?
+        AND ia.entity_level = 'ad'
+        AND e.account_id = ?
+    ),
+    ranked AS (
       SELECT
+        ia.report_date,
         ia.entity_id AS ad_id,
         ia.metrics_group_key,
         ia.requested_at,
@@ -714,11 +729,12 @@ async function fetchLatestAdRuns(db, accountId, reportDate, limit) {
       JOIN entities e
         ON e.entity_kind = 'ad'
        AND e.entity_id = ia.entity_id
-      WHERE ia.report_date = ?
+      WHERE ia.report_date = (SELECT report_date FROM effective_report)
         AND ia.entity_level = 'ad'
         AND e.account_id = ?
     )
     SELECT
+      report_date,
       ad_id,
       metrics_group_key,
       requested_at,
@@ -729,9 +745,10 @@ async function fetchLatestAdRuns(db, accountId, reportDate, limit) {
     WHERE rn = 1
     ORDER BY requested_at DESC
     LIMIT ?
-  `).bind(reportDate, accountId, limit).all();
+  `).bind(reportDate, accountId, accountId, limit).all();
 
   return asArray(rows?.results).map((row) => ({
+    report_date: safeString(row.report_date),
     ad_id: safeString(row.ad_id),
     metrics_group_key: safeString(row.metrics_group_key),
     requested_at: safeString(row.requested_at),

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent } from '@/tabs'
 import { Input } from '@/input'
 import { BrDatePickerInput } from '@/br-date-picker'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/tooltip'
+import { Tooltip, TooltipButton, TooltipContent, TooltipLabel, TooltipTrigger } from '@/tooltip'
 import { useKV } from '@/spark-mock'
 import { DEFAULT_UNIT_OPTIONS, useGlobalUnitSelection } from '@/unitSelection'
 import { dispatchEscalaHeaderAction, subscribeEscalaHeaderState } from '@/escalaHeaderBridge'
@@ -22,7 +22,7 @@ import { dispatchInsumosHeaderAction, subscribeInsumosHeaderState } from '@/insu
 import type { InsumosHeaderState, InsumosOverviewPeriod } from '@/insumosTypes'
 import { dispatchMetaAdsHeaderAction, subscribeMetaAdsHeaderState } from '@/metaAdsHeaderBridge'
 import type { MetaAdsHeaderState } from '@/metaAdsTypes'
-import { CalendarX2, CheckCircle2, Circle, CircleDot, Download, Pencil, RefreshCw, Settings2, Shield, Sparkles } from 'lucide-react'
+import { CalendarX2, CheckCircle2, Circle, CircleDot, Download, Pencil, Plus, RefreshCw, Shield, Sparkles, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
@@ -866,14 +866,15 @@ export default function AppFunctionalNeatlab() {
                                     />
                                     <p className="text-[10px] text-blue-100/70 tracking-[0.25em] uppercase truncate mt-1">CRM</p>
                                 </div>
-                                <button
-                                    type="button"
-                                    onClick={() => setSidebarPinned((v) => !v)}
-                                    title={sidebarPinned ? 'Desafixar menu' : 'Fixar menu'}
-                                    className={`rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.12] text-blue-100/80 hover:text-white transition-colors ${sidebarExpanded ? 'px-2 py-2 text-sm' : 'hidden'}`}
-                                >
-                                    {sidebarPinned ? '📌' : '📍'}
-                                </button>
+                                <TooltipButton label={sidebarPinned ? 'Desafixar menu' : 'Fixar menu'}>
+                                    <button
+                                        type="button"
+                                        onClick={() => setSidebarPinned((v) => !v)}
+                                        className={`rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.12] text-blue-100/80 hover:text-white transition-colors ${sidebarExpanded ? 'px-2 py-2 text-sm' : 'hidden'}`}
+                                    >
+                                        {sidebarPinned ? '📌' : '📍'}
+                                    </button>
+                                </TooltipButton>
                             </div>
 
                             {/* User Info */}
@@ -882,22 +883,24 @@ export default function AppFunctionalNeatlab() {
                                     <div className="w-8 h-8 rounded-lg bg-gradient-blue flex items-center justify-center text-sm font-semibold text-white">
                                         {(user?.name || 'U').charAt(0).toUpperCase()}
                                     </div>
-                                    <button
-                                        type="button"
-                                        onClick={() => setProfileOpen(true)}
-                                        className={`flex-1 min-w-0 text-left ${sidebarExpanded ? '' : 'hidden'}`}
-                                        title="Abrir perfil"
-                                    >
-                                        <p className="font-semibold text-white text-sm leading-tight truncate">{user?.name || 'Usuário'}</p>
-                                        <p className="text-xs text-blue-300/70 truncate">{user?.email}</p>
-                                    </button>
-                                    <button
-                                        onClick={signOut}
-                                        className={`${sidebarExpanded ? 'text-xs' : 'text-sm'} text-blue-300/70 hover:text-red-400 transition-all duration-300 hover:scale-105`}
-                                        title="Sair"
-                                    >
-                                        ⏻
-                                    </button>
+                                    <TooltipButton label="Abrir perfil">
+                                        <button
+                                            type="button"
+                                            onClick={() => setProfileOpen(true)}
+                                            className={`flex-1 min-w-0 text-left ${sidebarExpanded ? '' : 'hidden'}`}
+                                        >
+                                            <p className="font-semibold text-white text-sm leading-tight truncate">{user?.name || 'Usuário'}</p>
+                                            <p className="text-xs text-blue-300/70 truncate">{user?.email}</p>
+                                        </button>
+                                    </TooltipButton>
+                                    <TooltipButton label="Sair">
+                                        <button
+                                            onClick={signOut}
+                                            className={`${sidebarExpanded ? 'text-xs' : 'text-sm'} text-blue-300/70 hover:text-red-400 transition-all duration-300 hover:scale-105`}
+                                        >
+                                            ⏻
+                                        </button>
+                                    </TooltipButton>
                                 </div>
                             </div>
                         </div>
@@ -919,14 +922,15 @@ export default function AppFunctionalNeatlab() {
 	                                        </svg>
 	                                    </span>
 	                                    {search ? (
-	                                        <button
-	                                            onClick={() => setSearch('')}
-	                                            className="absolute right-3 top-1/2 -translate-y-1/2 text-blue-300/60 hover:text-white transition-colors"
-	                                            title="Limpar busca"
-	                                            aria-label="Limpar busca"
-	                                        >
-	                                            ✕
-	                                        </button>
+	                                        <TooltipButton label="Limpar busca">
+	                                            <button
+	                                                onClick={() => setSearch('')}
+	                                                className="absolute right-3 top-1/2 -translate-y-1/2 text-blue-300/60 hover:text-white transition-colors"
+	                                                aria-label="Limpar busca"
+	                                            >
+	                                                ✕
+	                                            </button>
+	                                        </TooltipButton>
 	                                    ) : null}
 	                                </div>
 	                            ) : null}
@@ -935,57 +939,58 @@ export default function AppFunctionalNeatlab() {
 	                                    const isLocked = !UNLOCKED_MODULE_KEYS.has(m.key)
 	                                    const isActive = active === m.key
 	                                    return (
-                                        <button
-                                            key={m.key}
-                                            onClick={() => {
-                                                if (isLocked) return
-                                                setActive(m.key)
-                                            }}
-                                            disabled={isLocked}
-                                            aria-disabled={isLocked}
-                                            aria-label={m.label}
-                                            title={isLocked ? `${m.label} (Em breve)` : m.label}
-                                            className={`w-full group relative overflow-hidden rounded-xl transition-all duration-300 animate-slide-up ${isLocked ? 'opacity-50 cursor-not-allowed' : ''
-                                                }`}
-                                            style={{ animationDelay: `${index * 50}ms` }}
-                                        >
-                                            <div className={`flex items-center gap-3 ${sidebarExpanded ? 'px-4' : 'px-0 justify-center'} py-3 relative z-10 transition-all duration-300 ${isActive
-                                                    ? 'text-white transform scale-[1.02]'
-                                                    : isLocked
-                                                        ? 'text-blue-100/60'
-                                                        : 'text-blue-100/80 hover:text-white hover:transform hover:scale-[1.01]'
-                                                }`}>
-                                                <span className="text-lg leading-none flex-shrink-0 transition-transform duration-300 group-hover:scale-110">{m.icon}</span>
-                                                {sidebarExpanded ? (
-                                                    <span className="truncate font-medium text-sm">{m.label}</span>
-                                                ) : null}
-                                                {sidebarExpanded ? (
-                                                    isLocked ? (
-                                                        <span className="ml-auto text-sm text-blue-100/80" aria-hidden>
-                                                            🔒
-                                                        </span>
-                                                    ) : isActive ? (
-                                                        <div className="ml-auto w-2 h-2 rounded-full bg-white animate-pulse"></div>
-                                                    ) : null
-                                                ) : (
-                                                    isLocked ? (
-                                                        <span className="absolute top-1 right-1 text-[10px] text-blue-100/80" aria-hidden>
-                                                            🔒
-                                                        </span>
-                                                    ) : isActive ? (
-                                                        <span className="absolute bottom-1 right-1 inline-block h-2 w-2 rounded-full bg-white animate-pulse" aria-hidden />
-                                                    ) : null
-                                                )}
-                                            </div>
+                                        <TooltipLabel label={m.label} description={isLocked ? 'Módulo em breve.' : undefined}>
+                                            <button
+                                                key={m.key}
+                                                onClick={() => {
+                                                    if (isLocked) return
+                                                    setActive(m.key)
+                                                }}
+                                                disabled={isLocked}
+                                                aria-disabled={isLocked}
+                                                aria-label={m.label}
+                                                className={`w-full group relative overflow-hidden rounded-xl transition-all duration-300 animate-slide-up ${isLocked ? 'opacity-50 cursor-not-allowed' : ''
+                                                    }`}
+                                                style={{ animationDelay: `${index * 50}ms` }}
+                                            >
+                                                <div className={`flex items-center gap-3 ${sidebarExpanded ? 'px-4' : 'px-0 justify-center'} py-3 relative z-10 transition-all duration-300 ${isActive
+                                                        ? 'text-white transform scale-[1.02]'
+                                                        : isLocked
+                                                            ? 'text-blue-100/60'
+                                                            : 'text-blue-100/80 hover:text-white hover:transform hover:scale-[1.01]'
+                                                    }`}>
+                                                    <span className="text-lg leading-none flex-shrink-0 transition-transform duration-300 group-hover:scale-110">{m.icon}</span>
+                                                    {sidebarExpanded ? (
+                                                        <span className="truncate font-medium text-sm">{m.label}</span>
+                                                    ) : null}
+                                                    {sidebarExpanded ? (
+                                                        isLocked ? (
+                                                            <span className="ml-auto text-sm text-blue-100/80" aria-hidden>
+                                                                🔒
+                                                            </span>
+                                                        ) : isActive ? (
+                                                            <div className="ml-auto w-2 h-2 rounded-full bg-white animate-pulse"></div>
+                                                        ) : null
+                                                    ) : (
+                                                        isLocked ? (
+                                                            <span className="absolute top-1 right-1 text-[10px] text-blue-100/80" aria-hidden>
+                                                                🔒
+                                                            </span>
+                                                        ) : isActive ? (
+                                                            <span className="absolute bottom-1 right-1 inline-block h-2 w-2 rounded-full bg-white animate-pulse" aria-hidden />
+                                                        ) : null
+                                                    )}
+                                                </div>
 
-                                            {/* Active state background */}
-                                            {isActive ? (
-                                                <div className="absolute inset-0 bg-gradient-blue rounded-xl shadow-premium animate-scale-in"></div>
-                                            ) : (
-                                                <div className={`absolute inset-0 bg-white/[0.05] rounded-xl transition-all duration-300 ${isLocked ? 'opacity-0' : 'hover:bg-white/[0.12] opacity-0 group-hover:opacity-100'
-                                                    }`}></div>
-                                            )}
-                                        </button>
+                                                {/* Active state background */}
+                                                {isActive ? (
+                                                    <div className="absolute inset-0 bg-gradient-blue rounded-xl shadow-premium animate-scale-in"></div>
+                                                ) : (
+                                                    <div className={`absolute inset-0 bg-white/[0.05] rounded-xl transition-all duration-300 ${isLocked ? 'opacity-0' : 'hover:bg-white/[0.12] opacity-0 group-hover:opacity-100'
+                                                        }`}></div>
+                                                )}
+                                            </button>
+                                        </TooltipLabel>
                                     )
                                 })()
                             ))}
@@ -1072,42 +1077,45 @@ export default function AppFunctionalNeatlab() {
 					                                                        </>
 					                                                    ) : null}
 
-						                                                    <Button
-						                                                    size="icon"
-						                                                        variant="ghost"
-						                                                        className="h-9 w-9 rounded-md bg-emerald-500/25 text-emerald-100 hover:bg-emerald-500/35"
-					                                                        onClick={() => {
-				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
-	                                                        }}
-			                                                        title="Entrada"
-			                                                        aria-label="Entrada"
-			                                                    >
-				                                                        <img src="/icons/shortcut-entrada.svg" alt="" aria-hidden className="h-5 w-5" />
-			                                                    </Button>
-						                                                    <Button
-						                                                    size="icon"
-						                                                        variant="ghost"
-						                                                        className="h-9 w-9 rounded-md bg-rose-500/30 text-rose-100 hover:bg-rose-500/40"
-					                                                        onClick={() => {
-				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
-	                                                        }}
-			                                                        title="Saída"
-			                                                        aria-label="Saída"
-			                                                    >
-				                                                        <img src="/icons/shortcut-saida.svg" alt="" aria-hidden className="h-5 w-5" />
-			                                                    </Button>
-				                                                    <Button
-				                                                    size="icon"
-				                                                        variant="ghost"
-				                                                        className="h-9 w-9 rounded-md bg-sky-500/30 text-sky-100 hover:bg-sky-500/40"
-				                                                        onClick={() => {
-				                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
-	                                                        }}
-			                                                        title="Transferência"
-			                                                        aria-label="Transferência"
-				                                                    >
-					                                                        <img src="/icons/shortcut-transferencia.svg" alt="" aria-hidden className="h-5 w-5" />
-					                                                    </Button>
+						                                                    <TooltipButton label="Entrada">
+						                                                        <Button
+						                                                            size="icon"
+						                                                            variant="ghost"
+						                                                            className="h-9 w-9 rounded-md bg-emerald-500/25 text-emerald-100 hover:bg-emerald-500/35"
+					                                                            onClick={() => {
+				                                                                dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
+	                                                            }}
+			                                                            aria-label="Entrada"
+			                                                        >
+				                                                            <img src="/icons/shortcut-entrada.svg" alt="" aria-hidden className="h-5 w-5" />
+			                                                        </Button>
+						                                                    </TooltipButton>
+						                                                    <TooltipButton label="Saída">
+						                                                        <Button
+						                                                            size="icon"
+						                                                            variant="ghost"
+						                                                            className="h-9 w-9 rounded-md bg-rose-500/30 text-rose-100 hover:bg-rose-500/40"
+					                                                            onClick={() => {
+				                                                                dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
+	                                                            }}
+			                                                            aria-label="Saída"
+			                                                        >
+				                                                            <img src="/icons/shortcut-saida.svg" alt="" aria-hidden className="h-5 w-5" />
+			                                                        </Button>
+						                                                    </TooltipButton>
+				                                                    <TooltipButton label="Transferência">
+				                                                        <Button
+				                                                            size="icon"
+				                                                            variant="ghost"
+				                                                            className="h-9 w-9 rounded-md bg-sky-500/30 text-sky-100 hover:bg-sky-500/40"
+				                                                            onClick={() => {
+				                                                                dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
+	                                                            }}
+			                                                            aria-label="Transferência"
+				                                                        >
+					                                                            <img src="/icons/shortcut-transferencia.svg" alt="" aria-hidden className="h-5 w-5" />
+					                                                        </Button>
+				                                                    </TooltipButton>
 					
 			                                                </div>
 						                                            </>
@@ -1238,14 +1246,24 @@ export default function AppFunctionalNeatlab() {
                                                                 <Select
                                                                     value={metaAdsHeaderState?.selectedAccountId || ''}
                                                                     onValueChange={(value) => {
+                                                                        if (value === '__meta_ads_add_connection__') {
+                                                                            dispatchMetaAdsHeaderAction({ type: 'connect' })
+                                                                            return
+                                                                        }
                                                                         dispatchMetaAdsHeaderAction({ type: 'set-account', value })
                                                                     }}
-                                                                    disabled={metaAdsHeaderState?.refreshing || !(metaAdsHeaderState?.accounts || []).length}
+                                                                    disabled={metaAdsHeaderState?.refreshing}
                                                                 >
                                                                     <SelectTrigger className="h-8 w-64 bg-white/[0.06] border-white/20 text-white">
                                                                         <SelectValue placeholder="Conta de anúncios" />
                                                                     </SelectTrigger>
                                                                     <SelectContent>
+                                                                        <SelectItem value="__meta_ads_add_connection__" className="bg-slate-950 text-sky-100 focus:bg-sky-500/15 focus:text-sky-50">
+                                                                            <div className="flex w-full items-center gap-2 pr-4">
+                                                                                <Plus className="size-3.5 text-sky-300" aria-hidden="true" />
+                                                                                <span>Adicionar conexão</span>
+                                                                            </div>
+                                                                        </SelectItem>
                                                                         {(metaAdsHeaderState?.accounts || []).map((account) => {
                                                                             const statusTone =
                                                                                 account.statusTone === 'success'
@@ -1257,13 +1275,32 @@ export default function AppFunctionalNeatlab() {
                                                                                             : 'bg-slate-950 text-slate-100 focus:bg-slate-800/90'
                                                                             return (
                                                                                 <SelectItem key={account.id} value={account.id} className={statusTone}>
-                                                                                    <div className="flex w-full items-center justify-between gap-3 pr-4">
+                                                                                    <div className="flex w-full items-center justify-between gap-3 pr-1">
                                                                                         <span className="truncate">{account.name || account.id}</span>
-                                                                                        {account.statusTone === 'success' ? (
-                                                                                            <CircleDot className="size-3.5 text-emerald-300" aria-hidden="true" />
-                                                                                        ) : (
-                                                                                            <Circle className={`size-3.5 ${account.statusTone === 'warning' ? 'text-amber-300' : account.statusTone === 'danger' ? 'text-rose-300' : 'text-slate-400'}`} aria-hidden="true" />
-                                                                                        )}
+                                                                                        <span className="inline-flex items-center gap-2">
+                                                                                            {account.statusTone === 'success' ? (
+                                                                                                <CircleDot className="size-3.5 text-emerald-300" aria-hidden="true" />
+                                                                                            ) : (
+                                                                                                <Circle className={`size-3.5 ${account.statusTone === 'warning' ? 'text-amber-300' : account.statusTone === 'danger' ? 'text-rose-300' : 'text-slate-400'}`} aria-hidden="true" />
+                                                                                            )}
+                                                                                            <button
+                                                                                                type="button"
+                                                                                                className="inline-flex size-5 items-center justify-center rounded-full border border-white/15 text-blue-100/70 transition hover:border-rose-300/50 hover:bg-rose-500/15 hover:text-rose-100"
+                                                                                                aria-label={`Remover ${account.name || account.id} da lista`}
+                                                                                                tabIndex={-1}
+                                                                                                onPointerDown={(event) => {
+                                                                                                    event.preventDefault()
+                                                                                                    event.stopPropagation()
+                                                                                                    dispatchMetaAdsHeaderAction({ type: 'remove-account', value: account.id })
+                                                                                                }}
+                                                                                                onClick={(event) => {
+                                                                                                    event.preventDefault()
+                                                                                                    event.stopPropagation()
+                                                                                                }}
+                                                                                            >
+                                                                                                <X className="size-3" aria-hidden="true" />
+                                                                                            </button>
+                                                                                        </span>
                                                                                     </div>
                                                                                 </SelectItem>
                                                                             )
@@ -1406,22 +1443,6 @@ export default function AppFunctionalNeatlab() {
                                                         size="icon"
                                                         variant="ghost"
                                                         className="h-8 w-8 rounded-full border border-white/15 bg-white/[0.06] text-blue-50 hover:bg-white/[0.12]"
-                                                        onClick={() => dispatchMetaAdsHeaderAction({ type: 'manage-connections' })}
-                                                        aria-label="Gerenciar conexao"
-                                                    >
-                                                        <Settings2 className="size-3.5" aria-hidden="true" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                    Gerenciar conexao
-                                                </TooltipContent>
-                                            </Tooltip>
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button
-                                                        size="icon"
-                                                        variant="ghost"
-                                                        className="h-8 w-8 rounded-full border border-white/15 bg-white/[0.06] text-blue-50 hover:bg-white/[0.12]"
                                                         onClick={() => dispatchMetaAdsHeaderAction({ type: 'refresh' })}
                                                         disabled={metaAdsHeaderState?.refreshing}
                                                         aria-label="Atualizar"
@@ -1430,14 +1451,9 @@ export default function AppFunctionalNeatlab() {
                                                     </Button>
                                                 </TooltipTrigger>
                                                 <TooltipContent>
-                                                    <div className="space-y-0.5">
-                                                        <div>Atualizar painel</div>
-                                                        <div className="text-[11px] text-slate-300">
-                                                            {metaAdsHeaderState?.sessionUpdatedAt
-                                                                ? `Última atualização: ${new Date(metaAdsHeaderState.sessionUpdatedAt).toLocaleString('pt-BR')}`
-                                                                : 'Sem atualização registrada nesta sessão.'}
-                                                        </div>
-                                                    </div>
+                                                    {metaAdsHeaderState?.sessionUpdatedAt
+                                                        ? `Atualizar. Ultima atualizacao: ${new Date(metaAdsHeaderState.sessionUpdatedAt).toLocaleString('pt-BR')}`
+                                                        : 'Atualizar'}
                                                 </TooltipContent>
                                             </Tooltip>
                                         </div>
@@ -1507,15 +1523,16 @@ export default function AppFunctionalNeatlab() {
                                     ) : null}
 		                                    {active === 'insumos' ? (
 		                                        <div className="flex items-start gap-2 min-w-[220px] justify-between rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-blue-200/70">
-		                                            <button
-		                                                type="button"
-		                                                className="inline-flex"
-		                                                onClick={() => setEstoqueThresholdsOpen(true)}
-		                                                title="Editar faixas de estoque"
-		                                                aria-label="Editar faixas de estoque"
-		                                            >
-		                                                <Badge className={`uppercase tracking-wide border ${estoqueBadgeClass}`}>Estoque</Badge>
-		                                            </button>
+		                                            <TooltipButton label="Editar faixas de estoque">
+		                                                <button
+		                                                    type="button"
+		                                                    className="inline-flex"
+		                                                    onClick={() => setEstoqueThresholdsOpen(true)}
+		                                                    aria-label="Editar faixas de estoque"
+		                                                >
+		                                                    <Badge className={`uppercase tracking-wide border ${estoqueBadgeClass}`}>Estoque</Badge>
+		                                                </button>
+		                                            </TooltipButton>
 		                                            <span className="ml-auto text-right flex-1">
 		                                                <span className="block font-mono text-blue-50">
 		                                                {insumosHeaderEstoque?.loading ? (
@@ -1546,51 +1563,54 @@ export default function AppFunctionalNeatlab() {
 		                                    ) : null}
 		                                    {active === 'insumos' ? (
 		                                        <div className="flex items-center gap-1">
-		                                            <Button
-		                                                size="icon"
-		                                                variant="ghost"
-		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
-		                                                onClick={() => {
-		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'expandAll' })
-	                                                }}
-		                                                title="Expandir tudo"
-		                                                aria-label="Expandir tudo"
-		                                            >
+		                                            <TooltipButton label="Expandir tudo">
+		                                                <Button
+		                                                    size="icon"
+		                                                    variant="ghost"
+		                                                    className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
+		                                                    onClick={() => {
+		                                                        dispatchInsumosHeaderAction({ type: 'layout', value: 'expandAll' })
+	                                                    }}
+		                                                    aria-label="Expandir tudo"
+		                                                >
 		                                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
 		                                                    <path d="M7 9l5 5 5-5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                    <path d="M7 14l5 5 5-5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                </svg>
-		                                            </Button>
-		                                            <Button
-		                                                size="icon"
-		                                                variant="ghost"
-		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
-		                                                onClick={() => {
-		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'collapseAll' })
-	                                                }}
-		                                                title="Contrair tudo"
-		                                                aria-label="Contrair tudo"
-		                                            >
+		                                                </Button>
+		                                            </TooltipButton>
+		                                            <TooltipButton label="Contrair tudo">
+		                                                <Button
+		                                                    size="icon"
+		                                                    variant="ghost"
+		                                                    className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
+		                                                    onClick={() => {
+		                                                        dispatchInsumosHeaderAction({ type: 'layout', value: 'collapseAll' })
+	                                                    }}
+		                                                    aria-label="Contrair tudo"
+		                                                >
 		                                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
 		                                                    <path d="M7 15l5-5 5 5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                    <path d="M7 10l5-5 5 5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                </svg>
-		                                            </Button>
-		                                            <Button
-		                                                size="icon"
-		                                                variant="ghost"
-		                                                className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
-		                                                onClick={() => {
-		                                                    dispatchInsumosHeaderAction({ type: 'layout', value: 'reset' })
-	                                                }}
-		                                                title="Resetar layout"
-		                                                aria-label="Resetar layout"
-		                                            >
+		                                                </Button>
+		                                            </TooltipButton>
+		                                            <TooltipButton label="Resetar layout">
+		                                                <Button
+		                                                    size="icon"
+		                                                    variant="ghost"
+		                                                    className="h-9 w-9 rounded-md bg-transparent text-white hover:bg-white/[0.10]"
+		                                                    onClick={() => {
+		                                                        dispatchInsumosHeaderAction({ type: 'layout', value: 'reset' })
+	                                                    }}
+		                                                    aria-label="Resetar layout"
+		                                                >
 		                                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
 		                                                    <path d="M21 12a9 9 0 1 1-3.1-6.7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                    <path d="M21 4v6h-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
 		                                                </svg>
-		                                            </Button>
+		                                                </Button>
+		                                            </TooltipButton>
 		                                        </div>
 		                                    ) : null}
                                     {UNLOCKED_MODULE_KEYS.has('notifications') && hasModuleAccess('notifications') ? (
@@ -1603,18 +1623,19 @@ export default function AppFunctionalNeatlab() {
 	                                    ) : null}
 
                                     {UNLOCKED_MODULE_KEYS.has('status') && hasModuleAccess('status') ? (
-                                        <Button
-                                            variant="outline"
-                                            className="bg-white/[0.08] border-white/20 text-white hover:bg-white/[0.12] h-11 w-11 p-0"
-	                                            onClick={() => {
-	                                                setSearch('')
-	                                                setActive('status')
-	                                            }}
-	                                            title="Status do sistema"
-	                                            aria-label="Status do sistema"
-	                                        >
-	                                            <span className="text-lg">⚙️</span>
-	                                        </Button>
+                                        <TooltipButton label="Status do sistema">
+                                            <Button
+                                                variant="outline"
+                                                className="bg-white/[0.08] border-white/20 text-white hover:bg-white/[0.12] h-11 w-11 p-0"
+	                                                onClick={() => {
+	                                                    setSearch('')
+	                                                    setActive('status')
+	                                                }}
+	                                                aria-label="Status do sistema"
+	                                            >
+	                                                <span className="text-lg">⚙️</span>
+	                                            </Button>
+                                        </TooltipButton>
 	                                    ) : null}
 	                                </div>
                             </div>
@@ -1686,42 +1707,45 @@ export default function AppFunctionalNeatlab() {
 		                                            </Select>
 		                                        </div>
 		                                        <div className="flex items-center gap-1">
-	                                                <Button
-	                                                    size="icon"
-	                                                    variant="ghost"
-                                                    className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
-                                                    onClick={() => {
-                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
-                                                    }}
-                                                    title="Entrada"
-                                                    aria-label="Entrada"
-                                                >
+	                                                <TooltipButton label="Entrada">
+	                                                    <Button
+	                                                        size="icon"
+	                                                        variant="ghost"
+                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
+                                                        onClick={() => {
+                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'ENTRADA' })
+                                                        }}
+                                                        aria-label="Entrada"
+                                                    >
                                                     <img src="/icons/shortcut-entrada.svg" alt="" aria-hidden className="h-11 w-11" />
-                                                </Button>
-                                                <Button
-                                                    size="icon"
-                                                    variant="ghost"
-                                                    className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
-                                                    onClick={() => {
-                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
-                                                    }}
-                                                    title="Saída"
-                                                    aria-label="Saída"
-                                                >
+                                                    </Button>
+                                                </TooltipButton>
+                                                <TooltipButton label="Saída">
+                                                    <Button
+                                                        size="icon"
+                                                        variant="ghost"
+                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
+                                                        onClick={() => {
+                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'BAIXA' })
+                                                        }}
+                                                        aria-label="Saída"
+                                                    >
                                                     <img src="/icons/shortcut-saida.svg" alt="" aria-hidden className="h-11 w-11" />
-                                                </Button>
-                                                <Button
-                                                    size="icon"
-                                                    variant="ghost"
-                                                    className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
-                                                    onClick={() => {
-                                                        dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
-                                                    }}
-                                                    title="Transferência"
-                                                    aria-label="Transferência"
-                                                >
+                                                    </Button>
+                                                </TooltipButton>
+                                                <TooltipButton label="Transferência">
+                                                    <Button
+                                                        size="icon"
+                                                        variant="ghost"
+                                                        className="bg-transparent text-white hover:bg-white/[0.10] p-0 size-11 rounded-full"
+                                                        onClick={() => {
+                                                            dispatchInsumosHeaderAction({ type: 'quick-op', value: 'TRANSFERENCIA' })
+                                                        }}
+                                                        aria-label="Transferência"
+                                                    >
 	                                                <img src="/icons/shortcut-transferencia.svg" alt="" aria-hidden className="h-11 w-11" />
-                                                </Button>
+                                                    </Button>
+                                                </TooltipButton>
 		
 	                                        </div>
 	                                    </div>

--- a/frontend/HarmoniaModule.tsx
+++ b/frontend/HarmoniaModule.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/tabs'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { LoadingPercentText } from '@/LoadingPattern'
+import { TooltipButton, TooltipLabel } from '@/tooltip'
 
 const WhatsAppUnifiedHub = React.lazy(() => import('@/WhatsAppUnifiedHub').then((m) => ({ default: m.WhatsAppUnifiedHub })))
 const OmnichannelCenter = React.lazy(() => import('@/OmnichannelCenter').then((m) => ({ default: m.OmnichannelCenter })))
@@ -694,15 +695,16 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
                     'Recarregar'
                   )}
                 </Button>
-                <Button
-                  variant="secondary"
-                  className="h-8"
-                  onClick={() => loadInbox('more')}
-                  disabled={inboxLoading || !inboxCursor?.cursorTs || !inboxCursor?.cursorId}
-                  title={!inboxCursor ? 'Carregue primeiro' : !inboxCursor.cursorTs ? 'Sem mais páginas' : 'Carregar mais'}
-                >
-                  Mais
-                </Button>
+                <TooltipButton label={!inboxCursor ? 'Carregue primeiro' : !inboxCursor.cursorTs ? 'Sem mais páginas' : 'Carregar mais'}>
+                  <Button
+                    variant="secondary"
+                    className="h-8"
+                    onClick={() => loadInbox('more')}
+                    disabled={inboxLoading || !inboxCursor?.cursorTs || !inboxCursor?.cursorId}
+                  >
+                    Mais
+                  </Button>
+                </TooltipButton>
               </div>
             </div>
 
@@ -721,30 +723,31 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
                 {filteredInboxItems.map((it) => {
                   const isActive = conversation?.id && String(conversation.id) === String(it.id)
                   return (
-                  <button
-                    key={it.id}
-                    type="button"
-                    onClick={() => openConversationById(it.id)}
-                    className={`w-full text-left rounded-xl border ${isActive ? 'border-emerald-400/50 bg-emerald-500/10' : 'border-white/10 bg-black/20'} hover:bg-white/[0.06] transition-colors px-3 py-2`}
-                    title="Abrir conversa"
-                  >
-                    <div className="flex items-center justify-between gap-3 text-xs">
-                      <div className="text-white/90 font-semibold truncate">
-                        {it.contact_display_name || it.contact_phone_raw || 'Contato'}
-                        {it.contact_opted_out_at ? <span className="ml-2 text-amber-200/80">(opt-out)</span> : null}
+                  <TooltipLabel label="Abrir conversa">
+                    <button
+                      key={it.id}
+                      type="button"
+                      onClick={() => openConversationById(it.id)}
+                      className={`w-full text-left rounded-xl border ${isActive ? 'border-emerald-400/50 bg-emerald-500/10' : 'border-white/10 bg-black/20'} hover:bg-white/[0.06] transition-colors px-3 py-2`}
+                    >
+                      <div className="flex items-center justify-between gap-3 text-xs">
+                        <div className="text-white/90 font-semibold truncate">
+                          {it.contact_display_name || it.contact_phone_raw || 'Contato'}
+                          {it.contact_opted_out_at ? <span className="ml-2 text-amber-200/80">(opt-out)</span> : null}
+                        </div>
+                        <div className="text-white/70">{fmtDateTime(it.last_activity_at || it.last_message_at || null)}</div>
                       </div>
-                      <div className="text-white/70">{fmtDateTime(it.last_activity_at || it.last_message_at || null)}</div>
-                    </div>
-                    <div className="mt-1 text-xs text-blue-100/70 truncate">
-                      {(it.last_message_text || '').trim()
-                        ? `${String(it.last_message_direction || '').toUpperCase() === 'OUTBOUND' ? 'OUT' : 'IN'}: ${it.last_message_text}`
-                        : '—'}
-                    </div>
-                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-blue-200/60">
-                      <div>stage: <span className="text-white/70">{it.stage || '—'}</span></div>
-                      <div className="truncate">id: <span className="text-white/60">{it.id}</span></div>
-                    </div>
-                  </button>
+                      <div className="mt-1 text-xs text-blue-100/70 truncate">
+                        {(it.last_message_text || '').trim()
+                          ? `${String(it.last_message_direction || '').toUpperCase() === 'OUTBOUND' ? 'OUT' : 'IN'}: ${it.last_message_text}`
+                          : '—'}
+                      </div>
+                      <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-blue-200/60">
+                        <div>stage: <span className="text-white/70">{it.stage || '—'}</span></div>
+                        <div className="truncate">id: <span className="text-white/60">{it.id}</span></div>
+                      </div>
+                    </button>
+                  </TooltipLabel>
                   )
                 })}
               </div>
@@ -1002,21 +1005,22 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
                   <code className="flex-1 text-xs text-white/90 bg-black/30 border border-white/10 rounded-lg px-2 py-1 overflow-hidden text-ellipsis">
                     {conversation.id || '—'}
                   </code>
-                  <Button
-                    variant="outline"
-                    className="h-9"
-                    onClick={() => {
-                      const id = String(conversation.id || '')
-                      if (!id) return
-                      try {
-                        void navigator.clipboard.writeText(id)
-                      } catch { /* ignore */ }
-                    }}
-                    disabled={!conversation.id}
-                    title="Copiar ID"
-                  >
-                    Copiar
-                  </Button>
+                  <TooltipButton label="Copiar ID">
+                    <Button
+                      variant="outline"
+                      className="h-9"
+                      onClick={() => {
+                        const id = String(conversation.id || '')
+                        if (!id) return
+                        try {
+                          void navigator.clipboard.writeText(id)
+                        } catch { /* ignore */ }
+                      }}
+                      disabled={!conversation.id}
+                    >
+                      Copiar
+                    </Button>
+                  </TooltipButton>
                 </div>
               </div>
             </CardContent>
@@ -1283,15 +1287,16 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
                                 'Recarregar'
                               )}
                             </Button>
-                            <Button
-                              variant="secondary"
-                              className="h-8"
-                              onClick={() => loadInbox('more')}
-                              disabled={inboxLoading || !inboxCursor?.cursorTs || !inboxCursor?.cursorId}
-                              title={!inboxCursor ? 'Carregue primeiro' : !inboxCursor.cursorTs ? 'Sem mais páginas' : 'Carregar mais'}
-                            >
-                              Mais
-                            </Button>
+                            <TooltipButton label={!inboxCursor ? 'Carregue primeiro' : !inboxCursor.cursorTs ? 'Sem mais páginas' : 'Carregar mais'}>
+                              <Button
+                                variant="secondary"
+                                className="h-8"
+                                onClick={() => loadInbox('more')}
+                                disabled={inboxLoading || !inboxCursor?.cursorTs || !inboxCursor?.cursorId}
+                              >
+                                Mais
+                              </Button>
+                            </TooltipButton>
                           </div>
                         </div>
 
@@ -1302,30 +1307,31 @@ export function HarmoniaModule({ mode = 'full', showHeader = true, showChannels 
                         {inboxItems.length ? (
                           <div className="max-h-[240px] overflow-auto space-y-2 pr-1">
                             {inboxItems.map((it) => (
-                              <button
-                                key={it.id}
-                                type="button"
-                                onClick={() => openConversationById(it.id)}
-                                className="w-full text-left rounded-xl border border-white/10 bg-black/20 hover:bg-white/[0.06] transition-colors px-3 py-2"
-                                title="Abrir conversa"
-                              >
-                                <div className="flex items-center justify-between gap-3 text-xs">
-                                  <div className="text-white/90 font-semibold truncate">
-                                    {it.contact_display_name || it.contact_phone_raw || 'Contato'}
-                                    {it.contact_opted_out_at ? <span className="ml-2 text-amber-200/80">(opt-out)</span> : null}
+                              <TooltipLabel label="Abrir conversa">
+                                <button
+                                  key={it.id}
+                                  type="button"
+                                  onClick={() => openConversationById(it.id)}
+                                  className="w-full text-left rounded-xl border border-white/10 bg-black/20 hover:bg-white/[0.06] transition-colors px-3 py-2"
+                                >
+                                  <div className="flex items-center justify-between gap-3 text-xs">
+                                    <div className="text-white/90 font-semibold truncate">
+                                      {it.contact_display_name || it.contact_phone_raw || 'Contato'}
+                                      {it.contact_opted_out_at ? <span className="ml-2 text-amber-200/80">(opt-out)</span> : null}
+                                    </div>
+                                    <div className="text-white/70">{fmtDateTime(it.last_activity_at || it.last_message_at || null)}</div>
                                   </div>
-                                  <div className="text-white/70">{fmtDateTime(it.last_activity_at || it.last_message_at || null)}</div>
-                                </div>
-                                <div className="mt-1 text-xs text-blue-100/70 truncate">
-                                  {(it.last_message_text || '').trim()
-                                    ? `${String(it.last_message_direction || '').toUpperCase() === 'OUTBOUND' ? 'OUT' : 'IN'}: ${it.last_message_text}`
-                                    : '—'}
-                                </div>
-                                <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-blue-200/60">
-                                  <div>stage: <span className="text-white/70">{it.stage || '—'}</span></div>
-                                  <div className="truncate">id: <span className="text-white/60">{it.id}</span></div>
-                                </div>
-                              </button>
+                                  <div className="mt-1 text-xs text-blue-100/70 truncate">
+                                    {(it.last_message_text || '').trim()
+                                      ? `${String(it.last_message_direction || '').toUpperCase() === 'OUTBOUND' ? 'OUT' : 'IN'}: ${it.last_message_text}`
+                                      : '—'}
+                                  </div>
+                                  <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-blue-200/60">
+                                    <div>stage: <span className="text-white/70">{it.stage || '—'}</span></div>
+                                    <div className="truncate">id: <span className="text-white/60">{it.id}</span></div>
+                                  </div>
+                                </button>
+                              </TooltipLabel>
                             ))}
                           </div>
                         ) : (

--- a/frontend/InsumosBarcodeScannerInline.tsx
+++ b/frontend/InsumosBarcodeScannerInline.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button } from '@/button'
+import { TooltipButton } from '@/tooltip'
 
 export function InsumosBarcodeScannerInline({
   onDetected,
@@ -251,14 +252,15 @@ export function InsumosBarcodeScannerInline({
             Inverter câmera
           </Button>
           {!running ? (
-            <Button
-              variant="outline"
-              onClick={() => void start('gesture')}
-              disabled={starting}
-              title={needsGesture ? 'Clique para solicitar permissão de câmera' : 'Tentar novamente'}
-            >
-              {starting ? 'Iniciando…' : needsGesture ? 'Ativar câmera' : 'Tentar novamente'}
-            </Button>
+            <TooltipButton label={needsGesture ? 'Clique para solicitar permissão de câmera' : 'Tentar novamente'}>
+              <Button
+                variant="outline"
+                onClick={() => void start('gesture')}
+                disabled={starting}
+              >
+                {starting ? 'Iniciando…' : needsGesture ? 'Ativar câmera' : 'Tentar novamente'}
+              </Button>
+            </TooltipButton>
           ) : null}
           <Button variant="secondary" onClick={() => { stop(); onClose() }}>Fechar</Button>
         </div>

--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -39,6 +39,13 @@ const buildRange = (days: MetaAdsReportWindowDays) => {
   return { since, until }
 }
 
+function assertAtLeastOneSettled<T>(results: PromiseSettledResult<T>[], message: string) {
+  if (results.length > 0 && results.every((result) => result.status === 'rejected')) {
+    const firstError = results.find((result) => result.status === 'rejected') as PromiseRejectedResult | undefined
+    throw firstError?.reason || new Error(message)
+  }
+}
+
 function formatCustomRangeLabel(range: MetaAdsCustomDateRange | null) {
   if (!range) return ''
   return `${range.since} -> ${range.until}`
@@ -463,6 +470,20 @@ export function MetaCampaignControlCenter() {
     }
   }
 
+  const handleRemoveAccount = async (adAccountId: string) => {
+    setRefreshing(true)
+    try {
+      await metaAdsApi.removeAdAccount({ adAccountId })
+      await refreshConnectedState()
+      toast.success('Conta removida da lista do Meta Ads')
+    } catch (error: any) {
+      setAccountsError(error)
+      toast.error(error?.message || 'Falha ao remover conta da lista')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   const handleReportWindowChange = async (nextWindowDays: MetaAdsReportWindowDays) => {
     if (nextWindowDays === reportWindowDays && !customRange) return
     setReportWindowDays(nextWindowDays)
@@ -471,10 +492,11 @@ export function MetaCampaignControlCenter() {
     if (!status?.connection.connected || !selectedAccount) return
     setRefreshing(true)
     try {
-      await Promise.allSettled([
+      const results = await Promise.allSettled([
         loadOverview({ windowDays: nextWindowDays, custom: null }),
         loadReport({ windowDays: nextWindowDays, custom: null }),
       ])
+      assertAtLeastOneSettled(results, 'Falha ao atualizar o período do Meta Ads')
       toast.success(`Janela ajustada para ${nextWindowDays} dias`)
     } catch (error: any) {
       setStatusError(error)
@@ -506,10 +528,11 @@ export function MetaCampaignControlCenter() {
     if (!status?.connection.connected || !selectedAccount) return
     setRefreshing(true)
     try {
-      await Promise.allSettled([
+      const results = await Promise.allSettled([
         loadOverview({ custom: nextCustomRange }),
         loadReport({ custom: nextCustomRange }),
       ])
+      assertAtLeastOneSettled(results, 'Falha ao aplicar o período personalizado')
       toast.success('Período personalizado aplicado ao Meta Ads')
     } catch (error: any) {
       setStatusError(error)
@@ -527,10 +550,11 @@ export function MetaCampaignControlCenter() {
     if (!status?.connection.connected || !selectedAccount) return
     setRefreshing(true)
     try {
-      await Promise.allSettled([
+      const results = await Promise.allSettled([
         loadOverview({ windowDays: reportWindowDays, custom: null }),
         loadReport({ windowDays: reportWindowDays, custom: null }),
       ])
+      assertAtLeastOneSettled(results, 'Falha ao restaurar o período padrão')
       toast.success(`Janela padrão de ${reportWindowDays} dias restaurada`)
     } catch (error: any) {
       setStatusError(error)
@@ -550,12 +574,20 @@ export function MetaCampaignControlCenter() {
         setManageConnectionsOpen(true)
         return
       }
+      if (action.type === 'connect') {
+        handleOpenOAuth()
+        return
+      }
       if (action.type === 'disconnect') {
         if (status?.connection.connected) handleDisconnect()
         return
       }
       if (action.type === 'set-account' && action.value) {
         handleSelectAccount(action.value)
+        return
+      }
+      if (action.type === 'remove-account' && action.value) {
+        handleRemoveAccount(action.value)
         return
       }
       if (action.type === 'set-report-window') {
@@ -566,7 +598,7 @@ export function MetaCampaignControlCenter() {
         handleOpenCustomRange()
       }
     })
-  }, [handleDisconnect, handleRefresh, handleReportWindowChange, handleSelectAccount, status?.connection.connected])
+  }, [handleDisconnect, handleRefresh, handleOpenOAuth, handleRemoveAccount, handleReportWindowChange, handleSelectAccount, status?.connection.connected])
 
   const missingConfig = status?.missingConfig || []
   const connectActionsDisabled =

--- a/frontend/MetaSentimentMonitor.tsx
+++ b/frontend/MetaSentimentMonitor.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/scroll-area"
 import { Progress } from "@/progress"
 import { Avatar, AvatarFallback, AvatarImage } from "@/avatar"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/select"
+import { TooltipLabel } from "@/tooltip"
 import { toast } from 'sonner'
 import {
   InstagramLogo,
@@ -799,21 +800,30 @@ export function MetaSentimentMonitor() {
                   return (
                     <div key={index} className="flex flex-col items-center space-y-2">
                       <div className="flex flex-col items-center space-y-1">
-                        <div
-                          className="bg-green-500 rounded-t w-8"
-                          style={{ height: `${positiveHeight * 2}px` }}
-                          title={`Positivas: ${trend.positive}`}
-                        ></div>
-                        <div
-                          className="bg-gray-400 w-8"
-                          style={{ height: `${neutralHeight * 2}px` }}
-                          title={`Neutras: ${trend.neutral}`}
-                        ></div>
-                        <div
-                          className="bg-red-500 rounded-b w-8"
-                          style={{ height: `${negativeHeight * 2}px` }}
-                          title={`Negativas: ${trend.negative}`}
-                        ></div>
+                        <TooltipLabel label="Positivas" description={String(trend.positive)}>
+                          <div
+                            className="bg-green-500 rounded-t w-8"
+                            style={{ height: `${positiveHeight * 2}px` }}
+                            aria-label={`Positivas: ${trend.positive}`}
+                            tabIndex={0}
+                          ></div>
+                        </TooltipLabel>
+                        <TooltipLabel label="Neutras" description={String(trend.neutral)}>
+                          <div
+                            className="bg-gray-400 w-8"
+                            style={{ height: `${neutralHeight * 2}px` }}
+                            aria-label={`Neutras: ${trend.neutral}`}
+                            tabIndex={0}
+                          ></div>
+                        </TooltipLabel>
+                        <TooltipLabel label="Negativas" description={String(trend.negative)}>
+                          <div
+                            className="bg-red-500 rounded-b w-8"
+                            style={{ height: `${negativeHeight * 2}px` }}
+                            aria-label={`Negativas: ${trend.negative}`}
+                            tabIndex={0}
+                          ></div>
+                        </TooltipLabel>
                       </div>
                       <span className="text-xs text-muted-foreground">
                         {new Date(trend.date as any).toLocaleDateString('pt-BR', { weekday: 'short' })}

--- a/frontend/MetaTrackingDashboard.tsx
+++ b/frontend/MetaTrackingDashboard.tsx
@@ -5,27 +5,27 @@ import { LinkBreak, WarningCircle } from '@phosphor-icons/react'
 function describeFallbackReason(report: MetaAdsReportResponse | null) {
   const reason = report?.fallbackReason
   if (reason === 'worker_unconfigured') {
-    return 'As métricas consolidadas ainda não estão disponíveis nesta leitura. O painel está usando dados parciais da Meta para não ficar vazio.'
+    return 'O consolidado do workflow ainda não está configurado neste runtime do CRM. O módulo caiu para o Graph para não ficar vazio.'
   }
   if (reason === 'worker_unauthorized') {
-    return 'O CRM não conseguiu acessar a fonte consolidada de métricas. O painel está usando dados parciais da Meta enquanto a credencial é normalizada.'
+    return 'O CRM não conseguiu autenticar a leitura do worker consolidado. O módulo caiu para o Graph enquanto a credencial do worker não é corrigida.'
   }
   if (reason === 'worker_unavailable') {
-    return 'A fonte consolidada de métricas não respondeu nesta leitura. O painel está usando dados parciais da Meta até o serviço voltar.'
+    return 'O worker consolidado ficou indisponível nesta leitura. O CRM caiu para o Graph até o consolidado voltar a responder.'
   }
   if (reason === 'worker_invalid_response') {
-    return 'A fonte consolidada retornou dados incompletos para esta tela. O painel está usando dados parciais da Meta para preservar a operação.'
+    return 'O worker consolidado respondeu em formato inválido para esta tela. O CRM caiu para o Graph para preservar a operação.'
   }
-  return 'As métricas consolidadas não responderam neste momento. O painel está usando dados parciais da Meta para não ficar vazio.'
+  return 'O consolidado do workflow não respondeu neste momento. O CRM caiu para o Graph da Meta para não deixar o módulo vazio.'
 }
 
 function describeWarning(warning: string) {
   if (warning === 'empty_report') return 'Sem consolidado diário para a janela consultada'
-  if (warning === 'graph_fallback') return 'Dados parciais da Meta'
-  if (warning === 'worker_unconfigured') return 'Fonte consolidada indisponível'
-  if (warning === 'worker_unauthorized') return 'Credencial pendente'
-  if (warning === 'worker_unavailable') return 'Fonte consolidada temporariamente indisponível'
-  if (warning === 'worker_invalid_response') return 'Fonte consolidada incompleta'
+  if (warning === 'graph_fallback') return 'Leitura degradada via Graph'
+  if (warning === 'worker_unconfigured') return 'Worker não configurado'
+  if (warning === 'worker_unauthorized') return 'Worker sem autorização'
+  if (warning === 'worker_unavailable') return 'Worker indisponível'
+  if (warning === 'worker_invalid_response') return 'Worker retornou payload inválido'
   return warning
 }
 
@@ -58,7 +58,7 @@ export function MetaTrackingDashboard({
         <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-amber-100">
           <div className="flex items-center gap-2 font-medium">
             <WarningCircle className="h-5 w-5" />
-            Métricas parciais
+            Avisos de leitura
           </div>
           {data?.source === 'graph-fallback' ? (
             <p className="mt-2 text-sm text-amber-100/90">{describeFallbackReason(data)}</p>

--- a/frontend/OpenEntityButton.tsx
+++ b/frontend/OpenEntityButton.tsx
@@ -1,4 +1,5 @@
 import { ArrowSquareOut } from '@phosphor-icons/react'
+import { TooltipButton } from '@/tooltip'
 
 export function OpenEntityButton({
   onClick,
@@ -8,14 +9,15 @@ export function OpenEntityButton({
   label?: string
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={label}
-      title={label.toLowerCase()}
-      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900/70 text-slate-200 transition hover:border-sky-500/40 hover:text-sky-100"
-    >
-      <ArrowSquareOut className="h-3.5 w-3.5" />
-    </button>
+    <TooltipButton label={label}>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900/70 text-slate-200 transition hover:border-sky-500/40 hover:text-sky-100"
+      >
+        <ArrowSquareOut className="h-3.5 w-3.5" />
+      </button>
+    </TooltipButton>
   )
 }

--- a/frontend/PipelineManager.tsx
+++ b/frontend/PipelineManager.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/tabs"
 import { Label } from "@/label"
 import { Switch } from "@/switch"
+import { TooltipLabel } from "@/tooltip"
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
 import {
   Plus,
@@ -379,11 +380,14 @@ export function PipelineManager() {
                         .sort((a, b) => a.order - b.order)
                         .map((stage, index) => (
                           <div key={stage.id} className="flex items-center space-x-1 flex-shrink-0">
-                            <div
-                              className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
-                              style={{ backgroundColor: stage.color }}
-                              title={stage.name}
-                            />
+                            <TooltipLabel label={stage.name}>
+                              <div
+                                className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                                style={{ backgroundColor: stage.color }}
+                                aria-label={stage.name}
+                                tabIndex={0}
+                              />
+                            </TooltipLabel>
                             {index < pipeline.stages.length - 1 && (
                               <ArrowRight className="h-3 w-3 text-muted-foreground" />
                             )}

--- a/frontend/SocialNetworksStudio.tsx
+++ b/frontend/SocialNetworksStudio.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/label'
 import { Badge } from '@/badge'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { Checkbox } from '@/checkbox'
+import { TooltipTruncate } from '@/tooltip'
 import { toast } from 'sonner'
 import { InstagramStudioPro } from '@/InstagramStudioPro'
 import { ThreadsStudio } from '@/ThreadsStudio'
@@ -929,9 +930,7 @@ export function SocialNetworksStudio() {
                       <div key={`${a.unitKey}:${a.platform}`} className="grid grid-cols-12 gap-2 px-3 py-2 text-xs text-white border-b border-white/5">
                         <div className="col-span-2 font-mono">{a.unitKey}</div>
                         <div className="col-span-2">{a.platform}</div>
-                        <div className="col-span-5 font-mono truncate" title={a.accountId}>
-                          {a.accountId}
-                        </div>
+                        <TooltipTruncate text={a.accountId} className="col-span-5 font-mono" />
                         <div className="col-span-2 font-mono">{a.apiVersion || '—'}</div>
                         <div className="col-span-1 flex justify-end gap-1">
                           <Button

--- a/frontend/TOOLTIPS.md
+++ b/frontend/TOOLTIPS.md
@@ -1,0 +1,88 @@
+# Tooltips no CRM
+
+## Objetivo
+`@/tooltip` é a base oficial para ajuda contextual curta no CRM. Use tooltip para reduzir ruído visual sem esconder contexto importante.
+
+## Quando usar
+- Botões `icon-only`
+- Siglas e métricas abreviadas
+- Badges de status ou labels ambíguos
+- Cabeçalhos curtos de tabela
+- Texto truncado
+- Ações sensíveis quando uma dica curta reduz erro operacional
+
+## Quando não usar
+- Explicações longas, críticas ou com múltiplos passos
+- Conteúdo que precisa de ação dentro da própria ajuda
+- Informação essencial para completar uma tarefa
+
+Nesses casos, prefira:
+- `Popover` para conteúdo mais rico ou acionável
+- `Dialog` para contexto crítico
+- texto inline para instrução indispensável
+
+## Comportamento padrão
+- Desktop: abre em `hover` e `focus`
+- Teclado: abre em `focus`, fecha de forma previsível e responde a `Escape`
+- Mobile/tablet: toque abre tooltip; toque fora fecha
+- Posicionamento: automático via Radix, com `collisionPadding` centralizado
+
+## Acessibilidade mínima
+- O gatilho deve ser focável quando o conteúdo precisar ser acessado por teclado
+- Ícones e botões devem manter `aria-label` quando aplicável
+- Tooltips devem ser curtos e legíveis, não substituir labels obrigatórias
+- Não depender de `title=` nativo como solução padrão
+
+## Exceções permitidas
+- `title` em `iframe` quando exigido por acessibilidade/semântica do elemento
+- props chamadas `title` em componentes internos, desde que não sejam tooltip nativo do navegador
+
+## Componentes oficiais
+
+### `TooltipLabel`
+Use para badges, siglas, cabeçalhos e elementos curtos.
+
+```tsx
+<TooltipLabel label="CTR" description="Taxa de cliques sobre impressões.">
+  <span tabIndex={0}>CTR</span>
+</TooltipLabel>
+```
+
+### `TooltipButton`
+Use para botões de ícone e ações rápidas.
+
+```tsx
+<TooltipButton label="Atualizar">
+  <Button size="icon" aria-label="Atualizar">...</Button>
+</TooltipButton>
+```
+
+### `TooltipIcon`
+Use para um ícone autônomo de ajuda/estado.
+
+```tsx
+<TooltipIcon
+  label="Conexão ativa"
+  description="A conta está pronta para operar."
+  icon={<CheckCircle className="h-4 w-4" />}
+/>
+```
+
+### `TooltipTruncate`
+Use para texto com truncamento visual.
+
+```tsx
+<TooltipTruncate text={fileName} className="max-w-[180px]" />
+```
+
+## Regras de conteúdo
+- Priorize um título curto
+- Use descrição apenas quando ela realmente evita dúvida
+- Evite tooltips longos, genéricos ou redundantes
+- Se o texto já estiver completamente claro na interface, não adicione tooltip
+
+## Regra para Popover
+`Popover` não substitui tooltip. Mantenha `Popover` apenas quando houver:
+- múltiplas linhas com estrutura rica
+- interação interna
+- navegação, seleção ou ação

--- a/frontend/WhatsAppBusinessHub.tsx
+++ b/frontend/WhatsAppBusinessHub.tsx
@@ -15,6 +15,7 @@ import { ScrollArea } from "@/scroll-area"
 import { Avatar, AvatarFallback, AvatarImage } from "@/avatar"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/dialog"
 import { RadioGroup, RadioGroupItem } from "@/radio-group"
+import { TooltipButton, TooltipLabel } from '@/tooltip'
 import { toast } from 'sonner'
 import { LoadingPercentText } from '@/LoadingPattern'
 import {
@@ -2736,47 +2737,53 @@ export function WhatsAppBusinessHub() {
           </p>
         </div>
         <div className="flex space-x-2 items-center">
-          <Badge 
-            variant="outline" 
-            title={aiSuppressed && aiResumeAt ? `IA pausada até ${new Date(aiResumeAt).toLocaleString('pt-BR')}` : 'Modo global da IA'}
-            className={`glass-morphism border-white/20 font-medium transition-all duration-300 ${
-              aiSuppressed 
-                ? 'border-red-500/30 text-red-300 bg-red-500/10' 
-                : aiMode === 'auto'
-                  ? 'border-green-500/30 text-green-300 bg-green-500/10'
-                  : aiMode === 'assist'
-                    ? 'border-yellow-500/30 text-yellow-300 bg-yellow-500/10'
-                    : 'border-gray-500/30 text-gray-300 bg-gray-500/10'
-            }`}
+          <TooltipLabel
+            label="Modo global da IA"
+            description={aiSuppressed && aiResumeAt ? `IA pausada até ${new Date(aiResumeAt).toLocaleString('pt-BR')}` : 'Define como a IA opera em todo o módulo.'}
           >
-            <div className="flex items-center gap-2">
-              <div className={`w-2 h-2 rounded-full ${
-                aiSuppressed ? 'bg-red-400' : aiMode === 'auto' ? 'bg-green-400 animate-pulse' : aiMode === 'assist' ? 'bg-yellow-400' : 'bg-gray-400'
-              }`}></div>
-              IA {aiSuppressed ? 'Pausada' : aiMode === 'auto' ? 'Ativa' : aiMode === 'assist' ? 'Assistida' : 'Desligada'}
-            </div>
-          </Badge>
-          <Button 
-            variant="outline" 
-            onClick={() => setIsConnectionsOpen(true)} 
-            title="Gerenciar conexões de contas WhatsApp"
-            className="glass-morphism border-white/20 text-blue-300 hover:text-white hover:bg-white/[0.05] transition-all duration-300 hover:scale-105"
-          >
-            Gerenciar Conexões
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`${aiMode === 'auto' ? 'bg-green-100 hover:bg-green-200' : aiMode === 'assist' ? 'bg-amber-100 hover:bg-amber-200' : 'bg-muted'} rounded-full`}
-            onClick={() => {
-              const modes: typeof aiMode[] = ['auto', 'assist', 'off']
-              const idx = modes.indexOf(aiMode)
-              setAiMode(modes[(idx + 1) % modes.length])
-            }}
-            title="Alternar IA (global)"
-          >
-            <Robot className={`h-4 w-4 ${aiMode === 'off' ? 'text-muted-foreground' : 'text-foreground'}`} />
-          </Button>
+            <Badge 
+              variant="outline" 
+              className={`glass-morphism border-white/20 font-medium transition-all duration-300 ${
+                aiSuppressed 
+                  ? 'border-red-500/30 text-red-300 bg-red-500/10' 
+                  : aiMode === 'auto'
+                    ? 'border-green-500/30 text-green-300 bg-green-500/10'
+                    : aiMode === 'assist'
+                      ? 'border-yellow-500/30 text-yellow-300 bg-yellow-500/10'
+                      : 'border-gray-500/30 text-gray-300 bg-gray-500/10'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <div className={`w-2 h-2 rounded-full ${
+                  aiSuppressed ? 'bg-red-400' : aiMode === 'auto' ? 'bg-green-400 animate-pulse' : aiMode === 'assist' ? 'bg-yellow-400' : 'bg-gray-400'
+                }`}></div>
+                IA {aiSuppressed ? 'Pausada' : aiMode === 'auto' ? 'Ativa' : aiMode === 'assist' ? 'Assistida' : 'Desligada'}
+              </div>
+            </Badge>
+          </TooltipLabel>
+          <TooltipButton label="Gerenciar conexões de contas WhatsApp">
+            <Button 
+              variant="outline" 
+              onClick={() => setIsConnectionsOpen(true)} 
+              className="glass-morphism border-white/20 text-blue-300 hover:text-white hover:bg-white/[0.05] transition-all duration-300 hover:scale-105"
+            >
+              Gerenciar Conexões
+            </Button>
+          </TooltipButton>
+          <TooltipButton label="Alternar IA (global)">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`${aiMode === 'auto' ? 'bg-green-100 hover:bg-green-200' : aiMode === 'assist' ? 'bg-amber-100 hover:bg-amber-200' : 'bg-muted'} rounded-full`}
+              onClick={() => {
+                const modes: typeof aiMode[] = ['auto', 'assist', 'off']
+                const idx = modes.indexOf(aiMode)
+                setAiMode(modes[(idx + 1) % modes.length])
+              }}
+            >
+              <Robot className={`h-4 w-4 ${aiMode === 'off' ? 'text-muted-foreground' : 'text-foreground'}`} />
+            </Button>
+          </TooltipButton>
           {!whatsapp.connected && (
             <div className="flex items-center space-x-2">
               <Button variant="outline" onClick={startInitialization} disabled={initializing}>
@@ -2821,16 +2828,20 @@ export function WhatsAppBusinessHub() {
               }}>Desconectar</Button>
             </div>
           )}
-          <Button variant="outline" onClick={handleExport} title="Exportar contatos e mensagens">
-            <Download className="h-4 w-4 mr-2" />
-            Exportar
-          </Button>
+          <TooltipButton label="Exportar contatos e mensagens">
+            <Button variant="outline" onClick={handleExport}>
+              <Download className="h-4 w-4 mr-2" />
+              Exportar
+            </Button>
+          </TooltipButton>
           <Dialog open={isNewConvOpen} onOpenChange={setIsNewConvOpen}>
             <DialogTrigger asChild>
-              <Button title="Criar nova conversa">
-                <Plus className="h-4 w-4 mr-2" />
-                Nova Conversa
-              </Button>
+              <TooltipButton label="Criar nova conversa">
+                <Button>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Nova Conversa
+                </Button>
+              </TooltipButton>
             </DialogTrigger>
             <DialogContent className="max-w-md">
               <DialogHeader>
@@ -2912,31 +2923,47 @@ export function WhatsAppBusinessHub() {
                   <CardTitle className="flex items-center justify-between">
                     <div className="flex items-center gap-2 flex-wrap">
                       {globalUnreadCount > 0 && (
-                        <Badge variant="secondary" title="Mensagens não lidas no total">Não lidas: {globalUnreadCount}</Badge>
+                        <TooltipLabel label="Mensagens não lidas no total">
+                          <Badge variant="secondary">Não lidas: {globalUnreadCount}</Badge>
+                        </TooltipLabel>
                       )}
-                      <Badge variant="outline" title="Total de conversas">Total: {contacts.length}</Badge>
+                      <TooltipLabel label="Total de conversas">
+                        <Badge variant="outline">Total: {contacts.length}</Badge>
+                      </TooltipLabel>
                       {/* Badges de filtros ativos */}
                       {!!contactsSearch.trim() && (
-                        <Badge variant="secondary" title="Filtro de texto">Filtro: “{contactsSearch.trim()}”</Badge>
+                        <TooltipLabel label="Filtro de texto">
+                          <Badge variant="secondary">Filtro: “{contactsSearch.trim()}”</Badge>
+                        </TooltipLabel>
                       )}
                       {globalSearchParams.tag && (
-                        <Badge variant="secondary" title="Etiqueta aplicada">Tag: {globalSearchParams.tag}</Badge>
+                        <TooltipLabel label="Etiqueta aplicada">
+                          <Badge variant="secondary">Tag: {globalSearchParams.tag}</Badge>
+                        </TooltipLabel>
                       )}
                       {globalSearchParams.has && (
-                        <Badge variant="secondary" title="Possui tipo">has: {globalSearchParams.has}</Badge>
+                        <TooltipLabel label="Possui tipo">
+                          <Badge variant="secondary">has: {globalSearchParams.has}</Badge>
+                        </TooltipLabel>
                       )}
                       {globalSearchParams.type && (
-                        <Badge variant="secondary" title="Tipo de mensagem">type: {globalSearchParams.type}</Badge>
+                        <TooltipLabel label="Tipo de mensagem">
+                          <Badge variant="secondary">type: {globalSearchParams.type}</Badge>
+                        </TooltipLabel>
                       )}
                       {globalSearchParams.phone && (
-                        <Badge variant="secondary" title="Telefone filtrado">phone: {globalSearchParams.phone}</Badge>
+                        <TooltipLabel label="Telefone filtrado">
+                          <Badge variant="secondary">phone: {globalSearchParams.phone}</Badge>
+                        </TooltipLabel>
                       )}
                       {(globalSearchParams.after || globalSearchParams.before) && (
-                        <Badge variant="secondary" title="Janela de data">
-                          {globalSearchParams.after ? `≥ ${globalSearchParams.after}` : ''}
-                          {globalSearchParams.after && globalSearchParams.before ? ' • ' : ''}
-                          {globalSearchParams.before ? `≤ ${globalSearchParams.before}` : ''}
-                        </Badge>
+                        <TooltipLabel label="Janela de data">
+                          <Badge variant="secondary">
+                            {globalSearchParams.after ? `≥ ${globalSearchParams.after}` : ''}
+                            {globalSearchParams.after && globalSearchParams.before ? ' • ' : ''}
+                            {globalSearchParams.before ? `≤ ${globalSearchParams.before}` : ''}
+                          </Badge>
+                        </TooltipLabel>
                       )}
                     </div>
                     {/* espaço à direita mantido vazio deliberadamente */}
@@ -2950,16 +2977,22 @@ export function WhatsAppBusinessHub() {
                         if (filterIdleTimerRef.current) { window.clearTimeout(filterIdleTimerRef.current); filterIdleTimerRef.current = null }
                         filterIdleTimerRef.current = window.setTimeout(() => { filteringActivityRef.current = false }, 600)
                       }} />
-                      <Button variant="outline" size="sm" title="Sincronizar agora" onClick={() => forceSync()} disabled={isSyncing}>
-                        {isSyncing ? (
-                          <span className="inline-flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full border-2 border-muted-foreground border-t-transparent animate-spin" /> Sync</span>
-                        ) : 'Sync'}
-                      </Button>
-                      <Button variant="outline" size="sm" title="Abrir filtros" onClick={() => {
-                        setFilterForm({ ...globalSearchParams, q: contactsSearch })
-                        setIsFilterDialogOpen(true)
-                      }}>Filtrar</Button>
-                      <Button variant="outline" size="sm" title={`Ordenar (${globalSort === 'recente' ? 'mais recentes' : 'mais antigos'})`} onClick={() => setIsOrderDialogOpen(true)}>Ordenar</Button>
+                      <TooltipButton label="Sincronizar agora">
+                        <Button variant="outline" size="sm" onClick={() => forceSync()} disabled={isSyncing}>
+                          {isSyncing ? (
+                            <span className="inline-flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full border-2 border-muted-foreground border-t-transparent animate-spin" /> Sync</span>
+                          ) : 'Sync'}
+                        </Button>
+                      </TooltipButton>
+                      <TooltipButton label="Abrir filtros">
+                        <Button variant="outline" size="sm" onClick={() => {
+                          setFilterForm({ ...globalSearchParams, q: contactsSearch })
+                          setIsFilterDialogOpen(true)
+                        }}>Filtrar</Button>
+                      </TooltipButton>
+                      <TooltipButton label={`Ordenar (${globalSort === 'recente' ? 'mais recentes' : 'mais antigos'})`}>
+                        <Button variant="outline" size="sm" onClick={() => setIsOrderDialogOpen(true)}>Ordenar</Button>
+                      </TooltipButton>
                     </div>
                   </div>
                 </CardHeader>
@@ -3325,12 +3358,14 @@ export function WhatsAppBusinessHub() {
                           {/* Compact hosts dropdown in connected view */}
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="outline" size="sm" title="Hosts locais">
-                                <span className="inline-flex items-center gap-2">
-                                  <span className={`inline-block w-2 h-2 rounded-full ${waInstances.some(i => i.alive) ? (waInstances.some(i => i.ready) ? 'bg-green-500' : 'bg-yellow-500') : 'bg-gray-400'}`}></span>
-                                  Hosts
-                                </span>
-                              </Button>
+                              <TooltipButton label="Hosts locais">
+                                <Button variant="outline" size="sm">
+                                  <span className="inline-flex items-center gap-2">
+                                    <span className={`inline-block w-2 h-2 rounded-full ${waInstances.some(i => i.alive) ? (waInstances.some(i => i.ready) ? 'bg-green-500' : 'bg-yellow-500') : 'bg-gray-400'}`}></span>
+                                    Hosts
+                                  </span>
+                                </Button>
+                              </TooltipButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="min-w-[260px]">
                               <div className="px-2 py-1.5 text-[11px] text-muted-foreground">Contas 1–9 (localhost)</div>
@@ -3353,27 +3388,35 @@ export function WhatsAppBusinessHub() {
                                     )}
                                   </div>
                                   <div className="flex items-center gap-1 shrink-0">
-                                    <Button size="icon" variant="ghost" className="h-7 w-7" title="Renomear" onClick={() => renameInstance(inst.instance, inst.name)}>
-                                      <Pencil className="h-3.5 w-3.5" />
-                                    </Button>
-                                    {inst.alive && (
-                                      <Button size="icon" variant="ghost" className="h-7 w-7" title="Desconectar" onClick={() => stopInstance(inst.instance)}>
-                                        <X className="h-3.5 w-3.5" />
+                                    <TooltipButton label="Renomear">
+                                      <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => renameInstance(inst.instance, inst.name)}>
+                                        <Pencil className="h-3.5 w-3.5" />
                                       </Button>
+                                    </TooltipButton>
+                                    {inst.alive && (
+                                      <TooltipButton label="Desconectar">
+                                        <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => stopInstance(inst.instance)}>
+                                          <X className="h-3.5 w-3.5" />
+                                        </Button>
+                                      </TooltipButton>
                                     )}
                                   </div>
                                 </div>
                               ))}
                             </DropdownMenuContent>
                           </DropdownMenu>
-                          <Button variant="outline" size="sm" onClick={() => setIsCallDialogOpen(true)} title="Ligar">
-                            <Phone className="h-4 w-4" />
-                          </Button>
+                          <TooltipButton label="Ligar">
+                            <Button variant="outline" size="sm" onClick={() => setIsCallDialogOpen(true)}>
+                              <Phone className="h-4 w-4" />
+                            </Button>
+                          </TooltipButton>
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="outline" size="sm" title="Ações de IA">
-                                <Robot className="h-4 w-4" />
-                              </Button>
+                              <TooltipButton label="Ações de IA">
+                                <Button variant="outline" size="sm">
+                                  <Robot className="h-4 w-4" />
+                                </Button>
+                              </TooltipButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="min-w-[220px]">
                               <DropdownMenuItem onClick={() => setAiMode('auto')}>{aiMode === 'auto' ? '✓ ' : ''}IA Automática</DropdownMenuItem>
@@ -3409,9 +3452,11 @@ export function WhatsAppBusinessHub() {
                           </DropdownMenu>
                           <DropdownMenu open={isMainMenuOpen} onOpenChange={setIsMainMenuOpen}>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="outline" size="sm" title="Menu">
-                                <List className="h-4 w-4" />
-                              </Button>
+                              <TooltipButton label="Menu">
+                                <Button variant="outline" size="sm">
+                                  <List className="h-4 w-4" />
+                                </Button>
+                              </TooltipButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="min-w-[240px]">
                               <DropdownMenuItem onClick={() => setIsNotesOpen(true)}>Adicionar notas</DropdownMenuItem>
@@ -3660,29 +3705,30 @@ export function WhatsAppBusinessHub() {
                           </div>
                         </ScrollArea>
                         {!isNearBottom && (
-                          <button
-                            type="button"
-                            aria-label="Ir para o fim"
-                            title="Ir para o fim"
-                            onClick={scrollToBottom}
-                            className="absolute bottom-3 right-2 p-2 rounded-full border bg-background/90 shadow hover:bg-background"
-                          >
-                            <ArrowDown className="h-5 w-5" />
-                          </button>
+                          <TooltipButton label="Ir para o fim">
+                            <button
+                              type="button"
+                              aria-label="Ir para o fim"
+                              onClick={scrollToBottom}
+                              className="absolute bottom-3 right-2 p-2 rounded-full border bg-background/90 shadow hover:bg-background"
+                            >
+                              <ArrowDown className="h-5 w-5" />
+                            </button>
+                          </TooltipButton>
                         )}
                       </div>
                       {/* AI Assist suggestions (chips) */}
                       {(effectiveAiMode === 'assist' || effectiveAiMode === 'auto') && !aiSuppressed && (aiSuggestionsByChat[selectedContact] || []).length > 0 && (
                         <div className="mb-2 flex flex-wrap gap-2">
                           {(aiSuggestionsByChat[selectedContact] || []).slice(0, 4).map((s, idx) => (
-                            <button
-                              key={idx}
-                              className="text-xs px-2 py-1 rounded-full border bg-muted hover:bg-muted/70"
-                              onClick={() => setMessageInput(prev => (prev && prev.trim().length ? (prev.trimEnd() + ' ' + s) : s))}
-                              title="Inserir sugestão"
-                            >
-                              {s}
-                            </button>
+                            <TooltipLabel key={idx} label="Inserir sugestão">
+                              <button
+                                className="text-xs px-2 py-1 rounded-full border bg-muted hover:bg-muted/70"
+                                onClick={() => setMessageInput(prev => (prev && prev.trim().length ? (prev.trimEnd() + ' ' + s) : s))}
+                              >
+                                {s}
+                              </button>
+                            </TooltipLabel>
                           ))}
                         </div>
                       )}
@@ -3729,9 +3775,11 @@ export function WhatsAppBusinessHub() {
 
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <Button variant="outline" size="sm" title="Anexar mídia">
-                              <ImageIcon className="h-4 w-4" />
-                            </Button>
+                            <TooltipButton label="Anexar mídia">
+                              <Button variant="outline" size="sm">
+                                <ImageIcon className="h-4 w-4" />
+                              </Button>
+                            </TooltipButton>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start">
                             <DropdownMenuItem onClick={() => {
@@ -3753,14 +3801,18 @@ export function WhatsAppBusinessHub() {
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
-                        <Button variant="outline" size="sm" onClick={() => docInputRef.current?.click()} title="Anexar documento">
-                          <FileText className="h-4 w-4" />
-                        </Button>
+                        <TooltipButton label="Anexar documento">
+                          <Button variant="outline" size="sm" onClick={() => docInputRef.current?.click()}>
+                            <FileText className="h-4 w-4" />
+                          </Button>
+                        </TooltipButton>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <Button variant={isRecording ? 'default' : 'outline'} size="sm" title={isRecording ? 'Parar/Áudio' : 'Áudio'}>
-                              <Microphone className="h-4 w-4" />
-                            </Button>
+                            <TooltipButton label={isRecording ? 'Parar ou enviar áudio' : 'Áudio'}>
+                              <Button variant={isRecording ? 'default' : 'outline'} size="sm">
+                                <Microphone className="h-4 w-4" />
+                              </Button>
+                            </TooltipButton>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start">
                             {!isRecording && (
@@ -3775,15 +3827,21 @@ export function WhatsAppBusinessHub() {
                             <span className="text-[11px] tabular-nums">{String(Math.floor(recordingSeconds / 60)).padStart(2, '0')}:{String(recordingSeconds % 60).padStart(2, '0')}</span>
                           </div>
                         )}
-                        <Button variant="outline" size="sm" onClick={() => setIsShareContactOpen(true)} title="Enviar contato">
-                          <Users className="h-4 w-4" />
-                        </Button>
-                        <Button variant="outline" size="sm" onClick={() => setIsPollOpen(true)} title="Criar enquete">
-                          <List className="h-4 w-4" />
-                        </Button>
-                        <Button variant="outline" size="sm" onClick={handleShareLocation} title="Compartilhar localização">
-                          <MapPin className="h-4 w-4" />
-                        </Button>
+                        <TooltipButton label="Enviar contato">
+                          <Button variant="outline" size="sm" onClick={() => setIsShareContactOpen(true)}>
+                            <Users className="h-4 w-4" />
+                          </Button>
+                        </TooltipButton>
+                        <TooltipButton label="Criar enquete">
+                          <Button variant="outline" size="sm" onClick={() => setIsPollOpen(true)}>
+                            <List className="h-4 w-4" />
+                          </Button>
+                        </TooltipButton>
+                        <TooltipButton label="Compartilhar localização">
+                          <Button variant="outline" size="sm" onClick={handleShareLocation}>
+                            <MapPin className="h-4 w-4" />
+                          </Button>
+                        </TooltipButton>
                         <Input
                           placeholder="Digite sua mensagem..."
                           value={messageInput}

--- a/frontend/WhatsAppPanel.tsx
+++ b/frontend/WhatsAppPanel.tsx
@@ -4,6 +4,7 @@ import { performAction } from './actionsRegistry'
 import { QRModal } from './QRModal'
 import WhatsAppDashboard from './WhatsAppDashboard'
 import { LoadingPercentText } from '@/LoadingPattern'
+import { TooltipTruncate } from '@/tooltip'
 
 interface GatewayStatus {
     ready?: boolean
@@ -761,7 +762,7 @@ export const WhatsAppPanel: React.FC = () => {
                                     <div className="grid md:grid-cols-3 gap-3">
                                         {attachments.map(a => (
                                             <div key={a.id} className="border rounded p-2 bg-gray-50 flex flex-col gap-1">
-                                                <div className="text-xs font-medium truncate" title={a.name}>{a.name}</div>
+                                                <TooltipTruncate text={a.name} className="text-xs font-medium" />
                                                 <div className="text-[10px] text-gray-500">{a.waType} • {(a.size / 1024).toFixed(1)} KB</div>
                                                 {a.waType === 'image' && <img src={a.dataUrl} className="h-20 w-full object-cover rounded" />}
                                                 <button className="mt-auto text-[10px] text-red-600 hover:underline" onClick={() => setAttachments(att => att.filter(x => x.id !== a.id))}>remover</button>

--- a/frontend/br-date-picker.tsx
+++ b/frontend/br-date-picker.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Calendar } from '@/calendar'
 import { Input } from '@/input'
 import { Popover, PopoverAnchor, PopoverContent } from '@/popover'
+import { TooltipButton } from '@/tooltip'
 
 function digitsToBrDateInput(raw: string) {
   const digits = String(raw || '').replace(/\D/g, '').slice(0, 8)
@@ -78,23 +79,24 @@ export function BrDatePickerInput({
             aria-label={ariaLabel}
             className={className}
           />
-          <button
-            type="button"
-            className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 rounded-md border border-white/10 bg-black/20 hover:bg-white/10 text-blue-100/80 cursor-pointer flex items-center justify-center"
-            onClick={() => setOpen((v) => !v)}
-            aria-label="Selecionar data"
-            title="Selecionar data"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-              <path
-                d="M8 2v3M16 2v3M4 8h16M6 4h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
+          <TooltipButton label="Selecionar data">
+            <button
+              type="button"
+              className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 rounded-md border border-white/10 bg-black/20 hover:bg-white/10 text-blue-100/80 cursor-pointer flex items-center justify-center"
+              onClick={() => setOpen((v) => !v)}
+              aria-label="Selecionar data"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path
+                  d="M8 2v3M16 2v3M4 8h16M6 4h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </TooltipButton>
         </div>
       </PopoverAnchor>
       <PopoverContent align="start" className="w-auto p-2">
@@ -112,4 +114,3 @@ export function BrDatePickerInput({
     </Popover>
   )
 }
-

--- a/frontend/e2e/meta-ads-module.spec.ts
+++ b/frontend/e2e/meta-ads-module.spec.ts
@@ -367,7 +367,6 @@ test.describe('meta ads', () => {
       window.open = () => null
     })
 
-    await page.getByLabel('Gerenciar conexao').first().click({ force: true })
     await page.getByRole('button', { name: 'Conectar com Facebook' }).click()
     await expect(page.getByRole('dialog')).toContainText('Permita a janela do Facebook')
     await expect(page.locator('body')).not.toContainText('A autenticação será aberta nesta mesma aba.')

--- a/frontend/escalaComponents.tsx
+++ b/frontend/escalaComponents.tsx
@@ -3,7 +3,7 @@ import { CalendarX2, Pencil, Shield, Sparkles } from 'lucide-react'
 import { Button } from '@/button'
 import { Checkbox } from '@/checkbox'
 import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/tooltip'
+import { Tooltip, TooltipContent, TooltipLabel, TooltipTrigger } from '@/tooltip'
 import { cn } from '@/utils'
 import { slugifySegment } from '@/escalaShared'
 import type { DayPlanSource, PrefillSuggestion } from '@/escalaTypes'
@@ -20,19 +20,21 @@ export function NoAttendanceChip({
   const text = String(label || 'Sem atendimento').trim() || 'Sem atendimento'
 
   return (
-    <div
-      className={cn(
-        'inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
-        blocked
-          ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
-          : 'border-white/10 bg-white/5 text-slate-200/80',
-      )}
-      data-testid={`escala-no-attendance-icon-${date}`}
-      aria-label={text}
-      title={text}
-    >
-      <CalendarX2 className="h-3.5 w-3.5" />
-    </div>
+    <TooltipLabel label={text}>
+      <div
+        className={cn(
+          'inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+          blocked
+            ? 'border-rose-200/35 bg-rose-500/14 text-rose-50'
+            : 'border-white/10 bg-white/5 text-slate-200/80',
+        )}
+        data-testid={`escala-no-attendance-icon-${date}`}
+        aria-label={text}
+        tabIndex={0}
+      >
+        <CalendarX2 className="h-3.5 w-3.5" />
+      </div>
+    </TooltipLabel>
   )
 }
 

--- a/frontend/escalaPanels.tsx
+++ b/frontend/escalaPanels.tsx
@@ -20,6 +20,7 @@ import {
 import { Input } from '@/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
 import { Progress } from '@/progress'
+import { TooltipButton } from '@/tooltip'
 import {
   Select,
   SelectContent,
@@ -161,57 +162,61 @@ export function EscalaTeamPanel({
               <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              <Button
-                type="button"
-                size="icon"
-                variant={teamFormMode === 'add' ? 'premium' : 'outline'}
-                onClick={onBeginAddTeamMember}
-                disabled={!!teamLoadError}
-                aria-label="Adicionar injetor"
-                title="Adicionar"
-                data-testid="escala-team-add"
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
+              <TooltipButton label="Adicionar">
+                <Button
+                  type="button"
+                  size="icon"
+                  variant={teamFormMode === 'add' ? 'premium' : 'outline'}
+                  onClick={onBeginAddTeamMember}
+                  disabled={!!teamLoadError}
+                  aria-label="Adicionar injetor"
+                  data-testid="escala-team-add"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </TooltipButton>
               {teamPanelExpanded ? (
                 <>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="premium"
-                    onClick={() => void onSaveTeamMember()}
-                    disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
-                    aria-label="Salvar cadastro do injetor"
-                    title="Salvar"
-                    data-testid="escala-team-save"
-                  >
-                    <Save className="h-4 w-4" />
-                  </Button>
+                  <TooltipButton label="Salvar">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="premium"
+                      onClick={() => void onSaveTeamMember()}
+                      disabled={!selectedTeamMemberDraft || !selectedTeamMemberDirty || savingTeamMember || !String(selectedTeamMemberDraft.name || '').trim()}
+                      aria-label="Salvar cadastro do injetor"
+                      data-testid="escala-team-save"
+                    >
+                      <Save className="h-4 w-4" />
+                    </Button>
+                  </TooltipButton>
+                  <TooltipButton label="Fechar">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      onClick={onCloseTeamPanel}
+                      aria-label="Fechar cadastro da equipe"
+                      data-testid="escala-team-close"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </TooltipButton>
+                </>
+              ) : (
+                <TooltipButton label="Editar">
                   <Button
                     type="button"
                     size="icon"
                     variant="outline"
-                    onClick={onCloseTeamPanel}
-                    aria-label="Fechar cadastro da equipe"
-                    title="Fechar"
-                    data-testid="escala-team-close"
+                    onClick={() => onBeginEditTeamMember(selectedTeamMember)}
+                    disabled={!selectedTeamMember || !!teamLoadError}
+                    aria-label="Editar injetor"
+                    data-testid="escala-team-edit"
                   >
-                    <X className="h-4 w-4" />
+                    <Pencil className="h-4 w-4" />
                   </Button>
-                </>
-              ) : (
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  onClick={() => onBeginEditTeamMember(selectedTeamMember)}
-                  disabled={!selectedTeamMember || !!teamLoadError}
-                  aria-label="Editar injetor"
-                  title="Editar"
-                  data-testid="escala-team-edit"
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
+                </TooltipButton>
               )}
             </div>
           </div>

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 
 export default [
   {
-    ignores: ['dist/**', 'node_modules/**', 'public/face-models/**', 'logs/**', 'scripts/**'],
+    ignores: ['dist/**', 'node_modules/**', '.wrangler/**', 'public/face-models/**', 'logs/**', 'scripts/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/frontend/functions/_lib/metaAdsGraph.ts
+++ b/frontend/functions/_lib/metaAdsGraph.ts
@@ -63,6 +63,32 @@ export type MetaSummary = {
   activeCampaigns: number
 }
 
+export type MetaInsightsLevel = 'campaign' | 'adset' | 'ad'
+
+export type MetaInsight = {
+  campaign_id?: string
+  campaign_name?: string
+  adset_id?: string
+  adset_name?: string
+  ad_id?: string
+  ad_name?: string
+  spend: number
+  reach?: number
+  impressions: number
+  clicks: number
+  linkClicks?: number
+  engagement?: number
+  instagramProfileVisits?: number
+  conversations: number
+  ctr: number
+  linkCtr?: number
+  cpc: number
+  linkCpc?: number
+  cpm: number
+  cpp?: number
+  frequency?: number
+}
+
 function parseGraphBaseUrl(version?: string) {
   return `https://graph.facebook.com/${esc(version) || DEFAULT_GRAPH_VERSION}`
 }
@@ -78,6 +104,32 @@ function parseRoas(value: unknown) {
     return asNumber((first as any)?.value)
   }
   return asNumber(value)
+}
+
+function parseActionValue(actions: unknown, candidates: string[]) {
+  if (!Array.isArray(actions)) return 0
+  const wanted = new Set(candidates.map((item) => item.toLowerCase()))
+  return actions.reduce((sum, action) => {
+    const type = esc((action as any)?.action_type).toLowerCase()
+    if (!type || !wanted.has(type)) return sum
+    return sum + asNumber((action as any)?.value)
+  }, 0)
+}
+
+function parseOptionalNumber(value: unknown) {
+  if (value === null || value === undefined || value === '') return undefined
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : undefined
+}
+
+function percent(numerator: number, denominator: number) {
+  if (!denominator) return 0
+  return Math.round((numerator / denominator) * 10000) / 100
+}
+
+function moneyRatio(numerator: number, denominator: number) {
+  if (!denominator) return 0
+  return Math.round((numerator / denominator) * 100) / 100
 }
 
 function normalizeAccountId(adAccountId: string) {
@@ -328,6 +380,86 @@ export async function getMetaAdsTrend(
     day: esc(row?.date_start),
     spend: asNumber(row?.spend),
   }))
+}
+
+export async function listMetaAdsInsights(
+  accessToken: string,
+  adAccountId: string,
+  level: MetaInsightsLevel,
+  range: { since: string; until: string },
+  version?: string,
+  appSecret?: string,
+): Promise<MetaInsight[]> {
+  const identityFields = ['campaign_id', 'campaign_name', 'adset_id', 'adset_name', 'ad_id', 'ad_name']
+  const metricFields = ['spend', 'reach', 'impressions', 'clicks', 'inline_link_clicks', 'ctr', 'cpc', 'cpm', 'cpp', 'frequency']
+  const collectInsights = (fields: string[]) => collectPaged<any>(
+    `/${normalizeAccountId(adAccountId)}/insights`,
+    {
+      fields: fields.join(','),
+      level,
+      time_range: JSON.stringify({ since: range.since, until: range.until }),
+      limit: 500,
+    },
+    accessToken,
+    version,
+    appSecret,
+  )
+  let rows: any[]
+  try {
+    rows = await collectInsights([...identityFields, ...metricFields, 'actions'])
+  } catch {
+    // Some accounts/apps reject richer action fields. Keep operational metrics available.
+    rows = await collectInsights([...identityFields, ...metricFields])
+  }
+
+  return rows.map((row) => {
+    const spend = asNumber(row?.spend)
+    const impressions = asNumber(row?.impressions)
+    const clicks = asNumber(row?.clicks)
+    const linkClicks = parseOptionalNumber(row?.inline_link_clicks)
+    const conversations = parseActionValue(row?.actions, [
+      'onsite_conversion.messaging_conversation_started_7d',
+      'onsite_conversion.messaging_conversation_started',
+      'onsite_conversion.total_messaging_connection',
+      'onsite_conversion.messaging_first_reply',
+    ])
+    const engagement = parseActionValue(row?.actions, [
+      'post_engagement',
+      'page_engagement',
+      'post_reaction',
+      'comment',
+      'like',
+    ])
+    const instagramProfileVisits = parseActionValue(row?.actions, [
+      'instagram_profile_visit',
+      'ig_profile_visit',
+      'onsite_conversion.instagram_profile_visit',
+    ])
+
+    return {
+      campaign_id: esc(row?.campaign_id),
+      campaign_name: esc(row?.campaign_name),
+      adset_id: esc(row?.adset_id),
+      adset_name: esc(row?.adset_name),
+      ad_id: esc(row?.ad_id),
+      ad_name: esc(row?.ad_name),
+      spend,
+      reach: parseOptionalNumber(row?.reach),
+      impressions,
+      clicks,
+      linkClicks,
+      engagement: engagement || undefined,
+      instagramProfileVisits: instagramProfileVisits || undefined,
+      conversations,
+      ctr: parseOptionalNumber(row?.ctr) ?? percent(clicks, impressions),
+      linkCtr: linkClicks === undefined ? undefined : percent(linkClicks, impressions),
+      cpc: parseOptionalNumber(row?.cpc) ?? moneyRatio(spend, clicks),
+      linkCpc: linkClicks === undefined ? undefined : moneyRatio(spend, linkClicks),
+      cpm: parseOptionalNumber(row?.cpm) ?? moneyRatio(spend * 1000, impressions),
+      cpp: parseOptionalNumber(row?.cpp),
+      frequency: parseOptionalNumber(row?.frequency),
+    }
+  })
 }
 
 export async function debugMetaAccessToken(

--- a/frontend/functions/_lib/metaAdsStore.ts
+++ b/frontend/functions/_lib/metaAdsStore.ts
@@ -12,6 +12,7 @@ export type MetaAdsConnection = {
   dataAccessExpiresAt?: string
   lastValidatedAt?: string
   selectedAdAccountId?: string
+  hiddenAdAccountIds?: string[]
   updatedAt: string
 }
 

--- a/frontend/functions/api/meta-ads/[[path]].ts
+++ b/frontend/functions/api/meta-ads/[[path]].ts
@@ -15,10 +15,12 @@ import {
   getMetaAdsTrend,
   getMetaProfile,
   type MetaAd as GraphMetaAd,
+  type MetaInsight as GraphMetaInsight,
   listMetaAdAccounts,
   listMetaAds,
   listMetaAdSets,
   listMetaCampaigns,
+  listMetaAdsInsights,
   type MetaAdSet as GraphMetaAdSet,
   type MetaCampaign as GraphMetaCampaign,
 } from '../../_lib/metaAdsGraph'
@@ -31,6 +33,9 @@ import {
 import type {
   MetaAd,
   MetaAdSet,
+  MetaAdsReportAd,
+  MetaAdsReportAdSet,
+  MetaAdsReportCampaign,
   MetaAdsReportFallbackReason,
   MetaCampaignRow,
   MetaCreativeInventoryItem,
@@ -385,6 +390,17 @@ function connectionSummary(connection: MetaAdsConnection | null) {
   }
 }
 
+function normalizeHiddenAdAccountIds(value: unknown) {
+  return Array.from(new Set((Array.isArray(value) ? value : [])
+    .map((item) => String(item || '').trim())
+    .filter(Boolean)))
+}
+
+function visibleAdAccounts<T extends { id?: string }>(accounts: T[], connection: MetaAdsConnection | null) {
+  const hidden = new Set(normalizeHiddenAdAccountIds(connection?.hiddenAdAccountIds))
+  return accounts.filter((account) => account.id && !hidden.has(account.id))
+}
+
 function resolveMissingConfig(context: any) {
   const cfg = runtimeConfig(context)
   const missing: string[] = []
@@ -501,6 +517,192 @@ function classifyWorkflowFallback(
 
 function buildFallbackWarnings(reason: MetaAdsReportFallbackReason) {
   return ['graph_fallback', reason]
+}
+
+function graphInsightById(rows: GraphMetaInsight[], idField: 'campaign_id' | 'adset_id' | 'ad_id') {
+  const map = new Map<string, GraphMetaInsight>()
+  for (const row of rows || []) {
+    const id = String(row[idField] || '').trim()
+    if (id) map.set(id, row)
+  }
+  return map
+}
+
+function zeroGraphInsight(): GraphMetaInsight {
+  return {
+    spend: 0,
+    impressions: 0,
+    clicks: 0,
+    conversations: 0,
+    ctr: 0,
+    cpc: 0,
+    cpm: 0,
+  }
+}
+
+function campaignReportFromGraph(campaign: GraphMetaCampaign, insight?: GraphMetaInsight): MetaAdsReportCampaign {
+  const metrics = insight || zeroGraphInsight()
+  return {
+    campaignId: campaign.id,
+    campaignName: campaign.name || campaign.id,
+    status: String(campaign.effective_status || campaign.status || '').trim().toUpperCase() || 'UNKNOWN',
+    spend: Number(metrics.spend || 0),
+    reach: metrics.reach,
+    impressions: Number(metrics.impressions || 0),
+    clicks: Number(metrics.clicks || 0),
+    linkClicks: metrics.linkClicks,
+    engagement: metrics.engagement,
+    instagramProfileVisits: metrics.instagramProfileVisits,
+    conversations: Number(metrics.conversations || 0),
+    ctr: Number(metrics.ctr || 0),
+    linkCtr: metrics.linkCtr,
+    cpc: Number(metrics.cpc || 0),
+    linkCpc: metrics.linkCpc,
+    cpm: Number(metrics.cpm || 0),
+    cpp: metrics.cpp,
+    frequency: metrics.frequency,
+  }
+}
+
+function adSetReportFromGraph(
+  adSet: GraphMetaAdSet,
+  campaignById: Map<string, GraphMetaCampaign>,
+  insight?: GraphMetaInsight,
+): MetaAdsReportAdSet {
+  const metrics = insight || zeroGraphInsight()
+  const campaign = campaignById.get(adSet.campaign_id || '')
+  return {
+    adSetId: adSet.id,
+    adSetName: adSet.name || adSet.id,
+    campaignId: adSet.campaign_id || '',
+    campaignName: campaign?.name || metrics.campaign_name || adSet.campaign_id || '',
+    spend: Number(metrics.spend || 0),
+    reach: metrics.reach,
+    impressions: Number(metrics.impressions || 0),
+    clicks: Number(metrics.clicks || 0),
+    linkClicks: metrics.linkClicks,
+    engagement: metrics.engagement,
+    instagramProfileVisits: metrics.instagramProfileVisits,
+    conversations: Number(metrics.conversations || 0),
+    ctr: Number(metrics.ctr || 0),
+    linkCtr: metrics.linkCtr,
+    cpc: Number(metrics.cpc || 0),
+    linkCpc: metrics.linkCpc,
+    cpm: Number(metrics.cpm || 0),
+    cpp: metrics.cpp,
+    frequency: metrics.frequency,
+  }
+}
+
+function adReportFromGraph(
+  ad: GraphMetaAd,
+  campaignById: Map<string, GraphMetaCampaign>,
+  adSetById: Map<string, GraphMetaAdSet>,
+  insight?: GraphMetaInsight,
+): MetaAdsReportAd {
+  const metrics = insight || zeroGraphInsight()
+  const campaign = campaignById.get(ad.campaign_id || '')
+  const adSet = adSetById.get(ad.adset_id || '')
+  return {
+    adId: ad.id,
+    adName: ad.name || ad.id,
+    adSetId: ad.adset_id || '',
+    adSetName: ad.adset_name || adSet?.name || metrics.adset_name || '',
+    campaignId: ad.campaign_id || '',
+    campaignName: ad.campaign_name || campaign?.name || metrics.campaign_name || '',
+    spend: Number(metrics.spend || 0),
+    reach: metrics.reach,
+    impressions: Number(metrics.impressions || 0),
+    clicks: Number(metrics.clicks || 0),
+    linkClicks: metrics.linkClicks,
+    engagement: metrics.engagement,
+    instagramProfileVisits: metrics.instagramProfileVisits,
+    conversations: Number(metrics.conversations || 0),
+    ctr: Number(metrics.ctr || 0),
+    linkCtr: metrics.linkCtr,
+    cpc: Number(metrics.cpc || 0),
+    linkCpc: metrics.linkCpc,
+    cpm: Number(metrics.cpm || 0),
+    cpp: metrics.cpp,
+    frequency: metrics.frequency,
+  }
+}
+
+async function fetchGraphInsightsSafely(
+  selected: { connection: MetaAdsConnection; adAccountId: string },
+  range: { since: string; until: string },
+  cfg: ReturnType<typeof runtimeConfig>,
+  level: 'campaign' | 'adset' | 'ad',
+) {
+  try {
+    return {
+      rows: await listMetaAdsInsights(
+        selected.connection.accessToken,
+        selected.adAccountId,
+        level,
+        range,
+        cfg.graphVersion,
+        cfg.appSecret,
+      ),
+      warning: null as string | null,
+    }
+  } catch (error) {
+    return {
+      rows: [] as GraphMetaInsight[],
+      warning: `graph_insights_${level}_unavailable`,
+      error: String((error as Error | null)?.message || error || ''),
+    }
+  }
+}
+
+async function buildGraphFallbackReport(
+  selected: { connection: MetaAdsConnection; adAccountId: string },
+  range: { since: string; until: string },
+  cfg: ReturnType<typeof runtimeConfig>,
+  reportWindow: MetaAdsWorkflowWindow,
+  fallbackReason: MetaAdsReportFallbackReason,
+) {
+  const [summary, campaigns, adSets, ads, campaignInsights, adSetInsights, adInsights] = await Promise.all([
+    getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, cfg.graphVersion, cfg.appSecret),
+    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
+    listMetaAdSets(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
+    listMetaAds(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
+    fetchGraphInsightsSafely(selected, range, cfg, 'campaign'),
+    fetchGraphInsightsSafely(selected, range, cfg, 'adset'),
+    fetchGraphInsightsSafely(selected, range, cfg, 'ad'),
+  ])
+  const campaignById = new Map(campaigns.map((campaign) => [campaign.id, campaign]))
+  const adSetById = new Map(adSets.map((adSet) => [adSet.id, adSet]))
+  const campaignInsightById = graphInsightById(campaignInsights.rows, 'campaign_id')
+  const adSetInsightById = graphInsightById(adSetInsights.rows, 'adset_id')
+  const adInsightById = graphInsightById(adInsights.rows, 'ad_id')
+  const warnings = [
+    ...buildFallbackWarnings(fallbackReason),
+    campaignInsights.warning,
+    adSetInsights.warning,
+    adInsights.warning,
+  ].filter(Boolean)
+
+  return {
+    ok: true,
+    source: 'graph-fallback',
+    fallbackReason,
+    window: reportWindow,
+    summary: {
+      ...summary,
+      source: 'graph',
+      activeCampaigns: campaigns.filter((campaign) => String(campaign.effective_status || campaign.status || '').toUpperCase() === 'ACTIVE').length,
+    },
+    metadata: {
+      reportDate: String(range.until || '').trim(),
+      runsCount: 0,
+      source: 'graph',
+    },
+    campaigns: campaigns.map((campaign) => campaignReportFromGraph(campaign, campaignInsightById.get(campaign.id))),
+    adSets: adSets.map((adSet) => adSetReportFromGraph(adSet, campaignById, adSetInsightById.get(adSet.id))),
+    ads: ads.map((ad) => adReportFromGraph(ad, campaignById, adSetById, adInsightById.get(ad.id))),
+    warnings,
+  }
 }
 
 async function readConnection(context: any, userId: string) {
@@ -725,6 +927,7 @@ async function handleOauthCallback(context: any) {
       getMetaProfile(accessToken, cfg.graphVersion, cfg.appSecret),
       validateMetaAccessToken(accessToken, cfg),
     ])
+    const previousConnection = await readConnection(context, userOrRes.id).catch(() => null)
 
     await writeConnection(context, userOrRes.id, {
       accessToken,
@@ -738,6 +941,7 @@ async function handleOauthCallback(context: any) {
         (longData?.expires_in ? new Date(Date.now() + Number(longData.expires_in || 0) * 1000).toISOString() : undefined),
       dataAccessExpiresAt: tokenValidation.dataAccessExpiresAt,
       lastValidatedAt: tokenValidation.lastValidatedAt,
+      hiddenAdAccountIds: normalizeHiddenAdAccountIds(previousConnection?.hiddenAdAccountIds),
       updatedAt: new Date().toISOString(),
     })
 
@@ -788,6 +992,9 @@ async function handleManualConnect(context: any) {
       validateMetaAccessToken(accessToken, cfg),
       listMetaAdAccounts(accessToken, cfg.graphVersion, cfg.appSecret),
     ])
+    const previousConnection = await readConnection(context, userOrRes.id).catch(() => null)
+    const hiddenAdAccountIds = normalizeHiddenAdAccountIds(previousConnection?.hiddenAdAccountIds)
+    const visibleAccounts = accounts.filter((account) => !hiddenAdAccountIds.includes(account.id))
     await writeConnection(context, userOrRes.id, {
       accessToken,
       tokenType: 'manual',
@@ -798,13 +1005,14 @@ async function handleManualConnect(context: any) {
       expiresAt: tokenValidation.expiresAt,
       dataAccessExpiresAt: tokenValidation.dataAccessExpiresAt,
       lastValidatedAt: tokenValidation.lastValidatedAt,
+      hiddenAdAccountIds,
       updatedAt: new Date().toISOString(),
-      selectedAdAccountId: accounts[0]?.id || undefined,
+      selectedAdAccountId: visibleAccounts[0]?.id || undefined,
     })
     return json(200, {
       ok: true,
       connected: true,
-      accountCount: accounts.length,
+      accountCount: visibleAccounts.length,
       connection: connectionSummary(await readConnection(context, userOrRes.id)),
     })
   } catch (error: any) {
@@ -840,14 +1048,18 @@ async function handleListAccounts(context: any) {
 
   const { connection, accounts } = await fetchLiveAccounts(context, userOrRes.id)
   if (!connection?.accessToken) return json(200, { ok: true, connected: false, accounts: [] })
+  const visibleAccounts = visibleAdAccounts(accounts, connection)
+  const selectedAdAccountId = visibleAccounts.some((account) => account.id === connection.selectedAdAccountId)
+    ? connection.selectedAdAccountId
+    : null
 
   return json(200, {
     ok: true,
     connected: true,
-    selectedAdAccountId: connection.selectedAdAccountId || null,
-    accounts: accounts.map((account) => ({
+    selectedAdAccountId,
+    accounts: visibleAccounts.map((account) => ({
       ...account,
-      isSelected: connection.selectedAdAccountId === account.id,
+      isSelected: selectedAdAccountId === account.id,
     })),
   })
 }
@@ -878,7 +1090,7 @@ async function handleSelectAccount(context: any) {
   }
   const cfg = runtimeConfig(context)
   const accounts = await listMetaAdAccounts(connection.accessToken, cfg.graphVersion, cfg.appSecret)
-  const selected = accounts.find((account) => account.id === adAccountId)
+  const selected = visibleAdAccounts(accounts, connection).find((account) => account.id === adAccountId)
   if (!selected) {
     return apiError(404, 'ACCOUNT_NOT_FOUND', {
       message: 'A conta de anúncios informada não foi encontrada para este usuário/token.',
@@ -893,6 +1105,63 @@ async function handleSelectAccount(context: any) {
     updatedAt: new Date().toISOString(),
   })
   return json(200, { ok: true, selectedAdAccountId: adAccountId })
+}
+
+async function handleRemoveAccount(context: any) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const csrfRes = requireCsrfForMutations(context)
+  if (csrfRes) return csrfRes
+
+  const body = await context.request.json().catch(() => null)
+  const adAccountId = String(body?.adAccountId || '').trim()
+  if (!adAccountId) {
+    return apiError(400, 'INVALID_INPUT', {
+      message: 'Informe a conta de anúncios que deve ser removida da lista.',
+      hint: 'Escolha uma conta válida na lista antes de remover.',
+      retryable: false,
+    })
+  }
+
+  const connection = await readConnection(context, userOrRes.id)
+  if (!connection?.accessToken) {
+    return apiError(404, 'NOT_CONNECTED', {
+      message: 'Nenhuma conexão Meta ativa foi encontrada para este usuário.',
+      hint: 'Conecte a conta Meta primeiro e depois remova contas da lista.',
+      retryable: false,
+    })
+  }
+
+  const cfg = runtimeConfig(context)
+  const accounts = await listMetaAdAccounts(connection.accessToken, cfg.graphVersion, cfg.appSecret)
+  const accountExists = accounts.some((account) => account.id === adAccountId)
+  if (!accountExists) {
+    return apiError(404, 'ACCOUNT_NOT_FOUND', {
+      message: 'A conta de anúncios informada não foi encontrada para este usuário/token.',
+      hint: 'Atualize a lista de contas antes de tentar remover novamente.',
+      retryable: true,
+    })
+  }
+
+  const hiddenAdAccountIds = Array.from(new Set([...normalizeHiddenAdAccountIds(connection.hiddenAdAccountIds), adAccountId]))
+  const visibleAccounts = accounts.filter((account) => !hiddenAdAccountIds.includes(account.id))
+  const selectedAdAccountId = connection.selectedAdAccountId === adAccountId
+    ? visibleAccounts[0]?.id || undefined
+    : connection.selectedAdAccountId
+
+  await writeConnection(context, userOrRes.id, {
+    ...connection,
+    selectedAdAccountId,
+    hiddenAdAccountIds,
+    updatedAt: new Date().toISOString(),
+  })
+
+  return json(200, {
+    ok: true,
+    removedAdAccountId: adAccountId,
+    selectedAdAccountId: selectedAdAccountId || null,
+    remainingAccountCount: visibleAccounts.length,
+  })
 }
 
 async function withSelectedAccount(
@@ -913,7 +1182,7 @@ async function withSelectedAccount(
     }
   }
   const adAccountId = String(connection.selectedAdAccountId || '').trim()
-  if (!adAccountId) {
+  if (!adAccountId || normalizeHiddenAdAccountIds(connection.hiddenAdAccountIds).includes(adAccountId)) {
     return {
       error: apiError(400, 'AD_ACCOUNT_NOT_SELECTED', {
         message: 'Nenhuma conta de anúncios foi selecionada.',
@@ -989,92 +1258,10 @@ async function handleReport(context: any) {
     }
   } catch (error) {
     const fallbackReason = classifyWorkflowFallback(error, cfg)
-    const [summary, campaigns] = await Promise.all([
-      getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, cfg.graphVersion, cfg.appSecret),
-      listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
-    ])
-
-    return json(200, {
-      ok: true,
-      source: 'graph-fallback',
-      fallbackReason,
-      window: reportWindow,
-      summary: {
-        ...summary,
-        source: 'graph',
-        activeCampaigns: campaigns.filter((campaign) => String(campaign.status || '').toUpperCase() === 'ACTIVE').length,
-      },
-      metadata: {
-        reportDate: String(range.until || '').trim(),
-        runsCount: 0,
-        source: 'graph',
-      },
-      campaigns: campaigns.map((campaign) => ({
-        campaignId: campaign.id,
-        campaignName: campaign.name || campaign.id,
-        status: String(campaign.effective_status || campaign.status || '').trim().toUpperCase() || 'UNKNOWN',
-        spend: 0,
-        reach: 0,
-        impressions: 0,
-        clicks: 0,
-        linkClicks: 0,
-        conversations: 0,
-        ctr: 0,
-        linkCtr: 0,
-        cpc: 0,
-        linkCpc: 0,
-        cpm: 0,
-        cpp: 0,
-        frequency: 0,
-      })),
-      adSets: [],
-      ads: [],
-      warnings: buildFallbackWarnings(fallbackReason),
-    })
+    return json(200, await buildGraphFallbackReport(selected, range, cfg, reportWindow, fallbackReason))
   }
 
-  const [summary, campaigns] = await Promise.all([
-    getMetaAdsSummary(selected.connection.accessToken, selected.adAccountId, range, cfg.graphVersion, cfg.appSecret),
-    listMetaCampaigns(selected.connection.accessToken, selected.adAccountId, cfg.graphVersion, cfg.appSecret),
-  ])
-
-  return json(200, {
-    ok: true,
-    source: 'graph-fallback',
-    fallbackReason: 'worker_unconfigured',
-    window: reportWindow,
-    summary: {
-      ...summary,
-      source: 'graph',
-      activeCampaigns: campaigns.filter((campaign) => String(campaign.status || '').toUpperCase() === 'ACTIVE').length,
-    },
-    metadata: {
-      reportDate: String(range.until || '').trim(),
-      runsCount: 0,
-      source: 'graph',
-    },
-    campaigns: campaigns.map((campaign) => ({
-      campaignId: campaign.id,
-      campaignName: campaign.name || campaign.id,
-      status: String(campaign.effective_status || campaign.status || '').trim().toUpperCase() || 'UNKNOWN',
-      spend: 0,
-      reach: 0,
-      impressions: 0,
-      clicks: 0,
-      linkClicks: 0,
-      conversations: 0,
-      ctr: 0,
-      linkCtr: 0,
-      cpc: 0,
-      linkCpc: 0,
-      cpm: 0,
-      cpp: 0,
-      frequency: 0,
-    })),
-    adSets: [],
-    ads: [],
-    warnings: buildFallbackWarnings('worker_unconfigured'),
-  })
+  return json(200, await buildGraphFallbackReport(selected, range, cfg, reportWindow, 'worker_unconfigured'))
 }
 
 async function handleInventory(context: any) {
@@ -1112,6 +1299,7 @@ export async function onRequest(context: any): Promise<Response> {
     if (method === 'POST' && (rest === '/disconnect' || rest === '/disconnect/')) return handleDisconnect(context)
     if (method === 'GET' && (rest === '/ad-accounts' || rest === '/ad-accounts/')) return handleListAccounts(context)
     if (method === 'POST' && (rest === '/ad-accounts/select' || rest === '/ad-accounts/select/')) return handleSelectAccount(context)
+    if (method === 'POST' && (rest === '/ad-accounts/remove' || rest === '/ad-accounts/remove/')) return handleRemoveAccount(context)
     if (method === 'GET' && (rest === '/summary' || rest === '/summary/')) return handleSummary(context)
     if (method === 'GET' && (rest === '/trend' || rest === '/trend/')) return handleTrend(context)
     if (method === 'GET' && (rest === '/report' || rest === '/report/')) return handleReport(context)

--- a/frontend/insumosPanels.tsx
+++ b/frontend/insumosPanels.tsx
@@ -10,6 +10,7 @@ import { InsumosBarcodeScannerInline } from '@/InsumosBarcodeScannerInline'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { Textarea } from '@/textarea'
+import { TooltipButton, TooltipLabel } from '@/tooltip'
 import {
   alertaTagLabel,
   alertaTagVariant,
@@ -254,9 +255,11 @@ export function InsumosInventoryDialog({
               placeholder="Buscar por código, produto, categoria…"
               className="ml-auto h-8 min-w-[160px] flex-1 md:min-w-0"
             />
-            <Button variant="outline" className="h-8 px-3" onClick={onExport} disabled={!isAuthed} title="Exportar CSV">
-              Exportar
-            </Button>
+            <TooltipButton label="Exportar CSV">
+              <Button variant="outline" className="h-8 px-3" onClick={onExport} disabled={!isAuthed}>
+                Exportar
+              </Button>
+            </TooltipButton>
             <Button variant="outline" className="h-8 px-3" onClick={onToggleCreate} disabled={!isAuthed}>
               {createOpen ? 'Fechar' : 'Adicionar'}
             </Button>
@@ -387,15 +390,16 @@ export function InsumosInventoryDialog({
                 <div>
                   <div className="mb-1 flex items-center justify-between gap-2">
                     <div className="text-xs text-blue-200/70">Lote</div>
-                    <Button
-                      variant={createNovoLote ? 'secondary' : 'outline'}
-                      size="sm"
-                      type="button"
-                      onClick={onToggleCreateNovoLote}
-                      title="Ative quando estiver cadastrando um lote adicional para um código já existente."
-                    >
-                      {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
-                    </Button>
+                    <TooltipButton label="Novo lote" description="Ative quando estiver cadastrando um lote adicional para um código já existente.">
+                      <Button
+                        variant={createNovoLote ? 'secondary' : 'outline'}
+                        size="sm"
+                        type="button"
+                        onClick={onToggleCreateNovoLote}
+                      >
+                        {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
+                      </Button>
+                    </TooltipButton>
                   </div>
                   <Input
                     value={createLote}
@@ -994,15 +998,16 @@ export function InsumosQuickOperationDialog({
               <div className="flex items-center justify-between gap-2">
                 <div className="text-xs text-blue-200/70">Lote/registro</div>
                 {showFefoToggle ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    type="button"
-                    onClick={onToggleAutoFefo}
-                    title="FEFO (First-Expire, First-Out): prioriza o lote com validade mais próxima"
-                  >
-                    FEFO {autoFefo ? 'auto' : 'manual'}
-                  </Button>
+                  <TooltipButton label="FEFO" description="First-Expire, First-Out: prioriza o lote com validade mais próxima.">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      type="button"
+                      onClick={onToggleAutoFefo}
+                    >
+                      FEFO {autoFefo ? 'auto' : 'manual'}
+                    </Button>
+                  </TooltipButton>
                 ) : null}
               </div>
               <Select value={selectedRegistro} onValueChange={onRegistroChange}>
@@ -1968,9 +1973,11 @@ export function InsumosCreateInlinePanel({
         <div>
           <div className="mb-1 flex items-center justify-between gap-2">
             <div className="text-xs text-blue-200/70">Lote</div>
-            <Button variant={createNovoLote ? 'secondary' : 'outline'} size="sm" type="button" onClick={onToggleCreateNovoLote} title="Ative quando estiver cadastrando um lote adicional para um código já existente.">
-              {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
-            </Button>
+            <TooltipButton label="Novo lote" description="Ative quando estiver cadastrando um lote adicional para um código já existente.">
+              <Button variant={createNovoLote ? 'secondary' : 'outline'} size="sm" type="button" onClick={onToggleCreateNovoLote}>
+                {createNovoLote ? 'Novo lote: on' : 'Novo lote: off'}
+              </Button>
+            </TooltipButton>
           </div>
           <Input value={createLote} onChange={(e) => onCreateLoteChange(e.target.value)} placeholder={createNovoLote ? 'obrigatório (ex: L2026-01)' : 'opcional'} />
         </div>
@@ -2097,16 +2104,16 @@ export function InsumosInventoryWorkspaceTable({
             return (
               <tr key={`${item.registro || ''}-${item.codigoBarras || ''}`} className={isSelected ? 'bg-white/5 hover:bg-white/10' : 'hover:bg-white/5'}>
                 <td className="min-w-0 p-3 align-top">
-                  <button
-                    type="button"
-                    className="group w-full cursor-pointer rounded-sm text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                    onClick={() => {
-                      if (!codigoBarras) return
-                      onSelectBarcode(codigoBarras)
-                    }}
-                    title={codigoBarras ? 'Ver movimentações deste insumo' : undefined}
-                    aria-pressed={isSelected}
-                  >
+                  <TooltipLabel label={codigoBarras ? 'Ver movimentações deste insumo' : 'Sem código de barras'}>
+                    <button
+                      type="button"
+                      className="group w-full cursor-pointer rounded-sm text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                      onClick={() => {
+                        if (!codigoBarras) return
+                        onSelectBarcode(codigoBarras)
+                      }}
+                      aria-pressed={isSelected}
+                    >
                     <div className="flex min-w-0 items-center justify-between gap-2">
                       <div className="line-clamp-2 break-words text-blue-50 group-hover:underline">{item.produto || '-'}</div>
                       {isSelected ? <div className="text-xs text-blue-200/60">Filtrando</div> : null}
@@ -2126,7 +2133,8 @@ export function InsumosInventoryWorkspaceTable({
                         {isExpirado ? <Badge variant="destructive">Expirado</Badge> : null}
                       </div>
                     ) : null}
-                  </button>
+                    </button>
+                  </TooltipLabel>
                 </td>
                 <td className="p-3 align-top text-blue-100/80">
                   <div className="flex min-w-0 items-center gap-2">
@@ -2602,36 +2610,38 @@ export function InsumosCategoryPoliciesPanel({
       <CardHeader className="relative pr-24">
         <CardTitle className="text-base text-white">Políticas por categoria</CardTitle>
         <div className="absolute right-2 top-2 flex items-center gap-1">
-          <div
-            {...dragHandleProps}
-            className="flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
-            title="Arraste para mover"
-            aria-label="Mover"
-            role="button"
-            tabIndex={0}
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-              <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-            </svg>
-          </div>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-            onClick={onToggleOpen}
-            title={panelOpen ? 'Contrair' : 'Expandir'}
-            aria-label={panelOpen ? 'Contrair' : 'Expandir'}
-          >
-            {panelOpen ? (
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+          <TooltipLabel label="Arraste para mover">
+            <div
+              {...dragHandleProps}
+              className="flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+              aria-label="Mover"
+              role="button"
+              tabIndex={0}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
               </svg>
-            ) : (
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            )}
-          </Button>
+            </div>
+          </TooltipLabel>
+          <TooltipButton label={panelOpen ? 'Contrair' : 'Expandir'}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+              onClick={onToggleOpen}
+              aria-label={panelOpen ? 'Contrair' : 'Expandir'}
+            >
+              {panelOpen ? (
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+            </Button>
+          </TooltipButton>
         </div>
       </CardHeader>
       {panelOpen ? (
@@ -2874,26 +2884,29 @@ export function InsumosAlertsPanel({
       <CardHeader className="flex flex-col gap-2">
         <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
           <div className="flex min-w-0 items-center gap-3">
-            <button
-              type="button"
-              {...dragHandleProps}
-              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
-              title="Arraste para mover"
-              aria-label="Mover"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-              </svg>
-            </button>
+            <TooltipLabel label="Arraste para mover">
+              <button
+                type="button"
+                {...dragHandleProps}
+                className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+                aria-label="Mover"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              </button>
+            </TooltipLabel>
             <CardTitle className="text-base text-white">Avisos</CardTitle>
             <div className="hidden items-center gap-3 text-xs text-blue-200/70 sm:flex">
               <span className="inline-flex items-center gap-1">
-                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/40 text-red-50" title="Crítico" aria-label="Crítico">
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M12 7v7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                    <circle cx="12" cy="17" r="1.5" fill="currentColor" />
-                  </svg>
-                </span>
+                <TooltipLabel label="Crítico" description="Itens com urgência operacional imediata.">
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/40 text-red-50" aria-label="Crítico" tabIndex={0}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M12 7v7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                      <circle cx="12" cy="17" r="1.5" fill="currentColor" />
+                    </svg>
+                  </span>
+                </TooltipLabel>
                 <span className="font-mono text-blue-50">
                   {showOverviewLoadingProgress ? (
                     <span className="inline-flex items-center gap-2">
@@ -2906,13 +2919,15 @@ export function InsumosAlertsPanel({
                 </span>
               </span>
               <span className="inline-flex items-center gap-1">
-                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500/35 text-amber-100" title="Atenção" aria-label="Atenção">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M12 3l9 16H3l9-16z" fill="currentColor" fillOpacity="0.45" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
-                    <path d="M12 9v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                    <circle cx="12" cy="16.5" r="1.2" fill="currentColor" />
-                  </svg>
-                </span>
+                <TooltipLabel label="Atenção" description="Itens que exigem acompanhamento próximo.">
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500/35 text-amber-100" aria-label="Atenção" tabIndex={0}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M12 3l9 16H3l9-16z" fill="currentColor" fillOpacity="0.45" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+                      <path d="M12 9v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                      <circle cx="12" cy="16.5" r="1.2" fill="currentColor" />
+                    </svg>
+                  </span>
+                </TooltipLabel>
                 <span className="font-mono text-blue-50">
                   {showOverviewLoadingProgress ? (
                     <span className="inline-flex items-center gap-2">
@@ -2965,32 +2980,35 @@ export function InsumosAlertsPanel({
             </Select>
             <Input value={alertasBusca} onChange={(event) => onAlertasBuscaChange(event.target.value)} placeholder="Buscar" className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0" />
             <div className="flex shrink-0 items-center gap-2">
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                onClick={onOpenPurchaseDialog}
-                disabled={purchaseDisabled}
-                title="Lista de compra"
-                aria-label="Lista de compra"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                  <path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.6a2 2 0 0 0 2-1.6L21 8H7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                  <circle cx="9" cy="20" r="1.6" fill="currentColor" />
-                  <circle cx="17" cy="20" r="1.6" fill="currentColor" />
-                </svg>
-              </Button>
-              <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} title={panelOpen ? 'Contrair' : 'Expandir'} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
-                {panelOpen ? (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              <TooltipButton label="Lista de compra">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                  onClick={onOpenPurchaseDialog}
+                  disabled={purchaseDisabled}
+                  aria-label="Lista de compra"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.6a2 2 0 0 0 2-1.6L21 8H7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                    <circle cx="9" cy="20" r="1.6" fill="currentColor" />
+                    <circle cx="17" cy="20" r="1.6" fill="currentColor" />
                   </svg>
-                ) : (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                )}
-              </Button>
+                </Button>
+              </TooltipButton>
+              <TooltipButton label={panelOpen ? 'Contrair' : 'Expandir'}>
+                <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
+                  {panelOpen ? (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  ) : (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </Button>
+              </TooltipButton>
             </div>
           </div>
         </div>
@@ -3010,7 +3028,6 @@ export function InsumosAlertsPanel({
                           className={`inline-flex w-full items-center gap-2 rounded-sm px-0.5 ${column.align.includes('right') ? 'justify-end' : 'justify-start'} cursor-pointer select-none ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40`}
                           onClick={() => onSortChange(column.key)}
                           aria-label={`Ordenar ${column.label}`}
-                          title={`Ordenar ${column.label}`}
                         >
                           <span>{column.label}</span>
                           <span className={`inline-flex items-center justify-center ${isActive ? 'text-white' : 'text-blue-100/30'}`} aria-hidden>
@@ -3057,7 +3074,6 @@ export function InsumosAlertsPanel({
                       onClick={() => {
                         if (code) onSelectBarcode(code)
                       }}
-                      title={row.codigoBarras ? 'Clique para usar este código de barras' : undefined}
                     >
                       <td className="p-3 align-top text-blue-50">
                         <div className="flex flex-wrap items-center gap-2 break-words text-blue-50">
@@ -3068,17 +3084,18 @@ export function InsumosAlertsPanel({
                         <div className="hidden break-all font-mono text-xs text-blue-200/60 md:block">{row.codigoBarras || '-'}</div>
                         {row.marca ? (
                           <div className="mt-1">
-                            <Badge
-                              style={buildTagStyle(getMarcaBgColor(row.marca))}
-                              className="cursor-pointer border hover:opacity-80"
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                onToggleMarcaFilter(String(row.marca || ''))
-                              }}
-                              title="Filtrar por marca"
-                            >
-                              {row.marca}
-                            </Badge>
+                            <TooltipLabel label="Filtrar por marca">
+                              <Badge
+                                style={buildTagStyle(getMarcaBgColor(row.marca))}
+                                className="cursor-pointer border hover:opacity-80"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onToggleMarcaFilter(String(row.marca || ''))
+                                }}
+                              >
+                                {row.marca}
+                              </Badge>
+                            </TooltipLabel>
                           </div>
                         ) : null}
                         {row.dataValidade ? (
@@ -3089,105 +3106,109 @@ export function InsumosAlertsPanel({
                         ) : null}
                       </td>
                       <td className="hidden p-3 text-blue-100/80 sm:table-cell">
-                        <Badge
-                          style={buildTagStyle(getCategoriaBgColor(row.categoria || 'Outros'))}
-                          className="cursor-pointer border hover:opacity-80"
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onToggleCategoriaFilter(String(row.categoria || 'Outros'))
-                          }}
-                          title="Filtrar por categoria"
-                        >
-                          {row.categoria || 'Outros'}
-                        </Badge>
+                        <TooltipLabel label="Filtrar por categoria">
+                          <Badge
+                            style={buildTagStyle(getCategoriaBgColor(row.categoria || 'Outros'))}
+                            className="cursor-pointer border hover:opacity-80"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              onToggleCategoriaFilter(String(row.categoria || 'Outros'))
+                            }}
+                          >
+                            {row.categoria || 'Outros'}
+                          </Badge>
+                        </TooltipLabel>
                       </td>
                       <td className="p-3">
                         <div className="flex flex-wrap gap-1">
                           {displayTags.map((tag) => (
-                            <Badge
-                              key={tag}
-                              variant={alertaTagVariant(tag)}
-                              className="cursor-pointer hover:opacity-80"
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                onToggleStatusFilter(tag)
-                              }}
-                              title="Filtrar por status"
-                            >
-                              {alertaTagLabel(tag)}
-                            </Badge>
+                            <TooltipLabel key={tag} label="Filtrar por status">
+                              <Badge
+                                variant={alertaTagVariant(tag)}
+                                className="cursor-pointer hover:opacity-80"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onToggleStatusFilter(tag)
+                                }}
+                              >
+                                {alertaTagLabel(tag)}
+                              </Badge>
+                            </TooltipLabel>
                           ))}
                         </div>
                       </td>
                       <td className="p-3">
                         <div className="flex flex-wrap gap-2">
                           {recommendation?.kind === 'TRANSFERENCIA' ? (
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="h-8 w-8 bg-sky-500/30 text-sky-100 hover:bg-sky-500/45"
-                              disabled={!canQuick}
-                              title="Transferir"
-                              aria-label="Transferir"
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                onOpenQuickOperation('TRANSFERENCIA', {
-                                  codigoBarras: code,
-                                  quantidade: recommendation.qty ?? 1,
-                                  fromUnidade: recommendation.fromUnidade ?? null,
-                                  toUnidade: recommendation.toUnidade ?? null,
-                                  obs: 'Transferência sugerida',
-                                })
-                              }}
-                            >
-                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                <path d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
-                            </Button>
+                            <TooltipButton label="Transferir">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8 bg-sky-500/30 text-sky-100 hover:bg-sky-500/45"
+                                disabled={!canQuick}
+                                aria-label="Transferir"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onOpenQuickOperation('TRANSFERENCIA', {
+                                    codigoBarras: code,
+                                    quantidade: recommendation.qty ?? 1,
+                                    fromUnidade: recommendation.fromUnidade ?? null,
+                                    toUnidade: recommendation.toUnidade ?? null,
+                                    obs: 'Transferência sugerida',
+                                  })
+                                }}
+                              >
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                  <path d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </Button>
+                            </TooltipButton>
                           ) : null}
                           {recommendation?.kind === 'ENTRADA' ? (
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="h-8 w-8 bg-emerald-500/30 text-emerald-100 hover:bg-emerald-500/45"
-                              disabled={!canQuick}
-                              title="Entrada"
-                              aria-label="Entrada"
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                onOpenQuickOperation('ENTRADA', {
-                                  codigoBarras: code,
-                                  quantidade: recommendation.qty ?? 1,
-                                  obs: 'Reposição sugerida',
-                                })
-                              }}
-                            >
-                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                <path d="M12 5v10m0 0-4-4m4 4 4-4M5 19h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
-                            </Button>
+                            <TooltipButton label="Entrada">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8 bg-emerald-500/30 text-emerald-100 hover:bg-emerald-500/45"
+                                disabled={!canQuick}
+                                aria-label="Entrada"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onOpenQuickOperation('ENTRADA', {
+                                    codigoBarras: code,
+                                    quantidade: recommendation.qty ?? 1,
+                                    obs: 'Reposição sugerida',
+                                  })
+                                }}
+                              >
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                  <path d="M12 5v10m0 0-4-4m4 4 4-4M5 19h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </Button>
+                            </TooltipButton>
                           ) : null}
                           {hasExpiringAction ? (
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="h-8 w-8 bg-rose-500/35 text-rose-100 hover:bg-rose-500/50"
-                              disabled={!canQuick}
-                              title={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
-                              aria-label={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                onOpenQuickOperation('BAIXA', {
-                                  codigoBarras: code,
-                                  quantidade: 1,
-                                  obs: row.tags.includes('EXPIRADO') ? 'Descarte (expirado)' : 'Saída (vencendo)',
-                                })
-                              }}
-                            >
-                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-                                <path d="M12 19V9m0 0-4 4m4-4 4 4M5 5h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
-                            </Button>
+                            <TooltipButton label={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8 bg-rose-500/35 text-rose-100 hover:bg-rose-500/50"
+                                disabled={!canQuick}
+                                aria-label={row.tags.includes('EXPIRADO') ? 'Descarte' : 'Saída'}
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onOpenQuickOperation('BAIXA', {
+                                    codigoBarras: code,
+                                    quantidade: 1,
+                                    obs: row.tags.includes('EXPIRADO') ? 'Descarte (expirado)' : 'Saída (vencendo)',
+                                  })
+                                }}
+                              >
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                                  <path d="M12 19V9m0 0-4 4m4-4 4 4M5 5h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </Button>
+                            </TooltipButton>
                           ) : null}
                           {hasQualityAction ? (
                             <Button
@@ -3333,17 +3354,18 @@ export function InsumosChartsPanel({
       <CardHeader className="flex flex-col gap-2">
         <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
           <div className="flex min-w-0 items-center gap-3">
-            <button
-              type="button"
-              {...dragHandleProps}
-              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
-              title="Arraste para mover"
-              aria-label="Mover"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-              </svg>
-            </button>
+            <TooltipLabel label="Arraste para mover">
+              <button
+                type="button"
+                {...dragHandleProps}
+                className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+                aria-label="Mover"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              </button>
+            </TooltipLabel>
             <CardTitle className="text-base text-white">Gráficos</CardTitle>
           </div>
           <div className="ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
@@ -3405,28 +3427,34 @@ export function InsumosChartsPanel({
             </Select>
             <Input value={chartsSearch} onChange={(event) => onChartsSearchChange(event.target.value)} placeholder="Buscar" className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0" />
             <div className="flex shrink-0 items-center gap-2">
-              <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onAddChart} disabled={!canAddChart} title="Adicionar gráfico" aria-label="Adicionar gráfico">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                  <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                </svg>
-              </Button>
-              <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onResetCharts} disabled={!canResetCharts} title="Resetar gráficos" aria-label="Resetar gráficos">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                  <path d="M20 12a8 8 0 1 1-2.34-5.66" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M20 4v6h-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Button>
-              <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} title={panelOpen ? 'Contrair' : 'Expandir'} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
-                {panelOpen ? (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              <TooltipButton label="Adicionar gráfico">
+                <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onAddChart} disabled={!canAddChart} aria-label="Adicionar gráfico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
                   </svg>
-                ) : (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </Button>
+              </TooltipButton>
+              <TooltipButton label="Resetar gráficos">
+                <Button variant="ghost" size="icon" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onResetCharts} disabled={!canResetCharts} aria-label="Resetar gráficos">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M20 12a8 8 0 1 1-2.34-5.66" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M20 4v6h-6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
-                )}
-              </Button>
+                </Button>
+              </TooltipButton>
+              <TooltipButton label={panelOpen ? 'Contrair' : 'Expandir'}>
+                <Button size="icon" variant="ghost" className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]" onClick={onToggleOpen} aria-label={panelOpen ? 'Contrair' : 'Expandir'}>
+                  {panelOpen ? (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  ) : (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </Button>
+              </TooltipButton>
             </div>
           </div>
         </div>
@@ -3460,9 +3488,11 @@ export function InsumosChartsPanel({
                         </SelectContent>
                       </Select>
                       {card.canRemove ? (
-                        <Button variant="outline" className="h-8 w-8 p-0" title="Remover gráfico" aria-label="Remover gráfico" onClick={() => onRemoveChart(card.key)}>
-                          ×
-                        </Button>
+                        <TooltipButton label="Remover gráfico">
+                          <Button variant="outline" className="h-8 w-8 p-0" aria-label="Remover gráfico" onClick={() => onRemoveChart(card.key)}>
+                            ×
+                          </Button>
+                        </TooltipButton>
                       ) : null}
                     </div>
 
@@ -3654,17 +3684,18 @@ export function InsumosMovementsPanel({
       <CardHeader className="flex flex-col gap-2">
         <div className="flex min-w-0 w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
           <div className="flex min-w-0 items-center gap-3">
-            <button
-              type="button"
-              {...dragHandleProps}
-              className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
-              title="Arraste para mover"
-              aria-label="Mover"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-              </svg>
-            </button>
+            <TooltipLabel label="Arraste para mover">
+              <button
+                type="button"
+                {...dragHandleProps}
+                className="mt-0.5 flex h-9 w-9 cursor-grab items-center justify-center rounded-md bg-transparent text-white hover:bg-white/[0.10] active:cursor-grabbing"
+                aria-label="Mover"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              </button>
+            </TooltipLabel>
             <CardTitle className="text-lg text-white">Movimentações</CardTitle>
           </div>
           <div className="flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
@@ -3712,52 +3743,55 @@ export function InsumosMovementsPanel({
               className="ml-auto h-8 min-w-[120px] flex-1 md:min-w-0"
             />
             <div className="flex shrink-0 items-center gap-2">
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                onClick={onOpenInventoryList}
-                title="Abrir lista de insumos"
-                aria-label="Abrir lista de insumos"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                  <path d="M8 6h12M8 12h12M8 18h12" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
-                  <circle cx="5" cy="6" r="1.5" fill="currentColor" />
-                  <circle cx="5" cy="12" r="1.5" fill="currentColor" />
-                  <circle cx="5" cy="18" r="1.5" fill="currentColor" />
-                </svg>
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                onClick={onExportCsv}
-                disabled={!isAuthed}
-                title="Exportar CSV"
-                aria-label="Exportar CSV"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                  <path d="M12 16V4m0 12-4-4m4 4 4-4M4 20h16" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
-                onClick={onToggleOpen}
-                title={panelOpen ? 'Contrair' : 'Expandir'}
-                aria-label={panelOpen ? 'Contrair' : 'Expandir'}
-              >
-                {panelOpen ? (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              <TooltipButton label="Abrir lista de insumos">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                  onClick={onOpenInventoryList}
+                  aria-label="Abrir lista de insumos"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M8 6h12M8 12h12M8 18h12" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                    <circle cx="5" cy="6" r="1.5" fill="currentColor" />
+                    <circle cx="5" cy="12" r="1.5" fill="currentColor" />
+                    <circle cx="5" cy="18" r="1.5" fill="currentColor" />
                   </svg>
-                ) : (
-                  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
-                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </Button>
+              </TooltipButton>
+              <TooltipButton label="Exportar CSV">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                  onClick={onExportCsv}
+                  disabled={!isAuthed}
+                  aria-label="Exportar CSV"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path d="M12 16V4m0 12-4-4m4 4 4-4M4 20h16" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
-                )}
-              </Button>
+                </Button>
+              </TooltipButton>
+              <TooltipButton label={panelOpen ? 'Contrair' : 'Expandir'}>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-9 w-9 bg-transparent text-white hover:bg-white/[0.10]"
+                  onClick={onToggleOpen}
+                  aria-label={panelOpen ? 'Contrair' : 'Expandir'}
+                >
+                  {panelOpen ? (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 15l6-6 6 6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  ) : (
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </Button>
+              </TooltipButton>
             </div>
           </div>
         </div>
@@ -3777,15 +3811,16 @@ export function InsumosMovementsPanel({
                       >
                         <div className="flex items-center justify-center gap-2">
                           {column.key ? (
-                            <button
-                              type="button"
-                              className={`cursor-pointer select-none rounded-sm px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline`}
-                              onClick={() => onSortChange(column.key!)}
-                              aria-label={`Ordenar ${column.label}`}
-                              title={`Ordenar ${column.label}`}
-                            >
-                              {column.label}
-                            </button>
+                            <TooltipLabel label={`Ordenar ${column.label}`}>
+                              <button
+                                type="button"
+                                className={`cursor-pointer select-none rounded-sm px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 ${isActive ? 'text-white' : 'text-blue-100/80'} hover:underline`}
+                                onClick={() => onSortChange(column.key!)}
+                                aria-label={`Ordenar ${column.label}`}
+                              >
+                                {column.label}
+                              </button>
+                            </TooltipLabel>
                           ) : (
                             <span>{column.label}</span>
                           )}
@@ -3817,15 +3852,16 @@ export function InsumosMovementsPanel({
                         <div className="text-xs text-blue-200/60">{row.timeLabel}</div>
                       </td>
                       <td className="p-3 text-center align-top">
-                        <button
-                          type="button"
-                          className="w-full cursor-pointer break-words rounded-sm text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                          onClick={() => onProductClick(row.productName)}
-                          title="Filtrar por produto"
-                          aria-pressed={row.productPressed}
-                        >
-                          <span className="line-clamp-2">{row.productName}</span>
-                        </button>
+                        <TooltipLabel label="Filtrar por produto">
+                          <button
+                            type="button"
+                            className="w-full cursor-pointer break-words rounded-sm text-center text-blue-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                            onClick={() => onProductClick(row.productName)}
+                            aria-pressed={row.productPressed}
+                          >
+                            <span className="line-clamp-2">{row.productName}</span>
+                          </button>
+                        </TooltipLabel>
                         {row.brandName && row.brandName !== '-' ? (
                           <div className="mt-1 flex flex-wrap justify-center gap-1 lg:hidden">
                             <Badge style={buildTagStyle(getMarcaBgColor(row.brandName))} className="border">
@@ -3836,34 +3872,36 @@ export function InsumosMovementsPanel({
                       </td>
                       <td className="hidden whitespace-nowrap p-3 text-center align-top md:table-cell">
                         {row.categoryName && row.categoryName !== '-' ? (
-                          <button
-                            type="button"
-                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                            onClick={() => onCategoryClick(row.categoryName)}
-                            title="Filtrar por categoria"
-                            aria-pressed={row.categoryPressed}
-                          >
-                            <Badge style={buildTagStyle(getCategoriaBgColor(row.categoryName))} className="border">
-                              {row.categoryName}
-                            </Badge>
-                          </button>
+                          <TooltipLabel label="Filtrar por categoria">
+                            <button
+                              type="button"
+                              className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                              onClick={() => onCategoryClick(row.categoryName)}
+                              aria-pressed={row.categoryPressed}
+                            >
+                              <Badge style={buildTagStyle(getCategoriaBgColor(row.categoryName))} className="border">
+                                {row.categoryName}
+                              </Badge>
+                            </button>
+                          </TooltipLabel>
                         ) : (
                           <span className="text-blue-100/70">-</span>
                         )}
                       </td>
                       <td className="hidden whitespace-nowrap p-3 text-center align-top lg:table-cell">
                         {row.brandName && row.brandName !== '-' ? (
-                          <button
-                            type="button"
-                            className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
-                            onClick={() => onBrandClick(row.brandName)}
-                            title="Filtrar por marca"
-                            aria-pressed={row.brandPressed}
-                          >
-                            <Badge style={buildTagStyle(getMarcaBgColor(row.brandName))} className="border">
-                              {row.brandName}
-                            </Badge>
-                          </button>
+                          <TooltipLabel label="Filtrar por marca">
+                            <button
+                              type="button"
+                              className="inline-flex w-full items-center justify-center rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40"
+                              onClick={() => onBrandClick(row.brandName)}
+                              aria-pressed={row.brandPressed}
+                            >
+                              <Badge style={buildTagStyle(getMarcaBgColor(row.brandName))} className="border">
+                                {row.brandName}
+                              </Badge>
+                            </button>
+                          </TooltipLabel>
                         ) : (
                           <span className="text-blue-100/70">-</span>
                         )}

--- a/frontend/metaAdsApi.ts
+++ b/frontend/metaAdsApi.ts
@@ -9,6 +9,7 @@ import {
   getMetaAdsLocalTrend,
   isMetaAdsLocalMockEnabled,
   listMetaAdsLocalAccounts,
+  removeMetaAdsLocalAccount,
   selectMetaAdsLocalAccount,
   simulateMetaAdsOAuthConnect,
 } from '@/metaAdsLocalMock'
@@ -80,6 +81,10 @@ export const metaAdsApi = {
     isMetaAdsLocalMockEnabled()
       ? selectMetaAdsLocalAccount(payload.adAccountId)
       : request('/ad-accounts/select', { method: 'POST', body: JSON.stringify(payload) }),
+  removeAdAccount: (payload: { adAccountId: string }) =>
+    isMetaAdsLocalMockEnabled()
+      ? removeMetaAdsLocalAccount(payload.adAccountId)
+      : request('/ad-accounts/remove', { method: 'POST', body: JSON.stringify(payload) }),
   summary: (params?: { since?: string; until?: string }) => {
     const search = new URLSearchParams(params as any).toString()
     return isMetaAdsLocalMockEnabled()

--- a/frontend/metaAdsHeaderBridge.ts
+++ b/frontend/metaAdsHeaderBridge.ts
@@ -42,11 +42,11 @@ export function normalizeMetaAdsHeaderAction(detail: unknown): MetaAdsHeaderActi
   const payload = detail as { type?: unknown; value?: unknown; action?: unknown }
   const rawType = String(payload.type || payload.action || '').trim()
   if (!rawType) return null
-  if (rawType === 'refresh' || rawType === 'manage-connections' || rawType === 'disconnect' || rawType === 'open-custom-period') {
+  if (rawType === 'refresh' || rawType === 'manage-connections' || rawType === 'disconnect' || rawType === 'open-custom-period' || rawType === 'connect') {
     return { type: rawType }
   }
-  if (rawType === 'set-account') {
-    return { type: 'set-account', value: String(payload.value || '') }
+  if (rawType === 'set-account' || rawType === 'remove-account') {
+    return { type: rawType, value: String(payload.value || '') }
   }
   if (rawType === 'set-report-window') {
     const value = Number(payload.value)

--- a/frontend/metaAdsLocalMock.ts
+++ b/frontend/metaAdsLocalMock.ts
@@ -21,6 +21,7 @@ type MetaAdsLocalState = {
   scenario: Exclude<MetaAdsLocalScenario, 'live' | 'unauthorized'>
   tokenType: 'oauth' | 'manual' | null
   selectedAdAccountId: string | null
+  hiddenAdAccountIds: string[]
   updatedAt: string | null
 }
 
@@ -44,7 +45,8 @@ function resolveWindowDays(params?: { since?: string; until?: string }): MetaAds
   return 60
 }
 
-function resolveWindowLabel(days: MetaAdsReportWindowDays) {
+function resolveWindowLabel(days: number) {
+  if (days <= 1) return 'last_24h'
   if (days === 7) return 'last_7d'
   return 'last_30d'
 }
@@ -129,6 +131,7 @@ function buildDefaultState(
     scenario,
     tokenType: scenario === 'disconnected' ? null : 'oauth',
     selectedAdAccountId: scenario === 'connected-ready' ? DEFAULT_ACCOUNT_ID : null,
+    hiddenAdAccountIds: [],
     updatedAt: scenario === 'disconnected' ? null : new Date().toISOString(),
   }
 }
@@ -180,6 +183,9 @@ function readState(syncFromUrl = true): MetaAdsLocalState | null {
       scenario,
       tokenType: parsed?.tokenType === 'manual' ? 'manual' : parsed?.tokenType === 'oauth' ? 'oauth' : null,
       selectedAdAccountId: typeof parsed?.selectedAdAccountId === 'string' ? parsed.selectedAdAccountId : null,
+      hiddenAdAccountIds: Array.isArray(parsed?.hiddenAdAccountIds)
+        ? Array.from(new Set(parsed.hiddenAdAccountIds.map((item: unknown) => String(item || '').trim()).filter(Boolean)))
+        : [],
       updatedAt: typeof parsed?.updatedAt === 'string' ? parsed.updatedAt : null,
     }
   } catch {
@@ -229,10 +235,11 @@ function buildStatus(state: MetaAdsLocalState): MetaAdsStatusResponse {
 }
 
 function buildAccounts(state: MetaAdsLocalState) {
+  const hidden = new Set(state.hiddenAdAccountIds)
   return ACCOUNT_FIXTURES.map((account) => ({
     ...account,
     isSelected: account.id === state.selectedAdAccountId,
-  }))
+  })).filter((account) => !hidden.has(account.id))
 }
 
 function requireConnectedState(): MetaAdsLocalState {
@@ -294,20 +301,24 @@ export function isMetaAdsLocalMockConnected() {
 
 export async function simulateMetaAdsOAuthConnect() {
   if (!canUseLocalStorage()) return
+  const current = readState(false)
   writeState({
     scenario: 'connected-no-account',
     tokenType: 'oauth',
     selectedAdAccountId: null,
+    hiddenAdAccountIds: current?.hiddenAdAccountIds || [],
     updatedAt: new Date().toISOString(),
   })
 }
 
 export async function connectMetaAdsManualLocal() {
   if (!canUseLocalStorage()) return
+  const current = readState(false)
   writeState({
     scenario: 'connected-no-account',
     tokenType: 'manual',
     selectedAdAccountId: null,
+    hiddenAdAccountIds: current?.hiddenAdAccountIds || [],
     updatedAt: new Date().toISOString(),
   })
 }
@@ -333,8 +344,41 @@ export async function selectMetaAdsLocalAccount(adAccountId: string) {
     scenario: 'connected-ready',
     tokenType: current.tokenType || 'oauth',
     selectedAdAccountId: adAccountId,
+    hiddenAdAccountIds: current.hiddenAdAccountIds.filter((id) => id !== adAccountId),
     updatedAt: new Date().toISOString(),
   })
+}
+
+export async function removeMetaAdsLocalAccount(adAccountId: string) {
+  const current = requireConnectedState()
+  const account = ACCOUNT_FIXTURES.find((item) => item.id === adAccountId)
+  if (!account) {
+    throw buildError({
+      code: 'META_ADS_ACCOUNT_NOT_FOUND',
+      status: 404,
+      message: 'A conta solicitada não existe no cenário local.',
+      hint: 'Escolha uma das contas simuladas exibidas na tela.',
+      retryable: false,
+    })
+  }
+  const hiddenAdAccountIds = Array.from(new Set([...current.hiddenAdAccountIds, adAccountId]))
+  const visible = ACCOUNT_FIXTURES.filter((item) => !hiddenAdAccountIds.includes(item.id))
+  const nextSelectedAdAccountId = current.selectedAdAccountId === adAccountId
+    ? visible[0]?.id || null
+    : current.selectedAdAccountId
+  writeState({
+    ...current,
+    scenario: nextSelectedAdAccountId ? 'connected-ready' : 'connected-no-account',
+    selectedAdAccountId: nextSelectedAdAccountId,
+    hiddenAdAccountIds,
+    updatedAt: new Date().toISOString(),
+  })
+  return {
+    ok: true,
+    removedAdAccountId: adAccountId,
+    selectedAdAccountId: nextSelectedAdAccountId,
+    remainingAccountCount: visible.length,
+  }
 }
 
 export async function getMetaAdsLocalStatus() {
@@ -365,7 +409,7 @@ export async function listMetaAdsLocalAccounts() {
 export async function getMetaAdsLocalSummary(params?: { since?: string; until?: string }): Promise<MetaAdsSummaryResponse> {
   const state = requireSelectedAccount()
   const days = resolveRequestedDays(params)
-  const window = resolveWindowLabel(resolveWindowDays(params))
+  const window = resolveWindowLabel(days)
   if (state.selectedAdAccountId === 'act_456') {
     const spend = roundMetric(interpolateMetric(days, { d7: 214.32, d30: 864.12, d60: 1240.9 }))
     const impressions = Math.round(interpolateMetric(days, { d7: 1880, d30: 7120, d60: 10240 }))
@@ -382,8 +426,8 @@ export async function getMetaAdsLocalSummary(params?: { since?: string; until?: 
     }
   }
   const spend = roundMetric(interpolateMetric(days, { d7: 512.48, d30: 1234.56, d60: 1610.98 }))
-  const impressions = Math.round(interpolateMetric(days, { d7: 3840, d30: 9999, d60: 61715 }))
-  const clicks = Math.round(interpolateMetric(days, { d7: 102, d30: 321, d60: 884 }))
+  const impressions = Math.round(interpolateMetric(days, { d7: 3840, d30: 9999, d60: 11740 }))
+  const clicks = Math.round(interpolateMetric(days, { d7: 102, d30: 321, d60: 424 }))
   const conversations = Math.round(interpolateMetric(days, { d7: 10, d30: 23, d60: 29 }))
   return {
     spend,
@@ -569,11 +613,14 @@ export async function getMetaAdsLocalReport(params?: { since?: string; until?: s
   const state = requireSelectedAccount()
   const days = resolveRequestedDays(params)
   const reportDate = '2026-05-14'
-  const windowLabel = resolveWindowLabel(resolveWindowDays(params))
+  const windowLabel = resolveWindowLabel(days)
   const spendKey = `ad_${windowLabel}_scalar_spend`
+  const reachKey = `ad_${windowLabel}_scalar_reach`
   const impressionsKey = `ad_${windowLabel}_scalar_impressions`
   const clicksKey = `ad_${windowLabel}_scalar_clicks`
   const linkClicksKey = `ad_${windowLabel}_inline_link_clicks`
+  const engagementKey = `ad_${windowLabel}_inline_post_engagement`
+  const instagramProfileVisitsKey = `ad_${windowLabel}_instagram_profile_visits`
   const conversationsKey = `ad_${windowLabel}_conversation_started`
   const rows =
     state.selectedAdAccountId === 'act_456'
@@ -587,9 +634,12 @@ export async function getMetaAdsLocalReport(params?: { since?: string; until?: s
             ad_id: 'ad_ret_1',
             ad_name: 'Anúncio Remarketing 1',
             [spendKey]: roundMetric(interpolateMetric(days, { d7: 214.32, d30: 864.12, d60: 1240.9 })),
+            [reachKey]: Math.round(interpolateMetric(days, { d7: 1420, d30: 5210, d60: 7420 })),
             [impressionsKey]: Math.round(interpolateMetric(days, { d7: 1880, d30: 7120, d60: 10240 })),
             [clicksKey]: Math.round(interpolateMetric(days, { d7: 57, d30: 214, d60: 332 })),
             [linkClicksKey]: Math.round(interpolateMetric(days, { d7: 39, d30: 138, d60: 214 })),
+            [engagementKey]: Math.round(interpolateMetric(days, { d7: 82, d30: 284, d60: 412 })),
+            [instagramProfileVisitsKey]: Math.round(interpolateMetric(days, { d7: 11, d30: 39, d60: 54 })),
             [conversationsKey]: Math.round(interpolateMetric(days, { d7: 5, d30: 19, d60: 28 })),
           },
         ]
@@ -603,9 +653,12 @@ export async function getMetaAdsLocalReport(params?: { since?: string; until?: s
             ad_id: 'ad_1',
             ad_name: 'Anúncio Primavera 1',
             [spendKey]: roundMetric(interpolateMetric(days, { d7: 342.2, d30: 834.56, d60: 1044.9 })),
+            [reachKey]: Math.round(interpolateMetric(days, { d7: 1610, d30: 4620, d60: 5980 })),
             [impressionsKey]: Math.round(interpolateMetric(days, { d7: 2210, d30: 6120, d60: 8120 })),
             [clicksKey]: Math.round(interpolateMetric(days, { d7: 79, d30: 201, d60: 281 })),
             [linkClicksKey]: Math.round(interpolateMetric(days, { d7: 52, d30: 147, d60: 194 })),
+            [engagementKey]: Math.round(interpolateMetric(days, { d7: 126, d30: 352, d60: 418 })),
+            [instagramProfileVisitsKey]: Math.round(interpolateMetric(days, { d7: 18, d30: 64, d60: 72 })),
             [conversationsKey]: Math.round(interpolateMetric(days, { d7: 6, d30: 14, d60: 18 })),
           },
           {
@@ -617,9 +670,12 @@ export async function getMetaAdsLocalReport(params?: { since?: string; until?: s
             ad_id: 'ad_2',
             ad_name: 'Anúncio WhatsApp 1',
             [spendKey]: roundMetric(interpolateMetric(days, { d7: 170.28, d30: 400, d60: 566.08 })),
+            [reachKey]: Math.round(interpolateMetric(days, { d7: 1190, d30: 2890, d60: 2760 })),
             [impressionsKey]: Math.round(interpolateMetric(days, { d7: 1630, d30: 3879, d60: 3620 })),
             [clicksKey]: Math.round(interpolateMetric(days, { d7: 45, d30: 120, d60: 143 })),
             [linkClicksKey]: Math.round(interpolateMetric(days, { d7: 31, d30: 84, d60: 97 })),
+            [engagementKey]: Math.round(interpolateMetric(days, { d7: 71, d30: 188, d60: 205 })),
+            [instagramProfileVisitsKey]: Math.round(interpolateMetric(days, { d7: 9, d30: 27, d60: 31 })),
             [conversationsKey]: Math.round(interpolateMetric(days, { d7: 4, d30: 9, d60: 11 })),
           },
         ]

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -5,14 +5,13 @@ import { CartesianGrid, LineChart, Line, XAxis, YAxis, Tooltip as RechartsToolti
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/dialog'
 import { EntityDetailModal, type EntityDetailSection } from '@/EntityDetailModal'
-import { Popover, PopoverContent, PopoverTrigger } from '@/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { Switch } from '@/switch'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/table'
 import { Textarea } from '@/textarea'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/tooltip'
+import { TooltipLabel } from '@/tooltip'
 import type {
   MetaAdAccount,
   MetaAd,
@@ -232,10 +231,9 @@ function MetaAdsHoverTooltip({
   children: ReactElement
 }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent>{content}</TooltipContent>
-    </Tooltip>
+    <TooltipLabel label={content}>
+      {children}
+    </TooltipLabel>
   )
 }
 
@@ -537,7 +535,7 @@ function MetaAdsMetricTile({
   )
 
   return (
-    <Card className={`${panelClass} ${size === 'wide' ? 'col-span-2' : ''}`}>
+    <Card className={`${panelClass} gap-0 overflow-hidden py-0 ${size === 'wide' ? 'col-span-2' : ''}`}>
       {tooltipLabel || description ? (
         <MetaAdsTableTooltip label={tooltipLabel || label} description={description}>
           {body}
@@ -1176,6 +1174,7 @@ export function MetaAdsOverviewPanel({
       return DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
     }
   })
+  const [metricSettingsOpen, setMetricSettingsOpen] = useState(false)
 
   useEffect(() => {
     try {
@@ -1452,94 +1451,101 @@ export function MetaAdsOverviewPanel({
     setMetricLayout((prev) => prev.map((item) => (item.key === key ? { ...item, ...patch } : item)))
   }
 
-  return (
-    <>
-      <MetaAdsPersistentError error={overviewError} onRetry={onRetry} />
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-xs uppercase tracking-[0.18em] text-slate-500">Resumo da conta</div>
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="outline" size="sm" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80">
-              <FadersHorizontal className="h-4 w-4" />
-              Personalizar métricas
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="max-h-[min(38rem,calc(100vh-7rem))] w-[min(26rem,calc(100vw-2rem))] overflow-y-auto border-slate-800/80 bg-slate-950 text-slate-100">
-            <div className="space-y-3">
-              <div className="space-y-1">
-                <div className="text-sm font-semibold text-white">Personalizar métricas</div>
+  const metricSettingsContent = (
+    <div className="space-y-3">
+      <div className="grid gap-2">
+        {metricLayout.map((config, index) => {
+          const tile = metricTiles.find((entry) => entry.key === config.key)
+          if (!tile) return null
+          return (
+            <div key={config.key} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 p-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-white">{tile.tooltipLabel || tile.label}</div>
+                <div className="truncate text-xs text-slate-400">{tile.description || tile.label}</div>
               </div>
-              <div className="space-y-2">
-                {metricLayout.map((config, index) => {
-                  const tile = metricTiles.find((entry) => entry.key === config.key)
-                  if (!tile) return null
-                  return (
-                    <div key={config.key} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 p-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-white">{tile.tooltipLabel || tile.label}</div>
-                        <div className="truncate text-xs text-slate-400">{tile.description || tile.label}</div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Switch
-                          checked={config.visible}
-                          onCheckedChange={(checked) => updateMetricTile(config.key, { visible: checked })}
-                          aria-label={`${config.visible ? 'Ocultar' : 'Exibir'} ${tile.label}`}
-                        />
-                        <Select
-                          value={config.size}
-                          onValueChange={(value) => updateMetricTile(config.key, { size: value === 'wide' ? 'wide' : 'compact' })}
-                        >
-                          <SelectTrigger className="h-8 w-[7.5rem] border-slate-700 bg-slate-950/70 text-xs text-slate-100">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="compact">Compacto</SelectItem>
-                            <SelectItem value="wide">Largo</SelectItem>
-                          </SelectContent>
-                        </Select>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 px-2 text-slate-300 hover:bg-slate-800/80 hover:text-white"
-                          onClick={() => moveMetricTile(config.key, -1)}
-                          disabled={index === 0}
-                          aria-label={`Mover ${tile.label} para cima`}
-                        >
-                          <CaretUp className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 px-2 text-slate-300 hover:bg-slate-800/80 hover:text-white"
-                          onClick={() => moveMetricTile(config.key, 1)}
-                          disabled={index === metricLayout.length - 1}
-                          aria-label={`Mover ${tile.label} para baixo`}
-                        >
-                          <CaretDown className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-              <div className="flex items-center justify-between pt-1">
-                <div className="text-xs text-slate-400">Cards ocultos saem do topo, mas continuam disponíveis aqui.</div>
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={config.visible}
+                  onCheckedChange={(checked) => updateMetricTile(config.key, { visible: checked })}
+                  aria-label={`${config.visible ? 'Ocultar' : 'Exibir'} ${tile.label}`}
+                />
+                <Select
+                  value={config.size}
+                  onValueChange={(value) => updateMetricTile(config.key, { size: value === 'wide' ? 'wide' : 'compact' })}
+                >
+                  <SelectTrigger className="h-8 w-[7.5rem] border-slate-700 bg-slate-950/70 text-xs text-slate-100">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="compact">Compacto</SelectItem>
+                    <SelectItem value="wide">Largo</SelectItem>
+                  </SelectContent>
+                </Select>
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
                   className="h-8 px-2 text-slate-300 hover:bg-slate-800/80 hover:text-white"
-                  onClick={() => setMetricLayout(DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT)}
+                  onClick={() => moveMetricTile(config.key, -1)}
+                  disabled={index === 0}
+                  aria-label={`Mover ${tile.label} para cima`}
                 >
-                  <EyeSlash className="h-4 w-4" />
-                  Resetar
+                  <CaretUp className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-slate-300 hover:bg-slate-800/80 hover:text-white"
+                  onClick={() => moveMetricTile(config.key, 1)}
+                  disabled={index === metricLayout.length - 1}
+                  aria-label={`Mover ${tile.label} para baixo`}
+                >
+                  <CaretDown className="h-4 w-4" />
                 </Button>
               </div>
             </div>
-          </PopoverContent>
-        </Popover>
+          )
+        })}
+      </div>
+      <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-xs text-slate-400">Cards ocultos saem do topo, mas continuam disponíveis aqui.</div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-2 text-slate-300 hover:bg-slate-800/80 hover:text-white"
+          onClick={() => setMetricLayout(DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT)}
+        >
+          <EyeSlash className="h-4 w-4" />
+          Resetar
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <MetaAdsPersistentError error={overviewError} onRetry={onRetry} />
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs uppercase tracking-[0.18em] text-slate-500">Resumo da conta</div>
+        <Dialog open={metricSettingsOpen} onOpenChange={setMetricSettingsOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline" size="sm" className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80">
+              <FadersHorizontal className="h-4 w-4" />
+              Personalizar métricas
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="border-slate-800/80 bg-slate-950 text-slate-100 sm:max-w-2xl" resizable={false}>
+            <DialogHeader>
+              <DialogTitle>Personalizar métricas</DialogTitle>
+              <DialogDescription>
+                Escolha quais métricas aparecem no topo, ajuste o tamanho dos cards e reorganize a ordem.
+              </DialogDescription>
+            </DialogHeader>
+            {metricSettingsContent}
+          </DialogContent>
+        </Dialog>
       </div>
       <div className="grid gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
         {visibleMetricTiles.length > 0 ? (

--- a/frontend/metaAdsTypes.ts
+++ b/frontend/metaAdsTypes.ts
@@ -270,7 +270,9 @@ export type MetaAdsHeaderState = {
 
 export type MetaAdsHeaderAction =
   | { type: 'set-account'; value: string }
+  | { type: 'remove-account'; value: string }
   | { type: 'set-report-window'; value: MetaAdsReportWindowDays }
+  | { type: 'connect' }
   | { type: 'open-custom-period' }
   | { type: 'refresh' }
   | { type: 'manage-connections' }

--- a/frontend/metaAdsWorkflowReport.ts
+++ b/frontend/metaAdsWorkflowReport.ts
@@ -133,6 +133,8 @@ export function buildMetaAdsWorkflowReport(
     const impressions = readMetric(row, window, ['scalar_impressions', 'impressions'])
     const clicks = readMetric(row, window, ['scalar_clicks', 'clicks'])
     const linkClicks = readOptionalMetric(row, window, ['inline_link_clicks'])
+    const engagement = readOptionalMetric(row, window, ['inline_post_engagement'])
+    const instagramProfileVisits = readOptionalMetric(row, window, ['instagram_profile_visits'])
     const conversations = readMetric(row, window, ['conversation_started', 'whatsapp_conversations_started'])
     const cpp = readOptionalMetric(row, window, ['scalar_cpp', 'cpp'])
     const frequency = readOptionalMetric(row, window, ['scalar_frequency', 'frequency'])
@@ -147,6 +149,8 @@ export function buildMetaAdsWorkflowReport(
       impressions: 0,
       clicks: 0,
       linkClicks: 0,
+      engagement: 0,
+      instagramProfileVisits: 0,
       conversations: 0,
       ctr: 0,
       linkCtr: 0,
@@ -162,6 +166,8 @@ export function buildMetaAdsWorkflowReport(
     current.impressions += impressions
     current.clicks += clicks
     current.linkClicks = Number(current.linkClicks || 0) + (linkClicks || 0)
+    current.engagement = Number(current.engagement || 0) + (engagement || 0)
+    current.instagramProfileVisits = Number(current.instagramProfileVisits || 0) + (instagramProfileVisits || 0)
     current.conversations += conversations
     current.cpp = Number(current.cpp || 0) + (cpp || 0)
     current.frequency = Number(current.frequency || 0) + (frequency || 0)
@@ -182,6 +188,8 @@ export function buildMetaAdsWorkflowReport(
         impressions: 0,
         clicks: 0,
         linkClicks: 0,
+        engagement: 0,
+        instagramProfileVisits: 0,
         conversations: 0,
         ctr: 0,
         linkCtr: 0,
@@ -196,6 +204,8 @@ export function buildMetaAdsWorkflowReport(
       currentAdSet.impressions += impressions
       currentAdSet.clicks += clicks
       currentAdSet.linkClicks = Number(currentAdSet.linkClicks || 0) + (linkClicks || 0)
+      currentAdSet.engagement = Number(currentAdSet.engagement || 0) + (engagement || 0)
+      currentAdSet.instagramProfileVisits = Number(currentAdSet.instagramProfileVisits || 0) + (instagramProfileVisits || 0)
       currentAdSet.conversations += conversations
       currentAdSet.cpp = Number(currentAdSet.cpp || 0) + (cpp || 0)
       currentAdSet.frequency = Number(currentAdSet.frequency || 0) + (frequency || 0)
@@ -216,6 +226,8 @@ export function buildMetaAdsWorkflowReport(
         impressions: 0,
         clicks: 0,
         linkClicks: 0,
+        engagement: 0,
+        instagramProfileVisits: 0,
         conversations: 0,
         ctr: 0,
         linkCtr: 0,
@@ -230,6 +242,8 @@ export function buildMetaAdsWorkflowReport(
       currentAd.impressions += impressions
       currentAd.clicks += clicks
       currentAd.linkClicks = Number(currentAd.linkClicks || 0) + (linkClicks || 0)
+      currentAd.engagement = Number(currentAd.engagement || 0) + (engagement || 0)
+      currentAd.instagramProfileVisits = Number(currentAd.instagramProfileVisits || 0) + (instagramProfileVisits || 0)
       currentAd.conversations += conversations
       currentAd.cpp = Number(currentAd.cpp || 0) + (cpp || 0)
       currentAd.frequency = Number(currentAd.frequency || 0) + (frequency || 0)

--- a/frontend/scripts/meta-ads-local-smoke.cjs
+++ b/frontend/scripts/meta-ads-local-smoke.cjs
@@ -42,10 +42,8 @@ async function main() {
   await expectVisible(page.getByRole('heading', { name: 'Meta Ads' }), 'Meta Ads heading')
 
   if (SCENARIO === 'connected-ready') {
-    await expectVisible(page.getByText('Conta Meta pronta para operar'), 'connected ready banner')
-    await expectVisible(page.getByText('Conta ativa: Conta Principal'), 'selected account')
-    await expectVisible(page.getByRole('tab', { name: 'Visão geral' }), 'overview tab')
-    await page.getByRole('tab', { name: 'Inventário' }).click()
+    await expectVisible(page.getByRole('combobox'), 'selected account combobox')
+    await expectVisible(page.getByLabel('Atualizar'), 'header refresh action')
     await expectVisible(page.getByText('Campanha Primavera'), 'inventory campaign')
   } else if (SCENARIO === 'unauthorized') {
     await expectVisible(page.getByText('Faça login no CRM para continuar'), 'unauthorized message')

--- a/frontend/sidebar.tsx
+++ b/frontend/sidebar.tsx
@@ -20,6 +20,7 @@ import {
 import { Skeleton } from "@/skeleton"
 import {
   Tooltip,
+  TooltipButton,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
@@ -283,24 +284,25 @@ function SidebarRail({ className, ...props }: ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
 
   return (
-    <button
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className
-      )}
-      {...props}
-    />
+    <TooltipButton label="Alternar sidebar">
+      <button
+        data-sidebar="rail"
+        data-slot="sidebar-rail"
+        aria-label="Toggle Sidebar"
+        tabIndex={-1}
+        onClick={toggleSidebar}
+        className={cn(
+          "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+          "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+          "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+          "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+          "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+          "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+          className
+        )}
+        {...props}
+      />
+    </TooltipButton>
   )
 }
 

--- a/frontend/tests/metaAdsModule.test.ts
+++ b/frontend/tests/metaAdsModule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   buildMetaAdsHealthState,
@@ -11,6 +11,7 @@ import {
   buildMetaAdsWorkflowReport,
   normalizeMetaAdsWorkflowAccountId,
 } from '../metaAdsWorkflowReport'
+import { listMetaAdsInsights } from '../functions/_lib/metaAdsGraph'
 import type { MetaAdsStatusResponse } from '../metaAdsTypes'
 
 const baseStatus = (overrides: Partial<MetaAdsStatusResponse> = {}): MetaAdsStatusResponse => ({
@@ -30,6 +31,10 @@ const baseStatus = (overrides: Partial<MetaAdsStatusResponse> = {}): MetaAdsStat
     expiresAt: null,
   },
   ...overrides,
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Meta Ads state helpers', () => {
@@ -296,5 +301,137 @@ describe('Meta Ads state helpers', () => {
       spend: 150,
       clicks: 50,
     })
+  })
+
+  it('parses Graph insights with action metrics for campaign fallback reports', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              campaign_id: 'cmp_1',
+              campaign_name: 'Campanha Primavera',
+              spend: '100',
+              reach: '50',
+              impressions: '1000',
+              clicks: '20',
+              inline_link_clicks: '12',
+              ctr: '2',
+              cpc: '5',
+              cpm: '100',
+              cpp: '2',
+              frequency: '2',
+              actions: [
+                { action_type: 'onsite_conversion.messaging_conversation_started_7d', value: '4' },
+                { action_type: 'post_engagement', value: '9' },
+                { action_type: 'instagram_profile_visit', value: '3' },
+              ],
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    )
+
+    const rows = await listMetaAdsInsights(
+      'token',
+      'act_123',
+      'campaign',
+      { since: '2026-05-01', until: '2026-05-07' },
+      'v20.0',
+    )
+
+    expect(rows[0]).toMatchObject({
+      campaign_id: 'cmp_1',
+      campaign_name: 'Campanha Primavera',
+      spend: 100,
+      reach: 50,
+      impressions: 1000,
+      clicks: 20,
+      linkClicks: 12,
+      conversations: 4,
+      engagement: 9,
+      instagramProfileVisits: 3,
+      ctr: 2,
+      linkCtr: 1.2,
+      cpc: 5,
+      linkCpc: 8.33,
+      cpm: 100,
+      cpp: 2,
+      frequency: 2,
+    })
+  })
+
+  it('falls back to basic Graph insight fields when action metrics are rejected', async () => {
+    const originalFetch = globalThis.fetch
+    const requests: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      requests.push(url)
+      if (requests.length === 1) {
+        return new Response(JSON.stringify({ error: { message: 'Unsupported get request for field actions' } }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              campaign_id: 'cmp_1',
+              campaign_name: 'Campanha 1',
+              spend: '123.45',
+              reach: '1000',
+              impressions: '2000',
+              clicks: '40',
+              inline_link_clicks: '25',
+              ctr: '2',
+              cpc: '3.08',
+              cpm: '61.72',
+              cpp: '0.12',
+              frequency: '2',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )
+    }) as typeof fetch
+
+    try {
+      const rows = await listMetaAdsInsights(
+        'token',
+        'act_123',
+        'campaign',
+        { since: '2026-05-01', until: '2026-05-30' },
+        'v20.0',
+      )
+
+      expect(requests).toHaveLength(2)
+      expect(requests[0]).toContain('actions')
+      expect(requests[1]).not.toContain('actions')
+      expect(rows[0]).toMatchObject({
+        campaign_id: 'cmp_1',
+        campaign_name: 'Campanha 1',
+        spend: 123.45,
+        reach: 1000,
+        impressions: 2000,
+        clicks: 40,
+        linkClicks: 25,
+        ctr: 2,
+        cpc: 3.08,
+        cpm: 61.72,
+        cpp: 0.12,
+        frequency: 2,
+      })
+      expect(rows[0].conversations).toBe(0)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })

--- a/frontend/tooltip.tsx
+++ b/frontend/tooltip.tsx
@@ -1,16 +1,30 @@
-import { ComponentProps } from "react"
+import {
+  cloneElement,
+  ComponentProps,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  useState,
+} from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/utils"
 
+const TOOLTIP_DELAY = 180
+const TOOLTIP_SKIP_DELAY = 80
+const TOOLTIP_SIDE_OFFSET = 8
+const TOOLTIP_COLLISION_PADDING = 12
+
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = TOOLTIP_DELAY,
+  skipDelayDuration = TOOLTIP_SKIP_DELAY,
   ...props
 }: ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
       {...props}
     />
   )
@@ -34,7 +48,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = TOOLTIP_SIDE_OFFSET,
   children,
   ...props
 }: ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -43,17 +57,210 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        collisionPadding={TOOLTIP_COLLISION_PADDING}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[120] w-fit max-w-72 origin-(--radix-tooltip-content-transform-origin) rounded-xl border border-white/12 bg-slate-950/96 px-3 py-2 text-[11px] text-slate-50 shadow-[0_16px_36px_rgba(15,23,42,0.34)] backdrop-blur-xl",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="fill-slate-950/96 z-[119] size-3" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+function TooltipCopy({
+  label,
+  description,
+}: {
+  label: ReactNode
+  description?: ReactNode
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-[11px] font-medium leading-tight text-white">{label}</div>
+      {description ? (
+        <div className="text-[10px] leading-snug text-slate-300/92">{description}</div>
+      ) : null}
+    </div>
+  )
+}
+
+type TooltipOverlayProps = {
+  label: ReactNode
+  description?: ReactNode
+  children: ReactNode
+  contentClassName?: string
+} & Omit<ComponentProps<typeof TooltipContent>, "children" | "className">
+
+function composeHandler<E>(
+  original?: (event: E) => void,
+  next?: (event: E) => void
+) {
+  return (event: E) => {
+    original?.(event)
+    next?.(event)
+  }
+}
+
+function enhanceTooltipTrigger(
+  child: ReactNode,
+  setOpen: (open: boolean) => void
+) {
+  if (!isValidElement(child)) return child
+  const element = child as ReactElement<any>
+  const nativeTag = typeof element.type === "string" ? element.type : ""
+  const nativeInteractive = ["a", "button", "input", "select", "textarea"].includes(nativeTag)
+  const shouldAddTabIndex = !nativeInteractive && element.props.tabIndex === undefined
+  return cloneElement(element, {
+    tabIndex: shouldAddTabIndex ? 0 : element.props.tabIndex,
+    onPointerEnter: composeHandler(element.props.onPointerEnter, (event: any) => {
+      const pointerType = event?.pointerType
+      if (!pointerType || pointerType === "mouse") {
+        setOpen(true)
+      }
+    }),
+    onPointerLeave: composeHandler(element.props.onPointerLeave, (event: any) => {
+      const pointerType = event?.pointerType
+      if (!pointerType || pointerType === "mouse") {
+        setOpen(false)
+      }
+    }),
+    onPointerDown: composeHandler(element.props.onPointerDown, (event: PointerEvent) => {
+      const pointerType = (event as PointerEvent & { pointerType?: string }).pointerType
+      if (pointerType === "touch" || pointerType === "pen") {
+        setOpen(true)
+      }
+    }),
+    onFocus: composeHandler(element.props.onFocus, () => setOpen(true)),
+    onBlur: composeHandler(element.props.onBlur, () => setOpen(false)),
+    onKeyDown: composeHandler(element.props.onKeyDown, (event: KeyboardEvent) => {
+      if ((event as KeyboardEvent).key === "Escape") {
+        setOpen(false)
+      }
+    }),
+  })
+}
+
+function TooltipLabel({
+  label,
+  description,
+  children,
+  contentClassName,
+  side = "top",
+  align = "center",
+  ...props
+}: TooltipOverlayProps) {
+  const [open, setOpen] = useState(false)
+  const trigger = enhanceTooltipTrigger(children, setOpen)
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+      <TooltipContent
+        side={side}
+        align={align}
+        className={contentClassName}
+        onPointerDownOutside={() => setOpen(false)}
+        {...props}
+      >
+        <TooltipCopy label={label} description={description} />
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function TooltipButton({
+  label,
+  description,
+  children,
+  ...props
+}: TooltipOverlayProps) {
+  return (
+    <TooltipLabel label={label} description={description} {...props}>
+      {children}
+    </TooltipLabel>
+  )
+}
+
+function TooltipIcon({
+  label,
+  description,
+  icon,
+  className,
+  iconClassName,
+  ...props
+}: {
+  label: ReactNode
+  description?: ReactNode
+  icon: ReactNode
+  className?: string
+  iconClassName?: string
+} & Omit<TooltipOverlayProps, "children" | "label" | "description">) {
+  return (
+    <TooltipLabel label={label} description={description} {...props}>
+      <button
+        type="button"
+        aria-label={typeof label === "string" ? label : undefined}
+        className={cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.04] text-slate-100 transition hover:border-white/20 hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+          className
+        )}
+      >
+        <span className={cn("inline-flex h-4 w-4 items-center justify-center", iconClassName)}>
+          {icon}
+        </span>
+      </button>
+    </TooltipLabel>
+  )
+}
+
+function TooltipTruncate({
+  text,
+  description,
+  className,
+  contentClassName,
+  side = "top",
+  align = "center",
+  ...props
+}: {
+  text: string
+  description?: ReactNode
+  className?: string
+  contentClassName?: string
+} & Omit<ComponentProps<"span">, "children"> &
+  Omit<ComponentProps<typeof TooltipContent>, "children" | "className">) {
+  return (
+    <TooltipLabel
+      label={text}
+      description={description}
+      side={side}
+      align={align}
+      contentClassName={contentClassName}
+      {...props}
+    >
+      <span
+        tabIndex={0}
+        className={cn(
+          "inline-block max-w-full truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+          className
+        )}
+      >
+        {text}
+      </span>
+    </TooltipLabel>
+  )
+}
+
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+  TooltipCopy,
+  TooltipLabel,
+  TooltipButton,
+  TooltipIcon,
+  TooltipTruncate,
+}


### PR DESCRIPTION
## Summary

This PR consolidates the Meta Ads CRM module hardening and global tooltip/UI polish tranche.

Main changes:
- hardens Meta Ads connection/account handling, header actions, local scenarios, period selection, and report refresh flows;
- improves Meta Ads workflow report parsing and Graph fallback metrics for campaign/ad set/ad level insights;
- consolidates the operational inventory UI with hierarchy, ranking, detail modals, compact metrics, tooltips, and local smoke coverage;
- standardizes tooltip primitives/wrappers and documents tooltip usage across the CRM;
- updates related CRM surfaces so icon-only actions, badges, tables, charts, and dense cards remain consistent;
- adds local CRM smoke helper scripts and focused Meta Ads tests.

## Validation

- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint -- --quiet`
- `npm --prefix frontend test -- --run metaAdsModule`
- `npm --prefix frontend run build`
- `CRM_OPEN_BROWSER=0 ./scripts/run-local-crm.sh --module meta-ads --meta-ads-scenario connected-ready --skip-build --smoke --no-browser`

## Deploy note

Direct Wrangler deploy from this machine is currently blocked because the local Cloudflare auth refresh token is expired (`invalid_grant`). GitHub publish flow is complete; deploy should proceed through the repository integration after merge, or via Wrangler after re-authentication.
