### PR TITLE
fix(crm): liberar módulos ativos para gestores

### DIFF
--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -385,8 +385,11 @@ export default function AppFunctionalNeatlab() {
         (moduleKey: string) => {
             const key = String(moduleKey || '').trim()
             if (!key) return false
-            if (key === 'escala-profissionais') return roleKey === 'GESTOR' || roleKey === 'GERENTE'
-            if (roleKey === 'GESTOR') return true
+            // Gestão do CRM não deve ficar limitada por listas de módulos
+            // eventualmente desatualizadas. Módulos ainda bloqueados continuam
+            // fora da navegação por UNLOCKED_MODULE_KEYS.
+            if (roleKey === 'GESTOR' || roleKey === 'ADMIN') return true
+            if (key === 'escala-profissionais') return roleKey === 'GERENTE'
             const allowed = Array.isArray(user?.allowedModules)
                 ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)
                 : []


### PR DESCRIPTION
Gestor e Admin passam a visualizar todos os módulos ativos do CRM, sem depender de allowedModules desatualizado. Módulos bloqueados continuam fora da navegação e as autorizações de API permanecem no backend.\n\nValidação local: typecheck, lint sem erros e build de produção aprovados.