### PR TITLE
Bootstrap shared Codex workspace runtime autonomy

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,116 @@
+# Shared Codex App actions for Skincos. Keep in sync with scripts/install-shared-codex-shortcuts.ps1.
+version = 1
+name = "skincos"
+
+[setup]
+script = ""
+
+[[actions]]
+name = "Shared Setup"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action SharedSetup"
+
+[[actions]]
+name = "Shared Validate"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action SharedValidate"
+
+[[actions]]
+name = "Runtime Setup"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action RuntimeSetup"
+
+[[actions]]
+name = "Runtime Validate"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action RuntimeValidate"
+
+[[actions]]
+name = "WSL Account Bootstrap"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action WslAccountBootstrap"
+
+[[actions]]
+name = "Shared Status"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action SharedStatus"
+
+[[actions]]
+name = "Codex Context"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CodexContext"
+
+[[actions]]
+name = "Thread Bootstrap"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action ThreadBootstrap"
+
+[[actions]]
+name = "New Worktree"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action NewWorktree"
+
+[[actions]]
+name = "Website Local Start"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action WebsiteLocalStart"
+
+[[actions]]
+name = "Website Local Stop"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action WebsiteLocalStop"
+
+[[actions]]
+name = "CRM Local"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmLocal"
+
+[[actions]]
+name = "CRM Site EF"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmSiteEf"
+
+[[actions]]
+name = "CRM Meta Ads"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmMetaAds"
+
+[[actions]]
+name = "CRM Atendimento Clínica"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmAtendimentoClinica"
+
+[[actions]]
+name = "CRM Local Stop"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmLocalStop"
+
+[[actions]]
+name = "Orb Status"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbStatus"
+
+[[actions]]
+name = "Orb Restart"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbRestart"
+
+[[actions]]
+name = "Orb Repair"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbRepair"
+
+[[actions]]
+name = "Orb Logs"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbLogs"
+
+[[actions]]
+name = "Orb Validate"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbValidate"
+
+[[actions]]
+name = "Orb Audit"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbAudit"

--- a/.gitignore
+++ b/.gitignore
@@ -197,4 +197,7 @@ frontend/test-results/
 output/
 
 # Codex local state
-.codex/
+.codex/*
+!.codex/environments/
+.codex/environments/*
+!.codex/environments/environment.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # Skincos Workspace Agent Rules
 
+## Multi-Account Continuity
+
+- This shared clone is the cross-account source of truth for project context, not
+  for secrets or Codex authentication state.
+- Before changing anything, read `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`,
+  and `DECISIONS.md`, then inspect `git status`.
+- Use branches in the format `codex/<windows-user-or-alias>/<task-slug>`.
+- Prefer worktrees under `C:\CodexShared\Worktrees\skincos\<actor>\<task-slug>`
+  when more than one account or user may work in parallel.
+- Never store `.env`, `.dev.vars`, `.cloudflared` credentials, `.codex`,
+  cookies, or API keys inside `C:\CodexShared`.
+- If local execution needs secrets, use a private overlay or a private clone
+  outside the shared area and document only variable names here.
+
 ## Default Codex App Startup
 
 - For non-trivial work in this repo, start by running or mentally applying

--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -3,11 +3,109 @@
 ## Current State
 
 - Shared multi-account clone created at `C:\CodexShared\Projetos\skincos`.
-- Legacy operator checkout remains at `C:\Users\julia\skincos` and is not part of
-  the shared continuity flow.
-- Main surfaces in this repository are `website/`, `frontend/`, `backend/`, and
-  supporting Cloudflare, GitHub Actions, and automation scripts.
-- Shared clone starts clean on `main` from commit `aeacbab2`.
+- The repo is now adopting a domain envelope rooted at `modules/`, `platform/`,
+  `ops/`, and `archive/`.
+- The shared n8n operational workspace now lives at
+  `C:\CodexShared\Projetos\skincos\modules\automations\n8n`.
+- The public website now lives at
+  `C:\CodexShared\Projetos\skincos\modules\site-public\website`.
+- The CRM API now lives at
+  `C:\CodexShared\Projetos\skincos\modules\crm\api`.
+- The CRM web app now lives at
+  `C:\CodexShared\Projetos\skincos\modules\crm\web`.
+- The Meta Ads workspace now lives at
+  `C:\CodexShared\Projetos\skincos\modules\meta-ads\meta-ads`.
+- The WhatsApp workspace now lives at
+  `C:\CodexShared\Projetos\skincos\modules\whatsapp\whatsapp`.
+- The former top-level `C:\CodexShared\Projetos\n8n` clone is no longer active
+  and now lives only as a rollback archive at
+  `C:\CodexShared\Projetos\_bootstrap\n8n-top-level-legacy-20260703T181656`.
+- Shared worktree root standardized at `C:\CodexShared\Worktrees\skincos`.
+- The shared clone `origin` now points to
+  `https://github.com/jubenitogarcia/skincos.git`, not to a legacy local path.
+- Validation from a second Windows user (`dev`) confirmed the shared clone can
+  be read directly from `C:\CodexShared` without opening `C:\Users\julia\...`.
+- Git on each Windows user still requires per-user `safe.directory`
+  registration before normal commands like `git status` work in the shared
+  clone or worktrees.
+- Shared operational scripts and Codex automation cwd pointers are being
+  updated to resolve the modular envelope paths instead of the legacy technical
+  roots.
+- Shared `skincos` now passes the local shared-clone validations:
+  `npm run codex:site:check`, `npm run codex:crm:site-smoke`, and
+  `npm run codex:crm:meta-ads-smoke`.
+- Shared workspace bootstrap/validation now live in
+  `scripts/setup-shared-codex-workspace.ps1`,
+  `scripts/validate-shared-codex-workspace.ps1`, and
+  `docs/codex-shared-workspace.md`.
+- Shared operational shortcuts now live in the common Start Menu at
+  `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`,
+  grouped by Setup, Contexto, Local, and Runtime.
+- The Codex App top-bar actions are now shared through the repo-tracked file
+  `.codex/environments/environment.toml`; the rest of `.codex` remains
+  untracked and per-user.
+- The shared Start Menu inventory and the Codex App top-bar inventory are being
+  realigned so every operator sees the same supported actions, including the
+  runtime repair entrypoint `Orb Repair`.
+- The live orb stack now runs from `skincos-*` system services under
+  `User=skincos`, with code in `modules/automations/n8n` and machine-scoped
+  runtime state in `C:\CodexRuntime\n8n`.
+- The canonical live orb env contract is now split into
+  `C:\CodexRuntime\n8n\env\n8n.env`,
+  `C:\CodexRuntime\n8n\env\n8n-business.env`, and
+  `C:\CodexRuntime\n8n\env\evolution-api.env`.
+- The live `n8n-business.env` now has the recoverable values backfilled from
+  the runtime (`EVOLUTION_API_KEY`, `DATABASE_URL`, `GOOGLE_CLIENT_ID`,
+  `GOOGLE_CLIENT_SECRET`, `N8N_DEFAULT_UNIT_SLUG`, `N8N_DEFAULT_UNIT_NAME`),
+  but `GOOGLE_CALENDAR_ID` and `N8N_DEFAULT_TEST_PHONE` still need manual
+  completion before a full orb smoke can be finished.
+- Legacy `systemctl --user` orb services in the `julia` WSL account were
+  disabled, and the shared runtime validation now passes again on the
+  machine-scoped stack.
+- The local PostgreSQL role/database `n8n_runtime` were provisioned to match
+  the shared `n8n.env` contract, which restored `skincos-n8n.service`.
+- The canonical shared repair path for future Postgres/runtime drift is now
+  `modules/automations/n8n/scripts/reconcile-mini-pc-runtime-postgres.sh`,
+  exposed publicly as `Orb Repair` through both the Start Menu and Codex App
+  project actions.
+- `skincos-cloudflared-cs.service` now reads its config from
+  `C:\CodexRuntime\cloudflared\cs` instead of `/etc/skincos`.
+- Shared runtime mirrors now also exist for
+  `C:\CodexRuntime\crm-api\env\crm-api.env` and
+  `C:\CodexRuntime\booking-api\env\booking-api.env`.
+- The machine-scoped support services `skincos-crm-api.service` and
+  `skincos-booking-api.service` now run from shared repo entrypoints in
+  `scripts/migration/` and persist runtime state in `C:\CodexRuntime\crm-api`
+  and `C:\CodexRuntime\booking-api`.
+- `skincos-cloudflared-cs.service` now uses the shared runtime home
+  `C:\CodexRuntime\cloudflared\cs`, so no installed `skincos-*` unit still
+  references `/etc/skincos`, `/srv/skincos`, or `/home/julia`.
+- Shared support-service convergence can now be reapplied with
+  `scripts/install-shared-support-system-services.sh`, and the latest legacy
+  unit backup lives in
+  `C:\CodexRuntime\n8n\rollback\legacy-services-20260706T194618`.
+- Shell entrypoints were normalized for WSL/Bash and `.gitattributes` now
+  enforces `LF` for `*.sh` and `*.command`.
+- The local CRM launcher now repairs the shared-clone first boot by generating
+  `modules/crm/web/dist/` when absent and syncing only non-secret local auth
+  toggles into `modules/crm/web/.dev.vars` for Pages local.
+- Strict preflight now passes all live/Cloudflare checks in Windows after
+  authenticating `gh` as `jubenitogarcia`, and WSL `gh` now also resolves to
+  the same GitHub account via `/home/julia/.config/gh/hosts.yml`.
+- The shared clone is currently on branch `codex/julia/shared-bootstrap` at
+  `5aad9549`; `origin/main` is `aeacbab2`, so the shared baseline is not yet a
+  clean `main` checkout.
+- The live `n8n` runtime is healthy and uses the local PostgreSQL database
+  `n8n_runtime` as its active metadata store, not the legacy
+  `C:\CodexRuntime\n8n\n8n-home\database.sqlite`.
+- The four clinic orb workflows `WORKFLOW_01..04` are now imported into the
+  live `n8n_runtime` project `sFC10b3Ypvv4LJFH` in inactive mode, with the
+  `wa_n8n` schema applied and a rollback dump stored under
+  `C:\CodexRuntime\n8n\exports\clinic-orb-live-20260707T001500Z\`.
+- The live DB now contains the expected credentials `Postgres (Skincos)` and
+  `Google Calendar (Skincos)`, but the imported Google credential came from a
+  legacy export that still has no proven Calendar scope, so activation remains
+  gated on credential review rather than on import itself.
 
 ## Operational Model
 
@@ -24,13 +122,59 @@
   Workers, D1, CRM, and tracking modules.
 - Some historical configs referenced operator-specific `cloudflared`
   credential paths; the shared clone now uses documented placeholders instead.
-- The legacy checkout may remain dirty and should not be treated as the shared
-  collaboration base.
+- The shared tree itself is not yet in a final publishable baseline because the
+  multi-account branch and LF normalization changes are still local.
+- The old Windows checkout was removed from the user profile; the shared clone
+  is now the only supported local collaboration base.
+- The live n8n runtime state remains machine-scoped in `C:\CodexRuntime\n8n`
+  and must stay outside `C:\CodexShared` even though the n8n code now lives
+  under `modules\automations\n8n`.
+- Shared runtime validation should fail if the orb stack reintroduces
+  `/home/julia`, `/srv/skincos`, `/etc/skincos`, or `systemctl --user`
+  references into its env files or installed units.
+- Local health validation after the handoff succeeded for
+  `http://127.0.0.1:5678/healthz`,
+  `http://127.0.0.1:8788/meta-review/healthz`, and
+  `https://orb.skincos.com.br/healthz`.
+- Support-service health validation now also succeeds for
+  `http://127.0.0.1:8099/health` and `http://127.0.0.1:8765/healthz` after the
+  shared-runtime cutover.
+- `Orb Validate` now retries health probes briefly after restart so a healthy
+  warm boot does not fail only because the HTTP listener is still coming up.
+- The current live `n8n` DB still contains unrelated workflows such as
+  `Livia`, `Meta Ads – Report`, and `Harmonia`, alongside the newly imported
+  clinic automation flows documented in
+  `modules/automations/n8n/README.md`.
+- A full orb business smoke still cannot be executed end-to-end on the live
+  runtime because `GOOGLE_CALENDAR_ID` and `N8N_DEFAULT_TEST_PHONE` are still
+  blank in `n8n-business.env`, and the imported Google credential has not yet
+  been proven against Google Calendar scope.
 
 ## Next Recommended Steps
 
-- Validate that another Windows user can open this clone and read the context
-  files without needing the original profile.
+- Reconcile `codex/julia/shared-bootstrap` against `origin/main` so the shared
+  repo can return to a clean baseline before destructive cleanup.
+- Review and, if needed, reauthorize the imported `Google Calendar (Skincos)`
+  credential against the real calendar scopes required by
+  `WORKFLOW_02_AGENDAMENTO.json`.
+- Fill the remaining manual business env values in
+  `C:\CodexRuntime\n8n\env\n8n-business.env`, especially
+  `GOOGLE_CALENDAR_ID` and `N8N_DEFAULT_TEST_PHONE`.
+- Run the live functional smoke only after that final binding step:
+  webhook inbound, Evolution inbound, and Google Calendar creation.
+- Keep `scripts/install-shared-support-system-services.sh` as the canonical way
+  to reapply `crm-api`, `booking-api`, and `cloudflared-cs` support services on
+  the shared runtime model.
+- Use `Orb Repair` instead of account-specific manual repair steps whenever the
+  live `n8n` runtime drifts away from the Postgres contract in
+  `C:\CodexRuntime\n8n\env\n8n.env`.
+- Continue draining residual legacy references from docs and helper scripts that
+  still mention `frontend/`, `backend/apps/meta-ads`, or
+  `backend/apps/whatsapp`.
 - Create per-task worktrees under `C:\CodexShared\Worktrees\skincos\...`.
+- Keep Codex local state, logs, temp files, browser profiles, and env overrides
+  in `%LOCALAPPDATA%\Codex\skincos\` for each operator.
 - If a task needs local runtime secrets, keep them outside the shared tree and
   document only the variable names and expected source.
+- Treat `C:\CodexShared\Projetos\skincos` as the only supported local code base
+  for shared work on this machine.

--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -1,0 +1,36 @@
+# CODEX_CONTEXT
+
+## Current State
+
+- Shared multi-account clone created at `C:\CodexShared\Projetos\skincos`.
+- Legacy operator checkout remains at `C:\Users\julia\skincos` and is not part of
+  the shared continuity flow.
+- Main surfaces in this repository are `website/`, `frontend/`, `backend/`, and
+  supporting Cloudflare, GitHub Actions, and automation scripts.
+- Shared clone starts clean on `main` from commit `aeacbab2`.
+
+## Operational Model
+
+- Use this clone for shared context, code review, task planning, branch/worktree
+  coordination, and clean implementation starts.
+- Keep secrets outside `C:\CodexShared`. Local execution that needs `.env` or
+  `.dev.vars` must use a private overlay or private clone per operator.
+- When work spans multiple accounts, document progress here and update
+  `TASKS.md` and `DECISIONS.md` before handing off.
+
+## Known Constraints
+
+- Existing production and migration-sensitive flows include Cloudflare Pages,
+  Workers, D1, CRM, and tracking modules.
+- Some historical configs referenced operator-specific `cloudflared`
+  credential paths; the shared clone now uses documented placeholders instead.
+- The legacy checkout may remain dirty and should not be treated as the shared
+  collaboration base.
+
+## Next Recommended Steps
+
+- Validate that another Windows user can open this clone and read the context
+  files without needing the original profile.
+- Create per-task worktrees under `C:\CodexShared\Worktrees\skincos\...`.
+- If a task needs local runtime secrets, keep them outside the shared tree and
+  document only the variable names and expected source.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -13,9 +13,216 @@
 - Why: the legacy checkout carries local state, caches, and migration residue.
 - Impact: new shared collaboration starts from the clean clone only.
 
+## 2026-07-03 - Remove the old skincos checkout after shared validation
+
+- Decision: remove the legacy `C:\Users\julia\skincos` checkout once the shared
+  clone passed local shared-clone smoke checks and cross-account validation.
+- Why: the old profile checkout is no longer needed for supported development
+  and keeping it around creates ambiguity about which tree is authoritative.
+- Impact: `C:\CodexShared\Projetos\skincos` becomes the only supported local
+  code base; if the root folder remains temporarily locked by the current
+  session, it should be deleted as soon as the handle is released.
+
 ## 2026-07-02 - Secrets stay out of the shared area
 
 - Decision: no `.env`, `.dev.vars`, `.codex`, `.cloudflared`, cookies, or
   tokens may be stored under `C:\CodexShared`.
 - Why: multiple local Windows users have access to the shared tree.
 - Impact: local runtime execution needs a private overlay or private clone.
+
+## 2026-07-02 - Shared clones need per-user Git trust bootstrap
+
+- Decision: every local Windows user must register shared clones and worktrees
+  under `git config --global safe.directory` before using them normally.
+- Why: Git blocks commands with `detected dubious ownership` when the clone is
+  owned by a different Windows SID.
+- Impact: cross-account onboarding must include a short Git bootstrap step.
+
+## 2026-07-02 - Shared clone origin must point to GitHub, not a local checkout
+
+- Decision: the shared `skincos` clone `origin` must use
+  `https://github.com/jubenitogarcia/skincos.git`.
+- Why: a shared clone cannot depend on `C:\Users\julia\skincos` being present on
+  another Windows user.
+- Impact: remote validation and future push/pull work become account-scoped
+  GitHub operations instead of local-path coupling.
+
+## 2026-07-03 - Shared local CRM boot must be self-healing on a clean clone
+
+- Decision: the shared local CRM launcher must repair first-boot gaps by
+  generating the CRM web `dist/` when absent and by syncing only non-secret
+  local auth toggles into the module-local `.dev.vars`.
+- Why: a clean shared clone does not carry prebuilt assets, and the Pages local
+  shell was failing in WSL even though the real issue was missing dist plus a
+  `LOCAL_AUTH_BYPASS=false` default being left behind in `.dev.vars`.
+- Impact: `npm run codex:crm:site-smoke` and
+  `npm run codex:crm:meta-ads-smoke` now work directly from the shared clone
+  without depending on the legacy checkout.
+
+## 2026-07-03 - Fold the shared n8n workspace into the skincos monorepo
+
+- Decision: treat `C:\CodexShared\Projetos\skincos\modules\automations\n8n` as
+  the canonical shared
+  n8n code root and retire `C:\CodexShared\Projetos\n8n` as an active project
+  path.
+- Why: the `skincos` repo is becoming the umbrella workspace for the clinic's
+  subprojects and tools, and keeping n8n as a sibling clone preserves
+  ambiguity about where the live automation code belongs.
+- Impact: runtime state still stays in `C:\CodexRuntime\n8n`, but systemd
+  units, docs, bootstrap scripts, and operator workflows should resolve n8n
+  code from `skincos\n8n`.
+
+## 2026-07-03 - Keep the retired top-level n8n clone only as rollback archive
+
+- Decision: archive the former top-level `C:\CodexShared\Projetos\n8n` clone at
+  `C:\CodexShared\Projetos\_bootstrap\n8n-top-level-legacy-20260703T181656`
+  instead of keeping it side-by-side with the active monorepo.
+- Why: the live services already run from
+  `C:\CodexShared\Projetos\skincos\modules\automations\n8n`
+  and leaving a second `n8n` root in `Projetos\` would keep operational
+  ambiguity alive.
+- Impact: active automation work must happen from
+  `skincos\modules\automations\n8n`; the archived copy is rollback-only and
+  should not receive new edits.
+
+## 2026-07-03 - Adopt a modular envelope rooted at modules/platform/ops/archive
+
+- Decision: reorganize `skincos` as a domain-first envelope with active product
+  code under `modules/`, shared cross-cutting code under `platform/`,
+  operational orchestration under `ops/`, and legacy material under `archive/`.
+- Why: top-level technical roots like `backend/`, `frontend/`, and `n8n/`
+  obscure business ownership and make the repo harder to navigate as the number
+  of subprojects grows.
+- Impact: new source-of-truth paths are module-centric, while `backend/` and
+  `frontend/` become transitional roots to be emptied over time.
+
+## 2026-07-03 - Move the first self-contained modules into the new envelope
+
+- Decision: move the public website to `modules/site-public/website`, the CRM
+  API to `modules/crm/api`, and the n8n automation workspace to
+  `modules/automations/n8n` in the first migration wave.
+- Why: these three blocks have clearer operational boundaries and reduce path
+  ambiguity immediately without forcing a same-day rewrite of every remaining
+  module.
+- Impact: root scripts, local launchers, health checks, and systemd user units
+  must resolve the new module paths; `frontend/`, `backend/apps/meta-ads`, and
+  `backend/apps/whatsapp` remain transitional for later waves.
+
+## 2026-07-03 - Complete the second envelope wave for CRM, Meta Ads, and WhatsApp
+
+- Decision: move the CRM web app to `modules/crm/web`, Meta Ads to
+  `modules/meta-ads/meta-ads`, and WhatsApp services to
+  `modules/whatsapp/whatsapp`.
+- Why: leaving those surfaces under `frontend/` and `backend/apps/*` preserved
+  the same ambiguity the envelope was supposed to remove.
+- Impact: root scripts, local launchers, health checks, capability maps, and
+  shared workspace docs must now treat those module paths as canonical.
+
+## 2026-07-06 - Run the live orb stack as machine-scoped system services
+
+- Decision: the live orb stack must run only from `skincos-*` system units
+  under `/etc/systemd/system`, with `User=skincos`, code in
+  `C:\CodexShared\Projetos\skincos\modules\automations\n8n`, and runtime state
+  in `C:\CodexRuntime\n8n`.
+- Why: the previous hybrid model mixed `systemctl --user`, operator-specific
+  homes, and legacy `/etc/skincos` or `/srv/skincos` state, which blocked true
+  multi-account autonomy.
+- Impact: `n8n.env`, `n8n-business.env`, and `evolution-api.env` in
+  `C:\CodexRuntime\n8n\env\` are now the canonical live env contract for the
+  orb stack, and validators should fail if orb services reintroduce
+  `/home/julia`, `/srv/skincos`, `/etc/skincos`, or `systemctl --user`.
+
+## 2026-07-06 - Publish shared operational shortcuts in the common Start Menu
+
+- Decision: install the Skincos operational launchers in
+  `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`.
+- Why: the workspace and runtime are now machine-shared, so bootstrap,
+  contexto, ambiente local, and runtime live actions must be equally reachable
+  from every local Windows account without depending on `npm` in Windows.
+- Impact: shared operators use the same PowerShell/WSL launchers for setup,
+  worktrees, local QA, and live orb operations.
+
+## 2026-07-07 - Version only the Codex App environment definition inside .codex
+
+- Decision: allow only `.codex/environments/environment.toml` to be committed
+  in the shared `skincos` repo and keep all other `.codex` content ignored and
+  per-user.
+- Why: the Start Menu shortcuts are already machine-shared, but the Codex App
+  top-bar actions need one portable project contract that works in both the
+  shared clone and per-user worktrees without leaking auth, cache, or session
+  state.
+- Impact: opening either the shared clone or a worktree in Codex App now loads
+  the same project actions, while `safe.directory`, Codex login, WSL bootstrap,
+  GitHub auth, and recent-project lists remain account-scoped.
+
+## 2026-07-07 - Publish one shared runtime repair path instead of relying on a principal account
+
+- Decision: expose `Orb Repair` as the canonical shared entrypoint for
+  PostgreSQL/runtime reconciliation, backed by
+  `modules/automations/n8n/scripts/reconcile-mini-pc-runtime-postgres.sh`.
+- Why: the multi-account mini-PC model breaks when Postgres repair knowledge
+  exists only in one operator account or one “principal” Codex session.
+- Impact: Start Menu shortcuts, Codex App project actions, and runbooks now
+  point to the same repair flow, which reads only the `DB_POSTGRESDB_*`
+  contract from `C:\CodexRuntime\n8n\env\n8n.env`, realigns the local
+  PostgreSQL role/database/schema, restarts the orb stack, validates health,
+  and stores redacted evidence under `C:\CodexRuntime\n8n\exports\repair-*`.
+
+## 2026-07-06 - Drain the last orb user services from the human WSL account
+
+- Decision: keep the `julia` WSL user manager free of live orb services and
+  treat any residual `n8n.service`, `orb-proxy.service`,
+  `cloudflared-orb.service`, `evolution-api.service`, or
+  `mini-pc-watchdog.timer` there as legacy-only artifacts.
+- Why: the shared mini-PC autonomy model breaks when the orb can still boot
+  from `systemctl --user` instead of the machine-scoped `skincos-*` units.
+- Impact: the live orb path is now singular, `Orb Validate` can enforce the
+  absence of active user services, and rollback for the old unit files lives in
+  `C:\CodexRuntime\n8n\rollback\`.
+
+## 2026-07-06 - Move the cs Cloudflare tunnel config into CodexRuntime
+
+- Decision: `skincos-cloudflared-cs.service` should read its config and
+  credentials from `C:\CodexRuntime\cloudflared\cs`.
+- Why: the `cs` tunnel is a machine-scoped live service, so keeping its
+  supported config under `/etc/skincos` preserved an unnecessary legacy root.
+- Impact: the remaining legacy service convergence now focuses on
+  `crm-api` and `booking-api`, while the `cs` tunnel already follows the shared
+  runtime model.
+
+## 2026-07-06 - Run crm-api and booking-api from shared repo launchers
+
+- Decision: `skincos-crm-api.service` and `skincos-booking-api.service` should
+  run from shared repo launchers under `scripts/migration/`, with env and
+  writable runtime state moved to `C:\CodexRuntime\crm-api` and
+  `C:\CodexRuntime\booking-api`.
+- Why: leaving those support services on `/srv/skincos` and `/etc/skincos`
+  preserved the same single-account coupling that the shared orb convergence
+  was meant to remove.
+- Impact: all installed `skincos-*` system units now resolve code from
+  `C:\CodexShared\Projetos\skincos` and machine-scoped state from
+  `C:\CodexRuntime\...`, while legacy unit files remain only as rollback
+  backups under `C:\CodexRuntime\n8n\rollback\`.
+
+## 2026-07-06 - Reapply support services with a shared installer
+
+- Decision: the canonical maintenance entrypoint for the non-orb support
+  services is `scripts/install-shared-support-system-services.sh`.
+- Why: the shared mini-PC model needs one repeatable installer for
+  `crm-api`, `booking-api`, and `cloudflared-cs` instead of ad hoc manual
+  edits under `/etc/systemd/system`.
+- Impact: future convergence, repair, or reprovisioning of those units should
+  happen from the repo, while service-specific env/config/state stays under
+  `C:\CodexRuntime`.
+
+## 2026-07-06 - Import the clinic orb flows into the live Postgres runtime and keep them inactive
+
+- Decision: import `WORKFLOW_01..04` and the expected `n8n` credentials into
+  the live `n8n_runtime` PostgreSQL metadata store, but keep all four clinic
+  workflows inactive until the Google Calendar binding is manually verified.
+- Why: the live `skincos-n8n.service` uses PostgreSQL rather than the legacy
+  SQLite file, and the recoverable Google OAuth export did not prove Calendar
+  scope or provide the missing `GOOGLE_CALENDAR_ID`.
+- Impact: the machine now has the clinic workflows, `wa_n8n` tables, and
+  baseline credentials ready in the live DB, while activation and end-to-end
+  smoke remain gated on final Google Calendar/OAuth review and test data.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,21 @@
+# DECISIONS
+
+## 2026-07-02 - Shared base lives outside user profiles
+
+- Decision: use `C:\CodexShared` as the shared Codex workspace root.
+- Why: avoids per-user profile isolation and avoids using the synced `G:` drive
+  as the primary Git collaboration base.
+- Impact: shared clones, worktrees, and continuity docs live in a neutral path.
+
+## 2026-07-02 - Keep the original skincos checkout as legacy
+
+- Decision: do not move or rewrite `C:\Users\julia\skincos`.
+- Why: the legacy checkout carries local state, caches, and migration residue.
+- Impact: new shared collaboration starts from the clean clone only.
+
+## 2026-07-02 - Secrets stay out of the shared area
+
+- Decision: no `.env`, `.dev.vars`, `.codex`, `.cloudflared`, cookies, or
+  tokens may be stored under `C:\CodexShared`.
+- Why: multiple local Windows users have access to the shared tree.
+- Impact: local runtime execution needs a private overlay or private clone.

--- a/TASKS.md
+++ b/TASKS.md
@@ -2,21 +2,33 @@
 
 ## Priority Backlog
 
-- [ ] Validate cross-user access to `C:\CodexShared\Projetos\skincos`.
-- [ ] Validate that a second Codex account can open this shared clone and follow
-  the continuity files without touching the legacy checkout.
-- [ ] Define the first shared worktree naming pattern for each active operator.
-- [ ] Audit remaining operator-specific paths or local assumptions before using
-  the shared clone for deploy-related work.
+- [ ] Reconcile the shared `codex/julia/shared-bootstrap` branch with
+  `origin/main` and return the shared repo to a trusted baseline.
+- [ ] Review and, if needed, reauthorize the imported live `n8n` credential
+  `Google Calendar (Skincos)` for the calendar scopes required by the clinic
+  workflows.
+- [ ] Fill the remaining manual `n8n-business.env` values
+  `GOOGLE_CALENDAR_ID` and `N8N_DEFAULT_TEST_PHONE`.
+- [ ] Run the full orb functional smoke with the now-populated
+  `C:\CodexRuntime\n8n\env\n8n-business.env`: inbound webhook, Evolution
+  inbound, and Google Calendar test event.
+- [ ] Audit non-repo private overlays against the shared baseline.
+- [ ] Drain remaining legacy path references from docs and low-priority helpers
+  that still mention `frontend/`, `backend/apps/meta-ads`, or
+  `backend/apps/whatsapp`.
 
 ## In Progress
 
-- [ ] Multi-account Codex workspace bootstrap on Windows.
+- [ ] Controlled activation path for the orb clinic workflows in the live `n8n`
+  runtime.
 
 ## Blocked / Needs Manual Follow-Up
 
 - [ ] Any task that requires real `.env`, `.dev.vars`, `.cloudflared`, or API
   credentials must use a private overlay outside `C:\CodexShared`.
+- [ ] Full orb business smoke is blocked until `GOOGLE_CALENDAR_ID`,
+  `N8N_DEFAULT_TEST_PHONE`, and a verified Google Calendar OAuth binding exist
+  on the live runtime.
 
 ## Done
 
@@ -25,3 +37,77 @@
   for cross-account continuity.
 - [x] Operator-specific `cloudflared` credential paths replaced with documented
   placeholders in the shared clone.
+- [x] Cross-user access validated from a second Windows user without using the
+  legacy checkout.
+- [x] Shared baseline worktree validated for cross-user Git access after
+  per-user `safe.directory` bootstrap.
+- [x] Shared clone `origin` corrected from a legacy local path to the GitHub
+  remote.
+- [x] Second Windows user authenticated to GitHub and validated remote
+  read/write access with non-destructive dry-runs.
+- [x] Shared operational scripts no longer depend on the legacy Windows
+  checkout path.
+- [x] Shared-clone shell entrypoints normalized for WSL and protected with
+  explicit `LF` rules in `.gitattributes`.
+- [x] Shared clone passes `npm run codex:site:check`.
+- [x] Shared clone passes `npm run codex:crm:site-smoke`.
+- [x] Shared clone passes `npm run codex:crm:meta-ads-smoke`.
+- [x] Legacy Windows checkout content under `C:\Users\julia\skincos` was
+  removed; the empty root is pending handle release from the current Codex
+  session.
+- [x] The old top-level `C:\CodexShared\Projetos\n8n` clone was retired from
+  active use and archived at
+  `C:\CodexShared\Projetos\_bootstrap\n8n-top-level-legacy-20260703T181656`
+  after the embedded `skincos\n8n` runtime handoff was validated.
+- [x] First modular-envelope wave created `modules/`, `platform/`, `ops/`, and
+  `archive/`, and moved `website/`, `n8n/`, and `backend/apps/crm-api/` into
+  their new canonical module paths.
+- [x] Second modular-envelope wave moved `frontend/` to `modules/crm/web`,
+  `backend/apps/meta-ads/` to `modules/meta-ads/meta-ads`, and
+  `backend/apps/whatsapp/` to `modules/whatsapp/whatsapp`.
+- [x] The live orb stack converged to system services under `User=skincos`,
+  with machine-scoped env/runtime state in `C:\CodexRuntime\n8n`.
+- [x] Shared runtime validation now checks both the runtime contract and the
+  absence of legacy orb references to `/home/julia`, `/srv/skincos`,
+  `/etc/skincos`, and `systemctl --user`.
+- [x] Shared operational shortcuts were installed in the common Start Menu for
+  all local Windows users.
+- [x] Codex App top-bar actions are now shared through the repo-tracked
+  `.codex/environments/environment.toml`, while the rest of `.codex` remains
+  private per account.
+- [x] Legacy WSL `systemctl --user` orb services were disabled in the `julia`
+  account so the machine-scoped `skincos-*` runtime is the only live orb path.
+- [x] The local PostgreSQL role/database `n8n_runtime` were provisioned to
+  match `C:\CodexRuntime\n8n\env\n8n.env`, restoring `skincos-n8n.service`.
+- [x] Recoverable values were backfilled into
+  `C:\CodexRuntime\n8n\env\n8n-business.env`, including `EVOLUTION_API_KEY`,
+  `DATABASE_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`,
+  `N8N_DEFAULT_UNIT_SLUG`, and `N8N_DEFAULT_UNIT_NAME`.
+- [x] `skincos-cloudflared-cs.service` was moved off `/etc/skincos` and now
+  reads its config from `C:\CodexRuntime\cloudflared\cs`.
+- [x] Runtime mirrors were created for `crm-api.env` and `booking-api.env`
+  under `C:\CodexRuntime`.
+- [x] `Shared Validate`, `Runtime Validate`, `Shared Status`, `Codex Context`,
+  `Orb Status`, `Orb Restart`, `Orb Audit`, and `Orb Validate` now succeed in
+  the shared baseline.
+- [x] `skincos-crm-api.service` and `skincos-booking-api.service` were
+  converged away from `/srv/skincos` and `/etc/skincos` to shared repo
+  launchers plus machine-scoped runtime homes in `C:\CodexRuntime`.
+- [x] `scripts/install-shared-support-system-services.sh` now reapplies the
+  shared runtime contract for `crm-api`, `booking-api`, and `cloudflared-cs`.
+- [x] The shared runtime now has a canonical `Orb Repair` path that reconciles
+  the live Postgres contract from `C:\CodexRuntime\n8n\env\n8n.env`, restarts
+  the orb stack, validates health, and writes redacted evidence under
+  `C:\CodexRuntime\n8n\exports\repair-<timestamp>\`.
+- [x] The Codex App project actions now mirror the documented shared launcher
+  inventory, including `Shared Validate`, `Runtime Setup`, `Runtime Validate`,
+  `Thread Bootstrap`, `CRM Site EF`, `CRM Meta Ads`, `CRM Atendimento Clínica`,
+  `Orb Logs`, `Orb Audit`, and `Orb Repair`.
+- [x] Windows `gh auth login` was completed for the current `julia` profile as
+  `jubenitogarcia`.
+- [x] WSL `gh auth status` now resolves to `jubenitogarcia` via
+  `/home/julia/.config/gh/hosts.yml`.
+- [x] The four clinic orb workflows `WORKFLOW_01..04` were imported into the
+  live `n8n_runtime` project in inactive mode.
+- [x] The live `n8n` DB now contains the expected credentials
+  `Postgres (Skincos)` and `Google Calendar (Skincos)`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,27 @@
+# TASKS
+
+## Priority Backlog
+
+- [ ] Validate cross-user access to `C:\CodexShared\Projetos\skincos`.
+- [ ] Validate that a second Codex account can open this shared clone and follow
+  the continuity files without touching the legacy checkout.
+- [ ] Define the first shared worktree naming pattern for each active operator.
+- [ ] Audit remaining operator-specific paths or local assumptions before using
+  the shared clone for deploy-related work.
+
+## In Progress
+
+- [ ] Multi-account Codex workspace bootstrap on Windows.
+
+## Blocked / Needs Manual Follow-Up
+
+- [ ] Any task that requires real `.env`, `.dev.vars`, `.cloudflared`, or API
+  credentials must use a private overlay outside `C:\CodexShared`.
+
+## Done
+
+- [x] Shared clone created in `C:\CodexShared\Projetos\skincos`.
+- [x] `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md` established
+  for cross-account continuity.
+- [x] Operator-specific `cloudflared` credential paths replaced with documented
+  placeholders in the shared clone.

--- a/backend/apps/agent-zero/cloudflared.yml
+++ b/backend/apps/agent-zero/cloudflared.yml
@@ -1,5 +1,7 @@
 tunnel: 6d1245d3-1ecb-4220-a64d-636d5ce259dc
-credentials-file: /Users/jubenitogarcia/.cloudflared/6d1245d3-1ecb-4220-a64d-636d5ce259dc.json
+# Set this to the local operator path outside the shared workspace, for example:
+# $HOME/.cloudflared/<TUNNEL_UUID>.json
+credentials-file: REPLACE_WITH_LOCAL_CLOUDFLARED_CREDENTIALS_PATH
 
 ingress:
   - hostname: a0.skincos.com.br

--- a/backend/apps/agent-zero/docker/run/config.yml
+++ b/backend/apps/agent-zero/docker/run/config.yml
@@ -1,5 +1,7 @@
 tunnel: 905c9281-870e-4f2b-a6e6-7918879c81d5
-credentials-file: C:\Users\julia\.cloudflared\68c26678-d372-439d-b9ca-5357a867b3a5.json
+# Set this to the local operator path outside the shared workspace, for example:
+# %USERPROFILE%\.cloudflared\<TUNNEL_UUID>.json
+credentials-file: REPLACE_WITH_LOCAL_CLOUDFLARED_CREDENTIALS_PATH
 
 ingress:
   - hostname: a0.skincos.com.br

--- a/backend/apps/whatsapp/gateway/cloudflare-config.yml
+++ b/backend/apps/whatsapp/gateway/cloudflare-config.yml
@@ -1,5 +1,7 @@
 ﻿tunnel: d111123b-da44-45f1-adf1-35303be34865
-credentials-file: C:\Users\julia\.cloudflared\d111123b-da44-45f1-adf1-35303be34865.json
+# Set this to the local operator path outside the shared workspace, for example:
+# %USERPROFILE%\.cloudflared\<TUNNEL_UUID>.json
+credentials-file: REPLACE_WITH_LOCAL_CLOUDFLARED_CREDENTIALS_PATH
 
 ingress:
   - hostname: wa.skincos.com.br

--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -1,0 +1,233 @@
+# Workspace compartilhado no Codex App
+
+Este repositório pode ser usado como base compartilhada no Codex App em:
+
+- `C:\CodexShared\Projetos\skincos`
+
+O objetivo desta pasta é servir como clone comum para contexto, revisão,
+planejamento e início limpo de implementação. Para evitar conflito entre
+operadores, o trabalho concorrente deve seguir estas regras.
+
+## Regras de operação
+
+- Não guardar segredos, cookies, `.env`, `.dev.vars`, `.codex` ou perfis de
+  browser dentro de `C:\CodexShared`.
+- Exceção única permitida: `.codex/environments/environment.toml`, porque ele
+  versiona os botões do topo do Codex App para o clone compartilhado e para os
+  worktrees. Nenhum outro arquivo de `.codex` deve ser salvo aqui.
+- Cada operador deve usar branch no formato
+  `codex/<windows-user-ou-alias>/<task-slug>`.
+- Se houver chance de trabalho concorrente, usar worktree dedicado em
+  `C:\CodexShared\Worktrees\skincos\<ator>\<task-slug>`.
+- O clone compartilhado deve ficar reservado para contexto, revisão, bootstrap
+  e tarefas curtas; mudanças longas ou paralelas devem migrar para worktree.
+- Estado local do Codex deve ficar fora do repositório compartilhado, em
+  `%LOCALAPPDATA%\Codex\skincos\`.
+
+## Fluxo de primeira execução por usuário
+
+1. Rodar o bootstrap do workspace compartilhado:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\scripts\setup-shared-codex-workspace.ps1
+   ```
+
+2. Rodar a validação do workspace:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\scripts\validate-shared-codex-workspace.ps1
+   ```
+
+3. Preparar o runtime compartilhado do orb/n8n:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\scripts\setup-shared-runtime.ps1
+   powershell -ExecutionPolicy Bypass -File .\scripts\validate-shared-runtime.ps1
+   ```
+
+4. Instalar os atalhos compartilhados:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\scripts\install-shared-codex-shortcuts.ps1
+   ```
+
+5. Dentro do WSL da conta, rodar o bootstrap da conta humana:
+
+   ```bash
+   cd /mnt/c/CodexShared/Projetos/skincos/modules/automations/n8n
+   bash scripts/bootstrap-imported-wsl-account.sh
+   ```
+
+6. Se a conta também for fazer operações Git pelo WSL, autenticar o GitHub CLI:
+
+   ```bash
+   gh auth login --web --git-protocol https --hostname github.com
+   ```
+
+7. Abrir manualmente o clone compartilhado ou o worktree no Codex App da
+   própria conta para carregar os botões do topo definidos em
+   `.codex/environments/environment.toml`.
+
+## Atalhos compartilhados
+
+Os atalhos ficam no Menu Iniciar compartilhado:
+
+- `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`
+
+Eles são agrupados em quatro pastas.
+
+### Setup
+
+- `Shared Setup`
+- `Shared Validate`
+- `Runtime Setup`
+- `Runtime Validate`
+- `WSL Account Bootstrap`
+
+### Contexto
+
+- `Shared Status`
+- `Codex Context`
+- `Thread Bootstrap`
+- `New Worktree`
+
+### Local
+
+- `Website Local Start`
+- `Website Local Stop`
+- `CRM Local`
+- `CRM Site EF`
+- `CRM Meta Ads`
+- `CRM Atendimento Clínica`
+- `CRM Local Stop`
+
+### Runtime
+
+- `Orb Status`
+- `Orb Restart`
+- `Orb Repair`
+- `Orb Logs`
+- `Orb Validate`
+- `Orb Audit`
+
+Esses atalhos convivem com um instalador complementar de serviços de suporte:
+
+- `bash ./scripts/install-shared-support-system-services.sh --apply`
+
+Ele reaplica o contrato compartilhado de `crm-api`, `booking-api` e
+`cloudflared-cs` sem depender de paths legados em `/srv/skincos` ou
+`/etc/skincos`.
+
+## Botões do topo no Codex App
+
+O projeto agora versiona o arquivo:
+
+- `.codex/environments/environment.toml`
+
+Esse arquivo define os botões do topo da janela do projeto no Codex App.
+Como ele é parte do repositório, o mesmo conjunto de ações aparece para qualquer
+usuário local que abra:
+
+- `C:\CodexShared\Projetos\skincos`; ou
+- um worktree criado a partir desse repositório.
+
+Limites importantes:
+
+- o Codex App não centraliza a lista de projetos recentes entre contas;
+- cada conta ainda precisa abrir manualmente o clone ou o worktree no app;
+- `safe.directory`, bootstrap WSL, login do `gh` e autenticação do Codex App
+  continuam por usuário;
+- os atalhos do Menu Iniciar e os botões do topo são complementares: o primeiro
+  é compartilhamento no Windows, o segundo é compartilhamento por projeto.
+
+## Local vs runtime live
+
+Os atalhos seguem dois modelos operacionais diferentes.
+
+### Ambiente local
+
+Usado para edição, QA e iteração dos projetos locais como website e CRM.
+
+- roda a partir do código em `C:\CodexShared\Projetos\skincos`;
+- guarda PID, logs e estado temporário em `%LOCALAPPDATA%\Codex\skincos\`;
+- não deve gravar artefatos operacionais novos no clone compartilhado nem no
+  worktree por padrão.
+
+### Runtime live
+
+Usado para status, restart, logs e validação do stack live do orb/n8n/Evolution.
+
+- resolve código a partir de `modules\automations\n8n`;
+- usa o runtime compartilhado em `C:\CodexRuntime\n8n`;
+- executa via WSL e `systemd` de sistema com os units `skincos-*`;
+- não deve depender de `systemctl --user` na conta humana para o orb;
+- espera um PostgreSQL local com o role/database `n8n_runtime` compatível com
+  o contrato de `C:\CodexRuntime\n8n\env\n8n.env`.
+- quando esse contrato estiver desalinhado, o fluxo suportado é `Orb Repair`,
+  não uma intervenção manual dependente de uma conta específica.
+
+Além do orb, o mini-PC agora mantém estes serviços de suporte no mesmo modelo
+compartilhado:
+
+- `skincos-crm-api.service`, com env em `C:\CodexRuntime\crm-api\env\crm-api.env`
+  e estado mutável em `C:\CodexRuntime\crm-api\var`;
+- `skincos-booking-api.service`, com env em
+  `C:\CodexRuntime\booking-api\env\booking-api.env`, venv em
+  `C:\CodexRuntime\booking-api\venv` e estado mutável em
+  `C:\CodexRuntime\booking-api\var`;
+- `skincos-cloudflared-cs.service`, com config e credenciais em
+  `C:\CodexRuntime\cloudflared\cs`.
+
+## Status rápido e worktrees
+
+Para ver em um único comando se o clone compartilhado está sujo, qual branch
+está ativa e quais worktrees já existem:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1
+```
+
+Para iniciar uma tarefa nova sem trabalhar direto no clone compartilhado:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\new-shared-worktree.ps1 -TaskSlug corrigir-site-ef -Fetch
+```
+
+Exemplo de saída esperada:
+
+- branch `codex/<usuario>/corrigir-site-ef`
+- worktree `C:\CodexShared\Worktrees\skincos\<usuario>\corrigir-site-ef`
+
+## Fluxo recomendado para múltiplos usuários no Codex
+
+1. Rodar bootstrap, validação e instalação dos atalhos uma vez por usuário.
+2. Abrir `C:\CodexShared\Projetos\skincos` no Codex App para entender o contexto.
+3. Usar `Codex Context` ou rodar `bash ./scripts/codex-context.sh` via WSL.
+4. Para qualquer tarefa paralela ou mais longa, criar um worktree por usuário/tarefa.
+5. Abrir o worktree no Codex App e trabalhar só nele.
+6. Rodar apps locais, logs, perfis e overrides apenas a partir do estado privado
+   em `%LOCALAPPDATA%\Codex\skincos\`.
+7. Antes de handoff, atualizar `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md`.
+
+Quando o worktree é aberto no Codex App, os botões do topo passam a chamar os
+scripts relativos daquele próprio worktree, sem cair de volta no clone
+compartilhado por hardcode de path.
+
+## Sobre a integração com o Codex App
+
+Os atalhos desta pasta são operacionais: eles chamam scripts PowerShell e WSL do
+próprio workspace. Eles não dependem de um executável interno estável do Codex
+App instalado no mini-PC, porque não foi encontrada uma instalação local
+canônica do aplicativo para usar como alvo suportado.
+
+`Orb Validate` faz retry curto nos health checks do orb para evitar falso
+negativo logo após um restart saudável do stack.
+
+`Orb Repair` lê somente as chaves `DB_POSTGRESDB_*` de
+`C:\CodexRuntime\n8n\env\n8n.env`, reconcilia role/database/schema do
+PostgreSQL local, reinicia o stack live e grava evidência redigida em
+`C:\CodexRuntime\n8n\exports\repair-<timestamp>\`.
+
+Na máquina validada em `2026-07-06`, o `gh` do Windows já foi autenticado como
+`jubenitogarcia`; o `gh` do WSL ainda exige login interativo por conta quando
+essa paridade for necessária.

--- a/docs/runbooks/mini-pc-autonomia-multiusuario.md
+++ b/docs/runbooks/mini-pc-autonomia-multiusuario.md
@@ -1,0 +1,272 @@
+# Mini-PC Autonomia Multiusuário
+
+Modelo oficial do mini-PC para `skincos`:
+
+- código compartilhado: `C:\CodexShared\Projetos\skincos`
+- worktrees compartilhados: `C:\CodexShared\Worktrees\skincos\<usuario>\<task-slug>`
+- runtime oficial do orb/n8n: `C:\CodexRuntime\n8n`
+- serviços WSL live: `systemd` de sistema com `User=skincos`
+- estado privado do Codex por operador: `%LOCALAPPDATA%\Codex\skincos\`
+- atalhos compartilhados: `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`
+
+## Bootstrap por conta Windows
+
+No PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\setup-shared-codex-workspace.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\validate-shared-codex-workspace.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\setup-shared-runtime.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\validate-shared-runtime.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\install-shared-codex-shortcuts.ps1
+```
+
+Dentro do WSL da conta:
+
+```bash
+cd /mnt/c/CodexShared/Projetos/skincos/modules/automations/n8n
+bash scripts/bootstrap-imported-wsl-account.sh
+```
+
+Se a conta também operar Git dentro do WSL, concluir o login do GitHub CLI:
+
+```bash
+gh auth login --web --git-protocol https --hostname github.com
+```
+
+Esse bootstrap da conta:
+
+- registra `safe.directory` no Git local do WSL;
+- prepara `C:\CodexRuntime\n8n`;
+- instala ou atualiza os units `skincos-*`;
+- valida se o `environment.toml` esperado do Codex App está presente;
+- não promove a conta humana a dona do runtime live.
+
+Depois do bootstrap, a conta ainda precisa abrir manualmente no Codex App o
+clone compartilhado ou um worktree próprio para carregar os botões do topo do
+projeto.
+
+## Inventário dos atalhos
+
+### Setup
+
+- `Shared Setup`
+- `Shared Validate`
+- `Runtime Setup`
+- `Runtime Validate`
+- `WSL Account Bootstrap`
+
+### Contexto
+
+- `Shared Status`
+- `Codex Context`
+- `Thread Bootstrap`
+- `New Worktree`
+
+### Local
+
+- `Website Local Start`
+- `Website Local Stop`
+- `CRM Local`
+- `CRM Site EF`
+- `CRM Meta Ads`
+- `CRM Atendimento Clínica`
+- `CRM Local Stop`
+
+### Runtime
+
+- `Orb Status`
+- `Orb Restart`
+- `Orb Repair`
+- `Orb Logs`
+- `Orb Validate`
+- `Orb Audit`
+
+## Botões do projeto no Codex App
+
+Além dos atalhos do Menu Iniciar, o repositório agora compartilha os botões do
+topo do Codex App por meio de:
+
+- `.codex/environments/environment.toml`
+
+Regras:
+
+- somente esse arquivo pode ser versionado dentro de `.codex`;
+- o restante de `.codex` continua privado por conta;
+- ao abrir `C:\CodexShared\Projetos\skincos` ou um worktree derivado no Codex
+  App, a conta enxerga o mesmo conjunto de ações do projeto;
+- os comandos do topo resolvem o projeto/worktree aberto dinamicamente, então
+  ações locais como `Codex Context` e `Website Local Start` passam a operar no
+  worktree atual quando ele for o projeto aberto no app.
+
+## Contrato de runtime
+
+Arquivos oficiais:
+
+- `C:\CodexRuntime\n8n\env\n8n.env`
+- `C:\CodexRuntime\n8n\env\n8n-business.env`
+- `C:\CodexRuntime\n8n\env\evolution-api.env`
+- `C:\CodexRuntime\crm-api\env\crm-api.env`
+- `C:\CodexRuntime\booking-api\env\booking-api.env`
+- `C:\CodexRuntime\cloudflared\cs\config.yml`
+
+Regras:
+
+- `n8n.env` guarda runtime base e metadata store do n8n;
+- `n8n-business.env` guarda envs funcionais de workflows, como `DATABASE_URL`,
+  `GOOGLE_*` e `EVOLUTION_*`;
+- `evolution-api.env` guarda a configuração própria da Evolution API;
+- `crm-api.env` guarda o contrato do `skincos-crm-api.service`;
+- `booking-api.env` guarda o contrato do `skincos-booking-api.service`;
+- nenhum segredo operacional novo deve ficar em `%USERPROFILE%`, `/home/julia`,
+  `/srv/skincos/app` ou `/etc/skincos`.
+
+## Ambiente local vs runtime live
+
+### Ambiente local
+
+Usado para iterar em website, CRM e módulos locais.
+
+- executa pelo código do workspace compartilhado ou do worktree;
+- usa o estado privado do operador em `%LOCALAPPDATA%\Codex\skincos\`;
+- não deve deixar PID, logs ou artefatos temporários em `C:\CodexShared`.
+
+### Runtime live
+
+Usado para status, logs, restart e validação do stack oficial do mini-PC.
+
+- resolve o código em `modules\automations\n8n`;
+- usa `C:\CodexRuntime\n8n` como contrato canônico;
+- opera via WSL + `systemd` de sistema com os serviços `skincos-*`;
+- não deve manter nenhum serviço orb ativo em `systemctl --user`;
+- depende de PostgreSQL local com role/database `n8n_runtime` alinhado ao
+  contrato de `C:\CodexRuntime\n8n\env\n8n.env`.
+- o caminho suportado para reconciliar esse contrato, sem depender de uma conta
+  “principal”, é `Orb Repair`.
+
+## Operação do runtime
+
+Comandos públicos equivalentes aos atalhos:
+
+```powershell
+cd C:\CodexShared\Projetos\skincos
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbStatus
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbRestart
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbRepair
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbLogs
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbValidate
+powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action OrbAudit
+```
+
+Os serviços live esperados são:
+
+- `skincos-n8n.service`
+- `skincos-orb-proxy.service`
+- `skincos-cloudflared-orb.service`
+- `skincos-evolution.service`
+- `skincos-mini-pc-watchdog.timer`
+- `skincos-crm-api.service`
+- `skincos-booking-api.service`
+- `skincos-cloudflared-cs.service`
+
+O comando `Orb Audit` lista todos os units `skincos-*` instalados
+no mini-PC e destaca referências legadas ainda acopladas a `/srv/skincos`,
+`/etc/skincos` ou `/home/julia`.
+
+`Orb Repair` lê apenas o contrato `DB_POSTGRESDB_*` de
+`C:\CodexRuntime\n8n\env\n8n.env`, reconcilia role/database/schema do
+PostgreSQL local, reinicia o stack live e encerra com `Orb Validate`. A
+evidência redigida fica em `C:\CodexRuntime\n8n\exports\repair-<timestamp>\`.
+
+`Orb Validate` faz retry curto nos health checks após restart para não marcar
+como falha um boot saudável que ainda está aquecendo o listener HTTP.
+
+Para reaplicar o contrato compartilhado dos serviços de suporte:
+
+```bash
+cd /mnt/c/CodexShared/Projetos/skincos
+bash ./scripts/install-shared-support-system-services.sh --apply
+```
+
+Esse instalador usa os launchers do repositório em `scripts/migration/` e os
+templates em `ops/runtime/systemd/system/`.
+
+## Importação controlada dos workflows clínicos do orb
+
+Quando o runtime live do `n8n` ainda não tiver os workflows `WORKFLOW_01..04`,
+use o helper abaixo para validar projeto, fazer backup do Postgres live e preparar o
+import como `active=false`:
+
+```bash
+cd /mnt/c/CodexShared/Projetos/skincos
+bash modules/automations/n8n/scripts/import-clinic-workflows-live.sh --project-id <project_id>
+```
+
+Para aplicar de fato no projeto escolhido:
+
+```bash
+cd /mnt/c/CodexShared/Projetos/skincos
+bash modules/automations/n8n/scripts/import-clinic-workflows-live.sh --apply --project-id <project_id>
+```
+
+Observações:
+
+- o script gera cópias temporárias com `active=false` para não ligar cron,
+  webhook ou Google Calendar sem revisão;
+- o runtime live usa o banco Postgres `n8n_runtime` definido em
+  `C:\CodexRuntime\n8n\env\n8n.env`, não o SQLite legado como metadata store
+  principal;
+- no dry-run, ele mostra se as credenciais `Postgres (Skincos)` e
+  `Google Calendar (Skincos)` ainda faltam no banco live;
+- no `--apply`, ele gera backup do banco Postgres e cópias de
+  `n8n.env`/`n8n-business.env` em
+  `C:\CodexRuntime\n8n\exports\clinic-orb-live-<timestamp>\`;
+- ele consegue preencher automaticamente apenas os valores recuperáveis do
+  `n8n-business.env`; `GOOGLE_CALENDAR_ID` e `N8N_DEFAULT_TEST_PHONE` continuam
+  dependentes de preenchimento manual quando estiverem ausentes;
+- a credencial `Google Calendar (Skincos)` pode ser importada a partir de um
+  export legado, mas ainda precisa de revisão/reauth se o OAuth disponível não
+  tiver escopo de Calendar.
+
+## Validação e handoff
+
+Checklist de handoff entre contas:
+
+1. Abrir o contexto no clone compartilhado.
+2. Rodar `Shared Validate`.
+3. Rodar `Runtime Validate`.
+4. Rodar `Orb Status`.
+5. Se o `n8n` falhar por desalinhamento do contrato Postgres, rodar `Orb Repair`.
+6. Se houver outra intervenção no runtime, concluir com `Orb Validate`.
+7. Registrar evidências em `C:\CodexRuntime\n8n\exports\<timestamp>\`.
+
+## Critérios de limpeza do legado
+
+Só remover o legado quando tudo abaixo for verdadeiro:
+
+- nenhum serviço live depende de `systemctl --user`;
+- `skincos-*` aponta para `C:\CodexShared\Projetos\skincos\modules\automations\n8n`;
+- `skincos-crm-api.service`, `skincos-booking-api.service` e
+  `skincos-cloudflared-cs.service` apontam para `C:\CodexShared\Projetos\skincos`
+  e `C:\CodexRuntime\...`, não para `/srv/skincos` ou `/etc/skincos`;
+- `orb.skincos.com.br/healthz` e `127.0.0.1:5678/healthz` estão saudáveis;
+- `127.0.0.1:8099/health` e `127.0.0.1:8765/healthz` estão saudáveis;
+- `C:\CodexRuntime\n8n` contém os envs e credenciais canônicos;
+- nenhum segredo canônico restante vive em `/etc/skincos`, `/srv/skincos`,
+  `%USERPROFILE%` ou `/home/julia`.
+
+## Observação sobre o Codex App
+
+Os atalhos compartilhados foram desenhados para operar o workspace e o runtime
+sem depender de um executável interno estável do Codex App no mini-PC. O fluxo
+suportado é abrir o repo ou o worktree no app manualmente e usar os atalhos para
+bootstrap, contexto, ambiente local e runtime live.
+
+Separação oficial:
+
+- `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`:
+  compartilhamento operacional no Windows;
+- `.codex/environments/environment.toml`: compartilhamento dos botões do topo
+  por projeto/worktree no Codex App;
+- login do Codex App, projetos recentes, `safe.directory`, bootstrap WSL e
+  `gh auth` seguem por conta local.

--- a/frontend/.dev.vars.example
+++ b/frontend/.dev.vars.example
@@ -1,3 +1,9 @@
+# Shared-workspace note:
+# - Copy to a private `.dev.vars` outside the shared area when possible.
+# - Do not store real HMAC keys in `C:\CodexShared`.
+# - Obtain production-equivalent values from the secure owner-managed source for
+#   this environment, never from another user's profile.
+
 INSUMOS_API_TARGET=https://api.skincos.com.br
 ESCALA_API_TARGET=https://escala-api.skincos.com.br
 AUTH_PATH_PREFIX=/insumos/auth

--- a/modules/automations/n8n/scripts/audit-mini-pc-service-footprint.sh
+++ b/modules/automations/n8n/scripts/audit-mini-pc-service-footprint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+legacy_patterns=(
+  "/home/julia"
+  "/srv/skincos"
+  "/etc/skincos"
+  "systemctl --user"
+)
+
+mapfile -t unit_files < <(sudo -n find /etc/systemd/system -maxdepth 1 \( -name 'skincos-*.service' -o -name 'skincos-*.timer' \) -type f | sort)
+
+if [[ "${#unit_files[@]}" -eq 0 ]]; then
+  echo "No skincos system units found."
+  exit 0
+fi
+
+echo "== installed skincos system units =="
+printf '%s\n' "${unit_files[@]}"
+
+echo "== active state =="
+for unit_path in "${unit_files[@]}"; do
+  unit_name="$(basename "$unit_path")"
+  if sudo -n systemctl --quiet is-active "$unit_name"; then
+    state="active"
+  else
+    state="inactive"
+  fi
+  printf '%s %s\n' "$unit_name" "$state"
+done
+
+echo "== legacy path references =="
+found=0
+for pattern in "${legacy_patterns[@]}"; do
+  if sudo -n grep -n -F "$pattern" "${unit_files[@]}" >/dev/null 2>&1; then
+    echo "pattern: $pattern"
+    sudo -n grep -n -F "$pattern" "${unit_files[@]}"
+    found=1
+  fi
+done
+
+if [[ "$found" == "0" ]]; then
+  echo "No legacy path references found in installed skincos system units."
+fi

--- a/modules/automations/n8n/scripts/bootstrap-imported-wsl-account.sh
+++ b/modules/automations/n8n/scripts/bootstrap-imported-wsl-account.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/lib/runtime-paths.sh"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd"
+    exit 1
+  fi
+}
+
+require_cmd git
+require_cmd systemctl
+require_cmd sudo
+
+git config --global --add safe.directory /mnt/c/CodexShared/Projetos/skincos/modules/automations/n8n || true
+git config --global --add safe.directory /mnt/c/CodexShared/Projetos/skincos || true
+
+mkdir -p \
+  "$N8N_RUNTIME_HOME/env" \
+  "$EVOLUTION_INSTANCES_DIR" \
+  "$EVOLUTION_STORE_DIR" \
+  "$N8N_DATA_HOME" \
+  "$CLOUDFLARED_HOME" \
+  "$N8N_LOG_DIR" \
+  "$N8N_HEALTH_DIR" \
+  "$N8N_TMP_DIR" \
+  "$N8N_BINARY_DATA_DIR" \
+  "$N8N_RUNTIME_HOME/backups"
+
+bash "$ROOT_DIR/scripts/install-mini-pc-system-services.sh"
+
+echo "Bootstrap da conta WSL concluido."
+echo "Se o GitHub ainda nao estiver autenticado neste perfil, rode:"
+echo "  gh auth login --hostname github.com --git-protocol https --web"
+echo
+echo "Validacao recomendada:"
+echo "  bash /mnt/c/CodexShared/Projetos/skincos/modules/automations/n8n/scripts/validate-mini-pc-system-runtime.sh"

--- a/modules/automations/n8n/scripts/lib/runtime-paths.sh
+++ b/modules/automations/n8n/scripts/lib/runtime-paths.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+  _runtime_paths_source="${BASH_SOURCE[0]}"
+else
+  _runtime_paths_source="$0"
+fi
+
+_runtime_paths_lib_dir="$(cd "$(dirname "$_runtime_paths_source")" && pwd)"
+_runtime_paths_script_dir="$(cd "$_runtime_paths_lib_dir/.." && pwd)"
+_runtime_paths_repo_root="$(cd "$_runtime_paths_script_dir/.." && pwd)"
+
+N8N_ROOT="${N8N_ROOT:-$_runtime_paths_repo_root}"
+N8N_RUNTIME_HOME="${N8N_RUNTIME_HOME:-/mnt/c/CodexRuntime/n8n}"
+CLOUDFLARED_HOME="${CLOUDFLARED_HOME:-$N8N_RUNTIME_HOME/cloudflared}"
+N8N_ENV_FILE="${N8N_ENV_FILE:-$N8N_RUNTIME_HOME/env/n8n.env}"
+N8N_BUSINESS_ENV_FILE="${N8N_BUSINESS_ENV_FILE:-$N8N_RUNTIME_HOME/env/n8n-business.env}"
+N8N_HEALTH_DIR="${N8N_HEALTH_DIR:-$N8N_RUNTIME_HOME/health}"
+N8N_LOG_DIR="${N8N_LOG_DIR:-$N8N_RUNTIME_HOME/logs}"
+N8N_TMP_DIR="${N8N_TMP_DIR:-$N8N_RUNTIME_HOME/tmp}"
+N8N_BINARY_DATA_DIR="${N8N_BINARY_DATA_DIR:-$N8N_RUNTIME_HOME/binary-data}"
+N8N_DATA_HOME="${N8N_DATA_HOME:-$N8N_RUNTIME_HOME/n8n-home}"
+N8N_DB_PATH="${N8N_DB_PATH:-$N8N_DATA_HOME/database.sqlite}"
+N8N_CONFIG_PATH="${N8N_CONFIG_PATH:-$N8N_DATA_HOME/config}"
+EVOLUTION_ENV_FILE="${EVOLUTION_ENV_FILE:-$N8N_RUNTIME_HOME/env/evolution-api.env}"
+EVOLUTION_INSTANCES_DIR="${EVOLUTION_INSTANCES_DIR:-$N8N_RUNTIME_HOME/evolution-api/instances}"
+EVOLUTION_STORE_DIR="${EVOLUTION_STORE_DIR:-$N8N_RUNTIME_HOME/evolution-api/store}"
+SKINCOS_N8N_SERVICE="${SKINCOS_N8N_SERVICE:-skincos-n8n.service}"
+SKINCOS_ORB_PROXY_SERVICE="${SKINCOS_ORB_PROXY_SERVICE:-skincos-orb-proxy.service}"
+SKINCOS_CLOUDFLARED_ORB_SERVICE="${SKINCOS_CLOUDFLARED_ORB_SERVICE:-skincos-cloudflared-orb.service}"
+SKINCOS_EVOLUTION_SERVICE="${SKINCOS_EVOLUTION_SERVICE:-skincos-evolution.service}"
+SKINCOS_WATCHDOG_SERVICE="${SKINCOS_WATCHDOG_SERVICE:-skincos-mini-pc-watchdog.service}"
+SKINCOS_WATCHDOG_TIMER="${SKINCOS_WATCHDOG_TIMER:-skincos-mini-pc-watchdog.timer}"
+
+export N8N_ROOT
+export N8N_RUNTIME_HOME
+export CLOUDFLARED_HOME
+export N8N_ENV_FILE
+export N8N_BUSINESS_ENV_FILE
+export N8N_HEALTH_DIR
+export N8N_LOG_DIR
+export N8N_TMP_DIR
+export N8N_BINARY_DATA_DIR
+export N8N_DATA_HOME
+export N8N_DB_PATH
+export N8N_CONFIG_PATH
+export EVOLUTION_ENV_FILE
+export EVOLUTION_INSTANCES_DIR
+export EVOLUTION_STORE_DIR
+export SKINCOS_N8N_SERVICE
+export SKINCOS_ORB_PROXY_SERVICE
+export SKINCOS_CLOUDFLARED_ORB_SERVICE
+export SKINCOS_EVOLUTION_SERVICE
+export SKINCOS_WATCHDOG_SERVICE
+export SKINCOS_WATCHDOG_TIMER

--- a/modules/automations/n8n/scripts/manage-mini-pc-system-services.sh
+++ b/modules/automations/n8n/scripts/manage-mini-pc-system-services.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/lib/runtime-paths.sh"
+
+action="${1:-status}"
+shift || true
+
+units=(
+  "$SKINCOS_N8N_SERVICE"
+  "$SKINCOS_ORB_PROXY_SERVICE"
+  "$SKINCOS_CLOUDFLARED_ORB_SERVICE"
+  "$SKINCOS_EVOLUTION_SERVICE"
+  "$SKINCOS_WATCHDOG_TIMER"
+)
+
+case "$action" in
+  status)
+    sudo -n systemctl --no-pager --plain status "${units[@]}"
+    ;;
+  restart)
+    sudo -n systemctl restart \
+      "$SKINCOS_N8N_SERVICE" \
+      "$SKINCOS_ORB_PROXY_SERVICE" \
+      "$SKINCOS_CLOUDFLARED_ORB_SERVICE" \
+      "$SKINCOS_EVOLUTION_SERVICE"
+    sudo -n systemctl restart "$SKINCOS_WATCHDOG_TIMER"
+    sudo -n systemctl --no-pager --plain status "${units[@]}"
+    ;;
+  logs)
+    lines="${1:-120}"
+    sudo -n journalctl -u "$SKINCOS_N8N_SERVICE" \
+      -u "$SKINCOS_ORB_PROXY_SERVICE" \
+      -u "$SKINCOS_CLOUDFLARED_ORB_SERVICE" \
+      -u "$SKINCOS_EVOLUTION_SERVICE" \
+      -u "$SKINCOS_WATCHDOG_SERVICE" \
+      -n "$lines" --no-pager -l
+    ;;
+  *)
+    echo "Usage: $0 {status|restart|logs [lines]}"
+    exit 1
+    ;;
+esac

--- a/modules/automations/n8n/scripts/reconcile-mini-pc-runtime-postgres.sh
+++ b/modules/automations/n8n/scripts/reconcile-mini-pc-runtime-postgres.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/lib/runtime-paths.sh"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+EXPORT_ROOT="$N8N_RUNTIME_HOME/exports/repair-$STAMP"
+REPORT_FILE="$EXPORT_ROOT/report.txt"
+CONTRACT_FILE="$EXPORT_ROOT/runtime-contract.redacted.env"
+DB_CHECK_FILE="$EXPORT_ROOT/postgres-contract-check.txt"
+RESTART_LOG="$EXPORT_ROOT/restart.log"
+VALIDATE_LOG="$EXPORT_ROOT/validate.log"
+
+required_keys=(
+  "DB_TYPE"
+  "DB_POSTGRESDB_HOST"
+  "DB_POSTGRESDB_PORT"
+  "DB_POSTGRESDB_DATABASE"
+  "DB_POSTGRESDB_USER"
+  "DB_POSTGRESDB_PASSWORD"
+  "DB_POSTGRESDB_SCHEMA"
+)
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_file() {
+  [[ -f "$1" ]] || {
+    echo "Missing required file: $1" >&2
+    exit 1
+  }
+}
+
+read_contract_value() {
+  local key="$1"
+  local line
+
+  line="$(grep -E "^${key}=" "$N8N_ENV_FILE" | tail -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${line#*=}" | tr -d '\r'
+}
+
+sql_literal() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/''/g")"
+}
+
+sql_identifier() {
+  printf '"%s"' "$(printf '%s' "$1" | sed 's/"/""/g')"
+}
+
+postgres_superuser_psql() {
+  sudo -n -u postgres psql --no-psqlrc -v ON_ERROR_STOP=1 --dbname postgres "$@"
+}
+
+runtime_db_psql() {
+  PGPASSWORD="$DB_POSTGRESDB_PASSWORD" \
+    psql --no-psqlrc \
+      -v ON_ERROR_STOP=1 \
+      -h "$DB_POSTGRESDB_HOST" \
+      -p "$DB_POSTGRESDB_PORT" \
+      -U "$DB_POSTGRESDB_USER" \
+      -d "$DB_POSTGRESDB_DATABASE" \
+      "$@"
+}
+
+require_cmd grep
+require_cmd psql
+require_cmd sed
+require_cmd sudo
+require_file "$N8N_ENV_FILE"
+
+for key in "${required_keys[@]}"; do
+  value="$(read_contract_value "$key" || true)"
+  if [[ -z "$value" ]]; then
+    echo "Missing required runtime contract entry: $key" >&2
+    exit 1
+  fi
+  printf -v "$key" '%s' "$value"
+done
+
+if [[ "$DB_TYPE" != "postgresdb" ]]; then
+  echo "This helper expects DB_TYPE=postgresdb in $N8N_ENV_FILE." >&2
+  exit 1
+fi
+
+case "$DB_POSTGRESDB_HOST" in
+  127.0.0.1|localhost|::1) ;;
+  *)
+    echo "Refusing to reconcile a non-local PostgreSQL host: $DB_POSTGRESDB_HOST" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$EXPORT_ROOT"
+
+db_name_ident="$(sql_identifier "$DB_POSTGRESDB_DATABASE")"
+db_user_ident="$(sql_identifier "$DB_POSTGRESDB_USER")"
+db_schema_ident="$(sql_identifier "$DB_POSTGRESDB_SCHEMA")"
+db_name_lit="$(sql_literal "$DB_POSTGRESDB_DATABASE")"
+db_user_lit="$(sql_literal "$DB_POSTGRESDB_USER")"
+db_password_lit="$(sql_literal "$DB_POSTGRESDB_PASSWORD")"
+db_schema_lit="$(sql_literal "$DB_POSTGRESDB_SCHEMA")"
+if [[ "$DB_POSTGRESDB_SCHEMA" == "public" ]]; then
+  db_search_path_sql="public"
+else
+  db_search_path_sql="$db_schema_ident, public"
+fi
+
+role_exists="$(postgres_superuser_psql -At -c "select 1 from pg_roles where rolname = $db_user_lit;" || true)"
+db_exists="$(postgres_superuser_psql -At -c "select 1 from pg_database where datname = $db_name_lit;" || true)"
+
+cat >"$CONTRACT_FILE" <<EOF
+DB_TYPE=$DB_TYPE
+DB_POSTGRESDB_HOST=$DB_POSTGRESDB_HOST
+DB_POSTGRESDB_PORT=$DB_POSTGRESDB_PORT
+DB_POSTGRESDB_DATABASE=$DB_POSTGRESDB_DATABASE
+DB_POSTGRESDB_USER=$DB_POSTGRESDB_USER
+DB_POSTGRESDB_PASSWORD=[REDACTED]
+DB_POSTGRESDB_SCHEMA=$DB_POSTGRESDB_SCHEMA
+EOF
+
+{
+  echo "repair_timestamp_utc=$STAMP"
+  echo "runtime_env_file=$N8N_ENV_FILE"
+  echo "runtime_export_root=$EXPORT_ROOT"
+  echo "db_host=$DB_POSTGRESDB_HOST"
+  echo "db_port=$DB_POSTGRESDB_PORT"
+  echo "db_name=$DB_POSTGRESDB_DATABASE"
+  echo "db_user=$DB_POSTGRESDB_USER"
+  echo "db_schema=$DB_POSTGRESDB_SCHEMA"
+  echo "role_exists_before=$([[ "$role_exists" == "1" ]] && echo yes || echo no)"
+  echo "database_exists_before=$([[ "$db_exists" == "1" ]] && echo yes || echo no)"
+} >"$REPORT_FILE"
+
+if [[ "$role_exists" == "1" ]]; then
+  postgres_superuser_psql <<SQL
+ALTER ROLE $db_user_ident LOGIN PASSWORD $db_password_lit;
+SQL
+  echo "role_action=altered" >>"$REPORT_FILE"
+else
+  postgres_superuser_psql <<SQL
+CREATE ROLE $db_user_ident LOGIN PASSWORD $db_password_lit;
+SQL
+  echo "role_action=created" >>"$REPORT_FILE"
+fi
+
+if [[ "$db_exists" == "1" ]]; then
+  postgres_superuser_psql <<SQL
+ALTER DATABASE $db_name_ident OWNER TO $db_user_ident;
+GRANT ALL PRIVILEGES ON DATABASE $db_name_ident TO $db_user_ident;
+SQL
+  echo "database_action=owner_aligned" >>"$REPORT_FILE"
+else
+  postgres_superuser_psql <<SQL
+CREATE DATABASE $db_name_ident OWNER $db_user_ident;
+GRANT ALL PRIVILEGES ON DATABASE $db_name_ident TO $db_user_ident;
+SQL
+  echo "database_action=created" >>"$REPORT_FILE"
+fi
+
+postgres_superuser_psql <<SQL
+ALTER ROLE $db_user_ident IN DATABASE $db_name_ident SET search_path TO $db_search_path_sql;
+SQL
+
+if [[ "$DB_POSTGRESDB_SCHEMA" == "public" ]]; then
+  sudo -n -u postgres psql --no-psqlrc -v ON_ERROR_STOP=1 --dbname "$DB_POSTGRESDB_DATABASE" <<SQL
+GRANT USAGE, CREATE ON SCHEMA public TO $db_user_ident;
+SQL
+  echo "schema_action=grants_refreshed_public" >>"$REPORT_FILE"
+else
+  sudo -n -u postgres psql --no-psqlrc -v ON_ERROR_STOP=1 --dbname "$DB_POSTGRESDB_DATABASE" <<SQL
+CREATE SCHEMA IF NOT EXISTS $db_schema_ident AUTHORIZATION $db_user_ident;
+ALTER SCHEMA $db_schema_ident OWNER TO $db_user_ident;
+GRANT USAGE, CREATE ON SCHEMA $db_schema_ident TO $db_user_ident;
+SQL
+  echo "schema_action=owner_aligned" >>"$REPORT_FILE"
+fi
+
+runtime_db_psql -At <<SQL >"$DB_CHECK_FILE"
+select 'db_user=' || current_user;
+select 'db_name=' || current_database();
+select 'schema_present=' || exists (
+  select 1
+  from information_schema.schemata
+  where schema_name = $db_schema_lit
+);
+show search_path;
+SQL
+
+echo "db_contract_check=$DB_CHECK_FILE" >>"$REPORT_FILE"
+
+{
+  echo "== restart =="
+  bash "$ROOT_DIR/scripts/manage-mini-pc-system-services.sh" restart
+} | tee "$RESTART_LOG"
+
+{
+  echo "== validate =="
+  bash "$ROOT_DIR/scripts/validate-mini-pc-system-runtime.sh"
+} | tee "$VALIDATE_LOG"
+
+{
+  echo "restart_log=$RESTART_LOG"
+  echo "validate_log=$VALIDATE_LOG"
+  echo "status=success"
+} >>"$REPORT_FILE"
+
+echo "Repair evidence saved to: $EXPORT_ROOT"

--- a/modules/automations/n8n/scripts/validate-mini-pc-system-runtime.sh
+++ b/modules/automations/n8n/scripts/validate-mini-pc-system-runtime.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/lib/runtime-paths.sh"
+
+N8N_HEALTH_URL="${N8N_HEALTH_URL:-http://127.0.0.1:5678/healthz}"
+ORB_PROXY_HEALTH_URL="${ORB_PROXY_HEALTH_URL:-http://127.0.0.1:8788/meta-review/healthz}"
+ORB_PUBLIC_HEALTH_URL="${ORB_PUBLIC_HEALTH_URL:-https://orb.skincos.com.br/healthz}"
+legacy_patterns=(
+  "/home/julia"
+  "/srv/skincos"
+  "/etc/skincos"
+  "systemctl --user"
+)
+
+check_url() {
+  local label="$1"
+  local url="$2"
+  local attempts="${3:-5}"
+  local sleep_seconds="${4:-3}"
+  local attempt=1
+  local output
+  echo "== $label =="
+  while (( attempt <= attempts )); do
+    if output="$(curl -fsS --max-time 15 "$url" 2>&1)"; then
+      printf '%s\n\n' "$output"
+      return 0
+    fi
+
+    if (( attempt == attempts )); then
+      printf '%s\n' "$output" >&2
+      return 1
+    fi
+
+    printf 'retry %s/%s in %ss\n' "$attempt" "$attempts" "$sleep_seconds" >&2
+    sleep "$sleep_seconds"
+    ((attempt++))
+  done
+}
+
+check_no_legacy_patterns() {
+  local label="$1"
+  shift
+  local paths=("$@")
+  local found=0
+  local pattern
+
+  for pattern in "${legacy_patterns[@]}"; do
+    if grep -R -n -F "$pattern" "${paths[@]}" >/dev/null 2>&1; then
+      echo "Legacy reference detected in $label: $pattern"
+      grep -R -n -F "$pattern" "${paths[@]}" || true
+      found=1
+    fi
+  done
+
+  if [[ "$found" == "1" ]]; then
+    exit 1
+  fi
+}
+
+echo "== runtime files =="
+for path in \
+  "$N8N_ENV_FILE" \
+  "$N8N_BUSINESS_ENV_FILE" \
+  "$EVOLUTION_ENV_FILE" \
+  "$CLOUDFLARED_HOME/orb-config.yml"; do
+  if [[ ! -f "$path" ]]; then
+    echo "Missing runtime file: $path"
+    exit 1
+  fi
+  printf 'ok %s\n' "$path"
+done
+
+echo "== permissions =="
+sudo -n -u skincos test -r "$N8N_ENV_FILE" && echo "skincos_can_read_n8n_env"
+sudo -n -u skincos test -r "$N8N_BUSINESS_ENV_FILE" && echo "skincos_can_read_business_env"
+sudo -n -u skincos test -r "$EVOLUTION_ENV_FILE" && echo "skincos_can_read_evolution_env"
+sudo -n -u skincos test -w "$N8N_LOG_DIR" && echo "skincos_can_write_logs"
+sudo -n -u skincos test -w "$N8N_BINARY_DATA_DIR" && echo "skincos_can_write_binary_data"
+sudo -n -u skincos test -w "$N8N_TMP_DIR" && echo "skincos_can_write_tmp"
+
+echo "== legacy path audit =="
+check_no_legacy_patterns "runtime env files" \
+  "$N8N_ENV_FILE" \
+  "$N8N_BUSINESS_ENV_FILE" \
+  "$EVOLUTION_ENV_FILE"
+check_no_legacy_patterns "installed orb system units" \
+  "/etc/systemd/system/$SKINCOS_N8N_SERVICE" \
+  "/etc/systemd/system/$SKINCOS_ORB_PROXY_SERVICE" \
+  "/etc/systemd/system/$SKINCOS_CLOUDFLARED_ORB_SERVICE" \
+  "/etc/systemd/system/$SKINCOS_EVOLUTION_SERVICE" \
+  "/etc/systemd/system/$SKINCOS_WATCHDOG_SERVICE" \
+  "/etc/systemd/system/$SKINCOS_WATCHDOG_TIMER"
+
+echo "== system services =="
+sudo -n systemctl --no-pager --plain status \
+  "$SKINCOS_N8N_SERVICE" \
+  "$SKINCOS_ORB_PROXY_SERVICE" \
+  "$SKINCOS_CLOUDFLARED_ORB_SERVICE" \
+  "$SKINCOS_EVOLUTION_SERVICE" \
+  "$SKINCOS_WATCHDOG_TIMER"
+
+echo "== legacy blockers =="
+if systemctl --user is-active --quiet n8n.service orb-proxy.service cloudflared-orb.service evolution-api.service mini-pc-watchdog.timer; then
+  echo "Legacy systemctl --user services are still active."
+  exit 1
+fi
+echo "legacy_user_services_inactive"
+
+check_url "n8n local" "$N8N_HEALTH_URL"
+check_url "orb-proxy local" "$ORB_PROXY_HEALTH_URL"
+check_url "orb public" "$ORB_PUBLIC_HEALTH_URL"
+
+echo "System runtime validation OK."

--- a/scripts/install-shared-codex-shortcuts.ps1
+++ b/scripts/install-shared-codex-shortcuts.ps1
@@ -1,0 +1,110 @@
+param(
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string]$StartMenuRoot = "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex",
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        try {
+            New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        }
+        catch [System.UnauthorizedAccessException] {
+            throw "Access denied while creating '$Path'. Re-run this installer from an elevated PowerShell session to publish shared Start Menu shortcuts for all local users."
+        }
+    }
+}
+
+function Remove-DirectoryIfExists {
+    param([string]$Path)
+
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+}
+
+function New-ShortcutFile {
+    param(
+        [string]$ShortcutPath,
+        [string]$TargetPath,
+        [string]$Arguments,
+        [string]$WorkingDirectory,
+        [string]$Description
+    )
+
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($ShortcutPath)
+    $shortcut.TargetPath = $TargetPath
+    $shortcut.Arguments = $Arguments
+    $shortcut.WorkingDirectory = $WorkingDirectory
+    $shortcut.Description = $Description
+    $shortcut.IconLocation = "$TargetPath,0"
+    $shortcut.Save()
+}
+
+if ($Uninstall) {
+    Remove-DirectoryIfExists -Path $StartMenuRoot
+    [pscustomobject]@{
+        action = "uninstall"
+        startMenuRoot = $StartMenuRoot
+        removed = $true
+    } | ConvertTo-Json -Depth 3
+    exit 0
+}
+
+$runner = Join-Path $ProjectRoot "scripts\run-shared-codex-shortcut.ps1"
+$powershellExe = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+
+$shortcuts = @(
+    @{ Group = "Setup"; Name = "Shared Setup"; Action = "SharedSetup"; Description = "Bootstrap do workspace compartilhado do Skincos." },
+    @{ Group = "Setup"; Name = "Shared Validate"; Action = "SharedValidate"; Description = "Validação do workspace compartilhado do Skincos." },
+    @{ Group = "Setup"; Name = "Runtime Setup"; Action = "RuntimeSetup"; Description = "Bootstrap do runtime compartilhado do orb/n8n." },
+    @{ Group = "Setup"; Name = "Runtime Validate"; Action = "RuntimeValidate"; Description = "Validação do runtime compartilhado do orb/n8n." },
+    @{ Group = "Setup"; Name = "WSL Account Bootstrap"; Action = "WslAccountBootstrap"; Description = "Bootstrap da conta WSL para o runtime compartilhado." },
+    @{ Group = "Contexto"; Name = "Shared Status"; Action = "SharedStatus"; Description = "Status rápido do clone compartilhado e das worktrees." },
+    @{ Group = "Contexto"; Name = "Codex Context"; Action = "CodexContext"; Description = "Contexto seguro do projeto para sessões no Codex." },
+    @{ Group = "Contexto"; Name = "Thread Bootstrap"; Action = "ThreadBootstrap"; Description = "Prompt base para novas threads do Codex App." },
+    @{ Group = "Contexto"; Name = "New Worktree"; Action = "NewWorktree"; Description = "Cria um worktree compartilhado para uma nova tarefa." },
+    @{ Group = "Local"; Name = "Website Local Start"; Action = "WebsiteLocalStart"; Description = "Sobe o website local usando o estado privado do operador." },
+    @{ Group = "Local"; Name = "Website Local Stop"; Action = "WebsiteLocalStop"; Description = "Encerra o website local rastreado no estado privado do operador." },
+    @{ Group = "Local"; Name = "CRM Local"; Action = "CrmLocal"; Description = "Sobe o CRM local com o estado privado do operador." },
+    @{ Group = "Local"; Name = "CRM Site EF"; Action = "CrmSiteEf"; Description = "Sobe o CRM local focado no módulo Site EF." },
+    @{ Group = "Local"; Name = "CRM Meta Ads"; Action = "CrmMetaAds"; Description = "Sobe o CRM local focado no módulo Meta Ads." },
+    @{ Group = "Local"; Name = "CRM Atendimento Clínica"; Action = "CrmAtendimentoClinica"; Description = "Sobe o módulo local de Atendimento Clínica." },
+    @{ Group = "Local"; Name = "CRM Local Stop"; Action = "CrmLocalStop"; Description = "Encerra os launchers locais de CRM rastreados no estado privado do operador." },
+    @{ Group = "Runtime"; Name = "Orb Status"; Action = "OrbStatus"; Description = "Mostra o status do stack live do orb/n8n." },
+    @{ Group = "Runtime"; Name = "Orb Restart"; Action = "OrbRestart"; Description = "Reinicia o stack live do orb/n8n." },
+    @{ Group = "Runtime"; Name = "Orb Repair"; Action = "OrbRepair"; Description = "Reconcilia o contrato Postgres do runtime live e valida o stack." },
+    @{ Group = "Runtime"; Name = "Orb Logs"; Action = "OrbLogs"; Description = "Mostra os logs recentes do stack live do orb/n8n." },
+    @{ Group = "Runtime"; Name = "Orb Validate"; Action = "OrbValidate"; Description = "Valida o runtime live do orb/n8n." },
+    @{ Group = "Runtime"; Name = "Orb Audit"; Action = "OrbAudit"; Description = "Audita os units skincos-* instalados no mini-PC." }
+)
+
+Ensure-Directory -Path $StartMenuRoot
+
+$installed = @()
+foreach ($shortcutSpec in $shortcuts) {
+    $groupPath = Join-Path $StartMenuRoot $shortcutSpec.Group
+    Ensure-Directory -Path $groupPath
+
+    $shortcutPath = Join-Path $groupPath ($shortcutSpec.Name + ".lnk")
+    $arguments = '-NoExit -ExecutionPolicy Bypass -File "{0}" -Action {1} -ProjectRoot "{2}"' -f $runner, $shortcutSpec.Action, $ProjectRoot
+    New-ShortcutFile -ShortcutPath $shortcutPath -TargetPath $powershellExe -Arguments $arguments -WorkingDirectory $ProjectRoot -Description $shortcutSpec.Description
+
+    $installed += [pscustomobject]@{
+        group = $shortcutSpec.Group
+        name = $shortcutSpec.Name
+        action = $shortcutSpec.Action
+        path = $shortcutPath
+    }
+}
+
+[pscustomobject]@{
+    action = "install"
+    startMenuRoot = $StartMenuRoot
+    installed = $installed
+} | ConvertTo-Json -Depth 4

--- a/scripts/invoke-skincos-wsl.ps1
+++ b/scripts/invoke-skincos-wsl.ps1
@@ -1,0 +1,108 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoCommand,
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string[]]$EnvVar = @(),
+    [switch]$SkipBootstrapCheck,
+    [switch]$SkipNodeCheck,
+    [switch]$SkipNpmCheck,
+    [switch]$SkipGitCheck,
+    [switch]$SkipRepoCheck
+)
+
+$ErrorActionPreference = "Stop"
+
+function Convert-WindowsPathToWsl {
+    param([string]$Path)
+
+    if ($Path -match '^(?<drive>[A-Za-z]):\\(?<rest>.*)$') {
+        $drive = $Matches.drive.ToLowerInvariant()
+        $rest = $Matches.rest -replace '\\', '/'
+        if ([string]::IsNullOrWhiteSpace($rest)) {
+            return "/mnt/$drive"
+        }
+        return "/mnt/$drive/$rest"
+    }
+
+    return $Path
+}
+
+function Convert-ToBashLiteral {
+    param([string]$Value)
+
+    return "'" + $Value.Replace("'", "'""'""'") + "'"
+}
+
+function Resolve-EnvVarEntry {
+    param([string]$Entry)
+
+    $parts = $Entry.Split('=', 2)
+    if ($parts.Count -ne 2 -or [string]::IsNullOrWhiteSpace($parts[0])) {
+        throw "EnvVar entry must use NAME=value format. Received: $Entry"
+    }
+
+    $name = $parts[0].Trim()
+    $value = [Environment]::ExpandEnvironmentVariables($parts[1])
+    if ($value -match '^[A-Za-z]:\\') {
+        $value = Convert-WindowsPathToWsl -Path $value
+    }
+
+    return [pscustomobject]@{
+        Name = $name
+        Value = $value
+    }
+}
+
+$wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+if (-not $wsl) {
+    throw "wsl.exe not found. Install or enable Windows Subsystem for Linux before using shared Skincos shortcuts."
+}
+
+$repoMountPath = Convert-WindowsPathToWsl -Path $ProjectRoot
+$defaultDistro = $null
+$defaultDistroLine = @(& $wsl.Source -l -v 2>$null) |
+    ForEach-Object { $_ -replace [char]0, '' } |
+    Where-Object { $_ -match '^\s*\*' } |
+    Select-Object -First 1
+if ($defaultDistroLine -match '^\s*\*\s+(?<name>.+?)\s{2,}') {
+    $defaultDistro = $Matches.name.Trim()
+}
+
+$bashLines = [System.Collections.Generic.List[string]]::new()
+$bashLines.Add("set -euo pipefail")
+
+if (-not $SkipRepoCheck) {
+    $bashLines.Add("if [[ ! -d $(Convert-ToBashLiteral -Value $repoMountPath) ]]; then echo 'Shared repo not found at $repoMountPath.'; exit 1; fi")
+}
+if (-not $SkipGitCheck) {
+    $bashLines.Add("if ! command -v git >/dev/null 2>&1; then echo 'git is not available in WSL. Install Git or fix the WSL toolchain first.'; exit 1; fi")
+}
+if (-not $SkipNodeCheck) {
+    $bashLines.Add("if ! command -v node >/dev/null 2>&1; then echo 'node is not available in WSL. Install Node.js or fix the WSL toolchain first.'; exit 1; fi")
+}
+if (-not $SkipNpmCheck) {
+    $bashLines.Add("if ! command -v npm >/dev/null 2>&1; then echo 'npm is not available in WSL. Install npm or fix the WSL toolchain first.'; exit 1; fi")
+}
+if (-not $SkipBootstrapCheck) {
+    $safeRepoLiteral = Convert-ToBashLiteral -Value $repoMountPath
+    $bashLines.Add("if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq $safeRepoLiteral; then echo 'WSL bootstrap for this user is not ready. Run: bash $repoMountPath/modules/automations/n8n/scripts/bootstrap-imported-wsl-account.sh'; exit 1; fi")
+}
+
+foreach ($entry in $EnvVar) {
+    $resolved = Resolve-EnvVarEntry -Entry $entry
+    $bashLines.Add("export $($resolved.Name)=" + (Convert-ToBashLiteral -Value $resolved.Value))
+}
+
+$bashLines.Add("cd " + (Convert-ToBashLiteral -Value $repoMountPath))
+$bashLines.Add($RepoCommand)
+$bashCommand = ($bashLines -join "`n")
+
+if ($defaultDistro) {
+    Write-Host "WSL default distro: $defaultDistro"
+}
+Write-Host "Running in WSL repo: $repoMountPath"
+
+& $wsl.Source bash -lc $bashCommand
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/new-shared-worktree.ps1
+++ b/scripts/new-shared-worktree.ps1
@@ -1,0 +1,87 @@
+param(
+    [string]$TaskSlug,
+    [string]$Actor = $env:USERNAME,
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
+    [string]$BaseRef = "origin/main",
+    [string]$BranchName,
+    [switch]$Fetch
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+    $TaskSlug = Read-Host "TaskSlug"
+}
+
+if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+    throw "TaskSlug is required."
+}
+
+function Normalize-Actor {
+    param([string]$Value)
+    return ($Value.Trim().ToLowerInvariant() -replace '[^a-z0-9._-]', '-')
+}
+
+function Normalize-Slug {
+    param([string]$Value)
+    return ($Value.Trim().ToLowerInvariant() -replace '[^a-z0-9._-]', '-')
+}
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Ensure-SafeDirectory {
+    param([string]$RepoPath)
+    $existing = @(git config --global --get-all safe.directory 2>$null)
+    $variants = @($RepoPath, $RepoPath.Replace('\', '/'))
+    foreach ($variant in $variants) {
+        if ($existing -notcontains $variant) {
+            git config --global --add safe.directory $variant
+        }
+    }
+}
+
+$normalizedActor = Normalize-Actor -Value $Actor
+$normalizedTask = Normalize-Slug -Value $TaskSlug
+
+if (-not $BranchName) {
+    $BranchName = "codex/$normalizedActor/$normalizedTask"
+}
+
+$actorRoot = Join-Path $WorktreeRoot $normalizedActor
+$worktreePath = Join-Path $actorRoot $normalizedTask
+
+Ensure-Directory -Path $actorRoot
+Ensure-SafeDirectory -RepoPath $ProjectRoot
+
+if ($Fetch) {
+    git -C $ProjectRoot fetch origin
+}
+
+if (Test-Path -LiteralPath $worktreePath) {
+    throw "Worktree already exists at '$worktreePath'."
+}
+
+$branchExists = (& git -C $ProjectRoot branch --list $BranchName)
+if ($branchExists) {
+    throw "Branch '$BranchName' already exists locally. Choose another TaskSlug or BranchName."
+}
+
+git -C $ProjectRoot worktree add $worktreePath -b $BranchName $BaseRef
+Ensure-SafeDirectory -RepoPath $worktreePath
+
+$result = [pscustomobject]@{
+    actor = $normalizedActor
+    taskSlug = $normalizedTask
+    branchName = $BranchName
+    baseRef = $BaseRef
+    projectRoot = $ProjectRoot
+    worktreePath = $worktreePath
+}
+
+$result | ConvertTo-Json -Depth 4

--- a/scripts/print-codex-thread-bootstrap.ps1
+++ b/scripts/print-codex-thread-bootstrap.ps1
@@ -1,0 +1,45 @@
+param(
+    [string]$TaskBrief = "Descreva aqui a tarefa",
+    [string]$TaskSlug = "definir-task-slug",
+    [switch]$Interactive,
+    [switch]$Json
+)
+
+if ($Interactive) {
+    $promptedTaskSlug = Read-Host "TaskSlug"
+    if (-not [string]::IsNullOrWhiteSpace($promptedTaskSlug)) {
+        $TaskSlug = $promptedTaskSlug
+    }
+
+    $promptedTaskBrief = Read-Host "TaskBrief"
+    if (-not [string]::IsNullOrWhiteSpace($promptedTaskBrief)) {
+        $TaskBrief = $promptedTaskBrief
+    }
+}
+
+$lines = @(
+    "Use este projeto compartilhado em `C:\CodexShared\Projetos\skincos` apenas como base de contexto e coordenação.",
+    "Antes de editar qualquer arquivo:",
+    "1. Leia `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md`.",
+    "2. Verifique o estado compartilhado com `powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1`.",
+    "3. Se a tarefa não for estritamente de leitura, crie um worktree dedicado com `powershell -ExecutionPolicy Bypass -File .\scripts\new-shared-worktree.ps1 -TaskSlug $TaskSlug -Fetch`.",
+    "4. Depois de criar o worktree, trabalhe apenas nele e trate o clone compartilhado como somente leitura para contexto.",
+    "5. Mantenha estado local, logs, perfis e overrides fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`.",
+    "6. Preserve alterações não relacionadas já existentes no projeto compartilhado ou em worktrees de outros usuários.",
+    "7. Antes de concluir, valide o que mudar e registre contexto relevante em `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md` quando fizer sentido.",
+    "",
+    "Tarefa desta thread: $TaskBrief"
+)
+
+$prompt = ($lines -join [Environment]::NewLine)
+
+if ($Json) {
+    [pscustomobject]@{
+        taskBrief = $TaskBrief
+        taskSlug = $TaskSlug
+        prompt = $prompt
+    } | ConvertTo-Json -Depth 3
+}
+else {
+    $prompt
+}

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -1,0 +1,199 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet(
+        "SharedSetup",
+        "SharedValidate",
+        "RuntimeSetup",
+        "RuntimeValidate",
+        "WslAccountBootstrap",
+        "SharedStatus",
+        "CodexContext",
+        "ThreadBootstrap",
+        "NewWorktree",
+        "WebsiteLocalStart",
+        "WebsiteLocalStop",
+        "CrmLocal",
+        "CrmSiteEf",
+        "CrmMetaAds",
+        "CrmAtendimentoClinica",
+        "CrmLocalStop",
+        "OrbStatus",
+        "OrbRestart",
+        "OrbLogs",
+        "OrbValidate",
+        "OrbAudit",
+        "OrbRepair"
+    )]
+    [string]$Action,
+    [string]$ProjectRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+function Resolve-ProjectRoot {
+    param(
+        [string]$RequestedPath,
+        [string]$ScriptDirectory
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        return (Resolve-Path -LiteralPath $RequestedPath).Path
+    }
+
+    $scriptProjectRoot = Split-Path -Parent $ScriptDirectory
+    if ((Test-Path -LiteralPath (Join-Path $scriptProjectRoot ".git")) -or
+        (Test-Path -LiteralPath (Join-Path $scriptProjectRoot "AGENTS.md"))) {
+        return (Resolve-Path -LiteralPath $scriptProjectRoot).Path
+    }
+
+    $currentPath = (Get-Location).Path
+    if ((Test-Path -LiteralPath (Join-Path $currentPath ".git")) -or
+        (Test-Path -LiteralPath (Join-Path $currentPath "AGENTS.md"))) {
+        return (Resolve-Path -LiteralPath $currentPath).Path
+    }
+
+    throw "Unable to resolve the Skincos project root automatically. Re-run the command from the project/worktree root or pass -ProjectRoot explicitly."
+}
+
+$ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot -ScriptDirectory $scriptRoot
+$localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
+$tmpRoot = Join-Path $localStateRoot "tmp"
+$logRoot = Join-Path $localStateRoot "logs"
+$wslInvoker = Join-Path $scriptRoot "invoke-skincos-wsl.ps1"
+
+function Ensure-LocalState {
+    foreach ($path in @($localStateRoot, $tmpRoot, $logRoot)) {
+        if (-not (Test-Path -LiteralPath $path)) {
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+        }
+    }
+}
+
+function Convert-WindowsPathToWsl {
+    param([string]$Path)
+
+    if ($Path -match '^(?<drive>[A-Za-z]):\\(?<rest>.*)$') {
+        $drive = $Matches.drive.ToLowerInvariant()
+        $rest = $Matches.rest -replace '\\', '/'
+        if ([string]::IsNullOrWhiteSpace($rest)) {
+            return "/mnt/$drive"
+        }
+        return "/mnt/$drive/$rest"
+    }
+
+    return $Path
+}
+
+function Convert-ToBashLiteral {
+    param([string]$Value)
+
+    return "'" + $Value.Replace("'", "'""'""'") + "'"
+}
+
+function Invoke-ShortcutWsl {
+    param(
+        [string]$Command,
+        [switch]$SkipBootstrapCheck
+    )
+
+    & $wslInvoker -ProjectRoot $ProjectRoot -RepoCommand $Command -SkipBootstrapCheck:$SkipBootstrapCheck
+}
+
+function Invoke-RepoPowerShellScript {
+    param([string]$ScriptName)
+
+    & (Join-Path $scriptRoot $ScriptName) -ProjectRoot $ProjectRoot
+}
+
+Ensure-LocalState
+
+$websitePid = Join-Path $tmpRoot "website-local-dev.pid"
+$websiteLog = Join-Path $logRoot "website-local-dev.log"
+$websitePort = Join-Path $tmpRoot "website-local-dev.port"
+$crmPid = Join-Path $tmpRoot "crm-local-dev.pid"
+$crmLog = Join-Path $logRoot "crm-local-dev.log"
+$atendimentoPid = Join-Path $tmpRoot "crm-atendimento-clinica-local.pid"
+$atendimentoLog = Join-Path $logRoot "crm-atendimento-clinica-local.log"
+
+$tmpRootWsl = Convert-WindowsPathToWsl -Path $tmpRoot
+$websitePidWsl = Convert-WindowsPathToWsl -Path $websitePid
+$websiteLogWsl = Convert-WindowsPathToWsl -Path $websiteLog
+$websitePortWsl = Convert-WindowsPathToWsl -Path $websitePort
+$crmPidWsl = Convert-WindowsPathToWsl -Path $crmPid
+$crmLogWsl = Convert-WindowsPathToWsl -Path $crmLog
+$atendimentoPidWsl = Convert-WindowsPathToWsl -Path $atendimentoPid
+$atendimentoLogWsl = Convert-WindowsPathToWsl -Path $atendimentoLog
+
+switch ($Action) {
+    "SharedSetup" { Invoke-RepoPowerShellScript -ScriptName "setup-shared-codex-workspace.ps1" }
+    "SharedValidate" { Invoke-RepoPowerShellScript -ScriptName "validate-shared-codex-workspace.ps1" }
+    "RuntimeSetup" { & (Join-Path $scriptRoot "setup-shared-runtime.ps1") }
+    "RuntimeValidate" { & (Join-Path $scriptRoot "validate-shared-runtime.ps1") }
+    "WslAccountBootstrap" {
+        Invoke-ShortcutWsl -SkipBootstrapCheck -Command "cd modules/automations/n8n && bash scripts/bootstrap-imported-wsl-account.sh"
+    }
+    "SharedStatus" { Invoke-RepoPowerShellScript -ScriptName "show-shared-codex-status.ps1" }
+    "CodexContext" { Invoke-ShortcutWsl -Command "bash ./scripts/codex-context.sh" }
+    "ThreadBootstrap" { & (Join-Path $scriptRoot "print-codex-thread-bootstrap.ps1") -Interactive }
+    "NewWorktree" { & (Join-Path $scriptRoot "new-shared-worktree.ps1") -Fetch }
+    "WebsiteLocalStart" {
+        Invoke-ShortcutWsl -Command ("WEBSITE_STATE_DIR={0} WEBSITE_PID_FILE={1} WEBSITE_LOG_FILE={2} WEBSITE_PORT_FILE={3} WEBSITE_DETACH=1 OPEN_BROWSER=0 bash ./scripts/run-local-website.sh" -f `
+            (Convert-ToBashLiteral -Value $tmpRootWsl), `
+            (Convert-ToBashLiteral -Value $websitePidWsl), `
+            (Convert-ToBashLiteral -Value $websiteLogWsl), `
+            (Convert-ToBashLiteral -Value $websitePortWsl))
+    }
+    "WebsiteLocalStop" {
+        Invoke-ShortcutWsl -Command ("WEBSITE_STATE_DIR={0} WEBSITE_PID_FILE={1} WEBSITE_PORT_FILE={2} bash ./scripts/run-local-website.sh --stop" -f `
+            (Convert-ToBashLiteral -Value $tmpRootWsl), `
+            (Convert-ToBashLiteral -Value $websitePidWsl), `
+            (Convert-ToBashLiteral -Value $websitePortWsl))
+    }
+    "CrmLocal" {
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
+            (Convert-ToBashLiteral -Value $crmPidWsl), `
+            (Convert-ToBashLiteral -Value $crmLogWsl))
+    }
+    "CrmSiteEf" {
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module site-tracking --meta-ads-scenario connected-ready" -f `
+            (Convert-ToBashLiteral -Value $crmPidWsl), `
+            (Convert-ToBashLiteral -Value $crmLogWsl))
+    }
+    "CrmMetaAds" {
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module meta-ads" -f `
+            (Convert-ToBashLiteral -Value $crmPidWsl), `
+            (Convert-ToBashLiteral -Value $crmLogWsl))
+    }
+    "CrmAtendimentoClinica" {
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento-clinica.sh" -f `
+            (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
+            (Convert-ToBashLiteral -Value $atendimentoLogWsl))
+    }
+    "CrmLocalStop" {
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento-clinica.sh --stop" -f `
+            (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
+            (Convert-ToBashLiteral -Value $atendimentoLogWsl))
+        Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
+            (Convert-ToBashLiteral -Value $crmPidWsl), `
+            (Convert-ToBashLiteral -Value $crmLogWsl))
+    }
+    "OrbStatus" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/manage-mini-pc-system-services.sh status"
+    }
+    "OrbRestart" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/manage-mini-pc-system-services.sh restart"
+    }
+    "OrbLogs" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/manage-mini-pc-system-services.sh logs 200"
+    }
+    "OrbValidate" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/validate-mini-pc-system-runtime.sh"
+    }
+    "OrbAudit" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/audit-mini-pc-service-footprint.sh"
+    }
+    "OrbRepair" {
+        Invoke-ShortcutWsl -Command "cd modules/automations/n8n && bash scripts/reconcile-mini-pc-runtime-postgres.sh"
+    }
+}

--- a/scripts/setup-shared-codex-workspace.ps1
+++ b/scripts/setup-shared-codex-workspace.ps1
@@ -1,0 +1,141 @@
+param(
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n",
+    [switch]$SkipAclRefresh,
+    [switch]$DeepAclRefresh
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-PathString {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    return $Path.Replace('\', '/').TrimEnd('/').ToLowerInvariant()
+}
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Ensure-SafeDirectory {
+    param([string]$RepoPath)
+    $existing = @(git config --global --get-all safe.directory 2>$null)
+    $normalizedRepoPath = Normalize-PathString -Path $RepoPath
+    $forwardSlashRepoPath = $RepoPath.Replace('\', '/')
+    $normalizedExisting = @($existing | ForEach-Object { Normalize-PathString -Path $_ })
+
+    if ($normalizedExisting -notcontains $normalizedRepoPath) {
+        git config --global --add safe.directory $RepoPath
+        git config --global --add safe.directory $forwardSlashRepoPath
+    }
+}
+
+function Get-CodexEnvironmentStatus {
+    param([string]$RepoPath)
+
+    $environmentPath = Join-Path $RepoPath ".codex\environments\environment.toml"
+    $tracked = $false
+    $ignored = $false
+
+    if (Test-Path -LiteralPath $environmentPath) {
+        $trackedOutput = @(& git -C $RepoPath ls-files .codex/environments/environment.toml 2>$null)
+        $tracked = $trackedOutput.Count -gt 0
+    }
+
+    & git -C $RepoPath check-ignore .codex/environments/environment.toml 1>$null 2>$null
+    $ignored = $LASTEXITCODE -eq 0
+
+    [pscustomobject]@{
+        path = $environmentPath
+        exists = Test-Path -LiteralPath $environmentPath
+        tracked = $tracked
+        ignored = $ignored
+        manualOpenRequired = $true
+        note = "Each Windows user still needs to open the repo or worktree manually in Codex App for the top-bar actions to appear in that account."
+    }
+}
+
+function Grant-SharedAcl {
+    param(
+        [string]$TargetPath,
+        [switch]$Recursive
+    )
+
+    $args = @($TargetPath, "/grant", "Users:(OI)(CI)M")
+    if ($Recursive) {
+        $args += @("/T", "/C")
+    }
+
+    icacls @args | Out-Null
+}
+
+Ensure-Directory -Path $ProjectRoot
+Ensure-Directory -Path $WorktreeRoot
+Ensure-Directory -Path (Join-Path $WorktreeRoot $env:USERNAME)
+Ensure-Directory -Path $RuntimeRoot
+
+$runtimeDirs = @(
+    $RuntimeRoot,
+    (Join-Path $RuntimeRoot "env"),
+    (Join-Path $RuntimeRoot "logs"),
+    (Join-Path $RuntimeRoot "health"),
+    (Join-Path $RuntimeRoot "tmp"),
+    (Join-Path $RuntimeRoot "binary-data"),
+    (Join-Path $RuntimeRoot "exports"),
+    (Join-Path $RuntimeRoot "backups"),
+    (Join-Path $RuntimeRoot "n8n-home"),
+    (Join-Path $RuntimeRoot "cloudflared"),
+    (Join-Path $RuntimeRoot "evolution-api"),
+    (Join-Path $RuntimeRoot "evolution-api\instances"),
+    (Join-Path $RuntimeRoot "evolution-api\store")
+)
+
+foreach ($dir in $runtimeDirs) {
+    Ensure-Directory -Path $dir
+}
+
+$localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
+$localStateDirs = @(
+    $localStateRoot,
+    (Join-Path $localStateRoot "logs"),
+    (Join-Path $localStateRoot "tmp"),
+    (Join-Path $localStateRoot "profiles"),
+    (Join-Path $localStateRoot "env-overrides")
+)
+
+foreach ($dir in $localStateDirs) {
+    Ensure-Directory -Path $dir
+}
+
+$codexEnvironment = Get-CodexEnvironmentStatus -RepoPath $ProjectRoot
+
+if (-not $SkipAclRefresh) {
+    Grant-SharedAcl -TargetPath $ProjectRoot -Recursive:$DeepAclRefresh
+    Grant-SharedAcl -TargetPath $WorktreeRoot -Recursive:$DeepAclRefresh
+    Grant-SharedAcl -TargetPath $RuntimeRoot -Recursive:$DeepAclRefresh
+}
+
+Ensure-SafeDirectory -RepoPath $ProjectRoot
+
+$result = [pscustomobject]@{
+    projectRoot = $ProjectRoot
+    worktreeRoot = $WorktreeRoot
+    actorWorktreeRoot = (Join-Path $WorktreeRoot $env:USERNAME)
+    runtimeRoot = $RuntimeRoot
+    runtimeDirs = $runtimeDirs
+    localStateRoot = $localStateRoot
+    localStateDirs = $localStateDirs
+    codexEnvironment = $codexEnvironment
+    aclRefreshed = (-not $SkipAclRefresh.IsPresent)
+    deepAclRefresh = $DeepAclRefresh.IsPresent
+    currentUser = $env:USERNAME
+}
+
+$result | ConvertTo-Json -Depth 4

--- a/scripts/setup-shared-runtime.ps1
+++ b/scripts/setup-shared-runtime.ps1
@@ -1,0 +1,97 @@
+param(
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n",
+    [switch]$SkipAclRefresh,
+    [switch]$DeepAclRefresh
+)
+
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Grant-SharedAcl {
+    param(
+        [string]$TargetPath,
+        [switch]$Recursive
+    )
+
+    $args = @($TargetPath, "/grant", "Users:(OI)(CI)M")
+    if ($Recursive) {
+        $args += @("/T", "/C")
+    }
+
+    icacls @args | Out-Null
+}
+
+function Ensure-File {
+    param(
+        [string]$Path,
+        [string[]]$Content
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $dir = Split-Path -Parent $Path
+        if ($dir) {
+            Ensure-Directory -Path $dir
+        }
+        Set-Content -LiteralPath $Path -Value $Content -Encoding ASCII
+    }
+}
+
+$runtimeDirs = @(
+    $RuntimeRoot,
+    (Join-Path $RuntimeRoot "env"),
+    (Join-Path $RuntimeRoot "logs"),
+    (Join-Path $RuntimeRoot "health"),
+    (Join-Path $RuntimeRoot "tmp"),
+    (Join-Path $RuntimeRoot "binary-data"),
+    (Join-Path $RuntimeRoot "exports"),
+    (Join-Path $RuntimeRoot "backups"),
+    (Join-Path $RuntimeRoot "rollback"),
+    (Join-Path $RuntimeRoot "n8n-home"),
+    (Join-Path $RuntimeRoot "cloudflared"),
+    (Join-Path $RuntimeRoot "evolution-api"),
+    (Join-Path $RuntimeRoot "evolution-api\instances"),
+    (Join-Path $RuntimeRoot "evolution-api\store")
+)
+
+foreach ($dir in $runtimeDirs) {
+    Ensure-Directory -Path $dir
+}
+
+$businessEnv = Join-Path $RuntimeRoot "env\n8n-business.env"
+Ensure-File -Path $businessEnv -Content @(
+    "# Shared n8n business env contract",
+    "# Fill real values outside the repo. Keep runtime base config in n8n.env.",
+    "N8N_PUBLIC_BASE_URL=https://orb.skincos.com.br",
+    "EVOLUTION_BASE_URL=https://wa.skincos.com.br",
+    "EVOLUTION_INSTANCE_NAME=skincos",
+    "EVOLUTION_API_KEY=",
+    "DATABASE_URL=",
+    "N8N_DEFAULT_UNIT_SLUG=",
+    "N8N_DEFAULT_UNIT_NAME=",
+    "N8N_UNIT_NAME_MAP=",
+    "N8N_HANDOFF_NOTIFY_NUMBER=",
+    "GOOGLE_CALENDAR_ID=",
+    "GOOGLE_CLIENT_ID=",
+    "GOOGLE_CLIENT_SECRET=",
+    "GOOGLE_REDIRECT_URI=https://orb.skincos.com.br/rest/oauth2-credential/callback",
+    "N8N_DEFAULT_TEST_PHONE="
+)
+
+if (-not $SkipAclRefresh) {
+    Grant-SharedAcl -TargetPath $RuntimeRoot -Recursive:$DeepAclRefresh
+}
+
+[pscustomobject]@{
+    runtimeRoot = $RuntimeRoot
+    runtimeDirs = $runtimeDirs
+    businessEnv = $businessEnv
+    aclRefreshed = (-not $SkipAclRefresh.IsPresent)
+    deepAclRefresh = $DeepAclRefresh.IsPresent
+    currentUser = $env:USERNAME
+} | ConvertTo-Json -Depth 4

--- a/scripts/show-shared-codex-status.ps1
+++ b/scripts/show-shared-codex-status.ps1
@@ -1,0 +1,93 @@
+param(
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-PathString {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    return $Path.Replace('\', '/').TrimEnd('/').ToLowerInvariant()
+}
+
+function Get-GitStatusSummary {
+    param([string]$RepoPath)
+
+    $branch = (& git -C $RepoPath rev-parse --abbrev-ref HEAD).Trim()
+    $statusLines = @(& git -C $RepoPath status --short)
+
+    [pscustomobject]@{
+        branch = $branch
+        dirtyCount = $statusLines.Count
+        isDirty = $statusLines.Count -gt 0
+        sample = @($statusLines | Select-Object -First 10)
+    }
+}
+
+function Get-WorktreeSummary {
+    param([string]$Root)
+
+    if (-not (Test-Path -LiteralPath $Root)) {
+        return @()
+    }
+
+    $items = @()
+    foreach ($actorDir in Get-ChildItem -LiteralPath $Root -Directory -Force | Sort-Object Name) {
+        foreach ($taskDir in Get-ChildItem -LiteralPath $actorDir.FullName -Directory -Force | Sort-Object Name) {
+            $branch = $null
+            if (Test-Path -LiteralPath (Join-Path $taskDir.FullName '.git')) {
+                $branch = (& git -C $taskDir.FullName rev-parse --abbrev-ref HEAD 2>$null).Trim()
+            }
+
+            $items += [pscustomobject]@{
+                actor = $actorDir.Name
+                task = $taskDir.Name
+                path = $taskDir.FullName
+                branch = $branch
+            }
+        }
+    }
+
+    return $items
+}
+
+$safeDirectories = @(git config --global --get-all safe.directory 2>$null)
+$normalizedProjectRoot = Normalize-PathString -Path $ProjectRoot
+$normalizedSafeDirectories = @($safeDirectories | ForEach-Object { Normalize-PathString -Path $_ })
+
+$localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
+$runtimeEnvRoot = Join-Path $RuntimeRoot "env"
+$status = [pscustomobject]@{
+    currentUser = $env:USERNAME
+    computerName = $env:COMPUTERNAME
+    projectRoot = $ProjectRoot
+    projectStatus = Get-GitStatusSummary -RepoPath $ProjectRoot
+    worktreeRoot = $WorktreeRoot
+    worktrees = @(Get-WorktreeSummary -Root $WorktreeRoot)
+    safeDirectoryRegistered = $normalizedSafeDirectories -contains $normalizedProjectRoot
+    safeDirectories = $safeDirectories
+    localStateRoot = $localStateRoot
+    localStateExists = Test-Path -LiteralPath $localStateRoot
+    runtimeRoot = $RuntimeRoot
+    runtimeExists = Test-Path -LiteralPath $RuntimeRoot
+    runtimeEnvRoot = $runtimeEnvRoot
+    runtimeEnvFiles = @(
+        "n8n.env",
+        "n8n-business.env",
+        "evolution-api.env"
+    ) | ForEach-Object {
+        $path = Join-Path $runtimeEnvRoot $_
+        [pscustomobject]@{
+            name = $_
+            exists = Test-Path -LiteralPath $path
+            path = $path
+        }
+    }
+}
+
+$status | ConvertTo-Json -Depth 5

--- a/scripts/validate-shared-codex-workspace.ps1
+++ b/scripts/validate-shared-codex-workspace.ps1
@@ -1,0 +1,148 @@
+param(
+    [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
+    [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-PathString {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    return $Path.Replace('\', '/').TrimEnd('/').ToLowerInvariant()
+}
+
+function Get-AccessEntry {
+    param(
+        [System.Security.AccessControl.DirectorySecurity]$Acl,
+        [string]$Identity
+    )
+
+    return $Acl.Access | Where-Object {
+        $_.IdentityReference.Value -eq $Identity -and
+        $_.AccessControlType -eq "Allow"
+    }
+}
+
+function Test-ModifyAccess {
+    param([string]$TargetPath)
+
+    $acl = Get-Acl -LiteralPath $TargetPath
+    $entry = Get-AccessEntry -Acl $acl -Identity "BUILTIN\Users"
+    $hasModify = $false
+
+    if ($entry) {
+        foreach ($rule in @($entry)) {
+            if ($rule.FileSystemRights.ToString().Contains("Modify")) {
+                $hasModify = $true
+                break
+            }
+        }
+    }
+
+    [pscustomobject]@{
+        path = $TargetPath
+        exists = (Test-Path -LiteralPath $TargetPath)
+        hasUsersModify = $hasModify
+        owner = $acl.Owner
+    }
+}
+
+function Get-EnabledUserCoverage {
+    $enabledUsers = @(Get-LocalUser | Where-Object Enabled)
+    $usersMembers = @((Get-LocalGroupMember -Group "Users").Name)
+    $adminsMembers = @((Get-LocalGroupMember -Group "Administrators").Name)
+
+    foreach ($user in $enabledUsers) {
+        $qualified = "$env:COMPUTERNAME\$($user.Name)"
+        [pscustomobject]@{
+            user = $qualified
+            coveredByUsersGroup = $usersMembers -contains $qualified
+            coveredByAdministratorsGroup = $adminsMembers -contains $qualified
+            hasWorkspaceAccess = ($usersMembers -contains $qualified) -or ($adminsMembers -contains $qualified)
+        }
+    }
+}
+
+function Get-CodexEnvironmentStatus {
+    param([string]$RepoPath)
+
+    $environmentPath = Join-Path $RepoPath ".codex\environments\environment.toml"
+    $tracked = $false
+    $ignored = $false
+
+    if (Test-Path -LiteralPath $environmentPath) {
+        $trackedOutput = @(& git -C $RepoPath ls-files .codex/environments/environment.toml 2>$null)
+        $tracked = $trackedOutput.Count -gt 0
+    }
+
+    & git -C $RepoPath check-ignore .codex/environments/environment.toml 1>$null 2>$null
+    $ignored = $LASTEXITCODE -eq 0
+
+    [pscustomobject]@{
+        path = $environmentPath
+        exists = Test-Path -LiteralPath $environmentPath
+        tracked = $tracked
+        ignored = $ignored
+        manualOpenRequired = $true
+        note = "Each Windows user still needs to open the repo or worktree manually in Codex App for the top-bar actions to appear in that account."
+    }
+}
+
+$projectCheck = Test-ModifyAccess -TargetPath $ProjectRoot
+$worktreeCheck = Test-ModifyAccess -TargetPath $WorktreeRoot
+$runtimeCheck = Test-ModifyAccess -TargetPath $RuntimeRoot
+$childChecks = @()
+$runtimeChildChecks = @()
+
+if (Test-Path -LiteralPath $ProjectRoot) {
+    $childChecks = Get-ChildItem -LiteralPath $ProjectRoot -Directory -Force |
+        Sort-Object Name |
+        ForEach-Object { Test-ModifyAccess -TargetPath $_.FullName }
+}
+
+if (Test-Path -LiteralPath $RuntimeRoot) {
+    $runtimeChildChecks = Get-ChildItem -LiteralPath $RuntimeRoot -Directory -Force |
+        Sort-Object Name |
+        ForEach-Object { Test-ModifyAccess -TargetPath $_.FullName }
+}
+
+$localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
+$localStateDirs = @(
+    $localStateRoot,
+    (Join-Path $localStateRoot "logs"),
+    (Join-Path $localStateRoot "tmp"),
+    (Join-Path $localStateRoot "profiles"),
+    (Join-Path $localStateRoot "env-overrides")
+)
+
+$safeDirectories = @(git config --global --get-all safe.directory 2>$null)
+$normalizedProjectRoot = Normalize-PathString -Path $ProjectRoot
+$normalizedSafeDirectories = @($safeDirectories | ForEach-Object { Normalize-PathString -Path $_ })
+$codexEnvironment = Get-CodexEnvironmentStatus -RepoPath $ProjectRoot
+
+$result = [pscustomobject]@{
+    project = $projectCheck
+    worktrees = $worktreeCheck
+    runtime = $runtimeCheck
+    projectChildren = $childChecks
+    runtimeChildren = $runtimeChildChecks
+    enabledUserCoverage = @(Get-EnabledUserCoverage)
+    currentUser = $env:USERNAME
+    safeDirectoryRegistered = $normalizedSafeDirectories -contains $normalizedProjectRoot
+    safeDirectories = $safeDirectories
+    codexEnvironment = $codexEnvironment
+    localStateDirs = @(
+        foreach ($dir in $localStateDirs) {
+            [pscustomobject]@{
+                path = $dir
+                exists = (Test-Path -LiteralPath $dir)
+            }
+        }
+    )
+}
+
+$result | ConvertTo-Json -Depth 5

--- a/scripts/validate-shared-runtime.ps1
+++ b/scripts/validate-shared-runtime.ps1
@@ -1,0 +1,87 @@
+param(
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-AccessEntry {
+    param(
+        [System.Security.AccessControl.DirectorySecurity]$Acl,
+        [string]$Identity
+    )
+
+    return $Acl.Access | Where-Object {
+        $_.IdentityReference.Value -eq $Identity -and
+        $_.AccessControlType -eq "Allow"
+    }
+}
+
+function Test-ModifyAccess {
+    param([string]$TargetPath)
+
+    $exists = Test-Path -LiteralPath $TargetPath
+    if (-not $exists) {
+        return [pscustomobject]@{
+            path = $TargetPath
+            exists = $false
+            hasUsersModify = $false
+            owner = $null
+        }
+    }
+
+    $acl = Get-Acl -LiteralPath $TargetPath
+    $entry = Get-AccessEntry -Acl $acl -Identity "BUILTIN\Users"
+    $hasModify = $false
+
+    if ($entry) {
+        foreach ($rule in @($entry)) {
+            if ($rule.FileSystemRights.ToString().Contains("Modify")) {
+                $hasModify = $true
+                break
+            }
+        }
+    }
+
+    [pscustomobject]@{
+        path = $TargetPath
+        exists = $true
+        hasUsersModify = $hasModify
+        owner = $acl.Owner
+    }
+}
+
+$requiredDirs = @(
+    $RuntimeRoot,
+    (Join-Path $RuntimeRoot "env"),
+    (Join-Path $RuntimeRoot "logs"),
+    (Join-Path $RuntimeRoot "health"),
+    (Join-Path $RuntimeRoot "tmp"),
+    (Join-Path $RuntimeRoot "binary-data"),
+    (Join-Path $RuntimeRoot "exports"),
+    (Join-Path $RuntimeRoot "n8n-home"),
+    (Join-Path $RuntimeRoot "cloudflared"),
+    (Join-Path $RuntimeRoot "evolution-api")
+)
+
+$requiredFiles = @(
+    (Join-Path $RuntimeRoot "env\n8n.env"),
+    (Join-Path $RuntimeRoot "env\n8n-business.env"),
+    (Join-Path $RuntimeRoot "env\evolution-api.env")
+)
+
+[pscustomobject]@{
+    runtime = (Test-ModifyAccess -TargetPath $RuntimeRoot)
+    requiredDirs = @(
+        foreach ($dir in $requiredDirs) {
+            Test-ModifyAccess -TargetPath $dir
+        }
+    )
+    requiredFiles = @(
+        foreach ($file in $requiredFiles) {
+            [pscustomobject]@{
+                path = $file
+                exists = (Test-Path -LiteralPath $file)
+            }
+        }
+    )
+} | ConvertTo-Json -Depth 5

--- a/website/.dev.vars.example
+++ b/website/.dev.vars.example
@@ -1,6 +1,12 @@
+# Shared-workspace note:
+# - Copy to a private `.dev.vars` outside the shared area when possible.
+# - Never commit or store real values under `C:\CodexShared`.
+# - Keep only variable names and safe acquisition notes in this repository.
+#
 # Copie para .dev.vars (não commitar) para usar em preview local via Wrangler/OpenNext
 
 # Opcional: links assinados para confirmar/recusar via WhatsApp/webhook (recomendado)
+# Obtenha com o responsável operacional do website / booking.
 BOOKING_DECISION_SECRET=
 # Opcional: token assinado para polling de status do agendamento (fallback: BOOKING_DECISION_SECRET)
 BOOKING_STATUS_SECRET=
@@ -24,6 +30,7 @@ TITAN_SMTP_PASS_BARRA=
 TITAN_SMTP_USER_NH=
 TITAN_SMTP_PASS_NH=
 # 2) Resend
+# Obtenha no provedor de e-mail aprovado para este ambiente.
 RESEND_API_KEY=
 # 3) Webhook próprio
 BOOKING_EMAIL_WEBHOOK_URL=


### PR DESCRIPTION
## Summary
Adds the shared Codex workspace bootstrap/runtime contract needed for multi-account use on the mini-PC, including shared Start Menu launchers, Codex App top-bar actions, shared workspace/runtime validation scripts, and the canonical \Orb Repair\ flow for Postgres/runtime drift.

## Notes
- This branch includes the prior shared bootstrap commit already present on the local \codex/julia/shared-bootstrap\ baseline.
- \Orb Repair\ is exposed through PowerShell launchers, Codex App project actions, and runbooks.
- Shared Start Menu shortcuts were republished on the mini-PC after elevating PowerShell.

## Validation
- PowerShell parser checks passed for the shared launcher scripts.
- \ash -n\ passed for the new runtime scripts.
- \.codex/environments/environment.toml\ is tracked and not ignored.
- Shared Start Menu now includes \Orb Repair\, \Orb Logs\, and \Orb Audit\.