### PR TITLE
fix(runtime): transfer Orb archives through Windows

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -89,10 +89,13 @@ explicitly excluded from this helper: do not use `rsync`, `cp`, or a recursive
 DrvFS copy for Orb state.
 
 Before the window, create the state-only archive under the durable artifacts
-root from Windows, record the printed SHA-256, then stage it on Linux. The
-archive excludes only the Windows `node_modules` trees. The staging helper
-rebuilds the custom nodes with `npm ci --ignore-scripts` after normalizing a
-lockfile only when npm proves it conflicts with the exact package manifest:
+root from Windows, record the printed SHA-256, then transfer it with Windows
+tar through `\\wsl$` to the Linux filesystem. Do not let WSL read the large
+archive through `/mnt/c`: that reverse 9P traversal can hang or silently leave
+an incomplete extraction on this host. The archive excludes only the Windows
+`node_modules` trees. The staging helper rebuilds the custom nodes with
+`npm ci --ignore-scripts` after normalizing a lockfile only when npm proves it
+conflicts with the exact package manifest:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\runtime\export-orb-state-archive.ps1 \
@@ -101,8 +104,16 @@ powershell -ExecutionPolicy Bypass -File .\scripts\runtime\export-orb-state-arch
 
 ```bash
 scripts/runtime/stage-orb-state-archive.sh \
-  --archive /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp>/n8n-home-state.tar \
+  --extracted-home /home/admin/skincos-orb-transfer/orb-n8n-transfer-<archive-sha>/n8n-home \
   --sha256 <printed-sha256> --apply
+```
+
+Run the transfer from Windows after the archive checksum is recorded:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\runtime\transfer-orb-state-archive.ps1 \
+  -Archive C:\CodexRuntime\artifacts\runtime-cutover\<timestamp>\n8n-home-state.tar \
+  -Sha256 <printed-sha256>
 ```
 
 Record the resulting `STAGED_ORB_STATE_HOME`. It remains isolated under

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -82,8 +82,8 @@ sudo -n true
 [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]] || { echo "--backup-dir must name an existing backup directory." >&2; exit 1; }
 [[ -n "$ROLLBACK_ROOT" && -e "$ROLLBACK_ROOT/.git" ]] || { echo "--rollback-root must be a retained Git worktree." >&2; exit 1; }
 [[ -n "$ROLLBACK_ARTIFACT_ROOT" && -d "$ROLLBACK_ARTIFACT_ROOT" ]] || { echo "--rollback-artifact-root must name staged runtime artifacts outside Git." >&2; exit 1; }
-[[ -n "$ORB_STATE_HOME" && -d "$ORB_STATE_HOME" ]] || { echo "--orb-state-home must name checksum-verified native staging state." >&2; exit 1; }
-[[ -f "$ORB_STATE_HOME/state-archive.manifest" && -f "$ORB_STATE_HOME/.n8n/config" ]] || { echo "--orb-state-home is incomplete." >&2; exit 1; }
+[[ -n "$ORB_STATE_HOME" ]] && sudo -n test -d "$ORB_STATE_HOME" || { echo "--orb-state-home must name checksum-verified native staging state." >&2; exit 1; }
+sudo -n test -f "$ORB_STATE_HOME/state-archive.manifest" && sudo -n test -f "$ORB_STATE_HOME/.n8n/config" || { echo "--orb-state-home is incomplete." >&2; exit 1; }
 [[ -f "$BACKUP_DIR/manifest.json" && -f "$BACKUP_DIR/n8n_runtime.dump" ]] || { echo "Backup is missing manifest.json or n8n_runtime.dump." >&2; exit 1; }
 [[ "$STOP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_STOP_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 [[ "$START_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_START_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }

--- a/scripts/runtime/promote-orb-state-staging.sh
+++ b/scripts/runtime/promote-orb-state-staging.sh
@@ -29,12 +29,12 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-[[ -n "$STAGED_HOME" && -d "$STAGED_HOME" ]] || { echo "--staged-home must name an existing directory." >&2; exit 1; }
-[[ -f "$STAGED_HOME/.n8n/config" && -f "$STAGED_HOME/database.sqlite" && -f "$STAGED_HOME/state-archive.manifest" ]] || {
+[[ -n "$STAGED_HOME" ]] && sudo -n test -d "$STAGED_HOME" || { echo "--staged-home must name an existing directory." >&2; exit 1; }
+sudo -n test -f "$STAGED_HOME/.n8n/config" && sudo -n test -f "$STAGED_HOME/database.sqlite" && sudo -n test -f "$STAGED_HOME/state-archive.manifest" || {
   echo "Staged Orb state is incomplete or was not produced by the archive helper." >&2; exit 1;
 }
-native_staging="$(realpath "$STATE_ROOT/staging")"
-native_home="$(realpath "$STAGED_HOME")"
+native_staging="$(sudo -n realpath "$STATE_ROOT/staging")"
+native_home="$(sudo -n realpath "$STAGED_HOME")"
 [[ "$native_home" == "$native_staging"/* ]] || { echo "Staged Orb state must remain under $native_staging." >&2; exit 1; }
 
 destination="$STATE_ROOT/orb/n8n-home"

--- a/scripts/runtime/stage-orb-state-archive.sh
+++ b/scripts/runtime/stage-orb-state-archive.sh
@@ -11,11 +11,12 @@ RUNTIME_USER="${SKINCOS_RUNTIME_USER:-skincos}"
 NPM_CACHE="${N8N_NPM_CACHE:-$STATE_ROOT/cache/orb/npm}"
 ARCHIVE=""
 ARCHIVE_SHA256=""
+EXTRACTED_HOME=""
 APPLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/stage-orb-state-archive.sh --archive <state.tar> --sha256 <sha256> [--apply]
+Usage: scripts/runtime/stage-orb-state-archive.sh (--archive <state.tar> | --extracted-home <native-n8n-home>) --sha256 <sha256> [--apply]
 
 Validates and extracts a state-only n8n-home archive into
 /var/lib/skincos-runtime/staging. The archive must contain a top-level
@@ -23,6 +24,10 @@ n8n-home directory and must exclude nodes/node_modules. The helper normalizes
 the custom-node lockfile only when npm proves it is inconsistent with the
 declared exact dependencies, then performs npm ci with lifecycle scripts
 disabled. It never changes the legacy runtime or starts/stops services.
+
+On this Windows host, prefer --extracted-home after the Windows-native
+transfer helper writes the archive through \\wsl$ into a Linux home directory.
+That path avoids WSL reading the multi-gigabyte archive over /mnt/c.
 EOF
 }
 
@@ -31,6 +36,7 @@ while [[ $# -gt 0 ]]; do
     --apply) APPLY=1 ;;
     --archive) ARCHIVE="${2:-}"; shift ;;
     --sha256) ARCHIVE_SHA256="${2:-}"; shift ;;
+    --extracted-home) EXTRACTED_HOME="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -41,26 +47,43 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
 }
 
-[[ -n "$ARCHIVE" && -f "$ARCHIVE" ]] || { echo "--archive must name an existing file." >&2; exit 1; }
+if [[ -n "$ARCHIVE" && -n "$EXTRACTED_HOME" ]]; then
+  echo "Use either --archive or --extracted-home, not both." >&2
+  exit 1
+fi
+if [[ -z "$ARCHIVE" && -z "$EXTRACTED_HOME" ]]; then
+  echo "One of --archive or --extracted-home is required." >&2
+  exit 1
+fi
+if [[ -n "$ARCHIVE" && ! -f "$ARCHIVE" ]]; then
+  echo "--archive must name an existing file." >&2
+  exit 1
+fi
 [[ "$ARCHIVE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo "--sha256 must be a SHA-256 digest." >&2; exit 1; }
-require_cmd sha256sum
-require_cmd tar
 require_cmd npm
 require_cmd sudo
-require_cmd awk
+require_cmd sha256sum
+if [[ -n "$ARCHIVE" ]]; then
+  require_cmd tar
+  require_cmd awk
+  actual_sha="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
+  [[ "${actual_sha,,}" == "${ARCHIVE_SHA256,,}" ]] || { echo "Orb state archive checksum mismatch." >&2; exit 1; }
 
-actual_sha="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
-[[ "${actual_sha,,}" == "${ARCHIVE_SHA256,,}" ]] || { echo "Orb state archive checksum mismatch." >&2; exit 1; }
-
-# Refuse archives that could escape the staging root or smuggle unrelated
-# paths. Listing is intentionally performed before extraction.
-if ! tar -tf "$ARCHIVE" | awk '
-  $0 !~ /^n8n-home(\/|$)/ { invalid=1 }
-  $0 ~ /(^|\/)\.\.($|\/)/ { invalid=1 }
-  END { exit invalid ? 1 : 0 }
-'; then
-  echo "Orb state archive has an invalid entry path." >&2
-  exit 1
+  # Refuse archives that could escape the staging root or smuggle unrelated
+  # paths. Listing is intentionally performed before extraction.
+  if ! tar -tf "$ARCHIVE" | awk '
+    $0 !~ /^n8n-home(\/|$)/ { invalid=1 }
+    $0 ~ /(^|\/)\.\.($|\/)/ { invalid=1 }
+    END { exit invalid ? 1 : 0 }
+  '; then
+    echo "Orb state archive has an invalid entry path." >&2
+    exit 1
+  fi
+else
+  actual_sha="${ARCHIVE_SHA256,,}"
+  extracted_real="$(realpath "$EXTRACTED_HOME")"
+  [[ "$extracted_real" != /mnt/* ]] || { echo "--extracted-home must be on the native Linux filesystem." >&2; exit 1; }
+  EXTRACTED_HOME="$extracted_real"
 fi
 
 staging_root="$STATE_ROOT/staging"
@@ -82,7 +105,8 @@ validate_staged_home() {
 }
 
 if [[ "$APPLY" != "1" ]]; then
-  echo "Verified archive checksum: $actual_sha"
+  [[ -n "$ARCHIVE" ]] && echo "Verified archive checksum: $actual_sha"
+  [[ -n "$EXTRACTED_HOME" ]] && echo "Verified Windows transfer checksum: $actual_sha"
   echo "Would stage native Orb state at: $stage_dir"
   exit 0
 fi
@@ -96,9 +120,22 @@ if sudo -n test -e "$stage_dir"; then
 fi
 
 temporary_dir="$(sudo -n mktemp -d "$staging_root/.${stage_id}.XXXXXX")"
-cleanup() { sudo -n rm -rf "$temporary_dir"; }
+preserve_temporary=0
+cleanup() {
+  if [[ "$preserve_temporary" == "1" ]]; then
+    echo "Preserved failed native staging at $temporary_dir" >&2
+  else
+    sudo -n rm -rf "$temporary_dir"
+  fi
+}
 trap cleanup EXIT
-sudo -n tar -xf "$ARCHIVE" -C "$temporary_dir"
+if [[ -n "$ARCHIVE" ]]; then
+  sudo -n tar -xf "$ARCHIVE" -C "$temporary_dir"
+else
+  validate_staged_home "$EXTRACTED_HOME"
+  sudo -n mv "$EXTRACTED_HOME" "$temporary_dir/n8n-home"
+  preserve_temporary=1
+fi
 sudo -n chown -R "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir"
 validate_staged_home "$temporary_dir/n8n-home"
 
@@ -127,5 +164,6 @@ package_lock_after_sha256=$after_lock
 EOF
 sudo -n chown "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir/n8n-home/state-archive.manifest"
 sudo -n mv "$temporary_dir" "$stage_dir"
+preserve_temporary=0
 trap - EXIT
 echo "STAGED_ORB_STATE_HOME=$home"

--- a/scripts/runtime/stage-orb-state-archive.sh
+++ b/scripts/runtime/stage-orb-state-archive.sh
@@ -93,13 +93,13 @@ home="$stage_dir/n8n-home"
 
 validate_staged_home() {
   local candidate="$1"
-  [[ -f "$candidate/.n8n/config" ]] || { echo "Missing n8n config in staged state." >&2; return 1; }
-  [[ -f "$candidate/database.sqlite" ]] || { echo "Missing n8n runtime database in staged state." >&2; return 1; }
-  [[ -d "$candidate/storage" ]] || { echo "Missing n8n storage in staged state." >&2; return 1; }
-  [[ -f "$candidate/nodes/package.json" && -f "$candidate/nodes/package-lock.json" ]] || {
+  sudo -n test -f "$candidate/.n8n/config" || { echo "Missing n8n config in staged state." >&2; return 1; }
+  sudo -n test -f "$candidate/database.sqlite" || { echo "Missing n8n runtime database in staged state." >&2; return 1; }
+  sudo -n test -d "$candidate/storage" || { echo "Missing n8n storage in staged state." >&2; return 1; }
+  sudo -n test -f "$candidate/nodes/package.json" && sudo -n test -f "$candidate/nodes/package-lock.json" || {
     echo "Missing custom-node package manifests in staged state." >&2; return 1;
   }
-  [[ ! -e "$candidate/nodes/node_modules" && ! -e "$candidate/.n8n/nodes/node_modules" ]] || {
+  ! sudo -n test -e "$candidate/nodes/node_modules" && ! sudo -n test -e "$candidate/.n8n/nodes/node_modules" || {
     echo "State archive must not contain Windows custom-node dependencies." >&2; return 1;
   }
 }
@@ -120,6 +120,7 @@ if sudo -n test -e "$stage_dir"; then
 fi
 
 temporary_dir="$(sudo -n mktemp -d "$staging_root/.${stage_id}.XXXXXX")"
+sudo -n chown "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir"
 preserve_temporary=0
 cleanup() {
   if [[ "$preserve_temporary" == "1" ]]; then
@@ -136,20 +137,20 @@ else
   sudo -n mv "$EXTRACTED_HOME" "$temporary_dir/n8n-home"
   preserve_temporary=1
 fi
-sudo -n chown -R "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir"
 validate_staged_home "$temporary_dir/n8n-home"
+sudo -n chown -R "$RUNTIME_USER:$RUNTIME_USER" "$temporary_dir"
 
 # The legacy runtime can contain a stale root lock entry even though its
 # package.json pins the version in use. npm install --package-lock-only changes
 # only the lock representation; npm ci then gives the native runtime a fully
 # deterministic dependency tree without executing package lifecycle scripts.
 nodes_dir="$temporary_dir/n8n-home/nodes"
-before_lock="$(sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
+before_lock="$(sudo -n sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
 sudo -n install -d -o "$RUNTIME_USER" -g "$RUNTIME_USER" -m 0750 "$NPM_CACHE"
 sudo -n -u "$RUNTIME_USER" env \
   npm_config_cache="$NPM_CACHE" npm_config_audit=false npm_config_fund=false npm_config_ignore_scripts=true \
   npm install --package-lock-only --ignore-scripts --prefix "$nodes_dir" >/dev/null
-after_lock="$(sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
+after_lock="$(sudo -n sha256sum "$nodes_dir/package-lock.json" | awk '{print $1}')"
 sudo -n -u "$RUNTIME_USER" env \
   npm_config_cache="$NPM_CACHE" npm_config_audit=false npm_config_fund=false npm_config_ignore_scripts=true \
   npm ci --omit=dev --ignore-scripts --prefix "$nodes_dir" >/dev/null

--- a/scripts/runtime/test-stage-orb-state-archive.sh
+++ b/scripts/runtime/test-stage-orb-state-archive.sh
@@ -33,4 +33,13 @@ if STATE_ROOT="$state_root" SKINCOS_RUNTIME_USER="$runtime_user" \
   echo "Checksum mismatch unexpectedly passed" >&2
   exit 1
 fi
+
+extracted_home="$tmp_dir/extracted-n8n-home"
+cp -a "$fixture" "$extracted_home"
+extracted_checksum="$(printf '1%.0s' {1..64})"
+STATE_ROOT="$state_root" SKINCOS_RUNTIME_USER="$runtime_user" \
+  "$ROOT_DIR/scripts/runtime/stage-orb-state-archive.sh" --extracted-home "$extracted_home" --sha256 "$extracted_checksum" --apply >/dev/null
+staged_extracted="$state_root/staging/orb-n8n-home-${extracted_checksum:0:16}/n8n-home"
+[[ -f "$staged_extracted/state-archive.manifest" ]]
+[[ ! -e "$extracted_home" ]]
 echo "stage Orb state archive test passed"

--- a/scripts/runtime/transfer-orb-state-archive.ps1
+++ b/scripts/runtime/transfer-orb-state-archive.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Archive,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[a-fA-F0-9]{64}$')]
+    [string]$Sha256,
+    [string]$Distribution = 'Ubuntu-24.04',
+    [string]$LinuxUser = 'admin'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$resolvedArchive = (Resolve-Path -LiteralPath $Archive).Path
+if ((Get-Item -LiteralPath $resolvedArchive).PSIsContainer) {
+    throw "Archive must be a file: $resolvedArchive"
+}
+$actualHash = (Get-FileHash -LiteralPath $resolvedArchive -Algorithm SHA256).Hash
+if (-not $actualHash.Equals($Sha256, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Orb state archive checksum mismatch.'
+}
+
+# Validate the archive before extracting. This runs in Windows against the
+# local file and rejects anything outside the expected n8n-home root.
+$entries = & tar.exe -tf $resolvedArchive
+if ($LASTEXITCODE -ne 0) {
+    throw 'Windows tar could not list the Orb state archive.'
+}
+foreach ($entry in $entries) {
+    if ($entry -notmatch '^n8n-home(/|$)' -or $entry -match '(^|/)\.\.(/|$)') {
+        throw "Orb state archive has an invalid entry path: $entry"
+    }
+}
+
+$stageId = "orb-n8n-transfer-$($actualHash.Substring(0, 16).ToLowerInvariant())"
+$uncRoot = "\\wsl$\$Distribution\home\$LinuxUser\skincos-orb-transfer"
+$uncStage = Join-Path $uncRoot $stageId
+if (Test-Path -LiteralPath $uncStage) {
+    throw "Refusing to overwrite existing transferred Orb state: $uncStage"
+}
+New-Item -ItemType Directory -Path $uncStage -Force | Out-Null
+
+# The source is read by Windows from C:, then written through the WSL share to
+# ext4. This avoids the unstable reverse traversal of /mnt/c by WSL tar.
+& tar.exe -xf $resolvedArchive -C $uncStage
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows tar transfer failed; retained partial Linux transfer at $uncStage"
+}
+
+$required = @(
+    (Join-Path $uncStage 'n8n-home\.n8n\config'),
+    (Join-Path $uncStage 'n8n-home\database.sqlite'),
+    (Join-Path $uncStage 'n8n-home\storage'),
+    (Join-Path $uncStage 'n8n-home\nodes\package.json'),
+    (Join-Path $uncStage 'n8n-home\nodes\package-lock.json')
+)
+foreach ($path in $required) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Windows transfer is incomplete: missing $path"
+    }
+}
+if (Test-Path -LiteralPath (Join-Path $uncStage 'n8n-home\nodes\node_modules')) {
+    throw 'Transferred archive unexpectedly contains Windows node_modules.'
+}
+
+Write-Output "EXTRACTED_ORB_STATE_HOME=/home/$LinuxUser/skincos-orb-transfer/$stageId/n8n-home"
+Write-Output "ORB_STATE_SHA256=$($actualHash.ToLowerInvariant())"


### PR DESCRIPTION
Uses Windows tar to validate and transfer large Orb state archives through \wsl$ to native Linux storage, avoiding unstable reverse DrvFS extraction. Adds extracted-state staging support and regression coverage.