### PR TITLE
feat(runtime): stage WhatsApp releases natively

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -1,9 +1,9 @@
 # Lifecycle runtime cutover
 
-This runbook moves active mutable state into the lifecycle layout without
-deleting the legacy tree during the change window. It is intentionally separate
-from the source-layout pull request: a merged path move is never proof that a
-service is safe to rename.
+This runbook moves active mutable state into native Linux filesystem roots
+without deleting the legacy tree during the change window. It is intentionally
+separate from the source-layout pull request: a merged path move is never proof
+that a service is safe to rename.
 
 ## Current validated checkpoint (2026-07-14)
 
@@ -12,9 +12,9 @@ service is safe to rename.
 - Rollback artifacts are staged at
   `C:\CodexRuntime\artifacts\runtime-cutover\20260714T170200Z` and linked
   only into the retained rollback worktree.
-- `C:\CodexRuntime\n8n\backups\daily\20260714T172136Z` has a successful
-  PostgreSQL restore verification. Incomplete `.partial-*` backup attempts
-  were removed after this checkpoint was validated.
+- `C:\CodexRuntime\backups\orb\manual\20260714T233342Z` has a successful
+  PostgreSQL restore verification and matching manifest checksum. Incomplete
+  `.partial-*` backup attempts were removed after this checkpoint was validated.
 - The cutover dry-run, rendered lifecycle units, local health and public Orb/
   CRM health passed. The legacy units remain authoritative until the final
   security-alert triage and scheduled cut window are complete.
@@ -56,8 +56,10 @@ drop-in to the lifecycle unit.
 3. `skincos-n8n-backup.service` has completed with `VERIFY_RESTORE=1`; record
    the resulting directory under `C:\CodexRuntime\n8n\backups\daily` and
    validate its manifest checksum before the cut.
-4. `scripts/runtime/prepare-lifecycle-layout.sh` and
-   `scripts/runtime/install-lifecycle-units.sh` both pass dry-run validation.
+4. `scripts/runtime/prepare-lifecycle-layout.sh`,
+   `scripts/runtime/install-lifecycle-units.sh`, and the WhatsApp release
+   launcher checks all pass. The reviewed main SHA is recorded for the native
+   WhatsApp release.
 5. The window owner has WSL `sudo -n` access. No regular code deploy, D1
    migration or workflow save runs during the window.
 
@@ -69,17 +71,37 @@ Run the pre-copy before the window; it does not stop services or remove data:
 scripts/runtime/prepare-lifecycle-layout.sh --apply
 ```
 
-On this Windows host, lifecycle copies under `C:\CodexRuntime` use native
-`robocopy` by default. It prevents WSL/DrvFS copy stalls while preserving the
-pre-copy rule (copy only missing files); final sync copies changed files but
-never deletes a legacy source or destination-only artifact. Set
-`LIFECYCLE_SYNC_TRANSPORT=rsync` only for a non-Windows runtime or an explicit
-diagnostic.
+The helper copies from the legacy Windows runtime into these native roots:
+
+- state and caches: `/var/lib/skincos-runtime`;
+- private configuration and secrets: `/etc/skincos` (root-owned, group
+  readable only by `skincos`);
+- logs: `/var/log/skincos`;
+- temporary data: `/var/tmp/skincos`.
+
+Backups and durable artifacts remain under `C:\CodexRuntime`. The pre-copy rule
+still applies (copy only missing files); final sync copies changed files but
+never deletes a legacy source or destination-only artifact. Copies from DrvFS
+to Linux use `rsync` under `sudo`, avoiding a runtime dependency on DrvFS.
 
 The pre-copy also transfers the active Livia workflow from the retained legacy
-source into `C:\CodexRuntime\state\orb\workflows`. The lifecycle Orb unit and
+source into `/var/lib/skincos-runtime/orb/workflows`. The lifecycle Orb unit and
 the official validator read this runtime location; no workflow state is copied
 into the new checkout.
+
+Before stopping the legacy WhatsApp service, stage the reviewed release on the
+native filesystem. This command is intentionally explicit about the release
+SHA and fails if the native lockfile install, Prisma generation or build cannot
+produce `dist/main.js`:
+
+```bash
+MESSAGING_RELEASE_ID=<reviewed-main-sha> \
+  scripts/runtime/prepare-messaging-whatsapp-release.sh --apply
+```
+
+The future `messaging-whatsapp.service` starts only
+`/opt/skincos/current/messaging-whatsapp/dist/main.js`; it never executes
+`npm install`, runs a build, or reads a worktree at service start.
 
 At the window, first stage and verify the non-Git rollback artifacts while
 legacy services are still healthy. This is non-disruptive and creates only
@@ -107,12 +129,12 @@ artifact directory:
 
 ```bash
 scripts/runtime/cutover-lifecycle-runtime.sh \
-  --backup-dir /mnt/c/CodexRuntime/n8n/backups/daily/<timestamp> \
+  --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
 
 scripts/runtime/cutover-lifecycle-runtime.sh --apply \
-  --backup-dir /mnt/c/CodexRuntime/n8n/backups/daily/<timestamp> \
+  --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
 ```
@@ -140,7 +162,8 @@ continue unless its runtime artifact links resolve to the staged bundle.
 
 ## Secret handling
 
-The copy helper reads no secret values to stdout. It relocates tunnel credential
-files into `C:\CodexRuntime\secrets`, rewrites only the local config file path,
-and applies a Windows ACL limited to `admin` and `LocalSystem`. No credential is
-written to the repository or to a worktree.
+The copy helper reads no secret values to stdout. It relocates private
+environment files and tunnel credentials into `/etc/skincos`, rewrites only the
+local tunnel config path, and restricts access to `root:skincos` with no
+world-readable permission. No credential is written to the repository or to a
+worktree.

--- a/ops/runtime/units/messaging-whatsapp.service
+++ b/ops/runtime/units/messaging-whatsapp.service
@@ -7,14 +7,15 @@ Wants=network-online.target
 Type=simple
 User=skincos
 Group=skincos
-WorkingDirectory=__REPO_ROOT__/messaging/channels/whatsapp/engine
+WorkingDirectory=/opt/skincos/current/messaging-whatsapp
+Environment=MESSAGING_RELEASE_ROOT=/opt/skincos/current/messaging-whatsapp
 Environment=WHATSAPP_RUNTIME_HOME=__STATE_ROOT__/messaging-whatsapp
 Environment=EVOLUTION_API_ENV_FILE=__CONFIG_ROOT__/messaging-whatsapp.env
 Environment=EVOLUTION_API_INSTANCES_DIR=__STATE_ROOT__/messaging-whatsapp/instances
 Environment=EVOLUTION_API_STORE_DIR=__STATE_ROOT__/messaging-whatsapp/store
 Environment=NODE20_BIN=/usr/bin
 EnvironmentFile=-__CONFIG_ROOT__/messaging-whatsapp.env
-ExecStart=/bin/bash -lc 'exec ./start-evolution-api.sh'
+ExecStart=__REPO_ROOT__/scripts/runtime/run-messaging-whatsapp-release.sh
 Restart=always
 RestartSec=10
 NoNewPrivileges=true

--- a/scripts/runtime/prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/prepare-messaging-whatsapp-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_DIR="$ROOT_DIR/messaging/channels/whatsapp/engine"
+RELEASE_BASE="${MESSAGING_RELEASE_BASE:-/opt/skincos/releases}"
+CURRENT_LINK="${MESSAGING_CURRENT_LINK:-/opt/skincos/current/messaging-whatsapp}"
+RELEASE_ID="${MESSAGING_RELEASE_ID:-}"
+DESTINATION="$RELEASE_BASE/$RELEASE_ID/messaging-whatsapp"
+APPLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/prepare-messaging-whatsapp-release.sh [--apply]
+
+Stages the WhatsApp engine as a native Linux release. With --apply it copies
+only tracked source and lockfiles, installs dependencies, generates Prisma,
+builds dist/main.js, and atomically updates the current symlink. It never reads
+or copies .env files; systemd loads the private environment separately.
+
+Set MESSAGING_RELEASE_ID to the reviewed main commit SHA before invoking this
+script. It is explicit because WSL cannot reliably resolve Windows worktree
+gitdir indirections during a production cutover.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[[ -f "$SOURCE_DIR/package-lock.json" ]] || { echo "Missing lockfile: $SOURCE_DIR/package-lock.json" >&2; exit 1; }
+[[ -f "$SOURCE_DIR/src/main.ts" ]] || { echo "Missing source entrypoint: $SOURCE_DIR/src/main.ts" >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'MESSAGING_RELEASE_ID must be a reviewed hexadecimal commit SHA.' >&2; exit 1; }
+
+echo "Release ID: $RELEASE_ID"
+echo "Source: $SOURCE_DIR"
+echo "Destination: $DESTINATION"
+if [[ "$APPLY" != "1" ]]; then
+  echo "Dry run complete. Use --apply after backup, CI and cutover gates pass."
+  exit 0
+fi
+
+command -v rsync >/dev/null 2>&1 || { echo 'Missing required command: rsync' >&2; exit 1; }
+command -v npm >/dev/null 2>&1 || { echo 'Missing required command: npm' >&2; exit 1; }
+command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
+sudo -n true
+
+sudo -n install -d -o skincos -g skincos -m 0750 "$DESTINATION"
+sudo -n rsync -a --delete \
+  --exclude '.env' --exclude '.env.*' --exclude 'node_modules' --exclude 'dist' \
+  "$SOURCE_DIR/" "$DESTINATION/"
+sudo -n chown -R skincos:skincos "$DESTINATION"
+
+sudo -n -u skincos env npm_config_cache=/var/lib/skincos-runtime/cache/npm \
+  npm --prefix "$DESTINATION" ci --ignore-scripts
+sudo -n -u skincos npm --prefix "$DESTINATION" run db:generate
+sudo -n -u skincos npm --prefix "$DESTINATION" run build
+[[ -f "$DESTINATION/dist/main.js" ]] || { echo "Build did not produce dist/main.js" >&2; exit 1; }
+
+sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$CURRENT_LINK")"
+sudo -n ln -sfn "$DESTINATION" "$CURRENT_LINK"
+echo "Native WhatsApp release prepared: $CURRENT_LINK -> $DESTINATION"

--- a/scripts/runtime/run-messaging-whatsapp-release.sh
+++ b/scripts/runtime/run-messaging-whatsapp-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production launcher: it never installs packages, runs Prisma generation, or
+# builds TypeScript. The release-preparation step must create all artifacts on
+# the Linux filesystem before systemd is allowed to start this process.
+RELEASE_ROOT="${MESSAGING_RELEASE_ROOT:-/opt/skincos/current/messaging-whatsapp}"
+ENV_FILE="${EVOLUTION_API_ENV_FILE:-/etc/skincos/messaging-whatsapp.env}"
+NODE_BIN="${NODE_BIN:-/usr/bin/node}"
+
+[[ -x "$NODE_BIN" ]] || { echo "Node runtime is unavailable: $NODE_BIN" >&2; exit 1; }
+[[ -d "$RELEASE_ROOT/node_modules" ]] || { echo "Native dependencies are unavailable: $RELEASE_ROOT/node_modules" >&2; exit 1; }
+[[ -f "$RELEASE_ROOT/dist/main.js" ]] || { echo "Release artifact is unavailable: $RELEASE_ROOT/dist/main.js" >&2; exit 1; }
+[[ -r "$ENV_FILE" ]] || { echo "Private WhatsApp environment is unavailable: $ENV_FILE" >&2; exit 1; }
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+export LOG_LEVEL="${LOG_LEVEL:-ERROR,WARN}"
+export LOG_COLOR="${LOG_COLOR:-false}"
+cd "$RELEASE_ROOT"
+exec "$NODE_BIN" dist/main.js

--- a/scripts/runtime/test-run-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-run-messaging-whatsapp-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LAUNCHER="$ROOT_DIR/scripts/runtime/run-messaging-whatsapp-release.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/release/node_modules" "$tmp_dir/release/dist" "$tmp_dir/bin"
+printf 'process.exit(0);\n' >"$tmp_dir/release/dist/main.js"
+printf 'PRIVATE_TEST_VALUE=loaded\n' >"$tmp_dir/runtime.env"
+printf '%s\n' '#!/usr/bin/env bash' 'test "$PRIVATE_TEST_VALUE" = loaded' 'test "$1" = dist/main.js' >"$tmp_dir/bin/node"
+chmod +x "$tmp_dir/bin/node"
+
+MESSAGING_RELEASE_ROOT="$tmp_dir/release" EVOLUTION_API_ENV_FILE="$tmp_dir/runtime.env" NODE_BIN="$tmp_dir/bin/node" \
+  "$LAUNCHER"
+
+rm -f "$tmp_dir/release/dist/main.js"
+if MESSAGING_RELEASE_ROOT="$tmp_dir/release" EVOLUTION_API_ENV_FILE="$tmp_dir/runtime.env" NODE_BIN="$tmp_dir/bin/node" "$LAUNCHER"; then
+  echo 'Launcher must fail closed without the built artifact.' >&2
+  exit 1
+fi
+
+echo 'Messaging WhatsApp native release launcher checks passed'


### PR DESCRIPTION
Stages the WhatsApp runtime under /opt/skincos, makes the launcher fail closed when artifacts or private configuration are absent, and removes production install/build behavior from the future unit path.\n\nValidation: bash syntax, dry-run with reviewed release SHA, launcher success/failure regression test, systemd unit verification.