### PR TITLE
fix(runtime): force Orb mutable paths onto ext4

### DIFF
--- a/.github/scripts/validate-architecture.mjs
+++ b/.github/scripts/validate-architecture.mjs
@@ -62,6 +62,26 @@ if (!/^Environment=N8N_TMP_DIR=\/tmp$/m.test(orbUnit)) {
   fail("orb.service must use its systemd-private /tmp namespace");
 }
 
+for (const unit of ["orb.service", "orb-proxy.service"]) {
+  const source = fs.readFileSync(path.join(root, "ops/runtime/units", unit), "utf8");
+  const legacyEnvironment = source.lastIndexOf("EnvironmentFile=-__CONFIG_ROOT__/orb-business.env");
+  const nativeEnvironment = source.lastIndexOf("EnvironmentFile=__CONFIG_ROOT__/orb-runtime-paths.env");
+  if (legacyEnvironment === -1 || nativeEnvironment <= legacyEnvironment) {
+    fail(`${unit} must load native Orb paths after the legacy secret environment`);
+  }
+}
+
+const lifecycleLayout = fs.readFileSync(path.join(root, "scripts/runtime/prepare-lifecycle-layout.sh"), "utf8");
+for (const variable of [
+  "N8N_RESTRICT_FILE_ACCESS_TO=/tmp",
+  "META_REVIEW_STORE_PATH=$STATE_ROOT/orb/meta-review-store.json",
+  "N8N_USER_FOLDER=$STATE_ROOT/orb/n8n-home",
+  "N8N_STORAGE_PATH=$STATE_ROOT/orb/n8n-home/.n8n/storage",
+  "N8N_LOG_FILE_LOCATION=$LOG_ROOT/orb/n8n.log",
+]) {
+  if (!lifecycleLayout.includes(variable)) fail(`native Orb path overlay is missing ${variable}`);
+}
+
 const crmRunner = fs.readFileSync(path.join(root, "crm/api/scripts/run.sh"), "utf8");
 if (!/dirname "\$\{BASH_SOURCE\[0\]\}"\)\/\.\.\/\.\.\/\.\./.test(crmRunner)) {
   fail("CRM runner must resolve the repository root three levels above crm/api/scripts");

--- a/ops/runtime/units/orb-proxy.service
+++ b/ops/runtime/units/orb-proxy.service
@@ -20,6 +20,7 @@ Environment=META_REVIEW_STORE_PATH=__STATE_ROOT__/orb/meta-review-store.json
 Environment=NODE_PATH=/usr/local/lib/node_modules/n8n/node_modules
 EnvironmentFile=-__CONFIG_ROOT__/orb.env
 EnvironmentFile=-__CONFIG_ROOT__/orb-business.env
+EnvironmentFile=__CONFIG_ROOT__/orb-runtime-paths.env
 ExecStart=/usr/bin/node orb-proxy/server.js
 Restart=always
 RestartSec=10

--- a/ops/runtime/units/orb.service
+++ b/ops/runtime/units/orb.service
@@ -27,6 +27,7 @@ Environment=N8N_STORAGE_PATH=__STATE_ROOT__/orb/n8n-home/.n8n/storage
 Environment=N8N_DIAGNOSTICS_ENABLED=false
 EnvironmentFile=-__CONFIG_ROOT__/orb.env
 EnvironmentFile=-__CONFIG_ROOT__/orb-business.env
+EnvironmentFile=__CONFIG_ROOT__/orb-runtime-paths.env
 ExecStartPre=__REPO_ROOT__/orb/engine/scripts/wait-for-local-postgres.sh
 ExecStart=/usr/local/bin/n8n start
 Restart=always

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -332,6 +332,20 @@ if [[ "$SKIP_LEGACY_TRANSFER" != "1" ]]; then
 fi
 
 if [[ "$APPLY" == "1" ]]; then
+  # Legacy Orb configuration also carries mutable-path variables. Keep the
+  # secret-bearing files byte-for-byte intact and layer a final, non-secret
+  # environment file after them so no lifecycle process can fall back to
+  # DrvFS for state, logs or temporary data.
+  printf '%s\n' \
+    "N8N_RESTRICT_FILE_ACCESS_TO=/tmp" \
+    "META_REVIEW_STORE_PATH=$STATE_ROOT/orb/meta-review-store.json" \
+    "N8N_USER_FOLDER=$STATE_ROOT/orb/n8n-home" \
+    "N8N_STORAGE_PATH=$STATE_ROOT/orb/n8n-home/.n8n/storage" \
+    "N8N_BINARY_DATA_DIR=$STATE_ROOT/orb/n8n-home/.n8n/storage" \
+    "N8N_LOG_FILE_LOCATION=$LOG_ROOT/orb/n8n.log" \
+    "N8N_TMP_DIR=/tmp" \
+    | sudo -n install -D -o root -g skincos -m 0640 /dev/stdin "$CONFIG_ROOT/orb-runtime-paths.env"
+
   # The runtime processes run as skincos:skincos. Keep the configuration root
   # root-owned, but preserve group read/traverse access for environment files
   # and Cloudflare credentials. Removing all group permissions would make the

--- a/scripts/runtime/test-prepare-lifecycle-layout.sh
+++ b/scripts/runtime/test-prepare-lifecycle-layout.sh
@@ -48,4 +48,11 @@ env "${layout_env[@]}" LEGACY_REPO_ROOT="$legacy_root" LIFECYCLE_SYNC_TRANSPORT=
   "$ROOT_DIR/scripts/runtime/prepare-lifecycle-layout.sh" --apply --final-sync --skip-legacy-transfer >/dev/null
 [[ ! -e "$runtime_root/state/messaging-whatsapp/instances" ]]
 [[ ! -e "$runtime_root/config/orb.env" ]]
+runtime_paths="$runtime_root/config/orb-runtime-paths.env"
+[[ -f "$runtime_paths" ]]
+grep -Fx "N8N_USER_FOLDER=$runtime_root/state/orb/n8n-home" "$runtime_paths" >/dev/null
+grep -Fx "N8N_STORAGE_PATH=$runtime_root/state/orb/n8n-home/.n8n/storage" "$runtime_paths" >/dev/null
+grep -Fx "N8N_LOG_FILE_LOCATION=$runtime_root/logs/orb/n8n.log" "$runtime_paths" >/dev/null
+grep -Fx 'N8N_RESTRICT_FILE_ACCESS_TO=/tmp' "$runtime_paths" >/dev/null
+! grep -q '/mnt/c/CodexRuntime/n8n' "$runtime_paths"
 echo "prepare lifecycle layout excludes Orb n8n-home test passed"


### PR DESCRIPTION
## Summary
- generate a non-secret native path overlay for Orb state, logs, temporary files and proxy state
- load that overlay after the retained secret environments in Orb and Orb Proxy
- preserve the secret-bearing legacy environment byte-for-byte
- add architecture and lifecycle regression checks

## Production evidence
The final Orb process entered uninterruptible p9_client_rpc I/O with an open descriptor at /mnt/c/CodexRuntime/n8n/logs/n8n.log. The retained environment still carried five DrvFS path variables and overrode the systemd Environment entries. Automatic rollback restored all eight legacy services.

## Validation
- node .github/scripts/validate-architecture.mjs
- bash -n scripts/runtime/prepare-lifecycle-layout.sh scripts/runtime/test-prepare-lifecycle-layout.sh
- bash scripts/runtime/test-prepare-lifecycle-layout.sh
- bash scripts/runtime/install-lifecycle-units.sh
- git diff --check