### PR TITLE
Update autonomy draft reference

### DIFF
--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -43,7 +43,7 @@
 - `codex/admin/meta-ads-publish-production-audit` contains uncommitted product
   work for the Meta Ads publish journal. It is intentionally isolated from the
   completed architecture/runtime program and must be reviewed in its own task.
-- PR #658 (`codex/admin/github-codex-autonomy`) remains a deliberate draft for
+- PR #674 (`codex/admin/github-codex-autonomy`) remains a deliberate draft for
   the optional GitHub autonomy broker; it is not part of the production
   runtime and has no deployment dependency.
 - The detached worktree under `%USERPROFILE%\.codex\worktrees` is Codex

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,7 +7,7 @@
 - [ ] Review and finish the independent Meta Ads publish-journal work in
   `codex/admin/meta-ads-publish-production-audit`; do not mix it into runtime
   cleanup commits.
-- [ ] Decide whether draft PR #658 should graduate from the optional GitHub
+- [ ] Decide whether draft PR #674 should graduate from the optional GitHub
   autonomy-broker experiment; it is isolated and not deployed.
 
 ## Done — architecture and runtime program


### PR DESCRIPTION
Update the preserved optional autonomy-broker draft reference from permanently closed PR #658 to its restored replacement PR #674. No runtime or product code changes.