### PR TITLE
fix(ci): smoke deployed workers by ownership

### DIFF
--- a/.github/scripts/test_workers_smoke.py
+++ b/.github/scripts/test_workers_smoke.py
@@ -1,0 +1,41 @@
+"""Regression tests for the post-deploy API and Inventory smoke helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("workers_smoke.py")
+SPEC = importlib.util.spec_from_file_location("workers_smoke", MODULE_PATH)
+assert SPEC and SPEC.loader
+workers_smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(workers_smoke)
+
+
+class WorkersSmokeTests(unittest.TestCase):
+    def test_normalize_base_url_accepts_https_origin(self) -> None:
+        self.assertEqual(workers_smoke.normalize_base_url("https://api.skincos.com.br/"), "https://api.skincos.com.br")
+
+    def test_normalize_base_url_rejects_non_origin_inputs(self) -> None:
+        for value in (
+            "http://api.skincos.com.br",
+            "https://api.skincos.com.br/insumos",
+            "https://user@example.com",
+            "https://api.skincos.com.br/?next=x",
+            "https://api.skincos.com.br/#fragment",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    workers_smoke.normalize_base_url(value)
+
+    def test_require_worker_health_checks_expected_identity_and_readiness(self) -> None:
+        workers_smoke.require_worker_health({"ok": True, "service": "api"}, service="api")
+        workers_smoke.require_worker_health({"ok": True, "ready": True, "service": "insumos"}, service="insumos", require_ready=True)
+        with self.assertRaises(RuntimeError):
+            workers_smoke.require_worker_health({"ok": True, "service": "api"}, service="insumos", require_ready=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/workers_smoke.py
+++ b/.github/scripts/workers_smoke.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Smoke-check the public API and Inventory Workers after a deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+
+
+def normalize_base_url(value: str) -> str:
+    parsed = urlparse(value.strip())
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in ("", "/")
+    ):
+        raise ValueError("API base URL must be an HTTPS origin without a path, query, fragment, or credentials")
+    return f"https://{parsed.netloc}"
+
+
+def fetch_json(base_url: str, path: str, timeout: int, user_agent: str) -> dict:
+    request = urllib.request.Request(f"{base_url}{path}", headers={"User-Agent": user_agent})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8", "strict"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"{path} returned HTTP {exc.code}: {body[:500]}") from exc
+    except (URLError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{path} did not return a valid JSON response") from exc
+
+
+def require_worker_health(payload: dict, *, service: str, require_ready: bool = False) -> None:
+    if payload.get("ok") is not True:
+        raise RuntimeError(f"{service} health ok=false: {payload}")
+    if payload.get("service") != service:
+        raise RuntimeError(f"{service} health returned unexpected service: {payload}")
+    if require_ready and payload.get("ready") is not True:
+        raise RuntimeError(f"{service} health ready=false: {payload}")
+
+
+def check_once(args: argparse.Namespace) -> None:
+    api = fetch_json(args.api_base_url, "/health", args.timeout, args.user_agent)
+    require_worker_health(api, service="api")
+
+    inventory = fetch_json(args.api_base_url, "/insumos/health", args.timeout, args.user_agent)
+    require_worker_health(inventory, service="insumos", require_ready=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run public API and Inventory Worker smoke checks")
+    parser.add_argument("--api-base-url", default=os.environ.get("API_BASE_URL", "https://api.skincos.com.br"))
+    parser.add_argument("--attempts", type=int, default=5)
+    parser.add_argument("--sleep-seconds", type=int, default=6)
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--user-agent", default="Mozilla/5.0 (compatible; WorkersAfterAutomergeSmoke/1.0)")
+    args = parser.parse_args()
+    args.api_base_url = normalize_base_url(args.api_base_url)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    for attempt in range(1, max(1, args.attempts) + 1):
+        try:
+            check_once(args)
+            print("API and Inventory Worker smoke check OK")
+            return 0
+        except Exception as exc:
+            print(f"Attempt {attempt} failed: {exc}", file=sys.stderr)
+            if attempt >= max(1, args.attempts):
+                return 1
+            time.sleep(max(0, args.sleep_seconds))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -133,18 +133,16 @@ jobs:
           set -euo pipefail
           bash backend/scripts/cloudflare-workers.sh deploy-all
 
-      - name: Smoke check Ponto (production)
+      - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
         env:
-          BASE_URL: https://crm.skincos.com.br
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          API_BASE_URL: https://api.skincos.com.br
         run: |
           set -euo pipefail
-          .github/scripts/ponto_smoke.py \
+          python3 .github/scripts/workers_smoke.py \
             --attempts 5 \
             --sleep-seconds 6 \
-            --user-agent "Mozilla/5.0 (compatible; PontoAfterAutomergeSmoke/1.0)"
+            --user-agent "Mozilla/5.0 (compatible; WorkersAfterAutomergeSmoke/1.0)"
 
       - name: Mark deployed SHA
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}


### PR DESCRIPTION
Corrige o pós-deploy de Workers: ele executava o smoke de Ponto (módulo sem rota pública ativa) após publicar API/Inventário, convertendo um deploy saudável em falha.\n\nAgora valida os endpoints proprietários https://api.skincos.com.br/health e /insumos/health, com identidade e readiness; inclui testes de regressão para o helper.\n\nValidações: testes Python do helper, smoke público, sintaxe YAML e diff Git.