### PR TITLE
fix(security): constrain CRM WhatsApp upstream routes

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test server/harmonia/__tests__/*.test.js server/atendimento/__tests__/*.test.js",
+    "test": "node --test server/__tests__/*.test.js server/harmonia/__tests__/*.test.js server/atendimento/__tests__/*.test.js services/__tests__/*.test.js",
     "import-atendimento-sheet": "node scripts/import-atendimento-sheet.mjs",
     "import-gerencia-sheet": "node scripts/import-gerencia-sheet.mjs"
   },

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -31,6 +31,7 @@ import { createHarmoniaRouter } from './server/harmonia/routes.js'
 import { startHarmoniaWorker } from './server/harmonia/worker.js'
 import { createTrackingDashboardRouter } from './server/trackingDashboardRoutes.js'
 import { createAtendimentoRouter } from './server/atendimento/routes.js'
+import { parseUnifiedChannelId, unifiedChannelUrl, unifiedSystemUrl } from './server/unifiedSystemUrl.js'
 
 // Axios for facade requests to Unified System
 import axios from 'axios'
@@ -4388,7 +4389,6 @@ app.post('/api/email/templates/:id/send-test', async (req, res) => {
 // UNIFIED SYSTEM FACADE ROUTES - Proxy WhatsAppPanel calls with X-API-Key
 // =================================================================
 
-const UNIFIED_SYSTEM_URL = 'http://localhost:3001'
 const CRM_UNIFIED_API_KEY = process.env.CRM_UNIFIED_API_KEY
 
 // Facade: GET /api/unified/status → Unified System /whatsapp/1/status (Legacy)
@@ -4396,7 +4396,7 @@ app.get('/api/unified/status', async (req, res) => {
     try {
         console.log(`[FACADE] Proxying legacy status request to Unified System`)
 
-        const response = await axios.get(`${UNIFIED_SYSTEM_URL}/whatsapp/1/status`, {
+        const response = await axios.get(unifiedChannelUrl('1', 'status'), {
             headers: {
                 'X-API-Key': CRM_UNIFIED_API_KEY,
                 'Content-Type': 'application/json'
@@ -4423,7 +4423,7 @@ app.get('/api/unified/qr', async (req, res) => {
     try {
         console.log(`[FACADE] Proxying legacy QR request to Unified System`)
 
-        const response = await axios.get(`${UNIFIED_SYSTEM_URL}/whatsapp/1/qr`, {
+        const response = await axios.get(unifiedChannelUrl('1', 'qr'), {
             headers: {
                 'X-API-Key': CRM_UNIFIED_API_KEY,
                 'Content-Type': 'application/json'
@@ -4450,7 +4450,7 @@ app.get('/api/qr', async (req, res) => {
     try {
         console.log(`[FACADE] Proxying direct QR request to Unified System`)
 
-        const response = await axios.get(`${UNIFIED_SYSTEM_URL}/api/qr`, {
+        const response = await axios.get(unifiedSystemUrl('/api/qr'), {
             headers: {
                 'X-API-Key': CRM_UNIFIED_API_KEY,
                 'Content-Type': 'application/json'
@@ -4475,10 +4475,13 @@ app.get('/api/qr', async (req, res) => {
 // Facade: GET /api/unified/whatsapp/:channelId/status → Unified System
 app.get('/api/unified/whatsapp/:channelId/status', async (req, res) => {
     try {
-        const { channelId } = req.params
+        const channelId = parseUnifiedChannelId(req.params.channelId)
+        if (!channelId) {
+            return res.status(400).json({ success: false, error: 'Invalid WhatsApp channel' })
+        }
         console.log(`[FACADE] Proxying status request for channel ${channelId} to Unified System`)
 
-        const response = await axios.get(`${UNIFIED_SYSTEM_URL}/whatsapp/${channelId}/status`, {
+        const response = await axios.get(unifiedChannelUrl(channelId, 'status'), {
             headers: {
                 'X-API-Key': CRM_UNIFIED_API_KEY,
                 'Content-Type': 'application/json'
@@ -4503,10 +4506,13 @@ app.get('/api/unified/whatsapp/:channelId/status', async (req, res) => {
 // Facade: GET /api/unified/whatsapp/:channelId/qr → Unified System
 app.get('/api/unified/whatsapp/:channelId/qr', async (req, res) => {
     try {
-        const { channelId } = req.params
+        const channelId = parseUnifiedChannelId(req.params.channelId)
+        if (!channelId) {
+            return res.status(400).json({ success: false, error: 'Invalid WhatsApp channel' })
+        }
         console.log(`[FACADE] Proxying QR request for channel ${channelId} to Unified System`)
 
-        const response = await axios.get(`${UNIFIED_SYSTEM_URL}/whatsapp/${channelId}/qr`, {
+        const response = await axios.get(unifiedChannelUrl(channelId, 'qr'), {
             headers: {
                 'X-API-Key': CRM_UNIFIED_API_KEY,
                 'Content-Type': 'application/json'
@@ -4531,7 +4537,10 @@ app.get('/api/unified/whatsapp/:channelId/qr', async (req, res) => {
 // 🆕 Facade: SSE Stream /api/unified/whatsapp/:channelId/qr/stream → Unified System
 app.get('/api/unified/whatsapp/:channelId/qr/stream', (req, res) => {
     try {
-        const { channelId } = req.params
+        const channelId = parseUnifiedChannelId(req.params.channelId)
+        if (!channelId) {
+            return res.status(400).json({ success: false, error: 'Invalid WhatsApp channel' })
+        }
         console.log(`[FACADE] Setting up SSE proxy for channel ${channelId} QR stream`)
 
         // Configure SSE headers
@@ -4544,7 +4553,7 @@ app.get('/api/unified/whatsapp/:channelId/qr/stream', (req, res) => {
         })
 
         // Create proxy to Unified System
-        const proxyUrl = `${UNIFIED_SYSTEM_URL}/whatsapp/${channelId}/qr/stream`
+        const proxyUrl = unifiedChannelUrl(channelId, 'qrStream')
 
         // Use axios with stream to proxy SSE
         const forwardHeaders = {

--- a/crm/api/server/__tests__/unifiedSystemUrl.test.js
+++ b/crm/api/server/__tests__/unifiedSystemUrl.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUnifiedChannelId, unifiedChannelUrl, unifiedSystemUrl } from '../unifiedSystemUrl.js'
+
+test('builds fixed Unified System routes for valid channels', () => {
+    assert.equal(unifiedSystemUrl('/api/qr'), 'http://localhost:3001/api/qr')
+    assert.equal(unifiedChannelUrl('1', 'status'), 'http://localhost:3001/whatsapp/1/status')
+    assert.equal(unifiedChannelUrl(9, 'qrStream'), 'http://localhost:3001/whatsapp/9/qr/stream')
+})
+
+test('rejects channel input that could alter the upstream path', () => {
+    for (const value of ['0', '10', '-1', '1?next=/api/qr', '1/../api/qr', '%2fapi%2fqr', '', null]) {
+        assert.equal(parseUnifiedChannelId(value), null)
+        assert.throws(() => unifiedChannelUrl(value, 'status'), /INVALID_UNIFIED_CHANNEL_ROUTE/)
+    }
+})

--- a/crm/api/server/unifiedSystemUrl.js
+++ b/crm/api/server/unifiedSystemUrl.js
@@ -1,0 +1,29 @@
+const UNIFIED_SYSTEM_ORIGIN = 'http://localhost:3001'
+
+const CHANNEL_PATHS = Object.freeze({
+    status: 'status',
+    qr: 'qr',
+    qrStream: 'qr/stream',
+})
+
+export function parseUnifiedChannelId(value) {
+    const channel = String(value ?? '').trim()
+    return /^[1-9]$/.test(channel) ? channel : null
+}
+
+export function unifiedSystemUrl(pathname) {
+    const url = new URL(pathname, UNIFIED_SYSTEM_ORIGIN)
+    if (url.origin !== UNIFIED_SYSTEM_ORIGIN) {
+        throw new Error('UNIFIED_SYSTEM_ORIGIN_MISMATCH')
+    }
+    return url.toString()
+}
+
+export function unifiedChannelUrl(channelId, resource) {
+    const channel = parseUnifiedChannelId(channelId)
+    const suffix = CHANNEL_PATHS[resource]
+    if (!channel || !suffix) {
+        throw new Error('INVALID_UNIFIED_CHANNEL_ROUTE')
+    }
+    return unifiedSystemUrl(`/whatsapp/${channel}/${suffix}`)
+}

--- a/crm/api/services/__tests__/whatsappOrchestrator.basic.test.js
+++ b/crm/api/services/__tests__/whatsappOrchestrator.basic.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { whatsappOrchestrator } from '../whatsappOrchestrator.js'
+import { buildLocalWhatsAppUrl, whatsappOrchestrator } from '../whatsappOrchestrator.js'
 
 test('whatsappOrchestrator maps channels to ports', () => {
     assert.equal(whatsappOrchestrator.channelToPort(1), 3001)
@@ -10,4 +10,11 @@ test('whatsappOrchestrator maps channels to ports', () => {
 test('whatsappOrchestrator returns all channels and ports arrays', () => {
     assert.equal(whatsappOrchestrator.getAllChannels().length, 9)
     assert.equal(whatsappOrchestrator.getAllPorts().length, 9)
+})
+
+test('whatsappOrchestrator only builds local allowlisted upstream URLs', () => {
+    assert.equal(buildLocalWhatsAppUrl(3001, '/api/status'), 'http://localhost:3001/api/status')
+    assert.equal(buildLocalWhatsAppUrl(3009, '/api/qr'), 'http://localhost:3009/api/qr')
+    assert.throws(() => buildLocalWhatsAppUrl(22, '/api/status'), /INVALID_WHATSAPP_LOCAL_PORT/)
+    assert.throws(() => buildLocalWhatsAppUrl(3001, '/api/status?next=https://attacker.invalid'), /INVALID_WHATSAPP_LOCAL_PATH/)
 })

--- a/crm/api/services/whatsappOrchestrator.js
+++ b/crm/api/services/whatsappOrchestrator.js
@@ -18,6 +18,12 @@ const DEFAULT_INSTANCES_FILE = process.env.VAR_DIR
   : path.join(BACKEND_ROOT, 'var', 'core', 'whatsapp_instances.json')
 const INSTANCES_FILE = process.env.WA_INSTANCES_FILE || DEFAULT_INSTANCES_FILE
 const PORTS_RANGE = { min: 3001, max: 3009 } // 9 available channels
+const LOCAL_WHATSAPP_PATHS = new Set([
+  '/api/status',
+  '/api/qr',
+  '/whatsapp/1/status',
+  '/start-client'
+])
 const DEFAULT_OFFICIAL_MODULE_PATH = path.join(SKINCOS_ROOT, 'modules', 'whatsapp', 'whatsapp', 'official-module')
 const LEGACY_OFFICIAL_MODULE_PATH = path.join(SKINCOS_ROOT, 'whatsapp', 'official-module')
 const WHATSAPP_MODULE_PATH = process.env.WHATSAPP_MODULE_PATH ||
@@ -25,9 +31,20 @@ const WHATSAPP_MODULE_PATH = process.env.WHATSAPP_MODULE_PATH ||
 
 // Authentication configuration for Unified System communication
 const CRM_UNIFIED_API_KEY = process.env.CRM_UNIFIED_API_KEY || 'unified-dev-key'
-const UNIFIED_SYSTEM_URL = process.env.UNIFIED_SYSTEM_URL || 'http://localhost:3001'
 // Lazy-init enforcement: do NOT auto-start client on readiness unless explicitly enabled
 const UNIFIED_AUTOSTART_ON_READY = process.env.UNIFIED_AUTOSTART_ON_READY === 'true'
+
+export function buildLocalWhatsAppUrl(port, pathname) {
+  if (!Number.isInteger(port) || port < PORTS_RANGE.min || port > PORTS_RANGE.max) {
+    throw new Error('INVALID_WHATSAPP_LOCAL_PORT')
+  }
+
+  if (!LOCAL_WHATSAPP_PATHS.has(pathname)) {
+    throw new Error('INVALID_WHATSAPP_LOCAL_PATH')
+  }
+
+  return `http://localhost:${port}${pathname}`
+}
 
 class WhatsAppOrchestrator {
   constructor() {
@@ -45,7 +62,8 @@ class WhatsAppOrchestrator {
   }
 
   // Helper method to create authenticated fetch requests to Unified System
-  async fetchUnifiedSystem(url, options = {}) {
+  async fetchUnifiedSystem(pathname, options = {}) {
+    const url = buildLocalWhatsAppUrl(3001, pathname)
     const headers = {
       'Content-Type': 'application/json',
       'X-API-Key': CRM_UNIFIED_API_KEY,
@@ -63,11 +81,10 @@ class WhatsAppOrchestrator {
 
   // Smart fetch method that automatically chooses authentication based on port
   async smartFetch(port, endpoint, options = {}) {
-    const url = `http://localhost:${port}${endpoint}`
-
     if (this.shouldUseAuthentication(port)) {
-      return this.fetchUnifiedSystem(url, options)
+      return this.fetchUnifiedSystem(endpoint, options)
     } else {
+      const url = buildLocalWhatsAppUrl(port, endpoint)
       return fetch(url, options)
     }
   }
@@ -490,7 +507,7 @@ class WhatsAppOrchestrator {
       if (targetChannel === 1 && process.env.UNIFIED_MODE === 'true') {
         console.log(`[WhatsApp Orchestrator] Forwarding Channel 1 start request to unified system`)
         try {
-          const response = await this.fetchUnifiedSystem(`${UNIFIED_SYSTEM_URL}/whatsapp/1/status`, {
+          const response = await this.fetchUnifiedSystem('/whatsapp/1/status', {
             method: 'GET'
           })
 
@@ -668,7 +685,7 @@ class WhatsAppOrchestrator {
         if (targetPort === 3001) {
           if (UNIFIED_AUTOSTART_ON_READY) {
             try {
-              const startResp = await this.fetchUnifiedSystem(`${UNIFIED_SYSTEM_URL}/start-client`, { method: 'POST' })
+              const startResp = await this.fetchUnifiedSystem('/start-client', { method: 'POST' })
               if (!startResp.ok) {
                 const errText = await startResp.text().catch(() => '')
                 console.warn(`[WhatsApp Orchestrator] start-client returned ${startResp.status}: ${errText}`)
@@ -875,7 +892,7 @@ class WhatsAppOrchestrator {
 
       // Use fetchUnifiedSystem directly for port 3001 to ensure authentication
       const response = port === 3001
-        ? await this.fetchUnifiedSystem(`${UNIFIED_SYSTEM_URL}/api/qr`, {
+        ? await this.fetchUnifiedSystem('/api/qr', {
           signal: controller.signal,
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
## Security remediation\n\nCloses the reachable CRM request-forgery findings for the Unified System facade and WhatsApp orchestrator.\n\n- accepts only CRM channels 1 through 9 before building facade URLs;\n- uses fixed localhost:3001 Unified System routes;\n- limits orchestrator calls to localhost ports 3001 through 3009 and an explicit path allowlist;\n- removes the environment-configurable Unified System origin;\n- includes regression tests in the CRM test command.\n\n## Evidence\n\n- CodeQL alerts #4285 through #4289 were traced to dynamically assembled localhost routes.\n- 
pm test: 74 passed.\n- 
ode --check crm/api/server.js and 
ode --check crm/api/services/whatsappOrchestrator.js passed.\n\nNo runtime service or secret was changed; deployment remains gated on required CI and the planned runtime cutover.