### PR TITLE
fix(timekeeping): make pinned deploy toolchain reproducible

### DIFF
--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -79,7 +79,10 @@ jobs:
           set -euo pipefail
           npm --prefix workforce/timekeeping ci --ignore-scripts
           npm --prefix api ci --ignore-scripts
-          (cd inventory && corepack pnpm install --frozen-lockfile --ignore-scripts)
+          # Node 22.12's bundled Corepack keyring cannot verify pnpm 9.15.4.
+          # Install the lockfile-declared version directly, rather than accepting
+          # an unpinned latest package-manager release.
+          (cd inventory && npx --yes pnpm@9.15.4 install --frozen-lockfile --ignore-scripts)
 
       - name: Verify checked-out source identity
         run: |


### PR DESCRIPTION
Corrige a falha do staging 29699653937 antes de migracoes: Node 22.12 Corepack nao reconhece a chave do pnpm 9.15.4. O workflow passa a usar npx com pnpm 9.15.4 explicitamente travado. Validado com npx pnpm 9.15.4 e git diff --check.