### PR TITLE
Fix website CSP and font preload warnings

### DIFF
--- a/website/contentSecurityPolicy.mjs
+++ b/website/contentSecurityPolicy.mjs
@@ -1,0 +1,14 @@
+export const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'self'",
+  "form-action 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://connect.facebook.net https://www.gstatic.com https://static.cloudflareinsights.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https:",
+  "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://connect.facebook.net https://graph.facebook.com https://www.google.com https://maps.googleapis.com https://maps.gstatic.com https://unavatar.io https://*.cdninstagram.com https://*.fbcdn.net https://*.instagram.com https://cloudflareinsights.com https://*.cloudflareinsights.com",
+  "frame-src 'self' https://www.google.com https://maps.google.com https://www.google.com.br",
+  "media-src 'self' data: blob: https:",
+].join("; ");

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -1,25 +1,12 @@
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { contentSecurityPolicy } from "./contentSecurityPolicy.mjs";
 
 /** @type {import('next').NextConfig} */
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "";
 const buildTime = process.env.NEXT_PUBLIC_BUILD_TIME || "";
 const appRoot = path.dirname(fileURLToPath(import.meta.url));
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "frame-ancestors 'self'",
-  "form-action 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://connect.facebook.net https://www.gstatic.com",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https:",
-  "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://connect.facebook.net https://graph.facebook.com https://www.google.com https://maps.googleapis.com https://maps.gstatic.com https://unavatar.io https://*.cdninstagram.com https://*.fbcdn.net https://*.instagram.com",
-  "frame-src 'self' https://www.google.com https://maps.google.com https://www.google.com.br",
-  "media-src 'self' data: blob: https:",
-].join("; ");
 
 initOpenNextCloudflareForDev();
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -18,6 +18,7 @@ const buildTime = process.env.NEXT_PUBLIC_BUILD_TIME ?? "";
 const brandUiFont = Oxanium({
   subsets: ["latin"],
   display: "swap",
+  preload: false,
   variable: "--font-brand-ui-loaded",
   weight: ["400", "500", "600", "700", "800"],
 });
@@ -25,6 +26,7 @@ const brandUiFont = Oxanium({
 const brandTextFont = Urbanist({
   subsets: ["latin"],
   display: "swap",
+  preload: false,
   variable: "--font-brand-text-loaded",
   weight: ["300", "400", "500", "600", "700", "800"],
 });

--- a/website/tests/securityHeaders.test.ts
+++ b/website/tests/securityHeaders.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const contentSecurityPolicySource = readFileSync(new URL("../contentSecurityPolicy.mjs", import.meta.url), "utf8");
+
+function directiveValue(name: string): string {
+    const directive = contentSecurityPolicySource.match(new RegExp(`"${name} ([^"]+)"`));
+    assert.ok(directive?.[1], `${name} directive should exist`);
+    return directive[1];
+}
+
+test("content security policy allows Cloudflare Insights script and beacon endpoints", () => {
+    assert.match(directiveValue("script-src"), /https:\/\/static\.cloudflareinsights\.com/);
+    assert.match(directiveValue("connect-src"), /https:\/\/cloudflareinsights\.com/);
+    assert.match(directiveValue("connect-src"), /https:\/\/\*\.cloudflareinsights\.com/);
+});


### PR DESCRIPTION
## Summary
- allow Cloudflare Insights in the website CSP for script loading and RUM/beacon connections
- move CSP into a side-effect-free module covered by a regression test
- disable automatic next/font preloads for the global brand fonts to remove unused .woff2 preload warnings while keeping CSS font loading

## Validation
- npx tsx --test tests/securityHeaders.test.ts
- npm run codex:site:check
- local production server + Playwright: 0 console errors/warnings, no .woff2 preload links, CSP header includes Cloudflare Insights