### PR TITLE
Implement Site EF domain connections

### DIFF
--- a/backend/apps/crm-api/server/trackingDashboardRoutes.js
+++ b/backend/apps/crm-api/server/trackingDashboardRoutes.js
@@ -1,9 +1,12 @@
 import { Router } from 'express'
 import {
     createTrackingCustomUrl,
+    createTrackingSiteConnection,
     getTrackingCustomUrls,
     getTrackingDashboardOverview,
+    getTrackingSiteConnections,
     updateTrackingCustomUrl,
+    updateTrackingSiteConnection,
 } from '../services/trackingDashboardService.js'
 
 function parsePositiveInt(value, fallback) {
@@ -20,7 +23,8 @@ export function createTrackingDashboardRouter() {
         const limit = Math.min(parsePositiveInt(req.query.limit, 12), 50)
 
         try {
-            const data = await getTrackingDashboardOverview({ days, limit })
+            const siteHost = String(req.query.siteHost || '').trim() || null
+            const data = await getTrackingDashboardOverview({ days, limit, siteHost })
             res.setHeader('cache-control', 'no-store')
             return res.status(200).json(data)
         } catch (error) {
@@ -75,6 +79,53 @@ export function createTrackingDashboardRouter() {
             return res.status(500).json({
                 ok: false,
                 error: 'tracking_custom_url_update_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.get('/site-connections', async (req, res) => {
+        const limit = Math.min(parsePositiveInt(req.query.limit, 100), 200)
+
+        try {
+            const data = await getTrackingSiteConnections({ limit })
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 200 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to list site connections', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_site_connections_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.post('/site-connections', async (req, res) => {
+        try {
+            const data = await createTrackingSiteConnection(req.body || {})
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 201 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to create site connection', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_site_connection_create_failed',
+                message: error instanceof Error ? error.message : 'unknown_error',
+            })
+        }
+    })
+
+    router.patch('/site-connections', async (req, res) => {
+        try {
+            const data = await updateTrackingSiteConnection(req.body || {})
+            res.setHeader('cache-control', 'no-store')
+            return res.status(data.ok ? 200 : data.status || 502).json(data)
+        } catch (error) {
+            console.error('[tracking-dashboard] failed to update site connection', error)
+            return res.status(500).json({
+                ok: false,
+                error: 'tracking_site_connection_update_failed',
                 message: error instanceof Error ? error.message : 'unknown_error',
             })
         }

--- a/backend/apps/crm-api/services/trackingDashboardService.js
+++ b/backend/apps/crm-api/services/trackingDashboardService.js
@@ -48,13 +48,14 @@ function readJsonPathString(input, paths) {
     return null
 }
 
-async function fetchWebsiteTrackingOverview({ days, limit, offsetDays = 0 }) {
+async function fetchWebsiteTrackingOverview({ days, limit, offsetDays = 0, siteHost = null }) {
     const baseUrl = sanitizeBaseUrl(process.env.TRACKING_WEBSITE_BASE_URL)
     const token = String(process.env.TRACKING_DASHBOARD_TOKEN || '').trim()
     const requestUrl = new URL('/api/tracking/dashboard', baseUrl)
     requestUrl.searchParams.set('days', String(days))
     requestUrl.searchParams.set('limit', String(limit))
     requestUrl.searchParams.set('offsetDays', String(offsetDays))
+    if (siteHost) requestUrl.searchParams.set('siteHost', String(siteHost))
 
     const headers = { accept: 'application/json' }
     if (token) headers.authorization = `Bearer ${token}`
@@ -139,6 +140,53 @@ async function fetchWebsiteTrackingCustomUrls({ method = 'GET', payload = null, 
     }
 }
 
+async function fetchWebsiteTrackingSiteConnections({ method = 'GET', payload = null, limit = 100 } = {}) {
+    const baseUrl = sanitizeBaseUrl(process.env.TRACKING_WEBSITE_BASE_URL)
+    const token = String(process.env.TRACKING_DASHBOARD_TOKEN || '').trim()
+    const requestUrl = new URL('/api/tracking/site-connections', baseUrl)
+    requestUrl.searchParams.set('limit', String(limit))
+
+    const headers = { accept: 'application/json' }
+    if (token) headers.authorization = `Bearer ${token}`
+    if (payload) headers['content-type'] = 'application/json'
+
+    try {
+        const response = await fetch(requestUrl, {
+            method,
+            headers,
+            body: payload ? JSON.stringify(payload) : undefined,
+        })
+        const text = await response.text()
+        let data = null
+        try {
+            data = text ? JSON.parse(text) : null
+        } catch {
+            data = null
+        }
+        if (!response.ok || data?.ok === false) {
+            return {
+                ok: false,
+                status: response.status,
+                sourceUrl: requestUrl.toString(),
+                error: data?.error || `HTTP ${response.status}`,
+            }
+        }
+        return {
+            ok: true,
+            status: response.status,
+            sourceUrl: requestUrl.toString(),
+            data,
+        }
+    } catch (error) {
+        return {
+            ok: false,
+            status: 0,
+            sourceUrl: requestUrl.toString(),
+            error: error instanceof Error ? error.message : 'website_site_connections_failed',
+        }
+    }
+}
+
 export async function getTrackingCustomUrls({ limit = 100 } = {}) {
     const response = await fetchWebsiteTrackingCustomUrls({ method: 'GET', limit })
     if (!response.ok) {
@@ -165,6 +213,7 @@ export async function createTrackingCustomUrl(payload) {
             status: response.status,
         }
     }
+    cache = null
     return {
         ok: true,
         customUrl: response.data?.customUrl || null,
@@ -180,9 +229,59 @@ export async function updateTrackingCustomUrl(payload) {
             status: response.status,
         }
     }
+    cache = null
     return {
         ok: true,
         customUrl: response.data?.customUrl || null,
+    }
+}
+
+export async function getTrackingSiteConnections({ limit = 100 } = {}) {
+    const response = await fetchWebsiteTrackingSiteConnections({ method: 'GET', limit })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+            siteConnections: [],
+        }
+    }
+    return {
+        ok: true,
+        sourceUrl: response.sourceUrl,
+        siteConnections: response.data?.siteConnections || [],
+    }
+}
+
+export async function createTrackingSiteConnection(payload) {
+    const response = await fetchWebsiteTrackingSiteConnections({ method: 'POST', payload, limit: 200 })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+        }
+    }
+    cache = null
+    return {
+        ok: true,
+        siteConnection: response.data?.siteConnection || null,
+    }
+}
+
+export async function updateTrackingSiteConnection(payload) {
+    const response = await fetchWebsiteTrackingSiteConnections({ method: 'PATCH', payload, limit: 200 })
+    if (!response.ok) {
+        return {
+            ok: false,
+            error: response.error,
+            status: response.status,
+        }
+    }
+    cache = null
+    return {
+        ok: true,
+        siteConnection: response.data?.siteConnection || null,
     }
 }
 
@@ -653,8 +752,9 @@ async function fetchWhatsappAttributionOverview({ sinceIso, limit }) {
 export async function getTrackingDashboardOverview(params = {}) {
     const days = parsePositiveInt(params.days, 30, 90)
     const limit = parsePositiveInt(params.limit, 12, 50)
+    const siteHost = String(params.siteHost || '').trim() || null
     const cacheTtlMs = parsePositiveInt(process.env.TRACKING_DASHBOARD_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS, 300_000)
-    const cacheKey = `${days}:${limit}`
+    const cacheKey = `${days}:${limit}:${siteHost || 'all'}`
 
     if (cache && cache.key === cacheKey && Date.now() - cache.createdAt < cacheTtlMs) {
         return cache.value
@@ -662,8 +762,8 @@ export async function getTrackingDashboardOverview(params = {}) {
 
     const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
     const [website, previousWebsite, whatsapp] = await Promise.all([
-        fetchWebsiteTrackingOverview({ days, limit, offsetDays: 0 }),
-        fetchWebsiteTrackingOverview({ days, limit: Math.min(limit, 5), offsetDays: days }),
+        fetchWebsiteTrackingOverview({ days, limit, offsetDays: 0, siteHost }),
+        fetchWebsiteTrackingOverview({ days, limit: Math.min(limit, 5), offsetDays: days, siteHost }),
         fetchWhatsappAttributionOverview({ sinceIso, limit }),
     ])
 
@@ -712,6 +812,7 @@ export async function getTrackingDashboardOverview(params = {}) {
         reconciliation,
         siteBehavior: website.available ? website.data?.siteBehavior || null : null,
         customLinks: website.available ? website.data?.customLinks || null : null,
+        siteConnections: website.available ? website.data?.siteConnections || null : null,
         siteFunnel: website.available ? website.data?.siteFunnel || null : null,
         behaviorQuality: website.available ? website.data?.behaviorQuality || null : null,
         governance: buildGovernance(),

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1375,7 +1375,7 @@ export default function AppFunctionalNeatlab() {
                                                         ) : null}
                                                         {active === 'site-tracking' ? (
                                                             <div className="flex items-center gap-2 max-w-[56vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                                                                <div className="flex items-center gap-1.5">
+                                                                <div className="flex h-8 w-64 items-stretch overflow-hidden rounded-md border border-white/20 bg-white/[0.06] text-white">
                                                                     <Select
                                                                         value={siteTrackingHeaderState?.selectedSiteId || ''}
                                                                         onValueChange={(value) => {
@@ -1383,15 +1383,11 @@ export default function AppFunctionalNeatlab() {
                                                                                 dispatchSiteTrackingHeaderAction({ type: 'connect' })
                                                                                 return
                                                                             }
-                                                                            if (value === '__site_tracking_rename_site__') {
-                                                                                dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: siteTrackingHeaderState?.selectedSiteId })
-                                                                                return
-                                                                            }
                                                                             dispatchSiteTrackingHeaderAction({ type: 'set-site', value })
                                                                         }}
                                                                         disabled={siteTrackingHeaderState?.refreshing}
                                                                     >
-                                                                        <SelectTrigger className="h-8 w-64 bg-white/[0.06] border-white/20 text-white">
+                                                                        <SelectTrigger className="h-full min-w-0 flex-1 rounded-none border-0 bg-transparent px-3 text-white shadow-none focus-visible:ring-0">
                                                                             <SelectValue placeholder="Site" />
                                                                         </SelectTrigger>
                                                                         <SelectContent>
@@ -1431,21 +1427,23 @@ export default function AppFunctionalNeatlab() {
                                                                                     <span>Adicionar conexão</span>
                                                                                 </div>
                                                                             </SelectItem>
-                                                                            <SelectItem value="__site_tracking_rename_site__" className="bg-slate-950 text-cyan-100 focus:bg-cyan-500/15 focus:text-cyan-50">
-                                                                                <div className="flex w-full items-center gap-2 pr-4">
-                                                                                    <Pencil className="size-3.5 text-cyan-300" aria-hidden="true" />
-                                                                                    <span>Renomear site</span>
-                                                                                </div>
-                                                                            </SelectItem>
                                                                         </SelectContent>
                                                                     </Select>
                                                                     <button
                                                                         type="button"
-                                                                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/15 bg-white/[0.05] text-cyan-100/80 transition hover:border-cyan-300/50 hover:bg-cyan-400/10 hover:text-cyan-50 disabled:cursor-not-allowed disabled:opacity-50"
+                                                                        className="inline-flex h-full w-8 shrink-0 items-center justify-center border-l border-white/15 bg-white/[0.03] text-cyan-100/80 transition hover:bg-cyan-400/10 hover:text-cyan-50 disabled:cursor-not-allowed disabled:opacity-50"
                                                                         aria-label="Renomear site selecionado"
                                                                         title="Renomear site"
                                                                         disabled={siteTrackingHeaderState?.refreshing || !siteTrackingHeaderState?.selectedSiteId}
-                                                                        onClick={() => dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: siteTrackingHeaderState?.selectedSiteId })}
+                                                                        onPointerDown={(event) => {
+                                                                            event.preventDefault()
+                                                                            event.stopPropagation()
+                                                                        }}
+                                                                        onClick={(event) => {
+                                                                            event.preventDefault()
+                                                                            event.stopPropagation()
+                                                                            dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: siteTrackingHeaderState?.selectedSiteId })
+                                                                        }}
                                                                     >
                                                                         <Pencil className="size-3.5" aria-hidden="true" />
                                                                     </button>

--- a/frontend/SiteTrackingModule.tsx
+++ b/frontend/SiteTrackingModule.tsx
@@ -10,6 +10,7 @@ import {
   SiteIssueAndClickSections,
   SiteLinkSections,
   SiteMetricsGrid,
+  type SiteConnectionForm,
   type ManagedSiteUrlForm,
 } from '@/siteTrackingComponents'
 import { emitSiteTrackingHeaderState, subscribeSiteTrackingHeaderAction } from '@/siteTrackingHeaderBridge'
@@ -50,9 +51,11 @@ const SITE_OPTIONS: SiteTrackingHeaderSiteOption[] = [
 ]
 const SITE_TRACKING_SITE_NAMES_KEY = 'skincos.siteTracking.siteNames.v1'
 
-async function fetchSiteTrackingOverview(days: WindowDays): Promise<TrackingOverviewResponse> {
+async function fetchSiteTrackingOverview(days: WindowDays, siteHost: string): Promise<TrackingOverviewResponse> {
   if (isMetaTrackingLocalMockEnabled()) return getMetaTrackingLocalOverview(days)
-  const response = await fetch(`/api/tracking/overview?days=${days}&limit=12`, { credentials: 'include' })
+  const params = new URLSearchParams({ days: String(days), limit: '12' })
+  if (siteHost) params.set('siteHost', siteHost)
+  const response = await fetch(`/api/tracking/overview?${params.toString()}`, { credentials: 'include' })
   const data = await response.json().catch(() => null)
   if (!response.ok || !data?.ok) {
     throw new Error(data?.message || data?.error || `Não foi possível carregar os dados do site (${response.status})`)
@@ -68,6 +71,9 @@ export function SiteTrackingModule() {
   const [error, setError] = useState<string | null>(null)
   const [connectionNoticeOpen, setConnectionNoticeOpen] = useState(false)
   const [savingManagedUrl, setSavingManagedUrl] = useState(false)
+  const [savingSiteConnection, setSavingSiteConnection] = useState(false)
+  const [renameSiteId, setRenameSiteId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
   const [siteNameOverrides, setSiteNameOverrides] = useState<Record<string, string>>(() => {
     try {
       if (typeof window === 'undefined') return {}
@@ -90,13 +96,13 @@ export function SiteTrackingModule() {
     setLoading(true)
     setError(null)
     try {
-      setData(await fetchSiteTrackingOverview(days))
+      setData(await fetchSiteTrackingOverview(days, selectedSiteId))
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Não foi possível carregar os dados do site')
     } finally {
       setLoading(false)
     }
-  }, [days])
+  }, [days, selectedSiteId])
 
   useEffect(() => {
     void load()
@@ -124,10 +130,24 @@ export function SiteTrackingModule() {
   const quality = useMemo(() => data?.behaviorQuality || {}, [data?.behaviorQuality])
   const alerts = listOrEmpty(data?.alerts)
   const operationalAlerts = alerts.filter((alert) => !isInternalPreviewAlert(alert))
-  const siteOptions = useMemo(() => SITE_OPTIONS.map((site) => ({
-    ...site,
-    name: siteNameOverrides[site.id] || site.name,
-  })), [siteNameOverrides])
+  const siteOptions = useMemo(() => {
+    const sites = new Map<string, SiteTrackingHeaderSiteOption>()
+    SITE_OPTIONS.forEach((site) => sites.set(site.id, site))
+    ;(data?.siteConnections?.sites || []).forEach((site) => {
+      if (site.active === false) return
+      sites.set(site.siteHost, {
+        id: site.siteHost,
+        name: site.name || site.siteHost,
+        host: site.siteHost,
+        statusLabel: site.statusLabel || 'Conexão ativa',
+        statusTone: site.statusTone === 'warning' || site.statusTone === 'danger' || site.statusTone === 'neutral' ? site.statusTone : 'success',
+      })
+    })
+    return Array.from(sites.values()).map((site) => ({
+      ...site,
+      name: siteNameOverrides[site.id] || site.name,
+    }))
+  }, [data?.siteConnections?.sites, siteNameOverrides])
   const selectedSite = siteOptions.find((site) => site.id === selectedSiteId) || siteOptions[0]
   const headerUpdatedAt = data?.generatedAt ? new Date(data.generatedAt).toISOString() : undefined
 
@@ -166,9 +186,8 @@ export function SiteTrackingModule() {
         const siteId = action.value || selectedSiteId
         const currentSite = siteOptions.find((site) => site.id === siteId)
         const currentName = currentSite?.name || currentSite?.host || siteId
-        const nextName = window.prompt('Nome exibido para este site', currentName)?.trim()
-        if (!nextName) return
-        setSiteNameOverrides((prev) => ({ ...prev, [siteId]: nextName }))
+        setRenameSiteId(siteId)
+        setRenameValue(currentName)
       }
     })
   }, [load, selectedSiteId, siteOptions])
@@ -386,6 +405,67 @@ export function SiteTrackingModule() {
       setSavingManagedUrl(false)
     }
   }
+  const saveSiteConnection = async (form: SiteConnectionForm) => {
+    setSavingSiteConnection(true)
+    try {
+      const siteHost = form.siteHost.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '')
+      if (!siteHost) throw new Error('Informe o domínio do site.')
+      if (isMetaTrackingLocalMockEnabled()) {
+        const now = Date.now()
+        setData((prev) => {
+          if (!prev) return prev
+          const existing = prev.siteConnections?.sites || []
+          const nextSite = {
+            id: form.id || siteHost,
+            siteHost,
+            host: siteHost,
+            name: form.name.trim() || siteHost,
+            statusLabel: form.statusLabel.trim() || 'Conexão ativa',
+            statusTone: form.statusTone,
+            source: 'crm',
+            active: form.active,
+            createdAtMs: existing.find((item) => item.siteHost === siteHost)?.createdAtMs || now,
+            updatedAtMs: now,
+            eventCount: existing.find((item) => item.siteHost === siteHost)?.eventCount || 0,
+            lastEventAtMs: existing.find((item) => item.siteHost === siteHost)?.lastEventAtMs || null,
+          }
+          return {
+            ...prev,
+            siteConnections: {
+              ...(prev.siteConnections || {}),
+              sites: existing.some((item) => item.siteHost === siteHost)
+                ? existing.map((item) => (item.siteHost === siteHost ? nextSite : item))
+                : [nextSite, ...existing],
+            },
+          }
+        })
+        setSelectedSiteId(siteHost)
+        return
+      }
+
+      const response = await fetch('/api/tracking/site-connections', {
+        method: form.id ? 'PATCH' : 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ ...form, siteHost }),
+      })
+      const payload = await response.json().catch(() => null)
+      if (!response.ok || payload?.ok === false) throw new Error(payload?.message || payload?.error || 'Não foi possível salvar a conexão')
+      const savedHost = payload?.siteConnection?.siteHost || siteHost
+      setSelectedSiteId(savedHost)
+      await load()
+    } finally {
+      setSavingSiteConnection(false)
+    }
+  }
+  const saveRename = () => {
+    if (!renameSiteId) return
+    const nextName = renameValue.trim()
+    if (!nextName) return
+    setSiteNameOverrides((prev) => ({ ...prev, [renameSiteId]: nextName }))
+    setRenameSiteId(null)
+    setRenameValue('')
+  }
   const handleMetricDragEnd = (result: DropResult) => {
     if (!result.destination || result.destination.droppableId !== 'site-tracking-metrics') return
     if (result.source.index === result.destination.index) return
@@ -413,7 +493,57 @@ export function SiteTrackingModule() {
         </div>
       ) : null}
 
-      {connectionNoticeOpen ? <ConnectionNotice onClose={() => setConnectionNoticeOpen(false)} /> : null}
+      {connectionNoticeOpen ? (
+        <ConnectionNotice
+          sites={data?.siteConnections?.sites || []}
+          saving={savingSiteConnection}
+          selectedSiteId={selectedSiteId}
+          onClose={() => setConnectionNoticeOpen(false)}
+          onSave={saveSiteConnection}
+        />
+      ) : null}
+
+      {renameSiteId ? (
+        <div className="fixed inset-0 z-[80] flex items-start justify-center bg-slate-950/70 px-4 pt-24 backdrop-blur-sm">
+          <form
+            className="w-full max-w-md rounded-2xl border border-cyan-400/20 bg-slate-950 p-5 text-slate-100 shadow-[0_24px_100px_rgba(8,145,178,0.18)]"
+            onSubmit={(event) => {
+              event.preventDefault()
+              saveRename()
+            }}
+          >
+            <div className="text-sm font-semibold uppercase tracking-wide text-cyan-100">Renomear site</div>
+            <label className="mt-4 block space-y-1 text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+              <span>Nome exibido</span>
+              <input
+                autoFocus
+                value={renameValue}
+                onChange={(event) => setRenameValue(event.target.value)}
+                className="h-10 w-full rounded-lg border border-slate-800 bg-slate-950/70 px-3 text-sm font-normal normal-case tracking-normal text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
+              />
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className="h-9 rounded-lg border border-slate-700 px-3 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+                onClick={() => {
+                  setRenameSiteId(null)
+                  setRenameValue('')
+                }}
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                disabled={!renameValue.trim()}
+                className="h-9 rounded-lg bg-cyan-500 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-400 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Salvar
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
 
       <SiteMetricsGrid
         hiddenMetricTiles={hiddenMetricTiles}

--- a/frontend/metaTrackingLocalMock.ts
+++ b/frontend/metaTrackingLocalMock.ts
@@ -102,6 +102,23 @@ export type TrackingOverviewResponse = {
       utmContent: string | null
     }>
   } | null
+  siteConnections?: {
+    selectedSiteHost?: string | null
+    sites?: Array<{
+      id: string
+      siteHost: string
+      host: string
+      name: string
+      statusLabel: string | null
+      statusTone: 'success' | 'warning' | 'danger' | 'neutral'
+      source: string
+      active: boolean
+      createdAtMs: number
+      updatedAtMs: number
+      eventCount: number
+      lastEventAtMs: number | null
+    }>
+  } | null
   siteFunnel?: {
     sessions?: number
     pageViews?: number
@@ -412,6 +429,25 @@ export function getMetaTrackingLocalOverview(days = 30): TrackingOverviewRespons
           utmSource: 'meta',
           utmCampaign: 'botox_novo_hamburgo',
           utmContent: 'video_botox_nh_01',
+        },
+      ],
+    },
+    siteConnections: {
+      selectedSiteHost: 'espacofacial.com',
+      sites: [
+        {
+          id: 'espacofacial.com',
+          siteHost: 'espacofacial.com',
+          host: 'espacofacial.com',
+          name: 'espacofacial.com',
+          statusLabel: 'Canônico do funil',
+          statusTone: 'success',
+          source: 'system',
+          active: true,
+          createdAtMs: now - 30 * 24 * 60 * 60 * 1000,
+          updatedAtMs: now - 60 * 60 * 1000,
+          eventCount: 420,
+          lastEventAtMs: now - 10 * 60 * 1000,
         },
       ],
     },

--- a/frontend/siteTrackingComponents.tsx
+++ b/frontend/siteTrackingComponents.tsx
@@ -52,6 +52,16 @@ type FunnelRow = {
 }
 
 export type ManagedSiteUrl = NonNullable<NonNullable<TrackingOverviewResponse['customLinks']>['managedUrls']>[number]
+export type SiteConnection = NonNullable<NonNullable<TrackingOverviewResponse['siteConnections']>['sites']>[number]
+
+export type SiteConnectionForm = {
+  id?: string
+  siteHost: string
+  name: string
+  statusLabel: string
+  statusTone: 'success' | 'warning' | 'danger' | 'neutral'
+  active: boolean
+}
 
 export type ManagedSiteUrlForm = {
   id?: string
@@ -83,6 +93,14 @@ const emptyManagedUrlForm: ManagedSiteUrlForm = {
   utmCampaign: '',
   utmContent: '',
   utmTerm: '',
+  active: true,
+}
+
+export const emptySiteConnectionForm: SiteConnectionForm = {
+  siteHost: '',
+  name: '',
+  statusLabel: 'Conexão ativa',
+  statusTone: 'success',
   active: true,
 }
 
@@ -279,19 +297,94 @@ export function RankedList({
   )
 }
 
-export function ConnectionNotice({ onClose }: { onClose: () => void }) {
+export function ConnectionNotice({
+  sites,
+  saving,
+  selectedSiteId,
+  onClose,
+  onSave,
+}: {
+  sites: SiteConnection[]
+  saving?: boolean
+  selectedSiteId?: string
+  onClose: () => void
+  onSave: (form: SiteConnectionForm) => Promise<void>
+}) {
+  const [form, setForm] = useState<SiteConnectionForm>(emptySiteConnectionForm)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const activeSites = sites.filter((site) => site.active !== false)
+  const selectedSite = activeSites.find((site) => site.siteHost === selectedSiteId || site.id === selectedSiteId)
+  const update = (patch: Partial<SiteConnectionForm>) => setForm((prev) => ({ ...prev, ...patch }))
+
   return (
     <section className="rounded-2xl border border-cyan-400/25 bg-cyan-500/10 p-4 text-cyan-50 shadow-[0_20px_80px_rgba(8,145,178,0.12)]">
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
+        <div className="min-w-0">
           <div className="text-sm font-semibold uppercase tracking-wide">Nova conexão de site</div>
           <p className="mt-1 max-w-3xl text-sm text-cyan-100/80">
-            A primeira conexão ativa é o funil canônico <span className="font-mono">espacofacial.com</span>. Para adicionar outro site, crie a origem no backend/CRM e inclua a allowlist de domínio antes de aceitar eventos.
+            Conecte um domínio para liberar o filtro do dashboard por site. Eventos enviados com esse host aparecem no seletor e nas métricas do período.
           </p>
+          {selectedSite ? (
+            <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-cyan-300/20 bg-cyan-950/40 px-3 py-1 text-xs text-cyan-100/85">
+              <span className="font-mono">{selectedSite.siteHost}</span>
+              <span>{selectedSite.statusLabel || 'Conexão ativa'}</span>
+            </div>
+          ) : null}
         </div>
         <Button variant="ghost" size="sm" className="border border-cyan-300/25 bg-cyan-400/10 text-cyan-50 hover:bg-cyan-400/18" onClick={onClose}>
           Fechar
         </Button>
+      </div>
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.72fr)]">
+        <div className="space-y-2">
+          {activeSites.map((site) => (
+            <div key={site.id} className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-slate-950/35 p-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold text-white">{site.name || site.siteHost}</div>
+                <div className="truncate font-mono text-xs text-cyan-100/70">{site.siteHost}</div>
+              </div>
+              <div className="text-right text-xs text-cyan-100/70">
+                <div>{site.statusLabel || 'Conexão ativa'}</div>
+                <div className="font-mono">{formatSiteTrackingNumber(site.eventCount)} eventos</div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <form
+          className="space-y-3 rounded-xl border border-cyan-300/20 bg-slate-950/45 p-4"
+          onSubmit={async (event) => {
+            event.preventDefault()
+            setFeedback(null)
+            try {
+              await onSave(form)
+              setForm(emptySiteConnectionForm)
+              setFeedback('Conexão cadastrada.')
+            } catch (error) {
+              setFeedback(error instanceof Error ? error.message : 'Não foi possível cadastrar a conexão.')
+            }
+          }}
+        >
+          <div>
+            <div className="text-sm font-semibold text-white">Adicionar domínio</div>
+            <div className="text-xs text-cyan-100/65">Use apenas o host, por exemplo site.espacofacial.com.</div>
+          </div>
+          <ManagedUrlField label="Domínio" value={form.siteHost} placeholder="novo-dominio.com" onChange={(siteHost) => update({ siteHost })} />
+          <ManagedUrlField label="Nome no seletor" value={form.name} placeholder="Campanha institucional" onChange={(name) => update({ name })} />
+          <ManagedUrlField label="Status" value={form.statusLabel} placeholder="Conexão ativa" onChange={(statusLabel) => update({ statusLabel })} />
+          <label className="flex items-center gap-2 text-sm text-cyan-100/85">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(event) => update({ active: event.target.checked })}
+              className="h-4 w-4 rounded border-cyan-900 bg-slate-950 text-cyan-500"
+            />
+            Conexão ativa
+          </label>
+          {feedback ? <div className="text-xs text-emerald-200">{feedback}</div> : null}
+          <Button type="submit" disabled={saving || !form.siteHost.trim()} className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+            {saving ? 'Salvando...' : 'Conectar site'}
+          </Button>
+        </form>
       </div>
     </section>
   )

--- a/website/src/app/api/tracking/dashboard/route.ts
+++ b/website/src/app/api/tracking/dashboard/route.ts
@@ -2,6 +2,13 @@ import { NextResponse } from "next/server";
 import { getBookingDb, type BookingRequestRow } from "@/lib/bookingDb";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
 import { serializeSiteCustomUrl, type SiteCustomUrlRow } from "@/lib/siteCustomUrls";
+import {
+    DEFAULT_SITE_HOST,
+    defaultSiteConnection,
+    normalizeOptionalSiteHost,
+    serializeSiteConnection,
+    type SiteConnectionRow,
+} from "@/lib/siteConnections";
 
 export const dynamic = "force-dynamic";
 
@@ -221,6 +228,24 @@ function linkLabel(row: SiteBehaviorRow): string | null {
     return null;
 }
 
+function hostMatches(urlValue: string | null | undefined, siteHost: string | null): boolean {
+    if (!siteHost) return true;
+    const expected = siteHost.toLowerCase();
+    const expectedWww = `www.${expected}`;
+    try {
+        const parsed = new URL(urlValue ?? "");
+        const host = parsed.hostname.toLowerCase();
+        return host === expected || host === expectedWww;
+    } catch {
+        return expected === DEFAULT_SITE_HOST && !urlValue;
+    }
+}
+
+function pageHostMatches(pageHost: string | null | undefined, siteHost: string): boolean {
+    const normalized = (pageHost ?? "").toLowerCase();
+    return normalized === siteHost || normalized === `www.${siteHost}` || (siteHost === DEFAULT_SITE_HOST && !normalized);
+}
+
 function classifyCoverageBucket(params: {
     hasTrackingContext: boolean;
     hasMetaEventId: boolean;
@@ -306,6 +331,8 @@ export async function GET(request: Request) {
     const days = Math.min(parsePositiveInt(url.searchParams.get("days"), 30), 90);
     const offsetDays = Math.min(parsePositiveInt(url.searchParams.get("offsetDays"), 0), 365);
     const limit = Math.min(parsePositiveInt(url.searchParams.get("limit"), 12), 50);
+    const selectedSiteHost = normalizeOptionalSiteHost(url.searchParams.get("siteHost"));
+    const selectedSiteHostWww = selectedSiteHost ? `www.${selectedSiteHost}` : null;
     const untilMs = Date.now() - offsetDays * 24 * 60 * 60 * 1000;
     const sinceMs = untilMs - days * 24 * 60 * 60 * 1000;
 
@@ -352,26 +379,58 @@ export async function GET(request: Request) {
             .all<MetaDeliveryRow>()
     ).results ?? [];
 
-    const siteBehaviorRows = (
-        await db
-            .prepare(
-                `SELECT id, event_name, session_id, created_at_ms, page_url, page_path, page_host, referrer, landing_page,
+    const siteBehaviorQuery = selectedSiteHost
+        ? `SELECT id, event_name, session_id, created_at_ms, page_url, page_path, page_host, referrer, landing_page,
+                        utm_source, utm_medium, utm_campaign, utm_content, utm_term, fbclid, fbp, fbc,
+                        link_url, link_host, link_path, link_type, placement, source, unit_slug, service_id,
+                        booking_id, consent_analytics, consent_marketing, metadata_json
+                 FROM site_behavior_events
+                 WHERE created_at_ms >= ? AND created_at_ms < ?
+                   AND (
+                    lower(page_host) = ?
+                    OR lower(page_host) = ?
+                    OR (? = ? AND page_host IS NULL)
+                   )
+                 ORDER BY created_at_ms DESC
+                 LIMIT 5000`
+        : `SELECT id, event_name, session_id, created_at_ms, page_url, page_path, page_host, referrer, landing_page,
                         utm_source, utm_medium, utm_campaign, utm_content, utm_term, fbclid, fbp, fbc,
                         link_url, link_host, link_path, link_type, placement, source, unit_slug, service_id,
                         booking_id, consent_analytics, consent_marketing, metadata_json
                  FROM site_behavior_events
                  WHERE created_at_ms >= ? AND created_at_ms < ?
                  ORDER BY created_at_ms DESC
-                 LIMIT 5000`,
-            )
-            .bind(sinceMs, untilMs)
-            .all<SiteBehaviorRow>()
+                 LIMIT 5000`;
+    const siteBehaviorStatement = db.prepare(siteBehaviorQuery);
+    const siteBehaviorRows = (
+        await (selectedSiteHost
+            ? siteBehaviorStatement.bind(sinceMs, untilMs, selectedSiteHost, selectedSiteHostWww, selectedSiteHost, DEFAULT_SITE_HOST)
+            : siteBehaviorStatement.bind(sinceMs, untilMs)
+        ).all<SiteBehaviorRow>()
     ).results ?? [];
 
-    const customUrlRows = (
-        await db
-            .prepare(
-                `SELECT
+    const customUrlQuery = selectedSiteHost
+        ? `SELECT
+                    u.id, u.site_host, u.name, u.slug_path, u.destination_url, u.destination_host, u.destination_path,
+                    u.description, u.source, u.placement, u.unit_slug, u.service_id,
+                    u.utm_source, u.utm_medium, u.utm_campaign, u.utm_content, u.utm_term,
+                    u.active, u.created_at_ms, u.updated_at_ms,
+                    COUNT(e.id) AS click_count,
+                    MAX(e.created_at_ms) AS last_click_at_ms
+                 FROM site_custom_urls u
+                 LEFT JOIN site_behavior_events e
+                    ON e.created_at_ms >= ? AND e.created_at_ms < ?
+                    AND (lower(e.page_host) = ? OR lower(e.page_host) = ?)
+                    AND (
+                        e.link_url = u.destination_url
+                        OR e.link_path = u.destination_path
+                        OR (u.utm_campaign IS NOT NULL AND e.utm_campaign = u.utm_campaign)
+                    )
+                 WHERE u.site_host = ?
+                 GROUP BY u.id
+                 ORDER BY u.updated_at_ms DESC
+                 LIMIT ?`
+        : `SELECT
                     u.id, u.site_host, u.name, u.slug_path, u.destination_url, u.destination_host, u.destination_path,
                     u.description, u.source, u.placement, u.unit_slug, u.service_id,
                     u.utm_source, u.utm_medium, u.utm_campaign, u.utm_content, u.utm_term,
@@ -388,10 +447,32 @@ export async function GET(request: Request) {
                     )
                  GROUP BY u.id
                  ORDER BY u.updated_at_ms DESC
-                 LIMIT ?`,
+                 LIMIT ?`;
+    const customUrlStatement = db.prepare(customUrlQuery);
+    const customUrlRows = (
+        await (selectedSiteHost
+            ? customUrlStatement.bind(sinceMs, untilMs, selectedSiteHost, selectedSiteHostWww, selectedSiteHost, limit)
+            : customUrlStatement.bind(sinceMs, untilMs, limit)
+        ).all<SiteCustomUrlRow>()
+    ).results ?? [];
+
+    const siteConnectionRows = (
+        await db
+            .prepare(
+                `SELECT
+                    c.id, c.site_host, c.name, c.status_label, c.status_tone, c.source,
+                    c.active, c.created_at_ms, c.updated_at_ms,
+                    COUNT(e.id) AS event_count,
+                    MAX(e.created_at_ms) AS last_event_at_ms
+                 FROM site_connections c
+                 LEFT JOIN site_behavior_events e
+                    ON lower(e.page_host) = c.site_host
+                    OR lower(e.page_host) = ('www.' || c.site_host)
+                 GROUP BY c.id
+                 ORDER BY c.updated_at_ms DESC
+                 LIMIT 100`,
             )
-            .bind(sinceMs, untilMs, limit)
-            .all<SiteCustomUrlRow>()
+            .all<SiteConnectionRow>()
     ).results ?? [];
 
     const sourceCounts = new Map<string, number>();
@@ -410,8 +491,11 @@ export async function GET(request: Request) {
     ]);
     const scheduleStatusByBookingId = new Map<string, string>();
 
+    const scopedWhatsappRows = selectedSiteHost
+        ? whatsappRows.filter((row) => hostMatches(row.page_url, selectedSiteHost))
+        : whatsappRows;
     let whatsappClicksWithTracking = 0;
-    const recentWhatsappClicks = whatsappRows.slice(0, limit).map((row) => {
+    const recentWhatsappClicks = scopedWhatsappRows.slice(0, limit).map((row) => {
         const tracking = normalizeAttribution(safeJsonParse(row.tracking_context_json));
         if (row.tracking_context_json) whatsappClicksWithTracking += 1;
         return {
@@ -429,7 +513,7 @@ export async function GET(request: Request) {
             utmCampaign: tracking.utmCampaign,
         };
     });
-    whatsappClicksWithTracking += whatsappRows.slice(limit).filter((row) => row.tracking_context_json).length;
+    whatsappClicksWithTracking += scopedWhatsappRows.slice(limit).filter((row) => row.tracking_context_json).length;
 
     let capiScheduleOk = 0;
     let capiScheduleFailed = 0;
@@ -704,6 +788,15 @@ export async function GET(request: Request) {
             })),
     };
 
+    const serializedConnections = siteConnectionRows.map(serializeSiteConnection);
+    if (!serializedConnections.some((site) => site.siteHost === DEFAULT_SITE_HOST)) {
+        const canonicalConnection = defaultSiteConnection();
+        const canonicalEvents = siteBehaviorRows.filter((row) => pageHostMatches(row.page_host, DEFAULT_SITE_HOST));
+        canonicalConnection.eventCount = canonicalEvents.length;
+        canonicalConnection.lastEventAtMs = canonicalEvents[0]?.created_at_ms ?? null;
+        serializedConnections.unshift(canonicalConnection);
+    }
+
     const behaviorQuality = {
         eventsWithCampaign: behaviorEventsWithCampaign,
         eventsWithFacebookIds: behaviorEventsWithFbIds,
@@ -731,7 +824,7 @@ export async function GET(request: Request) {
             bookingsWithMarketingConsent,
             bookingsWithAnalyticsConsent,
             bookingsWithFacebookIds: bookingsWithFbIdentifiers,
-            whatsappClicks: whatsappRows.length,
+            whatsappClicks: scopedWhatsappRows.length,
             whatsappClicksWithTrackingContext: whatsappClicksWithTracking,
             capiScheduleOk,
             capiScheduleFailed,
@@ -748,6 +841,10 @@ export async function GET(request: Request) {
         byUnit: sortMapEntries(unitCounts, "unitSlug").slice(0, 6),
         siteBehavior,
         customLinks,
+        siteConnections: {
+            selectedSiteHost,
+            sites: serializedConnections,
+        },
         siteFunnel,
         behaviorQuality,
         recentBookings,

--- a/website/src/app/api/tracking/site-connections/route.ts
+++ b/website/src/app/api/tracking/site-connections/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+import { getBookingDb } from "@/lib/bookingDb";
+import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import {
+    DEFAULT_SITE_HOST,
+    defaultSiteConnection,
+    normalizeSiteConnectionInput,
+    serializeSiteConnection,
+    type SiteConnectionRow,
+} from "@/lib/siteConnections";
+
+export const dynamic = "force-dynamic";
+
+function json(data: unknown, init?: ResponseInit) {
+    return NextResponse.json(data, {
+        headers: { "cache-control": "no-store" },
+        ...init,
+    });
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+function readToken(request: Request): string {
+    const auth = (request.headers.get("authorization") ?? "").trim();
+    if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+    return (request.headers.get("x-tracking-dashboard-token") ?? "").trim();
+}
+
+async function isAuthorized(request: Request): Promise<boolean> {
+    const expected = await getRuntimeSecret("TRACKING_DASHBOARD_TOKEN");
+    if (process.env.NODE_ENV === "production" && !expected) return false;
+    if (!expected) return true;
+    return constantTimeEqual(readToken(request), expected);
+}
+
+async function readConnections(limit: number) {
+    const db = await getBookingDb();
+    const rows = (
+        await db
+            .prepare(
+                `SELECT
+                    c.id, c.site_host, c.name, c.status_label, c.status_tone, c.source,
+                    c.active, c.created_at_ms, c.updated_at_ms,
+                    COUNT(e.id) AS event_count,
+                    MAX(e.created_at_ms) AS last_event_at_ms
+                 FROM site_connections c
+                 LEFT JOIN site_behavior_events e
+                    ON lower(e.page_host) = c.site_host
+                    OR lower(e.page_host) = ('www.' || c.site_host)
+                 GROUP BY c.id
+                 ORDER BY c.updated_at_ms DESC
+                 LIMIT ?`,
+            )
+            .bind(limit)
+            .all<SiteConnectionRow>()
+    ).results ?? [];
+
+    const serialized = rows.map(serializeSiteConnection);
+    if (!serialized.some((site) => site.siteHost === DEFAULT_SITE_HOST)) {
+        serialized.unshift(defaultSiteConnection());
+    }
+    return serialized;
+}
+
+export async function GET(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    const url = new URL(request.url);
+    const limit = Math.min(Math.max(Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
+    return json({ ok: true, siteConnections: await readConnections(limit) });
+}
+
+export async function POST(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    let input;
+    try {
+        input = normalizeSiteConnectionInput(await request.json().catch(() => null));
+    } catch (error) {
+        return json({ ok: false, error: error instanceof Error ? error.message : "invalid_payload" }, { status: 400 });
+    }
+
+    const now = Date.now();
+    const id = crypto.randomUUID();
+    const db = await getBookingDb();
+    await db
+        .prepare(
+            `INSERT INTO site_connections (
+                id, site_host, name, status_label, status_tone, source, active, created_at_ms, updated_at_ms
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(site_host) DO UPDATE SET
+                name = excluded.name,
+                status_label = excluded.status_label,
+                status_tone = excluded.status_tone,
+                source = excluded.source,
+                active = excluded.active,
+                updated_at_ms = excluded.updated_at_ms`,
+        )
+        .bind(
+            id,
+            input.siteHost,
+            input.name,
+            input.statusLabel,
+            input.statusTone,
+            input.source,
+            input.active ? 1 : 0,
+            now,
+            now,
+        )
+        .run();
+
+    return json({
+        ok: true,
+        siteConnection: (await readConnections(200)).find((item) => item.siteHost === input.siteHost) ?? null,
+    }, { status: 201 });
+}
+
+export async function PATCH(request: Request) {
+    if (!(await isAuthorized(request))) return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    let input;
+    try {
+        input = normalizeSiteConnectionInput(await request.json().catch(() => null));
+    } catch (error) {
+        return json({ ok: false, error: error instanceof Error ? error.message : "invalid_payload" }, { status: 400 });
+    }
+    if (!input.id) return json({ ok: false, error: "id_required" }, { status: 400 });
+
+    const db = await getBookingDb();
+    await db
+        .prepare(
+            `UPDATE site_connections
+             SET site_host = ?, name = ?, status_label = ?, status_tone = ?, source = ?, active = ?, updated_at_ms = ?
+             WHERE id = ?`,
+        )
+        .bind(
+            input.siteHost,
+            input.name,
+            input.statusLabel,
+            input.statusTone,
+            input.source,
+            input.active ? 1 : 0,
+            Date.now(),
+            input.id,
+        )
+        .run();
+
+    return json({
+        ok: true,
+        siteConnection: (await readConnections(200)).find((item) => item.id === input.id) ?? null,
+    });
+}

--- a/website/src/lib/bookingDb.ts
+++ b/website/src/lib/bookingDb.ts
@@ -287,6 +287,25 @@ async function ensureSchema(db: D1DatabaseLike) {
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_updated ON site_custom_urls(updated_at_ms);").run();
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_campaign ON site_custom_urls(utm_campaign, updated_at_ms);").run();
     await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_custom_urls_unit ON site_custom_urls(unit_slug, updated_at_ms);").run();
+
+    await db
+        .prepare(
+            `CREATE TABLE IF NOT EXISTS site_connections (
+                id TEXT PRIMARY KEY,
+                site_host TEXT NOT NULL,
+                name TEXT NOT NULL,
+                status_label TEXT,
+                status_tone TEXT NOT NULL DEFAULT 'success',
+                source TEXT NOT NULL DEFAULT 'crm',
+                active INTEGER NOT NULL DEFAULT 1,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            );`,
+        )
+        .run();
+
+    await db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_site_connections_host ON site_connections(site_host);").run();
+    await db.prepare("CREATE INDEX IF NOT EXISTS idx_site_connections_updated ON site_connections(updated_at_ms);").run();
 }
 
 async function tryAddColumn(db: D1DatabaseLike, table: string, columnDef: string) {

--- a/website/src/lib/siteConnections.ts
+++ b/website/src/lib/siteConnections.ts
@@ -1,0 +1,112 @@
+import { clampText, sanitizeOneLine } from "@/lib/bookingDb";
+
+export const DEFAULT_SITE_HOST = "espacofacial.com";
+
+export type SiteConnectionRow = {
+    id: string;
+    site_host: string;
+    name: string;
+    status_label: string | null;
+    status_tone: string;
+    source: string;
+    active: number;
+    created_at_ms: number;
+    updated_at_ms: number;
+    event_count?: number;
+    last_event_at_ms?: number | null;
+};
+
+export type NormalizedSiteConnectionInput = {
+    id?: string;
+    siteHost: string;
+    name: string;
+    statusLabel: string | null;
+    statusTone: "success" | "warning" | "danger" | "neutral";
+    source: string;
+    active: boolean;
+};
+
+function textOrNull(value: unknown, max = 160): string | null {
+    if (typeof value !== "string") return null;
+    const normalized = sanitizeOneLine(value);
+    return normalized ? clampText(normalized, max) : null;
+}
+
+function normalizeRawHost(value: unknown): string | null {
+    const raw = textOrNull(value, 253)?.toLowerCase();
+    if (!raw) return null;
+    const withoutProtocol = raw.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+    const withoutWww = withoutProtocol.replace(/^www\./, "");
+    if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(withoutWww)) {
+        return null;
+    }
+    return withoutWww;
+}
+
+export function normalizeSiteHost(value: unknown): string {
+    const host = normalizeRawHost(value);
+    if (!host) throw new Error("invalid_site_host");
+    return host;
+}
+
+export function normalizeOptionalSiteHost(value: unknown): string | null {
+    if (value == null || value === "") return null;
+    const host = normalizeRawHost(value);
+    return host || null;
+}
+
+export function siteHostVariants(siteHost: string): string[] {
+    const normalized = normalizeSiteHost(siteHost);
+    return normalized.startsWith("www.") ? [normalized] : [normalized, `www.${normalized}`];
+}
+
+export function normalizeSiteConnectionInput(raw: unknown): NormalizedSiteConnectionInput {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("invalid_payload");
+    const body = raw as Record<string, unknown>;
+    const siteHost = normalizeSiteHost(body.siteHost ?? body.site_host);
+    const statusTone = textOrNull(body.statusTone ?? body.status_tone, 40);
+    const allowedTone = statusTone === "warning" || statusTone === "danger" || statusTone === "neutral" ? statusTone : "success";
+    return {
+        id: textOrNull(body.id, 100) ?? undefined,
+        siteHost,
+        name: textOrNull(body.name, 180) ?? siteHost,
+        statusLabel: textOrNull(body.statusLabel ?? body.status_label, 120) ?? "Conexão ativa",
+        statusTone: allowedTone,
+        source: textOrNull(body.source, 80) ?? "crm",
+        active: body.active !== false,
+    };
+}
+
+export function defaultSiteConnection() {
+    return {
+        id: DEFAULT_SITE_HOST,
+        siteHost: DEFAULT_SITE_HOST,
+        name: DEFAULT_SITE_HOST,
+        host: DEFAULT_SITE_HOST,
+        statusLabel: "Canônico do funil",
+        statusTone: "success" as const,
+        source: "system",
+        active: true,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+        eventCount: 0,
+        lastEventAtMs: null as number | null,
+    };
+}
+
+export function serializeSiteConnection(row: SiteConnectionRow) {
+    return {
+        id: row.id,
+        siteHost: row.site_host,
+        name: row.name,
+        host: row.site_host,
+        statusLabel: row.status_label,
+        statusTone: row.status_tone,
+        source: row.source,
+        active: row.active === 1,
+        createdAtMs: row.created_at_ms,
+        updatedAtMs: row.updated_at_ms,
+        eventCount: Number(row.event_count ?? 0),
+        lastEventAtMs: row.last_event_at_ms ?? null,
+    };
+}

--- a/website/src/lib/siteCustomUrls.ts
+++ b/website/src/lib/siteCustomUrls.ts
@@ -1,4 +1,5 @@
 import { clampText, sanitizeOneLine, slugify } from "@/lib/bookingDb";
+import { DEFAULT_SITE_HOST, normalizeOptionalSiteHost } from "@/lib/siteConnections";
 
 export type SiteCustomUrlRow = {
     id: string;
@@ -46,8 +47,6 @@ export type NormalizedSiteCustomUrlInput = {
     active: boolean;
 };
 
-const DEFAULT_SITE_HOST = "espacofacial.com";
-const ALLOWED_SITE_HOSTS = new Set(["espacofacial.com", "www.espacofacial.com"]);
 const ALLOWED_DESTINATION_HOSTS = new Set([
     "espacofacial.com",
     "www.espacofacial.com",
@@ -66,9 +65,7 @@ function textOrNull(value: unknown, max = 160): string | null {
 }
 
 function canonicalHost(value: unknown): string {
-    const raw = textOrNull(value, 180)?.toLowerCase() ?? DEFAULT_SITE_HOST;
-    const host = raw.replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/^www\./, "");
-    return ALLOWED_SITE_HOSTS.has(host) ? host : DEFAULT_SITE_HOST;
+    return normalizeOptionalSiteHost(value) ?? DEFAULT_SITE_HOST;
 }
 
 function normalizeSlugPath(value: unknown, fallbackName: string): string {


### PR DESCRIPTION
## Summary
- adds authenticated Site EF site connection management backed by D1 site_connections
- filters website tracking dashboard/custom URLs by selected siteHost and exposes connections to the CRM
- replaces the rename prompt with an in-app modal and moves the pencil into the selector control while removing the rename menu item

## Validation
- npm --prefix frontend run typecheck
- npm --prefix frontend run build
- npm --prefix website run typecheck
- npm --prefix backend/apps/crm-api test
- npm run codex:crm:site-smoke
- Playwright local check: rename modal opens, selector keeps Add connection, rename menu item removed, connection form opens