### PR TITLE
Add Site EF tracking URL management

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Plataforma interna (local) para automações e operações da clínica.
 ### Testar CRM local
 - Launcher recomendado: `npm run crm:local`
 - Atalho direto para o módulo Meta Ads: `npm run crm:local:meta-ads`
+- Atalho direto para o módulo Site EF: `npm run crm:local:site-tracking`
 - Atalho macOS: `./start-crm-local.command`
+- Atalho macOS para Site EF: `./start-crm-site-tracking-local.command`
 - Perfil default: `realistic`
   - sobe o CRM via `Pages Functions` local (`frontend/scripts/dev_pages.sh`)
   - ativa bypass local de auth apenas em `localhost`
@@ -93,6 +95,12 @@ Plataforma interna (local) para automações e operações da clínica.
   - para pular o build prévio quando você só quiser iterar rápido em UI local: `npm run crm:local:meta-ads -- --skip-build`
   - para rodar uma smoke automatizada do módulo após subir o CRM:
     - `npm run crm:local:meta-ads -- --smoke`
+- Para testar `Site EF` / tracking do site antes de publicar:
+  - fluxo local simplificado: `npm run crm:local:site-tracking`
+    - abre o CRM já no módulo `Site EF`
+    - usa o cenário local `connected-ready`, que também habilita o mock local de tracking agregado em `localhost`
+    - para pular o build prévio quando você só quiser iterar rápido em UI local: `npm run crm:local:site-tracking -- --skip-build`
+  - no macOS, também é possível abrir por duplo clique em `start-crm-site-tracking-local.command`
 
 ## Docs
 - Mapa do backend: `backend/docs/INDEX.md`

--- a/backend/apps/crm-api/server/trackingDashboardRoutes.js
+++ b/backend/apps/crm-api/server/trackingDashboardRoutes.js
@@ -1,5 +1,10 @@
 import { Router } from 'express'
-import { getTrackingDashboardOverview } from '../services/trackingDashboardService.js'
+import {
+    createTrackingCustomUrl,
+    getTrackingCustomUrls,
+    getTrackingDashboardOverview,
+    updateTrackingCustomUrl,
+} from '../services/trackingDashboardService.js'
 
 function parsePositiveInt(value, fallback) {
     const parsed = Number.parseInt(String(value ?? ''), 10)
@@ -23,6 +28,53 @@ export function createTrackingDashboardRouter() {
             return res.status(500).json({
                 ok: false,
                 error: 'tracking_dashboard_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.get('/custom-urls', async (req, res) => {
+        const limit = Math.min(parsePositiveInt(req.query.limit, 100), 200)
+
+        try {
+            const data = await getTrackingCustomUrls({ limit })
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 200 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to list custom urls', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_custom_urls_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.post('/custom-urls', async (req, res) => {
+        try {
+            const data = await createTrackingCustomUrl(req.body || {})
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 201 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to create custom url', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_custom_url_create_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.patch('/custom-urls', async (req, res) => {
+        try {
+            const data = await updateTrackingCustomUrl(req.body || {})
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 200 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to update custom url', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_custom_url_update_failed',
                 message: error instanceof Error ? error.message : 'unknown_error',
             })
         }

--- a/backend/apps/crm-api/services/trackingDashboardService.js
+++ b/backend/apps/crm-api/services/trackingDashboardService.js
@@ -92,6 +92,100 @@ async function fetchWebsiteTrackingOverview({ days, limit, offsetDays = 0 }) {
     }
 }
 
+async function fetchWebsiteTrackingCustomUrls({ method = 'GET', payload = null, limit = 100 } = {}) {
+    const baseUrl = sanitizeBaseUrl(process.env.TRACKING_WEBSITE_BASE_URL)
+    const token = String(process.env.TRACKING_DASHBOARD_TOKEN || '').trim()
+    const requestUrl = new URL('/api/tracking/custom-urls', baseUrl)
+    requestUrl.searchParams.set('limit', String(limit))
+
+    const headers = { accept: 'application/json' }
+    if (token) headers.authorization = `Bearer ${token}`
+    if (payload) headers['content-type'] = 'application/json'
+
+    try {
+        const response = await fetch(requestUrl, {
+            method,
+            headers,
+            body: payload ? JSON.stringify(payload) : undefined,
+        })
+        const text = await response.text()
+        let data = null
+        try {
+            data = text ? JSON.parse(text) : null
+        } catch {
+            data = null
+        }
+        if (!response.ok || data?.ok === false) {
+            return {
+                ok: false,
+                status: response.status,
+                sourceUrl: requestUrl.toString(),
+                error: data?.error || `HTTP ${response.status}`,
+            }
+        }
+        return {
+            ok: true,
+            status: response.status,
+            sourceUrl: requestUrl.toString(),
+            data,
+        }
+    } catch (error) {
+        return {
+            ok: false,
+            status: 0,
+            sourceUrl: requestUrl.toString(),
+            error: error instanceof Error ? error.message : 'website_custom_urls_failed',
+        }
+    }
+}
+
+export async function getTrackingCustomUrls({ limit = 100 } = {}) {
+    const response = await fetchWebsiteTrackingCustomUrls({ method: 'GET', limit })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+            customUrls: [],
+        }
+    }
+    return {
+        ok: true,
+        sourceUrl: response.sourceUrl,
+        customUrls: response.data?.customUrls || [],
+    }
+}
+
+export async function createTrackingCustomUrl(payload) {
+    const response = await fetchWebsiteTrackingCustomUrls({ method: 'POST', payload, limit: 200 })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+        }
+    }
+    return {
+        ok: true,
+        customUrl: response.data?.customUrl || null,
+    }
+}
+
+export async function updateTrackingCustomUrl(payload) {
+    const response = await fetchWebsiteTrackingCustomUrls({ method: 'PATCH', payload, limit: 200 })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+        }
+    }
+    return {
+        ok: true,
+        customUrl: response.data?.customUrl || null,
+    }
+}
+
 function toNumber(value) {
     const parsed = Number(value || 0)
     return Number.isFinite(parsed) ? parsed : 0

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -32,6 +32,8 @@ import { dispatchInsumosHeaderAction, subscribeInsumosHeaderState } from '@/insu
 import type { InsumosHeaderState, InsumosOverviewPeriod } from '@/insumosTypes'
 import { dispatchMetaAdsHeaderAction, subscribeMetaAdsHeaderState } from '@/metaAdsHeaderBridge'
 import type { MetaAdsHeaderState } from '@/metaAdsTypes'
+import { dispatchSiteTrackingHeaderAction, subscribeSiteTrackingHeaderState } from '@/siteTrackingHeaderBridge'
+import type { SiteTrackingHeaderState } from '@/siteTrackingTypes'
 import { CalendarX2, CheckCircle2, Download, Pencil, Plus, RefreshCw, Shield, Sparkles, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
@@ -379,6 +381,7 @@ export default function AppFunctionalNeatlab() {
         const [atendimentoHeaderState, setAtendimentoHeaderState] = useState<AtendimentoHeaderState | null>(null)
         const [escalaHeaderState, setEscalaHeaderState] = useState<EscalaHeaderState | null>(null)
         const [metaAdsHeaderState, setMetaAdsHeaderState] = useState<MetaAdsHeaderState | null>(null)
+        const [siteTrackingHeaderState, setSiteTrackingHeaderState] = useState<SiteTrackingHeaderState | null>(null)
         const [metaAdsAccountRemovalId, setMetaAdsAccountRemovalId] = useState<string | null>(null)
         const metaAdsAccountPendingRemoval = useMemo(
             () => (metaAdsHeaderState?.accounts || []).find((account) => account.id === metaAdsAccountRemovalId) || null,
@@ -552,6 +555,12 @@ export default function AppFunctionalNeatlab() {
                     })
                 }, [])
 
+                React.useEffect(() => {
+                    return subscribeSiteTrackingHeaderState((detail) => {
+                        setSiteTrackingHeaderState(detail)
+                    })
+                }, [])
+
 	    // Allow forcing a module via URL, e.g. http://localhost:5173/?module=capabilities
 	    React.useEffect(() => {
 	        try {
@@ -591,6 +600,12 @@ export default function AppFunctionalNeatlab() {
                 React.useEffect(() => {
                     if (active !== 'meta-ads') {
                         setMetaAdsHeaderState(null)
+                    }
+                }, [active])
+
+                React.useEffect(() => {
+                    if (active !== 'site-tracking') {
+                        setSiteTrackingHeaderState(null)
                     }
                 }, [active])
 
@@ -1053,7 +1068,7 @@ export default function AppFunctionalNeatlab() {
 					                                        </h1>
 			                                    </div>
 				                                    <div className="w-px h-8 bg-white/20 hidden lg:block"></div>
-				                                    <div className={`${active === 'escala-profissionais' || active === 'meta-ads' ? 'flex min-w-0' : 'hidden lg:flex'} items-center gap-2`}>
+				                                    <div className={`${active === 'escala-profissionais' || active === 'meta-ads' || active === 'site-tracking' ? 'flex min-w-0' : 'hidden lg:flex'} items-center gap-2`}>
 				                                        {active === 'insumos' ? (
 					                                            <>
 					                                                <Select
@@ -1358,6 +1373,73 @@ export default function AppFunctionalNeatlab() {
                                                                 </Select>
                                                             </div>
                                                         ) : null}
+                                                        {active === 'site-tracking' ? (
+                                                            <div className="flex items-center gap-2 max-w-[56vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                                                <Select
+                                                                    value={siteTrackingHeaderState?.selectedSiteId || ''}
+                                                                    onValueChange={(value) => {
+                                                                        if (value === '__site_tracking_add_connection__') {
+                                                                            dispatchSiteTrackingHeaderAction({ type: 'connect' })
+                                                                            return
+                                                                        }
+                                                                        if (value === '__site_tracking_rename_site__') {
+                                                                            dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: siteTrackingHeaderState?.selectedSiteId })
+                                                                            return
+                                                                        }
+                                                                        dispatchSiteTrackingHeaderAction({ type: 'set-site', value })
+                                                                    }}
+                                                                    disabled={siteTrackingHeaderState?.refreshing}
+                                                                >
+                                                                    <SelectTrigger className="h-8 w-64 bg-white/[0.06] border-white/20 text-white">
+                                                                        <SelectValue placeholder="Site" />
+                                                                    </SelectTrigger>
+                                                                    <SelectContent>
+                                                                        {[...(siteTrackingHeaderState?.sites || [])]
+                                                                            .sort((a, b) => {
+                                                                                if (a.id === siteTrackingHeaderState?.selectedSiteId) return -1
+                                                                                if (b.id === siteTrackingHeaderState?.selectedSiteId) return 1
+                                                                                return (a.name || a.host || a.id).localeCompare(b.name || b.host || b.id, 'pt-BR')
+                                                                            })
+                                                                            .map((site) => {
+                                                                                const isSelectedSite = site.id === siteTrackingHeaderState?.selectedSiteId
+                                                                                const statusTone =
+                                                                                    site.statusTone === 'success'
+                                                                                        ? 'bg-emerald-500/12 text-emerald-100 focus:bg-emerald-500/20 focus:text-emerald-50'
+                                                                                        : site.statusTone === 'warning'
+                                                                                            ? 'bg-amber-500/12 text-amber-100 focus:bg-amber-500/20 focus:text-amber-50'
+                                                                                            : site.statusTone === 'danger'
+                                                                                                ? 'bg-rose-500/12 text-rose-100 focus:bg-rose-500/20 focus:text-rose-50'
+                                                                                                : 'bg-slate-950 text-slate-100 focus:bg-slate-800/90'
+                                                                                return (
+                                                                                    <SelectItem
+                                                                                        key={site.id}
+                                                                                        value={site.id}
+                                                                                        className={`${statusTone} ${isSelectedSite ? 'border-l-2 border-cyan-300/80 font-semibold ring-1 ring-inset ring-cyan-300/20' : 'border-l-2 border-transparent font-normal'}`}
+                                                                                        hideIndicator
+                                                                                    >
+                                                                                        <div className="flex min-w-0 flex-col pr-4 leading-tight">
+                                                                                            <span className={`truncate ${isSelectedSite ? 'text-white' : ''}`}>{site.name || site.host || site.id}</span>
+                                                                                            {site.statusLabel ? <span className="truncate text-[10px] font-normal opacity-70">{site.statusLabel}</span> : null}
+                                                                                        </div>
+                                                                                    </SelectItem>
+                                                                                )
+                                                                            })}
+                                                                        <SelectItem value="__site_tracking_add_connection__" className="bg-slate-950 text-cyan-100 focus:bg-cyan-500/15 focus:text-cyan-50">
+                                                                            <div className="flex w-full items-center gap-2 pr-4">
+                                                                                <Plus className="size-3.5 text-cyan-300" aria-hidden="true" />
+                                                                                <span>Adicionar conexão</span>
+                                                                            </div>
+                                                                        </SelectItem>
+                                                                        <SelectItem value="__site_tracking_rename_site__" className="bg-slate-950 text-cyan-100 focus:bg-cyan-500/15 focus:text-cyan-50">
+                                                                            <div className="flex w-full items-center gap-2 pr-4">
+                                                                                <Pencil className="size-3.5 text-cyan-300" aria-hidden="true" />
+                                                                                <span>Renomear site</span>
+                                                                            </div>
+                                                                        </SelectItem>
+                                                                    </SelectContent>
+                                                                </Select>
+                                                            </div>
+                                                        ) : null}
 		                                    </div>
 	                                </div>
 
@@ -1502,6 +1584,45 @@ export default function AppFunctionalNeatlab() {
                                                 <TooltipContent>
                                                     {metaAdsHeaderState?.sessionUpdatedAt
                                                         ? `Atualizar. Ultima atualizacao: ${new Date(metaAdsHeaderState.sessionUpdatedAt).toLocaleString('pt-BR')}`
+                                                        : 'Atualizar'}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </div>
+                                    ) : null}
+                                    {active === 'site-tracking' ? (
+                                        <div className="flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                            <div className="flex items-center gap-1 rounded-full border border-white/15 bg-white/[0.06] p-1">
+                                                {[7, 30, 60, 90].map((period) => (
+                                                    <button
+                                                        key={period}
+                                                        type="button"
+                                                        className={`h-6 rounded-full px-2.5 text-xs transition ${
+                                                            siteTrackingHeaderState?.windowDays === period
+                                                                ? 'bg-white/16 text-white'
+                                                                : 'text-blue-100/80 hover:bg-white/[0.08] hover:text-white'
+                                                        }`}
+                                                        onClick={() => dispatchSiteTrackingHeaderAction({ type: 'set-window', value: period as 7 | 30 | 60 | 90 })}
+                                                    >
+                                                        {period}d
+                                                    </button>
+                                                ))}
+                                            </div>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        size="icon"
+                                                        variant="ghost"
+                                                        className="h-8 w-8 rounded-full border border-white/15 bg-white/[0.06] text-blue-50 hover:bg-white/[0.12]"
+                                                        onClick={() => dispatchSiteTrackingHeaderAction({ type: 'refresh' })}
+                                                        disabled={siteTrackingHeaderState?.refreshing}
+                                                        aria-label="Atualizar Site EF"
+                                                    >
+                                                        <RefreshCw className={`size-3.5 ${siteTrackingHeaderState?.refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    {siteTrackingHeaderState?.updatedAt
+                                                        ? `Atualizar. Ultima atualizacao: ${new Date(siteTrackingHeaderState.updatedAt).toLocaleString('pt-BR')}`
                                                         : 'Atualizar'}
                                                 </TooltipContent>
                                             </Tooltip>

--- a/frontend/SiteTrackingModule.tsx
+++ b/frontend/SiteTrackingModule.tsx
@@ -1,125 +1,90 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Badge } from '@/badge'
-import { Button } from '@/button'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { DropResult } from '@hello-pangea/dnd'
 import { getMetaTrackingLocalOverview, isMetaTrackingLocalMockEnabled, type TrackingOverviewResponse } from '@/metaTrackingLocalMock'
-import { ArrowClockwise, ChartLineUp, CursorClick, Funnel, LinkSimple, Pulse, WarningCircle } from '@phosphor-icons/react'
+import {
+  ConnectionNotice,
+  ManagedSiteUrlsSection,
+  OperationalAlerts,
+  SiteBehaviorSections,
+  SiteFunnelSection,
+  SiteIssueAndClickSections,
+  SiteLinkSections,
+  SiteMetricsGrid,
+  type ManagedSiteUrlForm,
+} from '@/siteTrackingComponents'
+import { emitSiteTrackingHeaderState, subscribeSiteTrackingHeaderAction } from '@/siteTrackingHeaderBridge'
+import {
+  DEFAULT_SITE_METRIC_LAYOUT,
+  SITE_TRACKING_METRIC_LAYOUT_KEY,
+  formatSiteTrackingNumber,
+  formatSiteTrackingPercent,
+  isInternalPreviewAlert,
+  listOrEmpty,
+  parseSiteMetricLayout,
+  siteTrackingNumberValue,
+  type SiteMetricAspect,
+  type SiteMetricKey,
+  type SiteMetricLayout,
+  type WindowDays,
+} from '@/siteTrackingPresentation'
+import type { SiteTrackingHeaderSiteOption } from '@/siteTrackingTypes'
+import {
+  ArrowClockwise,
+  ChartLineUp,
+  CursorClick,
+  Funnel,
+  LinkSimple,
+  Pulse,
+  ShieldCheck,
+  WhatsappLogo,
+} from '@phosphor-icons/react'
 
-type WindowDays = 7 | 30 | 60 | 90
-
-const WINDOW_OPTIONS: WindowDays[] = [7, 30, 60, 90]
-
-function n(value: unknown): number {
-  const parsed = Number(value || 0)
-  return Number.isFinite(parsed) ? parsed : 0
-}
-
-export function formatSiteTrackingNumber(value: unknown): string {
-  return new Intl.NumberFormat('pt-BR').format(n(value))
-}
-
-export function formatSiteTrackingPercent(value: unknown): string {
-  return `${formatSiteTrackingNumber(value)}%`
-}
-
-export function siteTrackingHealthTone(status?: string | null) {
-  if (status === 'healthy') return 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100'
-  if (status === 'critical') return 'border-red-400/30 bg-red-500/10 text-red-100'
-  return 'border-amber-400/30 bg-amber-500/10 text-amber-100'
-}
-
-export function funnelBarWidth(value: unknown, max: unknown): string {
-  const denominator = Math.max(1, n(max))
-  return `${Math.max(4, Math.min(100, Math.round((n(value) / denominator) * 100)))}%`
-}
-
-function fmtDate(ms?: number | null) {
-  if (!ms) return 'sem data'
-  return new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(ms))
-}
-
-function shortUrl(value?: string | null) {
-  if (!value) return 'sem link'
-  try {
-    const url = new URL(value)
-    return `${url.hostname}${url.pathname}${url.search ? '?...' : ''}`
-  } catch {
-    return value.length > 72 ? `${value.slice(0, 72)}...` : value
-  }
-}
-
-function listOrEmpty<T>(items: T[] | undefined | null): T[] {
-  return Array.isArray(items) ? items : []
-}
+const SITE_OPTIONS: SiteTrackingHeaderSiteOption[] = [
+  {
+    id: 'espacofacial.com',
+    name: 'espacofacial.com',
+    host: 'espacofacial.com',
+    statusLabel: 'Canônico do funil',
+    statusTone: 'success',
+  },
+]
+const SITE_TRACKING_SITE_NAMES_KEY = 'skincos.siteTracking.siteNames.v1'
 
 async function fetchSiteTrackingOverview(days: WindowDays): Promise<TrackingOverviewResponse> {
   if (isMetaTrackingLocalMockEnabled()) return getMetaTrackingLocalOverview(days)
   const response = await fetch(`/api/tracking/overview?days=${days}&limit=12`, { credentials: 'include' })
   const data = await response.json().catch(() => null)
   if (!response.ok || !data?.ok) {
-    throw new Error(data?.message || data?.error || `tracking_overview_${response.status}`)
+    throw new Error(data?.message || data?.error || `Não foi possível carregar os dados do site (${response.status})`)
   }
   return data as TrackingOverviewResponse
 }
 
-function MetricCard({ label, value, detail }: { label: string; value: string; detail?: string }) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
-      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">{label}</div>
-      <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
-      {detail ? <div className="mt-1 text-xs text-slate-400">{detail}</div> : null}
-    </div>
-  )
-}
-
-function Section({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
-  return (
-    <section className="rounded-lg border border-white/10 bg-slate-950/60 p-5">
-      <div className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-300">
-        {icon}
-        {title}
-      </div>
-      {children}
-    </section>
-  )
-}
-
-function RankedList({
-  items,
-  labelKey,
-  empty,
-}: {
-  items: Array<Record<string, unknown>>
-  labelKey: string
-  empty: string
-}) {
-  if (!items.length) return <div className="text-sm text-slate-500">{empty}</div>
-  const max = Math.max(...items.map((item) => n(item.count)))
-  return (
-    <div className="space-y-3">
-      {items.map((item, index) => {
-        const label = String(item[labelKey] || 'sem valor')
-        const count = n(item.count)
-        return (
-          <div key={`${label}-${index}`} className="space-y-1">
-            <div className="flex items-center justify-between gap-3 text-sm">
-              <span className="min-w-0 truncate text-slate-200">{label}</span>
-              <span className="font-mono text-slate-400">{formatSiteTrackingNumber(count)}</span>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
-              <div className="h-full rounded-full bg-cyan-400" style={{ width: funnelBarWidth(count, max) }} />
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
 export function SiteTrackingModule() {
   const [days, setDays] = useState<WindowDays>(30)
+  const [selectedSiteId, setSelectedSiteId] = useState('espacofacial.com')
   const [data, setData] = useState<TrackingOverviewResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [connectionNoticeOpen, setConnectionNoticeOpen] = useState(false)
+  const [savingManagedUrl, setSavingManagedUrl] = useState(false)
+  const [siteNameOverrides, setSiteNameOverrides] = useState<Record<string, string>>(() => {
+    try {
+      if (typeof window === 'undefined') return {}
+      const parsed = JSON.parse(window.localStorage.getItem(SITE_TRACKING_SITE_NAMES_KEY) || '{}')
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  })
+  const [metricLayout, setMetricLayout] = useState<SiteMetricLayout[]>(() => {
+    try {
+      if (typeof window === 'undefined') return DEFAULT_SITE_METRIC_LAYOUT
+      return parseSiteMetricLayout(window.localStorage.getItem(SITE_TRACKING_METRIC_LAYOUT_KEY))
+    } catch {
+      return DEFAULT_SITE_METRIC_LAYOUT
+    }
+  })
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -127,7 +92,7 @@ export function SiteTrackingModule() {
     try {
       setData(await fetchSiteTrackingOverview(days))
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'tracking_overview_failed')
+      setError(err instanceof Error ? err.message : 'Não foi possível carregar os dados do site')
     } finally {
       setLoading(false)
     }
@@ -137,176 +102,339 @@ export function SiteTrackingModule() {
     void load()
   }, [load])
 
-  const summary = data?.website?.data?.summary || {}
-  const behaviorSummary = data?.siteBehavior?.summary || {}
-  const funnel = data?.siteFunnel || {}
-  const quality = data?.behaviorQuality || {}
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SITE_TRACKING_METRIC_LAYOUT_KEY, JSON.stringify(metricLayout))
+    } catch {
+      // ignore local layout persistence errors
+    }
+  }, [metricLayout])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SITE_TRACKING_SITE_NAMES_KEY, JSON.stringify(siteNameOverrides))
+    } catch {
+      // ignore local name persistence errors
+    }
+  }, [siteNameOverrides])
+
+  const summary = useMemo(() => data?.website?.data?.summary || {}, [data?.website?.data?.summary])
+  const behaviorSummary = useMemo(() => data?.siteBehavior?.summary || {}, [data?.siteBehavior?.summary])
+  const funnel = useMemo(() => data?.siteFunnel || {}, [data?.siteFunnel])
+  const quality = useMemo(() => data?.behaviorQuality || {}, [data?.behaviorQuality])
   const alerts = listOrEmpty(data?.alerts)
+  const operationalAlerts = alerts.filter((alert) => !isInternalPreviewAlert(alert))
+  const siteOptions = useMemo(() => SITE_OPTIONS.map((site) => ({
+    ...site,
+    name: siteNameOverrides[site.id] || site.name,
+  })), [siteNameOverrides])
+  const selectedSite = siteOptions.find((site) => site.id === selectedSiteId) || siteOptions[0]
+  const headerUpdatedAt = data?.generatedAt ? new Date(data.generatedAt).toISOString() : undefined
+
+  useEffect(() => {
+    emitSiteTrackingHeaderState({
+      refreshing: loading,
+      sites: siteOptions,
+      selectedSiteId,
+      selectedSiteName: selectedSite?.name,
+      windowDays: days,
+      updatedAt: headerUpdatedAt,
+    })
+  }, [days, headerUpdatedAt, loading, selectedSite?.name, selectedSiteId, siteOptions])
+
+  useEffect(() => () => emitSiteTrackingHeaderState(null), [])
+
+  useEffect(() => {
+    return subscribeSiteTrackingHeaderAction((action) => {
+      if (action.type === 'refresh') {
+        void load()
+        return
+      }
+      if (action.type === 'set-window') {
+        setDays(action.value)
+        return
+      }
+      if (action.type === 'set-site') {
+        setSelectedSiteId(action.value)
+        return
+      }
+      if (action.type === 'connect') {
+        setConnectionNoticeOpen(true)
+        return
+      }
+      if (action.type === 'rename-site') {
+        const siteId = action.value || selectedSiteId
+        const currentSite = siteOptions.find((site) => site.id === siteId)
+        const currentName = currentSite?.name || currentSite?.host || siteId
+        const nextName = window.prompt('Nome exibido para este site', currentName)?.trim()
+        if (!nextName) return
+        setSiteNameOverrides((prev) => ({ ...prev, [siteId]: nextName }))
+      }
+    })
+  }, [load, selectedSiteId, siteOptions])
 
   const funnelRows = useMemo(() => [
-    { label: 'Sessões', value: n(funnel.sessions) },
-    { label: 'Pageviews', value: n(funnel.pageViews) },
-    { label: 'Cliques CTA/link', value: n(funnel.ctaClicks) },
-    { label: 'Agendamento iniciado', value: n(funnel.bookingStarted) },
-    { label: 'Etapa final aberta', value: n(funnel.finalStepOpened) },
-    { label: 'Agendamentos confirmados', value: n(funnel.confirmedBookings) },
+    { label: 'Sessões', value: siteTrackingNumberValue(funnel.sessions) },
+    { label: 'Pageviews', value: siteTrackingNumberValue(funnel.pageViews) },
+    { label: 'Cliques CTA/link', value: siteTrackingNumberValue(funnel.ctaClicks) },
+    { label: 'Agendamento iniciado', value: siteTrackingNumberValue(funnel.bookingStarted) },
+    { label: 'Etapa final aberta', value: siteTrackingNumberValue(funnel.finalStepOpened) },
+    { label: 'Agendamentos confirmados', value: siteTrackingNumberValue(funnel.confirmedBookings) },
   ], [funnel])
   const funnelMax = Math.max(...funnelRows.map((row) => row.value), 1)
+  const metricTiles = useMemo(() => [
+    {
+      key: 'sessions' as const,
+      label: 'Visitas',
+      tooltipLabel: 'Visitas no site',
+      description: 'Volume agregado de pessoas navegando pelo site no período selecionado.',
+      value: formatSiteTrackingNumber(behaviorSummary.sessions),
+      detail: `${formatSiteTrackingNumber(behaviorSummary.pageViews)} páginas vistas`,
+      icon: Pulse,
+      toneClass: 'border-cyan-500/25 bg-cyan-500/12 text-cyan-100',
+    },
+    {
+      key: 'bookings' as const,
+      label: 'Agendamentos',
+      tooltipLabel: 'Agendamentos confirmados',
+      description: 'Reservas confirmadas pelo fluxo do site no período selecionado.',
+      value: formatSiteTrackingNumber(summary.confirmedBookings),
+      detail: `${formatSiteTrackingPercent(data?.coverage?.trackingContext)} com origem`,
+      icon: Funnel,
+      toneClass: 'border-emerald-500/25 bg-emerald-500/12 text-emerald-100',
+    },
+    {
+      key: 'whatsapp' as const,
+      label: 'WhatsApp',
+      tooltipLabel: 'Cliques de WhatsApp no site',
+      description: 'Cliques em WhatsApp saindo do site com origem preservada.',
+      value: formatSiteTrackingNumber(summary.whatsappClicks),
+      detail: `${formatSiteTrackingPercent(data?.coverage?.whatsappTracking)} com origem`,
+      icon: WhatsappLogo,
+      toneClass: 'border-green-500/25 bg-green-500/12 text-green-100',
+    },
+    {
+      key: 'schedule' as const,
+      label: 'Conversões Meta',
+      tooltipLabel: 'Agendamentos enviados à Meta',
+      description: 'Agendamentos confirmados enviados para melhorar a otimização das campanhas.',
+      value: formatSiteTrackingNumber(summary.capiScheduleOk),
+      detail: `${formatSiteTrackingPercent(data?.coverage?.scheduleDelivery)} enviados`,
+      icon: ShieldCheck,
+      toneClass: 'border-blue-500/25 bg-blue-500/12 text-blue-100',
+    },
+    {
+      key: 'origin' as const,
+      label: 'Origem preservada',
+      tooltipLabel: 'Origem preservada',
+      description: 'Percentual de agendamentos em que foi possível manter campanha, fonte ou origem até a reserva.',
+      value: formatSiteTrackingPercent(data?.coverage?.trackingContext),
+      detail: 'campanha ou canal',
+      icon: LinkSimple,
+      toneClass: 'border-teal-500/25 bg-teal-500/12 text-teal-100',
+    },
+    {
+      key: 'reservationLink' as const,
+      label: 'Reserva vinculada',
+      tooltipLabel: 'Reserva vinculada',
+      description: 'Percentual de reservas com identificação suficiente para evitar contagem duplicada nos relatórios.',
+      value: formatSiteTrackingPercent(data?.coverage?.metaEventId),
+      detail: 'sem duplicidade',
+      icon: ShieldCheck,
+      toneClass: 'border-sky-500/25 bg-sky-500/12 text-sky-100',
+    },
+    {
+      key: 'facebook' as const,
+      label: 'Atribuição Meta',
+      tooltipLabel: 'Atribuição Meta',
+      description: 'Reservas com sinais suficientes para associar a origem a campanhas da Meta.',
+      value: formatSiteTrackingPercent(data?.coverage?.facebookIds),
+      detail: 'cliques identificados',
+      icon: LinkSimple,
+      toneClass: 'border-indigo-500/25 bg-indigo-500/12 text-indigo-100',
+    },
+    {
+      key: 'marketing' as const,
+      label: 'Consentimento',
+      tooltipLabel: 'Consentimento marketing',
+      description: 'Agendamentos em que o visitante autorizou mensuração de marketing.',
+      value: formatSiteTrackingPercent(data?.coverage?.marketingConsent),
+      detail: 'reservas permitidas',
+      icon: ChartLineUp,
+      toneClass: 'border-violet-500/25 bg-violet-500/12 text-violet-100',
+    },
+    {
+      key: 'campaign' as const,
+      label: 'Campanhas',
+      tooltipLabel: 'Campanhas identificadas',
+      description: 'Interações do site com campanha identificada no período.',
+      value: formatSiteTrackingPercent(quality.campaignCoverage),
+      detail: `${formatSiteTrackingNumber(quality.eventsWithCampaign)} interações`,
+      icon: CursorClick,
+      toneClass: 'border-amber-500/25 bg-amber-500/12 text-amber-100',
+    },
+    {
+      key: 'conversion' as const,
+      label: 'Visita -> Reserva',
+      tooltipLabel: 'Taxa de conversão visita para reserva',
+      description: 'Taxa agregada de sessões que chegaram a agendamento confirmado.',
+      value: formatSiteTrackingPercent(funnel.visitToBookingRate),
+      detail: `${formatSiteTrackingNumber(funnel.confirmedBookings)} reservas`,
+      icon: ArrowClockwise,
+      toneClass: 'border-rose-500/25 bg-rose-500/12 text-rose-100',
+    },
+  ], [
+    behaviorSummary.pageViews,
+    behaviorSummary.sessions,
+    data?.coverage?.facebookIds,
+    data?.coverage?.marketingConsent,
+    data?.coverage?.metaEventId,
+    data?.coverage?.scheduleDelivery,
+    data?.coverage?.trackingContext,
+    data?.coverage?.whatsappTracking,
+    funnel.confirmedBookings,
+    funnel.visitToBookingRate,
+    quality.campaignCoverage,
+    quality.eventsWithCampaign,
+    summary.capiScheduleOk,
+    summary.confirmedBookings,
+    summary.whatsappClicks,
+  ])
+  const visibleMetricTiles = useMemo(() => {
+    const byKey = new Map(metricTiles.map((tile) => [tile.key, tile]))
+    return metricLayout
+      .map((config) => {
+        const tile = byKey.get(config.key)
+        if (!tile || !config.visible) return null
+        return { ...tile, width: config.width, height: config.height, aspect: config.aspect }
+      })
+      .filter(Boolean) as Array<(typeof metricTiles)[number] & { width: number; height: number; aspect: SiteMetricAspect }>
+  }, [metricLayout, metricTiles])
+  const hiddenMetricTiles = useMemo(() => {
+    const byKey = new Map(metricTiles.map((tile) => [tile.key, tile]))
+    return metricLayout
+      .filter((config) => !config.visible)
+      .map((config) => byKey.get(config.key))
+      .filter(Boolean) as typeof metricTiles
+  }, [metricLayout, metricTiles])
+  const updateMetricTile = (key: SiteMetricKey, patch: Partial<SiteMetricLayout>) => {
+    setMetricLayout((prev) => prev.map((item) => (item.key === key ? { ...item, ...patch } : item)))
+  }
+  const saveManagedUrl = async (form: ManagedSiteUrlForm) => {
+    setSavingManagedUrl(true)
+    try {
+      if (isMetaTrackingLocalMockEnabled()) {
+        const now = Date.now()
+        setData((prev) => {
+          if (!prev) return prev
+          const existing = prev.customLinks?.managedUrls || []
+          const nextUrl = {
+            id: form.id || `local_url_${now}`,
+            siteHost: selectedSiteId,
+            name: form.name,
+            slugPath: form.slugPath || `/campanhas/${form.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'link'}`,
+            publicUrl: `https://${selectedSiteId}${form.slugPath || `/campanhas/${form.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'link'}`}`,
+            destinationUrl: form.destinationUrl,
+            destinationHost: (() => {
+              try { return new URL(form.destinationUrl).hostname } catch { return null }
+            })(),
+            destinationPath: (() => {
+              try {
+                const url = new URL(form.destinationUrl)
+                return `${url.pathname}${url.search}${url.hash}`
+              } catch {
+                return null
+              }
+            })(),
+            description: form.description || null,
+            source: 'manual',
+            placement: form.placement || null,
+            unitSlug: form.unitSlug || null,
+            serviceId: form.serviceId || null,
+            utmSource: form.utmSource || null,
+            utmMedium: form.utmMedium || null,
+            utmCampaign: form.utmCampaign || null,
+            utmContent: form.utmContent || null,
+            utmTerm: form.utmTerm || null,
+            active: form.active,
+            createdAtMs: existing.find((item) => item.id === form.id)?.createdAtMs || now,
+            updatedAtMs: now,
+            clickCount: existing.find((item) => item.id === form.id)?.clickCount || 0,
+            lastClickAtMs: existing.find((item) => item.id === form.id)?.lastClickAtMs || null,
+          }
+          return {
+            ...prev,
+            customLinks: {
+              ...(prev.customLinks || {}),
+              managedUrls: form.id ? existing.map((item) => (item.id === form.id ? nextUrl : item)) : [nextUrl, ...existing],
+            },
+          }
+        })
+        return
+      }
+
+      const response = await fetch('/api/tracking/custom-urls', {
+        method: form.id ? 'PATCH' : 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ ...form, siteHost: selectedSiteId }),
+      })
+      const payload = await response.json().catch(() => null)
+      if (!response.ok || payload?.ok === false) throw new Error(payload?.message || payload?.error || 'Não foi possível salvar a URL')
+      await load()
+    } finally {
+      setSavingManagedUrl(false)
+    }
+  }
+  const handleMetricDragEnd = (result: DropResult) => {
+    if (!result.destination || result.destination.droppableId !== 'site-tracking-metrics') return
+    if (result.source.index === result.destination.index) return
+    const visibleKeys = metricLayout.filter((item) => item.visible).map((item) => item.key)
+    const movedKey = visibleKeys[result.source.index]
+    if (!movedKey) return
+    setMetricLayout((prev) => {
+      const next = [...prev]
+      const sourceIndex = next.findIndex((item) => item.key === movedKey)
+      if (sourceIndex < 0) return prev
+      const [entry] = next.splice(sourceIndex, 1)
+      const visibleAfterRemoval = next.filter((item) => item.visible)
+      const beforeKey = visibleAfterRemoval[result.destination?.index ?? 0]?.key
+      const destinationIndex = beforeKey ? next.findIndex((item) => item.key === beforeKey) : next.length
+      next.splice(destinationIndex < 0 ? next.length : destinationIndex, 0, entry)
+      return next
+    })
+  }
 
   return (
     <div className="space-y-6 text-slate-100">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-cyan-200">
-            <Pulse className="h-5 w-5" />
-            Site Tracking
-          </div>
-          <h1 className="mt-2 text-3xl font-semibold text-white">espacofacial.com</h1>
-          <p className="mt-1 max-w-3xl text-sm text-slate-400">
-            Acompanhamento agregado de comportamento, campanhas, links personalizados, WhatsApp, agendamentos e qualidade de tracking do site.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {WINDOW_OPTIONS.map((option) => (
-            <Button
-              key={option}
-              variant={days === option ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setDays(option)}
-            >
-              {option}d
-            </Button>
-          ))}
-          <Button variant="outline" size="sm" onClick={load} disabled={loading}>
-            <ArrowClockwise className={loading ? 'animate-spin' : ''} />
-            Atualizar
-          </Button>
-        </div>
-      </div>
-
       {error ? (
         <div className="rounded-lg border border-red-400/30 bg-red-500/10 p-4 text-red-100">
-          Falha ao carregar tracking do site: {error}
+          Falha ao carregar acompanhamento do site: {error}
         </div>
       ) : null}
 
-      {data?.health ? (
-        <div className={`rounded-lg border p-4 ${siteTrackingHealthTone(data.health.status)}`}>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <div className="text-sm font-semibold uppercase tracking-wide">Saúde do tracking: {data.health.label}</div>
-              <div className="mt-1 text-sm opacity-90">{data.health.summary}</div>
-            </div>
-            {data.partial ? <Badge variant="warning">Leitura parcial</Badge> : <Badge variant="success">Leitura completa</Badge>}
-          </div>
-        </div>
-      ) : null}
+      {connectionNoticeOpen ? <ConnectionNotice onClose={() => setConnectionNoticeOpen(false)} /> : null}
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard label="Sessões anônimas" value={formatSiteTrackingNumber(behaviorSummary.sessions)} detail={`${formatSiteTrackingNumber(behaviorSummary.pageViews)} pageviews`} />
-        <MetricCard label="Agendamentos" value={formatSiteTrackingNumber(summary.confirmedBookings)} detail={`${formatSiteTrackingPercent(data?.coverage?.trackingContext)} com tracking_context`} />
-        <MetricCard label="WhatsApp no site" value={formatSiteTrackingNumber(summary.whatsappClicks)} detail={`${formatSiteTrackingPercent(data?.coverage?.whatsappTracking)} com contexto`} />
-        <MetricCard label="Schedule CAPI OK" value={formatSiteTrackingNumber(summary.capiScheduleOk)} detail={`${formatSiteTrackingPercent(data?.coverage?.scheduleDelivery)} entrega`} />
-        <MetricCard label="FB IDs" value={formatSiteTrackingPercent(data?.coverage?.facebookIds)} detail="fbp/fbc/fbclid em bookings" />
-        <MetricCard label="Consentimento marketing" value={formatSiteTrackingPercent(data?.coverage?.marketingConsent)} detail="bookings confirmados" />
-        <MetricCard label="Campanhas em eventos" value={formatSiteTrackingPercent(quality.campaignCoverage)} detail={`${formatSiteTrackingNumber(quality.eventsWithCampaign)} eventos com utm_campaign`} />
-        <MetricCard label="Taxa visita -> booking" value={formatSiteTrackingPercent(funnel.visitToBookingRate)} detail={`${formatSiteTrackingNumber(funnel.confirmedBookings)} confirmações`} />
-      </div>
+      <SiteMetricsGrid
+        hiddenMetricTiles={hiddenMetricTiles}
+        visibleMetricTiles={visibleMetricTiles}
+        onDragEnd={handleMetricDragEnd}
+        onHide={(key) => updateMetricTile(key, { visible: false })}
+        onResize={updateMetricTile}
+        onRestore={() => setMetricLayout(DEFAULT_SITE_METRIC_LAYOUT)}
+        onShow={(key) => updateMetricTile(key, { visible: true })}
+      />
 
-      {alerts.length ? (
-        <Section title="Alertas operacionais" icon={<WarningCircle className="h-5 w-5" />}>
-          <div className="grid gap-3 md:grid-cols-2">
-            {alerts.map((alert) => (
-              <div key={alert.code} className="rounded-lg border border-white/10 bg-white/[0.03] p-4">
-                <Badge variant={alert.severity === 'critical' ? 'destructive' : 'warning'}>{alert.severity}</Badge>
-                <div className="mt-3 font-semibold text-white">{alert.title}</div>
-                <div className="mt-1 text-sm text-slate-400">{alert.message}</div>
-              </div>
-            ))}
-          </div>
-        </Section>
-      ) : null}
-
-      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-        <Section title="Funil do site" icon={<Funnel className="h-5 w-5" />}>
-          <div className="space-y-4">
-            {funnelRows.map((row) => (
-              <div key={row.label} className="space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-slate-300">{row.label}</span>
-                  <span className="font-mono text-white">{formatSiteTrackingNumber(row.value)}</span>
-                </div>
-                <div className="h-2 overflow-hidden rounded-full bg-white/10">
-                  <div className="h-full rounded-full bg-emerald-400" style={{ width: funnelBarWidth(row.value, funnelMax) }} />
-                </div>
-              </div>
-            ))}
-          </div>
-        </Section>
-
-        <Section title="Qualidade de tracking" icon={<ChartLineUp className="h-5 w-5" />}>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <MetricCard label="tracking_context" value={formatSiteTrackingPercent(data?.coverage?.trackingContext)} />
-            <MetricCard label="meta_event_id" value={formatSiteTrackingPercent(data?.coverage?.metaEventId)} />
-            <MetricCard label="FB IDs" value={formatSiteTrackingPercent(data?.coverage?.facebookIds)} />
-            <MetricCard label="Marketing" value={formatSiteTrackingPercent(data?.coverage?.marketingConsent)} />
-          </div>
-        </Section>
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-3">
-        <Section title="Páginas mais vistas" icon={<CursorClick className="h-5 w-5" />}>
-          <RankedList items={listOrEmpty(data?.siteBehavior?.topPages)} labelKey="pagePath" empty="Sem pageviews agregados ainda." />
-        </Section>
-        <Section title="Entradas" icon={<CursorClick className="h-5 w-5" />}>
-          <RankedList items={listOrEmpty(data?.siteBehavior?.topEntryPages)} labelKey="pagePath" empty="Sem páginas de entrada no período." />
-        </Section>
-        <Section title="Campanhas" icon={<LinkSimple className="h-5 w-5" />}>
-          <RankedList items={listOrEmpty(data?.website?.data?.topCampaigns)} labelKey="utmCampaign" empty="Sem campanhas atribuídas no período." />
-        </Section>
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-2">
-        <Section title="Links personalizados e CTAs" icon={<LinkSimple className="h-5 w-5" />}>
-          <RankedList items={listOrEmpty(data?.customLinks?.topLinks)} labelKey="linkUrl" empty="Sem cliques em links rastreados." />
-        </Section>
-        <Section title="Links sem UTM" icon={<WarningCircle className="h-5 w-5" />}>
-          <RankedList items={listOrEmpty(data?.customLinks?.linksMissingUtm)} labelKey="linkUrl" empty="Nenhum link sem UTM relevante no período." />
-        </Section>
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-2">
-        <Section title="Bookings com tracking incompleto" icon={<WarningCircle className="h-5 w-5" />}>
-          <div className="space-y-3">
-            {listOrEmpty(data?.reconciliation?.incompleteBookings).slice(0, 8).map((booking) => (
-              <div key={booking.id} className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="font-mono text-xs text-slate-400">{booking.id}</span>
-                  <Badge variant="outline">{booking.primaryCause}</Badge>
-                </div>
-                <div className="mt-2 text-sm text-slate-300">{booking.unitSlug} · {booking.utmSource || 'sem origem'} · {booking.utmCampaign || 'sem campanha'}</div>
-              </div>
-            ))}
-            {!listOrEmpty(data?.reconciliation?.incompleteBookings).length ? <div className="text-sm text-slate-500">Nenhum booking incompleto no período.</div> : null}
-          </div>
-        </Section>
-
-        <Section title="Cliques recentes" icon={<CursorClick className="h-5 w-5" />}>
-          <div className="space-y-3">
-            {listOrEmpty(data?.customLinks?.recentClicks).slice(0, 8).map((click) => (
-              <div key={click.id} className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-semibold text-white">{click.eventName}</span>
-                  <span className="text-xs text-slate-500">{fmtDate(click.createdAtMs)}</span>
-                </div>
-                <div className="mt-1 truncate text-sm text-slate-300">{shortUrl(click.linkUrl)}</div>
-                <div className="mt-1 text-xs text-slate-500">{click.utmCampaign || 'sem campanha'} · {click.placement || 'sem placement'}</div>
-              </div>
-            ))}
-            {!listOrEmpty(data?.customLinks?.recentClicks).length ? <div className="text-sm text-slate-500">Nenhum clique recente no período.</div> : null}
-          </div>
-        </Section>
-      </div>
+      <OperationalAlerts alerts={operationalAlerts} />
+      <SiteFunnelSection rows={funnelRows} max={funnelMax} />
+      <SiteBehaviorSections data={data} />
+      <ManagedSiteUrlsSection
+        urls={listOrEmpty(data?.customLinks?.managedUrls)}
+        saving={savingManagedUrl}
+        onSave={saveManagedUrl}
+      />
+      <SiteLinkSections data={data} />
+      <SiteIssueAndClickSections data={data} />
     </div>
   )
 }

--- a/frontend/metaTrackingLocalMock.ts
+++ b/frontend/metaTrackingLocalMock.ts
@@ -55,6 +55,31 @@ export type TrackingOverviewResponse = {
     byService?: Array<{ serviceId: string; count: number }>
   } | null
   customLinks?: {
+    managedUrls?: Array<{
+      id: string
+      siteHost: string
+      name: string
+      slugPath: string
+      publicUrl: string
+      destinationUrl: string
+      destinationHost: string | null
+      destinationPath: string | null
+      description: string | null
+      source: string
+      placement: string | null
+      unitSlug: string | null
+      serviceId: string | null
+      utmSource: string | null
+      utmMedium: string | null
+      utmCampaign: string | null
+      utmContent: string | null
+      utmTerm: string | null
+      active: boolean
+      createdAtMs: number
+      updatedAtMs: number
+      clickCount: number
+      lastClickAtMs: number | null
+    }>
     topLinks?: Array<{ linkUrl: string; count: number }>
     topUtmContent?: Array<{ utmContent: string; count: number }>
     linksMissingUtm?: Array<{ linkUrl: string; count: number }>
@@ -325,6 +350,33 @@ export function getMetaTrackingLocalOverview(days = 30): TrackingOverviewRespons
       ],
     },
     customLinks: {
+      managedUrls: [
+        {
+          id: 'url_preview_1',
+          siteHost: 'espacofacial.com',
+          name: 'Botox Novo Hamburgo Meta',
+          slugPath: '/campanhas/botox-novo-hamburgo-meta',
+          publicUrl: 'https://espacofacial.com/campanhas/botox-novo-hamburgo-meta',
+          destinationUrl: 'https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox&utm_source=meta&utm_medium=paid_social&utm_campaign=botox_novo_hamburgo&utm_content=video_botox_nh_01',
+          destinationHost: 'espacofacial.com',
+          destinationPath: '/agendamento?unit=novo-hamburgo&service=botox&utm_source=meta&utm_medium=paid_social&utm_campaign=botox_novo_hamburgo&utm_content=video_botox_nh_01',
+          description: 'URL principal para anúncios de botox em Novo Hamburgo.',
+          source: 'manual',
+          placement: 'meta_ads',
+          unitSlug: 'novo-hamburgo',
+          serviceId: 'botox',
+          utmSource: 'meta',
+          utmMedium: 'paid_social',
+          utmCampaign: 'botox_novo_hamburgo',
+          utmContent: 'video_botox_nh_01',
+          utmTerm: null,
+          active: true,
+          createdAtMs: now - 12 * 24 * 60 * 60 * 1000,
+          updatedAtMs: now - 60 * 60 * 1000,
+          clickCount: 18,
+          lastClickAtMs: now - 30 * 60 * 1000,
+        },
+      ],
       topLinks: [
         { linkUrl: 'https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox&utm_source=meta', count: 18 },
         { linkUrl: 'https://espacofacial.com/api/whatsapp/redirect?dest=...', count: 12 },

--- a/frontend/siteTrackingComponents.tsx
+++ b/frontend/siteTrackingComponents.tsx
@@ -1,0 +1,632 @@
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { DragDropContext, Draggable, Droppable, type DraggableProvidedDragHandleProps, type DropResult } from '@hello-pangea/dnd'
+import { Badge } from '@/badge'
+import { Button } from '@/button'
+import { Card, CardContent } from '@/card'
+import type { TrackingOverviewResponse } from '@/metaTrackingLocalMock'
+import {
+  DEFAULT_SITE_METRIC_LAYOUT,
+  cycleMetricDimensions,
+  displayEventName,
+  displayIncompleteCause,
+  fmtDate,
+  formatSiteTrackingNumber,
+  funnelBarWidth,
+  listOrEmpty,
+  shortUrl,
+  siteTrackingNumberValue,
+  type SiteMetricAspect,
+  type SiteMetricKey,
+  type SiteMetricLayout,
+} from '@/siteTrackingPresentation'
+import { TooltipLabel } from '@/tooltip'
+import {
+  CursorClick,
+  DotsSixVertical,
+  EyeSlash,
+  Funnel,
+  LinkSimple,
+  Pulse,
+  WarningCircle,
+} from '@phosphor-icons/react'
+
+export const siteTrackingPanelClass = 'border-slate-800/80 bg-slate-950/60 shadow-[0_20px_80px_rgba(2,6,23,0.35)] backdrop-blur-xl'
+
+type SiteMetricTileData = {
+  key: SiteMetricKey
+  label: string
+  tooltipLabel?: string
+  description?: string
+  value: ReactNode
+  detail?: string
+  icon: typeof Pulse
+  toneClass: string
+  width: number
+  height: number
+  aspect: SiteMetricAspect
+}
+
+type FunnelRow = {
+  label: string
+  value: number
+}
+
+export type ManagedSiteUrl = NonNullable<NonNullable<TrackingOverviewResponse['customLinks']>['managedUrls']>[number]
+
+export type ManagedSiteUrlForm = {
+  id?: string
+  name: string
+  slugPath: string
+  destinationUrl: string
+  description: string
+  placement: string
+  unitSlug: string
+  serviceId: string
+  utmSource: string
+  utmMedium: string
+  utmCampaign: string
+  utmContent: string
+  utmTerm: string
+  active: boolean
+}
+
+const emptyManagedUrlForm: ManagedSiteUrlForm = {
+  name: '',
+  slugPath: '',
+  destinationUrl: 'https://espacofacial.com/agendamento',
+  description: '',
+  placement: '',
+  unitSlug: '',
+  serviceId: '',
+  utmSource: 'meta',
+  utmMedium: 'paid_social',
+  utmCampaign: '',
+  utmContent: '',
+  utmTerm: '',
+  active: true,
+}
+
+function managedUrlToForm(url: ManagedSiteUrl): ManagedSiteUrlForm {
+  return {
+    id: url.id,
+    name: url.name || '',
+    slugPath: url.slugPath || '',
+    destinationUrl: url.destinationUrl || 'https://espacofacial.com/agendamento',
+    description: url.description || '',
+    placement: url.placement || '',
+    unitSlug: url.unitSlug || '',
+    serviceId: url.serviceId || '',
+    utmSource: url.utmSource || '',
+    utmMedium: url.utmMedium || '',
+    utmCampaign: url.utmCampaign || '',
+    utmContent: url.utmContent || '',
+    utmTerm: url.utmTerm || '',
+    active: url.active !== false,
+  }
+}
+
+function ManagedUrlField({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string
+  value: string
+  placeholder?: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <label className="space-y-1 text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+      <span>{label}</span>
+      <input
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-10 w-full rounded-lg border border-slate-800 bg-slate-950/70 px-3 text-sm font-normal normal-case tracking-normal text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
+      />
+    </label>
+  )
+}
+
+function SiteMetricTile({
+  label,
+  tooltipLabel,
+  description,
+  value,
+  detail,
+  icon: Icon,
+  toneClass,
+  width,
+  height,
+  aspect,
+  dragHandleProps,
+  onHide,
+  onResize,
+}: SiteMetricTileData & {
+  dragHandleProps?: DraggableProvidedDragHandleProps | null
+  onHide?: () => void
+  onResize?: (dimensions: { width: number; height: number; aspect?: SiteMetricAspect }) => void
+}) {
+  const isSquare = aspect === '1:1'
+  const isWide = aspect === '2:1'
+  const isLandscape = aspect === '4:3'
+  const roomy = width >= 300 && height >= 150
+  const body = (
+    <CardContent
+      tabIndex={tooltipLabel || description ? 0 : undefined}
+      className={`flex h-full outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/45 ${
+        isWide
+          ? 'items-center justify-between gap-4 px-10 py-4 text-left'
+          : isLandscape
+            ? 'items-start justify-between gap-3 p-4 text-left'
+            : 'items-center justify-center gap-3 p-4 text-center'
+      }`}
+    >
+      <div className={`${isWide ? 'flex min-w-0 items-center gap-3' : 'flex min-w-0 flex-col gap-2'} ${isSquare ? 'items-center' : 'items-start'}`}>
+        <div className={`inline-flex ${roomy || isSquare ? 'h-9 w-9' : 'h-8 w-8'} shrink-0 items-center justify-center rounded-full border ${toneClass}`}>
+          <Icon className={roomy || isSquare ? 'h-4 w-4' : 'h-3.5 w-3.5'} weight="fill" />
+        </div>
+        <div className={`min-w-0 space-y-0.5 ${isSquare ? 'text-center' : ''}`}>
+          <div className={`${isWide ? 'text-[10px]' : 'text-[9px] sm:text-[10px]'} font-medium uppercase tracking-[0.14em] text-slate-400`}>{label}</div>
+          {detail && !isSquare ? <div className="text-[9px] leading-tight text-slate-500">{detail}</div> : null}
+        </div>
+      </div>
+      <div className={`${isWide ? 'min-w-[7rem] text-right' : isSquare ? 'text-center' : 'w-full'} space-y-1`}>
+        <div className={`${isWide ? 'text-[1.35rem]' : isLandscape ? 'text-[1.3rem]' : 'text-[1.24rem]'} font-semibold leading-tight text-white`}>{value}</div>
+        {description && (isWide || (isLandscape && roomy)) ? <div className={`${isWide ? 'ml-auto max-w-40' : 'max-w-56'} text-[10px] leading-snug text-slate-400`}>{description}</div> : null}
+      </div>
+    </CardContent>
+  )
+  const aspectClass =
+    aspect === '2:1'
+      ? 'bg-[radial-gradient(circle_at_15%_20%,rgba(34,211,238,0.13),transparent_36%),rgba(2,6,23,0.72)]'
+      : aspect === '4:3'
+        ? 'bg-[linear-gradient(135deg,rgba(15,23,42,0.88),rgba(2,6,23,0.74))]'
+        : 'bg-[radial-gradient(circle_at_50%_20%,rgba(45,212,191,0.12),transparent_42%),rgba(2,6,23,0.78)]'
+  return (
+    <Card className={`group relative h-full gap-0 overflow-hidden py-0 transition hover:border-cyan-400/25 hover:bg-slate-900/70 ${siteTrackingPanelClass} ${aspectClass}`}>
+      <button
+        type="button"
+        className="absolute left-2 top-2 z-10 inline-flex h-6 w-6 cursor-grab items-center justify-center rounded-full border border-slate-700/75 bg-slate-950/45 text-slate-500 opacity-60 shadow-sm transition hover:scale-105 hover:border-cyan-400/40 hover:text-cyan-100 hover:opacity-100 active:cursor-grabbing group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/45"
+        aria-label={`Mover métrica ${tooltipLabel || label}`}
+        {...dragHandleProps}
+      >
+        <DotsSixVertical className="h-3.5 w-3.5" weight="bold" />
+      </button>
+      {onHide ? (
+        <button
+          type="button"
+          className="absolute right-2 top-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-700/80 bg-slate-950/60 text-slate-400 opacity-70 shadow-sm transition hover:border-rose-400/40 hover:text-rose-100 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/45"
+          aria-label={`Ocultar métrica ${tooltipLabel || label}`}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onHide()
+          }}
+        >
+          <EyeSlash className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
+      {tooltipLabel || description ? (
+        <TooltipLabel label={<span className="block space-y-1"><span className="block font-medium text-slate-100">{tooltipLabel || label}</span>{description ? <span className="block">{description}</span> : null}</span>}>
+          {body}
+        </TooltipLabel>
+      ) : (
+        body
+      )}
+      {onResize ? (
+        <TooltipLabel label="Alternar formato" description={`Clique para alternar entre 1:1, 4:3 e 2:1. Atual: ${aspect}.`}>
+          <button
+            type="button"
+            className="absolute bottom-1.5 right-1.5 z-10 h-6 w-6 rounded-br-2xl border-b border-r border-slate-500/50 bg-gradient-to-br from-transparent via-transparent to-cyan-300/10 opacity-65 transition hover:border-cyan-300/70 hover:bg-cyan-400/10 hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/45"
+            aria-label={`Alternar formato da métrica ${tooltipLabel || label}`}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              onResize(cycleMetricDimensions(width, height, aspect))
+            }}
+          >
+            <span className="absolute bottom-1 right-1 h-2.5 w-2.5 rounded-br-xl border-b border-r border-cyan-200/35" aria-hidden="true" />
+          </button>
+        </TooltipLabel>
+      ) : null}
+    </Card>
+  )
+}
+
+export function SiteTrackingSection({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
+  return (
+    <section className={`rounded-2xl p-5 ${siteTrackingPanelClass}`}>
+      <div className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-300">
+        {icon}
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export function RankedList({
+  items,
+  labelKey,
+  empty,
+}: {
+  items: Array<Record<string, unknown>>
+  labelKey: string
+  empty: string
+}) {
+  if (!items.length) return <div className="text-sm text-slate-500">{empty}</div>
+  const max = Math.max(...items.map((item) => siteTrackingNumberValue(item.count)))
+  return (
+    <div className="space-y-3">
+      {items.map((item, index) => {
+        const label = String(item[labelKey] || 'sem valor')
+        const count = siteTrackingNumberValue(item.count)
+        return (
+          <div key={`${label}-${index}`} className="space-y-1">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="min-w-0 truncate text-slate-200">{label}</span>
+              <span className="font-mono text-slate-400">{formatSiteTrackingNumber(count)}</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
+              <div className="h-full rounded-full bg-cyan-400" style={{ width: funnelBarWidth(count, max) }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function ConnectionNotice({ onClose }: { onClose: () => void }) {
+  return (
+    <section className="rounded-2xl border border-cyan-400/25 bg-cyan-500/10 p-4 text-cyan-50 shadow-[0_20px_80px_rgba(8,145,178,0.12)]">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="text-sm font-semibold uppercase tracking-wide">Nova conexão de site</div>
+          <p className="mt-1 max-w-3xl text-sm text-cyan-100/80">
+            A primeira conexão ativa é o funil canônico <span className="font-mono">espacofacial.com</span>. Para adicionar outro site, crie a origem no backend/CRM e inclua a allowlist de domínio antes de aceitar eventos.
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" className="border border-cyan-300/25 bg-cyan-400/10 text-cyan-50 hover:bg-cyan-400/18" onClick={onClose}>
+          Fechar
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+export function SiteMetricsGrid({
+  hiddenMetricTiles,
+  visibleMetricTiles,
+  onDragEnd,
+  onHide,
+  onRestore,
+  onResize,
+  onShow,
+}: {
+  hiddenMetricTiles: Array<Pick<SiteMetricTileData, 'key' | 'label'>>
+  visibleMetricTiles: SiteMetricTileData[]
+  onDragEnd: (result: DropResult) => void
+  onHide: (key: SiteMetricKey) => void
+  onRestore: () => void
+  onResize: (key: SiteMetricKey, dimensions: Partial<SiteMetricLayout>) => void
+  onShow: (key: SiteMetricKey) => void
+}) {
+  return (
+    <div className="space-y-3">
+      {hiddenMetricTiles.length > 0 ? (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <span className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Ocultas</span>
+          {hiddenMetricTiles.map((tile) => (
+            <Button
+              key={tile.key}
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 rounded-full border border-slate-800 bg-slate-900/55 px-2 text-[11px] text-slate-300 hover:border-cyan-400/35 hover:bg-slate-800/80 hover:text-white"
+              onClick={() => onShow(tile.key)}
+            >
+              + {tile.label}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-[11px] text-slate-400 hover:bg-slate-800/80 hover:text-white"
+            onClick={onRestore}
+          >
+            Restaurar padrão
+          </Button>
+        </div>
+      ) : null}
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="site-tracking-metrics" direction="horizontal">
+          {(dropProvided) => (
+            <div ref={dropProvided.innerRef} {...dropProvided.droppableProps} className="relative flex flex-wrap items-stretch gap-2">
+              {visibleMetricTiles.length > 0 ? (
+                visibleMetricTiles.map((tile, index) => (
+                  <Draggable key={tile.key} draggableId={`site-tracking-metric-${tile.key}`} index={index}>
+                    {(dragProvided, snapshot) => (
+                      <div
+                        ref={dragProvided.innerRef}
+                        {...dragProvided.draggableProps}
+                        className={`min-w-0 flex-none ${snapshot.isDragging ? 'z-30' : ''}`}
+                        style={
+                          {
+                            ...dragProvided.draggableProps.style,
+                            width: `min(${tile.width}px, 100%)`,
+                            height: tile.height,
+                          } as CSSProperties
+                        }
+                      >
+                        <SiteMetricTile
+                          {...tile}
+                          dragHandleProps={dragProvided.dragHandleProps}
+                          onHide={() => onHide(tile.key)}
+                          onResize={(dimensions) => onResize(tile.key, dimensions)}
+                        />
+                      </div>
+                    )}
+                  </Draggable>
+                ))
+              ) : (
+                <Card className={`${siteTrackingPanelClass} w-full`}>
+                  <CardContent className="flex min-h-[72px] items-center justify-between gap-3 p-4 text-sm text-slate-300">
+                    <span>Nenhuma métrica visível no resumo do site.</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="border-slate-700 bg-slate-900/60 text-slate-100 hover:bg-slate-800/80"
+                      onClick={onRestore}
+                    >
+                      Restaurar métricas
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+              {dropProvided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
+  )
+}
+
+export function OperationalAlerts({
+  alerts,
+}: {
+  alerts: NonNullable<TrackingOverviewResponse['alerts']>
+}) {
+  if (!alerts.length) return null
+  return (
+    <SiteTrackingSection title="Alertas operacionais" icon={<WarningCircle className="h-5 w-5" />}>
+      <div className="grid gap-3 md:grid-cols-2">
+        {alerts.map((alert) => (
+          <div key={alert.code} className="rounded-lg border border-white/10 bg-white/[0.03] p-4">
+            <Badge variant={alert.severity === 'critical' ? 'destructive' : 'warning'}>{alert.severity === 'critical' ? 'Crítico' : 'Atenção'}</Badge>
+            <div className="mt-3 font-semibold text-white">{alert.title}</div>
+            <div className="mt-1 text-sm text-slate-400">{alert.message}</div>
+          </div>
+        ))}
+      </div>
+    </SiteTrackingSection>
+  )
+}
+
+export function SiteFunnelSection({ rows, max }: { rows: FunnelRow[]; max: number }) {
+  return (
+    <div className="grid gap-6">
+      <SiteTrackingSection title="Funil do site" icon={<Funnel className="h-5 w-5" />}>
+        <div className="space-y-4">
+          {rows.map((row) => (
+            <div key={row.label} className="space-y-1">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-slate-300">{row.label}</span>
+                <span className="font-mono text-white">{formatSiteTrackingNumber(row.value)}</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-white/10">
+                <div className="h-full rounded-full bg-emerald-400" style={{ width: funnelBarWidth(row.value, max) }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </SiteTrackingSection>
+    </div>
+  )
+}
+
+export function SiteBehaviorSections({ data }: { data: TrackingOverviewResponse | null }) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-3">
+      <SiteTrackingSection title="Páginas mais vistas" icon={<CursorClick className="h-5 w-5" />}>
+        <RankedList items={listOrEmpty(data?.siteBehavior?.topPages)} labelKey="pagePath" empty="Sem pageviews agregados ainda." />
+      </SiteTrackingSection>
+      <SiteTrackingSection title="Entradas" icon={<CursorClick className="h-5 w-5" />}>
+        <RankedList items={listOrEmpty(data?.siteBehavior?.topEntryPages)} labelKey="pagePath" empty="Sem páginas de entrada no período." />
+      </SiteTrackingSection>
+      <SiteTrackingSection title="Campanhas" icon={<LinkSimple className="h-5 w-5" />}>
+        <RankedList items={listOrEmpty(data?.website?.data?.topCampaigns)} labelKey="utmCampaign" empty="Sem campanhas atribuídas no período." />
+      </SiteTrackingSection>
+    </div>
+  )
+}
+
+export function ManagedSiteUrlsSection({
+  urls,
+  saving,
+  onSave,
+}: {
+  urls: ManagedSiteUrl[]
+  saving?: boolean
+  onSave: (form: ManagedSiteUrlForm) => Promise<void>
+}) {
+  const [form, setForm] = useState<ManagedSiteUrlForm>(emptyManagedUrlForm)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!editingId) return
+    const current = urls.find((url) => url.id === editingId)
+    if (current) setForm(managedUrlToForm(current))
+  }, [editingId, urls])
+
+  const update = (patch: Partial<ManagedSiteUrlForm>) => setForm((prev) => ({ ...prev, ...patch }))
+  const reset = () => {
+    setEditingId(null)
+    setForm(emptyManagedUrlForm)
+    setFeedback(null)
+  }
+
+  return (
+    <SiteTrackingSection title="URLs personalizadas" icon={<LinkSimple className="h-5 w-5" />}>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(340px,0.8fr)]">
+        <div className="space-y-3">
+          {urls.length ? urls.map((url) => (
+            <div key={url.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-semibold text-white">{url.name}</span>
+                    <Badge variant={url.active ? 'success' : 'secondary'}>{url.active ? 'Ativa' : 'Pausada'}</Badge>
+                  </div>
+                  <div className="mt-1 truncate font-mono text-xs text-cyan-100">{url.publicUrl}</div>
+                  <div className="mt-1 truncate text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
+                  <div className="mt-2 text-xs text-slate-500">
+                    {url.utmCampaign || 'sem campanha'} · {url.unitSlug || 'sem unidade'} · {url.serviceId || 'sem procedimento'}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-3">
+                  <div className="text-right">
+                    <div className="font-mono text-lg font-semibold text-white">{formatSiteTrackingNumber(url.clickCount)}</div>
+                    <div className="text-[10px] uppercase tracking-[0.12em] text-slate-500">cliques</div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="border-slate-700 bg-slate-950/60 text-slate-100 hover:bg-slate-800"
+                    onClick={() => {
+                      setEditingId(url.id)
+                      setFeedback(null)
+                    }}
+                  >
+                    Editar
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhuma URL personalizada cadastrada ainda.</div>}
+        </div>
+
+        <form
+          className="space-y-3 rounded-xl border border-cyan-400/20 bg-cyan-500/[0.04] p-4"
+          onSubmit={async (event) => {
+            event.preventDefault()
+            setFeedback(null)
+            try {
+              await onSave(form)
+              setFeedback(editingId ? 'URL atualizada.' : 'URL cadastrada.')
+              setEditingId(null)
+              setForm(emptyManagedUrlForm)
+            } catch (error) {
+              setFeedback(error instanceof Error ? error.message : 'Não foi possível salvar a URL.')
+            }
+          }}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-white">{editingId ? 'Editar URL' : 'Adicionar URL'}</div>
+              <div className="text-xs text-slate-500">Use para links de campanha, anúncios e atalhos monitorados.</div>
+            </div>
+            {editingId ? (
+              <Button type="button" variant="ghost" size="sm" className="text-slate-400 hover:text-white" onClick={reset}>
+                Cancelar
+              </Button>
+            ) : null}
+          </div>
+          <ManagedUrlField label="Nome" value={form.name} placeholder="Botox Novo Hamburgo Meta" onChange={(name) => update({ name })} />
+          <ManagedUrlField label="URL final" value={form.destinationUrl} placeholder="https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox" onChange={(destinationUrl) => update({ destinationUrl })} />
+          <ManagedUrlField label="Atalho" value={form.slugPath} placeholder="/campanhas/botox-novo-hamburgo-meta" onChange={(slugPath) => update({ slugPath })} />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <ManagedUrlField label="utm_source" value={form.utmSource} onChange={(utmSource) => update({ utmSource })} />
+            <ManagedUrlField label="utm_medium" value={form.utmMedium} onChange={(utmMedium) => update({ utmMedium })} />
+            <ManagedUrlField label="utm_campaign" value={form.utmCampaign} onChange={(utmCampaign) => update({ utmCampaign })} />
+            <ManagedUrlField label="utm_content" value={form.utmContent} onChange={(utmContent) => update({ utmContent })} />
+            <ManagedUrlField label="Unidade" value={form.unitSlug} placeholder="novo-hamburgo" onChange={(unitSlug) => update({ unitSlug })} />
+            <ManagedUrlField label="Procedimento" value={form.serviceId} placeholder="botox" onChange={(serviceId) => update({ serviceId })} />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(event) => update({ active: event.target.checked })}
+              className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-cyan-500"
+            />
+            URL ativa
+          </label>
+          {feedback ? <div className="text-xs text-emerald-300">{feedback}</div> : null}
+          <Button type="submit" disabled={saving || !form.name.trim() || !form.destinationUrl.trim()} className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+            {saving ? 'Salvando...' : editingId ? 'Salvar alterações' : 'Cadastrar URL'}
+          </Button>
+        </form>
+      </div>
+    </SiteTrackingSection>
+  )
+}
+
+export function SiteLinkSections({ data }: { data: TrackingOverviewResponse | null }) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      <SiteTrackingSection title="Links personalizados e CTAs" icon={<LinkSimple className="h-5 w-5" />}>
+        <RankedList items={listOrEmpty(data?.customLinks?.topLinks)} labelKey="linkUrl" empty="Sem cliques em links rastreados." />
+      </SiteTrackingSection>
+      <SiteTrackingSection title="Links sem campanha identificada" icon={<WarningCircle className="h-5 w-5" />}>
+        <RankedList items={listOrEmpty(data?.customLinks?.linksMissingUtm)} labelKey="linkUrl" empty="Nenhum link sem campanha identificada no período." />
+      </SiteTrackingSection>
+    </div>
+  )
+}
+
+export function SiteIssueAndClickSections({ data }: { data: TrackingOverviewResponse | null }) {
+  const incompleteBookings = listOrEmpty(data?.reconciliation?.incompleteBookings)
+  const recentClicks = listOrEmpty(data?.customLinks?.recentClicks)
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      <SiteTrackingSection title="Reservas com origem incompleta" icon={<WarningCircle className="h-5 w-5" />}>
+        <div className="space-y-3">
+          {incompleteBookings.slice(0, 8).map((booking) => (
+            <div key={booking.id} className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-mono text-xs text-slate-400">{booking.id}</span>
+                <Badge variant="outline">{displayIncompleteCause(booking.primaryCause)}</Badge>
+              </div>
+              <div className="mt-2 text-sm text-slate-300">{booking.unitSlug} · {booking.utmSource || 'sem origem'} · {booking.utmCampaign || 'sem campanha'}</div>
+            </div>
+          ))}
+          {!incompleteBookings.length ? <div className="text-sm text-slate-500">Nenhuma reserva com origem incompleta no período.</div> : null}
+        </div>
+      </SiteTrackingSection>
+
+      <SiteTrackingSection title="Cliques recentes" icon={<CursorClick className="h-5 w-5" />}>
+        <div className="space-y-3">
+          {recentClicks.slice(0, 8).map((click) => (
+            <div key={click.id} className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold text-white">{displayEventName(click.eventName)}</span>
+                <span className="text-xs text-slate-500">{fmtDate(click.createdAtMs)}</span>
+              </div>
+              <div className="mt-1 truncate text-sm text-slate-300">{shortUrl(click.linkUrl)}</div>
+              <div className="mt-1 text-xs text-slate-500">{click.utmCampaign || 'sem campanha'} · {click.placement || 'sem posição'}</div>
+            </div>
+          ))}
+          {!recentClicks.length ? <div className="text-sm text-slate-500">Nenhum clique recente no período.</div> : null}
+        </div>
+      </SiteTrackingSection>
+    </div>
+  )
+}

--- a/frontend/siteTrackingHeaderBridge.ts
+++ b/frontend/siteTrackingHeaderBridge.ts
@@ -1,0 +1,91 @@
+import type {
+  SiteTrackingHeaderAction,
+  SiteTrackingHeaderBadgeTone,
+  SiteTrackingHeaderState,
+  SiteTrackingWindowDays,
+} from '@/siteTrackingTypes'
+
+const SITE_TRACKING_HEADER_EVENT = 'skincos:site-tracking:header'
+const SITE_TRACKING_ACTION_EVENT = 'skincos:site-tracking:action'
+
+function isBadgeTone(value: unknown): value is SiteTrackingHeaderBadgeTone {
+  return value === 'neutral' || value === 'success' || value === 'warning' || value === 'danger'
+}
+
+function isWindowDays(value: unknown): value is SiteTrackingWindowDays {
+  return value === 7 || value === 30 || value === 60 || value === 90
+}
+
+export function normalizeSiteTrackingHeaderState(detail: unknown): SiteTrackingHeaderState | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as Partial<SiteTrackingHeaderState>
+  if (!Array.isArray(payload.sites)) return null
+  return {
+    refreshing: Boolean(payload.refreshing),
+    sites: payload.sites.map((site) => ({
+      id: String(site?.id || ''),
+      name: String(site?.name || site?.host || site?.id || ''),
+      host: String(site?.host || site?.id || ''),
+      statusLabel: site?.statusLabel ? String(site.statusLabel) : undefined,
+      statusTone: isBadgeTone(site?.statusTone) ? site.statusTone : undefined,
+    })).filter((site) => site.id),
+    selectedSiteId: String(payload.selectedSiteId || ''),
+    windowDays: isWindowDays(payload.windowDays) ? payload.windowDays : 30,
+    selectedSiteName: payload.selectedSiteName ? String(payload.selectedSiteName) : undefined,
+    updatedAt: payload.updatedAt ? String(payload.updatedAt) : undefined,
+  }
+}
+
+export function normalizeSiteTrackingHeaderAction(detail: unknown): SiteTrackingHeaderAction | null {
+  if (!detail || typeof detail !== 'object') return null
+  const payload = detail as { type?: unknown; value?: unknown; action?: unknown }
+  const rawType = String(payload.type || payload.action || '').trim()
+  if (rawType === 'refresh' || rawType === 'connect') return { type: rawType }
+  if (rawType === 'rename-site') {
+    const value = String(payload.value || '').trim()
+    return value ? { type: 'rename-site', value } : { type: 'rename-site' }
+  }
+  if (rawType === 'set-site') {
+    const value = String(payload.value || '').trim()
+    return value ? { type: 'set-site', value } : null
+  }
+  if (rawType === 'set-window') {
+    const value = Number(payload.value)
+    return isWindowDays(value) ? { type: 'set-window', value } : null
+  }
+  return null
+}
+
+export function emitSiteTrackingHeaderState(detail: SiteTrackingHeaderState | null) {
+  try {
+    window.dispatchEvent(new CustomEvent<SiteTrackingHeaderState | null>(SITE_TRACKING_HEADER_EVENT, { detail }))
+  } catch {
+    // ignore browser event bridge errors
+  }
+}
+
+export function dispatchSiteTrackingHeaderAction(action: SiteTrackingHeaderAction) {
+  try {
+    window.dispatchEvent(new CustomEvent<SiteTrackingHeaderAction>(SITE_TRACKING_ACTION_EVENT, { detail: action }))
+  } catch {
+    // ignore browser event bridge errors
+  }
+}
+
+export function subscribeSiteTrackingHeaderState(callback: (state: SiteTrackingHeaderState | null) => void) {
+  const handler = (event: Event) => {
+    callback(normalizeSiteTrackingHeaderState((event as CustomEvent<unknown>).detail))
+  }
+  window.addEventListener(SITE_TRACKING_HEADER_EVENT, handler as EventListener)
+  return () => window.removeEventListener(SITE_TRACKING_HEADER_EVENT, handler as EventListener)
+}
+
+export function subscribeSiteTrackingHeaderAction(callback: (action: SiteTrackingHeaderAction) => void) {
+  const handler = (event: Event) => {
+    const action = normalizeSiteTrackingHeaderAction((event as CustomEvent<unknown>).detail)
+    if (!action) return
+    callback(action)
+  }
+  window.addEventListener(SITE_TRACKING_ACTION_EVENT, handler as EventListener)
+  return () => window.removeEventListener(SITE_TRACKING_ACTION_EVENT, handler as EventListener)
+}

--- a/frontend/siteTrackingPresentation.ts
+++ b/frontend/siteTrackingPresentation.ts
@@ -1,0 +1,182 @@
+import type { SiteTrackingWindowDays } from '@/siteTrackingTypes'
+
+export type SiteMetricKey =
+  | 'sessions'
+  | 'bookings'
+  | 'whatsapp'
+  | 'schedule'
+  | 'origin'
+  | 'reservationLink'
+  | 'facebook'
+  | 'marketing'
+  | 'campaign'
+  | 'conversion'
+
+export type SiteMetricAspect = '1:1' | '4:3' | '2:1'
+
+export type SiteMetricLayout = {
+  key: SiteMetricKey
+  visible: boolean
+  width: number
+  height: number
+  aspect: SiteMetricAspect
+}
+
+export type WindowDays = SiteTrackingWindowDays
+
+export const SITE_TRACKING_METRIC_LAYOUT_KEY = 'skincos.siteTracking.layout.metrics.v2'
+
+export const SITE_METRIC_DIMENSIONS = {
+  minWidth: 140,
+  maxWidth: 680,
+  minHeight: 96,
+  maxHeight: 520,
+  defaultWidth: 224,
+  defaultHeight: 168,
+} as const
+
+export const SITE_METRIC_ASPECTS: SiteMetricAspect[] = ['1:1', '4:3', '2:1']
+
+export const DEFAULT_SITE_METRIC_LAYOUT: SiteMetricLayout[] = [
+  { key: 'sessions', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'bookings', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'whatsapp', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'schedule', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'origin', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'reservationLink', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'facebook', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'marketing', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'campaign', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+  { key: 'conversion', visible: true, width: SITE_METRIC_DIMENSIONS.defaultWidth, height: SITE_METRIC_DIMENSIONS.defaultHeight, aspect: '4:3' },
+]
+
+export function siteTrackingNumberValue(value: unknown): number {
+  const parsed = Number(value || 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function formatSiteTrackingNumber(value: unknown): string {
+  return new Intl.NumberFormat('pt-BR').format(siteTrackingNumberValue(value))
+}
+
+export function formatSiteTrackingPercent(value: unknown): string {
+  return `${formatSiteTrackingNumber(value)}%`
+}
+
+export function funnelBarWidth(value: unknown, max: unknown): string {
+  const denominator = Math.max(1, siteTrackingNumberValue(max))
+  return `${Math.max(4, Math.min(100, Math.round((siteTrackingNumberValue(value) / denominator) * 100)))}%`
+}
+
+function clampMetricDimension(value: unknown, min: number, max: number, fallback: number) {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return fallback
+  return Math.min(max, Math.max(min, Math.round(numberValue)))
+}
+
+function getMetricAspect(value: unknown, width?: unknown, height?: unknown): SiteMetricAspect {
+  if (value === '1:1' || value === '4:3' || value === '2:1') return value
+  const ratio = Number(width) > 0 && Number(height) > 0 ? Number(width) / Number(height) : 4 / 3
+  const ratios: Record<SiteMetricAspect, number> = { '1:1': 1, '4:3': 4 / 3, '2:1': 2 }
+  return SITE_METRIC_ASPECTS.reduce((closest, option) => {
+    const closestDelta = Math.abs(ratios[closest] - ratio)
+    const optionDelta = Math.abs(ratios[option] - ratio)
+    return optionDelta < closestDelta ? option : closest
+  }, '4:3' as SiteMetricAspect)
+}
+
+export function fitMetricBoxToAspect(width: number, height: number, aspect: SiteMetricAspect) {
+  const ratio = aspect === '1:1' ? 1 : aspect === '2:1' ? 2 : 4 / 3
+  const nextHeight = clampMetricDimension(Math.round(width / ratio), SITE_METRIC_DIMENSIONS.minHeight, SITE_METRIC_DIMENSIONS.maxHeight, height)
+  return {
+    width: clampMetricDimension(Math.round(nextHeight * ratio), SITE_METRIC_DIMENSIONS.minWidth, SITE_METRIC_DIMENSIONS.maxWidth, width),
+    height: nextHeight,
+  }
+}
+
+export function cycleMetricDimensions(width: number, height: number, currentAspect: SiteMetricAspect) {
+  const currentIndex = SITE_METRIC_ASPECTS.indexOf(currentAspect)
+  const aspect = SITE_METRIC_ASPECTS[(currentIndex + 1) % SITE_METRIC_ASPECTS.length]
+  return { ...fitMetricBoxToAspect(width, height, aspect), aspect }
+}
+
+export function parseSiteMetricLayout(raw: string | null | undefined): SiteMetricLayout[] {
+  try {
+    const parsed = raw ? JSON.parse(raw) : null
+    const items = Array.isArray(parsed) ? parsed : []
+    const seen = new Set<SiteMetricKey>()
+    const normalized = items
+      .map((item) => {
+        const key = String(item?.key || '').trim() as SiteMetricKey
+        const fallback = DEFAULT_SITE_METRIC_LAYOUT.find((entry) => entry.key === key)
+        if (!fallback || seen.has(key)) return null
+        seen.add(key)
+        const aspect = getMetricAspect(item?.aspect, item?.width, item?.height)
+        const dimensions = fitMetricBoxToAspect(
+          clampMetricDimension(item?.width, SITE_METRIC_DIMENSIONS.minWidth, SITE_METRIC_DIMENSIONS.maxWidth, fallback.width),
+          clampMetricDimension(item?.height, SITE_METRIC_DIMENSIONS.minHeight, SITE_METRIC_DIMENSIONS.maxHeight, fallback.height),
+          aspect,
+        )
+        return {
+          key,
+          visible: item?.visible !== false,
+          width: dimensions.width,
+          height: dimensions.height,
+          aspect,
+        }
+      })
+      .filter(Boolean) as SiteMetricLayout[]
+    const missing = DEFAULT_SITE_METRIC_LAYOUT.filter((entry) => !seen.has(entry.key))
+    return [...normalized, ...missing]
+  } catch {
+    return DEFAULT_SITE_METRIC_LAYOUT
+  }
+}
+
+export function fmtDate(ms?: number | null) {
+  if (!ms) return 'sem data'
+  return new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(ms))
+}
+
+export function shortUrl(value?: string | null) {
+  if (!value) return 'sem link'
+  try {
+    const url = new URL(value)
+    if (url.pathname.includes('/api/whatsapp/redirect')) return 'WhatsApp pelo site'
+    return `${url.hostname}${url.pathname}${url.search ? '?...' : ''}`
+  } catch {
+    return value.length > 72 ? `${value.slice(0, 72)}...` : value
+  }
+}
+
+export function displayEventName(value?: string | null) {
+  const normalized = String(value || '').toLowerCase()
+  if (normalized.includes('whatsapp')) return 'Clique no WhatsApp'
+  if (normalized.includes('booking_confirmed')) return 'Reserva confirmada'
+  if (normalized.includes('booking')) return 'Agendamento'
+  if (normalized.includes('cta')) return 'Clique em chamada'
+  if (normalized.includes('external')) return 'Clique externo'
+  return value ? String(value).replace(/_/g, ' ') : 'Interação'
+}
+
+export function displayIncompleteCause(value?: string | null) {
+  const normalized = String(value || '').toLowerCase()
+  if (normalized.includes('meta') || normalized.includes('event')) return 'Reserva sem vínculo completo'
+  if (normalized.includes('facebook') || normalized.includes('fb')) return 'Origem Meta incompleta'
+  if (normalized.includes('tracking') || normalized.includes('context')) return 'Origem não preservada'
+  if (normalized.includes('consent')) return 'Consentimento ausente'
+  return value ? String(value).replace(/_/g, ' ') : 'Origem incompleta'
+}
+
+export function isInternalPreviewAlert(alert: { code?: string; title?: string; message?: string }) {
+  const haystack = `${alert.code || ''} ${alert.title || ''} ${alert.message || ''}`.toLowerCase()
+  return haystack.includes('local_preview') || haystack.includes('modo local') || haystack.includes('cenário simulado')
+}
+
+export function alertSeverityLabel(severity?: string) {
+  return severity === 'critical' ? 'Crítico' : 'Atenção'
+}
+
+export function listOrEmpty<T>(items: T[] | undefined | null): T[] {
+  return Array.isArray(items) ? items : []
+}

--- a/frontend/siteTrackingTypes.ts
+++ b/frontend/siteTrackingTypes.ts
@@ -1,0 +1,27 @@
+export type SiteTrackingWindowDays = 7 | 30 | 60 | 90
+
+export type SiteTrackingHeaderBadgeTone = 'neutral' | 'success' | 'warning' | 'danger'
+
+export type SiteTrackingHeaderSiteOption = {
+  id: string
+  name: string
+  host: string
+  statusLabel?: string
+  statusTone?: SiteTrackingHeaderBadgeTone
+}
+
+export type SiteTrackingHeaderState = {
+  refreshing: boolean
+  sites: SiteTrackingHeaderSiteOption[]
+  selectedSiteId: string
+  windowDays: SiteTrackingWindowDays
+  selectedSiteName?: string
+  updatedAt?: string
+}
+
+export type SiteTrackingHeaderAction =
+  | { type: 'set-site'; value: string }
+  | { type: 'rename-site'; value?: string }
+  | { type: 'set-window'; value: SiteTrackingWindowDays }
+  | { type: 'connect' }
+  | { type: 'refresh' }

--- a/frontend/tests/siteTrackingModule.test.ts
+++ b/frontend/tests/siteTrackingModule.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  normalizeSiteTrackingHeaderAction,
+  normalizeSiteTrackingHeaderState,
+} from '../siteTrackingHeaderBridge'
+import {
+  DEFAULT_SITE_METRIC_LAYOUT,
+  displayEventName,
+  displayIncompleteCause,
   formatSiteTrackingNumber,
   formatSiteTrackingPercent,
   funnelBarWidth,
-  siteTrackingHealthTone,
-} from '../SiteTrackingModule'
+  isInternalPreviewAlert,
+  parseSiteMetricLayout,
+  shortUrl,
+} from '../siteTrackingPresentation'
 
 describe('SiteTrackingModule helpers', () => {
   it('formats numbers and percentages for pt-BR operators', () => {
@@ -20,9 +29,82 @@ describe('SiteTrackingModule helpers', () => {
     expect(funnelBarWidth(200, 100)).toBe('100%')
   })
 
-  it('maps health states to the expected semantic tone classes', () => {
-    expect(siteTrackingHealthTone('healthy')).toContain('emerald')
-    expect(siteTrackingHealthTone('critical')).toContain('red')
-    expect(siteTrackingHealthTone('degraded')).toContain('amber')
+  it('restores invalid metric layout payloads to the default layout', () => {
+    expect(parseSiteMetricLayout('not-json')).toEqual(DEFAULT_SITE_METRIC_LAYOUT)
+  })
+
+  it('normalizes persisted metric layout and appends missing metrics', () => {
+    const layout = parseSiteMetricLayout(JSON.stringify([
+      { key: 'facebook', visible: false, width: 9999, height: 20, aspect: '2:1' },
+      { key: 'facebook', visible: true, width: 100, height: 100, aspect: '1:1' },
+      { key: 'unknown', visible: true },
+    ]))
+
+    expect(layout[0]).toMatchObject({
+      key: 'facebook',
+      visible: false,
+      width: 680,
+      height: 340,
+      aspect: '2:1',
+    })
+    expect(layout).toHaveLength(DEFAULT_SITE_METRIC_LAYOUT.length)
+    expect(layout.filter((item) => item.key === 'facebook')).toHaveLength(1)
+  })
+
+  it('keeps operational labels user-facing instead of leaking internal event names', () => {
+    expect(displayEventName('whatsapp_redirect_click')).toBe('Clique no WhatsApp')
+    expect(displayEventName('booking_confirmed')).toBe('Reserva confirmada')
+    expect(displayIncompleteCause('meta_event_id_missing')).toBe('Reserva sem vínculo completo')
+    expect(displayIncompleteCause('tracking_context_missing')).toBe('Origem não preservada')
+  })
+
+  it('hides local preview alerts from the operational surface', () => {
+    expect(isInternalPreviewAlert({
+      code: 'LOCAL_PREVIEW_MODE',
+      title: 'Modo local controlado',
+      message: 'Cenário simulado para validar o preview local.',
+    })).toBe(true)
+    expect(isInternalPreviewAlert({
+      code: 'CAPI_DELIVERY_DROP',
+      title: 'Queda no envio de conversões',
+      message: 'Revise as últimas falhas.',
+    })).toBe(false)
+  })
+
+  it('shortens tracked WhatsApp redirect URLs into a readable label', () => {
+    expect(shortUrl('https://espacofacial.com/api/whatsapp/redirect?dest=abc&utm_source=meta')).toBe('WhatsApp pelo site')
+    expect(shortUrl('https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox')).toBe('espacofacial.com/agendamento?...')
+  })
+})
+
+describe('site tracking header bridge', () => {
+  it('normalizes header state without accepting invalid sites or windows', () => {
+    const state = normalizeSiteTrackingHeaderState({
+      refreshing: true,
+      selectedSiteId: 'espacofacial.com',
+      windowDays: 999,
+      sites: [
+        { id: 'espacofacial.com', name: 'Espaço Facial', host: 'espacofacial.com', statusTone: 'success' },
+        { id: '', name: 'invalid' },
+      ],
+    })
+
+    expect(state).toMatchObject({
+      refreshing: true,
+      selectedSiteId: 'espacofacial.com',
+      windowDays: 30,
+      sites: [{ id: 'espacofacial.com', name: 'Espaço Facial', host: 'espacofacial.com', statusTone: 'success' }],
+    })
+  })
+
+  it('normalizes valid header actions and rejects invalid payloads', () => {
+    expect(normalizeSiteTrackingHeaderAction({ type: 'refresh' })).toEqual({ type: 'refresh' })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'connect' })).toEqual({ type: 'connect' })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'rename-site' })).toEqual({ type: 'rename-site' })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'rename-site', value: 'espacofacial.com' })).toEqual({ type: 'rename-site', value: 'espacofacial.com' })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'set-site', value: 'espacofacial.com' })).toEqual({ type: 'set-site', value: 'espacofacial.com' })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'set-window', value: 90 })).toEqual({ type: 'set-window', value: 90 })
+    expect(normalizeSiteTrackingHeaderAction({ type: 'set-window', value: 15 })).toBeNull()
+    expect(normalizeSiteTrackingHeaderAction({ type: 'set-site', value: '' })).toBeNull()
   })
 })

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "crm:local": "bash ./scripts/run-local-crm.sh",
     "crm:local:meta-ads": "CRM_MODULE=meta-ads bash ./scripts/run-local-crm.sh",
+    "crm:local:site-tracking": "CRM_MODULE=site-tracking CRM_META_ADS_SCENARIO=connected-ready bash ./scripts/run-local-crm.sh",
     "quality:frontend": "npm --prefix frontend run lint && npm --prefix frontend run typecheck && npm --prefix frontend run test && npm --prefix frontend run build",
     "quality:website": "npm --prefix website run lint && npm --prefix website run typecheck && npm --prefix website run test && npm --prefix website run build",
     "quality:backend:crm-api": "npm --prefix backend/apps/crm-api test",

--- a/scripts/cloudflare-token-health.sh
+++ b/scripts/cloudflare-token-health.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-}"
+TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+PROJECT="${CLOUDFLARE_PAGES_PROJECT:-skincos}"
+WEBSITE_DB="${CLOUDFLARE_WEBSITE_D1_NAME:-espacofacial-booking}"
+WRANGLER_CWD="${WRANGLER_CWD:-website}"
+STRICT="${STRICT:-0}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/cloudflare-token-health.sh [--strict]
+
+Checks Cloudflare access without printing secrets:
+- CLOUDFLARE_API_TOKEN validity via /user/tokens/verify.
+- Account-scoped API access when CLOUDFLARE_ACCOUNT_ID is present.
+- Pages project read access.
+- D1 database visibility for espacofacial-booking.
+- Local Wrangler OAuth fallback when no API token is present.
+
+Required for CI/automation:
+  CLOUDFLARE_API_TOKEN
+  CLOUDFLARE_ACCOUNT_ID
+
+Optional:
+  CLOUDFLARE_PAGES_PROJECT       default: skincos
+  CLOUDFLARE_WEBSITE_D1_NAME     default: espacofacial-booking
+  WRANGLER_CWD                   default: website
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict) STRICT=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+ok() { printf 'OK   %s\n' "$*"; }
+warn() { printf 'WARN %s\n' "$*"; }
+fail() { printf 'FAIL %s\n' "$*" >&2; exit 1; }
+
+cf_get() {
+  local path="$1"
+  curl -fsS \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4${path}"
+}
+
+assert_success_json() {
+  local label="$1"
+  local payload="$2"
+  node -e '
+    const fs = require("node:fs");
+    const label = process.argv[1];
+    const payload = fs.readFileSync(0, "utf8");
+    let data;
+    try { data = JSON.parse(payload); } catch { process.exit(2); }
+    if (!data.success) {
+      const errors = Array.isArray(data.errors) ? data.errors.map((e) => `${e.code || "unknown"}:${e.message || ""}`).join(", ") : "unknown";
+      console.error(`FAIL ${label}: ${errors}`);
+      process.exit(1);
+    }
+  ' "$label" <<<"$payload"
+}
+
+if [[ -n "$TOKEN" ]]; then
+  verify_payload="$(cf_get "/user/tokens/verify")" || fail "Cloudflare token verify request failed"
+  assert_success_json "Cloudflare token verify failed" "$verify_payload"
+  ok "Cloudflare API token is valid"
+
+  if [[ -z "$ACCOUNT_ID" ]]; then
+    if [[ "$STRICT" == "1" ]]; then
+      fail "CLOUDFLARE_ACCOUNT_ID is required in strict mode"
+    fi
+    warn "CLOUDFLARE_ACCOUNT_ID is missing; account-scoped checks skipped"
+    exit 0
+  fi
+
+  account_payload="$(cf_get "/accounts/${ACCOUNT_ID}")" || fail "Cloudflare account read failed"
+  assert_success_json "Cloudflare account read failed" "$account_payload"
+  ok "Cloudflare account is readable"
+
+  pages_payload="$(cf_get "/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT}")" || fail "Cloudflare Pages project read failed: ${PROJECT}"
+  assert_success_json "Cloudflare Pages project read failed" "$pages_payload"
+  ok "Cloudflare Pages project is readable: ${PROJECT}"
+
+  d1_payload="$(cf_get "/accounts/${ACCOUNT_ID}/d1/database")" || fail "Cloudflare D1 list failed"
+  assert_success_json "Cloudflare D1 list failed" "$d1_payload"
+  if node -e '
+    const fs = require("node:fs");
+    const dbName = process.argv[1];
+    const data = JSON.parse(fs.readFileSync(0, "utf8"));
+    const found = Array.isArray(data.result) && data.result.some((db) => db.name === dbName);
+    process.exit(found ? 0 : 1);
+  ' "$WEBSITE_DB" <<<"$d1_payload"; then
+    ok "Cloudflare D1 database is visible: ${WEBSITE_DB}"
+  else
+    fail "Cloudflare D1 database not visible to token: ${WEBSITE_DB}"
+  fi
+
+  exit 0
+fi
+
+if [[ -d "$WRANGLER_CWD" ]]; then
+  if (cd "$WRANGLER_CWD" && npx --yes wrangler@4 whoami >/tmp/skincos-wrangler-whoami.log 2>&1); then
+    ok "Wrangler local OAuth is authenticated"
+    sed -n '1,28p' /tmp/skincos-wrangler-whoami.log | sed 's/^/     /'
+    if (cd "$WRANGLER_CWD" && npx --yes wrangler@4 d1 execute "$WEBSITE_DB" --remote --command "SELECT 1 AS ok;" >/tmp/skincos-wrangler-d1-smoke.log 2>&1); then
+      ok "Wrangler local OAuth can read remote D1: ${WEBSITE_DB}"
+    else
+      cat /tmp/skincos-wrangler-d1-smoke.log >&2 || true
+      if [[ "$STRICT" == "1" ]]; then
+        fail "Wrangler local OAuth is authenticated but cannot access remote D1: ${WEBSITE_DB}"
+      fi
+      warn "Wrangler local OAuth is authenticated but cannot access remote D1: ${WEBSITE_DB}"
+    fi
+    exit 0
+  fi
+  cat /tmp/skincos-wrangler-whoami.log >&2 || true
+fi
+
+if [[ "$STRICT" == "1" ]]; then
+  fail "No valid CLOUDFLARE_API_TOKEN and Wrangler local OAuth is not healthy"
+fi
+
+warn "No valid Cloudflare API token found and Wrangler local OAuth is unavailable"

--- a/scripts/codex-preflight.sh
+++ b/scripts/codex-preflight.sh
@@ -154,21 +154,21 @@ check_github() {
 check_cloudflare() {
   $SKIP_CLOUDFLARE && { warn "Cloudflare auth check skipped"; return; }
 
-  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-    ok "CLOUDFLARE_API_TOKEN is present in local environment"
-    return
+  local strict_arg=()
+  if $STRICT || $CI_MODE; then
+    strict_arg=(--strict)
   fi
 
-  if [[ -d frontend ]]; then
-    if (cd frontend && npx --yes wrangler@4 whoami >/tmp/codex-wrangler-whoami.log 2>&1); then
-      ok "Wrangler is authenticated locally"
-      sed -n '1,28p' /tmp/codex-wrangler-whoami.log | sed 's/^/     /'
+  if [[ -x scripts/cloudflare-token-health.sh ]]; then
+    if scripts/cloudflare-token-health.sh "${strict_arg[@]}" >/tmp/codex-cloudflare-token-health.log 2>&1; then
+      ok "Cloudflare token health check passed"
+      sed -n '1,36p' /tmp/codex-cloudflare-token-health.log | sed 's/^/     /'
     else
-      cat /tmp/codex-wrangler-whoami.log >&2 || true
-      fail "Wrangler is not authenticated and CLOUDFLARE_API_TOKEN is not set"
+      cat /tmp/codex-cloudflare-token-health.log >&2 || true
+      fail "Cloudflare token health check failed"
     fi
   else
-    fail "frontend directory not found; cannot run wrangler whoami"
+    fail "scripts/cloudflare-token-health.sh is missing or not executable"
   fi
 }
 

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -41,12 +41,12 @@ Perfis:
 
 Opções:
   --profile NAME                 realistic | session
-  --module NAME                  Abre o CRM já no módulo informado (ex.: meta-ads)
+  --module NAME                  Abre o CRM já no módulo informado (ex.: meta-ads, site-tracking)
   --crm-host HOST                Host do Vite (default: 127.0.0.1)
   --vite-port PORT               Porta do Vite (default: 5173)
   --pages-port PORT              Porta do Pages local (default: 8791)
   --meta-ads-scenario NAME       live | disconnected | connected-no-account | connected-ready | unauthorized
-                                 Ativa um cenário local controlado do Meta Ads em localhost.
+                                 Ativa um cenário local controlado do Meta Ads/tracking em localhost.
   --skip-build                   Não roda build do frontend antes de subir o Pages local
   --with-insumos                 Sobe Worker local do Insumos e aponta o CRM para ele
   --insumos-port PORT            Porta do Worker local de Insumos (default: 8787)
@@ -61,6 +61,7 @@ Opções:
 Exemplos:
   ./scripts/run-local-crm.sh
   ./scripts/run-local-crm.sh --module meta-ads
+  ./scripts/run-local-crm.sh --module site-tracking
   ./scripts/run-local-crm.sh --module meta-ads --meta-ads-scenario live
   ./scripts/run-local-crm.sh --module meta-ads --smoke
   ./scripts/run-local-crm.sh /meta-ads --with-insumos --insumos-snapshot ./tmp/insumos.json
@@ -121,11 +122,11 @@ if [[ -n "$CRM_MODULE" ]]; then
   CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "module" "$CRM_MODULE")"
 fi
 
-if [[ "$CRM_MODULE" == "meta-ads" && -z "$CRM_META_ADS_SCENARIO" && "$CRM_PROFILE" == "realistic" ]]; then
+if [[ ("$CRM_MODULE" == "meta-ads" || "$CRM_MODULE" == "site-tracking") && -z "$CRM_META_ADS_SCENARIO" && "$CRM_PROFILE" == "realistic" ]]; then
   CRM_META_ADS_SCENARIO="connected-ready"
 fi
 
-if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
+if [[ ("$CRM_MODULE" == "meta-ads" || "$CRM_MODULE" == "site-tracking") && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
   CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "metaAdsLocalScenario" "$CRM_META_ADS_SCENARIO")"
 fi
 
@@ -320,8 +321,8 @@ echo "Rota inicial: $CRM_ROUTE"
 if [[ -n "$CRM_MODULE" ]]; then
   echo "Módulo inicial: $CRM_MODULE"
 fi
-if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" ]]; then
-  echo "Cenário Meta Ads: $CRM_META_ADS_SCENARIO"
+if [[ ("$CRM_MODULE" == "meta-ads" || "$CRM_MODULE" == "site-tracking") && -n "$CRM_META_ADS_SCENARIO" ]]; then
+  echo "Cenário local de tracking: $CRM_META_ADS_SCENARIO"
 fi
 echo "URLs:"
 echo "  Local  : $DEFAULT_URL"
@@ -439,8 +440,8 @@ if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
 else
   echo "  - Insumos continua usando o target definido em frontend/.dev.vars ou frontend/wrangler.toml."
 fi
-if [[ "$CRM_MODULE" == "meta-ads" && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
-  echo "  - Meta Ads está em cenário local controlado; o fluxo de conexão é simulado só em localhost."
+if [[ ("$CRM_MODULE" == "meta-ads" || "$CRM_MODULE" == "site-tracking") && -n "$CRM_META_ADS_SCENARIO" && "$CRM_META_ADS_SCENARIO" != "live" ]]; then
+  echo "  - Meta Ads/tracking está em cenário local controlado; o fluxo é simulado só em localhost."
 fi
 echo ""
 

--- a/start-crm-site-tracking-local.command
+++ b/start-crm-site-tracking-local.command
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+export CRM_OPEN_BROWSER="${CRM_OPEN_BROWSER:-1}"
+export CRM_MODULE="${CRM_MODULE:-site-tracking}"
+export CRM_META_ADS_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}"
+
+exec ./scripts/run-local-crm.sh "${1:-/}" --module "$CRM_MODULE" --meta-ads-scenario "$CRM_META_ADS_SCENARIO" "${@:2}"

--- a/website/src/app/api/tracking/custom-urls/route.ts
+++ b/website/src/app/api/tracking/custom-urls/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server";
+import { getBookingDb } from "@/lib/bookingDb";
+import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import {
+    normalizeSiteCustomUrlInput,
+    serializeSiteCustomUrl,
+    type SiteCustomUrlRow,
+} from "@/lib/siteCustomUrls";
+
+export const dynamic = "force-dynamic";
+
+function json(data: unknown, init?: ResponseInit) {
+    return NextResponse.json(data, {
+        headers: { "cache-control": "no-store" },
+        ...init,
+    });
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+    return (request.headers.get("x-tracking-dashboard-token") ?? "").trim();
+}
+
+async function isAuthorized(request: Request): Promise<boolean> {
+    const expected = await getRuntimeSecret("TRACKING_DASHBOARD_TOKEN");
+    if (process.env.NODE_ENV === "production" && !expected) return false;
+    if (!expected) return true;
+    return constantTimeEqual(readToken(request), expected);
+}
+
+async function readCustomUrls(limit: number) {
+    const db = await getBookingDb();
+    const rows = (
+        await db
+            .prepare(
+                `SELECT
+                    u.id, u.site_host, u.name, u.slug_path, u.destination_url, u.destination_host, u.destination_path,
+                    u.description, u.source, u.placement, u.unit_slug, u.service_id,
+                    u.utm_source, u.utm_medium, u.utm_campaign, u.utm_content, u.utm_term,
+                    u.active, u.created_at_ms, u.updated_at_ms,
+                    COUNT(e.id) AS click_count,
+                    MAX(e.created_at_ms) AS last_click_at_ms
+                 FROM site_custom_urls u
+                 LEFT JOIN site_behavior_events e
+                    ON e.link_url = u.destination_url
+                    OR e.link_path = u.destination_path
+                    OR e.utm_campaign = u.utm_campaign
+                 GROUP BY u.id
+                 ORDER BY u.updated_at_ms DESC
+                 LIMIT ?`,
+            )
+            .bind(limit)
+            .all<SiteCustomUrlRow>()
+    ).results ?? [];
+    return rows.map(serializeSiteCustomUrl);
+}
+
+export async function GET(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    const url = new URL(request.url);
+    const limit = Math.min(Math.max(Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
+    return json({ ok: true, customUrls: await readCustomUrls(limit) });
+}
+
+export async function POST(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    let input;
+    try {
+        input = normalizeSiteCustomUrlInput(await request.json().catch(() => null));
+    } catch (error) {
+        return json({ ok: false, error: error instanceof Error ? error.message : "invalid_payload" }, { status: 400 });
+    }
+    const now = Date.now();
+    const id = crypto.randomUUID();
+    const db = await getBookingDb();
+    await db
+        .prepare(
+            `INSERT INTO site_custom_urls (
+                id, site_host, name, slug_path, destination_url, destination_host, destination_path,
+                description, source, placement, unit_slug, service_id,
+                utm_source, utm_medium, utm_campaign, utm_content, utm_term,
+                active, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+            id,
+            input.siteHost,
+            input.name,
+            input.slugPath,
+            input.destinationUrl,
+            input.destinationHost,
+            input.destinationPath,
+            input.description,
+            input.source,
+            input.placement,
+            input.unitSlug,
+            input.serviceId,
+            input.utmSource,
+            input.utmMedium,
+            input.utmCampaign,
+            input.utmContent,
+            input.utmTerm,
+            input.active ? 1 : 0,
+            now,
+            now,
+        )
+        .run();
+    return json({ ok: true, customUrl: (await readCustomUrls(200)).find((item) => item.id === id) ?? null }, { status: 201 });
+}
+
+export async function PATCH(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    let input;
+    try {
+        input = normalizeSiteCustomUrlInput(await request.json().catch(() => null));
+    } catch (error) {
+        return json({ ok: false, error: error instanceof Error ? error.message : "invalid_payload" }, { status: 400 });
+    }
+    if (!input.id) return json({ ok: false, error: "id_required" }, { status: 400 });
+    const db = await getBookingDb();
+    await db
+        .prepare(
+            `UPDATE site_custom_urls
+             SET site_host = ?, name = ?, slug_path = ?, destination_url = ?, destination_host = ?, destination_path = ?,
+                 description = ?, source = ?, placement = ?, unit_slug = ?, service_id = ?,
+                 utm_source = ?, utm_medium = ?, utm_campaign = ?, utm_content = ?, utm_term = ?,
+                 active = ?, updated_at_ms = ?
+             WHERE id = ?`,
+        )
+        .bind(
+            input.siteHost,
+            input.name,
+            input.slugPath,
+            input.destinationUrl,
+            input.destinationHost,
+            input.destinationPath,
+            input.description,
+            input.source,
+            input.placement,
+            input.unitSlug,
+            input.serviceId,
+            input.utmSource,
+            input.utmMedium,
+            input.utmCampaign,
+            input.utmContent,
+            input.utmTerm,
+            input.active ? 1 : 0,
+            Date.now(),
+            input.id,
+        )
+        .run();
+    return json({ ok: true, customUrl: (await readCustomUrls(200)).find((item) => item.id === input.id) ?? null });
+}

--- a/website/src/app/api/tracking/dashboard/route.ts
+++ b/website/src/app/api/tracking/dashboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getBookingDb, type BookingRequestRow } from "@/lib/bookingDb";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import { serializeSiteCustomUrl, type SiteCustomUrlRow } from "@/lib/siteCustomUrls";
 
 export const dynamic = "force-dynamic";
 
@@ -367,6 +368,32 @@ export async function GET(request: Request) {
             .all<SiteBehaviorRow>()
     ).results ?? [];
 
+    const customUrlRows = (
+        await db
+            .prepare(
+                `SELECT
+                    u.id, u.site_host, u.name, u.slug_path, u.destination_url, u.destination_host, u.destination_path,
+                    u.description, u.source, u.placement, u.unit_slug, u.service_id,
+                    u.utm_source, u.utm_medium, u.utm_campaign, u.utm_content, u.utm_term,
+                    u.active, u.created_at_ms, u.updated_at_ms,
+                    COUNT(e.id) AS click_count,
+                    MAX(e.created_at_ms) AS last_click_at_ms
+                 FROM site_custom_urls u
+                 LEFT JOIN site_behavior_events e
+                    ON e.created_at_ms >= ? AND e.created_at_ms < ?
+                    AND (
+                        e.link_url = u.destination_url
+                        OR e.link_path = u.destination_path
+                        OR (u.utm_campaign IS NOT NULL AND e.utm_campaign = u.utm_campaign)
+                    )
+                 GROUP BY u.id
+                 ORDER BY u.updated_at_ms DESC
+                 LIMIT ?`,
+            )
+            .bind(sinceMs, untilMs, limit)
+            .all<SiteCustomUrlRow>()
+    ).results ?? [];
+
     const sourceCounts = new Map<string, number>();
     const campaignCounts = new Map<string, number>();
     const unitCounts = new Map<string, number>();
@@ -650,6 +677,7 @@ export async function GET(request: Request) {
     };
 
     const customLinks = {
+        managedUrls: customUrlRows.map(serializeSiteCustomUrl),
         topLinks: sortMapEntries(behaviorLinkCounts, "linkUrl").slice(0, 10),
         topUtmContent: sortMapEntries(behaviorUtmContentCounts, "utmContent").slice(0, 10),
         linksMissingUtm: sortMapEntries(behaviorMissingUtmLinkCounts, "linkUrl").slice(0, 10),

--- a/website/src/lib/bookingDb.ts
+++ b/website/src/lib/bookingDb.ts
@@ -255,6 +255,38 @@ async function ensureSchema(db: D1DatabaseLike) {
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_behavior_page_path ON site_behavior_events(page_path, created_at_ms);").run();
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_behavior_unit ON site_behavior_events(unit_slug, created_at_ms);").run();
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_behavior_service ON site_behavior_events(service_id, created_at_ms);").run();
+
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS site_custom_urls (
+                id TEXT PRIMARY KEY,
+                site_host TEXT NOT NULL,
+                name TEXT NOT NULL,
+                slug_path TEXT NOT NULL,
+                destination_url TEXT NOT NULL,
+                destination_host TEXT,
+                destination_path TEXT,
+                description TEXT,
+                source TEXT NOT NULL DEFAULT 'manual',
+                placement TEXT,
+                unit_slug TEXT,
+                service_id TEXT,
+                utm_source TEXT,
+                utm_medium TEXT,
+                utm_campaign TEXT,
+                utm_content TEXT,
+                utm_term TEXT,
+                active INTEGER NOT NULL DEFAULT 1,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            );`,
+        )
+        .run();
+
+    await db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_custom_urls_host_slug ON site_custom_urls(site_host, slug_path);").run();
+    await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_updated ON site_custom_urls(updated_at_ms);").run();
+    await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_campaign ON site_custom_urls(utm_campaign, updated_at_ms);").run();
+    await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_unit ON site_custom_urls(unit_slug, updated_at_ms);").run();
 }
 
 async function tryAddColumn(db: D1DatabaseLike, table: string, columnDef: string) {

--- a/website/src/lib/siteCustomUrls.ts
+++ b/website/src/lib/siteCustomUrls.ts
@@ -1,0 +1,186 @@
+import { clampText, sanitizeOneLine, slugify } from "@/lib/bookingDb";
+
+export type SiteCustomUrlRow = {
+    id: string;
+    site_host: string;
+    name: string;
+    slug_path: string;
+    destination_url: string;
+    destination_host: string | null;
+    destination_path: string | null;
+    description: string | null;
+    source: string;
+    placement: string | null;
+    unit_slug: string | null;
+    service_id: string | null;
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_content: string | null;
+    utm_term: string | null;
+    active: number;
+    created_at_ms: number;
+    updated_at_ms: number;
+    click_count?: number;
+    last_click_at_ms?: number | null;
+};
+
+export type NormalizedSiteCustomUrlInput = {
+    id?: string;
+    siteHost: string;
+    name: string;
+    slugPath: string;
+    destinationUrl: string;
+    destinationHost: string | null;
+    destinationPath: string | null;
+    description: string | null;
+    source: string;
+    placement: string | null;
+    unitSlug: string | null;
+    serviceId: string | null;
+    utmSource: string | null;
+    utmMedium: string | null;
+    utmCampaign: string | null;
+    utmContent: string | null;
+    utmTerm: string | null;
+    active: boolean;
+};
+
+const DEFAULT_SITE_HOST = "espacofacial.com";
+const ALLOWED_SITE_HOSTS = new Set(["espacofacial.com", "www.espacofacial.com"]);
+const ALLOWED_DESTINATION_HOSTS = new Set([
+    "espacofacial.com",
+    "www.espacofacial.com",
+    "app.espacofacial.com.br",
+    "espacofacial.com.br",
+    "www.espacofacial.com.br",
+    "api.whatsapp.com",
+    "wa.me",
+    "wa.skincos.com.br",
+]);
+
+function textOrNull(value: unknown, max = 160): string | null {
+    if (typeof value !== "string") return null;
+    const normalized = sanitizeOneLine(value);
+    return normalized ? clampText(normalized, max) : null;
+}
+
+function canonicalHost(value: unknown): string {
+    const raw = textOrNull(value, 180)?.toLowerCase() ?? DEFAULT_SITE_HOST;
+    const host = raw.replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/^www\./, "");
+    return ALLOWED_SITE_HOSTS.has(host) ? host : DEFAULT_SITE_HOST;
+}
+
+function normalizeSlugPath(value: unknown, fallbackName: string): string {
+    const raw = textOrNull(value, 180);
+    if (raw) {
+        const path = raw.startsWith("/") ? raw : `/${raw}`;
+        const clean = path
+            .replace(/\/{2,}/g, "/")
+            .replace(/\s+/g, "-")
+            .replace(/[?#].*$/, "")
+            .toLowerCase();
+        if (/^\/[a-z0-9][a-z0-9._/-]{1,178}$/.test(clean) && !clean.startsWith("/api/")) return clean;
+    }
+    const fallback = slugify(fallbackName || "campanha");
+    return `/campanhas/${fallback || "link"}`;
+}
+
+function normalizeDestinationUrl(value: unknown): { url: string; host: string | null; path: string | null } {
+    const raw = textOrNull(value, 1200);
+    if (!raw) throw new Error("destination_url_required");
+    let parsed: URL;
+    try {
+        parsed = new URL(raw, "https://espacofacial.com");
+    } catch {
+        throw new Error("invalid_destination_url");
+    }
+    if (parsed.protocol !== "https:") throw new Error("destination_url_must_be_https");
+    const host = parsed.hostname.toLowerCase();
+    if (!ALLOWED_DESTINATION_HOSTS.has(host)) throw new Error("destination_host_not_allowed");
+    return {
+        url: parsed.toString(),
+        host,
+        path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+    };
+}
+
+function readUtm(body: Record<string, unknown>, camelKey: string, snakeKey: string): string | null {
+    return textOrNull(body[camelKey] ?? body[snakeKey], 160);
+}
+
+function mergeUtmIntoDestination(destinationUrl: string, input: NormalizedSiteCustomUrlInput): string {
+    const url = new URL(destinationUrl);
+    const params: Array<[string, string | null]> = [
+        ["utm_source", input.utmSource],
+        ["utm_medium", input.utmMedium],
+        ["utm_campaign", input.utmCampaign],
+        ["utm_content", input.utmContent],
+        ["utm_term", input.utmTerm],
+    ];
+    for (const [key, value] of params) {
+        if (value && !url.searchParams.has(key)) url.searchParams.set(key, value);
+    }
+    return url.toString();
+}
+
+export function normalizeSiteCustomUrlInput(raw: unknown): NormalizedSiteCustomUrlInput {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("invalid_payload");
+    const body = raw as Record<string, unknown>;
+    const name = textOrNull(body.name, 180);
+    if (!name) throw new Error("name_required");
+    const destination = normalizeDestinationUrl(body.destinationUrl ?? body.destination_url);
+    const input: NormalizedSiteCustomUrlInput = {
+        id: textOrNull(body.id, 100) ?? undefined,
+        siteHost: canonicalHost(body.siteHost ?? body.site_host),
+        name,
+        slugPath: normalizeSlugPath(body.slugPath ?? body.slug_path, name),
+        destinationUrl: destination.url,
+        destinationHost: destination.host,
+        destinationPath: destination.path,
+        description: textOrNull(body.description, 500),
+        source: textOrNull(body.source, 80) ?? "manual",
+        placement: textOrNull(body.placement, 120),
+        unitSlug: textOrNull(body.unitSlug ?? body.unit_slug, 120),
+        serviceId: textOrNull(body.serviceId ?? body.service_id, 120),
+        utmSource: readUtm(body, "utmSource", "utm_source"),
+        utmMedium: readUtm(body, "utmMedium", "utm_medium"),
+        utmCampaign: readUtm(body, "utmCampaign", "utm_campaign"),
+        utmContent: readUtm(body, "utmContent", "utm_content"),
+        utmTerm: readUtm(body, "utmTerm", "utm_term"),
+        active: body.active !== false,
+    };
+    input.destinationUrl = mergeUtmIntoDestination(input.destinationUrl, input);
+    const merged = normalizeDestinationUrl(input.destinationUrl);
+    input.destinationHost = merged.host;
+    input.destinationPath = merged.path;
+    return input;
+}
+
+export function serializeSiteCustomUrl(row: SiteCustomUrlRow) {
+    return {
+        id: row.id,
+        siteHost: row.site_host,
+        name: row.name,
+        slugPath: row.slug_path,
+        publicUrl: `https://${row.site_host}${row.slug_path}`,
+        destinationUrl: row.destination_url,
+        destinationHost: row.destination_host,
+        destinationPath: row.destination_path,
+        description: row.description,
+        source: row.source,
+        placement: row.placement,
+        unitSlug: row.unit_slug,
+        serviceId: row.service_id,
+        utmSource: row.utm_source,
+        utmMedium: row.utm_medium,
+        utmCampaign: row.utm_campaign,
+        utmContent: row.utm_content,
+        utmTerm: row.utm_term,
+        active: row.active === 1,
+        createdAtMs: row.created_at_ms,
+        updatedAtMs: row.updated_at_ms,
+        clickCount: Number(row.click_count ?? 0),
+        lastClickAtMs: row.last_click_at_ms ?? null,
+    };
+}

--- a/website/tests/siteCustomUrls.test.ts
+++ b/website/tests/siteCustomUrls.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeSiteCustomUrlInput } from "../src/lib/siteCustomUrls";
+
+test("normalizeSiteCustomUrlInput creates a safe campaign URL record", () => {
+    const input = normalizeSiteCustomUrlInput({
+        name: "Botox Novo Hamburgo",
+        slugPath: "campanhas/botox-nh",
+        destinationUrl: "https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox",
+        utmSource: "meta",
+        utmMedium: "paid_social",
+        utmCampaign: "botox_novo_hamburgo",
+        utmContent: "video_01",
+        unitSlug: "novo-hamburgo",
+        serviceId: "botox",
+    });
+
+    assert.equal(input.siteHost, "espacofacial.com");
+    assert.equal(input.slugPath, "/campanhas/botox-nh");
+    assert.equal(input.destinationHost, "espacofacial.com");
+    assert.equal(input.destinationUrl, "https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox&utm_source=meta&utm_medium=paid_social&utm_campaign=botox_novo_hamburgo&utm_content=video_01");
+    assert.equal(input.utmCampaign, "botox_novo_hamburgo");
+    assert.equal(input.unitSlug, "novo-hamburgo");
+});
+
+test("normalizeSiteCustomUrlInput rejects unsafe destinations and API slugs", () => {
+    assert.throws(
+        () => normalizeSiteCustomUrlInput({
+            name: "Destino inseguro",
+            destinationUrl: "http://evil.example/path",
+        }),
+        /destination_url_must_be_https/,
+    );
+
+    assert.equal(
+        normalizeSiteCustomUrlInput({
+            name: "Slug API",
+            slugPath: "/api/private",
+            destinationUrl: "https://espacofacial.com/agendamento",
+        }).slugPath,
+        "/campanhas/slug-api",
+    );
+});


### PR DESCRIPTION
## Resumo
- adiciona gestão de URLs personalizadas no módulo Site EF do CRM
- expõe API first-party de URLs personalizadas no website e proxy no crm-api
- adiciona persistência D1 idempotente para `site_custom_urls`
- refatora o módulo Site EF em componentes/helpers testáveis
- adiciona preflight robusto de Cloudflare/D1 e atalho local do Site EF

## Validação local
- `npm --prefix website run test`
- `npm --prefix website run typecheck`
- `npm --prefix website run build`
- `npm --prefix website run lint`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend test -- tests/siteTrackingModule.test.ts`
- `npm --prefix frontend run lint -- --quiet`
- `npm --prefix frontend run build`
- `npm --prefix backend/apps/crm-api test`
- `scripts/cloudflare-token-health.sh --strict`

## Observações
- `scripts/codex-preflight.sh --strict` validou GitHub, Cloudflare e endpoints, mas retorna bloqueio enquanto houver alterações não relacionadas no worktree local.
- `backend/apps/automations/scraper/run_scraper.py` e evidências locais não foram incluídos neste commit.