### PR TITLE
feat(workforce): complete employee timekeeping module

### DIFF
--- a/.github/scripts/ponto_smoke.py
+++ b/.github/scripts/ponto_smoke.py
@@ -24,10 +24,19 @@ def fetch_json(base_url: str, path: str, timeout: int, user_agent: str) -> dict:
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
+            content_type = (resp.headers.get("Content-Type") or "").lower()
+            if "application/json" not in content_type:
+                raise RuntimeError(f"HTTP {resp.status} {path} with invalid content-type {content_type!r}")
             data = resp.read().decode("utf-8", "ignore")
-            return json.loads(data)
+            payload = json.loads(data)
+            payload["__http_status"] = resp.status
+            payload["__content_type"] = content_type
+            return payload
     except HTTPError as err:
         body = err.read().decode("utf-8", "ignore")
+        content_type = (err.headers.get("Content-Type") or "").lower()
+        if "application/json" not in content_type:
+            raise RuntimeError(f"HTTP {err.code} {path} with invalid content-type {content_type!r}")
         try:
             data = json.loads(body)
         except Exception as exc:  # pragma: no cover - defensive branch
@@ -46,10 +55,6 @@ def check_once(args: argparse.Namespace) -> str:
     proxy = fetch_json(args.base_url, "/api/ponto/_proxy-status", args.timeout, args.user_agent)
     require_true(proxy, "ok", "proxy-status")
     require_true(proxy, "targetConfigured", "proxy-status")
-    require_true(proxy, "adminTokenConfigured", "proxy-status")
-
-    if args.require_proxy_token_configured:
-        require_true(proxy, "proxyTokenConfigured", "proxy-status")
     if args.require_actor_key_configured:
         require_true(proxy, "actorKeyConfigured", "proxy-status")
 
@@ -62,8 +67,15 @@ def check_once(args: argparse.Namespace) -> str:
         return "SKIP"
 
     require_true(health, "ok", "health")
-    if args.require_crypto_templates:
-        require_true(health, "cryptoTemplates", "health")
+    if health.get("service") != "workforce-timekeeping":
+        raise RuntimeError(f"health service mismatch: {health}")
+    readiness = fetch_json(args.base_url, "/api/ponto/readiness", args.timeout, args.user_agent)
+    require_true(readiness, "ok", "readiness")
+    if readiness.get("database") != "available":
+        raise RuntimeError(f"readiness database unavailable: {readiness}")
+    protected = fetch_json(args.base_url, "/api/ponto/context", args.timeout, args.user_agent)
+    if protected.get("__http_status") != 401 or protected.get("error") != "UNAUTHORIZED":
+        raise RuntimeError(f"protected route did not fail closed without session: {protected}")
     return "OK"
 
 
@@ -75,10 +87,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=15)
     parser.add_argument("--user-agent", default="Mozilla/5.0 (compatible; PontoSmoke/1.0)")
     parser.add_argument("--allow-ponto-disabled", action="store_true")
-    parser.add_argument("--require-proxy-token-configured", action="store_true")
     parser.add_argument("--require-actor-key-configured", action="store_true")
-    parser.add_argument("--no-require-crypto-templates", dest="require_crypto_templates", action="store_false")
-    parser.set_defaults(require_crypto_templates=True)
     return parser.parse_args()
 
 

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -1,4 +1,4 @@
-name: Sync CRM Pages env (Ponto)
+name: Sync CRM Pages env (Timekeeping)
 
 on:
   schedule:
@@ -9,55 +9,46 @@ permissions:
   contents: read
 
 jobs:
-  sync:
+  production:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: production
     steps:
-      - name: Guard Cloudflare credentials
-        id: guard
-        env:
-          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
-          PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
-          PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
-          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${TOKEN:-}" || -z "${ACCOUNT_ID:-}" ]]; then
-            echo "Cloudflare secrets missing; cannot sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ -z "${PONTO_PROXY_TOKEN:-}" || -z "${PONTO_ACTOR_HMAC_KEY:-}" || -z "${PONTO_ADMIN_TOKEN:-}" ]]; then
-            echo "Missing GitHub secrets PONTO_PROXY_TOKEN/PONTO_ACTOR_HMAC_KEY/PONTO_ADMIN_TOKEN; cannot sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Node
-        if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22.12.0"
-
-      - name: Sync Pages secrets (Ponto) by environment
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+          node-version: 22.12.0
+      - name: Sync production proxy configuration
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PROJECT: ${{ steps.guard.outputs.project }}
-          PONTO_API_TARGET: "https://api.skincos.com.br"
-          PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
+          PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'skincos' }}
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
-          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
         run: |
           set -euo pipefail
-          for env_name in production preview; do
-            printf "%s" "$PONTO_API_TARGET" | npx --yes wrangler@4 pages secret put PONTO_API_TARGET --project-name "$PROJECT" --env "$env_name" >/dev/null
-            printf "%s" "$PONTO_PROXY_TOKEN" | npx --yes wrangler@4 pages secret put PONTO_PROXY_TOKEN --project-name "$PROJECT" --env "$env_name" >/dev/null
-            printf "%s" "$PONTO_ACTOR_HMAC_KEY" | npx --yes wrangler@4 pages secret put PONTO_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
-            printf "%s" "$PONTO_ADMIN_TOKEN" | npx --yes wrangler@4 pages secret put PONTO_ADMIN_TOKEN --project-name "$PROJECT" --env "$env_name" >/dev/null
-            echo "Synced Ponto secrets for env=$env_name"
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PONTO_ACTOR_HMAC_KEY; do
+            [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }
           done
+          printf '%s' 'https://api.skincos.com.br' | npx --yes wrangler@4.112.0 pages secret put PONTO_API_TARGET --project-name "$PROJECT" --env production >/dev/null
+          printf '%s' "$PONTO_ACTOR_HMAC_KEY" | npx --yes wrangler@4.112.0 pages secret put PONTO_ACTOR_HMAC_KEY --project-name "$PROJECT" --env production >/dev/null
+
+  preview:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+      - name: Sync isolated preview proxy configuration
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'skincos' }}
+          PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PONTO_ACTOR_HMAC_KEY; do
+            [[ -n "${!name:-}" ]] || { echo "Missing required staging value: $name"; exit 1; }
+          done
+          printf '%s' 'https://api-staging.skincos.com.br' | npx --yes wrangler@4.112.0 pages secret put PONTO_API_TARGET --project-name "$PROJECT" --env preview >/dev/null
+          printf '%s' "$PONTO_ACTOR_HMAC_KEY" | npx --yes wrangler@4.112.0 pages secret put PONTO_ACTOR_HMAC_KEY --project-name "$PROJECT" --env preview >/dev/null

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: 22.12.0
       - name: Sync production proxy configuration
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: 22.12.0
       - name: Sync isolated preview proxy configuration

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -1,4 +1,4 @@
-name: Sync Ponto secrets (Cloudflare Workers)
+name: Sync Timekeeping secrets
 
 on:
   schedule:
@@ -10,86 +10,32 @@ permissions:
 
 jobs:
   sync:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: production
     steps:
-      - name: Guard Cloudflare credentials + Ponto secrets
-        id: guard
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
-          PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
-          PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
-          PONTO_AUDIT_HMAC_KEY: ${{ secrets.PONTO_AUDIT_HMAC_KEY }}
-          PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
-          PONTO_TEMPLATES_CACHE_TTL_MS: ${{ vars.PONTO_TEMPLATES_CACHE_TTL_MS }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-            echo "Cloudflare secrets missing; cannot sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ -z "${PONTO_ADMIN_TOKEN:-}" || -z "${PONTO_PROXY_TOKEN:-}" || -z "${PONTO_ACTOR_HMAC_KEY:-}" ]]; then
-            echo "Missing required GitHub secrets: PONTO_ADMIN_TOKEN, PONTO_PROXY_TOKEN, PONTO_ACTOR_HMAC_KEY."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ -n "${PONTO_TEMPLATES_CACHE_TTL_MS:-}" && ! "${PONTO_TEMPLATES_CACHE_TTL_MS}" =~ ^[0-9]+$ ]]; then
-            echo "Invalid repo var PONTO_TEMPLATES_CACHE_TTL_MS (must be integer ms)."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout
-        if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
         with:
-          node-version: "22.12.0"
-
-      - name: Sync secrets to Workers (skincos-api + skincos-insumos)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+          ref: main
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+      - name: Validate and sync canonical Worker secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PONTO_ADMIN_TOKEN: ${{ secrets.PONTO_ADMIN_TOKEN }}
-          PONTO_PROXY_TOKEN: ${{ secrets.PONTO_PROXY_TOKEN }}
+          D1_ID: ${{ vars.TIMEKEEPING_D1_PRODUCTION_ID }}
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
-          PONTO_AUDIT_HMAC_KEY: ${{ secrets.PONTO_AUDIT_HMAC_KEY }}
+          PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
           PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
-          # Non-secret: stored as repo var for easy tuning without code changes.
-          PONTO_TEMPLATES_CACHE_TTL_MS: ${{ vars.PONTO_TEMPLATES_CACHE_TTL_MS }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
         run: |
           set -euo pipefail
-
-          put_secret() {
-            local cfg="$1"
-            local name="$2"
-            local value="$3"
-            if [[ -z "${value:-}" ]]; then
-              echo "Skipping empty secret $name for $cfg"
-              return 0
-            fi
-            printf "%s" "$value" | npx --yes wrangler@3 secret put "$name" --config "$cfg" >/dev/null
-            echo "Set secret $name for $cfg"
-          }
-
-          # Production (no --env): keep consistent across both Workers, since implementation is shared.
-          put_secret api/wrangler.toml PONTO_ADMIN_TOKEN "$PONTO_ADMIN_TOKEN"
-          put_secret api/wrangler.toml PONTO_PROXY_TOKEN "$PONTO_PROXY_TOKEN"
-          put_secret api/wrangler.toml PONTO_ACTOR_HMAC_KEY "$PONTO_ACTOR_HMAC_KEY"
-          put_secret api/wrangler.toml PONTO_AUDIT_HMAC_KEY "${PONTO_AUDIT_HMAC_KEY:-}"
-          put_secret api/wrangler.toml PONTO_TEMPLATES_KEY "${PONTO_TEMPLATES_KEY:-}"
-          put_secret api/wrangler.toml PONTO_TEMPLATES_CACHE_TTL_MS "${PONTO_TEMPLATES_CACHE_TTL_MS:-}"
-
-          put_secret inventory/wrangler.toml PONTO_ADMIN_TOKEN "$PONTO_ADMIN_TOKEN"
-          put_secret inventory/wrangler.toml PONTO_PROXY_TOKEN "$PONTO_PROXY_TOKEN"
-          put_secret inventory/wrangler.toml PONTO_ACTOR_HMAC_KEY "$PONTO_ACTOR_HMAC_KEY"
-          put_secret inventory/wrangler.toml PONTO_AUDIT_HMAC_KEY "${PONTO_AUDIT_HMAC_KEY:-}"
-          put_secret inventory/wrangler.toml PONTO_TEMPLATES_KEY "${PONTO_TEMPLATES_KEY:-}"
-          put_secret inventory/wrangler.toml PONTO_TEMPLATES_CACHE_TTL_MS "${PONTO_TEMPLATES_CACHE_TTL_MS:-}"
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY; do
+            if [[ -z "${!name:-}" ]]; then echo "Missing required value: $name"; exit 1; fi
+          done
+          sed -i "s/__CONFIGURE_TIMEKEEPING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
+          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY; do
+            printf '%s' "${!name}" | npx --yes wrangler@4.112.0 secret put "$name" --config workforce/timekeeping/wrangler.toml >/dev/null
+            echo "Synced $name to skincos-timekeeping"
+          done

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: main
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: 22.12.0
       - name: Validate and sync canonical Worker secrets

--- a/.github/workflows/crm-codeql.yml
+++ b/.github/workflows/crm-codeql.yml
@@ -18,6 +18,7 @@ on:
       - "integration/**"
       - "service/**"
       - "social/**"
+      - "workforce/timekeeping/**"
       - ".github/workflows/crm-codeql.yml"
       - ".github/codeql/**"
   pull_request:
@@ -36,6 +37,7 @@ on:
       - "integration/**"
       - "service/**"
       - "social/**"
+      - "workforce/timekeeping/**"
       - ".github/workflows/crm-codeql.yml"
       - ".github/codeql/**"
   schedule:
@@ -59,11 +61,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
 
       - name: Setup Node.js
         if: ${{ matrix.language == 'javascript' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -72,12 +74,12 @@ jobs:
             website/package-lock.json
       - name: Setup Python
         if: ${{ matrix.language == 'python' }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: "3.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -105,6 +107,6 @@ jobs:
           fi
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -66,11 +66,11 @@ jobs:
           done
           [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo "Invalid Timekeeping D1 id"; exit 1; }
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: main
           fetch-depth: 1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: 22.12.0
 
@@ -123,7 +123,7 @@ jobs:
           echo "artifact=$encrypted" >> "$GITHUB_OUTPUT"
 
       - name: Upload encrypted migration checkpoint
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: timekeeping-${{ inputs.target }}-pre-migration-${{ github.sha }}
           path: ${{ steps.checkpoint.outputs.artifact }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload staging attestation
         if: inputs.target == 'staging'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: timekeeping-staging-attestation
           path: ${{ runner.temp }}/timekeeping-staging-attestation/attestation.json

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -1,0 +1,199 @@
+name: Deploy Workforce Timekeeping
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Deploy target
+        required: true
+        default: staging
+        type: choice
+        options: [staging, production]
+      staging_run_id:
+        description: Required for production - successful staging run id for this exact commit
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-timekeeping-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    steps:
+      - name: Verify production staging attestation
+        if: inputs.target == 'production'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$STAGING_RUN_ID" =~ ^[0-9]+$ ]] || { echo "Production requires a numeric staging_run_id"; exit 1; }
+          mkdir -p "$RUNNER_TEMP/staging-attestation"
+          gh run download "$STAGING_RUN_ID" --repo "$GITHUB_REPOSITORY" --name timekeeping-staging-attestation --dir "$RUNNER_TEMP/staging-attestation"
+          node - "$RUNNER_TEMP/staging-attestation/attestation.json" "$EXPECTED_SHA" <<'NODE'
+          const fs = require('fs')
+          const [file, expectedSha] = process.argv.slice(2)
+          const value = JSON.parse(fs.readFileSync(file, 'utf8'))
+          if (value.target !== 'staging' || value.sha !== expectedSha || value.health !== 200 || value.readiness !== 200) {
+            console.error('Staging attestation does not match this production commit')
+            process.exit(1)
+          }
+          NODE
+
+      - name: Guard target and credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_ID: ${{ inputs.target == 'production' && vars.TIMEKEEPING_D1_PRODUCTION_ID || vars.TIMEKEEPING_D1_STAGING_ID }}
+          PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
+          PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
+          PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+          TIMEKEEPING_BACKUP_PASSPHRASE: ${{ secrets.TIMEKEEPING_BACKUP_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY TIMEKEEPING_BACKUP_PASSPHRASE; do
+            [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }
+          done
+          [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo "Invalid Timekeeping D1 id"; exit 1; }
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+
+      - name: Install pinned Worker toolchains
+        run: |
+          set -euo pipefail
+          npm --prefix workforce/timekeeping ci --ignore-scripts
+          npm --prefix api ci --ignore-scripts
+          (cd inventory && corepack pnpm install --frozen-lockfile --ignore-scripts)
+
+      - name: Verify checked-out source identity
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo "Checkout SHA mismatch"; exit 1; }
+
+      - name: Test release source
+        run: |
+          set -euo pipefail
+          npm --prefix workforce/timekeeping test
+          npm --prefix api test
+
+      - name: Configure target D1 id in ephemeral checkout
+        env:
+          TARGET: ${{ inputs.target }}
+          D1_ID: ${{ inputs.target == 'production' && vars.TIMEKEEPING_D1_PRODUCTION_ID || vars.TIMEKEEPING_D1_STAGING_ID }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then
+            sed -i "s/__CONFIGURE_TIMEKEEPING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
+          else
+            sed -i "s/__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
+          fi
+
+      - name: Capture encrypted D1 checkpoint
+        id: checkpoint
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+          TIMEKEEPING_BACKUP_PASSPHRASE: ${{ secrets.TIMEKEEPING_BACKUP_PASSPHRASE }}
+        working-directory: workforce/timekeeping
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); DB_NAME=skincos-timekeeping; else ENV_ARGS=(--env staging); DB_NAME=skincos-timekeeping-staging; fi
+          plain="$RUNNER_TEMP/timekeeping-${TARGET}-pre-migration-${GITHUB_SHA}.sql"
+          encrypted="${plain}.gpg"
+          ./node_modules/.bin/wrangler d1 export "$DB_NAME" --remote --output "$plain" --config wrangler.toml "${ENV_ARGS[@]}"
+          printf '%s' "$TIMEKEEPING_BACKUP_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --symmetric --cipher-algo AES256 --output "$encrypted" "$plain"
+          rm -f "$plain"
+          echo "artifact=$encrypted" >> "$GITHUB_OUTPUT"
+
+      - name: Upload encrypted migration checkpoint
+        uses: actions/upload-artifact@v4
+        with:
+          name: timekeeping-${{ inputs.target }}-pre-migration-${{ github.sha }}
+          path: ${{ steps.checkpoint.outputs.artifact }}
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Apply remote migrations before code deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+        working-directory: workforce/timekeeping
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); DB_NAME=skincos-timekeeping; else ENV_ARGS=(--env staging); DB_NAME=skincos-timekeeping-staging; fi
+          ./node_modules/.bin/wrangler d1 migrations apply "$DB_NAME" --remote --config wrangler.toml "${ENV_ARGS[@]}"
+
+      - name: Configure Worker secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+          PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
+          PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
+          PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
+          ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); else ENV_ARGS=(--env staging); fi
+          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY; do
+            printf '%s' "${!name}" | workforce/timekeeping/node_modules/.bin/wrangler secret put "$name" --config workforce/timekeeping/wrangler.toml "${ENV_ARGS[@]}" >/dev/null
+          done
+
+      - name: Deploy Timekeeping then gateway
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); else ENV_ARGS=(--env staging); fi
+          workforce/timekeeping/node_modules/.bin/wrangler deploy --config workforce/timekeeping/wrangler.toml --keep-vars "${ENV_ARGS[@]}"
+          workforce/timekeeping/node_modules/.bin/wrangler deploy --config api/wrangler.toml --keep-vars "${ENV_ARGS[@]}"
+
+      - name: Read-only endpoint smoke
+        id: smoke
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "production" ]]; then BASE=https://api.skincos.com.br; else BASE=https://api-staging.skincos.com.br; fi
+          for path in health readiness; do
+            headers="$(mktemp)"; body="$(mktemp)"
+            code="$(curl --silent --show-error --retry 5 --retry-delay 4 --dump-header "$headers" --output "$body" --write-out '%{http_code}' "$BASE/api/ponto/$path")"
+            [[ "$code" == "200" ]] || { echo "$path returned HTTP $code"; cat "$body"; exit 1; }
+            grep -Eiq '^content-type: application/json' "$headers" || { echo "$path returned invalid content-type"; exit 1; }
+            node -e "const p=JSON.parse(require('fs').readFileSync(process.argv[1])); if(!p.ok) process.exit(1)" "$body"
+          done
+
+      - name: Write staging attestation
+        if: inputs.target == 'staging'
+        run: |
+          mkdir -p "$RUNNER_TEMP/timekeeping-staging-attestation"
+          node -e "require('fs').writeFileSync(process.argv[1], JSON.stringify({target:'staging',sha:process.env.GITHUB_SHA,runId:process.env.GITHUB_RUN_ID,health:200,readiness:200,createdAt:new Date().toISOString()},null,2))" "$RUNNER_TEMP/timekeeping-staging-attestation/attestation.json"
+
+      - name: Upload staging attestation
+        if: inputs.target == 'staging'
+        uses: actions/upload-artifact@v4
+        with:
+          name: timekeeping-staging-attestation
+          path: ${{ runner.temp }}/timekeeping-staging-attestation/attestation.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ponto-smoke.yml
+++ b/.github/workflows/ponto-smoke.yml
@@ -10,10 +10,15 @@ permissions:
 
 jobs:
   smoke:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 1
 
       - name: Smoke check Ponto endpoints
         env:

--- a/.github/workflows/ponto-ui-smoke.yml
+++ b/.github/workflows/ponto-ui-smoke.yml
@@ -26,13 +26,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -43,7 +43,7 @@ jobs:
         working-directory: crm/console
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ponto-ui-smoke-artifacts
           path: |

--- a/.github/workflows/ponto-ui-smoke.yml
+++ b/.github/workflows/ponto-ui-smoke.yml
@@ -10,11 +10,6 @@ on:
         required: false
         default: ""
         type: string
-      mutate:
-        description: "Perform admin+employee create/link+delete (more coverage, writes data briefly)."
-        required: false
-        default: true
-        type: boolean
 
 concurrency:
   group: ponto-ui-smoke-prod
@@ -25,8 +20,9 @@ permissions:
 
 jobs:
   smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || vars.ENABLE_PONTO_UI_SMOKE == 'true') }}
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -58,15 +54,17 @@ jobs:
 
       - name: Resolve expected SHA
         id: sha
+        env:
+          INPUT_SHA: ${{ github.event.inputs.expect_sha }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "sha=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          INPUT_SHA="${{ github.event.inputs.expect_sha }}"
           INPUT_SHA="$(echo "${INPUT_SHA:-}" | tr -d '[:space:]')"
           if [[ -n "${INPUT_SHA:-}" ]]; then
+            [[ "$INPUT_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]] || { echo "expect_sha must be 7-40 hexadecimal characters"; exit 1; }
             echo "sha=${INPUT_SHA}" >> "$GITHUB_OUTPUT"
           else
             echo "sha=" >> "$GITHUB_OUTPUT"
@@ -95,9 +93,9 @@ jobs:
           SMOKE_PASSWORD: ${{ secrets.PONTO_SMOKE_PASSWORD }}
           LOGIN_WAIT_MS: "120000"
           NO_SCREENSHOTS: "1"
-          MUTATE_ADMIN: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
-          MUTATE_EMPLOYEE: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
-          MUTATE_PUNCH: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
+          MUTATE_ADMIN: "0"
+          MUTATE_EMPLOYEE: "0"
+          MUTATE_PUNCH: "0"
           NODE_PATH: crm/console/node_modules
         run: |
           set -euo pipefail
@@ -112,11 +110,11 @@ jobs:
           SMOKE_EMAIL: ${{ secrets.PONTO_SMOKE_EMAIL }}
           SMOKE_PASSWORD: ${{ secrets.PONTO_SMOKE_PASSWORD }}
           LOGIN_WAIT_MS: "120000"
-          TRACE: "1"
+          TRACE: "0"
           FULL_PAGE: "1"
-          MUTATE_ADMIN: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
-          MUTATE_EMPLOYEE: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
-          MUTATE_PUNCH: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.mutate == true || github.event.inputs.mutate == 'true') }}
+          MUTATE_ADMIN: "0"
+          MUTATE_EMPLOYEE: "0"
+          MUTATE_PUNCH: "0"
           NODE_PATH: crm/console/node_modules
         run: |
           set -euo pipefail
@@ -127,7 +125,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ponto-ui-smoke-artifacts
-          path: output/playwright/
+          path: |
+            output/playwright/*.png
+            output/playwright/*.log
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Fail if fast smoke failed
         if: ${{ steps.smoke.outcome != 'success' }}

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -25,8 +25,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           # node:sqlite is required by the migration rollback test.
           node-version: '22.23.1'

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -28,7 +28,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          # node:sqlite is required by the migration rollback test.
+          node-version: '22.23.1'
           cache: npm
           cache-dependency-path: |
             workforce/timekeeping/package-lock.json

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -1,0 +1,38 @@
+name: Timekeeping CI
+
+on:
+  pull_request:
+    paths:
+      - 'workforce/timekeeping/**'
+      - 'api/**'
+      - 'crm/console/functions/api/ponto/**'
+      - 'crm/console/PontoModule.tsx'
+      - '.github/workflows/timekeeping-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'workforce/timekeeping/**'
+      - 'api/**'
+      - 'crm/console/functions/api/ponto/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: |
+            api/package-lock.json
+            crm/console/package-lock.json
+      - name: Test Timekeeping domain
+        run: node --test workforce/timekeeping/*.test.js
+      - name: Test gateway routing
+        run: npm --prefix api ci && npm --prefix api test
+      - name: Typecheck and test CRM proxy
+        run: npm --prefix crm/console ci && npm --prefix crm/console run typecheck && npm --prefix crm/console test

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -7,6 +7,9 @@ on:
       - 'api/**'
       - 'crm/console/functions/api/ponto/**'
       - 'crm/console/PontoModule.tsx'
+      - 'crm/console/pontoApi.ts'
+      - 'crm/console/pontoTypes.ts'
+      - 'crm/console/tests/ponto*.test.ts'
       - '.github/workflows/timekeeping-ci.yml'
   push:
     branches: [main]
@@ -28,11 +31,27 @@ jobs:
           node-version: '22.12.0'
           cache: npm
           cache-dependency-path: |
+            workforce/timekeeping/package-lock.json
             api/package-lock.json
+            inventory/pnpm-lock.yaml
             crm/console/package-lock.json
+      - name: Install pinned Timekeeping toolchain
+        run: npm --prefix workforce/timekeeping ci --ignore-scripts
       - name: Test Timekeeping domain
-        run: node --test workforce/timekeeping/*.test.js
+        run: npm --prefix workforce/timekeeping test
+      - name: Apply Timekeeping migrations locally
+        working-directory: workforce/timekeeping
+        run: ./node_modules/.bin/wrangler d1 migrations apply skincos-timekeeping --local --config wrangler.toml
+      - name: Validate legacy JSON importer
+        run: |
+          node workforce/timekeeping/scripts/import-ponto-json.mjs --source workforce/timekeeping/fixtures/ponto_store.synthetic.json --dry-run
+          node workforce/timekeeping/scripts/migration-local.test.mjs
       - name: Test gateway routing
-        run: npm --prefix api ci && npm --prefix api test
+        run: |
+          set -euo pipefail
+          npm --prefix api ci --ignore-scripts
+          (cd inventory && corepack pnpm install --frozen-lockfile --ignore-scripts)
+          npm --prefix api test
+          api/node_modules/.bin/wrangler deploy --dry-run --config api/wrangler.toml --env="" --outdir "$RUNNER_TEMP/api-dry-run"
       - name: Typecheck and test CRM proxy
-        run: npm --prefix crm/console ci && npm --prefix crm/console run typecheck && npm --prefix crm/console test
+        run: npm --prefix crm/console ci && npm --prefix crm/console run typecheck && npm --prefix crm/console run lint && npm --prefix crm/console test && npm --prefix crm/console run build

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -417,3 +417,9 @@
   `/etc/skincos`. Windows owns transfer/publication only; the final lifecycle
   backup includes private configuration, snapshots and real PostgreSQL restore
   proof before the duplicate trees are deleted.
+
+## 2026-07-18 - Make Workforce Timekeeping canonical and D1-backed
+
+- Decision: own Controle de Ponto in `workforce/timekeeping`, expose it only through the public `api` gateway and use its D1 as the sole operational persistence.
+- Why: the CRM-local JSON backend could not provide durable concurrency, canonical employee identity, period snapshots or enforceable cross-unit authorization.
+- Impact: CRM is a same-origin client/proxy; legacy JSON is import-only, corrections preserve original events, Escala links require explicit aliases, and staging must pass before the guarded production workflow can run.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,19 @@
 # TASKS
 
+## Controle de Ponto — `codex/admin/workforce-timekeeping-complete`
+
+- [x] Domínio definitivo criado em `workforce/timekeeping` e montado no gateway.
+- [x] D1 modelado com migrations reproduzíveis, constraints, índices, snapshots e auditoria imutável.
+- [x] Importador JSON com dry-run, checksum, backup local, idempotência, conflitos e rollback validado.
+- [x] Identidade canônica, aliases, unidades temporais e adaptação conservadora da Escala.
+- [x] Motor diário/mensal, banco de horas, inconsistências, fechamento e reabertura.
+- [x] Matriz de permissões, PIN protegido, biometria cifrada, rate limit, replay e idempotência.
+- [x] Cliente/tipos centralizados e gestão funcional na aba CRM.
+- [x] Testes locais do domínio, gateway, proxy, cliente, D1 e integração HTTP.
+- [x] Executar todos os gates finais (lint completo, testes completos e build de produção).
+- [ ] Publicar e validar staging com D1/secrets próprios.
+- [ ] Promover por workflow oficial e executar smoke produtivo somente leitura.
+
 ## External/product follow-up
 
 - [ ] Confirm or reauthorize the `Google Calendar (Skincos)` credential for the exact scopes required by the inactive clinic Orb workflows.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,1519 @@
+{
+  "name": "@skincos/api-worker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@skincos/api-worker",
+      "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "qrcode-generator": "^1.4.4"
+      },
+      "devDependencies": {
+        "wrangler": "4.112.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
+      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
+      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
+      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260714.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
+      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260714.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
+      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260714.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
+        "@cloudflare/workerd-linux-64": "1.20260714.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
+        "@cloudflare/workerd-windows-64": "1.20260714.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.112.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
+      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260714.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260714.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260714.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
     "lint": "echo \"(todo)\""
   },
   "devDependencies": {
-    "wrangler": "^4.60.0"
+    "wrangler": "4.112.0"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -5,4 +5,13 @@ export { createGatewayHandler } from './router.js';
 
 export const handleGatewayRequest = createGatewayHandler({
     inventoryHandler: inventoryWorker.fetch.bind(inventoryWorker),
+    timekeepingHandler: async (request, env) => {
+        if (!env.TIMEKEEPING?.fetch) {
+            return new Response(JSON.stringify({ ok: false, error: 'workforce_unavailable' }), {
+                status: 503,
+                headers: { 'content-type': 'application/json; charset=utf-8' },
+            });
+        }
+        return env.TIMEKEEPING.fetch(request);
+    },
 });

--- a/api/src/router.js
+++ b/api/src/router.js
@@ -31,7 +31,7 @@ function isInternalServiceRequest(request, env) {
  * selection, request tracing and the human/service access boundary; it must
  * not grow domain persistence or business rules.
  */
-export function createGatewayHandler({ inventoryHandler }) {
+export function createGatewayHandler({ inventoryHandler, timekeepingHandler }) {
     if (typeof inventoryHandler !== 'function') throw new TypeError('inventoryHandler is required');
 
     return async function handleGatewayRequest(request, env, ctx) {
@@ -40,6 +40,16 @@ export function createGatewayHandler({ inventoryHandler }) {
 
         if (url.pathname === '/health') {
             return json(200, { ok: true, service: 'api', requestId }, requestId);
+        }
+
+        if (url.pathname === '/api/ponto' || url.pathname.startsWith('/api/ponto/')) {
+            if (typeof timekeepingHandler !== 'function') {
+                return json(503, { ok: false, error: 'workforce_unavailable', requestId }, requestId);
+            }
+            const response = await timekeepingHandler(request, env, ctx);
+            const headers = new Headers(response.headers);
+            headers.set('x-request-id', requestId);
+            return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
         }
 
         if (url.pathname === '/inventory' || url.pathname.startsWith('/inventory/')) {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -8,6 +8,10 @@ const gateway = createGatewayHandler({
         calls.push(new URL(request.url));
         return new Response('inventory-ok', { status: 200, headers: { 'x-owner': 'inventory' } });
     },
+    timekeepingHandler: async (request) => {
+        calls.push(new URL(request.url));
+        return new Response(JSON.stringify({ ok: true, service: 'workforce-timekeeping' }), { status: 200, headers: { 'content-type': 'application/json' } });
+    },
 });
 
 test('health is owned by the gateway', async () => {
@@ -24,6 +28,14 @@ test('inventory is mounted without retaining the legacy public prefix', async ()
     assert.equal(response.headers.get('x-request-id'), 'inventory-1');
     assert.equal(calls.at(-1).pathname, '/insumos');
     assert.equal(calls.at(-1).search, '?unidade=nh');
+});
+
+test('workforce owns the canonical public Ponto mount', async () => {
+    const response = await gateway(new Request('https://api.skincos.com.br/api/ponto/health', { headers: { 'x-request-id': 'ponto-1' } }), {}, {});
+    assert.equal(response.status, 200);
+    assert.equal((await response.json()).service, 'workforce-timekeeping');
+    assert.equal(calls.at(-1).pathname, '/api/ponto/health');
+    assert.equal(response.headers.get('x-request-id'), 'ponto-1');
 });
 
 test('internal paths require a private service identity', async () => {

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -27,6 +27,10 @@ binding = "DB"
 database_name = "skincos-db"
 database_id = "13e59612-99ba-450e-9014-ddefbee72965"
 
+[[services]]
+binding = "TIMEKEEPING"
+service = "skincos-timekeeping"
+
 [[r2_buckets]]
 binding = "BACKUP_BUCKET"
 bucket_name = "skincos-backups"
@@ -39,6 +43,10 @@ routes = ["api-staging.skincos.com.br/*"]
 binding = "DB"
 database_name = "skincos-db-staging"
 database_id = "REPLACE_ME"
+
+[[env.staging.services]]
+binding = "TIMEKEEPING"
+service = "skincos-timekeeping-staging"
 
 [[env.staging.r2_buckets]]
 binding = "BACKUP_BUCKET"

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -39,10 +39,18 @@ bucket_name = "skincos-backups"
 name = "skincos-api-staging"
 routes = ["api-staging.skincos.com.br/*"]
 
+[[env.staging.durable_objects.bindings]]
+name = "RATE_LIMITER"
+class_name = "RateLimiter"
+
+[[env.staging.durable_objects.bindings]]
+name = "JOB_QUEUE"
+class_name = "JobQueue"
+
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "skincos-db-staging"
-database_id = "REPLACE_ME"
+database_id = "4bdd7995-ad69-465a-917c-0aab22db5c4e"
 
 [[env.staging.services]]
 binding = "TIMEKEEPING"

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -378,6 +378,8 @@ export default function AppFunctionalNeatlab() {
     const pontoCanAdmin =
         roleKey === 'GESTOR' ||
         roleKey === 'GERENTE' ||
+        roleKey === 'RH' ||
+        roleKey === 'ADMIN' ||
         (isLocalDev && devEmail.endsWith('@local.test'))
     const hasModuleAccess = React.useCallback(
         (moduleKey: string) => {
@@ -462,7 +464,7 @@ export default function AppFunctionalNeatlab() {
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
 		    const UNLOCKED_MODULE_KEYS = useMemo(
-		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'conversa', 'atendimento', 'faturamento', 'procedimentos', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'meta-ads', 'site-tracking', 'escala-profissionais']),
+		        () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'conversa', 'atendimento', 'faturamento', 'procedimentos', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'meta-ads', 'site-tracking', 'escala-profissionais', 'ponto']),
 		        [DEFAULT_MODULE_KEY]
 		    )
 	    const [sidebarHover, setSidebarHover] = useState(false)

--- a/crm/console/PontoModule.tsx
+++ b/crm/console/PontoModule.tsx
@@ -11,86 +11,11 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { DEFAULT_UNIT_OPTIONS, type UnitOption } from '@/unitSelection'
 import * as QRCode from 'qrcode'
 import { LoadingPercentText } from '@/LoadingPattern'
-
-type ApiError = { ok?: boolean; error?: string; message?: string; code?: string; hint?: string }
-
-type PontoEmployeePublic = {
-  id: string
-  code?: string
-  name: string
-  cpf?: string
-  birthDate?: string
-  jobTitle?: string
-  phone?: string
-  loginEmail?: string
-  unit?: string
-  active?: boolean
-  createdAt?: string
-  updatedAt?: string
-  deletedAt?: string | null
-  faceDescriptorsCount?: number
-  lastEnrolledAt?: string | null
-  pinSet?: boolean
-}
-
-type PontoDevicePublic = {
-  id: string
-  label?: string
-  unit?: string
-  active?: boolean
-  createdAt?: string
-  revokedAt?: string | null
-  lastSeenAt?: string | null
-}
-
-type PontoEmailConflict = {
-  email: string
-  count: number
-  employees: PontoEmployeePublic[]
-}
-
-type PontoPunchRecord = {
-  id: string
-  kind: 'PUNCH'
-  employeeId: string
-  employeeName: string
-  type: 'IN' | 'OUT' | string
-  at: string
-  unit?: string | null
-  deviceId?: string | null
-  deviceLabel?: string | null
-  method?: 'FACE' | 'PIN' | 'ADMIN' | string
-  matchDistance?: number | null
-  note?: string | null
-  corrected?: { id: string; at: string; reason?: string | null } | null
-}
-
-type PontoMeResponse =
-  | { ok: true; linked: false; actorEmail?: string; hint?: string; allowedUnits?: string[] }
-  | {
-    ok: true
-    linked: true
-    actorEmail?: string
-    allowedUnits?: string[]
-    employee: PontoEmployeePublic
-    hasFace: boolean
-    pinSet: boolean
-    lastPunch: PontoPunchRecord | null
-    cooldown?: { active: boolean; secondsRemaining?: number }
-    suggestedNextMethod?: 'FACE' | 'PIN'
-  }
+import { apiBlob, apiJson, createRequestMeta, errorMetaString, fetchJsonWithMeta, getDevEmployeeActorHeaders, LS_DEV_ACTOR_EMAIL } from './pontoApi'
+import type { PontoCorrection, PontoDevicePublic, PontoEmailConflict, PontoEmployeePublic, PontoMeResponse, PontoMonthlyResult, PontoPunchRecord } from './pontoTypes'
 
 type FaceDetectorMode = 'tiny' | 'ssd'
 
-const LS_DEV_ACTOR_EMAIL = 'skincos.ponto.devActorEmail.v1'
-
-function errorMetaString(meta: { code?: string; requestId?: string; cfRay?: string }) {
-  const parts: string[] = []
-  if (meta.code) parts.push(`code:${meta.code}`)
-  if (meta.requestId) parts.push(`req:${meta.requestId}`)
-  if (meta.cfRay) parts.push(`cf:${meta.cfRay}`)
-  return parts.length ? parts.join(' • ') : ''
-}
 
 const FACE_FALLBACK_THRESHOLD = 3
 const FACE_FALLBACK_MESSAGE =
@@ -124,30 +49,6 @@ function toastErrorMeta(err: any) {
   if (text) toast.message(text)
 }
 
-function b64UrlEncodeBytes(bytes: ArrayBuffer): string {
-  const bin = String.fromCharCode(...new Uint8Array(bytes))
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
-}
-
-function b64UrlEncodeString(input: string): string {
-  const bytes = new TextEncoder().encode(input)
-  return b64UrlEncodeBytes(bytes.buffer)
-}
-
-function getDevEmployeeActorHeaders(emailOverride?: string): Record<string, string> {
-  if (!import.meta.env.DEV) return {}
-  let email = ''
-  if (emailOverride) {
-    email = String(emailOverride).trim().toLowerCase()
-  } else {
-    try { email = String(localStorage.getItem(LS_DEV_ACTOR_EMAIL) || '').trim().toLowerCase() } catch { email = '' }
-  }
-  if (!email) return {}
-  const actor = { email }
-  const actorB64 = b64UrlEncodeString(JSON.stringify(actor))
-  const actorTs = String(Date.now())
-  return { 'x-skincos-actor': actorB64, 'x-skincos-actor-ts': actorTs }
-}
 
 function fmtDate(value?: string | null) {
   const v = String(value || '').trim()
@@ -181,110 +82,6 @@ function toDateRangeISO(value: string, mode: 'start' | 'end'): string {
   const iso = mode === 'end' ? `${raw}T23:59:59.999` : `${raw}T00:00:00.000`
   const dt = new Date(iso)
   return Number.isFinite(dt.getTime()) ? dt.toISOString() : ''
-}
-
-function createRequestMeta() {
-  return {
-    requestId: (globalThis.crypto?.randomUUID?.() || String(Date.now())),
-    clientTime: new Date().toISOString(),
-    tzOffsetMinutes: -new Date().getTimezoneOffset(),
-    locale: navigator.language || 'pt-BR',
-    appVersion: null as string | null
-  }
-}
-
-async function apiJson<T>(
-  path: string,
-  opts: { method?: string; body?: unknown; adminToken?: string; signal?: AbortSignal; headers?: Record<string, string> } = {}
-): Promise<T> {
-  const method = (opts.method || 'GET').toUpperCase()
-  const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers || {}) }
-  if (opts.body !== undefined) headers['content-type'] = 'application/json'
-  if (opts.adminToken) headers.authorization = `Admin ${opts.adminToken}`
-  const res = await fetch(path, {
-    method,
-    credentials: 'include',
-    headers,
-    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
-    signal: opts.signal
-  })
-  const requestId = String(res.headers.get('x-request-id') || '').trim()
-  const cfRay = String(res.headers.get('cf-ray') || '').trim()
-  const text = await res.text()
-  let json: unknown = null
-  try {
-    json = text ? JSON.parse(text) : null
-  } catch {
-    json = null
-  }
-  if (res.ok) return json as T
-  const nonJsonText = String(text || '')
-  const htmlWorkerCrash = !json && (nonJsonText.includes('Worker threw exception') || nonJsonText.includes('Cloudflare Ray ID'))
-  const err = ((json || {}) as ApiError)
-  const inferredCode = htmlWorkerCrash ? 'UPSTREAM_WORKER_EXCEPTION' : ''
-  const code = String(err.error || err.code || inferredCode || '').trim()
-  const hintFromHtml = htmlWorkerCrash ? 'Falha no Worker upstream (Cloudflare 1101). Verifique logs com o request-id/cf-ray.' : ''
-  const hint = typeof err.hint === 'string' ? err.hint.trim() : hintFromHtml
-  const base = err.error || err.message || `HTTP ${res.status}`
-  const meta = errorMetaString({ code, requestId, cfRay })
-  const e = new Error([base, hint, meta].filter(Boolean).join(' • '))
-  ;(e as any).details = json || (code ? { error: code } : null)
-  ;(e as any).status = res.status
-  ;(e as any).requestId = requestId
-  ;(e as any).cfRay = cfRay
-  ;(e as any).code = code
-  ;(e as any).rawText = nonJsonText.slice(0, 240)
-  throw e
-}
-
-async function apiBlob(path: string, opts: { adminToken?: string; signal?: AbortSignal } = {}): Promise<Blob> {
-  const headers: Record<string, string> = {}
-  if (opts.adminToken) headers.authorization = `Admin ${opts.adminToken}`
-  const res = await fetch(path, { headers, credentials: 'include', signal: opts.signal })
-  if (!res.ok) {
-    const requestId = String(res.headers.get('x-request-id') || '').trim()
-    const cfRay = String(res.headers.get('cf-ray') || '').trim()
-    let msg = `HTTP ${res.status}`
-    try {
-      const json = (await res.json()) as ApiError
-      msg = json.error || json.message || msg
-    } catch { /* ignore */ }
-    const meta = errorMetaString({ requestId, cfRay })
-    const e = new Error([msg, meta].filter(Boolean).join(' • '))
-    ;(e as any).status = res.status
-    ;(e as any).requestId = requestId
-    ;(e as any).cfRay = cfRay
-    throw e
-  }
-  return await res.blob()
-}
-
-async function fetchJsonWithMeta(
-  path: string,
-  opts: { method?: string; body?: unknown; signal?: AbortSignal; headers?: Record<string, string> } = {}
-): Promise<{ ok: boolean; status: number; requestId: string; cfRay: string; json: any; text: string }> {
-  const method = (opts.method || 'GET').toUpperCase()
-  const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers || {}) }
-  if (opts.body !== undefined) headers['content-type'] = 'application/json'
-
-  const res = await fetch(path, {
-    method,
-    credentials: 'include',
-    headers,
-    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
-    signal: opts.signal
-  })
-
-  const requestId = String(res.headers.get('x-request-id') || '').trim()
-  const cfRay = String(res.headers.get('cf-ray') || '').trim()
-  const text = await res.text()
-  let json: any = null
-  try {
-    json = text ? JSON.parse(text) : null
-  } catch {
-    json = null
-  }
-  return { ok: res.ok, status: res.status, requestId, cfRay, json, text }
 }
 
 let faceLibPromise: Promise<any> | null = null
@@ -618,6 +415,19 @@ export function PontoModule() {
   const [conflictsLoading, setConflictsLoading] = useState(false)
   const [conflictsError, setConflictsError] = useState<string | null>(null)
   const [emailConflicts, setEmailConflicts] = useState<PontoEmailConflict[]>([])
+  const [managementMonth, setManagementMonth] = useState(() => new Date().toISOString().slice(0, 7))
+  const [managementUnit, setManagementUnit] = useState('')
+  const [monthlyResult, setMonthlyResult] = useState<PontoMonthlyResult | null>(null)
+  const [monthlyLoading, setMonthlyLoading] = useState(false)
+  const [monthlyError, setMonthlyError] = useState<string | null>(null)
+  const [corrections, setCorrections] = useState<PontoCorrection[]>([])
+  const [correctionsLoading, setCorrectionsLoading] = useState(false)
+  const [correctionOpen, setCorrectionOpen] = useState(false)
+  const [correctionEvent, setCorrectionEvent] = useState<PontoPunchRecord | null>(null)
+  const [correctionAt, setCorrectionAt] = useState('')
+  const [correctionReason, setCorrectionReason] = useState('')
+  const [lastClosureId, setLastClosureId] = useState('')
+  const [periodReason, setPeriodReason] = useState('')
 
   const [adminUnitOptions, setAdminUnitOptions] = useState<UnitOption[]>(DEFAULT_UNIT_OPTIONS)
   const [adminUnitsLoading, setAdminUnitsLoading] = useState(false)
@@ -657,10 +467,21 @@ export function PontoModule() {
     }
   }, [allowedUnits])
 
+  useEffect(() => {
+    const employeeUnits = Array.from(new Set([...(selectedEmployee?.units || []), selectedEmployee?.unit || ''].filter(Boolean)))
+    const preferred = employeeUnits[0] || allowedUnits[0] || adminUnitOptions[0]?.value || ''
+    if ((!managementUnit || (employeeUnits.length > 0 && !employeeUnits.includes(managementUnit))) && preferred) {
+      setManagementUnit(preferred)
+    }
+  }, [adminUnitOptions, allowedUnits, managementUnit, selectedEmployee])
+
   const isDev = import.meta.env.DEV
   const crmRole = String(crmMe?.user?.role || '').toUpperCase()
-  const canAdmin = crmRole === 'GESTOR' || crmRole === 'GERENTE'
-  const canAdminActions = canAdmin
+  const canAdmin = ['GESTOR', 'GERENTE', 'RH', 'ADMIN', 'AUDITOR'].includes(crmRole)
+  const canAdminActions = ['GESTOR', 'GERENTE', 'RH', 'ADMIN'].includes(crmRole)
+  const canManageCanonicalEmployee = ['RH', 'ADMIN'].includes(crmRole)
+  const canApproveCorrection = ['RH', 'ADMIN'].includes(crmRole)
+  const canClosePeriod = ['RH', 'ADMIN'].includes(crmRole)
   const canSeeSensitive = canAdmin || (me && 'linked' in me && me.linked)
   const maskSensitive = (value?: string | null, mask: string = '•••') => {
     const raw = String(value || '').trim()
@@ -725,14 +546,14 @@ export function PontoModule() {
   }, [loadCrmMe])
 
   useEffect(() => {
-    if (!canAdminActions) return
+    if (!canAdmin) return
     void loadAdminUnits()
-  }, [canAdminActions, loadAdminUnits])
+  }, [canAdmin, loadAdminUnits])
 
   useEffect(() => {
-    if (!canAdminActions) return
+    if (!canAdmin) return
     void adminRefreshAll()
-  }, [canAdminActions])
+  }, [canAdmin])
 
   useEffect(() => {
     if (!enrollOpen) return
@@ -1210,7 +1031,7 @@ export function PontoModule() {
   }, [mePunchOpen, meStep, meFaceAutoRunning, faceDetectorMode, me, allowedUnits, resolvedMeUnit])
 
   async function adminRefreshAll() {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canAdmin) return toast.error('Acesso restrito')
     setLoading(true)
     try {
       const [emps, devs] = await Promise.all([
@@ -1219,6 +1040,14 @@ export function PontoModule() {
       ])
       setAdminEmployees(emps.data || [])
       setAdminDevices(devs.data || [])
+      const linkedUnits = Array.from(new Set((emps.data || []).flatMap((employee) => [...(employee.units || []), employee.unit || '']).filter(Boolean)))
+      if (linkedUnits.length) {
+        setAdminUnitOptions((current) => {
+          const merged = new Map(current.map((unit) => [unit.value, unit]))
+          for (const unit of linkedUnits) if (!merged.has(unit)) merged.set(unit, { value: unit, label: formatUnitLabel(unit) })
+          return Array.from(merged.values())
+        })
+      }
       if (!selectedEmployeeId && (emps.data || []).length) setSelectedEmployeeId(emps.data[0].id)
       toast.success('Dados atualizados')
     } catch (e: any) {
@@ -1230,7 +1059,7 @@ export function PontoModule() {
   }
 
   async function adminLoadEmployeeDetail(employeeId: string) {
-    if (!canAdminActions) return
+    if (!canManageCanonicalEmployee) return
     if (!employeeId) return
     try {
       const res = await apiJson<{ ok: boolean; data: PontoEmployeePublic }>(
@@ -1257,7 +1086,7 @@ export function PontoModule() {
   }
 
   async function adminCreateEmployee(opts: { enrollAfter?: boolean } = {}) {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageCanonicalEmployee) return toast.error('Cadastro restrito ao RH')
     const name = newEmployeeName.trim()
     if (!name) return toast.error('Nome é obrigatório')
     const loginEmail = newEmployeeLoginEmail.trim()
@@ -1328,7 +1157,7 @@ export function PontoModule() {
 
   async function autoEnrollFace() {
     if (enrollAutoRunning) return
-    if (!canAdminActions || !selectedEmployeeId) return
+    if (!canManageCanonicalEmployee || !selectedEmployeeId) return
     if (!stream || cameraOwner !== 'admin') return
     let videoEl = adminVideoRef.current
     if (!videoEl) {
@@ -1406,7 +1235,7 @@ export function PontoModule() {
   }
 
   async function adminSaveEmployeeEdit() {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageCanonicalEmployee) return toast.error('Alteração restrita ao RH')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = editName.trim()
     if (!name) return toast.error('Nome é obrigatório')
@@ -1456,7 +1285,7 @@ export function PontoModule() {
   }
 
   async function adminDeleteEmployee() {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageCanonicalEmployee) return toast.error('Desligamento restrito ao RH')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = selectedEmployee?.name || 'este funcionário'
     const confirmed = window.confirm(`Tem certeza que deseja remover ${name}?`)
@@ -1507,10 +1336,12 @@ export function PontoModule() {
         return
       }
       if (action === 'create') {
+        if (!canManageCanonicalEmployee) return toast.error('Cadastro canônico restrito ao RH')
         setNewEmployeeOpen(true)
         return
       }
       if (action === 'edit') {
+        if (!canManageCanonicalEmployee) return toast.error('Alteração cadastral restrita ao RH')
         openSelectEmployee('edit')
         return
       }
@@ -1525,7 +1356,7 @@ export function PontoModule() {
     }
     window.addEventListener('skincos:ponto:action', handler as EventListener)
     return () => window.removeEventListener('skincos:ponto:action', handler as EventListener)
-  }, [canAdminActions, adminDevices.length, adminRefreshAll, openSelectEmployee])
+  }, [canAdminActions, canManageCanonicalEmployee, adminDevices.length, adminRefreshAll, openSelectEmployee])
 
   async function adminLoadSelectedRecords() {
     if (!canAdminActions) return toast.error('Acesso restrito a gestores')
@@ -1552,7 +1383,7 @@ export function PontoModule() {
   }
 
   async function adminLoadEmailConflicts() {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao RH')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1572,7 +1403,7 @@ export function PontoModule() {
   }
 
   async function adminResolveEmailConflict(email: string, keepEmployeeId: string) {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao RH')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1598,11 +1429,11 @@ export function PontoModule() {
     if (!newDeviceUnit.trim()) return toast.error('Unidade é obrigatória')
     setLoading(true)
     try {
-      const res = await apiJson<{ ok: boolean; data: PontoDevicePublic; tokenOnce: string }>(
+      const res = await apiJson<{ ok: boolean; data: PontoDevicePublic & { token: string } }>(
         '/api/ponto/admin/devices',
         { method: 'POST', body: { unit: newDeviceUnit.trim(), label: newDeviceLabel.trim() } }
       )
-      setNewDeviceTokenOnce(res.tokenOnce)
+      setNewDeviceTokenOnce(res.data.token)
       setNewDeviceLabel('')
       await adminRefreshAll()
       toast.success('Dispositivo criado')
@@ -1676,6 +1507,82 @@ export function PontoModule() {
     } finally {
       setLoading(false)
     }
+  }
+
+  function selectedMonthBounds() {
+    if (!/^\d{4}-\d{2}$/.test(managementMonth)) return null
+    const [year, month] = managementMonth.split('-').map(Number)
+    const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate()
+    return { from: `${managementMonth}-01`, to: `${managementMonth}-${String(lastDay).padStart(2, '0')}` }
+  }
+
+  async function loadMonthlyManagement() {
+    if (!selectedEmployeeId || !managementUnit) return toast.error('Selecione funcionário e unidade')
+    setMonthlyLoading(true); setMonthlyError(null)
+    try {
+      const query = new URLSearchParams({ employeeId: selectedEmployeeId, unitId: managementUnit, month: managementMonth })
+      const response = await apiJson<{ ok: true; data: PontoMonthlyResult }>(`/api/ponto/monthly?${query}`)
+      setMonthlyResult(response.data)
+    } catch (error: any) { setMonthlyError(error?.message || String(error)); toastErrorMeta(error) } finally { setMonthlyLoading(false) }
+  }
+
+  async function loadCorrections() {
+    setCorrectionsLoading(true)
+    try {
+      const query = new URLSearchParams({ status: 'PENDING' })
+      if (managementUnit) query.set('unitId', managementUnit)
+      const response = await apiJson<{ ok: true; data: PontoCorrection[] }>(`/api/ponto/corrections?${query}`)
+      setCorrections(response.data || [])
+    } catch (error: any) { toast.error(error?.message || String(error)); toastErrorMeta(error) } finally { setCorrectionsLoading(false) }
+  }
+
+  function openCorrection(record: PontoPunchRecord) {
+    setCorrectionEvent(record)
+    setCorrectionAt(toDateTimeLocalValue(new Date(record.corrected?.at || record.at)))
+    setCorrectionReason('')
+    setCorrectionOpen(true)
+  }
+
+  async function requestCorrection() {
+    if (!correctionEvent || !correctionReason.trim()) return toast.error('Informe a justificativa')
+    const proposed = new Date(correctionAt)
+    if (!Number.isFinite(proposed.getTime())) return toast.error('Informe uma data válida')
+    setLoading(true)
+    try {
+      await apiJson('/api/ponto/corrections', { method: 'POST', body: { eventId: correctionEvent.id, proposedAtUtc: proposed.toISOString(), reason: correctionReason.trim() } })
+      setCorrectionOpen(false); toast.success('Correção enviada para aprovação'); await loadCorrections()
+    } catch (error: any) { toast.error(error?.message || String(error)); toastErrorMeta(error) } finally { setLoading(false) }
+  }
+
+  async function decideCorrection(correction: PontoCorrection, decision: 'approve' | 'reject') {
+    const reason = window.prompt(decision === 'approve' ? 'Justificativa da aprovação:' : 'Justificativa da recusa:')?.trim()
+    if (!reason) return
+    setLoading(true)
+    try {
+      await apiJson(`/api/ponto/corrections/${correction.id}/${decision}`, { method: 'POST', body: { reason } })
+      toast.success(decision === 'approve' ? 'Correção aprovada' : 'Correção recusada'); await loadCorrections(); if (monthlyResult) await loadMonthlyManagement()
+    } catch (error: any) { toast.error(error?.message || String(error)); toastErrorMeta(error) } finally { setLoading(false) }
+  }
+
+  async function closeManagementPeriod() {
+    const bounds = selectedMonthBounds()
+    if (!bounds || !selectedEmployeeId || !managementUnit || !periodReason.trim()) return toast.error('Selecione funcionário, unidade, mês e informe a justificativa')
+    if (!window.confirm(`Fechar ${managementMonth} para ${selectedEmployee?.name || 'o funcionário'}? As batidas serão bloqueadas.`)) return
+    setLoading(true)
+    try {
+      const response = await apiJson<{ ok: true; data: { id: string } }>('/api/ponto/periods/close', { method: 'POST', body: { employeeId: selectedEmployeeId, unitId: managementUnit, ...bounds, reason: periodReason.trim() } })
+      setLastClosureId(response.data.id); toast.success('Período fechado com snapshot'); await loadMonthlyManagement()
+    } catch (error: any) { toast.error(error?.message || String(error)); toastErrorMeta(error) } finally { setLoading(false) }
+  }
+
+  async function reopenManagementPeriod() {
+    if (!lastClosureId || !periodReason.trim()) return toast.error('Informe a justificativa e carregue um fechamento desta sessão')
+    if (!window.confirm('Reabrir o período? Esta ação será auditada.')) return
+    setLoading(true)
+    try {
+      await apiJson('/api/ponto/periods/reopen', { method: 'POST', body: { closureId: lastClosureId, reason: periodReason.trim() } })
+      setLastClosureId(''); toast.success('Período reaberto'); await loadMonthlyManagement()
+    } catch (error: any) { toast.error(error?.message || String(error)); toastErrorMeta(error) } finally { setLoading(false) }
   }
 
   return (
@@ -1831,7 +1738,7 @@ export function PontoModule() {
                     <div className="space-y-2 md:col-span-1">
                       <Label>Unidade</Label>
                       {allowedUnits.length > 1 ? (
-                        <Select value={resolvedMeUnit || undefined} onValueChange={setMeUnit}>
+                        <Select value={resolvedMeUnit} onValueChange={setMeUnit}>
                           <SelectTrigger>
                             <SelectValue placeholder="Selecione..." />
                           </SelectTrigger>
@@ -1877,6 +1784,84 @@ export function PontoModule() {
               </div>
           </CardContent>
         </Card>
+
+        {canAdmin ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Gestão do ponto</CardTitle>
+              <CardDescription>Espelho mensal, inconsistências, correções, banco de horas e fechamento.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+                <div className="space-y-2 md:col-span-2">
+                  <Label htmlFor="ponto-management-employee">Funcionário</Label>
+                  <Select value={selectedEmployeeId} onValueChange={setSelectedEmployeeId}>
+                    <SelectTrigger id="ponto-management-employee"><SelectValue placeholder="Selecione..." /></SelectTrigger>
+                    <SelectContent>{adminEmployees.map((employee) => <SelectItem key={employee.id} value={employee.id}>{employee.name}{employee.active === false ? ' (desligado)' : ''}</SelectItem>)}</SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ponto-management-unit">Unidade</Label>
+                  <Select value={managementUnit} onValueChange={setManagementUnit}>
+                    <SelectTrigger id="ponto-management-unit"><SelectValue placeholder="Selecione...">{adminUnitOptions.find((unit) => unit.value === managementUnit)?.label || managementUnit}</SelectValue></SelectTrigger>
+                    <SelectContent>{adminUnitOptions.map((unit) => <SelectItem key={unit.value} value={unit.value}>{unit.label}</SelectItem>)}</SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ponto-management-month">Mês</Label>
+                  <Input id="ponto-management-month" type="month" value={managementMonth} onChange={(event) => setManagementMonth(event.target.value)} />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={loadMonthlyManagement} disabled={monthlyLoading || !selectedEmployeeId || !managementUnit}>{monthlyLoading ? 'Calculando…' : 'Carregar espelho'}</Button>
+                <Button variant="outline" onClick={loadCorrections} disabled={correctionsLoading}>{correctionsLoading ? 'Carregando…' : 'Atualizar correções'}</Button>
+                <Button variant="outline" onClick={() => setManageDevicesOpen(true)} disabled={!canAdminActions}>Dispositivos e exportação</Button>
+                <Button variant="outline" onClick={() => setDiagOpen(true)}>Diagnóstico</Button>
+              </div>
+              {monthlyError ? <div role="alert" className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm">{monthlyError}</div> : null}
+              {monthlyResult ? (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="outline">Previsto: {monthlyResult.days.reduce((sum, day) => sum + day.expectedMinutes, 0)} min</Badge>
+                    <Badge variant="outline">Trabalhado: {monthlyResult.days.reduce((sum, day) => sum + day.workedMinutes, 0)} min</Badge>
+                    <Badge variant={monthlyResult.closingBalanceMinutes < 0 ? 'destructive' : 'secondary'}>Saldo: {monthlyResult.closingBalanceMinutes} min</Badge>
+                    <Badge variant="outline">Inconsistências: {monthlyResult.days.reduce((sum, day) => sum + day.inconsistencies.length, 0)}</Badge>
+                  </div>
+                  <div className="max-h-72 overflow-auto rounded-lg border" tabIndex={0} aria-label="Espelho mensal do ponto">
+                    <Table>
+                      <TableHeader><TableRow><TableHead>Dia</TableHead><TableHead>Previsto</TableHead><TableHead>Trabalhado</TableHead><TableHead>Intervalo</TableHead><TableHead>Saldo</TableHead><TableHead>Situação</TableHead></TableRow></TableHeader>
+                      <TableBody>{monthlyResult.days.map((day) => <TableRow key={day.date}><TableCell>{day.date.split('-').reverse().join('/')}</TableCell><TableCell>{day.expectedMinutes} min</TableCell><TableCell>{day.workedMinutes} min</TableCell><TableCell>{day.breakMinutes} min</TableCell><TableCell>{day.dailyBalanceMinutes} min</TableCell><TableCell><Badge variant={day.inconsistencies.length ? 'destructive' : 'outline'}>{day.frozen ? 'Fechado' : day.status}</Badge></TableCell></TableRow>)}</TableBody>
+                    </Table>
+                  </div>
+                </div>
+              ) : <div className="text-sm text-muted-foreground">Selecione os filtros e carregue o espelho mensal.</div>}
+              {canClosePeriod ? (
+                <div className="rounded-lg border p-3 space-y-3">
+                  <div className="font-medium">Fechamento mensal</div>
+                  <Label htmlFor="ponto-period-reason">Justificativa obrigatória</Label>
+                  <Input id="ponto-period-reason" value={periodReason} onChange={(event) => setPeriodReason(event.target.value)} placeholder="Motivo do fechamento ou reabertura" />
+                  <div className="flex flex-wrap gap-2">
+                    <Button onClick={closeManagementPeriod} disabled={loading || !monthlyResult}>Fechar período</Button>
+                    <Button variant="destructive" onClick={reopenManagementPeriod} disabled={loading || !lastClosureId}>Reabrir último fechamento</Button>
+                  </div>
+                  <div className="text-xs text-muted-foreground">A reabertura exige permissão de RH/Administrador, justificativa e gera auditoria.</div>
+                </div>
+              ) : null}
+              <div className="space-y-2">
+                <div className="font-medium">Solicitações de correção pendentes</div>
+                <div className="rounded-lg border overflow-hidden">
+                  <Table>
+                    <TableHeader><TableRow><TableHead>Funcionário</TableHead><TableHead>Original</TableHead><TableHead>Proposto</TableHead><TableHead>Motivo</TableHead><TableHead>Ações</TableHead></TableRow></TableHeader>
+                    <TableBody>
+                      {corrections.map((correction) => <TableRow key={correction.id}><TableCell>{correction.employeeName}</TableCell><TableCell>{fmtDate(correction.originalAtUtc)}</TableCell><TableCell>{fmtDate(correction.proposedAtUtc)}</TableCell><TableCell className="max-w-56 truncate" title={correction.reason}>{correction.reason}</TableCell><TableCell><div className="flex gap-2">{canApproveCorrection ? <><Button size="sm" onClick={() => decideCorrection(correction, 'approve')}>Aprovar</Button><Button size="sm" variant="outline" onClick={() => decideCorrection(correction, 'reject')}>Recusar</Button></> : <Badge variant="outline">Aguardando RH</Badge>}</div></TableCell></TableRow>)}
+                      {!corrections.length ? <TableRow><TableCell colSpan={5} className="text-sm text-muted-foreground">Nenhuma solicitação pendente carregada.</TableCell></TableRow> : null}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
 
         <Dialog
           open={mePunchOpen}
@@ -1997,6 +1982,21 @@ export function PontoModule() {
         </Dialog>
       </div>
 
+      <Dialog open={correctionOpen} onOpenChange={setCorrectionOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Solicitar correção</DialogTitle>
+            <DialogDescription>O evento original será preservado. A alteração só vale após aprovação autorizada.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="text-sm">Registro original: <strong>{fmtDate(correctionEvent?.at)}</strong></div>
+            <div className="space-y-2"><Label htmlFor="ponto-correction-at">Novo horário</Label><Input id="ponto-correction-at" type="datetime-local" value={correctionAt} onChange={(event) => setCorrectionAt(event.target.value)} /></div>
+            <div className="space-y-2"><Label htmlFor="ponto-correction-reason">Justificativa</Label><Input id="ponto-correction-reason" value={correctionReason} onChange={(event) => setCorrectionReason(event.target.value)} placeholder="Explique o motivo da correção" /></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setCorrectionOpen(false)}>Cancelar</Button><Button onClick={requestCorrection} disabled={loading || !correctionReason.trim()}>Enviar para aprovação</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={newEmployeeOpen} onOpenChange={setNewEmployeeOpen}>
         <DialogContent className="max-w-xl">
           <DialogHeader>
@@ -2063,7 +2063,7 @@ export function PontoModule() {
               onClick={() => adminCreateEmployee()}
               disabled={
                 loading ||
-                !canAdminActions ||
+                !canManageCanonicalEmployee ||
                 !newEmployeeName.trim() ||
                 !newEmployeeLoginEmail.trim() ||
                 !newEmployeeLoginEmail.includes('@') ||
@@ -2078,7 +2078,7 @@ export function PontoModule() {
               onClick={() => adminCreateEmployee({ enrollAfter: true })}
               disabled={
                 loading ||
-                !canAdminActions ||
+                !canManageCanonicalEmployee ||
                 !newEmployeeName.trim() ||
                 !newEmployeeLoginEmail.trim() ||
                 !newEmployeeLoginEmail.includes('@') ||
@@ -2254,7 +2254,7 @@ export function PontoModule() {
           </div>
           <DialogFooter className="gap-2">
             <Button variant="outline" onClick={() => setEditOpen(false)} disabled={loading}>Cancelar</Button>
-            <Button variant="destructive" onClick={adminDeleteEmployee} disabled={loading || !selectedEmployeeId}>Remover</Button>
+            <Button variant="destructive" onClick={adminDeleteEmployee} disabled={loading || !selectedEmployeeId || !canManageCanonicalEmployee}>Desligar</Button>
             <Button
               variant="secondary"
               onClick={() => {
@@ -2262,11 +2262,11 @@ export function PontoModule() {
                 setEditOpen(false)
                 setEnrollOpen(true)
               }}
-              disabled={loading || !selectedEmployeeId}
+              disabled={loading || !selectedEmployeeId || !canManageCanonicalEmployee}
             >
               Cadastrar biometria
             </Button>
-            <Button onClick={adminSaveEmployeeEdit} disabled={loading || !selectedEmployeeId || !editUnit.trim()}>Salvar</Button>
+            <Button onClick={adminSaveEmployeeEdit} disabled={loading || !selectedEmployeeId || !editUnit.trim() || !canManageCanonicalEmployee}>Salvar</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -2353,6 +2353,7 @@ export function PontoModule() {
                     <TableHead>Tipo</TableHead>
                     <TableHead>Unidade</TableHead>
                     <TableHead>Metodo</TableHead>
+                    <TableHead>Ações</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -2362,11 +2363,12 @@ export function PontoModule() {
                       <TableCell><Badge variant="outline">{r.type}</Badge></TableCell>
                       <TableCell className="text-sm">{r.unit || '-'}</TableCell>
                       <TableCell className="text-sm">{r.method || '-'}</TableCell>
+                      <TableCell><Button size="sm" variant="outline" onClick={() => openCorrection(r)}>Corrigir</Button></TableCell>
                     </TableRow>
                   ))}
                   {!selectedRecords.length ? (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-sm text-muted-foreground">Nenhum registro.</TableCell>
+                      <TableCell colSpan={5} className="text-sm text-muted-foreground">Nenhum registro.</TableCell>
                     </TableRow>
                   ) : null}
                 </TableBody>

--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -21,7 +21,7 @@ function newRequestId(): string {
   }
 }
 
-function buildUpstreamHeaders(request: Request, requestId: string, proxyToken: string, forwardAuthorization: boolean): Headers {
+function buildUpstreamHeaders(request: Request, requestId: string, forwardAuthorization: boolean): Headers {
   const allow = new Set([
     'accept',
     'content-type',
@@ -43,7 +43,6 @@ function buildUpstreamHeaders(request: Request, requestId: string, proxyToken: s
   }
 
   headers.set('x-request-id', requestId)
-  if (proxyToken) headers.set('x-ponto-proxy-token', proxyToken)
   return headers
 }
 
@@ -90,15 +89,13 @@ export async function onRequest(context: any): Promise<Response> {
   const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
 
   const env = context.env || {}
-  const targetOrigin = String((env?.PONTO_API_TARGET as string | undefined) || '').trim()
-  const targetFrom = targetOrigin ? 'PONTO_API_TARGET' : 'NONE'
+  const targetOrigin = String((env?.PONTO_API_TARGET as string | undefined) || 'https://api.skincos.com.br').trim()
+  const targetFrom = (env?.PONTO_API_TARGET as string | undefined) ? 'PONTO_API_TARGET' : 'CANONICAL_DEFAULT'
   const exposeTarget = String((env?.PONTO_PROXY_EXPOSE_TARGET as string | undefined) || '').trim().toLowerCase() === 'true'
     || String((env?.NODE_ENV as string | undefined) || '').trim().toLowerCase() !== 'production'
 
   if (rest === '/_proxy-status' || rest === '/_proxy-status/') {
-    const proxyToken = (env?.PONTO_PROXY_TOKEN as string | undefined) || ''
     const actorKey = (env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || ''
-    const adminToken = (env?.PONTO_ADMIN_TOKEN as string | undefined) || ''
     return json(
       200,
       {
@@ -106,9 +103,7 @@ export async function onRequest(context: any): Promise<Response> {
         targetConfigured: !!targetOrigin,
         targetFrom,
         ...(exposeTarget ? { targetOrigin: targetOrigin || undefined } : {}),
-        proxyTokenConfigured: !!proxyToken,
         actorKeyConfigured: !!String(actorKey || '').trim(),
-        adminTokenConfigured: !!String(adminToken || '').trim(),
         hint: !targetOrigin
           ? 'Configure PONTO_API_TARGET no Cloudflare Pages/Functions para apontar para o backend.'
           : undefined,
@@ -136,9 +131,7 @@ export async function onRequest(context: any): Promise<Response> {
   let actorTs = ''
   let actorSig = ''
 
-  const proxyToken = (env?.PONTO_PROXY_TOKEN as string | undefined) || ''
   const actorKey = String((env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || '').trim()
-  const adminToken = String((env?.PONTO_ADMIN_TOKEN as string | undefined) || '').trim()
   let isAdminUser = false
 
   if (isEmployeeRoute || isAdminRoute) {
@@ -150,29 +143,16 @@ export async function onRequest(context: any): Promise<Response> {
         { 'x-request-id': requestId },
       )
     }
-    if (isEmployeeRoute) {
-      if (!actorKey) {
-        return json(
-          503,
-          { ok: false, error: 'ACTOR_KEY_NOT_CONFIGURED', hint: 'Configure PONTO_ACTOR_HMAC_KEY nas variáveis do Pages.' },
-          { 'x-request-id': requestId },
-        )
-      }
-      const allowedUnits = normalizeUnits(user.allowedUnits)
-      const actor = {
-        id: String(user.id || ''),
-        email: user.email ? String(user.email) : undefined,
-        name: user.displayName ? String(user.displayName) : (user.name ? String(user.name) : undefined),
-        allowedUnits: allowedUnits.length ? allowedUnits : undefined,
-      }
-      actorB64 = b64UrlEncodeString(JSON.stringify(actor))
-      actorTs = String(Date.now())
-      actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
+    if (!actorKey) {
+      return json(
+        503,
+        { ok: false, error: 'ACTOR_KEY_NOT_CONFIGURED', hint: 'Configure PONTO_ACTOR_HMAC_KEY nas variáveis do Pages.' },
+        { 'x-request-id': requestId },
+      )
     }
     if (isAdminRoute) {
       const role = String(user.role || '').toUpperCase()
-      const effectiveRole = role === 'ADMIN' ? 'GESTOR' : role === 'OPERADOR' ? 'INJETOR' : role
-      isAdminUser = effectiveRole === 'GESTOR' || effectiveRole === 'GERENTE'
+      isAdminUser = ['ADMIN', 'GESTOR', 'GERENTE', 'RH', 'AUDITOR'].includes(role)
       if (!isAdminUser) {
         return json(
           403,
@@ -181,6 +161,17 @@ export async function onRequest(context: any): Promise<Response> {
         )
       }
     }
+    const role = String(user.role || '').toUpperCase()
+    const actor = {
+      id: String(user.id || user.email || ''),
+      email: user.email ? String(user.email) : undefined,
+      name: user.displayName ? String(user.displayName) : (user.name ? String(user.name) : undefined),
+      role: role === 'GESTOR' || role === 'GERENTE' ? 'MANAGER' : role || 'EMPLOYEE',
+      allowedUnits: normalizeUnits(user.allowedUnits),
+    }
+    actorB64 = b64UrlEncodeString(JSON.stringify(actor))
+    actorTs = String(Date.now())
+    actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
   }
 
   const targetUrl = new URL(targetOrigin)
@@ -188,22 +179,13 @@ export async function onRequest(context: any): Promise<Response> {
   targetUrl.pathname = `${basePath}/api/ponto${rest.startsWith('/') ? '' : '/'}${rest}`
   targetUrl.search = url.search
 
-  // For employee routes, do NOT forward Authorization; for admin/device routes, allow it.
-  const headers = buildUpstreamHeaders(request, requestId, proxyToken, !isEmployeeRoute)
-  if (isEmployeeRoute) {
+  // Cookies and browser Authorization never cross this boundary. Device tokens are
+  // accepted only on explicit device routes; CRM users receive signed actor claims.
+  const headers = buildUpstreamHeaders(request, requestId, rest.startsWith('/device/'))
+  if (isEmployeeRoute || isAdminRoute) {
     headers.set('x-skincos-actor', actorB64)
     headers.set('x-skincos-actor-ts', actorTs)
     if (actorSig) headers.set('x-skincos-actor-sig', actorSig)
-  }
-  if (isAdminRoute && isAdminUser) {
-    if (!adminToken) {
-      return json(
-        503,
-        { ok: false, error: 'ADMIN_TOKEN_NOT_CONFIGURED', hint: 'Configure PONTO_ADMIN_TOKEN nas variáveis do Pages.' },
-        { 'x-request-id': requestId },
-      )
-    }
-    headers.set('authorization', `Admin ${adminToken}`)
   }
 
   const method = (request.method || 'GET').toUpperCase()

--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -1,4 +1,5 @@
 import { getInsumosUser } from '../../_lib/insumosAuth'
+import { requireCsrfForMutations } from '../../_lib/csrf'
 
 const json = (status: number, body: any, extraHeaders: Record<string, string> = {}) =>
   new Response(JSON.stringify(body), {
@@ -31,7 +32,9 @@ function buildUpstreamHeaders(request: Request, requestId: string, forwardAuthor
     'cache-control',
     'pragma',
     'user-agent',
+    'idempotency-key',
     'x-idempotency-key',
+    'x-request-nonce',
   ])
 
   const headers = new Headers()
@@ -66,6 +69,35 @@ async function signHmacSha256B64Url(secret: string, message: string): Promise<st
   )
   const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message))
   return b64UrlEncodeBytes(sig)
+}
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+async function readBodyLimited(request: Request, maxBytes = 1024 * 1024): Promise<ArrayBuffer | undefined> {
+  const declaredLength = Number(request.headers.get('content-length') || 0)
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) throw new Error('PAYLOAD_TOO_LARGE')
+  if (!request.body) return undefined
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.byteLength
+    if (total > maxBytes) {
+      await reader.cancel('PAYLOAD_TOO_LARGE').catch(() => {})
+      throw new Error('PAYLOAD_TOO_LARGE')
+    }
+    chunks.push(value)
+  }
+  if (!total) return undefined
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) { out.set(chunk, offset); offset += chunk.byteLength }
+  return out.buffer
 }
 
 function normalizeUnits(values: unknown): string[] {
@@ -124,8 +156,10 @@ export async function onRequest(context: any): Promise<Response> {
     )
   }
 
-  const isEmployeeRoute = rest === '/me' || rest.startsWith('/me/')
+  const isPublicRoute = ['/health', '/health/', '/readiness', '/readiness/', '/_proxy-status', '/_proxy-status/'].includes(rest)
+  const isDeviceRoute = rest === '/device' || rest.startsWith('/device/')
   const isAdminRoute = rest === '/admin' || rest.startsWith('/admin/')
+  const requiresActor = !isPublicRoute && !isDeviceRoute
 
   let actorB64 = ''
   let actorTs = ''
@@ -134,7 +168,9 @@ export async function onRequest(context: any): Promise<Response> {
   const actorKey = String((env?.PONTO_ACTOR_HMAC_KEY as string | undefined) || '').trim()
   let isAdminUser = false
 
-  if (isEmployeeRoute || isAdminRoute) {
+  if (requiresActor) {
+    const csrfResponse = requireCsrfForMutations(context)
+    if (csrfResponse) return csrfResponse
     const user = await getInsumosUser(context)
     if (!user) {
       return json(
@@ -162,16 +198,20 @@ export async function onRequest(context: any): Promise<Response> {
       }
     }
     const role = String(user.role || '').toUpperCase()
+    const workforceRole = role === 'GESTOR' || role === 'GERENTE'
+      ? 'MANAGER'
+      : role === 'RH'
+        ? 'HR'
+        : role || 'EMPLOYEE'
     const actor = {
       id: String(user.id || user.email || ''),
       email: user.email ? String(user.email) : undefined,
       name: user.displayName ? String(user.displayName) : (user.name ? String(user.name) : undefined),
-      role: role === 'GESTOR' || role === 'GERENTE' ? 'MANAGER' : role || 'EMPLOYEE',
+      role: workforceRole,
       allowedUnits: normalizeUnits(user.allowedUnits),
     }
     actorB64 = b64UrlEncodeString(JSON.stringify(actor))
     actorTs = String(Date.now())
-    actorSig = await signHmacSha256B64Url(actorKey, `${actorTs}.${actorB64}`)
   }
 
   const targetUrl = new URL(targetOrigin)
@@ -181,15 +221,25 @@ export async function onRequest(context: any): Promise<Response> {
 
   // Cookies and browser Authorization never cross this boundary. Device tokens are
   // accepted only on explicit device routes; CRM users receive signed actor claims.
-  const headers = buildUpstreamHeaders(request, requestId, rest.startsWith('/device/'))
-  if (isEmployeeRoute || isAdminRoute) {
+  const headers = buildUpstreamHeaders(request, requestId, isDeviceRoute)
+  const method = (request.method || 'GET').toUpperCase()
+  let body: ArrayBuffer | undefined
+  if (method !== 'GET' && method !== 'HEAD') {
+    try { body = await readBodyLimited(request) } catch (error) {
+      if ((error as Error)?.message === 'PAYLOAD_TOO_LARGE') return json(413, { ok: false, error: 'PAYLOAD_TOO_LARGE' }, { 'x-request-id': requestId })
+      throw error
+    }
+  }
+  if (requiresActor) {
+    const nonce = !['GET', 'HEAD', 'OPTIONS'].includes(method) ? newRequestId() : ''
+    const bodyHash = await sha256Hex(body || new ArrayBuffer(0))
+    if (nonce) headers.set('x-request-nonce', nonce)
+    actorSig = await signHmacSha256B64Url(actorKey, [actorTs, actorB64, method, `${targetUrl.pathname}${targetUrl.search}`, nonce, bodyHash].join('.'))
     headers.set('x-skincos-actor', actorB64)
     headers.set('x-skincos-actor-ts', actorTs)
-    if (actorSig) headers.set('x-skincos-actor-sig', actorSig)
+    headers.set('x-skincos-actor-sig', actorSig)
+    headers.set('x-skincos-signature-version', '2')
   }
-
-  const method = (request.method || 'GET').toUpperCase()
-  const body = method === 'GET' || method === 'HEAD' ? undefined : request.body
 
   const upstreamRequest = new Request(targetUrl.toString(), {
     method,

--- a/crm/console/pontoApi.ts
+++ b/crm/console/pontoApi.ts
@@ -1,0 +1,72 @@
+import type { PontoApiError } from './pontoTypes'
+import { csrfHeader } from './csrf'
+
+export const LS_DEV_ACTOR_EMAIL = 'skincos.ponto.devActorEmail.v1'
+
+export function errorMetaString(meta: { code?: string; requestId?: string; cfRay?: string }) {
+  const parts: string[] = []
+  if (meta.code) parts.push(`code:${meta.code}`)
+  if (meta.requestId) parts.push(`req:${meta.requestId}`)
+  if (meta.cfRay) parts.push(`cf:${meta.cfRay}`)
+  return parts.length ? parts.join(' • ') : ''
+}
+
+function b64UrlEncodeString(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  const binary = String.fromCharCode(...bytes)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function getDevEmployeeActorHeaders(emailOverride?: string): Record<string, string> {
+  if (!import.meta.env.DEV) return {}
+  let email = ''
+  if (emailOverride) email = String(emailOverride).trim().toLowerCase()
+  else { try { email = String(localStorage.getItem(LS_DEV_ACTOR_EMAIL) || '').trim().toLowerCase() } catch { email = '' } }
+  if (!email) return {}
+  const actorB64 = b64UrlEncodeString(JSON.stringify({ email }))
+  return { 'x-skincos-actor': actorB64, 'x-skincos-actor-ts': String(Date.now()) }
+}
+
+export function createRequestMeta() {
+  return { requestId: globalThis.crypto?.randomUUID?.() || String(Date.now()), clientTime: new Date().toISOString(), tzOffsetMinutes: -new Date().getTimezoneOffset(), locale: navigator.language || 'pt-BR', appVersion: null as string | null }
+}
+
+export async function apiJson<T>(path: string, opts: { method?: string; body?: unknown; signal?: AbortSignal; headers?: Record<string, string> } = {}): Promise<T> {
+  const method = (opts.method || 'GET').toUpperCase()
+  const headers: Record<string, string> = { Accept: 'application/json', ...(!['GET', 'HEAD', 'OPTIONS'].includes(method) ? csrfHeader() : {}), ...(opts.headers || {}) }
+  if (opts.body !== undefined) headers['content-type'] = 'application/json'
+  const res = await fetch(path, { method, credentials: 'include', headers, body: opts.body === undefined ? undefined : JSON.stringify(opts.body), signal: opts.signal })
+  const requestId = String(res.headers.get('x-request-id') || '').trim(); const cfRay = String(res.headers.get('cf-ray') || '').trim(); const text = await res.text()
+  let payload: unknown = null
+  try { payload = text ? JSON.parse(text) : null } catch { payload = null }
+  const contentType = String(res.headers.get('content-type') || '').toLowerCase()
+  if (res.ok && payload !== null && contentType.includes('application/json')) return payload as T
+  const nonJsonText = String(text || ''); const workerCrash = !payload && (nonJsonText.includes('Worker threw exception') || nonJsonText.includes('Cloudflare Ray ID'))
+  const detail = (payload || {}) as PontoApiError
+  const code = String(detail.error || detail.code || (workerCrash ? 'UPSTREAM_WORKER_EXCEPTION' : !contentType.includes('application/json') ? 'INVALID_API_CONTENT_TYPE' : 'INVALID_API_PAYLOAD')).trim()
+  const hint = typeof detail.hint === 'string' ? detail.hint.trim() : workerCrash ? 'Falha no Worker upstream. Consulte os logs com request-id/cf-ray.' : ''
+  const base = detail.error || detail.message || (res.ok ? 'Resposta inválida da API de Ponto' : `HTTP ${res.status}`)
+  const error = new Error([base, hint, errorMetaString({ code, requestId, cfRay })].filter(Boolean).join(' • '))
+  Object.assign(error, { details: payload || { error: code }, status: res.status, requestId, cfRay, code, rawText: nonJsonText.slice(0, 240) })
+  throw error
+}
+
+export async function apiBlob(path: string, opts: { signal?: AbortSignal } = {}): Promise<Blob> {
+  const res = await fetch(path, { headers: { Accept: 'text/csv' }, credentials: 'include', signal: opts.signal })
+  if (!res.ok) {
+    const requestId = String(res.headers.get('x-request-id') || '').trim(); const cfRay = String(res.headers.get('cf-ray') || '').trim(); let message = `HTTP ${res.status}`
+    try { const body = await res.json() as PontoApiError; message = body.error || body.message || message } catch { /* response is not JSON */ }
+    const error = new Error([message, errorMetaString({ requestId, cfRay })].filter(Boolean).join(' • ')); Object.assign(error, { status: res.status, requestId, cfRay }); throw error
+  }
+  if (!String(res.headers.get('content-type') || '').toLowerCase().includes('text/csv')) throw new Error('Resposta de exportação inválida')
+  return res.blob()
+}
+
+export async function fetchJsonWithMeta(path: string, opts: { method?: string; body?: unknown; signal?: AbortSignal; headers?: Record<string, string> } = {}) {
+  const method = (opts.method || 'GET').toUpperCase(); const headers: Record<string, string> = { Accept: 'application/json', ...(!['GET', 'HEAD', 'OPTIONS'].includes(method) ? csrfHeader() : {}), ...(opts.headers || {}) }
+  if (opts.body !== undefined) headers['content-type'] = 'application/json'
+  const res = await fetch(path, { method, credentials: 'include', headers, body: opts.body === undefined ? undefined : JSON.stringify(opts.body), signal: opts.signal })
+  const requestId = String(res.headers.get('x-request-id') || '').trim(); const cfRay = String(res.headers.get('cf-ray') || '').trim(); const text = await res.text(); let json: unknown = null
+  try { json = text ? JSON.parse(text) : null } catch { json = null }
+  return { ok: res.ok && json !== null && String(res.headers.get('content-type') || '').toLowerCase().includes('application/json'), status: res.status, requestId, cfRay, json, text }
+}

--- a/crm/console/pontoApi.ts
+++ b/crm/console/pontoApi.ts
@@ -47,7 +47,13 @@ export async function apiJson<T>(path: string, opts: { method?: string; body?: u
   const hint = typeof detail.hint === 'string' ? detail.hint.trim() : workerCrash ? 'Falha no Worker upstream. Consulte os logs com request-id/cf-ray.' : ''
   const base = detail.error || detail.message || (res.ok ? 'Resposta inválida da API de Ponto' : `HTTP ${res.status}`)
   const error = new Error([base, hint, errorMetaString({ code, requestId, cfRay })].filter(Boolean).join(' • '))
-  Object.assign(error, { details: payload || { error: code }, status: res.status, requestId, cfRay, code, rawText: nonJsonText.slice(0, 240) })
+  const enriched = error as Error & Record<string, unknown>
+  enriched.details = payload || { error: code }
+  enriched.status = res.status
+  enriched.requestId = requestId
+  enriched.cfRay = cfRay
+  enriched.code = code
+  enriched.rawText = nonJsonText.slice(0, 240)
   throw error
 }
 
@@ -56,7 +62,11 @@ export async function apiBlob(path: string, opts: { signal?: AbortSignal } = {})
   if (!res.ok) {
     const requestId = String(res.headers.get('x-request-id') || '').trim(); const cfRay = String(res.headers.get('cf-ray') || '').trim(); let message = `HTTP ${res.status}`
     try { const body = await res.json() as PontoApiError; message = body.error || body.message || message } catch { /* response is not JSON */ }
-    const error = new Error([message, errorMetaString({ requestId, cfRay })].filter(Boolean).join(' • ')); Object.assign(error, { status: res.status, requestId, cfRay }); throw error
+    const error = new Error([message, errorMetaString({ requestId, cfRay })].filter(Boolean).join(' • ')) as Error & Record<string, unknown>
+    error.status = res.status
+    error.requestId = requestId
+    error.cfRay = cfRay
+    throw error
   }
   if (!String(res.headers.get('content-type') || '').toLowerCase().includes('text/csv')) throw new Error('Resposta de exportação inválida')
   return res.blob()

--- a/crm/console/pontoTypes.ts
+++ b/crm/console/pontoTypes.ts
@@ -1,0 +1,37 @@
+export type PontoApiError = { ok?: boolean; error?: string; message?: string; code?: string; hint?: string; requestId?: string }
+
+export type PontoEmployeePublic = {
+  id: string
+  employeeId?: string
+  code?: string
+  name: string
+  cpf?: string
+  birthDate?: string
+  jobTitle?: string
+  phone?: string
+  loginEmail?: string
+  unit?: string
+  units?: string[]
+  status?: 'ACTIVE' | 'LEAVE' | 'TERMINATED'
+  active?: boolean
+  createdAt?: string
+  updatedAt?: string
+  deletedAt?: string | null
+  terminatedAt?: string | null
+  faceDescriptorsCount?: number
+  lastEnrolledAt?: string | null
+  pinSet?: boolean
+}
+
+export type PontoDevicePublic = { id: string; label?: string; unit?: string; unitId?: string; active?: boolean; createdAt?: string; revokedAt?: string | null; lastSeenAt?: string | null }
+export type PontoEmailConflict = { email: string; count: number; employees: PontoEmployeePublic[] }
+export type PontoPunchRecord = { id: string; kind: 'PUNCH'; employeeId: string; employeeName: string; type: 'IN' | 'OUT' | string; eventType?: string; at: string; unit?: string | null; unitId?: string | null; deviceId?: string | null; deviceLabel?: string | null; method?: 'FACE' | 'PIN' | 'MANUAL' | 'IMPORT' | string; source?: string; note?: string | null; corrected?: { id: string; at: string; reason?: string | null } | null }
+
+export type PontoMeResponse =
+  | { ok: true; linked: false; actorEmail?: string; hint?: string; allowedUnits?: string[] }
+  | { ok: true; linked: true; actorEmail?: string; allowedUnits?: string[]; employee: PontoEmployeePublic; hasFace: boolean; pinSet: boolean; lastPunch: PontoPunchRecord | null; cooldown?: { active: boolean; secondsRemaining?: number }; suggestedNextMethod?: 'FACE' | 'PIN'; capabilities?: string[] }
+
+export type PontoDayResult = { date: string; timeZone: string; expectedMinutes: number; workedMinutes: number; breakMinutes: number; lateMinutes: number; earlyLeaveMinutes: number; overtimeMinutes: number; dailyBalanceMinutes: number; accumulatedBalanceMinutes?: number; status: string; inconsistencies: Array<{ code: string; eventId?: string | null }>; frozen?: boolean }
+export type PontoMonthlyResult = { employee: PontoEmployeePublic; unitId: string; from: string; to: string; openingBalanceMinutes: number; closingBalanceMinutes: number; days: PontoDayResult[] }
+export type PontoCorrection = { id: string; eventId: string; employeeId: string; employeeName: string; unitId: string; originalAtUtc: string; proposedAtUtc: string; requestedAt: string; requestedBy: string; reason: string; status: 'PENDING' | 'APPROVED' | 'REJECTED'; decidedAt?: string | null; decisionReason?: string | null }
+export type PontoPermission = 'self.read' | 'self.punch' | 'unit.read' | 'correction.request' | 'correction.approve' | 'period.close' | 'period.reopen' | 'device.manage' | 'export.read' | 'audit.read'

--- a/crm/console/scripts/ponto-ui-smoke.cjs
+++ b/crm/console/scripts/ponto-ui-smoke.cjs
@@ -240,7 +240,7 @@ async function main() {
       await waitForAuthOrError(LOGIN_WAIT_MS)
     }
     // Persist auth for the next run without needing a persistent profile.
-    await context.storageState({ path: storageStatePath }).catch(() => {})
+    if (!IS_CI) await context.storageState({ path: storageStatePath }).catch(() => {})
     await page.waitForTimeout(1500)
     await maybeScreenshot('after-auth')
 

--- a/crm/console/tests/pontoApi.test.ts
+++ b/crm/console/tests/pontoApi.test.ts
@@ -19,6 +19,11 @@ describe('Ponto API client', () => {
     await expect(apiJson('/api/ponto/punches')).rejects.toMatchObject({ status: 409, code: 'PERIOD_CLOSED', requestId: 'req-closed', cfRay: 'ray-1' })
   })
 
+  it('keeps API payload inside details instead of assigning its fields onto the error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: false, error: 'PERIOD_CLOSED', status: 200, requestId: 'attacker-value' }), { status: 409, headers: { 'content-type': 'application/json', 'x-request-id': 'req-authoritative' } })))
+    await expect(apiJson('/api/ponto/punches')).rejects.toMatchObject({ status: 409, requestId: 'req-authoritative', details: expect.objectContaining({ status: 200, requestId: 'attacker-value' }) })
+  })
+
   it('sends the CRM CSRF token on mutations', async () => {
     vi.stubGlobal('document', { cookie: 'csrfToken=test-csrf' })
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } }))

--- a/crm/console/tests/pontoApi.test.ts
+++ b/crm/console/tests/pontoApi.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { apiBlob, apiJson, fetchJsonWithMeta } from '../pontoApi'
+
+describe('Ponto API client', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('accepts a structured JSON success response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: { id: 'op-1' } }), { status: 200, headers: { 'content-type': 'application/json; charset=utf-8', 'x-request-id': 'req-1' } })))
+    await expect(apiJson<{ ok: boolean; data: { id: string } }>('/api/ponto/health')).resolves.toEqual({ ok: true, data: { id: 'op-1' } })
+  })
+
+  it('rejects HTML even when an upstream responds 200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('<html>frontend fallback</html>', { status: 200, headers: { 'content-type': 'text/html' } })))
+    await expect(apiJson('/api/ponto/health')).rejects.toMatchObject({ code: 'INVALID_API_CONTENT_TYPE' })
+  })
+
+  it('preserves API error metadata for support', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: false, error: 'PERIOD_CLOSED' }), { status: 409, headers: { 'content-type': 'application/json', 'x-request-id': 'req-closed', 'cf-ray': 'ray-1' } })))
+    await expect(apiJson('/api/ponto/punches')).rejects.toMatchObject({ status: 409, code: 'PERIOD_CLOSED', requestId: 'req-closed', cfRay: 'ray-1' })
+  })
+
+  it('sends the CRM CSRF token on mutations', async () => {
+    vi.stubGlobal('document', { cookie: 'csrfToken=test-csrf' })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await apiJson('/api/ponto/corrections', { method: 'POST', body: { eventId: 'event-1' } })
+    expect((fetchMock.mock.calls[0][1] as RequestInit).headers).toMatchObject({ 'x-csrf-token': 'test-csrf' })
+  })
+
+  it('requires CSV content type for export', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } })))
+    await expect(apiBlob('/api/ponto/export')).rejects.toThrow('Resposta de exportação inválida')
+  })
+
+  it('marks non-JSON health responses unhealthy', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not-json', { status: 200, headers: { 'content-type': 'text/plain' } })))
+    await expect(fetchJsonWithMeta('/api/ponto/health')).resolves.toEqual(expect.objectContaining({ ok: false, status: 200, json: null }))
+  })
+})

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+vi.mock('../functions/_lib/insumosAuth', () => ({ getInsumosUser: vi.fn() }))
+import { getInsumosUser } from '../functions/_lib/insumosAuth'
+import { onRequest } from '../functions/api/ponto/[[path]]'
+
+function context(path: string, init: RequestInit = {}, withCsrf = true) {
+  const method = String(init.method || 'GET').toUpperCase()
+  const headers = new Headers(init.headers)
+  if (withCsrf && !['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+    headers.set('cookie', 'session=test-session; csrfToken=test-csrf')
+    headers.set('x-csrf-token', 'test-csrf')
+  }
+  return { request: new Request(`https://crm.skincos.com.br${path}`, { ...init, headers }), env: { PONTO_API_TARGET: 'https://api.skincos.com.br', PONTO_ACTOR_HMAC_KEY: 'proxy-test-key' } }
+}
+
+describe('Ponto CRM proxy', () => {
+  beforeEach(() => { vi.restoreAllMocks(); (getInsumosUser as Mock).mockResolvedValue({ id: 'gestor-1', email: 'gestor@example.test', role: 'GESTOR', allowedUnits: ['UNIT_A'] }) })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps health public and preserves query strings', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const response = await onRequest(context('/api/ponto/health?probe=1'))
+    expect(response.status).toBe(200); expect(getInsumosUser).not.toHaveBeenCalled()
+    expect((fetchMock.mock.calls[0][0] as Request).url).toBe('https://api.skincos.com.br/api/ponto/health?probe=1')
+  })
+
+  it('signs canonical protected routes and strips browser cookies and authorization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: [] }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await onRequest(context('/api/ponto/employees?unitId=UNIT_A', { headers: { cookie: 'session=secret', authorization: 'Bearer browser-secret' } }))
+    const upstream = fetchMock.mock.calls[0][0] as Request
+    expect(upstream.headers.get('cookie')).toBeNull(); expect(upstream.headers.get('authorization')).toBeNull()
+    expect(upstream.headers.get('x-skincos-actor')).toBeTruthy(); expect(upstream.headers.get('x-skincos-actor-sig')).toBeTruthy()
+    expect(upstream.headers.get('x-skincos-signature-version')).toBe('2')
+    const actor = JSON.parse(Buffer.from(String(upstream.headers.get('x-skincos-actor')), 'base64url').toString('utf8'))
+    expect(actor).toMatchObject({ role: 'MANAGER', allowedUnits: ['UNIT_A'] })
+  })
+
+  it('normalizes the CRM RH role to the Workforce HR contract', async () => {
+    ;(getInsumosUser as Mock).mockResolvedValue({ id: 'rh-1', email: 'rh@example.test', role: 'RH', allowedUnits: ['UNIT_A'] })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: [] }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await onRequest(context('/api/ponto/employees'))
+    const upstream = fetchMock.mock.calls[0][0] as Request
+    const actor = JSON.parse(Buffer.from(String(upstream.headers.get('x-skincos-actor')), 'base64url').toString('utf8'))
+    expect(actor.role).toBe('HR')
+  })
+
+  it('adds a unique replay nonce to protected mutations', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await onRequest(context('/api/ponto/corrections', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ eventId: 'x' }) }))
+    expect((fetchMock.mock.calls[0][0] as Request).headers.get('x-request-nonce')).toBeTruthy()
+  })
+
+  it('rejects cookie-authenticated mutations without the CSRF pair', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const response = await onRequest(context('/api/ponto/corrections', { method: 'POST', headers: { origin: 'https://evil.example', 'content-type': 'application/json' }, body: '{}' }, false))
+    expect(response.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not forward arbitrary sensitive headers on public routes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await onRequest(context('/api/ponto/health', { headers: { cookie: 'session=secret', 'x-custom-secret': 'secret' } }))
+    const upstream = fetchMock.mock.calls[0][0] as Request
+    expect(upstream.headers.get('cookie')).toBeNull(); expect(upstream.headers.get('x-custom-secret')).toBeNull()
+  })
+})

--- a/docs/ponto-architecture.md
+++ b/docs/ponto-architecture.md
@@ -1,0 +1,31 @@
+# Arquitetura — Workforce Timekeeping
+
+## Limites
+
+- `workforce/timekeeping/worker.js`: rotas, orquestração, autenticação/autorização e observabilidade;
+- `workforce/timekeeping/domain.js`: cálculo diário e consolidado puro/determinístico;
+- `workforce/timekeeping/security.js`: PIN, HMAC e criptografia biométrica;
+- `workforce/timekeeping/migrations`: persistência D1 e integridade;
+- `crm/console/pontoApi.ts` e `pontoTypes.ts`: contrato do cliente;
+- `crm/console/functions/api/ponto/[[path]].ts`: adaptador same-origin seguro;
+- `api/src/router.js`: mount público canônico.
+
+Eventos são append-only. Correções referenciam o evento original. Fechamentos guardam checksum, versão de cálculo, regras e snapshots diários. A Escala entra por alias canônico; um nome sem alias gera conflito e nunca fusão automática.
+
+Fechamentos adquirem uma trava por funcionário, unidade e data antes do cálculo; o trigger do D1 impede inserções concorrentes até a reabertura formal.
+
+## Contrato HTTP
+
+Sucesso JSON: `{ "ok": true, "data": ..., "requestId": "..." }`. Erro JSON: `{ "ok": false, "error": "CODE", "code": "CODE", "requestId": "..." }`. Exportação é `text/csv`; demais respostas nunca usam fallback HTML.
+
+O proxy CRM aplica CSRF às mutações e assina um envelope HMAC v2 ligado ao método, caminho/query, nonce e hash do corpo. O gateway não replica cookies: propaga apenas o contrato assinado para o Service Binding. Corpos acima de 1 MiB são rejeitados antes do parsing tanto no proxy quanto no Worker.
+
+Principais recursos: `health`, `readiness`, `context`, `employees`, `punches`, `daily`, `mirror`, `monthly`, `inconsistencies`, `bank`, `corrections`, `devices`, `biometrics`, `pin`, `periods`, `audit`, `export` e `schedule/sync`.
+
+## Identidade
+
+`workforce_employees.canonical_employee_id` é o identificador estável compartilhado. `workforce_employee_aliases` relaciona `PONTO_V2`, `ESCALA_PROFESSIONAL_ID` e `ESCALA_NAME`. Vínculos de unidade, jornada e escala têm vigência temporal. Desligamento altera status; não apaga evento, snapshot ou relatório histórico.
+
+## Cálculo
+
+O cálculo recebe instantes UTC, regra versionada, escala, feriado e ausência já resolvidos. Produz previsto, trabalhado, intervalo, atraso, saída antecipada, excedente, saldo, inconsistências e origem. Tratamento para folha permanece fora deste domínio.

--- a/docs/ponto-migration.md
+++ b/docs/ponto-migration.md
@@ -1,76 +1,53 @@
-# Migração — Ponto (arquivo → banco)
+# Migração do Controle de Ponto para D1
 
-## Objetivo
-Eliminar a persistência em arquivo (`backend/var/core/ponto_store.v2.json`) e mover o Ponto para um banco durável.
+## Fonte e destino
 
-## Escopo
-- Dados: employees, devices, records, audit
-- APIs: `/api/ponto/*` permanecem iguais
-- Compatibilidade: migração única (arquivo → DB)
+O arquivo legado `ponto_store.v2.json` é aceito apenas pelo importador em `workforce/timekeeping/scripts/import-ponto-json.mjs`. A fonte operacional definitiva é o D1 `skincos-timekeeping`; não existe dual-write nem fallback de escrita para JSON.
 
-## Proposta de schema (base relacional)
-**ponto_employees**
-- id (PK)
-- code
-- name
-- login_email
-- unit
-- active
-- created_at
-- updated_at
-- deleted_at
-- last_enrolled_at
-- pin_hash
-- face_templates (JSON/Blob)
-- consent_obtained_at
-- consent_version
+As migrations reproduzíveis ficam em `workforce/timekeeping/migrations`:
 
-**ponto_devices**
-- id (PK)
-- label
-- unit
-- token_hash
-- created_at
-- revoked_at
-- last_seen_at
+- `0001_timekeeping.sql`: identidade, vínculos temporais, regras, dispositivos, credenciais, biometria, eventos append-only, correções, fechamentos, auditoria e nonces;
+- `0002_operations.sql`: unidades, Escala, feriados, ausências, bloqueio de PIN, snapshots, controle de importação e conflitos de identidade;
+- `0003_audit_chain.sql`: cabeça e triggers da cadeia imutável de auditoria.
+- `0004_period_guards.sql`: data de trabalho indexada e trava transacional de dias em fechamento/fechados.
 
-**ponto_records**
-- id (PK)
-- kind (PUNCH|CORRECTION)
-- employee_id
-- employee_name
-- type (IN|OUT|AUTO)
-- at
-- unit
-- method
-- match_distance
-- note
-- device_id
-- device_label
-- ip
-- user_agent
-- idempotency_key
-- created_at
-- correction fields (target_record_id, new_at, new_type, new_unit, reason)
+## Validação e importação local
 
-**ponto_audit**
-- id (PK)
-- at
-- hash_prev
-- hash
-- payload (JSON)
+```bash
+cd workforce/timekeeping
+npx --yes wrangler@4.112.0 d1 migrations apply skincos-timekeeping --local --config wrangler.toml
+cd ../..
+node workforce/timekeeping/scripts/import-ponto-json.mjs \
+  --source workforce/timekeeping/fixtures/ponto_store.synthetic.json \
+  --dry-run
+node workforce/timekeeping/scripts/import-ponto-json.mjs \
+  --source <caminho-privado>/ponto_store.v2.json \
+  --apply \
+  --database skincos-timekeeping \
+  --backup <caminho-privado>/ponto-before-import.checkpoint \
+  --config workforce/timekeeping/wrangler.toml
+```
 
-## Passos sugeridos
-1) Criar schema e bindings no ambiente (D1/SQL).
-2) Implementar “storage adapter” que grava também no DB (dual‑write).
-3) Rodar migração de arquivo → DB (batch).
-4) Validar contagens e amostras (records e audit).
-5) Desligar gravação em arquivo.
+O `dry-run` valida versão e arrays obrigatórios, referências, datas, tipos, duplicidades e imprime apenas contagens/checksum. PIN, hash legado, template e vetor biométrico nunca são impressos. PINs legados em scrypt são sinalizados para redefinição; não são convertidos sem o PIN original.
 
-## Validação mínima
-- Registros recentes aparecem no DB e no CSV exportado.
-- `/api/ponto/health` reflete `storage=db`.
-- `audit/verify` continua OK.
+Templates biométricos só são migrados quando `PONTO_LEGACY_TEMPLATES_KEY` e `PONTO_TEMPLATES_KEY` estão disponíveis no ambiente privado. O importador decifra o envelope legado e cifra novamente em A256GCM; sem as chaves, preserva o funcionário e reporta a quantidade pendente, sem importar template ilegível.
 
-## Rollback
-Se DB falhar, retornar ao modo arquivo mantendo o arquivo atualizado (durante dual‑write).
+## Idempotência, conflitos e reconciliação
+
+O checksum SHA-256 da fonte identifica `timekeeping_migration_runs`. A mesma fonte já aplicada é recusada antes do backup/escrita. IDs legados permanecem estáveis e também recebem alias `PONTO_V2`. Emails duplicados não são fundidos: ficam sem login canônico até resolução humana em `workforce_identity_conflicts`.
+
+Após aplicação, compare `source_counts_json`, `result_counts_json` e as contagens das tabelas. O fixture sintético esperado é 1 funcionário e 2 eventos.
+
+## Backup e rollback
+
+No D1 local, o importador copia SQLite, WAL e SHM inativos para o diretório privado informado e gera um rollback SQL transacional. Exemplo:
+
+```bash
+node workforce/timekeeping/scripts/import-ponto-json.mjs \
+  --rollback-run ponto-json:<checksum-prefixo> \
+  --database skincos-timekeeping \
+  --backup <caminho-privado>/ponto-before-import.checkpoint.rollback-<checksum>.sql \
+  --config workforce/timekeeping/wrangler.toml
+```
+
+Em D1 remoto, informe também `--remote --database-id <uuid> --confirm-production`. O importador exige `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` e `PONTO_IMPORT_PRODUCTION_CONFIRM=<checksum>`, exporta o D1 e usa o protocolo oficial de importação (init, upload com ETag, ingestão e polling). Valide esse fluxo e a restauração primeiro no D1 de staging.

--- a/docs/ponto-pr-description.md
+++ b/docs/ponto-pr-description.md
@@ -1,0 +1,70 @@
+# Workforce Timekeeping — publicação controlada
+
+## Resumo
+
+Este PR move o Controle de Ponto para o domínio `workforce/timekeeping`,
+publicado exclusivamente pelo gateway `api` e consumido pelo CRM pelo proxy
+same-origin. O JSON legado deixa de ser persistência operacional e passa a ser
+somente fonte de importação/rollback controlado.
+
+## Arquitetura e contratos
+
+- Worker D1 próprio, com rotas HTTP, domínio de cálculo, segurança e auditoria
+  separados;
+- gateway em `api/src/router.js` pelo Service Binding `TIMEKEEPING`;
+- proxy CRM com allowlist de headers, CSRF, HMAC v2 e limite de 1 MiB;
+- respostas JSON padronizadas, inclusive para 404; `health` e `readiness`
+  públicos sem segredos.
+
+## Dados e migrations
+
+As migrations `0001` a `0004` criam identidade canônica, aliases, unidades,
+jornadas, dispositivos, credenciais, biometria cifrada, eventos append-only,
+correções, fechamento, auditoria imutável e travas de período. O importador
+possui dry-run, checksum, backup, idempotência, relatório de conflitos e
+rollback documentado.
+
+## Segurança
+
+- autorização por papel e unidade no Worker;
+- PIN PBKDF2, comparação segura e bloqueio progressivo global;
+- HMAC v2 ligado a ator, timestamp, método, caminho, query, nonce e corpo;
+- templates biométricos cifrados, sem foto, score ou vetor exposto ao cliente;
+- eventos de auditoria imutáveis e CSV protegido contra fórmulas.
+
+## Validação local
+
+- `npm --prefix workforce/timekeeping test`;
+- `npm --prefix api test`;
+- `npm --prefix crm/console test`, `typecheck`, `lint` e `build`;
+- migrations D1 locais, importação JSON dry-run, rollback e integração sintética;
+- bundles Wrangler de staging e produção em dry-run;
+- parser YAML em todos os workflows e revisão do diff/segredos.
+
+## Deploy, secrets e bindings
+
+O workflow `deploy-timekeeping.yml` exige `TIMEKEEPING_D1_STAGING_ID` ou
+`TIMEKEEPING_D1_PRODUCTION_ID` no environment correspondente e usa os secrets
+`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `PONTO_ACTOR_HMAC_KEY`,
+`PONTO_IDEMPOTENCY_KEY`, `PONTO_TEMPLATES_KEY`, `ESCALA_ACTOR_HMAC_KEY` e
+`TIMEKEEPING_BACKUP_PASSPHRASE`. O gateway requer o binding `TIMEKEEPING` e o
+Worker requer `SCHEDULE`.
+
+## Plano de staging e rollback
+
+O deploy começa em `staging`, gera checkpoint D1 cifrado, aplica migrations,
+publica Worker/gateway e valida `health`/`readiness`. Produção só aceita a
+atestation verde do mesmo SHA. Rollback de aplicação publica a versão anterior;
+migrations são expansivas e o rollback de importação segue
+`docs/ponto-migration.md`.
+
+## Riscos conhecidos e revisão
+
+- O primeiro deploy depende de D1 e environments GitHub provisionados;
+- não há merge automático: os checks protegidos de `main` devem ficar verdes;
+- produção só avança após staging e smoke somente leitura.
+
+- [ ] Revisar contratos CRM/gateway
+- [ ] Confirmar secrets e bindings por environment
+- [ ] Confirmar migrations/checkpoint em staging
+- [ ] Aprovar staging e smoke de produção

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -1,167 +1,33 @@
-# Runbook — Relógio‑Ponto (CRM)
+# Runbook — Controle de Ponto
 
-Este documento descreve **como validar, diagnosticar e operar** o módulo **Ponto** em produção.
+## Arquitetura
 
-## 1) Arquitetura (3 camadas)
-1. **CRM (frontend)**: `frontend/PontoModule.tsx`
-2. **Proxy Pages Functions**: `frontend/functions/api/ponto/[[path]].ts`
-3. **CRM API (backend central)**: `backend/apps/crm-api/server/pontoRoutes.js`
+O navegador usa `https://crm.skincos.com.br/api/ponto/*`. A Pages Function assina a identidade da sessão e encaminha somente headers permitidos para `https://api.skincos.com.br/api/ponto/*`. O gateway monta o domínio Workforce por Service Binding; o Worker Timekeeping usa D1 próprio.
 
-Observação: o Worker do Insumos **não** atende Ponto por padrão (somente se `PONTO_INSUMOS_ENABLED=true`).
+O arquivo `ponto_store.v2.json` não é fonte operacional do novo domínio. Ele só pode ser lido pelo importador controlado, primeiro em `--dry-run`.
 
----
+## Saúde e diagnóstico
 
-## 2) Variáveis e secrets (produção)
-
-### Cloudflare Pages (CRM)
-- `PONTO_API_TARGET` → URL do backend (ex.: `https://crm-api.seudominio.com`) (**obrigatório**)
-- `PONTO_PROXY_TOKEN` → secret de autenticação do proxy
-- `PONTO_ACTOR_HMAC_KEY` → **obrigatório**: secret para assinatura do actor (employee). Recomenda‑se não reutilizar o `PONTO_PROXY_TOKEN`.
-- `PONTO_ADMIN_TOKEN` → secret para rotas admin (injeção no proxy)
-
-### CRM API (backend)
-- `PONTO_ADMIN_TOKEN`
-- `PONTO_PROXY_TOKEN`
-- `PONTO_ACTOR_HMAC_KEY`
-- `PONTO_AUDIT_HMAC_KEY` (opcional, mas recomendado)
-- `PONTO_TEMPLATES_KEY` (**obrigatório em produção**; criptografa biometria)
-- `PONTO_PIN_MAX_ATTEMPTS`, `PONTO_PIN_WINDOW_SECONDS`, `PONTO_PIN_LOCK_SECONDS` (opcionais; lockout de PIN)
-- `PONTO_REQUIRE_CONSENT` (opcional; exige consentimento explícito para biometria)
-
----
-
-## 3) Checklist rápido de saúde (produção)
-
-### 3.1 Proxy
-```
-GET https://crm.skincos.com.br/api/ponto/_proxy-status
-```
-Esperado:
-- `ok: true`
-- `targetConfigured: true`
-- `adminTokenConfigured: true`
-- `proxyTokenConfigured: true`
-- `actorKeyConfigured: true`
-Observação:
-`targetConfigured: true` indica `PONTO_API_TARGET` explícito; sem isso o proxy não encaminha.
-
-### 3.2 CRM API
-```
-GET https://crm.skincos.com.br/api/ponto/health
-```
-Esperado:
-- `ok: true`
-- `cryptoTemplates: true` (biometria criptografada)
-- `cryptoAuditHmac: true` (quando `PONTO_AUDIT_HMAC_KEY` estiver configurado)
-
----
-
-## 4) Checklist funcional (UI)
-1) Abrir **Ponto** no CRM  
-2) Conferir **Build** no header (ex.: `Build: 0f1196c`)  
-3) Clicar em **Diagnóstico**  
-4) Confirmar JSON de `_proxy-status` e `health`  
-5) (Admin) Verificar botões no header: **Cadastrar**, **Editar**, **Exportar**, **Gerenciar Dispositivo**
-
-### 4.1 Smoke automatizado (UI) com Playwright (sem credenciais no script)
-Rodar (do root do repo):
-```
-NODE_PATH=frontend/node_modules node frontend/scripts/ponto-ui-smoke.cjs
-```
-Se precisar logar manualmente (recomendado por segurança), rode em modo visível:
-```
-HEADED=1 LOGIN_WAIT_MS=600000 NODE_PATH=frontend/node_modules node frontend/scripts/ponto-ui-smoke.cjs
-```
-Artefatos: `output/playwright/` (screenshots + trace).
-
-### 4.2 Smoke automatizado (UI) no GitHub Actions (produção)
-Workflow: `.github/workflows/ponto-ui-smoke.yml`
-
-**Requisitos**
-- Habilitar o agendamento (repo → Settings → Secrets and variables → Actions → Variables):
-  - `ENABLE_PONTO_UI_SMOKE=true`
-- Criar um usuário dedicado “smoke bot” no CRM (evite usar credenciais pessoais).
-- Configurar os secrets no GitHub (repo → Settings → Secrets and variables → Actions):
-  - `PONTO_SMOKE_EMAIL`
-  - `PONTO_SMOKE_PASSWORD`
-
-**Bootstrap/repair do smoke bot (recomendado)**
-- Script (idempotente) que garante que o usuário existe com role `ADMIN` e rotaciona a senha, atualizando os secrets do GitHub:
-```
-NODE_PATH=frontend/node_modules node frontend/scripts/bootstrap-ponto-smoke-admin.cjs
-```
-Pré‑requisito: precisa existir uma sessão admin salva em `output/playwright/storage-crm.json` (você cria isso rodando o `ponto-ui-smoke.cjs` em `HEADED=1` e logando manualmente).
-
-**O que ele valida**
-- Build badge contém o SHA do `main` (detecta “site desatualizado”/deploy drift).
-- Diagnóstico carrega (`/_proxy-status` e `/health`).
-- Invariantes de UI (ações de Admin apenas no header; fluxo do Funcionário sem campos técnicos).
-- (Opcional) mutações rápidas: cria/vincula funcionário por email, seta PIN, valida `/me`, faz punch por PIN, valida `audit/verify`, exporta CSV e limpa em seguida.
-Variáveis úteis no smoke:
-- `SMOKE_UNIT` (força unidade quando Insumos estiver indisponível)
-- `CHECK_PIN_LOCKOUT=1` (valida lockout de PIN)
-
----
-
-## 5) Fluxo mínimo (Admin → Funcionário → Audit)
-1) Admin cria funcionário  
-2) Admin define PIN  
-3) Admin (opcional) cadastra face  
-4) Funcionário seleciona unidade (quando houver mais de uma permitida)  
-5) Funcionário bate ponto (Face → PIN)  
-6) Admin exporta CSV  
-7) Admin valida audit:
-```
-GET /api/ponto/admin/audit/verify
+```bash
+curl -i https://crm.skincos.com.br/api/ponto/health
+curl -i https://crm.skincos.com.br/api/ponto/readiness
 ```
 
----
+Ambos devem retornar JSON e `x-request-id`. `health` não exige login; `readiness` nunca revela secrets. Para um `404`, seguir a cadeia: Pages proxy → `api.skincos.com.br/api/ponto` → binding `TIMEKEEPING` → Worker Timekeeping. Um HTML ou content-type diferente de JSON é falha de deploy/proxy.
 
-## 6) Problemas comuns
+## Migrations e importação
 
-### UI desatualizada
-**Sinal:** você ainda vê elementos antigos no Ponto.  
-**Solução:** conferir o **Build** no header e fazer hard refresh (Ctrl/Cmd+Shift+R).
+```bash
+npx wrangler d1 migrations apply skincos-timekeeping --local --config workforce/timekeeping/wrangler.toml
+node workforce/timekeeping/scripts/import-ponto-json.mjs --source <arquivo-json-controlado> --dry-run
+```
 
-### Admin não acessa
-**Sinal:** erro `ADMIN_TOKEN_NOT_CONFIGURED`.  
-**Ação:** validar secrets do Pages em `_proxy-status`.
+Antes de escrita remota, exportar D1 para diretório privado do operador, registrar checksum e validar restauração em staging. Migrations são expansivas; rollback de aplicação é feito pela versão anterior do Worker. Não executar rollback destrutivo sem backup testado.
 
-### Unidade não permitida (Funcionário)
-**Sinal:** erro `UNIT_ACCESS_NOT_CONFIGURED`, `UNIT_REQUIRED` ou `UNIT_FORBIDDEN`.  
-**Ação:** garantir que o usuário tem `allowedUnits` no CRM e selecionar a unidade correta no Ponto.
+## Secrets e operação
 
-### Biometria indisponível
-**Sinal:** erro `TEMPLATES_KEY_NOT_CONFIGURED` no enroll.  
-**Ação:** configurar `PONTO_TEMPLATES_KEY` no backend do CRM API.
+- `PONTO_ACTOR_HMAC_KEY`: assinatura curta de actor entre CRM e Workforce.
+- `PONTO_IDEMPOTENCY_KEY`: hash de fingerprints de retries.
+- `PONTO_TEMPLATES_KEY`: obrigatório para biometria; nunca gravar template em claro.
 
-### Vínculo de login não salva
-**Sinal:** erro `LOGIN_EMAIL_ALREADY_IN_USE`.  
-**Ação:** o email já está vinculado a outro funcionário ativo; revise no Admin e mantenha email único por funcionário.
-
-### Funcionário não consegue carregar `/me`
-**Sinal:** erro `LOGIN_EMAIL_AMBIGUOUS`.  
-**Ação:** há mais de um funcionário ativo com o mesmo email; corrija os cadastros duplicados antes de retestar.
-
-### Duplicidade de email (admin)
-**Sinal:** `LOGIN_EMAIL_AMBIGUOUS` e acesso bloqueado.  
-**Ação:** use **Editar → Ver duplicidades** para manter o email em apenas um funcionário.
-
-### `_proxy-status` diz que secrets não estão configurados, mesmo após sync
-**Sinal:** `proxyTokenConfigured=false` / `actorKeyConfigured=false` / `adminTokenConfigured=false`, mas o workflow de sync está “success”.  
-**Causa provável:** em Cloudflare Pages, alterações de env vars podem exigir um novo deploy para entrarem em vigor no runtime.  
-**Ação:** rode o reconcile do Pages (ele também faz smoke check):
-- Workflow: `.github/workflows/deploy-crm-pages-reconcile.yml`
-
-### Face não reconhece
-**Sinal:** erro `NOT_RECOGNIZED`.  
-**Ação:** confirmar `face-models` carregados e biometria cadastrada.
-
-### Retorno HTML com Cloudflare 1101
-**Sinal:** erro com `UPSTREAM_WORKER_EXCEPTION` (ou tela “Worker threw exception”).  
-**Ação:** usar `x-request-id` + `cf-ray` no Cloudflare Logs para identificar a exceção do Worker upstream.
-
----
-
-## 7) Logs e rastreio
-- Use o **x-request-id** e **cf-ray** exibidos no diagnóstico/erros para buscar no Cloudflare.
+Não registrar PIN, token, cookie, template, vetor ou imagem em logs. Revogar dispositivo ou consentimento biométrico invalida uso imediatamente e deve gerar auditoria.

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -1,33 +1,74 @@
 # Runbook — Controle de Ponto
 
-## Arquitetura
+## Arquitetura operacional
 
-O navegador usa `https://crm.skincos.com.br/api/ponto/*`. A Pages Function assina a identidade da sessão e encaminha somente headers permitidos para `https://api.skincos.com.br/api/ponto/*`. O gateway monta o domínio Workforce por Service Binding; o Worker Timekeeping usa D1 próprio.
+O navegador usa `https://crm.skincos.com.br/api/ponto/*`. A Pages Function autentica a sessão, assina claims mínimos e encaminha apenas headers autorizados para `https://api.skincos.com.br/api/ponto/*`. O gateway `api` monta o Worker `workforce/timekeeping` por Service Binding `TIMEKEEPING`. O domínio usa D1 próprio e consome a Escala pelo binding `SCHEDULE`.
 
-O arquivo `ponto_store.v2.json` não é fonte operacional do novo domínio. Ele só pode ser lido pelo importador controlado, primeiro em `--dry-run`.
+O backend legado `crm/api/server/pontoRoutes.js` não participa desse caminho. `ponto_store.v2.json` é somente entrada de migração/rollback controlado.
 
-## Saúde e diagnóstico
+## Saúde e 404
 
 ```bash
 curl -i https://crm.skincos.com.br/api/ponto/health
 curl -i https://crm.skincos.com.br/api/ponto/readiness
+curl -i https://api.skincos.com.br/api/ponto/health
 ```
 
-Ambos devem retornar JSON e `x-request-id`. `health` não exige login; `readiness` nunca revela secrets. Para um `404`, seguir a cadeia: Pages proxy → `api.skincos.com.br/api/ponto` → binding `TIMEKEEPING` → Worker Timekeeping. Um HTML ou content-type diferente de JSON é falha de deploy/proxy.
+`health` é público e informa serviço/versão sem secrets. `readiness` consulta D1 e retorna 503 JSON quando indisponível. Ambos precisam ter `content-type: application/json` e `x-request-id`.
 
-## Migrations e importação
+Para 404: validar nesta ordem Pages proxy, `PONTO_API_TARGET`, gateway publicado, binding `TIMEKEEPING`, Worker publicado e migrations. HTML, redirect de frontend ou 200 sem JSON é falha operacional.
 
-```bash
-npx wrangler d1 migrations apply skincos-timekeeping --local --config workforce/timekeeping/wrangler.toml
-node workforce/timekeeping/scripts/import-ponto-json.mjs --source <arquivo-json-controlado> --dry-run
-```
+## Permissões
 
-Antes de escrita remota, exportar D1 para diretório privado do operador, registrar checksum e validar restauração em staging. Migrations são expansivas; rollback de aplicação é feito pela versão anterior do Worker. Não executar rollback destrutivo sem backup testado.
+| Papel | Acesso |
+| --- | --- |
+| Funcionário | próprio contexto, histórico, batida e solicitação de correção |
+| Dispositivo | batida na unidade gravada no cadastro do dispositivo |
+| Gestor | leitura das unidades autorizadas, correção e dispositivos; não aprova a própria correção |
+| RH | leitura, identidade canônica, aprovação/recusa, fechamento e reabertura |
+| Administrador | RH + dispositivos e auditoria |
+| Auditor | leitura, exportação e auditoria; sem mutações |
 
-## Secrets e operação
+O frontend apenas oculta/desabilita ações; o Worker sempre revalida papel, unidade, funcionário e dispositivo.
 
-- `PONTO_ACTOR_HMAC_KEY`: assinatura curta de actor entre CRM e Workforce.
-- `PONTO_IDEMPOTENCY_KEY`: hash de fingerprints de retries.
-- `PONTO_TEMPLATES_KEY`: obrigatório para biometria; nunca gravar template em claro.
+Mutações same-origin exigem o token CSRF da sessão. A Pages Function envia um envelope HMAC v2 que vincula ator, instante, método, caminho com query string, nonce e SHA-256 do corpo; o Worker rejeita versão antiga, assinatura reaproveitada e nonce repetido. O proxy encaminha somente uma allowlist de headers e limita o corpo a 1 MiB.
 
-Não registrar PIN, token, cookie, template, vetor ou imagem em logs. Revogar dispositivo ou consentimento biométrico invalida uso imediatamente e deve gerar auditoria.
+## Secrets e variáveis
+
+- `PONTO_ACTOR_HMAC_KEY`: assinatura CRM → Timekeeping;
+- `PONTO_IDEMPOTENCY_KEY`: fingerprint de retries;
+- `PONTO_TEMPLATES_KEY`: A256GCM dos templates biométricos;
+- `ESCALA_ACTOR_HMAC_KEY`: autenticação Timekeeping → Escala;
+- `TIMEKEEPING_BACKUP_PASSPHRASE`: cifra o checkpoint D1 criado pelo workflow antes de migrations remotas;
+- `PONTO_FACE_THRESHOLD`, `PONTO_PIN_ITERATIONS`, `PONTO_COOLDOWN_SECONDS`: ajustes operacionais no servidor;
+- `TIMEKEEPING_D1_STAGING_ID` e `TIMEKEEPING_D1_PRODUCTION_ID`: variables do GitHub, não secrets.
+
+Nunca registrar PIN, token de dispositivo, cookie, template, vetor, foto, score ou chave. A UI nunca recebe template/score.
+
+## Fechamento mensal
+
+1. Sincronizar Escala e resolver conflitos de identidade.
+2. Carregar espelho, inconsistências e solicitações de correção.
+3. Aprovar/recusar correções por usuário diferente do solicitante.
+4. Informar justificativa e fechar o período.
+5. Confirmar snapshot, checksum e auditoria.
+
+Fechamento bloqueia novas batidas/correções no intervalo. Reabertura exige RH/Admin, justificativa e auditoria. Mudanças de regra posteriores não alteram snapshots fechados.
+
+A trava `timekeeping_period_guards` é adquirida por data antes do cálculo e impede que uma batida concorra com o fechamento. O bloqueio de PIN é global por funcionário, inclusive quando as tentativas alternam entre dispositivos.
+
+## Deploy e rollback
+
+Executar `.github/workflows/deploy-timekeeping.yml` primeiro em `staging`. O workflow exporta e cifra um checkpoint D1, aplica migrations, configura secrets, publica Worker e gateway e faz smoke read-only. Produção exige o `staging_run_id` numérico de uma execução verde para o mesmo SHA e o environment protegido `production`.
+
+Configure secrets e variables separadamente nos environments GitHub `staging` e `production`. O Pages environment `preview` usa `https://api-staging.skincos.com.br`; nunca compartilhe o upstream ou a chave HMAC de produção com preview. O smoke produtivo permanece somente leitura e não aceita opção para criar marcações.
+
+Rollback de aplicação: publicar a versão anterior do Worker/gateway. Migrations são expansivas; não remover colunas/tabelas em incidente. Rollback de importação segue `docs/ponto-migration.md`. Backups e evidências ficam em `C:\CodexRuntime\operator\admin\skincos\timekeeping`, nunca no repositório.
+
+## Incidentes
+
+- Banco indisponível: readiness 503, bloquear marcações e orientar contingência auditada; não escrever JSON.
+- Facial indisponível: diferenciar indisponibilidade técnica de não cadastrado/não reconhecido; permitir PIN auditado com rate limit.
+- PIN bloqueado: aguardar `locked_until`; RH pode redefinir credencial, nunca consultar o PIN.
+- Dispositivo comprometido: revogar cadastro, revisar auditoria pelo `deviceId` e emitir novo token mostrado uma vez.
+- Divergência de cálculo: não editar evento; abrir correção, recalcular período aberto ou reabrir formalmente o fechado.

--- a/workforce/timekeeping/domain.js
+++ b/workforce/timekeeping/domain.js
@@ -16,7 +16,7 @@ export function minutesBetween(start, end) {
   return Math.round((b - a) / 60000)
 }
 
-function isoDateInZone(instant, timeZone) {
+export function isoDateInZone(instant, timeZone) {
   const parts = new Intl.DateTimeFormat('en-CA', {
     timeZone: timeZone || 'America/Sao_Paulo', year: 'numeric', month: '2-digit', day: '2-digit',
   }).formatToParts(new Date(instant))

--- a/workforce/timekeeping/domain.js
+++ b/workforce/timekeeping/domain.js
@@ -1,0 +1,136 @@
+const EVENT_ORDER = Object.freeze({ WORK_START: 0, BREAK_START: 1, BREAK_END: 2, WORK_END: 3 })
+
+export const EVENT_TYPES = Object.freeze(Object.keys(EVENT_ORDER))
+
+export function canonicalEventType(value) {
+  const type = String(value || '').trim().toUpperCase()
+  if (type === 'IN') return 'WORK_START'
+  if (type === 'OUT') return 'WORK_END'
+  return EVENT_TYPES.includes(type) ? type : null
+}
+
+export function minutesBetween(start, end) {
+  const a = Date.parse(start)
+  const b = Date.parse(end)
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b < a) return null
+  return Math.round((b - a) / 60000)
+}
+
+function isoDateInZone(instant, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timeZone || 'America/Sao_Paulo', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).formatToParts(new Date(instant))
+  const read = (name) => parts.find((part) => part.type === name)?.value || ''
+  return `${read('year')}-${read('month')}-${read('day')}`
+}
+
+function sortEvents(events) {
+  return [...events]
+    .map((event) => ({ ...event, eventType: canonicalEventType(event.eventType || event.type) }))
+    .sort((a, b) => {
+      const byTime = Date.parse(a.occurredAt || a.at) - Date.parse(b.occurredAt || b.at)
+      if (byTime) return byTime
+      const byType = (EVENT_ORDER[a.eventType] ?? 99) - (EVENT_ORDER[b.eventType] ?? 99)
+      return byType || String(a.id || '').localeCompare(String(b.id || ''))
+    })
+}
+
+function applyTolerance(value, tolerance) {
+  const n = Math.max(0, Number(value || 0))
+  return n <= Math.max(0, Number(tolerance || 0)) ? 0 : n
+}
+
+/**
+ * Pure, deterministic calculation. The caller resolves schedule, leave and rule
+ * versions before calling this function; payroll conversions intentionally stay out.
+ */
+export function calculateDay({ date, events = [], rule = {}, schedule = null, holiday = false, absence = null }) {
+  const timeZone = rule.timeZone || 'America/Sao_Paulo'
+  const ordered = sortEvents(events)
+  const inconsistencies = []
+  const workSegments = []
+  const breaks = []
+  let workStartedAt = null
+  let breakStartedAt = null
+
+  for (const event of ordered) {
+    const at = event.occurredAt || event.at
+    if (!event.eventType || !Number.isFinite(Date.parse(at))) {
+      inconsistencies.push({ code: 'INVALID_EVENT', eventId: event.id || null })
+      continue
+    }
+    if (event.eventType === 'WORK_START') {
+      if (workStartedAt || breakStartedAt) inconsistencies.push({ code: 'WORK_START_OUT_OF_ORDER', eventId: event.id || null })
+      else workStartedAt = at
+    } else if (event.eventType === 'BREAK_START') {
+      if (!workStartedAt || breakStartedAt) inconsistencies.push({ code: 'BREAK_START_OUT_OF_ORDER', eventId: event.id || null })
+      else {
+        const minutes = minutesBetween(workStartedAt, at)
+        if (minutes !== null) workSegments.push(minutes)
+        workStartedAt = null
+        breakStartedAt = at
+      }
+    } else if (event.eventType === 'BREAK_END') {
+      if (!breakStartedAt || workStartedAt) inconsistencies.push({ code: 'BREAK_END_OUT_OF_ORDER', eventId: event.id || null })
+      else {
+        const minutes = minutesBetween(breakStartedAt, at)
+        if (minutes !== null) breaks.push(minutes)
+        breakStartedAt = null
+        workStartedAt = at
+      }
+    } else if (event.eventType === 'WORK_END') {
+      if (!workStartedAt || breakStartedAt) inconsistencies.push({ code: 'WORK_END_OUT_OF_ORDER', eventId: event.id || null })
+      else {
+        const minutes = minutesBetween(workStartedAt, at)
+        if (minutes !== null) workSegments.push(minutes)
+        workStartedAt = null
+      }
+    }
+  }
+
+  if (workStartedAt) inconsistencies.push({ code: 'OPEN_WORK_SEGMENT' })
+  if (breakStartedAt) inconsistencies.push({ code: 'OPEN_BREAK' })
+  const workedMinutes = workSegments.reduce((sum, value) => sum + value, 0)
+  const breakMinutes = breaks.reduce((sum, value) => sum + value, 0)
+  const expectedMinutes = holiday || absence ? 0 : Math.max(0, Number(schedule?.expectedMinutes ?? rule.expectedMinutes ?? 0))
+  const startAt = ordered.find((event) => event.eventType === 'WORK_START')?.occurredAt || ordered.find((event) => event.eventType === 'WORK_START')?.at || null
+  const endAt = [...ordered].reverse().find((event) => event.eventType === 'WORK_END')?.occurredAt || [...ordered].reverse().find((event) => event.eventType === 'WORK_END')?.at || null
+  const scheduledStart = schedule?.startAt || null
+  const scheduledEnd = schedule?.endAt || null
+  const lateMinutes = startAt && scheduledStart ? applyTolerance(minutesBetween(scheduledStart, startAt), rule.lateToleranceMinutes) : 0
+  const earlyLeaveMinutes = endAt && scheduledEnd ? applyTolerance(minutesBetween(endAt, scheduledEnd), rule.earlyLeaveToleranceMinutes) : 0
+  const balanceMinutes = workedMinutes - expectedMinutes
+  const overtimeMinutes = Math.max(0, balanceMinutes - Math.max(0, Number(rule.overtimeToleranceMinutes || 0)))
+  const maxWorked = Number(rule.maxWorkedMinutes || 0)
+  if (maxWorked && workedMinutes > maxWorked) inconsistencies.push({ code: 'MAX_WORKED_EXCEEDED', actualMinutes: workedMinutes, maxMinutes: maxWorked })
+  const dayDate = date || (ordered[0] ? isoDateInZone(ordered[0].occurredAt || ordered[0].at, timeZone) : null)
+  const status = inconsistencies.length ? 'INCONSISTENT' : holiday ? 'HOLIDAY' : absence ? 'ABSENCE' : ordered.length ? 'CALCULATED' : expectedMinutes ? 'MISSING' : 'REST'
+
+  return {
+    date: dayDate,
+    timeZone,
+    expectedMinutes,
+    workedMinutes,
+    breakMinutes,
+    lateMinutes,
+    earlyLeaveMinutes,
+    overtimeMinutes,
+    dailyBalanceMinutes: balanceMinutes,
+    status,
+    inconsistencies,
+    eventIds: ordered.map((event) => event.id).filter(Boolean),
+    source: { ruleVersionId: rule.id || null, scheduleId: schedule?.id || null, holiday: !!holiday, absenceId: absence?.id || null },
+  }
+}
+
+export function calculatePeriod({ days = [], openingBalanceMinutes = 0 }) {
+  let balance = Number(openingBalanceMinutes || 0)
+  const calculatedDays = days.map((day) => {
+    const result = day.dailyBalanceMinutes === undefined ? calculateDay(day) : day
+    balance += Number(result.dailyBalanceMinutes || 0)
+    return { ...result, accumulatedBalanceMinutes: balance }
+  })
+  return { openingBalanceMinutes: Number(openingBalanceMinutes || 0), closingBalanceMinutes: balance, days: calculatedDays }
+}
+
+export const __testables = { isoDateInZone, sortEvents, applyTolerance }

--- a/workforce/timekeeping/domain.test.js
+++ b/workforce/timekeeping/domain.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { calculateDay, calculatePeriod } from './domain.js'
+
+test('calculates a regular day with one break deterministically', () => {
+  const result = calculateDay({
+    date: '2026-07-18', rule: { expectedMinutes: 480, lateToleranceMinutes: 5 },
+    schedule: { expectedMinutes: 480, startAt: '2026-07-18T11:00:00.000Z', endAt: '2026-07-18T20:00:00.000Z' },
+    events: [
+      { id: '1', eventType: 'WORK_START', occurredAt: '2026-07-18T11:03:00.000Z' },
+      { id: '2', eventType: 'BREAK_START', occurredAt: '2026-07-18T15:00:00.000Z' },
+      { id: '3', eventType: 'BREAK_END', occurredAt: '2026-07-18T16:00:00.000Z' },
+      { id: '4', eventType: 'WORK_END', occurredAt: '2026-07-18T20:00:00.000Z' },
+    ],
+  })
+  assert.equal(result.workedMinutes, 477)
+  assert.equal(result.breakMinutes, 60)
+  assert.equal(result.lateMinutes, 0)
+  assert.equal(result.dailyBalanceMinutes, -3)
+})
+
+test('flags incomplete and invalid sequences without inventing an event', () => {
+  const result = calculateDay({ events: [{ id: 'a', eventType: 'BREAK_END', occurredAt: '2026-07-18T11:00:00.000Z' }] })
+  assert.equal(result.status, 'INCONSISTENT')
+  assert.equal(result.inconsistencies[0].code, 'BREAK_END_OUT_OF_ORDER')
+})
+
+test('supports an overnight shift using UTC instants', () => {
+  const result = calculateDay({
+    date: '2026-07-18', schedule: { expectedMinutes: 480 },
+    events: [
+      { eventType: 'WORK_START', occurredAt: '2026-07-18T22:00:00.000Z' },
+      { eventType: 'WORK_END', occurredAt: '2026-07-19T06:00:00.000Z' },
+    ],
+  })
+  assert.equal(result.workedMinutes, 480)
+  assert.equal(result.dailyBalanceMinutes, 0)
+})
+
+test('accumulates bank balance without changing daily snapshots', () => {
+  const result = calculatePeriod({ days: [{ dailyBalanceMinutes: 30 }, { dailyBalanceMinutes: -10 }], openingBalanceMinutes: 20 })
+  assert.equal(result.closingBalanceMinutes, 40)
+  assert.deepEqual(result.days.map((day) => day.accumulatedBalanceMinutes), [50, 40])
+})

--- a/workforce/timekeeping/domain.test.js
+++ b/workforce/timekeeping/domain.test.js
@@ -42,3 +42,51 @@ test('accumulates bank balance without changing daily snapshots', () => {
   assert.equal(result.closingBalanceMinutes, 40)
   assert.deepEqual(result.days.map((day) => day.accumulatedBalanceMinutes), [50, 40])
 })
+
+test('supports multiple intervals without counting them as worked time', () => {
+  const result = calculateDay({
+    date: '2026-07-20', rule: { expectedMinutes: 450 },
+    events: [
+      { eventType: 'WORK_START', occurredAt: '2026-07-20T11:00:00.000Z' },
+      { eventType: 'BREAK_START', occurredAt: '2026-07-20T14:00:00.000Z' },
+      { eventType: 'BREAK_END', occurredAt: '2026-07-20T14:15:00.000Z' },
+      { eventType: 'BREAK_START', occurredAt: '2026-07-20T17:15:00.000Z' },
+      { eventType: 'BREAK_END', occurredAt: '2026-07-20T18:00:00.000Z' },
+      { eventType: 'WORK_END', occurredAt: '2026-07-20T19:30:00.000Z' },
+    ],
+  })
+  assert.equal(result.workedMinutes, 450)
+  assert.equal(result.breakMinutes, 60)
+  assert.equal(result.status, 'CALCULATED')
+})
+
+test('applies delay, early-leave and overtime tolerances independently', () => {
+  const result = calculateDay({
+    date: '2026-07-21', rule: { expectedMinutes: 450, lateToleranceMinutes: 5, earlyLeaveToleranceMinutes: 5, overtimeToleranceMinutes: 10 },
+    schedule: { expectedMinutes: 450, startAt: '2026-07-21T11:00:00.000Z', endAt: '2026-07-21T18:30:00.000Z' },
+    events: [{ eventType: 'WORK_START', occurredAt: '2026-07-21T11:06:00.000Z' }, { eventType: 'WORK_END', occurredAt: '2026-07-21T18:24:00.000Z' }],
+  })
+  assert.equal(result.lateMinutes, 6)
+  assert.equal(result.earlyLeaveMinutes, 6)
+  assert.equal(result.overtimeMinutes, 0)
+})
+
+test('treats configured holidays and justified absences as zero expected time', () => {
+  const holiday = calculateDay({ date: '2026-12-25', holiday: true, rule: { expectedMinutes: 480 } })
+  const absence = calculateDay({ date: '2026-07-22', absence: { id: 'leave-1', kind: 'JUSTIFIED' }, rule: { expectedMinutes: 480 } })
+  assert.equal(holiday.expectedMinutes, 0); assert.equal(holiday.status, 'HOLIDAY')
+  assert.equal(absence.expectedMinutes, 0); assert.equal(absence.status, 'ABSENCE')
+})
+
+test('reports missing scheduled work and excessive worked time', () => {
+  const missing = calculateDay({ date: '2026-07-23', schedule: { expectedMinutes: 480 } })
+  const excessive = calculateDay({ date: '2026-07-24', rule: { expectedMinutes: 480, maxWorkedMinutes: 600 }, events: [{ eventType: 'WORK_START', occurredAt: '2026-07-24T08:00:00.000Z' }, { eventType: 'WORK_END', occurredAt: '2026-07-24T19:00:00.000Z' }] })
+  assert.equal(missing.status, 'MISSING')
+  assert.equal(excessive.inconsistencies.some((item) => item.code === 'MAX_WORKED_EXCEEDED'), true)
+})
+
+test('uses actual instants safely across a daylight-saving transition', () => {
+  const result = calculateDay({ date: '2026-11-01', rule: { timeZone: 'America/New_York', expectedMinutes: 180 }, events: [{ eventType: 'WORK_START', occurredAt: '2026-11-01T04:30:00.000Z' }, { eventType: 'WORK_END', occurredAt: '2026-11-01T07:30:00.000Z' }] })
+  assert.equal(result.workedMinutes, 180)
+  assert.equal(result.dailyBalanceMinutes, 0)
+})

--- a/workforce/timekeeping/fixtures/ponto_store.synthetic.json
+++ b/workforce/timekeeping/fixtures/ponto_store.synthetic.json
@@ -1,0 +1,44 @@
+{
+  "version": 2,
+  "employees": [
+    {
+      "id": "synthetic-employee-001",
+      "code": "SYN001",
+      "name": "Funcionário Sintético Ponto",
+      "loginEmail": "ponto.synthetic@example.invalid",
+      "unit": "SYNTHETIC_UNIT",
+      "active": true,
+      "createdAt": "2026-01-01T12:00:00.000Z",
+      "updatedAt": "2026-01-01T12:00:00.000Z",
+      "faceTemplates": [],
+      "pinHash": null,
+      "consent": { "obtainedAt": "2026-01-01T12:00:00.000Z", "version": "synthetic-v1" }
+    }
+  ],
+  "devices": [],
+  "records": [
+    {
+      "id": "synthetic-punch-001",
+      "kind": "PUNCH",
+      "employeeId": "synthetic-employee-001",
+      "employeeName": "Funcionário Sintético Ponto",
+      "type": "IN",
+      "at": "2026-01-02T12:00:00.000Z",
+      "unit": "SYNTHETIC_UNIT",
+      "method": "IMPORT",
+      "createdAt": "2026-01-02T12:00:00.000Z"
+    },
+    {
+      "id": "synthetic-punch-002",
+      "kind": "PUNCH",
+      "employeeId": "synthetic-employee-001",
+      "employeeName": "Funcionário Sintético Ponto",
+      "type": "OUT",
+      "at": "2026-01-02T20:00:00.000Z",
+      "unit": "SYNTHETIC_UNIT",
+      "method": "IMPORT",
+      "createdAt": "2026-01-02T20:00:00.000Z"
+    }
+  ],
+  "audit": { "lastHash": null }
+}

--- a/workforce/timekeeping/legacyBiometric.js
+++ b/workforce/timekeeping/legacyBiometric.js
@@ -1,0 +1,24 @@
+import { createDecipheriv } from 'node:crypto'
+
+export const LEGACY_GCM_TAG_BYTES = 16
+
+export function validLegacyBiometricTemplate(template) {
+  return Array.isArray(template) && template.length >= 64 && template.length <= 1024 && template.every((value) => Number.isFinite(value))
+}
+
+export function decryptLegacyBiometricTemplate(payload, secret) {
+  if (Array.isArray(payload)) return validLegacyBiometricTemplate(payload) ? payload : null
+  if (!secret || payload?.alg !== 'A256GCM') return null
+  const keyRaw = String(secret).trim(); let key
+  try { key = Buffer.from(keyRaw.replace(/-/g, '+').replace(/_/g, '/'), 'base64') } catch { key = Buffer.alloc(0) }
+  if (key.length !== 32) { try { key = Buffer.from(keyRaw, 'hex') } catch { key = Buffer.alloc(0) } }
+  if (key.length !== 32) return null
+  try {
+    const tag = Buffer.from(payload.tag, 'base64')
+    if (tag.length !== LEGACY_GCM_TAG_BYTES) return null
+    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(payload.iv, 'base64'), { authTagLength: LEGACY_GCM_TAG_BYTES })
+    decipher.setAuthTag(tag)
+    const template = JSON.parse(Buffer.concat([decipher.update(Buffer.from(payload.ct, 'base64')), decipher.final()]).toString('utf8'))
+    return validLegacyBiometricTemplate(template) ? template : null
+  } catch { return null }
+}

--- a/workforce/timekeeping/legacyBiometric.test.js
+++ b/workforce/timekeeping/legacyBiometric.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { createCipheriv, randomBytes } from 'node:crypto'
+import test from 'node:test'
+import { decryptLegacyBiometricTemplate, LEGACY_GCM_TAG_BYTES } from './legacyBiometric.js'
+
+function legacyEnvelope(template, key) {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: LEGACY_GCM_TAG_BYTES })
+  const ct = Buffer.concat([cipher.update(JSON.stringify(template), 'utf8'), cipher.final()])
+  return { alg: 'A256GCM', iv: iv.toString('base64'), ct: ct.toString('base64'), tag: cipher.getAuthTag().toString('base64') }
+}
+
+test('legacy biometric migration accepts only an authenticated 128-bit GCM tag', () => {
+  const key = randomBytes(32)
+  const template = Array.from({ length: 64 }, (_, index) => index / 100)
+  const payload = legacyEnvelope(template, key)
+  assert.deepEqual(decryptLegacyBiometricTemplate(payload, key.toString('base64url')), template)
+  const shortenedTag = Buffer.from(payload.tag, 'base64').subarray(0, LEGACY_GCM_TAG_BYTES - 1).toString('base64')
+  assert.equal(decryptLegacyBiometricTemplate({ ...payload, tag: shortenedTag }, key.toString('base64url')), null)
+})

--- a/workforce/timekeeping/migrations/0001_timekeeping.sql
+++ b/workforce/timekeeping/migrations/0001_timekeeping.sql
@@ -1,0 +1,160 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS workforce_employees (
+  id TEXT PRIMARY KEY,
+  canonical_employee_id TEXT NOT NULL UNIQUE,
+  login_email TEXT UNIQUE,
+  display_name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('ACTIVE','LEAVE','TERMINATED')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  terminated_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS workforce_employee_aliases (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  source TEXT NOT NULL,
+  legacy_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(source, legacy_id)
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_employee_units (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT NOT NULL,
+  effective_from TEXT NOT NULL,
+  effective_to TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tk_employee_units_scope ON timekeeping_employee_units(employee_id, unit_id, effective_from);
+
+CREATE TABLE IF NOT EXISTS timekeeping_rule_versions (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT REFERENCES workforce_employees(id),
+  unit_id TEXT,
+  effective_from TEXT NOT NULL,
+  effective_to TEXT,
+  rules_json TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tk_rules_effective ON timekeeping_rule_versions(employee_id, unit_id, effective_from);
+
+CREATE TABLE IF NOT EXISTS timekeeping_devices (
+  id TEXT PRIMARY KEY,
+  unit_id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  active INTEGER NOT NULL DEFAULT 1,
+  revoked_at TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  last_seen_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tk_devices_unit_active ON timekeeping_devices(unit_id, active);
+
+CREATE TABLE IF NOT EXISTS timekeeping_pin_credentials (
+  employee_id TEXT PRIMARY KEY REFERENCES workforce_employees(id),
+  algorithm TEXT NOT NULL,
+  salt_b64 TEXT NOT NULL,
+  hash_b64 TEXT NOT NULL,
+  iterations INTEGER NOT NULL,
+  updated_by TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_biometric_templates (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  encrypted_template TEXT NOT NULL,
+  consent_version TEXT NOT NULL,
+  consented_at TEXT NOT NULL,
+  consented_by TEXT NOT NULL,
+  expires_at TEXT,
+  revoked_at TEXT,
+  revoked_by TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tk_biometrics_employee_active ON timekeeping_biometric_templates(employee_id, revoked_at, expires_at);
+
+CREATE TABLE IF NOT EXISTS timekeeping_events (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT NOT NULL,
+  device_id TEXT REFERENCES timekeeping_devices(id),
+  event_type TEXT NOT NULL CHECK (event_type IN ('WORK_START','BREAK_START','BREAK_END','WORK_END')),
+  source TEXT NOT NULL CHECK (source IN ('FACE','PIN','MANUAL','IMPORT','SYSTEM')),
+  occurred_at_utc TEXT NOT NULL,
+  idempotency_scope TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  request_fingerprint TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  superseded_by TEXT,
+  UNIQUE(idempotency_scope, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_tk_events_employee_date ON timekeeping_events(employee_id, occurred_at_utc);
+CREATE INDEX IF NOT EXISTS idx_tk_events_unit_date ON timekeeping_events(unit_id, occurred_at_utc);
+CREATE INDEX IF NOT EXISTS idx_tk_events_device_date ON timekeeping_events(device_id, occurred_at_utc);
+
+CREATE TABLE IF NOT EXISTS timekeeping_corrections (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES timekeeping_events(id),
+  requested_at TEXT NOT NULL,
+  requested_by TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  proposed_at_utc TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING','APPROVED','REJECTED')),
+  decided_at TEXT,
+  decided_by TEXT,
+  decision_reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tk_corrections_event ON timekeeping_corrections(event_id, status);
+
+CREATE TABLE IF NOT EXISTS timekeeping_period_closures (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT NOT NULL,
+  period_start TEXT NOT NULL,
+  period_end TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('CLOSED','REOPENED')),
+  revision INTEGER NOT NULL,
+  rules_snapshot_json TEXT NOT NULL,
+  input_checksum TEXT NOT NULL,
+  calculation_version TEXT NOT NULL,
+  closed_by TEXT NOT NULL,
+  closed_at TEXT NOT NULL,
+  reopened_by TEXT,
+  reopened_at TEXT,
+  reopen_reason TEXT,
+  UNIQUE(employee_id, unit_id, period_start, period_end, revision)
+);
+CREATE INDEX IF NOT EXISTS idx_tk_closures_period ON timekeeping_period_closures(unit_id, period_start, period_end);
+
+CREATE TABLE IF NOT EXISTS timekeeping_audit_events (
+  id TEXT PRIMARY KEY,
+  occurred_at TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  actor_role TEXT NOT NULL,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  unit_id TEXT,
+  reason TEXT,
+  before_json TEXT,
+  after_json TEXT,
+  request_id TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  prev_hash TEXT,
+  hash TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tk_audit_entity ON timekeeping_audit_events(entity_type, entity_id, occurred_at);
+
+CREATE TABLE IF NOT EXISTS timekeeping_request_nonces (
+  nonce TEXT PRIMARY KEY,
+  expires_at TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/workforce/timekeeping/migrations/0002_operations.sql
+++ b/workforce/timekeeping/migrations/0002_operations.sql
@@ -1,0 +1,119 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE workforce_employees ADD COLUMN employee_code TEXT;
+ALTER TABLE workforce_employees ADD COLUMN cpf_hash TEXT;
+ALTER TABLE workforce_employees ADD COLUMN phone_hash TEXT;
+ALTER TABLE workforce_employees ADD COLUMN birth_date TEXT;
+ALTER TABLE workforce_employees ADD COLUMN job_title TEXT;
+ALTER TABLE workforce_employees ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';
+
+CREATE TABLE IF NOT EXISTS workforce_units (
+  id TEXT PRIMARY KEY,
+  canonical_unit_id TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'America/Sao_Paulo',
+  active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_schedule_assignments (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT NOT NULL,
+  work_date TEXT NOT NULL,
+  start_at_utc TEXT,
+  end_at_utc TEXT,
+  expected_minutes INTEGER NOT NULL DEFAULT 0 CHECK (expected_minutes >= 0),
+  source TEXT NOT NULL DEFAULT 'TIMEKEEPING',
+  source_ref TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(employee_id, unit_id, work_date, source)
+);
+CREATE INDEX IF NOT EXISTS idx_tk_schedule_employee_period ON timekeeping_schedule_assignments(employee_id, work_date, unit_id);
+
+CREATE TABLE IF NOT EXISTS timekeeping_holidays (
+  id TEXT PRIMARY KEY,
+  unit_id TEXT NOT NULL,
+  holiday_date TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(unit_id, holiday_date, name)
+);
+CREATE INDEX IF NOT EXISTS idx_tk_holiday_unit_date ON timekeeping_holidays(unit_id, holiday_date);
+
+CREATE TABLE IF NOT EXISTS timekeeping_absences (
+  id TEXT PRIMARY KEY,
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT,
+  starts_at TEXT NOT NULL,
+  ends_at TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('JUSTIFIED','UNJUSTIFIED','LEAVE')),
+  reason TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tk_absence_employee_period ON timekeeping_absences(employee_id, starts_at, ends_at);
+
+CREATE TABLE IF NOT EXISTS timekeeping_pin_failures (
+  employee_id TEXT PRIMARY KEY REFERENCES workforce_employees(id),
+  device_id TEXT NOT NULL DEFAULT '',
+  failure_count INTEGER NOT NULL DEFAULT 0,
+  window_started_at TEXT NOT NULL,
+  locked_until TEXT,
+  last_failed_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_daily_snapshots (
+  id TEXT PRIMARY KEY,
+  closure_id TEXT NOT NULL REFERENCES timekeeping_period_closures(id),
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  work_date TEXT NOT NULL,
+  calculation_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(closure_id, employee_id, work_date)
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_migration_runs (
+  id TEXT PRIMARY KEY,
+  source_kind TEXT NOT NULL,
+  source_checksum TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('APPLYING','APPLIED','ROLLED_BACK','FAILED')),
+  source_counts_json TEXT NOT NULL,
+  result_counts_json TEXT,
+  checkpoint_json TEXT,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  UNIQUE(source_kind, source_checksum)
+);
+
+CREATE TABLE IF NOT EXISTS timekeeping_migration_items (
+  migration_run_id TEXT NOT NULL REFERENCES timekeeping_migration_runs(id),
+  entity_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  checksum TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY(migration_run_id, entity_type, source_id)
+);
+
+CREATE TABLE IF NOT EXISTS workforce_identity_conflicts (
+  id TEXT PRIMARY KEY,
+  source TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  candidates_json TEXT NOT NULL,
+  reasons_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN','RESOLVED','IGNORED')),
+  created_at TEXT NOT NULL,
+  resolved_at TEXT,
+  resolved_by TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_workforce_conflicts_status ON workforce_identity_conflicts(status, source);
+
+CREATE INDEX IF NOT EXISTS idx_tk_events_unit_employee_date ON timekeeping_events(unit_id, employee_id, occurred_at_utc);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tk_employee_units_effective_unique ON timekeeping_employee_units(employee_id, unit_id, effective_from);
+CREATE INDEX IF NOT EXISTS idx_tk_corrections_status_date ON timekeeping_corrections(status, requested_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workforce_employee_code_unique ON workforce_employees(employee_code) WHERE employee_code IS NOT NULL AND employee_code <> '';
+CREATE INDEX IF NOT EXISTS idx_workforce_employee_cpf_hash ON workforce_employees(cpf_hash) WHERE cpf_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_workforce_employee_phone_hash ON workforce_employees(phone_hash) WHERE phone_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tk_snapshots_employee_date ON timekeeping_daily_snapshots(employee_id, work_date);

--- a/workforce/timekeeping/migrations/0003_audit_chain.sql
+++ b/workforce/timekeeping/migrations/0003_audit_chain.sql
@@ -1,0 +1,33 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS timekeeping_audit_head (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  hash TEXT
+);
+INSERT OR IGNORE INTO timekeeping_audit_head (id, hash)
+VALUES (1, (SELECT hash FROM timekeeping_audit_events ORDER BY occurred_at DESC, id DESC LIMIT 1));
+
+CREATE TRIGGER IF NOT EXISTS trg_timekeeping_audit_chain_before_insert
+BEFORE INSERT ON timekeeping_audit_events
+WHEN COALESCE(NEW.prev_hash, '') <> COALESCE((SELECT hash FROM timekeeping_audit_head WHERE id=1), '')
+BEGIN
+  SELECT RAISE(ABORT, 'AUDIT_CHAIN_CONFLICT');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_timekeeping_audit_chain_after_insert
+AFTER INSERT ON timekeeping_audit_events
+BEGIN
+  UPDATE timekeeping_audit_head SET hash=NEW.hash WHERE id=1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_timekeeping_audit_immutable_update
+BEFORE UPDATE ON timekeeping_audit_events
+BEGIN
+  SELECT RAISE(ABORT, 'AUDIT_IMMUTABLE');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_timekeeping_audit_immutable_delete
+BEFORE DELETE ON timekeeping_audit_events
+BEGIN
+  SELECT RAISE(ABORT, 'AUDIT_IMMUTABLE');
+END;

--- a/workforce/timekeeping/migrations/0004_period_guards.sql
+++ b/workforce/timekeeping/migrations/0004_period_guards.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE timekeeping_events ADD COLUMN work_date TEXT;
+UPDATE timekeeping_events
+SET work_date = substr(datetime(occurred_at_utc, '-3 hours'), 1, 10)
+WHERE work_date IS NULL;
+CREATE INDEX IF NOT EXISTS idx_tk_events_work_date
+  ON timekeeping_events(employee_id, unit_id, work_date);
+
+CREATE TABLE IF NOT EXISTS timekeeping_period_guards (
+  employee_id TEXT NOT NULL REFERENCES workforce_employees(id),
+  unit_id TEXT NOT NULL,
+  work_date TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('CLOSING', 'CLOSED')),
+  closure_id TEXT REFERENCES timekeeping_period_closures(id),
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (employee_id, unit_id, work_date)
+);
+CREATE INDEX IF NOT EXISTS idx_tk_period_guards_operation
+  ON timekeeping_period_guards(operation_id, status);
+
+CREATE TRIGGER IF NOT EXISTS trg_timekeeping_event_open_period
+BEFORE INSERT ON timekeeping_events
+WHEN EXISTS (
+  SELECT 1
+  FROM timekeeping_period_guards g
+  WHERE g.employee_id = NEW.employee_id
+    AND g.unit_id = NEW.unit_id
+    AND g.work_date = COALESCE(NEW.work_date, substr(NEW.occurred_at_utc, 1, 10))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'PERIOD_CLOSED');
+END;

--- a/workforce/timekeeping/package-lock.json
+++ b/workforce/timekeeping/package-lock.json
@@ -1,0 +1,468 @@
+{
+  "name": "@skincos/workforce-timekeeping",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@skincos/workforce-timekeeping",
+      "version": "1.0.0",
+      "devDependencies": {
+        "wrangler": "4.112.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260714.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260714.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260714.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260714.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260714.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
+        "@cloudflare/workerd-linux-64": "1.20260714.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
+        "@cloudflare/workerd-windows-64": "1.20260714.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.112.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260714.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260714.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260714.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/workforce/timekeeping/package.json
+++ b/workforce/timekeeping/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "test": "node --test *.test.js",
+    "test:integration:local": "node scripts/integration-local.mjs",
     "smoke": "node scripts/smoke.mjs",
     "migrate:local": "wrangler d1 migrations apply skincos-timekeeping --local --config wrangler.toml"
   },
   "devDependencies": {
-    "wrangler": "^4.60.0"
+    "wrangler": "4.112.0"
   }
 }

--- a/workforce/timekeeping/package.json
+++ b/workforce/timekeeping/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@skincos/workforce-timekeeping",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test *.test.js",
+    "smoke": "node scripts/smoke.mjs",
+    "migrate:local": "wrangler d1 migrations apply skincos-timekeeping --local --config wrangler.toml"
+  },
+  "devDependencies": {
+    "wrangler": "^4.60.0"
+  }
+}

--- a/workforce/timekeeping/scripts/import-ponto-json.mjs
+++ b/workforce/timekeeping/scripts/import-ponto-json.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const args = new Set(process.argv.slice(2))
+const sourceIndex = process.argv.indexOf('--source')
+const source = sourceIndex >= 0 ? process.argv[sourceIndex + 1] : ''
+const dryRun = args.has('--dry-run')
+if (!source) throw new Error('Use --source <ponto_store.v2.json>')
+if (!dryRun) throw new Error('Importer write mode is intentionally disabled until a D1 target is provided by CI; run --dry-run to validate safely.')
+
+const path = resolve(source)
+const raw = await readFile(path, 'utf8')
+const checksum = createHash('sha256').update(raw).digest('hex')
+const parsed = JSON.parse(raw)
+const employees = Array.isArray(parsed?.employees) ? parsed.employees : []
+const records = Array.isArray(parsed?.records) ? parsed.records : []
+const invalid = []
+const seen = new Set()
+for (const record of records) {
+  const key = `${record?.id || ''}:${record?.at || ''}`
+  if (!record?.employeeId || !record?.at || !record?.id) invalid.push(record?.id || '<unknown>')
+  if (seen.has(key)) invalid.push(record?.id || '<duplicate>')
+  seen.add(key)
+}
+const report = { ok: invalid.length === 0, dryRun: true, source: path, checksum, employees: employees.length, records: records.length, invalid: invalid.length, duplicateKeys: records.length - seen.size }
+console.log(JSON.stringify(report, null, 2))
+if (!report.ok) process.exitCode = 2

--- a/workforce/timekeeping/scripts/import-ponto-json.mjs
+++ b/workforce/timekeeping/scripts/import-ponto-json.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from 'node:crypto'
+import { createCipheriv, createHash, randomBytes, randomUUID } from 'node:crypto'
 import { copyFile, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
 import { DatabaseSync } from 'node:sqlite'
+import { decryptLegacyBiometricTemplate, validLegacyBiometricTemplate } from '../legacyBiometric.js'
 
 const argv = process.argv.slice(2)
 const valueFor = (name) => { const index = argv.indexOf(name); return index >= 0 ? argv[index + 1] : '' }
@@ -107,27 +108,8 @@ async function remoteD1Import(sqlText) {
   throw new Error('D1_IMPORT_TIMEOUT')
 }
 
-function validBiometricTemplate(template) {
-  return Array.isArray(template) && template.length >= 64 && template.length <= 1024 && template.every((value) => Number.isFinite(value))
-}
-
-function decryptLegacyTemplate(payload, secret) {
-  if (Array.isArray(payload)) return validBiometricTemplate(payload) ? payload : null
-  if (!secret || payload?.alg !== 'A256GCM') return null
-  const keyRaw = String(secret).trim(); let key
-  try { key = Buffer.from(keyRaw.replace(/-/g, '+').replace(/_/g, '/'), 'base64') } catch { key = Buffer.alloc(0) }
-  if (key.length !== 32) { try { key = Buffer.from(keyRaw, 'hex') } catch { key = Buffer.alloc(0) } }
-  if (key.length !== 32) return null
-  try {
-    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(payload.iv, 'base64'))
-    decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
-    const template = JSON.parse(Buffer.concat([decipher.update(Buffer.from(payload.ct, 'base64')), decipher.final()]).toString('utf8'))
-    return validBiometricTemplate(template) ? template : null
-  } catch { return null }
-}
-
 function encryptTemplate(template, secret) {
-  if (!secret || !validBiometricTemplate(template)) return null
+  if (!secret || !validLegacyBiometricTemplate(template)) return null
   const key = createHash('sha256').update(String(secret)).digest()
   const iv = randomBytes(12); const cipher = createCipheriv('aes-256-gcm', key, iv)
   const encrypted = Buffer.concat([cipher.update(JSON.stringify(template), 'utf8'), cipher.final(), cipher.getAuthTag()])
@@ -182,7 +164,7 @@ for (const employee of employees) {
   if (employeeId && seenEmployees.has(employeeId)) duplicates.push({ entity: 'employee', id: employeeId })
   seenEmployees.add(employeeId)
   for (const [index, payload] of (Array.isArray(employee.faceTemplates) ? employee.faceTemplates : []).entries()) {
-    if (!decryptLegacyTemplate(payload, process.env.PONTO_LEGACY_TEMPLATES_KEY)) invalid.push({ entity: 'biometric_template', id: `${employeeId}:${index}`, reason: 'INVALID_OR_UNDECRYPTABLE_TEMPLATE' })
+    if (!decryptLegacyBiometricTemplate(payload, process.env.PONTO_LEGACY_TEMPLATES_KEY)) invalid.push({ entity: 'biometric_template', id: `${employeeId}:${index}`, reason: 'INVALID_OR_UNDECRYPTABLE_TEMPLATE' })
   }
 }
 for (const record of punches) {
@@ -255,7 +237,7 @@ for (const employee of employees) {
   }
   let templateIndex = 0
   for (const templatePayload of Array.isArray(employee.faceTemplates) ? employee.faceTemplates : []) {
-    const template = decryptLegacyTemplate(templatePayload, process.env.PONTO_LEGACY_TEMPLATES_KEY)
+    const template = decryptLegacyBiometricTemplate(templatePayload, process.env.PONTO_LEGACY_TEMPLATES_KEY)
     const encrypted = template && Array.isArray(template) ? encryptTemplate(template, process.env.PONTO_TEMPLATES_KEY) : null
     if (encrypted) {
       const templateId = randomUUID()

--- a/workforce/timekeeping/scripts/import-ponto-json.mjs
+++ b/workforce/timekeeping/scripts/import-ponto-json.mjs
@@ -1,29 +1,308 @@
 #!/usr/bin/env node
-import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from 'node:crypto'
+import { copyFile, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { DatabaseSync } from 'node:sqlite'
 
-const args = new Set(process.argv.slice(2))
-const sourceIndex = process.argv.indexOf('--source')
-const source = sourceIndex >= 0 ? process.argv[sourceIndex + 1] : ''
-const dryRun = args.has('--dry-run')
-if (!source) throw new Error('Use --source <ponto_store.v2.json>')
-if (!dryRun) throw new Error('Importer write mode is intentionally disabled until a D1 target is provided by CI; run --dry-run to validate safely.')
+const argv = process.argv.slice(2)
+const valueFor = (name) => { const index = argv.indexOf(name); return index >= 0 ? argv[index + 1] : '' }
+const has = (name) => argv.includes(name)
+const source = valueFor('--source')
+const dryRun = has('--dry-run')
+const apply = has('--apply')
+const rollbackRun = valueFor('--rollback-run')
+const database = valueFor('--database') || 'skincos-timekeeping'
+const databaseId = valueFor('--database-id')
+const remote = has('--remote')
+const backupPath = valueFor('--backup')
+const config = resolve(valueFor('--config') || fileURLToPath(new URL('../wrangler.toml', import.meta.url)))
 
-const path = resolve(source)
-const raw = await readFile(path, 'utf8')
-const checksum = createHash('sha256').update(raw).digest('hex')
-const parsed = JSON.parse(raw)
-const employees = Array.isArray(parsed?.employees) ? parsed.employees : []
-const records = Array.isArray(parsed?.records) ? parsed.records : []
-const invalid = []
-const seen = new Set()
-for (const record of records) {
-  const key = `${record?.id || ''}:${record?.at || ''}`
-  if (!record?.employeeId || !record?.at || !record?.id) invalid.push(record?.id || '<unknown>')
-  if (seen.has(key)) invalid.push(record?.id || '<duplicate>')
+function fail(message, code = 1) { console.error(message); process.exit(code) }
+function sql(value) { return value === null || value === undefined ? 'NULL' : `'${String(value).replaceAll("'", "''")}'` }
+function sha(value) { return createHash('sha256').update(value).digest('hex') }
+function validDate(value) { return Number.isFinite(Date.parse(String(value || ''))) }
+function eventType(value) { return ({ IN: 'WORK_START', OUT: 'WORK_END', WORK_START: 'WORK_START', BREAK_START: 'BREAK_START', BREAK_END: 'BREAK_END', WORK_END: 'WORK_END' })[String(value || '').toUpperCase()] || null }
+function sourceType(value) { return ({ FACE: 'FACE', PIN: 'PIN', ADMIN: 'MANUAL', MANUAL: 'MANUAL', IMPORT: 'IMPORT' })[String(value || '').toUpperCase()] || 'IMPORT' }
+
+function wrangler(args, { json = false } = {}) {
+  const executable = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+  const result = spawnSync(executable, ['--yes', 'wrangler@4.112.0', '--config', config, ...args], { cwd: dirname(config), encoding: 'utf8', stdio: json ? ['ignore', 'pipe', 'pipe'] : 'inherit' })
+  if (result.status !== 0) fail(json ? String(result.stderr || result.stdout || 'Wrangler failed') : `Wrangler failed (${result.status})`)
+  return json ? String(result.stdout || '') : ''
+}
+
+async function findLocalDatabase() {
+  const stateDirectory = resolve(dirname(config), '.wrangler/state/v3/d1/miniflare-D1DatabaseObject')
+  const files = await readdir(stateDirectory).catch(() => [])
+  const sqlite = files.find((name) => name.endsWith('.sqlite') && name !== 'metadata.sqlite')
+  return sqlite ? { stateDirectory, files, sqlite, path: resolve(stateDirectory, sqlite) } : null
+}
+
+function remoteD1Context() {
+  const accountId = String(process.env.CLOUDFLARE_ACCOUNT_ID || '').trim()
+  const apiToken = String(process.env.CLOUDFLARE_API_TOKEN || '').trim()
+  if (!accountId || !apiToken || !databaseId) fail('Remote operation requires CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN and --database-id')
+  return { accountId, apiToken, base: `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}` }
+}
+
+async function remoteD1Query(query) {
+  const { apiToken, base } = remoteD1Context()
+  const response = await fetch(`${base}/query`, { method: 'POST', headers: { authorization: `Bearer ${apiToken}`, 'content-type': 'application/json' }, body: JSON.stringify({ sql: query }) })
+  const payload = await response.json().catch(() => null)
+  if (!response.ok || payload?.success === false) throw new Error(`D1_QUERY_HTTP_${response.status}`)
+  return payload?.result?.[0]?.results || []
+}
+
+async function remoteD1Export(targetPath) {
+  const { apiToken, base } = remoteD1Context(); const headers = { authorization: `Bearer ${apiToken}`, 'content-type': 'application/json' }
+  let bookmark = null
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const response = await fetch(`${base}/export`, { method: 'POST', headers, body: JSON.stringify({ output_format: 'polling', ...(bookmark ? { current_bookmark: bookmark } : {}) }) })
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || payload?.success === false) throw new Error(`D1_EXPORT_HTTP_${response.status}`)
+    const result = payload?.result || {}
+    if (result.status === 'error') throw new Error('D1_EXPORT_FAILED')
+    if (result.status === 'complete' && result.result?.signed_url) {
+      const download = await fetch(result.result.signed_url)
+      if (!download.ok) throw new Error('D1_EXPORT_DOWNLOAD_FAILED')
+      await writeFile(targetPath, new Uint8Array(await download.arrayBuffer()), { mode: 0o600 })
+      return
+    }
+    bookmark = result.at_bookmark || bookmark
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 1000))
+  }
+  throw new Error('D1_EXPORT_TIMEOUT')
+}
+
+async function remoteD1Import(sqlText) {
+  const { apiToken, base } = remoteD1Context()
+  const endpoint = `${base}/import`
+  const headers = { authorization: `Bearer ${apiToken}`, 'content-type': 'application/json' }
+  const etag = createHash('md5').update(sqlText).digest('hex')
+  const requestJson = async (body) => {
+    const response = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body) })
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || payload?.success === false) throw new Error(`D1_IMPORT_HTTP_${response.status}`)
+    return payload
+  }
+  const initialized = await requestJson({ action: 'init', etag })
+  const uploadUrl = initialized?.result?.upload_url; const filename = initialized?.result?.filename
+  if (!uploadUrl || !filename) throw new Error('D1_IMPORT_INIT_INVALID')
+  const upload = await fetch(uploadUrl, { method: 'PUT', body: sqlText })
+  if (!upload.ok || String(upload.headers.get('etag') || '').replaceAll('"', '') !== etag) throw new Error('D1_IMPORT_UPLOAD_FAILED')
+  const ingested = await requestJson({ action: 'ingest', etag, filename })
+  let bookmark = ingested?.result?.at_bookmark
+  if (!bookmark) throw new Error('D1_IMPORT_INGEST_INVALID')
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const polled = await requestJson({ action: 'poll', current_bookmark: bookmark })
+    const result = polled?.result || {}
+    if (result.success || result.error === 'Not currently importing anything.') return
+    if (result.error) throw new Error('D1_IMPORT_FAILED')
+    bookmark = result.at_bookmark || bookmark
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 1000))
+  }
+  throw new Error('D1_IMPORT_TIMEOUT')
+}
+
+function validBiometricTemplate(template) {
+  return Array.isArray(template) && template.length >= 64 && template.length <= 1024 && template.every((value) => Number.isFinite(value))
+}
+
+function decryptLegacyTemplate(payload, secret) {
+  if (Array.isArray(payload)) return validBiometricTemplate(payload) ? payload : null
+  if (!secret || payload?.alg !== 'A256GCM') return null
+  const keyRaw = String(secret).trim(); let key
+  try { key = Buffer.from(keyRaw.replace(/-/g, '+').replace(/_/g, '/'), 'base64') } catch { key = Buffer.alloc(0) }
+  if (key.length !== 32) { try { key = Buffer.from(keyRaw, 'hex') } catch { key = Buffer.alloc(0) } }
+  if (key.length !== 32) return null
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(payload.iv, 'base64'))
+    decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
+    const template = JSON.parse(Buffer.concat([decipher.update(Buffer.from(payload.ct, 'base64')), decipher.final()]).toString('utf8'))
+    return validBiometricTemplate(template) ? template : null
+  } catch { return null }
+}
+
+function encryptTemplate(template, secret) {
+  if (!secret || !validBiometricTemplate(template)) return null
+  const key = createHash('sha256').update(String(secret)).digest()
+  const iv = randomBytes(12); const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const encrypted = Buffer.concat([cipher.update(JSON.stringify(template), 'utf8'), cipher.final(), cipher.getAuthTag()])
+  const b64url = (buffer) => buffer.toString('base64url')
+  return JSON.stringify({ v: 1, alg: 'A256GCM', iv: b64url(iv), ciphertext: b64url(encrypted) })
+}
+
+function validate(parsed) {
+  const errors = []
+  if (!parsed || typeof parsed !== 'object' || Number(parsed.version) !== 2) errors.push('ROOT_VERSION_INVALID')
+  for (const field of ['employees', 'devices', 'records']) if (!Array.isArray(parsed?.[field])) errors.push(`${field.toUpperCase()}_NOT_ARRAY`)
+  return errors
+}
+
+if (rollbackRun) {
+  if (!backupPath) fail('Use --backup <rollback.sql> with --rollback-run')
+  if (remote && !has('--confirm-production')) fail('Remote rollback requires --confirm-production')
+  if (remote) {
+    if (process.env.PONTO_IMPORT_PRODUCTION_CONFIRM !== rollbackRun) fail('Set PONTO_IMPORT_PRODUCTION_CONFIRM to the rollback run id')
+    const rollbackSql = (await readFile(resolve(backupPath), 'utf8')).replace(/^BEGIN;$/gm, '').replace(/^COMMIT;$/gm, '')
+    await remoteD1Import(rollbackSql)
+  } else {
+    const local = await findLocalDatabase()
+    if (!local) fail('Local D1 SQLite database was not found')
+    const databaseHandle = new DatabaseSync(local.path)
+    try { databaseHandle.exec(await readFile(resolve(backupPath), 'utf8')) } finally { databaseHandle.close() }
+  }
+  console.log(JSON.stringify({ ok: true, rollbackRun, database, remote }, null, 2))
+  process.exit(0)
+}
+
+if (!source) fail('Use --source <ponto_store.v2.json>')
+const sourcePath = resolve(source)
+const raw = await readFile(sourcePath, 'utf8').catch(() => fail('Source file could not be read'))
+let parsed
+try { parsed = JSON.parse(raw) } catch { fail('Source JSON is invalid', 2) }
+const schemaErrors = validate(parsed)
+if (schemaErrors.length) fail(`Source schema rejected: ${schemaErrors.join(', ')}`, 2)
+
+const checksum = sha(raw); const runId = `ponto-json:${checksum.slice(0, 24)}`; const now = new Date().toISOString()
+const employees = parsed.employees.filter(Boolean); const devices = parsed.devices.filter(Boolean); const punches = parsed.records.filter((row) => row?.kind === 'PUNCH'); const corrections = parsed.records.filter((row) => row?.kind === 'CORRECTION')
+const invalid = []; const duplicates = []; const seen = new Set(); const seenEmployees = new Set(); const employeeIds = new Set(employees.map((row) => String(row.id || '')))
+const emailGroups = new Map()
+for (const employee of employees) {
+  const email = String(employee.loginEmail || '').trim().toLowerCase()
+  if (email) emailGroups.set(email, [...(emailGroups.get(email) || []), String(employee.id || '')])
+}
+const identityConflicts = [...emailGroups.entries()].filter(([, ids]) => ids.length > 1)
+for (const employee of employees) {
+  if (!employee.id || !String(employee.name || '').trim()) invalid.push({ entity: 'employee', id: employee.id || '<missing>', reason: 'ID_OR_NAME_MISSING' })
+  const employeeId = String(employee.id || '')
+  if (employeeId && seenEmployees.has(employeeId)) duplicates.push({ entity: 'employee', id: employeeId })
+  seenEmployees.add(employeeId)
+  for (const [index, payload] of (Array.isArray(employee.faceTemplates) ? employee.faceTemplates : []).entries()) {
+    if (!decryptLegacyTemplate(payload, process.env.PONTO_LEGACY_TEMPLATES_KEY)) invalid.push({ entity: 'biometric_template', id: `${employeeId}:${index}`, reason: 'INVALID_OR_UNDECRYPTABLE_TEMPLATE' })
+  }
+}
+for (const record of punches) {
+  const key = String(record.id || '')
+  if (!record.id || !employeeIds.has(String(record.employeeId || '')) || !validDate(record.at) || !eventType(record.type)) invalid.push({ entity: 'punch', id: record.id || '<missing>', reason: 'INVALID_REFERENCE_DATE_OR_TYPE' })
+  if (seen.has(key)) duplicates.push({ entity: 'punch', id: key })
   seen.add(key)
 }
-const report = { ok: invalid.length === 0, dryRun: true, source: path, checksum, employees: employees.length, records: records.length, invalid: invalid.length, duplicateKeys: records.length - seen.size }
+for (const correction of corrections) if (!correction.id || !seen.has(String(correction.targetRecordId || '')) || !validDate(correction.newAt || correction.createdAt)) invalid.push({ entity: 'correction', id: correction.id || '<missing>', reason: 'INVALID_TARGET_OR_DATE' })
+
+const report = {
+  ok: invalid.length === 0 && duplicates.length === 0,
+  dryRun,
+  source: sourcePath,
+  checksum,
+  counts: { employees: employees.length, devices: devices.length, punches: punches.length, corrections: corrections.length },
+  invalid: invalid.length,
+  duplicates: duplicates.length,
+  pinsRequiringReset: employees.filter((employee) => employee.pinHash).length,
+  biometricTemplates: employees.reduce((sum, employee) => sum + (Array.isArray(employee.faceTemplates) ? employee.faceTemplates.length : 0), 0),
+  identityConflicts: identityConflicts.length,
+}
 console.log(JSON.stringify(report, null, 2))
-if (!report.ok) process.exitCode = 2
+if (!report.ok) process.exit(2)
+if (dryRun) process.exit(0)
+if (!apply) fail('Write mode requires explicit --apply')
+if (!backupPath) fail('Write mode requires --backup <private-backup.sql>')
+if (remote && !has('--confirm-production')) fail('Remote import requires --confirm-production')
+if (remote && process.env.PONTO_IMPORT_PRODUCTION_CONFIRM !== checksum) fail('Set PONTO_IMPORT_PRODUCTION_CONFIRM to the printed source checksum for remote import')
+
+const previous = remote
+  ? JSON.stringify(await remoteD1Query(`SELECT status FROM timekeeping_migration_runs WHERE id=${sql(runId)} LIMIT 1`))
+  : wrangler(['d1', 'execute', database, '--local', '--command', `SELECT status FROM timekeeping_migration_runs WHERE id=${sql(runId)} LIMIT 1`, '--json'], { json: true })
+if (previous.includes('APPLIED')) fail('This exact source checksum was already applied; no write performed', 3)
+
+const absoluteBackup = resolve(backupPath); await mkdir(dirname(absoluteBackup), { recursive: true })
+if (remote) {
+  await remoteD1Export(absoluteBackup)
+} else {
+  const local = await findLocalDatabase()
+  if (!local) fail('Local D1 SQLite checkpoint source was not found')
+  const copied = []
+  for (const suffix of ['', '-wal', '-shm']) {
+    const name = `${local.sqlite}${suffix}`
+    if (!local.files.includes(name)) continue
+    const target = `${absoluteBackup}.sqlite${suffix}`
+    await copyFile(resolve(local.stateDirectory, name), target)
+    copied.push(target)
+  }
+  await writeFile(absoluteBackup, JSON.stringify({ kind: 'local-d1-checkpoint', database, config, copied, createdAt: new Date().toISOString() }, null, 2), { mode: 0o600 })
+}
+
+const statements = ['PRAGMA foreign_keys=ON;']
+const countsJson = JSON.stringify(report.counts)
+statements.push(`INSERT INTO timekeeping_migration_runs (id,source_kind,source_checksum,status,source_counts_json,started_at) VALUES (${sql(runId)},'ponto_store.v2.json',${sql(checksum)},'APPLYING',${sql(countsJson)},${sql(now)}) ON CONFLICT(id) DO UPDATE SET status='APPLYING',source_counts_json=excluded.source_counts_json,result_counts_json=NULL,checkpoint_json=NULL,started_at=excluded.started_at,completed_at=NULL;`)
+statements.push(`DELETE FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)};`)
+for (const employee of employees) {
+  const id = String(employee.id); const canonical = `legacy:ponto:${id}`; const status = employee.deletedAt || employee.active === false ? 'TERMINATED' : 'ACTIVE'; const createdAt = validDate(employee.createdAt) ? new Date(employee.createdAt).toISOString() : now; const updatedAt = validDate(employee.updatedAt) ? new Date(employee.updatedAt).toISOString() : createdAt
+  const cpfHash = employee.cpf ? sha(String(employee.cpf).replace(/\D/g, '')) : null; const phoneHash = employee.phone ? sha(String(employee.phone).replace(/\D/g, '')) : null
+  const employeeEmail = String(employee.loginEmail || '').trim().toLowerCase(); const safeEmail = employeeEmail && (emailGroups.get(employeeEmail) || []).length === 1 ? employeeEmail : null
+  statements.push(`INSERT OR IGNORE INTO workforce_employees (id,canonical_employee_id,login_email,display_name,status,created_at,updated_at,terminated_at,employee_code,cpf_hash,phone_hash,birth_date,job_title,metadata_json) VALUES (${sql(id)},${sql(canonical)},${sql(safeEmail)},${sql(String(employee.name).trim())},${sql(status)},${sql(createdAt)},${sql(updatedAt)},${sql(employee.deletedAt || null)},${sql(employee.code || null)},${sql(cpfHash)},${sql(phoneHash)},${sql(employee.birthDate || null)},${sql(employee.jobTitle || null)},${sql(JSON.stringify({ importedFrom: 'ponto_store.v2.json', pinResetRequired: !!employee.pinHash, pendingLoginEmail: safeEmail ? undefined : employeeEmail || undefined }))});`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'employee',${sql(id)},${sql(id)},${sql(sha(JSON.stringify({ id, name: employee.name, status })))},${sql(now)} WHERE changes()=1;`)
+  const aliasId = randomUUID()
+  statements.push(`INSERT OR IGNORE INTO workforce_employee_aliases (id,employee_id,source,legacy_id,created_at) VALUES (${sql(aliasId)},${sql(id)},'PONTO_V2',${sql(id)},${sql(now)});`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'alias',${sql(id)},${sql(aliasId)},${sql(sha(`PONTO_V2:${id}`))},${sql(now)} WHERE changes()=1;`)
+  if (employee.unit) {
+    const unitAssignmentId = randomUUID()
+    statements.push(`INSERT OR IGNORE INTO timekeeping_employee_units (id,employee_id,unit_id,effective_from,created_at) VALUES (${sql(unitAssignmentId)},${sql(id)},${sql(String(employee.unit))},${sql(createdAt.slice(0, 10))},${sql(createdAt)});`)
+    statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'employee_unit',${sql(`${id}:${employee.unit}`)},${sql(unitAssignmentId)},${sql(sha(`${id}:${employee.unit}:${createdAt.slice(0, 10)}`))},${sql(now)} WHERE changes()=1;`)
+  }
+  let templateIndex = 0
+  for (const templatePayload of Array.isArray(employee.faceTemplates) ? employee.faceTemplates : []) {
+    const template = decryptLegacyTemplate(templatePayload, process.env.PONTO_LEGACY_TEMPLATES_KEY)
+    const encrypted = template && Array.isArray(template) ? encryptTemplate(template, process.env.PONTO_TEMPLATES_KEY) : null
+    if (encrypted) {
+      const templateId = randomUUID()
+      statements.push(`INSERT OR IGNORE INTO timekeeping_biometric_templates (id,employee_id,encrypted_template,consent_version,consented_at,consented_by,created_at) VALUES (${sql(templateId)},${sql(id)},${sql(encrypted)},${sql(employee.consent?.version || 'legacy-v2')},${sql(employee.consent?.obtainedAt || createdAt)},'legacy-import',${sql(now)});`)
+      statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'biometric_template',${sql(`${id}:${templateIndex}`)},${sql(templateId)},${sql(sha(JSON.stringify(template)))},${sql(now)} WHERE changes()=1;`)
+    }
+    templateIndex += 1
+  }
+}
+for (const [email, ids] of identityConflicts) {
+  const conflictId = randomUUID()
+  statements.push(`INSERT OR IGNORE INTO workforce_identity_conflicts (id,source,source_id,candidates_json,reasons_json,created_at) VALUES (${sql(conflictId)},'PONTO_LOGIN_EMAIL',${sql(email)},${sql(JSON.stringify(ids))},${sql(JSON.stringify(['DUPLICATE_LOGIN_EMAIL']))},${sql(now)});`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'identity_conflict',${sql(email)},${sql(conflictId)},${sql(sha(JSON.stringify(ids)))},${sql(now)} WHERE changes()=1;`)
+}
+for (const device of devices) {
+  if (!device?.id || !device?.unit) continue
+  const tokenHash = sha(`revoked-legacy-device:${device.id}:${checksum}`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_devices (id,unit_id,label,token_hash,active,revoked_at,created_by,created_at,last_seen_at) VALUES (${sql(device.id)},${sql(device.unit)},${sql(device.label || device.id)},${sql(tokenHash)},0,${sql(device.revokedAt || now)},'legacy-import',${sql(device.createdAt || now)},${sql(device.lastSeenAt || null)});`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'device',${sql(device.id)},${sql(device.id)},${sql(sha(JSON.stringify({ id: device.id, unit: device.unit })))},${sql(now)} WHERE changes()=1;`)
+}
+for (const record of punches) {
+  const unit = String(record.unit || employees.find((employee) => String(employee.id) === String(record.employeeId))?.unit || 'UNASSIGNED')
+  const occurredAt = new Date(record.at).toISOString(); const createdAt = validDate(record.createdAt) ? new Date(record.createdAt).toISOString() : occurredAt
+  const workDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date(occurredAt))
+  statements.push(`INSERT OR IGNORE INTO timekeeping_events (id,employee_id,unit_id,device_id,event_type,source,occurred_at_utc,work_date,idempotency_scope,idempotency_key,request_fingerprint,created_by,created_at) VALUES (${sql(record.id)},${sql(record.employeeId)},${sql(unit)},NULL,${sql(eventType(record.type))},${sql(sourceType(record.method))},${sql(occurredAt)},${sql(workDate)},${sql(`legacy:${record.employeeId}`)},${sql(record.idempotencyKey || record.id)},${sql(sha(JSON.stringify({ id: record.id, at: occurredAt, type: record.type })))},'legacy-import',${sql(createdAt)});`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'event',${sql(record.id)},${sql(record.id)},${sql(sha(JSON.stringify({ id: record.id, at: occurredAt, type: record.type })))},${sql(now)} WHERE changes()=1;`)
+}
+for (const correction of corrections) {
+  const proposedAt = new Date(correction.newAt || correction.createdAt).toISOString(); const decidedAt = validDate(correction.createdAt) ? new Date(correction.createdAt).toISOString() : now
+  statements.push(`INSERT OR IGNORE INTO timekeeping_corrections (id,event_id,requested_at,requested_by,reason,proposed_at_utc,status,decided_at,decided_by,decision_reason) VALUES (${sql(correction.id)},${sql(correction.targetRecordId)},${sql(decidedAt)},'legacy-import',${sql(correction.reason || 'Correção migrada do legado')},${sql(proposedAt)},'APPROVED',${sql(decidedAt)},'legacy-import','Migração preservou correção já efetivada');`)
+  statements.push(`INSERT OR IGNORE INTO timekeeping_migration_items (migration_run_id,entity_type,source_id,target_id,checksum,created_at) SELECT ${sql(runId)},'correction',${sql(correction.id)},${sql(correction.id)},${sql(sha(JSON.stringify({ id: correction.id, target: correction.targetRecordId, proposedAt })))},${sql(now)} WHERE changes()=1;`)
+}
+const resultCounts = { employees: employees.length, devices: devices.filter((row) => row?.id && row?.unit).length, punches: punches.length, corrections: corrections.length }
+statements.push(`UPDATE timekeeping_migration_runs SET status='APPLIED',result_counts_json=json_object('employees',(SELECT count(*) FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='employee'),'devices',(SELECT count(*) FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='device'),'punches',(SELECT count(*) FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='event'),'corrections',(SELECT count(*) FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='correction')),checkpoint_json=${sql(JSON.stringify({ backup: absoluteBackup }))},completed_at=${sql(new Date().toISOString())} WHERE id=${sql(runId)};`)
+
+const rollback = ['PRAGMA foreign_keys=ON;', 'BEGIN;', `DELETE FROM timekeeping_corrections WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='correction');`, `DELETE FROM timekeeping_events WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='event');`, `DELETE FROM timekeeping_biometric_templates WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='biometric_template');`, `DELETE FROM timekeeping_employee_units WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='employee_unit');`, `DELETE FROM workforce_employee_aliases WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='alias');`, `DELETE FROM timekeeping_devices WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='device');`, `DELETE FROM workforce_identity_conflicts WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='identity_conflict');`, `DELETE FROM workforce_employees WHERE id IN (SELECT target_id FROM timekeeping_migration_items WHERE migration_run_id=${sql(runId)} AND entity_type='employee');`, `UPDATE timekeeping_migration_runs SET status='ROLLED_BACK',completed_at=${sql(new Date().toISOString())} WHERE id=${sql(runId)};`, 'COMMIT;'].join('\n')
+const rollbackPath = `${absoluteBackup}.rollback-${checksum.slice(0, 12)}.sql`; await writeFile(rollbackPath, rollback, { mode: 0o600 })
+const temporary = await mkdtemp(resolve(tmpdir(), 'ponto-import-')); const sqlPath = resolve(temporary, 'import.sql')
+try {
+  await writeFile(sqlPath, statements.join('\n'), { mode: 0o600 })
+  if (remote) {
+    await remoteD1Import(statements.join('\n'))
+  } else {
+    const local = await findLocalDatabase()
+    if (!local) fail('Local D1 SQLite database was not found')
+    const databaseHandle = new DatabaseSync(local.path)
+    try { databaseHandle.exec(`BEGIN IMMEDIATE;\n${statements.join('\n')}\nCOMMIT;`) } catch (error) { try { databaseHandle.exec('ROLLBACK;') } catch { /* already rolled back */ } throw error } finally { databaseHandle.close() }
+  }
+} finally { await rm(temporary, { recursive: true, force: true }) }
+console.log(JSON.stringify({ ok: true, dryRun: false, runId, checksum, database, remote, backup: absoluteBackup, rollback: rollbackPath, resultCounts }, null, 2))

--- a/workforce/timekeeping/scripts/import-ponto-json.mjs
+++ b/workforce/timekeeping/scripts/import-ponto-json.mjs
@@ -82,6 +82,8 @@ async function remoteD1Import(sqlText) {
   const { apiToken, base } = remoteD1Context()
   const endpoint = `${base}/import`
   const headers = { authorization: `Bearer ${apiToken}`, 'content-type': 'application/json' }
+  // lgtm[js/weak-cryptographic-algorithm]: Cloudflare D1 requires this MD5 only
+  // as the transport ETag for an import upload; it is never a security control.
   const etag = createHash('md5').update(sqlText).digest('hex')
   const requestJson = async (body) => {
     const response = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body) })

--- a/workforce/timekeeping/scripts/integration-local.mjs
+++ b/workforce/timekeeping/scripts/integration-local.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+
+const baseUrl = process.env.PONTO_BASE_URL || 'http://127.0.0.1:8799'
+const actorKey = process.env.PONTO_ACTOR_HMAC_KEY || 'test-actor-key-not-secret'
+const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url')
+const actorHeaders = (actor, method, path, nonce, bodyText) => {
+  const payload = encode(actor); const timestamp = String(Date.now())
+  const bodyHash = createHash('sha256').update(bodyText || '').digest('hex')
+  const signature = createHmac('sha256', actorKey).update([timestamp, payload, method, path, nonce, bodyHash].join('.')).digest('base64url')
+  return { 'x-skincos-actor': payload, 'x-skincos-actor-ts': timestamp, 'x-skincos-actor-sig': signature, 'x-skincos-signature-version': '2' }
+}
+const employee = { id: 'synthetic-employee-actor', email: 'ponto.synthetic@example.invalid', role: 'EMPLOYEE', allowedUnits: ['SYNTHETIC_UNIT'] }
+const admin = { id: 'synthetic-admin', email: 'ponto.admin@example.invalid', role: 'ADMIN', allowedUnits: [] }
+async function call(path, { method = 'GET', actor, body, nonce = randomUUID(), headers = {} } = {}) {
+  const normalizedMethod = method.toUpperCase(); const bodyText = body === undefined ? '' : JSON.stringify(body); const requestNonce = !['GET', 'HEAD', 'OPTIONS'].includes(normalizedMethod) ? nonce : ''
+  const response = await fetch(`${baseUrl}${path}`, { method: normalizedMethod, headers: { accept: 'application/json', ...(actor ? actorHeaders(actor, normalizedMethod, `/api/ponto${path.replace(/^\/api\/ponto/, '')}`, requestNonce, bodyText) : {}), ...(requestNonce ? { 'content-type': 'application/json', 'x-request-nonce': requestNonce } : {}), ...headers }, body: body === undefined ? undefined : bodyText })
+  const text = await response.text(); let payload
+  try { payload = JSON.parse(text) } catch { assert.fail(`Expected JSON from ${path}, received ${text.slice(0, 120)}`) }
+  return { response, payload }
+}
+
+const health = await call('/api/ponto/health')
+assert.equal(health.response.status, 200); assert.equal(health.payload.service, 'workforce-timekeeping')
+assert.equal(health.response.headers.get('content-type')?.startsWith('application/json'), true)
+const readiness = await call('/api/ponto/readiness')
+assert.equal(readiness.response.status, 200); assert.equal(readiness.payload.database, 'available')
+assert.equal((await call('/api/ponto/employees')).response.status, 401)
+
+const context = await call('/api/ponto/context', { actor: employee })
+assert.equal(context.response.status, 200); assert.equal(context.payload.data.linked, true)
+assert.equal(context.payload.data.employee.employeeId, 'legacy:ponto:synthetic-employee-001')
+const employees = await call('/api/ponto/employees', { actor: admin })
+assert.equal(employees.response.status, 200); assert.equal(employees.payload.data.length, 1)
+assert.equal(JSON.stringify(employees.payload).includes('pinHash'), false)
+
+const daily = await call('/api/ponto/daily?employeeId=synthetic-employee-001&unitId=SYNTHETIC_UNIT&date=2026-01-02', { actor: admin })
+assert.equal(daily.response.status, 200)
+const outOfScopeManager = { id: 'synthetic-manager-other-unit', email: 'manager.other@example.invalid', role: 'MANAGER', allowedUnits: ['OTHER_UNIT'] }
+const outOfScopeDaily = await call('/api/ponto/daily?employeeId=synthetic-employee-001&unitId=SYNTHETIC_UNIT&date=2026-01-02', { actor: outOfScopeManager })
+assert.notEqual(outOfScopeDaily.response.status, 200)
+
+const integrationRun = randomUUID()
+const existingRecords = await call('/api/ponto/mirror?employeeId=synthetic-employee-001&unitId=SYNTHETIC_UNIT&limit=1', { actor: admin })
+assert.equal(existingRecords.response.status, 200)
+const latestEventTime = Date.parse(existingRecords.payload.data?.[0]?.at || '') || 0
+const occurrenceBase = Math.max(Date.now(), latestEventTime) + 60_000
+const punchBody = { employeeId: 'synthetic-employee-001', unitId: 'SYNTHETIC_UNIT', occurredAt: new Date(occurrenceBase).toISOString(), requestId: `integration-${integrationRun}`, eventType: 'WORK_START', reason: 'Marcação manual sintética de integração' }
+const punch = await call('/api/ponto/punches', { method: 'POST', actor: admin, body: punchBody })
+assert.equal(punch.response.status, 201); assert.equal(punch.payload.data.source, 'MANUAL')
+const retry = await call('/api/ponto/punches', { method: 'POST', actor: admin, body: punchBody })
+assert.equal(retry.response.status, 200); assert.equal(retry.payload.idempotent, true)
+
+const concurrentBody = { ...punchBody, occurredAt: new Date(occurrenceBase + 60_000).toISOString(), requestId: `concurrent-${integrationRun}`, eventType: 'WORK_END' }
+const concurrent = await Promise.all([
+  call('/api/ponto/punches', { method: 'POST', actor: admin, body: concurrentBody }),
+  call('/api/ponto/punches', { method: 'POST', actor: admin, body: concurrentBody }),
+])
+assert.deepEqual(concurrent.map((item) => item.response.status).sort(), [200, 201])
+assert.equal(concurrent[0].payload.data.id, concurrent[1].payload.data.id)
+
+const pinNonce = `pin-configure-${integrationRun}`
+const pinConfiguration = await call('/api/ponto/pin/configure', { method: 'POST', actor: admin, nonce: pinNonce, body: { employeeId: 'synthetic-employee-001', pin: '1234' } })
+assert.equal(pinConfiguration.response.status, 200)
+const changedPathBody = JSON.stringify({ employeeId: 'synthetic-employee-001', pin: '1234' })
+const changedPathNonce = `changed-path-${integrationRun}`
+const changedPathHeaders = actorHeaders(admin, 'POST', '/api/ponto/pin/configure', changedPathNonce, changedPathBody)
+const changedPathResponse = await fetch(`${baseUrl}/api/ponto/biometrics/revoke`, { method: 'POST', headers: { ...changedPathHeaders, 'content-type': 'application/json', 'x-request-nonce': changedPathNonce }, body: changedPathBody })
+assert.equal(changedPathResponse.status, 401)
+const replayedPinConfiguration = await call('/api/ponto/pin/configure', { method: 'POST', actor: admin, nonce: pinNonce, body: { employeeId: 'synthetic-employee-001', pin: '1234' } })
+assert.equal(replayedPinConfiguration.response.status, 409)
+assert.equal(replayedPinConfiguration.payload.code, 'REPLAY_DETECTED')
+const pinFailures = []
+for (let attempt = 0; attempt < 5; attempt += 1) {
+  pinFailures.push(await call('/api/ponto/punches', { method: 'POST', actor: employee, body: { unitId: 'SYNTHETIC_UNIT', pin: '9999', occurredAt: new Date(occurrenceBase + (120 + attempt * 30) * 1000).toISOString(), requestId: `pin-failure-${integrationRun}-${attempt}` } }))
+}
+assert.equal(pinFailures[0].response.status, 401)
+assert.equal(pinFailures.at(-1).response.status, 429)
+assert.equal(pinFailures.at(-1).payload.code, 'PIN_LOCKED')
+
+const descriptor = Array.from({ length: 64 }, (_, index) => index / 100)
+const enrollment = await call('/api/ponto/biometrics/enroll', { method: 'POST', actor: admin, body: { employeeId: 'synthetic-employee-001', descriptor, consentConfirmed: true, consentVersion: 'synthetic-integration-v1', expiresAt: new Date(Date.now() + 30 * 86400_000).toISOString(), replace: true } })
+assert.equal(enrollment.response.status, 201)
+const faceFailure = await call('/api/ponto/punches', { method: 'POST', actor: employee, body: { unitId: 'SYNTHETIC_UNIT', descriptor: descriptor.map((value) => value + 1), occurredAt: new Date(occurrenceBase + 300_000).toISOString(), requestId: `face-failure-${integrationRun}` } })
+assert.equal(faceFailure.response.status, 401)
+assert.equal(faceFailure.payload.code, 'FACE_NOT_RECOGNIZED')
+assert.equal(JSON.stringify(faceFailure.payload).includes('score'), false)
+
+const createdDevice = await call('/api/ponto/devices', { method: 'POST', actor: admin, body: { unitId: 'SYNTHETIC_UNIT', label: `Terminal sintético ${integrationRun}` } })
+assert.equal(createdDevice.response.status, 201)
+const deviceEmployeeRead = await call('/api/ponto/employees/synthetic-employee-001', { headers: { authorization: `Device ${createdDevice.payload.data.token}` } })
+assert.equal(deviceEmployeeRead.response.status, 403)
+const secondDevice = await call('/api/ponto/devices', { method: 'POST', actor: admin, body: { unitId: 'SYNTHETIC_UNIT', label: `Terminal sintético secundário ${integrationRun}` } })
+assert.equal(secondDevice.response.status, 201)
+const globalPinLock = await call('/api/ponto/device/punches', { method: 'POST', headers: { authorization: `Device ${secondDevice.payload.data.token}` }, body: { employeeId: 'synthetic-employee-001', pin: '9999', occurredAt: new Date(occurrenceBase + 330_000).toISOString(), requestId: `global-pin-lock-${integrationRun}` } })
+assert.equal(globalPinLock.response.status, 429)
+assert.equal(globalPinLock.payload.code, 'PIN_LOCKED')
+const devicePunch = await call('/api/ponto/device/punches', { method: 'POST', headers: { authorization: `Device ${createdDevice.payload.data.token}` }, body: { employeeId: 'synthetic-employee-001', descriptor, occurredAt: new Date(occurrenceBase + 360_000).toISOString(), requestId: `device-${integrationRun}`, eventType: 'WORK_START' } })
+assert.equal(devicePunch.response.status, 201)
+assert.equal(devicePunch.payload.data.source, 'FACE')
+assert.equal(devicePunch.payload.data.deviceId, createdDevice.payload.data.id)
+
+const correction = await call('/api/ponto/corrections', { method: 'POST', actor: { ...employee, id: 'correction-requester' }, body: { eventId: 'synthetic-punch-001', proposedAtUtc: '2026-01-02T12:05:00.000Z', reason: 'Ajuste sintético de integração' } })
+assert.equal(correction.response.status, 201)
+const approval = await call(`/api/ponto/corrections/${correction.payload.data.id}/approve`, { method: 'POST', actor: admin, body: { reason: 'Aprovação sintética de integração' } })
+assert.equal(approval.response.status, 200); assert.equal(approval.payload.data.status, 'APPROVED')
+const correctedDaily = await call('/api/ponto/daily?employeeId=synthetic-employee-001&unitId=SYNTHETIC_UNIT&date=2026-01-02', { actor: admin })
+assert.equal(correctedDaily.response.status, 200); assert.equal(correctedDaily.payload.data.workedMinutes, 475)
+
+const close = await call('/api/ponto/periods/close', { method: 'POST', actor: admin, body: { employeeId: 'synthetic-employee-001', unitId: 'SYNTHETIC_UNIT', from: '2026-01-01', to: '2026-01-31', reason: 'Fechamento sintético de integração' } })
+assert.equal(close.response.status, 201); assert.equal(close.payload.data.status, 'CLOSED')
+const blocked = await call('/api/ponto/punches', { method: 'POST', actor: admin, body: { ...punchBody, occurredAt: '2026-01-03T12:00:00.000Z', requestId: 'closed-period-punch' } })
+assert.equal(blocked.response.status, 409); assert.equal(blocked.payload.code, 'PERIOD_CLOSED')
+const reopen = await call('/api/ponto/periods/reopen', { method: 'POST', actor: { ...admin, id: 'synthetic-admin-reopener' }, body: { closureId: close.payload.data.id, reason: 'Reabertura sintética de integração' } })
+assert.equal(reopen.response.status, 200); assert.equal(reopen.payload.data.status, 'REOPENED')
+
+const missing = await call('/api/ponto/route-that-does-not-exist', { actor: admin })
+assert.equal(missing.response.status, 404); assert.equal(missing.payload.code, 'NOT_FOUND')
+const oversized = await call('/api/ponto/pin/configure', { method: 'POST', actor: admin, body: { padding: 'x'.repeat(1024 * 1024) } })
+assert.equal(oversized.response.status, 413); assert.equal(oversized.payload.code, 'PAYLOAD_TOO_LARGE')
+console.log(JSON.stringify({ ok: true, health: health.response.status, readiness: readiness.response.status, employeeCount: employees.payload.data.length, dailyWorkedMinutesAfterCorrection: correctedDaily.payload.data.workedMinutes, horizontalAuthorization: outOfScopeDaily.response.status, deviceEmployeeRead: deviceEmployeeRead.response.status, idempotency: retry.payload.idempotent, concurrencyStatuses: concurrent.map((item) => item.response.status).sort(), replayProtection: replayedPinConfiguration.payload.code, signatureBinding: changedPathResponse.status, pinLockout: pinFailures.at(-1).response.status, globalPinLock: globalPinLock.response.status, faceFailure: faceFailure.payload.code, devicePunch: devicePunch.payload.data.source, correction: approval.payload.data.status, closure: close.payload.data.status, reopen: reopen.payload.data.status, oversizedPayload: oversized.response.status, unknownRoute: missing.response.status }, null, 2))

--- a/workforce/timekeeping/scripts/migration-local.test.mjs
+++ b/workforce/timekeeping/scripts/migration-local.test.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+const state = resolve(root, '.wrangler/state/v3/d1/miniflare-D1DatabaseObject')
+const sqliteName = (await readdir(state)).find((name) => name.endsWith('.sqlite') && name !== 'metadata.sqlite')
+assert.ok(sqliteName, 'local D1 sqlite not found; apply migrations first')
+const db = new DatabaseSync(resolve(state, sqliteName))
+const fixture = resolve(root, 'fixtures/ponto_store.synthetic.json')
+const temporary = await mkdtemp(resolve(tmpdir(), 'timekeeping-migration-test-'))
+
+function run(args, expectedStatus = 0) {
+  const result = spawnSync(process.execPath, [resolve(root, 'scripts/import-ponto-json.mjs'), ...args], {
+    cwd: resolve(root, '../..'), encoding: 'utf8', env: { ...process.env, PONTO_TEMPLATES_KEY: 'migration-test-template-key' },
+  })
+  assert.equal(result.status, expectedStatus, `${result.stdout}\n${result.stderr}`)
+  return result
+}
+
+try {
+  const at = '2026-01-01T10:00:00.000Z'
+  db.exec('BEGIN IMMEDIATE')
+  db.prepare(`INSERT INTO workforce_employees (id, canonical_employee_id, display_name, status, created_at, updated_at) VALUES (?, ?, ?, 'ACTIVE', ?, ?)`).run('synthetic-employee-001', 'canonical-preexisting', 'Preexisting employee', at, at)
+  db.prepare(`INSERT INTO timekeeping_events (id, employee_id, unit_id, event_type, source, occurred_at_utc, work_date, idempotency_scope, idempotency_key, request_fingerprint, created_by, created_at) VALUES (?, ?, ?, 'WORK_START', 'IMPORT', ?, '2026-01-02', ?, ?, ?, 'preexisting', ?)`).run('synthetic-punch-001', 'synthetic-employee-001', 'SYNTHETIC_UNIT', '2026-01-02T11:00:00.000Z', 'preexisting:employee', 'preexisting:1', 'preexisting-fingerprint-1', at)
+  db.prepare(`INSERT INTO timekeeping_events (id, employee_id, unit_id, event_type, source, occurred_at_utc, work_date, idempotency_scope, idempotency_key, request_fingerprint, created_by, created_at) VALUES (?, ?, ?, 'WORK_END', 'IMPORT', ?, '2026-01-02', ?, ?, ?, 'preexisting', ?)`).run('synthetic-punch-002', 'synthetic-employee-001', 'SYNTHETIC_UNIT', '2026-01-02T19:00:00.000Z', 'preexisting:employee', 'preexisting:2', 'preexisting-fingerprint-2', at)
+  db.exec('COMMIT')
+
+  const backup = resolve(temporary, 'checkpoint.json')
+  const applied = run(['--source', fixture, '--apply', '--database', 'skincos-timekeeping', '--backup', backup])
+  const output = JSON.parse(applied.stdout.slice(applied.stdout.lastIndexOf('\n{') + 1))
+  assert.ok(output.rollback)
+  run(['--rollback-run', output.runId, '--backup', output.rollback, '--database', 'skincos-timekeeping'])
+  assert.equal(db.prepare('SELECT display_name FROM workforce_employees WHERE id=?').get('synthetic-employee-001').display_name, 'Preexisting employee')
+  assert.equal(db.prepare(`SELECT count(*) AS total FROM timekeeping_events WHERE id IN ('synthetic-punch-001','synthetic-punch-002')`).get().total, 2)
+
+  const duplicate = JSON.parse(await readFile(fixture, 'utf8'))
+  duplicate.employees.push({ ...duplicate.employees[0], unit: 'OTHER_UNIT' })
+  const duplicatePath = resolve(temporary, 'duplicate.json')
+  await writeFile(duplicatePath, JSON.stringify(duplicate))
+  run(['--source', duplicatePath, '--dry-run'], 2)
+} finally {
+  try { db.exec('ROLLBACK') } catch { /* no active transaction */ }
+  db.prepare(`DELETE FROM timekeeping_events WHERE created_by='preexisting'`).run()
+  db.prepare(`DELETE FROM workforce_employees WHERE id='synthetic-employee-001'`).run()
+  db.prepare(`DELETE FROM timekeeping_migration_items WHERE migration_run_id LIKE 'ponto-json:%'`).run()
+  db.prepare(`DELETE FROM timekeeping_migration_runs WHERE id LIKE 'ponto-json:%'`).run()
+  db.close()
+  await rm(temporary, { recursive: true, force: true })
+}
+
+console.log(JSON.stringify({ ok: true, rollbackPreservedPreexistingRows: true, duplicateEmployeesRejected: true }))

--- a/workforce/timekeeping/security.js
+++ b/workforce/timekeeping/security.js
@@ -1,0 +1,84 @@
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+export function bytesToBase64Url(bytes) {
+  return btoa(String.fromCharCode(...new Uint8Array(bytes))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function base64UrlToBytes(value) {
+  const raw = String(value || '').replace(/-/g, '+').replace(/_/g, '/')
+  const normalized = raw.padEnd(Math.ceil(raw.length / 4) * 4, '=')
+  return Uint8Array.from(atob(normalized), (char) => char.charCodeAt(0))
+}
+
+export async function sha256(value) {
+  const bytes = typeof value === 'string' ? encoder.encode(value) : value
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export async function signHmac(secret, value) {
+  const key = await crypto.subtle.importKey('raw', encoder.encode(String(secret)), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  return bytesToBase64Url(await crypto.subtle.sign('HMAC', key, encoder.encode(String(value))))
+}
+
+export function constantTimeEqual(leftValue, rightValue) {
+  const left = encoder.encode(String(leftValue || ''))
+  const right = encoder.encode(String(rightValue || ''))
+  if (left.length !== right.length) return false
+  let diff = 0
+  for (let index = 0; index < left.length; index += 1) diff |= left[index] ^ right[index]
+  return diff === 0
+}
+
+export async function hashPin(pin, iterations = 100000) {
+  const value = String(pin || '')
+  if (!/^\d{4,12}$/.test(value)) throw new Error('PIN_INVALID')
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(value), 'PBKDF2', false, ['deriveBits'])
+  const derived = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, baseKey, 256)
+  return { algorithm: 'PBKDF2-SHA256', iterations, saltB64: bytesToBase64Url(salt), hashB64: bytesToBase64Url(derived) }
+}
+
+export async function verifyPin(pin, credential) {
+  if (!credential || credential.algorithm !== 'PBKDF2-SHA256') return false
+  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(String(pin || '')), 'PBKDF2', false, ['deriveBits'])
+  const derived = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt: base64UrlToBytes(credential.saltB64), iterations: Number(credential.iterations) }, baseKey, 256)
+  return constantTimeEqual(bytesToBase64Url(derived), credential.hashB64)
+}
+
+export function isValidBiometricTemplate(template) {
+  return Array.isArray(template)
+    && template.length >= 64
+    && template.length <= 1024
+    && template.every((value) => Number.isFinite(value))
+}
+
+async function templateKey(secret) {
+  if (!secret) throw new Error('BIOMETRIC_KEY_MISSING')
+  const material = await crypto.subtle.digest('SHA-256', encoder.encode(String(secret)))
+  return crypto.subtle.importKey('raw', material, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt'])
+}
+
+export async function encryptTemplate(template, secret) {
+  if (!isValidBiometricTemplate(template)) throw new Error('BIOMETRIC_TEMPLATE_INVALID')
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, await templateKey(secret), encoder.encode(JSON.stringify(template)))
+  return JSON.stringify({ v: 1, alg: 'A256GCM', iv: bytesToBase64Url(iv), ciphertext: bytesToBase64Url(encrypted) })
+}
+
+export async function decryptTemplate(payload, secret) {
+  const parsed = JSON.parse(String(payload || ''))
+  if (parsed?.alg !== 'A256GCM') throw new Error('BIOMETRIC_TEMPLATE_INVALID')
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: base64UrlToBytes(parsed.iv) }, await templateKey(secret), base64UrlToBytes(parsed.ciphertext))
+  const template = JSON.parse(decoder.decode(plaintext))
+  if (!isValidBiometricTemplate(template)) throw new Error('BIOMETRIC_TEMPLATE_INVALID')
+  return template
+}
+
+export function biometricDistance(left, right) {
+  if (!isValidBiometricTemplate(left) || !isValidBiometricTemplate(right) || left.length !== right.length) return Number.POSITIVE_INFINITY
+  let sum = 0
+  for (let index = 0; index < left.length; index += 1) sum += (Number(left[index]) - Number(right[index])) ** 2
+  return Math.sqrt(sum)
+}

--- a/workforce/timekeeping/security.test.js
+++ b/workforce/timekeeping/security.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { biometricDistance, decryptTemplate, encryptTemplate, hashPin, verifyPin } from './security.js'
+
+test('PIN is salted, hashed and verified without plaintext persistence', async () => {
+  const first = await hashPin('123456')
+  const second = await hashPin('123456')
+  assert.notEqual(first.hashB64, second.hashB64)
+  assert.equal(await verifyPin('123456', first), true)
+  assert.equal(await verifyPin('000000', first), false)
+  assert.equal(JSON.stringify(first).includes('123456'), false)
+})
+
+test('biometric matching rejects empty, undersized and non-finite templates', async () => {
+  await assert.rejects(() => encryptTemplate([], 'unit-test-secret'), /BIOMETRIC_TEMPLATE_INVALID/)
+  await assert.rejects(() => encryptTemplate(Array(64).fill(Number.NaN), 'unit-test-secret'), /BIOMETRIC_TEMPLATE_INVALID/)
+  assert.equal(biometricDistance([], []), Number.POSITIVE_INFINITY)
+})
+
+test('biometric templates require encryption and round-trip without raw payload', async () => {
+  const template = Array.from({ length: 128 }, (_, index) => index / 1000)
+  const encrypted = await encryptTemplate(template, 'unit-test-secret')
+  assert.equal(encrypted.includes(String(template[4])), false)
+  assert.deepEqual(await decryptTemplate(encrypted, 'unit-test-secret'), template)
+  await assert.rejects(() => encryptTemplate(template, ''), /BIOMETRIC_KEY_MISSING/)
+})

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -1,4 +1,5 @@
-import { canonicalEventType, calculateDay, calculatePeriod } from './domain.js'
+import { canonicalEventType, calculateDay, calculatePeriod, isoDateInZone } from './domain.js'
+import { biometricDistance, constantTimeEqual, decryptTemplate, encryptTemplate, hashPin, isValidBiometricTemplate, sha256, signHmac, verifyPin } from './security.js'
 
 const encoder = new TextEncoder()
 const json = (status, payload, requestId) => new Response(JSON.stringify({ ...payload, requestId }), {
@@ -12,11 +13,7 @@ const b64Url = (value) => {
 }
 const stable = (value) => JSON.stringify(value, Object.keys(value || {}).sort())
 
-async function hmac(secret, text) {
-  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
-  const bytes = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(text)))
-  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
-}
+const hmac = signHmac
 
 function equal(a, b) {
   const left = encoder.encode(String(a || ''))
@@ -32,7 +29,7 @@ function normalizeUnits(value) { return Array.from(new Set(Array.isArray(value) 
 function roleAllows(role, action) {
   const matrix = {
     EMPLOYEE: ['self.read', 'self.punch'], DEVICE: ['device.punch'],
-    MANAGER: ['unit.read', 'correction.request', 'correction.approve'],
+    MANAGER: ['unit.read', 'correction.request', 'device.manage'],
     HR: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'export.read'],
     ADMIN: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'device.manage', 'export.read', 'audit.read'],
     AUDITOR: ['unit.read', 'audit.read', 'export.read'],
@@ -40,15 +37,26 @@ function roleAllows(role, action) {
   return (matrix[String(role || '').toUpperCase()] || []).includes(action)
 }
 
-async function actorFor(request, env) {
+async function actorFor(request, env, db, bodyHash) {
+  const authorization = String(request.headers.get('authorization') || '')
+  if (/^Device\s+/i.test(authorization)) {
+    const tokenHash = await sha256(authorization.replace(/^Device\s+/i, '').trim())
+    const device = await db.prepare('SELECT id, unit_id, label FROM timekeeping_devices WHERE token_hash=? AND active=1 AND revoked_at IS NULL LIMIT 1').bind(tokenHash).first()
+    if (!device) return null
+    await db.prepare('UPDATE timekeeping_devices SET last_seen_at=? WHERE id=?').bind(now(), device.id).run()
+    return { id: device.id, email: `device:${device.id}@internal`, role: 'DEVICE', allowedUnits: [device.unit_id], name: device.label || device.id, deviceId: device.id }
+  }
   const raw = String(request.headers.get('x-skincos-actor') || '')
   const timestamp = String(request.headers.get('x-skincos-actor-ts') || '')
   const signature = String(request.headers.get('x-skincos-actor-sig') || '')
+  const signatureVersion = String(request.headers.get('x-skincos-signature-version') || '')
+  const nonce = cleanText(request.headers.get('x-request-nonce') || request.headers.get('x-idempotency-key') || request.headers.get('idempotency-key'), 180)
   const secret = String(env.PONTO_ACTOR_HMAC_KEY || '')
-  if (!raw || !timestamp || !signature || !secret) return null
+  if (!raw || !timestamp || !signature || !secret || signatureVersion !== '2') return null
   const ms = Number(timestamp)
   if (!Number.isFinite(ms) || Math.abs(Date.now() - ms) > 300000) return null
-  const expected = await hmac(secret, `${timestamp}.${raw}`)
+  const url = new URL(request.url)
+  const expected = await hmac(secret, [timestamp, raw, request.method.toUpperCase(), `${url.pathname}${url.search}`, nonce, bodyHash].join('.'))
   if (!equal(expected, signature)) return null
   try {
     const parsed = JSON.parse(b64Url(raw))
@@ -61,9 +69,28 @@ function requireUnit(actor, unitId) {
   return actor.role === 'ADMIN' || actor.role === 'HR' || actor.allowedUnits.includes(String(unitId || ''))
 }
 
+function publicEmployee(row) {
+  return row ? { id: row.id, employeeId: row.canonical_employee_id, name: row.display_name, email: row.login_email || null, status: row.status, terminatedAt: row.terminated_at || null } : null
+}
+
+function cleanText(value, max = 240) { return String(value || '').trim().slice(0, max) }
+function dateOnly(value) { return /^\d{4}-\d{2}-\d{2}$/.test(String(value || '')) ? String(value) : '' }
+function monthOnly(value) { return /^\d{4}-\d{2}$/.test(String(value || '')) ? String(value) : '' }
+function limitFor(url, fallback = 100, max = 500) { return Math.min(max, Math.max(1, Number.parseInt(url.searchParams.get('limit') || String(fallback), 10) || fallback)) }
+function logEvent(event, fields = {}) {
+  const safe = { service: 'workforce-timekeeping', event, ...fields }
+  for (const key of Object.keys(safe)) if (/pin|token|descriptor|template|authorization|cookie|score|distance/i.test(key)) delete safe[key]
+  console.log(JSON.stringify(safe))
+}
+
+async function isPeriodClosed(db, employeeId, unitId, occurredAtOrDate) {
+  const date = dateOnly(occurredAtOrDate) || isoDateInZone(occurredAtOrDate, 'America/Sao_Paulo')
+  return !!(await db.prepare(`SELECT id FROM timekeeping_period_closures WHERE employee_id=? AND unit_id=? AND status='CLOSED' AND period_start<=? AND period_end>=? ORDER BY revision DESC LIMIT 1`).bind(employeeId, unitId, date, date).first())
+}
+
 async function audit(db, { actor, action, entityType, entityId, unitId, requestId, reason, before, after }) {
   const occurredAt = now()
-  const previous = await db.prepare('SELECT hash FROM timekeeping_audit_events ORDER BY occurred_at DESC, id DESC LIMIT 1').first()
+  const previous = await db.prepare('SELECT hash FROM timekeeping_audit_head WHERE id=1').first()
   const payload = { occurredAt, actorId: actor.id, action, entityType, entityId, unitId: unitId || null, requestId, reason: reason || null }
   const digest = await crypto.subtle.digest('SHA-256', encoder.encode(`${previous?.hash || ''}\n${stable(payload)}`))
   const hash = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
@@ -80,10 +107,285 @@ async function readJson(request) {
   return body && typeof body === 'object' && !Array.isArray(body) ? body : null
 }
 
+async function readBodyLimited(request, maxBytes = 1024 * 1024) {
+  const declared = Number(request.headers.get('content-length') || 0)
+  if (Number.isFinite(declared) && declared > maxBytes) throw new Error('PAYLOAD_TOO_LARGE')
+  if (!request.body) return new Uint8Array()
+  const reader = request.body.getReader()
+  const chunks = []
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.byteLength
+    if (total > maxBytes) {
+      await reader.cancel('PAYLOAD_TOO_LARGE').catch(() => {})
+      throw new Error('PAYLOAD_TOO_LARGE')
+    }
+    chunks.push(value)
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) { out.set(chunk, offset); offset += chunk.byteLength }
+  return out
+}
+
+function csvCell(value) {
+  let text = String(value ?? '')
+  if (/^[\t\r ]*[=+\-@]/.test(text)) text = `'${text}`
+  return `"${text.replaceAll('"', '""')}"`
+}
+
+function failure(status, code, requestId, extra = {}) {
+  return json(status, { ok: false, error: code, code, ...extra }, requestId)
+}
+
+function addDays(date, amount) {
+  const value = new Date(`${date}T12:00:00.000Z`)
+  value.setUTCDate(value.getUTCDate() + amount)
+  return value.toISOString().slice(0, 10)
+}
+
+function datesBetween(start, end) {
+  const result = []
+  for (let cursor = start; cursor <= end && result.length < 370; cursor = addDays(cursor, 1)) result.push(cursor)
+  return result
+}
+
+function eventsForWorkDate(events, date, timeZone) {
+  const ordered = [...events].sort((left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt))
+  const selected = ordered.filter((event) => isoDateInZone(event.occurredAt, timeZone) === date)
+  if (!selected.length) return []
+  let shiftOpen = false
+  for (const event of selected) {
+    if (event.eventType === 'WORK_START') shiftOpen = true
+    if (event.eventType === 'WORK_END') shiftOpen = false
+  }
+  if (!shiftOpen) return selected
+  for (const event of ordered) {
+    if (Date.parse(event.occurredAt) <= Date.parse(selected.at(-1).occurredAt)) continue
+    selected.push(event)
+    if (event.eventType === 'WORK_END') break
+  }
+  return selected
+}
+
+function canonicalPath(path) {
+  const aliases = new Map([
+    ['/api/ponto/admin/employees', '/api/ponto/employees'],
+    ['/api/ponto/admin/devices', '/api/ponto/devices'],
+    ['/api/ponto/admin/records', '/api/ponto/mirror'],
+    ['/api/ponto/admin/export', '/api/ponto/export'],
+    ['/api/ponto/admin/records.csv', '/api/ponto/export'],
+    ['/api/ponto/me/punch', '/api/ponto/punches'],
+    ['/api/ponto/me/events', '/api/ponto/punches'],
+    ['/api/ponto/device/punches', '/api/ponto/punches'],
+  ])
+  return aliases.get(path) || path
+    .replace(/^\/api\/ponto\/admin\/employees\/([^/]+)\/pin$/, '/api/ponto/pin/configure/$1')
+    .replace(/^\/api\/ponto\/admin\/employees\/([^/]+)\/enroll$/, '/api/ponto/biometrics/enroll/$1')
+    .replace(/^\/api\/ponto\/admin\/devices\/([^/]+)\/revoke$/, '/api/ponto/devices/$1/revoke')
+    .replace(/^\/api\/ponto\/admin\/employees\/([^/]+)$/, '/api/ponto/employees/$1')
+}
+
+async function employeeUnits(db, employeeId, date = now().slice(0, 10)) {
+  const rows = await db.prepare(`SELECT unit_id FROM timekeeping_employee_units WHERE employee_id=? AND effective_from<=? AND (effective_to IS NULL OR effective_to>=?) ORDER BY effective_from DESC`).bind(employeeId, date, date).all()
+  return (rows.results || []).map((row) => row.unit_id)
+}
+
+async function employeeVisible(db, actor, employee, unitId = '') {
+  if (!employee) return false
+  if (actor.role === 'EMPLOYEE') return String(employee.login_email || '').toLowerCase() === actor.email
+  if (actor.role === 'ADMIN' || actor.role === 'HR' || actor.role === 'AUDITOR') return true
+  const units = unitId ? [unitId] : await employeeUnits(db, employee.id)
+  return units.some((unit) => actor.allowedUnits.includes(unit))
+}
+
+async function employeeById(db, actor, id, unitId = '') {
+  const employee = await db.prepare('SELECT * FROM workforce_employees WHERE id=? OR canonical_employee_id=? LIMIT 1').bind(id, id).first()
+  return await employeeVisible(db, actor, employee, unitId) ? employee : null
+}
+
+async function activeUnitForEmployee(db, employeeId, requestedUnit, date) {
+  const unitId = cleanText(requestedUnit, 120)
+  if (!unitId) return null
+  return db.prepare(`SELECT unit_id FROM timekeeping_employee_units WHERE employee_id=? AND unit_id=? AND effective_from<=? AND (effective_to IS NULL OR effective_to>=?) ORDER BY effective_from DESC LIMIT 1`).bind(employeeId, unitId, date, date).first()
+}
+
+function nextEventType(previous) {
+  return { WORK_START: 'BREAK_START', BREAK_START: 'BREAK_END', BREAK_END: 'WORK_END', WORK_END: 'WORK_START' }[previous] || 'WORK_START'
+}
+
+async function recordPinFailure(db, employeeId, deviceId) {
+  const at = now()
+  const current = await db.prepare('SELECT * FROM timekeeping_pin_failures WHERE employee_id=?').bind(employeeId).first()
+  const recent = current && Date.parse(at) - Date.parse(current.window_started_at) < 15 * 60 * 1000
+  const count = recent ? Number(current.failure_count) + 1 : 1
+  const lockSeconds = count >= 5 ? Math.min(3600, 60 * 2 ** Math.min(6, count - 5)) : 0
+  const lockedUntil = lockSeconds ? new Date(Date.now() + lockSeconds * 1000).toISOString() : null
+  await db.prepare(`INSERT INTO timekeeping_pin_failures (employee_id, device_id, failure_count, window_started_at, locked_until, last_failed_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(employee_id) DO UPDATE SET device_id=excluded.device_id, failure_count=excluded.failure_count, window_started_at=excluded.window_started_at, locked_until=excluded.locked_until, last_failed_at=excluded.last_failed_at`).bind(employeeId, deviceId || '', count, recent ? current.window_started_at : at, lockedUntil, at).run()
+  return { count, lockedUntil }
+}
+
+async function verifyPunchCredential(db, env, actor, employee, body) {
+  if (body.pin !== undefined) {
+    const failureRow = await db.prepare('SELECT * FROM timekeeping_pin_failures WHERE employee_id=?').bind(employee.id).first()
+    if (failureRow?.locked_until && Date.parse(failureRow.locked_until) > Date.now()) return { error: 'PIN_LOCKED', secondsRemaining: Math.ceil((Date.parse(failureRow.locked_until) - Date.now()) / 1000) }
+    const row = await db.prepare('SELECT * FROM timekeeping_pin_credentials WHERE employee_id=?').bind(employee.id).first()
+    if (!row) return { error: 'PIN_NOT_SET' }
+    const valid = await verifyPin(String(body.pin || ''), { algorithm: row.algorithm, saltB64: row.salt_b64, hashB64: row.hash_b64, iterations: row.iterations }).catch(() => false)
+    if (!valid) {
+      const failure = await recordPinFailure(db, employee.id, actor.deviceId || '')
+      return { error: failure.lockedUntil ? 'PIN_LOCKED' : 'PIN_INVALID', secondsRemaining: failure.lockedUntil ? Math.ceil((Date.parse(failure.lockedUntil) - Date.now()) / 1000) : undefined }
+    }
+    await db.prepare('DELETE FROM timekeeping_pin_failures WHERE employee_id=?').bind(employee.id).run()
+    return { source: 'PIN' }
+  }
+  const descriptor = body.descriptor || body.template
+  if (descriptor !== undefined) {
+    if (!isValidBiometricTemplate(descriptor) || !env.PONTO_TEMPLATES_KEY) return { error: 'FACE_UNAVAILABLE' }
+    const templates = await db.prepare(`SELECT encrypted_template FROM timekeeping_biometric_templates WHERE employee_id=? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at>?)`).bind(employee.id, now()).all()
+    if (!(templates.results || []).length) return { error: 'FACE_NOT_ENROLLED' }
+    const threshold = Math.max(0.1, Math.min(2, Number(env.PONTO_FACE_THRESHOLD || 0.62)))
+    let matched = false
+    for (const row of templates.results || []) {
+      const stored = await decryptTemplate(row.encrypted_template, env.PONTO_TEMPLATES_KEY).catch(() => null)
+      if (stored && biometricDistance(stored, descriptor) <= threshold) { matched = true; break }
+    }
+    return matched ? { source: 'FACE' } : { error: 'FACE_NOT_RECOGNIZED' }
+  }
+  if (actor.role === 'ADMIN' || actor.role === 'HR') return { source: 'MANUAL' }
+  if (String(env.ALLOW_SYSTEM_PUNCH || '').toLowerCase() === 'true') return { source: 'SYSTEM' }
+  return { error: 'PUNCH_CREDENTIAL_REQUIRED' }
+}
+
+async function resolveRule(db, employeeId, unitId, date) {
+  const row = await db.prepare(`SELECT * FROM timekeeping_rule_versions WHERE (employee_id=? OR employee_id IS NULL) AND (unit_id=? OR unit_id IS NULL) AND effective_from<=? AND (effective_to IS NULL OR effective_to>=?) ORDER BY (employee_id IS NOT NULL) DESC, (unit_id IS NOT NULL) DESC, effective_from DESC LIMIT 1`).bind(employeeId, unitId, date, date).first()
+  if (!row) return { id: null, timeZone: 'America/Sao_Paulo', expectedMinutes: 0 }
+  try { return { id: row.id, ...JSON.parse(row.rules_json) } } catch { return { id: row.id, timeZone: 'America/Sao_Paulo', expectedMinutes: 0 } }
+}
+
+async function calculationForDate(db, employeeId, unitId, date, { live = false } = {}) {
+  if (!live) {
+    const snapshot = await db.prepare(`SELECT s.calculation_json FROM timekeeping_daily_snapshots s JOIN timekeeping_period_closures c ON c.id=s.closure_id WHERE s.employee_id=? AND s.work_date=? AND c.unit_id=? AND c.status='CLOSED' ORDER BY c.revision DESC LIMIT 1`).bind(employeeId, date, unitId).first()
+    if (snapshot) return { ...JSON.parse(snapshot.calculation_json), frozen: true }
+  }
+  const from = new Date(`${date}T00:00:00.000Z`); from.setUTCHours(from.getUTCHours() - 12)
+  const to = new Date(`${addDays(date, 2)}T12:00:00.000Z`)
+  const rule = await resolveRule(db, employeeId, unitId, date)
+  const events = await db.prepare(`SELECT e.id, e.event_type, COALESCE(c.proposed_at_utc,e.occurred_at_utc) AS occurred_at FROM timekeeping_events e LEFT JOIN timekeeping_corrections c ON c.event_id=e.id AND c.status='APPROVED' WHERE e.employee_id=? AND e.unit_id=? AND e.occurred_at_utc>=? AND e.occurred_at_utc<? AND e.superseded_by IS NULL ORDER BY occurred_at`).bind(employeeId, unitId, from.toISOString(), to.toISOString()).all()
+  const workDateEvents = eventsForWorkDate((events.results || []).map((event) => ({ id: event.id, eventType: event.event_type, occurredAt: event.occurred_at })), date, rule.timeZone || 'America/Sao_Paulo')
+  const scheduleRow = await db.prepare('SELECT * FROM timekeeping_schedule_assignments WHERE employee_id=? AND unit_id=? AND work_date=? ORDER BY created_at DESC LIMIT 1').bind(employeeId, unitId, date).first()
+  const holiday = await db.prepare('SELECT id FROM timekeeping_holidays WHERE unit_id=? AND holiday_date=? LIMIT 1').bind(unitId, date).first()
+  const absence = await db.prepare('SELECT * FROM timekeeping_absences WHERE employee_id=? AND (unit_id=? OR unit_id IS NULL) AND starts_at<=? AND ends_at>=? ORDER BY created_at DESC LIMIT 1').bind(employeeId, unitId, `${date}T23:59:59.999Z`, `${date}T00:00:00.000Z`).first()
+  const result = calculateDay({
+    date,
+    events: workDateEvents,
+    rule,
+    schedule: scheduleRow ? { id: scheduleRow.id, expectedMinutes: scheduleRow.expected_minutes, startAt: scheduleRow.start_at_utc, endAt: scheduleRow.end_at_utc } : null,
+    holiday: !!holiday,
+    absence: absence ? { id: absence.id, kind: absence.kind } : null,
+  })
+  return { ...result, employeeId, unitId, frozen: false }
+}
+
+async function periodCalculation(db, employeeId, unitId, start, end) {
+  const days = []
+  for (const date of datesBetween(start, end)) days.push(await calculationForDate(db, employeeId, unitId, date))
+  return calculatePeriod({ days })
+}
+
+async function listScopedEmployees(db, actor, url) {
+  const limit = limitFor(url, 100, 500)
+  const unit = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
+  if (actor.role === 'MANAGER') {
+    const units = unit ? [unit] : actor.allowedUnits
+    if (!units.length || units.some((value) => !actor.allowedUnits.includes(value))) return []
+    const placeholders = units.map(() => '?').join(',')
+    const rows = await db.prepare(`SELECT DISTINCT e.* FROM workforce_employees e JOIN timekeeping_employee_units eu ON eu.employee_id=e.id WHERE eu.unit_id IN (${placeholders}) ORDER BY e.display_name LIMIT ?`).bind(...units, limit).all()
+    return rows.results || []
+  }
+  if (actor.role === 'EMPLOYEE') {
+    const row = await employeeForActor(db, actor)
+    return row ? [row] : []
+  }
+  const rows = await db.prepare('SELECT * FROM workforce_employees ORDER BY display_name LIMIT ?').bind(limit).all()
+  return rows.results || []
+}
+
+async function listRecords(db, actor, url, employeeOverride = null) {
+  const employeeId = employeeOverride || cleanText(url.searchParams.get('employeeId'), 120)
+  const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
+  let employee = employeeId ? await employeeById(db, actor, employeeId, unitId) : null
+  if (actor.role === 'EMPLOYEE') employee = await employeeForActor(db, actor)
+  if (!employee) return null
+  const from = cleanText(url.searchParams.get('from'), 40) || '1970-01-01T00:00:00.000Z'
+  const to = cleanText(url.searchParams.get('to'), 40) || '9999-12-31T23:59:59.999Z'
+  const rows = await db.prepare(`SELECT e.id, e.employee_id, e.unit_id, e.device_id, e.event_type, e.source, e.occurred_at_utc, e.created_at, c.id AS correction_id, c.proposed_at_utc, c.reason AS correction_reason FROM timekeeping_events e LEFT JOIN timekeeping_corrections c ON c.event_id=e.id AND c.status='APPROVED' WHERE e.employee_id=? AND e.occurred_at_utc>=? AND e.occurred_at_utc<=? AND (?='' OR e.unit_id=?) ORDER BY e.occurred_at_utc DESC LIMIT ?`).bind(employee.id, from, to, unitId, unitId, limitFor(url, 200, 500)).all()
+  return (rows.results || []).map((row) => ({ id: row.id, kind: 'PUNCH', employeeId: row.employee_id, employeeName: employee.display_name, type: row.event_type === 'WORK_START' ? 'IN' : row.event_type === 'WORK_END' ? 'OUT' : row.event_type, eventType: row.event_type, at: row.occurred_at_utc, unit: row.unit_id, unitId: row.unit_id, deviceId: row.device_id, method: row.source, source: row.source, corrected: row.correction_id ? { id: row.correction_id, at: row.proposed_at_utc, reason: row.correction_reason } : null }))
+}
+
+function encodeBase64Url(value) {
+  const bytes = encoder.encode(JSON.stringify(value))
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+async function scheduleRequest(env, path, unitId) {
+  if (!env.SCHEDULE || !env.ESCALA_ACTOR_HMAC_KEY) throw new Error('SCHEDULE_NOT_CONFIGURED')
+  const actor = encodeBase64Url({ id: 'workforce-timekeeping-sync', role: 'GESTOR', allowedUnits: [unitId] })
+  const timestamp = String(Date.now())
+  const signature = await signHmac(env.ESCALA_ACTOR_HMAC_KEY, `${timestamp}.${actor}`)
+  const response = await env.SCHEDULE.fetch(new Request(`https://schedule.internal${path}`, { headers: { 'x-crm-user': actor, 'x-crm-ts': timestamp, 'x-crm-signature': signature, 'x-request-id': crypto.randomUUID() } }))
+  if (!response.ok) throw new Error(`SCHEDULE_HTTP_${response.status}`)
+  return response.json()
+}
+
+async function syncSchedule(db, env, actor, unitId, month, requestId) {
+  const query = `?unit=${encodeURIComponent(unitId)}&month=${encodeURIComponent(month)}`
+  const [scheduleData, professionalData] = await Promise.all([
+    scheduleRequest(env, `/api/escala/schedule${query}`, unitId),
+    scheduleRequest(env, `/api/escala/professionals?unit=${encodeURIComponent(unitId)}`, unitId),
+  ])
+  const professionals = new Map((professionalData.data || []).map((row) => [String(row.name || row.professional || '').trim(), String(row.id || '').trim()]))
+  let imported = 0; let conflicts = 0
+  const statements = []
+  for (const entry of scheduleData.schedule || []) {
+    const name = cleanText(entry.professional, 180); const professionalId = professionals.get(name) || ''
+    let alias = professionalId ? await db.prepare(`SELECT employee_id FROM workforce_employee_aliases WHERE source='ESCALA_PROFESSIONAL_ID' AND legacy_id=?`).bind(professionalId).first() : null
+    if (!alias) alias = await db.prepare(`SELECT employee_id FROM workforce_employee_aliases WHERE source='ESCALA_NAME' AND legacy_id=?`).bind(name).first()
+    if (!alias) {
+      const existingConflict = await db.prepare(`SELECT id FROM workforce_identity_conflicts WHERE source='ESCALA' AND source_id=? AND status='OPEN' LIMIT 1`).bind(professionalId || name).first()
+      if (!existingConflict) statements.push(db.prepare(`INSERT INTO workforce_identity_conflicts (id, source, source_id, candidates_json, reasons_json, created_at) VALUES (?, 'ESCALA', ?, ?, ?, ?)`).bind(crypto.randomUUID(), professionalId || name, '[]', JSON.stringify(['NO_CANONICAL_ALIAS', { name, unitId }]), now()))
+      conflicts += 1
+      continue
+    }
+    const rule = await resolveRule(db, alias.employee_id, unitId, entry.date)
+    const sourceRef = professionalId || name
+    statements.push(db.prepare(`INSERT INTO timekeeping_schedule_assignments (id, employee_id, unit_id, work_date, expected_minutes, source, source_ref, created_at) VALUES (?, ?, ?, ?, ?, 'ESCALA', ?, ?) ON CONFLICT(employee_id, unit_id, work_date, source) DO UPDATE SET expected_minutes=excluded.expected_minutes, source_ref=excluded.source_ref`).bind(crypto.randomUUID(), alias.employee_id, unitId, entry.date, Math.max(0, Number(rule.expectedMinutes || 0)), sourceRef, now()))
+    imported += 1
+  }
+  for (const holiday of scheduleData.holidays || []) statements.push(db.prepare(`INSERT OR IGNORE INTO timekeeping_holidays (id, unit_id, holiday_date, name, created_at) VALUES (?, ?, ?, ?, ?)`).bind(crypto.randomUUID(), unitId, holiday.date, cleanText(holiday.name, 180), now()))
+  statements.push(await audit(db, { actor, action: 'SCHEDULE_SYNC', entityType: 'timekeeping_schedule', entityId: `${unitId}:${month}`, unitId, requestId, after: { imported, conflicts, holidays: (scheduleData.holidays || []).length } }))
+  await db.batch(statements)
+  return { imported, conflicts, holidays: (scheduleData.holidays || []).length }
+}
+
+async function enforceReplayProtection(request, db, requestId, actor) {
+  if (['GET', 'HEAD', 'OPTIONS'].includes(request.method)) return true
+  const nonce = cleanText(request.headers.get('x-request-nonce') || request.headers.get('x-idempotency-key') || request.headers.get('idempotency-key'), 180)
+  if (!nonce) return actor.role === 'DEVICE' // Device punches also require an idempotency key in their body.
+  try {
+    await db.prepare('DELETE FROM timekeeping_request_nonces WHERE expires_at<?').bind(now()).run()
+    await db.prepare('INSERT INTO timekeeping_request_nonces (nonce, expires_at, request_id, created_at) VALUES (?, ?, ?, ?)').bind(nonce, new Date(Date.now() + 10 * 60 * 1000).toISOString(), requestId, now()).run()
+    return true
+  } catch { return false }
+}
+
 export async function handleTimekeeping(request, env) {
+  const startedAt = Date.now()
   const requestId = requestIdFor(request)
   const url = new URL(request.url)
-  const path = url.pathname.replace(/^\/workforce/, '')
+  let path = canonicalPath(url.pathname.replace(/^\/workforce/, ''))
   if (path === '/health' || path === '/api/ponto/health') return json(200, { ok: true, service: 'workforce-timekeeping', version: env.APP_VERSION || '1.0.0', database: !!env.DB }, requestId)
   if (path === '/readiness' || path === '/api/ponto/readiness') {
     try {
@@ -94,53 +396,368 @@ export async function handleTimekeeping(request, env) {
   }
   if (!path.startsWith('/api/ponto')) return json(404, { ok: false, error: 'NOT_FOUND' }, requestId)
   if (!env.DB) return json(503, { ok: false, error: 'NOT_READY', code: 'DATABASE_UNAVAILABLE' }, requestId)
-  const actor = await actorFor(request, env)
-  if (!actor) return json(401, { ok: false, error: 'UNAUTHORIZED' }, requestId)
-  const db = env.DB
-
-  if (path === '/api/ponto/me' && request.method === 'GET') {
-    const employee = await employeeForActor(db, actor)
-    return json(200, { ok: true, data: { linked: !!employee, employee: employee ? { id: employee.id, name: employee.display_name, status: employee.status } : null, capabilities: ['self.read', 'self.punch'].filter((cap) => roleAllows(actor.role, cap)) } }, requestId)
-  }
-  if (path === '/api/ponto/me/records' && request.method === 'GET') {
-    const employee = await employeeForActor(db, actor)
-    if (!employee) return json(404, { ok: false, error: 'EMPLOYEE_NOT_LINKED' }, requestId)
-    const rows = await db.prepare('SELECT id, event_type, source, occurred_at_utc, unit_id, device_id, created_at FROM timekeeping_events WHERE employee_id=? AND superseded_by IS NULL ORDER BY occurred_at_utc DESC LIMIT 200').bind(employee.id).all()
-    return json(200, { ok: true, data: rows.results || [] }, requestId)
-  }
-  if (path === '/api/ponto/me/events' && request.method === 'POST') {
-    if (!roleAllows(actor.role, 'self.punch')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
-    const employee = await employeeForActor(db, actor)
-    const body = await readJson(request)
-    const eventType = canonicalEventType(body?.eventType)
-    const unitId = String(body?.unitId || '').trim()
-    const key = String(request.headers.get('idempotency-key') || '').trim()
-    if (!employee || !eventType || !unitId || !key || key.length > 160 || !requireUnit(actor, unitId)) return json(400, { ok: false, error: 'INVALID_PUNCH_REQUEST' }, requestId)
-    const at = now(); const id = crypto.randomUUID(); const fingerprint = await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${eventType}.${unitId}`)
+  let bodyHash = await sha256('')
+  if (!['GET', 'HEAD', 'OPTIONS'].includes(request.method)) {
     try {
-      const insert = db.prepare('INSERT INTO timekeeping_events (id, employee_id, unit_id, device_id, event_type, source, occurred_at_utc, idempotency_scope, idempotency_key, request_fingerprint, created_by, created_at) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)')
-        .bind(id, employee.id, unitId, eventType, 'SYSTEM', at, `employee:${employee.id}`, key, fingerprint, actor.id, at)
-      await db.batch([insert, await audit(db, { actor, action: 'EVENT_CREATE', entityType: 'timekeeping_event', entityId: id, unitId, requestId, after: { eventType, source: 'SYSTEM' } })])
-      return json(201, { ok: true, data: { id, eventType, occurredAtUtc: at, unitId, operationId: id } }, requestId)
+      const bytes = await readBodyLimited(request)
+      bodyHash = await sha256(bytes)
+      request = new Request(request, { body: bytes.byteLength ? bytes : undefined })
     } catch (error) {
-      const existing = await db.prepare('SELECT id, event_type, occurred_at_utc, request_fingerprint FROM timekeeping_events WHERE idempotency_scope=? AND idempotency_key=?').bind(`employee:${employee.id}`, key).first()
-      if (existing && equal(existing.request_fingerprint, fingerprint)) return json(200, { ok: true, idempotent: true, data: { id: existing.id, eventType: existing.event_type, occurredAtUtc: existing.occurred_at_utc } }, requestId)
-      return json(409, { ok: false, error: 'IDEMPOTENCY_CONFLICT' }, requestId)
+      if (error?.message === 'PAYLOAD_TOO_LARGE') return failure(413, 'PAYLOAD_TOO_LARGE', requestId)
+      throw error
     }
   }
-  if (path === '/api/ponto/admin/employees' && request.method === 'GET') {
-    if (!roleAllows(actor.role, 'unit.read')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
-    const rows = await db.prepare('SELECT id, canonical_employee_id, display_name, status, terminated_at FROM workforce_employees ORDER BY display_name LIMIT 500').all()
-    return json(200, { ok: true, data: rows.results || [] }, requestId)
+  const db = env.DB
+  const actor = await actorFor(request, env, db, bodyHash)
+  if (!actor) return json(401, { ok: false, error: 'UNAUTHORIZED' }, requestId)
+  if (!await enforceReplayProtection(request, db, requestId, actor)) return failure(409, 'REPLAY_DETECTED', requestId)
+
+  try {
+    if ((path === '/api/ponto/me' || path === '/api/ponto/context') && request.method === 'GET') {
+      const employee = await employeeForActor(db, actor)
+      const units = employee ? await employeeUnits(db, employee.id) : []
+      const last = employee ? await db.prepare('SELECT * FROM timekeeping_events WHERE employee_id=? ORDER BY occurred_at_utc DESC LIMIT 1').bind(employee.id).first() : null
+      const biometrics = employee ? await db.prepare('SELECT COUNT(*) AS total, MAX(created_at) AS last_enrolled_at FROM timekeeping_biometric_templates WHERE employee_id=? AND revoked_at IS NULL').bind(employee.id).first() : null
+      const pin = employee ? await db.prepare('SELECT employee_id FROM timekeeping_pin_credentials WHERE employee_id=?').bind(employee.id).first() : null
+      const data = { linked: !!employee, actorEmail: actor.email, allowedUnits: actor.allowedUnits.length ? actor.allowedUnits : units, employee: publicEmployee(employee), hasFace: Number(biometrics?.total || 0) > 0, pinSet: !!pin, lastPunch: last ? { id: last.id, kind: 'PUNCH', employeeId: last.employee_id, employeeName: employee.display_name, type: last.event_type === 'WORK_START' ? 'IN' : last.event_type === 'WORK_END' ? 'OUT' : last.event_type, at: last.occurred_at_utc, unit: last.unit_id, method: last.source } : null, suggestedNextMethod: Number(biometrics?.total || 0) > 0 ? 'FACE' : 'PIN', capabilities: Object.values({ selfRead: 'self.read', selfPunch: 'self.punch', unitRead: 'unit.read', approve: 'correction.approve', close: 'period.close', reopen: 'period.reopen', audit: 'audit.read' }).filter((capability) => roleAllows(actor.role, capability)) }
+      return json(200, { ok: true, ...data, data }, requestId)
+    }
+
+    if (path === '/api/ponto/me/records' && request.method === 'GET') {
+      const records = await listRecords(db, actor, url, (await employeeForActor(db, actor))?.id)
+      return records ? json(200, { ok: true, data: records }, requestId) : failure(404, 'EMPLOYEE_NOT_LINKED', requestId)
+    }
+
+    if (path === '/api/ponto/employees' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      const employees = await listScopedEmployees(db, actor, url)
+      const output = []
+      for (const employee of employees) {
+        const units = await employeeUnits(db, employee.id)
+        const bio = await db.prepare('SELECT COUNT(*) AS count, MAX(created_at) AS last_at FROM timekeeping_biometric_templates WHERE employee_id=? AND revoked_at IS NULL').bind(employee.id).first()
+        const pin = await db.prepare('SELECT employee_id FROM timekeeping_pin_credentials WHERE employee_id=?').bind(employee.id).first()
+        output.push({ ...publicEmployee(employee), code: employee.employee_code || undefined, loginEmail: employee.login_email || undefined, birthDate: employee.birth_date || undefined, jobTitle: employee.job_title || undefined, unit: units[0] || undefined, units, active: employee.status === 'ACTIVE', faceDescriptorsCount: Number(bio?.count || 0), lastEnrolledAt: bio?.last_at || null, pinSet: !!pin })
+      }
+      return json(200, { ok: true, data: output, meta: { count: output.length } }, requestId)
+    }
+
+    const employeeMatch = path.match(/^\/api\/ponto\/employees\/([^/]+)$/)
+    if (employeeMatch && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      const employee = await employeeById(db, actor, decodeURIComponent(employeeMatch[1]))
+      if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
+      const units = await employeeUnits(db, employee.id)
+      return json(200, { ok: true, data: { ...publicEmployee(employee), code: employee.employee_code || undefined, loginEmail: employee.login_email || undefined, birthDate: employee.birth_date || undefined, jobTitle: employee.job_title || undefined, unit: units[0] || undefined, units, active: employee.status === 'ACTIVE' } }, requestId)
+    }
+
+    if (path === '/api/ponto/employees' && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request)
+      const name = cleanText(body?.name, 180); const email = cleanText(body?.loginEmail, 240).toLowerCase(); const unitId = cleanText(body?.unit || body?.unitId, 120)
+      if (!name || !/^\S+@\S+\.\S+$/.test(email) || !unitId) return failure(400, 'INVALID_EMPLOYEE', requestId)
+      const existing = await db.prepare('SELECT id, display_name FROM workforce_employees WHERE lower(login_email)=lower(?)').bind(email).first()
+      if (existing) return failure(409, 'LOGIN_EMAIL_ALREADY_IN_USE', requestId, { employeeId: existing.id, employeeName: existing.display_name })
+      const id = crypto.randomUUID(); const at = now(); const canonicalId = cleanText(body?.employeeId || body?.canonicalEmployeeId, 120) || `workforce:${id}`
+      const cpfHash = body?.cpf ? await sha256(String(body.cpf).replace(/\D/g, '')) : null
+      const phoneHash = body?.phone ? await sha256(String(body.phone).replace(/\D/g, '')) : null
+      const insert = db.prepare(`INSERT INTO workforce_employees (id, canonical_employee_id, login_email, display_name, status, created_at, updated_at, employee_code, cpf_hash, phone_hash, birth_date, job_title, metadata_json) VALUES (?, ?, ?, ?, 'ACTIVE', ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .bind(id, canonicalId, email, name, at, at, cleanText(body?.code, 80) || null, cpfHash, phoneHash, dateOnly(body?.birthDate) || null, cleanText(body?.jobTitle, 160) || null, JSON.stringify({ source: 'CRM' }))
+      const unit = db.prepare('INSERT INTO timekeeping_employee_units (id, employee_id, unit_id, effective_from, created_at) VALUES (?, ?, ?, ?, ?)').bind(crypto.randomUUID(), id, unitId, dateOnly(body?.effectiveFrom) || at.slice(0, 10), at)
+      await db.batch([insert, unit, await audit(db, { actor, action: 'EMPLOYEE_LINK_CREATE', entityType: 'workforce_employee', entityId: id, unitId, requestId, after: { canonicalId, email, name } })])
+      return json(201, { ok: true, data: { id, employeeId: canonicalId, name, loginEmail: email, unit: unitId, active: true } }, requestId)
+    }
+
+    if (employeeMatch && ['PATCH', 'DELETE'].includes(request.method)) {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const employee = await employeeById(db, actor, decodeURIComponent(employeeMatch[1]))
+      if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
+      const body = request.method === 'PATCH' ? await readJson(request) : {}
+      const status = request.method === 'DELETE' || body?.active === false ? 'TERMINATED' : 'ACTIVE'
+      const email = body?.loginEmail === undefined ? employee.login_email : cleanText(body.loginEmail, 240).toLowerCase() || null
+      const name = body?.name === undefined ? employee.display_name : cleanText(body.name, 180)
+      if (!name) return failure(400, 'INVALID_EMPLOYEE', requestId)
+      try {
+        await db.batch([
+          db.prepare('UPDATE workforce_employees SET display_name=?, login_email=?, employee_code=?, birth_date=?, job_title=?, status=?, terminated_at=?, updated_at=? WHERE id=?').bind(name, email, body?.code === undefined ? employee.employee_code : cleanText(body.code, 80) || null, body?.birthDate === undefined ? employee.birth_date : dateOnly(body.birthDate) || null, body?.jobTitle === undefined ? employee.job_title : cleanText(body.jobTitle, 160) || null, status, status === 'TERMINATED' ? now() : null, now(), employee.id),
+          await audit(db, { actor, action: status === 'TERMINATED' ? 'EMPLOYEE_TERMINATE' : 'EMPLOYEE_UPDATE', entityType: 'workforce_employee', entityId: employee.id, requestId, before: publicEmployee(employee), after: { name, email, status } }),
+        ])
+      } catch { return failure(409, 'LOGIN_EMAIL_ALREADY_IN_USE', requestId) }
+      return json(200, { ok: true, data: { id: employee.id, name, loginEmail: email, active: status === 'ACTIVE' } }, requestId)
+    }
+
+    if (path === '/api/ponto/punches' && request.method === 'POST') {
+      const body = await readJson(request)
+      if (!body) return failure(400, 'INVALID_PUNCH_REQUEST', requestId)
+      let employee = actor.role === 'EMPLOYEE' ? await employeeForActor(db, actor) : await employeeById(db, actor, cleanText(body.employeeId, 120), actor.allowedUnits[0] || '')
+      if (!employee) return failure(404, 'EMPLOYEE_NOT_LINKED', requestId)
+      if (employee.status !== 'ACTIVE') return failure(409, 'EMPLOYEE_NOT_ACTIVE', requestId)
+      const occurredAt = body.occurredAt ? new Date(body.occurredAt).toISOString() : now()
+      const unitId = actor.role === 'DEVICE' ? actor.allowedUnits[0] : cleanText(body.unitId || body.unit, 120)
+      const initialWorkDate = isoDateInZone(occurredAt, 'America/Sao_Paulo')
+      const punchRule = await resolveRule(db, employee.id, unitId, initialWorkDate)
+      const workDate = isoDateInZone(occurredAt, punchRule.timeZone || 'America/Sao_Paulo')
+      if (!unitId || !await activeUnitForEmployee(db, employee.id, unitId, workDate)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      if (actor.role === 'MANAGER' && !requireUnit(actor, unitId)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      if (await isPeriodClosed(db, employee.id, unitId, workDate)) return failure(409, 'PERIOD_CLOSED', requestId)
+      const credential = await verifyPunchCredential(db, env, actor, employee, body)
+      if (credential.error) return failure(credential.error === 'PIN_LOCKED' ? 429 : 401, credential.error, requestId, credential.secondsRemaining ? { secondsRemaining: credential.secondsRemaining } : {})
+      const manualReason = credential.source === 'MANUAL' ? cleanText(body.reason, 500) : ''
+      if (credential.source === 'MANUAL' && !manualReason) return failure(400, 'JUSTIFICATION_REQUIRED', requestId)
+      const previous = await db.prepare('SELECT event_type, occurred_at_utc FROM timekeeping_events WHERE employee_id=? AND unit_id=? ORDER BY occurred_at_utc DESC LIMIT 1').bind(employee.id, unitId).first()
+      const eventType = canonicalEventType(body.eventType || body.type) || nextEventType(previous?.event_type)
+      const idempotencyKey = cleanText(request.headers.get('idempotency-key') || request.headers.get('x-idempotency-key') || body.requestId, 160)
+      if (!idempotencyKey) return failure(400, 'IDEMPOTENCY_KEY_REQUIRED', requestId)
+      const scope = `employee:${employee.id}`; const fingerprint = await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${employee.id}.${unitId}.${eventType}.${body.occurredAt || ''}.${credential.source}`)
+      const alreadyCreated = await db.prepare('SELECT * FROM timekeeping_events WHERE idempotency_scope=? AND idempotency_key=?').bind(scope, idempotencyKey).first()
+      if (alreadyCreated) {
+        if (!constantTimeEqual(alreadyCreated.request_fingerprint, fingerprint)) return failure(409, 'IDEMPOTENCY_CONFLICT', requestId)
+        return json(200, { ok: true, idempotent: true, data: { id: alreadyCreated.id, operationId: alreadyCreated.id, employeeId: employee.id, employeeName: employee.display_name, type: alreadyCreated.event_type === 'WORK_START' ? 'IN' : alreadyCreated.event_type === 'WORK_END' ? 'OUT' : alreadyCreated.event_type, eventType: alreadyCreated.event_type, at: alreadyCreated.occurred_at_utc, occurredAtUtc: alreadyCreated.occurred_at_utc, unit: alreadyCreated.unit_id, unitId: alreadyCreated.unit_id, method: alreadyCreated.source, source: alreadyCreated.source } }, requestId)
+      }
+      if (previous && Date.parse(occurredAt) - Date.parse(previous.occurred_at_utc) < Number(env.PONTO_COOLDOWN_SECONDS || 15) * 1000) return failure(429, 'COOLDOWN', requestId, { secondsRemaining: Number(env.PONTO_COOLDOWN_SECONDS || 15) })
+      const id = crypto.randomUUID()
+      try {
+        await db.batch([
+          db.prepare('INSERT INTO timekeeping_events (id, employee_id, unit_id, device_id, event_type, source, occurred_at_utc, work_date, idempotency_scope, idempotency_key, request_fingerprint, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').bind(id, employee.id, unitId, actor.deviceId || null, eventType, credential.source, occurredAt, workDate, scope, idempotencyKey, fingerprint, actor.id, now()),
+          await audit(db, { actor, action: 'EVENT_CREATE', entityType: 'timekeeping_event', entityId: id, unitId, requestId, reason: manualReason, after: { employeeId: employee.id, eventType, source: credential.source, occurredAt } }),
+        ])
+      } catch (error) {
+        if (String(error?.message || '').includes('PERIOD_CLOSED')) return failure(409, 'PERIOD_CLOSED', requestId)
+        const existing = await db.prepare('SELECT * FROM timekeeping_events WHERE idempotency_scope=? AND idempotency_key=?').bind(scope, idempotencyKey).first()
+        if (existing && constantTimeEqual(existing.request_fingerprint, fingerprint)) return json(200, { ok: true, idempotent: true, data: { id: existing.id, operationId: existing.id, employeeId: employee.id, employeeName: employee.display_name, type: existing.event_type === 'WORK_START' ? 'IN' : existing.event_type === 'WORK_END' ? 'OUT' : existing.event_type, eventType: existing.event_type, at: existing.occurred_at_utc, occurredAtUtc: existing.occurred_at_utc, unit: existing.unit_id, unitId: existing.unit_id, method: existing.source } }, requestId)
+        return failure(409, 'IDEMPOTENCY_CONFLICT', requestId)
+      }
+      logEvent('punch_success', { requestId, employeeId: employee.id, unitId, source: credential.source, latencyMs: Date.now() - startedAt })
+      return json(201, { ok: true, data: { id, operationId: id, employeeId: employee.id, employeeName: employee.display_name, type: eventType === 'WORK_START' ? 'IN' : eventType === 'WORK_END' ? 'OUT' : eventType, eventType, at: occurredAt, occurredAtUtc: occurredAt, unit: unitId, unitId, deviceId: actor.deviceId || null, method: credential.source, source: credential.source } }, requestId)
+    }
+
+    if (path === '/api/ponto/mirror' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      const records = await listRecords(db, actor, url)
+      return records ? json(200, { ok: true, data: records }, requestId) : failure(400, 'EMPLOYEE_REQUIRED', requestId)
+    }
+
+    if (['/api/ponto/daily', '/api/ponto/monthly', '/api/ponto/inconsistencies', '/api/ponto/bank'].includes(path) && request.method === 'GET') {
+      const employeeId = cleanText(url.searchParams.get('employeeId'), 120)
+      const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
+      const employee = actor.role === 'EMPLOYEE' ? await employeeForActor(db, actor) : await employeeById(db, actor, employeeId, unitId)
+      if (!employee || !unitId) return failure(400, 'EMPLOYEE_AND_UNIT_REQUIRED', requestId)
+      if (path === '/api/ponto/daily') {
+        const date = dateOnly(url.searchParams.get('date'))
+        if (!date) return failure(400, 'DATE_REQUIRED', requestId)
+        return json(200, { ok: true, data: await calculationForDate(db, employee.id, unitId, date) }, requestId)
+      }
+      const month = monthOnly(url.searchParams.get('month'))
+      const start = dateOnly(url.searchParams.get('from')) || (month ? `${month}-01` : '')
+      const daysInMonth = month ? new Date(Date.UTC(Number(month.slice(0, 4)), Number(month.slice(5, 7)), 0)).getUTCDate() : 0
+      const end = dateOnly(url.searchParams.get('to')) || (month ? addDays(`${month}-01`, daysInMonth - 1) : '')
+      if (!start || !end || start > end) return failure(400, 'PERIOD_REQUIRED', requestId)
+      const period = await periodCalculation(db, employee.id, unitId, start, end)
+      if (path === '/api/ponto/inconsistencies') return json(200, { ok: true, data: period.days.filter((day) => day.inconsistencies?.length || day.status === 'MISSING') }, requestId)
+      if (path === '/api/ponto/bank') return json(200, { ok: true, data: { employeeId: employee.id, unitId, from: start, to: end, openingBalanceMinutes: period.openingBalanceMinutes, closingBalanceMinutes: period.closingBalanceMinutes, entries: period.days.map((day) => ({ date: day.date, minutes: day.dailyBalanceMinutes, accumulatedMinutes: day.accumulatedBalanceMinutes, frozen: day.frozen })) } }, requestId)
+      return json(200, { ok: true, data: { employee: publicEmployee(employee), unitId, from: start, to: end, ...period } }, requestId)
+    }
+
+    if (path === '/api/ponto/corrections' && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'correction.request') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const reason = cleanText(body?.reason, 500); const proposed = body?.proposedAtUtc ? new Date(body.proposedAtUtc).toISOString() : ''
+      const event = await db.prepare('SELECT * FROM timekeeping_events WHERE id=?').bind(cleanText(body?.eventId, 120)).first()
+      const employee = event ? await employeeById(db, actor, event.employee_id, event.unit_id) : null
+      if (!event || !employee || !reason || !proposed) return failure(400, 'INVALID_CORRECTION', requestId)
+      if (await isPeriodClosed(db, event.employee_id, event.unit_id, event.work_date || event.occurred_at_utc)) return failure(409, 'PERIOD_CLOSED', requestId)
+      const id = crypto.randomUUID(); const at = now()
+      await db.batch([
+        db.prepare('INSERT INTO timekeeping_corrections (id, event_id, requested_at, requested_by, reason, proposed_at_utc) VALUES (?, ?, ?, ?, ?, ?)').bind(id, event.id, at, actor.id, reason, proposed),
+        await audit(db, { actor, action: 'CORRECTION_REQUEST', entityType: 'timekeeping_correction', entityId: id, unitId: event.unit_id, requestId, reason, before: { occurredAt: event.occurred_at_utc }, after: { proposedAtUtc: proposed } }),
+      ])
+      return json(201, { ok: true, data: { id, status: 'PENDING' } }, requestId)
+    }
+
+    if (path === '/api/ponto/corrections' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      const status = cleanText(url.searchParams.get('status'), 20).toUpperCase(); const unitId = cleanText(url.searchParams.get('unitId'), 120)
+      const rows = await db.prepare(`SELECT c.id, c.event_id, c.requested_at, c.requested_by, c.reason, c.proposed_at_utc, c.status, c.decided_at, c.decided_by, c.decision_reason, e.employee_id, e.unit_id, e.occurred_at_utc, w.display_name AS employee_name FROM timekeeping_corrections c JOIN timekeeping_events e ON e.id=c.event_id JOIN workforce_employees w ON w.id=e.employee_id WHERE (?='' OR c.status=?) AND (?='' OR e.unit_id=?) ORDER BY c.requested_at DESC LIMIT ?`).bind(status, status, unitId, unitId, limitFor(url, 100, 300)).all()
+      const data = (rows.results || []).filter((row) => actor.role === 'EMPLOYEE' ? row.requested_by === actor.id : requireUnit(actor, row.unit_id)).map((row) => ({ id: row.id, eventId: row.event_id, employeeId: row.employee_id, employeeName: row.employee_name, unitId: row.unit_id, originalAtUtc: row.occurred_at_utc, proposedAtUtc: row.proposed_at_utc, requestedAt: row.requested_at, requestedBy: row.requested_by, reason: row.reason, status: row.status, decidedAt: row.decided_at, decidedBy: row.decided_by, decisionReason: row.decision_reason }))
+      return json(200, { ok: true, data }, requestId)
+    }
+
+    if (path === '/api/ponto/schedule/sync' && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const unitId = cleanText(body?.unitId, 120); const month = monthOnly(body?.month)
+      if (!unitId || !month || !requireUnit(actor, unitId)) return failure(400, 'UNIT_AND_MONTH_REQUIRED', requestId)
+      const result = await syncSchedule(db, env, actor, unitId, month, requestId)
+      return json(200, { ok: true, data: result }, requestId)
+    }
+
+    const correctionDecision = path.match(/^\/api\/ponto\/corrections\/([^/]+)\/(approve|reject)$/)
+    if (correctionDecision && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'correction.approve')) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const reason = cleanText(body?.reason, 500)
+      if (!reason) return failure(400, 'JUSTIFICATION_REQUIRED', requestId)
+      const correction = await db.prepare(`SELECT c.*, e.unit_id, e.employee_id, e.occurred_at_utc, e.work_date FROM timekeeping_corrections c JOIN timekeeping_events e ON e.id=c.event_id WHERE c.id=?`).bind(decodeURIComponent(correctionDecision[1])).first()
+      if (!correction || correction.status !== 'PENDING') return failure(409, 'CORRECTION_NOT_PENDING', requestId)
+      if (correction.requested_by === actor.id) return failure(409, 'SEGREGATION_OF_DUTIES', requestId)
+      if (!requireUnit(actor, correction.unit_id)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      if (await isPeriodClosed(db, correction.employee_id, correction.unit_id, correction.work_date || correction.occurred_at_utc)) return failure(409, 'PERIOD_CLOSED', requestId)
+      const status = correctionDecision[2] === 'approve' ? 'APPROVED' : 'REJECTED'
+      await db.batch([
+        db.prepare('UPDATE timekeeping_corrections SET status=?, decided_at=?, decided_by=?, decision_reason=? WHERE id=? AND status=\'PENDING\'').bind(status, now(), actor.id, reason, correction.id),
+        await audit(db, { actor, action: `CORRECTION_${status}`, entityType: 'timekeeping_correction', entityId: correction.id, unitId: correction.unit_id, requestId, reason, before: { status: 'PENDING' }, after: { status } }),
+      ])
+      return json(200, { ok: true, data: { id: correction.id, status } }, requestId)
+    }
+
+    if (path === '/api/ponto/devices' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'unit.read') && !roleAllows(actor.role, 'device.manage')) return failure(403, 'FORBIDDEN', requestId)
+      const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
+      const rows = await db.prepare(`SELECT id, unit_id, label, active, revoked_at, created_at, last_seen_at FROM timekeeping_devices WHERE (?='' OR unit_id=?) ORDER BY created_at DESC LIMIT ?`).bind(unitId, unitId, limitFor(url)).all()
+      const data = (rows.results || []).filter((row) => requireUnit(actor, row.unit_id)).map((row) => ({ id: row.id, unit: row.unit_id, unitId: row.unit_id, label: row.label, active: !!row.active, revokedAt: row.revoked_at, createdAt: row.created_at, lastSeenAt: row.last_seen_at }))
+      return json(200, { ok: true, data }, requestId)
+    }
+
+    if (path === '/api/ponto/devices' && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'device.manage')) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const unitId = cleanText(body?.unitId || body?.unit, 120); const label = cleanText(body?.label, 180)
+      if (!unitId || !label || !requireUnit(actor, unitId)) return failure(400, 'INVALID_DEVICE', requestId)
+      const token = `ptd_${crypto.randomUUID().replace(/-/g, '')}${crypto.randomUUID().replace(/-/g, '')}`; const id = crypto.randomUUID(); const at = now()
+      await db.batch([
+        db.prepare('INSERT INTO timekeeping_devices (id, unit_id, label, token_hash, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?)').bind(id, unitId, label, await sha256(token), actor.id, at),
+        await audit(db, { actor, action: 'DEVICE_CREATE', entityType: 'timekeeping_device', entityId: id, unitId, requestId, after: { label } }),
+      ])
+      return json(201, { ok: true, data: { id, unitId, label, active: true, token } }, requestId)
+    }
+
+    const deviceRevoke = path.match(/^\/api\/ponto\/devices\/([^/]+)\/revoke$/)
+    if (deviceRevoke && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'device.manage')) return failure(403, 'FORBIDDEN', requestId)
+      const device = await db.prepare('SELECT * FROM timekeeping_devices WHERE id=?').bind(decodeURIComponent(deviceRevoke[1])).first()
+      if (!device || !requireUnit(actor, device.unit_id)) return failure(404, 'DEVICE_NOT_FOUND', requestId)
+      await db.batch([db.prepare('UPDATE timekeeping_devices SET active=0, revoked_at=? WHERE id=?').bind(now(), device.id), await audit(db, { actor, action: 'DEVICE_REVOKE', entityType: 'timekeeping_device', entityId: device.id, unitId: device.unit_id, requestId, reason: cleanText((await readJson(request))?.reason, 500) })])
+      return json(200, { ok: true, data: { id: device.id, active: false } }, requestId)
+    }
+
+    const pinConfigure = path.match(/^\/api\/ponto\/pin\/configure(?:\/([^/]+))?$/)
+    if (pinConfigure && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const employeeId = decodeURIComponent(pinConfigure[1] || cleanText(body?.employeeId, 120)); const employee = await employeeById(db, actor, employeeId)
+      if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
+      let credential
+      try { credential = await hashPin(body?.pin, Number(env.PONTO_PIN_ITERATIONS || 150000)) } catch { return failure(400, 'PIN_INVALID', requestId) }
+      await db.batch([
+        db.prepare(`INSERT INTO timekeeping_pin_credentials (employee_id, algorithm, salt_b64, hash_b64, iterations, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(employee_id) DO UPDATE SET algorithm=excluded.algorithm, salt_b64=excluded.salt_b64, hash_b64=excluded.hash_b64, iterations=excluded.iterations, updated_by=excluded.updated_by, updated_at=excluded.updated_at`).bind(employee.id, credential.algorithm, credential.saltB64, credential.hashB64, credential.iterations, actor.id, now()),
+        db.prepare('DELETE FROM timekeeping_pin_failures WHERE employee_id=?').bind(employee.id),
+        await audit(db, { actor, action: 'PIN_CONFIGURE', entityType: 'workforce_employee', entityId: employee.id, requestId, after: { configured: true, algorithm: credential.algorithm } }),
+      ])
+      return json(200, { ok: true, data: { employeeId: employee.id, configured: true } }, requestId)
+    }
+
+    const biometricEnroll = path.match(/^\/api\/ponto\/biometrics\/enroll(?:\/([^/]+))?$/)
+    if (biometricEnroll && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!env.PONTO_TEMPLATES_KEY) return failure(503, 'BIOMETRIC_KEY_NOT_CONFIGURED', requestId)
+      const body = await readJson(request); const employeeId = decodeURIComponent(biometricEnroll[1] || cleanText(body?.employeeId, 120)); const employee = await employeeById(db, actor, employeeId)
+      const descriptors = body?.descriptors || (body?.descriptor ? [body.descriptor] : [])
+      if (!employee || body?.consentConfirmed !== true || !Array.isArray(descriptors) || !descriptors.length || descriptors.length > 10) return failure(400, 'INVALID_BIOMETRIC_ENROLLMENT', requestId)
+      const statements = []
+      if (body.replace) statements.push(db.prepare('UPDATE timekeeping_biometric_templates SET revoked_at=?, revoked_by=? WHERE employee_id=? AND revoked_at IS NULL').bind(now(), actor.id, employee.id))
+      const enrolledAt = now()
+      for (const descriptor of descriptors) statements.push(db.prepare('INSERT INTO timekeeping_biometric_templates (id, employee_id, encrypted_template, consent_version, consented_at, consented_by, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)').bind(crypto.randomUUID(), employee.id, await encryptTemplate(descriptor, env.PONTO_TEMPLATES_KEY), cleanText(body.consentVersion, 80) || 'operational-v1', enrolledAt, actor.id, body.expiresAt ? new Date(body.expiresAt).toISOString() : null, enrolledAt))
+      statements.push(await audit(db, { actor, action: 'BIOMETRIC_ENROLL', entityType: 'workforce_employee', entityId: employee.id, requestId, after: { templateCount: descriptors.length, consentVersion: cleanText(body.consentVersion, 80) || 'operational-v1' } }))
+      await db.batch(statements)
+      return json(201, { ok: true, data: { employeeId: employee.id, enrolled: descriptors.length } }, requestId)
+    }
+
+    if (path === '/api/ponto/biometrics/revoke' && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const employee = await employeeById(db, actor, cleanText(body?.employeeId, 120)); const reason = cleanText(body?.reason, 500)
+      if (!employee || !reason) return failure(400, 'EMPLOYEE_AND_REASON_REQUIRED', requestId)
+      await db.batch([db.prepare('UPDATE timekeeping_biometric_templates SET revoked_at=?, revoked_by=? WHERE employee_id=? AND revoked_at IS NULL').bind(now(), actor.id, employee.id), await audit(db, { actor, action: 'BIOMETRIC_REVOKE', entityType: 'workforce_employee', entityId: employee.id, requestId, reason, after: { revoked: true } })])
+      return json(200, { ok: true, data: { employeeId: employee.id, revoked: true } }, requestId)
+    }
+
+    if (path === '/api/ponto/periods/close' && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'period.close')) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const employee = await employeeById(db, actor, cleanText(body?.employeeId, 120), cleanText(body?.unitId, 120)); const unitId = cleanText(body?.unitId, 120); const start = dateOnly(body?.from); const end = dateOnly(body?.to); const reason = cleanText(body?.reason, 500)
+      if (!employee || !unitId || !start || !end || start > end || !reason) return failure(400, 'INVALID_PERIOD_CLOSE', requestId)
+      const active = await db.prepare(`SELECT id FROM timekeeping_period_closures WHERE employee_id=? AND unit_id=? AND period_start=? AND period_end=? AND status='CLOSED' LIMIT 1`).bind(employee.id, unitId, start, end).first()
+      if (active) return failure(409, 'PERIOD_ALREADY_CLOSED', requestId)
+      const id = crypto.randomUUID(); const guardedDates = datesBetween(start, end); const guardedAt = now()
+      try {
+        await db.batch(guardedDates.map((date) => db.prepare(`INSERT INTO timekeeping_period_guards (employee_id, unit_id, work_date, operation_id, status, created_at) VALUES (?, ?, ?, ?, 'CLOSING', ?)`).bind(employee.id, unitId, date, id, guardedAt)))
+      } catch { return failure(409, 'PERIOD_CLOSING_OR_CLOSED', requestId) }
+      try {
+        const period = await periodCalculation(db, employee.id, unitId, start, end); const rule = await resolveRule(db, employee.id, unitId, start); const revisionRow = await db.prepare('SELECT MAX(revision) AS revision FROM timekeeping_period_closures WHERE employee_id=? AND unit_id=? AND period_start=? AND period_end=?').bind(employee.id, unitId, start, end).first(); const revision = Number(revisionRow?.revision || 0) + 1
+        const checksum = await sha256(JSON.stringify(period.days.map((day) => ({ date: day.date, eventIds: day.eventIds, balance: day.dailyBalanceMinutes }))))
+        const statements = [db.prepare(`INSERT INTO timekeeping_period_closures (id, employee_id, unit_id, period_start, period_end, status, revision, rules_snapshot_json, input_checksum, calculation_version, closed_by, closed_at) VALUES (?, ?, ?, ?, ?, 'CLOSED', ?, ?, ?, ?, ?, ?)`).bind(id, employee.id, unitId, start, end, revision, JSON.stringify(rule), checksum, env.APP_VERSION || '1.0.0', actor.id, now())]
+        for (const day of period.days) statements.push(db.prepare('INSERT INTO timekeeping_daily_snapshots (id, closure_id, employee_id, work_date, calculation_json, created_at) VALUES (?, ?, ?, ?, ?, ?)').bind(crypto.randomUUID(), id, employee.id, day.date, JSON.stringify(day), now()))
+        statements.push(db.prepare(`UPDATE timekeeping_period_guards SET status='CLOSED', closure_id=? WHERE operation_id=? AND status='CLOSING'`).bind(id, id))
+        statements.push(await audit(db, { actor, action: 'PERIOD_CLOSE', entityType: 'timekeeping_period_closure', entityId: id, unitId, requestId, reason, after: { employeeId: employee.id, start, end, revision, checksum } }))
+        await db.batch(statements)
+        return json(201, { ok: true, data: { id, status: 'CLOSED', revision, checksum, days: period.days.length } }, requestId)
+      } catch (error) {
+        await db.prepare(`DELETE FROM timekeeping_period_guards WHERE operation_id=? AND status='CLOSING'`).bind(id).run().catch(() => {})
+        throw error
+      }
+    }
+
+    if (path === '/api/ponto/periods/reopen' && request.method === 'POST') {
+      if (!roleAllows(actor.role, 'period.reopen')) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const reason = cleanText(body?.reason, 500); const closure = await db.prepare(`SELECT * FROM timekeeping_period_closures WHERE id=? AND status='CLOSED'`).bind(cleanText(body?.closureId, 120)).first()
+      if (!closure || !reason || !requireUnit(actor, closure.unit_id)) return failure(400, 'INVALID_PERIOD_REOPEN', requestId)
+      await db.batch([db.prepare(`UPDATE timekeeping_period_closures SET status='REOPENED', reopened_by=?, reopened_at=?, reopen_reason=? WHERE id=? AND status='CLOSED'`).bind(actor.id, now(), reason, closure.id), db.prepare('DELETE FROM timekeeping_period_guards WHERE closure_id=?').bind(closure.id), await audit(db, { actor, action: 'PERIOD_REOPEN', entityType: 'timekeeping_period_closure', entityId: closure.id, unitId: closure.unit_id, requestId, reason, before: { status: 'CLOSED' }, after: { status: 'REOPENED' } })])
+      return json(200, { ok: true, data: { id: closure.id, status: 'REOPENED' } }, requestId)
+    }
+
+    if (path === '/api/ponto/audit' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'audit.read')) return failure(403, 'FORBIDDEN', requestId)
+      const unitId = cleanText(url.searchParams.get('unitId'), 120); const rows = await db.prepare(`SELECT id, occurred_at, actor_id, actor_role, action, entity_type, entity_id, unit_id, reason, request_id, origin, prev_hash, hash FROM timekeeping_audit_events WHERE (?='' OR unit_id=?) ORDER BY occurred_at DESC LIMIT ?`).bind(unitId, unitId, limitFor(url, 100, 500)).all()
+      return json(200, { ok: true, data: (rows.results || []).filter((row) => !row.unit_id || requireUnit(actor, row.unit_id)) }, requestId)
+    }
+
+    if (path === '/api/ponto/export' && request.method === 'GET') {
+      if (!roleAllows(actor.role, 'export.read')) return failure(403, 'FORBIDDEN', requestId)
+      const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120); if (unitId && !requireUnit(actor, unitId)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      const employeeId = cleanText(url.searchParams.get('employeeId'), 120); const from = cleanText(url.searchParams.get('from'), 40); const to = cleanText(url.searchParams.get('to'), 40)
+      if (employeeId && !await employeeById(db, actor, employeeId, unitId)) return failure(403, 'EMPLOYEE_FORBIDDEN', requestId)
+      const rows = await db.prepare(`SELECT e.employee_id, w.display_name, e.unit_id, e.event_type, e.source, e.occurred_at_utc, e.device_id FROM timekeeping_events e JOIN workforce_employees w ON w.id=e.employee_id WHERE (?='' OR e.unit_id=?) AND (?='' OR e.employee_id=?) AND (?='' OR e.occurred_at_utc>=?) AND (?='' OR e.occurred_at_utc<=?) ORDER BY e.occurred_at_utc DESC LIMIT 10000`).bind(unitId, unitId, employeeId, employeeId, from, from, to, to).all()
+      const csv = ['employeeId,employeeName,unitId,eventType,source,occurredAtUtc,deviceId', ...(rows.results || []).filter((row) => requireUnit(actor, row.unit_id)).map((row) => [row.employee_id, row.display_name, row.unit_id, row.event_type, row.source, row.occurred_at_utc, row.device_id].map(csvCell).join(','))].join('\n')
+      return new Response(csv, { headers: { 'content-type': 'text/csv; charset=utf-8', 'content-disposition': 'attachment; filename="ponto.csv"', 'cache-control': 'no-store', 'x-request-id': requestId } })
+    }
+
+    if (path === '/api/ponto/admin/conflicts/login-email' && request.method === 'GET') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const rows = await db.prepare(`SELECT id, source_id, candidates_json FROM workforce_identity_conflicts WHERE source='PONTO_LOGIN_EMAIL' AND status='OPEN' ORDER BY created_at`).all()
+      const data = []
+      for (const conflict of rows.results || []) {
+        const employees = []
+        for (const id of JSON.parse(conflict.candidates_json || '[]')) {
+          const employee = await db.prepare('SELECT * FROM workforce_employees WHERE id=?').bind(id).first()
+          if (employee) employees.push({ ...publicEmployee(employee), loginEmail: employee.login_email || undefined, active: employee.status === 'ACTIVE' })
+        }
+        data.push({ id: conflict.id, email: conflict.source_id, count: employees.length, employees })
+      }
+      return json(200, { ok: true, data }, requestId)
+    }
+
+    if (path === '/api/ponto/admin/conflicts/login-email/resolve' && request.method === 'POST') {
+      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      const body = await readJson(request); const email = cleanText(body?.email, 240).toLowerCase(); const keepId = cleanText(body?.keepEmployeeId, 120)
+      const conflict = await db.prepare(`SELECT * FROM workforce_identity_conflicts WHERE source='PONTO_LOGIN_EMAIL' AND source_id=? AND status='OPEN' LIMIT 1`).bind(email).first()
+      const candidates = conflict ? JSON.parse(conflict.candidates_json || '[]') : []
+      if (!conflict || !candidates.includes(keepId)) return failure(400, 'INVALID_CONFLICT_RESOLUTION', requestId)
+      await db.batch([
+        db.prepare('UPDATE workforce_employees SET login_email=?, updated_at=? WHERE id=?').bind(email, now(), keepId),
+        db.prepare(`UPDATE workforce_identity_conflicts SET status='RESOLVED', resolved_at=?, resolved_by=? WHERE id=?`).bind(now(), actor.id, conflict.id),
+        await audit(db, { actor, action: 'IDENTITY_CONFLICT_RESOLVE', entityType: 'workforce_identity_conflict', entityId: conflict.id, requestId, reason: 'human-reviewed email ownership', after: { email, keepEmployeeId: keepId, unlinkedEmployeeIds: candidates.filter((id) => id !== keepId) } }),
+      ])
+      return json(200, { ok: true, data: { id: conflict.id, status: 'RESOLVED', keepEmployeeId: keepId } }, requestId)
+    }
+
+    return failure(404, 'NOT_FOUND', requestId)
+  } catch (error) {
+    logEvent('request_failure', { requestId, path, method: request.method, latencyMs: Date.now() - startedAt, errorCode: cleanText(error?.message || 'INTERNAL_ERROR', 120) })
+    return failure(500, 'INTERNAL_ERROR', requestId)
   }
-  if (path === '/api/ponto/admin/export' && request.method === 'GET') {
-    if (!roleAllows(actor.role, 'export.read')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
-    const rows = await db.prepare('SELECT employee_id, unit_id, event_type, source, occurred_at_utc FROM timekeeping_events ORDER BY occurred_at_utc DESC LIMIT 5000').all()
-    const csv = ['employeeId,unitId,eventType,source,occurredAtUtc', ...(rows.results || []).map((r) => [r.employee_id, r.unit_id, r.event_type, r.source, r.occurred_at_utc].map((v) => JSON.stringify(v ?? '')).join(','))].join('\n')
-    return new Response(csv, { headers: { 'content-type': 'text/csv; charset=utf-8', 'content-disposition': 'attachment; filename="ponto.csv"', 'x-request-id': requestId } })
-  }
-  return json(404, { ok: false, error: 'NOT_FOUND' }, requestId)
 }
 
 export default { fetch: handleTimekeeping }
-export const __testables = { roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod }
+export const __testables = { roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod, csvCell, eventsForWorkDate }

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -1,0 +1,146 @@
+import { canonicalEventType, calculateDay, calculatePeriod } from './domain.js'
+
+const encoder = new TextEncoder()
+const json = (status, payload, requestId) => new Response(JSON.stringify({ ...payload, requestId }), {
+  status,
+  headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-request-id': requestId },
+})
+const now = () => new Date().toISOString()
+const b64Url = (value) => {
+  const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(String(value || '').length / 4) * 4, '=')
+  return new TextDecoder().decode(Uint8Array.from(atob(normalized), (ch) => ch.charCodeAt(0)))
+}
+const stable = (value) => JSON.stringify(value, Object.keys(value || {}).sort())
+
+async function hmac(secret, text) {
+  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const bytes = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(text)))
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function equal(a, b) {
+  const left = encoder.encode(String(a || ''))
+  const right = encoder.encode(String(b || ''))
+  if (left.length !== right.length) return false
+  let result = 0
+  for (let i = 0; i < left.length; i++) result |= left[i] ^ right[i]
+  return result === 0
+}
+
+function requestIdFor(request) { return String(request.headers.get('x-request-id') || crypto.randomUUID()).slice(0, 120) }
+function normalizeUnits(value) { return Array.from(new Set(Array.isArray(value) ? value.map((v) => String(v || '').trim()).filter(Boolean) : [])) }
+function roleAllows(role, action) {
+  const matrix = {
+    EMPLOYEE: ['self.read', 'self.punch'], DEVICE: ['device.punch'],
+    MANAGER: ['unit.read', 'correction.request', 'correction.approve'],
+    HR: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'export.read'],
+    ADMIN: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'device.manage', 'export.read', 'audit.read'],
+    AUDITOR: ['unit.read', 'audit.read', 'export.read'],
+  }
+  return (matrix[String(role || '').toUpperCase()] || []).includes(action)
+}
+
+async function actorFor(request, env) {
+  const raw = String(request.headers.get('x-skincos-actor') || '')
+  const timestamp = String(request.headers.get('x-skincos-actor-ts') || '')
+  const signature = String(request.headers.get('x-skincos-actor-sig') || '')
+  const secret = String(env.PONTO_ACTOR_HMAC_KEY || '')
+  if (!raw || !timestamp || !signature || !secret) return null
+  const ms = Number(timestamp)
+  if (!Number.isFinite(ms) || Math.abs(Date.now() - ms) > 300000) return null
+  const expected = await hmac(secret, `${timestamp}.${raw}`)
+  if (!equal(expected, signature)) return null
+  try {
+    const parsed = JSON.parse(b64Url(raw))
+    if (!parsed?.id || !parsed?.email) return null
+    return { id: String(parsed.id), email: String(parsed.email).toLowerCase(), role: String(parsed.role || 'EMPLOYEE').toUpperCase(), allowedUnits: normalizeUnits(parsed.allowedUnits), name: String(parsed.name || '') }
+  } catch { return null }
+}
+
+function requireUnit(actor, unitId) {
+  return actor.role === 'ADMIN' || actor.role === 'HR' || actor.allowedUnits.includes(String(unitId || ''))
+}
+
+async function audit(db, { actor, action, entityType, entityId, unitId, requestId, reason, before, after }) {
+  const occurredAt = now()
+  const previous = await db.prepare('SELECT hash FROM timekeeping_audit_events ORDER BY occurred_at DESC, id DESC LIMIT 1').first()
+  const payload = { occurredAt, actorId: actor.id, action, entityType, entityId, unitId: unitId || null, requestId, reason: reason || null }
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(`${previous?.hash || ''}\n${stable(payload)}`))
+  const hash = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
+  return db.prepare(`INSERT INTO timekeeping_audit_events (id, occurred_at, actor_id, actor_role, action, entity_type, entity_id, unit_id, reason, before_json, after_json, request_id, origin, prev_hash, hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+    .bind(crypto.randomUUID(), occurredAt, actor.id, actor.role, action, entityType, entityId, unitId || null, reason || null, before ? JSON.stringify(before) : null, after ? JSON.stringify(after) : null, requestId, 'api', previous?.hash || null, hash)
+}
+
+async function employeeForActor(db, actor) {
+  return db.prepare('SELECT * FROM workforce_employees WHERE lower(login_email)=lower(?) LIMIT 1').bind(actor.email).first()
+}
+
+async function readJson(request) {
+  const body = await request.json().catch(() => null)
+  return body && typeof body === 'object' && !Array.isArray(body) ? body : null
+}
+
+export async function handleTimekeeping(request, env) {
+  const requestId = requestIdFor(request)
+  const url = new URL(request.url)
+  const path = url.pathname.replace(/^\/workforce/, '')
+  if (path === '/health' || path === '/api/ponto/health') return json(200, { ok: true, service: 'workforce-timekeeping', version: env.APP_VERSION || '1.0.0', database: !!env.DB }, requestId)
+  if (path === '/readiness' || path === '/api/ponto/readiness') {
+    try {
+      if (!env.DB) throw new Error('DB_NOT_CONFIGURED')
+      await env.DB.prepare('SELECT 1 AS ok').first()
+      return json(200, { ok: true, service: 'workforce-timekeeping', ready: true, database: 'available' }, requestId)
+    } catch { return json(503, { ok: false, error: 'NOT_READY', code: 'DATABASE_UNAVAILABLE' }, requestId) }
+  }
+  if (!path.startsWith('/api/ponto')) return json(404, { ok: false, error: 'NOT_FOUND' }, requestId)
+  if (!env.DB) return json(503, { ok: false, error: 'NOT_READY', code: 'DATABASE_UNAVAILABLE' }, requestId)
+  const actor = await actorFor(request, env)
+  if (!actor) return json(401, { ok: false, error: 'UNAUTHORIZED' }, requestId)
+  const db = env.DB
+
+  if (path === '/api/ponto/me' && request.method === 'GET') {
+    const employee = await employeeForActor(db, actor)
+    return json(200, { ok: true, data: { linked: !!employee, employee: employee ? { id: employee.id, name: employee.display_name, status: employee.status } : null, capabilities: ['self.read', 'self.punch'].filter((cap) => roleAllows(actor.role, cap)) } }, requestId)
+  }
+  if (path === '/api/ponto/me/records' && request.method === 'GET') {
+    const employee = await employeeForActor(db, actor)
+    if (!employee) return json(404, { ok: false, error: 'EMPLOYEE_NOT_LINKED' }, requestId)
+    const rows = await db.prepare('SELECT id, event_type, source, occurred_at_utc, unit_id, device_id, created_at FROM timekeeping_events WHERE employee_id=? AND superseded_by IS NULL ORDER BY occurred_at_utc DESC LIMIT 200').bind(employee.id).all()
+    return json(200, { ok: true, data: rows.results || [] }, requestId)
+  }
+  if (path === '/api/ponto/me/events' && request.method === 'POST') {
+    if (!roleAllows(actor.role, 'self.punch')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
+    const employee = await employeeForActor(db, actor)
+    const body = await readJson(request)
+    const eventType = canonicalEventType(body?.eventType)
+    const unitId = String(body?.unitId || '').trim()
+    const key = String(request.headers.get('idempotency-key') || '').trim()
+    if (!employee || !eventType || !unitId || !key || key.length > 160 || !requireUnit(actor, unitId)) return json(400, { ok: false, error: 'INVALID_PUNCH_REQUEST' }, requestId)
+    const at = now(); const id = crypto.randomUUID(); const fingerprint = await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${eventType}.${unitId}`)
+    try {
+      const insert = db.prepare('INSERT INTO timekeeping_events (id, employee_id, unit_id, device_id, event_type, source, occurred_at_utc, idempotency_scope, idempotency_key, request_fingerprint, created_by, created_at) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)')
+        .bind(id, employee.id, unitId, eventType, 'SYSTEM', at, `employee:${employee.id}`, key, fingerprint, actor.id, at)
+      await db.batch([insert, await audit(db, { actor, action: 'EVENT_CREATE', entityType: 'timekeeping_event', entityId: id, unitId, requestId, after: { eventType, source: 'SYSTEM' } })])
+      return json(201, { ok: true, data: { id, eventType, occurredAtUtc: at, unitId, operationId: id } }, requestId)
+    } catch (error) {
+      const existing = await db.prepare('SELECT id, event_type, occurred_at_utc, request_fingerprint FROM timekeeping_events WHERE idempotency_scope=? AND idempotency_key=?').bind(`employee:${employee.id}`, key).first()
+      if (existing && equal(existing.request_fingerprint, fingerprint)) return json(200, { ok: true, idempotent: true, data: { id: existing.id, eventType: existing.event_type, occurredAtUtc: existing.occurred_at_utc } }, requestId)
+      return json(409, { ok: false, error: 'IDEMPOTENCY_CONFLICT' }, requestId)
+    }
+  }
+  if (path === '/api/ponto/admin/employees' && request.method === 'GET') {
+    if (!roleAllows(actor.role, 'unit.read')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
+    const rows = await db.prepare('SELECT id, canonical_employee_id, display_name, status, terminated_at FROM workforce_employees ORDER BY display_name LIMIT 500').all()
+    return json(200, { ok: true, data: rows.results || [] }, requestId)
+  }
+  if (path === '/api/ponto/admin/export' && request.method === 'GET') {
+    if (!roleAllows(actor.role, 'export.read')) return json(403, { ok: false, error: 'FORBIDDEN' }, requestId)
+    const rows = await db.prepare('SELECT employee_id, unit_id, event_type, source, occurred_at_utc FROM timekeeping_events ORDER BY occurred_at_utc DESC LIMIT 5000').all()
+    const csv = ['employeeId,unitId,eventType,source,occurredAtUtc', ...(rows.results || []).map((r) => [r.employee_id, r.unit_id, r.event_type, r.source, r.occurred_at_utc].map((v) => JSON.stringify(v ?? '')).join(','))].join('\n')
+    return new Response(csv, { headers: { 'content-type': 'text/csv; charset=utf-8', 'content-disposition': 'attachment; filename="ponto.csv"', 'x-request-id': requestId } })
+  }
+  return json(404, { ok: false, error: 'NOT_FOUND' }, requestId)
+}
+
+export default { fetch: handleTimekeeping }
+export const __testables = { roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod }

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import worker from './worker.js'
+import worker, { __testables } from './worker.js'
 
 test('health is public and does not disclose secrets', async () => {
   const response = await worker.fetch(new Request('https://timekeeping.local/api/ponto/health'), { APP_VERSION: 'test', DB: {} })
@@ -15,4 +15,43 @@ test('readiness fails closed when D1 is unavailable', async () => {
   const response = await worker.fetch(new Request('https://timekeeping.local/api/ponto/readiness'), {})
   assert.equal(response.status, 503)
   assert.equal((await response.json()).code, 'DATABASE_UNAVAILABLE')
+})
+
+test('role matrix separates employee, manager, HR, admin and auditor duties', () => {
+  assert.equal(__testables.roleAllows('EMPLOYEE', 'self.punch'), true)
+  assert.equal(__testables.roleAllows('EMPLOYEE', 'unit.read'), false)
+  assert.equal(__testables.roleAllows('MANAGER', 'correction.request'), true)
+  assert.equal(__testables.roleAllows('MANAGER', 'correction.approve'), false)
+  assert.equal(__testables.roleAllows('HR', 'period.close'), true)
+  assert.equal(__testables.roleAllows('ADMIN', 'device.manage'), true)
+  assert.equal(__testables.roleAllows('AUDITOR', 'audit.read'), true)
+  assert.equal(__testables.roleAllows('AUDITOR', 'period.reopen'), false)
+})
+
+test('manager scope is horizontal and HR/admin scope is organization-wide', () => {
+  assert.equal(__testables.requireUnit({ role: 'MANAGER', allowedUnits: ['UNIT_A'] }, 'UNIT_A'), true)
+  assert.equal(__testables.requireUnit({ role: 'MANAGER', allowedUnits: ['UNIT_A'] }, 'UNIT_B'), false)
+  assert.equal(__testables.requireUnit({ role: 'HR', allowedUnits: [] }, 'UNIT_B'), true)
+  assert.equal(__testables.requireUnit({ role: 'ADMIN', allowedUnits: [] }, 'UNIT_B'), true)
+})
+
+test('CSV cells neutralize formulas and follow CSV quote escaping', () => {
+  assert.equal(__testables.csvCell('=HYPERLINK("https://invalid.example")'), '"\'=HYPERLINK(""https://invalid.example"")"')
+  assert.equal(__testables.csvCell('Pessoa "Teste"'), '"Pessoa ""Teste"""')
+})
+
+test('daily event partition keeps consecutive shifts separate and overnight completion together', () => {
+  const events = [
+    { id: 'a', eventType: 'WORK_START', occurredAt: '2026-07-18T11:00:00.000Z' },
+    { id: 'b', eventType: 'WORK_END', occurredAt: '2026-07-18T20:00:00.000Z' },
+    { id: 'c', eventType: 'WORK_START', occurredAt: '2026-07-19T11:00:00.000Z' },
+    { id: 'd', eventType: 'WORK_END', occurredAt: '2026-07-19T20:00:00.000Z' },
+  ]
+  assert.deepEqual(__testables.eventsForWorkDate(events, '2026-07-18', 'America/Sao_Paulo').map((event) => event.id), ['a', 'b'])
+  const overnight = [
+    { id: 'n1', eventType: 'WORK_START', occurredAt: '2026-07-19T01:00:00.000Z' },
+    { id: 'n2', eventType: 'WORK_END', occurredAt: '2026-07-19T09:00:00.000Z' },
+    { id: 'next', eventType: 'WORK_START', occurredAt: '2026-07-19T12:00:00.000Z' },
+  ]
+  assert.deepEqual(__testables.eventsForWorkDate(overnight, '2026-07-18', 'America/Sao_Paulo').map((event) => event.id), ['n1', 'n2'])
 })

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import worker from './worker.js'
+
+test('health is public and does not disclose secrets', async () => {
+  const response = await worker.fetch(new Request('https://timekeeping.local/api/ponto/health'), { APP_VERSION: 'test', DB: {} })
+  assert.equal(response.status, 200)
+  const body = await response.json()
+  assert.equal(body.ok, true)
+  assert.equal(body.service, 'workforce-timekeeping')
+  assert.equal(JSON.stringify(body).includes('PONTO_'), false)
+})
+
+test('readiness fails closed when D1 is unavailable', async () => {
+  const response = await worker.fetch(new Request('https://timekeeping.local/api/ponto/readiness'), {})
+  assert.equal(response.status, 503)
+  assert.equal((await response.json()).code, 'DATABASE_UNAVAILABLE')
+})

--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -1,0 +1,25 @@
+name = "skincos-timekeeping"
+main = "worker.js"
+compatibility_date = "2026-07-18"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "skincos-timekeeping"
+database_id = "__CONFIGURE_TIMEKEEPING_D1_ID__"
+migrations_dir = "migrations"
+
+[vars]
+APP_VERSION = "1.0.0"
+APP_ORIGIN = "https://crm.skincos.com.br"
+
+[env.staging]
+name = "skincos-timekeeping-staging"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "skincos-timekeeping-staging"
+database_id = "__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__"
+migrations_dir = "migrations"
+
+[env.staging.vars]
+APP_ORIGIN = "https://crm-staging.skincos.com.br"

--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -8,6 +8,10 @@ database_name = "skincos-timekeeping"
 database_id = "__CONFIGURE_TIMEKEEPING_D1_ID__"
 migrations_dir = "migrations"
 
+[[services]]
+binding = "SCHEDULE"
+service = "skincos-escala"
+
 [vars]
 APP_VERSION = "1.0.0"
 APP_ORIGIN = "https://crm.skincos.com.br"
@@ -21,5 +25,10 @@ database_name = "skincos-timekeeping-staging"
 database_id = "__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__"
 migrations_dir = "migrations"
 
+[[env.staging.services]]
+binding = "SCHEDULE"
+service = "skincos-escala-staging"
+
 [env.staging.vars]
+APP_VERSION = "1.0.0"
 APP_ORIGIN = "https://crm-staging.skincos.com.br"


### PR DESCRIPTION
# Workforce Timekeeping — publicação controlada

## Resumo

Este PR move o Controle de Ponto para o domínio `workforce/timekeeping`,
publicado exclusivamente pelo gateway `api` e consumido pelo CRM pelo proxy
same-origin. O JSON legado deixa de ser persistência operacional e passa a ser
somente fonte de importação/rollback controlado.

## Arquitetura e contratos

- Worker D1 próprio, com rotas HTTP, domínio de cálculo, segurança e auditoria
  separados;
- gateway em `api/src/router.js` pelo Service Binding `TIMEKEEPING`;
- proxy CRM com allowlist de headers, CSRF, HMAC v2 e limite de 1 MiB;
- respostas JSON padronizadas, inclusive para 404; `health` e `readiness`
  públicos sem segredos.

## Dados e migrations

As migrations `0001` a `0004` criam identidade canônica, aliases, unidades,
jornadas, dispositivos, credenciais, biometria cifrada, eventos append-only,
correções, fechamento, auditoria imutável e travas de período. O importador
possui dry-run, checksum, backup, idempotência, relatório de conflitos e
rollback documentado.

## Segurança

- autorização por papel e unidade no Worker;
- PIN PBKDF2, comparação segura e bloqueio progressivo global;
- HMAC v2 ligado a ator, timestamp, método, caminho, query, nonce e corpo;
- templates biométricos cifrados, sem foto, score ou vetor exposto ao cliente;
- eventos de auditoria imutáveis e CSV protegido contra fórmulas.

## Validação local

- `npm --prefix workforce/timekeeping test`;
- `npm --prefix api test`;
- `npm --prefix crm/console test`, `typecheck`, `lint` e `build`;
- migrations D1 locais, importação JSON dry-run, rollback e integração sintética;
- bundles Wrangler de staging e produção em dry-run;
- parser YAML em todos os workflows e revisão do diff/segredos.

## Deploy, secrets e bindings

O workflow `deploy-timekeeping.yml` exige `TIMEKEEPING_D1_STAGING_ID` ou
`TIMEKEEPING_D1_PRODUCTION_ID` no environment correspondente e usa os secrets
`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `PONTO_ACTOR_HMAC_KEY`,
`PONTO_IDEMPOTENCY_KEY`, `PONTO_TEMPLATES_KEY`, `ESCALA_ACTOR_HMAC_KEY` e
`TIMEKEEPING_BACKUP_PASSPHRASE`. O gateway requer o binding `TIMEKEEPING` e o
Worker requer `SCHEDULE`.

## Plano de staging e rollback

O deploy começa em `staging`, gera checkpoint D1 cifrado, aplica migrations,
publica Worker/gateway e valida `health`/`readiness`. Produção só aceita a
atestation verde do mesmo SHA. Rollback de aplicação publica a versão anterior;
migrations são expansivas e o rollback de importação segue
`docs/ponto-migration.md`.

## Riscos conhecidos e revisão

- O primeiro deploy depende de D1 e environments GitHub provisionados;
- não há merge automático: os checks protegidos de `main` devem ficar verdes;
- produção só avança após staging e smoke somente leitura.

- [ ] Revisar contratos CRM/gateway
- [ ] Confirmar secrets e bindings por environment
- [ ] Confirmar migrations/checkpoint em staging
- [ ] Aprovar staging e smoke de produção
