### PR TITLE
fix(orb): transfer native backups through Windows

### DIFF
--- a/orb/engine/scripts/backup-n8n.sh
+++ b/orb/engine/scripts/backup-n8n.sh
@@ -17,9 +17,16 @@ RUNTIME_SERVICE="${RUNTIME_SERVICE:-$SKINCOS_N8N_SERVICE}"
 VERIFY_RESTORE="${VERIFY_RESTORE:-auto}"
 BACKUP_STORAGE_COPY_TRANSPORT="${BACKUP_STORAGE_COPY_TRANSPORT:-auto}"
 ROBOCOPY_BIN="${ROBOCOPY_BIN:-}"
+CERTUTIL_BIN="${CERTUTIL_BIN:-}"
+WINDOWS_TAR_BIN="${WINDOWS_TAR_BIN:-}"
+WINDOWS_TRANSFER_LINUX_USER="${WINDOWS_TRANSFER_LINUX_USER:-admin}"
+BACKUP_NATIVE_TRANSFER_ROOT="${BACKUP_NATIVE_TRANSFER_ROOT:-/home/$WINDOWS_TRANSFER_LINUX_USER/skincos-orb-backup-transfer}"
 timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
 partial="$BACKUP_ROOT/.partial-$timestamp"
 dest="$BACKUP_ROOT/$timestamp"
+native_transfer_dir=""
+storage_format="directory"
+storage_archive_sha_json="null"
 
 case "$BACKUP_STORAGE_COPY_TRANSPORT" in
   auto|robocopy|rsync) ;;
@@ -46,6 +53,9 @@ cleanup() {
   fi
   if [[ "$status" != "0" ]]; then
     rm -rf "$partial"
+  fi
+  if [[ -n "$native_transfer_dir" ]]; then
+    rm -rf "$native_transfer_dir"
   fi
   exit "$status"
 }
@@ -78,6 +88,75 @@ resolve_robocopy() {
   return 1
 }
 
+resolve_windows_validator() {
+  local candidate
+  if [[ -z "$CERTUTIL_BIN" ]]; then
+    for candidate in /mnt/c/Windows/System32/certutil.exe /mnt/c/WINDOWS/system32/certutil.exe; do
+      if [[ -x "$candidate" ]]; then CERTUTIL_BIN="$candidate"; break; fi
+    done
+  fi
+  if [[ -z "$WINDOWS_TAR_BIN" ]]; then
+    for candidate in /mnt/c/Windows/System32/tar.exe /mnt/c/WINDOWS/system32/tar.exe; do
+      if [[ -x "$candidate" ]]; then WINDOWS_TAR_BIN="$candidate"; break; fi
+    done
+  fi
+  [[ -n "$CERTUTIL_BIN" && -n "$WINDOWS_TAR_BIN" ]] || {
+    echo "Windows certutil.exe and tar.exe are required for native storage backup transfer." >&2
+    return 1
+  }
+}
+
+sync_native_storage_via_windows() {
+  resolve_robocopy || { echo "robocopy.exe is required for native storage backup transfer." >&2; return 1; }
+  resolve_windows_validator
+  command -v tar >/dev/null 2>&1 || { echo "tar is required for native storage backup transfer." >&2; return 1; }
+  id "$WINDOWS_TRANSFER_LINUX_USER" >/dev/null 2>&1 || {
+    echo "Windows transfer Linux user is unavailable: $WINDOWS_TRANSFER_LINUX_USER" >&2
+    return 1
+  }
+
+  native_transfer_dir="$BACKUP_NATIVE_TRANSFER_ROOT/$timestamp"
+  install -d -m 0700 "$native_transfer_dir"
+  if [[ "$(id -u)" == "0" ]]; then
+    chown "$WINDOWS_TRANSFER_LINUX_USER:$WINDOWS_TRANSFER_LINUX_USER" "$native_transfer_dir"
+  elif [[ "$(id -un)" != "$WINDOWS_TRANSFER_LINUX_USER" ]]; then
+    echo "Native transfer staging must run as root or $WINDOWS_TRANSFER_LINUX_USER." >&2
+    return 1
+  fi
+  local archive="$native_transfer_dir/storage.tar"
+  tar -C "$N8N_STORAGE_PATH" -cf "$archive" .
+  if [[ "$(id -u)" == "0" ]]; then
+    chown "$WINDOWS_TRANSFER_LINUX_USER:$WINDOWS_TRANSFER_LINUX_USER" "$archive"
+  fi
+  chmod 0600 "$archive"
+
+  local source_sha source_windows destination_windows destination_file_windows destination_sha status=0
+  source_sha="$(sha256sum "$archive" | awk '{print $1}')"
+  # The common backup scaffold creates this directory for directory-format
+  # copies. Native Linux state is stored as a tar archive instead, so do not
+  # leave a misleading empty storage/ payload beside storage.tar.
+  rmdir "$partial/storage"
+  source_windows="$(wslpath -w "$native_transfer_dir")"
+  destination_windows="$(wslpath -w "$partial")"
+  destination_file_windows="${destination_windows}\\storage.tar"
+  "$ROBOCOPY_BIN" "$source_windows" "$destination_windows" storage.tar /COPY:DAT /R:2 /W:1 /NFL /NDL /NJH /NJS /NP >/dev/null || status=$?
+  if (( status > 7 )); then
+    echo "Windows-native storage archive transfer failed with robocopy exit code $status." >&2
+    return "$status"
+  fi
+  "$WINDOWS_TAR_BIN" -tf "$destination_file_windows" >/dev/null
+  destination_sha="$("$CERTUTIL_BIN" -hashfile "$destination_file_windows" SHA256 | tr -d '\r ' | grep -E '^[0-9A-Fa-f]{64}$' | head -n1 | tr 'A-F' 'a-f')"
+  [[ -n "$destination_sha" && "$destination_sha" == "$source_sha" ]] || {
+    echo "Windows-native storage archive checksum mismatch." >&2
+    return 1
+  }
+
+  storage_format="tar"
+  storage_archive_sha_json="\"$source_sha\""
+  rm -rf "$native_transfer_dir"
+  native_transfer_dir=""
+}
+
 should_use_robocopy() {
   if [[ "$BACKUP_STORAGE_COPY_TRANSPORT" == "rsync" ]]; then
     return 1
@@ -92,6 +171,10 @@ should_use_robocopy() {
 }
 
 sync_storage() {
+  if [[ "$N8N_STORAGE_PATH" != /mnt/c/* && "$partial" == /mnt/c/* ]]; then
+    sync_native_storage_via_windows
+    return
+  fi
   if should_use_robocopy; then
     local source_windows destination_windows status=0
     source_windows="$(wslpath -w "$N8N_STORAGE_PATH")"
@@ -173,6 +256,8 @@ cat > "$partial/manifest.json" <<EOF
   "workflowCount": $workflow_count,
   "storagePath": "$N8N_STORAGE_PATH",
   "storageBytes": $storage_bytes_json,
+  "storageFormat": "$storage_format",
+  "storageArchiveSha256": $storage_archive_sha_json,
   "restoreVerified": $restore_verified,
   "retentionDays": $RETENTION_DAYS,
   "retentionCount": ${RETENTION_COUNT:-null}

--- a/orb/engine/scripts/test-backup-n8n-storage-copy.sh
+++ b/orb/engine/scripts/test-backup-n8n-storage-copy.sh
@@ -20,10 +20,13 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 test_root="/mnt/c/CodexRuntime/tmp/backup-storage-copy-test.$$"
 runtime_root="$test_root/runtime"
 backup_root="$test_root/backups"
+native_backup_root="$test_root/native-backups"
 fake_bin="$test_root/fake-bin"
+native_runtime_root="/home/admin/skincos-backup-storage-copy-test.$$"
 
 cleanup() {
   rm -rf "$test_root"
+  rm -rf "$native_runtime_root"
 }
 trap cleanup EXIT
 
@@ -100,5 +103,37 @@ backup_dir="$(find "$backup_root" -mindepth 1 -maxdepth 1 -type d ! -name '.part
 [[ -f "$backup_dir/runtime/env/n8n-business.env" ]]
 grep -q '"restoreVerified": true' "$backup_dir/manifest.json"
 grep -q '"storageBytes": null' "$backup_dir/manifest.json"
+
+mkdir -p "$native_runtime_root/n8n-home/.n8n/storage/nested" "$native_runtime_root/env" "$native_runtime_root/health"
+printf 'native-payload\n' > "$native_runtime_root/n8n-home/.n8n/storage/nested/file.txt"
+printf 'config\n' > "$native_runtime_root/n8n-home/.n8n/config"
+printf 'N8N_ENCRYPTION_KEY=test-only\n' > "$native_runtime_root/env/n8n.env"
+printf 'N8N_DEFAULT_UNIT_SLUG=test-only\n' > "$native_runtime_root/env/n8n-business.env"
+
+PATH="$fake_bin:$PATH" \
+  N8N_ROOT="$repo_root" \
+  N8N_RUNTIME_HOME="$native_runtime_root" \
+  N8N_ENV_FILE="$native_runtime_root/env/n8n.env" \
+  N8N_BUSINESS_ENV_FILE="$native_runtime_root/env/n8n-business.env" \
+  N8N_DATA_HOME="$native_runtime_root/n8n-home" \
+  N8N_STATE_HOME="$native_runtime_root/n8n-home/.n8n" \
+  N8N_STORAGE_PATH="$native_runtime_root/n8n-home/.n8n/storage" \
+  N8N_CONFIG_PATH="$native_runtime_root/n8n-home/.n8n/config" \
+  N8N_HEALTH_DIR="$native_runtime_root/health" \
+  BACKUP_ROOT="$native_backup_root" \
+  BACKUP_NATIVE_TRANSFER_ROOT="$native_runtime_root/transfer" \
+  BACKUP_STORAGE_COPY_TRANSPORT=auto \
+  ROBOCOPY_BIN="$robocopy_bin" \
+  MANAGE_N8N_SERVICE=0 \
+  VERIFY_RESTORE=1 \
+  RETENTION_COUNT=1 \
+  bash "$repo_root/scripts/backup-n8n.sh"
+
+backup_dir="$(find "$native_backup_root" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -print -quit)"
+[[ -f "$backup_dir/storage.tar" ]]
+[[ ! -e "$backup_dir/storage" ]]
+grep -q '"restoreVerified": true' "$backup_dir/manifest.json"
+grep -q '"storageFormat": "tar"' "$backup_dir/manifest.json"
+grep -Eq '"storageArchiveSha256": "[0-9a-f]{64}"' "$backup_dir/manifest.json"
 
 echo "backup robocopy storage test passed"


### PR DESCRIPTION
﻿## Summary
- archives native Linux n8n storage on ext4 before crossing the Windows boundary
- makes Windows `robocopy` read the WSL UNC path and write the NTFS backup
- validates the transferred archive with Windows `tar` and SHA-256 before retention
- records storage format and archive checksum in the backup manifest

## Why
The prior post-cutover backup recursively copied ext4 state to `/mnt/c` from WSL and could block in `p9_client_rpc`. This keeps recursive traversal on ext4 and makes the Windows process perform the cross-filesystem transfer.

## Validation
- `bash -n orb/engine/scripts/backup-n8n.sh orb/engine/scripts/test-backup-n8n-storage-copy.sh`
- `bash orb/engine/scripts/test-backup-n8n-storage-copy.sh`
- `npm run validate:mini-pc:local` in `orb/engine`
- `node .github/scripts/validate-architecture.mjs`

## Rollback
Revert this commit; the last verified runtime backup remains retained until a replacement completes and passes restore verification.
