### PR TITLE
[codex] add project autonomy preflight

### DIFF
--- a/.github/workflows/codex-autonomy-preflight.yml
+++ b/.github/workflows/codex-autonomy-preflight.yml
@@ -1,0 +1,33 @@
+name: Codex Autonomy Preflight
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "42 8 * * 1"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
+      GH_REPO: ${{ github.repository }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CRM_API_BASIC_AUTH: ${{ secrets.CRM_API_BASIC_AUTH }}
+      META_ADS_REPORT_WORKER_API_TOKEN: ${{ secrets.META_ADS_REPORT_WORKER_API_TOKEN }}
+      INTEGRATIONS_ENCRYPTION_SECRET: ${{ secrets.INTEGRATIONS_ENCRYPTION_SECRET }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+      ENABLE_CRM_PAGES_DEPLOY: ${{ vars.ENABLE_CRM_PAGES_DEPLOY }}
+      ENABLE_CRM_API_DEPLOY: ${{ vars.ENABLE_CRM_API_DEPLOY }}
+      META_ADS_REPORT_WORKER_BASE_URL: ${{ vars.META_ADS_REPORT_WORKER_BASE_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Codex autonomy preflight
+        run: scripts/codex-preflight.sh --ci --strict

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Plataforma interna (local) para automações e operações da clínica.
 - Stack principal (recomendado): `./backend/scripts/dev.sh watch`
 - CRM (frontend + API): `./frontend/restart_crm.sh --watch-full`
 - CRM local production-like: `npm run crm:local`
+- Preflight de autonomia Codex/deploy: `npm run codex:preflight`
 - Website público: `npm run website:dev` (porta padrão do Next: `http://localhost:3000`)
 - macOS (sem terminal): dê duplo clique em `start-platform.command`
  - Meta Ads (API + worker): `./backend/scripts/meta-ads.sh start`
@@ -97,6 +98,7 @@ Plataforma interna (local) para automações e operações da clínica.
 - Mapa do backend: `backend/docs/INDEX.md`
 - Política de lockfiles: `backend/docs/LOCKFILES.md`
 - Segredos e rotação: `docs/secrets-rotation.md`
+- Autonomia Codex/deploy: `docs/codex-autonomy.md`
 - Observabilidade/SLOs: `docs/observability.md`
 - Catálogo de serviços: `docs/service-catalog.md`
 - Ownership e operação: `docs/ownership-model.md`

--- a/docs/codex-autonomy.md
+++ b/docs/codex-autonomy.md
@@ -1,0 +1,116 @@
+# Codex autonomy runbook
+
+This project is set up so Codex can implement, validate, ship, and verify changes with minimal human intervention.
+
+## What must stay valid
+
+- Local GitHub CLI auth: `gh auth status`
+- Local Cloudflare auth: `cd frontend && npx wrangler whoami`
+- GitHub deploy secrets:
+  - `CLOUDFLARE_API_TOKEN`
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - `GH_TOKEN`
+  - `CRM_API_BASIC_AUTH`
+  - `META_ADS_REPORT_WORKER_API_TOKEN`
+  - `INTEGRATIONS_ENCRYPTION_SECRET`
+- GitHub deploy variables:
+  - `CLOUDFLARE_PAGES_PROJECT`
+  - `ENABLE_CRM_PAGES_DEPLOY`
+  - `ENABLE_CRM_API_DEPLOY`
+  - `META_ADS_REPORT_WORKER_BASE_URL`
+
+Secret values must never be committed or printed in logs. The preflight only checks presence and operational reachability.
+
+## Local preflight
+
+Run before critical deploy, secret rotation, or when Codex needs full autonomy:
+
+```bash
+npm run codex:preflight
+```
+
+For strict mode:
+
+```bash
+scripts/codex-preflight.sh --strict
+```
+
+Strict mode exits non-zero for warnings as well as failures. Use it for release readiness. Normal mode is better during local development because it reports local dirty files as warnings.
+
+## GitHub preflight
+
+Workflow:
+
+```text
+.github/workflows/codex-autonomy-preflight.yml
+```
+
+It runs weekly and can be triggered manually from GitHub Actions. It verifies that the CI environment still has the secrets, variables, endpoints, workflows, and security exception dates needed for autonomous operation.
+
+## Operational model
+
+Preferred flow:
+
+1. Codex creates a `codex/*` branch.
+2. Codex implements changes and validates locally.
+3. Codex pushes and opens a PR.
+4. GitHub checks and security gates run.
+5. Automerge merges only after required checks pass.
+6. After-automerge deploy workflows reconcile CRM Pages, Workers, and CRM API.
+7. Codex verifies production health endpoints.
+
+Manual deploys through local Wrangler are allowed when needed, but GitHub Actions are the preferred path because they are auditable and repeatable.
+
+## When to rotate credentials
+
+Rotate deploy credentials if:
+
+- `scripts/codex-preflight.sh` reports missing or invalid Cloudflare/GitHub auth.
+- GitHub deploy workflows fail with missing or unauthorized Cloudflare credentials.
+- Cloudflare token scope changes are required.
+- The normal 90-day rotation window from `docs/secrets-rotation.md` is reached.
+
+After rotation, run:
+
+```bash
+npm run codex:preflight
+gh workflow run codex-autonomy-preflight.yml
+```
+
+## Scope required for the Cloudflare token
+
+The token used by GitHub Actions should allow the current deployment surface:
+
+- Account read
+- Workers scripts write
+- Workers routes write
+- Workers KV write
+- Pages write
+- D1 write
+- R2 write if website/session sync needs it
+- Zone read for routed workers and audits
+- Secrets write for workflows that sync Worker/Pages secrets
+
+Use least privilege, but do not split tokens unless there is a concrete security or ownership reason. Too many partially scoped tokens make autonomous deployment less reliable.
+
+## Expected healthy endpoints
+
+The preflight checks these endpoints:
+
+- `https://crm.skincos.com.br/?module=meta-ads`
+- `https://crm.skincos.com.br/api/health`
+- `https://crm.skincos.com.br/api/insumos/health`
+- `https://api.skincos.com.br/health`
+- `https://skincos-meta-ads-performance-report.skincos.workers.dev/health`
+- `https://crm.skincos.com.br/api/meta-ads/status`
+
+`/api/meta-ads/status` may return `401` without a CRM session; this is treated as healthy because it proves the route is alive and enforcing auth.
+
+## Human-only responsibilities
+
+Codex can operate the repo, CI, deploys, and Cloudflare resources when credentials are valid. Humans still own:
+
+- Creating or revoking provider accounts.
+- Approving new third-party billing or paid products.
+- Providing fresh OAuth consent when a provider requires browser login.
+- Deciding whether to grant broader permissions than the documented token scope.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "quality:backend:python": "cd backend && python -m pytest tests/unit --cov=config --cov-report=term --cov-fail-under=80",
     "quality:security": "node ./scripts/check-js-security-exceptions.mjs && bash ./backend/scripts/ci-no-demo-guard.sh",
     "quality:critical": "npm run quality:frontend && npm run quality:website && npm run quality:backend:crm-api && npm run quality:backend:python && npm run quality:security",
+    "codex:preflight": "bash ./scripts/codex-preflight.sh",
     "website:install": "npm --prefix website ci",
     "website:dev": "npm --prefix website run dev",
     "website:local": "bash ./scripts/run-local-website.sh",

--- a/scripts/codex-preflight.sh
+++ b/scripts/codex-preflight.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="${GH_REPO:-jubenitogarcia/skincos}"
+STRICT=false
+CI_MODE=false
+SKIP_HTTP=false
+SKIP_CLOUDFLARE=false
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/codex-preflight.sh [--strict] [--ci] [--skip-http] [--skip-cloudflare]
+
+Checks the operational autonomy prerequisites for Codex:
+- GitHub CLI auth and required repo secrets/vars.
+- Cloudflare local auth or CLOUDFLARE_API_TOKEN.
+- Security exception expiry dates.
+- Critical workflow files.
+- Production health endpoints.
+
+No secret values are printed.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict) STRICT=true ;;
+    --ci) CI_MODE=true ;;
+    --skip-http) SKIP_HTTP=true ;;
+    --skip-cloudflare) SKIP_CLOUDFLARE=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+cd "$ROOT_DIR"
+
+failures=0
+warnings=0
+
+ok() { printf 'OK   %s\n' "$*"; }
+warn() { printf 'WARN %s\n' "$*"; warnings=$((warnings + 1)); }
+fail() { printf 'FAIL %s\n' "$*"; failures=$((failures + 1)); }
+
+require_cmd() {
+  if command -v "$1" >/dev/null 2>&1; then
+    ok "command available: $1"
+  else
+    fail "missing command: $1"
+  fi
+}
+
+check_git() {
+  require_cmd git
+  [[ $failures -gt 0 ]] && return
+
+  local branch status
+  branch="$(git branch --show-current 2>/dev/null || true)"
+  status="$(git status --short 2>/dev/null || true)"
+  ok "git repository detected on branch ${branch:-detached}"
+
+  if [[ -n "$status" ]]; then
+    warn "working tree has local changes; review before commit/deploy"
+    printf '%s\n' "$status" | sed 's/^/     /'
+  else
+    ok "working tree clean"
+  fi
+}
+
+check_github() {
+  require_cmd gh
+  [[ $failures -gt 0 ]] && return
+
+  if gh auth status >/tmp/codex-gh-auth.log 2>&1; then
+    ok "GitHub CLI authenticated"
+  else
+    cat /tmp/codex-gh-auth.log >&2 || true
+    fail "GitHub CLI is not authenticated"
+    return
+  fi
+
+  local required_secrets=(
+    CLOUDFLARE_API_TOKEN
+    CLOUDFLARE_ACCOUNT_ID
+    GH_TOKEN
+    CRM_API_BASIC_AUTH
+    META_ADS_REPORT_WORKER_API_TOKEN
+    INTEGRATIONS_ENCRYPTION_SECRET
+  )
+  local required_vars=(
+    CLOUDFLARE_PAGES_PROJECT
+    ENABLE_CRM_PAGES_DEPLOY
+    ENABLE_CRM_API_DEPLOY
+    META_ADS_REPORT_WORKER_BASE_URL
+  )
+
+  if gh secret list -R "$REPO" >/tmp/codex-gh-secrets.tsv 2>/tmp/codex-gh-secrets.err; then
+    ok "GitHub repo secrets are listable for $REPO"
+    local name
+    for name in "${required_secrets[@]}"; do
+      if awk '{print $1}' /tmp/codex-gh-secrets.tsv | grep -qx "$name"; then
+        ok "GitHub secret configured: $name"
+      else
+        fail "missing GitHub secret: $name"
+      fi
+    done
+  else
+    if $CI_MODE; then
+      ok "GitHub secrets are not listable with the CI token; checking injected env instead"
+      local name
+      for name in "${required_secrets[@]}"; do
+        if [[ -n "${!name:-}" ]]; then
+          ok "GitHub secret injected into job env: $name"
+        else
+          warn "secret not available in job env: $name"
+        fi
+      done
+    else
+      cat /tmp/codex-gh-secrets.err >&2 || true
+      fail "cannot list GitHub repo secrets for $REPO"
+    fi
+  fi
+
+  if gh variable list -R "$REPO" >/tmp/codex-gh-vars.tsv 2>/tmp/codex-gh-vars.err; then
+    ok "GitHub repo variables are listable for $REPO"
+    local name
+    for name in "${required_vars[@]}"; do
+      if awk '{print $1}' /tmp/codex-gh-vars.tsv | grep -qx "$name"; then
+        ok "GitHub variable configured: $name"
+      else
+        fail "missing GitHub variable: $name"
+      fi
+    done
+  else
+    if $CI_MODE; then
+      ok "GitHub variables are not listable with the CI token; checking injected env instead"
+      local name
+      for name in "${required_vars[@]}"; do
+        if [[ -n "${!name:-}" ]]; then
+          ok "GitHub variable injected into job env: $name"
+        else
+          warn "variable not available in job env: $name"
+        fi
+      done
+    else
+      cat /tmp/codex-gh-vars.err >&2 || true
+      fail "cannot list GitHub repo variables for $REPO"
+    fi
+  fi
+}
+
+check_cloudflare() {
+  $SKIP_CLOUDFLARE && { warn "Cloudflare auth check skipped"; return; }
+
+  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    ok "CLOUDFLARE_API_TOKEN is present in local environment"
+    return
+  fi
+
+  if [[ -d frontend ]]; then
+    if (cd frontend && npx --yes wrangler@4 whoami >/tmp/codex-wrangler-whoami.log 2>&1); then
+      ok "Wrangler is authenticated locally"
+      sed -n '1,28p' /tmp/codex-wrangler-whoami.log | sed 's/^/     /'
+    else
+      cat /tmp/codex-wrangler-whoami.log >&2 || true
+      fail "Wrangler is not authenticated and CLOUDFLARE_API_TOKEN is not set"
+    fi
+  else
+    fail "frontend directory not found; cannot run wrangler whoami"
+  fi
+}
+
+check_security_exception_expiry() {
+  local result
+  result="$(python3 - <<'PY'
+from pathlib import Path
+from datetime import date
+import csv
+today = date.today()
+files = [
+    Path(".github/security/pip-audit-vuln-exceptions.csv"),
+    Path(".github/security/pip-audit-path-exceptions.csv"),
+    Path(".github/security/bandit-exceptions.csv"),
+]
+bad = []
+for path in files:
+    if not path.exists():
+        continue
+    with path.open(newline="") as handle:
+        reader = csv.reader(row for row in handle if not row.lstrip().startswith("#") and row.strip())
+        for row in reader:
+            if len(row) < 2:
+                continue
+            expires = row[1].strip() if "pip-audit" in path.name else (row[2].strip() if len(row) > 2 else "")
+            try:
+                exp = date.fromisoformat(expires)
+            except ValueError:
+                bad.append(f"{path}: invalid expiry {expires}")
+                continue
+            if exp < today:
+                bad.append(f"{path}: expired {expires}: {row}")
+print("\n".join(bad))
+PY
+)"
+  if [[ -n "$result" ]]; then
+    fail "security exception expiry check failed"
+    printf '%s\n' "$result" | sed 's/^/     /'
+  else
+    ok "security exception expiry dates are valid"
+  fi
+}
+
+check_workflows() {
+  local workflows=(
+    .github/workflows/codex-automerge.yml
+    .github/workflows/dispatch-after-automerge-fallback.yml
+    .github/workflows/deploy-crm-pages-after-automerge.yml
+    .github/workflows/deploy-crm-api-after-automerge.yml
+    .github/workflows/deploy-workers-after-automerge.yml
+    .github/workflows/cloudflare-audit.yml
+    .github/workflows/security-secrets-audit.yml
+  )
+  local file
+  for file in "${workflows[@]}"; do
+    if [[ -f "$file" ]]; then
+      ok "workflow present: $file"
+    else
+      fail "missing workflow: $file"
+    fi
+  done
+}
+
+check_http() {
+  $SKIP_HTTP && { warn "HTTP health checks skipped"; return; }
+
+  local checks=(
+    "https://crm.skincos.com.br/?module=meta-ads|200|CRM Pages shell"
+    "https://crm.skincos.com.br/api/health|200|CRM Pages health"
+    "https://crm.skincos.com.br/api/insumos/health|200|Insumos proxy health"
+    "https://api.skincos.com.br/health|200|Core worker health"
+    "https://skincos-meta-ads-performance-report.skincos.workers.dev/health|200|Meta Ads report worker health"
+    "https://crm.skincos.com.br/api/meta-ads/status|200,401|Meta Ads status endpoint"
+  )
+  local spec url expected label code
+  for spec in "${checks[@]}"; do
+    IFS='|' read -r url expected label <<<"$spec"
+    code="$(curl -sS -o /tmp/codex-http-body -w '%{http_code}' --max-time 15 "$url" || true)"
+    if [[ ",$expected," == *",$code,"* ]]; then
+      ok "$label responded with HTTP $code"
+    else
+      if $STRICT; then
+        fail "$label unexpected HTTP $code (expected $expected): $url"
+      else
+        warn "$label unexpected HTTP $code (expected $expected): $url"
+      fi
+      sed -n '1,6p' /tmp/codex-http-body | sed 's/^/     /' || true
+    fi
+  done
+}
+
+echo "Codex project autonomy preflight"
+echo "repo=$REPO strict=$STRICT ci=$CI_MODE"
+echo
+
+check_git
+check_github
+check_cloudflare
+check_security_exception_expiry
+check_workflows
+check_http
+
+echo
+echo "Summary: failures=$failures warnings=$warnings"
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+if $STRICT && [[ "$warnings" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a local `npm run codex:preflight` command for Codex/GitHub/Cloudflare readiness checks
- add a scheduled/manual GitHub Actions preflight workflow for CI-side autonomy validation
- document the operational model, required secrets/vars, Cloudflare token scope, and human-only responsibilities

## Validation
- `bash -n scripts/codex-preflight.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codex-autonomy-preflight.yml'); puts 'yaml ok'"`
- `npm run codex:preflight` (0 failures, 1 expected local dirty-tree warning while preparing the commit)
