### PR TITLE
fix: run semgrep with current cli

### DIFF
--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -252,12 +252,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Run Semgrep
-        uses: returntocorp/semgrep-action@v1
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          entryPoint: semgrep
-          args: scan --config auto --sarif --output semgrep.sarif
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+          python-version: '3.x'
+      - name: Install Semgrep CLI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'semgrep>=1.72.0'
+      - name: Run Semgrep
+        run: semgrep scan --config auto --sarif --output semgrep.sarif
       - name: Upload Semgrep SARIF
         if: ${{ hashFiles('semgrep.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary
- replace the deprecated `returntocorp/semgrep-action@v1` wrapper with a direct Semgrep CLI installation
- pin the workflow to a Semgrep version range that supports the current registry severity enums
- preserve the existing SARIF upload step

## Validation
- workflow diff review for `.github/workflows/security-secrets-audit.yml`
- prior failing evidence from `Security & Secrets Audit` runs on `#590` and `#591`
