### PR TITLE
fix(ci): apply worker smoke across deploy workflows

### DIFF
--- a/.github/workflows/deploy-core-workers-reconcile.yml
+++ b/.github/workflows/deploy-core-workers-reconcile.yml
@@ -107,12 +107,14 @@ jobs:
           npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars
           npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars
 
-      - name: Smoke check (basic)
+      - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
         run: |
           set -euo pipefail
-          curl -fsS -H 'User-Agent: CoreWorkerSmoke/1.0' https://api.skincos.com.br/insumos/health >/dev/null
-          curl -fsS -H 'User-Agent: CoreWorkerSmoke/1.0' https://api.skincos.com.br/api/ponto/health >/dev/null
+          python3 .github/scripts/workers_smoke.py \
+            --attempts 5 \
+            --sleep-seconds 6 \
+            --user-agent "Mozilla/5.0 (compatible; CoreWorkerReconcileSmoke/1.0)"
 
       - name: Mark deployed SHA
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -64,9 +64,11 @@ jobs:
           npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars
           npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars
 
-      - name: Smoke check (basic)
+      - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
-          curl -fsS -H 'User-Agent: CoreWorkerSmoke/1.0' https://api.skincos.com.br/insumos/health >/dev/null
-          curl -fsS -H 'User-Agent: CoreWorkerSmoke/1.0' https://api.skincos.com.br/api/ponto/health >/dev/null
+          python3 .github/scripts/workers_smoke.py \
+            --attempts 5 \
+            --sleep-seconds 6 \
+            --user-agent "Mozilla/5.0 (compatible; CoreWorkerSmoke/1.0)"

--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -78,15 +78,11 @@ jobs:
             bash backend/scripts/cloudflare-workers.sh deploy --before "$GITHUB_BEFORE_SHA" --after "$GITHUB_SHA"
           fi
 
-      - name: Smoke check Ponto (production)
+      - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.guard.outputs.skip != 'true' && github.ref_name == 'main' }}
-        env:
-          BASE_URL: https://crm.skincos.com.br
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
-          .github/scripts/ponto_smoke.py \
+          python3 .github/scripts/workers_smoke.py \
             --attempts 5 \
             --sleep-seconds 6 \
-            --user-agent "Mozilla/5.0 (compatible; PontoDeploySmoke/1.0)"
+            --user-agent "Mozilla/5.0 (compatible; WorkersDeploySmoke/1.0)"

--- a/.github/workflows/deploy-workers-reconcile.yml
+++ b/.github/workflows/deploy-workers-reconcile.yml
@@ -98,16 +98,12 @@ jobs:
           key: workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
 
-      - name: Smoke check Ponto (production)
+      - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         continue-on-error: true
-        env:
-          BASE_URL: https://crm.skincos.com.br
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
-          .github/scripts/ponto_smoke.py \
+          python3 .github/scripts/workers_smoke.py \
             --attempts 5 \
             --sleep-seconds 6 \
-            --user-agent "Mozilla/5.0 (compatible; PontoWorkersReconcile/1.0)"
+            --user-agent "Mozilla/5.0 (compatible; WorkersReconcileSmoke/1.0)"


### PR DESCRIPTION
Completa a correção do pipeline: todos os workflows de deploy/reconciliação de API e Inventário passam a chamar o smoke proprietário de Workers, em vez de validar a rota do módulo Ponto.\n\nValidações: testes de regressão do helper, smoke público da API/Inventário, parse dos 48 workflows e busca sem referências a Ponto nos workflows de Workers.