### PR TITLE
fix(security): update Pillow to 12.2.0

### DIFF
--- a/social/instagram/instagrapi/pyproject.toml
+++ b/social/instagram/instagrapi/pyproject.toml
@@ -82,7 +82,7 @@ Repository = "https://github.com/subzeroid/instagrapi"
 [project.optional-dependencies]
 test = [
     "flake8==7.3.0",
-    "Pillow==11.3.0",
+    "Pillow==12.2.0",
     "isort==6.0.1",
     "bandit==1.8.6",
     "mike==2.1.3",

--- a/social/instagram/instagrapi/requirements-test.txt
+++ b/social/instagram/instagrapi/requirements-test.txt
@@ -1,5 +1,5 @@
 flake8==7.3.0
-Pillow==11.3.0
+Pillow==12.2.0
 isort==6.0.1
 bandit==1.8.6
 pytest-xdist==3.8.0


### PR DESCRIPTION
## Security remediation\nUpdates Pillow from 11.3.0 to 12.2.0 in both instagrapi test dependency declarations. This closes Dependabot alerts #1271, #1273, #1277, #1278, #1279 and #1283.\n\n## Scope and reachability\nPillow is used by the Instagram module image helpers; image parsing is a reachable boundary for media handling.\n\n## Validation\n- installed Pillow 12.2.0 in a clean native-Linux virtual environment\n- created an RGB image through the public PIL API\n- verified both declarations are aligned\n\nNo application code or runtime state changed.