### PR TITLE
site: sync esfa redirects during website deploy

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -184,6 +184,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Sync esfa.co managed redirects (D1)
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        working-directory: modules/site-public/website
+        run: npm run custom-urls:migrate:esfa -- --apply --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Smoke test production
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: modules/site-public/website

--- a/modules/site-public/website/scripts/migrate-esfa-redirects.ts
+++ b/modules/site-public/website/scripts/migrate-esfa-redirects.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { listEsfaManagedRedirectSeeds, ESFA_SITE_HOST, type EsfaManagedUrlSeed } from "../src/lib/esfaManagedRedirects";
+import {
+    ESFA_MIGRATED_SOURCE,
+    ESFA_SITE_HOST,
+    listEsfaManagedRedirectSeeds,
+    type EsfaManagedUrlSeed,
+} from "../src/lib/esfaManagedRedirects";
 
 const execFileAsync = promisify(execFile);
 const DATABASE_NAME = "espacofacial-booking";
@@ -142,6 +147,10 @@ function buildPlan(existingRows: ExistingRedirectRow[], seeds: EsfaManagedUrlSee
             continue;
         }
         if (canonicalUrl(existing.destination_url) !== canonicalUrl(seed.destinationUrl)) {
+            if (existing.source === ESFA_MIGRATED_SOURCE) {
+                plan.updates.push({ existing, seed });
+                continue;
+            }
             plan.conflicts.push({ existing, seed });
             continue;
         }


### PR DESCRIPTION
## Resumo
- sincroniza o catálogo `esfa.co` no D1 após publicar o worker de redirects no deploy do site
- permite que o migrador atualize destinos de linhas com `source = cloudflare_worker_migrated`, mantendo conflitos para redirects manuais

## Por quê
O PR #598 atualizou o site e o fallback estático do worker, mas os short links `esfa.co/bss/dramarinalima` e `esfa.co/nh/dramarinalima` continuaram apontando para WhatsApp antigo porque `site_custom_urls` no D1 tem precedência sobre `ESFA_REDIRECTS`.

## Validação
- `npm run quality:website`
- produção principal já validada no merge do #598: `x-app-build=f76cb4ea03a37385fd37c469fe043a118630e9ec`, `/api/hero-media` com `aniversario-7-anos-2026`, `/api/equipe` sem Marina

Rollback: reverter este PR remove a sincronização automática; os dados D1 podem ser revertidos manualmente com os destinos antigos capturados no histórico do PR #598, se necessário.