### PR TITLE
fix(ci): serialize CRM Pages deployments

### DIFF
--- a/.github/scripts/validate-architecture.mjs
+++ b/.github/scripts/validate-architecture.mjs
@@ -90,4 +90,14 @@ if (crmRunner.includes("/../../../..")) {
   fail("CRM runner escapes the native source release by resolving four parent directories");
 }
 
+for (const workflow of ["deploy-crm-pages.yml", "deploy-crm-pages-reconcile.yml"]) {
+  const source = fs.readFileSync(path.join(root, ".github/workflows", workflow), "utf8");
+  if (!/^  group: deploy-crm-pages$/m.test(source)) {
+    fail(`${workflow} must share the production deployment concurrency group`);
+  }
+  if (!/^  cancel-in-progress: false$/m.test(source)) {
+    fail(`${workflow} must serialize rather than cancel an in-flight production deployment`);
+  }
+}
+
 if (!process.exitCode) process.stdout.write("Architecture contract validation OK.\n");

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -14,8 +14,8 @@ on:
         type: boolean
 
 concurrency:
-  group: deploy-crm-pages-reconcile-main
-  cancel-in-progress: true
+  group: deploy-crm-pages
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: deploy-crm-pages-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-crm-pages
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Evidência

O deploy principal do SHA 1f358714 falhou após 15 tentativas com route_not_found enquanto o reconcile concorrente publicava o mesmo SHA. O reconcile concluiu verde no mesmo SHA, incluindo smoke do Ponto e UI.

## Correção

- usa o mesmo grupo de concorrência nos dois workflows;
- serializa sem cancelar uma publicação em andamento;
- adiciona contrato de arquitetura para impedir regressão.

## Validação

- node .github/scripts/validate-architecture.mjs;
- o reconcile 29452963199 validou produção no SHA 1f358714.