### PR TITLE
fix(security): restrict credentialed CRM CORS origins

### DIFF
--- a/crm/api/package-lock.json
+++ b/crm/api/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "exceljs": "^4.4.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.2.2",
         "googleapis": "^173.0.0",
         "http-proxy-middleware": "^3.0.5",
         "luxon": "^3.7.0",
@@ -859,6 +860,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1493,6 +1512,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2815,13 +2843,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "exceljs": "^4.4.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.2.2",
     "googleapis": "^173.0.0",
     "http-proxy-middleware": "^3.0.5",
     "luxon": "^3.7.0",
@@ -26,6 +27,7 @@
   },
   "overrides": {
     "glob": "^13.0.6",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "uuid": "11.1.1"
   }
 }

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -32,6 +32,7 @@ import { startHarmoniaWorker } from './server/harmonia/worker.js'
 import { createTrackingDashboardRouter } from './server/trackingDashboardRoutes.js'
 import { createAtendimentoRouter } from './server/atendimento/routes.js'
 import { parseUnifiedChannelId, unifiedChannelUrl, unifiedSystemUrl } from './server/unifiedSystemUrl.js'
+import { configuredCorsOrigins, isAllowedCrmCorsOrigin } from './server/corsPolicy.js'
 
 // Axios for facade requests to Unified System
 import axios from 'axios'
@@ -497,9 +498,22 @@ app.get('/api/core/status', async (req, res) => {
     }
 })
 
-// Critical: Enhanced CORS configuration to prevent API access issues
+const CRM_CORS_ORIGINS = configuredCorsOrigins()
+const isAllowedCorsOrigin = (origin) => isAllowedCrmCorsOrigin(origin, { allowedOrigins: CRM_CORS_ORIGINS })
+const setAllowedCorsHeaders = (req, res) => {
+    const origin = req.headers.origin
+    if (!origin || !isAllowedCorsOrigin(origin)) return false
+    res.header('Access-Control-Allow-Origin', origin)
+    res.header('Access-Control-Allow-Credentials', 'true')
+    res.header('Vary', 'Origin')
+    return true
+}
+
+// Credentialed CORS is restricted to explicit product origins.
 app.use(cors({
-    origin: true, // Allow all origins in development
+    origin(origin, callback) {
+        callback(null, isAllowedCorsOrigin(origin))
+    },
     credentials: true, // Essential for SSE/EventSource and auth cookies
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
     allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'X-Requested-With', 'Accept', 'X-CSRF-Token', 'X-Tenant-Key', 'X-User-Role', 'X-CRM-Role', 'X-Role'],
@@ -510,10 +524,11 @@ app.use(cors({
 // Handle preflight OPTIONS requests early to prevent middleware conflicts
 app.use((req, res, next) => {
     if (req.method === 'OPTIONS') {
-        res.header('Access-Control-Allow-Origin', req.headers.origin || '*')
+        if (req.headers.origin && !setAllowedCorsHeaders(req, res)) {
+            return res.sendStatus(403)
+        }
         res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS,PATCH')
         res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control, X-Requested-With, Accept, X-CSRF-Token, X-Tenant-Key, X-User-Role, X-CRM-Role, X-Role')
-        res.header('Access-Control-Allow-Credentials', 'true')
         return res.sendStatus(200)
     }
     next()
@@ -3428,8 +3443,7 @@ app.get('/api/ai-suppression/events', (req, res) => {
     res.setHeader('Pragma', 'no-cache')
     res.setHeader('Expires', '0')
     res.setHeader('Connection', 'keep-alive')
-    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*')
-    res.setHeader('Access-Control-Allow-Credentials', 'true')
+    setAllowedCorsHeaders(req, res)
     res.setHeader('X-Accel-Buffering', 'no') // Disable nginx buffering
 
     // Flush headers immediately
@@ -3518,8 +3532,7 @@ app.get('/api/conversations/events', (req, res) => {
     res.setHeader('Pragma', 'no-cache')
     res.setHeader('Expires', '0')
     res.setHeader('Connection', 'keep-alive')
-    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*')
-    res.setHeader('Access-Control-Allow-Credentials', 'true')
+    setAllowedCorsHeaders(req, res)
     res.setHeader('X-Accel-Buffering', 'no') // Disable proxy buffering
 
     // Flush headers and set status immediately

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import cors from 'cors'
+import { rateLimit } from 'express-rate-limit'
 import { randomUUID, createHmac, timingSafeEqual, randomBytes, createHash, createCipheriv, createDecipheriv } from 'crypto'
 import nodeUtil from 'node:util'
 import { promises as fs } from 'fs'
@@ -500,6 +501,7 @@ app.get('/api/core/status', async (req, res) => {
 
 const CRM_CORS_ORIGINS = configuredCorsOrigins()
 const isAllowedCorsOrigin = (origin) => isAllowedCrmCorsOrigin(origin, { allowedOrigins: CRM_CORS_ORIGINS })
+const CRM_API_RATE_LIMIT_PER_MIN = Math.max(30, Math.min(10_000, Number(process.env.CRM_API_RATE_LIMIT_PER_MIN || 300) || 300))
 const setAllowedCorsHeaders = (req, res) => {
     const origin = req.headers.origin
     if (!origin || !isAllowedCorsOrigin(origin)) return false
@@ -519,6 +521,14 @@ app.use(cors({
     allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'X-Requested-With', 'Accept', 'X-CSRF-Token', 'X-Tenant-Key', 'X-User-Role', 'X-CRM-Role', 'X-Role'],
     exposedHeaders: ['Content-Length', 'X-Total-Count'],
     optionsSuccessStatus: 200 // Legacy browser support
+}))
+
+app.use('/api', rateLimit({
+    windowMs: 60_000,
+    limit: CRM_API_RATE_LIMIT_PER_MIN,
+    standardHeaders: 'draft-8',
+    legacyHeaders: false,
+    message: { success: false, error: 'RATE_LIMITED', hint: 'Too many requests. Try again soon.' }
 }))
 
 // Handle preflight OPTIONS requests early to prevent middleware conflicts

--- a/crm/api/server/__tests__/corsPolicy.test.js
+++ b/crm/api/server/__tests__/corsPolicy.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { configuredCorsOrigins, isAllowedCrmCorsOrigin } from '../corsPolicy.js'
+
+test('allows only explicit production CRM origins', () => {
+    const allowed = configuredCorsOrigins('https://crm.skincos.com.br,https://espacofacial.com')
+    assert.equal(isAllowedCrmCorsOrigin('https://crm.skincos.com.br', { allowedOrigins: allowed, environment: 'production' }), true)
+    assert.equal(isAllowedCrmCorsOrigin('https://attacker.invalid', { allowedOrigins: allowed, environment: 'production' }), false)
+    assert.equal(isAllowedCrmCorsOrigin('https://crm.skincos.com.br.evil.invalid', { allowedOrigins: allowed, environment: 'production' }), false)
+})
+
+test('permits loopback development origins but never production wildcard behavior', () => {
+    const allowed = configuredCorsOrigins('https://crm.skincos.com.br')
+    assert.equal(isAllowedCrmCorsOrigin('http://localhost:5173', { allowedOrigins: allowed, environment: 'development' }), true)
+    assert.equal(isAllowedCrmCorsOrigin('http://localhost:5173', { allowedOrigins: allowed, environment: 'production' }), false)
+    assert.equal(isAllowedCrmCorsOrigin('null', { allowedOrigins: allowed, environment: 'development' }), false)
+})

--- a/crm/api/server/corsPolicy.js
+++ b/crm/api/server/corsPolicy.js
@@ -1,0 +1,37 @@
+const PRODUCTION_ORIGINS = Object.freeze([
+    'https://crm.skincos.com.br',
+    'https://espacofacial.com',
+    'https://www.espacofacial.com',
+    'https://espacofacial.com.br',
+    'https://app.espacofacial.com.br'
+])
+
+export function configuredCorsOrigins(value = process.env.CRM_CORS_ALLOWED_ORIGINS) {
+    const configured = String(value || '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+
+    return new Set(configured.length ? configured : PRODUCTION_ORIGINS)
+}
+
+export function isAllowedCrmCorsOrigin(origin, {
+    allowedOrigins = configuredCorsOrigins(),
+    environment = process.env.NODE_ENV || 'development'
+} = {}) {
+    if (!origin) return true
+
+    let parsed
+    try {
+        parsed = new URL(origin)
+    } catch {
+        return false
+    }
+
+    if (parsed.origin !== origin) return false
+    if (allowedOrigins.has(origin)) return true
+
+    return environment !== 'production' &&
+        parsed.protocol === 'http:' &&
+        (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')
+}


### PR DESCRIPTION
## Security remediation

Fixes CodeQL high CORS findings #4341 through #4343 and adds a real API-wide request limit for the CRM routes identified by #4255 through #4267.

- credentialed CORS has an explicit production allowlist;
- loopback is allowed only outside production;
- OPTIONS and SSE use the same origin decision;
- all CRM /api routes use express-rate-limit, configurable through CRM_API_RATE_LIMIT_PER_MIN;
- uuid is overridden to 11.1.1, removing the audited exceljs transitive advisory.

## Validation

- npm audit --omit=dev: 0 vulnerabilities.
- npm test: 76 passed.
- node --check crm/api/server.js: passed.