### PR TITLE
fix(runtime): stage Orb state through verified archives

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -5,10 +5,11 @@ without deleting the legacy tree during the change window. It is intentionally
 separate from the source-layout pull request: a merged path move is never proof
 that a service is safe to rename.
 
-## Current validated checkpoint (2026-07-14)
+## Current validated checkpoint (2026-07-15)
 
-- Pre-copy completed with the Windows-native transport and the runtime Livia
-  workflow matches the retained legacy source by SHA-256.
+- A checksum-verified, state-only Orb archive has been extracted into a native
+  Linux staging directory. This replaces recursive DrvFS traversal of
+  `n8n-home`, which can block WSL in uninterruptible I/O on this host.
 - Rollback artifacts are staged at
   `C:\CodexRuntime\artifacts\runtime-cutover\20260714T170200Z` and linked
   only into the retained rollback worktree.
@@ -56,7 +57,8 @@ drop-in to the lifecycle unit.
 3. `skincos-n8n-backup.service` has completed with `VERIFY_RESTORE=1`; record
    the resulting directory under `C:\CodexRuntime\n8n\backups\daily` and
    validate its manifest checksum before the cut.
-4. `scripts/runtime/prepare-lifecycle-layout.sh`,
+4. `scripts/runtime/stage-orb-state-archive.sh`,
+   `scripts/runtime/prepare-lifecycle-layout.sh`,
    `scripts/runtime/install-lifecycle-units.sh`, and both native release
    launchers pass. The reviewed main SHA is recorded for the native source and
    WhatsApp releases.
@@ -65,7 +67,8 @@ drop-in to the lifecycle unit.
 
 ## Cut sequence
 
-Run the pre-copy before the window; it does not stop services or remove data:
+Run the generic non-Orb pre-copy before the window; it does not stop services
+or remove data:
 
 ```bash
 scripts/runtime/prepare-lifecycle-layout.sh --apply
@@ -81,8 +84,31 @@ The helper copies from the legacy Windows runtime into these native roots:
 
 Backups and durable artifacts remain under `C:\CodexRuntime`. The pre-copy rule
 still applies (copy only missing files); final sync copies changed files but
-never deletes a legacy source or destination-only artifact. Copies from DrvFS
-to Linux use `rsync` under `sudo`, avoiding a runtime dependency on DrvFS.
+never deletes a legacy source or destination-only artifact. `n8n-home` is
+explicitly excluded from this helper: do not use `rsync`, `cp`, or a recursive
+DrvFS copy for Orb state.
+
+Before the window, create the state-only archive under the durable artifacts
+root from Windows, record the printed SHA-256, then stage it on Linux. The
+archive excludes only the Windows `node_modules` trees. The staging helper
+rebuilds the custom nodes with `npm ci --ignore-scripts` after normalizing a
+lockfile only when npm proves it conflicts with the exact package manifest:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\runtime\export-orb-state-archive.ps1 \
+  -ArtifactRoot C:\CodexRuntime\artifacts\runtime-cutover\<timestamp>
+```
+
+```bash
+scripts/runtime/stage-orb-state-archive.sh \
+  --archive /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>/n8n-home-state.tar \
+  --sha256 <printed-sha256> --apply
+```
+
+Record the resulting `STAGED_ORB_STATE_HOME`. It remains isolated under
+`/var/lib/skincos-runtime/staging` until the cutover script atomically promotes
+it after the legacy units have stopped. A new archive is required for every
+attempted cut; a staging directory is never silently reused.
 
 The pre-copy also transfers the active Livia workflow from the retained legacy
 source into `/var/lib/skincos-runtime/orb/workflows`. The lifecycle Orb unit and
@@ -141,16 +167,19 @@ artifact directory:
 scripts/runtime/cutover-lifecycle-runtime.sh \
   --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
-  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
+  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
+  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home
 
 scripts/runtime/cutover-lifecycle-runtime.sh --apply \
   --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
-  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>
+  --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
+  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home
 ```
 
 The apply command captures all old unit files, stops only the seven legacy
-units, makes the final non-destructive data sync, installs and starts `orb`,
+units, atomically promotes the checksum-verified native Orb state, makes the
+remaining final non-destructive data sync, installs and starts `orb`,
 `orb-proxy`, `messaging-whatsapp`, `crm`, `booking`, `cloudflare-orb` and
 `cloudflare-runtime`. It requires local Orb health plus public Orb and CRM
 health. Legacy stop/start operations are asynchronous but bounded; a timeout

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "api:test": "npm --prefix api test",
     "booking:test": "npm --prefix booking test",
     "runtime:lifecycle:prepare": "bash ./scripts/runtime/prepare-lifecycle-layout.sh",
+    "runtime:orb-state:test": "bash ./scripts/runtime/test-stage-orb-state-archive.sh",
     "runtime:lifecycle:preflight": "bash ./scripts/runtime/cutover-lifecycle-runtime.sh",
     "runtime:lifecycle:cutover": "bash ./scripts/runtime/cutover-lifecycle-runtime.sh --apply",
     "runtime:backup:storage-copy:test": "bash ./orb/engine/scripts/test-backup-n8n-storage-copy.sh",

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -16,6 +16,7 @@ APPLY=0
 BACKUP_DIR=""
 ROLLBACK_ROOT=""
 ROLLBACK_ARTIFACT_ROOT=""
+ORB_STATE_HOME=""
 CHECKPOINT_DIR=""
 CUTOVER_STARTED=0
 CUTOVER_COMPLETE=0
@@ -44,12 +45,13 @@ new_units=(
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts>
-  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts>
+  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home>
+  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home>
 
 Without --apply, prints and validates the cutover prerequisites. --apply
-stops only the listed legacy services, performs the non-destructive final
-sync, starts the lifecycle services and runs health checks. If a post-stop step
+stops only the listed legacy services, promotes checksum-verified native Orb
+state, performs the non-destructive final sync, starts the lifecycle services
+and runs health checks. If a post-stop step
 fails it restores the captured legacy units against --rollback-root and starts
 them again. The rollback artifacts must first be staged outside Git with
 scripts/runtime/stage-rollback-artifacts.sh. It never deletes legacy runtime
@@ -63,6 +65,7 @@ while [[ $# -gt 0 ]]; do
     --backup-dir) BACKUP_DIR="${2:-}"; shift ;;
     --rollback-root) ROLLBACK_ROOT="${2:-}"; shift ;;
     --rollback-artifact-root) ROLLBACK_ARTIFACT_ROOT="${2:-}"; shift ;;
+    --orb-state-home) ORB_STATE_HOME="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -79,6 +82,8 @@ sudo -n true
 [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]] || { echo "--backup-dir must name an existing backup directory." >&2; exit 1; }
 [[ -n "$ROLLBACK_ROOT" && -e "$ROLLBACK_ROOT/.git" ]] || { echo "--rollback-root must be a retained Git worktree." >&2; exit 1; }
 [[ -n "$ROLLBACK_ARTIFACT_ROOT" && -d "$ROLLBACK_ARTIFACT_ROOT" ]] || { echo "--rollback-artifact-root must name staged runtime artifacts outside Git." >&2; exit 1; }
+[[ -n "$ORB_STATE_HOME" && -d "$ORB_STATE_HOME" ]] || { echo "--orb-state-home must name checksum-verified native staging state." >&2; exit 1; }
+[[ -f "$ORB_STATE_HOME/state-archive.manifest" && -f "$ORB_STATE_HOME/.n8n/config" ]] || { echo "--orb-state-home is incomplete." >&2; exit 1; }
 [[ -f "$BACKUP_DIR/manifest.json" && -f "$BACKUP_DIR/n8n_runtime.dump" ]] || { echo "Backup is missing manifest.json or n8n_runtime.dump." >&2; exit 1; }
 [[ "$STOP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_STOP_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 [[ "$START_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_START_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
@@ -223,12 +228,14 @@ echo "Rollback worktree: $ROLLBACK_ROOT"
 echo "Rollback runtime artifacts: $ROLLBACK_ARTIFACT_ROOT"
 echo "Native source release: $SOURCE_ROOT"
 echo "Native WhatsApp release: $MESSAGING_RELEASE_ROOT"
+echo "Native Orb state staging: $ORB_STATE_HOME"
 echo "Lifecycle source: $ROOT_DIR"
 printf 'Legacy services: %s\n' "${legacy_units[*]}"
 printf 'Lifecycle services: %s\n' "${new_units[*]}"
 
 if [[ "$APPLY" != "1" ]]; then
   validate_rollback_artifacts
+  "$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --staged-home "$ORB_STATE_HOME"
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh"
   SOURCE_ROOT="$SOURCE_ROOT" "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh"
   echo "Preflight passed. Use --apply only in the scheduled cut window."
@@ -241,6 +248,7 @@ CUTOVER_STARTED=1
 
 echo "Stopping legacy ingress and runtimes."
 stop_units_bounded "${legacy_units[@]}"
+"$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --apply --staged-home "$ORB_STATE_HOME"
 "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync
 BOOKING_API_RUNTIME_HOME="$STATE_ROOT/booking" EF_SCRAPER_VENV_DIR="$STATE_ROOT/booking/venv" "$SOURCE_ROOT/scripts/booking/bootstrap-venv.sh"
 "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh" --apply

--- a/scripts/runtime/export-orb-state-archive.ps1
+++ b/scripts/runtime/export-orb-state-archive.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+param(
+    [string]$LegacyHome = 'C:\CodexRuntime\n8n\n8n-home',
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactRoot,
+    [switch]$RequireLegacyOrbStopped
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $LegacyHome -PathType Container)) {
+    throw "Legacy Orb home does not exist: $LegacyHome"
+}
+
+if ($RequireLegacyOrbStopped) {
+    & wsl.exe -d Ubuntu-24.04 -u root -- systemctl is-active --quiet skincos-n8n.service
+    if ($LASTEXITCODE -eq 0) {
+        throw 'Refusing to create an authoritative Orb state archive while skincos-n8n.service is active.'
+    }
+}
+
+$resolvedHome = (Resolve-Path -LiteralPath $LegacyHome).Path
+$parent = Split-Path -Parent $resolvedHome
+$leaf = Split-Path -Leaf $resolvedHome
+if ($leaf -ne 'n8n-home') {
+    throw "LegacyHome must end in n8n-home, got: $resolvedHome"
+}
+
+$resolvedArtifactRoot = [System.IO.Path]::GetFullPath($ArtifactRoot)
+New-Item -ItemType Directory -Path $resolvedArtifactRoot -Force | Out-Null
+$archive = Join-Path $resolvedArtifactRoot 'n8n-home-state.tar'
+$manifest = Join-Path $resolvedArtifactRoot 'n8n-home-state.manifest.json'
+if (Test-Path -LiteralPath $archive -or Test-Path -LiteralPath $manifest) {
+    throw "Refusing to overwrite an existing Orb state archive in: $resolvedArtifactRoot"
+}
+
+# Windows tar cannot safely serialize its generated node_modules reparse
+# points. They are rebuilt natively by stage-orb-state-archive.sh from the
+# included package manifests; no state, configuration or custom-node source is
+# excluded.
+$tarArguments = @(
+    '-cf', $archive,
+    '--exclude=n8n-home/nodes/node_modules',
+    '--exclude=n8n-home/.n8n/nodes/node_modules',
+    '-C', $parent,
+    $leaf
+)
+
+& tar.exe @tarArguments
+if ($LASTEXITCODE -ne 0) {
+    $failed = "$archive.partial-$(Get-Date -Format 'yyyyMMddTHHmmssZ')"
+    if (Test-Path -LiteralPath $archive) {
+        Move-Item -LiteralPath $archive -Destination $failed -Force
+    }
+    throw "Windows tar failed while creating Orb state archive; retained any partial output as $failed"
+}
+
+$item = Get-Item -LiteralPath $archive
+if ($item.Length -le 0) {
+    throw 'Orb state archive is empty.'
+}
+$sha256 = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+$record = [ordered]@{
+    createdUtc = (Get-Date).ToUniversalTime().ToString('o')
+    source = $resolvedHome
+    archive = $item.Name
+    archiveBytes = $item.Length
+    sha256 = $sha256
+    nodesDependencies = 'excluded-and-rebuilt-natively'
+    legacyOrbStoppedRequired = [bool]$RequireLegacyOrbStopped
+}
+$record | ConvertTo-Json | Set-Content -LiteralPath $manifest -Encoding utf8NoBOM
+Write-Output "ORB_STATE_ARCHIVE=$archive"
+Write-Output "ORB_STATE_SHA256=$sha256"

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -13,13 +13,12 @@ ARTIFACT_ROOT="${ARTIFACT_ROOT:-$RUNTIME_ROOT/artifacts}"
 LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT:-/mnt/c/CodexShared/Projetos/skincos}"
 APPLY=0
 FINAL_SYNC=0
-SKIP_ORB_STATE=0
 SKIP_MESSAGING_STATE=0
 SYNC_TRANSPORT="${LIFECYCLE_SYNC_TRANSPORT:-auto}"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-lifecycle-layout.sh [--apply] [--final-sync] [--skip-orb-state] [--skip-messaging-state]
+Usage: scripts/runtime/prepare-lifecycle-layout.sh [--apply] [--final-sync] [--skip-messaging-state]
 
 Copies mutable runtime state from the Windows legacy layout to native Linux
 state/config/log/tmp roots. C:\CodexRuntime remains the durable location for
@@ -27,8 +26,6 @@ backups and artifacts. Without --apply it reports the planned copies.
 --final-sync updates existing destination files but never deletes a legacy
 source or an existing destination. It is reserved for the short window after
 the old services have stopped.
---skip-orb-state is only for an already-completed independent pre-copy. It
-cannot be combined with --final-sync.
 --skip-messaging-state has the same restriction for the WhatsApp channel.
 
 LIFECYCLE_SYNC_TRANSPORT chooses the directory-copy transport: auto (default)
@@ -41,7 +38,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply) APPLY=1 ;;
     --final-sync) FINAL_SYNC=1 ;;
-    --skip-orb-state) SKIP_ORB_STATE=1 ;;
+    --skip-orb-state)
+      echo "--skip-orb-state was retired. Stage Orb state with stage-orb-state-archive.sh." >&2
+      exit 1
+      ;;
     --skip-messaging-state) SKIP_MESSAGING_STATE=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
@@ -53,7 +53,7 @@ if [[ "$FINAL_SYNC" == "1" && "$APPLY" != "1" ]]; then
   echo "--final-sync requires --apply." >&2
   exit 1
 fi
-if [[ "$FINAL_SYNC" == "1" && ( "$SKIP_ORB_STATE" == "1" || "$SKIP_MESSAGING_STATE" == "1" ) ]]; then
+if [[ "$FINAL_SYNC" == "1" && "$SKIP_MESSAGING_STATE" == "1" ]]; then
   echo "State skip options cannot be used during the final sync." >&2
   exit 1
 fi
@@ -283,11 +283,12 @@ for directory in "${directories[@]}"; do
   fi
 done
 
-if [[ "$SKIP_ORB_STATE" == "1" ]]; then
-  echo "SKIP orb state: completed by the independently recorded pre-copy."
-else
-  sync_path "$legacy_orb/n8n-home" "$STATE_ROOT/orb"
-fi
+# DrvFS metadata traversal across n8n-home has repeatedly left rsync in D
+# state on this host. Orb state is therefore always staged through the
+# checksum-verified archive helper into the native filesystem. The final
+# cutover promotes that prepared directory atomically after legacy services
+# stop; this generic layout helper must never recurse through n8n-home.
+echo "ORB state is archive-staged separately; n8n-home is intentionally not synced here."
 if [[ "$SKIP_MESSAGING_STATE" == "1" ]]; then
   echo "SKIP messaging state: completed by the independently recorded pre-copy."
 else

--- a/scripts/runtime/promote-orb-state-staging.sh
+++ b/scripts/runtime/promote-orb-state-staging.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Promotion is intentionally a native filesystem rename. Legacy services read
+# C:\CodexRuntime, so a failed lifecycle cutover can restart them without
+# consuming or deleting this staged state.
+
+STATE_ROOT="${STATE_ROOT:-/var/lib/skincos-runtime}"
+STAGED_HOME=""
+APPLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/promote-orb-state-staging.sh --staged-home <native-path> [--apply]
+
+Moves a checksum-verified staged n8n-home into the final native Orb state
+location. Any pre-existing native destination is renamed to a timestamped
+checkpoint; it is never deleted by this helper.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --staged-home) STAGED_HOME="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[[ -n "$STAGED_HOME" && -d "$STAGED_HOME" ]] || { echo "--staged-home must name an existing directory." >&2; exit 1; }
+[[ -f "$STAGED_HOME/.n8n/config" && -f "$STAGED_HOME/database.sqlite" && -f "$STAGED_HOME/state-archive.manifest" ]] || {
+  echo "Staged Orb state is incomplete or was not produced by the archive helper." >&2; exit 1;
+}
+native_staging="$(realpath "$STATE_ROOT/staging")"
+native_home="$(realpath "$STAGED_HOME")"
+[[ "$native_home" == "$native_staging"/* ]] || { echo "Staged Orb state must remain under $native_staging." >&2; exit 1; }
+
+destination="$STATE_ROOT/orb/n8n-home"
+timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
+checkpoint="$STATE_ROOT/orb/n8n-home.pre-cutover-$timestamp"
+echo "Would promote $native_home -> $destination"
+if [[ "$APPLY" != "1" ]]; then
+  exit 0
+fi
+
+command -v sudo >/dev/null 2>&1 || { echo "Missing sudo." >&2; exit 1; }
+sudo -n true
+sudo -n install -d -o skincos -g skincos -m 0750 "$STATE_ROOT/orb"
+if sudo -n test -e "$destination"; then
+  sudo -n mv "$destination" "$checkpoint"
+  echo "Preserved previous native Orb state at $checkpoint"
+fi
+sudo -n mv "$native_home" "$destination"
+echo "PROMOTED_ORB_STATE_HOME=$destination"

--- a/scripts/runtime/stage-orb-state-archive.sh
+++ b/scripts/runtime/stage-orb-state-archive.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract a Windows-produced Orb state archive once, on the native Linux
+# filesystem. This deliberately replaces recursive DrvFS copies of n8n-home.
+# The archive contains state only: custom-node dependencies are rebuilt from
+# the package manifests on Linux.
+
+STATE_ROOT="${STATE_ROOT:-/var/lib/skincos-runtime}"
+RUNTIME_USER="${SKINCOS_RUNTIME_USER:-skincos}"
+NPM_CACHE="${N8N_NPM_CACHE:-$STATE_ROOT/cache/orb/npm}"
+ARCHIVE=""
+ARCHIVE_SHA256=""
+APPLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/stage-orb-state-archive.sh --archive <state.tar> --sha256 <sha256> [--apply]
+
+Validates and extracts a state-only n8n-home archive into
+/var/lib/skincos-runtime/staging. The archive must contain a top-level
+n8n-home directory and must exclude nodes/node_modules. The helper normalizes
+the custom-node lockfile only when npm proves it is inconsistent with the
+declared exact dependencies, then performs npm ci with lifecycle scripts
+disabled. It never changes the legacy runtime or starts/stops services.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --archive) ARCHIVE="${2:-}"; shift ;;
+    --sha256) ARCHIVE_SHA256="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
+}
+
+[[ -n "$ARCHIVE" && -f "$ARCHIVE" ]] || { echo "--archive must name an existing file." >&2; exit 1; }
+[[ "$ARCHIVE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo "--sha256 must be a SHA-256 digest." >&2; exit 1; }
+require_cmd sha256sum
+require_cmd tar
+require_cmd npm
+require_cmd sudo
+require_cmd awk
+
+actual_sha="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
+[[ "${actual_sha,,}" == "${ARCHIVE_SHA256,,}" ]] || { echo "Orb state archive checksum mismatch." >&2; exit 1; }
+
+# Refuse archives that could escape the staging root or smuggle unrelated
+# paths. Listing is intentionally performed before extraction.
+if ! tar -tf "$ARCHIVE" | awk '
+  $0 !~ /^n8n-home(\/|$)/ { invalid=1 }
+  $0 ~ /(^|\/)\.\.($|\/)/ { invalid=1 }
+  END { exit invalid ? 1 : 0 }
+'; then
+  echo "Orb state archive has an invalid entry path." >&2
+  exit 1
+fi
+
+staging_root="$STATE_ROOT/staging"
+stage_id="orb-n8n-home-${actual_sha:0:16}"
+stage_dir="$staging_root/$stage_id"
+home="$stage_dir/n8n-home"
+
+validate_staged_home() {
+  local candidate="$1"
+  [[ -f "$candidate/.n8n/config" ]] || { echo "Missing n8n config in staged state." >&2; return 1; }
+  [[ -f "$candidate/database.sqlite" ]] || { echo "Missing n8n runtime database in staged state." >&2; return 1; }
+  [[ -d "$candidate/storage" ]] || { echo "Missing n8n storage in staged state." >&2; return 1; }
+  [[ -f "$candidate/nodes/package.json" && -f "$candidate/nodes/package-lock.json" ]] || {
+    echo "Missing custom-node package manifests in staged state." >&2; return 1;
+  }
+  [[ ! -e "$candidate/nodes/node_modules" && ! -e "$candidate/.n8n/nodes/node_modules" ]] || {
+    echo "State archive must not contain Windows custom-node dependencies." >&2; return 1;
+  }
+}
+
+if [[ "$APPLY" != "1" ]]; then
+  echo "Verified archive checksum: $actual_sha"
+  echo "Would stage native Orb state at: $stage_dir"
+  exit 0
+fi
+
+sudo -n true
+id "$RUNTIME_USER" >/dev/null 2>&1 || { echo "Runtime user does not exist: $RUNTIME_USER" >&2; exit 1; }
+sudo -n install -d -o "$RUNTIME_USER" -g "$RUNTIME_USER" -m 0750 "$staging_root"
+if sudo -n test -e "$stage_dir"; then
+  echo "Refusing to overwrite existing staged Orb state: $stage_dir" >&2
+  exit 1
+fi
+
+temporary_dir="$(sudo -n mktemp -d "$staging_root/.${stage_id}.XXXXXX")"
+cleanup() { sudo -n rm -rf "$temporary_dir"; }
+trap cleanup EXIT
+sudo -n tar -xf "$ARCHIVE" -C "$temporary_dir"
+sudo -n chown -R "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir"
+validate_staged_home "$temporary_dir/n8n-home"
+
+# The legacy runtime can contain a stale root lock entry even though its
+# package.json pins the version in use. npm install --package-lock-only changes
+# only the lock representation; npm ci then gives the native runtime a fully
+# deterministic dependency tree without executing package lifecycle scripts.
+nodes_dir="$temporary_dir/n8n-home/nodes"
+before_lock="$(sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
+sudo -n install -d -o "$RUNTIME_USER" -g "$RUNTIME_USER" -m 0750 "$NPM_CACHE"
+sudo -n -u "$RUNTIME_USER" env \
+  npm_config_cache="$NPM_CACHE" npm_config_audit=false npm_config_fund=false npm_config_ignore_scripts=true \
+  npm install --package-lock-only --ignore-scripts --prefix "$nodes_dir" >/dev/null
+after_lock="$(sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
+sudo -n -u "$RUNTIME_USER" env \
+  npm_config_cache="$NPM_CACHE" npm_config_audit=false npm_config_fund=false npm_config_ignore_scripts=true \
+  npm ci --omit=dev --ignore-scripts --prefix "$nodes_dir" >/dev/null
+
+sudo -n mkdir -p "$temporary_dir/n8n-home/.n8n/nodes"
+sudo -n ln -s ../../nodes/node_modules "$temporary_dir/n8n-home/.n8n/nodes/node_modules"
+sudo -n chown -h "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir/n8n-home/.n8n/nodes/node_modules"
+sudo -n tee "$temporary_dir/n8n-home/state-archive.manifest" >/dev/null <<EOF
+archive_sha256=$actual_sha
+package_lock_before_sha256=$before_lock
+package_lock_after_sha256=$after_lock
+EOF
+sudo -n chown "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir/n8n-home/state-archive.manifest"
+sudo -n mv "$temporary_dir" "$stage_dir"
+trap - EXIT
+echo "STAGED_ORB_STATE_HOME=$home"

--- a/scripts/runtime/test-prepare-lifecycle-layout.sh
+++ b/scripts/runtime/test-prepare-lifecycle-layout.sh
@@ -28,16 +28,15 @@ printf '{"name":"Livia"}\n' >"$legacy_root/orb/engine/workflows/livia.active.jso
 env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply >/dev/null
 
-[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "source-v1" ]]
+[[ ! -e "$runtime_root/state/orb/n8n-home/payload.txt" ]]
 [[ -f "$runtime_root/state/orb/workflows/livia.active.json" ]]
 
-printf 'destination-preserved\n' >"$runtime_root/state/orb/n8n-home/payload.txt"
 printf 'source-v2\n' >"$runtime_root/n8n/n8n-home/payload.txt"
 env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply >/dev/null
-[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "destination-preserved" ]]
+[[ ! -e "$runtime_root/state/orb/n8n-home/payload.txt" ]]
 
 env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync >/dev/null
-[[ "$(<"$runtime_root/state/orb/n8n-home/payload.txt")" == "source-v2" ]]
-echo "prepare lifecycle layout robocopy test passed"
+[[ ! -e "$runtime_root/state/orb/n8n-home/payload.txt" ]]
+echo "prepare lifecycle layout excludes Orb n8n-home test passed"

--- a/scripts/runtime/test-stage-orb-state-archive.sh
+++ b/scripts/runtime/test-stage-orb-state-archive.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'sudo -n rm -rf "$tmp_dir"' EXIT
+fixture="$tmp_dir/n8n-home"
+mkdir -p "$fixture/.n8n" "$fixture/storage" "$fixture/nodes"
+printf 'config\n' >"$fixture/.n8n/config"
+printf 'database\n' >"$fixture/database.sqlite"
+printf 'storage\n' >"$fixture/storage/payload"
+cat >"$fixture/nodes/package.json" <<'EOF'
+{"name":"fixture-nodes","private":true,"dependencies":{}}
+EOF
+cat >"$fixture/nodes/package-lock.json" <<'EOF'
+{"name":"fixture-nodes","lockfileVersion":3,"requires":true,"packages":{"":{"name":"fixture-nodes","dependencies":{}}}}
+EOF
+archive="$tmp_dir/orb-state.tar"
+tar -cf "$archive" -C "$tmp_dir" n8n-home
+checksum="$(sha256sum "$archive" | awk '{print $1}')"
+runtime_user="$(id -un)"
+state_root="$tmp_dir/state"
+
+STATE_ROOT="$state_root" SKINCOS_RUNTIME_USER="$runtime_user" \
+  "$ROOT_DIR/scripts/runtime/stage-orb-state-archive.sh" --archive "$archive" --sha256 "$checksum" --apply >/dev/null
+staged_home="$state_root/staging/orb-n8n-home-${checksum:0:16}/n8n-home"
+[[ -f "$staged_home/state-archive.manifest" ]]
+[[ -L "$staged_home/.n8n/nodes/node_modules" ]]
+[[ "$(readlink "$staged_home/.n8n/nodes/node_modules")" == "../../nodes/node_modules" ]]
+
+if STATE_ROOT="$state_root" SKINCOS_RUNTIME_USER="$runtime_user" \
+  "$ROOT_DIR/scripts/runtime/stage-orb-state-archive.sh" --archive "$archive" --sha256 "$(printf '0%.0s' {1..64})" >/dev/null 2>&1; then
+  echo "Checksum mismatch unexpectedly passed" >&2
+  exit 1
+fi
+echo "stage Orb state archive test passed"


### PR DESCRIPTION
Replaces recursive DrvFS n8n-home copying with checksum-verified archive staging and atomic native promotion. Includes regression coverage for archive validation, lock normalization, dependency rebuild, symlink reconstruction, and checksum rejection.