### PR TITLE
fix(security): restrict WhatsApp media and webhook URLs

### DIFF
--- a/messaging/channels/whatsapp/gateway/media_helper.js
+++ b/messaging/channels/whatsapp/gateway/media_helper.js
@@ -2,14 +2,17 @@
 const axios = require('axios');
 const { MessageMedia } = require('./index');
 const VideoOptimizer = require('./video_optimizer');
+const { assertPublicHttpsUrl } = require('../security/publicUrl');
 
 async function createMediaFromUrl(url) {
     try {
-        console.log('🔄 Baixando mídia via axios:', url);
+        const safeUrl = await assertPublicHttpsUrl(url);
+        console.log('🔄 Baixando mídia via axios:', safeUrl);
 
-        const response = await axios.get(url, {
+        const response = await axios.get(safeUrl, {
             responseType: 'arraybuffer',
             timeout: 30000,
+            maxRedirects: 0,
             headers: {
                 'User-Agent': 'WhatsApp Bot/1.0'
             },
@@ -32,7 +35,7 @@ async function createMediaFromUrl(url) {
         const base64Data = buffer.toString('base64');
 
         const mimetype = response.headers['content-type'] || 'application/octet-stream';
-        const filename = url.split('/').pop().split('?')[0] || 'media';
+        const filename = new URL(safeUrl).pathname.split('/').pop() || 'media';
         const filesize = buffer.length;
 
         console.log('✅ Mídia processada:');
@@ -52,10 +55,12 @@ async function createMediaFromUrl(url) {
 // Função para validar URL antes de baixar
 async function validateMediaUrl(url) {
     try {
-        console.log('🔍 Validando URL:', url);
+        const safeUrl = await assertPublicHttpsUrl(url);
+        console.log('🔍 Validando URL:', safeUrl);
 
-        const response = await axios.head(url, {
+        const response = await axios.head(safeUrl, {
             timeout: 10000,
+            maxRedirects: 0,
             headers: {
                 'User-Agent': 'WhatsApp Bot/1.0'
             }
@@ -78,7 +83,7 @@ async function validateMediaUrl(url) {
         // WhatsApp Web tem limitações com arquivos muito grandes
         if (contentLength) {
             const sizeMB = parseInt(contentLength) / 1024 / 1024;
-            const isVideo = url.toLowerCase().includes('.mp4') || url.toLowerCase().includes('video') || contentType.includes('video');
+            const isVideo = safeUrl.toLowerCase().includes('.mp4') || safeUrl.toLowerCase().includes('video') || contentType.includes('video');
             const maxSize = isVideo ? 25 : 5;
 
             if (sizeMB > maxSize) {

--- a/messaging/channels/whatsapp/official-module/extensions/media-handler.js
+++ b/messaging/channels/whatsapp/official-module/extensions/media-handler.js
@@ -1,6 +1,7 @@
 const { MessageMedia, Location } = require('../../official');
 const axios = require('axios');
 const MediaConverter = require('./media-converter');
+const { assertPublicHttpsUrl } = require('../../security/publicUrl');
 
 class MediaHandler {
     constructor(client) {
@@ -92,29 +93,8 @@ class MediaHandler {
     }
 
     // Validação de segurança para URLs
-    validateUrl(url) {
-        try {
-            const parsedUrl = new URL(url);
-
-            // Só aceita HTTP/HTTPS
-            if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-                throw new Error('Only HTTP/HTTPS URLs are allowed');
-            }
-
-            // Bloqueia IPs privados básicos
-            const hostname = parsedUrl.hostname.toLowerCase();
-            if (hostname === 'localhost' ||
-                hostname.startsWith('127.') ||
-                hostname.startsWith('192.168.') ||
-                hostname.startsWith('10.') ||
-                hostname.startsWith('172.')) {
-                throw new Error('Private IP addresses are not allowed');
-            }
-
-            return true;
-        } catch (error) {
-            throw new Error(`Invalid URL: ${error.message}`);
-        }
+    async validateUrl(url) {
+        return assertPublicHttpsUrl(url);
     }
 
     async sendImage(number, imageUrl, caption = '') {
@@ -125,7 +105,7 @@ class MediaHandler {
 
     async _sendImageInternal(number, imageUrl, caption = '') {
         try {
-            this.validateUrl(imageUrl);
+            imageUrl = await this.validateUrl(imageUrl);
             const media = await MessageMedia.fromUrl(imageUrl, { unsafeMime: true });
             const chatId = number.includes('@c.us') ? number : `${number}@c.us`;
 
@@ -151,14 +131,14 @@ class MediaHandler {
 
     async _sendVideoInternal(number, videoUrl, caption = '') {
         try {
-            this.validateUrl(videoUrl);
+            videoUrl = await this.validateUrl(videoUrl);
             const chatId = number.includes('@c.us') ? number : `${number}@c.us`;
 
             console.log(`🎬 Iniciando envio de vídeo com otimização automática: ${videoUrl}`);
 
             // 1. VERIFICAR TAMANHO ANTES DO DOWNLOAD (HEAD request para economizar largura de banda)
             try {
-                const headResponse = await axios.head(videoUrl, { timeout: 30000 });
+                const headResponse = await axios.head(videoUrl, { timeout: 30000, maxRedirects: 0 });
                 const contentLength = parseInt(headResponse.headers['content-length'] || '0');
                 const estimatedSizeMB = contentLength / (1024 * 1024);
 
@@ -175,7 +155,8 @@ class MediaHandler {
             const response = await axios.get(videoUrl, {
                 responseType: 'arraybuffer',
                 timeout: 180000, // 3 minutos para download de vídeos grandes
-                maxContentLength: 210 * 1024 * 1024 // Limite de 210MB
+                maxContentLength: 210 * 1024 * 1024, // Limite de 210MB
+                maxRedirects: 0
             });
             const originalBuffer = Buffer.from(response.data);
             const originalMimetype = response.headers['content-type'] || 'video/mp4';
@@ -250,7 +231,7 @@ class MediaHandler {
 
     async _sendDocumentInternal(number, documentUrl, caption = '', filename = null) {
         try {
-            this.validateUrl(documentUrl);
+            documentUrl = await this.validateUrl(documentUrl);
             const media = await MessageMedia.fromUrl(documentUrl, { unsafeMime: true });
             if (filename) {
                 media.filename = filename;
@@ -280,7 +261,7 @@ class MediaHandler {
 
     async _sendAudioInternal(number, audioUrl) {
         try {
-            this.validateUrl(audioUrl);
+            audioUrl = await this.validateUrl(audioUrl);
             const chatId = number.includes('@c.us') ? number : `${number}@c.us`;
 
             console.log(`🎵 Iniciando envio de áudio com conversão automática: ${audioUrl}`);
@@ -288,7 +269,8 @@ class MediaHandler {
             // 1. BAIXAR ARQUIVO ORIGINAL
             const response = await axios.get(audioUrl, {
                 responseType: 'arraybuffer',
-                timeout: 30000
+                timeout: 30000,
+                maxRedirects: 0
             });
             const originalBuffer = Buffer.from(response.data);
             const originalMimetype = response.headers['content-type'] || 'audio/wav';
@@ -357,7 +339,7 @@ class MediaHandler {
 
     async sendSticker(number, stickerUrl) {
         try {
-            this.validateUrl(stickerUrl);
+            stickerUrl = await this.validateUrl(stickerUrl);
             const media = await MessageMedia.fromUrl(stickerUrl, { unsafeMime: true });
             const chatId = number.includes('@c.us') ? number : `${number}@c.us`;
 

--- a/messaging/channels/whatsapp/official-module/official-whatsapp.js
+++ b/messaging/channels/whatsapp/official-module/official-whatsapp.js
@@ -7,6 +7,7 @@ const os = require('os');
 const fs = require('fs');
 const helmet = require('helmet');
 const session = require('express-session');
+const { assertPublicHttpsUrl } = require('../security/publicUrl');
 
 // Import security middleware
 const {
@@ -230,8 +231,9 @@ async function dispatchWebhook(webhook, fullPayload, attempt = 1) {
     const bodyString = JSON.stringify(fullPayload);
 
     try {
+        const safeUrl = await assertPublicHttpsUrl(webhook.url);
         const signature = crypto.createHmac('sha256', webhook.secret || 'default_secret').update(bodyString).digest('hex');
-        await axios.post(webhook.url, bodyString, {
+        await axios.post(safeUrl, bodyString, {
             headers: {
                 'Content-Type': 'application/json',
                 'X-Webhook-Id': webhook.id,
@@ -240,7 +242,8 @@ async function dispatchWebhook(webhook, fullPayload, attempt = 1) {
                 'X-Event-Type': fullPayload.event,
                 'X-Event-Version': '1'
             },
-            timeout: 10000
+            timeout: 10000,
+            maxRedirects: 0
         });
     } catch (e) {
         status = 'error';
@@ -1540,7 +1543,7 @@ app.post('/start-client', async (req, res) => {
 // ========== WEBHOOK APIs ==========
 
 // Create webhook
-app.post('/v1/webhooks', (req, res) => {
+app.post('/v1/webhooks', authenticate({ required: true }), async (req, res) => {
     try {
         const { url, secret, events = [] } = req.body;
 
@@ -1548,9 +1551,10 @@ app.post('/v1/webhooks', (req, res) => {
             return res.status(400).json({ success: false, error: 'URL is required' });
         }
 
+        const safeUrl = await assertPublicHttpsUrl(url);
         const webhook = {
             id: crypto.randomUUID(),
-            url: url,
+            url: safeUrl,
             secret: secret || crypto.randomUUID(),
             events: Array.isArray(events) ? events : [],
             active: true,
@@ -1571,7 +1575,7 @@ app.post('/v1/webhooks', (req, res) => {
 });
 
 // List webhooks
-app.get('/v1/webhooks', (req, res) => {
+app.get('/v1/webhooks', authenticate({ required: true }), (req, res) => {
     try {
         res.json({
             success: true,
@@ -1585,7 +1589,7 @@ app.get('/v1/webhooks', (req, res) => {
 });
 
 // Delete webhook
-app.delete('/v1/webhooks/:id', (req, res) => {
+app.delete('/v1/webhooks/:id', authenticate({ required: true }), (req, res) => {
     try {
         const webhookId = req.params.id;
         const index = webhooksStore.findIndex(w => w.id === webhookId);
@@ -1607,7 +1611,7 @@ app.delete('/v1/webhooks/:id', (req, res) => {
 });
 
 // Test webhook
-app.post('/v1/webhooks/test', (req, res) => {
+app.post('/v1/webhooks/test', authenticate({ required: true }), (req, res) => {
     try {
         const { webhookId, eventType = 'test' } = req.body;
 
@@ -1630,7 +1634,7 @@ app.post('/v1/webhooks/test', (req, res) => {
 });
 
 // Get webhook deliveries
-app.get('/v1/webhooks/:id/deliveries', (req, res) => {
+app.get('/v1/webhooks/:id/deliveries', authenticate({ required: true }), (req, res) => {
     try {
         const webhookId = req.params.id;
         const limit = parseInt(req.query.limit) || 50;

--- a/messaging/channels/whatsapp/official/src/structures/MessageMedia.js
+++ b/messaging/channels/whatsapp/official/src/structures/MessageMedia.js
@@ -5,6 +5,7 @@ const path = require('path');
 const mime = require('mime');
 const fetch = require('node-fetch');
 const { URL } = require('url');
+const { assertPublicHttpsUrl } = require('../../../security/publicUrl');
 
 /**
  * Media attached to a message
@@ -65,7 +66,8 @@ class MessageMedia {
      * @returns {Promise<MessageMedia>}
      */
     static async fromUrl(url, options = {}) {
-        const pUrl = new URL(url);
+        const safeUrl = await assertPublicHttpsUrl(url);
+        const pUrl = new URL(safeUrl);
         let mimetype = mime.getType(pUrl.pathname);
 
         if (!mimetype && !options.unsafeMime)
@@ -73,7 +75,7 @@ class MessageMedia {
 
         async function fetchData (url, options) {
             const reqOptions = Object.assign({ headers: { accept: 'image/* video/* text/* audio/*' } }, options);
-            const response = await fetch(url, reqOptions);
+            const response = await fetch(url, { ...reqOptions, redirect: 'error' });
             const mime = response.headers.get('Content-Type');
             const size = response.headers.get('Content-Length');
 
@@ -95,8 +97,8 @@ class MessageMedia {
         }
 
         const res = options.client
-            ? (await options.client.pupPage.evaluate(fetchData, url, options.reqOptions))
-            : (await fetchData(url, options.reqOptions));
+            ? (await options.client.pupPage.evaluate(fetchData, safeUrl, options.reqOptions))
+            : (await fetchData(safeUrl, options.reqOptions));
 
         const filename = options.filename ||
             (res.name ? res.name[0] : (pUrl.pathname.split('/').pop() || 'file'));

--- a/messaging/channels/whatsapp/security/publicUrl.js
+++ b/messaging/channels/whatsapp/security/publicUrl.js
@@ -1,0 +1,50 @@
+const dns = require('dns').promises;
+const net = require('net');
+
+function isPrivateIpAddress(address) {
+    if (net.isIP(address) === 4) {
+        const [first, second] = address.split('.').map(Number);
+        return first === 0 || first === 10 || first === 127 ||
+            (first === 169 && second === 254) ||
+            (first === 172 && second >= 16 && second <= 31) ||
+            (first === 192 && second === 168) || first >= 224;
+    }
+
+    const normalized = address.toLowerCase();
+    return normalized === '::1' || normalized === '::' ||
+        normalized.startsWith('fc') || normalized.startsWith('fd') ||
+        normalized.startsWith('fe8') || normalized.startsWith('fe9') ||
+        normalized.startsWith('fea') || normalized.startsWith('feb');
+}
+
+function parsePublicHttpsUrl(value) {
+    if (typeof value !== 'string') throw new Error('URL must be a string');
+
+    const url = new URL(value);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port) {
+        throw new Error('Only credential-free HTTPS URLs on the default port are allowed');
+    }
+
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    if (hostname.toLowerCase() === 'localhost' ||
+        (net.isIP(hostname) && isPrivateIpAddress(hostname))) {
+        throw new Error('Private network URLs are not allowed');
+    }
+
+    return url;
+}
+
+async function assertPublicHttpsUrl(value) {
+    const url = parsePublicHttpsUrl(value);
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    if (net.isIP(hostname)) return url.toString();
+
+    const addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+    if (!addresses.length || addresses.some(({ address }) => isPrivateIpAddress(address))) {
+        throw new Error('URL hostname resolves to a private or invalid address');
+    }
+
+    return url.toString();
+}
+
+module.exports = { assertPublicHttpsUrl, isPrivateIpAddress, parsePublicHttpsUrl };

--- a/messaging/channels/whatsapp/security/test/publicUrl.test.js
+++ b/messaging/channels/whatsapp/security/test/publicUrl.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { isPrivateIpAddress, parsePublicHttpsUrl } = require('../publicUrl');
+
+test('accepts credential-free HTTPS public URL syntax', () => {
+    assert.equal(parsePublicHttpsUrl('https://cdn.example.com/media/file.jpg').hostname, 'cdn.example.com');
+});
+
+test('rejects private, credentialed and non-HTTPS URL syntax before network access', () => {
+    for (const value of [
+        'http://cdn.example.com/file.jpg',
+        'https://user:pass@cdn.example.com/file.jpg',
+        'https://localhost/file.jpg',
+        'https://127.0.0.1/file.jpg',
+        'https://192.168.0.10/file.jpg',
+        'https://[::1]/file.jpg',
+        'https://cdn.example.com:8443/file.jpg'
+    ]) {
+        assert.throws(() => parsePublicHttpsUrl(value));
+    }
+
+    assert.equal(isPrivateIpAddress('10.0.0.1'), true);
+    assert.equal(isPrivateIpAddress('8.8.8.8'), false);
+    assert.equal(isPrivateIpAddress('::1'), true);
+});


### PR DESCRIPTION
## Security remediation\n\nAddresses CodeQL critical request-forgery alerts #4290 through #4295.\n\n- media and webhook destinations must be credential-free HTTPS URLs on the default port;\n- private, loopback, link-local, multicast and DNS-resolved private addresses are rejected;\n- redirects are disabled for outbound media/webhook requests;\n- webhook management routes require existing authentication and destinations are validated again when dispatched.\n\n## Validation\n\n- 
ode --test messaging/channels/whatsapp/security/test/publicUrl.test.js: 2 passed, including IPv4 and IPv6 private-address cases.\n- Syntax checks passed for all four modified request paths.\n\nRuntime deployment is intentionally deferred to the approved messaging-whatsapp cutover; the active legacy unit remains the rollback surface.