### PR TITLE
docs: record validated runtime cutover checkpoint

### DIFF
--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -20,8 +20,9 @@
   smoke-tested.
 - The next runtime target is
   `C:\CodexRuntime\{state,config,logs,backups,artifacts,cache,tmp}\<domain>`
-  with a flat, ACL-restricted `C:\CodexRuntime\secrets\` directory. No live
-  runtime data has been moved yet.
+  with a flat, ACL-restricted `C:\CodexRuntime\secrets\` directory. A
+  non-disruptive pre-copy and rollback-artifact stage have been validated; no
+  lifecycle unit has been installed or cut over yet.
 - `orb/engine` is the isolated implementation boundary for the current
   workflow engine. Vendor names must not appear in new public paths, service
   names or user-facing runbooks.

--- a/TASKS.md
+++ b/TASKS.md
@@ -11,9 +11,10 @@
 - [ ] **Wave 4 — Booking + EF integration:** introduce the D1 outbox/ledger,
   idempotency, lease and `provisional`/`confirmed`/`failed`/`manual_review`
   state model; use a simulated EF executor before any external reservation.
-- [ ] **Wave 5 — runtime cutover:** pre-copy to the lifecycle layout, create a
-  verified fresh backup, rename units in a short window, and retain rollback
-  evidence. The executable contract is
+- [ ] **Wave 5 — runtime cutover:** pre-copy, rollback artifacts and a fresh
+  restore-verified backup are complete. The remaining work is the short unit
+  cut window after security-alert triage, followed by local/public smoke and
+  rollback retention. The executable contract is
   `docs/runbooks/lifecycle-runtime-cutover.md`; do not change the WSL VHD,
   Codex authentication or mandatory Windows state.
 - [ ] **Wave 6 — retirement:** remove old source paths, direct public routes,

--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -5,6 +5,20 @@ deleting the legacy tree during the change window. It is intentionally separate
 from the source-layout pull request: a merged path move is never proof that a
 service is safe to rename.
 
+## Current validated checkpoint (2026-07-14)
+
+- Pre-copy completed with the Windows-native transport and the runtime Livia
+  workflow matches the retained legacy source by SHA-256.
+- Rollback artifacts are staged at
+  `C:\CodexRuntime\artifacts\runtime-cutover\20260714T170200Z` and linked
+  only into the retained rollback worktree.
+- `C:\CodexRuntime\n8n\backups\daily\20260714T172136Z` has a successful
+  PostgreSQL restore verification. Incomplete `.partial-*` backup attempts
+  were removed after this checkpoint was validated.
+- The cutover dry-run, rendered lifecycle units, local health and public Orb/
+  CRM health passed. The legacy units remain authoritative until the final
+  security-alert triage and scheduled cut window are complete.
+
 ## Preconditions
 
 1. The source PR is merged, the canonical checkout is fast-forwarded, and all


### PR DESCRIPTION
## Summary
- record the completed lifecycle pre-copy, staged rollback bundle and restore-verified backup
- clarify that legacy services remain authoritative until the controlled cut
- prevent redundant preparatory work while security triage remains pending

## Validation
- `git diff --check`
- local lifecycle transport, rollback staging and backup tests passed before this documentation update
- current footprint audit reports healthy local/public Orb and CRM endpoints