### PR TITLE
docs: add shared Codex continuity contract

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,26 @@
+# Shared Codex App actions for the shared skincos clone and its worktrees.
+version = 1
+name = "skincos"
+
+[setup]
+script = ""
+
+[[actions]]
+name = "Shared Status"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action SharedStatus"
+
+[[actions]]
+name = "Codex Context"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CodexContext"
+
+[[actions]]
+name = "Thread Bootstrap"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action ThreadBootstrap"
+
+[[actions]]
+name = "New Worktree"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action NewWorktree"

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ output/
 
 # Codex local state
 .codex/
+!.codex/
+!.codex/environments/
+!.codex/environments/environment.toml

--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -1,0 +1,51 @@
+# CODEX_CONTEXT
+
+## Current State
+
+- The shared collaboration path for this machine is
+  `C:\CodexShared\Projetos\skincos`.
+- Dedicated worktrees should live under
+  `C:\CodexShared\Worktrees\skincos\<user>\<task-slug>`.
+- This repository still uses the current canonical roots in `backend/`,
+  `frontend/`, `website/`, `n8n/`, `ops/`, `docs/`, and `scripts/`.
+- Operators may use different Codex/OpenAI accounts while remaining inside the
+  same OpenAI Business or Enterprise workspace.
+- Private Codex thread history is not assumed to be shared automatically across
+  those operators.
+- The supported continuity contract for operators is now versioned in:
+  `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md`.
+- Shared Codex App project actions are now versioned through
+  `.codex/environments/environment.toml`.
+- The public repo entrypoints for cross-account continuity are:
+  `scripts/show-shared-codex-status.ps1`,
+  `scripts/print-codex-thread-bootstrap.ps1`,
+  `scripts/new-shared-worktree.ps1`, and
+  `scripts/run-shared-codex-shortcut.ps1`.
+
+## Operational Model
+
+- Treat the shared clone as the cross-account source of truth for context and
+  coordination.
+- Treat a dedicated worktree as the only place to perform implementation work
+  when a task may edit files or overlap with another operator.
+- Keep local Codex state, browser state, temp files, and auth state outside the
+  shared repo in `%LOCALAPPDATA%\Codex\skincos\`.
+- Use the continuity files instead of relying on another operator's private
+  Codex thread to be visible.
+
+## Known Constraints
+
+- The OpenAI workspace can improve human collaboration, but it does not replace
+  repository-backed handoff.
+- Shared OpenAI projects or shared links are optional coordination aids only.
+- No shared operator flow should depend on copying `.codex` state between
+  Windows profiles.
+
+## Next Recommended Steps
+
+- Publish this multi-account baseline so future operators bootstrap from a
+  tracked remote branch instead of a local-only state.
+- Expand the shared project actions only through public repo scripts, then
+  document each new action in the shared workspace docs.
+- Keep `TASKS.md` and `DECISIONS.md` current whenever the multi-account model
+  changes.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,39 @@
+# DECISIONS
+
+## 2026-07-08 - Treat the repository as the continuity contract between Codex operators
+
+- Decision: use `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md` as the
+  required handoff surface between operators on the shared mini-PC.
+- Why: each Windows operator may use a different Codex/OpenAI account, and
+  private Codex threads are not assumed to be visible across those accounts.
+- Impact: any task that changes current state, next steps, or operational
+  decisions must update the relevant continuity file before handoff.
+
+## 2026-07-08 - Keep Codex App sharing limited to project actions
+
+- Decision: allow only `.codex/environments/environment.toml` to be committed
+  for Codex App integration in the shared repo.
+- Why: project actions should be shared, but private Codex auth, caches,
+  session history, and local state must remain per operator.
+- Impact: the same top-bar actions can appear in the shared clone and in
+  worktrees without attempting to share private `.codex` state.
+
+## 2026-07-08 - Require bootstrap prompts for new shared threads
+
+- Decision: new Codex threads that start from the shared clone or from a
+  worktree must use `scripts/print-codex-thread-bootstrap.ps1`.
+- Why: the bootstrap prompt is the consistent way to inject task slug, expected
+  branch/worktree, validation commands, and continuity rules into a new private
+  thread.
+- Impact: an operator should not consider a new thread ready for multi-account
+  handoff until that bootstrap context has been applied.
+
+## 2026-07-08 - Treat OpenAI workspace collaboration as optional, not operational
+
+- Decision: shared OpenAI projects and shared chat links may be used for human
+  coordination, but they are not part of the technical source of truth.
+- Why: workspace collaboration features can help people coordinate, but the
+  mini-PC must remain operable from the repository, worktrees, and public
+  scripts alone.
+- Impact: repository state remains authoritative even when OpenAI workspace
+  collaboration features are available.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ Plataforma interna (local) para automações e operações da clínica.
 - Segredos e rotação: `docs/secrets-rotation.md`
 - Autonomia Codex/deploy: `docs/codex-autonomy.md`
 - Codex App nativo: `docs/codex-app-native.md`
+- Workspace compartilhado Codex: `docs/codex-shared-workspace.md`
+- Bootstrap de threads compartilhadas: `docs/codex-thread-bootstrap.md`
+- Runbook de autonomia multiusuário: `docs/runbooks/mini-pc-autonomia-multiusuario.md`
 - Observabilidade/SLOs: `docs/observability.md`
 - Catálogo de serviços: `docs/service-catalog.md`
 - Ownership e operação: `docs/ownership-model.md`

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,29 @@
+# TASKS
+
+## Priority Backlog
+
+- [ ] Publish the multi-account continuity baseline to the remote repository.
+- [ ] Expand the shared project-action surface only through public repo
+  scripts, then document each addition.
+- [ ] Decide whether the OpenAI workspace will use shared projects as an
+  optional operator coordination layer.
+
+## In Progress
+
+- [ ] Move the shared continuity contract into the repository so it no longer
+  depends on any single operator's private Codex thread.
+
+## Blocked / Needs Manual Follow-Up
+
+- [ ] Shared Codex threads across separate OpenAI users are not available by
+  default, even inside the same Business or Enterprise workspace.
+- [ ] Any shared-project or shared-link workflow inside the OpenAI workspace
+  depends on workspace features and permissions outside this repository.
+
+## Done
+
+- [x] Define repository-backed continuity files for multi-account handoff:
+  `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md`.
+- [x] Add a public thread bootstrap generator for shared operators.
+- [x] Add shared Codex App project actions for status, context, thread
+  bootstrap, and worktree creation.

--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -1,0 +1,88 @@
+# Shared Codex workspace for skincos
+
+This repository can be used as the shared Codex workspace at:
+
+- `C:\CodexShared\Projetos\skincos`
+
+The goal of that path is to be the common source of truth for context, review,
+planning, and cross-account handoff. It is not the place for secrets, Codex
+session databases, or operator-specific auth state.
+
+## Operating rules
+
+- Keep secrets, cookies, `.env`, `.dev.vars`, browser profiles, and private
+  `.codex` state out of `C:\CodexShared`.
+- The only supported committed `.codex` content is
+  `.codex/environments/environment.toml`, so the same project actions appear in
+  the shared clone and in derived worktrees.
+- Each operator uses their own Codex/OpenAI account, even when all operators
+  belong to the same OpenAI Business or Enterprise workspace.
+- Do not expect private Codex threads to be visible across operators by
+  default. Continuity must come from the repository, worktrees, and handoff
+  files.
+- Use branches in the format `codex/<windows-user-or-alias>/<task-slug>`.
+- Prefer worktrees under
+  `C:\CodexShared\Worktrees\skincos\<actor>\<task-slug>` when a task may edit
+  code or run in parallel with another operator.
+- Keep local Codex state in `%LOCALAPPDATA%\Codex\skincos\`.
+
+## Shared continuity contract
+
+The required continuity files are:
+
+- `CODEX_CONTEXT.md`
+- `TASKS.md`
+- `DECISIONS.md`
+
+Use them as follows:
+
+- `CODEX_CONTEXT.md`: current machine and repo state that a new operator needs
+  before acting.
+- `TASKS.md`: backlog, in-progress work, and blocked follow-up.
+- `DECISIONS.md`: durable operational or structural decisions that should not
+  live only inside a private Codex thread.
+
+If a handoff changes current state, next steps, or a decision, update the
+relevant file before ending the task.
+
+## Shared project actions in Codex App
+
+This branch now versions:
+
+- `.codex/environments/environment.toml`
+
+Those actions are intentionally thin wrappers around public repo scripts:
+
+- `Shared Status`
+- `Codex Context`
+- `Thread Bootstrap`
+- `New Worktree`
+
+They must remain relative to the opened project so the same action works in the
+shared clone and in any derived worktree.
+
+## Thread bootstrap
+
+When starting a new Codex thread from the shared clone or a worktree, use:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\print-codex-thread-bootstrap.ps1 `
+  -TaskSlug review-crm-auth `
+  -TaskBrief "Investigate the local CRM auth behavior without editing the shared clone directly."
+```
+
+That prompt enforces the shared operating rules, prints the expected branch and
+worktree, and lists the validation commands expected before handoff.
+
+## Optional collaboration inside OpenAI workspace
+
+If your OpenAI Business or Enterprise workspace supports shared projects, they
+can be used as an optional human coordination layer for:
+
+- summary context,
+- links to PRs, branches, and worktrees,
+- shared chat links,
+- operator checklists.
+
+They must not replace the repository, runtime scripts, or handoff files as the
+operational source of truth.

--- a/docs/codex-thread-bootstrap.md
+++ b/docs/codex-thread-bootstrap.md
@@ -1,0 +1,39 @@
+# Codex thread bootstrap for shared operators
+
+When an operator opens a new Codex thread against the shared clone or one of
+its worktrees, the first prompt should come from:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\print-codex-thread-bootstrap.ps1 `
+  -TaskSlug <task-slug> `
+  -TaskBrief "<describe the task>"
+```
+
+## What the bootstrap must include
+
+Every bootstrap prompt must carry:
+
+- the task objective,
+- the normalized task slug,
+- the expected `codex/<actor>/<task-slug>` branch,
+- the expected worktree path,
+- the instruction to treat the shared clone as read-only when edits are needed,
+- the instruction to read `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`, and
+  `DECISIONS.md`,
+- the expected validation commands for the task,
+- the reminder that each operator has a private Codex thread history.
+
+## Why this is required
+
+Operators in the same OpenAI organization still keep separate private Codex
+threads. The bootstrap prompt is how the repo supplies consistent operating
+context without relying on a prior private thread being visible.
+
+## Example flow
+
+1. Open `C:\CodexShared\Projetos\skincos` in Codex App.
+2. Run `Thread Bootstrap`.
+3. If the task may edit files, create the suggested worktree.
+4. Continue work only inside that worktree.
+5. Before handoff, update `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md`
+   when current state, next steps, or decisions changed.

--- a/docs/runbooks/mini-pc-autonomia-multiusuario.md
+++ b/docs/runbooks/mini-pc-autonomia-multiusuario.md
@@ -1,0 +1,53 @@
+# Mini-PC multi-account autonomy
+
+Official model for the skincos mini-PC:
+
+- shared code base: `C:\CodexShared\Projetos\skincos`
+- shared worktrees: `C:\CodexShared\Worktrees\skincos\<user>\<task-slug>`
+- private Codex local state: `%LOCALAPPDATA%\Codex\skincos\`
+- shared Codex project actions: `.codex/environments/environment.toml`
+- shared continuity files: `CODEX_CONTEXT.md`, `TASKS.md`, `DECISIONS.md`
+
+## Identity model
+
+- Each Windows account may use a different Codex/OpenAI user.
+- Those operators can still belong to the same OpenAI Business or Enterprise
+  workspace.
+- That workspace does not make private Codex threads automatically visible to
+  other operators.
+- Therefore the mini-PC must treat repository state, worktrees, and continuity
+  files as the supported handoff mechanism.
+
+## Minimum per-account bootstrap
+
+For each Windows account:
+
+1. Register the shared clone as a Git `safe.directory`.
+2. Open the shared clone in Codex App manually.
+3. Use the shared project actions from `.codex/environments/environment.toml`.
+4. Keep local state in `%LOCALAPPDATA%\Codex\skincos\`.
+5. Use a dedicated worktree for any task that may edit files or run in
+   parallel.
+
+## Supported operator workflow
+
+1. Read `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md`.
+2. Run `Shared Status`.
+3. Run `Thread Bootstrap`.
+4. If the task may edit code, create a worktree and reopen that worktree in
+   Codex App.
+5. Work only inside the worktree.
+6. Before handoff, update the continuity files.
+
+## Optional OpenAI workspace collaboration
+
+If shared projects are available in your OpenAI workspace, use them only as an
+optional coordination layer for:
+
+- shared links,
+- links to PRs and worktrees,
+- human checklists,
+- summary context.
+
+Do not depend on those workspace features for the technical operation of the
+mini-PC.

--- a/scripts/new-shared-worktree.ps1
+++ b/scripts/new-shared-worktree.ps1
@@ -1,0 +1,92 @@
+param(
+    [string]$TaskSlug,
+    [string]$Actor = $env:USERNAME,
+    [string]$ProjectRoot,
+    [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
+    [string]$BaseRef = "origin/main",
+    [string]$BranchName,
+    [switch]$Fetch
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ProjectRoot {
+    param([string]$RequestedPath)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        return (Resolve-Path -LiteralPath $RequestedPath).Path
+    }
+
+    return (Resolve-Path -LiteralPath (Split-Path -Parent $PSScriptRoot)).Path
+}
+
+function Normalize-Value {
+    param([string]$Value)
+    return ($Value.Trim().ToLowerInvariant() -replace '[^a-z0-9._-]', '-')
+}
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Ensure-SafeDirectory {
+    param([string]$RepoPath)
+
+    $existing = @(git config --global --get-all safe.directory 2>$null)
+    $variants = @($RepoPath, $RepoPath.Replace('\', '/'))
+    foreach ($variant in $variants) {
+        if ($existing -notcontains $variant) {
+            git config --global --add safe.directory $variant
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+    $TaskSlug = Read-Host "TaskSlug"
+}
+
+if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+    throw "TaskSlug is required."
+}
+
+$ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot
+$normalizedActor = Normalize-Value -Value $Actor
+$normalizedTask = Normalize-Value -Value $TaskSlug
+
+if (-not $BranchName) {
+    $BranchName = "codex/$normalizedActor/$normalizedTask"
+}
+
+$actorRoot = Join-Path $WorktreeRoot $normalizedActor
+$worktreePath = Join-Path $actorRoot $normalizedTask
+
+Ensure-Directory -Path $actorRoot
+Ensure-SafeDirectory -RepoPath $ProjectRoot
+
+if ($Fetch) {
+    git -C $ProjectRoot fetch origin
+}
+
+if (Test-Path -LiteralPath $worktreePath) {
+    throw "Worktree already exists at '$worktreePath'."
+}
+
+$branchExists = (& git -C $ProjectRoot branch --list $BranchName)
+if ($branchExists) {
+    throw "Branch '$BranchName' already exists locally. Choose another TaskSlug or BranchName."
+}
+
+git -C $ProjectRoot worktree add $worktreePath -b $BranchName $BaseRef
+Ensure-SafeDirectory -RepoPath $worktreePath
+
+[pscustomobject]@{
+    actor = $normalizedActor
+    taskSlug = $normalizedTask
+    branchName = $BranchName
+    baseRef = $BaseRef
+    projectRoot = $ProjectRoot
+    worktreePath = $worktreePath
+} | ConvertTo-Json -Depth 4

--- a/scripts/print-codex-thread-bootstrap.ps1
+++ b/scripts/print-codex-thread-bootstrap.ps1
@@ -1,0 +1,110 @@
+param(
+    [string]$TaskBrief = "Describe the task here",
+    [string]$TaskSlug = "define-task-slug",
+    [string]$Actor = $env:USERNAME,
+    [string[]]$ValidationCommands = @(
+        "npm run codex:context",
+        "<add task-specific validation commands before finishing>"
+    ),
+    [switch]$Interactive,
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-Value {
+    param([string]$Value)
+    return ($Value.Trim().ToLowerInvariant() -replace '[^a-z0-9._-]', '-')
+}
+
+function Normalize-ValidationCommands {
+    param([string[]]$Values)
+
+    $normalized = @()
+    foreach ($value in $Values) {
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            continue
+        }
+
+        foreach ($part in ($value -split '[;,]')) {
+            $trimmed = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+                $normalized += $trimmed
+            }
+        }
+    }
+
+    return $normalized
+}
+
+if ($Interactive) {
+    $promptedTaskSlug = Read-Host "TaskSlug"
+    if (-not [string]::IsNullOrWhiteSpace($promptedTaskSlug)) {
+        $TaskSlug = $promptedTaskSlug
+    }
+
+    $promptedTaskBrief = Read-Host "TaskBrief"
+    if (-not [string]::IsNullOrWhiteSpace($promptedTaskBrief)) {
+        $TaskBrief = $promptedTaskBrief
+    }
+
+    $promptedValidation = Read-Host "ValidationCommands (semicolon separated, optional)"
+    if (-not [string]::IsNullOrWhiteSpace($promptedValidation)) {
+        $ValidationCommands = @(
+            $promptedValidation.Split(';') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        )
+    }
+}
+
+$normalizedActor = Normalize-Value -Value $Actor
+$normalizedTask = Normalize-Value -Value $TaskSlug
+$expectedBranch = "codex/$normalizedActor/$normalizedTask"
+$expectedWorktree = "C:\CodexShared\Worktrees\skincos\$normalizedActor\$normalizedTask"
+$validationLines = @(Normalize-ValidationCommands -Values $ValidationCommands)
+
+if ($validationLines.Count -eq 0) {
+    $validationLines = @("<add task-specific validation commands before finishing>")
+}
+
+$lines = @(
+    "Use this shared project in `C:\CodexShared\Projetos\skincos` only as a context and coordination base.",
+    "Before editing any file:",
+    "1. Read `AGENTS.md`, `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md`.",
+    "2. Check the shared state with `powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1`.",
+    "3. If the task is not strictly read-only, create a dedicated worktree with `powershell -ExecutionPolicy Bypass -File .\scripts\new-shared-worktree.ps1 -TaskSlug $normalizedTask -Fetch`.",
+    "4. After creating the worktree, work only there and treat the shared clone as read-only context.",
+    "5. Keep local state, logs, profiles, and overrides outside the shared repo in `%LOCALAPPDATA%\Codex\skincos\`.",
+    "6. Each operator uses their own Codex/OpenAI account. Do not assume visibility into other operators' private Codex threads.",
+    "7. Use `CODEX_CONTEXT.md`, `TASKS.md`, and `DECISIONS.md` as the handoff contract between operators.",
+    "8. Before finishing, validate the change and update the continuity files when the task changes current state, next steps, or operational decisions.",
+    "",
+    "Task slug: $normalizedTask",
+    "Expected branch: $expectedBranch",
+    "Expected worktree: $expectedWorktree",
+    "",
+    "Expected validation commands:"
+)
+
+foreach ($command in $validationLines) {
+    $lines += "- $command"
+}
+
+$lines += ""
+$lines += "Task for this thread: $TaskBrief"
+
+$prompt = ($lines -join [Environment]::NewLine)
+
+if ($Json) {
+    [pscustomobject]@{
+        actor = $normalizedActor
+        taskBrief = $TaskBrief
+        taskSlug = $normalizedTask
+        expectedBranch = $expectedBranch
+        expectedWorktree = $expectedWorktree
+        validationCommands = $validationLines
+        prompt = $prompt
+    } | ConvertTo-Json -Depth 5
+}
+else {
+    $prompt
+}

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -1,0 +1,64 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet(
+        "SharedStatus",
+        "CodexContext",
+        "ThreadBootstrap",
+        "NewWorktree"
+    )]
+    [string]$Action,
+    [string]$ProjectRoot,
+    [string]$TaskSlug,
+    [string]$TaskBrief,
+    [string[]]$ValidationCommands
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Resolve-ProjectRoot {
+    param([string]$RequestedPath)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        return (Resolve-Path -LiteralPath $RequestedPath).Path
+    }
+
+    return (Resolve-Path -LiteralPath (Split-Path -Parent $scriptRoot)).Path
+}
+
+$ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot
+
+switch ($Action) {
+    "SharedStatus" {
+        & (Join-Path $scriptRoot "show-shared-codex-status.ps1") -ProjectRoot $ProjectRoot
+    }
+    "CodexContext" {
+        Push-Location $ProjectRoot
+        try {
+            npm run codex:context
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    "ThreadBootstrap" {
+        $params = @{
+            TaskSlug = $TaskSlug
+            TaskBrief = $TaskBrief
+        }
+
+        if ($ValidationCommands) {
+            $params.ValidationCommands = $ValidationCommands
+        }
+
+        if ([string]::IsNullOrWhiteSpace($TaskSlug) -and [string]::IsNullOrWhiteSpace($TaskBrief)) {
+            $params.Interactive = $true
+        }
+
+        & (Join-Path $scriptRoot "print-codex-thread-bootstrap.ps1") @params
+    }
+    "NewWorktree" {
+        & (Join-Path $scriptRoot "new-shared-worktree.ps1") -TaskSlug $TaskSlug -ProjectRoot $ProjectRoot -Fetch
+    }
+}

--- a/scripts/show-shared-codex-status.ps1
+++ b/scripts/show-shared-codex-status.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$ProjectRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ProjectRoot {
+    param([string]$RequestedPath)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        return (Resolve-Path -LiteralPath $RequestedPath).Path
+    }
+
+    return (Resolve-Path -LiteralPath (Split-Path -Parent $PSScriptRoot)).Path
+}
+
+$ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot
+$branch = (& git -C $ProjectRoot branch --show-current).Trim()
+$status = @(git -C $ProjectRoot status --short)
+$worktrees = @(git -C $ProjectRoot worktree list --porcelain)
+$safeDirectories = @(git config --global --get-all safe.directory 2>$null)
+
+[pscustomobject]@{
+    projectRoot = $ProjectRoot
+    branch = $branch
+    hasLocalChanges = ($status.Count -gt 0)
+    status = $status
+    worktrees = $worktrees
+    safeDirectories = $safeDirectories
+} | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## Summary
- add a repo-backed continuity contract for Windows users with separate Codex/OpenAI accounts
- version shared Codex App project actions through .codex/environments/environment.toml
- add shared scripts for status, thread bootstrap, shortcut routing, and worktree creation
- document the multi-user mini-PC model and where all local users should find the shared information

## Validation
- powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1
- powershell -ExecutionPolicy Bypass -File .\scripts\print-codex-thread-bootstrap.ps1 -TaskSlug testar-handoff -TaskBrief 'Validate cross-account continuity' -ValidationCommands 'npm run codex:context,git status --short'
- powershell -ExecutionPolicy Bypass -File .\scripts\run-shared-codex-shortcut.ps1 -Action ThreadBootstrap -TaskSlug testar-handoff -TaskBrief 'Validate cross-account continuity' -ValidationCommands 'npm run codex:context,git status --short'
- git diff --check

## Notes
- This change does not deploy an application surface; it publishes shared repo contracts and operator docs so every local Windows user can bootstrap and hand off work consistently.