### PR TITLE
Fix mobile Junho 2026 hero crop

### DIFF
--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -8621,7 +8621,9 @@ video.heroMediaEl {
   }
 
   .heroMedia {
-    max-height: 440px;
+    height: clamp(560px, calc(100vw * 16 / 9), 720px);
+    max-height: none;
+    min-height: 0;
   }
 
   .heroMediaEl {
@@ -8752,8 +8754,9 @@ video.heroMediaEl {
   }
 
   .heroMedia {
-    max-height: 380px;
-    min-height: 260px;
+    height: clamp(560px, calc(100vw * 16 / 9), 720px);
+    max-height: none;
+    min-height: 0;
   }
 
   .homeUnitSelector__actions {


### PR DESCRIPTION
## Summary
- increases the mobile hero container height so 9x16 Junho 2026 campaign art keeps its lower CTA visible
- keeps the existing mobile asset selection and object-fit behavior intact

## Validation
- npx tsx --test tests/heroMediaShared.test.ts
- npm run codex:site:check
- Playwright local mobile viewport 390x844: hero renders mobile junho-2026 asset at 390x693 with 13 carousel items and visible lower CTA