### PR TITLE
fix(runtime): transfer lifecycle state through native Linux staging

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -19,6 +19,12 @@ that a service is safe to rename.
 - The cutover dry-run, rendered lifecycle units, local health and public Orb/
   CRM health passed. The legacy units remain authoritative until the final
   security-alert triage and scheduled cut window are complete.
+- Non-Orb state is pre-copied through a Windows-created TAR and extracted on
+  ext4. The first verified transfer contained 9,969 WhatsApp session files,
+  CRM state and private runtime configuration; file-count, three session hash
+  samples and three private configuration hashes matched without logging a
+  credential value. A new final transfer is still required after the legacy
+  units stop; a pre-copy is never promoted as the final delta.
 
 ## Legacy proxy bridge before the cut
 
@@ -67,11 +73,19 @@ drop-in to the lifecycle unit.
 
 ## Cut sequence
 
-Run the generic non-Orb pre-copy before the window; it does not stop services
-or remove data:
+Run the non-Orb pre-copy before the window; it does not stop services or remove
+data. Do **not** use the old generic helper to recurse from `/mnt/c`: this host
+has demonstrated blocked I/O when WSL traverses Windows runtime directories.
+The PowerShell command reads `C:` natively, writes one TAR through `\\wsl$`,
+and the Linux helper extracts and applies it only on ext4:
 
 ```bash
-scripts/runtime/prepare-lifecycle-layout.sh --apply
+powershell -ExecutionPolicy Bypass -File .\scripts\runtime\transfer-lifecycle-state.ps1
+```
+
+```bash
+scripts/runtime/apply-lifecycle-state-transfer.sh \
+  --transfer-root /home/admin/skincos-lifecycle-transfer/<transfer-id> --apply
 ```
 
 The helper copies from the legacy Windows runtime into these native roots:
@@ -83,10 +97,10 @@ The helper copies from the legacy Windows runtime into these native roots:
 - temporary data: `/var/tmp/skincos`.
 
 Backups and durable artifacts remain under `C:\CodexRuntime`. The pre-copy rule
-still applies (copy only missing files); final sync copies changed files but
-never deletes a legacy source or destination-only artifact. `n8n-home` is
-explicitly excluded from this helper: do not use `rsync`, `cp`, or a recursive
-DrvFS copy for Orb state.
+still applies (copy only missing files); the final Windows TAR overlays changed
+source files but never deletes a legacy source or destination-only artifact.
+`n8n-home` is explicitly excluded from this helper: do not use `rsync`, `cp`,
+or a recursive DrvFS copy for Orb state.
 
 Before the window, create the state-only archive under the durable artifacts
 root from Windows, record the printed SHA-256, then transfer it with Windows
@@ -179,18 +193,20 @@ scripts/runtime/cutover-lifecycle-runtime.sh \
   --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
-  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home
+  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home \
+  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1
 
 scripts/runtime/cutover-lifecycle-runtime.sh --apply \
   --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
-  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home
+  --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home \
+  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1
 ```
 
 The apply command captures all old unit files, stops only the seven legacy
-units, atomically promotes the checksum-verified native Orb state, makes the
-remaining final non-destructive data sync, installs and starts `orb`,
+units, has Windows create and transfer the final non-Orb delta, atomically
+promotes the checksum-verified native Orb state, installs and starts `orb`,
 `orb-proxy`, `messaging-whatsapp`, `crm`, `booking`, `cloudflare-orb` and
 `cloudflare-runtime`. It requires local Orb health plus public Orb and CRM
 health. Legacy stop/start operations are asynchronous but bounded; a timeout

--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -194,19 +194,24 @@ scripts/runtime/cutover-lifecycle-runtime.sh \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
   --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home \
-  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1
+  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1 \
+  --windows-orb-export-script C:\CodexShared\Projetos\skincos\scripts\runtime\export-orb-state-archive.ps1 \
+  --windows-orb-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-orb-state-archive.ps1
 
 scripts/runtime/cutover-lifecycle-runtime.sh --apply \
   --backup-dir /mnt/c/CodexRuntime/backups/orb/manual/<timestamp> \
   --rollback-root /mnt/c/CodexShared/Worktrees/skincos/admin/runtime-cutover-rollback \
   --rollback-artifact-root /mnt/c/CodexRuntime/artifacts/runtime-cutover/<timestamp> \
   --orb-state-home /var/lib/skincos-runtime/staging/orb-n8n-home-<archive-sha>/n8n-home \
-  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1
+  --windows-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-lifecycle-state.ps1 \
+  --windows-orb-export-script C:\CodexShared\Projetos\skincos\scripts\runtime\export-orb-state-archive.ps1 \
+  --windows-orb-transfer-script C:\CodexShared\Projetos\skincos\scripts\runtime\transfer-orb-state-archive.ps1
 ```
 
 The apply command captures all old unit files, stops only the seven legacy
-units, has Windows create and transfer the final non-Orb delta, atomically
-promotes the checksum-verified native Orb state, installs and starts `orb`,
+units, has Windows create and transfer the final non-Orb delta, creates a new
+authoritative Orb archive only after the legacy n8n service is stopped, then
+atomically promotes that checksum-verified native state and starts `orb`,
 `orb-proxy`, `messaging-whatsapp`, `crm`, `booking`, `cloudflare-orb` and
 `cloudflare-runtime`. It requires local Orb health plus public Orb and CRM
 health. Legacy stop/start operations are asynchronous but bounded; a timeout

--- a/scripts/runtime/apply-lifecycle-state-transfer.sh
+++ b/scripts/runtime/apply-lifecycle-state-transfer.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Applies a Windows-initiated transfer that already resides on the native Linux
+# filesystem. This script deliberately never traverses /mnt/c.
+
+TRANSFER_ROOT=""
+APPLY=0
+FINAL_SYNC=0
+STATE_ROOT="${STATE_ROOT:-/var/lib/skincos-runtime}"
+CONFIG_ROOT="${CONFIG_ROOT:-/etc/skincos}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-/mnt/c/CodexRuntime/artifacts}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/apply-lifecycle-state-transfer.sh --transfer-root <native-linux-path> [--apply] [--final-sync]
+
+Validates and applies a transfer created by transfer-lifecycle-state.ps1.
+The transfer root must be under the native Linux filesystem; /mnt/c is refused.
+Without --apply it validates the manifest and reports the planned operation.
+--final-sync overlays the final stopped-service delta; it never deletes native
+or legacy content.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --transfer-root) TRANSFER_ROOT="${2:-}"; shift ;;
+    --apply) APPLY=1 ;;
+    --final-sync) FINAL_SYNC=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[[ -n "$TRANSFER_ROOT" && -d "$TRANSFER_ROOT" ]] || { echo "--transfer-root must name an existing native transfer directory." >&2; exit 1; }
+[[ "$TRANSFER_ROOT" != /mnt/c/* ]] || { echo "Transfer root must be native Linux storage, never /mnt/c." >&2; exit 1; }
+[[ "$FINAL_SYNC" == "0" || "$APPLY" == "1" ]] || { echo "--final-sync requires --apply." >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is required." >&2; exit 1; }
+command -v rsync >/dev/null || { echo "rsync is required for native-to-native application." >&2; exit 1; }
+command -v sha256sum >/dev/null || { echo "sha256sum is required." >&2; exit 1; }
+command -v tar >/dev/null || { echo "tar is required." >&2; exit 1; }
+command -v sudo >/dev/null || { echo "sudo is required." >&2; exit 1; }
+sudo -n true
+
+manifest="$TRANSFER_ROOT/inventory.json"
+payload_archive="$TRANSFER_ROOT/payload.tar"
+[[ -f "$manifest" && -f "$payload_archive" ]] || { echo "Transfer is missing inventory.json or payload.tar." >&2; exit 1; }
+python3 - "$manifest" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding='utf-8-sig') as handle:
+    document = json.load(handle)
+if document.get('schema') != 1 or document.get('mode') not in {'precopy', 'final'}:
+    raise SystemExit('Unsupported lifecycle transfer manifest.')
+entries = document.get('entries')
+if not isinstance(entries, dict) or not entries:
+    raise SystemExit('Transfer manifest has no entries.')
+PY
+expected_archive_sha="$(python3 - "$manifest" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding='utf-8-sig') as handle:
+    print(json.load(handle)['stateArchive']['sha256'])
+PY
+)"
+actual_archive_sha="$(sha256sum "$payload_archive" | awk '{print $1}')"
+[[ "$expected_archive_sha" == "$actual_archive_sha" ]] || { echo "Lifecycle state archive checksum mismatch." >&2; exit 1; }
+payload="$TRANSFER_ROOT/payload"
+if [[ ! -d "$payload" ]]; then
+  mkdir -p "$payload"
+  if ! tar -tf "$payload_archive" | awk '
+    $0 !~ /^(n8n\/evolution-api\/(instances|store)|crm-api\/var|booking-api\/(chrome-profile|report|debug))(\/|$)/ { invalid=1 }
+    $0 ~ /(^|\/)\.\.($|\/)/ { invalid=1 }
+    END { exit invalid ? 1 : 0 }
+  '; then
+    echo "Lifecycle state archive contains an unexpected path." >&2
+    exit 1
+  fi
+  tar -xf "$payload_archive" -C "$payload"
+fi
+
+copy_tree() {
+  local relative="$1" destination="$2"
+  local source="$payload/$relative"
+  [[ -d "$source" ]] || return 0
+  echo "TREE $relative -> $destination"
+  [[ "$APPLY" == "1" ]] || return 0
+  sudo -n install -d -o skincos -g skincos -m 0750 "$destination"
+  local -a args=(-a)
+  [[ "$FINAL_SYNC" == "0" ]] && args+=(--ignore-existing)
+  sudo -n rsync "${args[@]}" "$source/" "$destination/"
+  sudo -n chown -R skincos:skincos "$destination"
+  sudo -n find "$destination" -type d -exec chmod 0750 {} +
+  sudo -n find "$destination" -type f -exec chmod 0640 {} +
+}
+
+install_private_file() {
+  local relative="$1" destination="$2"
+  local source="$TRANSFER_ROOT/$relative"
+  if [[ ! -f "$source" ]] && ! sudo -n test -f "$source"; then
+    source="$(python3 - "$manifest" "$relative" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding='utf-8-sig') as handle:
+    value = json.load(handle).get('nativeSources', {}).get(sys.argv[2], '')
+if value.startswith('/etc/skincos/') and '..' not in value.split('/'):
+    print(value)
+PY
+)"
+    [[ -n "$source" ]] && sudo -n test -f "$source" || { echo "Required transfer item missing: $relative" >&2; exit 1; }
+  fi
+  echo "PRIVATE $relative -> $destination"
+  if [[ "$APPLY" == "1" ]]; then
+    sudo -n install -D -o root -g skincos -m 0640 "$source" "$destination"
+  fi
+}
+
+rewrite_credential_path() {
+  local config="$1" credential="$2"
+  [[ "$APPLY" == "1" ]] || return 0
+  local escaped
+  escaped="$(printf '%s' "$credential" | sed 's/[&|]/\\&/g')"
+  sudo -n sed -i -E "s|^([[:space:]]*credentials-file:[[:space:]]*).*|\\1$escaped|" "$config"
+}
+
+copy_tree n8n/evolution-api/instances "$STATE_ROOT/messaging-whatsapp/instances"
+copy_tree n8n/evolution-api/store "$STATE_ROOT/messaging-whatsapp/store"
+copy_tree crm-api/var "$STATE_ROOT/crm/var"
+copy_tree booking-api/chrome-profile "$STATE_ROOT/booking/chrome-profile"
+copy_tree booking-api/report "$ARTIFACT_ROOT/booking/report"
+copy_tree booking-api/debug "$ARTIFACT_ROOT/booking/debug"
+
+install_private_file config/orb.env "$CONFIG_ROOT/orb.env"
+install_private_file config/orb-business.env "$CONFIG_ROOT/orb-business.env"
+install_private_file config/messaging-whatsapp.env "$CONFIG_ROOT/messaging-whatsapp.env"
+install_private_file config/crm.env "$CONFIG_ROOT/crm.env"
+install_private_file config/booking.env "$CONFIG_ROOT/booking.env"
+install_private_file config/cloudflare/orb/config.yml "$CONFIG_ROOT/cloudflare/orb/config.yml"
+install_private_file config/cloudflare/orb/credential.json "$CONFIG_ROOT/cloudflare-orb.json"
+install_private_file config/cloudflare/runtime/config.yml "$CONFIG_ROOT/cloudflare/runtime/config.yml"
+install_private_file config/cloudflare/runtime/credential.json "$CONFIG_ROOT/cloudflare-runtime.json"
+
+if [[ "$APPLY" == "1" ]]; then
+  sudo -n install -D -o root -g skincos -m 0640 /dev/stdin "$CONFIG_ROOT/cloudflare/runtime/tunnel.env" <<EOF
+CLOUDFLARED_CONFIG_PATH=$CONFIG_ROOT/cloudflare/runtime/config.yml
+EOF
+  rewrite_credential_path "$CONFIG_ROOT/cloudflare/orb/config.yml" "$CONFIG_ROOT/cloudflare-orb.json"
+  rewrite_credential_path "$CONFIG_ROOT/cloudflare/runtime/config.yml" "$CONFIG_ROOT/cloudflare-runtime.json"
+  sudo -n chown -R root:skincos "$CONFIG_ROOT"
+  sudo -n find "$CONFIG_ROOT" -type d -exec chmod 0750 {} +
+  sudo -n find "$CONFIG_ROOT" -type f -exec chmod 0640 {} +
+fi
+
+if [[ "$APPLY" == "1" ]]; then
+  echo "Lifecycle transfer $([[ "$FINAL_SYNC" == "1" ]] && echo final-sync || echo pre-copy) validated and applied."
+else
+  echo "Lifecycle transfer $([[ "$FINAL_SYNC" == "1" ]] && echo final-sync || echo pre-copy) validated."
+fi

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -17,6 +17,7 @@ BACKUP_DIR=""
 ROLLBACK_ROOT=""
 ROLLBACK_ARTIFACT_ROOT=""
 ORB_STATE_HOME=""
+WINDOWS_TRANSFER_SCRIPT=""
 CHECKPOINT_DIR=""
 CUTOVER_STARTED=0
 CUTOVER_COMPLETE=0
@@ -45,12 +46,13 @@ new_units=(
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home>
-  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home>
+  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1>
+  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1>
 
 Without --apply, prints and validates the cutover prerequisites. --apply
-stops only the listed legacy services, promotes checksum-verified native Orb
-state, performs the non-destructive final sync, starts the lifecycle services
+stops only the listed legacy services, obtains the final non-Orb state delta
+through a Windows PowerShell process into native Linux storage, promotes
+checksum-verified native Orb state, starts the lifecycle services
 and runs health checks. If a post-stop step
 fails it restores the captured legacy units against --rollback-root and starts
 them again. The rollback artifacts must first be staged outside Git with
@@ -66,6 +68,7 @@ while [[ $# -gt 0 ]]; do
     --rollback-root) ROLLBACK_ROOT="${2:-}"; shift ;;
     --rollback-artifact-root) ROLLBACK_ARTIFACT_ROOT="${2:-}"; shift ;;
     --orb-state-home) ORB_STATE_HOME="${2:-}"; shift ;;
+    --windows-transfer-script) WINDOWS_TRANSFER_SCRIPT="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -87,6 +90,8 @@ sudo -n test -f "$ORB_STATE_HOME/state-archive.manifest" && sudo -n test -f "$OR
 [[ -f "$BACKUP_DIR/manifest.json" && -f "$BACKUP_DIR/n8n_runtime.dump" ]] || { echo "Backup is missing manifest.json or n8n_runtime.dump." >&2; exit 1; }
 [[ "$STOP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_STOP_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 [[ "$START_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_START_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
+[[ -n "$WINDOWS_TRANSFER_SCRIPT" ]] || { echo "--windows-transfer-script is required: final state must be copied by Windows, not read recursively through /mnt/c." >&2; exit 1; }
+command -v powershell.exe >/dev/null 2>&1 || { echo "powershell.exe is required for the Windows-native final transfer." >&2; exit 1; }
 
 expected_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["databaseSha256"])' "$BACKUP_DIR/manifest.json")"
 actual_sha="$(sha256sum "$BACKUP_DIR/n8n_runtime.dump" | awk '{print $1}')"
@@ -214,6 +219,20 @@ restore_legacy_services() {
   start_units_bounded "${legacy_units[@]}"
 }
 
+run_final_windows_transfer() {
+  local output transfer_root
+  echo "Capturing final non-Orb delta through Windows into native Linux storage."
+  output="$(powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_TRANSFER_SCRIPT" -FinalSync)" || {
+    echo "Windows final transfer failed; legacy services will be restored." >&2
+    return 1
+  }
+  printf '%s\n' "$output"
+  transfer_root="$(printf '%s\n' "$output" | awk -F= '/^LIFECYCLE_TRANSFER_ROOT=/{print $2; exit}')"
+  [[ -n "$transfer_root" ]] || { echo "Windows transfer did not report LIFECYCLE_TRANSFER_ROOT." >&2; return 1; }
+  [[ "$transfer_root" != /mnt/c/* ]] || { echo "Windows transfer incorrectly returned a DrvFS path." >&2; return 1; }
+  "$ROOT_DIR/scripts/runtime/apply-lifecycle-state-transfer.sh" --transfer-root "$transfer_root" --apply --final-sync
+}
+
 on_exit() {
   local status=$?
   if [[ "$APPLY" == "1" && "$CUTOVER_STARTED" == "1" && "$CUTOVER_COMPLETE" != "1" ]]; then
@@ -229,6 +248,7 @@ echo "Rollback runtime artifacts: $ROLLBACK_ARTIFACT_ROOT"
 echo "Native source release: $SOURCE_ROOT"
 echo "Native WhatsApp release: $MESSAGING_RELEASE_ROOT"
 echo "Native Orb state staging: $ORB_STATE_HOME"
+echo "Windows final-transfer script: $WINDOWS_TRANSFER_SCRIPT"
 echo "Lifecycle source: $ROOT_DIR"
 printf 'Legacy services: %s\n' "${legacy_units[*]}"
 printf 'Lifecycle services: %s\n' "${new_units[*]}"
@@ -236,7 +256,7 @@ printf 'Lifecycle services: %s\n' "${new_units[*]}"
 if [[ "$APPLY" != "1" ]]; then
   validate_rollback_artifacts
   "$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --staged-home "$ORB_STATE_HOME"
-  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh"
+  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --skip-legacy-transfer
   SOURCE_ROOT="$SOURCE_ROOT" "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh"
   echo "Preflight passed. Use --apply only in the scheduled cut window."
   exit 0
@@ -248,8 +268,9 @@ CUTOVER_STARTED=1
 
 echo "Stopping legacy ingress and runtimes."
 stop_units_bounded "${legacy_units[@]}"
+run_final_windows_transfer
 "$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --apply --staged-home "$ORB_STATE_HOME"
-"$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync
+"$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync --skip-legacy-transfer
 BOOKING_API_RUNTIME_HOME="$STATE_ROOT/booking" EF_SCRAPER_VENV_DIR="$STATE_ROOT/booking/venv" "$SOURCE_ROOT/scripts/booking/bootstrap-venv.sh"
 "$ROOT_DIR/scripts/runtime/install-lifecycle-units.sh" --apply
 

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -18,6 +18,8 @@ ROLLBACK_ROOT=""
 ROLLBACK_ARTIFACT_ROOT=""
 ORB_STATE_HOME=""
 WINDOWS_TRANSFER_SCRIPT=""
+WINDOWS_ORB_EXPORT_SCRIPT=""
+WINDOWS_ORB_TRANSFER_SCRIPT=""
 CHECKPOINT_DIR=""
 CUTOVER_STARTED=0
 CUTOVER_COMPLETE=0
@@ -46,8 +48,8 @@ new_units=(
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1>
-  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1>
+  scripts/runtime/cutover-lifecycle-runtime.sh --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1> --windows-orb-export-script <windows-ps1> --windows-orb-transfer-script <windows-ps1>
+  scripts/runtime/cutover-lifecycle-runtime.sh --apply --backup-dir <verified-backup> --rollback-root <legacy-worktree> --rollback-artifact-root <runtime-artifacts> --orb-state-home <native-staging-home> --windows-transfer-script <windows-ps1> --windows-orb-export-script <windows-ps1> --windows-orb-transfer-script <windows-ps1>
 
 Without --apply, prints and validates the cutover prerequisites. --apply
 stops only the listed legacy services, obtains the final non-Orb state delta
@@ -69,6 +71,8 @@ while [[ $# -gt 0 ]]; do
     --rollback-artifact-root) ROLLBACK_ARTIFACT_ROOT="${2:-}"; shift ;;
     --orb-state-home) ORB_STATE_HOME="${2:-}"; shift ;;
     --windows-transfer-script) WINDOWS_TRANSFER_SCRIPT="${2:-}"; shift ;;
+    --windows-orb-export-script) WINDOWS_ORB_EXPORT_SCRIPT="${2:-}"; shift ;;
+    --windows-orb-transfer-script) WINDOWS_ORB_TRANSFER_SCRIPT="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -79,7 +83,7 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
 }
 
-for command in curl readlink sha256sum python3 systemctl; do require_cmd "$command"; done
+for command in curl readlink sha256sum python3 systemctl wslpath awk; do require_cmd "$command"; done
 require_cmd sudo
 sudo -n true
 [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]] || { echo "--backup-dir must name an existing backup directory." >&2; exit 1; }
@@ -91,6 +95,7 @@ sudo -n test -f "$ORB_STATE_HOME/state-archive.manifest" && sudo -n test -f "$OR
 [[ "$STOP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_STOP_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 [[ "$START_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { echo "CUTOVER_START_TIMEOUT_SECONDS must be a positive integer." >&2; exit 1; }
 [[ -n "$WINDOWS_TRANSFER_SCRIPT" ]] || { echo "--windows-transfer-script is required: final state must be copied by Windows, not read recursively through /mnt/c." >&2; exit 1; }
+[[ -n "$WINDOWS_ORB_EXPORT_SCRIPT" && -n "$WINDOWS_ORB_TRANSFER_SCRIPT" ]] || { echo "Windows Orb export and transfer scripts are required: a stale Orb staging directory cannot be promoted." >&2; exit 1; }
 command -v powershell.exe >/dev/null 2>&1 || { echo "powershell.exe is required for the Windows-native final transfer." >&2; exit 1; }
 
 expected_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["databaseSha256"])' "$BACKUP_DIR/manifest.json")"
@@ -233,6 +238,26 @@ run_final_windows_transfer() {
   "$ROOT_DIR/scripts/runtime/apply-lifecycle-state-transfer.sh" --transfer-root "$transfer_root" --apply --final-sync
 }
 
+run_final_orb_transfer() {
+  local export_output archive archive_sha transfer_output extracted_home staged_output staged_home windows_artifact_root
+  windows_artifact_root="$(wslpath -w "$RUNTIME_ROOT/artifacts/runtime-cutover/$timestamp")"
+  echo "Creating authoritative Orb state archive through Windows after legacy services stopped."
+  export_output="$(powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_ORB_EXPORT_SCRIPT" -ArtifactRoot "$windows_artifact_root" -RequireLegacyOrbStopped)" || return 1
+  printf '%s\n' "$export_output"
+  archive="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_ARCHIVE=/{print $2; exit}')"
+  archive_sha="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_SHA256=/{print $2; exit}')"
+  [[ -n "$archive" && "$archive_sha" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo "Windows Orb export did not return an archive and SHA-256." >&2; return 1; }
+  transfer_output="$(powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_ORB_TRANSFER_SCRIPT" -Archive "$archive" -Sha256 "$archive_sha")" || return 1
+  printf '%s\n' "$transfer_output"
+  extracted_home="$(printf '%s\n' "$transfer_output" | awk -F= '/^EXTRACTED_ORB_STATE_HOME=/{print $2; exit}')"
+  [[ -n "$extracted_home" && "$extracted_home" != /mnt/* ]] || { echo "Windows Orb transfer did not return native extracted state." >&2; return 1; }
+  staged_output="$("$ROOT_DIR/scripts/runtime/stage-orb-state-archive.sh" --extracted-home "$extracted_home" --sha256 "$archive_sha" --apply)" || return 1
+  printf '%s\n' "$staged_output"
+  staged_home="$(printf '%s\n' "$staged_output" | awk -F= '/^STAGED_ORB_STATE_HOME=/{print $2; exit}')"
+  [[ -n "$staged_home" ]] || { echo "Native Orb stage did not return STAGED_ORB_STATE_HOME." >&2; return 1; }
+  ORB_STATE_HOME="$staged_home"
+}
+
 on_exit() {
   local status=$?
   if [[ "$APPLY" == "1" && "$CUTOVER_STARTED" == "1" && "$CUTOVER_COMPLETE" != "1" ]]; then
@@ -249,6 +274,8 @@ echo "Native source release: $SOURCE_ROOT"
 echo "Native WhatsApp release: $MESSAGING_RELEASE_ROOT"
 echo "Native Orb state staging: $ORB_STATE_HOME"
 echo "Windows final-transfer script: $WINDOWS_TRANSFER_SCRIPT"
+echo "Windows Orb export script: $WINDOWS_ORB_EXPORT_SCRIPT"
+echo "Windows Orb transfer script: $WINDOWS_ORB_TRANSFER_SCRIPT"
 echo "Lifecycle source: $ROOT_DIR"
 printf 'Legacy services: %s\n' "${legacy_units[*]}"
 printf 'Lifecycle services: %s\n' "${new_units[*]}"
@@ -269,6 +296,7 @@ CUTOVER_STARTED=1
 echo "Stopping legacy ingress and runtimes."
 stop_units_bounded "${legacy_units[@]}"
 run_final_windows_transfer
+run_final_orb_transfer
 "$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --apply --staged-home "$ORB_STATE_HOME"
 "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync --skip-legacy-transfer
 BOOKING_API_RUNTIME_HOME="$STATE_ROOT/booking" EF_SCRAPER_VENV_DIR="$STATE_ROOT/booking/venv" "$SOURCE_ROOT/scripts/booking/bootstrap-venv.sh"

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -14,11 +14,13 @@ LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT:-/mnt/c/CodexShared/Projetos/skincos}"
 APPLY=0
 FINAL_SYNC=0
 SKIP_MESSAGING_STATE=0
+SKIP_RUNTIME_DATA=0
+SKIP_LEGACY_TRANSFER=0
 SYNC_TRANSPORT="${LIFECYCLE_SYNC_TRANSPORT:-auto}"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-lifecycle-layout.sh [--apply] [--final-sync] [--skip-messaging-state]
+Usage: scripts/runtime/prepare-lifecycle-layout.sh [--apply] [--final-sync] [--skip-messaging-state] [--skip-runtime-data] [--skip-legacy-transfer]
 
 Copies mutable runtime state from the Windows legacy layout to native Linux
 state/config/log/tmp roots. C:\CodexRuntime remains the durable location for
@@ -27,6 +29,11 @@ backups and artifacts. Without --apply it reports the planned copies.
 source or an existing destination. It is reserved for the short window after
 the old services have stopped.
 --skip-messaging-state has the same restriction for the WhatsApp channel.
+--skip-runtime-data skips every recursive legacy directory copy after a
+Windows-to-Linux transfer has staged those paths natively.
+--skip-legacy-transfer skips every legacy runtime read. It is only valid when
+apply-lifecycle-state-transfer.sh has staged both data and private config from
+Windows through \\wsl$; it prevents a cutover from falling back to DrvFS.
 
 LIFECYCLE_SYNC_TRANSPORT chooses the directory-copy transport: auto (default)
 uses Windows robocopy for paths on /mnt/c and rsync otherwise; robocopy and
@@ -43,6 +50,8 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     --skip-messaging-state) SKIP_MESSAGING_STATE=1 ;;
+    --skip-runtime-data) SKIP_RUNTIME_DATA=1 ;;
+    --skip-legacy-transfer) SKIP_LEGACY_TRANSFER=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -289,36 +298,47 @@ done
 # cutover promotes that prepared directory atomically after legacy services
 # stop; this generic layout helper must never recurse through n8n-home.
 echo "ORB state is archive-staged separately; n8n-home is intentionally not synced here."
-if [[ "$SKIP_MESSAGING_STATE" == "1" ]]; then
+if [[ "$SKIP_LEGACY_TRANSFER" == "1" ]]; then
+  echo "SKIP legacy data and private configuration: Windows-native transfer is authoritative."
+elif [[ "$SKIP_RUNTIME_DATA" == "1" ]]; then
+  echo "SKIP legacy runtime directories: transferred through the Windows-native channel."
+elif [[ "$SKIP_MESSAGING_STATE" == "1" ]]; then
   echo "SKIP messaging state: completed by the independently recorded pre-copy."
 else
   sync_path "$legacy_orb/evolution-api/instances" "$STATE_ROOT/messaging-whatsapp"
   sync_path "$legacy_orb/evolution-api/store" "$STATE_ROOT/messaging-whatsapp"
+  workflows_source="$(resolve_workflows_dir "$LEGACY_REPO_ROOT" || true)"
+  if [[ -n "$workflows_source" ]]; then
+    sync_path "$workflows_source" "$STATE_ROOT/orb"
+  else
+    echo "SKIP missing Orb workflows under $LEGACY_REPO_ROOT"
+  fi
+  sync_path "$legacy_orb/logs/." "$LOG_ROOT/orb"
+  sync_path "$legacy_crm/var" "$STATE_ROOT/crm"
+  sync_path "$legacy_booking/report" "$ARTIFACT_ROOT/booking"
+  sync_path "$legacy_booking/debug" "$ARTIFACT_ROOT/booking"
+  sync_path "$legacy_booking/chrome-profile" "$STATE_ROOT/booking"
+  echo "REBUILD $STATE_ROOT/booking/venv from the locked booking requirements during cutover"
 fi
-workflows_source="$(resolve_workflows_dir "$LEGACY_REPO_ROOT" || true)"
-if [[ -n "$workflows_source" ]]; then
-  sync_path "$workflows_source" "$STATE_ROOT/orb"
-else
-  echo "SKIP missing Orb workflows under $LEGACY_REPO_ROOT"
-fi
-sync_path "$legacy_orb/logs/." "$LOG_ROOT/orb"
-sync_path "$legacy_crm/var" "$STATE_ROOT/crm"
-sync_path "$legacy_booking/report" "$ARTIFACT_ROOT/booking"
-sync_path "$legacy_booking/debug" "$ARTIFACT_ROOT/booking"
-sync_path "$legacy_booking/chrome-profile" "$STATE_ROOT/booking"
-echo "REBUILD $STATE_ROOT/booking/venv from the locked booking requirements during cutover"
 
-sync_secret "$legacy_orb/env/n8n.env" "$secrets_dir/orb.env"
-sync_secret "$legacy_orb/env/n8n-business.env" "$secrets_dir/orb-business.env"
-sync_secret "$legacy_orb/env/evolution-api.env" "$secrets_dir/messaging-whatsapp.env"
-sync_secret "$legacy_crm/env/crm-api.env" "$secrets_dir/crm.env"
-sync_secret "$legacy_booking/env/booking-api.env" "$secrets_dir/booking.env"
-sync_tunnel_config orb "$legacy_orb/cloudflared/orb-config.yml" "$CONFIG_ROOT/cloudflare/orb/config.yml" "$secrets_dir/cloudflare-orb.json"
-sync_runtime_tunnel
+if [[ "$SKIP_LEGACY_TRANSFER" != "1" ]]; then
+  sync_secret "$legacy_orb/env/n8n.env" "$secrets_dir/orb.env"
+  sync_secret "$legacy_orb/env/n8n-business.env" "$secrets_dir/orb-business.env"
+  sync_secret "$legacy_orb/env/evolution-api.env" "$secrets_dir/messaging-whatsapp.env"
+  sync_secret "$legacy_crm/env/crm-api.env" "$secrets_dir/crm.env"
+  sync_secret "$legacy_booking/env/booking-api.env" "$secrets_dir/booking.env"
+  sync_tunnel_config orb "$legacy_orb/cloudflared/orb-config.yml" "$CONFIG_ROOT/cloudflare/orb/config.yml" "$secrets_dir/cloudflare-orb.json"
+  sync_runtime_tunnel
+fi
 
 if [[ "$APPLY" == "1" ]]; then
+  # The runtime processes run as skincos:skincos. Keep the configuration root
+  # root-owned, but preserve group read/traverse access for environment files
+  # and Cloudflare credentials. Removing all group permissions would make the
+  # final tunnel units fail only after the legacy services are stopped.
   sudo -n chown -R root:skincos "$CONFIG_ROOT"
-  sudo -n chmod -R go-rwx "$CONFIG_ROOT"
+  sudo -n find "$CONFIG_ROOT" -type d -exec chmod 0750 {} +
+  sudo -n find "$CONFIG_ROOT" -type f -exec chmod 0640 {} +
   echo "Copy complete. Legacy runtime was preserved; only the coordinated cutover may stop services or retire old paths."
 else
   echo "Dry run complete. Use --apply only after the source PR, backup checkpoint and service cutover plan are approved."

--- a/scripts/runtime/test-prepare-lifecycle-layout.sh
+++ b/scripts/runtime/test-prepare-lifecycle-layout.sh
@@ -39,4 +39,13 @@ env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=
 env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync >/dev/null
 [[ ! -e "$runtime_root/state/orb/n8n-home/payload.txt" ]]
+
+# The cutover path must be able to avoid *all* legacy reads after the
+# Windows-native transfer is staged. It may not recreate secrets or state from
+# the test legacy root even during the final window.
+rm -rf "$runtime_root/state" "$runtime_root/config"
+env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=robocopy \
+  "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync --skip-legacy-transfer >/dev/null
+[[ ! -e "$runtime_root/state/messaging-whatsapp/instances" ]]
+[[ ! -e "$runtime_root/config/orb.env" ]]
 echo "prepare lifecycle layout excludes Orb n8n-home test passed"

--- a/scripts/runtime/transfer-lifecycle-state.ps1
+++ b/scripts/runtime/transfer-lifecycle-state.ps1
@@ -1,0 +1,149 @@
+[CmdletBinding()]
+param(
+  [string]$RuntimeRoot = 'C:\CodexRuntime',
+  [string]$Distribution = 'Ubuntu-24.04',
+  [string]$LinuxUser = 'admin',
+  [string]$TransferId = (Get-Date -Format 'yyyyMMddTHHmmssZ'),
+  [switch]$FinalSync
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-TreeInventory([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return [ordered]@{ exists = $false; files = 0; bytes = 0; latestUtc = $null }
+  }
+  $items = @(Get-ChildItem -LiteralPath $Path -Force -Recurse -File -ErrorAction Stop)
+  $latest = $items | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+  return [ordered]@{
+    exists = $true
+    files = $items.Count
+    bytes = [Int64](($items | Measure-Object -Property Length -Sum).Sum)
+    latestUtc = if ($latest) { $latest.LastWriteTimeUtc.ToString('o') } else { (Get-Item -LiteralPath $Path).LastWriteTimeUtc.ToString('o') }
+  }
+}
+
+function Copy-File([string]$Source, [string]$Destination, [string]$Label) {
+  if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) { throw "Required private runtime file is missing: $Label" }
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
+  Copy-Item -LiteralPath $Source -Destination $Destination -Force
+  $item = Get-Item -LiteralPath $Source
+  return [ordered]@{ exists = $true; files = 1; bytes = [Int64]$item.Length; latestUtc = $item.LastWriteTimeUtc.ToString('o') }
+}
+
+function Get-EnvValue([string]$Path, [string]$Name) {
+  $line = Get-Content -LiteralPath $Path | Where-Object { $_ -match "^$([regex]::Escape($Name))=" } | Select-Object -First 1
+  if (-not $line) { return $null }
+  return ($line -split '=', 2)[1].Trim().Trim('"')
+}
+
+function Get-TunnelCredential([string]$Config) {
+  $line = Get-Content -LiteralPath $Config | Where-Object { $_ -match '^\s*credentials-file\s*:' } | Select-Object -First 1
+  if (-not $line) { throw "Tunnel config has no credentials-file entry: $Config" }
+  return (($line -split ':', 2)[1]).Trim().Trim('"')
+}
+
+function Resolve-WindowsRuntimePath([string]$Path) {
+  $candidate = $Path.Trim().Trim('"')
+  if ($candidate -match '^/mnt/([A-Za-z])/(.+)$') {
+    return ('{0}:\{1}' -f $matches[1].ToUpperInvariant(), ($matches[2] -replace '/', '\'))
+  }
+  return $candidate
+}
+
+function Copy-PrivateRuntimeFile([string]$Source, [string]$Destination, [string]$Label, [string]$Relative, [System.Collections.IDictionary]$NativeSources) {
+  $windowsPath = Resolve-WindowsRuntimePath $Source
+  if (Test-Path -LiteralPath $windowsPath -PathType Leaf) {
+    return Copy-File $windowsPath $Destination $Label
+  }
+  # Some legacy tunnel units already keep only their credential in native
+  # /etc/skincos. Record that private native origin for the Linux apply step;
+  # do not read it back through /mnt/c or expose its contents in this manifest.
+  if ($Source -match '^/etc/skincos/') {
+    $NativeSources[$Relative] = $Source
+    return [ordered]@{ exists = $true; files = 1; bytes = $null; latestUtc = $null; origin = 'native-linux' }
+  }
+  throw "Required private runtime file is missing: $Label"
+}
+
+$wslRoot = "\\wsl$\$Distribution\home\$LinuxUser\skincos-lifecycle-transfer\$TransferId"
+$artifactRoot = Join-Path $RuntimeRoot "artifacts\lifecycle-transfer\$TransferId"
+New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $wslRoot | Out-Null
+
+$source = @{
+  'n8n/evolution-api/instances' = Join-Path $RuntimeRoot 'n8n\evolution-api\instances'
+  'n8n/evolution-api/store' = Join-Path $RuntimeRoot 'n8n\evolution-api\store'
+  'crm-api/var' = Join-Path $RuntimeRoot 'crm-api\var'
+  'booking-api/chrome-profile' = Join-Path $RuntimeRoot 'booking-api\chrome-profile'
+  'booking-api/report' = Join-Path $RuntimeRoot 'booking-api\report'
+  'booking-api/debug' = Join-Path $RuntimeRoot 'booking-api\debug'
+}
+
+$inventory = [ordered]@{}
+$nativeSources = [ordered]@{}
+$tarEntries = [System.Collections.Generic.List[string]]::new()
+foreach ($entry in $source.GetEnumerator()) {
+  $inventory[$entry.Key] = Get-TreeInventory $entry.Value
+  if ($inventory[$entry.Key].exists) { [void]$tarEntries.Add($entry.Key) }
+}
+
+# A single Windows-created tar is copied through \\wsl$ and extracted only on
+# ext4. Direct UNC traversal of thousands of active WhatsApp session files is
+# too slow for the short cutover window; this still avoids recursive WSL reads
+# of C: while preserving the source tree's names and timestamps.
+$payloadArchive = Join-Path $artifactRoot 'lifecycle-state.tar'
+if ($tarEntries.Count -gt 0) {
+  & tar.exe -cf $payloadArchive -C $RuntimeRoot @($tarEntries)
+} else {
+  & tar.exe -cf $payloadArchive --files-from NUL
+}
+if ($LASTEXITCODE -ne 0) { throw 'Windows tar failed while creating lifecycle state transfer.' }
+$archiveHash = (Get-FileHash -LiteralPath $payloadArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+Copy-Item -LiteralPath $payloadArchive -Destination (Join-Path $wslRoot 'payload.tar') -Force
+
+$legacyN8n = Join-Path $RuntimeRoot 'n8n'
+$legacyCrm = Join-Path $RuntimeRoot 'crm-api'
+$legacyBooking = Join-Path $RuntimeRoot 'booking-api'
+$privateFiles = @{
+  'config/orb.env' = Join-Path $legacyN8n 'env\n8n.env'
+  'config/orb-business.env' = Join-Path $legacyN8n 'env\n8n-business.env'
+  'config/messaging-whatsapp.env' = Join-Path $legacyN8n 'env\evolution-api.env'
+  'config/crm.env' = Join-Path $legacyCrm 'env\crm-api.env'
+  'config/booking.env' = Join-Path $legacyBooking 'env\booking-api.env'
+}
+foreach ($entry in $privateFiles.GetEnumerator()) {
+  $inventory[$entry.Key] = Copy-File $entry.Value (Join-Path $wslRoot $entry.Key) $entry.Key
+}
+
+$orbConfig = Join-Path $legacyN8n 'cloudflared\orb-config.yml'
+$orbCredential = Get-TunnelCredential $orbConfig
+$inventory['config/cloudflare/orb/config.yml'] = Copy-File $orbConfig (Join-Path $wslRoot 'config\cloudflare\orb\config.yml') 'orb tunnel config'
+$inventory['config/cloudflare/orb/credential.json'] = Copy-PrivateRuntimeFile $orbCredential (Join-Path $wslRoot 'config\cloudflare\orb\credential.json') 'orb tunnel credential' 'config/cloudflare/orb/credential.json' $nativeSources
+
+$runtimeTunnelEnv = Join-Path $RuntimeRoot 'cloudflared\cs\cloudflared-cs.env'
+$runtimeConfig = Resolve-WindowsRuntimePath (Get-EnvValue $runtimeTunnelEnv 'CLOUDFLARED_CONFIG_PATH')
+if (-not $runtimeConfig) { throw 'Runtime Cloudflare tunnel environment has no CLOUDFLARED_CONFIG_PATH.' }
+$runtimeCredential = Get-TunnelCredential $runtimeConfig
+$inventory['config/cloudflare/runtime/config.yml'] = Copy-File $runtimeConfig (Join-Path $wslRoot 'config\cloudflare\runtime\config.yml') 'runtime tunnel config'
+$inventory['config/cloudflare/runtime/credential.json'] = Copy-PrivateRuntimeFile $runtimeCredential (Join-Path $wslRoot 'config\cloudflare\runtime\credential.json') 'runtime tunnel credential' 'config/cloudflare/runtime/credential.json' $nativeSources
+
+# The inventory intentionally contains only metadata and no hashes of private
+# contents or variable values. It stays in the Linux-private transfer root.
+$manifest = [ordered]@{
+  schema = 1
+  transferId = $TransferId
+  mode = if ($FinalSync) { 'final' } else { 'precopy' }
+  createdUtc = (Get-Date).ToUniversalTime().ToString('o')
+  runtimeRoot = $RuntimeRoot
+  stateArchive = [ordered]@{ name = 'payload.tar'; sha256 = $archiveHash; bytes = (Get-Item -LiteralPath $payloadArchive).Length }
+  nativeSources = $nativeSources
+  entries = $inventory
+}
+$manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $wslRoot 'inventory.json') -Encoding UTF8
+
+Write-Output "LIFECYCLE_TRANSFER_ROOT=/home/$LinuxUser/skincos-lifecycle-transfer/$TransferId"
+Write-Output "MODE=$($manifest.mode)"
+foreach ($entry in $inventory.GetEnumerator()) {
+  Write-Output ("{0}: files={1} bytes={2} latestUtc={3}" -f $entry.Key, $entry.Value.files, $entry.Value.bytes, $entry.Value.latestUtc)
+}


### PR DESCRIPTION
Windows-created archive transfer into native Linux staging; validates checksum and least-privilege state/config application; cutover captures final post-stop delta with rollback. Validated locally with lifecycle tests, real pre-copy integrity samples and cutover preflight. No state, backup or credential is included.