### PR TITLE
fix: require explicit rollback link replacement

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -30,6 +30,11 @@ Run the pre-copy before the window; it does not stop services or remove data:
 scripts/runtime/prepare-lifecycle-layout.sh --apply
 ```
 
+The pre-copy also transfers the active Livia workflow from the retained legacy
+source into `C:\CodexRuntime\state\orb\workflows`. The lifecycle Orb unit and
+the official validator read this runtime location; no workflow state is copied
+into the new checkout.
+
 At the window, first stage and verify the non-Git rollback artifacts while
 legacy services are still healthy. This is non-disruptive and creates only
 runtime artifacts plus symlinks in the retained rollback worktree:

--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -42,8 +42,10 @@ scripts/runtime/stage-rollback-artifacts.sh \
 
 Use a new timestamped artifact directory for every attempted cut. The staging
 helper refuses to overwrite a prior rollback bundle or an existing worktree
-link that points elsewhere; resolve either condition deliberately before a
-window rather than replacing an active rollback path implicitly.
+link that points elsewhere. If a prior recovery left an older symbolic link in
+the worktree, verify the new timestamped bundle and add
+`--replace-rollback-links`; this can replace symbolic links only, never a
+regular file or directory.
 
 Then use the real backup directory, retained worktree and the exact staged
 artifact directory:

--- a/ops/runtime/units/orb.service
+++ b/ops/runtime/units/orb.service
@@ -16,6 +16,7 @@ Environment=N8N_ENV_FILE=__RUNTIME_ROOT__/secrets/orb.env
 Environment=N8N_BUSINESS_ENV_FILE=__RUNTIME_ROOT__/secrets/orb-business.env
 Environment=N8N_DATA_HOME=__RUNTIME_ROOT__/state/orb/n8n-home
 Environment=N8N_USER_FOLDER=__RUNTIME_ROOT__/state/orb/n8n-home
+Environment=N8N_WORKFLOWS_DIR=__RUNTIME_ROOT__/state/orb/workflows
 Environment=N8N_LOG_DIR=__RUNTIME_ROOT__/logs/orb
 Environment=N8N_HEALTH_DIR=__RUNTIME_ROOT__/state/orb/health
 Environment=N8N_TMP_DIR=__RUNTIME_ROOT__/tmp/orb

--- a/orb/engine/scripts/lib/runtime-paths.js
+++ b/orb/engine/scripts/lib/runtime-paths.js
@@ -24,7 +24,7 @@ module.exports = {
   runtimeHome,
   dataHome,
   cloudflaredHome,
-  workflowsDir: resolveFromRoot('workflows'),
+  workflowsDir: process.env.N8N_WORKFLOWS_DIR || resolveFromRoot('workflows'),
   workflowSrcDir: resolveFromRoot('workflow-src'),
   envFile: process.env.N8N_ENV_FILE || path.join(runtimeHome, 'env', 'n8n.env'),
   tmpDir: process.env.N8N_TMP_DIR || path.join(runtimeHome, 'tmp'),

--- a/orb/engine/scripts/validate-mini-pc-system-runtime.sh
+++ b/orb/engine/scripts/validate-mini-pc-system-runtime.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/lib/runtime-paths.sh"
 
+N8N_WORKFLOWS_DIR="${N8N_WORKFLOWS_DIR:-/mnt/c/CodexRuntime/state/orb/workflows}"
+export N8N_WORKFLOWS_DIR
+
 N8N_HEALTH_URL="${N8N_HEALTH_URL:-http://127.0.0.1:5678/healthz}"
 N8N_AUTH_SURFACE_URL="${N8N_AUTH_SURFACE_URL:-http://127.0.0.1:5678/rest/login}"
 ORB_PROXY_HEALTH_URL="${ORB_PROXY_HEALTH_URL:-http://127.0.0.1:8788/meta-review/healthz}"
@@ -132,6 +135,7 @@ for path in \
   "$EVOLUTION_ENV_FILE" \
   "$N8N_CONFIG_PATH" \
   "$N8N_NODES_DIR/package.json" \
+  "$N8N_WORKFLOWS_DIR/livia.active.json" \
   "$CLOUDFLARED_HOME/orb-config.yml"; do
   if [[ ! -f "$path" ]]; then
     echo "Missing runtime file: $path"

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # the legacy runtime intact. The coordinated cutover script owns stop/start.
 
 RUNTIME_ROOT="${RUNTIME_ROOT:-/mnt/c/CodexRuntime}"
+LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT:-/mnt/c/CodexShared/Projetos/skincos}"
 APPLY=0
 FINAL_SYNC=0
 SKIP_ORB_STATE=0
@@ -200,7 +201,7 @@ done
 if [[ "$SKIP_ORB_STATE" == "1" ]]; then
   echo "SKIP orb state: completed by the independently recorded pre-copy."
 else
-  sync_path "$legacy_orb/n8n-home" "$RUNTIME_ROOT/state/orb"
+sync_path "$legacy_orb/n8n-home" "$RUNTIME_ROOT/state/orb"
 fi
 if [[ "$SKIP_MESSAGING_STATE" == "1" ]]; then
   echo "SKIP messaging state: completed by the independently recorded pre-copy."
@@ -208,6 +209,7 @@ else
   sync_path "$legacy_orb/evolution-api/instances" "$RUNTIME_ROOT/state/messaging-whatsapp"
   sync_path "$legacy_orb/evolution-api/store" "$RUNTIME_ROOT/state/messaging-whatsapp"
 fi
+sync_path "$LEGACY_REPO_ROOT/modules/automations/n8n/workflows" "$RUNTIME_ROOT/state/orb"
 sync_path "$legacy_orb/logs/." "$RUNTIME_ROOT/logs/orb"
 sync_path "$legacy_crm/var" "$RUNTIME_ROOT/state/crm"
 sync_path "$legacy_booking/report" "$RUNTIME_ROOT/artifacts/booking"

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -201,7 +201,7 @@ done
 if [[ "$SKIP_ORB_STATE" == "1" ]]; then
   echo "SKIP orb state: completed by the independently recorded pre-copy."
 else
-sync_path "$legacy_orb/n8n-home" "$RUNTIME_ROOT/state/orb"
+  sync_path "$legacy_orb/n8n-home" "$RUNTIME_ROOT/state/orb"
 fi
 if [[ "$SKIP_MESSAGING_STATE" == "1" ]]; then
   echo "SKIP messaging state: completed by the independently recorded pre-copy."

--- a/scripts/runtime/stage-rollback-artifacts.sh
+++ b/scripts/runtime/stage-rollback-artifacts.sh
@@ -12,13 +12,14 @@ ROLLBACK_ROOT=""
 ARTIFACT_ROOT=""
 SOURCE_LIVIA_WORKFLOW=""
 SOURCE_CRM_NODE_MODULES=""
+REPLACE_ROLLBACK_LINKS=0
 
 usage() {
   cat <<'EOF'
 Usage:
   scripts/runtime/stage-rollback-artifacts.sh \
     --rollback-root <legacy-worktree> \
-    --artifact-root <CodexRuntime-artifact-directory>
+    --artifact-root <CodexRuntime-artifact-directory> [--replace-rollback-links]
 
 The artifact directory must be under C:\CodexRuntime. The helper copies the
 runtime Livia workflow and CRM production dependencies there, then creates
@@ -26,6 +27,10 @@ verified symlinks in the retained rollback worktree. It requires a new, empty
 artifact directory so an existing rollback bundle is never overwritten. Run it
 before the dry-run and retain the artifacts until the post-cut backup and smoke
 checks complete.
+
+--replace-rollback-links is required only when a rollback worktree already has
+a symbolic link to an older staged bundle. It may replace symbolic links only;
+it never removes regular files or directories.
 EOF
 }
 
@@ -35,6 +40,7 @@ while [[ $# -gt 0 ]]; do
     --artifact-root) ARTIFACT_ROOT="${2:-}"; shift ;;
     --source-livia-workflow) SOURCE_LIVIA_WORKFLOW="${2:-}"; shift ;;
     --source-crm-node-modules) SOURCE_CRM_NODE_MODULES="${2:-}"; shift ;;
+    --replace-rollback-links) REPLACE_ROLLBACK_LINKS=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -79,8 +85,13 @@ link_artifact() {
   mkdir -p "$(dirname "$link")"
   if [[ -L "$link" ]]; then
     [[ "$(readlink -f "$link")" == "$(readlink -f "$target")" ]] || {
-      echo "Existing rollback link points elsewhere: $link" >&2
-      return 1
+      if [[ "$REPLACE_ROLLBACK_LINKS" != "1" ]]; then
+        echo "Existing rollback link points elsewhere: $link (use --replace-rollback-links after verifying the new bundle)." >&2
+        return 1
+      fi
+      rm "$link"
+      ln -s "$target" "$link"
+      return 0
     }
     return 0
   fi

--- a/scripts/runtime/test-runtime-workflows-path.sh
+++ b/scripts/runtime/test-runtime-workflows-path.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+expected="$(mktemp -d)"
+trap 'rm -rf "$expected"' EXIT
+
+N8N_WORKFLOWS_DIR="$expected" node - "$ROOT_DIR/orb/engine/scripts/lib/runtime-paths.js" <<'NODE'
+const assert = require('node:assert/strict');
+const runtimePaths = require(process.argv[2]);
+assert.equal(runtimePaths.workflowsDir, process.env.N8N_WORKFLOWS_DIR);
+NODE
+
+echo "runtime workflows path test passed"

--- a/scripts/runtime/test-stage-rollback-artifacts.sh
+++ b/scripts/runtime/test-stage-rollback-artifacts.sh
@@ -35,4 +35,16 @@ if RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" \
   echo "staging unexpectedly overwrote an existing rollback bundle" >&2
   exit 1
 fi
+
+replacement_root="$tmp_dir/replacement"
+replacement_artifact_root="$runtime_root/artifacts/runtime-cutover/replacement"
+mkdir -p "$replacement_root/modules/automations/n8n/workflows" "$replacement_root/modules/crm/api" "$tmp_dir/old-dependencies"
+touch "$replacement_root/.git"
+ln -s "$tmp_dir/old-dependencies" "$replacement_root/modules/crm/api/node_modules"
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" \
+  bash "$ROOT_DIR/scripts/runtime/stage-rollback-artifacts.sh" \
+    --rollback-root "$replacement_root" \
+    --artifact-root "$replacement_artifact_root" \
+    --replace-rollback-links >/dev/null
+[[ "$(readlink -f "$replacement_root/modules/crm/api/node_modules")" == "$(readlink -f "$replacement_artifact_root/crm/node_modules")" ]]
 echo "stage-rollback-artifacts test passed"


### PR DESCRIPTION
## What changed

- adds an explicit `--replace-rollback-links` opt-in for a retained rollback worktree that still points at an older dependency bundle;
- keeps the safe default: existing artifact bundles, regular files and directories are never overwritten or removed;
- adds coverage for the controlled symbolic-link replacement path.

## Why

The recovered CRM legacy unit currently uses a compatibility symlink. The cutover preflight correctly requires the new CodexRuntime bundle, but staging needed a deliberate way to replace only that old symbolic link after the new bundle is verified.

## Validation

- shell syntax validation;
- rollback-artifact regression test, including rejection of overwrite and explicit symbolic-link replacement;
- lifecycle unit template validation.

No runtime service, secret, data, deploy, backup retention, or cleanup action is part of this PR.