### PR TITLE
feat: migrate esfa redirects into crm tracking

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -387,6 +387,10 @@ export default function AppFunctionalNeatlab() {
             () => (metaAdsHeaderState?.accounts || []).find((account) => account.id === metaAdsAccountRemovalId) || null,
             [metaAdsAccountRemovalId, metaAdsHeaderState?.accounts],
         )
+        const siteTrackingSelectedSite = useMemo(
+            () => (siteTrackingHeaderState?.sites || []).find((site) => site.id === siteTrackingHeaderState?.selectedSiteId) || null,
+            [siteTrackingHeaderState],
+        )
 				    const [insumosHeaderStatus, setInsumosHeaderStatus] = useState<InsumosHeaderState['status']>(null)
 				    const [insumosHeaderEstoque, setInsumosHeaderEstoque] = useState<InsumosHeaderState['stock']>(null)
                     const defaultEstoqueThresholds = React.useMemo(() => ({ warning: 50000, critical: 20000 }), [])
@@ -1374,8 +1378,8 @@ export default function AppFunctionalNeatlab() {
                                                             </div>
                                                         ) : null}
                                                         {active === 'site-tracking' ? (
-                                                            <div className="flex items-center gap-2 max-w-[56vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                                                                <div className="flex h-8 w-64 items-stretch overflow-hidden rounded-md border border-white/20 bg-white/[0.06] text-white">
+                                                            <div className="flex min-w-0 items-center gap-2">
+                                                                <div className="flex h-10 min-w-[18rem] max-w-[min(26rem,42vw)] flex-1 items-stretch overflow-hidden rounded-xl border border-white/20 bg-white/[0.06] text-white">
                                                                     <Select
                                                                         value={siteTrackingHeaderState?.selectedSiteId || ''}
                                                                         onValueChange={(value) => {
@@ -1388,7 +1392,14 @@ export default function AppFunctionalNeatlab() {
                                                                         disabled={siteTrackingHeaderState?.refreshing}
                                                                     >
                                                                         <SelectTrigger className="h-full min-w-0 flex-1 rounded-none border-0 bg-transparent px-3 text-white shadow-none focus-visible:ring-0">
-                                                                            <SelectValue placeholder="Site" />
+                                                                            <div className="flex min-w-0 flex-1 flex-col items-start justify-center text-left leading-none">
+                                                                                <span className="w-full truncate text-[15px] font-semibold text-white">
+                                                                                    {siteTrackingSelectedSite?.name || siteTrackingHeaderState?.selectedSiteName || 'Selecione um site'}
+                                                                                </span>
+                                                                                <span className="mt-1 w-full truncate text-[11px] font-medium text-slate-400">
+                                                                                    {siteTrackingSelectedSite?.statusLabel || siteTrackingSelectedSite?.host || 'Sem conexão selecionada'}
+                                                                                </span>
+                                                                            </div>
                                                                         </SelectTrigger>
                                                                         <SelectContent>
                                                                             {[...(siteTrackingHeaderState?.sites || [])]
@@ -1601,7 +1612,7 @@ export default function AppFunctionalNeatlab() {
                                         </div>
                                     ) : null}
                                     {active === 'site-tracking' ? (
-                                        <div className="flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                        <div className="flex shrink-0 items-center gap-1.5">
                                             <div className="flex items-center gap-1 rounded-full border border-white/15 bg-white/[0.06] p-1">
                                                 {[7, 30, 60, 90].map((period) => (
                                                     <button
@@ -1631,10 +1642,18 @@ export default function AppFunctionalNeatlab() {
                                                         <RefreshCw className={`size-3.5 ${siteTrackingHeaderState?.refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
                                                     </Button>
                                                 </TooltipTrigger>
-                                                <TooltipContent>
-                                                    {siteTrackingHeaderState?.updatedAt
-                                                        ? `Atualizar. Ultima atualizacao: ${new Date(siteTrackingHeaderState.updatedAt).toLocaleString('pt-BR')}`
-                                                        : 'Atualizar'}
+                                                <TooltipContent className="max-w-80">
+                                                    <div className="space-y-1">
+                                                        <div className="text-[11px] font-medium leading-tight text-white">Atualizar painel do Site EF</div>
+                                                        {siteTrackingHeaderState?.dataSourceLabel || siteTrackingHeaderState?.updatedAt || siteTrackingHeaderState?.dataSiteHost ? (
+                                                            <div className="space-y-0.5 text-[10px] leading-snug text-slate-300/92">
+                                                                {siteTrackingHeaderState?.dataSourceLabel ? <div>Fonte: {siteTrackingHeaderState.dataSourceLabel}</div> : null}
+                                                                <div>Janela: {siteTrackingHeaderState?.windowDays || 30} dias</div>
+                                                                {siteTrackingHeaderState?.updatedAt ? <div>Atualizado: {new Date(siteTrackingHeaderState.updatedAt).toLocaleString('pt-BR')}</div> : null}
+                                                                {siteTrackingHeaderState?.dataSiteHost ? <div>Site: {siteTrackingHeaderState.dataSiteHost}</div> : null}
+                                                            </div>
+                                                        ) : null}
+                                                    </div>
                                                 </TooltipContent>
                                             </Tooltip>
                                         </div>
@@ -1935,11 +1954,11 @@ export default function AppFunctionalNeatlab() {
                         </header>
 
                         {/* Premium Main Content */}
-                        <main className={`flex-1 p-8 relative ${active === 'atendimento' ? 'overflow-hidden flex min-h-0 flex-col' : 'overflow-auto'} ${active === 'meta-ads' ? 'meta-ads-main' : ''}`}>
+                        <main className={`relative flex-1 p-8 ${active === 'atendimento' ? 'flex min-h-0 flex-col overflow-hidden' : active === 'site-tracking' ? 'min-w-0 overflow-x-hidden overflow-y-auto' : 'overflow-auto'} ${active === 'meta-ads' ? 'meta-ads-main' : ''}`}>
                             {/* Content Background */}
                             <div className={`absolute inset-0 ${active === 'meta-ads' ? 'meta-ads-main-bg' : 'bg-white/[0.02] backdrop-blur-sm'}`}></div>
 
-                            <div className={`relative z-10 ${active === 'atendimento' ? 'flex h-full min-h-0 flex-col' : ''}`}>
+                            <div className={`relative z-10 min-w-0 ${active === 'atendimento' ? 'flex h-full min-h-0 flex-col' : active === 'site-tracking' ? 'max-w-full overflow-x-hidden' : ''}`}>
                                 <div className="hidden">{search}</div>
                                 <ErrorBoundary>
                                     <Suspense fallback={
@@ -1958,7 +1977,7 @@ export default function AppFunctionalNeatlab() {
                                                 const moduleEntry = m as (typeof modules)[number]
                                                 const isActive = moduleEntry.key === active
                                                 return (
-                                                    <div key={moduleEntry.key} hidden={!isActive} className={active === 'atendimento' ? 'h-full min-h-0' : undefined}>
+                                                    <div key={moduleEntry.key} hidden={!isActive} className={active === 'atendimento' ? 'h-full min-h-0' : active === 'site-tracking' ? 'min-w-0 max-w-full overflow-x-hidden' : undefined}>
                                                         {moduleEntry.component}
                                                     </div>
                                                 )

--- a/frontend/SiteTrackingModule.tsx
+++ b/frontend/SiteTrackingModule.tsx
@@ -151,7 +151,6 @@ export function SiteTrackingModule() {
   const selectedSite = siteOptions.find((site) => site.id === selectedSiteId) || siteOptions[0]
   const headerUpdatedAt = data?.generatedAt ? new Date(data.generatedAt).toISOString() : undefined
   const dataSourceLabel = data?.website?.data?.source || (data?.website?.available ? 'website_d1' : null)
-  const dataUpdatedLabel = data?.generatedAt ? new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(data.generatedAt)) : null
 
   useEffect(() => {
     emitSiteTrackingHeaderState({
@@ -161,8 +160,10 @@ export function SiteTrackingModule() {
       selectedSiteName: selectedSite?.name,
       windowDays: days,
       updatedAt: headerUpdatedAt,
+      dataSourceLabel: dataSourceLabel || undefined,
+      dataSiteHost: selectedSite?.host || undefined,
     })
-  }, [days, headerUpdatedAt, loading, selectedSite?.name, selectedSiteId, siteOptions])
+  }, [dataSourceLabel, days, headerUpdatedAt, loading, selectedSite?.host, selectedSite?.name, selectedSiteId, siteOptions])
 
   useEffect(() => () => emitSiteTrackingHeaderState(null), [])
 
@@ -351,10 +352,10 @@ export function SiteTrackingModule() {
           const existing = prev.customLinks?.managedUrls || []
           const nextUrl = {
             id: form.id || `local_url_${now}`,
-            siteHost: selectedSiteId,
+            siteHost: form.siteHost || selectedSiteId,
             name: form.name,
             slugPath: form.slugPath || `/campanhas/${form.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'link'}`,
-            publicUrl: `https://${selectedSiteId}${form.slugPath || `/campanhas/${form.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'link'}`}`,
+            publicUrl: `https://${form.siteHost || selectedSiteId}${form.slugPath || `/campanhas/${form.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'link'}`}`,
             destinationUrl: form.destinationUrl,
             destinationHost: (() => {
               try { return new URL(form.destinationUrl).hostname } catch { return null }
@@ -398,7 +399,7 @@ export function SiteTrackingModule() {
         method: form.id ? 'PATCH' : 'POST',
         credentials: 'include',
         headers: { 'content-type': 'application/json', accept: 'application/json' },
-        body: JSON.stringify({ ...form, siteHost: selectedSiteId }),
+        body: JSON.stringify({ ...form, siteHost: form.siteHost || selectedSiteId }),
       })
       const payload = await response.json().catch(() => null)
       if (!response.ok || payload?.ok === false) throw new Error(payload?.message || payload?.error || 'Não foi possível salvar a URL')
@@ -488,7 +489,7 @@ export function SiteTrackingModule() {
   }
 
   return (
-    <div className="space-y-6 text-slate-100">
+    <div className="min-w-0 max-w-full space-y-6 overflow-x-hidden text-slate-100">
       {error ? (
         <div className="rounded-lg border border-red-400/30 bg-red-500/10 p-4 text-red-100">
           Falha ao carregar acompanhamento do site: {error}
@@ -547,15 +548,6 @@ export function SiteTrackingModule() {
         </div>
       ) : null}
 
-      {dataSourceLabel ? (
-        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-800/70 bg-slate-950/35 px-3 py-2 text-[11px] uppercase tracking-[0.14em] text-slate-500">
-          <span>Fonte: {dataSourceLabel}</span>
-          {data?.window?.days ? <span>Janela: {data.window.days} dias</span> : null}
-          {dataUpdatedLabel ? <span>Atualizado: {dataUpdatedLabel}</span> : null}
-          {selectedSite?.host ? <span>Site: {selectedSite.host}</span> : null}
-        </div>
-      ) : null}
-
       <SiteMetricsGrid
         hiddenMetricTiles={hiddenMetricTiles}
         visibleMetricTiles={visibleMetricTiles}
@@ -570,6 +562,7 @@ export function SiteTrackingModule() {
       <SiteFunnelSection rows={funnelRows} max={funnelMax} />
       <SiteBehaviorSections data={data} />
       <ManagedSiteUrlsSection
+        defaultSiteHost={selectedSiteId}
         urls={listOrEmpty(data?.customLinks?.managedUrls)}
         cloudflareRedirects={listOrEmpty(data?.customLinks?.cloudflareRedirects)}
         saving={savingManagedUrl}

--- a/frontend/siteTrackingComponents.tsx
+++ b/frontend/siteTrackingComponents.tsx
@@ -3,7 +3,9 @@ import { DragDropContext, Draggable, Droppable, type DraggableProvidedDragHandle
 import { Badge } from '@/badge'
 import { Button } from '@/button'
 import { Card, CardContent } from '@/card'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
 import type { TrackingOverviewResponse } from '@/metaTrackingLocalMock'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
 import {
   DEFAULT_SITE_METRIC_LAYOUT,
   cycleMetricDimensions,
@@ -26,6 +28,7 @@ import {
   EyeSlash,
   Funnel,
   LinkSimple,
+  Plus,
   Pulse,
   WarningCircle,
 } from '@phosphor-icons/react'
@@ -66,6 +69,7 @@ export type SiteConnectionForm = {
 
 export type ManagedSiteUrlForm = {
   id?: string
+  siteHost: string
   name: string
   slugPath: string
   destinationUrl: string
@@ -81,20 +85,23 @@ export type ManagedSiteUrlForm = {
   active: boolean
 }
 
-const emptyManagedUrlForm: ManagedSiteUrlForm = {
-  name: '',
-  slugPath: '',
-  destinationUrl: 'https://espacofacial.com/agendamento',
-  description: '',
-  placement: '',
-  unitSlug: '',
-  serviceId: '',
-  utmSource: 'meta',
-  utmMedium: 'paid_social',
-  utmCampaign: '',
-  utmContent: '',
-  utmTerm: '',
-  active: true,
+function createEmptyManagedUrlForm(siteHost: string): ManagedSiteUrlForm {
+  return {
+    siteHost,
+    name: '',
+    slugPath: '',
+    destinationUrl: 'https://espacofacial.com/agendamento',
+    description: '',
+    placement: '',
+    unitSlug: '',
+    serviceId: '',
+    utmSource: 'meta',
+    utmMedium: 'paid_social',
+    utmCampaign: '',
+    utmContent: '',
+    utmTerm: '',
+    active: true,
+  }
 }
 
 export const emptySiteConnectionForm: SiteConnectionForm = {
@@ -108,6 +115,7 @@ export const emptySiteConnectionForm: SiteConnectionForm = {
 function managedUrlToForm(url: ManagedSiteUrl): ManagedSiteUrlForm {
   return {
     id: url.id,
+    siteHost: url.siteHost || 'espacofacial.com',
     name: url.name || '',
     slugPath: url.slugPath || '',
     destinationUrl: url.destinationUrl || 'https://espacofacial.com/agendamento',
@@ -122,6 +130,12 @@ function managedUrlToForm(url: ManagedSiteUrl): ManagedSiteUrlForm {
     utmTerm: url.utmTerm || '',
     active: url.active !== false,
   }
+}
+
+function formatManagedUrlHostLabel(siteHost: string) {
+  if (siteHost === 'esfa.co') return 'esfa.co · atalho curto'
+  if (siteHost === 'espacofacial.com') return 'espacofacial.com · site principal'
+  return siteHost
 }
 
 function ManagedUrlField({
@@ -254,12 +268,25 @@ function SiteMetricTile({
   )
 }
 
-export function SiteTrackingSection({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
+export function SiteTrackingSection({
+  title,
+  icon,
+  action,
+  children,
+}: {
+  title: string
+  icon: ReactNode
+  action?: ReactNode
+  children: ReactNode
+}) {
   return (
-    <section className={`rounded-2xl p-5 ${siteTrackingPanelClass}`}>
-      <div className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-300">
-        {icon}
-        {title}
+    <section className={`min-w-0 overflow-hidden rounded-2xl p-5 ${siteTrackingPanelClass}`}>
+      <div className="mb-4 flex items-center justify-between gap-3 text-sm font-semibold uppercase tracking-wide text-slate-300">
+        <div className="flex min-w-0 items-center gap-2">
+          {icon}
+          <span className="truncate">{title}</span>
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
       </div>
       {children}
     </section>
@@ -278,17 +305,17 @@ export function RankedList({
   if (!items.length) return <div className="text-sm text-slate-500">{empty}</div>
   const max = Math.max(...items.map((item) => siteTrackingNumberValue(item.count)))
   return (
-    <div className="space-y-3">
+    <div className="min-w-0 space-y-3">
       {items.map((item, index) => {
         const label = String(item[labelKey] || 'sem valor')
         const count = siteTrackingNumberValue(item.count)
         return (
-          <div key={`${label}-${index}`} className="space-y-1">
+          <div key={`${label}-${index}`} className="min-w-0 space-y-1">
             <div className="flex items-center justify-between gap-3 text-sm">
               <span className="min-w-0 truncate text-slate-200">{label}</span>
               <span className="font-mono text-slate-400">{formatSiteTrackingNumber(count)}</span>
             </div>
-            <div className="h-1.5 max-w-md overflow-hidden rounded-full bg-white/10">
+            <div className="h-1.5 w-full max-w-full overflow-hidden rounded-full bg-white/10">
               <div className="h-full rounded-full bg-cyan-400" style={{ width: funnelBarWidth(count, max) }} />
             </div>
           </div>
@@ -536,7 +563,7 @@ export function SiteFunnelSection({ rows, max }: { rows: FunnelRow[]; max: numbe
 
 export function SiteBehaviorSections({ data }: { data: TrackingOverviewResponse | null }) {
   return (
-    <div className="grid gap-4 lg:grid-cols-3">
+    <div className="grid min-w-0 gap-4 xl:grid-cols-3">
       <SiteTrackingSection title="Páginas mais vistas" icon={<CursorClick className="h-5 w-5" />}>
         <RankedList items={listOrEmpty(data?.siteBehavior?.topPages)} labelKey="pagePath" empty="Sem pageviews agregados ainda." />
       </SiteTrackingSection>
@@ -551,19 +578,23 @@ export function SiteBehaviorSections({ data }: { data: TrackingOverviewResponse 
 }
 
 export function ManagedSiteUrlsSection({
+  defaultSiteHost,
   urls,
   cloudflareRedirects,
   saving,
   onSave,
 }: {
+  defaultSiteHost: string
   urls: ManagedSiteUrl[]
   cloudflareRedirects: CloudflareRedirectUrl[]
   saving?: boolean
   onSave: (form: ManagedSiteUrlForm) => Promise<void>
 }) {
-  const [form, setForm] = useState<ManagedSiteUrlForm>(emptyManagedUrlForm)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [form, setForm] = useState<ManagedSiteUrlForm>(() => createEmptyManagedUrlForm(defaultSiteHost))
   const [editingId, setEditingId] = useState<string | null>(null)
   const [feedback, setFeedback] = useState<string | null>(null)
+  const hostOptions = Array.from(new Set([defaultSiteHost, 'esfa.co', ...urls.map((url) => url.siteHost)])).filter(Boolean)
 
   useEffect(() => {
     if (!editingId) return
@@ -571,17 +602,51 @@ export function ManagedSiteUrlsSection({
     if (current) setForm(managedUrlToForm(current))
   }, [editingId, urls])
 
+  useEffect(() => {
+    if (editingId || dialogOpen) return
+    setForm(createEmptyManagedUrlForm(defaultSiteHost))
+  }, [defaultSiteHost, dialogOpen, editingId])
+
   const update = (patch: Partial<ManagedSiteUrlForm>) => setForm((prev) => ({ ...prev, ...patch }))
-  const reset = () => {
+  const closeDialog = () => {
+    setDialogOpen(false)
     setEditingId(null)
-    setForm(emptyManagedUrlForm)
+    setForm(createEmptyManagedUrlForm(defaultSiteHost))
     setFeedback(null)
+  }
+  const openCreate = () => {
+    setEditingId(null)
+    setFeedback(null)
+    setForm(createEmptyManagedUrlForm(defaultSiteHost))
+    setDialogOpen(true)
+  }
+  const openEditor = (url: ManagedSiteUrl) => {
+    setEditingId(url.id)
+    setFeedback(null)
+    setForm(managedUrlToForm(url))
+    setDialogOpen(true)
   }
 
   return (
-    <SiteTrackingSection title="URLs personalizadas" icon={<LinkSimple className="h-5 w-5" />}>
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(340px,0.8fr)]">
-        <div className="space-y-3">
+    <SiteTrackingSection
+      title="URLs personalizadas"
+      icon={<LinkSimple className="h-5 w-5" />}
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 border-slate-700 bg-slate-950/60 text-slate-100 hover:bg-slate-800"
+          aria-label="Adicionar URL personalizada"
+          title="Adicionar URL personalizada"
+          onClick={openCreate}
+        >
+          <Plus className="h-4 w-4" weight="bold" />
+        </Button>
+      }
+    >
+      <div className="min-w-0 space-y-5">
+        <div className="min-w-0 space-y-3">
           <div className="flex items-center justify-between gap-3">
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Gerenciadas no CRM</div>
@@ -589,131 +654,169 @@ export function ManagedSiteUrlsSection({
             </div>
             <Badge variant="outline">{formatSiteTrackingNumber(urls.length)}</Badge>
           </div>
-          {urls.length ? urls.map((url) => (
-            <div key={url.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-semibold text-white">{url.name}</span>
-                    <Badge variant={url.active ? 'success' : 'secondary'}>{url.active ? 'Ativa' : 'Pausada'}</Badge>
-                  </div>
-                  <div className="mt-1 truncate font-mono text-xs text-cyan-100">{url.publicUrl}</div>
-                  <div className="mt-1 truncate text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
-                  <div className="mt-2 text-xs text-slate-500">
-                    {url.utmCampaign || 'sem campanha'} · {url.unitSlug || 'sem unidade'} · {url.serviceId || 'sem procedimento'}
+          {urls.length ? (
+            <div className="max-h-[34rem] space-y-3 overflow-y-auto pr-1">
+              {urls.map((url) => (
+                <div key={url.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold text-white">{url.name}</span>
+                        <Badge variant={url.active ? 'success' : 'secondary'}>{url.active ? 'Ativa' : 'Pausada'}</Badge>
+                        <Badge variant="outline">{formatManagedUrlHostLabel(url.siteHost)}</Badge>
+                      </div>
+                      <div className="mt-1 break-all font-mono text-xs text-cyan-100">{url.publicUrl}</div>
+                      <div className="mt-1 break-all text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
+                      <div className="mt-2 text-xs text-slate-500">
+                        {url.utmCampaign || 'sem campanha'} · {url.unitSlug || 'sem unidade'} · {url.serviceId || 'sem procedimento'}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3">
+                      <div className="text-right">
+                        <div className="font-mono text-lg font-semibold text-white">{formatSiteTrackingNumber(url.clickCount)}</div>
+                        <div className="text-[10px] uppercase tracking-[0.12em] text-slate-500">cliques</div>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="border-slate-700 bg-slate-950/60 text-slate-100 hover:bg-slate-800"
+                        onClick={() => openEditor(url)}
+                      >
+                        Editar
+                      </Button>
+                    </div>
                   </div>
                 </div>
-                <div className="flex shrink-0 items-center gap-3">
-                  <div className="text-right">
-                    <div className="font-mono text-lg font-semibold text-white">{formatSiteTrackingNumber(url.clickCount)}</div>
-                    <div className="text-[10px] uppercase tracking-[0.12em] text-slate-500">cliques</div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="border-slate-700 bg-slate-950/60 text-slate-100 hover:bg-slate-800"
-                    onClick={() => {
-                      setEditingId(url.id)
-                      setFeedback(null)
-                    }}
-                  >
-                    Editar
-                  </Button>
-                </div>
-              </div>
+              ))}
             </div>
-          )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhuma URL gerenciada no CRM cadastrada ainda.</div>}
+          ) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhuma URL gerenciada no CRM cadastrada ainda.</div>}
 
           <div className="pt-3">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Atalhos Cloudflare</div>
-                <div className="text-xs text-slate-500">Links read-only do worker esfa.co. Edição permanece no catálogo de redirects.</div>
+                <div className="text-xs text-slate-500">Fallback operacional enquanto houver atalhos ainda não migrados para o CRM.</div>
               </div>
               <Badge variant="outline">{formatSiteTrackingNumber(cloudflareRedirects.length)}</Badge>
             </div>
-            <div className="mt-3 max-h-[420px] space-y-2 overflow-y-auto pr-1">
-              {cloudflareRedirects.length ? cloudflareRedirects.map((url) => (
-                <div key={url.id} className="rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="font-semibold text-slate-100">{url.name}</span>
-                        <Badge variant="secondary">Cloudflare</Badge>
+            {cloudflareRedirects.length ? (
+              <div className="mt-3 max-h-[24rem] space-y-2 overflow-y-auto pr-1">
+                {cloudflareRedirects.map((url) => (
+                  <div key={url.id} className="rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-semibold text-slate-100">{url.name}</span>
+                          <Badge variant="secondary">Cloudflare</Badge>
+                        </div>
+                        <div className="mt-1 break-all font-mono text-xs text-cyan-100">{url.publicUrl}</div>
+                        <div className="mt-1 break-all text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
                       </div>
-                      <div className="mt-1 truncate font-mono text-xs text-cyan-100">{url.publicUrl}</div>
-                      <div className="mt-1 truncate text-sm text-slate-400">{shortUrl(url.destinationUrl)}</div>
-                    </div>
-                    <div className="text-right text-[10px] uppercase tracking-[0.12em] text-slate-500">
-                      Read-only
+                      <div className="text-right text-[10px] uppercase tracking-[0.12em] text-slate-500">
+                        Read-only
+                      </div>
                     </div>
                   </div>
-                </div>
-              )) : <div className="rounded-xl border border-dashed border-slate-800 bg-white/[0.02] p-5 text-sm text-slate-500">Nenhum atalho Cloudflare carregado.</div>}
-            </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-3 rounded-xl border border-emerald-500/15 bg-emerald-500/8 p-4 text-sm text-emerald-100/90">
+                Todos os atalhos esfa.co desta superfície já estão gerenciados no CRM.
+              </div>
+            )}
           </div>
         </div>
+      </div>
+      <Dialog open={dialogOpen} onOpenChange={(open) => {
+        setDialogOpen(open)
+        if (!open) closeDialog()
+      }}>
+        <DialogContent className="max-w-3xl border-slate-800/80 bg-slate-950 text-slate-100">
+          <DialogHeader>
+            <DialogTitle>{editingId ? 'Editar URL personalizada' : 'Adicionar URL personalizada'}</DialogTitle>
+            <DialogDescription>
+              Use para links de campanha, anúncios, atalhos curtos e redirecionamentos monitorados.
+            </DialogDescription>
+          </DialogHeader>
 
-        <form
-          className="space-y-3 rounded-xl border border-cyan-400/20 bg-cyan-500/[0.04] p-4"
-          onSubmit={async (event) => {
-            event.preventDefault()
-            setFeedback(null)
-            try {
-              await onSave(form)
-              setFeedback(editingId ? 'URL atualizada.' : 'URL cadastrada.')
-              setEditingId(null)
-              setForm(emptyManagedUrlForm)
-            } catch (error) {
-              setFeedback(error instanceof Error ? error.message : 'Não foi possível salvar a URL.')
-            }
-          }}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div className="text-sm font-semibold text-white">{editingId ? 'Editar URL' : 'Adicionar URL'}</div>
-              <div className="text-xs text-slate-500">Use para links de campanha, anúncios e atalhos monitorados.</div>
+          <form
+            className="space-y-4"
+            onSubmit={async (event) => {
+              event.preventDefault()
+              setFeedback(null)
+              try {
+                await onSave(form)
+                closeDialog()
+              } catch (error) {
+                setFeedback(error instanceof Error ? error.message : 'Não foi possível salvar a URL.')
+              }
+            }}
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="space-y-1 text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                <span>Host público</span>
+                <Select value={form.siteHost} onValueChange={(siteHost) => update({ siteHost })}>
+                  <SelectTrigger className="h-10 w-full border-slate-800 bg-slate-950/70 text-slate-100">
+                    <SelectValue placeholder="Selecione o host" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {hostOptions.map((siteHost) => (
+                      <SelectItem key={siteHost} value={siteHost}>
+                        {formatManagedUrlHostLabel(siteHost)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+              <ManagedUrlField label="Posicionamento" value={form.placement} placeholder="campaign" onChange={(placement) => update({ placement })} />
             </div>
-            {editingId ? (
-              <Button type="button" variant="ghost" size="sm" className="text-slate-400 hover:text-white" onClick={reset}>
+
+            <ManagedUrlField label="Nome" value={form.name} placeholder="Botox Novo Hamburgo Meta" onChange={(name) => update({ name })} />
+            <ManagedUrlField label="URL final" value={form.destinationUrl} placeholder="https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox" onChange={(destinationUrl) => update({ destinationUrl })} />
+            <ManagedUrlField label="Atalho" value={form.slugPath} placeholder="/campanhas/botox-novo-hamburgo-meta" onChange={(slugPath) => update({ slugPath })} />
+            <ManagedUrlField label="Descrição" value={form.description} placeholder="Resumo operacional do link" onChange={(description) => update({ description })} />
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <ManagedUrlField label="utm_source" value={form.utmSource} onChange={(utmSource) => update({ utmSource })} />
+              <ManagedUrlField label="utm_medium" value={form.utmMedium} onChange={(utmMedium) => update({ utmMedium })} />
+              <ManagedUrlField label="utm_campaign" value={form.utmCampaign} onChange={(utmCampaign) => update({ utmCampaign })} />
+              <ManagedUrlField label="utm_content" value={form.utmContent} onChange={(utmContent) => update({ utmContent })} />
+              <ManagedUrlField label="utm_term" value={form.utmTerm} onChange={(utmTerm) => update({ utmTerm })} />
+              <ManagedUrlField label="Unidade" value={form.unitSlug} placeholder="novo-hamburgo" onChange={(unitSlug) => update({ unitSlug })} />
+              <ManagedUrlField label="Procedimento" value={form.serviceId} placeholder="botox" onChange={(serviceId) => update({ serviceId })} />
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={form.active}
+                onChange={(event) => update({ active: event.target.checked })}
+                className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-cyan-500"
+              />
+              URL ativa
+            </label>
+
+            {feedback ? <div className="text-sm text-rose-200">{feedback}</div> : null}
+
+            <DialogFooter>
+              <Button type="button" variant="outline" className="border-slate-700 bg-slate-950/60 text-slate-100 hover:bg-slate-800" onClick={closeDialog}>
                 Cancelar
               </Button>
-            ) : null}
-          </div>
-          <ManagedUrlField label="Nome" value={form.name} placeholder="Botox Novo Hamburgo Meta" onChange={(name) => update({ name })} />
-          <ManagedUrlField label="URL final" value={form.destinationUrl} placeholder="https://espacofacial.com/agendamento?unit=novo-hamburgo&service=botox" onChange={(destinationUrl) => update({ destinationUrl })} />
-          <ManagedUrlField label="Atalho" value={form.slugPath} placeholder="/campanhas/botox-novo-hamburgo-meta" onChange={(slugPath) => update({ slugPath })} />
-          <div className="grid gap-3 sm:grid-cols-2">
-            <ManagedUrlField label="utm_source" value={form.utmSource} onChange={(utmSource) => update({ utmSource })} />
-            <ManagedUrlField label="utm_medium" value={form.utmMedium} onChange={(utmMedium) => update({ utmMedium })} />
-            <ManagedUrlField label="utm_campaign" value={form.utmCampaign} onChange={(utmCampaign) => update({ utmCampaign })} />
-            <ManagedUrlField label="utm_content" value={form.utmContent} onChange={(utmContent) => update({ utmContent })} />
-            <ManagedUrlField label="Unidade" value={form.unitSlug} placeholder="novo-hamburgo" onChange={(unitSlug) => update({ unitSlug })} />
-            <ManagedUrlField label="Procedimento" value={form.serviceId} placeholder="botox" onChange={(serviceId) => update({ serviceId })} />
-          </div>
-          <label className="flex items-center gap-2 text-sm text-slate-300">
-            <input
-              type="checkbox"
-              checked={form.active}
-              onChange={(event) => update({ active: event.target.checked })}
-              className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-cyan-500"
-            />
-            URL ativa
-          </label>
-          {feedback ? <div className="text-xs text-emerald-300">{feedback}</div> : null}
-          <Button type="submit" disabled={saving || !form.name.trim() || !form.destinationUrl.trim()} className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
-            {saving ? 'Salvando...' : editingId ? 'Salvar alterações' : 'Cadastrar URL'}
-          </Button>
-        </form>
-      </div>
+              <Button type="submit" disabled={saving || !form.name.trim() || !form.destinationUrl.trim()} className="bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+                {saving ? 'Salvando...' : editingId ? 'Salvar alterações' : 'Cadastrar URL'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </SiteTrackingSection>
   )
 }
 
 export function SiteLinkSections({ data }: { data: TrackingOverviewResponse | null }) {
   return (
-    <div className="grid gap-6 xl:grid-cols-2">
+    <div className="grid min-w-0 gap-6 xl:grid-cols-2">
       <SiteTrackingSection title="Links personalizados e CTAs" icon={<LinkSimple className="h-5 w-5" />}>
         <RankedList items={listOrEmpty(data?.customLinks?.topLinks)} labelKey="linkUrl" empty="Sem cliques em links rastreados." />
       </SiteTrackingSection>
@@ -728,7 +831,7 @@ export function SiteIssueAndClickSections({ data }: { data: TrackingOverviewResp
   const incompleteBookings = listOrEmpty(data?.reconciliation?.incompleteBookings)
   const recentClicks = listOrEmpty(data?.customLinks?.recentClicks)
   return (
-    <div className="grid gap-6 xl:grid-cols-2">
+    <div className="grid min-w-0 gap-6 xl:grid-cols-2">
       <SiteTrackingSection title="Reservas com origem incompleta" icon={<WarningCircle className="h-5 w-5" />}>
         <div className="space-y-3">
           {incompleteBookings.slice(0, 8).map((booking) => (

--- a/frontend/siteTrackingHeaderBridge.ts
+++ b/frontend/siteTrackingHeaderBridge.ts
@@ -33,6 +33,8 @@ export function normalizeSiteTrackingHeaderState(detail: unknown): SiteTrackingH
     windowDays: isWindowDays(payload.windowDays) ? payload.windowDays : 30,
     selectedSiteName: payload.selectedSiteName ? String(payload.selectedSiteName) : undefined,
     updatedAt: payload.updatedAt ? String(payload.updatedAt) : undefined,
+    dataSourceLabel: payload.dataSourceLabel ? String(payload.dataSourceLabel) : undefined,
+    dataSiteHost: payload.dataSiteHost ? String(payload.dataSiteHost) : undefined,
   }
 }
 

--- a/frontend/siteTrackingTypes.ts
+++ b/frontend/siteTrackingTypes.ts
@@ -17,6 +17,8 @@ export type SiteTrackingHeaderState = {
   windowDays: SiteTrackingWindowDays
   selectedSiteName?: string
   updatedAt?: string
+  dataSourceLabel?: string
+  dataSiteHost?: string
 }
 
 export type SiteTrackingHeaderAction =

--- a/frontend/tests/siteTrackingModule.test.ts
+++ b/frontend/tests/siteTrackingModule.test.ts
@@ -83,6 +83,8 @@ describe('site tracking header bridge', () => {
       refreshing: true,
       selectedSiteId: 'espacofacial.com',
       windowDays: 999,
+      dataSourceLabel: 'website_d1',
+      dataSiteHost: 'espacofacial.com',
       sites: [
         { id: 'espacofacial.com', name: 'Espaço Facial', host: 'espacofacial.com', statusTone: 'success' },
         { id: '', name: 'invalid' },
@@ -93,6 +95,8 @@ describe('site tracking header bridge', () => {
       refreshing: true,
       selectedSiteId: 'espacofacial.com',
       windowDays: 30,
+      dataSourceLabel: 'website_d1',
+      dataSiteHost: 'espacofacial.com',
       sites: [{ id: 'espacofacial.com', name: 'Espaço Facial', host: 'espacofacial.com', statusTone: 'success' }],
     })
   })

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "test": "tsx --test tests/*.test.ts",
     "smoke": "node scripts/smoke.mjs",
     "smoke:strict": "SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs",
+    "custom-urls:migrate:esfa": "tsx scripts/migrate-esfa-redirects.ts",
     "tracking:governance": "node scripts/audit-tracking-governance.mjs",
     "quality:pr": "npm run audit:360:ci",
     "quality:check": "npm run lint && npm run typecheck && npm run test && npm run build && npm run smoke",

--- a/website/scripts/migrate-esfa-redirects.ts
+++ b/website/scripts/migrate-esfa-redirects.ts
@@ -1,0 +1,264 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { listEsfaManagedRedirectSeeds, ESFA_SITE_HOST, type EsfaManagedUrlSeed } from "../src/lib/esfaManagedRedirects";
+
+const execFileAsync = promisify(execFile);
+const DATABASE_NAME = "espacofacial-booking";
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+type ExistingRedirectRow = {
+    id: string;
+    site_host: string;
+    name: string;
+    slug_path: string;
+    destination_url: string;
+    destination_host: string | null;
+    destination_path: string | null;
+    description: string | null;
+    source: string;
+    placement: string | null;
+    unit_slug: string | null;
+    service_id: string | null;
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_content: string | null;
+    utm_term: string | null;
+    active: number;
+    created_at_ms: number;
+    updated_at_ms: number;
+};
+
+type MigrationPlan = {
+    inserts: EsfaManagedUrlSeed[];
+    updates: Array<{ existing: ExistingRedirectRow; seed: EsfaManagedUrlSeed }>;
+    skips: Array<{ existing: ExistingRedirectRow; seed: EsfaManagedUrlSeed }>;
+    conflicts: Array<{ existing: ExistingRedirectRow; seed: EsfaManagedUrlSeed }>;
+};
+
+function hasFlag(flag: string): boolean {
+    return process.argv.includes(flag);
+}
+
+function sqlString(value: string | null): string {
+    if (value === null) return "NULL";
+    return `'${value.replace(/'/g, "''")}'`;
+}
+
+function canonicalUrl(value: string): string {
+    return new URL(value).toString();
+}
+
+function extractRows(payload: unknown): ExistingRedirectRow[] {
+    if (Array.isArray(payload)) {
+        for (const item of payload) {
+            const rows = extractRows(item);
+            if (rows.length) return rows;
+        }
+        return [];
+    }
+    if (!payload || typeof payload !== "object") return [];
+    const record = payload as Record<string, unknown>;
+    if (Array.isArray(record.results)) return record.results as ExistingRedirectRow[];
+    if (record.result) return extractRows(record.result);
+    if (Array.isArray(record.rows)) return record.rows as ExistingRedirectRow[];
+    if (Array.isArray(record.data)) return record.data as ExistingRedirectRow[];
+    return [];
+}
+
+async function runWranglerJson(query: string, remote: boolean): Promise<unknown> {
+    const args = [
+        "wrangler",
+        "d1",
+        "execute",
+        DATABASE_NAME,
+        "--json",
+        "--command",
+        query,
+    ];
+    args.push(remote ? "--remote" : "--local");
+    const { stdout } = await execFileAsync("npx", args, {
+        cwd: WEBSITE_ROOT,
+        maxBuffer: 8 * 1024 * 1024,
+    });
+    return JSON.parse(stdout);
+}
+
+async function readExistingRows(remote: boolean): Promise<ExistingRedirectRow[]> {
+    const payload = await runWranglerJson(
+        `SELECT
+            id, site_host, name, slug_path, destination_url, destination_host, destination_path,
+            description, source, placement, unit_slug, service_id,
+            utm_source, utm_medium, utm_campaign, utm_content, utm_term,
+            active, created_at_ms, updated_at_ms
+         FROM site_custom_urls
+         WHERE site_host = '${ESFA_SITE_HOST}'
+         ORDER BY slug_path ASC;`,
+        remote,
+    );
+    return extractRows(payload);
+}
+
+function seedMatchesExisting(existing: ExistingRedirectRow, seed: EsfaManagedUrlSeed): boolean {
+    return (
+        existing.id === seed.id &&
+        existing.site_host === seed.siteHost &&
+        existing.name === seed.name &&
+        existing.slug_path === seed.slugPath &&
+        canonicalUrl(existing.destination_url) === canonicalUrl(seed.destinationUrl) &&
+        (existing.destination_host ?? null) === (seed.destinationHost ?? null) &&
+        (existing.destination_path ?? null) === (seed.destinationPath ?? null) &&
+        (existing.description ?? null) === (seed.description ?? null) &&
+        existing.source === seed.source &&
+        (existing.placement ?? null) === (seed.placement ?? null) &&
+        (existing.unit_slug ?? null) === (seed.unitSlug ?? null) &&
+        (existing.service_id ?? null) === (seed.serviceId ?? null) &&
+        (existing.utm_source ?? null) === (seed.utmSource ?? null) &&
+        (existing.utm_medium ?? null) === (seed.utmMedium ?? null) &&
+        (existing.utm_campaign ?? null) === (seed.utmCampaign ?? null) &&
+        (existing.utm_content ?? null) === (seed.utmContent ?? null) &&
+        (existing.utm_term ?? null) === (seed.utmTerm ?? null) &&
+        existing.active === (seed.active ? 1 : 0)
+    );
+}
+
+function buildPlan(existingRows: ExistingRedirectRow[], seeds: EsfaManagedUrlSeed[]): MigrationPlan {
+    const existingBySlug = new Map(existingRows.map((row) => [row.slug_path, row]));
+    const plan: MigrationPlan = {
+        inserts: [],
+        updates: [],
+        skips: [],
+        conflicts: [],
+    };
+
+    for (const seed of seeds) {
+        const existing = existingBySlug.get(seed.slugPath);
+        if (!existing) {
+            plan.inserts.push(seed);
+            continue;
+        }
+        if (canonicalUrl(existing.destination_url) !== canonicalUrl(seed.destinationUrl)) {
+            plan.conflicts.push({ existing, seed });
+            continue;
+        }
+        if (seedMatchesExisting(existing, seed)) {
+            plan.skips.push({ existing, seed });
+            continue;
+        }
+        plan.updates.push({ existing, seed });
+    }
+
+    return plan;
+}
+
+function renderInsert(seed: EsfaManagedUrlSeed): string {
+    return `INSERT INTO site_custom_urls (
+id, site_host, name, slug_path, destination_url, destination_host, destination_path,
+description, source, placement, unit_slug, service_id,
+utm_source, utm_medium, utm_campaign, utm_content, utm_term,
+active, created_at_ms, updated_at_ms
+) VALUES (
+${sqlString(seed.id)}, ${sqlString(seed.siteHost)}, ${sqlString(seed.name)}, ${sqlString(seed.slugPath)}, ${sqlString(seed.destinationUrl)}, ${sqlString(seed.destinationHost)}, ${sqlString(seed.destinationPath)},
+${sqlString(seed.description)}, ${sqlString(seed.source)}, ${sqlString(seed.placement)}, ${sqlString(seed.unitSlug)}, ${sqlString(seed.serviceId)},
+${sqlString(seed.utmSource)}, ${sqlString(seed.utmMedium)}, ${sqlString(seed.utmCampaign)}, ${sqlString(seed.utmContent)}, ${sqlString(seed.utmTerm)},
+${seed.active ? 1 : 0}, ${seed.createdAtMs}, ${seed.updatedAtMs}
+);`;
+}
+
+function renderUpdate(entry: { existing: ExistingRedirectRow; seed: EsfaManagedUrlSeed }): string {
+    const { existing, seed } = entry;
+    return `UPDATE site_custom_urls
+SET id = ${sqlString(seed.id)},
+    name = ${sqlString(seed.name)},
+    destination_url = ${sqlString(seed.destinationUrl)},
+    destination_host = ${sqlString(seed.destinationHost)},
+    destination_path = ${sqlString(seed.destinationPath)},
+    description = ${sqlString(seed.description)},
+    source = ${sqlString(seed.source)},
+    placement = ${sqlString(seed.placement)},
+    unit_slug = ${sqlString(seed.unitSlug)},
+    service_id = ${sqlString(seed.serviceId)},
+    utm_source = ${sqlString(seed.utmSource)},
+    utm_medium = ${sqlString(seed.utmMedium)},
+    utm_campaign = ${sqlString(seed.utmCampaign)},
+    utm_content = ${sqlString(seed.utmContent)},
+    utm_term = ${sqlString(seed.utmTerm)},
+    active = ${seed.active ? 1 : 0},
+    updated_at_ms = ${seed.updatedAtMs}
+WHERE site_host = ${sqlString(existing.site_host)}
+  AND slug_path = ${sqlString(existing.slug_path)};`;
+}
+
+function printSummary(plan: MigrationPlan, seedCount: number) {
+    console.log(`total_catalogo=${seedCount}`);
+    console.log(`inserts=${plan.inserts.length}`);
+    console.log(`updates=${plan.updates.length}`);
+    console.log(`skips=${plan.skips.length}`);
+    console.log(`conflicts=${plan.conflicts.length}`);
+    if (plan.conflicts.length) {
+        console.log("conflict_details=");
+        for (const conflict of plan.conflicts.slice(0, 20)) {
+            console.log(
+                `${conflict.seed.slugPath} => atual=${conflict.existing.destination_url} :: catalogo=${conflict.seed.destinationUrl}`,
+            );
+        }
+        if (plan.conflicts.length > 20) {
+            console.log(`... +${plan.conflicts.length - 20} conflitos adicionais`);
+        }
+    }
+}
+
+async function applyPlan(plan: MigrationPlan, remote: boolean) {
+    if (!plan.inserts.length && !plan.updates.length) return;
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "skincos-esfa-migrate-"));
+    const sqlFile = path.join(tempDir, "migrate-esfa-redirects.sql");
+    const statements = [...plan.inserts.map(renderInsert), ...plan.updates.map(renderUpdate)];
+    await writeFile(sqlFile, `${statements.join("\n")}\n`, "utf8");
+    try {
+        await execFileAsync(
+            "npx",
+            [
+                "wrangler",
+                "d1",
+                "execute",
+                DATABASE_NAME,
+                "--file",
+                sqlFile,
+                remote ? "--remote" : "--local",
+            ],
+            {
+                cwd: WEBSITE_ROOT,
+                maxBuffer: 8 * 1024 * 1024,
+            },
+        );
+    } finally {
+        await rm(tempDir, { recursive: true, force: true });
+    }
+}
+
+async function main() {
+    const apply = hasFlag("--apply");
+    const remote = hasFlag("--remote") || !hasFlag("--local");
+    const now = Date.now();
+    const seeds = listEsfaManagedRedirectSeeds(now);
+    const existingRows = await readExistingRows(remote);
+    const plan = buildPlan(existingRows, seeds);
+    printSummary(plan, seeds.length);
+    if (!apply) return;
+    if (plan.conflicts.length) {
+        process.exitCode = 2;
+        return;
+    }
+    await applyPlan(plan, remote);
+    const refreshedRows = await readExistingRows(remote);
+    console.log(`final_rows=${refreshedRows.length}`);
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+});

--- a/website/src/app/api/tracking/dashboard/route.ts
+++ b/website/src/app/api/tracking/dashboard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getBookingDb, type BookingRequestRow } from "@/lib/bookingDb";
-import { listEsfaRedirects } from "@/lib/esfaRedirects";
+import { ESFA_SITE_HOST, listEsfaFallbackRedirects } from "@/lib/esfaManagedRedirects";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
 import { serializeSiteCustomUrl, type SiteCustomUrlRow } from "@/lib/siteCustomUrls";
 import {
@@ -410,6 +410,10 @@ export async function GET(request: Request) {
         ).all<SiteBehaviorRow>()
     ).results ?? [];
 
+    const managedUrlHosts = selectedSiteHost
+        ? Array.from(new Set(selectedSiteHost === DEFAULT_SITE_HOST ? [selectedSiteHost, ESFA_SITE_HOST] : [selectedSiteHost]))
+        : [];
+    const customUrlHostPlaceholders = managedUrlHosts.map(() => "?").join(", ");
     const customUrlQuery = selectedSiteHost
         ? `SELECT
                     u.id, u.site_host, u.name, u.slug_path, u.destination_url, u.destination_host, u.destination_path,
@@ -427,7 +431,7 @@ export async function GET(request: Request) {
                         OR e.link_path = u.destination_path
                         OR (u.utm_campaign IS NOT NULL AND e.utm_campaign = u.utm_campaign)
                     )
-                 WHERE u.site_host = ?
+                 WHERE u.site_host IN (${customUrlHostPlaceholders})
                  GROUP BY u.id
                  ORDER BY u.updated_at_ms DESC
                  LIMIT ?`
@@ -452,7 +456,7 @@ export async function GET(request: Request) {
     const customUrlStatement = db.prepare(customUrlQuery);
     const customUrlRows = (
         await (selectedSiteHost
-            ? customUrlStatement.bind(sinceMs, untilMs, selectedSiteHost, selectedSiteHostWww, selectedSiteHost, limit)
+            ? customUrlStatement.bind(sinceMs, untilMs, selectedSiteHost, selectedSiteHostWww, ...managedUrlHosts, limit)
             : customUrlStatement.bind(sinceMs, untilMs, limit)
         ).all<SiteCustomUrlRow>()
     ).results ?? [];
@@ -763,7 +767,7 @@ export async function GET(request: Request) {
 
     const customLinks = {
         managedUrls: customUrlRows.map(serializeSiteCustomUrl),
-        cloudflareRedirects: listEsfaRedirects(),
+        cloudflareRedirects: listEsfaFallbackRedirects(customUrlRows),
         topLinks: sortMapEntries(behaviorLinkCounts, "linkUrl").slice(0, 10),
         topUtmContent: sortMapEntries(behaviorUtmContentCounts, "utmContent").slice(0, 10),
         linksMissingUtm: sortMapEntries(behaviorMissingUtmLinkCounts, "linkUrl").slice(0, 10),

--- a/website/src/lib/esfaManagedRedirects.ts
+++ b/website/src/lib/esfaManagedRedirects.ts
@@ -1,0 +1,106 @@
+import {
+    buildEsfaRedirectLabel,
+    listEsfaRedirects,
+    normalizeEsfaRedirectPath,
+} from "@/lib/esfaRedirects";
+import {
+    normalizeSiteCustomUrlInput,
+    type NormalizedSiteCustomUrlInput,
+    type SiteCustomUrlRow,
+} from "@/lib/siteCustomUrls";
+
+export const ESFA_SITE_HOST = "esfa.co";
+export const ESFA_MIGRATED_SOURCE = "cloudflare_worker_migrated";
+
+type ManagedUrlIdentity =
+    | Pick<SiteCustomUrlRow, "site_host" | "slug_path">
+    | { siteHost: string; slugPath: string };
+
+export type EsfaManagedUrlSeed = NormalizedSiteCustomUrlInput & {
+    id: string;
+    createdAtMs: number;
+    updatedAtMs: number;
+};
+
+function fnv1a(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < input.length; index += 1) {
+        hash ^= input.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function inferPlacement(slugPath: string, destinationHost: string | null): string {
+    const normalizedPath = normalizeEsfaRedirectPath(slugPath);
+    const host = (destinationHost ?? "").toLowerCase();
+    if (host === "api.whatsapp.com" || host === "wa.me" || host === "chat.whatsapp.com") return "whatsapp";
+    if (host === "www.google.com") return "maps";
+    if (host === "www.facebook.com" || host === "www.instagram.com") return "social";
+    if (host === "payment-link-v3.stone.com.br") return "payment";
+    if (host === "auto.bsbank.com.br") return "campaign";
+    if (
+        host === "espacofacial.com" ||
+        host === "www.espacofacial.com" ||
+        host === "espacofacial.com.br" ||
+        host === "www.espacofacial.com.br" ||
+        host === "app.espacofacial.com.br"
+    ) {
+        return normalizedPath.startsWith("/campanhas/") ? "campaign" : "internal";
+    }
+    return "campaign";
+}
+
+function inferUnitSlug(slugPath: string): string | null {
+    const normalizedPath = normalizeEsfaRedirectPath(slugPath);
+    if (normalizedPath === "/bss" || normalizedPath.startsWith("/bss/")) return "barrashoppingsul";
+    if (normalizedPath === "/nh" || normalizedPath.startsWith("/nh/")) return "novo-hamburgo";
+    return null;
+}
+
+export function buildEsfaManagedRedirectSeed(params: {
+    slugPath: string;
+    destinationUrl: string;
+    now?: number;
+}): EsfaManagedUrlSeed {
+    const normalizedSlugPath = normalizeEsfaRedirectPath(params.slugPath);
+    const now = params.now ?? Date.now();
+    const normalized = normalizeSiteCustomUrlInput({
+        siteHost: ESFA_SITE_HOST,
+        name: buildEsfaRedirectLabel(normalizedSlugPath),
+        slugPath: normalizedSlugPath,
+        destinationUrl: params.destinationUrl,
+        description: "Migrado do catálogo esfa.co",
+        source: ESFA_MIGRATED_SOURCE,
+        placement: inferPlacement(normalizedSlugPath, null),
+        unitSlug: inferUnitSlug(normalizedSlugPath),
+        active: true,
+    });
+    return {
+        ...normalized,
+        id: `esfa_${fnv1a(`${ESFA_SITE_HOST}|${normalizedSlugPath}`)}`,
+        placement: inferPlacement(normalizedSlugPath, normalized.destinationHost),
+        unitSlug: inferUnitSlug(normalizedSlugPath),
+        createdAtMs: now,
+        updatedAtMs: now,
+    };
+}
+
+export function listEsfaManagedRedirectSeeds(now = Date.now()): EsfaManagedUrlSeed[] {
+    return listEsfaRedirects().map((entry) =>
+        buildEsfaManagedRedirectSeed({
+            slugPath: entry.slugPath,
+            destinationUrl: entry.destinationUrl,
+            now,
+        }),
+    );
+}
+
+export function listEsfaFallbackRedirects(identities: ManagedUrlIdentity[]) {
+    const migratedPaths = new Set(
+        identities
+            .filter((item) => (("site_host" in item ? item.site_host : item.siteHost) || "").toLowerCase() === ESFA_SITE_HOST)
+            .map((item) => normalizeEsfaRedirectPath("slug_path" in item ? item.slug_path : item.slugPath)),
+    );
+    return listEsfaRedirects({ excludePaths: migratedPaths });
+}

--- a/website/src/lib/esfaRedirects.ts
+++ b/website/src/lib/esfaRedirects.ts
@@ -124,7 +124,7 @@ export function normalizeEsfaRedirectPath(pathname: string): string {
   return lower;
 }
 
-function labelFromPath(path: string): string {
+export function buildEsfaRedirectLabel(path: string): string {
   return path
     .replace(/^\/+/, '')
     .split('/')
@@ -133,17 +133,24 @@ function labelFromPath(path: string): string {
     .join(' / ') || 'Início';
 }
 
-export function listEsfaRedirects() {
+export function listEsfaRedirects(options: { excludePaths?: Iterable<string> } = {}) {
+  const excludedPaths = new Set(
+    Array.from(options.excludePaths ?? [], (value) => normalizeEsfaRedirectPath(String(value || ''))).filter(Boolean),
+  );
   return Object.entries(ESFA_REDIRECTS)
-    .sort(([a], [b]) => a.localeCompare(b, 'pt-BR'))
-    .map(([slugPath, destinationUrl]) => ({
-      id: `esfa:${slugPath}`,
-      siteHost: 'esfa.co',
-      name: labelFromPath(slugPath),
-      slugPath,
-      publicUrl: `https://esfa.co${slugPath}`,
-      destinationUrl,
-      source: 'cloudflare_worker' as const,
-      active: true,
-    }));
+    .map(([rawSlugPath, destinationUrl]) => {
+      const slugPath = normalizeEsfaRedirectPath(rawSlugPath);
+      return {
+        id: `esfa:${slugPath}`,
+        siteHost: 'esfa.co',
+        name: buildEsfaRedirectLabel(slugPath),
+        slugPath,
+        publicUrl: `https://esfa.co${slugPath}`,
+        destinationUrl,
+        source: 'cloudflare_worker' as const,
+        active: true,
+      };
+    })
+    .filter((entry) => !excludedPaths.has(entry.slugPath))
+    .sort((a, b) => a.slugPath.localeCompare(b.slugPath, 'pt-BR'));
 }

--- a/website/src/lib/siteCustomUrls.ts
+++ b/website/src/lib/siteCustomUrls.ts
@@ -56,6 +56,12 @@ const ALLOWED_DESTINATION_HOSTS = new Set([
     "api.whatsapp.com",
     "wa.me",
     "wa.skincos.com.br",
+    "www.google.com",
+    "payment-link-v3.stone.com.br",
+    "www.facebook.com",
+    "www.instagram.com",
+    "chat.whatsapp.com",
+    "auto.bsbank.com.br",
 ]);
 
 function textOrNull(value: unknown, max = 160): string | null {
@@ -77,7 +83,7 @@ function normalizeSlugPath(value: unknown, fallbackName: string): string {
             .replace(/\s+/g, "-")
             .replace(/[?#].*$/, "")
             .toLowerCase();
-        if (/^\/[a-z0-9][a-z0-9._/-]{1,178}$/.test(clean) && !clean.startsWith("/api/")) return clean;
+        if (/^\/[\p{L}\p{N}][\p{L}\p{N}._/-]{1,178}$/u.test(clean) && !clean.startsWith("/api/")) return clean;
     }
     const fallback = slugify(fallbackName || "campanha");
     return `/campanhas/${fallback || "link"}`;

--- a/website/tests/esfaManagedRedirects.test.ts
+++ b/website/tests/esfaManagedRedirects.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    ESFA_MIGRATED_SOURCE,
+    buildEsfaManagedRedirectSeed,
+    listEsfaFallbackRedirects,
+    listEsfaManagedRedirectSeeds,
+} from "../src/lib/esfaManagedRedirects";
+
+test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects", () => {
+    const seed = buildEsfaManagedRedirectSeed({
+        slugPath: "/bss/clubebotox",
+        destinationUrl: "https://payment-link-v3.stone.com.br/pl_lqrbavJ9pR50k6HBBt48jYoAPENQXxek",
+        now: 123,
+    });
+
+    assert.equal(seed.id.startsWith("esfa_"), true);
+    assert.equal(seed.siteHost, "esfa.co");
+    assert.equal(seed.slugPath, "/bss/clubebotox");
+    assert.equal(seed.placement, "payment");
+    assert.equal(seed.unitSlug, "barrashoppingsul");
+    assert.equal(seed.source, ESFA_MIGRATED_SOURCE);
+    assert.equal(seed.createdAtMs, 123);
+});
+
+test("listEsfaManagedRedirectSeeds covers the full static catalog", () => {
+    const seeds = listEsfaManagedRedirectSeeds(456);
+
+    assert.equal(seeds.length, 96);
+    assert.equal(new Set(seeds.map((seed) => seed.slugPath)).size, seeds.length);
+    assert.equal(seeds.every((seed) => seed.siteHost === "esfa.co"), true);
+});
+
+test("listEsfaFallbackRedirects excludes redirects already migrated to D1", () => {
+    const fallbacks = listEsfaFallbackRedirects([
+        { site_host: "esfa.co", slug_path: "/bss/comochegar" },
+        { site_host: "espacofacial.com", slug_path: "/campanhas/botox-nh" },
+    ]);
+
+    assert.equal(fallbacks.some((entry) => entry.slugPath === "/bss/comochegar"), false);
+    assert.equal(fallbacks.some((entry) => entry.slugPath === "/nh/comochegar"), true);
+});

--- a/website/tests/siteCustomUrls.test.ts
+++ b/website/tests/siteCustomUrls.test.ts
@@ -41,3 +41,16 @@ test("normalizeSiteCustomUrlInput rejects unsafe destinations and API slugs", ()
         "/campanhas/slug-api",
     );
 });
+
+test("normalizeSiteCustomUrlInput preserves unicode slugs and accepts approved external hosts", () => {
+    const input = normalizeSiteCustomUrlInput({
+        siteHost: "esfa.co",
+        name: "Avalie nosso espaço",
+        slugPath: "/bss/avalienossoespaço",
+        destinationUrl: "https://www.google.com/maps/place//data=!4m3!3m2!1s0x9519795c306ed865:0xb5f05aac9b865daa!12e1",
+    });
+
+    assert.equal(input.siteHost, "esfa.co");
+    assert.equal(input.slugPath, "/bss/avalienossoespaço");
+    assert.equal(input.destinationHost, "www.google.com");
+});

--- a/website/workers/esfa-redirector/worker.ts
+++ b/website/workers/esfa-redirector/worker.ts
@@ -1,11 +1,49 @@
 import { ESFA_PRESERVE_QUERYSTRING, ESFA_REDIRECTS, normalizeEsfaRedirectPath } from '../../src/lib/esfaRedirects';
 
+type D1PreparedStatement = {
+  bind: (...values: unknown[]) => D1PreparedStatement;
+  first: <T = unknown>() => Promise<T | null>;
+};
+
+type D1DatabaseLike = {
+  prepare: (query: string) => D1PreparedStatement;
+};
+
+type WorkerEnv = {
+  BOOKING_DB?: D1DatabaseLike;
+};
+
+type RedirectRow = {
+  destination_url: string;
+};
+
+async function readManagedRedirect(env: WorkerEnv, slugPath: string): Promise<string | null> {
+  const db = env.BOOKING_DB;
+  if (!db) return null;
+  try {
+    const row = await db
+      .prepare(
+        `SELECT destination_url
+         FROM site_custom_urls
+         WHERE active = 1
+           AND site_host = ?
+           AND slug_path = ?
+         LIMIT 1`,
+      )
+      .bind('esfa.co', slugPath)
+      .first<RedirectRow>();
+    return row?.destination_url ?? null;
+  } catch {
+    return null;
+  }
+}
+
 const worker = {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
     const path = normalizeEsfaRedirectPath(url.pathname);
 
-    const targetBase = ESFA_REDIRECTS[path];
+    const targetBase = (await readManagedRedirect(env, path)) || ESFA_REDIRECTS[path];
     if (!targetBase) return new Response("Not Found", { status: 404 });
 
     const target = new URL(targetBase);

--- a/website/workers/esfa-redirector/wrangler.toml
+++ b/website/workers/esfa-redirector/wrangler.toml
@@ -7,3 +7,8 @@ routes = [
 	{ pattern = "esfa.co/*", zone_name = "esfa.co" },
 	{ pattern = "www.esfa.co/*", zone_name = "esfa.co" },
 ]
+
+[[d1_databases]]
+binding = "BOOKING_DB"
+database_name = "espacofacial-booking"
+database_id = "9765b1fb-11a4-462c-9657-8a438c755725"


### PR DESCRIPTION
## Summary
- tighten the Site EF header/layout and move URL creation to a modal workflow
- migrate the static `esfa.co` redirects into CRM-managed D1 records and expose fallback-only leftovers in the dashboard
- make the `esfa-redirector` worker read D1 first while preserving the static catalog as fallback

## Validation
- npm run quality:frontend
- npm run quality:website
- npm run codex:crm:site-smoke
- npm run codex:preflight
- cd website && npx wrangler deploy -c workers/esfa-redirector/wrangler.toml --dry-run
- npm --prefix website run custom-urls:migrate:esfa -- --remote
- npm --prefix website run custom-urls:migrate:esfa -- --apply --remote
- re-run dry-run to confirm `skips=96`
- remote D1 verification: `site_custom_urls` has 96 `esfa.co` rows and no duplicate `(site_host, slug_path)` pairs
