### PR TITLE
fix: use robocopy for rollback artifact staging

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -59,6 +59,10 @@ the worktree, verify the new timestamped bundle and add
 `--replace-rollback-links`; this can replace symbolic links only, never a
 regular file or directory.
 
+On this Windows host, rollback artifact staging uses native `robocopy` for CRM
+dependencies under `C:\`; use `ROLLBACK_ARTIFACT_SYNC_TRANSPORT=rsync` only for
+a non-Windows runtime or an explicit diagnostic.
+
 Then use the real backup directory, retained worktree and the exact staged
 artifact directory:
 

--- a/scripts/runtime/stage-rollback-artifacts.sh
+++ b/scripts/runtime/stage-rollback-artifacts.sh
@@ -13,6 +13,7 @@ ARTIFACT_ROOT=""
 SOURCE_LIVIA_WORKFLOW=""
 SOURCE_CRM_NODE_MODULES=""
 REPLACE_ROLLBACK_LINKS=0
+SYNC_TRANSPORT="${ROLLBACK_ARTIFACT_SYNC_TRANSPORT:-auto}"
 
 usage() {
   cat <<'EOF'
@@ -31,6 +32,9 @@ checks complete.
 --replace-rollback-links is required only when a rollback worktree already has
 a symbolic link to an older staged bundle. It may replace symbolic links only;
 it never removes regular files or directories.
+
+ROLLBACK_ARTIFACT_SYNC_TRANSPORT chooses the dependency-copy transport: auto
+(default) uses Windows robocopy for paths on /mnt/c and rsync otherwise.
 EOF
 }
 
@@ -56,6 +60,10 @@ require_cmd readlink
 require_cmd sha256sum
 [[ -n "$ROLLBACK_ROOT" && -e "$ROLLBACK_ROOT/.git" ]] || { echo "--rollback-root must name a retained Git worktree." >&2; exit 1; }
 [[ -n "$ARTIFACT_ROOT" ]] || { echo "--artifact-root is required." >&2; exit 1; }
+case "$SYNC_TRANSPORT" in
+  auto|robocopy|rsync) ;;
+  *) echo "ROLLBACK_ARTIFACT_SYNC_TRANSPORT must be auto, robocopy or rsync." >&2; exit 1 ;;
+esac
 
 runtime_root_real="$(readlink -f "$RUNTIME_ROOT")"
 artifact_root_real="$(readlink -m "$ARTIFACT_ROOT")"
@@ -73,11 +81,42 @@ SOURCE_CRM_NODE_MODULES="${SOURCE_CRM_NODE_MODULES:-$LEGACY_REPO_ROOT/modules/cr
 [[ -f "$SOURCE_LIVIA_WORKFLOW" ]] || { echo "Missing source Livia workflow: $SOURCE_LIVIA_WORKFLOW" >&2; exit 1; }
 [[ -d "$SOURCE_CRM_NODE_MODULES/express" ]] || { echo "Missing source CRM dependencies: $SOURCE_CRM_NODE_MODULES/express" >&2; exit 1; }
 
+should_use_robocopy() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$SYNC_TRANSPORT" == "rsync" ]]; then
+    return 1
+  fi
+  if [[ "$SYNC_TRANSPORT" == "robocopy" ]]; then
+    command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy.exe is required by ROLLBACK_ARTIFACT_SYNC_TRANSPORT=robocopy." >&2; exit 1; }
+    return 0
+  fi
+  command -v robocopy.exe >/dev/null 2>&1 && [[ "$source" == /mnt/c/* && "$destination" == /mnt/c/* ]]
+}
+
+sync_dependencies() {
+  local source="$1"
+  local destination="$2"
+  if ! should_use_robocopy "$source" "$destination"; then
+    rsync -a "$source/" "$destination/"
+    return
+  fi
+
+  local source_windows destination_windows status=0
+  source_windows="$(wslpath -w "$source")"
+  destination_windows="$(wslpath -w "$destination")"
+  robocopy.exe "$source_windows" "$destination_windows" /E /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP >/dev/null || status=$?
+  if (( status > 7 )); then
+    echo "robocopy failed with exit code $status for CRM rollback dependencies." >&2
+    return "$status"
+  fi
+}
+
 workflow_target="$ARTIFACT_ROOT/orb/workflows/livia.active.json"
 dependencies_target="$ARTIFACT_ROOT/crm/node_modules"
 mkdir -p "$(dirname "$workflow_target")" "$(dirname "$dependencies_target")"
 install -m 0640 "$SOURCE_LIVIA_WORKFLOW" "$workflow_target"
-rsync -a "$SOURCE_CRM_NODE_MODULES/" "$dependencies_target/"
+sync_dependencies "$SOURCE_CRM_NODE_MODULES" "$dependencies_target"
 
 link_artifact() {
   local target="$1"

--- a/scripts/runtime/test-stage-rollback-artifacts-windows-copy.sh
+++ b/scripts/runtime/test-stage-rollback-artifacts-windows-copy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy test skipped: unavailable"; exit 0; }
+
+tmp_dir="$(mktemp -d /mnt/c/CodexRuntime/tmp/rollback-artifact-test.XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+runtime_root="$tmp_dir/runtime"
+legacy_root="$tmp_dir/legacy"
+rollback_root="$tmp_dir/rollback"
+artifact_root="$runtime_root/artifacts/runtime-cutover/test"
+
+mkdir -p \
+  "$legacy_root/modules/automations/n8n/workflows" \
+  "$legacy_root/modules/crm/api/node_modules/express" \
+  "$rollback_root/modules/automations/n8n/workflows" \
+  "$rollback_root/modules/crm/api"
+touch "$rollback_root/.git"
+printf '{"name":"Livia"}\n' >"$legacy_root/modules/automations/n8n/workflows/livia.active.json"
+printf '{}' >"$legacy_root/modules/crm/api/node_modules/express/package.json"
+
+RUNTIME_ROOT="$runtime_root" LEGACY_REPO_ROOT="$legacy_root" ROLLBACK_ARTIFACT_SYNC_TRANSPORT=robocopy \
+  "$ROOT_DIR/scripts/runtime/stage-rollback-artifacts.sh" \
+    --rollback-root "$rollback_root" \
+    --artifact-root "$artifact_root" >/dev/null
+
+[[ -f "$artifact_root/crm/node_modules/express/package.json" ]]
+[[ "$(readlink -f "$rollback_root/modules/crm/api/node_modules")" == "$(readlink -f "$artifact_root/crm/node_modules")" ]]
+echo "stage rollback artifacts robocopy test passed"


### PR DESCRIPTION
## What changed

- uses native Windows `robocopy` when staging CRM rollback dependencies under `C:\`;
- retains `rsync` for non-Windows paths or explicit diagnostics;
- adds a host-level regression test that validates the actual artifact staging path and rollback symlink.

## Why

The lifecycle pre-copy proved that WSL `rsync` can stall in DrvFS I/O. The rollback artifact stage copied the same class of Windows-resident dependency tree and therefore needed the same safe transport.

## Validation

- shell syntax validation;
- existing Linux-path staging regression test;
- real Windows `robocopy` staging test in a disposable `C:\CodexRuntime\tmp` directory.

No runtime service, secret, deployment, backup or legacy directory was changed.