### PR TITLE
fix: migrate Luize and Rafaela into Escala D1

### DIFF
--- a/backend/apps/escala-api/migrations-d1/0004_add_luize_rafaela_professionals.sql
+++ b/backend/apps/escala-api/migrations-d1/0004_add_luize_rafaela_professionals.sql
@@ -1,0 +1,47 @@
+INSERT OR REPLACE INTO professionals (
+  id,
+  name,
+  status,
+  role,
+  shift,
+  nickname,
+  phone,
+  email,
+  instagram,
+  units_json
+) VALUES (
+  'f922c4ee-5366-4824-b2a9-a2b355dfb91a',
+  'Luize Baum',
+  'Ativo',
+  'Injetor',
+  'Manhã, Tarde',
+  'Dra. Lu',
+  '5551996978180',
+  'luize00@hotmail.com',
+  'dra.luizebaum',
+  '["BarraShoppingSul"]'
+);
+
+INSERT OR REPLACE INTO professionals (
+  id,
+  name,
+  status,
+  role,
+  shift,
+  nickname,
+  phone,
+  email,
+  instagram,
+  units_json
+) VALUES (
+  'fe8ad2f7-17c1-42a5-803e-de96311cf03a',
+  'Rafaela Ferreira',
+  'Ativo',
+  'Injetor',
+  'Manhã, Tarde',
+  'Dra. Rafa',
+  '5551991472649',
+  'rmachadoferreira@icloud.com',
+  'dra.rafaelaferreira',
+  '["Novo Hamburgo"]'
+);


### PR DESCRIPTION
## Summary
- add a D1 migration to upsert Luize Baum and Rafaela Ferreira in production
- use the existing Escala API deploy workflow to apply the migration remotely

## Validation
- migration file reviewed against the current professionals schema
- deploy target is backend/apps/escala-api only
