### PR TITLE
fix: use robocopy for lifecycle runtime sync

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -30,6 +30,13 @@ Run the pre-copy before the window; it does not stop services or remove data:
 scripts/runtime/prepare-lifecycle-layout.sh --apply
 ```
 
+On this Windows host, lifecycle copies under `C:\CodexRuntime` use native
+`robocopy` by default. It prevents WSL/DrvFS copy stalls while preserving the
+pre-copy rule (copy only missing files); final sync copies changed files but
+never deletes a legacy source or destination-only artifact. Set
+`LIFECYCLE_SYNC_TRANSPORT=rsync` only for a non-Windows runtime or an explicit
+diagnostic.
+
 The pre-copy also transfers the active Livia workflow from the retained legacy
 source into `C:\CodexRuntime\state\orb\workflows`. The lifecycle Orb unit and
 the official validator read this runtime location; no workflow state is copied

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -10,6 +10,7 @@ APPLY=0
 FINAL_SYNC=0
 SKIP_ORB_STATE=0
 SKIP_MESSAGING_STATE=0
+SYNC_TRANSPORT="${LIFECYCLE_SYNC_TRANSPORT:-auto}"
 
 usage() {
   cat <<'EOF'
@@ -23,6 +24,10 @@ the old services have stopped.
 --skip-orb-state is only for an already-completed independent pre-copy. It
 cannot be combined with --final-sync.
 --skip-messaging-state has the same restriction for the WhatsApp channel.
+
+LIFECYCLE_SYNC_TRANSPORT chooses the directory-copy transport: auto (default)
+uses Windows robocopy for paths on /mnt/c and rsync otherwise; robocopy and
+rsync force a specific transport.
 EOF
 }
 
@@ -46,6 +51,10 @@ if [[ "$FINAL_SYNC" == "1" && ( "$SKIP_ORB_STATE" == "1" || "$SKIP_MESSAGING_STA
   echo "State skip options cannot be used during the final sync." >&2
   exit 1
 fi
+case "$SYNC_TRANSPORT" in
+  auto|robocopy|rsync) ;;
+  *) echo "LIFECYCLE_SYNC_TRANSPORT must be auto, robocopy or rsync." >&2; exit 1 ;;
+esac
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
@@ -105,10 +114,51 @@ sync_path() {
   fi
   echo "COPY $source -> $destination"
   if [[ "$APPLY" == "1" ]]; then
-    mkdir -p "$destination"
-    local -a args=(-a)
-    [[ "$FINAL_SYNC" == "0" ]] && args+=(--ignore-existing)
-    rsync "${args[@]}" "$source" "$destination/"
+    if should_use_robocopy "$source" "$destination"; then
+      sync_path_robocopy "$source" "$destination"
+    else
+      mkdir -p "$destination"
+      local -a args=(-a)
+      [[ "$FINAL_SYNC" == "0" ]] && args+=(--ignore-existing)
+      rsync "${args[@]}" "$source" "$destination/"
+    fi
+  fi
+}
+
+should_use_robocopy() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$SYNC_TRANSPORT" == "rsync" ]]; then
+    return 1
+  fi
+  if [[ "$SYNC_TRANSPORT" == "robocopy" ]]; then
+    command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy.exe is required by LIFECYCLE_SYNC_TRANSPORT=robocopy." >&2; exit 1; }
+    return 0
+  fi
+  command -v robocopy.exe >/dev/null 2>&1 && [[ "$source" == /mnt/c/* && "$destination" == /mnt/c/* ]]
+}
+
+sync_path_robocopy() {
+  local source="$1"
+  local destination="$2"
+  local normalized_source="${source%/.}"
+  local target="$destination"
+  if [[ "$source" != */. ]]; then
+    target="$destination/$(basename "$normalized_source")"
+  fi
+  mkdir -p "$target"
+
+  local source_windows target_windows status=0
+  source_windows="$(wslpath -w "$normalized_source")"
+  target_windows="$(wslpath -w "$target")"
+  local -a args=(/E /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP)
+  if [[ "$FINAL_SYNC" == "0" ]]; then
+    args+=(/XC /XN /XO)
+  fi
+  robocopy.exe "$source_windows" "$target_windows" "${args[@]}" >/dev/null || status=$?
+  if (( status > 7 )); then
+    echo "robocopy failed with exit code $status for $source -> $target." >&2
+    return "$status"
   fi
 }
 

--- a/scripts/runtime/test-prepare-lifecycle-layout.sh
+++ b/scripts/runtime/test-prepare-lifecycle-layout.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy test skipped: unavailable"; exit 0; }
+
+tmp_dir="$(mktemp -d /mnt/c/CodexRuntime/tmp/lifecycle-layout-test.XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+runtime_root="$tmp_dir/runtime"
+legacy_root="$tmp_dir/legacy"
+
+mkdir -p \
+  "$runtime_root/n8n/n8n-home" \
+  "$runtime_root/n8n/evolution-api/instances" \
+  "$runtime_root/n8n/evolution-api/store" \
+  "$legacy_root/modules/automations/n8n/workflows"
+printf 'source-v1\n' >"$runtime_root/n8n/n8n-home/payload.txt"
+printf '{"name":"Livia"}\n' >"$legacy_root/modules/automations/n8n/workflows/livia.active.json"
+
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
+  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply >/dev/null
+
+[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "source-v1" ]]
+[[ -f "$runtime_root/state/orb/workflows/livia.active.json" ]]
+
+printf 'destination-preserved\n' >"$runtime_root/state/orb/n8n-home/payload.txt"
+printf 'source-v2\n' >"$runtime_root/n8n/n8n-home/payload.txt"
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
+  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply >/dev/null
+[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "destination-preserved" ]]
+
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
+  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync >/dev/null
+[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "source-v2" ]]
+echo "prepare lifecycle layout robocopy test passed"


### PR DESCRIPTION
## What changed

- uses native Windows `robocopy` automatically when both lifecycle copy paths are under `C:\`;
- preserves pre-copy semantics by copying only missing files, while final sync updates changed files without deleting either source or destination-only data;
- retains `rsync` for non-Windows mounts and explicit diagnostics;
- adds a host-level regression test for missing-only and final-delta behavior.

## Why

The WSL/DrvFS `rsync` pre-copy entered uninterruptible `p9_client_rpc` I/O during the active n8n state copy. This would make the cutover's final delta unsafe to rely on. Native Windows copy avoids that transport boundary while retaining the non-destructive lifecycle contract.

## Validation

- shell syntax validation;
- real `robocopy` lifecycle test in a disposable directory under `C:\CodexRuntime\tmp`;
- lifecycle unit template validation.

No service was stopped and no runtime data, secret, backup, deploy, or legacy directory was deleted.