### PR TITLE
fix(orb): restore Windows interop for backups

### DIFF
--- a/orb/engine/scripts/backup-n8n.sh
+++ b/orb/engine/scripts/backup-n8n.sh
@@ -106,7 +106,23 @@ resolve_windows_validator() {
   }
 }
 
+ensure_windows_interop() {
+  if [[ -n "${WSL_INTEROP:-}" && -S "$WSL_INTEROP" ]]; then
+    return 0
+  fi
+  # systemd services do not inherit the interactive WSL interop socket. WSL
+  # maintains this stable link to init's current socket specifically so native
+  # services can launch Windows processes without depending on a shell PID.
+  if [[ -S /run/WSL/1_interop ]]; then
+    export WSL_INTEROP=/run/WSL/1_interop
+    return 0
+  fi
+  echo 'A live WSL interoperability socket is required for Windows-native backup transfer.' >&2
+  return 1
+}
+
 sync_native_storage_via_windows() {
+  ensure_windows_interop
   resolve_robocopy || { echo "robocopy.exe is required for native storage backup transfer." >&2; return 1; }
   resolve_windows_validator
   command -v tar >/dev/null 2>&1 || { echo "tar is required for native storage backup transfer." >&2; return 1; }
@@ -176,6 +192,7 @@ sync_storage() {
     return
   fi
   if should_use_robocopy; then
+    ensure_windows_interop
     local source_windows destination_windows status=0
     source_windows="$(wslpath -w "$N8N_STORAGE_PATH")"
     destination_windows="$(wslpath -w "$partial/storage")"

--- a/orb/engine/scripts/test-backup-n8n-storage-copy.sh
+++ b/orb/engine/scripts/test-backup-n8n-storage-copy.sh
@@ -79,7 +79,8 @@ exit 0
 EOF
 chmod +x "$fake_bin"/*
 
-PATH="$fake_bin:$PATH" \
+env -u WSL_INTEROP \
+  PATH="$fake_bin:$PATH" \
   N8N_ROOT="$repo_root" \
   N8N_RUNTIME_HOME="$runtime_root" \
   N8N_ENV_FILE="$runtime_root/env/n8n.env" \
@@ -110,7 +111,8 @@ printf 'config\n' > "$native_runtime_root/n8n-home/.n8n/config"
 printf 'N8N_ENCRYPTION_KEY=test-only\n' > "$native_runtime_root/env/n8n.env"
 printf 'N8N_DEFAULT_UNIT_SLUG=test-only\n' > "$native_runtime_root/env/n8n-business.env"
 
-PATH="$fake_bin:$PATH" \
+env -u WSL_INTEROP \
+  PATH="$fake_bin:$PATH" \
   N8N_ROOT="$repo_root" \
   N8N_RUNTIME_HOME="$native_runtime_root" \
   N8N_ENV_FILE="$native_runtime_root/env/n8n.env" \


### PR DESCRIPTION
﻿## Summary
- discovers WSL's stable init interop socket when a systemd service has no `WSL_INTEROP`
- exports that socket only for Windows-native backup transfer
- exercises both NTFS and native ext4 storage modes with `WSL_INTEROP` explicitly removed

## Incident evidence
The first scheduled-service execution of the new backup failed safely with:
- `/mnt/c/Windows/System32/robocopy.exe: Invalid argument`
- `/mnt/c/Windows/System32/tar.exe: Invalid argument`

The previous verified backup was preserved and `orb.service` restarted healthy. A transient systemd regression test now passes without inheriting interactive WSL environment.

## Validation
- transient `systemd-run --wait --pipe` of `test-backup-n8n-storage-copy.sh`
- `bash -n` for both scripts
- `npm run validate:mini-pc:local`
- architecture contract validation

## Rollback
Revert this commit. The prior restore-verified backup remains retained until a replacement completes successfully.
