### PR TITLE
Fix preflight and refresh CI action runtimes

### DIFF
--- a/.github/workflows/central-e2e-smoke.yml
+++ b/.github/workflows/central-e2e-smoke.yml
@@ -11,12 +11,12 @@ jobs:
     name: Central E2E Smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22.12.0"
           cache: 'npm'
           cache-dependency-path: |
             frontend/package-lock.json

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (no submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -35,9 +35,9 @@ jobs:
           bash backend/scripts/ci-no-demo-guard.sh
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22.12.0"
           cache: npm
           cache-dependency-path: website/package-lock.json
 

--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure jq
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-alerting-export.yml
+++ b/.github/workflows/cloudflare-alerting-export.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure jq
         shell: bash

--- a/.github/workflows/cloudflare-audit.yml
+++ b/.github/workflows/cloudflare-audit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run drift audit
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -33,13 +33,13 @@ jobs:
           echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Checkout (for worker wrangler config)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync Pages secret (Escala) by environment
         env:

--- a/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
+++ b/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
@@ -45,9 +45,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync Meta Ads report token to Cloudflare Pages
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync Pages secrets (Ponto) by environment
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync secret to Cloudflare Pages (wrangler pages secret put)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync secrets to Workers (skincos-api + skincos-insumos)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/codex-autonomy-preflight.yml
+++ b/.github/workflows/codex-autonomy-preflight.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Codex autonomy preflight
         run: scripts/codex-preflight.sh --ci --strict

--- a/.github/workflows/crm-codeql.yml
+++ b/.github/workflows/crm-codeql.yml
@@ -42,25 +42,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         if: ${{ matrix.language == 'javascript' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: |
             frontend/package-lock.json
             website/package-lock.json
       - name: Setup Python
         if: ${{ matrix.language == 'python' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -88,6 +88,6 @@ jobs:
           fi
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-core-workers-reconcile.yml
+++ b/.github/workflows/deploy-core-workers-reconcile.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Install worker deps (insumos + api)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Install worker deps (insumos + api)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-crm-api-after-automerge.yml
+++ b/.github/workflows/deploy-crm-api-after-automerge.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-crm-api-reconcile.yml
+++ b/.github/workflows/deploy-crm-api-reconcile.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout main
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -105,15 +105,15 @@ jobs:
 
       - name: Checkout merge commit
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.merge_commit_sha }}
 
       - name: Setup Node
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
@@ -122,9 +122,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -57,13 +57,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/deploy-escala-api-reconcile.yml
+++ b/.github/workflows/deploy-escala-api-reconcile.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
@@ -95,9 +95,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync Escala worker secret (production)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -47,13 +47,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Sync Escala worker secret (production)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -42,13 +42,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Deploy Worker (wrangler)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-social-publisher-worker-reconcile.yml
+++ b/.github/workflows/deploy-social-publisher-worker-reconcile.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
@@ -64,9 +64,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Deploy Worker (wrangler)
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Deploy Worker (wrangler)
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -57,11 +57,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -104,15 +104,15 @@ jobs:
 
       - name: Checkout merge commit
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.merge_commit_sha }}
 
       - name: Setup Node
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/deploy-workers-reconcile.yml
+++ b/.github/workflows/deploy-workers-reconcile.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
@@ -61,9 +61,9 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Setup pnpm (corepack)
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/escala-api-smoke.yml
+++ b/.github/workflows/escala-api-smoke.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Resolve target
         id: target

--- a/.github/workflows/escala-ui-e2e.yml
+++ b/.github/workflows/escala-ui-e2e.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/insumos-api-slo.yml
+++ b/.github/workflows/insumos-api-slo.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Insumos API SLO monitor
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/insumos-ui-smoke.yml
+++ b/.github/workflows/insumos-ui-smoke.yml
@@ -25,15 +25,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/lint-format-static.yml
+++ b/.github/workflows/lint-format-static.yml
@@ -12,7 +12,7 @@ jobs:
     name: JS/TS Checks (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Repository policy checks
         run: |
@@ -23,9 +23,9 @@ jobs:
           bash backend/scripts/ci-no-demo-guard.sh
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22.12.0"
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
@@ -118,9 +118,9 @@ jobs:
     name: Python Lint & Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/ponto-smoke.yml
+++ b/.github/workflows/ponto-smoke.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Smoke check Ponto endpoints
         env:

--- a/.github/workflows/ponto-ui-smoke.yml
+++ b/.github/workflows/ponto-ui-smoke.yml
@@ -30,15 +30,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -16,7 +16,7 @@ jobs:
     name: Scan for secrets (Gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run Gitleaks
@@ -29,11 +29,11 @@ jobs:
     name: Dependency Audit (JS/TS)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22.12.0"
 
       - name: NPM audit (root + frontend + website lockfiles)
         run: |
@@ -60,9 +60,9 @@ jobs:
     name: Pip Audit (Python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -161,9 +161,9 @@ jobs:
     name: Bandit (Python SAST)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -251,7 +251,7 @@ jobs:
     name: Semgrep (SAST)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Semgrep
         uses: returntocorp/semgrep-action@v1
         with:
@@ -260,6 +260,6 @@ jobs:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep SARIF
         if: ${{ hashFiles('semgrep.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/sync-website-cloudflare-security.yml
+++ b/.github/workflows/sync-website-cloudflare-security.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/test-coverage-quality.yml
+++ b/.github/workflows/test-coverage-quality.yml
@@ -12,11 +12,11 @@ jobs:
     name: Frontend & Website Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22.12.0"
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
@@ -62,9 +62,9 @@ jobs:
     name: Python Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Python
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/scripts/codex-preflight.sh
+++ b/scripts/codex-preflight.sh
@@ -154,13 +154,15 @@ check_github() {
 check_cloudflare() {
   $SKIP_CLOUDFLARE && { warn "Cloudflare auth check skipped"; return; }
 
-  local strict_arg=()
-  if $STRICT || $CI_MODE; then
-    strict_arg=(--strict)
-  fi
-
   if [[ -x scripts/cloudflare-token-health.sh ]]; then
-    if scripts/cloudflare-token-health.sh "${strict_arg[@]}" >/tmp/codex-cloudflare-token-health.log 2>&1; then
+    local status=0
+    if $STRICT || $CI_MODE; then
+      scripts/cloudflare-token-health.sh --strict >/tmp/codex-cloudflare-token-health.log 2>&1 || status=$?
+    else
+      scripts/cloudflare-token-health.sh >/tmp/codex-cloudflare-token-health.log 2>&1 || status=$?
+    fi
+
+    if [[ "$status" -eq 0 ]]; then
       ok "Cloudflare token health check passed"
       sed -n '1,36p' /tmp/codex-cloudflare-token-health.log | sed 's/^/     /'
     else


### PR DESCRIPTION
## Summary
- Fix codex preflight Cloudflare check on Bash with nounset by avoiding empty array expansion.
- Refresh GitHub Actions runtime dependencies to current major versions: checkout/setup-node/setup-python and CodeQL v4.
- Move workflow Node setup from 20 to 22.12.0 to avoid deprecation warnings.

## Validation
- npm run codex:preflight
- ruby YAML parse for .github/workflows/*.yml
- bash -n scripts/codex-preflight.sh
- npm -C frontend run typecheck
- npm -C frontend run build
- npm -C website run typecheck
- npm run quality:security

## Scope notes
- Existing local changes in backend/apps/automations/scraper/run_scraper.py and .playwright-mcp/ were not included.