### PR TITLE
Add live Meta Ads entity editing

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -980,9 +980,8 @@ export default function AppFunctionalNeatlab() {
 	                                    const isLocked = !UNLOCKED_MODULE_KEYS.has(m.key)
 	                                    const isActive = active === m.key
 	                                    return (
-                                        <TooltipLabel label={m.label} description={isLocked ? 'Módulo em breve.' : undefined}>
+                                        <TooltipLabel key={m.key} label={m.label} description={isLocked ? 'Módulo em breve.' : undefined}>
                                             <button
-                                                key={m.key}
                                                 onClick={() => {
                                                     if (isLocked) return
                                                     setActive(m.key)

--- a/frontend/EntityDetailModal.tsx
+++ b/frontend/EntityDetailModal.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
+import type { ReactNode } from 'react'
 
 function formatDetailValue(value: unknown) {
   if (value == null || value === '') return '—'
@@ -35,6 +36,8 @@ export function EntityDetailModal({
   description,
   previewUrl,
   sections,
+  children,
+  footer,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -42,6 +45,8 @@ export function EntityDetailModal({
   description: string
   previewUrl?: string | null
   sections: EntityDetailSection[]
+  children?: ReactNode
+  footer?: ReactNode
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -58,6 +63,8 @@ export function EntityDetailModal({
             </div>
           ) : null}
 
+          {children}
+
           {sections.map((section) => (
             <div key={section.title} className="space-y-3">
               <div className="text-sm font-medium text-white">{section.title}</div>
@@ -71,14 +78,16 @@ export function EntityDetailModal({
         </div>
 
         <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80"
-            onClick={() => onOpenChange(false)}
-          >
-            Fechar
-          </Button>
+          {footer || (
+            <Button
+              type="button"
+              variant="outline"
+              className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80"
+              onClick={() => onOpenChange(false)}
+            >
+              Fechar
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/MetaCampaignControlCenter.tsx
+++ b/frontend/MetaCampaignControlCenter.tsx
@@ -32,6 +32,43 @@ import type {
 } from '@/metaAdsTypes'
 
 const DEFAULT_REPORT_WINDOW_DAYS: MetaAdsReportWindowDays = 30
+const META_ADS_CACHE_TTL_MS = 5 * 60 * 1000
+const META_ADS_CACHE_PREFIX = 'skincos.metaAds.cache.v1'
+
+type MetaAdsOverviewCachePayload = {
+  summary: MetaAdsSummaryResponse
+  trend: MetaAdsTrendPoint[]
+}
+
+function getMetaAdsCacheKey(kind: string, accountId: string, range?: MetaAdsCustomDateRange) {
+  const rangeKey = range ? `${range.since}:${range.until}` : 'account'
+  return `${META_ADS_CACHE_PREFIX}:${kind}:${accountId || 'selected'}:${rangeKey}`
+}
+
+function readMetaAdsCache<T>(kind: string, accountId: string, range?: MetaAdsCustomDateRange): T | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = window.localStorage.getItem(getMetaAdsCacheKey(kind, accountId, range))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { savedAt?: number; data?: T }
+    if (!parsed.savedAt || Date.now() - parsed.savedAt > META_ADS_CACHE_TTL_MS) return null
+    return parsed.data ?? null
+  } catch {
+    return null
+  }
+}
+
+function writeMetaAdsCache<T>(kind: string, accountId: string, data: T, range?: MetaAdsCustomDateRange) {
+  try {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(
+      getMetaAdsCacheKey(kind, accountId, range),
+      JSON.stringify({ savedAt: Date.now(), data }),
+    )
+  } catch {
+    // Cache is an optimization only; never block the CRM if storage is unavailable.
+  }
+}
 
 const buildRange = (days: MetaAdsReportWindowDays) => {
   const since = format(subDays(new Date(), Math.max(0, days - 1)), 'yyyy-MM-dd')
@@ -65,6 +102,9 @@ export function MetaCampaignControlCenter() {
   const [inventoryError, setInventoryError] = useState<MetaAdsApiError | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  const [overviewLoading, setOverviewLoading] = useState(false)
+  const [reportLoading, setReportLoading] = useState(false)
+  const [inventoryLoading, setInventoryLoading] = useState(false)
   const [manualToken, setManualToken] = useState('')
   const [reportWindowDays, setReportWindowDays] = useState<MetaAdsReportWindowDays>(DEFAULT_REPORT_WINDOW_DAYS)
   const [customRange, setCustomRange] = useState<MetaAdsCustomDateRange | null>(null)
@@ -184,9 +224,21 @@ export function MetaCampaignControlCenter() {
   const loadOverview = async (options?: {
     windowDays?: MetaAdsReportWindowDays
     custom?: MetaAdsCustomDateRange | null
+    accountId?: string
   }) => {
+    const range = getEffectiveRange(options)
+    const accountKey = options?.accountId || status?.connection.selectedAdAccountId || selectedAccount?.id || 'selected'
+    const cached = readMetaAdsCache<MetaAdsOverviewCachePayload>('overview', accountKey, range)
+    let hasUsableCache = false
+    if (cached?.summary) {
+      hasUsableCache = true
+      setSummary(cached.summary)
+      setTrend(Array.isArray(cached.trend) ? cached.trend : [])
+      setOverviewError(null)
+    }
+    setOverviewLoading(true)
     try {
-      const { since, until } = getEffectiveRange(options)
+      const { since, until } = range
       const [nextSummary, nextTrend] = await Promise.all([
         metaAdsApi.summary({ since, until }),
         metaAdsApi.trend({ since, until }),
@@ -194,38 +246,74 @@ export function MetaCampaignControlCenter() {
       setSummary(nextSummary)
       setTrend(Array.isArray(nextTrend) ? nextTrend : [])
       setOverviewError(null)
+      writeMetaAdsCache<MetaAdsOverviewCachePayload>(
+        'overview',
+        accountKey,
+        { summary: nextSummary, trend: Array.isArray(nextTrend) ? nextTrend : [] },
+        range,
+      )
     } catch (error: any) {
-      setSummary(null)
-      setTrend([])
+      if (!hasUsableCache) {
+        setSummary(null)
+        setTrend([])
+      }
       setOverviewError(error)
       throw error
+    } finally {
+      setOverviewLoading(false)
     }
   }
 
   const loadReport = async (options?: {
     windowDays?: MetaAdsReportWindowDays
     custom?: MetaAdsCustomDateRange | null
+    accountId?: string
   }) => {
+    const range = getEffectiveRange(options)
+    const accountKey = options?.accountId || status?.connection.selectedAdAccountId || selectedAccount?.id || 'selected'
+    const cached = readMetaAdsCache<MetaAdsReportResponse>('report', accountKey, range)
+    let hasUsableCache = false
+    if (cached) {
+      hasUsableCache = true
+      setReport(cached)
+      setReportError(null)
+    }
+    setReportLoading(true)
     try {
-      const nextReport = await metaAdsApi.report(getEffectiveRange(options))
+      const nextReport = await metaAdsApi.report(range)
       setReport(nextReport)
       setReportError(null)
+      writeMetaAdsCache('report', accountKey, nextReport, range)
     } catch (error) {
-      setReport(null)
+      if (!hasUsableCache) setReport(null)
       setReportError(error instanceof Error ? error.message : 'Falha ao carregar o consolidado de Meta Ads')
       throw error
+    } finally {
+      setReportLoading(false)
     }
   }
 
-  const loadInventory = async () => {
+  const loadInventory = async (accountId?: string) => {
+    const accountKey = accountId || status?.connection.selectedAdAccountId || selectedAccount?.id || 'selected'
+    const cached = readMetaAdsCache<MetaInventoryResponse['inventory']>('inventory', accountKey)
+    let hasUsableCache = false
+    if (cached) {
+      hasUsableCache = true
+      setInventory(cached)
+      setInventoryError(null)
+    }
+    setInventoryLoading(true)
     try {
       const data = await metaAdsApi.inventory()
       setInventory(data.inventory || null)
       setInventoryError(null)
+      if (data.inventory) writeMetaAdsCache('inventory', accountKey, data.inventory)
     } catch (error: any) {
-      setInventory(null)
+      if (!hasUsableCache) setInventory(null)
       setInventoryError(error)
       throw error
+    } finally {
+      setInventoryLoading(false)
     }
   }
 
@@ -249,7 +337,11 @@ export function MetaCampaignControlCenter() {
       return nextStatus
     }
 
-    await Promise.allSettled([loadOverview(), loadReport(), loadInventory()])
+    await Promise.allSettled([
+      loadOverview({ accountId: nextStatus.connection.selectedAdAccountId }),
+      loadReport({ accountId: nextStatus.connection.selectedAdAccountId }),
+      loadInventory(nextStatus.connection.selectedAdAccountId),
+    ])
     return nextStatus
   }
 
@@ -471,12 +563,34 @@ export function MetaCampaignControlCenter() {
   }
 
   const handleRemoveAccount = async (adAccountId: string) => {
+    const previousAccounts = accounts
+    const removedAccount = accounts.find((account) => account.id === adAccountId)
+    const nextAccounts = accounts.filter((account) => account.id !== adAccountId)
+    setAccounts(nextAccounts)
+    if (removedAccount?.isSelected) {
+      setSummary(null)
+      setTrend([])
+      setReport(null)
+      setInventory(null)
+      setStatus((current) =>
+        current
+          ? {
+              ...current,
+              connection: {
+                ...current.connection,
+                selectedAdAccountId: nextAccounts.find((account) => account.isSelected)?.id || '',
+              },
+            }
+          : current,
+      )
+    }
     setRefreshing(true)
     try {
       await metaAdsApi.removeAdAccount({ adAccountId })
       await refreshConnectedState()
       toast.success('Conta removida da lista do Meta Ads')
     } catch (error: any) {
+      setAccounts(previousAccounts)
       setAccountsError(error)
       toast.error(error?.message || 'Falha ao remover conta da lista')
     } finally {
@@ -667,14 +781,26 @@ export function MetaCampaignControlCenter() {
                 report={report}
                 overviewError={overviewError}
                 onRetry={handleRefresh}
+                loading={loading || overviewLoading || reportLoading}
+                syncing={refreshing || overviewLoading || reportLoading}
               />
               {inventory ? (
-                <MetaAdsInventoryPanel selectedAccount={selectedAccount} inventory={inventory} report={report} inventoryError={inventoryError} onRetry={handleRefresh} />
+                <MetaAdsInventoryPanel
+                  selectedAccount={selectedAccount}
+                  inventory={inventory}
+                  report={report}
+                  inventoryError={inventoryError}
+                  onRetry={handleRefresh}
+                  onEntityUpdated={handleRefresh}
+                  loading={loading || inventoryLoading || reportLoading}
+                  syncing={refreshing || inventoryLoading || reportLoading}
+                />
               ) : (
                 <MetaAdsEmptyState
-                  message="Ainda não foi possível carregar o inventário desta conta."
-                  actionLabel="Atualizar agora"
-                  onAction={handleRefresh}
+                  message={inventoryLoading ? 'Sincronizando inventário da conta Meta Ads...' : 'Ainda não foi possível carregar o inventário desta conta.'}
+                  actionLabel={inventoryLoading ? undefined : 'Atualizar agora'}
+                  onAction={inventoryLoading ? undefined : handleRefresh}
+                  loading={inventoryLoading || loading}
                 />
               )}
               <MetaTrackingDashboard

--- a/frontend/functions/_lib/metaAdsGraph.ts
+++ b/frontend/functions/_lib/metaAdsGraph.ts
@@ -90,6 +90,26 @@ export type MetaInsight = {
   frequency?: number
 }
 
+export type MetaAdsEntityType = 'campaign' | 'adset' | 'ad' | 'creative'
+
+const ENTITY_DETAIL_FIELDS: Record<MetaAdsEntityType, string> = {
+  campaign:
+    'id,account_id,name,status,effective_status,objective,daily_budget,lifetime_budget,bid_strategy,buying_type,special_ad_categories,start_time,stop_time,created_time,updated_time,issues_info,recommendations',
+  adset:
+    'id,account_id,name,status,effective_status,campaign{id,name},campaign_id,daily_budget,lifetime_budget,bid_strategy,billing_event,optimization_goal,promoted_object,targeting,start_time,end_time,created_time,updated_time,issues_info,recommendations',
+  ad:
+    'id,account_id,name,status,effective_status,campaign{id,name},adset{id,name},creative{id,name,thumbnail_url,image_url,effective_object_story_id,object_story_spec,url_tags,title,body,call_to_action_type},tracking_specs,conversion_specs,created_time,updated_time,issues_info,recommendations',
+  creative:
+    'id,account_id,name,thumbnail_url,image_url,effective_object_story_id,object_story_id,object_story_spec,asset_feed_spec,image_hash,video_id,body,title,call_to_action_type,url_tags,instagram_permalink_url,object_url,created_time,updated_time',
+}
+
+const ENTITY_SAFE_DETAIL_FIELDS: Record<MetaAdsEntityType, string> = {
+  campaign: 'id,account_id,name,status,effective_status,objective,daily_budget,lifetime_budget,start_time,stop_time,created_time,updated_time',
+  adset: 'id,account_id,name,status,effective_status,campaign{id,name},campaign_id,daily_budget,lifetime_budget,bid_strategy,optimization_goal,start_time,end_time,created_time,updated_time',
+  ad: 'id,account_id,name,status,effective_status,campaign{id,name},adset{id,name},creative{id,name,thumbnail_url,image_url,effective_object_story_id},created_time,updated_time',
+  creative: 'id,account_id,name,thumbnail_url,image_url,effective_object_story_id,object_story_id,title,body,url_tags',
+}
+
 function parseGraphBaseUrl(version?: string) {
   return `https://graph.facebook.com/${esc(version) || DEFAULT_GRAPH_VERSION}`
 }
@@ -174,6 +194,43 @@ async function graphFetch<T = any>(
   const data = await res.json().catch(() => null)
   if (!res.ok || data?.error) {
     throw new Error(data?.error?.message || data?.error_description || `Meta Graph HTTP ${res.status}`)
+  }
+  return data as T
+}
+
+async function graphPost<T = any>(
+  path: string,
+  params: Record<string, string | number | boolean | undefined | null>,
+  accessToken: string,
+  version?: string,
+  appSecret?: string,
+): Promise<T> {
+  const body = new URLSearchParams()
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value == null || value === '') continue
+    body.set(key, String(value))
+  }
+  body.set('access_token', accessToken)
+  const appSecretProof = await buildAppSecretProof(accessToken, appSecret)
+  if (appSecretProof) body.set('appsecret_proof', appSecretProof)
+
+  const url = `${parseGraphBaseUrl(version)}${path.startsWith('/') ? '' : '/'}${path}`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  })
+  const data = await res.json().catch(() => null)
+  if (!res.ok || data?.error) {
+    const err = data?.error || {}
+    const message = err?.error_user_msg || err?.message || data?.error_description || `Meta Graph HTTP ${res.status}`
+    const error = new Error(message)
+    ;(error as any).meta = err
+    ;(error as any).status = res.status
+    throw error
   }
   return data as T
 }
@@ -462,6 +519,49 @@ export async function listMetaAdsInsights(
       frequency: parseOptionalNumber(row?.frequency),
     }
   })
+}
+
+export async function getMetaAdsEntityDetail(
+  accessToken: string,
+  type: MetaAdsEntityType,
+  id: string,
+  version?: string,
+  appSecret?: string,
+) {
+  const cleanId = esc(id)
+  if (!cleanId) throw new Error('Meta Ads entity id is required')
+  try {
+    return await graphFetch<any>(
+      `/${cleanId}`,
+      { fields: ENTITY_DETAIL_FIELDS[type] },
+      accessToken,
+      version,
+      appSecret,
+    )
+  } catch (error) {
+    const detail = await graphFetch<any>(
+      `/${cleanId}`,
+      { fields: ENTITY_SAFE_DETAIL_FIELDS[type] },
+      accessToken,
+      version,
+      appSecret,
+    )
+    detail._crm_detail_warning = String((error as Error | null)?.message || error || 'detail_fields_fallback')
+    return detail
+  }
+}
+
+export async function updateMetaAdsEntity(
+  accessToken: string,
+  type: Exclude<MetaAdsEntityType, 'creative'>,
+  id: string,
+  patch: Record<string, string | number | boolean | undefined | null>,
+  version?: string,
+  appSecret?: string,
+) {
+  const cleanId = esc(id)
+  if (!cleanId) throw new Error('Meta Ads entity id is required')
+  return graphPost<any>(`/${cleanId}`, patch, accessToken, version, appSecret)
 }
 
 export async function debugMetaAccessToken(

--- a/frontend/functions/api/meta-ads/[[path]].ts
+++ b/frontend/functions/api/meta-ads/[[path]].ts
@@ -11,6 +11,7 @@ import {
 } from '../../_lib/metaAdsStore'
 import {
   debugMetaAccessToken,
+  getMetaAdsEntityDetail,
   getMetaAdsSummary,
   getMetaAdsTrend,
   getMetaProfile,
@@ -21,8 +22,10 @@ import {
   listMetaAdSets,
   listMetaCampaigns,
   listMetaAdsInsights,
+  updateMetaAdsEntity,
   type MetaAdSet as GraphMetaAdSet,
   type MetaCampaign as GraphMetaCampaign,
+  type MetaAdsEntityType as GraphMetaAdsEntityType,
 } from '../../_lib/metaAdsGraph'
 import {
   aggregateMetaAdsWorkflowSummary,
@@ -37,6 +40,7 @@ import type {
   MetaAdsReportAdSet,
   MetaAdsReportCampaign,
   MetaAdsReportFallbackReason,
+  MetaAdsEntityPatch,
   MetaCampaignRow,
   MetaCreativeInventoryItem,
 } from '../../../metaAdsTypes'
@@ -1265,6 +1269,247 @@ async function handleReport(context: any) {
   return json(200, await buildGraphFallbackReport(selected, range, cfg, reportWindow, 'worker_unconfigured'))
 }
 
+const META_ADS_EDITABLE_FIELDS: Record<Exclude<GraphMetaAdsEntityType, 'creative'>, Set<string>> = {
+  campaign: new Set(['name', 'status', 'daily_budget', 'lifetime_budget', 'start_time', 'stop_time']),
+  adset: new Set(['name', 'status', 'daily_budget', 'lifetime_budget', 'start_time', 'end_time', 'bid_strategy', 'optimization_goal']),
+  ad: new Set(['name', 'status']),
+}
+
+function normalizeAccountIdForCompare(value: unknown) {
+  return String(value || '').trim().replace(/^act_/, '')
+}
+
+function normalizeEntityAccountId(detail: any) {
+  return normalizeAccountIdForCompare(detail?.account_id || detail?.account?.id)
+}
+
+function normalizeMetaStatus(value: unknown) {
+  const status = String(value || '').trim().toUpperCase()
+  if (!status) return ''
+  if (!['ACTIVE', 'PAUSED'].includes(status)) {
+    throw new MetaAdsRouteError(400, 'META_ADS_INVALID_STATUS', {
+      message: 'O status informado não é permitido nesta edição.',
+      hint: 'Use apenas Ativa ou Pausada para alterações feitas pelo CRM.',
+      retryable: false,
+    })
+  }
+  return status
+}
+
+function sanitizeBudgetValue(value: unknown, label: string) {
+  if (value === null || value === undefined || value === '') return ''
+  const raw = String(value).trim()
+  if (!/^\d+$/.test(raw)) {
+    throw new MetaAdsRouteError(400, 'META_ADS_INVALID_BUDGET', {
+      message: `${label} deve ser informado em centavos, usando somente números.`,
+      hint: 'A Meta espera orçamento como inteiro na menor unidade da moeda da conta.',
+      retryable: false,
+    })
+  }
+  return raw
+}
+
+function sanitizeDateValue(value: unknown, label: string) {
+  if (value === null || value === undefined || value === '') return ''
+  const raw = String(value).trim()
+  const timestamp = Date.parse(raw)
+  if (!Number.isFinite(timestamp)) {
+    throw new MetaAdsRouteError(400, 'META_ADS_INVALID_DATE', {
+      message: `${label} deve ser uma data válida.`,
+      hint: 'Use uma data em formato ISO ou selecione a data pelo campo do CRM.',
+      retryable: false,
+    })
+  }
+  return raw
+}
+
+function sanitizeEntityPatch(type: Exclude<GraphMetaAdsEntityType, 'creative'>, input: MetaAdsEntityPatch) {
+  const allowed = META_ADS_EDITABLE_FIELDS[type]
+  const patch: Record<string, string> = {}
+  const unknownFields = Object.keys(input || {}).filter((field) => !allowed.has(field))
+  if (unknownFields.length) {
+    throw new MetaAdsRouteError(400, 'META_ADS_FIELD_NOT_EDITABLE', {
+      message: 'Um ou mais campos enviados não podem ser editados pelo CRM.',
+      hint: `Campos bloqueados: ${unknownFields.join(', ')}.`,
+      retryable: false,
+      extra: { unknownFields, editableFields: Array.from(allowed) },
+    })
+  }
+
+  if (typeof input.name !== 'undefined') {
+    const name = String(input.name || '').trim()
+    if (!name) {
+      throw new MetaAdsRouteError(400, 'META_ADS_NAME_REQUIRED', {
+        message: 'O nome não pode ficar vazio.',
+        retryable: false,
+      })
+    }
+    patch.name = name
+  }
+  if (typeof input.status !== 'undefined') {
+    const status = normalizeMetaStatus(input.status)
+    if (status) patch.status = status
+  }
+  if (typeof input.daily_budget !== 'undefined') {
+    const value = sanitizeBudgetValue(input.daily_budget, 'Orçamento diário')
+    if (value) patch.daily_budget = value
+  }
+  if (typeof input.lifetime_budget !== 'undefined') {
+    const value = sanitizeBudgetValue(input.lifetime_budget, 'Orçamento vitalício')
+    if (value) patch.lifetime_budget = value
+  }
+  if (typeof input.start_time !== 'undefined') {
+    const value = sanitizeDateValue(input.start_time, 'Data de início')
+    if (value) patch.start_time = value
+  }
+  if (typeof input.stop_time !== 'undefined') {
+    const value = sanitizeDateValue(input.stop_time, 'Data de fim da campanha')
+    if (value) patch.stop_time = value
+  }
+  if (typeof input.end_time !== 'undefined') {
+    const value = sanitizeDateValue(input.end_time, 'Data de fim do conjunto')
+    if (value) patch.end_time = value
+  }
+  if (typeof input.bid_strategy !== 'undefined') {
+    const value = String(input.bid_strategy || '').trim()
+    if (value) patch.bid_strategy = value
+  }
+  if (typeof input.optimization_goal !== 'undefined') {
+    const value = String(input.optimization_goal || '').trim()
+    if (value) patch.optimization_goal = value
+  }
+
+  if (!Object.keys(patch).length) {
+    throw new MetaAdsRouteError(400, 'META_ADS_EMPTY_PATCH', {
+      message: 'Nenhuma alteração válida foi enviada.',
+      retryable: false,
+    })
+  }
+  return patch
+}
+
+function buildLiveEntity(type: GraphMetaAdsEntityType, detail: any, adAccountId: string, scopes: string[]) {
+  const editableFields = type === 'creative' ? [] : Array.from(META_ADS_EDITABLE_FIELDS[type])
+  const hasAdsManagement = scopes.includes('ads_management')
+  const editable = type !== 'creative' && hasAdsManagement
+  return {
+    type,
+    id: String(detail?.id || '').trim(),
+    accountId: normalizeAccountIdForCompare(detail?.account_id || adAccountId),
+    editable,
+    readOnlyReason:
+      type === 'creative'
+        ? 'Criativos ficam somente leitura nesta versão. Alterações seguras exigem criar uma variação e substituir no anúncio.'
+        : hasAdsManagement
+          ? null
+          : 'A conexão atual não possui o escopo ads_management para editar no Gerenciador de Anúncios.',
+    editableFields,
+    fields: detail || {},
+    raw: detail || {},
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+async function getVerifiedEntityDetail(
+  selected: { connection: MetaAdsConnection; adAccountId: string },
+  type: GraphMetaAdsEntityType,
+  entityId: string,
+  cfg: ReturnType<typeof runtimeConfig>,
+) {
+  const detail = await getMetaAdsEntityDetail(
+    selected.connection.accessToken,
+    type,
+    entityId,
+    cfg.graphVersion,
+    cfg.appSecret,
+  )
+  const detailAccountId = normalizeEntityAccountId(detail)
+  if (detailAccountId && detailAccountId !== normalizeAccountIdForCompare(selected.adAccountId)) {
+    throw new MetaAdsRouteError(403, 'META_ADS_ENTITY_ACCOUNT_MISMATCH', {
+      message: 'Este item não pertence à conta de anúncios selecionada.',
+      hint: 'Troque para a conta correta antes de abrir ou editar este item.',
+      retryable: false,
+    })
+  }
+  return detail
+}
+
+function parseEntityRoute(rest: string) {
+  const match = rest.match(/^\/entities\/(campaign|adset|ad|creative)\/([^/]+)\/?$/)
+  if (!match) return null
+  return {
+    type: match[1] as GraphMetaAdsEntityType,
+    id: decodeURIComponent(match[2] || ''),
+  }
+}
+
+async function handleEntityDetail(context: any, type: GraphMetaAdsEntityType, entityId: string) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const selected = await withSelectedAccount(context, userOrRes.id)
+  if ('error' in selected) return selected.error
+
+  const cfg = runtimeConfig(context)
+  const detail = await getVerifiedEntityDetail(selected, type, entityId, cfg)
+  const scopes = normalizeScopes([...(selected.connection.grantedScopes || []), ...(selected.connection.scopes || [])])
+  return json(200, {
+    ok: true,
+    entity: buildLiveEntity(type, detail, selected.adAccountId, scopes),
+  })
+}
+
+async function handleEntityUpdate(context: any, type: GraphMetaAdsEntityType, entityId: string) {
+  const userOrRes = await requireSocialAdmin(context)
+  if (userOrRes instanceof Response) return userOrRes
+  const csrfRes = requireCsrfForMutations(context)
+  if (csrfRes) return csrfRes
+  const selected = await withSelectedAccount(context, userOrRes.id)
+  if ('error' in selected) return selected.error
+
+  if (type === 'creative') {
+    return apiError(405, 'META_ADS_CREATIVE_READ_ONLY', {
+      message: 'Criativos estão em modo somente leitura nesta versão.',
+      hint: 'Para alterar criativos com segurança será necessário criar uma variação e substituir no anúncio.',
+      retryable: false,
+    })
+  }
+
+  const scopes = normalizeScopes([...(selected.connection.grantedScopes || []), ...(selected.connection.scopes || [])])
+  if (!scopes.includes('ads_management')) {
+    return apiError(403, 'META_ADS_SCOPE_REQUIRED', {
+      message: 'A conexão atual não permite editar itens no Gerenciador de Anúncios.',
+      hint: 'Reconecte a Meta concedendo o escopo ads_management.',
+      retryable: false,
+      extra: { requiredScope: 'ads_management', grantedScopes: scopes },
+    })
+  }
+
+  const cfg = runtimeConfig(context)
+  const before = await getVerifiedEntityDetail(selected, type, entityId, cfg)
+  const body = await context.request.json().catch(() => null)
+  const patch = sanitizeEntityPatch(type, (body?.patch || body || {}) as MetaAdsEntityPatch)
+  await updateMetaAdsEntity(selected.connection.accessToken, type, entityId, patch, cfg.graphVersion, cfg.appSecret)
+  const after = await getVerifiedEntityDetail(selected, type, entityId, cfg)
+  const changedFields = Object.keys(patch)
+  const audit = {
+    entityType: type,
+    entityId,
+    adAccountId: selected.adAccountId,
+    changedFields,
+    timestamp: new Date().toISOString(),
+    before: Object.fromEntries(changedFields.map((field) => [field, before?.[field]])),
+    after: Object.fromEntries(changedFields.map((field) => [field, after?.[field]])),
+    userId: userOrRes.id,
+  }
+
+  return json(200, {
+    ok: true,
+    entity: buildLiveEntity(type, after, selected.adAccountId, scopes),
+    changedFields,
+    audit,
+  })
+}
+
 async function handleInventory(context: any) {
   const userOrRes = await requireSocialAdmin(context)
   if (userOrRes instanceof Response) return userOrRes
@@ -1292,19 +1537,22 @@ export async function onRequest(context: any): Promise<Response> {
     const url = new URL(request.url)
     const prefix = '/api/meta-ads'
     const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
+    const entityRoute = parseEntityRoute(rest)
 
-    if (method === 'GET' && (rest === '/status' || rest === '/status/')) return handleStatus(context)
-    if (method === 'GET' && (rest === '/oauth/start' || rest === '/oauth/start/')) return handleOauthStart(context)
-    if (method === 'GET' && (rest === '/oauth/callback' || rest === '/oauth/callback/')) return handleOauthCallback(context)
-    if (method === 'POST' && (rest === '/connect/manual' || rest === '/connect/manual/')) return handleManualConnect(context)
-    if (method === 'POST' && (rest === '/disconnect' || rest === '/disconnect/')) return handleDisconnect(context)
-    if (method === 'GET' && (rest === '/ad-accounts' || rest === '/ad-accounts/')) return handleListAccounts(context)
-    if (method === 'POST' && (rest === '/ad-accounts/select' || rest === '/ad-accounts/select/')) return handleSelectAccount(context)
-    if (method === 'POST' && (rest === '/ad-accounts/remove' || rest === '/ad-accounts/remove/')) return handleRemoveAccount(context)
-    if (method === 'GET' && (rest === '/summary' || rest === '/summary/')) return handleSummary(context)
-    if (method === 'GET' && (rest === '/trend' || rest === '/trend/')) return handleTrend(context)
-    if (method === 'GET' && (rest === '/report' || rest === '/report/')) return handleReport(context)
-    if (method === 'GET' && (rest === '/inventory' || rest === '/inventory/')) return handleInventory(context)
+    if (method === 'GET' && (rest === '/status' || rest === '/status/')) return await handleStatus(context)
+    if (method === 'GET' && (rest === '/oauth/start' || rest === '/oauth/start/')) return await handleOauthStart(context)
+    if (method === 'GET' && (rest === '/oauth/callback' || rest === '/oauth/callback/')) return await handleOauthCallback(context)
+    if (method === 'POST' && (rest === '/connect/manual' || rest === '/connect/manual/')) return await handleManualConnect(context)
+    if (method === 'POST' && (rest === '/disconnect' || rest === '/disconnect/')) return await handleDisconnect(context)
+    if (method === 'GET' && (rest === '/ad-accounts' || rest === '/ad-accounts/')) return await handleListAccounts(context)
+    if (method === 'POST' && (rest === '/ad-accounts/select' || rest === '/ad-accounts/select/')) return await handleSelectAccount(context)
+    if (method === 'POST' && (rest === '/ad-accounts/remove' || rest === '/ad-accounts/remove/')) return await handleRemoveAccount(context)
+    if (method === 'GET' && (rest === '/summary' || rest === '/summary/')) return await handleSummary(context)
+    if (method === 'GET' && (rest === '/trend' || rest === '/trend/')) return await handleTrend(context)
+    if (method === 'GET' && (rest === '/report' || rest === '/report/')) return await handleReport(context)
+    if (method === 'GET' && (rest === '/inventory' || rest === '/inventory/')) return await handleInventory(context)
+    if (entityRoute && method === 'GET') return await handleEntityDetail(context, entityRoute.type, entityRoute.id)
+    if (entityRoute && method === 'PATCH') return await handleEntityUpdate(context, entityRoute.type, entityRoute.id)
 
     return apiError(404, 'NOT_FOUND', {
       message: 'Endpoint Meta Ads não encontrado.',

--- a/frontend/metaAdsApi.ts
+++ b/frontend/metaAdsApi.ts
@@ -3,6 +3,7 @@ import {
   connectMetaAdsManualLocal,
   disconnectMetaAdsLocal,
   getMetaAdsLocalInventory,
+  getMetaAdsLocalEntityDetail,
   getMetaAdsLocalReport,
   getMetaAdsLocalStatus,
   getMetaAdsLocalSummary,
@@ -12,6 +13,7 @@ import {
   removeMetaAdsLocalAccount,
   selectMetaAdsLocalAccount,
   simulateMetaAdsOAuthConnect,
+  updateMetaAdsLocalEntity,
 } from '@/metaAdsLocalMock'
 import { normalizeMetaAdsApiError } from '@/metaAdsState'
 import type {
@@ -21,6 +23,10 @@ import type {
   MetaAdsSummaryResponse,
   MetaAdsTrendPoint,
   MetaInventoryResponse,
+  MetaAdsEntityDetailResponse,
+  MetaAdsEntityPatch,
+  MetaAdsEntityType,
+  MetaAdsEntityUpdateResponse,
 } from '@/metaAdsTypes'
 
 const META_ADS_API_URL =
@@ -104,4 +110,15 @@ export const metaAdsApi = {
       : request<MetaAdsReportResponse>(`/report${search ? `?${search}` : ''}`)
   },
   inventory: () => (isMetaAdsLocalMockEnabled() ? getMetaAdsLocalInventory() : request<MetaInventoryResponse>('/inventory')),
+  entityDetail: (type: MetaAdsEntityType, id: string) =>
+    isMetaAdsLocalMockEnabled()
+      ? getMetaAdsLocalEntityDetail(type, id)
+      : request<MetaAdsEntityDetailResponse>(`/entities/${type}/${encodeURIComponent(id)}`),
+  updateEntity: (type: MetaAdsEntityType, id: string, patch: MetaAdsEntityPatch) =>
+    isMetaAdsLocalMockEnabled()
+      ? updateMetaAdsLocalEntity(type, id, patch)
+      : request<MetaAdsEntityUpdateResponse>(`/entities/${type}/${encodeURIComponent(id)}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ patch }),
+        }),
 }

--- a/frontend/metaAdsLocalMock.ts
+++ b/frontend/metaAdsLocalMock.ts
@@ -2,6 +2,10 @@ import type {
   MetaAdAccount,
   MetaAdsReportResponse,
   MetaAdsApiError,
+  MetaAdsEntityDetailResponse,
+  MetaAdsEntityPatch,
+  MetaAdsEntityType,
+  MetaAdsEntityUpdateResponse,
   MetaAdsReportWindowDays,
   MetaAdsStatusResponse,
   MetaAdsSummaryResponse,
@@ -27,8 +31,11 @@ type MetaAdsLocalState = {
 
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
 const STORAGE_KEY = 'metaAds.localState.v1'
+const ENTITY_PATCH_STORAGE_KEY = 'metaAds.localEntityPatches.v1'
 const SCENARIO_QUERY_KEY = 'metaAdsLocalScenario'
 const DEFAULT_ACCOUNT_ID = 'act_123'
+
+type LocalEntityPatchMap = Partial<Record<MetaAdsEntityType, Record<string, MetaAdsEntityPatch>>>
 
 function resolveRequestedDays(params?: { since?: string; until?: string }): number {
   const since = params?.since ? new Date(params.since) : null
@@ -67,6 +74,36 @@ function interpolateMetric(days: number, anchors: { d7: number; d30: number; d60
 function roundMetric(value: number, digits = 2) {
   const factor = 10 ** digits
   return Math.round(value * factor) / factor
+}
+
+function readLocalEntityPatches(): LocalEntityPatchMap {
+  try {
+    return JSON.parse(window.localStorage.getItem(ENTITY_PATCH_STORAGE_KEY) || '{}') || {}
+  } catch {
+    return {}
+  }
+}
+
+function writeLocalEntityPatch(type: MetaAdsEntityType, id: string, patch: MetaAdsEntityPatch) {
+  const current = readLocalEntityPatches()
+  current[type] = {
+    ...(current[type] || {}),
+    [id]: {
+      ...((current[type] || {})[id] || {}),
+      ...patch,
+    },
+  }
+  window.localStorage.setItem(ENTITY_PATCH_STORAGE_KEY, JSON.stringify(current))
+}
+
+function applyLocalEntityPatches(inventory: MetaInventoryResponse['inventory']) {
+  const patches = readLocalEntityPatches()
+  return {
+    campaigns: inventory.campaigns.map((campaign) => ({ ...campaign, ...((patches.campaign || {})[campaign.id] || {}) })),
+    adSets: inventory.adSets.map((adSet) => ({ ...adSet, ...((patches.adset || {})[adSet.id] || {}) })),
+    ads: inventory.ads.map((ad) => ({ ...ad, ...((patches.ad || {})[ad.id] || {}) })),
+    creatives: inventory.creatives.map((creative) => ({ ...creative, ...((patches.creative || {})[creative.id] || {}) })),
+  }
 }
 
 function buildAdaptiveTrend(
@@ -453,7 +490,7 @@ export async function getMetaAdsLocalInventory(): Promise<MetaInventoryResponse>
     return {
       ok: true,
       accountId,
-      inventory: {
+      inventory: applyLocalEntityPatches({
         campaigns: [
           {
             id: 'cmp_ret_1',
@@ -502,14 +539,14 @@ export async function getMetaAdsLocalInventory(): Promise<MetaInventoryResponse>
             adName: 'Anúncio Remarketing 1',
           },
         ],
-      },
+      }),
     }
   }
 
   return {
     ok: true,
     accountId,
-    inventory: {
+    inventory: applyLocalEntityPatches({
       campaigns: [
           {
             id: 'cmp_1',
@@ -605,6 +642,83 @@ export async function getMetaAdsLocalInventory(): Promise<MetaInventoryResponse>
           effectiveObjectStoryId: 'story_2',
         },
       ],
+    }),
+  }
+}
+
+function localEditableFields(type: MetaAdsEntityType) {
+  if (type === 'creative') return []
+  if (type === 'ad') return ['name', 'status']
+  if (type === 'campaign') return ['name', 'status', 'daily_budget', 'lifetime_budget', 'start_time', 'stop_time']
+  return ['name', 'status', 'daily_budget', 'lifetime_budget', 'start_time', 'end_time', 'bid_strategy', 'optimization_goal']
+}
+
+function buildLocalEntityDetail(type: MetaAdsEntityType, id: string, fields: Record<string, unknown>, accountId: string): MetaAdsEntityDetailResponse {
+  const editableFields = localEditableFields(type)
+  return {
+    ok: true,
+    entity: {
+      type,
+      id,
+      accountId,
+      editable: type !== 'creative',
+      readOnlyReason:
+        type === 'creative'
+          ? 'Criativos ficam somente leitura nesta versão local; alterações reais exigem criar uma variação e substituir no anúncio.'
+          : null,
+      editableFields,
+      fields,
+      raw: fields,
+      updatedAt: new Date().toISOString(),
+    },
+  }
+}
+
+export async function getMetaAdsLocalEntityDetail(type: MetaAdsEntityType, id: string): Promise<MetaAdsEntityDetailResponse> {
+  const inventory = await getMetaAdsLocalInventory()
+  const entity =
+    type === 'campaign'
+      ? inventory.inventory.campaigns.find((item) => item.id === id)
+      : type === 'adset'
+        ? inventory.inventory.adSets.find((item) => item.id === id)
+        : type === 'ad'
+          ? inventory.inventory.ads.find((item) => item.id === id)
+          : inventory.inventory.creatives.find((item) => item.id === id)
+  if (!entity) {
+    throw {
+      code: 'META_ADS_ENTITY_NOT_FOUND',
+      message: 'Item Meta Ads não encontrado no mock local.',
+      retryable: false,
+    }
+  }
+  return buildLocalEntityDetail(type, id, entity as Record<string, unknown>, inventory.accountId)
+}
+
+export async function updateMetaAdsLocalEntity(
+  type: MetaAdsEntityType,
+  id: string,
+  patch: MetaAdsEntityPatch,
+): Promise<MetaAdsEntityUpdateResponse> {
+  if (type === 'creative') {
+    throw {
+      code: 'META_ADS_CREATIVE_READ_ONLY',
+      message: 'Criativos estão em modo somente leitura nesta versão.',
+      retryable: false,
+    }
+  }
+  writeLocalEntityPatch(type, id, patch)
+  const detail = await getMetaAdsLocalEntityDetail(type, id)
+  const changedFields = Object.keys(patch)
+  return {
+    ok: true,
+    entity: detail.entity,
+    changedFields,
+    audit: {
+      entityType: type,
+      entityId: id,
+      adAccountId: detail.entity.accountId,
+      changedFields,
+      timestamp: new Date().toISOString(),
     },
   }
 }

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -8,10 +8,12 @@ import { Button } from '@/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import { EntityDetailModal, type EntityDetailSection } from '@/EntityDetailModal'
+import { Input } from '@/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/table'
 import { Textarea } from '@/textarea'
 import { TooltipLabel } from '@/tooltip'
+import { metaAdsApi } from '@/metaAdsApi'
 import type {
   MetaAdAccount,
   MetaAd,
@@ -23,16 +25,20 @@ import type {
   MetaAdsSummaryResponse,
   MetaAdsTab,
   MetaAdsTrendPoint,
+  MetaAdsLiveEntityDetail,
+  MetaAdsEntityPatch,
   MetaCampaignRow,
   MetaCreativeInventoryItem,
 } from '@/metaAdsTypes'
 import { describeMetaAdAccountStatus } from '@/metaAdsState'
+import { toast } from 'sonner'
 import {
   ArrowClockwise,
   CaretDown,
   CaretRight,
   CurrencyDollar,
   CheckCircle,
+  DotsSixVertical,
   Eye,
   FacebookLogo,
   FadersHorizontal,
@@ -102,8 +108,10 @@ type MetaAdsOverviewMetricLayout = {
   visible: boolean
   size: MetaAdsOverviewMetricSize
 }
+type MetaAdsInventoryColumnKey = MetaAdsInventorySortKey
 
 const META_ADS_OVERVIEW_METRIC_LAYOUT_KEY = 'skincos.metaAds.layout.overviewMetrics.v1'
+const META_ADS_INVENTORY_COLUMN_WIDTHS_KEY = 'skincos.metaAds.layout.inventoryColumns.v1'
 const DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT: MetaAdsOverviewMetricLayout[] = [
   { key: 'spend', visible: true, size: 'compact' },
   { key: 'conversations', visible: true, size: 'compact' },
@@ -118,6 +126,48 @@ const DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT: MetaAdsOverviewMetricLayout[] = [
   { key: 'cpm', visible: true, size: 'compact' },
   { key: 'cpp', visible: true, size: 'compact' },
   { key: 'frequency', visible: true, size: 'compact' },
+]
+const META_ADS_INVENTORY_COLUMN_LIMITS: Record<MetaAdsInventoryColumnKey, { width: number; min: number; max: number }> = {
+  item: { width: 300, min: 220, max: 520 },
+  rank: { width: 86, min: 72, max: 120 },
+  status: { width: 92, min: 76, max: 128 },
+  objective: { width: 112, min: 88, max: 160 },
+  items: { width: 92, min: 78, max: 132 },
+  spend: { width: 124, min: 104, max: 176 },
+  conversations: { width: 112, min: 92, max: 156 },
+  cpcv: { width: 108, min: 92, max: 152 },
+  clicks: { width: 104, min: 88, max: 144 },
+  reach: { width: 108, min: 92, max: 152 },
+  impressions: { width: 118, min: 98, max: 164 },
+  engagement: { width: 112, min: 92, max: 154 },
+  igRedirect: { width: 152, min: 124, max: 220 },
+  ctr: { width: 116, min: 96, max: 164 },
+  cpc: { width: 116, min: 96, max: 164 },
+  cpm: { width: 108, min: 90, max: 152 },
+  cpp: { width: 108, min: 90, max: 152 },
+  frequency: { width: 112, min: 92, max: 152 },
+  cul: { width: 108, min: 90, max: 152 },
+}
+const META_ADS_INVENTORY_COLUMN_ORDER: MetaAdsInventoryColumnKey[] = [
+  'item',
+  'rank',
+  'status',
+  'objective',
+  'items',
+  'spend',
+  'conversations',
+  'cpcv',
+  'clicks',
+  'reach',
+  'impressions',
+  'engagement',
+  'igRedirect',
+  'ctr',
+  'cpc',
+  'cpm',
+  'cpp',
+  'frequency',
+  'cul',
 ]
 
 function parseMetaAdsOverviewMetricLayout(raw: string | null | undefined): MetaAdsOverviewMetricLayout[] {
@@ -145,6 +195,39 @@ function parseMetaAdsOverviewMetricLayout(raw: string | null | undefined): MetaA
     return normalized.length ? normalized : DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
   } catch {
     return DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
+  }
+}
+
+function clampMetaAdsInventoryColumnWidth(key: MetaAdsInventoryColumnKey, width: number) {
+  const limits = META_ADS_INVENTORY_COLUMN_LIMITS[key]
+  return Math.min(limits.max, Math.max(limits.min, Math.round(width)))
+}
+
+function getDefaultMetaAdsInventoryColumnWidths(): Record<MetaAdsInventoryColumnKey, number> {
+  return META_ADS_INVENTORY_COLUMN_ORDER.reduce(
+    (acc, key) => {
+      acc[key] = META_ADS_INVENTORY_COLUMN_LIMITS[key].width
+      return acc
+    },
+    {} as Record<MetaAdsInventoryColumnKey, number>,
+  )
+}
+
+function parseMetaAdsInventoryColumnWidths(raw: string | null | undefined): Record<MetaAdsInventoryColumnKey, number> {
+  const defaults = getDefaultMetaAdsInventoryColumnWidths()
+  try {
+    const parsed = raw ? JSON.parse(raw) : null
+    if (!parsed || typeof parsed !== 'object') return defaults
+    return META_ADS_INVENTORY_COLUMN_ORDER.reduce(
+      (acc, key) => {
+        const value = Number((parsed as Record<string, unknown>)[key])
+        acc[key] = Number.isFinite(value) ? clampMetaAdsInventoryColumnWidth(key, value) : defaults[key]
+        return acc
+      },
+      {} as Record<MetaAdsInventoryColumnKey, number>,
+    )
+  } catch {
+    return defaults
   }
 }
 
@@ -601,11 +684,11 @@ function MetaAdsMetricTile({
   const body = (
     <CardContent
       tabIndex={tooltipLabel || description ? 0 : undefined}
-      className={`flex flex-col items-center justify-center gap-1 p-2 text-center outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45 ${isWide ? 'min-h-[94px]' : 'min-h-[84px]'}`}
+      className={`flex flex-col items-center justify-center gap-1 p-2 text-center outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45 ${isWide ? 'min-h-[104px] sm:min-h-[112px]' : 'min-h-[76px] sm:min-h-[84px]'}`}
     >
       {content}
       <div className="space-y-0.5">
-        <div className="text-[1.05rem] font-semibold leading-tight text-white sm:text-[1.2rem] lg:text-[1.3rem]">{value}</div>
+        <div className="text-[1rem] font-semibold leading-tight text-white sm:text-[1.12rem] lg:text-[1.2rem]">{value}</div>
         {isWide && description ? <div className="mx-auto max-w-52 text-[10px] leading-snug text-slate-400">{description}</div> : null}
       </div>
     </CardContent>
@@ -634,14 +717,14 @@ function MetaAdsMetricTile({
   }
 
   return (
-    <Card className={`group relative gap-0 overflow-hidden py-0 transition ${panelClass} ${isWide ? 'col-span-2' : ''}`}>
+    <Card className={`group relative gap-0 overflow-hidden py-0 transition hover:border-sky-400/25 hover:bg-slate-900/70 ${panelClass}`}>
       <button
         type="button"
-        className="absolute left-2 top-2 z-10 inline-flex h-6 w-6 cursor-grab items-center justify-center rounded-full border border-slate-700/75 bg-slate-950/45 text-slate-500 opacity-45 shadow-sm transition hover:scale-105 hover:border-sky-400/40 hover:text-sky-100 hover:opacity-100 active:cursor-grabbing group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
+        className="absolute left-2 top-2 z-10 inline-flex h-6 w-6 cursor-grab items-center justify-center rounded-full border border-slate-700/75 bg-slate-950/45 text-slate-500 opacity-60 shadow-sm transition hover:scale-105 hover:border-sky-400/40 hover:text-sky-100 hover:opacity-100 active:cursor-grabbing group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
         aria-label={`Mover card ${tooltipLabel || label}`}
         {...dragHandleProps}
       >
-        <FadersHorizontal className="h-3.5 w-3.5" />
+        <DotsSixVertical className="h-3.5 w-3.5" weight="bold" />
       </button>
       {onHide ? (
         <button
@@ -667,7 +750,7 @@ function MetaAdsMetricTile({
       {onResize ? (
         <button
           type="button"
-          className="absolute bottom-1.5 right-1.5 z-10 h-5 w-5 cursor-se-resize rounded-br-2xl border-b border-r border-slate-500/50 bg-gradient-to-br from-transparent via-transparent to-slate-500/10 text-transparent opacity-55 transition hover:border-sky-300/60 hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
+          className="absolute bottom-1.5 right-1.5 z-10 h-5 w-5 cursor-se-resize rounded-br-2xl border-b border-r border-slate-500/50 bg-gradient-to-br from-transparent via-transparent to-sky-300/10 opacity-60 transition hover:border-sky-300/70 hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
           aria-label={`${isWide ? 'Reduzir' : 'Ampliar'} card ${tooltipLabel || label}`}
           onPointerDown={handleResizePointerDown}
           onPointerMove={handleResizePointerMove}
@@ -676,9 +759,41 @@ function MetaAdsMetricTile({
             resizeStartRef.current = null
           }}
         >
-          redimensionar
+          <span className="absolute bottom-1 right-1 h-2.5 w-2.5 rounded-br-xl border-b border-r border-sky-200/35" aria-hidden="true" />
         </button>
       ) : null}
+    </Card>
+  )
+}
+
+function MetaAdsSyncOverlay({
+  show,
+  label = 'Sincronizando dados da Meta',
+}: {
+  show?: boolean
+  label?: string
+}) {
+  if (!show) return null
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20 flex items-start justify-end rounded-[inherit] bg-slate-950/18 p-3">
+      <div className="inline-flex items-center gap-2 rounded-full border border-sky-400/25 bg-slate-950/85 px-3 py-1.5 text-xs font-medium text-sky-100 shadow-[0_12px_32px_rgba(14,165,233,0.16)] backdrop-blur-md">
+        <Spinner className="h-3.5 w-3.5 animate-spin text-sky-300" />
+        {label}
+      </div>
+    </div>
+  )
+}
+
+function MetaAdsLoadingCard({ label = 'Carregando dados da Meta Ads' }: { label?: string }) {
+  return (
+    <Card className={panelClass}>
+      <CardContent className="flex min-h-40 flex-col items-center justify-center gap-3 py-10 text-center text-sm text-slate-300">
+        <Spinner className="h-6 w-6 animate-spin text-sky-300" />
+        <div className="space-y-1">
+          <div className="font-medium text-white">{label}</div>
+          <div className="text-xs text-slate-500">Mantendo dados recentes em cache para acelerar a próxima abertura.</div>
+        </div>
+      </CardContent>
     </Card>
   )
 }
@@ -698,10 +813,21 @@ function describeAdAccountStatus(account: MetaAdAccount) {
   }
 }
 
-export function MetaAdsEmptyState({ message, actionLabel, onAction }: { message: string; actionLabel?: string; onAction?: () => void }) {
+export function MetaAdsEmptyState({
+  message,
+  actionLabel,
+  onAction,
+  loading,
+}: {
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+  loading?: boolean
+}) {
   return (
     <Card className={panelClass}>
       <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-sm text-slate-300">
+        {loading ? <Spinner className="h-5 w-5 animate-spin text-sky-300" /> : null}
         <div>{message}</div>
         {actionLabel && onAction ? <Button variant="outline" onClick={onAction}>{actionLabel}</Button> : null}
       </CardContent>
@@ -903,15 +1029,59 @@ function MetaAdsEntityDetailDialog({
   detail,
   open,
   onOpenChange,
+  onEntityUpdated,
 }: {
   detail: MetaAdsEntityDetail | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onEntityUpdated?: () => void | Promise<void>
 }) {
+  const [liveEntity, setLiveEntity] = useState<MetaAdsLiveEntityDetail | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [form, setForm] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (!open || !detail) return
+    let cancelled = false
+    setLiveEntity(null)
+    setDetailError(null)
+    setLoadingDetail(true)
+
+    metaAdsApi.entityDetail(detail.kind, detail.payload.id)
+      .then((response) => {
+        if (cancelled) return
+        setLiveEntity(response.entity)
+        const nextForm: Record<string, string> = {}
+        for (const field of response.entity.editableFields || []) {
+          const value = response.entity.fields?.[field]
+          if (value !== undefined && value !== null) nextForm[field] = String(value)
+        }
+        setForm(nextForm)
+      })
+      .catch((error) => {
+        if (cancelled) return
+        setDetailError(error?.message || 'Falha ao carregar os dados live da Meta.')
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDetail(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [detail, open])
+
   if (!detail) return null
 
-  const previewUrl = detail.kind === 'creative' ? detail.payload.imageUrl || detail.payload.thumbnailUrl : undefined
+  const fields = liveEntity?.fields || detail.payload
+  const previewUrl =
+    detail.kind === 'creative'
+      ? String((fields as any).image_url || (fields as any).thumbnail_url || detail.payload.imageUrl || detail.payload.thumbnailUrl || '')
+      : undefined
   const hasValue = (value: unknown) => value !== undefined && value !== null && value !== ''
+  const fieldValue = (key: string, fallback?: unknown) => (hasValue((fields as any)?.[key]) ? (fields as any)[key] : fallback)
   const filterSections = (sections: EntityDetailSection[]) =>
     sections
       .map((section) => ({
@@ -927,10 +1097,12 @@ function MetaAdsEntityDetailDialog({
       {
         title: 'Identificação',
         fields: [
-          { label: 'Nome', value: payload.name },
-          { label: 'ID', value: payload.id },
-          { label: 'Status', value: payload.effective_status || payload.status },
-          { label: 'Objetivo', value: payload.objective },
+          { label: 'Nome', value: fieldValue('name', payload.name) },
+          { label: 'ID', value: fieldValue('id', payload.id) },
+          { label: 'Status configurado', value: fieldValue('status', payload.status) },
+          { label: 'Status efetivo', value: fieldValue('effective_status', payload.effective_status || payload.status) },
+          { label: 'Objetivo', value: fieldValue('objective', payload.objective) },
+          { label: 'Tipo de compra', value: fieldValue('buying_type') },
         ],
       },
       {
@@ -943,15 +1115,18 @@ function MetaAdsEntityDetailDialog({
       {
         title: 'Orçamento',
         fields: [
-          { label: 'Orçamento diário', value: payload.daily_budget },
-          { label: 'Orçamento vitalício', value: payload.lifetime_budget },
+          { label: 'Orçamento diário', value: fieldValue('daily_budget', payload.daily_budget) },
+          { label: 'Orçamento vitalício', value: fieldValue('lifetime_budget', payload.lifetime_budget) },
+          { label: 'Estratégia de lance', value: fieldValue('bid_strategy') },
         ],
       },
       {
         title: 'Janela operacional',
         fields: [
-          { label: 'Início', value: payload.start_time },
-          { label: 'Fim', value: payload.stop_time },
+          { label: 'Início', value: fieldValue('start_time', payload.start_time) },
+          { label: 'Fim', value: fieldValue('stop_time', payload.stop_time) },
+          { label: 'Criado em', value: fieldValue('created_time') },
+          { label: 'Atualizado em', value: fieldValue('updated_time') },
         ],
       },
     ])
@@ -961,10 +1136,11 @@ function MetaAdsEntityDetailDialog({
       {
         title: 'Identificação',
         fields: [
-          { label: 'Nome', value: payload.name },
-          { label: 'ID', value: payload.id },
-          { label: 'Status', value: payload.effective_status || payload.status },
-          { label: 'Campanha', value: payload.campaign_name || payload.campaign_id },
+          { label: 'Nome', value: fieldValue('name', payload.name) },
+          { label: 'ID', value: fieldValue('id', payload.id) },
+          { label: 'Status configurado', value: fieldValue('status', payload.status) },
+          { label: 'Status efetivo', value: fieldValue('effective_status', payload.effective_status || payload.status) },
+          { label: 'Campanha', value: (fields as any)?.campaign?.name || payload.campaign_name || payload.campaign_id },
         ],
       },
       {
@@ -974,17 +1150,20 @@ function MetaAdsEntityDetailDialog({
       {
         title: 'Otimização e orçamento',
         fields: [
-          { label: 'Meta de otimização', value: payload.optimization_goal },
-          { label: 'Estratégia de lance', value: payload.bid_strategy },
-          { label: 'Orçamento diário', value: payload.daily_budget },
-          { label: 'Orçamento vitalício', value: payload.lifetime_budget },
+          { label: 'Meta de otimização', value: fieldValue('optimization_goal', payload.optimization_goal) },
+          { label: 'Evento de cobrança', value: fieldValue('billing_event') },
+          { label: 'Estratégia de lance', value: fieldValue('bid_strategy', payload.bid_strategy) },
+          { label: 'Orçamento diário', value: fieldValue('daily_budget', payload.daily_budget) },
+          { label: 'Orçamento vitalício', value: fieldValue('lifetime_budget', payload.lifetime_budget) },
         ],
       },
       {
         title: 'Janela operacional',
         fields: [
-          { label: 'Início', value: payload.start_time },
-          { label: 'Fim', value: payload.end_time },
+          { label: 'Início', value: fieldValue('start_time', payload.start_time) },
+          { label: 'Fim', value: fieldValue('end_time', payload.end_time) },
+          { label: 'Criado em', value: fieldValue('created_time') },
+          { label: 'Atualizado em', value: fieldValue('updated_time') },
         ],
       },
     ])
@@ -994,18 +1173,21 @@ function MetaAdsEntityDetailDialog({
       {
         title: 'Identificação',
         fields: [
-          { label: 'Nome', value: payload.name },
-          { label: 'ID', value: payload.id },
-          { label: 'Status', value: payload.effective_status || payload.status },
+          { label: 'Nome', value: fieldValue('name', payload.name) },
+          { label: 'ID', value: fieldValue('id', payload.id) },
+          { label: 'Status configurado', value: fieldValue('status', payload.status) },
+          { label: 'Status efetivo', value: fieldValue('effective_status', payload.effective_status || payload.status) },
         ],
       },
       {
         title: 'Relacionamentos',
         fields: [
-          { label: 'Campanha', value: payload.campaign_name || payload.campaign_id },
-          { label: 'Conjunto de anúncios', value: payload.adset_name || payload.adset_id },
-          { label: 'Criativo', value: payload.creative?.name || payload.creative?.id },
-          { label: 'Story ID efetivo', value: payload.creative?.effective_object_story_id },
+          { label: 'Campanha', value: (fields as any)?.campaign?.name || payload.campaign_name || payload.campaign_id },
+          { label: 'Conjunto de anúncios', value: (fields as any)?.adset?.name || payload.adset_name || payload.adset_id },
+          { label: 'Criativo', value: (fields as any)?.creative?.name || payload.creative?.name || payload.creative?.id },
+          { label: 'Story ID efetivo', value: (fields as any)?.creative?.effective_object_story_id || payload.creative?.effective_object_story_id },
+          { label: 'Criado em', value: fieldValue('created_time') },
+          { label: 'Atualizado em', value: fieldValue('updated_time') },
         ],
       },
     ])
@@ -1018,9 +1200,12 @@ function MetaAdsEntityDetailDialog({
         title: 'Identificação',
         fields: [
           { label: 'Nome', value: displayName },
-          { label: 'Nome original na Meta', value: dynamicName ? payload.name : null },
-          { label: 'ID', value: payload.id },
-          { label: 'Story ID efetivo', value: payload.effectiveObjectStoryId },
+          { label: 'Nome original na Meta', value: dynamicName ? fieldValue('name', payload.name) : null },
+          { label: 'ID', value: fieldValue('id', payload.id) },
+          { label: 'Story ID efetivo', value: fieldValue('effective_object_story_id', payload.effectiveObjectStoryId) },
+          { label: 'Object story ID', value: fieldValue('object_story_id') },
+          { label: 'Tipo CTA', value: fieldValue('call_to_action_type') },
+          { label: 'URL tags', value: fieldValue('url_tags') },
         ],
       },
       {
@@ -1032,6 +1217,43 @@ function MetaAdsEntityDetailDialog({
         ],
       },
     ])
+  }
+
+  const editableFields = liveEntity?.editableFields || []
+  const canEdit = Boolean(liveEntity?.editable && editableFields.length)
+  const changedPatch = editableFields.reduce((patch, field) => {
+    const previous = String((liveEntity?.fields as any)?.[field] ?? '')
+    const next = String(form[field] ?? '')
+    if (next !== previous) {
+      ;(patch as Record<string, string>)[field] = next
+    }
+    return patch
+  }, {} as MetaAdsEntityPatch)
+  const hasChanges = Object.keys(changedPatch).length > 0
+  const setFormField = (field: string, value: string) => setForm((current) => ({ ...current, [field]: value }))
+  const handleSave = async () => {
+    if (!detail || !hasChanges) return
+    const sensitive = Object.keys(changedPatch).some((field) => field === 'status' || field.includes('budget'))
+    if (sensitive && !window.confirm('Confirmar alteração no Gerenciador de Anúncios da Meta? A mudança será aplicada na conta selecionada.')) {
+      return
+    }
+    setSaving(true)
+    try {
+      const response = await metaAdsApi.updateEntity(detail.kind, detail.payload.id, changedPatch)
+      setLiveEntity(response.entity)
+      const nextForm: Record<string, string> = {}
+      for (const field of response.entity.editableFields || []) {
+        const value = response.entity.fields?.[field]
+        if (value !== undefined && value !== null) nextForm[field] = String(value)
+      }
+      setForm(nextForm)
+      toast.success('Alteração enviada para o Gerenciador de Anúncios')
+      await onEntityUpdated?.()
+    } catch (error: any) {
+      toast.error(error?.message || 'Falha ao atualizar item na Meta')
+    } finally {
+      setSaving(false)
+    }
   }
 
   return (
@@ -1050,7 +1272,98 @@ function MetaAdsEntityDetailDialog({
       }
       previewUrl={previewUrl}
       sections={sections}
-    />
+      footer={
+        <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Fechar
+          </Button>
+          {canEdit ? (
+            <Button
+              type="button"
+              className="bg-sky-500 text-slate-950 hover:bg-sky-400"
+              onClick={handleSave}
+              disabled={!hasChanges || saving || loadingDetail}
+            >
+              {saving ? 'Salvando na Meta...' : 'Salvar na Meta'}
+            </Button>
+          ) : null}
+        </div>
+      }
+    >
+      <div className="rounded-2xl border border-slate-800/80 bg-slate-900/55 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-sm font-medium text-white">Dados live do Gerenciador de Anúncios</div>
+            <div className="text-xs text-slate-400">
+              {loadingDetail
+                ? 'Carregando configuração atual da Meta...'
+                : detailError
+                  ? detailError
+                  : liveEntity
+                    ? `Atualizado em ${new Date(liveEntity.updatedAt).toLocaleString('pt-BR')}`
+                    : 'Abrindo com os dados locais do inventário.'}
+            </div>
+          </div>
+          {loadingDetail ? <Spinner className="h-5 w-5 animate-spin text-sky-300" /> : null}
+          {!loadingDetail && liveEntity?.editable ? <Badge className="bg-emerald-500/15 text-emerald-100">Editável</Badge> : null}
+          {!loadingDetail && liveEntity && !liveEntity.editable ? <Badge className="bg-slate-700/70 text-slate-200">Somente leitura</Badge> : null}
+        </div>
+        {liveEntity?.readOnlyReason ? <div className="mt-3 text-xs text-slate-300">{liveEntity.readOnlyReason}</div> : null}
+      </div>
+
+      {canEdit ? (
+        <div className="space-y-3 rounded-2xl border border-sky-500/20 bg-sky-500/5 p-4">
+          <div>
+            <div className="text-sm font-medium text-white">Edição segura</div>
+            <div className="text-xs text-slate-400">Somente os campos abaixo são enviados para a Meta. Campos bloqueados permanecem apenas leitura.</div>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {editableFields.includes('name') ? (
+              <label className="space-y-1 text-xs text-slate-300">
+                Nome
+                <Input value={form.name || ''} onChange={(event) => setFormField('name', event.target.value)} className="h-10 border-slate-700 bg-slate-950/70 text-slate-100" />
+              </label>
+            ) : null}
+            {editableFields.includes('status') ? (
+              <label className="space-y-1 text-xs text-slate-300">
+                Status
+                <Select value={form.status || ''} onValueChange={(value) => setFormField('status', value)}>
+                  <SelectTrigger className="h-10 border-slate-700 bg-slate-950/70 text-slate-100">
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ACTIVE">Ativa</SelectItem>
+                    <SelectItem value="PAUSED">Pausada</SelectItem>
+                  </SelectContent>
+                </Select>
+              </label>
+            ) : null}
+            {(['daily_budget', 'lifetime_budget', 'start_time', 'stop_time', 'end_time', 'bid_strategy', 'optimization_goal'] as const).map((field) =>
+              editableFields.includes(field) ? (
+                <label key={field} className="space-y-1 text-xs text-slate-300">
+                  {{
+                    daily_budget: 'Orçamento diário (centavos)',
+                    lifetime_budget: 'Orçamento vitalício (centavos)',
+                    start_time: 'Início',
+                    stop_time: 'Fim da campanha',
+                    end_time: 'Fim do conjunto',
+                    bid_strategy: 'Estratégia de lance',
+                    optimization_goal: 'Meta de otimização',
+                  }[field]}
+                  <Input value={form[field] || ''} onChange={(event) => setFormField(field, event.target.value)} className="h-10 border-slate-700 bg-slate-950/70 text-slate-100" />
+                </label>
+              ) : null,
+            )}
+          </div>
+        </div>
+      ) : null}
+    </EntityDetailModal>
   )
 }
 
@@ -1297,6 +1610,8 @@ export function MetaAdsOverviewPanel({
   report,
   overviewError,
   onRetry,
+  loading,
+  syncing,
 }: {
   selectedAccount: MetaAdAccount
   summary: MetaAdsSummaryResponse | null
@@ -1304,6 +1619,8 @@ export function MetaAdsOverviewPanel({
   report: MetaAdsReportResponse | null
   overviewError: MetaAdsApiError | null
   onRetry?: () => void
+  loading?: boolean
+  syncing?: boolean
 }) {
   const [metricLayout, setMetricLayout] = useState<MetaAdsOverviewMetricLayout[]>(() => {
     try {
@@ -1603,6 +1920,16 @@ export function MetaAdsOverviewPanel({
       return next
     })
   }
+  const hasOverviewData = Boolean(primarySummary || trend.length || report)
+
+  if (loading && !hasOverviewData) {
+    return (
+      <>
+        <MetaAdsPersistentError error={overviewError} onRetry={onRetry} />
+        <MetaAdsLoadingCard label="Sincronizando resumo da conta Meta Ads" />
+      </>
+    )
+  }
 
   return (
     <>
@@ -1645,8 +1972,9 @@ export function MetaAdsOverviewPanel({
             <div
               ref={dropProvided.innerRef}
               {...dropProvided.droppableProps}
-              className="grid grid-cols-[repeat(auto-fit,minmax(9.5rem,1fr))] gap-2"
+              className="relative grid grid-flow-dense grid-cols-[repeat(auto-fit,minmax(8.25rem,1fr))] gap-2 sm:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))]"
             >
+              <MetaAdsSyncOverlay show={syncing && hasOverviewData} label="Atualizando métricas" />
               {visibleMetricTiles.length > 0 ? (
                 visibleMetricTiles.map((tile, index) => (
                   <Draggable key={tile.key} draggableId={`meta-ads-metric-${tile.key}`} index={index}>
@@ -1695,7 +2023,8 @@ export function MetaAdsOverviewPanel({
         </Droppable>
       </DragDropContext>
 
-      <Card className={panelClass}>
+      <Card className={`${panelClass} relative overflow-hidden`}>
+        <MetaAdsSyncOverlay show={syncing && trend.length > 0} label="Atualizando tendência" />
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <PresentationChart className="h-5 w-5 text-sky-300" />
@@ -1758,19 +2087,41 @@ export function MetaAdsInventoryPanel({
   report,
   inventoryError,
   onRetry,
+  onEntityUpdated,
+  loading,
+  syncing,
 }: {
   selectedAccount: MetaAdAccount
   inventory: MetaAdsInventory
   report: MetaAdsReportResponse | null
   inventoryError: MetaAdsApiError | null
   onRetry?: () => void
+  onEntityUpdated?: () => void | Promise<void>
+  loading?: boolean
+  syncing?: boolean
 }) {
   const [detail, setDetail] = useState<MetaAdsEntityDetail | null>(null)
   const [collapsedCampaignIds, setCollapsedCampaignIds] = useState<string[]>([])
   const [collapsedAdSetIds, setCollapsedAdSetIds] = useState<string[]>([])
   const [sortKey, setSortKey] = useState<MetaAdsInventorySortKey>('rank')
   const [sortDir, setSortDir] = useState<MetaAdsInventorySortDir>('asc')
+  const [columnWidths, setColumnWidths] = useState<Record<MetaAdsInventoryColumnKey, number>>(() => {
+    try {
+      return parseMetaAdsInventoryColumnWidths(window.localStorage.getItem(META_ADS_INVENTORY_COLUMN_WIDTHS_KEY))
+    } catch {
+      return getDefaultMetaAdsInventoryColumnWidths()
+    }
+  })
+  const columnResizeRef = useRef<{ key: MetaAdsInventoryColumnKey; startX: number; startWidth: number } | null>(null)
   const currency = selectedAccount.currency || 'USD'
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(META_ADS_INVENTORY_COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths))
+    } catch {
+      // Column sizing is a preference; ignore storage failures.
+    }
+  }, [columnWidths])
 
   const campaignOrderMap = useMemo(
     () => new Map(inventory.campaigns.map((campaign, index) => [campaign.id, index])),
@@ -2148,12 +2499,17 @@ export function MetaAdsInventoryPanel({
     return ((adOrderMap.get(left.id) ?? 0) - (adOrderMap.get(right.id) ?? 0))
   }, [adMetricsMap, adOrderMap, adRankMap, filteredCreativesByAd, sortKey, sortMultiplier])
 
-  const rowClass = () => 'border-slate-800/80 transition hover:bg-slate-900/45'
+  const rowClass = (level: InventoryTreeRow['level']) => {
+    const base = 'border-slate-800/80 transition'
+    if (level === 'campaign') return `${base} bg-sky-500/[0.045] hover:bg-sky-500/[0.09]`
+    if (level === 'adset') return `${base} bg-fuchsia-500/[0.04] hover:bg-fuchsia-500/[0.085]`
+    return `${base} bg-amber-500/[0.035] hover:bg-amber-500/[0.08]`
+  }
 
   const itemButtonClass = 'min-w-0 truncate text-left transition hover:text-sky-200'
-  const campaignItemClass = `${itemButtonClass} text-[15px] font-semibold text-white`
-  const adSetItemClass = `${itemButtonClass} text-sm font-medium text-slate-100`
-  const adItemClass = `${itemButtonClass} text-sm font-normal text-slate-200`
+  const campaignItemClass = `${itemButtonClass} text-[15px] font-semibold tracking-[0.01em] text-white`
+  const adSetItemClass = `${itemButtonClass} text-sm font-medium italic text-fuchsia-50`
+  const adItemClass = `${itemButtonClass} text-[13px] font-normal text-amber-50/90`
   const describeCount = (filteredCount: number, totalCount: number, singular: string, plural: string) =>
     filteredCount === totalCount ? `${totalCount} ${totalCount === 1 ? singular : plural}` : `${filteredCount} de ${totalCount}`
   const toggleCampaign = (campaignId: string) => {
@@ -2211,6 +2567,32 @@ export function MetaAdsInventoryPanel({
     filteredAdSetsByCampaign,
     filteredCampaigns,
   ])
+  const inventoryTableWidth = useMemo(
+    () => META_ADS_INVENTORY_COLUMN_ORDER.reduce((sum, key) => sum + columnWidths[key], 0),
+    [columnWidths],
+  )
+
+  const handleColumnResizeStart = (key: MetaAdsInventoryColumnKey, event: PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    columnResizeRef.current = { key, startX: event.clientX, startWidth: columnWidths[key] }
+    event.currentTarget.setPointerCapture?.(event.pointerId)
+  }
+
+  const handleColumnResizeMove = (event: PointerEvent<HTMLButtonElement>) => {
+    const state = columnResizeRef.current
+    if (!state) return
+    event.preventDefault()
+    const nextWidth = clampMetaAdsInventoryColumnWidth(state.key, state.startWidth + event.clientX - state.startX)
+    setColumnWidths((current) => (current[state.key] === nextWidth ? current : { ...current, [state.key]: nextWidth }))
+  }
+
+  const handleColumnResizeEnd = (event: PointerEvent<HTMLButtonElement>) => {
+    if (!columnResizeRef.current) return
+    event.preventDefault()
+    event.stopPropagation()
+    columnResizeRef.current = null
+  }
 
   const renderUnavailableMetricCell = () => (
     <MetaAdsTableTooltip
@@ -2221,11 +2603,11 @@ export function MetaAdsInventoryPanel({
     </MetaAdsTableTooltip>
   )
 
-  const columnHelp: Partial<Record<MetaAdsInventorySortKey | 'statusLabel' | 'objectiveLabel', { label: string; description?: string }>> = {
+  const columnHelp: Partial<Record<MetaAdsInventoryColumnKey, { label: string; description?: string }>> = {
     item: { label: 'Item', description: 'Nome da campanha, conjunto ou anúncio.' },
     rank: { label: 'Rank', description: 'Posição relativa pelo consolidado do período.' },
-    statusLabel: { label: 'Status', description: 'Situação operacional atual do item na Meta.' },
-    objectiveLabel: { label: 'Objetivo', description: 'Objetivo principal de entrega e otimização.' },
+    status: { label: 'Status', description: 'Situação operacional atual do item na Meta.' },
+    objective: { label: 'Objetivo', description: 'Objetivo principal de entrega e otimização.' },
     items: { label: 'Itens', description: 'Quantidade de itens filhos ativos e inativos.' },
     spend: { label: 'Investimento', description: 'Valor total investido no período selecionado.' },
     conversations: { label: 'Conversa', description: 'Conversas iniciadas atribuídas ao item.' },
@@ -2243,7 +2625,7 @@ export function MetaAdsInventoryPanel({
     cul: { label: 'CU / CUL', description: 'Cliques únicos e cliques únicos em link, quando disponíveis.' },
   }
 
-  const renderSortHead = (key: MetaAdsInventorySortKey, label: string) => {
+  const renderSortHead = (key: MetaAdsInventoryColumnKey, label: string) => {
     const isActive = sortKey === key
     const help = columnHelp[key]
     return (
@@ -2277,11 +2659,45 @@ export function MetaAdsInventoryPanel({
     )
   }
 
+  const renderResizableHead = (key: MetaAdsInventoryColumnKey, label: string, className = 'text-center') => (
+    <TableHead
+      data-testid={`meta-ads-inventory-head-${key}`}
+      className={`sticky top-0 z-30 border-b border-slate-800 bg-slate-950/95 px-2 backdrop-blur-md ${className}`}
+      style={{
+        width: columnWidths[key],
+        minWidth: columnWidths[key],
+        maxWidth: columnWidths[key],
+      }}
+    >
+      <div className={`relative flex h-10 items-center ${className.includes('text-left') ? 'justify-start' : 'justify-center'}`}>
+        {renderSortHead(key, label)}
+        <button
+          type="button"
+          data-testid={`meta-ads-column-resize-${key}`}
+          aria-label={`Ajustar largura da coluna ${columnHelp[key]?.label || label}`}
+          className="absolute -right-2 top-1/2 h-7 w-3 -translate-y-1/2 cursor-col-resize rounded-full border border-transparent transition hover:border-sky-400/35 hover:bg-sky-400/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
+          onPointerDown={(event) => handleColumnResizeStart(key, event)}
+          onPointerMove={handleColumnResizeMove}
+          onPointerUp={handleColumnResizeEnd}
+          onPointerCancel={handleColumnResizeEnd}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+        >
+          <span className="mx-auto block h-4 w-px rounded-full bg-slate-500/55" aria-hidden="true" />
+        </button>
+      </div>
+    </TableHead>
+  )
+
   return (
     <>
       <MetaAdsPersistentError error={inventoryError} onRetry={onRetry} />
-      <MetaAdsEntityDetailDialog detail={detail} open={Boolean(detail)} onOpenChange={(open) => !open && setDetail(null)} />
-      <Card className={panelClass}>
+      {loading && !inventoryTreeRows.length ? <MetaAdsLoadingCard label="Sincronizando estrutura operacional" /> : null}
+      <MetaAdsEntityDetailDialog detail={detail} open={Boolean(detail)} onOpenChange={(open) => !open && setDetail(null)} onEntityUpdated={onEntityUpdated} />
+      <Card className={`${panelClass} relative overflow-hidden`}>
+        <MetaAdsSyncOverlay show={syncing && inventoryTreeRows.length > 0} label="Atualizando estrutura" />
         <CardHeader>
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div>
@@ -2295,32 +2711,41 @@ export function MetaAdsInventoryPanel({
             </div>
           </div>
         </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow className="border-slate-800">
-                <TableHead>{renderSortHead('item', 'Item')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('rank', 'Rank')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('status', 'Status')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('objective', 'Objetivo')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('items', 'Itens')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('spend', 'Invest.')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('conversations', 'Conversa')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('cpcv', 'CPCv')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('clicks', 'Clique')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('reach', 'Alcance')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('impressions', 'Impressão')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('engagement', 'Engaj.')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('igRedirect', 'Redirecionamento')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('ctr', 'CTR/CTRL')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('cpc', 'CPC/CPCL')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('cpm', 'CPM')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('cpp', 'CPP')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('frequency', 'Frequência')}</TableHead>
-                <TableHead className="text-center">{renderSortHead('cul', 'CU/CUL')}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
+        <CardContent className="px-6 pb-6">
+          <div
+            data-testid="meta-ads-inventory-scroll"
+            className="max-h-[min(62vh,36rem)] overflow-auto rounded-2xl border border-slate-800/75 bg-slate-950/20 shadow-inner scrollbar-thin scrollbar-thumb-slate-700/70 scrollbar-track-slate-950/40"
+          >
+            <table className="caption-bottom table-fixed text-sm" style={{ width: inventoryTableWidth, minWidth: '100%' }}>
+              <colgroup>
+                {META_ADS_INVENTORY_COLUMN_ORDER.map((key) => (
+                  <col key={key} style={{ width: columnWidths[key] }} />
+                ))}
+              </colgroup>
+              <TableHeader>
+                <TableRow className="border-slate-800">
+                  {renderResizableHead('item', 'Item', 'text-left')}
+                  {renderResizableHead('rank', 'Rank')}
+                  {renderResizableHead('status', 'Status')}
+                  {renderResizableHead('objective', 'Objetivo')}
+                  {renderResizableHead('items', 'Itens')}
+                  {renderResizableHead('spend', 'Invest.')}
+                  {renderResizableHead('conversations', 'Conversa')}
+                  {renderResizableHead('cpcv', 'CPCv')}
+                  {renderResizableHead('clicks', 'Clique')}
+                  {renderResizableHead('reach', 'Alcance')}
+                  {renderResizableHead('impressions', 'Impressão')}
+                  {renderResizableHead('engagement', 'Engaj.')}
+                  {renderResizableHead('igRedirect', 'Redirecionamento')}
+                  {renderResizableHead('ctr', 'CTR/CTRL')}
+                  {renderResizableHead('cpc', 'CPC/CPCL')}
+                  {renderResizableHead('cpm', 'CPM')}
+                  {renderResizableHead('cpp', 'CPP')}
+                  {renderResizableHead('frequency', 'Frequência')}
+                  {renderResizableHead('cul', 'CU/CUL')}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
               {inventoryTreeRows.map((row) => {
                 if (row.level === 'campaign') {
                   const campaign = row.campaign
@@ -2333,7 +2758,7 @@ export function MetaAdsInventoryPanel({
                       ? campaignMetrics.spend / campaignMetrics.conversations
                       : null
                   return (
-                    <TableRow key={row.key} className={rowClass()}>
+                    <TableRow key={row.key} className={rowClass(row.level)}>
                       <TableCell>
                         <div className="space-y-1">
                           <div className="grid grid-cols-[1.75rem_1.75rem_minmax(0,1fr)] items-center gap-2">
@@ -2425,7 +2850,7 @@ export function MetaAdsInventoryPanel({
                       ? adSetMetrics.spend / adSetMetrics.conversations
                       : null
                   return (
-                    <TableRow key={row.key} className={rowClass()}>
+                    <TableRow key={row.key} className={rowClass(row.level)}>
                       <TableCell>
                         <div className="space-y-1">
                           <div className="grid grid-cols-[1.75rem_1.75rem_minmax(0,1fr)] items-center gap-2">
@@ -2514,7 +2939,7 @@ export function MetaAdsInventoryPanel({
                     ? adMetrics.spend / adMetrics.conversations
                     : null
                 return (
-                  <TableRow key={row.key} className={rowClass()}>
+                  <TableRow key={row.key} className={rowClass(row.level)}>
                     <TableCell>
                       <div className="space-y-1">
                         <div className="grid grid-cols-[1.75rem_1.75rem_minmax(0,1fr)] items-center gap-2">
@@ -2584,7 +3009,8 @@ export function MetaAdsInventoryPanel({
                 )
               })}
             </TableBody>
-          </Table>
+          </table>
+          </div>
         </CardContent>
       </Card>
 

--- a/frontend/metaAdsTypes.ts
+++ b/frontend/metaAdsTypes.ts
@@ -113,6 +113,50 @@ export type MetaCreativeInventoryItem = {
   campaignName?: string | null
 }
 
+export type MetaAdsEntityType = 'campaign' | 'adset' | 'ad' | 'creative'
+
+export type MetaAdsEntityPatch = {
+  name?: string
+  status?: 'ACTIVE' | 'PAUSED'
+  daily_budget?: string
+  lifetime_budget?: string
+  start_time?: string
+  stop_time?: string
+  end_time?: string
+  bid_strategy?: string
+  optimization_goal?: string
+}
+
+export type MetaAdsLiveEntityDetail = {
+  type: MetaAdsEntityType
+  id: string
+  accountId: string
+  editable: boolean
+  readOnlyReason?: string | null
+  editableFields: string[]
+  fields: Record<string, unknown>
+  raw?: Record<string, unknown>
+  updatedAt: string
+}
+
+export type MetaAdsEntityDetailResponse = {
+  ok: boolean
+  entity: MetaAdsLiveEntityDetail
+}
+
+export type MetaAdsEntityUpdateResponse = {
+  ok: boolean
+  entity: MetaAdsLiveEntityDetail
+  changedFields: string[]
+  audit: {
+    entityType: MetaAdsEntityType
+    entityId: string
+    adAccountId: string
+    changedFields: string[]
+    timestamp: string
+  }
+}
+
 export type MetaAdsInventory = {
   campaigns: MetaCampaignRow[]
   adSets: MetaAdSet[]

--- a/frontend/tests/metaAdsEntitiesApi.test.ts
+++ b/frontend/tests/metaAdsEntitiesApi.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+vi.mock('../functions/_lib/socialAuth', () => ({
+  requireSocialAdmin: vi.fn(),
+}))
+
+vi.mock('../functions/_lib/r2', () => ({
+  getShareBucket: vi.fn(),
+}))
+
+vi.mock('../functions/_lib/integrationsEncryption', () => ({
+  getIntegrationsEncryptionSecret: vi.fn(),
+  integrationsEncryptionSecretRequired: vi.fn(() => false),
+}))
+
+vi.mock('../functions/_lib/metaAdsStore', () => ({
+  readMetaAdsConnectionDecrypted: vi.fn(),
+  writeMetaAdsConnection: vi.fn(),
+  deleteMetaAdsConnection: vi.fn(),
+}))
+
+vi.mock('../functions/_lib/metaAdsGraph', async () => {
+  const actual = await vi.importActual<typeof import('../functions/_lib/metaAdsGraph')>('../functions/_lib/metaAdsGraph')
+  return {
+    ...actual,
+    getMetaAdsEntityDetail: vi.fn(),
+    updateMetaAdsEntity: vi.fn(),
+  }
+})
+
+import { onRequest } from '../functions/api/meta-ads/[[path]].ts'
+import { requireSocialAdmin } from '../functions/_lib/socialAuth'
+import { getShareBucket } from '../functions/_lib/r2'
+import { readMetaAdsConnectionDecrypted } from '../functions/_lib/metaAdsStore'
+import { getMetaAdsEntityDetail, updateMetaAdsEntity } from '../functions/_lib/metaAdsGraph'
+
+function createContext(url: string, init?: RequestInit) {
+  return {
+    request: new Request(url, {
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        cookie: 'csrfToken=test-csrf',
+        'x-csrf-token': 'test-csrf',
+        origin: 'https://crm.skincos.com.br',
+        ...(init?.headers || {}),
+      },
+      ...init,
+    }),
+    env: {
+      META_GRAPH_VERSION: 'v20.0',
+    },
+  }
+}
+
+function mockConnection(scopes = ['ads_read', 'ads_management']) {
+  ;(requireSocialAdmin as Mock).mockResolvedValue({ id: 'user-1', role: 'GESTOR' })
+  ;(getShareBucket as Mock).mockReturnValue({})
+  ;(readMetaAdsConnectionDecrypted as Mock).mockResolvedValue({
+    accessToken: 'token',
+    tokenType: 'oauth',
+    selectedAdAccountId: 'act_123',
+    scopes,
+    grantedScopes: scopes,
+    updatedAt: '2026-05-28T12:00:00.000Z',
+  })
+}
+
+describe('Meta Ads live entity API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockConnection()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns live entity details for the selected ad account', async () => {
+    ;(getMetaAdsEntityDetail as Mock).mockResolvedValue({
+      id: 'cmp_1',
+      account_id: 'act_123',
+      name: 'Campanha Primavera',
+      status: 'ACTIVE',
+      effective_status: 'ACTIVE',
+    })
+
+    const response = await onRequest(createContext('https://crm.skincos.com.br/api/meta-ads/entities/campaign/cmp_1'))
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        entity: expect.objectContaining({
+          type: 'campaign',
+          id: 'cmp_1',
+          accountId: '123',
+          editable: true,
+          editableFields: expect.arrayContaining(['name', 'status']),
+        }),
+      }),
+    )
+  })
+
+  it('rejects live details for entities outside the selected ad account', async () => {
+    ;(getMetaAdsEntityDetail as Mock).mockResolvedValue({
+      id: 'cmp_1',
+      account_id: 'act_999',
+      name: 'Outra conta',
+    })
+
+    const response = await onRequest(createContext('https://crm.skincos.com.br/api/meta-ads/entities/campaign/cmp_1'))
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        code: 'META_ADS_ENTITY_ACCOUNT_MISMATCH',
+      }),
+    )
+  })
+
+  it('updates allowlisted campaign fields through Graph only after ownership validation', async () => {
+    ;(getMetaAdsEntityDetail as Mock)
+      .mockResolvedValueOnce({
+        id: 'cmp_1',
+        account_id: 'act_123',
+        name: 'Campanha Primavera',
+        status: 'ACTIVE',
+      })
+      .mockResolvedValueOnce({
+        id: 'cmp_1',
+        account_id: 'act_123',
+        name: 'Campanha Primavera v2',
+        status: 'PAUSED',
+      })
+    ;(updateMetaAdsEntity as Mock).mockResolvedValue({ success: true })
+
+    const response = await onRequest(
+      createContext('https://crm.skincos.com.br/api/meta-ads/entities/campaign/cmp_1', {
+        method: 'PATCH',
+        body: JSON.stringify({ patch: { name: 'Campanha Primavera v2', status: 'PAUSED' } }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateMetaAdsEntity).toHaveBeenCalledWith('token', 'campaign', 'cmp_1', {
+      name: 'Campanha Primavera v2',
+      status: 'PAUSED',
+    }, 'v20.0', '')
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        changedFields: ['name', 'status'],
+      }),
+    )
+  })
+
+  it('blocks non-allowlisted update fields', async () => {
+    ;(getMetaAdsEntityDetail as Mock).mockResolvedValue({
+      id: 'cmp_1',
+      account_id: 'act_123',
+      name: 'Campanha Primavera',
+    })
+
+    const response = await onRequest(
+      createContext('https://crm.skincos.com.br/api/meta-ads/entities/campaign/cmp_1', {
+        method: 'PATCH',
+        body: JSON.stringify({ patch: { objective: 'MESSAGES' } }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(updateMetaAdsEntity).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        code: 'META_ADS_FIELD_NOT_EDITABLE',
+      }),
+    )
+  })
+
+  it('keeps creatives read-only in V1', async () => {
+    const response = await onRequest(
+      createContext('https://crm.skincos.com.br/api/meta-ads/entities/creative/cr_1', {
+        method: 'PATCH',
+        body: JSON.stringify({ patch: { name: 'Novo criativo' } }),
+      }),
+    )
+
+    expect(response.status).toBe(405)
+    expect(updateMetaAdsEntity).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        code: 'META_ADS_CREATIVE_READ_ONLY',
+      }),
+    )
+  })
+})

--- a/frontend/tests/metaAdsModule.test.ts
+++ b/frontend/tests/metaAdsModule.test.ts
@@ -11,7 +11,7 @@ import {
   buildMetaAdsWorkflowReport,
   normalizeMetaAdsWorkflowAccountId,
 } from '../metaAdsWorkflowReport'
-import { listMetaAdsInsights } from '../functions/_lib/metaAdsGraph'
+import { getMetaAdsEntityDetail, listMetaAdsInsights, updateMetaAdsEntity } from '../functions/_lib/metaAdsGraph'
 import type { MetaAdsStatusResponse } from '../metaAdsTypes'
 
 const baseStatus = (overrides: Partial<MetaAdsStatusResponse> = {}): MetaAdsStatusResponse => ({
@@ -433,5 +433,69 @@ describe('Meta Ads state helpers', () => {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+
+  it('fetches live Meta Ads entity details with the expected Graph fields', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'cmp_1',
+          account_id: 'act_123',
+          name: 'Campanha Primavera',
+          status: 'ACTIVE',
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    )
+
+    const detail = await getMetaAdsEntityDetail('token', 'campaign', 'cmp_1', 'v20.0')
+    expect(detail).toMatchObject({ id: 'cmp_1', account_id: 'act_123', status: 'ACTIVE' })
+    const requestedUrl = String((globalThis.fetch as any).mock.calls[0][0])
+    expect(requestedUrl).toContain('/v20.0/cmp_1?')
+    expect(requestedUrl).toContain('fields=')
+    expect(decodeURIComponent(requestedUrl)).toContain('daily_budget')
+    expect(decodeURIComponent(requestedUrl)).toContain('issues_info')
+  })
+
+  it('falls back to safe entity detail fields when rich Meta fields are rejected', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unsupported field issues_info' } }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'cmp_1', account_id: 'act_123', name: 'Campanha 1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+    const detail = await getMetaAdsEntityDetail('token', 'campaign', 'cmp_1', 'v20.0')
+    expect(detail).toMatchObject({ id: 'cmp_1', account_id: 'act_123', _crm_detail_warning: 'Unsupported field issues_info' })
+    const fallbackUrl = String((globalThis.fetch as any).mock.calls[1][0])
+    expect(decodeURIComponent(fallbackUrl)).not.toContain('issues_info')
+  })
+
+  it('updates Meta Ads entities through POST form payloads', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const result = await updateMetaAdsEntity('token', 'ad', 'ad_1', { name: 'Novo anúncio', status: 'PAUSED' }, 'v20.0')
+    expect(result).toEqual({ success: true })
+    const [url, init] = (globalThis.fetch as any).mock.calls[0]
+    expect(String(url)).toBe('https://graph.facebook.com/v20.0/ad_1')
+    expect(init.method).toBe('POST')
+    expect(String(init.body)).toContain('name=Novo+an%C3%BAncio')
+    expect(String(init.body)).toContain('status=PAUSED')
+    expect(String(init.body)).toContain('access_token=token')
   })
 })


### PR DESCRIPTION
## Summary
- add live Meta Ads entity detail/update API endpoints for campaigns, ad sets, ads and read-only creatives
- wire the CRM modal to fetch live Graph details, edit allowlisted fields and refresh module data after save
- add local mock support and API contract tests for ownership, allowlist and creative read-only behavior

## Validation
- npm --prefix frontend run typecheck
- npm --prefix frontend run test
- npm --prefix frontend run build
- npm --prefix frontend run lint (0 errors; existing warnings remain)

## Safety
- PATCH requests validate admin session, CSRF, selected account ownership and field allowlists before calling Meta Graph
- creative editing is read-only in this V1
- production verification should use no-op updates only unless a target entity/field is explicitly approved
