### PR TITLE
Refactor Meta Ads presentation helpers

### DIFF
--- a/frontend/e2e/meta-ads-module.spec.ts
+++ b/frontend/e2e/meta-ads-module.spec.ts
@@ -13,6 +13,7 @@ async function mockCrmUser(page: Page) {
 async function openMetaAds(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('app.activeModule', 'meta-ads')
+    localStorage.removeItem('skincos.metaAds.layout.overviewMetrics.v5')
   })
   await page.goto('/')
   await page.reload()
@@ -278,6 +279,58 @@ test.describe('meta ads', () => {
       })
     })
 
+    await page.route('**/api/meta-ads/entities/ad/ad_1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          entity: {
+            type: 'ad',
+            id: 'ad_1',
+            accountId: '123',
+            editable: true,
+            editableFields: ['name', 'status'],
+            fields: {
+              id: 'ad_1',
+              account_id: 'act_123',
+              name: 'Anúncio 1',
+              status: 'ACTIVE',
+              effective_status: 'ACTIVE',
+              campaign_id: 'cmp_1',
+              campaign_name: 'Campanha Primavera',
+              adset_id: 'set_1',
+              adset_name: 'Conjunto 1',
+              creative: {
+                id: 'cr_1',
+                name: 'Criativo 1',
+                effective_object_story_id: 'story_1',
+                thumbnail_url: '/icons/insumos-icon-192.png',
+                image_url: '/icons/insumos-icon-192.png',
+                body: 'Texto principal',
+                title: 'Título principal',
+                call_to_action_type: 'MESSAGE_PAGE',
+                object_url: 'https://example.com',
+                asset_feed_spec: {
+                  bodies: [{ text: 'Texto principal' }, { text: 'Texto alternativo' }],
+                  titles: [{ text: 'Título principal' }, { text: 'Título alternativo' }],
+                  descriptions: [{ text: 'Descrição principal' }],
+                  call_to_action_types: ['MESSAGE_PAGE'],
+                  link_urls: [{ website_url: 'https://example.com' }],
+                  images: [
+                    { hash: 'hash_3x4', url: '/icons/insumos-icon-192.png', width: 900, height: 1200 },
+                    { hash: 'hash_2x1', url: '/icons/icon-512.png', width: 1200, height: 600 },
+                  ],
+                },
+              },
+            },
+            raw: {},
+            updatedAt: '2026-05-14T12:00:00.000Z',
+          },
+        }),
+      })
+    })
+
     await openMetaAds(page)
 
     await expect(page.getByText('Conta Meta pronta para operar')).toHaveCount(0)
@@ -296,6 +349,23 @@ test.describe('meta ads', () => {
     await expect(page.getByText('Comece conectando a Meta ao CRM.')).toHaveCount(0)
     await expect(page.getByText('OAuth:')).toHaveCount(0)
 
+    const spendFormatButton = page.getByLabel('Alternar formato do card Investimento')
+    await spendFormatButton.click()
+    await expect.poll(async () => page.evaluate(() => {
+      const layout = JSON.parse(localStorage.getItem('skincos.metaAds.layout.overviewMetrics.v5') || '[]')
+      return layout.find((item: { key?: string; aspect?: string }) => item.key === 'spend')?.aspect
+    })).toBe('2:1')
+    await spendFormatButton.click()
+    await expect.poll(async () => page.evaluate(() => {
+      const layout = JSON.parse(localStorage.getItem('skincos.metaAds.layout.overviewMetrics.v5') || '[]')
+      return layout.find((item: { key?: string; aspect?: string }) => item.key === 'spend')?.aspect
+    })).toBe('1:1')
+    await spendFormatButton.click()
+    await expect.poll(async () => page.evaluate(() => {
+      const layout = JSON.parse(localStorage.getItem('skincos.metaAds.layout.overviewMetrics.v5') || '[]')
+      return layout.find((item: { key?: string; aspect?: string }) => item.key === 'spend')?.aspect
+    })).toBe('4:3')
+
     await expect(page.locator('body')).toContainText('Mapa da conta Meta')
     await expect(page.getByRole('button', { name: 'Campanha Primavera' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Conjunto 1' })).toBeVisible()
@@ -305,7 +375,7 @@ test.describe('meta ads', () => {
 
     const objectiveCell = page.locator('tbody tr').first().locator('td').nth(3).locator('[aria-label]').first()
     await objectiveCell.hover()
-    await expect(page.getByRole('tooltip')).toContainText('Prioriza cadastros, formulários ou conversas')
+    await expect(page.getByRole('tooltip').filter({ hasText: 'Geração de Lead' })).toContainText('Prioriza pessoas com maior chance')
 
     await page.getByRole('button', { name: 'Campanha Primavera' }).click()
     await expect(page.getByRole('dialog')).toContainText('Campanha Primavera')
@@ -319,12 +389,20 @@ test.describe('meta ads', () => {
     await page.getByRole('button', { name: 'Fechar' }).click()
 
     await page.getByRole('button', { name: 'Anúncio 1', exact: true }).click()
-    await expect(page.getByRole('dialog')).toContainText('Anúncio 1')
+    await expect(page.getByRole('dialog').locator('input').first()).toHaveValue('Anúncio 1')
     await expect(page.getByRole('dialog')).toContainText('Criativos do anúncio')
     await expect(page.getByRole('dialog')).toContainText('Mídias do criativo')
+    await expect(page.getByRole('dialog').getByText('Mídias do criativo')).toHaveCount(1)
+    await expect(page.getByRole('dialog')).toContainText('Variações do criativo')
+    await expect(page.getByRole('dialog').getByText('Mídias', { exact: true })).toHaveCount(0)
     await expect(page.getByRole('dialog')).toContainText('Criativo 1')
     await expect(page.getByRole('dialog')).toContainText('Story ID')
     await expect(page.getByRole('dialog')).toContainText('story_1')
+    const mediaHeading = page.getByRole('dialog').getByText('Mídias do criativo')
+    const variationsHeading = page.getByRole('dialog').getByText('Variações do criativo')
+    const mediaBox = await mediaHeading.boundingBox()
+    const variationsBox = await variationsHeading.boundingBox()
+    expect(mediaBox?.y ?? 0).toBeLessThan(variationsBox?.y ?? 0)
     await page.getByRole('button', { name: 'Fechar' }).click()
 
     const firstRow = page.locator('tbody tr').first()

--- a/frontend/metaAdsPanels.tsx
+++ b/frontend/metaAdsPanels.tsx
@@ -17,6 +17,21 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Textarea } from '@/textarea'
 import { TooltipLabel } from '@/tooltip'
 import { metaAdsApi } from '@/metaAdsApi'
+import {
+  DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT,
+  META_ADS_METRIC_TILE_DIMENSIONS,
+  META_ADS_OVERVIEW_METRIC_LAYOUT_KEY,
+  buildMetaAdsCreativeVariationGroups,
+  cycleMetaAdsMetricDimensions,
+  describeMetaAdsHeaderValue,
+  formatMetaAdsEnumLabel,
+  parseMetaAdsOverviewMetricLayout,
+  type MetaAdsCreativeVariationGroup,
+  type MetaAdsCreativeVariationItem,
+  type MetaAdsOverviewMetricAspect,
+  type MetaAdsOverviewMetricKey,
+  type MetaAdsOverviewMetricLayout,
+} from '@/metaAdsPresentation'
 import type {
   MetaAdAccount,
   MetaAd,
@@ -98,66 +113,9 @@ type MetaAdsInventorySortKey =
   | 'frequency'
   | 'cul'
 type MetaAdsInventorySortDir = 'asc' | 'desc'
-type MetaAdsOverviewMetricKey =
-  | 'spend'
-  | 'conversations'
-  | 'cpcv'
-  | 'clicks'
-  | 'reach'
-  | 'impressions'
-  | 'engagement'
-  | 'redirect'
-  | 'ctr'
-  | 'cpc'
-  | 'cpm'
-  | 'cpp'
-  | 'frequency'
-  | 'trend'
-type MetaAdsOverviewMetricSize = 'compact' | 'wide'
-type MetaAdsOverviewMetricAspect = '1:1' | '4:3' | '2:1'
-type MetaAdsOverviewMetricLayout = {
-  key: MetaAdsOverviewMetricKey
-  visible: boolean
-  width: number
-  height: number
-  aspect: MetaAdsOverviewMetricAspect
-}
 type MetaAdsInventoryColumnKey = MetaAdsInventorySortKey
 
-const META_ADS_OVERVIEW_METRIC_LAYOUT_KEY = 'skincos.metaAds.layout.overviewMetrics.v5'
 const META_ADS_INVENTORY_COLUMN_WIDTHS_KEY = 'skincos.metaAds.layout.inventoryColumns.v1'
-const META_ADS_METRIC_TILE_DIMENSIONS = {
-  minWidth: 140,
-  maxWidth: 680,
-  minHeight: 96,
-  maxHeight: 520,
-  defaultWidth: 224,
-  defaultHeight: 168,
-  trendWidth: 520,
-  trendHeight: 260,
-} as const
-const META_ADS_METRIC_ASPECT_RATIOS: Record<MetaAdsOverviewMetricAspect, number> = {
-  '1:1': 1,
-  '4:3': 4 / 3,
-  '2:1': 2,
-}
-const META_ADS_METRIC_ASPECT_ORDER: MetaAdsOverviewMetricAspect[] = ['1:1', '4:3', '2:1']
-const DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT: MetaAdsOverviewMetricLayout[] = [
-  { key: 'spend', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'conversations', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'cpcv', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'clicks', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'reach', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'impressions', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'engagement', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'redirect', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'ctr', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'cpc', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'cpm', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'cpp', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'frequency', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
-  { key: 'trend', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.trendWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.trendHeight, aspect: '2:1' },
-]
 const META_ADS_INVENTORY_COLUMN_LIMITS: Record<MetaAdsInventoryColumnKey, { width: number; min: number; max: number }> = {
   item: { width: 300, min: 220, max: 520 },
   rank: { width: 86, min: 72, max: 120 },
@@ -291,142 +249,6 @@ const META_ADS_MODAL_HEADER_FIELDS = new Set(['id', 'account_id', 'name', 'statu
 const META_ADS_MODAL_TIMELINE_FIELDS = new Set(['start_time', 'stop_time', 'end_time', 'created_time', 'updated_time'])
 const META_ADS_EDITABLE_DATE_FIELDS = new Set(['start_time', 'stop_time', 'end_time'])
 const META_ADS_BUDGET_FIELDS = new Set(['daily_budget', 'lifetime_budget'])
-
-function clampMetaAdsMetricDimension(value: unknown, min: number, max: number, fallback: number) {
-  const numberValue = Number(value)
-  if (!Number.isFinite(numberValue)) return fallback
-  return Math.min(max, Math.max(min, Math.round(numberValue)))
-}
-
-function getMetaAdsMetricAspect(value: unknown, width?: unknown, height?: unknown): MetaAdsOverviewMetricAspect {
-  if (value === '1:1' || value === '4:3' || value === '2:1') return value
-  if (value === '3:4') return '4:3'
-  const ratio = Number(width) > 0 && Number(height) > 0 ? Number(width) / Number(height) : META_ADS_METRIC_ASPECT_RATIOS['4:3']
-  return META_ADS_METRIC_ASPECT_ORDER.reduce((closest, option) => {
-    const closestDelta = Math.abs(META_ADS_METRIC_ASPECT_RATIOS[closest] - ratio)
-    const optionDelta = Math.abs(META_ADS_METRIC_ASPECT_RATIOS[option] - ratio)
-    return optionDelta < closestDelta ? option : closest
-  }, '4:3' as MetaAdsOverviewMetricAspect)
-}
-
-function fitMetaAdsMetricDimensionsToAspect(width: unknown, aspect: MetaAdsOverviewMetricAspect, fallbackHeight: number) {
-  const ratio = META_ADS_METRIC_ASPECT_RATIOS[aspect]
-  const nextWidth = clampMetaAdsMetricDimension(
-    width,
-    META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
-    META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
-    META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth,
-  )
-  const nextHeight = clampMetaAdsMetricDimension(
-    Math.round(nextWidth / ratio),
-    META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
-    META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
-    fallbackHeight,
-  )
-  return { width: Math.round(nextHeight * ratio), height: nextHeight }
-}
-
-function fitMetaAdsMetricBoxToAspect(width: number, height: number, aspect: MetaAdsOverviewMetricAspect) {
-  const ratio = META_ADS_METRIC_ASPECT_RATIOS[aspect]
-  const byWidthHeight = clampMetaAdsMetricDimension(
-    Math.round(width / ratio),
-    META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
-    META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
-    height,
-  )
-  const byWidth = {
-    width: clampMetaAdsMetricDimension(
-      Math.round(byWidthHeight * ratio),
-      META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
-      META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
-      width,
-    ),
-    height: byWidthHeight,
-  }
-  const byHeightWidth = clampMetaAdsMetricDimension(
-    Math.round(height * ratio),
-    META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
-    META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
-    width,
-  )
-  const byHeight = {
-    width: byHeightWidth,
-    height: clampMetaAdsMetricDimension(
-      Math.round(byHeightWidth / ratio),
-      META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
-      META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
-      height,
-    ),
-  }
-  const widthDelta = Math.abs(byWidth.width - width) + Math.abs(byWidth.height - height)
-  const heightDelta = Math.abs(byHeight.width - width) + Math.abs(byHeight.height - height)
-  return widthDelta <= heightDelta ? byWidth : byHeight
-}
-
-function cycleMetaAdsMetricDimensions(
-  width: number,
-  height: number,
-  currentAspect: MetaAdsOverviewMetricAspect,
-) {
-  const currentIndex = META_ADS_METRIC_ASPECT_ORDER.indexOf(currentAspect)
-  const aspect = META_ADS_METRIC_ASPECT_ORDER[(currentIndex + 1) % META_ADS_METRIC_ASPECT_ORDER.length]
-  return { ...fitMetaAdsMetricBoxToAspect(width, height, aspect), aspect }
-}
-
-function getDefaultMetaAdsMetricDimensions(key: MetaAdsOverviewMetricKey, legacySize?: MetaAdsOverviewMetricSize) {
-  if (key === 'trend') {
-    return {
-      width: legacySize === 'compact' ? 320 : META_ADS_METRIC_TILE_DIMENSIONS.trendWidth,
-      height: legacySize === 'compact' ? 160 : META_ADS_METRIC_TILE_DIMENSIONS.trendHeight,
-    }
-  }
-  return {
-    width: legacySize === 'wide' ? 340 : META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth,
-    height: legacySize === 'wide' ? 255 : META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight,
-  }
-}
-
-function parseMetaAdsOverviewMetricLayout(raw: string | null | undefined): MetaAdsOverviewMetricLayout[] {
-  try {
-    const parsed = raw ? JSON.parse(raw) : null
-    const items = Array.isArray(parsed) ? parsed : []
-    const seen = new Set<MetaAdsOverviewMetricKey>()
-    const normalized = items
-      .map((item) => {
-        const key = String(item?.key || '').trim() as MetaAdsOverviewMetricKey
-        if (!DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT.some((entry) => entry.key === key)) return null
-        if (seen.has(key)) return null
-        seen.add(key)
-        const fallback = getDefaultMetaAdsMetricDimensions(key, item?.size === 'wide' ? 'wide' : 'compact')
-        const aspect = getMetaAdsMetricAspect(item?.aspect, item?.width, item?.height)
-        const dimensions = fitMetaAdsMetricDimensionsToAspect(
-          clampMetaAdsMetricDimension(
-            item?.width,
-            META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
-            META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
-            fallback.width,
-          ),
-          aspect,
-          fallback.height,
-        )
-        return {
-          key,
-          visible: item?.visible !== false,
-          width: dimensions.width,
-          height: dimensions.height,
-          aspect,
-        } satisfies MetaAdsOverviewMetricLayout
-      })
-      .filter(Boolean) as MetaAdsOverviewMetricLayout[]
-
-    for (const fallback of DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT) {
-      if (!seen.has(fallback.key)) normalized.push(fallback)
-    }
-    return normalized.length ? normalized : DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
-  } catch {
-    return DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
-  }
-}
 
 function getMetaAdsLiveFieldLabel(field: string) {
   return META_ADS_LIVE_FIELD_LABELS[field] || field.replace(/_/g, ' ')
@@ -968,7 +790,7 @@ function describeObjective(objective?: string | null) {
   if (normalized === 'LEADS' || normalized === 'LEAD_GENERATION') {
     return {
       title: 'Geração de Lead',
-      description: 'Prioriza cadastros, formulários ou conversas com potencial de virar atendimento.',
+      description: describeMetaAdsHeaderValue('objective', normalized),
       icon: Target,
       toneClass: 'border-sky-500/25 bg-sky-500/12 text-sky-100',
     }
@@ -1137,119 +959,6 @@ function getMetaAdsCreativeDisplayName(creative: MetaCreativeInventoryItem) {
     .replace(/\s+/g, ' ')
     .trim()
   return sanitizedName.length <= 72 ? sanitizedName : 'Criativo dinâmico'
-}
-
-function formatMetaAdsEnumLabel(value?: unknown) {
-  const raw = String(value || '').trim()
-  if (!raw) return ''
-  const normalized = raw.toUpperCase()
-  const labels: Record<string, string> = {
-    AUCTION: 'Leilão',
-    BUYING_TYPE_AUCTION: 'Leilão',
-    LEADS: 'Geração de Lead',
-    LEAD_GENERATION: 'Geração de Lead',
-    OUTCOME_LEADS: 'Geração de Leads',
-    CONVERSATIONS: 'Conversas',
-    MESSAGES: 'Mensagens',
-    ENGAGED_USERS: 'Engajamento',
-    TRAFFIC: 'Tráfego',
-    LINK_CLICKS: 'Cliques no link',
-    OUTBOUND_CLICKS: 'Cliques externos',
-    REACH: 'Alcance',
-    IMPRESSIONS: 'Impressões',
-    POST_ENGAGEMENT: 'Engajamento',
-    PAGE_LIKES: 'Curtidas na página',
-    EVENT_RESPONSES: 'Respostas ao evento',
-    VIDEO_VIEWS: 'Visualizações de vídeo',
-    APP_INSTALLS: 'Instalações do app',
-    BRAND_AWARENESS: 'Reconhecimento da marca',
-    LOCAL_AWARENESS: 'Reconhecimento local',
-    STORE_VISITS: 'Visitas à loja',
-    VALUE: 'Valor',
-    LANDING_PAGE_VIEWS: 'Visualizações da página',
-    QUALITY_CALL: 'Ligação qualificada',
-    SALES: 'Vendas',
-    CONVERSIONS: 'Conversões',
-    OFFSITE_CONVERSIONS: 'Conversões no site',
-    LEARN_MORE: 'Saiba mais',
-    SIGN_UP: 'Cadastre-se',
-    CONTACT_US: 'Fale conosco',
-    WHATSAPP_MESSAGE: 'Enviar mensagem',
-    MESSAGE_PAGE: 'Enviar mensagem',
-    BOOK_NOW: 'Agendar agora',
-    APPLY_NOW: 'Inscrever-se',
-    DOWNLOAD: 'Baixar',
-    SHOP_NOW: 'Comprar agora',
-    GET_QUOTE: 'Solicitar orçamento',
-    LOWEST_COST_WITHOUT_CAP: 'Menor custo sem limite',
-    LOWEST_COST_WITH_BID_CAP: 'Menor custo com limite de lance',
-    COST_CAP: 'Controle de custo',
-    BID_CAP: 'Limite de lance',
-    ABSOLUTE_OCPM: 'Otimização por mil impressões',
-    TARGET_COST: 'Custo alvo',
-    NONE: 'Sem estratégia definida',
-    RESERVED: 'Reservado',
-    REACH_AND_FREQUENCY: 'Alcance e frequência',
-    CLICKS: 'Cliques',
-    THRUPLAY: 'ThruPlay',
-    TWO_SECOND_CONTINUOUS_VIDEO_VIEWS: 'Visualizações contínuas',
-  }
-  if (labels[normalized]) return labels[normalized]
-  return normalized
-    .split('_')
-    .filter(Boolean)
-    .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
-    .join(' ')
-}
-
-type MetaAdsHeaderSignalKind = 'objective' | 'optimization_goal' | 'bid_strategy' | 'buying_type' | 'billing_event'
-
-function describeMetaAdsHeaderValue(kind: MetaAdsHeaderSignalKind, value?: unknown) {
-  const normalized = String(value || '').trim().toUpperCase()
-  const generic: Record<MetaAdsHeaderSignalKind, string> = {
-    objective: 'Define o resultado principal que a campanha busca entregar.',
-    optimization_goal: 'Define o tipo de resultado que o conjunto prioriza na entrega.',
-    bid_strategy: 'Define como a Meta distribui o orçamento durante os leilões.',
-    buying_type: 'Define como a entrega dos anúncios é comprada na Meta.',
-    billing_event: 'Define qual entrega a Meta usa para calcular a cobrança.',
-  }
-  const billingDescriptions: Record<string, string> = {
-    IMPRESSIONS: 'A cobrança acompanha o volume de impressões entregues.',
-    LINK_CLICKS: 'A cobrança acompanha cliques no link configurado.',
-    CLICKS: 'A cobrança acompanha cliques registrados no anúncio.',
-    CONVERSATIONS: 'A cobrança acompanha conversas iniciadas pelos anúncios.',
-    THRUPLAY: 'A cobrança acompanha visualizações de vídeo qualificadas como ThruPlay.',
-    TWO_SECOND_CONTINUOUS_VIDEO_VIEWS: 'A cobrança acompanha visualizações contínuas de vídeo por pelo menos dois segundos.',
-  }
-  if (kind === 'billing_event') return billingDescriptions[normalized] || generic.billing_event
-  const descriptions: Record<string, string> = {
-    LEAD_GENERATION: 'Prioriza pessoas com maior chance de enviar cadastro ou iniciar uma conversa qualificada.',
-    LEADS: 'Prioriza pessoas com maior chance de enviar cadastro ou iniciar uma conversa qualificada.',
-    OUTCOME_LEADS: 'Prioriza oportunidades de lead dentro da configuração atual da campanha.',
-    MESSAGES: 'Prioriza conversas iniciadas nos canais configurados para o anúncio.',
-    CONVERSATIONS: 'Prioriza conversas iniciadas nos canais configurados para o anúncio.',
-    ENGAGED_USERS: 'Prioriza pessoas com maior chance de interagir com o anúncio.',
-    TRAFFIC: 'Prioriza visitas ao destino configurado, como site, WhatsApp ou landing page.',
-    LINK_CLICKS: 'Prioriza pessoas com maior probabilidade de clicar no link.',
-    OUTBOUND_CLICKS: 'Prioriza cliques que levam a pessoa para fora da Meta.',
-    REACH: 'Busca alcançar o maior número possível de pessoas do público definido.',
-    IMPRESSIONS: 'Busca gerar o maior volume possível de exibições.',
-    POST_ENGAGEMENT: 'Prioriza curtidas, comentários, compartilhamentos e outras interações.',
-    SALES: 'Prioriza ações de valor, como compra, agendamento ou outra conversão configurada.',
-    CONVERSIONS: 'Prioriza ações de valor, como compra, agendamento ou outra conversão configurada.',
-    OFFSITE_CONVERSIONS: 'Prioriza ações de conversão registradas fora da Meta, como no site.',
-    LOWEST_COST_WITHOUT_CAP: 'A Meta busca o maior volume de resultados dentro do orçamento, sem limite máximo de lance definido.',
-    LOWEST_COST_WITH_BID_CAP: 'A Meta tenta manter o menor custo possível sem ultrapassar o limite de lance configurado.',
-    COST_CAP: 'A Meta tenta manter o custo médio próximo do valor definido.',
-    BID_CAP: 'A entrega respeita um limite máximo de lance em cada leilão.',
-    TARGET_COST: 'A Meta tenta manter o custo próximo de um alvo definido ao longo da entrega.',
-    ABSOLUTE_OCPM: 'Usa otimização por mil impressões quando a configuração exige entrega mais controlada.',
-    AUCTION: 'Os anúncios competem em leilão a cada oportunidade de entrega.',
-    BUYING_TYPE_AUCTION: 'Os anúncios competem em leilão a cada oportunidade de entrega.',
-    RESERVED: 'Entrega comprada antecipadamente com volume e preço mais previsíveis.',
-    REACH_AND_FREQUENCY: 'Entrega planejada para controlar alcance e frequência antes da veiculação.',
-  }
-  return descriptions[normalized] || generic[kind]
 }
 
 function MetaAdsHeaderTooltipDescription({
@@ -2285,254 +1994,15 @@ function resolveMetaAdsAdCreatives({
   return Array.from(byId.values())
 }
 
-type MetaAdsCreativeVariationGroup = {
-  label: string
-  values: MetaAdsCreativeVariationItem[]
-  kind?: 'text' | 'media'
-}
-
-type MetaAdsCreativeVariationItem = {
-  value: string
-  previewUrl?: string | null
-  aspectLabel?: string | null
-  mediaKind?: 'image' | 'video'
-}
-
-function asMetaAdsRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
-}
-
-function getMetaAdsObjectValue(source: unknown, path: string[]) {
-  let current = source
-  for (const key of path) {
-    const record = asMetaAdsRecord(current)
-    if (!record) return undefined
-    current = record[key]
-  }
-  return current
-}
-
-function extractMetaAdsCreativeValue(value: unknown) {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string' || typeof value === 'number') return String(value).trim()
-  const record = asMetaAdsRecord(value)
-  if (!record) return ''
-  const candidate =
-    record.text ||
-    record.body ||
-    record.title ||
-    record.name ||
-    record.description ||
-    record.type ||
-    record.call_to_action_type ||
-    record.website_url ||
-    record.url ||
-    record.link ||
-    record.hash ||
-    record.image_hash ||
-    record.video_id
-  return typeof candidate === 'string' || typeof candidate === 'number' ? String(candidate).trim() : ''
-}
-
-function collectMetaAdsCreativeValues(values: unknown[], formatter?: (value: string) => string) {
-  const seen = new Set<string>()
-  const collected: MetaAdsCreativeVariationItem[] = []
-  values.flatMap((value) => Array.isArray(value) ? value : [value]).forEach((value) => {
-    const extracted = extractMetaAdsCreativeValue(value)
-    if (!extracted) return
-    const formatted = formatter ? formatter(extracted) : extracted
-    const normalized = formatted.toLowerCase()
-    if (!formatted || seen.has(normalized)) return
-    seen.add(normalized)
-    collected.push({ value: formatted })
-  })
-  return collected
-}
-
-function formatMetaAdsCreativeActionLabel(value: string) {
-  return formatMetaAdsEnumLabel(value)
-}
-
-function extractMetaAdsCreativeMediaUrl(record: Record<string, unknown> | null) {
-  if (!record) return null
-  const candidate =
-    record.url ||
-    record.image_url ||
-    record.thumbnail_url ||
-    record.permalink_url ||
-    record.picture ||
-    record.source
-  return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null
-}
-
-function getMetaAdsMediaAspectLabel(value: unknown) {
-  const record = asMetaAdsRecord(value)
-  if (!record) return null
-  const width = Number(record.width || record.original_width)
-  const height = Number(record.height || record.original_height)
-  if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
-    const ratio = width / height
-    if (Math.abs(ratio - 1) < 0.08) return '1x1'
-    if (Math.abs(ratio - 0.75) < 0.08) return '3x4'
-    if (Math.abs(ratio - 4 / 3) < 0.08) return '4x3'
-    if (Math.abs(ratio - 2) < 0.12) return '2x1'
-    const gcd = (a: number, b: number): number => (b ? gcd(b, a % b) : a)
-    const divisor = gcd(Math.round(width), Math.round(height)) || 1
-    const simplifiedWidth = Math.round(width / divisor)
-    const simplifiedHeight = Math.round(height / divisor)
-    if (simplifiedWidth > 0 && simplifiedHeight > 0 && simplifiedWidth <= 9 && simplifiedHeight <= 9) return `${simplifiedWidth}x${simplifiedHeight}`
-  }
-  const aspect = String(record.aspect_ratio || record.aspect || record.crop || '').trim().toLowerCase()
-  if (aspect) {
-    if (aspect.includes('1:1') || aspect.includes('1x1') || aspect.includes('square')) return '1x1'
-    if (aspect.includes('3:4') || aspect.includes('3x4') || aspect.includes('vertical')) return '3x4'
-    if (aspect.includes('4:3') || aspect.includes('4x3')) return '4x3'
-    if (aspect.includes('2:1') || aspect.includes('2x1') || aspect.includes('wide')) return '2x1'
-  }
-  return null
-}
-
-function collectMetaAdsCreativeMediaValues(values: unknown[], fallbackPreview?: string | null) {
-  const seen = new Set<string>()
-  const collected: MetaAdsCreativeVariationItem[] = []
-  values.flatMap((value) => Array.isArray(value) ? value : [value]).forEach((value, index) => {
-    const extracted = extractMetaAdsCreativeValue(value)
-    if (!extracted) return
-    const normalized = extracted.toLowerCase()
-    if (seen.has(normalized)) return
-    seen.add(normalized)
-    const record = asMetaAdsRecord(value)
-    const previewUrl = extractMetaAdsCreativeMediaUrl(record) || (index === 0 ? fallbackPreview || null : null)
-    collected.push({
-      value: extracted,
-      previewUrl,
-      aspectLabel: getMetaAdsMediaAspectLabel(value),
-      mediaKind: record?.video_id || record?.source ? 'video' : 'image',
-    })
-  })
-  return collected
-}
-
-function buildMetaAdsCreativeVariationGroups(raw?: MetaAdCreativeRef, fallbackPreview?: string | null): MetaAdsCreativeVariationGroup[] {
-  if (!raw) return []
-  const assetFeed = asMetaAdsRecord(raw.asset_feed_spec)
-  const objectStory = asMetaAdsRecord(raw.object_story_spec)
-  const objectLinkData = getMetaAdsObjectValue(objectStory, ['link_data'])
-  const objectVideoData = getMetaAdsObjectValue(objectStory, ['video_data'])
-  const objectPhotoData = getMetaAdsObjectValue(objectStory, ['photo_data'])
-  const objectCallToAction = getMetaAdsObjectValue(objectStory, ['link_data', 'call_to_action']) || getMetaAdsObjectValue(objectStory, ['video_data', 'call_to_action'])
-  const objectCallToActionValue = getMetaAdsObjectValue(objectCallToAction, ['value'])
-
-  const groups: MetaAdsCreativeVariationGroup[] = [
-    {
-      label: 'Textos',
-      values: collectMetaAdsCreativeValues([
-        raw.body,
-        assetFeed?.bodies,
-        getMetaAdsObjectValue(objectLinkData, ['message']),
-        getMetaAdsObjectValue(objectVideoData, ['message']),
-        getMetaAdsObjectValue(objectPhotoData, ['caption']),
-      ]),
-    },
-    {
-      label: 'Títulos',
-      values: collectMetaAdsCreativeValues([
-        raw.title,
-        assetFeed?.titles,
-        getMetaAdsObjectValue(objectLinkData, ['name']),
-        getMetaAdsObjectValue(objectVideoData, ['title']),
-      ]),
-    },
-    {
-      label: 'Descrições',
-      values: collectMetaAdsCreativeValues([
-        assetFeed?.descriptions,
-        getMetaAdsObjectValue(objectLinkData, ['description']),
-      ]),
-    },
-    {
-      label: 'CTAs',
-      values: collectMetaAdsCreativeValues([
-        raw.call_to_action_type,
-        assetFeed?.call_to_action_types,
-        getMetaAdsObjectValue(objectCallToAction, ['type']),
-      ], formatMetaAdsCreativeActionLabel),
-    },
-    {
-      label: 'URLs',
-      values: collectMetaAdsCreativeValues([
-        raw.object_url,
-        assetFeed?.link_urls,
-        getMetaAdsObjectValue(objectLinkData, ['link']),
-        getMetaAdsObjectValue(objectCallToActionValue, ['link']),
-      ]),
-    },
-    {
-      label: 'Mídias',
-      kind: 'media',
-      values: collectMetaAdsCreativeMediaValues([
-        raw.image_hash,
-        raw.video_id,
-        assetFeed?.images,
-        assetFeed?.videos,
-      ], fallbackPreview),
-    },
-  ]
-
-  return groups.filter((group) => group.values.length > 0)
-}
-
-function MetaAdsCreativeVariationPanel({
-  group,
-  onPreview,
-}: {
-  group: MetaAdsCreativeVariationGroup
-  onPreview?: (item: MetaAdsCreativeVariationItem, index: number) => void
-}) {
+function MetaAdsCreativeVariationPanel({ group }: { group: MetaAdsCreativeVariationGroup }) {
   return (
     <div className="min-w-0 rounded-xl border border-slate-800/85 bg-slate-950/40 p-3">
       <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-slate-500">{group.label}</div>
-      <div className={group.kind === 'media' ? 'mt-2 grid gap-2 sm:grid-cols-2' : 'mt-2 space-y-2'}>
+      <div className="mt-2 space-y-2">
         {group.values.map((item, index) => (
           <div key={`${group.label}-${index}-${item.value}`} className="rounded-lg border border-slate-800/70 bg-slate-950/55 px-3 py-2 text-xs leading-5 text-slate-200">
-            {group.kind === 'media' ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-sky-300/80">
-                    Variação {index + 1}{item.aspectLabel ? ` · ${item.aspectLabel}` : ''}
-                  </span>
-                  {item.previewUrl ? (
-                    <button
-                      type="button"
-                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-sky-400/25 bg-sky-400/10 text-sky-100 transition hover:border-sky-300/50 hover:bg-sky-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
-                      aria-label={`Expandir mídia da variação ${index + 1}`}
-                      onClick={() => onPreview?.(item, index)}
-                    >
-                      <MagnifyingGlassPlus className="h-3.5 w-3.5" />
-                    </button>
-                  ) : null}
-                </div>
-                {item.previewUrl ? (
-                  <button
-                    type="button"
-                    className="group/media block w-full overflow-hidden rounded-lg border border-slate-700/70 bg-slate-950/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/45"
-                    onClick={() => onPreview?.(item, index)}
-                  >
-                    <img src={item.previewUrl} alt={`Mídia da variação ${index + 1}`} className="h-28 w-full object-cover transition group-hover/media:scale-[1.02]" loading="lazy" referrerPolicy="no-referrer" />
-                  </button>
-                ) : (
-                  <div className="flex h-20 items-center justify-center rounded-lg border border-dashed border-slate-700/70 bg-slate-950/60 text-[11px] text-slate-500">
-                    Miniatura indisponível
-                  </div>
-                )}
-                <span className="block break-all font-mono text-[11px] text-blue-100/70">{item.value}</span>
-              </div>
-            ) : (
-              <>
-                {group.values.length > 1 ? <span className="mb-1 block text-[10px] font-medium uppercase tracking-[0.14em] text-sky-300/80">Variação {index + 1}</span> : null}
-                <span className="whitespace-pre-wrap break-words">{item.value}</span>
-              </>
-            )}
+            {group.values.length > 1 ? <span className="mb-1 block text-[10px] font-medium uppercase tracking-[0.14em] text-sky-300/80">Variação {index + 1}</span> : null}
+            <span className="whitespace-pre-wrap break-words">{item.value}</span>
           </div>
         ))}
       </div>
@@ -2651,7 +2121,7 @@ function MetaAdsAdCreativeDetails({ creative }: { creative: MetaAdsResolvedAdCre
           <div className="mb-3 text-sm font-medium text-slate-100">Variações do criativo</div>
           <div className="grid gap-3 lg:grid-cols-2">
             {contentVariationGroups.map((group) => (
-              <MetaAdsCreativeVariationPanel key={group.label} group={group} onPreview={(item, index) => setExpandedMedia({ item, index })} />
+              <MetaAdsCreativeVariationPanel key={group.label} group={group} />
             ))}
           </div>
         </div>

--- a/frontend/metaAdsPresentation.ts
+++ b/frontend/metaAdsPresentation.ts
@@ -1,0 +1,506 @@
+import type { MetaAdCreativeRef } from '@/metaAdsTypes'
+
+export type MetaAdsOverviewMetricKey =
+  | 'spend'
+  | 'conversations'
+  | 'cpcv'
+  | 'clicks'
+  | 'reach'
+  | 'impressions'
+  | 'engagement'
+  | 'redirect'
+  | 'ctr'
+  | 'cpc'
+  | 'cpm'
+  | 'cpp'
+  | 'frequency'
+  | 'trend'
+
+export type MetaAdsOverviewMetricSize = 'compact' | 'wide'
+export type MetaAdsOverviewMetricAspect = '1:1' | '4:3' | '2:1'
+export type MetaAdsOverviewMetricLayout = {
+  key: MetaAdsOverviewMetricKey
+  visible: boolean
+  width: number
+  height: number
+  aspect: MetaAdsOverviewMetricAspect
+}
+
+export type MetaAdsHeaderSignalKind = 'objective' | 'optimization_goal' | 'bid_strategy' | 'buying_type' | 'billing_event'
+
+export type MetaAdsCreativeVariationItem = {
+  value: string
+  previewUrl?: string | null
+  aspectLabel?: string | null
+  mediaKind?: 'image' | 'video'
+}
+
+export type MetaAdsCreativeVariationGroup = {
+  label: string
+  values: MetaAdsCreativeVariationItem[]
+  kind?: 'text' | 'media'
+}
+
+export const META_ADS_OVERVIEW_METRIC_LAYOUT_KEY = 'skincos.metaAds.layout.overviewMetrics.v5'
+export const META_ADS_METRIC_TILE_DIMENSIONS = {
+  minWidth: 140,
+  maxWidth: 680,
+  minHeight: 96,
+  maxHeight: 520,
+  defaultWidth: 224,
+  defaultHeight: 168,
+  trendWidth: 520,
+  trendHeight: 260,
+} as const
+export const META_ADS_METRIC_ASPECT_RATIOS: Record<MetaAdsOverviewMetricAspect, number> = {
+  '1:1': 1,
+  '4:3': 4 / 3,
+  '2:1': 2,
+}
+export const META_ADS_METRIC_ASPECT_ORDER: MetaAdsOverviewMetricAspect[] = ['1:1', '4:3', '2:1']
+export const DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT: MetaAdsOverviewMetricLayout[] = [
+  { key: 'spend', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'conversations', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'cpcv', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'clicks', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'reach', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'impressions', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'engagement', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'redirect', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'ctr', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'cpc', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'cpm', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'cpp', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'frequency', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'trend', visible: true, width: META_ADS_METRIC_TILE_DIMENSIONS.trendWidth, height: META_ADS_METRIC_TILE_DIMENSIONS.trendHeight, aspect: '2:1' },
+]
+
+export function clampMetaAdsMetricDimension(value: unknown, min: number, max: number, fallback: number) {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return fallback
+  return Math.min(max, Math.max(min, Math.round(numberValue)))
+}
+
+export function getMetaAdsMetricAspect(value: unknown, width?: unknown, height?: unknown): MetaAdsOverviewMetricAspect {
+  if (value === '1:1' || value === '4:3' || value === '2:1') return value
+  if (value === '3:4') return '4:3'
+  const ratio = Number(width) > 0 && Number(height) > 0 ? Number(width) / Number(height) : META_ADS_METRIC_ASPECT_RATIOS['4:3']
+  return META_ADS_METRIC_ASPECT_ORDER.reduce((closest, option) => {
+    const closestDelta = Math.abs(META_ADS_METRIC_ASPECT_RATIOS[closest] - ratio)
+    const optionDelta = Math.abs(META_ADS_METRIC_ASPECT_RATIOS[option] - ratio)
+    return optionDelta < closestDelta ? option : closest
+  }, '4:3' as MetaAdsOverviewMetricAspect)
+}
+
+export function fitMetaAdsMetricDimensionsToAspect(width: unknown, aspect: MetaAdsOverviewMetricAspect, fallbackHeight: number) {
+  const ratio = META_ADS_METRIC_ASPECT_RATIOS[aspect]
+  const nextWidth = clampMetaAdsMetricDimension(
+    width,
+    META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
+    META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
+    META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth,
+  )
+  const nextHeight = clampMetaAdsMetricDimension(
+    Math.round(nextWidth / ratio),
+    META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
+    META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
+    fallbackHeight,
+  )
+  return { width: Math.round(nextHeight * ratio), height: nextHeight }
+}
+
+export function fitMetaAdsMetricBoxToAspect(width: number, height: number, aspect: MetaAdsOverviewMetricAspect) {
+  const ratio = META_ADS_METRIC_ASPECT_RATIOS[aspect]
+  const byWidthHeight = clampMetaAdsMetricDimension(
+    Math.round(width / ratio),
+    META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
+    META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
+    height,
+  )
+  const byWidth = {
+    width: clampMetaAdsMetricDimension(
+      Math.round(byWidthHeight * ratio),
+      META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
+      META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
+      width,
+    ),
+    height: byWidthHeight,
+  }
+  const byHeightWidth = clampMetaAdsMetricDimension(
+    Math.round(height * ratio),
+    META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
+    META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
+    width,
+  )
+  const byHeight = {
+    width: byHeightWidth,
+    height: clampMetaAdsMetricDimension(
+      Math.round(byHeightWidth / ratio),
+      META_ADS_METRIC_TILE_DIMENSIONS.minHeight,
+      META_ADS_METRIC_TILE_DIMENSIONS.maxHeight,
+      height,
+    ),
+  }
+  const widthDelta = Math.abs(byWidth.width - width) + Math.abs(byWidth.height - height)
+  const heightDelta = Math.abs(byHeight.width - width) + Math.abs(byHeight.height - height)
+  return widthDelta <= heightDelta ? byWidth : byHeight
+}
+
+export function cycleMetaAdsMetricDimensions(
+  width: number,
+  height: number,
+  currentAspect: MetaAdsOverviewMetricAspect,
+) {
+  const currentIndex = META_ADS_METRIC_ASPECT_ORDER.indexOf(currentAspect)
+  const aspect = META_ADS_METRIC_ASPECT_ORDER[(currentIndex + 1) % META_ADS_METRIC_ASPECT_ORDER.length]
+  return { ...fitMetaAdsMetricBoxToAspect(width, height, aspect), aspect }
+}
+
+export function getDefaultMetaAdsMetricDimensions(key: MetaAdsOverviewMetricKey, legacySize?: MetaAdsOverviewMetricSize) {
+  if (key === 'trend') {
+    return {
+      width: legacySize === 'compact' ? 320 : META_ADS_METRIC_TILE_DIMENSIONS.trendWidth,
+      height: legacySize === 'compact' ? 160 : META_ADS_METRIC_TILE_DIMENSIONS.trendHeight,
+    }
+  }
+  return {
+    width: legacySize === 'wide' ? 340 : META_ADS_METRIC_TILE_DIMENSIONS.defaultWidth,
+    height: legacySize === 'wide' ? 255 : META_ADS_METRIC_TILE_DIMENSIONS.defaultHeight,
+  }
+}
+
+export function parseMetaAdsOverviewMetricLayout(raw: string | null | undefined): MetaAdsOverviewMetricLayout[] {
+  try {
+    const parsed = raw ? JSON.parse(raw) : null
+    const items = Array.isArray(parsed) ? parsed : []
+    const seen = new Set<MetaAdsOverviewMetricKey>()
+    const normalized = items
+      .map((item) => {
+        const key = String(item?.key || '').trim() as MetaAdsOverviewMetricKey
+        if (!DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT.some((entry) => entry.key === key)) return null
+        if (seen.has(key)) return null
+        seen.add(key)
+        const fallback = getDefaultMetaAdsMetricDimensions(key, item?.size === 'wide' ? 'wide' : 'compact')
+        const aspect = getMetaAdsMetricAspect(item?.aspect, item?.width, item?.height)
+        const dimensions = fitMetaAdsMetricDimensionsToAspect(
+          clampMetaAdsMetricDimension(
+            item?.width,
+            META_ADS_METRIC_TILE_DIMENSIONS.minWidth,
+            META_ADS_METRIC_TILE_DIMENSIONS.maxWidth,
+            fallback.width,
+          ),
+          aspect,
+          fallback.height,
+        )
+        return {
+          key,
+          visible: item?.visible !== false,
+          width: dimensions.width,
+          height: dimensions.height,
+          aspect,
+        } satisfies MetaAdsOverviewMetricLayout
+      })
+      .filter(Boolean) as MetaAdsOverviewMetricLayout[]
+
+    for (const fallback of DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT) {
+      if (!seen.has(fallback.key)) normalized.push(fallback)
+    }
+    return normalized.length ? normalized : DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
+  } catch {
+    return DEFAULT_META_ADS_OVERVIEW_METRIC_LAYOUT
+  }
+}
+
+export function formatMetaAdsEnumLabel(value?: unknown) {
+  const normalized = String(value || '').trim().toUpperCase()
+  if (!normalized) return 'Não informado'
+  const labels: Record<string, string> = {
+    LEADS: 'Geração de Lead',
+    LEAD_GENERATION: 'Geração de Lead',
+    OUTCOME_LEADS: 'Geração de Leads',
+    AUCTION: 'Leilão',
+    BUYING_TYPE_AUCTION: 'Leilão',
+    MESSAGES: 'Mensagens',
+    CONVERSATIONS: 'Conversas',
+    ENGAGED_USERS: 'Engajamento',
+    LINK_CLICKS: 'Cliques no link',
+    OUTBOUND_CLICKS: 'Cliques externos',
+    TRAFFIC: 'Tráfego',
+    REACH: 'Alcance',
+    IMPRESSIONS: 'Impressões',
+    POST_ENGAGEMENT: 'Engajamento',
+    PAGE_LIKES: 'Curtidas na página',
+    EVENT_RESPONSES: 'Respostas ao evento',
+    VIDEO_VIEWS: 'Visualizações de vídeo',
+    APP_INSTALLS: 'Instalações do app',
+    BRAND_AWARENESS: 'Reconhecimento da marca',
+    LOCAL_AWARENESS: 'Reconhecimento local',
+    STORE_VISITS: 'Visitas à loja',
+    VALUE: 'Valor',
+    LANDING_PAGE_VIEWS: 'Visualizações da página',
+    QUALITY_CALL: 'Ligação qualificada',
+    SALES: 'Vendas',
+    CONVERSIONS: 'Conversões',
+    OFFSITE_CONVERSIONS: 'Conversões no site',
+    LEARN_MORE: 'Saiba mais',
+    SIGN_UP: 'Cadastre-se',
+    CONTACT_US: 'Fale conosco',
+    WHATSAPP_MESSAGE: 'Enviar mensagem',
+    MESSAGE_PAGE: 'Enviar mensagem',
+    BOOK_NOW: 'Agendar agora',
+    APPLY_NOW: 'Inscrever-se',
+    DOWNLOAD: 'Baixar',
+    SHOP_NOW: 'Comprar agora',
+    GET_QUOTE: 'Solicitar orçamento',
+    LOWEST_COST_WITHOUT_CAP: 'Menor custo sem limite',
+    LOWEST_COST_WITH_BID_CAP: 'Menor custo com limite de lance',
+    COST_CAP: 'Controle de custo',
+    BID_CAP: 'Limite de lance',
+    ABSOLUTE_OCPM: 'Otimização por mil impressões',
+    TARGET_COST: 'Custo alvo',
+    NONE: 'Sem estratégia definida',
+    RESERVED: 'Reservado',
+    REACH_AND_FREQUENCY: 'Alcance e frequência',
+    CLICKS: 'Cliques',
+    THRUPLAY: 'ThruPlay',
+    TWO_SECOND_CONTINUOUS_VIDEO_VIEWS: 'Visualizações contínuas',
+  }
+  if (labels[normalized]) return labels[normalized]
+  return normalized
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+    .join(' ')
+}
+
+export function describeMetaAdsHeaderValue(kind: MetaAdsHeaderSignalKind, value?: unknown) {
+  const normalized = String(value || '').trim().toUpperCase()
+  const generic: Record<MetaAdsHeaderSignalKind, string> = {
+    objective: 'Define o resultado principal que a campanha busca entregar.',
+    optimization_goal: 'Define o tipo de resultado que o conjunto prioriza na entrega.',
+    bid_strategy: 'Define como a Meta distribui o orçamento durante os leilões.',
+    buying_type: 'Define como a entrega dos anúncios é comprada na Meta.',
+    billing_event: 'Define qual entrega a Meta usa para calcular a cobrança.',
+  }
+  const billingDescriptions: Record<string, string> = {
+    IMPRESSIONS: 'A cobrança acompanha o volume de impressões entregues.',
+    LINK_CLICKS: 'A cobrança acompanha cliques no link configurado.',
+    CLICKS: 'A cobrança acompanha cliques registrados no anúncio.',
+    CONVERSATIONS: 'A cobrança acompanha conversas iniciadas pelos anúncios.',
+    THRUPLAY: 'A cobrança acompanha visualizações de vídeo qualificadas como ThruPlay.',
+    TWO_SECOND_CONTINUOUS_VIDEO_VIEWS: 'A cobrança acompanha visualizações contínuas de vídeo por pelo menos dois segundos.',
+  }
+  if (kind === 'billing_event') return billingDescriptions[normalized] || generic.billing_event
+  const descriptions: Record<string, string> = {
+    LEAD_GENERATION: 'Prioriza pessoas com maior chance de enviar cadastro ou iniciar uma conversa qualificada.',
+    LEADS: 'Prioriza pessoas com maior chance de enviar cadastro ou iniciar uma conversa qualificada.',
+    OUTCOME_LEADS: 'Prioriza oportunidades de lead dentro da configuração atual da campanha.',
+    MESSAGES: 'Prioriza conversas iniciadas nos canais configurados para o anúncio.',
+    CONVERSATIONS: 'Prioriza conversas iniciadas nos canais configurados para o anúncio.',
+    ENGAGED_USERS: 'Prioriza pessoas com maior chance de interagir com o anúncio.',
+    TRAFFIC: 'Prioriza visitas ao destino configurado, como site, WhatsApp ou landing page.',
+    LINK_CLICKS: 'Prioriza pessoas com maior probabilidade de clicar no link.',
+    OUTBOUND_CLICKS: 'Prioriza cliques que levam a pessoa para fora da Meta.',
+    REACH: 'Busca alcançar o maior número possível de pessoas do público definido.',
+    IMPRESSIONS: 'Busca gerar o maior volume possível de exibições.',
+    POST_ENGAGEMENT: 'Prioriza curtidas, comentários, compartilhamentos e outras interações.',
+    SALES: 'Prioriza ações de valor, como compra, agendamento ou outra conversão configurada.',
+    CONVERSIONS: 'Prioriza ações de valor, como compra, agendamento ou outra conversão configurada.',
+    OFFSITE_CONVERSIONS: 'Prioriza ações de conversão registradas fora da Meta, como no site.',
+    LOWEST_COST_WITHOUT_CAP: 'A Meta busca o maior volume de resultados dentro do orçamento, sem limite máximo de lance definido.',
+    LOWEST_COST_WITH_BID_CAP: 'A Meta tenta manter o menor custo possível sem ultrapassar o limite de lance configurado.',
+    COST_CAP: 'A Meta tenta manter o custo médio próximo do valor definido.',
+    BID_CAP: 'A entrega respeita um limite máximo de lance em cada leilão.',
+    TARGET_COST: 'A Meta tenta manter o custo próximo de um alvo definido ao longo da entrega.',
+    ABSOLUTE_OCPM: 'Usa otimização por mil impressões quando a configuração exige entrega mais controlada.',
+    AUCTION: 'Os anúncios competem em leilão a cada oportunidade de entrega.',
+    BUYING_TYPE_AUCTION: 'Os anúncios competem em leilão a cada oportunidade de entrega.',
+    RESERVED: 'Entrega comprada antecipadamente com volume e preço mais previsíveis.',
+    REACH_AND_FREQUENCY: 'Entrega planejada para controlar alcance e frequência antes da veiculação.',
+  }
+  return descriptions[normalized] || generic[kind]
+}
+
+function asMetaAdsRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function getMetaAdsObjectValue(source: unknown, path: string[]) {
+  let current = source
+  for (const key of path) {
+    const record = asMetaAdsRecord(current)
+    if (!record) return undefined
+    current = record[key]
+  }
+  return current
+}
+
+function extractMetaAdsCreativeValue(value: unknown) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string' || typeof value === 'number') return String(value).trim()
+  const record = asMetaAdsRecord(value)
+  if (!record) return ''
+  const candidate =
+    record.text ||
+    record.body ||
+    record.title ||
+    record.name ||
+    record.description ||
+    record.type ||
+    record.call_to_action_type ||
+    record.website_url ||
+    record.url ||
+    record.link ||
+    record.hash ||
+    record.image_hash ||
+    record.video_id
+  return typeof candidate === 'string' || typeof candidate === 'number' ? String(candidate).trim() : ''
+}
+
+export function collectMetaAdsCreativeValues(values: unknown[], formatter?: (value: string) => string) {
+  const seen = new Set<string>()
+  const collected: MetaAdsCreativeVariationItem[] = []
+  values.flatMap((value) => Array.isArray(value) ? value : [value]).forEach((value) => {
+    const extracted = extractMetaAdsCreativeValue(value)
+    if (!extracted) return
+    const formatted = formatter ? formatter(extracted) : extracted
+    const normalized = formatted.toLowerCase()
+    if (!formatted || seen.has(normalized)) return
+    seen.add(normalized)
+    collected.push({ value: formatted })
+  })
+  return collected
+}
+
+export function formatMetaAdsCreativeActionLabel(value: string) {
+  return formatMetaAdsEnumLabel(value)
+}
+
+function extractMetaAdsCreativeMediaUrl(record: Record<string, unknown> | null) {
+  if (!record) return null
+  const candidate =
+    record.url ||
+    record.image_url ||
+    record.thumbnail_url ||
+    record.permalink_url ||
+    record.picture ||
+    record.source
+  return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null
+}
+
+function getMetaAdsMediaAspectLabel(value: unknown) {
+  const record = asMetaAdsRecord(value)
+  if (!record) return null
+  const width = Number(record.width || record.original_width)
+  const height = Number(record.height || record.original_height)
+  if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+    const ratio = width / height
+    if (Math.abs(ratio - 1) < 0.08) return '1x1'
+    if (Math.abs(ratio - 0.75) < 0.08) return '3x4'
+    if (Math.abs(ratio - 4 / 3) < 0.08) return '4x3'
+    if (Math.abs(ratio - 2) < 0.12) return '2x1'
+    const gcd = (a: number, b: number): number => (b ? gcd(b, a % b) : a)
+    const divisor = gcd(Math.round(width), Math.round(height)) || 1
+    const simplifiedWidth = Math.round(width / divisor)
+    const simplifiedHeight = Math.round(height / divisor)
+    if (simplifiedWidth > 0 && simplifiedHeight > 0 && simplifiedWidth <= 9 && simplifiedHeight <= 9) return `${simplifiedWidth}x${simplifiedHeight}`
+  }
+  const aspect = String(record.aspect_ratio || record.aspect || record.crop || '').trim().toLowerCase()
+  if (aspect) {
+    if (aspect.includes('1:1') || aspect.includes('1x1') || aspect.includes('square')) return '1x1'
+    if (aspect.includes('3:4') || aspect.includes('3x4') || aspect.includes('vertical')) return '3x4'
+    if (aspect.includes('4:3') || aspect.includes('4x3')) return '4x3'
+    if (aspect.includes('2:1') || aspect.includes('2x1') || aspect.includes('wide')) return '2x1'
+  }
+  return null
+}
+
+export function collectMetaAdsCreativeMediaValues(values: unknown[], fallbackPreview?: string | null) {
+  const seen = new Set<string>()
+  const collected: MetaAdsCreativeVariationItem[] = []
+  values.flatMap((value) => Array.isArray(value) ? value : [value]).forEach((value, index) => {
+    const extracted = extractMetaAdsCreativeValue(value)
+    if (!extracted) return
+    const normalized = extracted.toLowerCase()
+    if (seen.has(normalized)) return
+    seen.add(normalized)
+    const record = asMetaAdsRecord(value)
+    const previewUrl = extractMetaAdsCreativeMediaUrl(record) || (index === 0 ? fallbackPreview || null : null)
+    collected.push({
+      value: extracted,
+      previewUrl,
+      aspectLabel: getMetaAdsMediaAspectLabel(value),
+      mediaKind: record?.video_id || record?.source ? 'video' : 'image',
+    })
+  })
+  return collected
+}
+
+export function buildMetaAdsCreativeVariationGroups(raw?: MetaAdCreativeRef, fallbackPreview?: string | null): MetaAdsCreativeVariationGroup[] {
+  if (!raw) return []
+  const assetFeed = asMetaAdsRecord(raw.asset_feed_spec)
+  const objectStory = asMetaAdsRecord(raw.object_story_spec)
+  const objectLinkData = getMetaAdsObjectValue(objectStory, ['link_data'])
+  const objectVideoData = getMetaAdsObjectValue(objectStory, ['video_data'])
+  const objectPhotoData = getMetaAdsObjectValue(objectStory, ['photo_data'])
+  const objectCallToAction = getMetaAdsObjectValue(objectStory, ['link_data', 'call_to_action']) || getMetaAdsObjectValue(objectStory, ['video_data', 'call_to_action'])
+  const objectCallToActionValue = getMetaAdsObjectValue(objectCallToAction, ['value'])
+
+  const groups: MetaAdsCreativeVariationGroup[] = [
+    {
+      label: 'Textos',
+      values: collectMetaAdsCreativeValues([
+        raw.body,
+        assetFeed?.bodies,
+        getMetaAdsObjectValue(objectLinkData, ['message']),
+        getMetaAdsObjectValue(objectVideoData, ['message']),
+        getMetaAdsObjectValue(objectPhotoData, ['caption']),
+      ]),
+    },
+    {
+      label: 'Títulos',
+      values: collectMetaAdsCreativeValues([
+        raw.title,
+        assetFeed?.titles,
+        getMetaAdsObjectValue(objectLinkData, ['name']),
+        getMetaAdsObjectValue(objectVideoData, ['title']),
+      ]),
+    },
+    {
+      label: 'Descrições',
+      values: collectMetaAdsCreativeValues([
+        assetFeed?.descriptions,
+        getMetaAdsObjectValue(objectLinkData, ['description']),
+      ]),
+    },
+    {
+      label: 'CTAs',
+      values: collectMetaAdsCreativeValues([
+        raw.call_to_action_type,
+        assetFeed?.call_to_action_types,
+        getMetaAdsObjectValue(objectCallToAction, ['type']),
+      ], formatMetaAdsCreativeActionLabel),
+    },
+    {
+      label: 'URLs',
+      values: collectMetaAdsCreativeValues([
+        raw.object_url,
+        assetFeed?.link_urls,
+        getMetaAdsObjectValue(objectLinkData, ['link']),
+        getMetaAdsObjectValue(objectCallToActionValue, ['link']),
+      ]),
+    },
+    {
+      label: 'Mídias',
+      kind: 'media',
+      values: collectMetaAdsCreativeMediaValues([
+        raw.image_hash,
+        raw.video_id,
+        assetFeed?.images,
+        assetFeed?.videos,
+      ], fallbackPreview),
+    },
+  ]
+
+  return groups.filter((group) => group.values.length > 0)
+}

--- a/frontend/tests/metaAdsPresentation.test.ts
+++ b/frontend/tests/metaAdsPresentation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildMetaAdsCreativeVariationGroups,
+  cycleMetaAdsMetricDimensions,
+  formatMetaAdsEnumLabel,
+  parseMetaAdsOverviewMetricLayout,
+} from '../metaAdsPresentation'
+import type { MetaAdCreativeRef } from '../metaAdsTypes'
+
+describe('Meta Ads presentation helpers', () => {
+  it('normalizes legacy overview metric layouts without losing defaults', () => {
+    const layout = parseMetaAdsOverviewMetricLayout(JSON.stringify([
+      { key: 'spend', visible: true, width: 300, height: 400, aspect: '3:4' },
+      { key: 'spend', visible: false, width: 200, height: 200, aspect: '1:1' },
+      { key: 'unknown', visible: true, width: 200, height: 200 },
+      { key: 'trend', visible: false, size: 'compact', width: 320, aspect: '2:1' },
+    ]))
+
+    const spend = layout.find((item) => item.key === 'spend')
+    const trend = layout.find((item) => item.key === 'trend')
+
+    expect(layout.filter((item) => item.key === 'spend')).toHaveLength(1)
+    expect(layout).toHaveLength(14)
+    expect(spend).toMatchObject({ key: 'spend', visible: true, aspect: '4:3' })
+    expect(trend).toMatchObject({ key: 'trend', visible: false, aspect: '2:1' })
+  })
+
+  it('cycles metric badges through the supported formats', () => {
+    const wide = cycleMetaAdsMetricDimensions(224, 168, '4:3')
+    const square = cycleMetaAdsMetricDimensions(wide.width, wide.height, wide.aspect)
+    const landscape = cycleMetaAdsMetricDimensions(square.width, square.height, square.aspect)
+
+    expect(wide.aspect).toBe('2:1')
+    expect(square.aspect).toBe('1:1')
+    expect(landscape.aspect).toBe('4:3')
+    expect(wide.width / wide.height).toBeCloseTo(2, 0)
+    expect(square.width / square.height).toBeCloseTo(1, 0)
+    expect(landscape.width / landscape.height).toBeCloseTo(4 / 3, 0)
+  })
+
+  it('separates creative text, CTA, URL and media variations for the ad modal', () => {
+    const creative: MetaAdCreativeRef = {
+      id: 'cr_1',
+      body: 'Texto principal',
+      call_to_action_type: 'MESSAGE_PAGE',
+      object_url: 'https://example.com',
+      asset_feed_spec: {
+        bodies: [{ text: 'Texto principal' }, { text: 'Texto alternativo' }],
+        titles: [{ text: 'Titulo A' }, { text: 'Titulo B' }],
+        descriptions: [{ text: 'Descricao A' }],
+        call_to_action_types: ['MESSAGE_PAGE'],
+        link_urls: [{ website_url: 'https://example.com' }],
+        images: [
+          { hash: 'hash_3x4', url: '/media/vertical.jpg', width: 900, height: 1200 },
+          { hash: 'hash_2x1', url: '/media/wide.jpg', width: 1200, height: 600 },
+        ],
+      },
+    }
+
+    const groups = buildMetaAdsCreativeVariationGroups(creative, '/fallback.jpg')
+    const media = groups.find((group) => group.kind === 'media')
+    const texts = groups.find((group) => group.label === 'Textos')
+    const ctas = groups.find((group) => group.label === 'CTAs')
+
+    expect(formatMetaAdsEnumLabel('LEAD_GENERATION')).toBe('Geração de Lead')
+    expect(texts?.values.map((item) => item.value)).toEqual(['Texto principal', 'Texto alternativo'])
+    expect(ctas?.values).toEqual([{ value: 'Enviar mensagem' }])
+    expect(media?.values).toEqual([
+      expect.objectContaining({ value: '/media/vertical.jpg', previewUrl: '/media/vertical.jpg', aspectLabel: '3x4', mediaKind: 'image' }),
+      expect.objectContaining({ value: '/media/wide.jpg', previewUrl: '/media/wide.jpg', aspectLabel: '2x1', mediaKind: 'image' }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Extract Meta Ads presentation helpers for enum labels, tooltip descriptions, metric badge layout cycling, and creative variation/media normalization.
- Simplify the ad modal so creative media is rendered once as the top creative block and text/title/description/CTA/URL variations are separated below.
- Add unit and E2E coverage for legacy metric layouts, badge format cycling, and creative media ordering.

## Validation
- npm --prefix frontend run typecheck
- npm --prefix frontend test -- metaAdsPresentation.test.ts metaAdsEntitiesApi.test.ts metaAdsModule.test.ts
- npm --prefix frontend run test:e2e -- meta-ads-module.spec.ts
- npm --prefix frontend run build
- npm --prefix frontend run lint
- git diff --check

## Notes
- Public API contracts and editable field allowlists were left unchanged.
- Existing unrelated working-tree changes were not staged.