### PR TITLE
fix: normalize vendored semgrep severities

### DIFF
--- a/backend/archive/tools/semgrep/semgrep_rules.json
+++ b/backend/archive/tools/semgrep/semgrep_rules.json
@@ -9497,7 +9497,7 @@
         "references": [
           "https://ozguralp.medium.com/unauthorized-google-maps-api-key-usage-cases-and-why-you-need-to-care-1ccb28bf21e"
         ],
-        "severity": "MEDIUM",
+        "severity": "WARNING",
         "subcategory": [
           "audit"
         ],


### PR DESCRIPTION
## Summary
- replace the invalid vendored Semgrep severity enum `MEDIUM` with the supported `WARNING`
- restore compatibility with the current `returntocorp/semgrep-action@v1` runtime used by CI

## Validation
- node -e 'const fs=require("fs");const s=fs.readFileSync("backend/archive/tools/semgrep/semgrep_rules.json","utf8");const m=[...s.matchAll(/"severity"\\s*:\\s*"([A-Z]+)"/g)].map(x=>x[1]); console.log([...new Set(m)].sort().join("\\n")); console.log("count",m.length)'
