### PR TITLE
Add anniversary campaign redirect aliases

### DIFF
--- a/modules/site-public/website/src/lib/aniversario7Redirects.ts
+++ b/modules/site-public/website/src/lib/aniversario7Redirects.ts
@@ -1,0 +1,17 @@
+export const ANIVERSARIO_7_ESFA_REDIRECTS: Record<string, string> = {
+    "/bss/aniver6anos": "https://esfa.co/bss/aniver7anos",
+    "/nh/aniver6anos": "https://esfa.co/nh/aniver7anos",
+    "/bss/aniver7anos": "https://espacofacial.com/agendamento?unit=barrashoppingsul&utm_source=esfa.co&utm_medium=short_link&utm_campaign=aniver7anos",
+    "/nh/aniver7anos": "https://espacofacial.com/agendamento?unit=novo-hamburgo&utm_source=esfa.co&utm_medium=short_link&utm_campaign=aniver7anos",
+};
+
+export const ANIVERSARIO_7_LEGACY_REDIRECTS: Record<string, string> = {
+    "/bss/aniver6anos": "https://esfa.co/bss/aniver7anos",
+    "/barrashoppingsul/aniver6anos": "https://esfa.co/bss/aniver7anos",
+    "/nh/aniver6anos": "https://esfa.co/nh/aniver7anos",
+    "/novohamburgo/aniver6anos": "https://esfa.co/nh/aniver7anos",
+    "/bss/aniver7anos": "https://esfa.co/bss/aniver7anos",
+    "/barrashoppingsul/aniver7anos": "https://esfa.co/bss/aniver7anos",
+    "/nh/aniver7anos": "https://esfa.co/nh/aniver7anos",
+    "/novohamburgo/aniver7anos": "https://esfa.co/nh/aniver7anos",
+};

--- a/modules/site-public/website/src/lib/esfaRedirects.ts
+++ b/modules/site-public/website/src/lib/esfaRedirects.ts
@@ -1,3 +1,5 @@
+import { ANIVERSARIO_7_ESFA_REDIRECTS } from "@/lib/aniversario7Redirects";
+
 export const ESFA_PRESERVE_QUERYSTRING = true;
 
 export const ESFA_REDIRECTS: Record<string, string> = {
@@ -38,6 +40,7 @@ export const ESFA_REDIRECTS: Record<string, string> = {
   "/nh/vip": "https://chat.whatsapp.com/EldkIVerELzESZKW8Iephz",
 
   // Campanhas
+  ...ANIVERSARIO_7_ESFA_REDIRECTS,
   "/bebadessafonte": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+HealthBodyRun+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
 
   // Interno

--- a/modules/site-public/website/src/lib/siteCustomUrls.ts
+++ b/modules/site-public/website/src/lib/siteCustomUrls.ts
@@ -53,6 +53,8 @@ const ALLOWED_DESTINATION_HOSTS = new Set([
     "app.espacofacial.com.br",
     "espacofacial.com.br",
     "www.espacofacial.com.br",
+    "esfa.co",
+    "www.esfa.co",
     "api.whatsapp.com",
     "wa.me",
     "wa.skincos.com.br",
@@ -108,6 +110,15 @@ function normalizeDestinationUrl(value: unknown): { url: string; host: string | 
     };
 }
 
+function normalizeComparablePath(pathname: string): string {
+    const normalized = pathname.replace(/\/+$/, "").toLowerCase();
+    return normalized || "/";
+}
+
+function isEsfaHost(host: string | null): boolean {
+    return host === "esfa.co" || host === "www.esfa.co";
+}
+
 function readUtm(body: Record<string, unknown>, camelKey: string, snakeKey: string): string | null {
     return textOrNull(body[camelKey] ?? body[snakeKey], 160);
 }
@@ -155,6 +166,9 @@ export function normalizeSiteCustomUrlInput(raw: unknown): NormalizedSiteCustomU
     };
     input.destinationUrl = mergeUtmIntoDestination(input.destinationUrl, input);
     const merged = normalizeDestinationUrl(input.destinationUrl);
+    if (input.siteHost === "esfa.co" && isEsfaHost(merged.host) && normalizeComparablePath(new URL(input.destinationUrl).pathname) === input.slugPath) {
+        throw new Error("destination_url_must_not_reference_self");
+    }
     input.destinationHost = merged.host;
     input.destinationPath = merged.path;
     return input;

--- a/modules/site-public/website/src/middleware.ts
+++ b/modules/site-public/website/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { isPathAllowedForSite } from "@/lib/site-config";
 import { buildWhatsappRedirectHrefFromRequest, isSupportedWhatsappUrl } from "@/lib/whatsappTracking";
 import { mergeCampaignParamsIntoUrl } from "@/lib/mergeCampaignParams";
+import { ANIVERSARIO_7_LEGACY_REDIRECTS } from "@/lib/aniversario7Redirects";
 
 function isPublicAsset(pathname: string): boolean {
     return (
@@ -84,6 +85,7 @@ export function middleware(req: NextRequest) {
         const normalizedPath = normalizeRedirectPath(pathname);
 
         const legacyRedirects: Record<string, string> = {
+            ...ANIVERSARIO_7_LEGACY_REDIRECTS,
             // LONG URLs (export)
             "/barrashoppingsul/comochegar": "https://www.google.com/maps/place/Espaço+Facial/@-30.0846697,-51.2458384,17z/data=!3m1!4b1!4m6!3m5!1s0x9519795c306ed865:0xb5f05aac9b865daa!8m2!3d-30.0846697!4d-51.2458384!16s%2Fg%2F11vywknzbf?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
             "/barrashoppingsul/fb": "https://www.facebook.com/espacofacial.barrashoppingsul",

--- a/modules/site-public/website/tests/esfaManagedRedirects.test.ts
+++ b/modules/site-public/website/tests/esfaManagedRedirects.test.ts
@@ -7,6 +7,7 @@ import {
     listEsfaManagedRedirectSeeds,
 } from "../src/lib/esfaManagedRedirects";
 import { ESFA_REDIRECTS } from "../src/lib/esfaRedirects";
+import { ANIVERSARIO_7_ESFA_REDIRECTS, ANIVERSARIO_7_LEGACY_REDIRECTS } from "../src/lib/aniversario7Redirects";
 
 test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects", () => {
     const seed = buildEsfaManagedRedirectSeed({
@@ -27,9 +28,18 @@ test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects",
 test("listEsfaManagedRedirectSeeds covers the full static catalog", () => {
     const seeds = listEsfaManagedRedirectSeeds(456);
 
-    assert.equal(seeds.length, 96);
+    assert.equal(seeds.length, Object.keys(ESFA_REDIRECTS).length);
     assert.equal(new Set(seeds.map((seed) => seed.slugPath)).size, seeds.length);
     assert.equal(seeds.every((seed) => seed.siteHost === "esfa.co"), true);
+});
+
+test("aniversario 7 campaign aliases converge to the canonical short links", () => {
+    assert.equal(ANIVERSARIO_7_ESFA_REDIRECTS["/bss/aniver6anos"], "https://esfa.co/bss/aniver7anos");
+    assert.equal(ANIVERSARIO_7_ESFA_REDIRECTS["/nh/aniver6anos"], "https://esfa.co/nh/aniver7anos");
+    assert.match(ANIVERSARIO_7_ESFA_REDIRECTS["/bss/aniver7anos"], /unit=barrashoppingsul/);
+    assert.match(ANIVERSARIO_7_ESFA_REDIRECTS["/nh/aniver7anos"], /unit=novo-hamburgo/);
+    assert.equal(ANIVERSARIO_7_LEGACY_REDIRECTS["/barrashoppingsul/aniver6anos"], "https://esfa.co/bss/aniver7anos");
+    assert.equal(ANIVERSARIO_7_LEGACY_REDIRECTS["/novohamburgo/aniver6anos"], "https://esfa.co/nh/aniver7anos");
 });
 
 test("listEsfaFallbackRedirects excludes redirects already migrated to D1", () => {

--- a/modules/site-public/website/tests/siteCustomUrls.test.ts
+++ b/modules/site-public/website/tests/siteCustomUrls.test.ts
@@ -54,3 +54,23 @@ test("normalizeSiteCustomUrlInput preserves unicode slugs and accepts approved e
     assert.equal(input.slugPath, "/bss/avalienossoespaço");
     assert.equal(input.destinationHost, "www.google.com");
 });
+
+test("normalizeSiteCustomUrlInput allows esfa aliases but prevents redirect loops", () => {
+    const alias = normalizeSiteCustomUrlInput({
+        siteHost: "esfa.co",
+        name: "Aniversario 6 anos BSS",
+        slugPath: "/bss/aniver6anos",
+        destinationUrl: "https://esfa.co/bss/aniver7anos",
+    });
+
+    assert.equal(alias.destinationHost, "esfa.co");
+    assert.throws(
+        () => normalizeSiteCustomUrlInput({
+            siteHost: "esfa.co",
+            name: "Loop",
+            slugPath: "/bss/aniver7anos",
+            destinationUrl: "https://www.esfa.co/bss/aniver7anos",
+        }),
+        /destination_url_must_not_reference_self/,
+    );
+});


### PR DESCRIPTION
Adds canonical aniver7anos short links for BSS and NH, redirects legacy aniver6anos aliases, and validates D1-safe aliases. Validation: website tests, lint, native WSL production build, and TypeScript.