### PR TITLE
fix: validate WSL keepalive process identity

### DIFF
--- a/scripts/start-wsl-runtime-keepalive.ps1
+++ b/scripts/start-wsl-runtime-keepalive.ps1
@@ -8,13 +8,46 @@ $ErrorActionPreference = "Stop"
 $wslPath = Join-Path $env:SystemRoot "System32\wsl.exe"
 $pidPath = Join-Path $stateDirectory "wsl-runtime-keepalive.pid"
 
+function Test-SkincosWslKeepaliveProcess {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Process,
+        [Parameter(Mandatory)]
+        [string]$ExpectedDistro
+    )
+
+    if ($Process.Name -ine "wsl.exe") {
+        return $false
+    }
+
+    $commandLine = [string]$Process.CommandLine
+    $distroPattern = [regex]::Escape($ExpectedDistro)
+    return $commandLine -match ('(?i)(?:^|\s)-d\s+"?{0}(?:"?|\s)' -f $distroPattern) -and
+        $commandLine -match "(?i)(?:^|\s)-u\s+root(?:\s|$)" -and
+        $commandLine -match "(?i)/bin/sleep\s+infinity(?:\s|$)"
+}
+
 if (Test-Path -LiteralPath $pidPath) {
     $existingPid = (Get-Content -LiteralPath $pidPath -Raw -ErrorAction SilentlyContinue).Trim()
-    if ($existingPid -match '^\d+$' -and (Get-Process -Id $existingPid -ErrorAction SilentlyContinue)) {
-        exit 0
+    if ($existingPid -match '^\d+$') {
+        $existingProcess = Get-CimInstance Win32_Process -Filter "ProcessId=$existingPid" -ErrorAction SilentlyContinue
+        if ($existingProcess -and (Test-SkincosWslKeepaliveProcess -Process $existingProcess -ExpectedDistro $Distro)) {
+            exit 0
+        }
     }
 
     Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
+}
+
+# A prior launcher can have lost its PID file. Reuse only a verified WSL client;
+# never treat a recycled Windows PID as proof that the runtime is still alive.
+$existingKeepalive = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    Test-SkincosWslKeepaliveProcess -Process $_ -ExpectedDistro $Distro
+} | Select-Object -First 1
+if ($existingKeepalive) {
+    New-Item -ItemType Directory -Force -Path $stateDirectory | Out-Null
+    Set-Content -LiteralPath $pidPath -Value $existingKeepalive.ProcessId -Encoding ascii
+    exit 0
 }
 
 # Detach from Task Scheduler so the WSL client survives after this launcher exits.

--- a/scripts/test-wsl-runtime-keepalive.ps1
+++ b/scripts/test-wsl-runtime-keepalive.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$launcher = Join-Path $PSScriptRoot "start-wsl-runtime-keepalive.ps1"
+$content = Get-Content -LiteralPath $launcher -Raw
+
+$requiredPatterns = @(
+    'function Test-SkincosWslKeepaliveProcess',
+    '\$Process\.Name -ine "wsl\.exe"',
+    'Get-CimInstance Win32_Process -Filter "ProcessId=\$existingPid"',
+    'never treat a recycled Windows PID as proof',
+    'Test-SkincosWslKeepaliveProcess -Process \$existingProcess -ExpectedDistro \$Distro',
+    'Test-SkincosWslKeepaliveProcess -Process \$_ -ExpectedDistro \$Distro'
+)
+
+foreach ($pattern in $requiredPatterns) {
+    if ($content -notmatch $pattern) {
+        throw "Keepalive regression guard missing required behavior: $pattern"
+    }
+}
+
+Write-Host "PASS: WSL keepalive verifies process identity before trusting a PID file."


### PR DESCRIPTION
## What changed\nThe hidden Windows keepalive launcher now verifies that its recorded PID is the expected wsl.exe sleep-infinity client before trusting it. It also recovers a missing PID file from an already-valid client.\n\n## Root cause\nA stale PID was reused by csrss.exe. The former launcher treated any live process with that PID as the keepalive, leaving WSL idle until vmIdleTimeout stopped the runtime.\n\n## Validation\n- PowerShell parser validation for both scripts\n- Regression guard for process identity validation\n- Live recovery from the stale PID to a verified wsl.exe client\n\nThis change prevents the host-idle shutdown that blocked the controlled runtime cutover.