### PR TITLE
fix(security): validate GBP diagnostic resource ids

### DIFF
--- a/website/src/app/api/gbp/health/route.ts
+++ b/website/src/app/api/gbp/health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildGbpLocationResource, parseGbpLocationId } from "@/lib/gbpDiagnostics";
 
 export const dynamic = "force-dynamic";
 
@@ -96,18 +97,6 @@ async function getAccessToken(): Promise<string> {
     return accessToken;
 }
 
-function parseLocationId(input: string): string | null {
-    const raw = (input ?? "").trim();
-    if (!raw) return null;
-    if (raw.startsWith("accounts/")) return null;
-    if (raw.startsWith("locations/")) {
-        const id = raw.slice("locations/".length).trim();
-        return id || null;
-    }
-    if (/^\d+$/.test(raw)) return raw;
-    return null;
-}
-
 async function listAccountIds(accessToken: string): Promise<string[]> {
     const res = await fetch("https://mybusiness.googleapis.com/v4/accounts", {
         headers: { authorization: `Bearer ${accessToken}` },
@@ -119,14 +108,14 @@ async function listAccountIds(accessToken: string): Promise<string[]> {
         .filter((name) => name.startsWith("accounts/"))
         .map((name) => name.slice("accounts/".length))
         .map((id) => id.trim())
-        .filter(Boolean);
+        .filter((id) => /^\d+$/.test(id));
     return Array.from(new Set(ids)).slice(0, 20);
 }
 
 async function discoverLocationResourceName(accessToken: string, locationId: string): Promise<string> {
     const accountIds = await listAccountIds(accessToken);
     for (const accountId of accountIds) {
-        const candidate = `accounts/${accountId}/locations/${locationId}`;
+        const candidate = buildGbpLocationResource(accountId, locationId);
         const probe = await fetch(`https://mybusiness.googleapis.com/v4/${candidate}`, {
             headers: { authorization: `Bearer ${accessToken}` },
         });
@@ -154,7 +143,7 @@ export async function GET(req: Request) {
 
     const { searchParams } = new URL(req.url);
     const locationParam = (searchParams.get("location") ?? "").trim();
-    const locationId = parseLocationId(locationParam);
+    const locationId = parseGbpLocationId(locationParam);
 
     const status: HealthStatus = {
         ok: false,

--- a/website/src/lib/gbpDiagnostics.ts
+++ b/website/src/lib/gbpDiagnostics.ts
@@ -1,0 +1,18 @@
+export function parseGbpLocationId(input: string): string | null {
+    const raw = (input ?? "").trim();
+    if (!raw || raw.startsWith("accounts/")) return null;
+
+    const id = raw.startsWith("locations/")
+        ? raw.slice("locations/".length).trim()
+        : raw;
+
+    return /^\d+$/.test(id) ? id : null;
+}
+
+export function buildGbpLocationResource(accountId: string, locationId: string): string {
+    if (!/^\d+$/.test(accountId) || !/^\d+$/.test(locationId)) {
+        throw new Error("invalid_gbp_resource_identifier");
+    }
+
+    return `accounts/${accountId}/locations/${locationId}`;
+}

--- a/website/tests/gbpDiagnostics.test.ts
+++ b/website/tests/gbpDiagnostics.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildGbpLocationResource, parseGbpLocationId } from "../src/lib/gbpDiagnostics";
+
+test("accepts only numeric Google Business Profile location identifiers", () => {
+    assert.equal(parseGbpLocationId("123456"), "123456");
+    assert.equal(parseGbpLocationId("locations/123456"), "123456");
+    assert.equal(parseGbpLocationId(" accounts/123/locations/456 "), null);
+});
+
+test("rejects path and query injection in Google Business Profile identifiers", () => {
+    for (const value of ["locations/123?alt=json", "locations/123/reviews", "../123", "123#fragment", "123%2freviews"]) {
+        assert.equal(parseGbpLocationId(value), null);
+    }
+
+    assert.equal(buildGbpLocationResource("456", "123"), "accounts/456/locations/123");
+    assert.throws(() => buildGbpLocationResource("456?x=1", "123"), /invalid_gbp_resource_identifier/);
+});


### PR DESCRIPTION
## Security remediation\n\nFixes CodeQL critical request-forgery findings #2542 and #2543 in the GBP diagnostics route. The route already required a private diagnostics token and used a fixed Google host; this change additionally permits only numeric account and location IDs before constructing the API resource path.\n\n## Validation\n\n- 
px --yes tsx --test website/tests/gbpDiagnostics.test.ts: 2 passed.\n- The complete website suite is left to CI: this Windows-backed worktree encountered an 
pm ci ENOTEMPTY cleanup race, recorded in local evidence, and no package configuration was changed.