### PR TITLE
ops: centralize durable operator artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,11 @@
 - Use branches in the format `codex/admin/<task-slug>`.
 - Prefer worktrees under `C:\CodexShared\Worktrees\skincos\admin\<task-slug>`
   when more than one Codex task may work in parallel.
-- Keep Codex operator state in `%LOCALAPPDATA%\Codex\skincos\` and not inside
-  the shared repo or shared worktree paths.
+- Keep Codex authentication, browser profiles, temporary files and PID state in
+  `%LOCALAPPDATA%\Codex\skincos\`. Keep durable operator artifacts (logs,
+  reports, checkpoints, evidence and local backups) in the private runtime at
+  `C:\CodexRuntime\operator\admin\skincos\`, never in the shared repo or a
+  shared worktree.
 - Register the shared repo as Git `safe.directory` for the WSL `admin` operator.
 - Never store `.env`, `.dev.vars`, `.cloudflared` credentials, `.codex`,
   cookies, or API keys inside `C:\CodexShared`.

--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -43,9 +43,10 @@
   `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`,
   condensed to the top-level launchers `Workspace`, `Contexto`, `Local`,
   `EF App`, and `Orb`.
-- Codex App and Start Menu actions now also expose the `app.espacofacial.com.br`
-  scraper in a hardened local-user mode, with report/debug/profile state routed
-  to `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\`.
+- Codex App and Start Menu actions now expose the `app.espacofacial.com.br`
+  scraper in a hardened operator mode: report/debug/log artifacts route to
+  `C:\CodexRuntime\operator\admin\skincos\scraper\`, while the authenticated
+  Chrome profile and private env files remain in `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\`.
 - The hardened scraper action set now includes `EF App Caixa` for guided cash
   and payments exports without writing outputs back into the repo, plus menu
   coverage for full sync, procedures, recorder, and token rotation.
@@ -198,8 +199,9 @@
   still mention `frontend/`, `backend/apps/meta-ads`, or
   `backend/apps/whatsapp`.
 - Create per-task worktrees under `C:\CodexShared\Worktrees\skincos\...`.
-- Keep Codex local state, logs, temp files, browser profiles, and env overrides
-  in `%LOCALAPPDATA%\Codex\skincos\` for each operator.
+- Keep Codex authentication, temp files, browser profiles, env overrides and
+  WSL keepalive state in `%LOCALAPPDATA%\Codex\skincos\`. Keep durable local
+  artifacts in `C:\CodexRuntime\operator\admin\skincos\`.
 - If a task needs local runtime secrets, keep them outside the shared tree and
   document only the variable names and expected source.
 - Treat `C:\CodexShared\Projetos\skincos` as the only supported local code base

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,15 @@
 # DECISIONS
 
+## 2026-07-13 - Split durable operator artifacts from local authentication state
+
+- Keep Codex authentication, browser profiles, private environment overlays,
+  temporary files and WSL keepalive state under `%LOCALAPPDATA%\Codex\skincos\`.
+- Store durable project artifacts for the sole human operator under the private
+  `C:\CodexRuntime\operator\admin\skincos\` runtime tree. This includes local
+  logs, reports, debug exports, checkpoints, evidence and local backups.
+- The transition keeps directory junctions only as compatibility pointers; they
+  do not duplicate data and must not become an alternate source of truth.
+
 ## 2026-07-02 - Shared base lives outside user profiles
 
 - Decision: use `C:\CodexShared` as the shared Codex workspace root.

--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -20,8 +20,10 @@ Tarefas simultâneas do Codex continuam usando worktrees para evitar conflitos.
   `C:\CodexShared\Worktrees\skincos\<ator>\<task-slug>`.
 - O clone compartilhado deve ficar reservado para contexto, revisão, bootstrap
   e tarefas curtas; mudanças longas ou paralelas devem migrar para worktree.
-- Estado local do Codex deve ficar fora do repositório compartilhado, em
-  `%LOCALAPPDATA%\Codex\skincos\`.
+- Autenticação, perfis de browser, envs privados, PID e temporários do Codex
+  ficam fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`.
+  Logs, relatórios, checkpoints, evidências e backups locais ficam no runtime
+  privado `C:\CodexRuntime\operator\admin\skincos\`.
 
 ## Fluxo de primeira execução do operador
 
@@ -184,22 +186,24 @@ Os atalhos seguem dois modelos operacionais diferentes.
 Usado para edição, QA e iteração dos projetos locais como website e CRM.
 
 - roda a partir do código em `C:\CodexShared\Projetos\skincos`;
-- guarda PID, logs e estado temporário em `%LOCALAPPDATA%\Codex\skincos\`;
+- guarda PID e estado temporário em `%LOCALAPPDATA%\Codex\skincos\`, e logs
+  persistentes em `C:\CodexRuntime\operator\admin\skincos\logs\`;
 - não deve gravar artefatos operacionais novos no clone compartilhado nem no
   worktree por padrão.
 
 Os launchers do scraper do `app.espacofacial.com.br` também seguem esse modelo:
 
 - código em `backend/apps/automations/scraper`;
-- `report/`, `debug/`, `logs`, `chrome-profile` e envs privados resolvidos em
-  `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\`;
+- `report/`, `debug/` e `logs` em
+  `C:\CodexRuntime\operator\admin\skincos\scraper\`; `chrome-profile` e envs
+  privados em `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\`;
 - uso por um operador principal, sem depender de manter sessão, outputs ou
   credenciais dentro do repositório.
 
 O botão `EF App Caixa` roda em modo interativo guiado no terminal do Codex App:
 
 - fixa o scraper em `EF_MODE=caixa`;
-- mantém os artefatos em `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\`;
+- mantém os artefatos em `C:\CodexRuntime\operator\admin\skincos\scraper\`;
 - ainda pergunta unidade e intervalo de datas antes da exportação.
 
 ### Runtime live
@@ -254,8 +258,9 @@ Exemplo de saída esperada:
 3. Usar `Codex Context` ou rodar `bash ./scripts/codex-context.sh` via WSL.
 4. Para qualquer tarefa paralela ou mais longa, criar um worktree por usuário/tarefa.
 5. Abrir o worktree no Codex App e trabalhar só nele.
-6. Rodar apps locais, logs, perfis e overrides apenas a partir do estado privado
-   em `%LOCALAPPDATA%\Codex\skincos\`.
+6. Rodar apps locais com perfil, autenticação, temporários e overrides em
+   `%LOCALAPPDATA%\Codex\skincos\`; os artefatos duráveis vão para o runtime
+   privado em `C:\CodexRuntime\operator\admin\skincos\`.
 7. Antes de handoff, atualizar `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md`.
 
 Quando o worktree é aberto no Codex App, os botões do topo passam a chamar os

--- a/docs/codex-thread-bootstrap.md
+++ b/docs/codex-thread-bootstrap.md
@@ -13,7 +13,7 @@ Antes de editar qualquer arquivo:
 2. Verifique o estado compartilhado com `powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1`.
 3. Se a tarefa não for estritamente de leitura, crie um worktree dedicado com `powershell -ExecutionPolicy Bypass -File .\scripts\new-shared-worktree.ps1 -TaskSlug <task-slug> -Fetch`.
 4. Depois de criar o worktree, trabalhe apenas nele e trate o clone compartilhado como somente leitura para contexto.
-5. Mantenha estado local, logs, perfis e overrides fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`.
+5. Mantenha autenticação, perfis e overrides fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`; logs e artefatos persistentes ficam em `C:\CodexRuntime\operator\admin\skincos\`.
 6. Preserve alterações não relacionadas já existentes no projeto compartilhado ou em worktrees de outros usuários.
 7. Antes de concluir, valide o que mudar e registre contexto relevante em `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md` quando fizer sentido.
 

--- a/docs/runbooks/mini-pc-autonomia-multiusuario.md
+++ b/docs/runbooks/mini-pc-autonomia-multiusuario.md
@@ -10,7 +10,9 @@ Modelo oficial atual do mini-PC para `skincos`:
   desacoplado e o rearma a cada minuto, sem armazenar senha ou exigir UAC
 - operador humano Windows e WSL: `admin`
 - conta Linux de serviço, sem uso interativo: `skincos`
-- estado privado do Codex: `%LOCALAPPDATA%\Codex\skincos\`
+- estado sensível/temporário do Codex: `%LOCALAPPDATA%\Codex\skincos\`
+- artefatos privados persistentes do operador:
+  `C:\CodexRuntime\operator\admin\skincos\`
 - atalhos compartilhados: `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`
 
 ## Disponibilidade do WSL
@@ -221,14 +223,15 @@ Regras:
 Usado para iterar em website, CRM e módulos locais.
 
 - executa pelo código do workspace compartilhado ou do worktree;
-- usa o estado privado do operador em `%LOCALAPPDATA%\Codex\skincos\`;
+- usa estado sensível/temporário em `%LOCALAPPDATA%\Codex\skincos\` e artefatos
+  persistentes em `C:\CodexRuntime\operator\admin\skincos\`;
 - não deve deixar PID, logs ou artefatos temporários em `C:\CodexShared`.
 
 Para o scraper do `app.espacofacial.com.br`, o estado privado adicional fica em:
 
-- `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\report`
-- `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\debug`
-- `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\logs`
+- `C:\CodexRuntime\operator\admin\skincos\scraper\report`
+- `C:\CodexRuntime\operator\admin\skincos\scraper\debug`
+- `C:\CodexRuntime\operator\admin\skincos\scraper\logs`
 - `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\chrome-profile`
 
 O launcher `EF App Caixa` permanece interativo por desenho: ele abre o modo

--- a/scripts/install-wsl-runtime-keepalive.ps1
+++ b/scripts/install-wsl-runtime-keepalive.ps1
@@ -78,14 +78,11 @@ Register-ScheduledTask `
 if (Test-Path -LiteralPath $legacyStartupPath) {
     $legacyContent = Get-Content -LiteralPath $legacyStartupPath -Raw
     if ($legacyContent -match '(?i)orb-stack-supervisor\.ps1') {
-        $legacyDirectory = Join-Path $stateDirectory "legacy-disabled"
-        New-Item -ItemType Directory -Force -Path $legacyDirectory | Out-Null
-        $legacyArchivePath = Join-Path $legacyDirectory ("start-orb-stack-wsl.{0}.cmd" -f (Get-Date -Format "yyyyMMddHHmmss"))
-        Move-Item -LiteralPath $legacyStartupPath -Destination $legacyArchivePath
-        Write-Host "Archived legacy OrbStack Startup launcher to $legacyArchivePath."
+        Remove-Item -LiteralPath $legacyStartupPath -Force
+        Write-Host "Removed legacy OrbStack Startup launcher: $legacyStartupPath"
     }
     else {
-        Write-Warning "Startup launcher was not archived because it no longer matches the known OrbStack supervisor signature: $legacyStartupPath"
+        Write-Warning "Startup launcher was not removed because it no longer matches the known OrbStack supervisor signature: $legacyStartupPath"
     }
 }
 

--- a/scripts/print-codex-thread-bootstrap.ps1
+++ b/scripts/print-codex-thread-bootstrap.ps1
@@ -24,7 +24,7 @@ $lines = @(
     "2. Verifique o estado compartilhado com `powershell -ExecutionPolicy Bypass -File .\scripts\show-shared-codex-status.ps1`.",
     "3. Se a tarefa não for estritamente de leitura, crie um worktree dedicado com `powershell -ExecutionPolicy Bypass -File .\scripts\new-shared-worktree.ps1 -TaskSlug $TaskSlug -Fetch`.",
     "4. Depois de criar o worktree, trabalhe apenas nele e trate o clone compartilhado como somente leitura para contexto.",
-    "5. Mantenha estado local, logs, perfis e overrides fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`.",
+    "5. Mantenha autenticação, perfis e overrides fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`; logs e artefatos persistentes ficam em C:\CodexRuntime\operator\admin\skincos\.",
     "6. Preserve alterações não relacionadas já existentes no projeto compartilhado ou em worktrees de outros usuários.",
     "7. Antes de concluir, valide o que mudar e registre contexto relevante em `CODEX_CONTEXT.md`, `TASKS.md` e `DECISIONS.md` quando fizer sentido.",
     "",

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -90,12 +90,21 @@ function Resolve-ProjectRoot {
 
 $ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot -ScriptDirectory $scriptRoot
 $localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
+$operatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos"
 $tmpRoot = Join-Path $localStateRoot "tmp"
-$logRoot = Join-Path $localStateRoot "logs"
+$logRoot = Join-Path $operatorRuntimeRoot "logs"
 $wslInvoker = Join-Path $scriptRoot "invoke-skincos-wsl.ps1"
 
 function Ensure-LocalState {
-    foreach ($path in @($localStateRoot, $tmpRoot, $logRoot)) {
+    foreach ($path in @(
+        $localStateRoot,
+        $tmpRoot,
+        $logRoot,
+        (Join-Path $operatorRuntimeRoot "scraper"),
+        (Join-Path $operatorRuntimeRoot "scraper\report"),
+        (Join-Path $operatorRuntimeRoot "scraper\debug"),
+        (Join-Path $operatorRuntimeRoot "scraper\logs")
+    )) {
         if (-not (Test-Path -LiteralPath $path)) {
             New-Item -ItemType Directory -Path $path -Force | Out-Null
         }
@@ -218,9 +227,10 @@ $crmLog = Join-Path $logRoot "crm-local-dev.log"
 $atendimentoPid = Join-Path $tmpRoot "crm-atendimento-local.pid"
 $atendimentoLog = Join-Path $logRoot "crm-atendimento-local.log"
 $efAppStateRoot = Join-Path $localStateRoot "espacofacial-app"
-$efAppOutputRoot = Join-Path $efAppStateRoot "report"
-$efAppDebugRoot = Join-Path $efAppStateRoot "debug"
-$efAppLogRoot = Join-Path $efAppStateRoot "logs"
+$efAppArtifactRoot = Join-Path $operatorRuntimeRoot "scraper"
+$efAppOutputRoot = Join-Path $efAppArtifactRoot "report"
+$efAppDebugRoot = Join-Path $efAppArtifactRoot "debug"
+$efAppLogRoot = Join-Path $efAppArtifactRoot "logs"
 $efAppChromeProfileRoot = Join-Path $efAppStateRoot "chrome-profile"
 $efAppBookingEnvFile = Join-Path $efAppStateRoot "booking_api.env"
 $efAppAgendaSyncEnvFile = Join-Path $efAppStateRoot "agenda_sync.env"

--- a/scripts/setup-shared-codex-workspace.ps1
+++ b/scripts/setup-shared-codex-workspace.ps1
@@ -2,6 +2,7 @@ param(
     [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
     [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
     [string]$RuntimeRoot = "C:\CodexRuntime\n8n",
+    [string]$OperatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos",
     [switch]$SkipAclRefresh,
     [switch]$DeepAclRefresh
 )
@@ -76,10 +77,21 @@ function Grant-SharedAcl {
     icacls @args | Out-Null
 }
 
+function Grant-PrivateOperatorAcl {
+    param([string]$TargetPath)
+
+    $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    & icacls.exe $TargetPath /inheritance:r /remove:g "Users" /grant:r "${currentIdentity}:(OI)(CI)F" "SYSTEM:(OI)(CI)F" "Administrators:(OI)(CI)F" /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to apply private operator ACLs to $TargetPath."
+    }
+}
+
 Ensure-Directory -Path $ProjectRoot
 Ensure-Directory -Path $WorktreeRoot
 Ensure-Directory -Path (Join-Path $WorktreeRoot $env:USERNAME)
 Ensure-Directory -Path $RuntimeRoot
+Ensure-Directory -Path $OperatorRuntimeRoot
 
 $runtimeDirs = @(
     $RuntimeRoot,
@@ -101,10 +113,28 @@ foreach ($dir in $runtimeDirs) {
     Ensure-Directory -Path $dir
 }
 
+$operatorRuntimeDirs = @(
+    $OperatorRuntimeRoot,
+    (Join-Path $OperatorRuntimeRoot "artifacts"),
+    (Join-Path $OperatorRuntimeRoot "artifacts\backup"),
+    (Join-Path $OperatorRuntimeRoot "artifacts\checkpoints"),
+    (Join-Path $OperatorRuntimeRoot "artifacts\evidence"),
+    (Join-Path $OperatorRuntimeRoot "logs"),
+    (Join-Path $OperatorRuntimeRoot "scraper"),
+    (Join-Path $OperatorRuntimeRoot "scraper\report"),
+    (Join-Path $OperatorRuntimeRoot "scraper\debug"),
+    (Join-Path $OperatorRuntimeRoot "scraper\logs")
+)
+
+foreach ($dir in $operatorRuntimeDirs) {
+    Ensure-Directory -Path $dir
+}
+
+Grant-PrivateOperatorAcl -TargetPath $OperatorRuntimeRoot
+
 $localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
 $localStateDirs = @(
     $localStateRoot,
-    (Join-Path $localStateRoot "logs"),
     (Join-Path $localStateRoot "tmp"),
     (Join-Path $localStateRoot "profiles"),
     (Join-Path $localStateRoot "env-overrides")
@@ -130,6 +160,8 @@ $result = [pscustomobject]@{
     actorWorktreeRoot = (Join-Path $WorktreeRoot $env:USERNAME)
     runtimeRoot = $RuntimeRoot
     runtimeDirs = $runtimeDirs
+    operatorRuntimeRoot = $OperatorRuntimeRoot
+    operatorRuntimeDirs = $operatorRuntimeDirs
     localStateRoot = $localStateRoot
     localStateDirs = $localStateDirs
     codexEnvironment = $codexEnvironment

--- a/scripts/show-shared-codex-status.ps1
+++ b/scripts/show-shared-codex-status.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
     [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
-    [string]$RuntimeRoot = "C:\CodexRuntime\n8n"
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n",
+    [string]$OperatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos"
 )
 
 $ErrorActionPreference = "Stop"
@@ -117,6 +118,8 @@ $normalizedSafeDirectories = @($safeDirectories | ForEach-Object { Normalize-Pat
 
 $localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
 $runtimeEnvRoot = Join-Path $RuntimeRoot "env"
+$operatorRuntimeExists = Test-Path -LiteralPath $OperatorRuntimeRoot
+$operatorRuntimeAcl = if ($operatorRuntimeExists) { Get-Acl -LiteralPath $OperatorRuntimeRoot } else { $null }
 $status = [pscustomobject]@{
     currentUser = $env:USERNAME
     computerName = $env:COMPUTERNAME
@@ -130,6 +133,9 @@ $status = [pscustomobject]@{
     localStateExists = Test-Path -LiteralPath $localStateRoot
     runtimeRoot = $RuntimeRoot
     runtimeExists = Test-Path -LiteralPath $RuntimeRoot
+    operatorRuntimeRoot = $OperatorRuntimeRoot
+    operatorRuntimeExists = $operatorRuntimeExists
+    operatorRuntimeOwner = if ($operatorRuntimeAcl) { $operatorRuntimeAcl.Owner } else { $null }
     runtimeEnvRoot = $runtimeEnvRoot
     runtimeEnvFiles = @(
         "n8n.env",

--- a/scripts/validate-shared-codex-workspace.ps1
+++ b/scripts/validate-shared-codex-workspace.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
     [string]$WorktreeRoot = "C:\CodexShared\Worktrees\skincos",
-    [string]$RuntimeRoot = "C:\CodexRuntime\n8n"
+    [string]$RuntimeRoot = "C:\CodexRuntime\n8n",
+    [string]$OperatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos"
 )
 
 $ErrorActionPreference = "Stop"
@@ -51,6 +52,28 @@ function Test-ModifyAccess {
     }
 }
 
+function Test-PrivateOperatorRuntime {
+    param([string]$TargetPath)
+
+    if (-not (Test-Path -LiteralPath $TargetPath)) {
+        return [pscustomobject]@{ path = $TargetPath; exists = $false; hasUsersAccess = $false; hasCurrentUserFullControl = $false; owner = $null }
+    }
+
+    $acl = Get-Acl -LiteralPath $TargetPath
+    $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $currentRules = @(Get-AccessEntry -Acl $acl -Identity $currentIdentity)
+    $hasCurrentUserFullControl = @($currentRules | Where-Object { $_.FileSystemRights.ToString().Contains("FullControl") }).Count -gt 0
+    $hasUsersAccess = @(Get-AccessEntry -Acl $acl -Identity "BUILTIN\Users").Count -gt 0
+
+    return [pscustomobject]@{
+        path = $TargetPath
+        exists = $true
+        hasUsersAccess = $hasUsersAccess
+        hasCurrentUserFullControl = $hasCurrentUserFullControl
+        owner = $acl.Owner
+    }
+}
+
 function Get-EnabledUserCoverage {
     $enabledUsers = @(Get-LocalUser | Where-Object Enabled)
     $usersMembers = @((Get-LocalGroupMember -Group "Users").Name)
@@ -95,6 +118,7 @@ function Get-CodexEnvironmentStatus {
 $projectCheck = Test-ModifyAccess -TargetPath $ProjectRoot
 $worktreeCheck = Test-ModifyAccess -TargetPath $WorktreeRoot
 $runtimeCheck = Test-ModifyAccess -TargetPath $RuntimeRoot
+$operatorRuntimeCheck = Test-PrivateOperatorRuntime -TargetPath $OperatorRuntimeRoot
 $childChecks = @()
 $runtimeChildChecks = @()
 
@@ -113,7 +137,6 @@ if (Test-Path -LiteralPath $RuntimeRoot) {
 $localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
 $localStateDirs = @(
     $localStateRoot,
-    (Join-Path $localStateRoot "logs"),
     (Join-Path $localStateRoot "tmp"),
     (Join-Path $localStateRoot "profiles"),
     (Join-Path $localStateRoot "env-overrides")
@@ -128,6 +151,7 @@ $result = [pscustomobject]@{
     project = $projectCheck
     worktrees = $worktreeCheck
     runtime = $runtimeCheck
+    operatorRuntime = $operatorRuntimeCheck
     projectChildren = $childChecks
     runtimeChildren = $runtimeChildChecks
     enabledUserCoverage = @(Get-EnabledUserCoverage)


### PR DESCRIPTION
Centraliza logs, relatórios, evidências, checkpoints e backups do operador no runtime privado; preserva autenticação e perfil local; remove o legado OrbStack.