### PR TITLE
fix(runtime): normalize Windows cutover output

### DIFF
--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          # Semgrep bundles a native semgrep-core executable. Pin a supported
+          # Python minor instead of following 3.x to a newly released runtime
+          # before the wheel bundle is available for it.
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: |
             backend/requirements.txt

--- a/scripts/runtime/cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/cutover-lifecycle-runtime.sh
@@ -297,7 +297,7 @@ run_final_windows_transfer() {
     return 1
   }
   printf '%s\n' "$output"
-  transfer_root="$(printf '%s\n' "$output" | awk -F= '/^LIFECYCLE_TRANSFER_ROOT=/{print $2; exit}')"
+  transfer_root="$(printf '%s\n' "$output" | awk -F= '/^LIFECYCLE_TRANSFER_ROOT=/{print $2; exit}' | tr -d '\r')"
   [[ -n "$transfer_root" ]] || { echo "Windows transfer did not report LIFECYCLE_TRANSFER_ROOT." >&2; return 1; }
   [[ "$transfer_root" != /mnt/c/* ]] || { echo "Windows transfer incorrectly returned a DrvFS path." >&2; return 1; }
   "$ROOT_DIR/scripts/runtime/apply-lifecycle-state-transfer.sh" --transfer-root "$transfer_root" --apply --final-sync
@@ -309,12 +309,12 @@ run_final_orb_transfer() {
   echo "Creating authoritative Orb state archive through Windows after legacy services stopped."
   export_output="$("$WINDOWS_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_ORB_EXPORT_SCRIPT" -ArtifactRoot "$windows_artifact_root" -RequireLegacyOrbStopped)" || return 1
   printf '%s\n' "$export_output"
-  archive="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_ARCHIVE=/{print $2; exit}')"
-  archive_sha="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_SHA256=/{print $2; exit}')"
+  archive="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_ARCHIVE=/{print $2; exit}' | tr -d '\r')"
+  archive_sha="$(printf '%s\n' "$export_output" | awk -F= '/^ORB_STATE_SHA256=/{print $2; exit}' | tr -d '\r')"
   [[ -n "$archive" && "$archive_sha" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo "Windows Orb export did not return an archive and SHA-256." >&2; return 1; }
   transfer_output="$("$WINDOWS_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$WINDOWS_ORB_TRANSFER_SCRIPT" -Archive "$archive" -Sha256 "$archive_sha")" || return 1
   printf '%s\n' "$transfer_output"
-  extracted_home="$(printf '%s\n' "$transfer_output" | awk -F= '/^EXTRACTED_ORB_STATE_HOME=/{print $2; exit}')"
+  extracted_home="$(printf '%s\n' "$transfer_output" | awk -F= '/^EXTRACTED_ORB_STATE_HOME=/{print $2; exit}' | tr -d '\r')"
   [[ -n "$extracted_home" && "$extracted_home" != /mnt/* ]] || { echo "Windows Orb transfer did not return native extracted state." >&2; return 1; }
   staged_output="$("$ROOT_DIR/scripts/runtime/stage-orb-state-archive.sh" --extracted-home "$extracted_home" --sha256 "$archive_sha" --apply)" || return 1
   printf '%s\n' "$staged_output"

--- a/scripts/runtime/test-cutover-lifecycle-runtime.sh
+++ b/scripts/runtime/test-cutover-lifecycle-runtime.sh
@@ -21,6 +21,10 @@ required=(
   'restore_legacy_watchdog()'
   'Quiescing the legacy watchdog.'
   'systemctl disable --now "$LEGACY_WATCHDOG_TIMER"'
+  "LIFECYCLE_TRANSFER_ROOT=/{print \$2; exit}' | tr -d '\\r'"
+  "ORB_STATE_ARCHIVE=/{print \$2; exit}' | tr -d '\\r'"
+  "ORB_STATE_SHA256=/{print \$2; exit}' | tr -d '\\r'"
+  "EXTRACTED_ORB_STATE_HOME=/{print \$2; exit}' | tr -d '\\r'"
 )
 
 for pattern in "${required[@]}"; do
@@ -29,6 +33,13 @@ for pattern in "${required[@]}"; do
     exit 1
   }
 done
+
+transfer_line=$'LIFECYCLE_TRANSFER_ROOT=/home/admin/skincos-lifecycle-transfer/example\r'
+transfer_root="$(printf '%s\n' "$transfer_line" | awk -F= '/^LIFECYCLE_TRANSFER_ROOT=/{print $2; exit}' | tr -d '\r')"
+[[ "$transfer_root" == '/home/admin/skincos-lifecycle-transfer/example' ]] || {
+  echo 'Windows CRLF transfer root was not normalized.' >&2
+  exit 1
+}
 
 function_file="$(mktemp)"
 trap 'rm -f "$function_file"' EXIT


### PR DESCRIPTION
What changed: normalize CRLF from all Windows-originated cutover outputs before paths and hashes are consumed. Root cause: the native transfer directory existed, but its path retained a Windows carriage return and failed the native directory check. Validation: cutover regression test exercises a CRLF transfer root; legacy services were automatically restored after the failed pre-promotion cut.