### PR TITLE
chore: add architecture governance contract

### DIFF
--- a/.github/scripts/validate-architecture.mjs
+++ b/.github/scripts/validate-architecture.mjs
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const readJson = (relativePath) => JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
+const fail = (message) => {
+  process.stderr.write(`architecture validation failed: ${message}\n`);
+  process.exitCode = 1;
+};
+
+const registry = readJson("platform/cloudflare/resource-registry.json");
+const catalog = readJson("scripts/catalog.json");
+
+if (registry.schemaVersion !== 1 || !registry.gateway?.productionHostname) {
+  fail("Cloudflare registry must declare schemaVersion 1 and a production hostname");
+}
+
+const resourceIds = new Set();
+const routes = new Set();
+for (const resource of registry.resources ?? []) {
+  if (!resource.id || !resource.owner || !Array.isArray(resource.routes)) {
+    fail("every Cloudflare resource needs id, owner and routes");
+    continue;
+  }
+  if (resourceIds.has(resource.id)) fail(`duplicate resource id ${resource.id}`);
+  resourceIds.add(resource.id);
+  for (const route of resource.routes) {
+    if (!route.startsWith("/")) fail(`route ${route} must start with /`);
+    if (routes.has(route)) fail(`duplicate route ${route}`);
+    routes.add(route);
+  }
+}
+
+if (catalog.schemaVersion !== 1 || !Array.isArray(catalog.owners) || catalog.owners.length === 0) {
+  fail("script catalog must declare schemaVersion 1 and at least one owner");
+}
+
+const map = fs.readFileSync(path.join(root, "docs/architecture/target-domain-map.md"), "utf8");
+for (const rootName of ["api", "booking", "integration", "messaging", "workforce", "shared", "platform", "ops", "scripts"]) {
+  if (!map.includes(`\`${rootName}\``)) fail(`target domain map is missing ${rootName}`);
+}
+
+if (!process.exitCode) process.stdout.write("Architecture contract validation OK.\n");

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -1,0 +1,16 @@
+name: Architecture governance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node .github/scripts/validate-architecture.mjs

--- a/docs/architecture/target-domain-map.md
+++ b/docs/architecture/target-domain-map.md
@@ -1,0 +1,60 @@
+# Target domain map
+
+This file is the source of truth for the domain-first reorganization.  It is a
+migration contract, not a compatibility layer: after its respective cutover,
+the former source path and public route must be removed rather than aliased.
+
+## Root ownership
+
+| Root | Owns | Does not own |
+| --- | --- | --- |
+| `ads` | Meta Ads campaigns, reporting and delivery | generic social publishing |
+| `api` | the only HTTP boundary at `api.skincos.com.br` | domain business rules or data ownership |
+| `booking` | availability, request lifecycle and reservation contracts | Selenium/browser execution |
+| `crm` | console shell, customers, leads and permissions | extracted product internals |
+| `finance` | cash, billing and financial imports | browser collection mechanics |
+| `integration` | external connectors, browser sessions and technical jobs | business data ownership |
+| `inventory` | supplies and stock | the gateway implementation |
+| `messaging` | inbox and channel adapters | social publishing |
+| `orb` | workflows, scheduling, retries and operator automation | public API ownership |
+| `service` | clinical treatment delivery and follow-up | system services or infrastructure |
+| `social` | editorial publishing and publishing integrations | inbox conversations |
+| `website` | public web experience | direct programmatic APIs after cutover |
+| `workforce` | staff schedule and timekeeping | patient appointment availability |
+| `shared` | neutral contracts and SDKs | product-owned implementations |
+| `platform` | Cloudflare governance, security and observability | product domain logic |
+| `ops` | deploy, runtime units and infrastructure definitions | mutable runtime state |
+| `scripts` | executable human/CI commands grouped by owner | product implementation code |
+| `tools` | active manual utilities | historical patches or vendor archives |
+
+## Connector data ownership
+
+`integration/ef` contains only external-system mechanics.  Its outputs are
+accepted by the semantic owner:
+
+- patient availability and reservations: `booking`;
+- cash and payments: `finance`;
+- procedures: `service`;
+- clients: `crm`.
+
+## Public and internal boundaries
+
+- All programmatic public routes use `https://api.skincos.com.br/<domain>`.
+- Website and CRM keep their UI deployments, but no longer expose separate
+  programmatic API surfaces after their cutovers.
+- `api/internal/*` has two callers: a CRM-authenticated human action or a
+  private service identity used by Workers, Orb and integration executors.
+- The gateway owns transport, request validation, authorization, correlation
+  and error envelopes.  A domain owns its data model, migrations and business
+  invariants.
+
+## Migration rules
+
+- `archive/` is not a final code location.  Proven obsolete material is
+  deleted after validation; Git history and verified runtime backups preserve
+  recovery evidence.
+- Vendor names are permitted only inside the isolated engine/dependency
+  boundary required to execute that vendor.  They are not public names,
+  runtime roots, service names or user-facing documentation.
+- A product may depend on another product only through a documented contract
+  in `shared/`; direct source imports across product roots are forbidden.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "architecture:validate": "node ./.github/scripts/validate-architecture.mjs",
     "module:automations:n8n:run": "node -e \"console.error('Deprecated: use npm --prefix modules/automations/n8n run local:legacy:run explicitly for local snapshot workflows, or the service:* commands for the shared runtime.'); process.exit(1)\"",
     "module:automations:n8n:legacy:local:run": "npm --prefix modules/automations/n8n run local:legacy:run --",
     "module:automations:n8n:mini-pc:validate": "node -e \"console.error('Deprecated: use module:automations:n8n:service:validate for the shared runtime, or the explicit legacy:user-service:validate command for historical checks.'); process.exit(1)\"",

--- a/platform/cloudflare/resource-registry.json
+++ b/platform/cloudflare/resource-registry.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "gateway": {
+    "sourceRoot": "api",
+    "productionHostname": "api.skincos.com.br",
+    "stagingHostname": "api-staging.skincos.com.br",
+    "rule": "The gateway owns HTTP transport; resource owners retain domain rules and migrations."
+  },
+  "resources": [
+    {
+      "id": "booking",
+      "owner": "booking",
+      "routes": ["/booking/*"],
+      "bindings": ["BOOKING_DB"],
+      "stores": ["D1:espacofacial-booking"],
+      "legacySources": ["modules/site-public/website/src/app/api/booking", "modules/site-public/website/src/app/api/agenda"]
+    },
+    {
+      "id": "inventory",
+      "owner": "inventory",
+      "routes": ["/inventory/*"],
+      "bindings": ["DB", "BACKUP_BUCKET", "RATE_LIMITER", "JOB_QUEUE"],
+      "stores": ["D1:skincos-db", "R2:skincos-backups"],
+      "legacySources": ["backend/apps/insumos"]
+    },
+    {
+      "id": "workforce-schedule",
+      "owner": "workforce/schedule",
+      "routes": ["/workforce/schedule/*"],
+      "bindings": ["SCHEDULE_DB"],
+      "stores": ["D1:skincos-escala"],
+      "legacySources": ["backend/apps/escala-api"]
+    },
+    {
+      "id": "ads-reporting",
+      "owner": "ads/meta",
+      "routes": ["/ads/*"],
+      "bindings": ["META_ADS_DB", "META_ADS_RAW"],
+      "stores": ["D1:skincos-meta-ads-performance-report", "R2:skincos-meta-ads-performance-report-raw"],
+      "legacySources": ["modules/meta-ads/meta-ads/apps/report-ingest-worker", "modules/automations/n8n/cloudflare/meta-ads-performance-report"]
+    },
+    {
+      "id": "token-vault",
+      "owner": "platform/security/token-vault",
+      "routes": ["/internal/token-vault/*"],
+      "bindings": ["TOKEN_VAULT_DB"],
+      "stores": ["D1:skincos-token-vault"],
+      "legacySources": ["backend/apps/token-vault"]
+    },
+    {
+      "id": "observability-alerts",
+      "owner": "platform/observability",
+      "routes": ["/internal/observability/*"],
+      "bindings": [],
+      "stores": [],
+      "legacySources": ["ops/obs-alert-webhook"]
+    },
+    {
+      "id": "social-publishing",
+      "owner": "social",
+      "routes": ["/social/*"],
+      "bindings": ["PUBLISHER_LOCK", "SHARE_BUCKET"],
+      "stores": ["DurableObject:PublisherLock", "R2:skincos-share"],
+      "legacySources": ["backend/apps/social-publisher", "backend/apps/instagram"]
+    }
+  ]
+}

--- a/scripts/catalog.json
+++ b/scripts/catalog.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "policy": "All executable entrypoints are centralized by owner under scripts/<owner>. Product code may expose package commands but must not add a second operational scripts tree.",
+  "owners": [
+    "workspace",
+    "runtime",
+    "api",
+    "booking",
+    "integration",
+    "website",
+    "crm",
+    "orb",
+    "ads",
+    "social",
+    "messaging",
+    "workforce",
+    "platform"
+  ],
+  "migration": {
+    "legacyRoots": ["backend/scripts", "modules/*/*/scripts", "scripts/migration"],
+    "cutoverRule": "A command is moved only after its package scripts, CI callers, Codex actions and runbook references resolve through the catalog."
+  }
+}

--- a/shared/module-sdk/README.md
+++ b/shared/module-sdk/README.md
@@ -1,0 +1,10 @@
+# Skincos module SDK
+
+`shared/module-sdk` is the only UI integration boundary between the CRM console
+and an extracted product module.  A module exposes metadata, authorization
+requirements and a lazy view through this contract; it never imports CRM
+internals.
+
+The concrete TypeScript package is created when the first CRM capability is
+extracted.  Keeping the contract here first prevents a module-federation
+dependency or reverse imports during the path migration.


### PR DESCRIPTION
## What changed
- adds the canonical domain map, Cloudflare resource registry, and command catalog
- adds a CI validation gate for the architecture contracts
- defines ownership boundaries for the upcoming source and runtime migrations

## Validation
- npm run architecture:validate
- git diff --check

## Rollback
Revert commit 3c6fb92f; no runtime, deployment, or public route changed in this wave.