### PR TITLE
fix: improve crm site tracking ui

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1413,6 +1413,25 @@ export default function AppFunctionalNeatlab() {
                                                                                             value={site.id}
                                                                                             className={`${statusTone} ${isSelectedSite ? 'border-l-2 border-cyan-300/80 font-semibold ring-1 ring-inset ring-cyan-300/20' : 'border-l-2 border-transparent font-normal'}`}
                                                                                             hideIndicator
+                                                                                            action={
+                                                                                                <button
+                                                                                                    type="button"
+                                                                                                    className="inline-flex size-6 items-center justify-center rounded-md text-cyan-100/70 transition hover:bg-cyan-400/15 hover:text-cyan-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/40"
+                                                                                                    aria-label={`Renomear ${site.name || site.host || site.id}`}
+                                                                                                    title="Renomear site"
+                                                                                                    onPointerDown={(event) => {
+                                                                                                        event.preventDefault()
+                                                                                                        event.stopPropagation()
+                                                                                                    }}
+                                                                                                    onClick={(event) => {
+                                                                                                        event.preventDefault()
+                                                                                                        event.stopPropagation()
+                                                                                                        dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: site.id })
+                                                                                                    }}
+                                                                                                >
+                                                                                                    <Pencil className="size-3.5" aria-hidden="true" />
+                                                                                                </button>
+                                                                                            }
                                                                                         >
                                                                                             <div className="flex min-w-0 flex-col pr-4 leading-tight">
                                                                                                 <span className={`truncate ${isSelectedSite ? 'text-white' : ''}`}>{site.name || site.host || site.id}</span>
@@ -1429,24 +1448,6 @@ export default function AppFunctionalNeatlab() {
                                                                             </SelectItem>
                                                                         </SelectContent>
                                                                     </Select>
-                                                                    <button
-                                                                        type="button"
-                                                                        className="inline-flex h-full w-8 shrink-0 items-center justify-center border-l border-white/15 bg-white/[0.03] text-cyan-100/80 transition hover:bg-cyan-400/10 hover:text-cyan-50 disabled:cursor-not-allowed disabled:opacity-50"
-                                                                        aria-label="Renomear site selecionado"
-                                                                        title="Renomear site"
-                                                                        disabled={siteTrackingHeaderState?.refreshing || !siteTrackingHeaderState?.selectedSiteId}
-                                                                        onPointerDown={(event) => {
-                                                                            event.preventDefault()
-                                                                            event.stopPropagation()
-                                                                        }}
-                                                                        onClick={(event) => {
-                                                                            event.preventDefault()
-                                                                            event.stopPropagation()
-                                                                            dispatchSiteTrackingHeaderAction({ type: 'rename-site', value: siteTrackingHeaderState?.selectedSiteId })
-                                                                        }}
-                                                                    >
-                                                                        <Pencil className="size-3.5" aria-hidden="true" />
-                                                                    </button>
                                                                 </div>
                                                             </div>
                                                         ) : null}

--- a/frontend/AuthScreen.tsx
+++ b/frontend/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { CircleCheck, Eye, EyeOff, KeyRound, LockKeyhole, Mail, ShieldCheck, UserRound } from 'lucide-react'
+import { CircleCheck, Eye, EyeOff, KeyRound, Mail, ShieldCheck, UserRound } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/card'
 import { Input } from '@/input'
 import { Button } from '@/button'
@@ -25,6 +25,7 @@ export function AuthScreen() {
     const [isVisible, setIsVisible] = useState(false)
     const [showPassword, setShowPassword] = useState(false)
     const [capsLock, setCapsLock] = useState(false)
+    const currentYear = new Date().getFullYear()
 
     useEffect(() => {
         setIsVisible(true)
@@ -119,9 +120,9 @@ export function AuthScreen() {
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-6 sm:px-6 lg:grid lg:grid-cols-[minmax(0,1fr)_480px] lg:items-center lg:gap-12 lg:py-10">
                 <header className={`order-1 mb-8 flex items-center justify-between transition-all duration-700 lg:absolute lg:left-6 lg:right-6 lg:top-6 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}>
                     <img
-                        src="/brand/espacofacial-logo-official-white.svg"
+                        src="/brand/espacofacial-logo-light.svg"
                         alt="Espaço Facial"
-                        className="h-10 w-auto max-w-[230px] sm:h-12 sm:max-w-[280px]"
+                        className="h-11 w-[230px] object-contain object-left sm:h-12 sm:w-[280px]"
                     />
                     <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-slate-300">
                         <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.65)]" />
@@ -130,27 +131,26 @@ export function AuthScreen() {
                 </header>
 
                 <section className={`order-3 mt-8 max-w-xl transition-all duration-700 lg:order-none lg:mt-0 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'}`}>
-                    <div className="mb-5 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold uppercase text-slate-300">
-                        <LockKeyhole className="h-3.5 w-3.5" aria-hidden />
-                        CRM corporativo
-                    </div>
                     <h1 className="max-w-xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
                         Relacionamento, operações e crescimento em uma única plataforma.
                     </h1>
                     <p className="mt-5 max-w-lg text-base leading-7 text-slate-300">
                         Acesso restrito para equipes autorizadas. Perfis, unidades e módulos são definidos por convite administrativo e aplicados no backend do CRM.
                     </p>
-                    <div className="mt-8 grid gap-3 text-sm text-slate-300 sm:grid-cols-3">
+                    <div className="mt-8 grid gap-3 text-center text-sm text-slate-300 sm:grid-cols-3">
                         <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
-                            <div className="text-lg font-semibold text-white">Convite</div>
+                            <KeyRound className="mx-auto h-5 w-5 text-cyan-200" aria-hidden />
+                            <div className="mt-3 text-lg font-semibold text-white">Convite</div>
                             <div className="mt-1 text-slate-400">Cadastro com token único</div>
                         </div>
                         <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
-                            <div className="text-lg font-semibold text-white">Escopo</div>
+                            <UserRound className="mx-auto h-5 w-5 text-violet-200" aria-hidden />
+                            <div className="mt-3 text-lg font-semibold text-white">Escopo</div>
                             <div className="mt-1 text-slate-400">Módulos e unidades por usuário</div>
                         </div>
                         <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
-                            <div className="text-lg font-semibold text-white">Sessão</div>
+                            <ShieldCheck className="mx-auto h-5 w-5 text-emerald-200" aria-hidden />
+                            <div className="mt-3 text-lg font-semibold text-white">Sessão</div>
                             <div className="mt-1 text-slate-400">Cookies seguros e CSRF</div>
                         </div>
                     </div>
@@ -279,7 +279,7 @@ export function AuthScreen() {
                                         Senha {mode === 'signup' && '(mínimo de 6 caracteres)'}
                                     </label>
                                     <div className="relative">
-                                        <LockKeyhole className={iconChrome} aria-hidden />
+                                        <KeyRound className={iconChrome} aria-hidden />
                                         <Input
                                             id="auth-password"
                                             name="password"
@@ -364,7 +364,7 @@ export function AuthScreen() {
                 </main>
 
                 <footer className={`order-4 mt-8 pb-2 text-center text-xs text-slate-500 transition-all duration-700 delay-200 lg:col-span-2 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}>
-                    © 2024 Espaço Facial CRM
+                    © {currentYear} Espaço Facial CRM
                 </footer>
             </div>
         </div>

--- a/frontend/SiteTrackingModule.tsx
+++ b/frontend/SiteTrackingModule.tsx
@@ -45,7 +45,7 @@ const SITE_OPTIONS: SiteTrackingHeaderSiteOption[] = [
     id: 'espacofacial.com',
     name: 'espacofacial.com',
     host: 'espacofacial.com',
-    statusLabel: 'Canônico do funil',
+    statusLabel: 'Domínio principal',
     statusTone: 'success',
   },
 ]
@@ -150,6 +150,8 @@ export function SiteTrackingModule() {
   }, [data?.siteConnections?.sites, siteNameOverrides])
   const selectedSite = siteOptions.find((site) => site.id === selectedSiteId) || siteOptions[0]
   const headerUpdatedAt = data?.generatedAt ? new Date(data.generatedAt).toISOString() : undefined
+  const dataSourceLabel = data?.website?.data?.source || (data?.website?.available ? 'website_d1' : null)
+  const dataUpdatedLabel = data?.generatedAt ? new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(data.generatedAt)) : null
 
   useEffect(() => {
     emitSiteTrackingHeaderState({
@@ -545,6 +547,15 @@ export function SiteTrackingModule() {
         </div>
       ) : null}
 
+      {dataSourceLabel ? (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-800/70 bg-slate-950/35 px-3 py-2 text-[11px] uppercase tracking-[0.14em] text-slate-500">
+          <span>Fonte: {dataSourceLabel}</span>
+          {data?.window?.days ? <span>Janela: {data.window.days} dias</span> : null}
+          {dataUpdatedLabel ? <span>Atualizado: {dataUpdatedLabel}</span> : null}
+          {selectedSite?.host ? <span>Site: {selectedSite.host}</span> : null}
+        </div>
+      ) : null}
+
       <SiteMetricsGrid
         hiddenMetricTiles={hiddenMetricTiles}
         visibleMetricTiles={visibleMetricTiles}
@@ -560,6 +571,7 @@ export function SiteTrackingModule() {
       <SiteBehaviorSections data={data} />
       <ManagedSiteUrlsSection
         urls={listOrEmpty(data?.customLinks?.managedUrls)}
+        cloudflareRedirects={listOrEmpty(data?.customLinks?.cloudflareRedirects)}
         saving={savingManagedUrl}
         onSave={saveManagedUrl}
       />

--- a/frontend/metaTrackingLocalMock.ts
+++ b/frontend/metaTrackingLocalMock.ts
@@ -80,6 +80,16 @@ export type TrackingOverviewResponse = {
       clickCount: number
       lastClickAtMs: number | null
     }>
+    cloudflareRedirects?: Array<{
+      id: string
+      siteHost: string
+      name: string
+      slugPath: string
+      publicUrl: string
+      destinationUrl: string
+      source: 'cloudflare_worker'
+      active: boolean
+    }>
     topLinks?: Array<{ linkUrl: string; count: number }>
     topUtmContent?: Array<{ utmContent: string; count: number }>
     linksMissingUtm?: Array<{ linkUrl: string; count: number }>
@@ -199,6 +209,7 @@ export type TrackingOverviewResponse = {
     error?: string
     sourceUrl?: string
     data?: {
+      source?: string
       summary?: Record<string, number>
       topSources?: Array<{ utmSource: string; count: number }>
       topCampaigns?: Array<{ utmCampaign: string; count: number }>
@@ -440,7 +451,7 @@ export function getMetaTrackingLocalOverview(days = 30): TrackingOverviewRespons
           siteHost: 'espacofacial.com',
           host: 'espacofacial.com',
           name: 'espacofacial.com',
-          statusLabel: 'Canônico do funil',
+          statusLabel: 'Domínio principal',
           statusTone: 'success',
           source: 'system',
           active: true,

--- a/frontend/siteTrackingComponents.tsx
+++ b/frontend/siteTrackingComponents.tsx
@@ -52,6 +52,7 @@ type FunnelRow = {
 }
 
 export type ManagedSiteUrl = NonNullable<NonNullable<TrackingOverviewResponse['customLinks']>['managedUrls']>[number]
+export type CloudflareRedirectUrl = NonNullable<NonNullable<TrackingOverviewResponse['customLinks']>['cloudflareRedirects']>[number]
 export type SiteConnection = NonNullable<NonNullable<TrackingOverviewResponse['siteConnections']>['sites']>[number]
 
 export type SiteConnectionForm = {
@@ -287,7 +288,7 @@ export function RankedList({
               <span className="min-w-0 truncate text-slate-200">{label}</span>
               <span className="font-mono text-slate-400">{formatSiteTrackingNumber(count)}</span>
             </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
+            <div className="h-1.5 max-w-md overflow-hidden rounded-full bg-white/10">
               <div className="h-full rounded-full bg-cyan-400" style={{ width: funnelBarWidth(count, max) }} />
             </div>
           </div>
@@ -535,7 +536,7 @@ export function SiteFunnelSection({ rows, max }: { rows: FunnelRow[]; max: numbe
 
 export function SiteBehaviorSections({ data }: { data: TrackingOverviewResponse | null }) {
   return (
-    <div className="grid gap-6 xl:grid-cols-3">
+    <div className="grid gap-4 lg:grid-cols-3">
       <SiteTrackingSection title="Páginas mais vistas" icon={<CursorClick className="h-5 w-5" />}>
         <RankedList items={listOrEmpty(data?.siteBehavior?.topPages)} labelKey="pagePath" empty="Sem pageviews agregados ainda." />
       </SiteTrackingSection>
@@ -551,10 +552,12 @@ export function SiteBehaviorSections({ data }: { data: TrackingOverviewResponse 
 
 export function ManagedSiteUrlsSection({
   urls,
+  cloudflareRedirects,
   saving,
   onSave,
 }: {
   urls: ManagedSiteUrl[]
+  cloudflareRedirects: CloudflareRedirectUrl[]
   saving?: boolean
   onSave: (form: ManagedSiteUrlForm) => Promise<void>
 }) {
@@ -579,6 +582,13 @@ export function ManagedSiteUrlsSection({
     <SiteTrackingSection title="URLs personalizadas" icon={<LinkSimple className="h-5 w-5" />}>
       <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(340px,0.8fr)]">
         <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Gerenciadas no CRM</div>
+              <div className="text-xs text-slate-500">Registros salvos no D1 e editáveis por esta tela.</div>
+            </div>
+            <Badge variant="outline">{formatSiteTrackingNumber(urls.length)}</Badge>
+          </div>
           {urls.length ? urls.map((url) => (
             <div key={url.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
               <div className="flex flex-wrap items-start justify-between gap-3">
@@ -613,7 +623,36 @@ export function ManagedSiteUrlsSection({
                 </div>
               </div>
             </div>
-          )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhuma URL personalizada cadastrada ainda.</div>}
+          )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhuma URL gerenciada no CRM cadastrada ainda.</div>}
+
+          <div className="pt-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Atalhos Cloudflare</div>
+                <div className="text-xs text-slate-500">Links read-only do worker esfa.co. Edição permanece no catálogo de redirects.</div>
+              </div>
+              <Badge variant="outline">{formatSiteTrackingNumber(cloudflareRedirects.length)}</Badge>
+            </div>
+            <div className="mt-3 max-h-[420px] space-y-2 overflow-y-auto pr-1">
+              {cloudflareRedirects.length ? cloudflareRedirects.map((url) => (
+                <div key={url.id} className="rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold text-slate-100">{url.name}</span>
+                        <Badge variant="secondary">Cloudflare</Badge>
+                      </div>
+                      <div className="mt-1 truncate font-mono text-xs text-cyan-100">{url.publicUrl}</div>
+                      <div className="mt-1 truncate text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
+                    </div>
+                    <div className="text-right text-[10px] uppercase tracking-[0.12em] text-slate-500">
+                      Read-only
+                    </div>
+                  </div>
+                </div>
+              )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhum atalho Cloudflare carregado.</div>}
+            </div>
+          </div>
         </div>
 
         <form

--- a/website/src/app/api/tracking/dashboard/route.ts
+++ b/website/src/app/api/tracking/dashboard/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getBookingDb, type BookingRequestRow } from "@/lib/bookingDb";
+import { listEsfaRedirects } from "@/lib/esfaRedirects";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
 import { serializeSiteCustomUrl, type SiteCustomUrlRow } from "@/lib/siteCustomUrls";
 import {
@@ -762,6 +763,7 @@ export async function GET(request: Request) {
 
     const customLinks = {
         managedUrls: customUrlRows.map(serializeSiteCustomUrl),
+        cloudflareRedirects: listEsfaRedirects(),
         topLinks: sortMapEntries(behaviorLinkCounts, "linkUrl").slice(0, 10),
         topUtmContent: sortMapEntries(behaviorUtmContentCounts, "utmContent").slice(0, 10),
         linksMissingUtm: sortMapEntries(behaviorMissingUtmLinkCounts, "linkUrl").slice(0, 10),

--- a/website/src/lib/esfaRedirects.ts
+++ b/website/src/lib/esfaRedirects.ts
@@ -1,0 +1,149 @@
+export const ESFA_PRESERVE_QUERYSTRING = true;
+
+export const ESFA_REDIRECTS: Record<string, string> = {
+  // BarraShoppingSul
+  "/bss/comochegar": "https://www.google.com/maps/place/Espaço+Facial/@-30.0846697,-51.2458384,17z/data=!3m1!4b1!4m6!3m5!1s0x9519795c306ed865:0xb5f05aac9b865daa!8m2!3d-30.0846697!4d-51.2458384!16s%2Fg%2F11vywknzbf?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
+  "/bss/faleconosco": "https://espacofacial.com/barrashoppingsul/faleconosco",
+  "/bss/faleconsco": "https://espacofacial.com/barrashoppingsul/faleconsco",
+  "/bss/fb": "https://www.facebook.com/espacofacial.barrashoppingsul",
+  "/bss/giftcard": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero presentear _alguém especial_ com o *Cartão Presente* da _Espaço Facial_ – *autoestima, beleza e bem-estar* em forma de presente! 💝",
+  "/bss/ig": "https://www.instagram.com/espacofacial_barrashoppingsul",
+  "/bss/alopecia": "https://payment-link-v3.stone.com.br/pl_7ezVNbW1nym2D4cz4IVa2rR0DxXJYdLP",
+  "/bss/clubebotox": "https://payment-link-v3.stone.com.br/pl_lqrbavJ9pR50k6HBBt48jYoAPENQXxek",
+  "/bss/clubelavieen": "https://payment-link-v3.stone.com.br/pl_r1gLZjbQ3nX4E7UKQfXEYwRO9Eom7GlV",
+  "/avalienossoespaço/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/avalienossoespaco/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/bss/avalienossoespaço": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/bss/avalienossoespaco": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nosavalie/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/bss/nosavalie": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/bss/vip": "https://chat.whatsapp.com/KsZ5LtGtXcCAg4HyyDWnSo",
+
+  // Novo Hamburgo
+  "/nh/comochegar": "https://www.google.com/maps/dir//Espaço+Facial+-+Av.+Dr.+Maurício+Cardoso,+1126+-+Jardim+Mauá,+Novo+Hamburgo+-+RS,+93548-515/@-29.6817035,-51.1190928,17z/data=!4m9!4m8!1m0!1m5!1m1!1s0x951943d467aca085:0x23f81b926e34d27b!2m2!1d-51.1190928!2d-29.6817035!3e0?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
+  "/nh/fb": "https://www.facebook.com/espacofacial.novohamburgo",
+  "/nh/fgts": "https://auto.bsbank.com.br/fgts-parceiro?partner=7deea206-1e21-41ff-be10-a3e1d4ce95cb",
+  "/nh/giftcard": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero presentear _alguém especial_ com o *Cartão Presente* da _Espaço Facial_ – *autoestima, beleza e bem-estar* em forma de presente! 💝",
+  "/nh/ig": "https://www.instagram.com/espacofacial_novohamburgo",
+  "/nh/alopecia": "https://payment-link-v3.stone.com.br/pl_JQ4p9nYxmGaNDO92slTBbZEdL76R1gX8",
+  "/nh/clubebotox": "https://payment-link-v3.stone.com.br/pl_2xNX5qopbEQAOw2iGHqbL9wdP8VRGYkB",
+  "/nh/clubelavieen": "https://payment-link-v3.stone.com.br/pl_QypjlV90JAxoW7DzTnfY8X46qDe7EO15",
+  "/nh/faleconosco": "https://espacofacial.com/novohamburgo/faleconosco",
+  "/avalienossoespaço/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/avalienossoespaco/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nh/avalienossoespaço": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nh/avalienossoespaco": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nh/nosavalie": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nosavalie/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
+  "/nh/vip": "https://chat.whatsapp.com/EldkIVerELzESZKW8Iephz",
+
+  // Campanhas
+  "/bebadessafonte": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+HealthBodyRun+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+
+  // Interno
+  "/sugereaqui": "https://espacofacial.com/sugereaqui",
+  "/meuespaço": "https://espacofacial.com/MeuEspaço",
+
+  // Doutores - BSS
+  "/bss/dragabrielamenegat": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Gabriela%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/bss/dramarinalima": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Marina%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/bss/drasamarassilva": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Samara%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/bss/dravivianemondin": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Viviane%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/bss/drmarcelogsoares": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Marcelo%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/bss/drviniciusvieira": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Vinícius%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+
+  // Doutores - NH
+  "/nh/dragabrielamenegat": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Gabriela%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/drajosielesouza": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Josiele%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/dramarinalima": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Marina%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/drasamarassilva": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Samara%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/dravivianemondin": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Viviane%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/drmarcelogsoares": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Marcelo%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+  "/nh/drviniciusvieira": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Vinícius%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
+
+  // Short URLs (campanhas)
+  "/alineschneidertv": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40alineschneidertv+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/amandahlr": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandahlr+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/amandameraa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandameraa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/amandawinck": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandawinck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/amarorocha_ofc": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amarorocha_ofc+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/aquelaminah": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40aquelaminah+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/braian_fiori29": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40braian_fiori29+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/brechobalonefebassi": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40brechobalonefebassi+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/brunamaralf": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40brunamaralf+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/carotremarin": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40carotremarin+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/denifreitas": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40denifreitas+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/dudaandradix": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40dudaandradix+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/dudamuniz_": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40dudamuniz_+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/eliseufrenzel": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40eliseufrenzel+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/erlethnunes": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40erlethnunes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/fefcv": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40fefcv+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/felipebkin": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40felipebkin+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/gabipospichil": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40gabipospichil+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/garcom_modelo": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40garcom_modelo+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/geschwertner": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40geschwertner+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/ggabrielaavilaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40ggabrielaavilaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/gi_ojeda": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40gi_ojeda+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/greice_marczewski": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40greice_marczewski+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/gusgho": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40gusgho+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/isaaaacardoso_": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40isaaaacardoso_+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/jaine_fernanda": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40jaine_fernanda+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/jubenitogarcia": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40jubenitogarcia+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/juliacarpess": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40juliacarpess+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/kesllyvargas": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40kesllyvargas+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/lanadarlling": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40lanadarlling+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/lucasf_if": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40lucasf_If+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/luisaaraamos": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40luisaaraamos+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/marianajreck": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40marianajreck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/mbmarianaboni": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40mbmarianaboni+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/micheletcorrea": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40micheletcorrea+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/morganawinck": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40morganawinck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/nataliablauth.fadadascores": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nataliablauth.fadadascores+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/nicolehummes": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nicolehummes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/nitametz": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nitametz+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/o_matheus_rosaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40o_matheus_rosaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/palomamaino": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40palomamaino+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/pamelabernardini": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40pamelabernardini+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/personalfernandonunes": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40personalfernandonunes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/popysmartins": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40popysmartins+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/renobree": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40renobree+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/samuel.santana.nh": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40samuel.santana.nh+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/steveigaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40steveigaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+  "/valykonrath": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40valykonrath+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
+};
+
+export function normalizeEsfaRedirectPath(pathname: string): string {
+  let decoded = pathname;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    decoded = pathname;
+  }
+  const lower = decoded.toLowerCase();
+  if (lower.length > 1 && lower.endsWith('/')) return lower.slice(0, -1);
+  return lower;
+}
+
+function labelFromPath(path: string): string {
+  return path
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+    .map((part) => part.replace(/[._-]+/g, ' '))
+    .join(' / ') || 'Início';
+}
+
+export function listEsfaRedirects() {
+  return Object.entries(ESFA_REDIRECTS)
+    .sort(([a], [b]) => a.localeCompare(b, 'pt-BR'))
+    .map(([slugPath, destinationUrl]) => ({
+      id: `esfa:${slugPath}`,
+      siteHost: 'esfa.co',
+      name: labelFromPath(slugPath),
+      slugPath,
+      publicUrl: `https://esfa.co${slugPath}`,
+      destinationUrl,
+      source: 'cloudflare_worker' as const,
+      active: true,
+    }));
+}

--- a/website/src/lib/siteConnections.ts
+++ b/website/src/lib/siteConnections.ts
@@ -83,7 +83,7 @@ export function defaultSiteConnection() {
         siteHost: DEFAULT_SITE_HOST,
         name: DEFAULT_SITE_HOST,
         host: DEFAULT_SITE_HOST,
-        statusLabel: "Canônico do funil",
+        statusLabel: "Domínio principal",
         statusTone: "success" as const,
         source: "system",
         active: true,

--- a/website/workers/esfa-redirector/worker.ts
+++ b/website/workers/esfa-redirector/worker.ts
@@ -1,139 +1,15 @@
-const PRESERVE_QUERYSTRING = true;
-
-const REDIRECTS: Record<string, string> = {
-  // BarraShoppingSul
-  "/bss/comochegar": "https://www.google.com/maps/place/Espaço+Facial/@-30.0846697,-51.2458384,17z/data=!3m1!4b1!4m6!3m5!1s0x9519795c306ed865:0xb5f05aac9b865daa!8m2!3d-30.0846697!4d-51.2458384!16s%2Fg%2F11vywknzbf?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
-  "/bss/faleconosco": "https://espacofacial.com/barrashoppingsul/faleconosco",
-  "/bss/faleconsco": "https://espacofacial.com/barrashoppingsul/faleconsco",
-  "/bss/fb": "https://www.facebook.com/espacofacial.barrashoppingsul",
-  "/bss/giftcard": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero presentear _alguém especial_ com o *Cartão Presente* da _Espaço Facial_ – *autoestima, beleza e bem-estar* em forma de presente! 💝",
-  "/bss/ig": "https://www.instagram.com/espacofacial_barrashoppingsul",
-  "/bss/alopecia": "https://payment-link-v3.stone.com.br/pl_7ezVNbW1nym2D4cz4IVa2rR0DxXJYdLP",
-  "/bss/clubebotox": "https://payment-link-v3.stone.com.br/pl_lqrbavJ9pR50k6HBBt48jYoAPENQXxek",
-  "/bss/clubelavieen": "https://payment-link-v3.stone.com.br/pl_r1gLZjbQ3nX4E7UKQfXEYwRO9Eom7GlV",
-  "/avalienossoespaço/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/avalienossoespaco/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/bss/avalienossoespaço": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/bss/avalienossoespaco": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nosavalie/bss": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/bss/nosavalie": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/bss/vip": "https://chat.whatsapp.com/KsZ5LtGtXcCAg4HyyDWnSo",
-
-  // Novo Hamburgo
-  "/nh/comochegar": "https://www.google.com/maps/dir//Espaço+Facial+-+Av.+Dr.+Maurício+Cardoso,+1126+-+Jardim+Mauá,+Novo+Hamburgo+-+RS,+93548-515/@-29.6817035,-51.1190928,17z/data=!4m9!4m8!1m0!1m5!1m1!1s0x951943d467aca085:0x23f81b926e34d27b!2m2!1d-51.1190928!2d-29.6817035!3e0?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
-  "/nh/fb": "https://www.facebook.com/espacofacial.novohamburgo",
-  "/nh/fgts": "https://auto.bsbank.com.br/fgts-parceiro?partner=7deea206-1e21-41ff-be10-a3e1d4ce95cb",
-  "/nh/giftcard": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero presentear _alguém especial_ com o *Cartão Presente* da _Espaço Facial_ – *autoestima, beleza e bem-estar* em forma de presente! 💝",
-  "/nh/ig": "https://www.instagram.com/espacofacial_novohamburgo",
-  "/nh/alopecia": "https://payment-link-v3.stone.com.br/pl_JQ4p9nYxmGaNDO92slTBbZEdL76R1gX8",
-  "/nh/clubebotox": "https://payment-link-v3.stone.com.br/pl_2xNX5qopbEQAOw2iGHqbL9wdP8VRGYkB",
-  "/nh/clubelavieen": "https://payment-link-v3.stone.com.br/pl_QypjlV90JAxoW7DzTnfY8X46qDe7EO15",
-  "/nh/faleconosco": "https://espacofacial.com/novohamburgo/faleconosco",
-  "/avalienossoespaço/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/avalienossoespaco/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nh/avalienossoespaço": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nh/avalienossoespaco": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nh/nosavalie": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nosavalie/nh": "https://www.google.com/maps/place//data=!4m3!3m2!1s0x951943d467aca085:0x23f81b926e34d27b!12e1?source=g.page.m.ia._&laa=nmx-review-solicitation-ia2",
-  "/nh/vip": "https://chat.whatsapp.com/EldkIVerELzESZKW8Iephz",
-
-  // Campanhas
-  "/bebadessafonte": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+HealthBodyRun+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-
-  // Interno
-  "/sugereaqui": "https://espacofacial.com/sugereaqui",
-  "/meuespaço": "https://espacofacial.com/MeuEspaço",
-
-  // Doutores - BSS
-  "/bss/dragabrielamenegat": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Gabriela%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/bss/dramarinalima": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Marina%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/bss/drasamarassilva": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Samara%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/bss/dravivianemondin": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Viviane%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/bss/drmarcelogsoares": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Marcelo%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/bss/drviniciusvieira": "https://api.whatsapp.com/send?phone=5551980882293&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Vinícius%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-
-  // Doutores - NH
-  "/nh/dragabrielamenegat": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Gabriela%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/drajosielesouza": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Josiele%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/dramarinalima": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Marina%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/drasamarassilva": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Samara%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/dravivianemondin": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20a%20%2ADra.%20Viviane%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/drmarcelogsoares": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Marcelo%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-  "/nh/drviniciusvieira": "https://api.whatsapp.com/send?phone=5551995811008&text=Quero%20agendar%20um%20hor%C3%A1rio%20com%20o%20%2ADr.%20Vinícius%2A%20na%20Espa%C3%A7o%20Facial%21%20%F0%9F%93%85",
-
-  // Short URLs (campanhas)
-  "/alineschneidertv": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40alineschneidertv+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/amandahlr": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandahlr+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/amandameraa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandameraa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/amandawinck": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amandawinck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/amarorocha_ofc": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40amarorocha_ofc+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/aquelaminah": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40aquelaminah+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/braian_fiori29": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40braian_fiori29+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/brechobalonefebassi": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40brechobalonefebassi+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/brunamaralf": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40brunamaralf+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/carotremarin": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40carotremarin+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/denifreitas": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40denifreitas+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/dudaandradix": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40dudaandradix+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/dudamuniz_": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40dudamuniz_+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/eliseufrenzel": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40eliseufrenzel+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/erlethnunes": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40erlethnunes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/fefcv": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40fefcv+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/felipebkin": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40felipebkin+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/gabipospichil": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40gabipospichil+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/garcom_modelo": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40garcom_modelo+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/geschwertner": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40geschwertner+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/ggabrielaavilaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40ggabrielaavilaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/gi_ojeda": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40gi_ojeda+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/greice_marczewski": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40greice_marczewski+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/gusgho": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40gusgho+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/isaaaacardoso_": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40isaaaacardoso_+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/jaine_fernanda": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40jaine_fernanda+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/jubenitogarcia": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40jubenitogarcia+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/juliacarpess": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40juliacarpess+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/kesllyvargas": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40kesllyvargas+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/lanadarlling": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40lanadarlling+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/lucasf_if": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40lucasf_If+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/luisaaraamos": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40luisaaraamos+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/marianajreck": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40marianajreck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/mbmarianaboni": "https://api.whatsapp.com/send?phone=5551980882293&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40mbmarianaboni+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/micheletcorrea": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40micheletcorrea+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/morganawinck": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40morganawinck+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/nataliablauth.fadadascores": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nataliablauth.fadadascores+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/nicolehummes": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nicolehummes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/nitametz": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40nitametz+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/o_matheus_rosaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40o_matheus_rosaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/palomamaino": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40palomamaino+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/pamelabernardini": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40pamelabernardini+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/personalfernandonunes": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40personalfernandonunes+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/popysmartins": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40popysmartins+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/renobree": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40renobree+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/samuel.santana.nh": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+do+%40samuel.santana.nh+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/steveigaa": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40steveigaa+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-  "/valykonrath": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+%40valykonrath+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
-};
-
-function normalizePath(pathname: string): string {
-  let decoded = pathname;
-  try {
-    decoded = decodeURIComponent(pathname);
-  } catch {
-    decoded = pathname;
-  }
-  const lower = decoded.toLowerCase();
-  if (lower.length > 1 && lower.endsWith("/")) return lower.slice(0, -1);
-  return lower;
-}
+import { ESFA_PRESERVE_QUERYSTRING, ESFA_REDIRECTS, normalizeEsfaRedirectPath } from '../../src/lib/esfaRedirects';
 
 const worker = {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
-    const path = normalizePath(url.pathname);
+    const path = normalizeEsfaRedirectPath(url.pathname);
 
-    const targetBase = REDIRECTS[path];
+    const targetBase = ESFA_REDIRECTS[path];
     if (!targetBase) return new Response("Not Found", { status: 404 });
 
     const target = new URL(targetBase);
-    if (PRESERVE_QUERYSTRING && url.search) {
+    if (ESFA_PRESERVE_QUERYSTRING && url.search) {
       const targetParams = new URLSearchParams(target.search);
       const incomingParams = new URLSearchParams(url.search);
       for (const [key, value] of incomingParams) {


### PR DESCRIPTION
## Summary
- fixes CRM login branding details: clean logo asset, dynamic year, removed redundant corporate badge, centered auth badges with lucide icons
- improves Site EF header UX: clearer "Domínio principal" copy and rename pencil only inside the site dropdown
- tightens Site EF dashboard layout and adds discreet data provenance labels
- extracts the `esfa.co` redirect catalog into a shared module and exposes Cloudflare shortcuts as read-only dashboard data, separate from D1-managed URLs

## Validation
- `npm run quality:frontend`
- `npm run quality:website`
- `npm run quality:backend:crm-api`
- `npm run codex:crm:site-smoke`
- `npm run codex:preflight`
- remote D1 read-only check: `site_custom_urls` count remains `0`, `changed_db: false`
- local Playwright visual QA for Site EF header/dropdown/data provenance/URL sections
- `wrangler deploy --dry-run` for `website/workers/esfa-redirector`

## Notes
- The CRM form continues to create only D1-managed URLs.
- `esfa.co` redirects are exposed as read-only Cloudflare shortcuts in this change.
- Existing unrelated local changes in `backend/apps/automations/scraper/run_scraper.py` and `.playwright-mcp/` were not staged.
