### PR TITLE
fix: harden lifecycle runtime rollback

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -10,7 +10,10 @@ service is safe to rename.
 1. The source PR is merged, the canonical checkout is fast-forwarded, and all
    required CI checks are green.
 2. A detached rollback worktree exists at the last known-good main commit. Keep
-   it until a post-cut verified backup and public smoke are complete.
+   it until a post-cut verified backup and public smoke are complete. A clean
+   worktree is source-only: stage the legacy Livia workflow and CRM production
+   dependencies under `C:\CodexRuntime\artifacts\runtime-cutover\<timestamp>`;
+   do not put runtime state or dependencies into Git.
 3. `skincos-n8n-backup.service` has completed with `VERIFY_RESTORE=1`; record
    the resulting directory under `C:\CodexRuntime\n8n\backups\daily` and
    validate its manifest checksum before the cut.
@@ -27,24 +30,45 @@ Run the pre-copy before the window; it does not stop services or remove data:
 scripts/runtime/prepare-lifecycle-layout.sh --apply
 ```
 
-At the window, use the real backup directory and the retained worktree:
+At the window, first stage and verify the non-Git rollback artifacts while
+legacy services are still healthy. This is non-disruptive and creates only
+runtime artifacts plus symlinks in the retained rollback worktree:
+
+```bash
+scripts/runtime/stage-rollback-artifacts.sh \
+  --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
+  --artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
+```
+
+Use a new timestamped artifact directory for every attempted cut. The staging
+helper refuses to overwrite a prior rollback bundle or an existing worktree
+link that points elsewhere; resolve either condition deliberately before a
+window rather than replacing an active rollback path implicitly.
+
+Then use the real backup directory, retained worktree and the exact staged
+artifact directory:
 
 ```bash
 scripts/runtime/cutover-lifecycle-runtime.sh \
   --backup-dir /mnt/c/CodexRuntime/n8n/backups/daily/<timestamp> \
-  --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback
+  --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
+  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
 
 scripts/runtime/cutover-lifecycle-runtime.sh --apply \
   --backup-dir /mnt/c/CodexRuntime/n8n/backups/daily/<timestamp> \
-  --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback
+  --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
+  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
 ```
 
 The apply command captures all old unit files, stops only the seven legacy
 units, makes the final non-destructive data sync, installs and starts `orb`,
 `orb-proxy`, `messaging-whatsapp`, `crm`, `booking`, `cloudflare-orb` and
 `cloudflare-runtime`. It requires local Orb health plus public Orb and CRM
-health. A failed post-stop step restores the captured units with paths rewritten
-to the retained rollback worktree and restarts the legacy services.
+health. Legacy stop/start operations are asynchronous but bounded; a timeout
+causes rollback instead of leaving the operator waiting indefinitely. A failed
+post-stop step restores the captured units with paths rewritten to the retained
+rollback worktree and restarts the legacy services. The dry-run refuses to
+continue unless its runtime artifact links resolve to the staged bundle.
 
 ## After the cut
 

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -12,9 +12,12 @@ LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT:-/mnt/c/CodexShared/Projetos/skincos}"
 APPLY=0
 BACKUP_DIR=""
 ROLLBACK_ROOT=""
+ROLLBACK_ARTIFACT_ROOT=""
 CHECKPOINT_DIR=""
 CUTOVER_STARTED=0
 CUTOVER_COMPLETE=0
+STOP_TIMEOUT_SECONDS="${CUTOVER_STOP_TIMEOUT_SECONDS:-90}"
+START_TIMEOUT_SECONDS="${CUTOVER_START_TIMEOUT_SECONDS:-180}"
 
 legacy_units=(
   skincos-cloudflared-orb.service
@@ -38,15 +41,16 @@ new_units=(
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree>
-  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree>
+  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts>
+  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts>
 
 Without --apply, prints and validates the cutover prerequisites. --apply
 stops only the listed legacy services, performs the non-destructive final
 sync, starts the lifecycle services and runs health checks. If a post-stop step
 fails it restores the captured legacy units against --rollback-root and starts
-them again. It never deletes legacy runtime data, backups or the rollback
-worktree.
+them again. The rollback artifacts must first be staged outside Git with
+scripts/runtime/stage-rollback-artifacts.sh. It never deletes legacy runtime
+data, backups or the rollback worktree.
 EOF
 }
 
@@ -55,6 +59,7 @@ while [[ $# -gt 0 ]]; do
     --apply) APPLY=1 ;;
     --backup-dir) BACKUP_DIR="${2:-}"; shift ;;
     --rollback-root) ROLLBACK_ROOT="${2:-}"; shift ;;
+    --rollback-artifact-root) ROLLBACK_ARTIFACT_ROOT="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -65,10 +70,13 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
 }
 
-for command in curl sha256sum python3 systemctl; do require_cmd "$command"; done
+for command in curl readlink sha256sum python3 systemctl; do require_cmd "$command"; done
 [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]] || { echo "--backup-dir must name an existing backup directory." >&2; exit 1; }
 [[ -n "$ROLLBACK_ROOT" && -e "$ROLLBACK_ROOT/.git" ]] || { echo "--rollback-root must be a retained Git worktree." >&2; exit 1; }
+[[ -n "$ROLLBACK_ARTIFACT_ROOT" && -d "$ROLLBACK_ARTIFACT_ROOT" ]] || { echo "--rollback-artifact-root must name staged runtime artifacts outside Git." >&2; exit 1; }
 [[ -f "$BACKUP_DIR/manifest.json" && -f "$BACKUP_DIR/n8n_runtime.dump" ]] || { echo "Backup is missing manifest.json or n8n_runtime.dump." >&2; exit 1; }
+[[ "$STOP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_STOP_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
+[[ "$START_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_START_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 
 expected_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["databaseSha256"])' "$BACKUP_DIR/manifest.json")"
 actual_sha="$(sha256sum "$BACKUP_DIR/n8n_runtime.dump" | awk '{print $1}')"
@@ -86,6 +94,59 @@ CHECKPOINT_DIR="$RUNTIME_ROOT/backups/runtime-cutover/$timestamp"
 
 legacy_unit_path() {
   sudo -n systemctl show --property=FragmentPath --value "$1"
+}
+
+wait_for_units_state() {
+  local expected="$1"
+  local timeout="$2"
+  shift 2
+  local deadline=$((SECONDS + timeout))
+  local unit state pending
+
+  while :; do
+    pending=0
+    for unit in "$@"; do
+      state="$(sudo -n systemctl is-active "$unit" 2>/dev/null || true)"
+      if [[ "$state" != "$expected" ]]; then
+        pending=1
+        printf 'unit=%s state=%s expected=%s\n' "$unit" "${state:-unknown}" "$expected" >&2
+      fi
+    done
+    [[ "$pending" == "0" ]] && return 0
+    if (( SECONDS >= deadline )); then
+      echo "Timed out waiting ${timeout}s for units to become ${expected}." >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+stop_units_bounded() {
+  sudo -n systemctl stop --no-block "$@"
+  wait_for_units_state inactive "$STOP_TIMEOUT_SECONDS" "$@"
+}
+
+start_units_bounded() {
+  sudo -n systemctl start --no-block "$@"
+  wait_for_units_state active "$START_TIMEOUT_SECONDS" "$@"
+}
+
+validate_rollback_artifacts() {
+  local workflow="$ROLLBACK_ARTIFACT_ROOT/orb/workflows/livia.active.json"
+  local crm_dependencies="$ROLLBACK_ARTIFACT_ROOT/crm/node_modules"
+  local rollback_workflow="$ROLLBACK_ROOT/modules/automations/n8n/workflows/livia.active.json"
+  local rollback_dependencies="$ROLLBACK_ROOT/modules/crm/api/node_modules"
+
+  [[ -f "$workflow" ]] || { echo "Missing staged Livia workflow: $workflow" >&2; return 1; }
+  [[ -d "$crm_dependencies/express" ]] || { echo "Missing staged CRM production dependencies: $crm_dependencies/express" >&2; return 1; }
+  [[ -L "$rollback_workflow" && "$(readlink -f "$rollback_workflow")" == "$(readlink -f "$workflow")" ]] || {
+    echo "Rollback worktree Livia workflow is not the verified runtime artifact." >&2
+    return 1
+  }
+  [[ -L "$rollback_dependencies" && "$(readlink -f "$rollback_dependencies")" == "$(readlink -f "$crm_dependencies")" ]] || {
+    echo "Rollback worktree CRM dependencies are not the verified runtime artifact." >&2
+    return 1
+  }
 }
 
 save_legacy_units() {
@@ -112,9 +173,10 @@ restore_legacy_services() {
   done
   sudo -n systemctl daemon-reload
   sudo -n systemctl disable "${new_units[@]}" orb-backup.timer >/dev/null 2>&1 || true
-  sudo -n systemctl stop "${new_units[@]}" >/dev/null 2>&1 || true
+  sudo -n systemctl stop --no-block "${new_units[@]}" >/dev/null 2>&1 || true
+  wait_for_units_state inactive "$STOP_TIMEOUT_SECONDS" "${new_units[@]}" || true
   sudo -n systemctl enable "${legacy_units[@]}" >/dev/null
-  sudo -n systemctl start skincos-n8n.service skincos-orb-proxy.service skincos-evolution.service skincos-crm-api.service skincos-booking-api.service skincos-cloudflared-orb.service skincos-cloudflared-cs.service
+  start_units_bounded "${legacy_units[@]}"
 }
 
 on_exit() {
@@ -128,28 +190,31 @@ trap on_exit EXIT INT TERM
 
 echo "Verified backup: $BACKUP_DIR"
 echo "Rollback worktree: $ROLLBACK_ROOT"
+echo "Rollback runtime artifacts: $ROLLBACK_ARTIFACT_ROOT"
 echo "Lifecycle source: $ROOT_DIR"
 printf 'Legacy services: %s\n' "${legacy_units[*]}"
 printf 'Lifecycle services: %s\n' "${new_units[*]}"
 
 if [[ "$APPLY" != "1" ]]; then
+  validate_rollback_artifacts
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh"
   "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh"
   echo "Preflight passed. Use --apply only in the scheduled cut window."
   exit 0
 fi
 
+validate_rollback_artifacts
 save_legacy_units
 CUTOVER_STARTED=1
 
 echo "Stopping legacy ingress and runtimes."
-sudo -n systemctl stop "${legacy_units[@]}"
+stop_units_bounded "${legacy_units[@]}"
 "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync
 BOOKING_API_RUNTIME_HOME="$RUNTIME_ROOT/state/booking" EF_SCRAPER_VENV_DIR="$RUNTIME_ROOT/state/booking/venv" "$ROOT_DIR/scripts/booking/bootstrap-venv.sh"
 "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh" --apply
 
 echo "Starting lifecycle runtimes and ingress."
-sudo -n systemctl start orb.service orb-proxy.service messaging-whatsapp.service crm.service booking.service cloudflare-orb.service cloudflare-runtime.service
+start_units_bounded "${new_units[@]}"
 
 for attempt in {1..12}; do
   if curl -fsS --connect-timeout 5 http://127.0.0.1:5678/healthz >/dev/null \

--- a/scripts/runtime/stage-rollback-artifacts.sh
+++ b/scripts/runtime/stage-rollback-artifacts.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A Git worktree is intentionally source-only. This helper stages the two
+# non-Git runtime inputs required by the legacy rollback path in CodexRuntime
+# and attaches them to the retained rollback worktree as symlinks. It does not
+# copy secrets, modify a service, or stop a process.
+
+RUNTIME_ROOT="${RUNTIME_ROOT:-/mnt/c/CodexRuntime}"
+LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT:-/mnt/c/CodexShared/Projetos/skincos}"
+ROLLBACK_ROOT=""
+ARTIFACT_ROOT=""
+SOURCE_LIVIA_WORKFLOW=""
+SOURCE_CRM_NODE_MODULES=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/runtime/stage-rollback-artifacts.sh \
+    --rollback-root <legacy-worktree> \
+    --artifact-root <CodexRuntime-artifact-directory>
+
+The artifact directory must be under C:\CodexRuntime. The helper copies the
+runtime Livia workflow and CRM production dependencies there, then creates
+verified symlinks in the retained rollback worktree. It requires a new, empty
+artifact directory so an existing rollback bundle is never overwritten. Run it
+before the dry-run and retain the artifacts until the post-cut backup and smoke
+checks complete.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rollback-root) ROLLBACK_ROOT="${2:-}"; shift ;;
+    --artifact-root) ARTIFACT_ROOT="${2:-}"; shift ;;
+    --source-livia-workflow) SOURCE_LIVIA_WORKFLOW="${2:-}"; shift ;;
+    --source-crm-node-modules) SOURCE_CRM_NODE_MODULES="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
+}
+
+require_cmd rsync
+require_cmd readlink
+require_cmd sha256sum
+[[ -n "$ROLLBACK_ROOT" && -e "$ROLLBACK_ROOT/.git" ]] || { echo "--rollback-root must name a retained Git worktree." >&2; exit 1; }
+[[ -n "$ARTIFACT_ROOT" ]] || { echo "--artifact-root is required." >&2; exit 1; }
+
+runtime_root_real="$(readlink -f "$RUNTIME_ROOT")"
+artifact_root_real="$(readlink -m "$ARTIFACT_ROOT")"
+case "$artifact_root_real" in
+  "$runtime_root_real"/*) ;;
+  *) echo "--artifact-root must be inside $RUNTIME_ROOT." >&2; exit 1 ;;
+esac
+if [[ -e "$ARTIFACT_ROOT" ]] && find "$ARTIFACT_ROOT" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "--artifact-root must be a new or empty directory; do not overwrite an existing rollback bundle." >&2
+  exit 1
+fi
+
+SOURCE_LIVIA_WORKFLOW="${SOURCE_LIVIA_WORKFLOW:-$LEGACY_REPO_ROOT/modules/automations/n8n/workflows/livia.active.json}"
+SOURCE_CRM_NODE_MODULES="${SOURCE_CRM_NODE_MODULES:-$LEGACY_REPO_ROOT/modules/crm/api/node_modules}"
+[[ -f "$SOURCE_LIVIA_WORKFLOW" ]] || { echo "Missing source Livia workflow: $SOURCE_LIVIA_WORKFLOW" >&2; exit 1; }
+[[ -d "$SOURCE_CRM_NODE_MODULES/express" ]] || { echo "Missing source CRM dependencies: $SOURCE_CRM_NODE_MODULES/express" >&2; exit 1; }
+
+workflow_target="$ARTIFACT_ROOT/orb/workflows/livia.active.json"
+dependencies_target="$ARTIFACT_ROOT/crm/node_modules"
+mkdir -p "$(dirname "$workflow_target")" "$(dirname "$dependencies_target")"
+install -m 0640 "$SOURCE_LIVIA_WORKFLOW" "$workflow_target"
+rsync -a "$SOURCE_CRM_NODE_MODULES/" "$dependencies_target/"
+
+link_artifact() {
+  local target="$1"
+  local link="$2"
+  mkdir -p "$(dirname "$link")"
+  if [[ -L "$link" ]]; then
+    [[ "$(readlink -f "$link")" == "$(readlink -f "$target")" ]] || {
+      echo "Existing rollback link points elsewhere: $link" >&2
+      return 1
+    }
+    return 0
+  fi
+  [[ ! -e "$link" ]] || { echo "Rollback path already exists and is not a symlink: $link" >&2; return 1; }
+  ln -s "$target" "$link"
+}
+
+link_artifact "$workflow_target" "$ROLLBACK_ROOT/modules/automations/n8n/workflows/livia.active.json"
+link_artifact "$dependencies_target" "$ROLLBACK_ROOT/modules/crm/api/node_modules"
+
+cat <<EOF
+Rollback artifacts staged.
+  workflow_sha256=$(sha256sum "$workflow_target" | awk '{print $1}')
+  workflow=$workflow_target
+  crm_dependencies=$dependencies_target
+EOF

--- a/scripts/runtime/test-stage-rollback-artifacts.sh
+++ b/scripts/runtime/test-stage-rollback-artifacts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+runtime_root="$tmp_dir/runtime"
+legacy_root="$tmp_dir/legacy"
+rollback_root="$tmp_dir/rollback"
+artifact_root="$runtime_root/artifacts/runtime-cutover/test"
+
+mkdir -p \
+  "$legacy_root/modules/automations/n8n/workflows" \
+  "$legacy_root/modules/crm/api/node_modules/express" \
+  "$rollback_root/modules/automations/n8n/workflows" \
+  "$rollback_root/modules/crm/api"
+touch "$rollback_root/.git"
+printf '{"name":"Livia"}\n' >"$legacy_root/modules/automations/n8n/workflows/livia.active.json"
+printf '{}' >"$legacy_root/modules/crm/api/node_modules/express/package.json"
+
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" \
+  bash "$ROOT_DIR/scripts/runtime/stage-rollback-artifacts.sh" \
+    --rollback-root "$rollback_root" \
+    --artifact-root "$artifact_root" >/dev/null
+
+[[ -L "$rollback_root/modules/automations/n8n/workflows/livia.active.json" ]]
+[[ -L "$rollback_root/modules/crm/api/node_modules" ]]
+[[ -f "$artifact_root/orb/workflows/livia.active.json" ]]
+[[ -f "$artifact_root/crm/node_modules/express/package.json" ]]
+if RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" \
+  bash "$ROOT_DIR/scripts/runtime/stage-rollback-artifacts.sh" \
+    --rollback-root "$rollback_root" \
+    --artifact-root "$artifact_root" >/dev/null 2>&1; then
+  echo "staging unexpectedly overwrote an existing rollback bundle" >&2
+  exit 1
+fi
+echo "stage-rollback-artifacts test passed"


### PR DESCRIPTION
## What changed

- stages the legacy Livia workflow and CRM production dependencies in `C:\CodexRuntime\artifacts`, outside Git;
- verifies rollback-worktree links resolve to that staged runtime bundle before either dry-run or cutover;
- changes service stop/start to asynchronous, bounded waits so a stuck stop triggers rollback instead of blocking indefinitely;
- documents the required staging and retains the bundle through post-cut validation.

## Why

The first cutover attempt exposed a gap: a clean Git worktree did not contain ignored operational artifacts or CRM dependencies, and `systemctl stop` could wait indefinitely. Legacy services were restored and remain the active rollback path; this PR prevents another cutover until those prerequisites are proven.

## Validation

- `bash -n` for the three runtime scripts;
- isolated staging regression test;
- full dry-run in a disposable runtime with checksum-verified backup, rollback artifacts and symlinks;
- `systemd-analyze verify` through `scripts/runtime/install-lifecycle-units.sh`.

No service, secret, runtime data, unit, deploy, or cleanup action is included in this PR.