### PR TITLE
Preserve redirect attribution without duplicates

### DIFF
--- a/modules/site-public/website/tests/esfaRedirectWorker.test.ts
+++ b/modules/site-public/website/tests/esfaRedirectWorker.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveEsfaRedirectTarget } from "../workers/esfa-redirector/worker";
+
+test("esfa redirect target preserves incoming attribution without duplicate keys", () => {
+    const target = resolveEsfaRedirectTarget(
+        "https://espacofacial.com/agendamento?unit=barrashoppingsul&utm_source=esfa.co&utm_medium=short_link&utm_campaign=aniver7anos",
+        "?utm_source=meta&utm_campaign=legacy&fbclid=fbclid_123",
+    );
+
+    assert.equal(
+        target,
+        "https://espacofacial.com/agendamento?unit=barrashoppingsul&utm_medium=short_link&utm_source=meta&utm_campaign=legacy&fbclid=fbclid_123",
+    );
+});
+
+test("esfa redirect target retains destination defaults without an incoming query string", () => {
+    assert.equal(
+        resolveEsfaRedirectTarget(
+            "https://espacofacial.com/agendamento?unit=novo-hamburgo&utm_campaign=aniver7anos",
+            "",
+        ),
+        "https://espacofacial.com/agendamento?unit=novo-hamburgo&utm_campaign=aniver7anos",
+    );
+});

--- a/modules/site-public/website/workers/esfa-redirector/worker.ts
+++ b/modules/site-public/website/workers/esfa-redirector/worker.ts
@@ -38,6 +38,20 @@ async function readManagedRedirect(env: WorkerEnv, slugPath: string): Promise<st
   }
 }
 
+export function resolveEsfaRedirectTarget(targetBase: string, incomingSearch: string): string {
+  const target = new URL(targetBase);
+  if (!ESFA_PRESERVE_QUERYSTRING || !incomingSearch) return target.toString();
+
+  const targetParams = new URLSearchParams(target.search);
+  const incomingParams = new URLSearchParams(incomingSearch);
+  const incomingKeys = new Set(Array.from(incomingParams.keys()));
+  for (const key of incomingKeys) targetParams.delete(key);
+  for (const [key, value] of incomingParams) targetParams.append(key, value);
+  const merged = targetParams.toString();
+  target.search = merged ? `?${merged}` : "";
+  return target.toString();
+}
+
 const worker = {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
@@ -46,18 +60,7 @@ const worker = {
     const targetBase = (await readManagedRedirect(env, path)) || ESFA_REDIRECTS[path];
     if (!targetBase) return new Response("Not Found", { status: 404 });
 
-    const target = new URL(targetBase);
-    if (ESFA_PRESERVE_QUERYSTRING && url.search) {
-      const targetParams = new URLSearchParams(target.search);
-      const incomingParams = new URLSearchParams(url.search);
-      for (const [key, value] of incomingParams) {
-        targetParams.append(key, value);
-      }
-      const merged = targetParams.toString();
-      target.search = merged ? `?${merged}` : "";
-    }
-
-    return Response.redirect(target.toString(), 301);
+    return Response.redirect(resolveEsfaRedirectTarget(targetBase, url.search), 301);
   },
 };
 


### PR DESCRIPTION
Fixes duplicate UTM parameters when an esfa.co short link has default campaign tags and receives attribution from an ad. Adds direct Worker coverage for replacement and default preservation.