### PR TITLE
fix: harden non-interactive scraper and token vault compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ backend/tools/xiaomi/token_extractor_docker/
 
 # Playwright artifacts (never commit)
 .playwright-cli/
+.playwright-mcp/
 .playwright-output/
 frontend/test-results/
 output/

--- a/backend/apps/automations/scraper/run_scraper.py
+++ b/backend/apps/automations/scraper/run_scraper.py
@@ -144,6 +144,9 @@ def _load_booking_env_file() -> None:
 
 
 def _prompt_yes_no(prompt: str, default: bool) -> bool:
+    if _is_non_interactive():
+        return default
+
     suffix = "Y/n" if default else "y/N"
     while True:
         raw = input(f"{prompt} ({suffix}): ").strip().lower()
@@ -168,8 +171,36 @@ def _env_flag(name: str) -> bool | None:
     return None
 
 
+def _is_non_interactive() -> bool:
+    if sys.stdin.isatty():
+        return False
+
+    non_interactive_env = _env_flag("EF_NON_INTERACTIVE")
+    if non_interactive_env is not None:
+        return non_interactive_env
+    return True
+
+
+def _safe_folder_name(value: str) -> str:
+    raw = (value or "").strip()
+    safe = "".join(ch if ch not in {"/", "\\", ":"} and ord(ch) >= 32 else "_" for ch in raw)
+    safe = safe.strip(" .")
+    return safe or "sem_unidade"
+
+
+def _unit_output_dir(base_output_dir: Path, unit_name: str) -> Path:
+    path = base_output_dir / _safe_folder_name(unit_name)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def _choose_output_dir() -> Path:
     default = os.getenv("EF_OUTPUT_DIR", str(default_output_dir()))
+    if _is_non_interactive():
+        chosen = Path(default)
+        chosen.mkdir(parents=True, exist_ok=True)
+        return chosen
+
     raw = input(f"Pasta de saída (ENTER p/ padrão: {default}): ").strip()
     chosen = Path(raw) if raw else Path(default)
     chosen.mkdir(parents=True, exist_ok=True)
@@ -178,6 +209,9 @@ def _choose_output_dir() -> Path:
 
 def _choose_unit_name() -> str:
     default = os.getenv("EF_UNIT_NAME", "").strip()
+    if _is_non_interactive():
+        return default
+
     if default:
         raw = input(f"Unidade (opcional, ENTER p/ manter: {default}): ").strip()
         return raw or default
@@ -191,22 +225,43 @@ def _choose_unit_from_list() -> str:
     options = [o.strip() for o in env.split(",") if o.strip()] if env else ["BarraShoppingSul", "Novo Hamburgo"]
 
     default = os.getenv("EF_UNIT_NAME", "").strip()
-    if default:
+    if default and _is_non_interactive():
         return default
 
+    env_units = os.getenv("EF_UNITS", "").strip()
+    if env_units:
+        units = [o.strip() for o in env_units.split(",") if o.strip()]
+        if len(units) == 1:
+            return units[0]
+
     if not options:
-        return ""
-    if len(options) == 1:
+        return default
+    if default and default not in options:
+        options.append(default)
+    if len(options) == 1 and not default:
         return options[0]
+
+    if _is_non_interactive():
+        print(
+            "Unidade não definida em modo não interativo. "
+            "Defina EF_UNIT_NAME ou EF_UNITS com uma única unidade."
+        )
+        print(f"Opções disponíveis: {', '.join(options)}")
+        return ""
 
     print("\nEscolha a unidade:")
     for i, opt in enumerate(options, start=1):
         print(f"{i}) {opt}")
-    print("0) Pular")
+    if default:
+        print(f"0) Pular | ENTER p/ padrão: {default}")
+    else:
+        print("0) Pular")
 
     while True:
         raw = input("> ").strip()
-        if raw == "0" or raw == "":
+        if raw == "":
+            return default
+        if raw == "0":
             return ""
         try:
             idx = int(raw)
@@ -236,9 +291,7 @@ def _get_credentials(*, persist_session: bool) -> tuple[str, str]:
     if email_default and password_default:
         return email_default, password_default
 
-    non_interactive_env = _env_flag("EF_NON_INTERACTIVE")
-    non_interactive = (non_interactive_env is True) or (not sys.stdin.isatty())
-    if non_interactive:
+    if _is_non_interactive():
         if not email_default or not password_default:
             print(
                 "Credenciais ausentes em modo não interativo. "
@@ -437,6 +490,9 @@ def _run_agenda(
 
 
 def _prompt_int(prompt: str, default: int, *, min_value: int = 1, max_value: int = 3650) -> int:
+    if _is_non_interactive():
+        return default
+
     while True:
         raw = input(f"{prompt} (ENTER p/ padrão: {default}): ").strip()
         if raw == "":
@@ -453,6 +509,9 @@ def _prompt_int(prompt: str, default: int, *, min_value: int = 1, max_value: int
 
 
 def _prompt_date(prompt: str, default: str) -> str:
+    if _is_non_interactive():
+        return default
+
     while True:
         raw = input(f"{prompt} (DD/MM/AAAA) (ENTER p/ padrão: {default}): ").strip()
         val = raw or default
@@ -1129,7 +1188,8 @@ def _run_cash_combined(headless: bool, output_dir: Path, unit_name: str, persist
 
         start_name = datetime.strptime(start_str, "%d/%m/%Y").strftime("%Y%m%d")
         end_name = datetime.strptime(end_str, "%d/%m/%Y").strftime("%Y%m%d")
-        xlsx_path = output_dir / f"caixa_recebimentos_completo_{start_name}_a_{end_name}.xlsx"
+        xlsx_output_dir = _unit_output_dir(output_dir, unit_name)
+        xlsx_path = xlsx_output_dir / f"caixa_recebimentos_completo_{start_name}_a_{end_name}.xlsx"
 
         if not dry_run:
             with pd.ExcelWriter(xlsx_path, engine="openpyxl") as writer:
@@ -1482,7 +1542,7 @@ def main() -> int:
         "agenda_delta",
         "caixa",
         "cash",
-    } and not unit_name:
+    }:
         unit_name = _choose_unit_from_list()
         if not unit_name:
             print("Unidade não selecionada.")

--- a/backend/apps/token-vault/README.md
+++ b/backend/apps/token-vault/README.md
@@ -6,7 +6,7 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 
 - `GET /internal/token-vault/health`
 - `GET /internal/token-vault/contract`
-- `GET /internal/token-vault/v1/tokens?provider=threads|instagram&active=true`
+- `GET /internal/token-vault/v1/tokens?provider=threads|instagram|facebook&active=true`
 - `POST /internal/token-vault/v1/tokens`
 - `PATCH /internal/token-vault/v1/tokens/:id`
 

--- a/backend/apps/token-vault/scripts/build-seed-from-csv.mjs
+++ b/backend/apps/token-vault/scripts/build-seed-from-csv.mjs
@@ -25,7 +25,7 @@ if (!rows.length) {
 const header = rows[0].map((value) => value.trim());
 const bodyRows = rows.slice(1).map((row) => Object.fromEntries(header.map((key, index) => [key, row[index] || ''])));
 const payloads = [];
-const stats = { threads: 0, instagram: 0 };
+const stats = { threads: 0, instagram: 0, facebook: 0 };
 
 for (const row of bodyRows) {
   const unit = slug(row.Unit || row.unit || '');
@@ -33,6 +33,8 @@ for (const row of bodyRows) {
   const thToken = clean(row.thToken);
   const igId = clean(row.igId);
   const igToken = clean(row.igToken);
+  const fbId = clean(row.fbId);
+  const fbToken = clean(row.fbToken);
 
   if (thId && thToken) {
     stats.threads += 1;
@@ -42,9 +44,13 @@ for (const row of bodyRows) {
     stats.instagram += 1;
     payloads.push(buildPayload({ provider: 'instagram', unit, externalAccountId: igId, token: igToken, source: row }));
   }
+  if (fbId && fbToken) {
+    stats.facebook += 1;
+    payloads.push(buildPayload({ provider: 'facebook', unit, externalAccountId: fbId, token: fbToken, source: row }));
+  }
 }
 
-console.error(`Importing token rows through API: threads=${stats.threads} instagram=${stats.instagram}`);
+console.error(`Importing token rows through API: threads=${stats.threads} instagram=${stats.instagram} facebook=${stats.facebook}`);
 
 for (const payload of payloads) {
   const response = await fetch(`${baseUrl.replace(/\/+$/, '')}/v1/tokens`, {

--- a/backend/apps/token-vault/src/index.js
+++ b/backend/apps/token-vault/src/index.js
@@ -4,7 +4,7 @@ const JSON_HEADERS = {
   'cache-control': 'no-store',
 };
 
-const PROVIDERS = new Set(['threads', 'instagram']);
+const PROVIDERS = new Set(['threads', 'instagram', 'facebook']);
 
 export default {
   async fetch(request, env, ctx) {
@@ -310,6 +310,10 @@ async function serializeToken(row, env) {
     base.igId = row.external_account_id;
     base.igToken = token;
   }
+  if (row.provider === 'facebook') {
+    base.fbId = row.external_account_id;
+    base.fbToken = token;
+  }
 
   return base;
 }
@@ -385,7 +389,7 @@ function contract(requestId) {
     service: 'skincos-token-vault',
     endpoints: {
       health: 'GET /internal/token-vault/health',
-      listTokens: 'GET /internal/token-vault/v1/tokens?provider=threads|instagram&active=true',
+      listTokens: 'GET /internal/token-vault/v1/tokens?provider=threads|instagram|facebook&active=true',
       createToken: 'POST /internal/token-vault/v1/tokens',
       updateToken: 'PATCH /internal/token-vault/v1/tokens/:id',
     },

--- a/backend/apps/token-vault/tests/index.test.js
+++ b/backend/apps/token-vault/tests/index.test.js
@@ -6,6 +6,7 @@ const encoder = new TextEncoder();
 const TEST_API_TOKEN = ['unit', 'auth', 'token'].join('-');
 const TEST_ENCRYPTION_KEY = ['unit', 'encryption', 'key', 'with', 'enough', 'length'].join('-');
 const THREADS_TOKEN = ['threads', 'fixture', 'token'].join('-');
+const FACEBOOK_TOKEN = ['facebook', 'fixture', 'token'].join('-');
 const INSTAGRAM_OLD_TOKEN = ['instagram', 'old', 'fixture'].join('-');
 const INSTAGRAM_NEW_TOKEN = ['instagram', 'new', 'fixture'].join('-');
 
@@ -140,6 +141,36 @@ test('lists decrypted provider tokens with compatibility fields', async () => {
   assert.equal(body.items[0].thId, '123');
   assert.equal(body.items[0].thToken, THREADS_TOKEN);
   assert.equal(body.items[0].token, THREADS_TOKEN);
+});
+
+test('lists facebook tokens with compatibility fields', async () => {
+  const db = new FakeDb();
+  db.tokens.push({
+    id: 'tok_facebook_1',
+    provider: 'facebook',
+    unit: 'novo_hamburgo',
+    external_account_id: '789',
+    token_type: 'long_lived_access_token',
+    token_ciphertext: await encryptForSeed(FACEBOOK_TOKEN, env(db).TOKEN_VAULT_ENCRYPTION_KEY),
+    expires_at: null,
+    last_refreshed_at: null,
+    active: 1,
+    metadata_json: '{}',
+    created_at: '2026-06-18T00:00:00.000Z',
+    updated_at: '2026-06-18T00:00:00.000Z',
+  });
+
+  const response = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/tokens?provider=facebook', {
+      headers: authHeaders(),
+    }),
+    env(db),
+  );
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(body.items[0].fbId, '789');
+  assert.equal(body.items[0].fbToken, FACEBOOK_TOKEN);
+  assert.equal(body.items[0].token, FACEBOOK_TOKEN);
 });
 
 test('patch updates encrypted token and writes audit without token payload', async () => {

--- a/frontend/scripts/atendimento-clinica-local-smoke.cjs
+++ b/frontend/scripts/atendimento-clinica-local-smoke.cjs
@@ -69,7 +69,13 @@ async function main() {
     await expectVisible(page.getByRole('heading', { name: 'Atend. Clínica' }), 'Atend. Clínica heading')
     await expectVisible(page.getByTestId('atendimento-table'), 'Atendimentos table')
     await expectVisible(page.getByTestId('atendimento-charts-panel'), 'Atendimento charts panel')
-    await expectVisible(page.getByTestId('atendimento-new').or(page.getByText('Novo atendimento')), 'new attendance action')
+    await expectVisible(
+      page
+        .getByTestId('atendimento-inline-client')
+        .or(page.getByTestId('atendimento-new'))
+        .or(page.getByText('Novo atendimento')),
+      'new attendance action'
+    )
 
     const globalError = await page.getByText(/DATABASE_URL_not_configured|ATENDIMENTO_CLINICA_API_TARGET|UPSTREAM_UNREACHABLE/).first().isVisible().catch(() => false)
     if (globalError) {


### PR DESCRIPTION
## Summary
- harden `backend/apps/automations/scraper/run_scraper.py` for non-interactive Codex runs, default selection handling, and per-unit Caixa output folders
- extend the token vault worker and CSV seed script to support `facebook` tokens alongside existing providers
- align the Atendimento Clinica local smoke with the current inline-create UI and ignore `.playwright-mcp/` local artifacts

## Validation
- `python3 -m py_compile backend/apps/automations/scraper/run_scraper.py`
- `npm --prefix backend/apps/token-vault test`
- `npm run codex:crm:atendimento-clinica-smoke`
- `npm run quality:frontend`
- `npm run quality:backend:crm-api`
- `npm --prefix backend/apps/escala-api test`
- `npm run quality:security`
