### PR TITLE
fix: use robocopy for n8n storage backups

### DIFF
--- a/orb/engine/RUNBOOK-UI.md
+++ b/orb/engine/RUNBOOK-UI.md
@@ -43,7 +43,11 @@ do operador fora do checkout compartilhado.
 ```bash
 $N8N_ROOT/scripts/backup-n8n.sh
 ```
-Obs: o backup automático diário via `launchd` foi desativado. Use apenas manualmente quando necessário.
+No WSL com o runtime em `C:\CodexRuntime`, deixe
+`BACKUP_STORAGE_COPY_TRANSPORT=auto` (o padrão): ele usa `robocopy` para o
+snapshot de storage e evita travamento de I/O do `rsync` no volume Windows. O
+backup continua exigindo o manifesto, checksum do dump e a verificação de
+restore antes de poder ser usado como checkpoint.
 
 ## Restore (manual)
 1. Pare o n8n.

--- a/orb/engine/scripts/backup-n8n.sh
+++ b/orb/engine/scripts/backup-n8n.sh
@@ -15,11 +15,17 @@ LOCK_FILE="${LOCK_FILE:-$N8N_RUNTIME_HOME/locks/n8n-backup.lock}"
 MANAGE_N8N_SERVICE="${MANAGE_N8N_SERVICE:-1}"
 RUNTIME_SERVICE="${RUNTIME_SERVICE:-$SKINCOS_N8N_SERVICE}"
 VERIFY_RESTORE="${VERIFY_RESTORE:-auto}"
+BACKUP_STORAGE_COPY_TRANSPORT="${BACKUP_STORAGE_COPY_TRANSPORT:-auto}"
 timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
 partial="$BACKUP_ROOT/.partial-$timestamp"
 dest="$BACKUP_ROOT/$timestamp"
 
-for command in pg_dump pg_restore psql createdb dropdb rsync flock sha256sum; do
+case "$BACKUP_STORAGE_COPY_TRANSPORT" in
+  auto|robocopy|rsync) ;;
+  *) echo "BACKUP_STORAGE_COPY_TRANSPORT must be auto, robocopy or rsync." >&2; exit 1 ;;
+esac
+
+for command in pg_dump pg_restore psql createdb dropdb flock sha256sum; do
   command -v "$command" >/dev/null 2>&1 || { echo "Missing required command: $command" >&2; exit 1; }
 done
 if [[ -n "$RETENTION_COUNT" ]]; then
@@ -50,6 +56,45 @@ if [[ "$MANAGE_N8N_SERVICE" == "1" ]] && systemctl is-active --quiet "$RUNTIME_S
   systemctl stop "$RUNTIME_SERVICE"
 fi
 
+should_use_robocopy() {
+  if [[ "$BACKUP_STORAGE_COPY_TRANSPORT" == "rsync" ]]; then
+    return 1
+  fi
+  if [[ "$BACKUP_STORAGE_COPY_TRANSPORT" == "robocopy" ]]; then
+    command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy.exe is required by BACKUP_STORAGE_COPY_TRANSPORT=robocopy." >&2; exit 1; }
+    return 0
+  fi
+  command -v robocopy.exe >/dev/null 2>&1 \
+    && [[ "$N8N_STORAGE_PATH" == /mnt/c/* ]] \
+    && [[ "$partial" == /mnt/c/* ]]
+}
+
+sync_storage() {
+  if should_use_robocopy; then
+    local source_windows destination_windows status=0
+    source_windows="$(wslpath -w "$N8N_STORAGE_PATH")"
+    destination_windows="$(wslpath -w "$partial/storage")"
+    # /MIR provides the same complete snapshot semantics as rsync --delete.
+    # Unlike rsync on DrvFS, robocopy does not block the WSL service process in
+    # p9_client_rpc while walking large Windows-hosted binary storage.
+    robocopy.exe "$source_windows" "$destination_windows" /MIR /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP >/dev/null || status=$?
+    if (( status > 7 )); then
+      echo "robocopy failed with exit code $status while backing up n8n storage." >&2
+      return "$status"
+    fi
+    return
+  fi
+
+  command -v rsync >/dev/null 2>&1 || { echo "rsync is required by BACKUP_STORAGE_COPY_TRANSPORT=rsync." >&2; exit 1; }
+  local previous rsync_args
+  previous="$(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk 'NR==1 {print $2}')"
+  rsync_args=(-a --delete)
+  if [[ -n "$previous" && -d "$previous/storage" ]]; then
+    rsync_args+=(--link-dest="$previous/storage")
+  fi
+  rsync "${rsync_args[@]}" "$N8N_STORAGE_PATH/" "$partial/storage/"
+}
+
 mkdir -p "$partial/runtime" "$partial/storage"
 
 sudo -n -u postgres pg_dump --format=custom --no-owner --no-acl \
@@ -60,17 +105,17 @@ install -m 0600 "$N8N_CONFIG_PATH" "$partial/runtime/config"
 cp -a "$N8N_RUNTIME_HOME/env" "$partial/runtime/env"
 chmod -R go-rwx "$partial/runtime"
 
-previous="$(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk 'NR==1 {print $2}')"
-rsync_args=(-a --delete)
-if [[ -n "$previous" && -d "$previous/storage" ]]; then
-  rsync_args+=(--link-dest="$previous/storage")
-fi
-rsync "${rsync_args[@]}" "$N8N_STORAGE_PATH/" "$partial/storage/"
+sync_storage
 
 db_sha="$(sha256sum "$partial/n8n_runtime.dump" | awk '{print $1}')"
 execution_count="$(sudo -n -u postgres psql -d n8n_runtime -Atqc 'select count(*) from n8n_runtime.execution_entity;')"
 workflow_count="$(sudo -n -u postgres psql -d n8n_runtime -Atqc 'select count(*) from n8n_runtime.workflow_entity;')"
-storage_bytes="$(du -sb "$N8N_STORAGE_PATH" | awk '{print $1}')"
+storage_bytes="unavailable"
+storage_bytes_json="null"
+if ! should_use_robocopy; then
+  storage_bytes="$(du -sb "$N8N_STORAGE_PATH" | awk '{print $1}')"
+  storage_bytes_json="$storage_bytes"
+fi
 
 run_restore=0
 if [[ "$VERIFY_RESTORE" == "1" ]]; then
@@ -102,7 +147,7 @@ cat > "$partial/manifest.json" <<EOF
   "executionCount": $execution_count,
   "workflowCount": $workflow_count,
   "storagePath": "$N8N_STORAGE_PATH",
-  "storageBytes": $storage_bytes,
+  "storageBytes": $storage_bytes_json,
   "restoreVerified": $restore_verified,
   "retentionDays": $RETENTION_DAYS,
   "retentionCount": ${RETENTION_COUNT:-null}
@@ -122,4 +167,4 @@ fi
 
 echo "Backup completed: $dest"
 echo "database_sha256=$db_sha"
-echo "executions=$execution_count workflows=$workflow_count storage_bytes=$storage_bytes"
+echo "executions=$execution_count workflows=$workflow_count storage_bytes=$storage_bytes transport=$BACKUP_STORAGE_COPY_TRANSPORT"

--- a/orb/engine/scripts/test-backup-n8n-storage-copy.sh
+++ b/orb/engine/scripts/test-backup-n8n-storage-copy.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercises the Windows-hosted storage branch without PostgreSQL or a live
+# service. The fake database commands keep the test focused on the snapshot,
+# manifest and restore-verification control flow.
+
+command -v robocopy.exe >/dev/null 2>&1 || { echo "backup robocopy test skipped: unavailable"; exit 0; }
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="/mnt/c/CodexRuntime/tmp/backup-storage-copy-test.$$"
+runtime_root="$test_root/runtime"
+backup_root="$test_root/backups"
+fake_bin="$test_root/fake-bin"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+mkdir -p "$runtime_root/n8n-home/.n8n/storage/nested" "$runtime_root/env" "$runtime_root/health" "$fake_bin"
+printf 'payload\n' > "$runtime_root/n8n-home/.n8n/storage/nested/file.txt"
+printf 'config\n' > "$runtime_root/n8n-home/.n8n/config"
+printf 'N8N_ENCRYPTION_KEY=test-only\n' > "$runtime_root/env/n8n.env"
+
+cat > "$fake_bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n) shift ;;
+    -u) shift 2 ;;
+    *) exec "$@" ;;
+  esac
+done
+EOF
+cat > "$fake_bin/pg_dump" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+for arg in "$@"; do
+  case "$arg" in
+    --file=*) printf 'dump\n' > "${arg#--file=}"; exit 0 ;;
+  esac
+done
+exit 1
+EOF
+cat > "$fake_bin/pg_restore" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--list" ]]; then
+  printf 'restore-list\n'
+fi
+EOF
+cat > "$fake_bin/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '1\n'
+EOF
+cat > "$fake_bin/createdb" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$fake_bin/dropdb" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fake_bin"/*
+
+PATH="$fake_bin:$PATH" \
+  N8N_ROOT="$repo_root" \
+  N8N_RUNTIME_HOME="$runtime_root" \
+  N8N_ENV_FILE="$runtime_root/env/n8n.env" \
+  N8N_DATA_HOME="$runtime_root/n8n-home" \
+  N8N_STATE_HOME="$runtime_root/n8n-home/.n8n" \
+  N8N_STORAGE_PATH="$runtime_root/n8n-home/.n8n/storage" \
+  N8N_CONFIG_PATH="$runtime_root/n8n-home/.n8n/config" \
+  N8N_HEALTH_DIR="$runtime_root/health" \
+  BACKUP_ROOT="$backup_root" \
+  BACKUP_STORAGE_COPY_TRANSPORT=robocopy \
+  MANAGE_N8N_SERVICE=0 \
+  VERIFY_RESTORE=1 \
+  RETENTION_COUNT=1 \
+  bash "$repo_root/scripts/backup-n8n.sh"
+
+backup_dir="$(find "$backup_root" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -print -quit)"
+[[ -f "$backup_dir/storage/nested/file.txt" ]]
+grep -q '"restoreVerified": true' "$backup_dir/manifest.json"
+grep -q '"storageBytes": null' "$backup_dir/manifest.json"
+
+echo "backup robocopy storage test passed"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "runtime:lifecycle:prepare": "bash ./scripts/runtime/prepare-lifecycle-layout.sh",
     "runtime:lifecycle:preflight": "bash ./scripts/runtime/cutover-lifecycle-runtime.sh",
     "runtime:lifecycle:cutover": "bash ./scripts/runtime/cutover-lifecycle-runtime.sh --apply",
+    "runtime:backup:storage-copy:test": "bash ./orb/engine/scripts/test-backup-n8n-storage-copy.sh",
     "crm:console:dev": "npm --prefix crm/console run dev",
     "crm:api:test": "npm --prefix crm/api test",
     "orb:service:status": "npm --prefix orb/engine run service:status --",


### PR DESCRIPTION
## Summary
- use Windows `robocopy` automatically for n8n binary-storage snapshots hosted in `C:\CodexRuntime`
- avoid the observed WSL DrvFS `rsync`/`du` I/O stall while retaining the dump checksum and restore verification
- add an isolated robocopy backup regression test

## Validation
- `npm run runtime:backup:storage-copy:test`
- `bash -n orb/engine/scripts/backup-n8n.sh`
- `git diff --check`

This is a prerequisite for creating the fresh verified runtime checkpoint before lifecycle cutover.