### PR TITLE
[codex] Add iCloud email alias routing runbook

### DIFF
--- a/docs/email-alias-routing-runbook.md
+++ b/docs/email-alias-routing-runbook.md
@@ -1,0 +1,90 @@
+# Roteamento de aliases de email
+
+## Objetivo
+
+Manter as contas principais do iCloud ja existentes e tratar somente aliases
+operacionais que devem cair na conta responsavel.
+
+Contas principais ja configuradas no iCloud:
+
+- `contato@skincos.com.br`
+- `rh@skincos.com.br`
+- `financeiro@skincos.com.br`
+
+Alias ativo neste momento:
+
+| Alias | Conta de destino |
+| --- | --- |
+| `compras@skincos.com.br` | `financeiro@skincos.com.br` |
+
+## Modelo correto no iCloud
+
+O dominio `skincos.com.br` recebe email pelo iCloud Mail. Portanto, o alias deve
+ser tratado no iCloud, nao no Cloudflare Email Routing.
+
+Para `compras@skincos.com.br -> financeiro@skincos.com.br`, use uma destas duas
+formas no iCloud:
+
+1. Preferencial: adicionar `compras@skincos.com.br` como endereco adicional da
+   mesma pessoa/conta que ja recebe `financeiro@skincos.com.br`.
+2. Alternativa: se o iCloud nao permitir o endereco adicional no dominio
+   customizado, criar uma regra no Mail do iCloud que encaminhe mensagens
+   recebidas por `compras@skincos.com.br` para `financeiro@skincos.com.br`.
+
+Nao recrie nem mova as contas principais `contato`, `rh` e `financeiro`. Elas
+servem como destinos finais.
+
+## Passos operacionais
+
+1. Acesse `https://www.icloud.com/icloudplus` com a Apple Account que administra
+   o dominio customizado `skincos.com.br`.
+2. Abra **Custom Email Domain**.
+3. Selecione `skincos.com.br`.
+4. Localize a pessoa/conta que contem `financeiro@skincos.com.br`.
+5. Adicione `compras@skincos.com.br` como endereco adicional desta mesma conta.
+6. Confirme qualquer verificacao exigida pelo iCloud.
+7. Envie um teste de uma conta externa para `compras@skincos.com.br`.
+8. Confirme que a mensagem chega em `financeiro@skincos.com.br`.
+
+## Validacao tecnica
+
+Antes e depois da alteracao, rode:
+
+```bash
+bash scripts/verify-email-alias-routing.sh
+```
+
+O script valida os guardrails tecnicos:
+
+- MX publico continua no iCloud;
+- SPF continua incluindo iCloud;
+- Cloudflare Email Routing continua desativado;
+- nao existe regra Cloudflare capturando `compras@skincos.com.br`.
+
+A entrega real do alias so pode ser validada com um envio externo para
+`compras@skincos.com.br`, porque a lista de aliases do iCloud nao e exposta pelo
+DNS publico.
+
+## Guardrail Cloudflare/GitHub
+
+Cloudflare deve permanecer apenas como DNS neste fluxo. Nao ative Cloudflare
+Email Routing para resolver aliases enquanto o dominio continua recebendo pelo
+iCloud.
+
+GitHub Actions pode automatizar auditoria futura, mas GitHub nao encaminha email
+e nao substitui a configuracao do iCloud.
+
+## Futuras inclusoes
+
+Quando novos aliases forem criados, registre a matriz neste formato:
+
+| Alias | Conta de destino |
+| --- | --- |
+| `compras@skincos.com.br` | `financeiro@skincos.com.br` |
+
+Para validar outro alias sem alterar o script:
+
+```bash
+ALIAS_ROUTES='compras@skincos.com.br=financeiro@skincos.com.br,novo@skincos.com.br=contato@skincos.com.br' \
+  bash scripts/verify-email-alias-routing.sh
+```

--- a/scripts/verify-email-alias-routing.sh
+++ b/scripts/verify-email-alias-routing.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-skincos.com.br}"
+ALIAS_ROUTES="${ALIAS_ROUTES:-compras@skincos.com.br=financeiro@skincos.com.br}"
+WRANGLER_CWD="${WRANGLER_CWD:-website}"
+
+fail=0
+
+ok() {
+  printf 'OK   %s\n' "$*"
+}
+
+warn() {
+  printf 'WARN %s\n' "$*"
+}
+
+bad() {
+  printf 'FAIL %s\n' "$*" >&2
+  fail=1
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    bad "required command not found: $1"
+  fi
+}
+
+need_cmd dig
+
+IFS=',' read -r -a route_pairs <<<"$ALIAS_ROUTES"
+if [[ "${#route_pairs[@]}" -eq 0 ]]; then
+  bad "ALIAS_ROUTES is empty"
+fi
+
+printf '[email-alias-routing] validating domain guardrails for %s\n' "$DOMAIN"
+printf '[email-alias-routing] expected aliases:\n'
+for pair in "${route_pairs[@]}"; do
+  alias="${pair%%=*}"
+  destination="${pair#*=}"
+  if [[ -z "$alias" || -z "$destination" || "$alias" == "$destination" || "$pair" != *"="* ]]; then
+    bad "invalid alias route: ${pair}"
+  else
+    printf 'ROUTE %s -> %s\n' "$alias" "$destination"
+  fi
+done
+
+mx_records="$(dig "$DOMAIN" MX +short | sort -n || true)"
+if [[ -z "$mx_records" ]]; then
+  bad "no MX records returned for ${DOMAIN}"
+else
+  printf '%s\n' "$mx_records" | sed 's/^/MX    /'
+fi
+
+if printf '%s\n' "$mx_records" | grep -Eq 'mx0[12]\.mail\.icloud\.com\.?$'; then
+  ok "iCloud MX records are present"
+else
+  bad "expected iCloud MX records are missing"
+fi
+
+if printf '%s\n' "$mx_records" | grep -Eq 'route[123]\.mx\.cloudflare\.net\.?$'; then
+  bad "Cloudflare Email Routing MX records are active; this would migrate domain email"
+else
+  ok "Cloudflare Email Routing MX records are not active"
+fi
+
+txt_records="$(dig "$DOMAIN" TXT +short || true)"
+if printf '%s\n' "$txt_records" | grep -Fq 'include:icloud.com'; then
+  ok "SPF includes iCloud"
+else
+  warn "SPF does not include iCloud; verify whether iCloud Mail is still the intended provider"
+fi
+
+settings_output=""
+rules_output=""
+
+if [[ -d "$WRANGLER_CWD" ]] && command -v npx >/dev/null 2>&1; then
+  settings_output="$(
+    cd "$WRANGLER_CWD"
+    npx --yes wrangler@4 email routing settings "$DOMAIN" 2>&1
+  )" || settings_status=$?
+  settings_status="${settings_status:-0}"
+
+  if [[ "$settings_status" -eq 0 ]]; then
+    if printf '%s\n' "$settings_output" | grep -Eq 'Enabled:[[:space:]]+false'; then
+      ok "Cloudflare Email Routing is disabled for ${DOMAIN}"
+    elif printf '%s\n' "$settings_output" | grep -Eq 'Enabled:[[:space:]]+true'; then
+      bad "Cloudflare Email Routing is enabled for ${DOMAIN}"
+    else
+      warn "could not parse Cloudflare Email Routing enabled state"
+    fi
+  else
+    warn "could not read Cloudflare Email Routing settings via Wrangler"
+  fi
+
+  rules_output="$(
+    cd "$WRANGLER_CWD"
+    npx --yes wrangler@4 email routing rules list "$DOMAIN" 2>&1
+  )" || rules_status=$?
+  rules_status="${rules_status:-0}"
+
+  if [[ "$rules_status" -eq 0 ]]; then
+    if printf '%s\n' "$rules_output" | grep -Fq 'No custom routing rules found.'; then
+      ok "no Cloudflare custom routing rules exist for ${DOMAIN}"
+    else
+      warn "Cloudflare has custom email routing rules; checking expected aliases"
+    fi
+
+    for pair in "${route_pairs[@]}"; do
+      alias="${pair%%=*}"
+      if [[ -n "$alias" ]] && printf '%s\n' "$rules_output" | grep -Fq "$alias"; then
+        bad "Cloudflare has a routing rule for ${alias}; iCloud should own this alias"
+      fi
+    done
+  else
+    warn "could not list Cloudflare Email Routing rules via Wrangler"
+  fi
+else
+  warn "Wrangler check skipped; ${WRANGLER_CWD}/ or npx unavailable"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  printf '[email-alias-routing] result: FAIL\n' >&2
+  exit 1
+fi
+
+printf '[email-alias-routing] result: OK\n'
+printf '[email-alias-routing] delivery still requires an external email test to each alias.\n'


### PR DESCRIPTION
## Summary
This PR adds a durable runbook and a read-only validator for SKINCOS email alias routing while the domain continues to receive mail through iCloud.

The immediate mapping documented here is `compras@skincos.com.br -> financeiro@skincos.com.br`. The scope is intentionally limited to alias forwarding into existing iCloud mailboxes. It does not provision new accounts and it does not migrate domain email reception to Cloudflare Email Routing.

## User impact
Before this change, the operational knowledge from the thread only lived in local context and could easily be lost. There was no repo-native guardrail to verify that the domain still pointed at iCloud MX and that Cloudflare Email Routing had not been activated by mistake.

With this change, the repository now contains:
- a runbook that documents the correct provider boundary and the concrete alias mapping;
- a read-only validation script that checks MX, SPF, Cloudflare Email Routing status, and Cloudflare routing-rule drift;
- a reusable `ALIAS_ROUTES` interface so future alias mappings can be validated without rewriting the script.

## Root cause
The routing surface was initially easy to misread because Cloudflare manages DNS for `skincos.com.br`, but the live MX records and mailbox ownership remain in iCloud. That means alias forwarding must be managed in iCloud, while Cloudflare should stay in a DNS-only role for this flow.

## Validation
I ran:

```bash
bash scripts/verify-email-alias-routing.sh
```

The script confirmed:
- iCloud MX records are present;
- Cloudflare Email Routing MX records are not active;
- SPF includes iCloud;
- Cloudflare Email Routing is disabled;
- no Cloudflare custom routing rule exists for `compras@skincos.com.br`.

The remaining non-automated proof is a real inbound email test to `compras@skincos.com.br` and confirmation that it reaches `financeiro@skincos.com.br`.
