### PR TITLE
fix: resolve robocopy for system backups

### DIFF
--- a/orb/engine/RUNBOOK-UI.md
+++ b/orb/engine/RUNBOOK-UI.md
@@ -47,7 +47,9 @@ No WSL com o runtime em `C:\CodexRuntime`, deixe
 `BACKUP_STORAGE_COPY_TRANSPORT=auto` (o padrão): ele usa `robocopy` para o
 snapshot de storage e evita travamento de I/O do `rsync` no volume Windows. O
 backup continua exigindo o manifesto, checksum do dump e a verificação de
-restore antes de poder ser usado como checkpoint.
+restore antes de poder ser usado como checkpoint. Em unidades `root`/systemd,
+o resolvedor usa o binário montado em `C:\Windows\System32` quando o
+`secure_path` do `sudo` não expõe `robocopy.exe`.
 
 ## Restore (manual)
 1. Pare o n8n.

--- a/orb/engine/scripts/backup-n8n.sh
+++ b/orb/engine/scripts/backup-n8n.sh
@@ -16,6 +16,7 @@ MANAGE_N8N_SERVICE="${MANAGE_N8N_SERVICE:-1}"
 RUNTIME_SERVICE="${RUNTIME_SERVICE:-$SKINCOS_N8N_SERVICE}"
 VERIFY_RESTORE="${VERIFY_RESTORE:-auto}"
 BACKUP_STORAGE_COPY_TRANSPORT="${BACKUP_STORAGE_COPY_TRANSPORT:-auto}"
+ROBOCOPY_BIN="${ROBOCOPY_BIN:-}"
 timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
 partial="$BACKUP_ROOT/.partial-$timestamp"
 dest="$BACKUP_ROOT/$timestamp"
@@ -56,15 +57,36 @@ if [[ "$MANAGE_N8N_SERVICE" == "1" ]] && systemctl is-active --quiet "$RUNTIME_S
   systemctl stop "$RUNTIME_SERVICE"
 fi
 
+resolve_robocopy() {
+  local candidate
+  if [[ -n "$ROBOCOPY_BIN" && -x "$ROBOCOPY_BIN" ]]; then
+    return 0
+  fi
+  candidate="$(command -v robocopy.exe 2>/dev/null || true)"
+  if [[ -n "$candidate" ]]; then
+    ROBOCOPY_BIN="$candidate"
+    return 0
+  fi
+  # systemd/root commonly uses a secure PATH that omits Windows interop
+  # entries. The mounted Windows binary remains executable from WSL.
+  for candidate in /mnt/c/Windows/System32/robocopy.exe /mnt/c/WINDOWS/system32/robocopy.exe; do
+    if [[ -x "$candidate" ]]; then
+      ROBOCOPY_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 should_use_robocopy() {
   if [[ "$BACKUP_STORAGE_COPY_TRANSPORT" == "rsync" ]]; then
     return 1
   fi
   if [[ "$BACKUP_STORAGE_COPY_TRANSPORT" == "robocopy" ]]; then
-    command -v robocopy.exe >/dev/null 2>&1 || { echo "robocopy.exe is required by BACKUP_STORAGE_COPY_TRANSPORT=robocopy." >&2; exit 1; }
+    resolve_robocopy || { echo "robocopy.exe is required by BACKUP_STORAGE_COPY_TRANSPORT=robocopy." >&2; exit 1; }
     return 0
   fi
-  command -v robocopy.exe >/dev/null 2>&1 \
+  resolve_robocopy \
     && [[ "$N8N_STORAGE_PATH" == /mnt/c/* ]] \
     && [[ "$partial" == /mnt/c/* ]]
 }
@@ -77,7 +99,7 @@ sync_storage() {
     # /MIR provides the same complete snapshot semantics as rsync --delete.
     # Unlike rsync on DrvFS, robocopy does not block the WSL service process in
     # p9_client_rpc while walking large Windows-hosted binary storage.
-    robocopy.exe "$source_windows" "$destination_windows" /MIR /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP >/dev/null || status=$?
+    "$ROBOCOPY_BIN" "$source_windows" "$destination_windows" /MIR /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP >/dev/null || status=$?
     if (( status > 7 )); then
       echo "robocopy failed with exit code $status while backing up n8n storage." >&2
       return "$status"

--- a/orb/engine/scripts/test-backup-n8n-storage-copy.sh
+++ b/orb/engine/scripts/test-backup-n8n-storage-copy.sh
@@ -5,7 +5,16 @@ set -euo pipefail
 # service. The fake database commands keep the test focused on the snapshot,
 # manifest and restore-verification control flow.
 
-command -v robocopy.exe >/dev/null 2>&1 || { echo "backup robocopy test skipped: unavailable"; exit 0; }
+robocopy_bin="$(command -v robocopy.exe 2>/dev/null || true)"
+if [[ -z "$robocopy_bin" ]]; then
+  for candidate in /mnt/c/Windows/System32/robocopy.exe /mnt/c/WINDOWS/system32/robocopy.exe; do
+    if [[ -x "$candidate" ]]; then
+      robocopy_bin="$candidate"
+      break
+    fi
+  done
+fi
+[[ -n "$robocopy_bin" ]] || { echo "backup robocopy test skipped: unavailable"; exit 0; }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 test_root="/mnt/c/CodexRuntime/tmp/backup-storage-copy-test.$$"
@@ -77,6 +86,7 @@ PATH="$fake_bin:$PATH" \
   N8N_HEALTH_DIR="$runtime_root/health" \
   BACKUP_ROOT="$backup_root" \
   BACKUP_STORAGE_COPY_TRANSPORT=robocopy \
+  ROBOCOPY_BIN="$robocopy_bin" \
   MANAGE_N8N_SERVICE=0 \
   VERIFY_RESTORE=1 \
   RETENTION_COUNT=1 \


### PR DESCRIPTION
## Summary
- resolve `robocopy.exe` from the mounted Windows system path when `sudo`/systemd secure PATH omits Windows interop entries
- keep automatic Windows-storage snapshots on the safe robocopy branch in the real root service context
- run the backup regression test under `root`

## Validation
- `sudo -n bash orb/engine/scripts/test-backup-n8n-storage-copy.sh`
- shell syntax and whitespace checks

This fixes the real runtime observation where the prior auto selection fell back to rsync under root.