### PR TITLE
site: add live release guardrails

### DIFF
--- a/docs/codex-app-native.md
+++ b/docs/codex-app-native.md
@@ -105,6 +105,22 @@ Use este quando o objetivo for pré-release do funil de site:
 npm run codex:site:release-check
 ```
 
+Use este depois de deploys do `espacofacial.com` para evitar redescobrir estado de produção:
+
+```bash
+npm run codex:site:live-check
+```
+
+## Checklist De Release Do Site
+
+- Trabalhe apenas na fonte de deploy `modules/site-public/website/`; a raiz antiga `website/` não dispara `.github/workflows/deploy-website-cloudflare.yml`.
+- Antes de confiar no PR, confirme branch/base, `refs/pull/<n>/merge` e checks/automerge no GitHub.
+- Rode `npm run quality:website` antes de publicar mudanças do site.
+- Depois do merge, valide `x-app-build`, `/api/hero-media?variant=desktop`, `/api/hero-media?variant=mobile` e `/api/equipe` em produção.
+- Para redirects, valide tanto URLs longas em `espacofacial.com` quanto short links `esfa.co`.
+- Lembre que `esfa.co` lê primeiro o D1 `site_custom_urls`; alterar `ESFA_REDIRECTS` ou publicar o Worker não basta quando já existe linha migrada no D1.
+- Prefira GitHub Actions para sincronização auditável de Worker/D1; Wrangler local pode não estar autenticado no mini-PC.
+
 ## Regras de segurança
 
 - Não imprimir secrets em logs.

--- a/modules/site-public/website/README.md
+++ b/modules/site-public/website/README.md
@@ -117,6 +117,25 @@ Deploy do worker de redirects (domínio `esfa.co`):
 npm run deploy:esfa
 ```
 
+Observação operacional:
+- Em produção, o Worker `esfa.co` consulta primeiro o D1 `site_custom_urls` e só usa `ESFA_REDIRECTS` como fallback.
+- Quando mudar short links já migrados, rode/siga o workflow oficial de deploy do site para aplicar `npm run custom-urls:migrate:esfa -- --apply --remote`.
+- Validar só `espacofacial.com` não cobre `esfa.co`; cheque os dois domínios.
+
+## Checklist de release
+
+Antes do PR:
+- Confirme que a mudança está em `modules/site-public/website/` ou no workflow `.github/workflows/deploy-website-cloudflare.yml`.
+- Rode `npm run quality:website` a partir da raiz do repo.
+- Para PRs, confirme que existe `refs/pull/<n>/merge` e que a base é o `main` atual.
+
+Depois do deploy:
+```bash
+npm run codex:site:live-check
+```
+
+O live-check valida `x-app-build`, campanha hero desktop/mobile, ausência de profissional removido em `/api/equipe` e redirects longos/curtos críticos.
+
 ## Ver logs (produção)
 
 Tail do Worker principal:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "codex:crm:meta-ads-smoke": "CRM_MODULE=meta-ads bash ./scripts/run-local-crm.sh --skip-build --exit-after-smoke",
     "codex:crm:atendimento-clinica-smoke": "bash ./scripts/run-local-atendimento-clinica.sh --skip-build --exit-after-smoke",
     "codex:site:check": "npm --prefix modules/site-public/website run test && npm --prefix modules/site-public/website run typecheck",
+    "codex:site:live-check": "node ./scripts/site-live-check.mjs",
     "codex:site:release-check": "npm run codex:preflight && npm run quality:website && npm run codex:crm:site-smoke",
     "website:install": "npm --prefix modules/site-public/website ci",
     "website:dev": "npm --prefix modules/site-public/website run dev",

--- a/scripts/codex-context.sh
+++ b/scripts/codex-context.sh
@@ -41,12 +41,21 @@ http_code() {
 section "Skincos Codex Context"
 printf 'cwd=%s\n' "$ROOT_DIR"
 printf 'date=%s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')"
-printf 'branch=%s\n' "$(git branch --show-current 2>/dev/null || printf 'detached')"
-printf 'head=%s\n' "$(git log -1 --oneline 2>/dev/null || printf 'unavailable')"
+branch="$(git branch --show-current 2>/dev/null || true)"
+head="$(git log -1 --oneline 2>/dev/null || true)"
+if [[ -n "$head" ]]; then
+  printf 'branch=%s\n' "${branch:-detached}"
+  printf 'head=%s\n' "$head"
+else
+  printf 'branch=unavailable\n'
+  printf 'head=unavailable\n'
+fi
 
 section "Worktree"
-status="$(git status --short 2>/dev/null || true)"
-if [[ -z "$status" ]]; then
+if ! status="$(git status --short 2>/dev/null)"; then
+  echo "git_status=unavailable"
+  echo "git_note=Git metadata could not be read from this shell; Windows/WSL worktrees may need safe.directory or a matching gitdir path."
+elif [[ -z "$status" ]]; then
   echo "clean=true"
 else
   echo "clean=false"
@@ -77,6 +86,7 @@ cat <<'EOF'
 context=npm run codex:context
 preflight=npm run codex:preflight
 site_check=npm run codex:site:check
+site_live_check=npm run codex:site:live-check
 site_release_check=npm run codex:site:release-check
 site_ef_smoke=npm run codex:crm:site-smoke
 meta_ads_smoke=npm run codex:crm:meta-ads-smoke
@@ -90,4 +100,16 @@ if $ONLINE; then
   printf 'crm.skincos.com.br=%s\n' "$(http_code 'https://crm.skincos.com.br')"
   printf 'crm_health=%s\n' "$(http_code 'https://crm.skincos.com.br/api/health')"
   printf 'site_custom_urls_unauth=%s (401 expected)\n' "$(http_code 'https://espacofacial.com/api/tracking/custom-urls')"
+
+  section "Live Website Release Signals"
+  if command -v node >/dev/null 2>&1 && [[ -f scripts/site-live-check.mjs ]]; then
+    node ./scripts/site-live-check.mjs --summary --no-fail || true
+  else
+    echo "site_live_check=SKIPPED (node unavailable)"
+  fi
+  cat <<'EOF'
+site_release_note=website deploy source is modules/site-public/website/; old website/ does not trigger deploy
+esfa_redirect_note=esfa.co resolves D1 site_custom_urls before ESFA_REDIRECTS fallback
+cloudflare_note=Wrangler local auth may be absent; prefer GitHub Actions for audited Worker/D1 production sync
+EOF
 fi

--- a/scripts/site-live-check.mjs
+++ b/scripts/site-live-check.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE_URL = "https://espacofacial.com";
+const DEFAULT_EXPECTED_CAMPAIGN = "aniversario-7-anos-2026";
+const DEFAULT_ABSENT_PATTERN = "Marina|dramarinalima";
+
+const args = new Set(process.argv.slice(2));
+const summaryMode = args.has("--summary");
+const noFail = args.has("--no-fail");
+
+const baseUrl = (process.env.SITE_LIVE_CHECK_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
+const expectedBuild = (process.env.SITE_LIVE_CHECK_EXPECT_BUILD || "").trim();
+const expectedCampaign = (process.env.SITE_LIVE_CHECK_EXPECT_CAMPAIGN || DEFAULT_EXPECTED_CAMPAIGN).trim();
+const absentPattern = (process.env.SITE_LIVE_CHECK_ABSENT_PATTERN || DEFAULT_ABSENT_PATTERN).trim();
+
+const redirectChecks = [
+    {
+        name: "long_bss_marina",
+        url: `${baseUrl}/barrashoppingsul/dramarinalima`,
+        expectedLocation: `${baseUrl}/barrashoppingsul`,
+    },
+    {
+        name: "long_nh_marina",
+        url: `${baseUrl}/novohamburgo/dramarinalima`,
+        expectedLocation: `${baseUrl}/novohamburgo`,
+    },
+    {
+        name: "short_bss_marina",
+        url: "https://esfa.co/bss/dramarinalima",
+        expectedLocation: `${baseUrl}/barrashoppingsul`,
+    },
+    {
+        name: "short_nh_marina",
+        url: "https://esfa.co/nh/dramarinalima",
+        expectedLocation: `${baseUrl}/novohamburgo`,
+    },
+];
+
+const results = [];
+
+function record(ok, label, details) {
+    results.push({ ok, label, details });
+}
+
+function normalizeUrl(value, base) {
+    return new URL(value, base).toString();
+}
+
+async function fetchWithTimeout(url, options = {}) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 12000);
+    try {
+        return await fetch(url, { ...options, signal: controller.signal });
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function campaignFromItems(items) {
+    const campaigns = new Set();
+    for (const item of items) {
+        const src = typeof item?.src === "string" ? item.src : "";
+        const match = src.match(/\/images\/hero\/campaigns\/([^/]+)\//);
+        if (match?.[1]) campaigns.add(match[1]);
+    }
+    return [...campaigns].sort();
+}
+
+async function readHeroVariant(variant) {
+    const res = await fetchWithTimeout(`${baseUrl}/api/hero-media?variant=${encodeURIComponent(variant)}`);
+    const text = await res.text();
+    if (!res.ok) {
+        throw new Error(`/api/hero-media?variant=${variant} returned ${res.status}: ${text.slice(0, 160)}`);
+    }
+    const payload = JSON.parse(text);
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const campaigns = campaignFromItems(items);
+    return { items, campaigns };
+}
+
+async function checkHomeBuild() {
+    const res = await fetchWithTimeout(`${baseUrl}/`, { method: "HEAD", redirect: "manual" });
+    const build = (res.headers.get("x-app-build") || "").trim();
+    const buildTime = (res.headers.get("x-app-build-time") || "").trim();
+    record(res.status === 200, "home_status", `${res.status}`);
+    record(Boolean(build), "x_app_build_present", build || "(empty)");
+    if (expectedBuild) {
+        record(build === expectedBuild, "x_app_build_expected", `expected=${expectedBuild} actual=${build || "(empty)"}`);
+    }
+    return { build, buildTime };
+}
+
+async function checkHeroMedia() {
+    for (const variant of ["desktop", "mobile"]) {
+        const { items, campaigns } = await readHeroVariant(variant);
+        record(items.length > 0, `hero_${variant}_items`, `count=${items.length}`);
+        record(campaigns.length === 1, `hero_${variant}_single_campaign`, campaigns.join(",") || "(none)");
+        if (expectedCampaign) {
+            record(
+                campaigns.includes(expectedCampaign),
+                `hero_${variant}_expected_campaign`,
+                `expected=${expectedCampaign} actual=${campaigns.join(",") || "(none)"}`,
+            );
+        }
+    }
+}
+
+async function checkEquipe() {
+    const res = await fetchWithTimeout(`${baseUrl}/api/equipe`);
+    const text = await res.text();
+    record(res.status === 200, "equipe_status", `${res.status}`);
+    if (absentPattern) {
+        const re = new RegExp(absentPattern, "i");
+        record(!re.test(text), "equipe_absent_pattern", absentPattern);
+    }
+}
+
+async function checkRedirects() {
+    for (const check of redirectChecks) {
+        const res = await fetchWithTimeout(check.url, { method: "HEAD", redirect: "manual" });
+        const location = res.headers.get("location") || "";
+        const actual = location ? normalizeUrl(location, check.url) : "";
+        const expected = normalizeUrl(check.expectedLocation, check.url);
+        record([301, 302, 307, 308].includes(res.status), `${check.name}_status`, `${res.status}`);
+        record(actual === expected, `${check.name}_location`, `expected=${expected} actual=${actual || "(empty)"}`);
+    }
+}
+
+function printResults(buildInfo) {
+    if (summaryMode) {
+        const failed = results.filter((result) => !result.ok);
+        console.log(`site_live_check=${failed.length ? "FAIL" : "OK"}`);
+        console.log(`site_build=${buildInfo.build || "(empty)"}`);
+        console.log(`site_build_time=${buildInfo.buildTime || "(empty)"}`);
+        for (const result of results) {
+            if (result.label.includes("hero_") || result.label.includes("short_") || result.label === "equipe_absent_pattern") {
+                console.log(`${result.ok ? "OK" : "FAIL"} ${result.label}: ${result.details}`);
+            }
+        }
+        return;
+    }
+
+    console.log(`Site live check: ${baseUrl}`);
+    console.log(`Expected campaign: ${expectedCampaign || "(not enforced)"}`);
+    console.log(`Absent equipe pattern: ${absentPattern || "(not enforced)"}`);
+    for (const result of results) {
+        console.log(`${result.ok ? "OK  " : "FAIL"} ${result.label}: ${result.details}`);
+    }
+}
+
+async function main() {
+    const buildInfo = await checkHomeBuild();
+    await checkHeroMedia();
+    await checkEquipe();
+    await checkRedirects();
+    printResults(buildInfo);
+
+    if (results.some((result) => !result.ok) && !noFail) {
+        process.exitCode = 1;
+    }
+}
+
+main().catch((error) => {
+    console.error(`site-live-check failed: ${error instanceof Error ? error.message : String(error)}`);
+    if (!noFail) process.exitCode = 1;
+});


### PR DESCRIPTION
## Resumo
- adiciona `npm run codex:site:live-check` para validar build, campanha hero, equipe e redirects longos/curtos em produção
- inclui sinais do live-check no `npm run codex:context:online`
- documenta o checklist de release do site e a nuance `esfa.co` -> D1 `site_custom_urls` antes de `ESFA_REDIRECTS`
- registra memória ad hoc local para evitar redescoberta em próximas threads

## Validação
- `npm run codex:site:live-check`
- `npm run codex:context:online`
- `npm run quality:website`

Observação: a nota de memória foi criada localmente em `C:\Users\admin\.codex\memories\extensions\ad_hoc\notes\2026-07-09-site-deploy-esfa-d1-guardrails.md` e não faz parte do PR.