### PR TITLE
Finalize native runtime audit record

### DIFF
--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -13,12 +13,19 @@
 - WhatsApp release: `/opt/skincos/current/messaging-whatsapp`; the only supported implementation is `messaging/channels/whatsapp/engine`.
 - Mutable state: `/var/lib/skincos-runtime`; private config/secrets: `/etc/skincos`; logs: `/var/log/skincos`; temporary runtime: `/var/tmp/skincos`.
 - Active units: `orb`, `orb-proxy`, `messaging-whatsapp`, `crm`, `booking`, `cloudflare-orb` and `cloudflare-runtime`.
-- Windows keepalive: scheduled task `SkincosWslRuntimeKeepalive`; Linux service supervision remains under `systemd`.
+- Windows keepalive: scheduled task `SkincosWslRuntimeKeepalive`; its single
+  anchor uses native cwd `/`, while Linux service supervision remains under
+  `systemd`.
 - The runtime survived a full WSL shutdown/start cycle with state and sessions preserved. Orb, CRM, Booking, WhatsApp and both Cloudflare tunnels passed local/public health checks with zero service restarts after promotion.
 
 ## Backup and rollback
 
-- Restore-verified Orb backup: `C:\CodexRuntime\backups\orb\daily\20260715T214829Z`; PostgreSQL and storage hashes were validated by a real restore.
+- Restore-verified Orb backup: `C:\CodexRuntime\backups\orb\daily\20260715T222726Z`; PostgreSQL and storage hashes were validated by a real restore.
+- Restore-verified lifecycle backup:
+  `C:\CodexRuntime\backups\runtime\20260715T231622Z`; it contains private
+  config, native Booking/CRM/WhatsApp state and PostgreSQL dumps. Restore tests
+  recreated 37 WhatsApp tables and 17 CRM tables in temporary databases, and
+  every Windows-published artifact matched its native SHA-256.
 - Scheduled backup owner: Windows task `SkincosOrbBackup`. It triggers a native
   `/var/backups/skincos/orb/daily` snapshot and publishes it to
   `C:\CodexRuntime\backups\orb\daily` only after restore, database checksum and
@@ -27,6 +34,17 @@
 - Native releases are immutable. Rollback repoints `/opt/skincos/current/*` to the prior release, restores the captured units/config and restarts only the affected services.
 - Cross-filesystem transfer is Windows-owned. Do not recursively traverse `C:`
   from WSL or launch Windows transfer binaries from a Linux service.
+
+## Preserved independent work
+
+- `codex/admin/meta-ads-publish-production-audit` contains uncommitted product
+  work for the Meta Ads publish journal. It is intentionally isolated from the
+  completed architecture/runtime program and must be reviewed in its own task.
+- PR #658 (`codex/admin/github-codex-autonomy`) remains a deliberate draft for
+  the optional GitHub autonomy broker; it is not part of the production
+  runtime and has no deployment dependency.
+- The detached worktree under `%USERPROFILE%\.codex\worktrees` is Codex
+  App-managed state and is not a project cleanup target while the App owns it.
 
 ## Messaging and CRM contract
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -405,3 +405,15 @@
 - Impact: Git history and the private cutover checkpoint preserve audit and
   rollback evidence; current operations use only the lifecycle installer,
   native runtime manager, release builders and Windows-owned backup publisher.
+
+## 2026-07-15 - Keep only publication, evidence and restore checkpoints on Windows
+
+- Decision: after the native runtime passed restart and public smoke gates,
+  remove mutable service trees from `C:\CodexRuntime`; retain only verified
+  backups, private operator evidence and `config\orb\publish-backup.ps1`.
+- Why: duplicated Booking, CRM, WhatsApp, tunnel and Orb state on NTFS no longer
+  had an active consumer and could silently revive the retired DrvFS contract.
+- Impact: native state is authoritative under `/var/lib/skincos-runtime` and
+  `/etc/skincos`. Windows owns transfer/publication only; the final lifecycle
+  backup includes private configuration, snapshots and real PostgreSQL restore
+  proof before the duplicate trees are deleted.

--- a/TASKS.md
+++ b/TASKS.md
@@ -4,6 +4,11 @@
 
 - [ ] Confirm or reauthorize the `Google Calendar (Skincos)` credential for the exact scopes required by the inactive clinic Orb workflows.
 - [ ] Provide `GOOGLE_CALENDAR_ID`, approved test data and a non-production-safe validation window before enabling a workflow that can create a real calendar event or booking.
+- [ ] Review and finish the independent Meta Ads publish-journal work in
+  `codex/admin/meta-ads-publish-production-audit`; do not mix it into runtime
+  cleanup commits.
+- [ ] Decide whether draft PR #658 should graduate from the optional GitHub
+  autonomy-broker experiment; it is isolated and not deployed.
 
 ## Done — architecture and runtime program
 
@@ -18,3 +23,9 @@
 - [x] Canonical code remains `C:\CodexShared\Projetos\skincos`; mutable state and secrets remain outside the shared repository.
 - [x] Legacy units, one-time migration launchers, applied workflow patchers and WSL backup timer were retired; daily backup scheduling is Windows-owned and restore-verified.
 - [x] Post-cutover Git, runtime, endpoint, scanner, backup, release and sensitive-artifact auditing completed with rollback preserved.
+- [x] Native releases were reduced to the active release plus one proven
+  rollback; obsolete transfer archives, recovery worktrees and generated local
+  dependencies were removed after consumer checks.
+- [x] CRM, Booking and WhatsApp state/config received a separate checksum-
+  verified backup with real PostgreSQL restores before Windows legacy state was
+  retired.

--- a/crm/api/scripts/sync-atendimento-local-mirror.mjs
+++ b/crm/api/scripts/sync-atendimento-local-mirror.mjs
@@ -6,6 +6,7 @@ import { createPgPool } from '../server/harmonia/store/pg.js'
 import { readAtendimentoSheet, readGerenciaSheet } from '../server/atendimento/importer.js'
 import {
     backupAtendimentoMirror,
+    DEFAULT_CRM_RUNTIME_HOME,
     ensureAtendimentoMirrorMetadata,
     getAtendimentoMirrorStatus,
     isLocalMirrorDestination,
@@ -22,7 +23,7 @@ const sourceMode = String(process.env.ATENDIMENTO_SOURCE_MODE || '').trim().toLo
 const atendimentoWorkbook = String(process.env.ATENDIMENTO_GOOGLE_XLSX_FILE || '').trim()
 const gerenciaWorkbook = String(process.env.GERENCIA_GOOGLE_XLSX_FILE || '').trim()
 const googleServiceAccountFile = String(process.env.ATENDIMENTO_GOOGLE_SA_FILE || '').trim()
-const runtimeHome = String(process.env.CRM_RUNTIME_HOME || '/mnt/c/CodexRuntime/crm-api').trim()
+const runtimeHome = String(process.env.CRM_RUNTIME_HOME || DEFAULT_CRM_RUNTIME_HOME).trim()
 
 function print(value) {
     process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)

--- a/crm/api/server/atendimento/__tests__/mirror.test.js
+++ b/crm/api/server/atendimento/__tests__/mirror.test.js
@@ -3,6 +3,11 @@ import assert from 'node:assert/strict'
 
 import { __testables } from '../mirror.js'
 
+test('defaults mutable CRM state to the native Linux filesystem', () => {
+    assert.equal(__testables.DEFAULT_CRM_RUNTIME_HOME, '/var/lib/skincos-runtime/crm')
+    assert.doesNotMatch(__testables.DEFAULT_CRM_RUNTIME_HOME, /^\/mnt\//)
+})
+
 test('accepts only the local Atendimento mirror database as destination', () => {
     assert.equal(
         __testables.isLocalMirrorDestination('postgresql://skincos@/skincos_crm_local?host=/var/run/postgresql'),

--- a/crm/api/server/atendimento/mirror.js
+++ b/crm/api/server/atendimento/mirror.js
@@ -20,6 +20,8 @@ export const MIRROR_TABLES = [
     'goal_table_rows',
 ]
 
+export const DEFAULT_CRM_RUNTIME_HOME = '/var/lib/skincos-runtime/crm'
+
 const LOCAL_DATABASE_NAME = 'skincos_crm_local'
 const IDENTIFIER_RE = /^[a-z_][a-z0-9_]*$/
 const INSERT_BATCH_SIZE = 250
@@ -192,7 +194,7 @@ async function runProcess(command, args) {
     })
 }
 
-export async function backupAtendimentoMirror(destinationUrl, runtimeHome = process.env.CRM_RUNTIME_HOME || '/mnt/c/CodexRuntime/crm-api') {
+export async function backupAtendimentoMirror(destinationUrl, runtimeHome = process.env.CRM_RUNTIME_HOME || DEFAULT_CRM_RUNTIME_HOME) {
     const backupDir = path.join(runtimeHome, 'backups', 'atendimento')
     await fs.mkdir(backupDir, { recursive: true })
     const stamp = new Date().toISOString().replace(/[:.]/g, '-')
@@ -338,6 +340,7 @@ export async function syncAtendimentoMirror({
 }
 
 export const __testables = {
+    DEFAULT_CRM_RUNTIME_HOME,
     connectionFingerprint,
     isLocalMirrorDestination,
     parsePostgresConnection,

--- a/docs/runbooks/atendimento-local-mirror.md
+++ b/docs/runbooks/atendimento-local-mirror.md
@@ -6,15 +6,15 @@ O CRM local usa `skincos_crm_local` para leituras, métricas e simulações do m
 
 O fluxo original foi recuperado do VHDX legado: Atendimento e Gerência eram lidos do Google Sheets por uma conta de serviço e importados no PostgreSQL local. A conta recuperada recebeu acesso `Leitor` às duas planilhas; ela não possui permissão para editar a origem.
 
-O sincronizador baixa XLSX autenticados pela API do Google Drive usando exclusivamente os escopos `drive.readonly` e `spreadsheets.readonly`. Os snapshots privados em `C:\CodexRuntime\crm-api\imports\` permanecem como contingência offline.
+O sincronizador baixa XLSX autenticados pela API do Google Drive usando exclusivamente os escopos `drive.readonly` e `spreadsheets.readonly`. Os snapshots privados em `/var/lib/skincos-runtime/crm/imports/` permanecem como contingência offline.
 
 ## Configuração privada no mini-PC
 
-`C:\CodexRuntime\crm-api\env\atendimento-source.env` deve permanecer privado e apontar para a credencial recuperada:
+`/etc/skincos/atendimento-source.env` deve permanecer privado e apontar para a credencial recuperada:
 
 ```bash
 ATENDIMENTO_SOURCE_MODE=google-sheets-live
-ATENDIMENTO_GOOGLE_SA_FILE=/mnt/c/CodexRuntime/crm-api/env/atendimento-google-service-account.json
+ATENDIMENTO_GOOGLE_SA_FILE=/etc/skincos/atendimento-google-service-account.json
 ```
 
 Não coloque a credencial em `crm-api.env`, `.dev.vars`, GitHub, Cloudflare, logs ou no repositório. `DATABASE_URL` em `crm-api.env` deve continuar apontando apenas para `skincos_crm_local`.
@@ -27,9 +27,9 @@ npm run codex:crm:atendimento-mirror-sync -- --dry-run
 npm run codex:crm:atendimento-mirror-sync -- --apply
 ```
 
-`--apply` exige a confirmação `SINCRONIZAR`, salva um dump em `C:\CodexRuntime\crm-api\backups\atendimento\`, conserva os dez últimos backups, reinicia o CRM API e roda o gate local. A atualização substitui simulações locais; use-a somente quando quiser renovar a base.
+`--apply` exige a confirmação `SINCRONIZAR`, salva um dump em `/var/lib/skincos-runtime/crm/backups/atendimento/`, conserva os dez últimos backups, reinicia o CRM API e roda o gate local. A atualização substitui simulações locais; use-a somente quando quiser renovar a base.
 
-O reinício aguarda até 120 segundos pela porta `8099`, pois o serviço carrega os módulos do CRM a partir do volume compartilhado antes de aceitar conexões. Se o health check não abrir nesse intervalo, a sincronização permanece aplicada e o comando falha explicitamente antes do gate.
+O reinício aguarda até 120 segundos pela porta `8099`, pois o serviço carrega os módulos do CRM a partir do release nativo antes de aceitar conexões. Se o health check não abrir nesse intervalo, a sincronização permanece aplicada e o comando falha explicitamente antes do gate.
 
 ## Garantias
 


### PR DESCRIPTION
## Summary
- make the Atendimento mirror default to native Linux runtime state and add a regression test
- align the private mirror runbook with the migrated native paths
- record the restore-verified lifecycle backup, post-cutover cleanup and intentionally preserved independent work

## Validation
- CRM API tests: 76 passed
- architecture contract validation: passed
- WSL keepalive regression: passed
- JavaScript syntax and git diff checks: passed
- native Atendimento status: 8,436 attendances, google-sheets-live
- lifecycle backup 20260715T231622Z: 6 hashes matched; temporary restores produced 37 WhatsApp and 17 CRM tables