### PR TITLE
ops: retire shared backups destination

### DIFF
--- a/modules/automations/n8n/CODEX_CONTEXT.md
+++ b/modules/automations/n8n/CODEX_CONTEXT.md
@@ -63,9 +63,10 @@
 - WSL distributions are installed per Windows user, so a new local account may
   still need its own `Ubuntu-24.04` bootstrap before it can operate the live
   runtime directly.
-- The exported distro tar currently lives under `C:\CodexShared\Projetos`
-  rather than `C:\CodexShared\Backups` because the current ACL on `Backups` is
-  read-only for `Users`.
+- The exported distro tar lives at
+  `C:\CodexShared\Projetos\_bootstrap\wsl\ubuntu-24.04-codex-base.tar`.
+  This is the single supported export location; the retired empty
+  `C:\CodexShared\Backups` folder is no longer part of the workflow.
 - The shared repo still carries local multi-account migration changes that have
   not yet been reconciled back to `main`.
 

--- a/modules/automations/n8n/scripts/export-wsl-codex-base.ps1
+++ b/modules/automations/n8n/scripts/export-wsl-codex-base.ps1
@@ -1,8 +1,7 @@
 $ErrorActionPreference = "Stop"
 
 $DistroName = "Ubuntu-24.04"
-$PreferredTargetDir = "C:\CodexShared\Backups\wsl"
-$FallbackTargetDir = "C:\CodexShared\Projetos\_bootstrap\wsl"
+$TargetDir = "C:\CodexShared\Projetos\_bootstrap\wsl"
 
 function Initialize-TargetDir {
   param([string]$Path)
@@ -14,12 +13,8 @@ function Initialize-TargetDir {
   }
 }
 
-if (Initialize-TargetDir $PreferredTargetDir) {
-  $TargetDir = $PreferredTargetDir
-} elseif (Initialize-TargetDir $FallbackTargetDir) {
-  $TargetDir = $FallbackTargetDir
-} else {
-  throw "Unable to create export directory in either '$PreferredTargetDir' or '$FallbackTargetDir'."
+if (-not (Initialize-TargetDir $TargetDir)) {
+  throw "Unable to create WSL export directory '$TargetDir'."
 }
 
 $TargetTar = Join-Path $TargetDir "ubuntu-24.04-codex-base.tar"


### PR DESCRIPTION
## Summary

- Route WSL exports only to the supported `_bootstrap\\wsl` location.
- Retire the unused shared `Backups` destination from operational documentation.

## Validation

- PowerShell syntax parse.
- Local Orb health: HTTP 200.
- Public Orb health: HTTP 200.

## Operational note

The empty `C:\\CodexShared\\Backups` directory still requires an elevated Windows cleanup because its ACL denies deletion from the standard operator token.
