### PR TITLE
fix(ponto): align UI smoke with workforce contract

### DIFF
--- a/crm/console/scripts/ponto-ui-smoke.cjs
+++ b/crm/console/scripts/ponto-ui-smoke.cjs
@@ -323,9 +323,7 @@ async function main() {
         // Local direct backend mode: no proxy-layer config to validate.
       } else {
         if (!diag.proxy.targetConfigured) throw new Error('Proxy status: targetConfigured=false')
-        if (!diag.proxy.proxyTokenConfigured) throw new Error('Proxy status: proxyTokenConfigured=false')
         if (!diag.proxy.actorKeyConfigured) throw new Error('Proxy status: actorKeyConfigured=false')
-        if (!diag.proxy.adminTokenConfigured) throw new Error('Proxy status: adminTokenConfigured=false')
       }
     } else {
       console.log('[ponto-ui-smoke] local mode: /api/ponto/_proxy-status not available (skipping proxy asserts).')
@@ -334,8 +332,8 @@ async function main() {
     if (!diag.health || diag.health.ok !== true) {
       throw new Error(`Health failed: HTTP ${diag.healthStatus} body=${String(diag.healthText || '').slice(0, 260)}`)
     }
-    if (!proxyMissing && diag.health.cryptoTemplates !== true) {
-      throw new Error('Health: cryptoTemplates=false (biometria não configurada)')
+    if (!proxyMissing && (diag.health.service !== 'workforce-timekeeping' || diag.health.database !== true)) {
+      throw new Error(`Health contract mismatch: ${String(diag.healthText || '').slice(0, 260)}`)
     }
 
     await page.keyboard.press('Escape')


### PR DESCRIPTION
## Motivo\nO smoke de interface ainda verificava campos de status exclusivos do backend legado. O proxy definitivo expõe apenas a configuração de target e da assinatura HMAC.\n\n## Alteração\n- remove as verificações de token/admin legadas;\n- valida o contrato publicado de workforce-timekeeping e disponibilidade do banco.\n\n## Validação\n- 
ode --check crm/console/scripts/ponto-ui-smoke.cjs (WSL);\n- CI da PR pendente.