### PR TITLE
fix(security): validate WhatsApp gateway query inputs

### DIFF
--- a/messaging/channels/whatsapp/gateway/bot_com_api.js
+++ b/messaging/channels/whatsapp/gateway/bot_com_api.js
@@ -11,6 +11,7 @@ try {
 const crypto = require('crypto');
 const qrcode = require('qrcode-terminal');
 const express = require('express');
+const { normalizeWhatsappContactId } = require('./inputValidation');
 const axios = require('axios');
 const cors = require('cors');
 const path = require('path');
@@ -388,7 +389,11 @@ async function listCommonGroups(contactIdRaw) {
         const e = new Error('Parâmetro contactId/phone é obrigatório');
         e.statusCode = 400; throw e;
     }
-    const contactId = contactIdRaw.includes('@') ? contactIdRaw : `${String(contactIdRaw).replace(/\D/g, '')}@c.us`;
+    const contactId = normalizeWhatsappContactId(contactIdRaw);
+    if (!contactId) {
+        const e = new Error('Parâmetro contactId/phone inválido');
+        e.statusCode = 400; throw e;
+    }
     const chats = await client.getChats();
     const groups = chats.filter(c => c.isGroup === true);
     const result = [];
@@ -1605,7 +1610,8 @@ app.get('/v1/messages', (req, res) => {
     let results = messagesStore;
     if (type) results = results.filter(m => m.type === type);
     if (to) {
-        const target = to.includes('@c.us') ? to : `${to.replace(/\D/g, '')}@c.us`;
+        const target = normalizeWhatsappContactId(to);
+        if (!target) return res.status(400).json({ success: false, message: 'Parâmetro to inválido' });
         results = results.filter(m => m.to === target);
     }
     const limited = results.slice(-Number(limit)).reverse();

--- a/messaging/channels/whatsapp/gateway/inputValidation.js
+++ b/messaging/channels/whatsapp/gateway/inputValidation.js
@@ -1,0 +1,12 @@
+function normalizeWhatsappContactId(value) {
+    if (typeof value !== 'string') return null;
+
+    const raw = value.trim();
+    if (!raw) return null;
+    if (/^\d+@c\.us$/i.test(raw)) return raw;
+
+    const digits = raw.replace(/\D/g, '');
+    return digits ? `${digits}@c.us` : null;
+}
+
+module.exports = { normalizeWhatsappContactId };

--- a/messaging/channels/whatsapp/gateway/test/inputValidation.test.js
+++ b/messaging/channels/whatsapp/gateway/test/inputValidation.test.js
@@ -1,0 +1,14 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { normalizeWhatsappContactId } = require('../inputValidation');
+
+test('normalizes a scalar WhatsApp contact identifier', () => {
+    assert.equal(normalizeWhatsappContactId('5511999999999'), '5511999999999@c.us');
+    assert.equal(normalizeWhatsappContactId('5511999999999@c.us'), '5511999999999@c.us');
+});
+
+test('rejects query arrays and non-contact input', () => {
+    assert.equal(normalizeWhatsappContactId(['5511999999999', '5511888888888']), null);
+    assert.equal(normalizeWhatsappContactId({ toString: () => '5511999999999' }), null);
+    assert.equal(normalizeWhatsappContactId('@c.us'), null);
+});


### PR DESCRIPTION
## Security remediation\n\nFixes CodeQL critical type-confusion findings #4344 and #4345. Query values used as WhatsApp IDs are now accepted only as scalar strings and are normalized through one helper.\n\n## Validation\n\n- 
ode --test messaging/channels/whatsapp/gateway/test/inputValidation.test.js: 2 passed.\n- 
ode --check messaging/channels/whatsapp/gateway/bot_com_api.js: passed.