### PR TITLE
ci(security): cover active domains with CodeQL

### DIFF
--- a/.github/workflows/crm-codeql.yml
+++ b/.github/workflows/crm-codeql.yml
@@ -8,8 +8,16 @@ on:
       - develop
     paths:
       - "crm/console/**"
+      - "crm/api/**"
       - "website/**"
       - "backend/**"
+      - "messaging/**"
+      - "orb/**"
+      - "api/**"
+      - "booking/**"
+      - "integration/**"
+      - "service/**"
+      - "social/**"
       - ".github/workflows/crm-codeql.yml"
       - ".github/codeql/**"
   pull_request:
@@ -18,13 +26,22 @@ on:
       - develop
     paths:
       - "crm/console/**"
+      - "crm/api/**"
       - "website/**"
       - "backend/**"
+      - "messaging/**"
+      - "orb/**"
+      - "api/**"
+      - "booking/**"
+      - "integration/**"
+      - "service/**"
+      - "social/**"
       - ".github/workflows/crm-codeql.yml"
       - ".github/codeql/**"
   schedule:
     # Executa semanalmente às quartas-feiras às 02:00 UTC
     - cron: "0 2 * * 3"
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/docs/architecture/code-scanning-baseline-triage.md
+++ b/docs/architecture/code-scanning-baseline-triage.md
@@ -62,6 +62,34 @@ proof that the underlying code is safe.
 - Orb Graph API helpers accept only resource paths, rejecting absolute URLs,
   query injection, and dot segments before constructing a request URL.
 
+## Remediation wave: 2026-07-14
+
+The following alerts were handled from their individual GitHub instances. The
+private evidence bundle records the alert number, path, ref and exact sink;
+this table records the source-control outcome without copying credentials,
+clinical data or request payloads into Git.
+
+| Alert IDs | Classification | Outcome |
+| --- | --- | --- |
+| CodeQL `#4285`–`#4289` | First-party reachable CRM Unified System facade | Fixed by constraining channels, ports and paths; regression tests are part of `crm/api` test. |
+| CodeQL `#4290`–`#4295` | First-party reachable WhatsApp media and webhook requests | Fixed with HTTPS-only public destination validation, DNS private-address rejection, no redirects and authenticated webhook management. |
+| CodeQL `#4344`–`#4345` | First-party gateway query input | Fixed by accepting only scalar, normalized WhatsApp IDs. |
+| CodeQL `#2542`–`#2543` | First-party GBP diagnostics resource path | Fixed by accepting only numeric account/location identifiers after diagnostics authentication. |
+| CodeQL `#4341`–`#4343` | First-party credentialed CRM CORS | Fixed with explicit origins; origin reflection is removed. |
+| CodeQL `#4239` | First-party CRM WhatsApp media URL | Fixed by accepting only parsed HTTPS `mmg.whatsapp.net` URLs or fixed-origin direct paths. |
+| CodeQL `#4255`–`#4267` | First-party CRM API exhaustion surface | Fixed with an API-wide `express-rate-limit` middleware; no sensitive route is skipped. |
+| CodeQL `#108` | First-party command injection | Source fix is integrated; an analysis from the current `main` revision is required before the historic instance is considered closed. |
+| CodeQL `#164`–`#177`, `#124`–`#125` | Historical moved paths | The recorded `backend/apps/**` paths are absent from the canonical tree. They remain open only until a current scan replaces historical instances; no path exclusion was added. |
+
+### Current-analysis requirement
+
+The CodeQL workflow formerly did not trigger on `crm/api`, `messaging`, `orb`
+or the other root domains. It now does, and it supports `workflow_dispatch`.
+After the coverage change reaches `main`, trigger the workflow against `main`,
+then inspect each remaining alert instance at that ref. A finding may be marked
+historical only when its recorded path is absent and no current-ref instance is
+open; a finding in a current active path remains a remediation task.
+
 ## Merge boundary
 
 The domain move may proceed only after the required repository CI checks pass,


### PR DESCRIPTION
## Security coverage correction

The CodeQL workflow previously triggered only for crm/console, website and backend changes. Active crm/api, messaging, orb and API domain changes could merge without a fresh CodeQL run.

This adds those active domains to push and pull request triggers and enables deliberate workflow dispatch for stale-alert reconciliation. It does not add any ignore or suppression.

Validation: YAML parsed successfully with PyYAML and git diff --check passed.