### PR TITLE
fix: keep local lib helpers ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,9 @@ dist/
 /downloads/
 eggs/
 .eggs/
-lib/*
+lib/
 !modules/automations/n8n/scripts/lib/
+modules/automations/n8n/scripts/lib/*
 !modules/automations/n8n/scripts/lib/runtime-paths.sh
 !modules/automations/n8n/scripts/lib/runtime-paths.js
 !modules/automations/n8n/scripts/lib/meta-ads-publish-execution-semantics.js


### PR DESCRIPTION
Restores the broad lib directory ignore while allowing only the three secret-free n8n runtime helper files tracked by PR 609. Validated that scripts/lib/shared-paths.sh remains ignored and the n8n contracts remain tracked.