### PR TITLE
feat: refine atendimento clinica period dashboard

### DIFF
--- a/backend/apps/crm-api/server/atendimentoClinica/__tests__/domain.test.js
+++ b/backend/apps/crm-api/server/atendimentoClinica/__tests__/domain.test.js
@@ -50,28 +50,29 @@ test('calculates internal doctor conversion metrics using CRM values and weighte
     })
 
     assert.equal(result.dailyGoal, 3100)
+    assert.equal(result.periodGoal, 15500)
     assert.equal(result.weeklyGoal, 15500)
     assert.equal(result.monthOperationalDays, 20)
     assert.equal(result.periodOperationalDays, 5)
     assertNear(result.average, 5500)
     assert.equal(result.median, 5000)
     assertNear(result.standardDeviation, 5000)
-    assertNear(result.cutLine, 4200)
+    assertNear(result.cutLine, 10400)
     assertNear(result.interval, 3750)
     assert.equal(result.intervalMultiplier, 0.75)
-    assert.deepEqual(result.levelCounts, { level0: 1, level1: 1, level2: 1, level3: 1 })
-    assert.equal(result.ratioDivisor, 6)
-    assert.match(result.formulas.cutLine, /media \* 0\.30/)
+    assert.deepEqual(result.levelCounts, { level0: 3, level1: 0, level2: 1, level3: 0 })
+    assert.equal(result.ratioDivisor, 2)
+    assert.match(result.formulas.cutLine, /meta_periodo \* 0\.50/)
     assert.match(result.formulas.interval, /desvio_padrao/)
     assert.match(result.formulas.ratioDivisor, /level0 \* 0/)
-    assertNear(result.ratios.upperRatio, 5 / 6)
-    assertNear(result.ratios.lowerRatio, 1 / 6)
-    assertNear(result.ratios.innerRatio, 0.5)
-    assertNear(result.ratios.outerRatio, 0.5)
+    assertNear(result.ratios.upperRatio, 1)
+    assertNear(result.ratios.lowerRatio, 0)
+    assertNear(result.ratios.innerRatio, 1)
+    assertNear(result.ratios.outerRatio, 0)
     assert.deepEqual(result.ranking.map((doctor) => `${doctor.rank}:${doctor.name}:${doctor.score}`), [
-        '1:Dra Destaque:3',
-        '2:Dra Positiva:2',
-        '3:Dra Corte:1',
+        '1:Dra Destaque:2',
+        '2:Dra Positiva:0',
+        '3:Dra Corte:0',
         '4:Dra Zero:0',
     ])
 })
@@ -109,9 +110,9 @@ test('keeps zero doctors ranked and includes active zero values in statistical c
     assert.equal(result.median, 500)
     assert.deepEqual(result.ranking.map((doctor) => `${doctor.name}:${doctor.score}`), [
         'Dra Venda B:3',
-        'Dra Venda A:2',
-        'Dra Zero A:1',
-        'Dra Zero B:1',
+        'Dra Venda A:1',
+        'Dra Zero A:0',
+        'Dra Zero B:0',
     ])
 })
 
@@ -199,6 +200,15 @@ test('calculates weighted daily and period goals across multiple months', () => 
     assert.equal(plan.periodGoal, 300000)
     assertNear(plan.dailyGoal, 13636.3636)
     assert.equal(plan.weeklyGoal, 300000)
+})
+
+test('returns zero daily goal when selected period has no operational days', () => {
+    const plan = calculateConversionGoalPlan([
+        { monthKey: '2026-06-01', monthlyGoal: 300000, monthOperationalDays: 20, periodOperationalDays: 0 },
+    ])
+    assert.equal(plan.periodGoal, 0)
+    assert.equal(plan.periodOperationalDays, 0)
+    assert.equal(plan.dailyGoal, 0)
 })
 
 test('normalizes currency, code and dates from spreadsheet-shaped values', () => {
@@ -426,7 +436,7 @@ test('derives Gerencia Conversão doctor ranking from goals, cut line and score 
     ]
     const report = buildConversionReportFromRawRows(rawRows, new Date('2026-06-16T12:00:00'))
     assert.equal(report.doctorRanking.sections.length, 1)
-    assert.equal(report.doctorRanking.sections[0].metrics.weeklyGoal.weekValue, 20)
+    assert.equal(report.doctorRanking.sections[0].metrics.periodGoal.weekValue, 20)
     assert.equal(report.doctorRanking.sections[0].metrics.cutLine.weekValue, 12)
     assert.equal(report.doctorRanking.topDoctors[0].name, 'Dra. A')
     assert.equal(report.doctorRanking.topDoctors[0].score, 3)

--- a/backend/apps/crm-api/server/atendimentoClinica/__tests__/store.test.js
+++ b/backend/apps/crm-api/server/atendimentoClinica/__tests__/store.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { canAccessAtendimento } from '../store.js'
+import { canAccessAtendimento, createAtendimentoStore } from '../store.js'
 
 test('scopes atendimento-clinica router access by consuming module', () => {
     const procedimentosActor = { role: 'INJETOR', allowedModules: ['procedimentos'] }
@@ -15,3 +15,271 @@ test('scopes atendimento-clinica router access by consuming module', () => {
     assert.equal(canAccessAtendimento(faturamentoActor, '/management/finance', 'GET'), true)
     assert.equal(canAccessAtendimento(faturamentoActor, '/management/catalog', 'GET'), false)
 })
+
+test('marks all-units conversion view as non-consolidated in crm ranking payload', async () => {
+    const fakePool = createFakePool(buildConversionPoolHandlers())
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const report = await store.managementConversionReport({ unit: 'all', date: '2026-06-16' }, { role: 'GESTOR' })
+
+    assert.equal(report.doctorRanking.sections[0].unitSlug, 'all')
+    assert.equal(report.doctorRanking.sections[0].isAggregate, true)
+    assert.equal(Object.keys(report.doctorRanking.sections[0].metrics || {}).length, 0)
+    assert.match(report.doctorRanking.sections[0].aggregateNotice || '', /Selecione uma unidade/i)
+    assert.equal(report.doctorRanking.topDoctors[0].name, 'Dra. A')
+})
+
+test('exposes period goal and hides monthly goal in unit conversion metrics', async () => {
+    const fakePool = createFakePool(buildConversionPoolHandlers())
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const report = await store.managementConversionReport({ unit: 'novo-hamburgo', date: '2026-06-16' }, { role: 'GESTOR' })
+    const metrics = report.doctorRanking.sections[0].metrics || {}
+    const goalPlan = report.doctorRanking.sections[0].goalPlan
+
+    assert.equal(report.doctorRanking.sections[0].unitSlug, 'novo-hamburgo')
+    assert.equal(metrics.periodGoal?.label, 'Meta do período')
+    assert.equal(metrics.periodGoal?.weekValue, 80)
+    assert.equal(metrics.dailyGoal?.weekValue, 80)
+    assert.equal('monthlyGoal' in metrics, false)
+    assert.equal(goalPlan?.periodOperationalDays, 1)
+    assert.equal(goalPlan?.periodGoal, 80)
+    assert.equal(goalPlan?.dailyGoal, 80)
+    assert.equal(goalPlan?.segments?.length, 1)
+    assert.equal(goalPlan?.segments?.[0]?.monthKey, '2026-06-01')
+    assert.equal(report.summary?.scheduleSource, 'crm')
+})
+
+test('returns segmented goal plan for cross-month periods without distorting the period goal', async () => {
+    const conversionRows = buildConversionRawRows()
+    const fakePool = createFakePool([
+        (sql) => sql.includes('select source_tab, source_row, cells') && { rows: conversionRows, rowCount: conversionRows.length },
+        (sql) => sql.includes('from crm_atendimento.units u') && {
+            rows: [{ id: 'unit-bss', slug: 'barra-shopping-sul', name: 'BarraShoppingSul' }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.professionals') && {
+            rows: [{ id: 'doc-b', name: 'Dra. B', role: 'Injetor', status: 'Ativo', units: ['BarraShoppingSul'], roles: ['Injetor'] }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('coalesce(sum(a.value), 0)::numeric as total') && sql.includes('group by u.slug') && !sql.includes('inj.id') && {
+            rows: [{ unit_slug: 'barra-shopping-sul', total: 30000 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('inj.id as doctor_id') && {
+            rows: [{ unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 30000 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.schedule_days') && { rows: [], rowCount: 0 },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goals') && {
+            rows: [
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-05-01', value: 31000 },
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-06-01', value: 30000 },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goal_levels') && {
+            rows: [
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-05-01', level_key: 'first', value: 31000 },
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-06-01', level_key: 'first', value: 30000 },
+            ],
+            rowCount: 2,
+        },
+    ])
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const report = await store.managementConversionReport(
+        { unit: 'barra-shopping-sul', date: '2026-06-13', from: '2026-05-15', to: '2026-06-13' },
+        { role: 'GESTOR' },
+    )
+    const section = report.doctorRanking.sections[0]
+
+    assert.equal(section.metrics.periodAttendanceTotal?.weekValue, 30000)
+    assert.equal(section.metrics.rankedDoctorTotal?.weekValue, 30000)
+    assert.equal(section.metrics.periodGoal?.weekValue, 30000)
+    assert.equal(section.metrics.dailyGoal?.weekValue, 1000)
+    assert.equal(section.goalPlan?.periodOperationalDays, 30)
+    assert.equal(section.goalPlan?.periodGoal, 30000)
+    assert.equal(section.goalPlan?.dailyGoal, 1000)
+    assert.equal(section.goalPlan?.segments?.length, 2)
+    assert.equal(section.goalPlan?.segments?.[0]?.monthKey, '2026-05-01')
+    assert.equal(section.goalPlan?.segments?.[0]?.monthOperationalDays, 31)
+    assert.equal(section.goalPlan?.segments?.[0]?.periodOperationalDays, 17)
+    assert.equal(section.goalPlan?.segments?.[0]?.periodGoal, 17000)
+    assert.equal(section.goalPlan?.segments?.[1]?.monthKey, '2026-06-01')
+    assert.equal(section.goalPlan?.segments?.[1]?.monthOperationalDays, 30)
+    assert.equal(section.goalPlan?.segments?.[1]?.periodOperationalDays, 13)
+    assert.equal(section.goalPlan?.segments?.[1]?.periodGoal, 13000)
+})
+
+test('returns row-based overview metrics with explicit quantity totals', async () => {
+    const fakePool = createFakePool([
+        (sql) => sql.includes('count(*)::int as total_attendances') && {
+            rows: [{ total_attendances: 2, quantity_total: 3, total_value: 1598, distinct_clients: 1 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes("to_char(a.service_date, 'YYYY-MM') as month") && {
+            rows: [{ month: '2026-06', count: 2, quantity_total: 3, value: 1598 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('p.name as label') && {
+            rows: [{ label: 'Botox', count: 2, quantity_total: 3, value: 1598 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes("coalesce(nullif(inj.name, ''), 'Sem injetor') as label") && {
+            rows: [{ label: 'Dra. A', count: 2, quantity_total: 3, value: 1598 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes("coalesce(nullif(con.name, ''), 'Sem consultor') as label") && {
+            rows: [{ label: 'Consultora A', count: 2, quantity_total: 3, value: 1598 }],
+            rowCount: 1,
+        },
+    ])
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const overview = await store.overview({}, { role: 'GESTOR' })
+
+    assert.equal(overview.summary.totalAttendances, 2)
+    assert.equal(overview.summary.quantityTotal, 3)
+    assert.equal(overview.summary.countMode, 'row')
+    assert.equal(overview.summary.averageTicket, 799)
+    assert.equal(overview.monthly[0].quantityTotal, 3)
+    assert.equal(overview.rankings.procedures[0].quantityTotal, 3)
+})
+
+test('returns finance totals with explicit quantity totals by unit', async () => {
+    const fakePool = createFakePool([
+        (sql) => sql.includes("from crm_atendimento.management_items") && {
+            rows: [{ source_tab: 'Caixa', source_row: 1, category: 'finance', label: 'Linha', active: true, sensitive: false, unit_slug: 'novo-hamburgo', record_date: '2026-06-10', payload: {}, imported_at: null, id: 'item-1' }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('count(*)::int as count') && sql.includes('group by u.slug, u.name') && {
+            rows: [{ unit_slug: 'novo-hamburgo', unit_name: 'Novo Hamburgo', count: 2, quantity_total: 3, value: 1598 }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goals g') && { rows: [], rowCount: 0 },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goal_levels gl') && { rows: [], rowCount: 0 },
+        (sql) => sql.includes('select slug, name from crm_atendimento.units order by name') && {
+            rows: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }],
+            rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.goal_table_rows') && { rows: [], rowCount: 0 },
+    ])
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const finance = await store.managementFinance({ role: 'GESTOR' })
+
+    assert.equal(finance.attendanceTotals?.units[0].count, 2)
+    assert.equal(finance.attendanceTotals?.units[0].quantityTotal, 3)
+    assert.equal(finance.attendanceTotals?.units[0].value, 1598)
+})
+
+test('does not suggest injector names on closed no-service days', async () => {
+    const fakePool = createFakePool([
+        (sql) => sql.includes('from crm_atendimento.schedule_days s') && sql.includes('limit 1') && {
+            rows: [{ date: '2026-06-10', doctor_name: 'Sem Atendimento', unit_slug: 'novo-hamburgo', unit_name: 'Novo Hamburgo' }],
+            rowCount: 1,
+        },
+    ])
+
+    const store = createAtendimentoStore({ pool: fakePool })
+    const result = await store.doctorSuggestion({ unit: 'novo-hamburgo', date: '2026-06-10' }, { role: 'GESTOR' })
+
+    assert.equal(result.doctorName, '')
+})
+
+function buildConversionPoolHandlers() {
+    const conversionRows = buildConversionRawRows()
+
+    return [
+        (sql) => sql.includes('select source_tab, source_row, cells') && { rows: conversionRows, rowCount: conversionRows.length },
+        (sql) => sql.includes('from crm_atendimento.units u') && {
+            rows: [
+                { id: 'unit-nh', slug: 'novo-hamburgo', name: 'Novo Hamburgo' },
+                { id: 'unit-bss', slug: 'barra-shopping-sul', name: 'BarraShoppingSul' },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('from crm_atendimento.professionals') && {
+            rows: [
+                { id: 'doc-a', name: 'Dra. A', role: 'Injetor', status: 'Ativo', units: ['Novo Hamburgo'], roles: ['Injetor'] },
+                { id: 'doc-b', name: 'Dra. B', role: 'Injetor', status: 'Ativo', units: ['BarraShoppingSul'], roles: ['Injetor'] },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('coalesce(sum(a.value), 0)::numeric as total') && sql.includes('group by u.slug') && !sql.includes('inj.id') && {
+            rows: [
+                { unit_slug: 'novo-hamburgo', total: 14 },
+                { unit_slug: 'barra-shopping-sul', total: 9 },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('inj.id as doctor_id') && {
+            rows: [
+                { unit_slug: 'novo-hamburgo', doctor_id: 'doc-a', doctor_name: 'Dra. A', total: 14 },
+                { unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 9 },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('from crm_atendimento.schedule_days') && {
+            rows: [
+                { unit_slug: 'novo-hamburgo', service_date: '2026-06-08', doctor_name: 'Dra. A' },
+                { unit_slug: 'barra-shopping-sul', service_date: '2026-06-08', doctor_name: 'Dra. B' },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goals') && {
+            rows: [
+                { unit_slug: 'novo-hamburgo', goal_month: '2026-06-01', value: 80 },
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-06-01', value: 40 },
+            ],
+            rowCount: 2,
+        },
+        (sql) => sql.includes('from crm_atendimento.monthly_unit_goal_levels') && {
+            rows: [
+                { unit_slug: 'novo-hamburgo', goal_month: '2026-06-01', level_key: 'first', value: 80 },
+                { unit_slug: 'barra-shopping-sul', goal_month: '2026-06-01', level_key: 'first', value: 40 },
+            ],
+            rowCount: 2,
+        },
+    ]
+}
+
+function buildConversionRawRows() {
+    const cells = (sourceRow, values) => ({
+        source_row: sourceRow,
+        cells: values.map((value, index) => ({ col: index + 1, a1: `${index + 1}${sourceRow}`, value })),
+    })
+    const bxIndex = 76
+    const bzIndex = 78
+    const withWidth = (base) => Array.from({ length: bzIndex }, (_, index) => base[index] ?? '')
+    return [
+        cells(1, withWidth({ 0: 'Nome', 2: 'JUNHO', [bxIndex - 1]: 'PONTUAÇÃO', [bzIndex - 1]: 'POSIÇÃO' })),
+        cells(2, withWidth({ 2: '1ª', 3: '2ª', [bxIndex - 1]: 'BX', [bzIndex - 1]: 'BZ' })),
+        cells(3, withWidth({ 0: 'META SEMANAL', 1: 'Novo Hamburgo', 3: 20 })),
+        cells(4, withWidth({ 0: 'LINHA CORTE', 1: 'Novo Hamburgo', 3: 12 })),
+        cells(5, withWidth({ 0: 'INTERVALO', 1: 'Novo Hamburgo', 3: 4 })),
+        cells(6, withWidth({ 0: 'Dra. B', 1: 'Novo Hamburgo', 3: 9, [bxIndex - 1]: 1, [bzIndex - 1]: '2ª' })),
+        cells(7, withWidth({ 0: 'Dra. A', 1: 'Novo Hamburgo', 3: 14, [bxIndex - 1]: 3, [bzIndex - 1]: '1ª' })),
+    ]
+}
+
+function createFakePool(handlers) {
+    const query = async (sql) => {
+        const normalizedSql = String(sql || '').replace(/\s+/g, ' ').trim()
+        for (const handler of handlers) {
+            const result = handler(normalizedSql)
+            if (result) return result
+        }
+        return { rows: [], rowCount: 0 }
+    }
+    return {
+        async connect() {
+            return {
+                query,
+                release() {},
+            }
+        },
+        query,
+    }
+}

--- a/backend/apps/crm-api/server/atendimentoClinica/domain.js
+++ b/backend/apps/crm-api/server/atendimentoClinica/domain.js
@@ -404,7 +404,7 @@ export function calculateConversionGoalPlan(segments = []) {
     const periodGoal = normalizedSegments.reduce((sum, segment) => sum + segment.periodGoal, 0)
     const dailyGoal = periodOperationalDays > 0
         ? periodGoal / periodOperationalDays
-        : (monthOperationalDays > 0 ? monthlyGoal / monthOperationalDays : 0)
+        : 0
     return {
         monthlyGoal,
         monthOperationalDays,
@@ -485,6 +485,7 @@ export function calculateDoctorConversionRanking({
     monthOperationalDays = 0,
     weekOperationalDays = 0,
     dailyGoal,
+    periodGoal,
     weeklyGoal,
     intervalMultiplier = DEFAULT_CONVERSION_INTERVAL_MULTIPLIER,
 } = {}) {
@@ -507,14 +508,16 @@ export function calculateDoctorConversionRanking({
     const dailyGoalValue = Number.isFinite(Number(dailyGoal))
         ? Number(dailyGoal)
         : (safeMonthDays > 0 ? monthlyGoalValue / safeMonthDays : 0)
-    const weeklyGoalValue = Number.isFinite(Number(weeklyGoal))
-        ? Number(weeklyGoal)
+    const periodGoalValue = Number.isFinite(Number(periodGoal))
+        ? Number(periodGoal)
+        : Number.isFinite(Number(weeklyGoal))
+            ? Number(weeklyGoal)
         : dailyGoalValue * safeWeekDays
     const avg = average(valuesForStatistics)
     const medianValue = median(valuesForStatistics)
     const effectiveIntervalMultiplier = Math.max(0, Number(intervalMultiplier || 0))
     const standardDeviation = sampleStandardDeviation(valuesForStatistics)
-    const cutLine = (avg * 0.3) + (medianValue * 0.2) + (dailyGoalValue * 0.5)
+    const cutLine = (avg * 0.3) + (medianValue * 0.2) + (periodGoalValue * 0.5)
     const interval = standardDeviation * effectiveIntervalMultiplier
     const lowerLimit = cutLine - interval
     const upperLimit = cutLine + interval
@@ -530,7 +533,8 @@ export function calculateDoctorConversionRanking({
             median: medianValue,
             monthlyGoal: monthlyGoalValue,
             dailyGoal: dailyGoalValue,
-            weeklyGoal: weeklyGoalValue,
+            periodGoal: periodGoalValue,
+            weeklyGoal: periodGoalValue,
             cutLine,
             interval,
             lowerLimit,
@@ -565,7 +569,8 @@ export function calculateDoctorConversionRanking({
         monthOperationalDays: safeMonthDays,
         periodOperationalDays: safeWeekDays,
         dailyGoal: dailyGoalValue,
-        weeklyGoal: weeklyGoalValue,
+        periodGoal: periodGoalValue,
+        weeklyGoal: periodGoalValue,
         average: avg,
         median: medianValue,
         standardDeviation,
@@ -577,7 +582,7 @@ export function calculateDoctorConversionRanking({
         levelCounts,
         ratioDivisor,
         formulas: {
-            cutLine: 'linha_corte = (media * 0.30) + (mediana * 0.20) + (meta_diaria * 0.50)',
+            cutLine: 'linha_corte = (media_periodo * 0.30) + (mediana_periodo * 0.20) + (meta_periodo * 0.50)',
             interval: 'intervalo = desvio_padrao(realizado_doutores) * multiplicador_intervalo',
             ratioDivisor: 'divisor = (level0 * 0) + (level1 * 1) + (level2 * 2) + (level3 * 3)',
         },
@@ -835,7 +840,7 @@ function buildConversionDoctorRanking(rows, monthColumn, weekColumn, bxColumn, b
     const metricKeys = new Map([
         ['total', 'total'],
         ['meta mensal', 'monthlyGoal'],
-        ['meta semanal', 'weeklyGoal'],
+        ['meta semanal', 'periodGoal'],
         ['meta diaria', 'dailyGoal'],
         ['media', 'average'],
         ['mediana', 'median'],

--- a/backend/apps/crm-api/server/atendimentoClinica/store.js
+++ b/backend/apps/crm-api/server/atendimentoClinica/store.js
@@ -475,10 +475,13 @@ async function fetchEscalaJson(target, actorKey, actor, restPath, params) {
     return json
 }
 
-async function readEscalaScheduleCoverage(selectedUnits, start, end, actor) {
+function normalizeEscalaScheduleDoctorName(row) {
+    const value = row?.professional ?? row?.doctor_name ?? row?.doctorName ?? row?.name
+    return String(value || '').trim()
+}
+
+async function readEscalaScheduleCoverage(pgPool, selectedUnits, start, end, actor) {
     const { target, actorKey } = getEscalaApiConfig()
-    if (!target || !actorKey || !selectedUnits.length) return { source: 'legacy-import', byUnit: new Map(), available: false }
-    const serviceActor = buildEscalaServiceActor(actor)
     const months = monthKeysBetween(start, end)
     const byUnit = new Map(selectedUnits.map((unit) => [unit.slug, {
         unit,
@@ -487,36 +490,81 @@ async function readEscalaScheduleCoverage(selectedUnits, start, end, actor) {
         holidayDates: new Set(),
         coveredMonths: new Set(),
     }]))
+    if (!target || !actorKey || !selectedUnits.length) return { source: 'crm', byUnit, available: false }
+    const serviceActor = buildEscalaServiceActor(actor)
+    const unitSlugs = selectedUnits.map((unit) => unit.slug)
+    const existingRows = await pgPool.query(
+        `select u.slug as unit_slug, s.service_date::text as service_date
+         from crm_atendimento.schedule_days s
+         join crm_atendimento.units u on u.id = s.unit_id
+         where u.slug = any($1)
+           and s.service_date >= $2::date
+           and s.service_date <= $3::date`,
+        [unitSlugs, start, end],
+    )
+    const existingByUnit = new Map()
+    for (const row of existingRows.rows) {
+        const dates = existingByUnit.get(row.unit_slug) || new Set()
+        dates.add(isoDateFromDb(row.service_date))
+        existingByUnit.set(row.unit_slug, dates)
+    }
     try {
         for (const unit of selectedUnits) {
             const coverage = byUnit.get(unit.slug)
+            const existingDates = existingByUnit.get(unit.slug) || new Set()
             for (const month of months) {
                 const json = await fetchEscalaJson(target, actorKey, serviceActor, '/schedule', { unit: unit.name, month })
                 const scheduleRows = Array.isArray(json.schedule) ? json.schedule : []
                 const closedRows = Array.isArray(json.closedDays) ? json.closedDays : []
                 const holidayRows = Array.isArray(json.holidays) ? json.holidays : []
-                if (scheduleRows.length || closedRows.length) coverage.coveredMonths.add(month)
+                if (scheduleRows.length || closedRows.length || holidayRows.length) coverage.coveredMonths.add(month)
+                const desiredByDate = new Map()
                 scheduleRows.forEach((row) => {
                     const date = isoDateFromDb(row.date)
-                    if (date) coverage.scheduledDates.add(date)
+                    const doctorName = normalizeEscalaScheduleDoctorName(row)
+                    if (!date || !doctorName) return
+                    coverage.scheduledDates.add(date)
+                    const entry = desiredByDate.get(date) || { doctors: new Set(), closed: false }
+                    entry.doctors.add(doctorName)
+                    desiredByDate.set(date, entry)
                 })
                 closedRows.forEach((row) => {
                     const date = isoDateFromDb(row.date)
                     if (date) {
                         coverage.closedDates.add(date)
                         coverage.coveredMonths.add(date.slice(0, 7))
+                        desiredByDate.set(date, { doctors: new Set(), closed: true })
                     }
                 })
                 holidayRows.forEach((row) => {
                     const date = isoDateFromDb(row.date)
-                    if (date) coverage.holidayDates.add(date)
+                    if (date) {
+                        coverage.holidayDates.add(date)
+                        coverage.coveredMonths.add(date.slice(0, 7))
+                        desiredByDate.set(date, { doctors: new Set(), closed: true })
+                    }
                 })
+                for (const [date, desired] of desiredByDate.entries()) {
+                    if (existingDates.has(date)) continue
+                    const doctorName = desired.closed
+                        ? GERENCIA_APPS_SCRIPT_CONFIG.noServiceLabel
+                        : Array.from(desired.doctors).join(', ')
+                    if (!doctorName) continue
+                    await upsertScheduleDay(pgPool, {
+                        unitSlug: unit.slug,
+                        unitName: unit.name,
+                        date,
+                        doctorName,
+                        year: Number(date.slice(0, 4)) || null,
+                    })
+                    existingDates.add(date)
+                }
             }
         }
-        return { source: 'escala-crm', byUnit, available: true }
+        return { source: 'crm', byUnit, available: true }
     } catch (error) {
-        console.warn('atendimento-clinica escala coverage fallback', error?.message || error)
-        return { source: 'legacy-import', byUnit: new Map(), available: false, error: String(error?.message || error || '') }
+        console.warn('atendimento-clinica escala coverage sync', error?.message || error)
+        return { source: 'crm', byUnit, available: false, error: String(error?.message || error || '') }
     }
 }
 
@@ -532,11 +580,7 @@ function countOperationalDaysWithEscala(unitSlug, scheduleByUnit, escalaCoverage
             continue
         }
         const legacySchedule = scheduleByUnit.get(unitSlug)
-        if (legacySchedule?.size) {
-            if (isOperationalScheduleValue(legacySchedule.get(date))) total += 1
-        } else if (defaultOperationalDay(unitSlug, date)) {
-            total += 1
-        }
+        if (legacySchedule?.size && isOperationalScheduleValue(legacySchedule.get(date))) total += 1
     }
     return total
 }
@@ -564,19 +608,27 @@ function moneyMetric(value, position = '', label = '', extra = {}) {
     }
 }
 
+function formatCurrencyDiagnostic(value) {
+    return Number(value || 0).toLocaleString('pt-BR', {
+        style: 'currency',
+        currency: 'BRL',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    })
+}
+
 function buildConversionMetricPayload(stats, unitName) {
     const levelCounts = stats.levelCounts || { level0: 0, level1: 0, level2: 0, level3: 0 }
-    const cutLineFormula = `${stats.formulas?.cutLine || 'linha_corte = (media * 0.30) + (mediana * 0.20) + (meta_diaria * 0.50)'}; valores = (${Number(stats.average || 0).toFixed(2)} * 0.30) + (${Number(stats.median || 0).toFixed(2)} * 0.20) + (${Number(stats.dailyGoal || 0).toFixed(2)} * 0.50)`
+    const cutLineFormula = `${stats.formulas?.cutLine || 'linha_corte = (media_periodo * 0.30) + (mediana_periodo * 0.20) + (meta_periodo * 0.50)'}; valores = (${Number(stats.average || 0).toFixed(2)} * 0.30) + (${Number(stats.median || 0).toFixed(2)} * 0.20) + (${Number(stats.periodGoal || stats.weeklyGoal || 0).toFixed(2)} * 0.50)`
     const intervalFormula = `${stats.formulas?.interval || 'intervalo = desvio_padrao(realizado_doutores) * multiplicador_intervalo'}; valores = ${Number(stats.standardDeviation || 0).toFixed(2)} * ${Number(stats.intervalMultiplier || 0).toFixed(2)}`
     const divisorFormula = `${stats.formulas?.ratioDivisor || 'divisor = (level0 * 0) + (level1 * 1) + (level2 * 2) + (level3 * 3)'}; valores = (${levelCounts.level0 || 0} * 0) + (${levelCounts.level1 || 0} * 1) + (${levelCounts.level2 || 0} * 2) + (${levelCounts.level3 || 0} * 3)`
     return {
         total: moneyMetric(stats.total, unitName, 'TOTAL'),
         rankedDoctorTotal: moneyMetric(stats.rankedDoctorTotal ?? stats.total, unitName, 'TOTAL RANQUEÁVEL'),
-        periodAttendanceTotal: moneyMetric(stats.periodAttendanceTotal ?? stats.total, unitName, 'TOTAL GERAL'),
+        periodAttendanceTotal: moneyMetric(stats.periodAttendanceTotal ?? stats.total, unitName, 'TOTAL DO PERÍODO'),
         eligibleDoctorCount: moneyMetric(stats.eligibleDoctorCount, unitName, 'Doutores elegíveis'),
-        monthlyGoal: moneyMetric(stats.monthlyGoal, unitName, 'Meta Mensal', { formula: 'meta_mensal = 1ª meta mensal da unidade/mês no CRM' }),
-        weeklyGoal: moneyMetric(stats.weeklyGoal, unitName, 'Meta Semanal', { formula: 'meta_semanal = meta_diaria * dias_trabalhados_periodo' }),
-        dailyGoal: moneyMetric(stats.dailyGoal, unitName, 'Meta Diária', { formula: 'meta_diaria = meta_mensal / dias_trabalhados_mes' }),
+        periodGoal: moneyMetric(stats.periodGoal ?? stats.weeklyGoal, unitName, 'Meta do período', { formula: 'meta_periodo = soma(meta_diaria_mes * dias_trabalhados_periodo_no_mes)' }),
+        dailyGoal: moneyMetric(stats.dailyGoal, unitName, 'Meta Diária', { formula: 'meta_diaria_media_periodo = meta_periodo / dias_trabalhados_periodo' }),
         monthOperationalDays: moneyMetric(stats.monthOperationalDays, unitName, 'Dias mês', { formula: 'dias_trabalhados_mes = dias operacionais do mês pela Escala CRM ou fallback' }),
         periodOperationalDays: moneyMetric(stats.periodOperationalDays, unitName, 'Dias período', { formula: 'dias_trabalhados_periodo = dias operacionais dentro do período selecionado' }),
         average: moneyMetric(stats.average, unitName, 'Média'),
@@ -597,6 +649,14 @@ function buildConversionMetricPayload(stats, unitName) {
         level2: moneyMetric(levelCounts.level2 || 0, unitName, 'Nível 2', { formula: 'nivel_2 = linha_corte <= realizado < limite_superior' }),
         level3: moneyMetric(levelCounts.level3 || 0, unitName, 'Nível 3', { formula: 'nivel_3 = realizado >= limite_superior' }),
     }
+}
+
+function normalizeAggregateCountValue(value) {
+    return Math.round(Number(value || 0) * 100) / 100
+}
+
+function buildAggregateConversionNotice() {
+    return 'As métricas de conversão usam meta, dias operacionais, linha de corte e intervalo por unidade. Selecione uma unidade para evitar consolidação estatística incorreta.'
 }
 
 async function buildInternalConversionMetrics(pgPool, period, query, actor) {
@@ -626,7 +686,7 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
     const goalMonthKeys = monthSegments.map((segment) => segment.monthKey)
     const scheduleStart = monthSegments[0]?.monthStart || bounds.monthStart
     const scheduleEnd = monthSegments[monthSegments.length - 1]?.monthEnd || bounds.monthEnd
-    const [professionals, weeklyTotals, doctorTotals, scheduleRows, goals, goalLevels] = await Promise.all([
+    const [professionals, weeklyTotals, doctorTotals, goals, goalLevels] = await Promise.all([
         pgPool.query(
             `select id, name, role, status, units, roles
              from crm_atendimento.professionals
@@ -656,15 +716,6 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
             [bounds.metricStart, bounds.metricEnd, unitSlugs],
         ),
         pgPool.query(
-            `select u.slug as unit_slug, s.service_date, s.doctor_name
-             from crm_atendimento.schedule_days s
-             join crm_atendimento.units u on u.id = s.unit_id
-             where s.service_date >= $1::date
-               and s.service_date <= $2::date
-               and u.slug = any($3)`,
-            [scheduleStart, scheduleEnd, unitSlugs],
-        ),
-        pgPool.query(
             `select u.slug as unit_slug, g.goal_month, g.value
              from crm_atendimento.monthly_unit_goals g
              join crm_atendimento.units u on u.id = g.unit_id
@@ -681,6 +732,16 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
             [goalMonthKeys, unitSlugs],
         ),
     ])
+    const escalaCoverage = await readEscalaScheduleCoverage(pgPool, selectedUnits, scheduleStart, scheduleEnd, actor)
+    const scheduleRows = await pgPool.query(
+        `select u.slug as unit_slug, s.service_date, s.doctor_name
+         from crm_atendimento.schedule_days s
+         join crm_atendimento.units u on u.id = s.unit_id
+         where s.service_date >= $1::date
+           and s.service_date <= $2::date
+           and u.slug = any($3)`,
+        [scheduleStart, scheduleEnd, unitSlugs],
+    )
 
     const weeklyTotalByUnit = new Map(weeklyTotals.rows.map((row) => [row.unit_slug, Number(row.total || 0)]))
     const doctorTotalByUnit = new Map()
@@ -697,8 +758,6 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
         unitMap.set(isoDateFromDb(row.service_date), row.doctor_name)
         scheduleByUnit.set(row.unit_slug, unitMap)
     }
-    const escalaCoverage = await readEscalaScheduleCoverage(selectedUnits, scheduleStart, scheduleEnd, actor)
-
     const baseGoalByUnitMonth = new Map()
     for (const row of goals.rows) {
         const monthKey = isoDateFromDb(row.goal_month || row.month || row.goalMonth)
@@ -722,12 +781,6 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
 
     const byUnit = new Map()
     const sections = []
-    const allDoctorInputs = []
-    const allDailyGoals = []
-    const allWeeklyGoals = []
-    let allMonthlyGoal = 0
-    let allMonthOperationalDays = 0
-    let allPeriodOperationalDays = 0
 
     for (const unit of selectedUnits) {
         const totals = doctorTotalByUnit.get(unit.slug) || new Map()
@@ -755,6 +808,7 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
             monthOperationalDays: goalPlan.monthOperationalDays,
             weekOperationalDays: goalPlan.periodOperationalDays,
             dailyGoal: goalPlan.dailyGoal,
+            periodGoal: goalPlan.periodGoal,
             weeklyGoal: goalPlan.weeklyGoal,
             intervalMultiplier,
         })
@@ -763,6 +817,19 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
             unitName: unit.name,
             unitSlug: unit.slug,
             metrics: byUnit.get(unit.slug),
+            goalPlan: {
+                periodOperationalDays: Number(goalPlan.periodOperationalDays || 0),
+                periodGoal: Number(goalPlan.periodGoal || 0),
+                dailyGoal: Number(goalPlan.dailyGoal || 0),
+                segments: (Array.isArray(goalPlan.segments) ? goalPlan.segments : []).map((segment) => ({
+                    monthKey: segment.monthKey,
+                    monthlyGoal: Number(segment.monthlyGoal || 0),
+                    monthOperationalDays: Number(segment.monthOperationalDays || 0),
+                    periodOperationalDays: Number(segment.periodOperationalDays || 0),
+                    dailyGoal: Number(segment.dailyGoal || 0),
+                    periodGoal: Number(segment.periodGoal || 0),
+                })),
+            },
             doctors: stats.ranking.map((doctor) => ({
                 id: doctor.id,
                 name: doctor.name,
@@ -779,26 +846,10 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
             isAggregate: false,
             period: bounds,
         })
-        allDoctorInputs.push(...doctors)
-        allDailyGoals.push(stats.dailyGoal)
-        allWeeklyGoals.push(stats.weeklyGoal)
-        allMonthlyGoal += goalPlan.monthlyGoal
-        allMonthOperationalDays += goalPlan.monthOperationalDays
-        allPeriodOperationalDays += goalPlan.periodOperationalDays
     }
 
-    const allStats = calculateDoctorConversionRanking({
-        doctors: allDoctorInputs,
-        monthlyGoal: allMonthlyGoal,
-        monthOperationalDays: allMonthOperationalDays,
-        weekOperationalDays: allPeriodOperationalDays,
-        dailyGoal: allDailyGoals.reduce((sum, value) => sum + value, 0),
-        weeklyGoal: allWeeklyGoals.reduce((sum, value) => sum + value, 0),
-        periodAttendanceTotal: Array.from(weeklyTotalByUnit.values()).reduce((sum, value) => sum + value, 0),
-        intervalMultiplier,
-    })
-    const allMetrics = buildConversionMetricPayload(allStats, 'Todas unidades')
-    byUnit.set('all', allMetrics)
+    const aggregateNotice = buildAggregateConversionNotice()
+    const warnings = []
     const allDoctors = sections
         .flatMap((section) => section.doctors)
         .sort((left, right) => Number(right.weekValue || 0) - Number(left.weekValue || 0)
@@ -809,11 +860,20 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
         sections.unshift({
             unitName: 'Todas unidades',
             unitSlug: 'all',
-            metrics: allMetrics,
+            metrics: {},
             doctors: allDoctors,
-            isAggregate: false,
+            isAggregate: true,
+            aggregateNotice,
             period: bounds,
         })
+    }
+    for (const section of sections) {
+        if (section.isAggregate) continue
+        const periodTotal = Number(section.metrics?.periodAttendanceTotal?.weekValue || 0)
+        const rankedTotal = Number(section.metrics?.rankedDoctorTotal?.weekValue || 0)
+        if (Math.abs(periodTotal - rankedTotal) > 0.009) {
+            warnings.push(`Conversão ${section.unitName}: total do período ${formatCurrencyDiagnostic(periodTotal)} difere do total ranqueável ${formatCurrencyDiagnostic(rankedTotal)}.`)
+        }
     }
     const scheduleCoverageRows = escalaCoverage.byUnit ? Array.from(escalaCoverage.byUnit.values()) : []
     return {
@@ -822,7 +882,8 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor) {
         topDoctors: allDoctors.slice(0, 8),
         period: bounds,
         intervalMultiplier,
-        scheduleSource: escalaCoverage.source || 'legacy-import',
+        warnings,
+        scheduleSource: escalaCoverage.source || 'crm',
         scheduleCoverageMonths: scheduleCoverageRows
             .flatMap((coverage) => Array.from(coverage.coveredMonths || []).map((month) => ({ unitSlug: coverage.unit.slug, unitName: coverage.unit.name, month }))),
     }
@@ -839,9 +900,13 @@ function applyInternalConversionMetrics(report, internalMetrics) {
     report.summary = {
         ...(report.summary || {}),
         doctorRankingSource: 'crm',
-        scheduleSource: internalMetrics.scheduleSource || 'legacy-import',
+        scheduleSource: internalMetrics.scheduleSource || 'crm',
         scheduleCoverageMonths: internalMetrics.scheduleCoverageMonths || [],
     }
+    report.warnings = [
+        ...((report.warnings || []).filter(Boolean)),
+        ...((internalMetrics.warnings || []).filter(Boolean)),
+    ]
     return report
 }
 
@@ -1282,46 +1347,126 @@ export function createAtendimentoStore(options = {}) {
             await ensureReady()
             const { where, params } = buildAttendanceWhere(query, actor)
             const whereSql = where.length ? `where ${where.join(' and ')}` : ''
-            const summary = await pgPool.query(
-                `${ATTENDANCE_SELECT}
-                 ${whereSql}`,
-                params,
-            )
-            const rows = summary.rows.map(mapAttendance)
-            const totalValue = rows.reduce((acc, row) => acc + row.value, 0)
-            const byMonth = new Map()
-            const byProcedure = new Map()
-            const byInjector = new Map()
-            const byConsultant = new Map()
-            for (const row of rows) {
-                const month = row.date.slice(0, 7)
-                const monthItem = byMonth.get(month) || { month, count: 0, value: 0 }
-                monthItem.count += 1
-                monthItem.value += row.value
-                byMonth.set(month, monthItem)
-                for (const [map, key] of [[byProcedure, row.procedureName], [byInjector, row.injectorName || 'Sem injetor'], [byConsultant, row.consultantName || 'Sem consultor']]) {
-                    const item = map.get(key) || { label: key, count: 0, value: 0 }
-                    item.count += 1
-                    item.value += row.value
-                    map.set(key, item)
-                }
-            }
-            const rank = (map) => Array.from(map.values()).sort((a, b) => b.value - a.value).slice(0, 12)
+            const [summary, monthly, procedures, injectors, consultants] = await Promise.all([
+                pgPool.query(
+                    `select
+                        count(*)::int as total_attendances,
+                        coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                        coalesce(sum(a.value), 0)::numeric as total_value,
+                        count(distinct nullif(lower(trim(a.client_name)), ''))::int as distinct_clients
+                     from crm_atendimento.attendances a
+                     join crm_atendimento.units u on u.id = a.unit_id
+                     join crm_atendimento.procedures p on p.id = a.procedure_id
+                     left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                     left join crm_atendimento.professionals con on con.id = a.consultant_id
+                     ${whereSql}`,
+                    params,
+                ),
+                pgPool.query(
+                    `select
+                        to_char(a.service_date, 'YYYY-MM') as month,
+                        count(*)::int as count,
+                        coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                        coalesce(sum(a.value), 0)::numeric as value
+                     from crm_atendimento.attendances a
+                     join crm_atendimento.units u on u.id = a.unit_id
+                     join crm_atendimento.procedures p on p.id = a.procedure_id
+                     left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                     left join crm_atendimento.professionals con on con.id = a.consultant_id
+                     ${whereSql}
+                     group by 1
+                     order by 1`,
+                    params,
+                ),
+                pgPool.query(
+                    `select
+                        p.name as label,
+                        count(*)::int as count,
+                        coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                        coalesce(sum(a.value), 0)::numeric as value
+                     from crm_atendimento.attendances a
+                     join crm_atendimento.units u on u.id = a.unit_id
+                     join crm_atendimento.procedures p on p.id = a.procedure_id
+                     left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                     left join crm_atendimento.professionals con on con.id = a.consultant_id
+                     ${whereSql}
+                     group by 1
+                     order by value desc, label
+                     limit 12`,
+                    params,
+                ),
+                pgPool.query(
+                    `select
+                        coalesce(nullif(inj.name, ''), 'Sem injetor') as label,
+                        count(*)::int as count,
+                        coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                        coalesce(sum(a.value), 0)::numeric as value
+                     from crm_atendimento.attendances a
+                     join crm_atendimento.units u on u.id = a.unit_id
+                     join crm_atendimento.procedures p on p.id = a.procedure_id
+                     left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                     left join crm_atendimento.professionals con on con.id = a.consultant_id
+                     ${whereSql}
+                     group by 1
+                     order by value desc, label
+                     limit 12`,
+                    params,
+                ),
+                pgPool.query(
+                    `select
+                        coalesce(nullif(con.name, ''), 'Sem consultor') as label,
+                        count(*)::int as count,
+                        coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                        coalesce(sum(a.value), 0)::numeric as value
+                     from crm_atendimento.attendances a
+                     join crm_atendimento.units u on u.id = a.unit_id
+                     join crm_atendimento.procedures p on p.id = a.procedure_id
+                     left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                     left join crm_atendimento.professionals con on con.id = a.consultant_id
+                     ${whereSql}
+                     group by 1
+                     order by value desc, label
+                     limit 12`,
+                    params,
+                ),
+            ])
+            const summaryRow = summary.rows[0] || {}
+            const totalAttendances = Number(summaryRow.total_attendances || 0)
+            const totalValue = normalizeAggregateCountValue(summaryRow.total_value)
             return {
                 summary: {
-                    totalAttendances: rows.length,
-                    totalValue: Math.round(totalValue * 100) / 100,
-                    averageTicket: rows.length ? Math.round((totalValue / rows.length) * 100) / 100 : 0,
-                    distinctClients: new Set(rows.map((row) => normalizeText(row.clientName))).size,
+                    totalAttendances,
+                    quantityTotal: normalizeAggregateCountValue(summaryRow.quantity_total),
+                    countMode: 'row',
+                    totalValue,
+                    averageTicket: totalAttendances ? Math.round((totalValue / totalAttendances) * 100) / 100 : 0,
+                    distinctClients: Number(summaryRow.distinct_clients || 0),
                 },
-                monthly: Array.from(byMonth.values()).sort((a, b) => a.month.localeCompare(b.month)).map((item) => ({
-                    ...item,
-                    value: Math.round(item.value * 100) / 100,
+                monthly: monthly.rows.map((item) => ({
+                    month: item.month,
+                    count: Number(item.count || 0),
+                    quantityTotal: normalizeAggregateCountValue(item.quantity_total),
+                    value: normalizeAggregateCountValue(item.value),
                 })),
                 rankings: {
-                    procedures: rank(byProcedure),
-                    injectors: rank(byInjector),
-                    consultants: rank(byConsultant),
+                    procedures: procedures.rows.map((item) => ({
+                        label: item.label,
+                        count: Number(item.count || 0),
+                        quantityTotal: normalizeAggregateCountValue(item.quantity_total),
+                        value: normalizeAggregateCountValue(item.value),
+                    })),
+                    injectors: injectors.rows.map((item) => ({
+                        label: item.label,
+                        count: Number(item.count || 0),
+                        quantityTotal: normalizeAggregateCountValue(item.quantity_total),
+                        value: normalizeAggregateCountValue(item.value),
+                    })),
+                    consultants: consultants.rows.map((item) => ({
+                        label: item.label,
+                        count: Number(item.count || 0),
+                        quantityTotal: normalizeAggregateCountValue(item.quantity_total),
+                        value: normalizeAggregateCountValue(item.value),
+                    })),
                 },
             }
         },
@@ -1340,13 +1485,18 @@ export function createAtendimentoStore(options = {}) {
                 params,
             )
             const count = await pgPool.query(
-                `${ATTENDANCE_SELECT}
+                `select count(*)::int as total
+                 from crm_atendimento.attendances a
+                 join crm_atendimento.units u on u.id = a.unit_id
+                 join crm_atendimento.procedures p on p.id = a.procedure_id
+                 left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                 left join crm_atendimento.professionals con on con.id = a.consultant_id
                  where ${where.join(' and ')}`,
                 params.slice(0, -2),
             )
             return {
                 data: out.rows.map(mapAttendance),
-                total: count.rowCount,
+                total: Number(count.rows[0]?.total || 0),
                 limit,
                 offset,
             }
@@ -1375,11 +1525,14 @@ export function createAtendimentoStore(options = {}) {
                  limit 1`,
                 [unit.slug, date],
             )
+            const doctorName = String(row.rows[0]?.doctor_name || '').trim()
+            const normalizedDoctorName = normalizeText(doctorName)
+            const noService = normalizeText(GERENCIA_APPS_SCRIPT_CONFIG.noServiceLabel)
             return {
                 unitSlug: unit.slug,
                 unitName: row.rows[0]?.unit_name || unit.name,
                 date,
-                doctorName: row.rows[0]?.doctor_name || '',
+                doctorName: doctorName && normalizedDoctorName !== noService ? doctorName : '',
             }
         },
 
@@ -1406,8 +1559,9 @@ export function createAtendimentoStore(options = {}) {
             const byDoctor = new Map()
             for (const row of result.rows.map(mapAttendance)) {
                 const doctor = row.injectorName || 'Sem injetor'
-                const item = byDoctor.get(doctor) || { doctorName: doctor, count: 0, totalValue: 0, remuneration: 0, rows: [] }
+                const item = byDoctor.get(doctor) || { doctorName: doctor, count: 0, quantityTotal: 0, totalValue: 0, remuneration: 0, rows: [] }
                 item.count += 1
+                item.quantityTotal += row.quantity
                 item.totalValue += row.value
                 item.rows.push({
                     date: row.date,
@@ -1424,6 +1578,7 @@ export function createAtendimentoStore(options = {}) {
                 const remuneration = totalValue > 0 ? Math.max(totalValue * 0.10, 212.50) : 0
                 return {
                     ...item,
+                    quantityTotal: normalizeAggregateCountValue(item.quantityTotal),
                     totalValue,
                     remuneration: Math.round(remuneration * 100) / 100,
                 }
@@ -1436,6 +1591,7 @@ export function createAtendimentoStore(options = {}) {
                 summary: {
                     doctors: doctors.length,
                     attendances: doctors.reduce((acc, item) => acc + item.count, 0),
+                    quantityTotal: normalizeAggregateCountValue(doctors.reduce((acc, item) => acc + Number(item.quantityTotal || 0), 0)),
                     totalValue: Math.round(doctors.reduce((acc, item) => acc + item.totalValue, 0) * 100) / 100,
                     remuneration: Math.round(doctors.reduce((acc, item) => acc + item.remuneration, 0) * 100) / 100,
                 },
@@ -1851,11 +2007,22 @@ export function createAtendimentoStore(options = {}) {
             const params = []
             applyActorUnitFilter(attendanceWhere, params, actor)
             const totals = await pgPool.query(
-                `${ATTENDANCE_SELECT}
-                 where ${attendanceWhere.join(' and ')}`,
+                `select
+                    u.slug as unit_slug,
+                    u.name as unit_name,
+                    count(*)::int as count,
+                    coalesce(sum(a.quantity), 0)::numeric as quantity_total,
+                    coalesce(sum(a.value), 0)::numeric as value
+                 from crm_atendimento.attendances a
+                 join crm_atendimento.units u on u.id = a.unit_id
+                 join crm_atendimento.procedures p on p.id = a.procedure_id
+                 left join crm_atendimento.professionals inj on inj.id = a.injector_id
+                 left join crm_atendimento.professionals con on con.id = a.consultant_id
+                 where ${attendanceWhere.join(' and ')}
+                 group by u.slug, u.name
+                 order by u.name`,
                 params,
             )
-            const mapped = totals.rows.map(mapAttendance)
             const monthlyGoalResult = await listMonthlyGoals(pgPool, {}, actor)
             return {
                 sourceTabs: Array.from(sourceTabs.values()),
@@ -1864,14 +2031,15 @@ export function createAtendimentoStore(options = {}) {
                 monthlyGoalLevels: monthlyGoalResult.goalLevels,
                 goalTables: (await listGoalTables(pgPool, {}, actor)).tables,
                 attendanceTotals: {
-                    units: Array.from(mapped.reduce((map, row) => {
-                        if (allowed.size && !allowed.has(row.unitSlug)) return map
-                        const item = map.get(row.unitSlug) || { unitSlug: row.unitSlug, unitName: row.unitName, count: 0, value: 0 }
-                        item.count += 1
-                        item.value += row.value
-                        map.set(row.unitSlug, item)
-                        return map
-                    }, new Map()).values()).map((item) => ({ ...item, value: Math.round(item.value * 100) / 100 })),
+                    units: totals.rows
+                        .filter((row) => !allowed.size || allowed.has(row.unit_slug))
+                        .map((item) => ({
+                            unitSlug: item.unit_slug,
+                            unitName: item.unit_name,
+                            count: Number(item.count || 0),
+                            quantityTotal: normalizeAggregateCountValue(item.quantity_total),
+                            value: normalizeAggregateCountValue(item.value),
+                        })),
                 },
             }
         },

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -43,7 +43,7 @@ import { dispatchSiteTrackingHeaderAction, subscribeSiteTrackingHeaderState } fr
 import type { SiteTrackingHeaderState } from '@/siteTrackingTypes'
 import { dispatchAtendimentoClinicaHeaderAction, subscribeAtendimentoClinicaHeaderState } from '@/atendimentoClinicaHeaderBridge'
 import type { AtendimentoClinicaHeaderState } from '@/atendimentoClinicaHeaderBridge'
-import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, ClipboardList, Download, Info, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Stethoscope, WalletCards, X } from 'lucide-react'
+import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, ClipboardList, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Stethoscope, WalletCards, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
@@ -76,6 +76,84 @@ function formatLocalIsoDate(date: Date) {
     const month = String(date.getMonth() + 1).padStart(2, '0')
     const day = String(date.getDate()).padStart(2, '0')
     return `${year}-${month}-${day}`
+}
+
+type AtendimentoClinicaQuickPreset = 'last7' | 'last30' | 'currentWeek' | 'currentMonth'
+
+const ATENDIMENTO_CLINICA_QUICK_PRESETS: Array<{
+    key: AtendimentoClinicaQuickPreset
+    label: string
+    tooltip: string
+    tooltipDescription?: string
+    icon?: 'currentWeek' | 'currentMonth'
+}> = [
+    { key: 'last7', label: '7d', tooltip: 'Últimos 7 dias' },
+    { key: 'last30', label: '30d', tooltip: 'Últimos 30 dias' },
+    { key: 'currentWeek', label: 'Semana atual', tooltip: 'Semana atual', tooltipDescription: 'Da segunda-feira até hoje.', icon: 'currentWeek' },
+    { key: 'currentMonth', label: 'Mês atual', tooltip: 'Mês atual', tooltipDescription: 'Do primeiro dia do mês até hoje.', icon: 'currentMonth' },
+]
+
+function AtendimentoClinicaCurrentWeekIcon() {
+    return (
+        <svg viewBox="0 0 20 20" fill="none" className="size-3.5" aria-hidden="true">
+            <path d="M5 3.75V5.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path d="M15 3.75V5.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <rect x="3.25" y="4.75" width="13.5" height="11.5" rx="3" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M3.75 7.5H16.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <rect x="5.25" y="10" width="9.5" height="2.75" rx="1.375" fill="currentColor" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+    )
+}
+
+function AtendimentoClinicaCurrentMonthIcon() {
+    return (
+        <svg viewBox="0 0 20 20" fill="none" className="size-3.5" aria-hidden="true">
+            <path d="M5 3.75V5.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path d="M15 3.75V5.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <rect x="3.25" y="4.75" width="13.5" height="11.5" rx="3" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M3.75 7.5H16.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path d="M6.25 10.5H8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+            <path d="M9.25 10.5H11" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+            <path d="M12.25 10.5H14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+            <path d="M6.25 13.25H13.75" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        </svg>
+    )
+}
+
+function renderAtendimentoClinicaQuickPresetIcon(icon?: 'currentWeek' | 'currentMonth') {
+    if (icon === 'currentWeek') return <AtendimentoClinicaCurrentWeekIcon />
+    if (icon === 'currentMonth') return <AtendimentoClinicaCurrentMonthIcon />
+    return null
+}
+
+function buildAtendimentoClinicaQuickRange(preset: AtendimentoClinicaQuickPreset, now = new Date()) {
+    const to = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    const from = new Date(to)
+    if (preset === 'last7') {
+        from.setDate(to.getDate() - 6)
+    } else if (preset === 'last30') {
+        from.setDate(to.getDate() - 29)
+    } else if (preset === 'currentWeek') {
+        const mondayOffset = (to.getDay() + 6) % 7
+        from.setDate(to.getDate() - mondayOffset)
+    } else {
+        from.setDate(1)
+    }
+    return {
+        from: formatLocalIsoDate(from),
+        to: formatLocalIsoDate(to),
+    }
+}
+
+function detectAtendimentoClinicaQuickPreset(filters?: { from?: string; to?: string } | null, now = new Date()): AtendimentoClinicaQuickPreset | null {
+    const from = String(filters?.from || '')
+    const to = String(filters?.to || '')
+    if (!from || !to) return null
+    for (const preset of ATENDIMENTO_CLINICA_QUICK_PRESETS) {
+        const range = buildAtendimentoClinicaQuickRange(preset.key, now)
+        if (range.from === from && range.to === to) return preset.key
+    }
+    return null
 }
 
 type ApiError = {
@@ -559,36 +637,30 @@ export default function AppFunctionalNeatlab() {
                             : 'bg-white/10 text-blue-100/70 border-white/15'
 
 			    const insumosMounted = useMemo(() => mountedModuleKeys.includes('insumos'), [mountedModuleKeys])
-                const atendimentoClinicaQuickWindow = React.useMemo(() => {
-                    const filters = atendimentoClinicaHeaderState?.filters
-                    if (!filters?.from || !filters?.to) return null
-                    const from = new Date(`${filters.from}T12:00:00`)
-                    const to = new Date(`${filters.to}T12:00:00`)
-                    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return null
-                    const diffDays = Math.round((to.getTime() - from.getTime()) / 86400000) + 1
-                    return diffDays === 7 || diffDays === 30 || diffDays === 60 ? diffDays : null
-                }, [atendimentoClinicaHeaderState?.filters])
+                const atendimentoClinicaQuickWindow = React.useMemo(
+                    () => detectAtendimentoClinicaQuickPreset(atendimentoClinicaHeaderState?.filters),
+                    [atendimentoClinicaHeaderState?.filters],
+                )
                 const atendimentoClinicaAdvancedFiltersActive = React.useMemo(() => {
                     const filters = atendimentoClinicaHeaderState?.filters
                     if (!filters) return false
+                    const quickPreset = detectAtendimentoClinicaQuickPreset(filters)
                     return Boolean(
-                        filters.from ||
-                        filters.to ||
+                        ((filters.from || filters.to) && !quickPreset) ||
                         (filters.procedure && filters.procedure !== 'all') ||
                         filters.code ||
                         (filters.injector && filters.injector !== 'all') ||
+                        (filters.consultant && filters.consultant !== 'all') ||
                         filters.search,
                     )
                 }, [atendimentoClinicaHeaderState?.filters])
-                const setAtendimentoClinicaQuickWindow = React.useCallback((days: 7 | 30 | 60) => {
-                    const to = new Date()
-                    const from = new Date()
-                    from.setDate(to.getDate() - days + 1)
+                const setAtendimentoClinicaQuickWindow = React.useCallback((preset: AtendimentoClinicaQuickPreset) => {
+                    const { from, to } = buildAtendimentoClinicaQuickRange(preset)
                     dispatchAtendimentoClinicaHeaderAction({
                         type: 'set-filter',
                         patch: {
-                            from: formatLocalIsoDate(from),
-                            to: formatLocalIsoDate(to),
+                            from,
+                            to,
                         },
                     })
                 }, [])
@@ -1566,35 +1638,6 @@ export default function AppFunctionalNeatlab() {
                                                                         ))}
                                                                     </SelectContent>
                                                                 </Select>
-                                                                <DropdownMenu>
-                                                                    <DropdownMenuTrigger asChild>
-                                                                        <Button
-                                                                            size="icon"
-                                                                            variant="ghost"
-                                                                            className="h-8 w-8 rounded-full border border-white/15 bg-white/[0.06] text-blue-50 hover:bg-white/[0.12]"
-                                                                            data-testid="atendimento-context-menu"
-                                                                            aria-label="Contexto Atend. Clínica"
-                                                                            title="Contexto"
-                                                                        >
-                                                                            <Info className="size-3.5" aria-hidden="true" />
-                                                                        </Button>
-                                                                    </DropdownMenuTrigger>
-                                                                    <DropdownMenuContent align="start" className="w-72 border-slate-700 bg-slate-950/95 p-2 text-slate-100 shadow-2xl backdrop-blur-xl">
-                                                                        <DropdownMenuLabel className="text-slate-200">Contexto do dashboard</DropdownMenuLabel>
-                                                                        <DropdownMenuSeparator className="bg-slate-800" />
-                                                                        {[
-                                                                            ['Status', atendimentoClinicaHeaderState?.loading ? 'Atualizando dados' : 'Dados carregados'],
-                                                                            ['Unidade', atendimentoClinicaHeaderState?.activeUnitLabel || 'Todas unidades'],
-                                                                            ['Período', atendimentoClinicaHeaderState?.periodLabel || 'Todos os períodos'],
-                                                                            ['Listagem', `${Number(atendimentoClinicaHeaderState?.total || 0).toLocaleString('pt-BR')} linhas`],
-                                                                        ].map(([label, value]) => (
-                                                                            <div key={label} className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-xs">
-                                                                                <span className="text-slate-400">{label}</span>
-                                                                                <span className="min-w-0 truncate text-right font-medium text-slate-100">{value}</span>
-                                                                            </div>
-                                                                        ))}
-                                                                    </DropdownMenuContent>
-                                                                </DropdownMenu>
                                                             </div>
                                                         ) : null}
 			                                    </div>
@@ -1797,19 +1840,46 @@ export default function AppFunctionalNeatlab() {
                                         <div className="flex items-center gap-1.5 max-w-[58vw] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                                             <div className="flex shrink-0 items-center gap-1.5">
                                                 <div className="flex items-center gap-1 rounded-full border border-white/15 bg-white/[0.06] p-1">
-                                                    {[7, 30, 60].map((period) => (
-                                                        <button
-                                                            key={period}
-                                                            type="button"
-                                                            className={`h-6 rounded-full px-2.5 text-xs transition ${
-                                                                atendimentoClinicaQuickWindow === period
-                                                                    ? 'bg-white/16 text-white'
-                                                                    : 'text-blue-100/80 hover:bg-white/[0.08] hover:text-white'
-                                                            }`}
-                                                            onClick={() => setAtendimentoClinicaQuickWindow(period as 7 | 30 | 60)}
-                                                        >
-                                                            {period}d
-                                                        </button>
+                                                    {ATENDIMENTO_CLINICA_QUICK_PRESETS.map((preset) => (
+                                                        preset.icon ? (
+                                                            <Tooltip key={preset.key}>
+                                                                <TooltipTrigger asChild>
+                                                                    <button
+                                                                        type="button"
+                                                                        aria-label={preset.tooltip}
+                                                                        title={preset.tooltip}
+                                                                        className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs transition ${
+                                                                            atendimentoClinicaQuickWindow === preset.key
+                                                                                ? 'bg-white/16 text-white'
+                                                                                : 'text-blue-100/80 hover:bg-white/[0.08] hover:text-white'
+                                                                        }`}
+                                                                        onClick={() => setAtendimentoClinicaQuickWindow(preset.key)}
+                                                                    >
+                                                                        <span className="inline-flex items-center justify-center opacity-90">{renderAtendimentoClinicaQuickPresetIcon(preset.icon)}</span>
+                                                                    </button>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent className="max-w-56">
+                                                                    <div className="space-y-1">
+                                                                        <div className="text-[11px] font-medium leading-tight text-white">{preset.tooltip}</div>
+                                                                        <div className="text-[10px] leading-snug text-slate-300/92">{preset.tooltipDescription}</div>
+                                                                    </div>
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        ) : (
+                                                            <button
+                                                                key={preset.key}
+                                                                type="button"
+                                                                title={preset.tooltip}
+                                                                className={`h-6 rounded-full px-2.5 text-xs transition ${
+                                                                    atendimentoClinicaQuickWindow === preset.key
+                                                                        ? 'bg-white/16 text-white'
+                                                                        : 'text-blue-100/80 hover:bg-white/[0.08] hover:text-white'
+                                                                }`}
+                                                                onClick={() => setAtendimentoClinicaQuickWindow(preset.key)}
+                                                            >
+                                                                {preset.label}
+                                                            </button>
+                                                        )
                                                     ))}
                                                     <DropdownMenu>
                                                         <DropdownMenuTrigger asChild>
@@ -1906,6 +1976,7 @@ export default function AppFunctionalNeatlab() {
                                                             onClick={() => dispatchAtendimentoClinicaHeaderAction({ type: 'refresh' })}
                                                             disabled={atendimentoClinicaHeaderState?.loading}
                                                             aria-label="Atualizar Atend. Clínica"
+                                                            data-testid="atendimento-header-refresh"
                                                         >
                                                             <RefreshCw className={`size-3.5 ${atendimentoClinicaHeaderState?.loading ? 'animate-spin' : ''}`} aria-hidden="true" />
                                                         </Button>
@@ -1913,8 +1984,12 @@ export default function AppFunctionalNeatlab() {
                                                     <TooltipContent className="max-w-72">
                                                         <div className="space-y-1">
                                                             <div className="text-[11px] font-medium leading-tight text-white">Atualizar Atend. Clínica</div>
-                                                            <div className="text-[10px] leading-snug text-slate-300/92">
-                                                                Último import: {atendimentoClinicaHeaderState?.latestImportLabel || 'Sem import recente'}
+                                                            <div className="space-y-0.5 text-[10px] leading-snug text-slate-300/92">
+                                                                <div>Status: {atendimentoClinicaHeaderState?.loading ? 'Atualizando dados' : 'Dados carregados'}</div>
+                                                                <div>Unidade: {atendimentoClinicaHeaderState?.activeUnitLabel || 'Todas unidades'}</div>
+                                                                <div>Período: {atendimentoClinicaHeaderState?.periodLabel || 'Todos os períodos'}</div>
+                                                                <div>Listagem: {Number(atendimentoClinicaHeaderState?.total || 0).toLocaleString('pt-BR')} linhas</div>
+                                                                <div>Último import: {atendimentoClinicaHeaderState?.latestImportLabel || 'Sem import recente'}</div>
                                                             </div>
                                                         </div>
                                                     </TooltipContent>

--- a/frontend/AtendimentoClinicaModule.tsx
+++ b/frontend/AtendimentoClinicaModule.tsx
@@ -30,7 +30,23 @@ import {
   Users,
   type LucideIcon,
 } from 'lucide-react'
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip as RechartsTooltip, XAxis, YAxis } from 'recharts'
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import { Button } from '@/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/dialog'
@@ -120,7 +136,7 @@ function hasAtendimentoInlineDraft(form: AtendimentoClinicaForm) {
 
 const panelClass = 'border-slate-800/80 bg-slate-950/60 shadow-[0_20px_80px_rgba(2,6,23,0.35)] backdrop-blur-xl'
 const ATENDIMENTO_METRIC_LAYOUT_KEY = 'skincos.atendimentoClinica.layout.metrics.v2'
-const ATENDIMENTO_CHART_LAYOUT_KEY = 'skincos.atendimentoClinica.layout.charts.v2'
+const ATENDIMENTO_CHART_LAYOUT_KEY = 'skincos.atendimentoClinica.layout.charts.v3'
 const ATTENDANCE_PAGE_SIZE = 50
 const DEFAULT_UNIT_LEGEND = [
   { slug: 'novo-hamburgo', name: 'Novo Hamburgo' },
@@ -157,10 +173,13 @@ type MetricTooltipSpec = {
   calculation: string
   usage: string
 }
+type ConversionGoalPlan = NonNullable<NonNullable<AtendimentoManagementConversionReport['doctorRanking']>['sections'][number]['goalPlan']>
+type ConversionRankingSection = NonNullable<AtendimentoManagementConversionReport['doctorRanking']>['sections'][number]
+type ConversionDoctorMetric = ConversionRankingSection['doctors'][number]
 
 type AtendimentoSortKey = 'date' | 'clientName' | 'procedureName' | 'injectorName' | 'consultantName' | 'value'
 type AtendimentoSortDir = 'asc' | 'desc'
-type AtendimentoChartPreset = 'monthly' | 'procedures' | 'injectors' | 'consultants'
+type AtendimentoChartPreset = 'monthly' | 'ticket' | 'procedures' | 'injectors' | 'consultants'
 type AtendimentoChartMetric = 'value' | 'count'
 type AtendimentoChartView = 'area' | 'line' | 'bar'
 type AtendimentoChartSlot = {
@@ -213,6 +232,7 @@ const DEFAULT_ATENDIMENTO_METRIC_LAYOUT: AtendimentoMetricLayoutItem[] = [
 
 const DEFAULT_ATENDIMENTO_CHART_SLOTS: AtendimentoChartSlot[] = [
   { presetId: 'monthly', metric: 'value', view: 'area', topN: 8 },
+  { presetId: 'ticket', metric: 'value', view: 'line', topN: 8 },
   { presetId: 'procedures', metric: 'value', view: 'bar', topN: 5 },
   { presetId: 'injectors', metric: 'value', view: 'bar', topN: 5 },
   { presetId: 'consultants', metric: 'value', view: 'bar', topN: 5 },
@@ -220,6 +240,7 @@ const DEFAULT_ATENDIMENTO_CHART_SLOTS: AtendimentoChartSlot[] = [
 
 const ATENDIMENTO_CHART_PRESETS: Array<{ id: AtendimentoChartPreset; label: string; icon: LucideIcon }> = [
   { id: 'monthly', label: 'Série mensal', icon: TrendingUp },
+  { id: 'ticket', label: 'Ticket médio', icon: TrendingUp },
   { id: 'procedures', label: 'Procedimentos', icon: BarChart3 },
   { id: 'injectors', label: 'Injetores', icon: Stethoscope },
   { id: 'consultants', label: 'Consultores', icon: Users },
@@ -449,7 +470,6 @@ function MetricGroupContent({ rows }: { rows: AtendimentoMetricGroupRow[] }) {
                   {row.tooltip ? <Info className="h-2.5 w-2.5 shrink-0 text-slate-500" /> : null}
                 </span>
               </MetricTooltip>
-              {row.detail ? <div className="truncate text-[10px] leading-tight text-slate-500">{row.detail}</div> : null}
             </div>
             <div className="shrink-0 text-[11px] font-semibold text-white">{row.value}</div>
           </div>
@@ -572,6 +592,23 @@ function periodLabel(filters: AtendimentoClinicaFilters) {
   return 'Todos os períodos'
 }
 
+function formatLocalIsoDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildCurrentMonthFilters(): AtendimentoClinicaFilters {
+  const today = new Date()
+  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+  return {
+    ...DEFAULT_ATENDIMENTO_FILTERS,
+    from: formatLocalIsoDate(monthStart),
+    to: formatLocalIsoDate(today),
+  }
+}
+
 function formatIsoDateBR(date?: string) {
   const [year, month, day] = String(date || '').slice(0, 10).split('-')
   if (!year || !month || !day) return ''
@@ -584,19 +621,18 @@ function inferGoalMonth(filters: AtendimentoClinicaFilters) {
 }
 
 const CONVERSION_METRIC_DEFINITIONS = [
-  { key: 'total', label: 'TOTAL', description: 'Resultado total dos doutores elegíveis no período de conversão.', calculation: 'Soma do realizado dos injetores ativos elegíveis no período.', usage: 'Base de média, mediana, corte, níveis e ranking.' },
-  { key: 'rankedDoctorTotal', label: 'Total ranqueável', description: 'Soma apenas dos atendimentos atribuídos aos doutores elegíveis.', calculation: 'Soma do valor realizado dos injetores ativos da unidade no período.', usage: 'Compara o volume usado no ranking contra o total geral do período.' },
-  { key: 'periodAttendanceTotal', label: 'Total geral', description: 'Faturamento total dos atendimentos no período filtrado.', calculation: 'Soma de todos os atendimentos da unidade/período, incluindo itens fora do ranking.', usage: 'Serve para conferência; não substitui o total ranqueável nas estatísticas dos doutores.' },
+  { key: 'total', label: 'TOTAL', description: 'Resultado total dos doutores elegíveis no período de conversão.', calculation: 'Soma do realizado dos injetores ativos elegíveis no período.', usage: 'Alias legado do total ranqueável; a leitura principal deve considerar os totais do período filtrado.' },
+  { key: 'rankedDoctorTotal', label: 'Total ranqueável', description: 'Subconjunto do período filtrado usado no ranking médico.', calculation: 'Soma do valor realizado dos injetores ativos elegíveis na unidade dentro do período.', usage: 'Permanece disponível internamente para auditoria de consistência do total do período.' },
+  { key: 'periodAttendanceTotal', label: 'Total do período', description: 'Faturamento total do período filtrado.', calculation: 'Soma de todos os atendimentos da unidade/período, incluindo itens fora do ranking.', usage: 'É o total principal exibido no dashboard; o CRM mantém o total ranqueável apenas como verificação interna.' },
   { key: 'eligibleDoctorCount', label: 'Doutores elegíveis', description: 'Quantidade de injetores ativos considerados no ranking.', calculation: 'Profissionais ativos com função Injetor na unidade selecionada.', usage: 'Define o universo usado em média, mediana, desvio, níveis e ranking.' },
-  { key: 'monthlyGoal', label: 'Meta mensal', description: 'Meta mensal da unidade usada como base comercial.', calculation: '1ª meta mensal cadastrada no CRM para unidade, mês e ano.', usage: 'Origina meta diária e meta do período.' },
-  { key: 'dailyGoal', label: 'Meta diária', description: 'Meta esperada por dia trabalhado.', calculation: 'meta_mensal / dias_trabalhados_mes.', usage: 'Compõe 50% da linha de corte.' },
-  { key: 'weeklyGoal', label: 'Meta período', description: 'Meta proporcional aos dias trabalhados no período selecionado.', calculation: 'meta_diaria * dias_trabalhados_periodo.', usage: 'Confere se a janela filtrada está acima ou abaixo do esperado.' },
-  { key: 'monthOperationalDays', label: 'Dias mês', description: 'Dias trabalhados usados para diluir a meta mensal.', calculation: 'Dias operacionais do mês pela Escala CRM ou fallback histórico.', usage: 'Define a meta diária.' },
+  { key: 'dailyGoal', label: 'Meta diária', description: 'Meta diária média do período selecionado.', calculation: 'meta_periodo / dias_trabalhados_periodo.', usage: 'Compõe 50% da linha de corte.' },
+  { key: 'periodGoal', label: 'Meta do período', description: 'Meta acumulada do período selecionado.', calculation: 'Soma das metas diárias dos dias trabalhados dentro do período.', usage: 'É a meta principal de comparação da janela filtrada.' },
+  { key: 'monthOperationalDays', label: 'Dias mês', description: 'Dias trabalhados usados para diluir a meta mensal.', calculation: 'Dias operacionais do mês consolidados na agenda do CRM.', usage: 'Define a meta diária.' },
   { key: 'periodOperationalDays', label: 'Dias período', description: 'Dias trabalhados dentro do filtro ativo.', calculation: 'Dias operacionais entre início e fim do período selecionado.', usage: 'Define a meta proporcional do período.' },
   { key: 'average', label: 'Média', description: 'Média do realizado dos doutores elegíveis.', calculation: 'total_ranqueável / doutores_elegíveis.', usage: 'Compõe 30% da linha de corte.' },
   { key: 'median', label: 'Mediana', description: 'Valor central do realizado dos doutores elegíveis.', calculation: 'Ordena os realizados e pega o centro; em par, média dos dois centrais.', usage: 'Compõe 20% da linha de corte e reduz distorção por extremos.' },
   { key: 'standardDeviation', label: 'Desvio padrão', description: 'Dispersão do realizado entre doutores elegíveis.', calculation: 'Desvio padrão amostral dos valores realizados.', usage: 'Multiplicado pelo fator de intervalo para definir a largura das faixas.' },
-  { key: 'cutLine', label: 'Linha Corte', description: 'Centro das faixas de classificação.', calculation: 'linha_corte = (média * 0,30) + (mediana * 0,20) + (meta_diária * 0,50).', usage: 'Separa níveis 1/2 e orienta os limites inferior e superior.' },
+  { key: 'cutLine', label: 'Linha Corte', description: 'Centro das faixas de classificação na escala do período selecionado.', calculation: 'linha_corte = (média_periodo * 0,30) + (mediana_periodo * 0,20) + (meta_periodo * 0,50).', usage: 'Separa níveis 1/2 e orienta os limites inferior e superior.' },
   { key: 'interval', label: 'Intervalo', description: 'Largura das faixas ao redor da linha de corte.', calculation: 'intervalo = desvio_padrao(realizado_doutores) * multiplicador_intervalo.', usage: 'Define limite inferior e superior.' },
   { key: 'intervalMultiplier', label: 'Multiplicador', description: 'Fator aplicado ao desvio padrão.', calculation: 'Configuração rankingDoctor.intervalMultiplier, com fallback 0,75.', usage: 'Ajusta a distribuição dos doutores entre os níveis.' },
   { key: 'lowerLimit', label: 'Limite inferior', description: 'Piso da faixa central.', calculation: 'linha_corte - intervalo.', usage: 'Abaixo dele o doutor entra no nível 0.' },
@@ -631,9 +667,8 @@ const CONVERSION_METRIC_ICON_BY_KEY: Record<ConversionMetricKey, LucideIcon> = {
   rankedDoctorTotal: Sigma,
   periodAttendanceTotal: Sigma,
   eligibleDoctorCount: Users,
-  monthlyGoal: Target,
   dailyGoal: CalendarRange,
-  weeklyGoal: CalendarRange,
+  periodGoal: Target,
   monthOperationalDays: CalendarRange,
   periodOperationalDays: CalendarRange,
   average: Gauge,
@@ -660,9 +695,8 @@ const CONVERSION_METRIC_TONE_BY_KEY: Record<ConversionMetricKey, AtendimentoMetr
   rankedDoctorTotal: 'sky',
   periodAttendanceTotal: 'sky',
   eligibleDoctorCount: 'emerald',
-  monthlyGoal: 'emerald',
   dailyGoal: 'emerald',
-  weeklyGoal: 'emerald',
+  periodGoal: 'emerald',
   monthOperationalDays: 'sky',
   periodOperationalDays: 'sky',
   average: 'violet',
@@ -693,62 +727,80 @@ const CONVERSION_METRIC_GROUPS: Array<{
   metricKeys: ConversionMetricKey[]
 }> = [
   {
-    key: 'conversion:stats',
-    label: 'Resumo',
-    icon: Sigma,
-    tone: 'sky',
-    description: 'Totais, doutores elegíveis e dispersão calculados pelo CRM para auditar a base do ranking.',
-    metricKeys: ['rankedDoctorTotal', 'periodAttendanceTotal', 'eligibleDoctorCount', 'average', 'median', 'standardDeviation'],
-  },
-  {
     key: 'conversion:goals',
     label: 'Metas',
     icon: Target,
     tone: 'emerald',
-    description: 'Metas e dias trabalhados usados para compor a linha de corte.',
-    metricKeys: ['monthlyGoal', 'dailyGoal', 'weeklyGoal', 'monthOperationalDays', 'periodOperationalDays'],
+    description: 'Metas e dias trabalhados do período filtrado usados para compor a linha de corte.',
+    metricKeys: ['dailyGoal', 'periodGoal', 'periodOperationalDays'],
+  },
+]
+
+const CONVERSION_DISTRIBUTION_DETAIL_GROUPS: Array<{
+  key: string
+  label: string
+  description: string
+  metricKeys: ConversionMetricKey[]
+}> = [
+  {
+    key: 'conversion:stats',
+    label: 'Resumo',
+    description: 'Total principal do período e dispersão calculada pelo CRM para auditar a base do ranking.',
+    metricKeys: ['periodAttendanceTotal', 'average', 'median', 'standardDeviation'],
   },
   {
     key: 'conversion:cut',
-    label: 'Corte e faixas',
-    icon: Ruler,
-    tone: 'violet',
+    label: 'Faixas',
     description: 'Linha de corte, intervalo e limites inferior/superior usados para separar faixas de desempenho.',
     metricKeys: ['cutLine', 'interval', 'intervalMultiplier', 'lowerLimit', 'upperLimit'],
   },
   {
     key: 'conversion:levels',
     label: 'Níveis',
-    icon: Trophy,
-    tone: 'amber',
     description: 'Quantidade de doutores classificados nos níveis 0, 1, 2 e 3.',
     metricKeys: ['level0', 'level1', 'level2', 'level3'],
   },
   {
     key: 'conversion:ratios',
     label: 'Razões',
-    icon: Percent,
-    tone: 'amber',
-    description: 'Razões superior, inferior, interior e exterior usadas na comparação das faixas.',
-    metricKeys: ['upperRatio', 'lowerRatio', 'innerRatio', 'outerRatio', 'ratioDivisor'],
+    description: 'Razões exterior, superior, interior e inferior usadas na comparação das faixas.',
+    metricKeys: ['outerRatio', 'upperRatio', 'innerRatio', 'lowerRatio', 'ratioDivisor'],
   },
 ]
 
 function buildMetricTooltip(
   definition: typeof CONVERSION_METRIC_DEFINITIONS[number],
-  formula?: string
+  formula?: string,
+  overrides?: Partial<MetricTooltipSpec>
 ): MetricTooltipSpec {
   return {
-    what: definition.description,
-    calculation: formula || definition.calculation,
-    usage: definition.usage,
+    what: overrides?.what || definition.description,
+    calculation: overrides?.calculation || formula || definition.calculation,
+    usage: overrides?.usage || definition.usage,
   }
 }
 
-function scheduleSourceLabel(source?: string) {
-  if (source === 'escala-crm') return 'Escala CRM'
-  if (source === 'legacy-import') return 'Fallback histórico'
-  return source || 'Não informado'
+function formatGoalPlanSegments(goalPlan?: ConversionGoalPlan) {
+  const segments = Array.isArray(goalPlan?.segments) ? goalPlan.segments : []
+  if (!segments.length) return ''
+  return segments
+    .map((segment) => {
+      const label = monthLabel(segment.monthKey)
+      return `${label}: meta mês ${formatCurrencyBRL(segment.monthlyGoal)}, dias mês ${formatNumberBR(segment.monthOperationalDays)}, dias período ${formatNumberBR(segment.periodOperationalDays)}, meta período ${formatCurrencyBRL(segment.periodGoal)}`
+    })
+    .join(' | ')
+}
+
+function buildGoalPlanTooltip(
+  definition: typeof CONVERSION_METRIC_DEFINITIONS[number],
+  formula: string | undefined,
+  goalPlan?: ConversionGoalPlan
+) {
+  const segmentSummary = formatGoalPlanSegments(goalPlan)
+  return buildMetricTooltip(definition, formula, {
+    calculation: segmentSummary ? `${formula || definition.calculation}; segmentos = ${segmentSummary}` : formula || definition.calculation,
+    usage: `${definition.usage} Todas as métricas visíveis deste bloco consideram somente o período filtrado; os dias do mês ficam apenas como insumo técnico da proporcionalização.`,
+  })
 }
 
 function formatConversionMetricValue(key: ConversionMetricKey, value: number) {
@@ -784,6 +836,315 @@ function PodiumBadge({ rank }: { rank: number }) {
   )
 }
 
+function getDoctorInitials(name: string) {
+  const parts = String(name || '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (!parts.length) return '--'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return `${parts[0][0] || ''}${parts[parts.length - 1][0] || ''}`.toUpperCase()
+}
+
+function resolveDoctorLevel(value: number, level: number | undefined, lowerLimit: number, cutLine: number, upperLimit: number) {
+  if (Number.isFinite(level)) return Number(level)
+  if (value >= upperLimit) return 3
+  if (value >= cutLine) return 2
+  if (value >= lowerLimit) return 1
+  return 0
+}
+
+function conversionLevelVisual(level: number) {
+  if (level >= 3) {
+    return {
+      label: 'Nível 3',
+      fill: '#34d399',
+      bandFill: 'rgba(52,211,153,0.09)',
+      ringClassName: 'ring-emerald-300/35',
+      badgeClassName: 'border-emerald-300/30 bg-emerald-400/12 text-emerald-100',
+    }
+  }
+  if (level === 2) {
+    return {
+      label: 'Nível 2',
+      fill: '#38bdf8',
+      bandFill: 'rgba(56,189,248,0.08)',
+      ringClassName: 'ring-sky-300/35',
+      badgeClassName: 'border-sky-300/30 bg-sky-400/12 text-sky-100',
+    }
+  }
+  if (level === 1) {
+    return {
+      label: 'Nível 1',
+      fill: '#fbbf24',
+      bandFill: 'rgba(251,191,36,0.08)',
+      ringClassName: 'ring-amber-300/35',
+      badgeClassName: 'border-amber-300/30 bg-amber-400/12 text-amber-100',
+    }
+  }
+  return {
+    label: 'Nível 0',
+    fill: '#f59e0b',
+    bandFill: 'rgba(245,158,11,0.08)',
+    ringClassName: 'ring-orange-300/35',
+    badgeClassName: 'border-orange-300/30 bg-orange-400/12 text-orange-100',
+  }
+}
+
+function ConversionDoctorBandsContent({
+  unitName,
+  doctors,
+  metrics,
+  detailGroups,
+}: {
+  unitName: string
+  doctors: ConversionDoctorMetric[]
+  metrics: ConversionRankingSection['metrics']
+  detailGroups: Array<{ key: string; label: string; description: string; rows: AtendimentoMetricGroupRow[] }>
+}) {
+  const cutLine = Number(metrics.cutLine?.weekValue || 0)
+  const interval = Number(metrics.interval?.weekValue || 0)
+  const lowerLimit = Number(metrics.lowerLimit?.weekValue ?? (cutLine - interval))
+  const upperLimit = Number(metrics.upperLimit?.weekValue ?? (cutLine + interval))
+  const chartDoctors = [...doctors]
+    .sort((left, right) => {
+      const rankDelta = Number(left.rank || 0) - Number(right.rank || 0)
+      if (rankDelta !== 0) return rankDelta
+      return String(left.name || '').localeCompare(String(right.name || ''), 'pt-BR', { sensitivity: 'base' })
+    })
+    .map((doctor) => {
+      const value = Number(doctor.weekValue || 0)
+      const level = resolveDoctorLevel(value, typeof doctor.level === 'number' ? doctor.level : undefined, lowerLimit, cutLine, upperLimit)
+      const visual = conversionLevelVisual(level)
+      return {
+        id: `${doctor.unitSlug || unitName}-${doctor.rank}-${doctor.name}`,
+        name: doctor.name,
+        unitName: doctor.unitName || unitName,
+        value,
+        score: Number(doctor.score || 0),
+        rank: Number(doctor.rank || 0),
+        level,
+        levelLabel: visual.label,
+        fill: visual.fill,
+        badgeClassName: visual.badgeClassName,
+        ringClassName: visual.ringClassName,
+        initials: getDoctorInitials(doctor.name),
+      }
+    })
+  const yValues = chartDoctors.map((doctor) => doctor.value)
+  const maxValue = Math.max(cutLine, upperLimit, ...yValues, 0)
+  const yMax = maxValue > 0 ? maxValue * 1.12 : 100
+  const hasBands = Number.isFinite(lowerLimit) && Number.isFinite(cutLine) && Number.isFinite(upperLimit) && upperLimit >= lowerLimit
+  const podiumDoctors = new Set(chartDoctors.filter((doctor) => doctor.rank >= 1 && doctor.rank <= 3).map((doctor) => doctor.id))
+  const chartHeightPx = 320
+  const chartMarginTop = 18
+  const chartMarginRight = 12
+  const chartMarginLeft = 6
+  const chartMarginBottom = 44
+  const yAxisWidth = 88
+  const plotInsetLeft = yAxisWidth + chartMarginLeft
+  const plotInsetRight = chartMarginRight
+  const plotHeight = chartHeightPx - chartMarginTop - chartMarginBottom
+  const chartMinWidthPx = plotInsetLeft + plotInsetRight + Math.max(chartDoctors.length, 1) * 72
+  const lineBadges = [
+    {
+      key: 'upper',
+      value: upperLimit,
+      label: `Limite superior ${formatCurrencyBRL(upperLimit)}`,
+      className: 'border-emerald-300/30 bg-emerald-400/12 text-emerald-100',
+      info: {
+        what: 'Maior limite operacional do período para a classificação.',
+        calculation: `Linha superior posicionada em ${formatCurrencyBRL(upperLimit)} no eixo Y do gráfico.`,
+        usage: 'Ajuda a identificar quem está acima da faixa de corte ampliada.',
+      } satisfies MetricTooltipSpec,
+    },
+    {
+      key: 'cut',
+      value: cutLine,
+      label: `Corte ${formatCurrencyBRL(cutLine)} · intervalo ${formatCurrencyBRL(interval)}`,
+      className: 'border-violet-300/30 bg-violet-400/12 text-violet-100',
+      info: {
+        what: 'Linha central de corte da distribuição do período.',
+        calculation: `Corte em ${formatCurrencyBRL(cutLine)} com intervalo operacional de ${formatCurrencyBRL(interval)}.`,
+        usage: 'É a referência principal para leitura de faixa e nível no gráfico.',
+      } satisfies MetricTooltipSpec,
+    },
+    {
+      key: 'lower',
+      value: lowerLimit,
+      label: `Limite inferior ${formatCurrencyBRL(lowerLimit)}`,
+      className: 'border-amber-300/30 bg-amber-400/12 text-amber-100',
+      info: {
+        what: 'Menor limite operacional do período para a classificação.',
+        calculation: `Linha inferior posicionada em ${formatCurrencyBRL(lowerLimit)} no eixo Y do gráfico.`,
+        usage: 'Mostra o piso da faixa usada para separar níveis inferiores.',
+      } satisfies MetricTooltipSpec,
+    },
+  ]
+  const lineBadgeTop = (value: number) => {
+    const normalized = yMax > 0 ? value / yMax : 0
+    const top = chartMarginTop + plotHeight * (1 - normalized)
+    return Math.max(chartMarginTop + 6, Math.min(chartHeightPx - chartMarginBottom - 6, top))
+  }
+
+  return (
+    <div className="space-y-3 pt-0.5" data-testid="atendimento-conversion-distribution">
+      <div className="rounded-xl border border-slate-800/80 bg-slate-950/45 p-3">
+        <div className="space-y-1">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">Leitura por doutor</div>
+          <p className="max-w-3xl text-[11px] leading-relaxed text-slate-300">
+            Cada coluna mostra o total do período por doutor. As faixas horizontais mantêm os níveis 0 a 3 visíveis na mesma escala para facilitar a leitura do corte.
+          </p>
+        </div>
+        <div className="mt-3 overflow-x-auto pb-1">
+          <div className="relative" style={{ minWidth: `${chartMinWidthPx}px`, height: `${chartHeightPx}px` }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={chartDoctors} margin={{ top: chartMarginTop, right: chartMarginRight, left: chartMarginLeft, bottom: chartMarginBottom }}>
+                <CartesianGrid vertical={false} stroke="rgba(148,163,184,0.12)" />
+                {hasBands ? (
+                  <>
+                    <ReferenceArea y1={0} y2={lowerLimit} fill={conversionLevelVisual(0).bandFill} ifOverflow="extendDomain" />
+                    <ReferenceArea y1={lowerLimit} y2={cutLine} fill={conversionLevelVisual(1).bandFill} ifOverflow="extendDomain" />
+                    <ReferenceArea y1={cutLine} y2={upperLimit} fill={conversionLevelVisual(2).bandFill} ifOverflow="extendDomain" />
+                    <ReferenceArea y1={upperLimit} y2={yMax} fill={conversionLevelVisual(3).bandFill} ifOverflow="extendDomain" />
+                  </>
+                ) : null}
+                <XAxis
+                  dataKey="initials"
+                  interval={0}
+                  height={chartMarginBottom}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={(tickProps: any) => {
+                    const doctor = chartDoctors.find((item) => item.id === tickProps.payload?.payload?.id) || chartDoctors[tickProps.index || 0]
+                    if (!doctor) return <g />
+                    return (
+                      <g transform={`translate(${tickProps.x},${tickProps.y})`}>
+                        <text textAnchor="middle" fill="#cbd5e1" fontSize="11" fontWeight="600">
+                          <tspan x="0" dy="12">{doctor.initials}</tspan>
+                          <tspan x="0" dy="14" fill="#94a3b8" fontSize="10" fontWeight="500">{formatNumberBR(doctor.score)} pts</tspan>
+                        </text>
+                      </g>
+                    )
+                  }}
+                />
+                <YAxis
+                  width={88}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: '#94a3b8', fontSize: 10 }}
+                  tickFormatter={(value: number) => formatCurrencyBRL(Number(value || 0))}
+                  domain={[0, yMax]}
+                />
+                <RechartsTooltip
+                  cursor={{ fill: 'rgba(148,163,184,0.08)' }}
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null
+                    const doctor = payload[0]?.payload as (typeof chartDoctors)[number] | undefined
+                    if (!doctor) return null
+                    return (
+                      <div className="min-w-[13rem] rounded-xl border border-slate-700 bg-slate-950/95 p-3 text-xs text-slate-200 shadow-2xl">
+                        <div className="font-semibold text-white">{doctor.name}</div>
+                        <div className="mt-2 space-y-1">
+                          <div className="flex items-center justify-between gap-3">
+                            <span>Realizado</span>
+                            <span className="font-semibold text-white">{formatCurrencyBRL(doctor.value)}</span>
+                          </div>
+                          <div className="flex items-center justify-between gap-3">
+                            <span>Nível</span>
+                            <span className="font-semibold text-white">{doctor.levelLabel}</span>
+                          </div>
+                          <div className="flex items-center justify-between gap-3">
+                            <span>Ranking</span>
+                            <span className="font-semibold text-white">#{doctor.rank || '-'}</span>
+                          </div>
+                          <div className="flex items-center justify-between gap-3">
+                            <span>Pontuação</span>
+                            <span className="font-semibold text-white">{formatNumberBR(doctor.score)} pts</span>
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  }}
+                />
+                <ReferenceLine y={lowerLimit} stroke="#f59e0b" strokeDasharray="4 4" ifOverflow="extendDomain" />
+                <ReferenceLine y={cutLine} stroke="#a78bfa" strokeWidth={1.5} ifOverflow="extendDomain" />
+                <ReferenceLine y={upperLimit} stroke="#34d399" strokeDasharray="4 4" ifOverflow="extendDomain" />
+                <Bar
+                  dataKey="value"
+                  radius={[8, 8, 0, 0]}
+                  maxBarSize={44}
+                  shape={(shapeProps: any) => {
+                    const { x, y, width, height, fill, payload } = shapeProps
+                    const hasPodium = podiumDoctors.has(payload.id)
+                    const rankBadge = hasPodium ? Number(payload.rank || 0) : null
+                    const badgeFill = rankBadge === 1 ? '#fbbf24' : rankBadge === 2 ? '#cbd5e1' : '#fdba74'
+                    const badgeText = rankBadge ? `${rankBadge}` : ''
+                    const badgeY = Number(height) > 24 ? Number(y) + 6 : chartMarginTop + 8
+                    const badgeX = Number(x) + Number(width) - 10
+                    return (
+                      <g>
+                        <rect x={x} y={y} width={width} height={height} rx={8} ry={8} fill={fill} fillOpacity={0.9} stroke={fill} />
+                        {rankBadge ? (
+                          <g>
+                            <circle cx={badgeX} cy={badgeY} r={9} fill={badgeFill} stroke="rgba(15,23,42,0.65)" strokeWidth={1.5} />
+                            <text x={badgeX} y={badgeY + 3.5} textAnchor="middle" fontSize="9" fontWeight="700" fill="#0f172a">
+                              {badgeText}
+                            </text>
+                          </g>
+                        ) : null}
+                      </g>
+                    )
+                  }}
+                >
+                  {chartDoctors.map((doctor) => (
+                    <Cell key={doctor.id} fill={doctor.fill} fillOpacity={0.9} stroke={doctor.fill} />
+                  ))}
+                </Bar>
+              </ComposedChart>
+            </ResponsiveContainer>
+            <div className="absolute inset-0">
+              {lineBadges.map((badge) => (
+                <div
+                  key={badge.key}
+                  className="absolute flex"
+                  style={{
+                    top: `${lineBadgeTop(badge.value)}px`,
+                    left: '0px',
+                    width: `${Math.max(0, plotInsetLeft - 10)}px`,
+                    transform: 'translateY(-50%)',
+                    justifyContent: 'flex-end',
+                  }}
+                >
+                  <TooltipLabel
+                    label={badge.key === 'upper' ? 'Limite superior' : badge.key === 'lower' ? 'Limite inferior' : 'Linha de corte'}
+                    description={<MetricTooltipContent info={badge.info} />}
+                    contentClassName="max-w-[20rem]"
+                  >
+                    <span className={`inline-flex cursor-help items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-medium shadow-[0_8px_24px_rgba(2,6,23,0.2)] ${badge.className}`}>
+                      {badge.key === 'upper' ? <ArrowUpToLine className="h-3 w-3" /> : badge.key === 'lower' ? <ArrowDownToLine className="h-3 w-3" /> : <Ruler className="h-3 w-3" />}
+                      {badge.label}
+                    </span>
+                  </TooltipLabel>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-2 lg:grid-cols-4">
+        {detailGroups.map((group) => (
+          <div key={group.key} className="min-w-0 rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">{group.label}</div>
+            <div className="mb-2 text-[11px] leading-relaxed text-slate-500">{group.description}</div>
+            <MetricGroupContent rows={group.rows} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function resolveAtendimentoChartPreset(id: AtendimentoChartPreset) {
   return ATENDIMENTO_CHART_PRESETS.find((preset) => preset.id === id) || ATENDIMENTO_CHART_PRESETS[0]
 }
@@ -795,6 +1156,17 @@ function getAtendimentoChartData(slot: AtendimentoChartSlot, overview: Atendimen
       value: Number(item.value || 0),
       count: Number(item.count || 0),
     }))
+  }
+  if (slot.presetId === 'ticket') {
+    return (overview?.monthly || []).slice(-Math.max(3, slot.topN)).map((item) => {
+      const count = Number(item.count || 0)
+      const totalValue = Number(item.value || 0)
+      return {
+        label: monthLabel(item.month),
+        value: count > 0 ? totalValue / count : 0,
+        count,
+      }
+    })
   }
   const rows = slot.presetId === 'injectors'
     ? overview?.rankings.injectors || []
@@ -824,13 +1196,16 @@ function AtendimentoChartCard({
   const preset = resolveAtendimentoChartPreset(slot.presetId)
   const PresetIcon = preset.icon
   const data = getAtendimentoChartData(slot, overview)
-  const dataKey = slot.metric === 'count' ? 'count' : 'value'
+  const metric = slot.presetId === 'ticket' ? 'value' : slot.metric
+  const dataKey = metric === 'count' ? 'count' : 'value'
   const labelFormatter = (value: unknown) => String(value || '')
-  const valueFormatter = (value: unknown) => slot.metric === 'count'
+  const valueFormatter = (value: unknown) => metric === 'count'
     ? formatNumberBR(Number(value || 0))
     : formatCurrencyBRL(Number(value || 0))
-  const view = slot.presetId === 'monthly' ? slot.view : slot.view === 'area' ? 'bar' : slot.view
-  const height = slot.presetId === 'monthly' ? 250 : 220
+  const view = slot.presetId === 'monthly' || slot.presetId === 'ticket'
+    ? slot.view
+    : slot.view === 'area' ? 'bar' : slot.view
+  const height = slot.presetId === 'monthly' || slot.presetId === 'ticket' ? 250 : 220
   return (
     <Card className={`${panelClass} min-w-0`}>
       <CardHeader className="flex flex-col gap-3 pb-2">
@@ -846,7 +1221,7 @@ function AtendimentoChartCard({
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Select value={slot.presetId} onValueChange={(value) => onChange({ presetId: value as AtendimentoChartPreset, view: value === 'monthly' ? 'area' : 'bar' })}>
+          <Select value={slot.presetId} onValueChange={(value) => onChange({ presetId: value as AtendimentoChartPreset, view: value === 'monthly' ? 'area' : value === 'ticket' ? 'line' : 'bar', metric: value === 'ticket' ? 'value' : slot.metric })}>
             <SelectTrigger className="h-8 min-w-[9rem] border-slate-700 bg-slate-900/70 text-xs text-slate-100">
               <SelectValue />
             </SelectTrigger>
@@ -854,21 +1229,27 @@ function AtendimentoChartCard({
               {ATENDIMENTO_CHART_PRESETS.map((item) => <SelectItem key={item.id} value={item.id}>{item.label}</SelectItem>)}
             </SelectContent>
           </Select>
-          <Select value={slot.metric} onValueChange={(value) => onChange({ metric: value as AtendimentoChartMetric })}>
-            <SelectTrigger className="h-8 w-24 border-slate-700 bg-slate-900/70 text-xs text-slate-100">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="value">R$</SelectItem>
-              <SelectItem value="count">Qtd</SelectItem>
-            </SelectContent>
-          </Select>
+          {slot.presetId === 'ticket' ? (
+            <span className="inline-flex h-8 items-center rounded-md border border-slate-700 bg-slate-900/70 px-2.5 text-xs text-slate-300">
+              Média por registro
+            </span>
+          ) : (
+            <Select value={slot.metric} onValueChange={(value) => onChange({ metric: value as AtendimentoChartMetric })}>
+              <SelectTrigger className="h-8 w-24 border-slate-700 bg-slate-900/70 text-xs text-slate-100">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="value">R$</SelectItem>
+                <SelectItem value="count">Qtd</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
           <Select value={view} onValueChange={(value) => onChange({ view: value as AtendimentoChartView })}>
             <SelectTrigger className="h-8 w-28 border-slate-700 bg-slate-900/70 text-xs text-slate-100">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {ATENDIMENTO_CHART_VIEWS.filter((item) => slot.presetId === 'monthly' || item.id !== 'area').map((item) => <SelectItem key={item.id} value={item.id}>{item.label}</SelectItem>)}
+              {ATENDIMENTO_CHART_VIEWS.filter((item) => slot.presetId === 'monthly' || slot.presetId === 'ticket' || item.id !== 'area').map((item) => <SelectItem key={item.id} value={item.id}>{item.label}</SelectItem>)}
             </SelectContent>
           </Select>
           <Select value={String(slot.topN)} onValueChange={(value) => onChange({ topN: Number(value) })}>
@@ -889,7 +1270,7 @@ function AtendimentoChartCard({
                 <LineChart data={data} margin={{ left: 0, right: 8, top: 12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.14)" />
                   <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => String(value).slice(0, 14)} />
-                  <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => slot.metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
+                  <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
                   <RechartsTooltip
                     contentStyle={{ background: 'rgba(2,6,23,0.94)', border: '1px solid rgba(51,65,85,0.8)', borderRadius: 14, color: '#e2e8f0' }}
                     formatter={(value) => valueFormatter(value)}
@@ -899,16 +1280,16 @@ function AtendimentoChartCard({
                   <Line type="monotone" dataKey={dataKey} stroke="#38bdf8" strokeWidth={2} dot={false} />
                 </LineChart>
               ) : view === 'bar' ? (
-                <BarChart data={data} layout={slot.presetId === 'monthly' ? 'horizontal' : 'vertical'} margin={{ left: 8, right: 12, top: 12, bottom: 0 }}>
+                <BarChart data={data} layout={slot.presetId === 'monthly' || slot.presetId === 'ticket' ? 'horizontal' : 'vertical'} margin={{ left: 8, right: 12, top: 12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.12)" />
-                  {slot.presetId === 'monthly' ? (
+                  {slot.presetId === 'monthly' || slot.presetId === 'ticket' ? (
                     <>
                       <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} />
-                      <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => slot.metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
+                      <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
                     </>
                   ) : (
                     <>
-                      <XAxis type="number" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => slot.metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
+                      <XAxis type="number" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
                       <YAxis type="category" dataKey="label" width={120} tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => String(value).slice(0, 18)} />
                     </>
                   )}
@@ -918,25 +1299,25 @@ function AtendimentoChartCard({
                     labelFormatter={labelFormatter}
                     labelStyle={{ color: '#bae6fd' }}
                   />
-                  <Bar dataKey={dataKey} fill="#38bdf8" radius={slot.presetId === 'monthly' ? [6, 6, 0, 0] : [0, 6, 6, 0]} />
+                  <Bar dataKey={dataKey} fill="#38bdf8" radius={slot.presetId === 'monthly' || slot.presetId === 'ticket' ? [6, 6, 0, 0] : [0, 6, 6, 0]} />
                 </BarChart>
               ) : (
                 <AreaChart data={data} margin={{ left: 0, right: 8, top: 12, bottom: 0 }}>
                   <defs>
-                    <linearGradient id={`atendimentoChartFill-${slot.presetId}-${slot.metric}`} x1="0" y1="0" x2="0" y2="1">
+                    <linearGradient id={`atendimentoChartFill-${slot.presetId}-${metric}`} x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.32} />
                       <stop offset="95%" stopColor="#38bdf8" stopOpacity={0.02} />
                     </linearGradient>
                   </defs>
                   <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} />
-                  <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => slot.metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
+                  <YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => metric === 'count' ? formatNumberBR(Number(value || 0)) : formatCurrencyBRL(Number(value || 0)).replace(',00', '')} />
                   <RechartsTooltip
                     contentStyle={{ background: 'rgba(2,6,23,0.94)', border: '1px solid rgba(51,65,85,0.8)', borderRadius: 14, color: '#e2e8f0' }}
                     formatter={(value) => valueFormatter(value)}
                     labelFormatter={labelFormatter}
                     labelStyle={{ color: '#bae6fd' }}
                   />
-                  <Area type="monotone" dataKey={dataKey} stroke="#38bdf8" strokeWidth={2} fill={`url(#atendimentoChartFill-${slot.presetId}-${slot.metric})`} />
+                  <Area type="monotone" dataKey={dataKey} stroke="#38bdf8" strokeWidth={2} fill={`url(#atendimentoChartFill-${slot.presetId}-${metric})`} />
                 </AreaChart>
               )}
             </ResponsiveContainer>
@@ -998,7 +1379,7 @@ function AtendimentoChartsPanel({
 }
 
 export function AtendimentoClinicaModule() {
-  const [filters, setFilters] = useState<AtendimentoClinicaFilters>(DEFAULT_ATENDIMENTO_FILTERS)
+  const [filters, setFilters] = useState<AtendimentoClinicaFilters>(() => buildCurrentMonthFilters())
   const [references, setReferences] = useState<AtendimentoClinicaReferences | null>(null)
   const [overview, setOverview] = useState<AtendimentoClinicaOverview | null>(null)
   const [rows, setRows] = useState<AtendimentoClinicaAttendance[]>([])
@@ -1211,26 +1592,13 @@ export function AtendimentoClinicaModule() {
       || sections.find((item) => Object.keys(item.metrics || {}).length)
       || sections[0]
     const conversionMetrics = conversionSection?.metrics || {}
+    const goalPlan = conversionSection?.goalPlan
     const period = doctorRanking?.period
     const conversionStart = period?.metricStart || period?.weekStart
     const conversionEnd = period?.metricEnd || period?.weekEnd
     const conversionPeriodDetail = conversionStart && conversionEnd
       ? `${formatIsoDateBR(conversionStart)} a ${formatIsoDateBR(conversionEnd)}`
       : conversionSection?.unitName || 'Conversão'
-    const scheduleSource = managementConversionReport?.summary?.scheduleSource
-    const scheduleSourceRow: AtendimentoMetricGroupRow = {
-      key: 'scheduleSource',
-      label: 'Fonte agenda',
-      value: scheduleSourceLabel(scheduleSource),
-      detail: managementConversionReport?.summary?.doctorRankingSource === 'crm' ? 'CRM' : 'Conversão',
-      icon: CalendarRange,
-      tone: scheduleSource === 'escala-crm' ? 'emerald' : 'amber',
-      tooltip: {
-        what: 'Origem dos dias trabalhados usados nas metas.',
-        calculation: 'O CRM prioriza a Escala; se não houver cobertura, usa o fallback histórico importado.',
-        usage: 'Afeta dias do mês, dias do período, meta diária e meta proporcional.',
-      },
-    }
     const aggregateNotice = conversionSection?.aggregateNotice || conversionMetrics.aggregateNotice?.position || ''
     if (aggregateNotice) {
       tiles.push({
@@ -1241,7 +1609,7 @@ export function AtendimentoClinicaModule() {
         icon: AlertTriangle,
         tone: 'amber',
         description: aggregateNotice,
-        wrapperClassName: 'sm:col-span-2',
+        wrapperClassName: 'col-span-full',
         content: (
           <div className="pt-0.5 text-[11px] leading-snug text-slate-400">
             {aggregateNotice}
@@ -1250,23 +1618,28 @@ export function AtendimentoClinicaModule() {
       })
     }
     const conversionDefinitions = new Map(CONVERSION_METRIC_DEFINITIONS.map((definition) => [definition.key, definition]))
+    const buildConversionRows = (metricKeys: ConversionMetricKey[]) => metricKeys
+      .flatMap((key): AtendimentoMetricGroupRow[] => {
+        const metric = conversionMetrics[key]
+        const definition = conversionDefinitions.get(key)
+        if (!metric || !definition) return []
+        const tooltip = key === 'dailyGoal' || key === 'periodGoal' || key === 'periodOperationalDays'
+          ? buildGoalPlanTooltip(definition, metric.formula, goalPlan)
+          : buildMetricTooltip(definition, metric.formula, {
+            usage: `${definition.usage} Todas as métricas exibidas aqui usam o período filtrado.`,
+          })
+        return [{
+          key,
+          label: definition.label,
+          value: formatConversionMetricValue(key, Number(metric.weekValue || 0)),
+          detail: metric.position || '',
+          tooltip,
+          icon: CONVERSION_METRIC_ICON_BY_KEY[key],
+          tone: CONVERSION_METRIC_TONE_BY_KEY[key],
+        }]
+      })
     for (const group of CONVERSION_METRIC_GROUPS) {
-      const rows = group.metricKeys
-        .flatMap((key): AtendimentoMetricGroupRow[] => {
-          const metric = conversionMetrics[key]
-          const definition = conversionDefinitions.get(key)
-          if (!metric || !definition) return []
-          return [{
-            key,
-            label: definition.label,
-            value: formatConversionMetricValue(key, Number(metric.weekValue || 0)),
-            detail: metric.position || conversionSection?.unitName || '',
-            tooltip: buildMetricTooltip(definition, metric.formula),
-            icon: CONVERSION_METRIC_ICON_BY_KEY[key],
-            tone: CONVERSION_METRIC_TONE_BY_KEY[key],
-          }]
-        })
-      if (group.key === 'conversion:goals') rows.push(scheduleSourceRow)
+      const rows = buildConversionRows(group.metricKeys)
       if (!rows.length) continue
       tiles.push({
         key: group.key,
@@ -1276,55 +1649,29 @@ export function AtendimentoClinicaModule() {
         icon: group.icon,
         tone: group.tone,
         description: group.description,
-        wrapperClassName: group.key === 'conversion:ratios' ? 'sm:col-span-2' : '',
         content: <MetricGroupContent rows={rows} />,
       })
     }
-
-    tiles.push({
-      key: 'ticket',
-      label: 'Ticket médio',
-      value: formatCurrencyBRL(overview?.summary.averageTicket || 0),
-      detail: 'Média por atendimento',
-      icon: TrendingUp,
-      tone: 'violet',
-      description: 'Faturamento filtrado dividido pela quantidade de atendimentos no período.',
-    })
-
-    const topDoctors = (managementConversionReport?.doctorRanking?.topDoctors || []).slice(0, 3)
-    if (topDoctors.length) {
+    const distributionGroups = CONVERSION_DISTRIBUTION_DETAIL_GROUPS
+      .map((group) => ({ ...group, rows: buildConversionRows(group.metricKeys) }))
+      .filter((group) => group.rows.length)
+    if (!aggregateNotice && conversionSection?.doctors?.length && distributionGroups.length) {
       tiles.push({
-        key: 'doctor-ranking',
-        label: 'Ranking',
-        value: `${topDoctors.length} doutores`,
-        detail: 'Top 3 do período',
-        icon: Trophy,
-        tone: 'amber',
-        description: 'Ranking interno do CRM para o período selecionado. Exibe os três doutores com maior pontuação calculada para conversão.',
-        wrapperClassName: 'sm:col-span-2',
+        key: 'conversion:distribution',
+        label: 'Faixas por doutor',
+        value: `${formatNumberBR(conversionSection.doctors.length)} doutores`,
+        detail: conversionPeriodDetail,
+        icon: Gauge,
+        tone: 'violet',
+        description: 'Visualização única das faixas de corte por doutor no período filtrado, mantendo o detalhamento técnico logo abaixo do gráfico.',
+        wrapperClassName: 'col-span-full',
         content: (
-          <div className="space-y-1.5 pt-0.5">
-            {topDoctors.map((doctor) => {
-              const score = Number(doctor.score || 0)
-              const doctorTooltip: MetricTooltipSpec = {
-                what: 'Posição do doutor no ranking de conversão do período.',
-                calculation: `Realizado: ${formatCurrencyBRL(Number(doctor.weekValue || 0))}. Nível: ${Number(doctor.level ?? 0)}. Pontuação: ${formatNumberBR(score)} pts.`,
-                usage: 'O ranking ordena por realizado, depois nível/pontuação, e usa nome como desempate estável.',
-              }
-              return (
-                <div key={`${doctor.unitSlug}-${doctor.rank}-${doctor.name}`} className="flex min-w-0 items-center gap-2">
-                  <PodiumBadge rank={doctor.rank} />
-                  <div className="min-w-0 flex-1">
-                    <MetricTooltip label={doctor.name} info={doctorTooltip}>
-                      <span className="block truncate text-[11px] font-semibold leading-tight text-white">{doctor.name}</span>
-                    </MetricTooltip>
-                    <div className="truncate text-[10px] leading-tight text-slate-500">{doctor.unitName}</div>
-                  </div>
-                  <div className="shrink-0 text-[11px] font-semibold text-slate-200">{formatNumberBR(score)} pts</div>
-                </div>
-              )
-            })}
-          </div>
+          <ConversionDoctorBandsContent
+            unitName={conversionSection.unitName}
+            doctors={conversionSection.doctors}
+            metrics={conversionMetrics}
+            detailGroups={distributionGroups}
+          />
         ),
       })
     }
@@ -1333,7 +1680,6 @@ export function AtendimentoClinicaModule() {
   }, [
     filters.unit,
     managementConversionReport,
-    overview?.summary.averageTicket,
   ])
 
   const metricDisplayLayout = useMemo(() => {
@@ -1744,7 +2090,7 @@ export function AtendimentoClinicaModule() {
             <div className="mx-3 mt-3 grid gap-2 lg:grid-cols-2">
               {reportPreview ? (
                 <div className="rounded-xl border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-50">
-                  Prévia: {formatNumberBR(reportPreview.summary.attendances)} atendimentos, {formatCurrencyBRL(reportPreview.summary.totalValue)} total, {formatCurrencyBRL(reportPreview.summary.remuneration)} remuneração.
+                  Prévia: {formatNumberBR(reportPreview.summary.attendances)} registros, {formatNumberBR(reportPreview.summary.quantityTotal || 0)} em quantidade, {formatCurrencyBRL(reportPreview.summary.totalValue)} total, {formatCurrencyBRL(reportPreview.summary.remuneration)} remuneração.
                 </div>
               ) : null}
             </div>

--- a/frontend/FaturamentoModule.tsx
+++ b/frontend/FaturamentoModule.tsx
@@ -419,8 +419,8 @@ export function FaturamentoModule() {
 
       <div className="grid gap-3 md:grid-cols-3">
         <Metric label="Faturamento Atendimento" value={formatCurrencyBRL(commercial?.summary?.totalValue || 0)} detail="Base transacional do Atend. Clínica" />
-        <Metric label="Atendimentos" value={formatNumberBR(commercial?.summary?.totalAttendances || 0)} detail="Volume usado na reconciliação futura" />
-        <Metric label="Ticket médio" value={formatCurrencyBRL(commercial?.summary?.averageTicket || 0)} detail="Média por atendimento" />
+        <Metric label="Atendimentos" value={formatNumberBR(commercial?.summary?.totalAttendances || 0)} detail="Registros usados na reconciliação futura" />
+        <Metric label="Ticket médio" value={formatCurrencyBRL(commercial?.summary?.averageTicket || 0)} detail="Média por registro" />
       </div>
 
       <Card className={`${panelClass}`}>

--- a/frontend/atendimentoClinicaApi.ts
+++ b/frontend/atendimentoClinicaApi.ts
@@ -68,15 +68,17 @@ export type AtendimentoClinicaReferences = {
 export type AtendimentoClinicaOverview = {
   summary: {
     totalAttendances: number
+    quantityTotal: number
+    countMode: 'row'
     totalValue: number
     averageTicket: number
     distinctClients: number
   }
-  monthly: Array<{ month: string; count: number; value: number }>
+  monthly: Array<{ month: string; count: number; quantityTotal: number; value: number }>
   rankings: {
-    procedures: Array<{ label: string; count: number; value: number }>
-    injectors: Array<{ label: string; count: number; value: number }>
-    consultants: Array<{ label: string; count: number; value: number }>
+    procedures: Array<{ label: string; count: number; quantityTotal: number; value: number }>
+    injectors: Array<{ label: string; count: number; quantityTotal: number; value: number }>
+    consultants: Array<{ label: string; count: number; quantityTotal: number; value: number }>
   }
 }
 
@@ -84,10 +86,11 @@ export type AtendimentoClinicaReportPreview = {
   unit: string
   from: string
   to: string
-  summary: { doctors: number; attendances: number; totalValue: number; remuneration: number }
+  summary: { doctors: number; attendances: number; quantityTotal: number; totalValue: number; remuneration: number }
   doctors: Array<{
     doctorName: string
     count: number
+    quantityTotal: number
     totalValue: number
     remuneration: number
     rows: Array<{ date: string; clientName: string; procedureName: string; quantity: number; value: number; consultantName: string }>
@@ -161,7 +164,7 @@ export type AtendimentoManagementFinance = {
   monthlyGoals?: AtendimentoMonthlyGoal[]
   monthlyGoalLevels?: AtendimentoMonthlyGoalLevel[]
   goalTables?: AtendimentoGoalTable[]
-  attendanceTotals?: { units: Array<{ unitSlug: string; unitName: string; count: number; value: number }> }
+  attendanceTotals?: { units: Array<{ unitSlug: string; unitName: string; count: number; quantityTotal: number; value: number }> }
 }
 
 export type AtendimentoMonthlyGoal = {
@@ -273,6 +276,19 @@ export type AtendimentoManagementConversionReport = {
       unitSlug: string
       isAggregate?: boolean
       aggregateNotice?: string
+      goalPlan?: {
+        periodOperationalDays: number
+        periodGoal: number
+        dailyGoal: number
+        segments: Array<{
+          monthKey: string
+          monthlyGoal: number
+          monthOperationalDays: number
+          periodOperationalDays: number
+          dailyGoal: number
+          periodGoal: number
+        }>
+      }
       metrics: Record<string, {
         label: string
         weekValue: number

--- a/frontend/e2e/atendimento-clinica.spec.ts
+++ b/frontend/e2e/atendimento-clinica.spec.ts
@@ -43,15 +43,17 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
     ok: true,
     summary: {
       totalAttendances: rows.length,
+      quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0),
+      countMode: 'row',
       totalValue: rows.reduce((acc, row) => acc + row.value, 0),
       averageTicket: rows.length ? rows.reduce((acc, row) => acc + row.value, 0) / rows.length : 0,
       distinctClients: rows.length,
     },
-    monthly: [{ month: '2026-06', count: rows.length, value: rows.reduce((acc, row) => acc + row.value, 0) }],
+    monthly: [{ month: '2026-06', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), value: rows.reduce((acc, row) => acc + row.value, 0) }],
     rankings: {
-      procedures: [{ label: 'Botox', count: rows.length, value: rows.reduce((acc, row) => acc + row.value, 0) }],
-      injectors: [{ label: 'Dra. Sintética', count: rows.length, value: rows.reduce((acc, row) => acc + row.value, 0) }],
-      consultants: [{ label: 'Consultora Sintética', count: rows.length, value: rows.reduce((acc, row) => acc + row.value, 0) }],
+      procedures: [{ label: 'Botox', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), value: rows.reduce((acc, row) => acc + row.value, 0) }],
+      injectors: [{ label: 'Dra. Sintética', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), value: rows.reduce((acc, row) => acc + row.value, 0) }],
+      consultants: [{ label: 'Consultora Sintética', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), value: rows.reduce((acc, row) => acc + row.value, 0) }],
     },
   })
 
@@ -76,8 +78,8 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
           unit: 'novo-hamburgo',
           from: '2026-06-10',
           to: '2026-06-10',
-          summary: { doctors: 1, attendances: rows.length, totalValue: rows.reduce((acc, row) => acc + row.value, 0), remuneration: 100 },
-          doctors: [{ doctorName: 'Dra. Sintética', count: rows.length, totalValue: rows.reduce((acc, row) => acc + row.value, 0), remuneration: 100, rows: [] }],
+          summary: { doctors: 1, attendances: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), totalValue: rows.reduce((acc, row) => acc + row.value, 0), remuneration: 100 },
+          doctors: [{ doctorName: 'Dra. Sintética', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), totalValue: rows.reduce((acc, row) => acc + row.value, 0), remuneration: 100, rows: [] }],
         }),
       })
     }
@@ -97,22 +99,49 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
           source: { monthColumn: 'AG', weekColumn: 'AH', bxColumn: 'BX', bzColumn: 'BZ' },
           config: { fileNamePrefix: 'Informe Conversão', unitsOrder: ['BarraShoppingSul', 'Novo Hamburgo'], ignoreLabels: [], specialRows: [] },
           doctorRanking: {
+            period: { metricStart: '2026-06-10', metricEnd: '2026-06-10' },
             sections: [{
               unitName: 'Novo Hamburgo',
               unitSlug: 'novo-hamburgo',
-              metrics: { weeklyGoal: { label: 'Meta Semanal', weekValue: 20, totalValue: 20 }, cutLine: { label: 'Linha Corte', weekValue: 12, totalValue: 12 } },
-              doctors: [{ name: 'Dra. Sintética', weekValue: 14, totalValue: 3, score: 3, position: '1ª', rank: 1 }],
+              goalPlan: {
+                periodOperationalDays: 1,
+                periodGoal: 20,
+                dailyGoal: 20,
+                segments: [{ monthKey: '2026-06-01', monthlyGoal: 20, monthOperationalDays: 1, periodOperationalDays: 1, dailyGoal: 20, periodGoal: 20 }],
+              },
+              metrics: {
+                periodAttendanceTotal: { label: 'Total do período', weekValue: rows.reduce((acc, row) => acc + row.value, 0), totalValue: rows.reduce((acc, row) => acc + row.value, 0) },
+                rankedDoctorTotal: { label: 'Total ranqueável', weekValue: rows.reduce((acc, row) => acc + row.value, 0), totalValue: rows.reduce((acc, row) => acc + row.value, 0) },
+                periodGoal: { label: 'Meta do período', weekValue: 20, totalValue: 20 },
+                dailyGoal: { label: 'Meta diária', weekValue: 20, totalValue: 20 },
+                periodOperationalDays: { label: 'Dias período', weekValue: 1, totalValue: 1 },
+                cutLine: { label: 'Linha Corte', weekValue: 12, totalValue: 12 },
+                interval: { label: 'Intervalo', weekValue: 4, totalValue: 4 },
+                intervalMultiplier: { label: 'Multiplicador', weekValue: 0.75, totalValue: 0.75 },
+                lowerLimit: { label: 'Limite inferior', weekValue: 8, totalValue: 8 },
+                upperLimit: { label: 'Limite superior', weekValue: 16, totalValue: 16 },
+                level0: { label: 'Nível 0', weekValue: 0, totalValue: 0 },
+                level1: { label: 'Nível 1', weekValue: 0, totalValue: 0 },
+                level2: { label: 'Nível 2', weekValue: 1, totalValue: 1 },
+                level3: { label: 'Nível 3', weekValue: 0, totalValue: 0 },
+                outerRatio: { label: 'Razão exterior', weekValue: 0.1, totalValue: 0.1 },
+                upperRatio: { label: 'Razão superior', weekValue: 0.2, totalValue: 0.2 },
+                innerRatio: { label: 'Razão interior', weekValue: 0.3, totalValue: 0.3 },
+                lowerRatio: { label: 'Razão inferior', weekValue: 0.4, totalValue: 0.4 },
+                ratioDivisor: { label: 'Divisor razões', weekValue: 2, totalValue: 2 },
+              },
+              doctors: [{ name: 'Dra. Sintética', weekValue: 14, totalValue: 3, score: 3, position: '1ª', rank: 1, level: 2 }],
             }],
-            topDoctors: [{ name: 'Dra. Sintética', unitName: 'Novo Hamburgo', unitSlug: 'novo-hamburgo', weekValue: 14, totalValue: 3, score: 3, position: '1ª', rank: 1 }],
+            topDoctors: [{ name: 'Dra. Sintética', unitName: 'Novo Hamburgo', unitSlug: 'novo-hamburgo', weekValue: 14, totalValue: 3, score: 3, position: '1ª', rank: 1, level: 2 }],
           },
           sections: [],
           warnings: [],
-          summary: { sections: 1, rows: 4 },
+          summary: { sections: 1, rows: 4, doctorRankingSource: 'crm', scheduleSource: 'crm' },
         }),
       })
     }
     if (url.pathname.endsWith('/management/finance')) {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, sourceTabs: [{ sourceTab: 'Caixa', rows: 2 }], items: [], attendanceTotals: { units: [{ unitSlug: 'novo-hamburgo', unitName: 'Novo Hamburgo', count: rows.length, value: rows.reduce((acc, row) => acc + row.value, 0) }] } }) })
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, sourceTabs: [{ sourceTab: 'Caixa', rows: 2 }], items: [], attendanceTotals: { units: [{ unitSlug: 'novo-hamburgo', unitName: 'Novo Hamburgo', count: rows.length, quantityTotal: rows.reduce((acc, row) => acc + Number(row.quantity || 0), 0), value: rows.reduce((acc, row) => acc + row.value, 0) }] } }) })
     }
     if (url.pathname.endsWith('/management/inventory')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, data: [{ id: 'inv-1', product: 'Produto Sintético', barraShoppingSul: 1, novoHamburgo: 2, sourceRow: 2 }] }) })
@@ -166,14 +195,38 @@ test.describe('atendimento clinica', () => {
     await page.goto('/?module=atendimento-clinica')
 
     await expect(page.getByRole('heading', { name: 'Atend. Clínica' })).toBeVisible({ timeout: 30000 })
-    await expect(page.getByTestId('atendimento-context-menu')).toBeVisible()
-    await page.getByTestId('atendimento-context-menu').click()
-    await expect(page.getByText('Dados carregados')).toBeVisible()
-    await expect(page.getByText('Listagem', { exact: true })).toBeVisible()
-    await page.keyboard.press('Escape')
-    await expect(page.getByTestId('atendimento-kpis')).toContainText('Ticket médio')
+    await expect(page.getByRole('button', { name: '7d' })).toHaveAttribute('title', 'Últimos 7 dias')
+    await expect(page.getByRole('button', { name: '30d' })).toHaveAttribute('title', 'Últimos 30 dias')
+    await expect(page.getByRole('button', { name: 'Semana atual' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Mês atual' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '60d' })).toHaveCount(0)
+    await page.getByTestId('atendimento-header-refresh').hover()
+    const refreshTooltip = page.getByRole('tooltip').filter({ hasText: 'Atualizar Atend. Clínica' })
+    await expect(refreshTooltip).toBeVisible()
+    await expect(refreshTooltip).toContainText('Status: Dados carregados')
+    await expect(refreshTooltip).toContainText('Listagem: 1 linhas')
+    await page.getByRole('button', { name: 'Semana atual' }).hover()
+    const weekTooltip = page.getByRole('tooltip').filter({ hasText: 'Semana atual' })
+    await expect(weekTooltip).toBeVisible()
+    await expect(weekTooltip).toContainText('Da segunda-feira até hoje.')
+    await page.getByRole('button', { name: 'Mês atual' }).hover()
+    const monthTooltip = page.getByRole('tooltip').filter({ hasText: 'Mês atual' })
+    await expect(monthTooltip).toBeVisible()
+    await expect(monthTooltip).toContainText('Do primeiro dia do mês até hoje.')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Ticket médio')
+    await expect(page.getByTestId('atendimento-kpis')).toContainText('Total do período')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Total ranqueável')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Doutores elegíveis')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Dias mês')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Fonte agenda')
+    await expect(page.getByTestId('atendimento-kpis')).toContainText('Faixas por doutor')
+    await expect(page.getByTestId('atendimento-kpi-ranking')).toHaveCount(0)
+    await expect(page.getByTestId('atendimento-kpi-resumo')).toHaveCount(0)
+    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Linha Corte')
+    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Razão Exterior')
+    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Resumo')
+    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('3 pts')
     await expect(page.getByTestId('atendimento-filters')).toBeVisible()
-    await expect(page.getByLabel('Mover Ticket médio')).toBeAttached()
     await expect(page.getByText('Gerência', { exact: true })).toHaveCount(0)
     await expect(page.getByTestId('atendimento-conversion-ranking')).toContainText('Dra. Sintética')
     await expect(page.getByTestId('atendimento-row-client-row-1')).toHaveValue('Cliente Inicial')
@@ -190,6 +243,8 @@ test.describe('atendimento clinica', () => {
     await expect(page.getByTestId('atendimento-table')).not.toContainText('120 visíveis')
     await expect(page.getByText('Top procedimentos')).toHaveCount(0)
     await expect(page.getByTestId('atendimento-charts-panel')).toBeVisible()
+    await expect(page.getByTestId('atendimento-charts-panel')).toContainText('Ticket médio')
+    await expect(page.getByTestId('atendimento-charts-panel')).toContainText('Média por registro')
     for (const tabName of [/Inventário/, /Pessoas/, /Escala/, /Comercial/, /Conversão/, /Caixa/, /Importação/]) {
       await expect(page.getByRole('tab', { name: tabName })).toHaveCount(0)
     }
@@ -230,7 +285,12 @@ test.describe('atendimento clinica', () => {
 
     await expect(page.getByRole('heading', { name: 'Atend. Clínica' })).toBeVisible({ timeout: 30000 })
     await expect(page.getByTestId('atendimento-filters')).toBeVisible()
-    await expect(page.getByTestId('atendimento-kpis')).toContainText('Ticket médio')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Ticket médio')
+    await expect(page.getByTestId('atendimento-charts-panel')).toContainText('Ticket médio')
+    await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Dias mês')
+    await expect(page.getByTestId('atendimento-kpi-ranking')).toHaveCount(0)
+    await expect(page.getByTestId('atendimento-kpi-resumo')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: '60d' })).toHaveCount(0)
     await expect(page.getByText('Gerência', { exact: true })).toHaveCount(0)
     await expect(page.getByTestId('atendimento-conversion-ranking')).toContainText('Dra. Sintética')
     for (const tabName of [/Inventário/, /Pessoas/, /Escala/, /Comercial/, /Conversão/, /Caixa/, /Importação/]) {

--- a/frontend/escalaPanels.tsx
+++ b/frontend/escalaPanels.tsx
@@ -159,7 +159,15 @@ export function EscalaTeamPanel({
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1">
               <div className="text-[11px] uppercase tracking-[0.22em] text-slate-300/60">Equipe</div>
-              <div className="mt-1 text-sm font-semibold text-white">Equipe</div>
+              <div className="mt-1 flex flex-wrap items-center gap-2">
+                <div className="text-sm font-semibold text-white">Equipe</div>
+                <span className="inline-flex items-center rounded-full border border-emerald-300/20 bg-emerald-400/10 px-2 py-0.5 text-[10px] font-medium text-emerald-100">
+                  Elegíveis ao ranking: {activeInjectors.length}
+                </span>
+              </div>
+              <div className="mt-1 text-[10px] leading-snug text-slate-400">
+                Injetores ativos da unidade usados na escala e no universo elegível do ranking.
+              </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
               <TooltipButton label="Adicionar">


### PR DESCRIPTION
## Summary
- consolidate atendimento-clinica metrics and goals around the selected period, with segmented monthly goal plans only as technical detail
- replace the fragmented ranking cards with a unified doctor bands visualization and period-focused metric details
- update backend/frontend contracts and tests to remove fallback goal semantics and support the new dashboard behavior

## Validation
- node --test backend/apps/crm-api/server/atendimentoClinica/__tests__/domain.test.js backend/apps/crm-api/server/atendimentoClinica/__tests__/store.test.js
- npm --prefix frontend run typecheck
- npm run codex:preflight
