### PR TITLE
fix(runtime): create WhatsApp build output before TypeScript

### DIFF
--- a/scripts/runtime/prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/prepare-messaging-whatsapp-release.sh
@@ -66,6 +66,10 @@ sudo -n rsync -a --delete \
   --exclude '.env' --exclude '.env.*' --exclude 'node_modules' --exclude 'dist' \
   "$SOURCE_DIR/" "$STAGING/"
 sudo -n chown -R skincos:skincos "$STAGING"
+# tsconfig writes its incremental build info under dist before tsup runs. The
+# release copy intentionally excludes generated dist, so create the native
+# output directory explicitly instead of depending on an old worktree build.
+sudo -n install -d -o skincos -g skincos -m 0750 "$STAGING/dist"
 
 sudo -n -u skincos env npm_config_cache="$NPM_CACHE" \
   npm --prefix "$STAGING" ci --ignore-scripts

--- a/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREPARE="$ROOT_DIR/scripts/runtime/prepare-messaging-whatsapp-release.sh"
+
+bash -n "$PREPARE"
+
+mkdir_line="$(grep -nF 'install -d -o skincos -g skincos -m 0750 "$STAGING/dist"' "$PREPARE" | cut -d: -f1)"
+build_line="$(grep -nF 'npm --prefix "$STAGING" run build' "$PREPARE" | cut -d: -f1)"
+[[ -n "$mkdir_line" && -n "$build_line" && "$mkdir_line" -lt "$build_line" ]] || {
+  echo 'Messaging release preparation must create native dist before the build.' >&2
+  exit 1
+}
+
+echo 'Messaging WhatsApp native release preparation checks passed'


### PR DESCRIPTION
Fixes a verified native-release failure: TypeScript writes incremental metadata under dist before tsup runs, while the release copy intentionally excludes generated dist. The launcher now provisions native dist with skincos ownership and a regression check verifies the ordering. No runtime state or credential is included.