### PR TITLE
fix(runtime): reuse verified Orb transfer

### DIFF
--- a/scripts/runtime/transfer-orb-state-archive.ps1
+++ b/scripts/runtime/transfer-orb-state-archive.ps1
@@ -36,8 +36,27 @@ foreach ($entry in $entries) {
 $stageId = "orb-n8n-transfer-$($actualHash.Substring(0, 16).ToLowerInvariant())"
 $uncRoot = "\\wsl$\$Distribution\home\$LinuxUser\skincos-orb-transfer"
 $uncStage = Join-Path $uncRoot $stageId
+
+$required = @(
+    (Join-Path $uncStage 'n8n-home\.n8n\config'),
+    (Join-Path $uncStage 'n8n-home\database.sqlite'),
+    (Join-Path $uncStage 'n8n-home\storage'),
+    (Join-Path $uncStage 'n8n-home\nodes\package.json'),
+    (Join-Path $uncStage 'n8n-home\nodes\package-lock.json')
+)
+
 if (Test-Path -LiteralPath $uncStage) {
-    throw "Refusing to overwrite existing transferred Orb state: $uncStage"
+    foreach ($path in $required) {
+        if (-not (Test-Path -LiteralPath $path)) {
+            throw "Refusing to overwrite incomplete transferred Orb state: $uncStage (missing $path)"
+        }
+    }
+    if (Test-Path -LiteralPath (Join-Path $uncStage 'n8n-home\nodes\node_modules')) {
+        throw "Refusing to reuse transferred Orb state with Windows node_modules: $uncStage"
+    }
+    Write-Output "EXTRACTED_ORB_STATE_HOME=/home/$LinuxUser/skincos-orb-transfer/$stageId/n8n-home"
+    Write-Output "ORB_STATE_SHA256=$($actualHash.ToLowerInvariant())"
+    exit 0
 }
 New-Item -ItemType Directory -Path $uncStage -Force | Out-Null
 
@@ -48,13 +67,6 @@ if ($LASTEXITCODE -ne 0) {
     throw "Windows tar transfer failed; retained partial Linux transfer at $uncStage"
 }
 
-$required = @(
-    (Join-Path $uncStage 'n8n-home\.n8n\config'),
-    (Join-Path $uncStage 'n8n-home\database.sqlite'),
-    (Join-Path $uncStage 'n8n-home\storage'),
-    (Join-Path $uncStage 'n8n-home\nodes\package.json'),
-    (Join-Path $uncStage 'n8n-home\nodes\package-lock.json')
-)
 foreach ($path in $required) {
     if (-not (Test-Path -LiteralPath $path)) {
         throw "Windows transfer is incomplete: missing $path"


### PR DESCRIPTION
Makes the Windows-to-ext4 Orb transfer idempotent only when the hash-derived destination already contains every required file and no node_modules. Incomplete destinations still fail closed. Validated against the real 5.5 GB archive and existing native transfer.