### PR TITLE
fix(timekeeping): bind the canonical Escala Workers

### DIFF
--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -10,7 +10,7 @@ migrations_dir = "migrations"
 
 [[services]]
 binding = "SCHEDULE"
-service = "skincos-escala"
+service = "skincos-escala-api"
 
 [vars]
 APP_VERSION = "1.0.0"
@@ -27,7 +27,7 @@ migrations_dir = "migrations"
 
 [[env.staging.services]]
 binding = "SCHEDULE"
-service = "skincos-escala-staging"
+service = "skincos-escala-api-staging"
 
 [env.staging.vars]
 APP_VERSION = "1.0.0"


### PR DESCRIPTION
Corrige o bloqueio da promocao de staging 29699844081: os nomes de service binding de Escala nao correspondiam aos Workers definidos em workforce/schedule/wrangler.toml. Sem migracoes adicionais ou publicacao de Worker nesta tentativa.