### PR TITLE
fix: accept failed units after lifecycle stop

### DIFF
--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -335,7 +335,12 @@ save_legacy_units
 CUTOVER_STARTED=1
 
 echo "Stopping legacy ingress and runtimes."
-stop_units_bounded "${legacy_units[@]}"
+if ! stop_units_bounded "${legacy_units[@]}"; then
+  echo "Legacy services did not reach a stopped state; restoring the retained stack before exit." >&2
+  restore_legacy_services
+  CUTOVER_STARTED=0
+  exit 1
+fi
 run_final_windows_transfer
 run_final_orb_transfer
 "$ROOT_DIR/scripts/runtime/promote-orb-state-staging.sh" --apply --staged-home "$ORB_STATE_HOME"

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -167,10 +167,14 @@ wait_for_units_state() {
     pending=0
     for unit in "$@"; do
       state="$(sudo -n systemctl is-active "$unit" 2>/dev/null || true)"
-      if [[ "$state" != "$expected" ]]; then
-        pending=1
-        printf 'unit=%s state=%s expected=%s\n' "$unit" "${state:-unknown}" "$expected" >&2
+      # `systemctl stop` can leave a unit in failed when its process exits
+      # during shutdown. It is still stopped, so accept that terminal state
+      # only while waiting for a stop; startup still requires active.
+      if [[ "$state" == "$expected" ]] || [[ "$expected" == "inactive" && "$state" == "failed" ]]; then
+        continue
       fi
+      pending=1
+      printf 'unit=%s state=%s expected=%s\n' "$unit" "${state:-unknown}" "$expected" >&2
     done
     [[ "$pending" == "0" ]] && return 0
     if (( SECONDS >= deadline )); then

--- a/scripts/runtime/test-cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/test-cutover-lifecycle-runtime.sh
@@ -13,6 +13,7 @@ required=(
   'to_windows_path()'
   'wslpath -w "$path"'
   '"$WINDOWS_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_TRANSFER_SCRIPT" -FinalSync'
+  '"$expected" == "inactive" && "$state" == "failed"'
 )
 
 for pattern in "${required[@]}"; do
@@ -22,4 +23,21 @@ for pattern in "${required[@]}"; do
   }
 done
 
-echo "PASS: cutover resolves Windows PowerShell without relying on the WSL PATH."
+function_file="$(mktemp)"
+trap 'rm -f "$function_file"' EXIT
+sed -n '/^wait_for_units_state()/,/^}$/p' "$SCRIPT" > "$function_file"
+# shellcheck source=/dev/null
+source "$function_file"
+
+sudo() {
+  [[ "$1" == "-n" ]] && shift
+  [[ "$1" == "systemctl" && "$2" == "is-active" ]] || return 1
+  printf 'failed\n'
+}
+
+# A failed unit has no running process after systemctl stop, and must not hold
+# the cutover in the legacy-stop phase. Startup is separately checked for active.
+wait_for_units_state inactive 1 stopped-unit.service
+unset -f sudo
+
+echo "PASS: cutover resolves Windows PowerShell and accepts failed as stopped."

--- a/scripts/runtime/test-cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/test-cutover-lifecycle-runtime.sh
@@ -14,6 +14,8 @@ required=(
   'wslpath -w "$path"'
   '"$WINDOWS_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_TRANSFER_SCRIPT" -FinalSync'
   '"$expected" == "inactive" && "$state" == "failed"'
+  'Legacy services did not reach a stopped state; restoring the retained stack before exit.'
+  'if ! stop_units_bounded "${legacy_units[@]}"; then'
 )
 
 for pattern in "${required[@]}"; do


### PR DESCRIPTION
## What changed\nThe lifecycle cutover now treats systemctl is-active = failed as stopped only during the legacy shutdown wait. Startup still requires ctive.\n\n## Incident evidence\nDuring the first controlled cut, skincos-crm-api.service exited in ailed while stopping. The previous wait interpreted it as running, aborted before transfer, and left all legacy units inactive. The captured checkpoint was used to restore the legacy stack; all local and public health checks returned.\n\n## Validation\n- bash syntax and resolver regression checks\n- focused test with a mocked systemctl is-active returning ailed\n- legacy restoration verified: seven units active and Orb, CRM, website and API public endpoints 200\n\nNo final units were installed by this PR.