### PR TITLE
Fix hero hydration layout shift

### DIFF
--- a/modules/site-public/website/src/components/HeroMedia.tsx
+++ b/modules/site-public/website/src/components/HeroMedia.tsx
@@ -3,7 +3,6 @@
 import TrackedBookingLink from "@/components/TrackedBookingLink";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
 import { getHeroMediaAspectRatio, getLocalHeroItems, normalizeHeroUnitSlug, type HeroMediaItem, type HeroMediaVariant } from "@/lib/heroMediaShared";
-import { getStoredUnitSlug } from "@/lib/unitSelection";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
@@ -170,6 +169,8 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
         },
         [initialItems, initialItemsByVariant, startupVariant],
     );
+    const desktopInitialAspectRatio = resolveFirstAspectRatio(resolveInitialItemsForVariant("desktop"));
+    const mobileInitialAspectRatio = resolveFirstAspectRatio(resolveInitialItemsForVariant("mobile"));
     const [index, setIndex] = useState(0);
     const [prevIndex, setPrevIndex] = useState<number | null>(null);
     const [prevFrameColors, setPrevFrameColors] = useState<HeroFrameColors>(HERO_DEFAULT_FRAME_COLORS);
@@ -186,7 +187,7 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
 
     type HeroStyle = CSSProperties &
         Record<
-            "--hero-ar" | "--hero-band-bg" | "--hero-band-bg-top" | "--hero-band-bg-bottom" | "--hero-cta-left" | "--hero-cta-top" | "--hero-cta-width" | "--hero-cta-height",
+            "--hero-ar" | "--hero-ar-desktop" | "--hero-ar-mobile" | "--hero-band-bg" | "--hero-band-bg-top" | "--hero-band-bg-bottom" | "--hero-cta-left" | "--hero-cta-top" | "--hero-cta-width" | "--hero-cta-height",
             string
         >;
     useEffect(() => {
@@ -206,8 +207,7 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
     }, []);
 
     const [items, setItems] = useState<HeroMediaItem[]>(() => {
-        const startupStoredUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
-        const startupTargetUnitSlug = startupStoredUnitSlug ?? initialUnitSlug ?? null;
+        const startupTargetUnitSlug = initialUnitSlug ?? null;
         const startupCampaignKey = campaignKey(startupVariant, startupTargetUnitSlug);
         const initialCampaignKey = campaignKey(startupVariant, initialUnitSlug ?? null);
         const startupInitialItems = resolveInitialItemsForVariant(startupVariant);
@@ -216,13 +216,11 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
         return getLocalHeroItems(startupVariant, { unitSlug: startupTargetUnitSlug });
     });
     const [loadedCampaignKey, setLoadedCampaignKey] = useState<string>(() => {
-        const startupStoredUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
-        const startupTargetUnitSlug = startupStoredUnitSlug ?? initialUnitSlug ?? null;
+        const startupTargetUnitSlug = initialUnitSlug ?? null;
         return campaignKey(startupVariant, startupTargetUnitSlug);
     });
 
-    const storedUnitSlug = typeof window === "undefined" ? null : getStoredUnitSlug();
-    const targetUnitSlug = unit?.slug ?? storedUnitSlug ?? initialUnitSlug ?? null;
+    const targetUnitSlug = unit?.slug ?? initialUnitSlug ?? null;
     const targetCampaignKey = campaignKey(variant, targetUnitSlug);
     const initialCampaignKey = campaignKey(variant, initialUnitSlug ?? null);
     const visibleItems = loadedCampaignKey === targetCampaignKey ? items : EMPTY_HERO_ITEMS;
@@ -471,6 +469,8 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
         const hotspot = item?.bookingHotspot;
         return {
             "--hero-ar": aspectRatio,
+            "--hero-ar-desktop": desktopInitialAspectRatio,
+            "--hero-ar-mobile": mobileInitialAspectRatio,
             "--hero-band-bg": frameColors.top,
             "--hero-band-bg-top": frameColors.top,
             "--hero-band-bg-bottom": frameColors.bottom,
@@ -479,7 +479,7 @@ export default function HeroMedia({ initialItems, initialItemsByVariant, initial
             "--hero-cta-width": hotspot ? `${hotspot.widthPct}%` : "0%",
             "--hero-cta-height": hotspot ? `${hotspot.heightPct}%` : "0%",
         };
-    }, [aspectRatio, frameColors.bottom, frameColors.top, item?.bookingHotspot]);
+    }, [aspectRatio, desktopInitialAspectRatio, frameColors.bottom, frameColors.top, item?.bookingHotspot, mobileInitialAspectRatio]);
 
     const renderLayer = (layerItem: HeroMediaItem, opts?: { kind?: "active" | "prev"; colors?: HeroFrameColors }) => {
         const kind = opts?.kind ?? "active";

--- a/modules/site-public/website/src/hooks/useCurrentUnit.ts
+++ b/modules/site-public/website/src/hooks/useCurrentUnit.ts
@@ -36,7 +36,9 @@ export function useCurrentUnit(): Unit | null {
     const slugFromQuery = useMemo(() => searchParams?.get("unit") ?? null, [searchParams]);
     const unitFromQuery = useMemo(() => findUnitBySlugOrAlias(slugFromQuery), [slugFromQuery]);
 
-    const [storedSlug, setStoredSlug] = useState<string | null>(() => getStoredUnitSlug());
+    // Storage is unavailable on the server. Reading it during the first client
+    // render makes the hydrated tree differ from the HTML already on screen.
+    const [storedSlug, setStoredSlug] = useState<string | null>(null);
 
     useEffect(() => {
         if (typeof window === "undefined") return;

--- a/modules/site-public/website/src/styles/globals.css
+++ b/modules/site-public/website/src/styles/globals.css
@@ -3209,7 +3209,7 @@ button:focus-visible {
 
 .heroMedia {
   width: 100%;
-  aspect-ratio: var(--hero-ar, 16 / 9);
+  aspect-ratio: var(--hero-ar-desktop, var(--hero-ar, 16 / 9));
   min-height: 320px;
   position: relative;
   z-index: 1;
@@ -3249,6 +3249,10 @@ button:focus-visible {
 }
 
 @media (max-width:900px) {
+  .heroMedia {
+    aspect-ratio: var(--hero-ar-mobile, var(--hero-ar, 9 / 16));
+  }
+
   .heroMediaResponsiveLayer--desktop {
     display: none;
   }
@@ -8640,8 +8644,6 @@ video.heroMediaEl {
   }
 
   .heroMedia {
-    height: clamp(560px, calc(100vw * 16 / 9), 720px);
-    max-height: none;
     min-height: 0;
   }
 
@@ -8663,10 +8665,6 @@ video.heroMediaEl {
 }
 
 @media (max-width:900px) {
-  .heroMedia {
-    max-height: 440px;
-  }
-
   .heroMediaEl {
     object-fit: cover;
   }
@@ -8773,8 +8771,6 @@ video.heroMediaEl {
   }
 
   .heroMedia {
-    height: clamp(560px, calc(100vw * 16 / 9), 720px);
-    max-height: none;
     min-height: 0;
   }
 


### PR DESCRIPTION
Corrige o salto visivel do hero durante a hidratacao. A causa era leitura de estado local no primeiro render do cliente, que divergia do HTML do servidor, somada a uma proporcao inicial dependente da variante detectada pelo servidor. O hero agora usa proporcoes de desktop e mobile definidas no HTML/CSS antes do JavaScript e adia a leitura do armazenamento local ate apos a hidratacao. Validado com lint, TypeScript, 68 testes e carregamento frio mobile.