### PR TITLE
fix(runtime): stage native backup before Windows transfer

### DIFF
--- a/orb/engine/scripts/backup-n8n.sh
+++ b/orb/engine/scripts/backup-n8n.sh
@@ -24,8 +24,16 @@ timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
 partial="$BACKUP_ROOT/.partial-$timestamp"
 dest="$BACKUP_ROOT/$timestamp"
 native_transfer_dir=""
+native_windows_transfer=0
 storage_format="directory"
+storage_archive_sha=""
 storage_archive_sha_json="null"
+
+if [[ "$N8N_STORAGE_PATH" != /mnt/c/* && "$BACKUP_ROOT" == /mnt/c/* ]]; then
+  native_windows_transfer=1
+  native_transfer_dir="$BACKUP_NATIVE_TRANSFER_ROOT/$timestamp"
+  partial="$native_transfer_dir/payload"
+fi
 
 case "$BACKUP_STORAGE_COPY_TRANSPORT" in
   auto|robocopy|rsync) ;;
@@ -39,7 +47,10 @@ if [[ -n "$RETENTION_COUNT" ]]; then
   [[ "$RETENTION_COUNT" =~ ^[1-9][0-9]*$ ]] || { echo "RETENTION_COUNT must be a positive integer." >&2; exit 1; }
 fi
 
-mkdir -p "$BACKUP_ROOT" "$(dirname "$LOCK_FILE")" "$N8N_HEALTH_DIR"
+mkdir -p "$(dirname "$LOCK_FILE")" "$N8N_HEALTH_DIR"
+if [[ "$native_windows_transfer" != "1" ]]; then
+  mkdir -p "$BACKUP_ROOT"
+fi
 exec 9>"$LOCK_FILE"
 flock -n 9 || { echo "Another n8n backup is already running." >&2; exit 1; }
 
@@ -60,11 +71,6 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 touch "$BACKUP_MARKER"
-
-if [[ "$MANAGE_N8N_SERVICE" == "1" ]] && systemctl is-active --quiet "$RUNTIME_SERVICE"; then
-  n8n_was_active=1
-  systemctl stop "$RUNTIME_SERVICE"
-fi
 
 resolve_robocopy() {
   local candidate
@@ -117,61 +123,109 @@ ensure_windows_interop() {
   return 1
 }
 
-sync_native_storage_via_windows() {
+invoke_windows_powershell() {
+  local powershell_script="$1" encoded_script
+  command -v iconv >/dev/null 2>&1 || {
+    echo "iconv is required for Windows PowerShell backup transfer." >&2
+    return 1
+  }
+  command -v base64 >/dev/null 2>&1 || {
+    echo "base64 is required for Windows PowerShell backup transfer." >&2
+    return 1
+  }
+  # Windows PowerShell expects -EncodedCommand as UTF-16LE. Encoding the whole
+  # program also prevents WSL from translating embedded UNC paths in argv and
+  # avoids the line-by-line parsing behavior of `-Command -` for try blocks.
+  encoded_script="$(printf '%s' "$powershell_script" | iconv -f UTF-8 -t UTF-16LE | base64 -w0)"
+  "$POWERSHELL_BIN" -NoProfile -NonInteractive -EncodedCommand "$encoded_script"
+}
+
+archive_native_storage() {
+  command -v tar >/dev/null 2>&1 || { echo "tar is required for native storage backup transfer." >&2; return 1; }
+  tar -C "$N8N_STORAGE_PATH" -cf "$partial/storage.tar" .
+  rmdir "$partial/storage"
+  storage_archive_sha="$(sha256sum "$partial/storage.tar" | awk '{print $1}')"
+  storage_format="tar"
+  storage_archive_sha_json="\"$storage_archive_sha\""
+}
+
+publish_native_backup() {
   ensure_windows_interop
   resolve_windows_powershell
-  command -v tar >/dev/null 2>&1 || { echo "tar is required for native storage backup transfer." >&2; return 1; }
   id "$WINDOWS_TRANSFER_LINUX_USER" >/dev/null 2>&1 || {
     echo "Windows transfer Linux user is unavailable: $WINDOWS_TRANSFER_LINUX_USER" >&2
     return 1
   }
-
-  native_transfer_dir="$BACKUP_NATIVE_TRANSFER_ROOT/$timestamp"
-  install -d -m 0700 "$native_transfer_dir"
-  if [[ "$(id -u)" == "0" ]]; then
-    chown "$WINDOWS_TRANSFER_LINUX_USER:$WINDOWS_TRANSFER_LINUX_USER" "$native_transfer_dir"
-  elif [[ "$(id -un)" != "$WINDOWS_TRANSFER_LINUX_USER" ]]; then
-    echo "Native transfer staging must run as root or $WINDOWS_TRANSFER_LINUX_USER." >&2
+  if (( EUID == 0 )); then
+    chown -R "$WINDOWS_TRANSFER_LINUX_USER:$WINDOWS_TRANSFER_LINUX_USER" "$native_transfer_dir"
+  elif [[ -n "$(find "$native_transfer_dir" ! -user "$WINDOWS_TRANSFER_LINUX_USER" -print -quit)" ]]; then
+    echo "Native backup staging is not owned by the Windows transfer user." >&2
     return 1
   fi
-  local archive="$native_transfer_dir/storage.tar"
-  tar -C "$N8N_STORAGE_PATH" -cf "$archive" .
-  if [[ "$(id -u)" == "0" ]]; then
-    chown "$WINDOWS_TRANSFER_LINUX_USER:$WINDOWS_TRANSFER_LINUX_USER" "$archive"
-  fi
-  chmod 0600 "$archive"
+  find "$native_transfer_dir" -type d -exec chmod 0700 {} +
+  find "$native_transfer_dir" -type f -exec chmod 0600 {} +
 
-  local source_sha source_windows destination_windows destination_file_windows destination_sha powershell_script
-  source_sha="$(sha256sum "$archive" | awk '{print $1}')"
-  # The common backup scaffold creates this directory for directory-format
-  # copies. Native Linux state is stored as a tar archive instead, so do not
-  # leave a misleading empty storage/ payload beside storage.tar.
-  rmdir "$partial/storage"
-  source_windows="$(wslpath -w "$native_transfer_dir")"
-  destination_windows="$(wslpath -w "$partial")"
-  destination_file_windows="${destination_windows}\\storage.tar"
-  # Passing a WSL UNC path directly as a Linux argv to a Windows executable is
-  # rewritten by WSL path translation. Send the command over stdin instead, so
-  # Windows PowerShell owns both UNC traversal and NTFS validation end to end.
+  local source_windows backup_root_windows powershell_script retention_count_value
+  source_windows="$(wslpath -w "$partial")"
+  backup_root_windows="$(wslpath -w "$BACKUP_ROOT")"
   source_windows="${source_windows//\'/\'\'}"
-  destination_windows="${destination_windows//\'/\'\'}"
-  destination_file_windows="${destination_file_windows//\'/\'\'}"
+  backup_root_windows="${backup_root_windows//\'/\'\'}"
+  retention_count_value="${RETENTION_COUNT:-0}"
   powershell_script="\$ErrorActionPreference = 'Stop'
-& robocopy.exe '$source_windows' '$destination_windows' storage.tar /COPY:DAT /R:2 /W:1 /NFL /NDL /NJH /NJS /NP | Out-Null
-if (\$LASTEXITCODE -gt 7) { throw \"robocopy failed with exit code \$LASTEXITCODE\" }
-& tar.exe -tf '$destination_file_windows' | Out-Null
-if (\$LASTEXITCODE -ne 0) { throw \"tar validation failed with exit code \$LASTEXITCODE\" }
-(Get-FileHash -LiteralPath '$destination_file_windows' -Algorithm SHA256).Hash.ToLowerInvariant()"
-  destination_sha="$(printf '%s' "$powershell_script" | "$POWERSHELL_BIN" -NoProfile -NonInteractive -Command - | tr -d '\r' | grep -E '^[0-9a-f]{64}$' | tail -n1)"
-  [[ -n "$destination_sha" && "$destination_sha" == "$source_sha" ]] || {
-    echo "Windows-native storage archive checksum mismatch." >&2
+\$ProgressPreference = 'SilentlyContinue'
+\$source = '$source_windows'
+\$backupRoot = '$backup_root_windows'
+\$partial = Join-Path \$backupRoot '.partial-$timestamp'
+\$destination = Join-Path \$backupRoot '$timestamp'
+New-Item -ItemType Directory -Force -Path \$backupRoot | Out-Null
+if (Test-Path -LiteralPath \$destination) { throw 'Backup destination already exists.' }
+if (Test-Path -LiteralPath \$partial) { Remove-Item -LiteralPath \$partial -Recurse -Force }
+try {
+  & robocopy.exe \$source \$partial /E /COPY:DAT /DCOPY:T /R:2 /W:1 /NFL /NDL /NJH /NJS /NP | Out-Null
+  if (\$LASTEXITCODE -gt 7) { throw \"robocopy failed with exit code \$LASTEXITCODE\" }
+  \$databaseHash = (Get-FileHash -LiteralPath (Join-Path \$partial 'n8n_runtime.dump') -Algorithm SHA256).Hash.ToLowerInvariant()
+  if (\$databaseHash -ne '$db_sha') { throw 'Database checksum mismatch after Windows transfer.' }
+  \$storageArchive = Join-Path \$partial 'storage.tar'
+  & tar.exe -tf \$storageArchive | Out-Null
+  if (\$LASTEXITCODE -ne 0) { throw \"tar validation failed with exit code \$LASTEXITCODE\" }
+  \$storageHash = (Get-FileHash -LiteralPath \$storageArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+  if (\$storageHash -ne '$storage_archive_sha') { throw 'Storage checksum mismatch after Windows transfer.' }
+  Move-Item -LiteralPath \$partial -Destination \$destination
+  \$backups = @(Get-ChildItem -LiteralPath \$backupRoot -Directory | Where-Object { \$_.Name -match '^\\d{8}T\\d{6}Z$' } | Sort-Object Name -Descending)
+  if ($retention_count_value -gt 0) {
+    \$backups | Select-Object -Skip $retention_count_value | Remove-Item -Recurse -Force
+  } else {
+    \$cutoff = (Get-Date).ToUniversalTime().AddDays(-$RETENTION_DAYS)
+    \$backups | Where-Object { \$_.LastWriteTimeUtc -lt \$cutoff } | Remove-Item -Recurse -Force
+  }
+  \$retained = @(Get-ChildItem -LiteralPath \$backupRoot -Directory | Where-Object { \$_.Name -match '^\\d{8}T\\d{6}Z$' } | Sort-Object Name -Descending)
+  Write-Output ('backup_destination=' + \$destination)
+  Write-Output ('retained_backups=' + ((\$retained | ForEach-Object Name) -join ','))
+} catch {
+  if (Test-Path -LiteralPath \$partial) { Remove-Item -LiteralPath \$partial -Recurse -Force }
+  throw
+}"
+  # Windows owns traversal, validation, atomic promotion and retention on C:.
+  invoke_windows_powershell "$powershell_script"
+}
+
+prepare_native_transfer() {
+  command -v tar >/dev/null 2>&1 || { echo "tar is required for native backup staging." >&2; return 1; }
+  install -d -m 0700 "$partial"
+}
+
+validate_native_transfer_prerequisites() {
+  local powershell_script
+  ensure_windows_interop
+  resolve_windows_powershell
+  id "$WINDOWS_TRANSFER_LINUX_USER" >/dev/null 2>&1 || {
+    echo "Windows transfer Linux user is unavailable: $WINDOWS_TRANSFER_LINUX_USER" >&2
     return 1
   }
-
-  storage_format="tar"
-  storage_archive_sha_json="\"$source_sha\""
-  rm -rf "$native_transfer_dir"
-  native_transfer_dir=""
+  # Prove Windows process startup before stopping Orb. The real transfer runs
+  # only after every backup artifact and restore check exist on native ext4.
+  powershell_script="\$ErrorActionPreference = 'Stop'; \$ProgressPreference = 'SilentlyContinue'; \$null = Get-Command robocopy.exe; \$null = Get-Command tar.exe"
+  invoke_windows_powershell "$powershell_script" >/dev/null
 }
 
 should_use_robocopy() {
@@ -188,8 +242,8 @@ should_use_robocopy() {
 }
 
 sync_storage() {
-  if [[ "$N8N_STORAGE_PATH" != /mnt/c/* && "$partial" == /mnt/c/* ]]; then
-    sync_native_storage_via_windows
+  if [[ "$native_windows_transfer" == "1" ]]; then
+    archive_native_storage
     return
   fi
   if should_use_robocopy; then
@@ -218,11 +272,21 @@ sync_storage() {
   rsync "${rsync_args[@]}" "$N8N_STORAGE_PATH/" "$partial/storage/"
 }
 
+if [[ "$native_windows_transfer" == "1" ]]; then
+  validate_native_transfer_prerequisites
+  prepare_native_transfer
+fi
+
+if [[ "$MANAGE_N8N_SERVICE" == "1" ]] && systemctl is-active --quiet "$RUNTIME_SERVICE"; then
+  n8n_was_active=1
+  systemctl stop "$RUNTIME_SERVICE"
+fi
+
 mkdir -p "$partial/runtime/env" "$partial/storage"
 
 sudo -n -u postgres pg_dump --format=custom --no-owner --no-acl \
-  --dbname=n8n_runtime --file="$partial/n8n_runtime.dump"
-sudo -n -u postgres pg_restore --list "$partial/n8n_runtime.dump" > "$partial/n8n_runtime.restore-list.txt"
+  --dbname=n8n_runtime > "$partial/n8n_runtime.dump"
+sudo -n -u postgres pg_restore --list < "$partial/n8n_runtime.dump" > "$partial/n8n_runtime.restore-list.txt"
 
 install -m 0600 "$N8N_CONFIG_PATH" "$partial/runtime/config"
 install -m 0600 "$N8N_ENV_FILE" "$partial/runtime/env/n8n.env"
@@ -254,7 +318,7 @@ restore_verified=false
 if [[ "$run_restore" == "1" ]]; then
   restore_db="n8n_restore_check_${timestamp//[^0-9]/}"
   sudo -n -u postgres createdb "$restore_db"
-  if ! sudo -n -u postgres pg_restore --no-owner --no-acl --dbname="$restore_db" "$partial/n8n_runtime.dump"; then
+  if ! sudo -n -u postgres pg_restore --no-owner --no-acl --dbname="$restore_db" < "$partial/n8n_runtime.dump"; then
     sudo -n -u postgres dropdb --if-exists "$restore_db"
     echo "Temporary PostgreSQL restore failed." >&2
     exit 1
@@ -282,15 +346,19 @@ cat > "$partial/manifest.json" <<EOF
 }
 EOF
 
-mv "$partial" "$dest"
-if [[ -n "$RETENTION_COUNT" ]]; then
-  mapfile -t backups < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -printf '%T@ %p\n' | sort -nr | awk '{ $1=""; sub(/^ /, ""); print }')
-  for ((index=RETENTION_COUNT; index<${#backups[@]}; index++)); do
-    echo "Pruning verified superseded backup: ${backups[$index]}"
-    rm -rf -- "${backups[$index]}"
-  done
+if [[ "$native_windows_transfer" == "1" ]]; then
+  publish_native_backup
 else
-  find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -mtime +"$RETENTION_DAYS" -print -exec rm -rf {} +
+  mv "$partial" "$dest"
+  if [[ -n "$RETENTION_COUNT" ]]; then
+    mapfile -t backups < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -printf '%T@ %p\n' | sort -nr | awk '{ $1=""; sub(/^ /, ""); print }')
+    for ((index=RETENTION_COUNT; index<${#backups[@]}; index++)); do
+      echo "Pruning verified superseded backup: ${backups[$index]}"
+      rm -rf -- "${backups[$index]}"
+    done
+  else
+    find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.partial-*' -mtime +"$RETENTION_DAYS" -print -exec rm -rf {} +
+  fi
 fi
 
 echo "Backup completed: $dest"

--- a/orb/engine/scripts/test-backup-n8n-storage-copy.sh
+++ b/orb/engine/scripts/test-backup-n8n-storage-copy.sh
@@ -25,6 +25,10 @@ fake_bin="$test_root/fake-bin"
 native_runtime_root="/home/admin/skincos-backup-storage-copy-test.$$"
 
 cleanup() {
+  if [[ "${KEEP_BACKUP_STORAGE_TEST:-0}" == "1" ]]; then
+    echo "backup storage test preserved: $test_root $native_runtime_root" >&2
+    return
+  fi
   rm -rf "$test_root"
   rm -rf "$native_runtime_root"
 }
@@ -55,7 +59,7 @@ for arg in "$@"; do
     --file=*) printf 'dump\n' > "${arg#--file=}"; exit 0 ;;
   esac
 done
-exit 1
+printf 'dump\n'
 EOF
 cat > "$fake_bin/pg_restore" <<'EOF'
 #!/usr/bin/env bash
@@ -106,6 +110,7 @@ grep -q '"restoreVerified": true' "$backup_dir/manifest.json"
 grep -q '"storageBytes": null' "$backup_dir/manifest.json"
 
 mkdir -p "$native_runtime_root/n8n-home/.n8n/storage/nested" "$native_runtime_root/env" "$native_runtime_root/health"
+mkdir -p "$native_backup_root"
 printf 'native-payload\n' > "$native_runtime_root/n8n-home/.n8n/storage/nested/file.txt"
 printf 'config\n' > "$native_runtime_root/n8n-home/.n8n/config"
 printf 'N8N_ENCRYPTION_KEY=test-only\n' > "$native_runtime_root/env/n8n.env"


### PR DESCRIPTION
Stages the complete Orb backup payload on native ext4, validates a real PostgreSQL restore there, then lets Windows copy and atomically promote it to C:. Uses encoded PowerShell to preserve UNC paths and applies retention only after database and storage checksums pass. Local validation: architecture contract, mini-PC script validation, and both backup transport branches.