### PR TITLE
fix(security): constrain CRM WhatsApp media URLs

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -32,6 +32,7 @@ import { startHarmoniaWorker } from './server/harmonia/worker.js'
 import { createTrackingDashboardRouter } from './server/trackingDashboardRoutes.js'
 import { createAtendimentoRouter } from './server/atendimento/routes.js'
 import { parseUnifiedChannelId, unifiedChannelUrl, unifiedSystemUrl } from './server/unifiedSystemUrl.js'
+import { resolveEvolutionMediaUrl } from './server/whatsappMediaUrl.js'
 
 // Axios for facade requests to Unified System
 import axios from 'axios'
@@ -4848,18 +4849,7 @@ function extractEvolutionMessageMeta(message) {
             msg?.ptvMessage?.directPath ||
             msg?.stickerMessage?.directPath
         )
-        const buildFromDirectPath = (value) => {
-            const path = String(value || '').trim()
-            if (!path) return undefined
-            if (path.startsWith('http://') || path.startsWith('https://')) return path
-            if (path.startsWith('/')) return `https://mmg.whatsapp.net${path}`
-            return `https://mmg.whatsapp.net/${path}`
-        }
-        const rawCandidate = typeof candidate === 'string' ? candidate.trim() : ''
-        const directUrl = buildFromDirectPath(directPath)
-        if (rawCandidate && !rawCandidate.startsWith('https://web.whatsapp.net')) return rawCandidate
-        if (directUrl) return directUrl
-        return rawCandidate || undefined
+        return resolveEvolutionMediaUrl(candidate, directPath)
     }
     const resolveMimeType = (msg) => {
         const candidate = (

--- a/crm/api/server/__tests__/whatsappMediaUrl.test.js
+++ b/crm/api/server/__tests__/whatsappMediaUrl.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveEvolutionMediaUrl } from '../whatsappMediaUrl.js'
+
+test('builds a fixed WhatsApp media URL from a direct path', () => {
+    assert.equal(
+        resolveEvolutionMediaUrl(undefined, '/v/t62.7118-24/123?token=abc'),
+        'https://mmg.whatsapp.net/v/t62.7118-24/123?token=abc'
+    )
+})
+
+test('rejects arbitrary, prefix-confusion and protocol-relative media URLs', () => {
+    for (const value of [
+        'https://web.whatsapp.net.evil.invalid/file',
+        'https://attacker.invalid/file',
+        'http://mmg.whatsapp.net/file',
+        'javascript:alert(1)'
+    ]) {
+        assert.equal(resolveEvolutionMediaUrl(value, undefined), undefined)
+    }
+
+    assert.equal(resolveEvolutionMediaUrl(undefined, '//attacker.invalid/file'), undefined)
+})

--- a/crm/api/server/whatsappMediaUrl.js
+++ b/crm/api/server/whatsappMediaUrl.js
@@ -1,0 +1,25 @@
+const WHATSAPP_MEDIA_ORIGIN = 'https://mmg.whatsapp.net'
+
+function normalizeWhatsappMediaUrl(value) {
+    if (typeof value !== 'string' || !value.trim()) return undefined
+
+    try {
+        const url = new URL(value.trim())
+        if (url.protocol !== 'https:' || url.hostname !== 'mmg.whatsapp.net') return undefined
+        return url.toString()
+    } catch {
+        return undefined
+    }
+}
+
+export function resolveEvolutionMediaUrl(candidate, directPath) {
+    const directValue = typeof directPath === 'string' ? directPath.trim() : ''
+    const directUrl = normalizeWhatsappMediaUrl(directValue)
+    if (directUrl) return directUrl
+
+    if (directValue && !directValue.startsWith('//') && !directValue.includes('://')) {
+        return new URL(`/${directValue.replace(/^\/+/, '')}`, WHATSAPP_MEDIA_ORIGIN).toString()
+    }
+
+    return normalizeWhatsappMediaUrl(candidate)
+}


### PR DESCRIPTION
## Security remediation

Fixes CodeQL high finding #4239. Evolution message media URLs are now either built from a direct path against the fixed WhatsApp media origin or accepted only when their parsed host is exactly mmg.whatsapp.net over HTTPS.

## Validation

- node --test crm/api/server/__tests__/whatsappMediaUrl.test.js: 2 passed.
- node --check crm/api/server.js: passed.