### PR TITLE
feat(crm): unificar Supervisor e Consultor

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -613,6 +613,9 @@ let saveVisualThemeTimer = null
 const ROLE_ALIASES = new Map([
     ['ADMIN', 'GESTOR'],
     ['OPERADOR', 'INJETOR'],
+    ['RH', 'SUPERVISOR'],
+    ['AUDITOR', 'SUPERVISOR'],
+    ['EMPLOYEE', 'CONSULTOR'],
 ])
 
 const normalizeRole = (value) => {

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -43,6 +43,7 @@ import { dispatchSiteTrackingHeaderAction, subscribeSiteTrackingHeaderState } fr
 import type { SiteTrackingHeaderState } from '@/siteTrackingTypes'
 import { dispatchAtendimentoHeaderAction, subscribeAtendimentoHeaderState } from '@/atendimentoHeaderBridge'
 import type { AtendimentoHeaderState } from '@/atendimentoHeaderBridge'
+import { hasCrmModuleAccess } from '@/crmRoleAccess'
 import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, ClipboardList, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Stethoscope, WalletCards, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
@@ -378,36 +379,12 @@ export default function AppFunctionalNeatlab() {
     const pontoCanAdmin =
         roleKey === 'GESTOR' ||
         roleKey === 'GERENTE' ||
-        roleKey === 'RH' ||
+        roleKey === 'SUPERVISOR' ||
         roleKey === 'ADMIN' ||
         (isLocalDev && devEmail.endsWith('@local.test'))
     const hasModuleAccess = React.useCallback(
         (moduleKey: string) => {
-            const key = String(moduleKey || '').trim()
-            if (!key) return false
-            // Gestão do CRM não deve ficar limitada por listas de módulos
-            // eventualmente desatualizadas. Módulos ainda bloqueados continuam
-            // fora da navegação por UNLOCKED_MODULE_KEYS.
-            if (roleKey === 'GESTOR' || roleKey === 'ADMIN') return true
-            if (key === 'escala-profissionais') return roleKey === 'GERENTE'
-            const allowed = Array.isArray(user?.allowedModules)
-                ? user.allowedModules.map(String).map((s) => s.trim()).filter(Boolean)
-                : []
-            if (!allowed.length) return true // compat: vazio/ausente => ALL
-            if (allowed.includes(key)) return true
-            if (key === 'procedimentos') {
-                return allowed.some((m) => ['procedimentos', 'atendimento'].includes(m))
-            }
-            if (key === 'faturamento') {
-                return allowed.some((m) => ['faturamento', 'atendimento'].includes(m))
-            }
-            if (key === 'conversa') {
-                return allowed.some((m) => ['whatsapp-business', 'harmonia', 'omnichannel'].includes(m))
-            }
-            if (key === 'ai-automation') {
-                return allowed.some((m) => ['ai-automation', 'automation', 'whatsapp-n8n'].includes(m))
-            }
-            return false
+            return hasCrmModuleAccess(roleKey, user?.allowedModules, moduleKey)
         },
         [allowedModulesKey, roleKey]
     )

--- a/crm/console/PontoModule.tsx
+++ b/crm/console/PontoModule.tsx
@@ -477,11 +477,12 @@ export function PontoModule() {
 
   const isDev = import.meta.env.DEV
   const crmRole = String(crmMe?.user?.role || '').toUpperCase()
-  const canAdmin = ['GESTOR', 'GERENTE', 'RH', 'ADMIN', 'AUDITOR'].includes(crmRole)
-  const canAdminActions = ['GESTOR', 'GERENTE', 'RH', 'ADMIN'].includes(crmRole)
-  const canManageCanonicalEmployee = ['RH', 'ADMIN'].includes(crmRole)
-  const canApproveCorrection = ['RH', 'ADMIN'].includes(crmRole)
-  const canClosePeriod = ['RH', 'ADMIN'].includes(crmRole)
+  const canAdmin = ['GESTOR', 'GERENTE', 'SUPERVISOR', 'ADMIN'].includes(crmRole)
+  const canAdminActions = ['GESTOR', 'GERENTE', 'SUPERVISOR', 'ADMIN'].includes(crmRole)
+  const canManageDevices = ['GESTOR', 'GERENTE', 'ADMIN'].includes(crmRole)
+  const canManageCanonicalEmployee = ['SUPERVISOR', 'ADMIN'].includes(crmRole)
+  const canApproveCorrection = ['SUPERVISOR', 'ADMIN'].includes(crmRole)
+  const canClosePeriod = ['SUPERVISOR', 'ADMIN'].includes(crmRole)
   const canSeeSensitive = canAdmin || (me && 'linked' in me && me.linked)
   const maskSensitive = (value?: string | null, mask: string = '•••') => {
     const raw = String(value || '').trim()
@@ -1086,7 +1087,7 @@ export function PontoModule() {
   }
 
   async function adminCreateEmployee(opts: { enrollAfter?: boolean } = {}) {
-    if (!canManageCanonicalEmployee) return toast.error('Cadastro restrito ao RH')
+    if (!canManageCanonicalEmployee) return toast.error('Cadastro restrito ao Supervisor')
     const name = newEmployeeName.trim()
     if (!name) return toast.error('Nome é obrigatório')
     const loginEmail = newEmployeeLoginEmail.trim()
@@ -1235,7 +1236,7 @@ export function PontoModule() {
   }
 
   async function adminSaveEmployeeEdit() {
-    if (!canManageCanonicalEmployee) return toast.error('Alteração restrita ao RH')
+    if (!canManageCanonicalEmployee) return toast.error('Alteração restrita ao Supervisor')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = editName.trim()
     if (!name) return toast.error('Nome é obrigatório')
@@ -1285,7 +1286,7 @@ export function PontoModule() {
   }
 
   async function adminDeleteEmployee() {
-    if (!canManageCanonicalEmployee) return toast.error('Desligamento restrito ao RH')
+    if (!canManageCanonicalEmployee) return toast.error('Desligamento restrito ao Supervisor')
     if (!selectedEmployeeId) return toast.error('Selecione um funcionário')
     const name = selectedEmployee?.name || 'este funcionário'
     const confirmed = window.confirm(`Tem certeza que deseja remover ${name}?`)
@@ -1336,12 +1337,12 @@ export function PontoModule() {
         return
       }
       if (action === 'create') {
-        if (!canManageCanonicalEmployee) return toast.error('Cadastro canônico restrito ao RH')
+        if (!canManageCanonicalEmployee) return toast.error('Cadastro canônico restrito ao Supervisor')
         setNewEmployeeOpen(true)
         return
       }
       if (action === 'edit') {
-        if (!canManageCanonicalEmployee) return toast.error('Alteração cadastral restrita ao RH')
+        if (!canManageCanonicalEmployee) return toast.error('Alteração cadastral restrita ao Supervisor')
         openSelectEmployee('edit')
         return
       }
@@ -1383,7 +1384,7 @@ export function PontoModule() {
   }
 
   async function adminLoadEmailConflicts() {
-    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao RH')
+    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao Supervisor')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1403,7 +1404,7 @@ export function PontoModule() {
   }
 
   async function adminResolveEmailConflict(email: string, keepEmployeeId: string) {
-    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao RH')
+    if (!canManageCanonicalEmployee) return toast.error('Resolução restrita ao Supervisor')
     setConflictsLoading(true)
     setConflictsError(null)
     try {
@@ -1425,7 +1426,7 @@ export function PontoModule() {
   }
 
   async function adminCreateDevice() {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageDevices) return toast.error('Gestão de dispositivos restrita a gerentes')
     if (!newDeviceUnit.trim()) return toast.error('Unidade é obrigatória')
     setLoading(true)
     try {
@@ -1446,7 +1447,7 @@ export function PontoModule() {
   }
 
   async function adminRevokeDevice(deviceId: string) {
-    if (!canAdminActions) return toast.error('Acesso restrito a gestores')
+    if (!canManageDevices) return toast.error('Gestão de dispositivos restrita a gerentes')
     setLoading(true)
     try {
       await apiJson('/api/ponto/admin/devices/' + deviceId + '/revoke', { method: 'POST' })
@@ -1844,7 +1845,7 @@ export function PontoModule() {
                     <Button onClick={closeManagementPeriod} disabled={loading || !monthlyResult}>Fechar período</Button>
                     <Button variant="destructive" onClick={reopenManagementPeriod} disabled={loading || !lastClosureId}>Reabrir último fechamento</Button>
                   </div>
-                  <div className="text-xs text-muted-foreground">A reabertura exige permissão de RH/Administrador, justificativa e gera auditoria.</div>
+                  <div className="text-xs text-muted-foreground">A reabertura exige permissão de Supervisor/Administrador, justificativa e gera auditoria.</div>
                 </div>
               ) : null}
               <div className="space-y-2">
@@ -1853,7 +1854,7 @@ export function PontoModule() {
                   <Table>
                     <TableHeader><TableRow><TableHead>Funcionário</TableHead><TableHead>Original</TableHead><TableHead>Proposto</TableHead><TableHead>Motivo</TableHead><TableHead>Ações</TableHead></TableRow></TableHeader>
                     <TableBody>
-                      {corrections.map((correction) => <TableRow key={correction.id}><TableCell>{correction.employeeName}</TableCell><TableCell>{fmtDate(correction.originalAtUtc)}</TableCell><TableCell>{fmtDate(correction.proposedAtUtc)}</TableCell><TableCell className="max-w-56 truncate" title={correction.reason}>{correction.reason}</TableCell><TableCell><div className="flex gap-2">{canApproveCorrection ? <><Button size="sm" onClick={() => decideCorrection(correction, 'approve')}>Aprovar</Button><Button size="sm" variant="outline" onClick={() => decideCorrection(correction, 'reject')}>Recusar</Button></> : <Badge variant="outline">Aguardando RH</Badge>}</div></TableCell></TableRow>)}
+                      {corrections.map((correction) => <TableRow key={correction.id}><TableCell>{correction.employeeName}</TableCell><TableCell>{fmtDate(correction.originalAtUtc)}</TableCell><TableCell>{fmtDate(correction.proposedAtUtc)}</TableCell><TableCell className="max-w-56 truncate" title={correction.reason}>{correction.reason}</TableCell><TableCell><div className="flex gap-2">{canApproveCorrection ? <><Button size="sm" onClick={() => decideCorrection(correction, 'approve')}>Aprovar</Button><Button size="sm" variant="outline" onClick={() => decideCorrection(correction, 'reject')}>Recusar</Button></> : <Badge variant="outline">Aguardando Supervisor</Badge>}</div></TableCell></TableRow>)}
                       {!corrections.length ? <TableRow><TableCell colSpan={5} className="text-sm text-muted-foreground">Nenhuma solicitação pendente carregada.</TableCell></TableRow> : null}
                     </TableBody>
                   </Table>
@@ -2397,7 +2398,7 @@ export function PontoModule() {
                   <Input value={newDeviceLabel} onChange={(e) => setNewDeviceLabel(e.target.value)} placeholder="Recepção, Sala 1..." />
                 </div>
                 <div className="flex items-end">
-                  <Button onClick={adminCreateDevice} disabled={loading || !canAdminActions}>Criar token</Button>
+                  <Button onClick={adminCreateDevice} disabled={loading || !canManageDevices}>Criar token</Button>
                 </div>
               </div>
               {newDeviceTokenOnce ? (
@@ -2446,7 +2447,7 @@ export function PontoModule() {
                       <TableCell className="text-sm text-muted-foreground">{fmtDate(d.lastSeenAt)}</TableCell>
                       <TableCell className="text-right">
                         {!d.revokedAt ? (
-                          <Button size="sm" variant="outline" onClick={() => adminRevokeDevice(d.id)} disabled={loading}>
+                          <Button size="sm" variant="outline" onClick={() => adminRevokeDevice(d.id)} disabled={loading || !canManageDevices}>
                             Revogar
                           </Button>
                         ) : null}

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -119,8 +119,8 @@ export function UsersModule() {
   const role = String(me?.user?.role || '').trim().toUpperCase()
   const canManageInvites = role === 'GESTOR'
   const inviteRoleOptions = role === 'GESTOR'
-    ? ['INJETOR', 'GERENTE', 'GESTOR']
-    : ['INJETOR', 'GERENTE']
+    ? ['CONSULTOR', 'SUPERVISOR', 'GERENTE', 'GESTOR']
+    : ['CONSULTOR', 'SUPERVISOR', 'GERENTE']
 
   const allowedUnits = Array.isArray(me?.user?.allowedUnits) ? me!.user!.allowedUnits!.filter(Boolean) : []
 
@@ -173,7 +173,7 @@ export function UsersModule() {
   const [inviteOpen, setInviteOpen] = React.useState(false)
   const [invitesLoading, setInvitesLoading] = React.useState(false)
   const [invites, setInvites] = React.useState<Invite[]>([])
-  const [inviteRole, setInviteRole] = React.useState<string>('INJETOR')
+  const [inviteRole, setInviteRole] = React.useState<string>('CONSULTOR')
   const [inviteMaxUses, setInviteMaxUses] = React.useState<string>('1')
   const [inviteExpiresInDays, setInviteExpiresInDays] = React.useState<string>('30')
   const [inviteAllowedUnits, setInviteAllowedUnits] = React.useState<string>('')
@@ -212,7 +212,7 @@ export function UsersModule() {
     setInviteTokenOnce(null)
     setInviteTokenHint(null)
     setInviteNote('')
-    setInviteRole((cur) => (inviteRoleOptions.includes(cur) ? cur : 'INJETOR'))
+    setInviteRole((cur) => (inviteRoleOptions.includes(cur) ? cur : 'CONSULTOR'))
     setInviteAllowedUnits((cur) => {
       if (cur.trim()) return cur
       return allowedUnits.length ? allowedUnits.join(',') : ''

--- a/crm/console/crmRoleAccess.ts
+++ b/crm/console/crmRoleAccess.ts
@@ -1,0 +1,26 @@
+export const CONSULTOR_MODULE_KEYS = new Set(['atendimento', 'ponto'])
+
+function normalizedModules(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map(String).map((entry) => entry.trim()).filter(Boolean)
+    : []
+}
+
+/** Navigation policy only; every API remains authorized on the server. */
+export function hasCrmModuleAccess(role: unknown, allowedModules: unknown, moduleKey: unknown): boolean {
+  const key = String(moduleKey || '').trim()
+  const roleKey = String(role || '').trim().toUpperCase()
+  if (!key) return false
+  if (roleKey === 'GESTOR' || roleKey === 'ADMIN') return true
+  if (roleKey === 'CONSULTOR' || roleKey === 'EMPLOYEE') return CONSULTOR_MODULE_KEYS.has(key)
+  if (key === 'escala-profissionais') return roleKey === 'GERENTE'
+
+  const allowed = normalizedModules(allowedModules)
+  if (!allowed.length) return true // compatibility for existing non-Consultor users
+  if (allowed.includes(key)) return true
+  if (key === 'procedimentos') return allowed.some((module) => ['procedimentos', 'atendimento'].includes(module))
+  if (key === 'faturamento') return allowed.some((module) => ['faturamento', 'atendimento'].includes(module))
+  if (key === 'conversa') return allowed.some((module) => ['whatsapp-business', 'harmonia', 'omnichannel'].includes(module))
+  if (key === 'ai-automation') return allowed.some((module) => ['ai-automation', 'automation', 'whatsapp-n8n'].includes(module))
+  return false
+}

--- a/crm/console/functions/_lib/crmAuth.ts
+++ b/crm/console/functions/_lib/crmAuth.ts
@@ -20,6 +20,9 @@ function normalizeRole(value: unknown): string {
   if (!raw) return ''
   if (raw === 'ADMIN') return 'GESTOR'
   if (raw === 'OPERADOR') return 'INJETOR'
+  // Preserve existing users/invites while exposing the canonical hierarchy.
+  if (raw === 'RH' || raw === 'AUDITOR') return 'SUPERVISOR'
+  if (raw === 'EMPLOYEE') return 'CONSULTOR'
   return raw
 }
 

--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -110,6 +110,13 @@ function normalizeUnits(values: unknown): string[] {
   return out
 }
 
+function normalizeCrmRole(value: unknown): string {
+  const role = String(value || '').trim().toUpperCase()
+  if (role === 'RH' || role === 'AUDITOR') return 'SUPERVISOR'
+  if (role === 'EMPLOYEE') return 'CONSULTOR'
+  return role
+}
+
 export async function onRequest(context: any): Promise<Response> {
   const request: Request = context.request
   const url = new URL(request.url)
@@ -187,8 +194,8 @@ export async function onRequest(context: any): Promise<Response> {
       )
     }
     if (isAdminRoute) {
-      const role = String(user.role || '').toUpperCase()
-      isAdminUser = ['ADMIN', 'GESTOR', 'GERENTE', 'RH', 'AUDITOR'].includes(role)
+      const role = normalizeCrmRole(user.role)
+      isAdminUser = ['ADMIN', 'GESTOR', 'GERENTE', 'SUPERVISOR'].includes(role)
       if (!isAdminUser) {
         return json(
           403,
@@ -197,12 +204,14 @@ export async function onRequest(context: any): Promise<Response> {
         )
       }
     }
-    const role = String(user.role || '').toUpperCase()
+    const role = normalizeCrmRole(user.role)
     const workforceRole = role === 'GESTOR' || role === 'GERENTE'
       ? 'MANAGER'
-      : role === 'RH'
-        ? 'HR'
-        : role || 'EMPLOYEE'
+      : role === 'SUPERVISOR'
+        ? 'SUPERVISOR'
+        : role === 'CONSULTOR'
+          ? 'CONSULTOR'
+          : role || 'CONSULTOR'
     const actor = {
       id: String(user.id || user.email || ''),
       email: user.email ? String(user.email) : undefined,

--- a/crm/console/tests/crmRoleAccess.test.ts
+++ b/crm/console/tests/crmRoleAccess.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { hasCrmModuleAccess } from '../crmRoleAccess'
+
+describe('CRM role module navigation', () => {
+  it('limits Consultor to Atendimento and Ponto even without an allowedModules list', () => {
+    expect(hasCrmModuleAccess('CONSULTOR', [], 'atendimento')).toBe(true)
+    expect(hasCrmModuleAccess('CONSULTOR', [], 'ponto')).toBe(true)
+    expect(hasCrmModuleAccess('CONSULTOR', [], 'faturamento')).toBe(false)
+    expect(hasCrmModuleAccess('CONSULTOR', ['insumos'], 'insumos')).toBe(false)
+  })
+
+  it('keeps the legacy Employee spelling constrained during the transition', () => {
+    expect(hasCrmModuleAccess('EMPLOYEE', [], 'atendimento')).toBe(true)
+    expect(hasCrmModuleAccess('EMPLOYEE', [], 'ponto')).toBe(true)
+    expect(hasCrmModuleAccess('EMPLOYEE', [], 'users')).toBe(false)
+  })
+})

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -38,14 +38,30 @@ describe('Ponto CRM proxy', () => {
     expect(actor).toMatchObject({ role: 'MANAGER', allowedUnits: ['UNIT_A'] })
   })
 
-  it('normalizes the CRM RH role to the Workforce HR contract', async () => {
+  it('normalizes legacy RH and Auditor roles to the Workforce Supervisor contract', async () => {
     ;(getInsumosUser as Mock).mockResolvedValue({ id: 'rh-1', email: 'rh@example.test', role: 'RH', allowedUnits: ['UNIT_A'] })
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: [] }), { headers: { 'content-type': 'application/json' } }))
     vi.stubGlobal('fetch', fetchMock)
-    await onRequest(context('/api/ponto/employees'))
+    await onRequest(context('/api/ponto/admin/employees'))
     const upstream = fetchMock.mock.calls[0][0] as Request
     const actor = JSON.parse(Buffer.from(String(upstream.headers.get('x-skincos-actor')), 'base64url').toString('utf8'))
-    expect(actor.role).toBe('HR')
+    expect(actor.role).toBe('SUPERVISOR')
+
+    ;(getInsumosUser as Mock).mockResolvedValue({ id: 'audit-1', email: 'audit@example.test', role: 'AUDITOR', allowedUnits: ['UNIT_A'] })
+    await onRequest(context('/api/ponto/employees'))
+    const legacyAuditorUpstream = fetchMock.mock.calls[1][0] as Request
+    const legacyAuditorActor = JSON.parse(Buffer.from(String(legacyAuditorUpstream.headers.get('x-skincos-actor')), 'base64url').toString('utf8'))
+    expect(legacyAuditorActor.role).toBe('SUPERVISOR')
+  })
+
+  it('maps Consultor to a self-service Workforce actor', async () => {
+    ;(getInsumosUser as Mock).mockResolvedValue({ id: 'consultor-1', email: 'consultor@example.test', role: 'CONSULTOR', allowedUnits: ['UNIT_A'] })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: [] }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    await onRequest(context('/api/ponto/me/records'))
+    const upstream = fetchMock.mock.calls[0][0] as Request
+    const actor = JSON.parse(Buffer.from(String(upstream.headers.get('x-skincos-actor')), 'base64url').toString('utf8'))
+    expect(actor.role).toBe('CONSULTOR')
   })
 
   it('adds a unique replay nonce to protected mutations', async () => {

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -26,15 +26,22 @@ function equal(a, b) {
 
 function requestIdFor(request) { return String(request.headers.get('x-request-id') || crypto.randomUUID()).slice(0, 120) }
 function normalizeUnits(value) { return Array.from(new Set(Array.isArray(value) ? value.map((v) => String(v || '').trim()).filter(Boolean) : [])) }
+function normalizeWorkforceRole(value) {
+  const raw = String(value || '').trim().toUpperCase()
+  if (raw === 'RH' || raw === 'AUDITOR') return 'SUPERVISOR'
+  if (raw === 'EMPLOYEE') return 'CONSULTOR'
+  return raw || 'CONSULTOR'
+}
+function isConsultor(actor) { return actor?.role === 'CONSULTOR' }
+function canManageWorkforce(actor) { return actor?.role === 'SUPERVISOR' || actor?.role === 'ADMIN' }
 function roleAllows(role, action) {
   const matrix = {
-    EMPLOYEE: ['self.read', 'self.punch'], DEVICE: ['device.punch'],
+    CONSULTOR: ['self.read', 'self.punch'], DEVICE: ['device.punch'],
     MANAGER: ['unit.read', 'correction.request', 'device.manage'],
-    HR: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'export.read'],
+    SUPERVISOR: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'export.read', 'audit.read'],
     ADMIN: ['unit.read', 'correction.request', 'correction.approve', 'period.close', 'period.reopen', 'device.manage', 'export.read', 'audit.read'],
-    AUDITOR: ['unit.read', 'audit.read', 'export.read'],
   }
-  return (matrix[String(role || '').toUpperCase()] || []).includes(action)
+  return (matrix[normalizeWorkforceRole(role)] || []).includes(action)
 }
 
 async function actorFor(request, env, db, bodyHash) {
@@ -61,12 +68,12 @@ async function actorFor(request, env, db, bodyHash) {
   try {
     const parsed = JSON.parse(b64Url(raw))
     if (!parsed?.id || !parsed?.email) return null
-    return { id: String(parsed.id), email: String(parsed.email).toLowerCase(), role: String(parsed.role || 'EMPLOYEE').toUpperCase(), allowedUnits: normalizeUnits(parsed.allowedUnits), name: String(parsed.name || '') }
+    return { id: String(parsed.id), email: String(parsed.email).toLowerCase(), role: normalizeWorkforceRole(parsed.role), allowedUnits: normalizeUnits(parsed.allowedUnits), name: String(parsed.name || '') }
   } catch { return null }
 }
 
 function requireUnit(actor, unitId) {
-  return actor.role === 'ADMIN' || actor.role === 'HR' || actor.allowedUnits.includes(String(unitId || ''))
+  return actor.role === 'ADMIN' || actor.allowedUnits.includes(String(unitId || ''))
 }
 
 function publicEmployee(row) {
@@ -195,8 +202,8 @@ async function employeeUnits(db, employeeId, date = now().slice(0, 10)) {
 
 async function employeeVisible(db, actor, employee, unitId = '') {
   if (!employee) return false
-  if (actor.role === 'EMPLOYEE') return String(employee.login_email || '').toLowerCase() === actor.email
-  if (actor.role === 'ADMIN' || actor.role === 'HR' || actor.role === 'AUDITOR') return true
+  if (isConsultor(actor)) return String(employee.login_email || '').toLowerCase() === actor.email
+  if (actor.role === 'ADMIN') return true
   const units = unitId ? [unitId] : await employeeUnits(db, employee.id)
   return units.some((unit) => actor.allowedUnits.includes(unit))
 }
@@ -254,7 +261,7 @@ async function verifyPunchCredential(db, env, actor, employee, body) {
     }
     return matched ? { source: 'FACE' } : { error: 'FACE_NOT_RECOGNIZED' }
   }
-  if (actor.role === 'ADMIN' || actor.role === 'HR') return { source: 'MANUAL' }
+  if (canManageWorkforce(actor)) return { source: 'MANUAL' }
   if (String(env.ALLOW_SYSTEM_PUNCH || '').toLowerCase() === 'true') return { source: 'SYSTEM' }
   return { error: 'PUNCH_CREDENTIAL_REQUIRED' }
 }
@@ -298,14 +305,14 @@ async function periodCalculation(db, employeeId, unitId, start, end) {
 async function listScopedEmployees(db, actor, url) {
   const limit = limitFor(url, 100, 500)
   const unit = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
-  if (actor.role === 'MANAGER') {
+  if (actor.role === 'MANAGER' || actor.role === 'SUPERVISOR') {
     const units = unit ? [unit] : actor.allowedUnits
     if (!units.length || units.some((value) => !actor.allowedUnits.includes(value))) return []
     const placeholders = units.map(() => '?').join(',')
     const rows = await db.prepare(`SELECT DISTINCT e.* FROM workforce_employees e JOIN timekeeping_employee_units eu ON eu.employee_id=e.id WHERE eu.unit_id IN (${placeholders}) ORDER BY e.display_name LIMIT ?`).bind(...units, limit).all()
     return rows.results || []
   }
-  if (actor.role === 'EMPLOYEE') {
+  if (isConsultor(actor)) {
     const row = await employeeForActor(db, actor)
     return row ? [row] : []
   }
@@ -317,7 +324,7 @@ async function listRecords(db, actor, url, employeeOverride = null) {
   const employeeId = employeeOverride || cleanText(url.searchParams.get('employeeId'), 120)
   const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
   let employee = employeeId ? await employeeById(db, actor, employeeId, unitId) : null
-  if (actor.role === 'EMPLOYEE') employee = await employeeForActor(db, actor)
+  if (isConsultor(actor)) employee = await employeeForActor(db, actor)
   if (!employee) return null
   const from = cleanText(url.searchParams.get('from'), 40) || '1970-01-01T00:00:00.000Z'
   const to = cleanText(url.searchParams.get('to'), 40) || '9999-12-31T23:59:59.999Z'
@@ -429,7 +436,7 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/employees' && request.method === 'GET') {
-      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      if (!roleAllows(actor.role, 'unit.read') && !isConsultor(actor)) return failure(403, 'FORBIDDEN', requestId)
       const employees = await listScopedEmployees(db, actor, url)
       const output = []
       for (const employee of employees) {
@@ -443,7 +450,7 @@ export async function handleTimekeeping(request, env) {
 
     const employeeMatch = path.match(/^\/api\/ponto\/employees\/([^/]+)$/)
     if (employeeMatch && request.method === 'GET') {
-      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      if (!roleAllows(actor.role, 'unit.read') && !isConsultor(actor)) return failure(403, 'FORBIDDEN', requestId)
       const employee = await employeeById(db, actor, decodeURIComponent(employeeMatch[1]))
       if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
       const units = await employeeUnits(db, employee.id)
@@ -451,10 +458,11 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/employees' && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request)
       const name = cleanText(body?.name, 180); const email = cleanText(body?.loginEmail, 240).toLowerCase(); const unitId = cleanText(body?.unit || body?.unitId, 120)
       if (!name || !/^\S+@\S+\.\S+$/.test(email) || !unitId) return failure(400, 'INVALID_EMPLOYEE', requestId)
+      if (!requireUnit(actor, unitId)) return failure(403, 'UNIT_FORBIDDEN', requestId)
       const existing = await db.prepare('SELECT id, display_name FROM workforce_employees WHERE lower(login_email)=lower(?)').bind(email).first()
       if (existing) return failure(409, 'LOGIN_EMAIL_ALREADY_IN_USE', requestId, { employeeId: existing.id, employeeName: existing.display_name })
       const id = crypto.randomUUID(); const at = now(); const canonicalId = cleanText(body?.employeeId || body?.canonicalEmployeeId, 120) || `workforce:${id}`
@@ -468,7 +476,7 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (employeeMatch && ['PATCH', 'DELETE'].includes(request.method)) {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const employee = await employeeById(db, actor, decodeURIComponent(employeeMatch[1]))
       if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
       const body = request.method === 'PATCH' ? await readJson(request) : {}
@@ -488,7 +496,7 @@ export async function handleTimekeeping(request, env) {
     if (path === '/api/ponto/punches' && request.method === 'POST') {
       const body = await readJson(request)
       if (!body) return failure(400, 'INVALID_PUNCH_REQUEST', requestId)
-      let employee = actor.role === 'EMPLOYEE' ? await employeeForActor(db, actor) : await employeeById(db, actor, cleanText(body.employeeId, 120), actor.allowedUnits[0] || '')
+      let employee = isConsultor(actor) ? await employeeForActor(db, actor) : await employeeById(db, actor, cleanText(body.employeeId, 120))
       if (!employee) return failure(404, 'EMPLOYEE_NOT_LINKED', requestId)
       if (employee.status !== 'ACTIVE') return failure(409, 'EMPLOYEE_NOT_ACTIVE', requestId)
       const occurredAt = body.occurredAt ? new Date(body.occurredAt).toISOString() : now()
@@ -497,7 +505,7 @@ export async function handleTimekeeping(request, env) {
       const punchRule = await resolveRule(db, employee.id, unitId, initialWorkDate)
       const workDate = isoDateInZone(occurredAt, punchRule.timeZone || 'America/Sao_Paulo')
       if (!unitId || !await activeUnitForEmployee(db, employee.id, unitId, workDate)) return failure(403, 'UNIT_FORBIDDEN', requestId)
-      if (actor.role === 'MANAGER' && !requireUnit(actor, unitId)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      if (!isConsultor(actor) && !requireUnit(actor, unitId)) return failure(403, 'UNIT_FORBIDDEN', requestId)
       if (await isPeriodClosed(db, employee.id, unitId, workDate)) return failure(409, 'PERIOD_CLOSED', requestId)
       const credential = await verifyPunchCredential(db, env, actor, employee, body)
       if (credential.error) return failure(credential.error === 'PIN_LOCKED' ? 429 : 401, credential.error, requestId, credential.secondsRemaining ? { secondsRemaining: credential.secondsRemaining } : {})
@@ -531,7 +539,7 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/mirror' && request.method === 'GET') {
-      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      if (!roleAllows(actor.role, 'unit.read') && !isConsultor(actor)) return failure(403, 'FORBIDDEN', requestId)
       const records = await listRecords(db, actor, url)
       return records ? json(200, { ok: true, data: records }, requestId) : failure(400, 'EMPLOYEE_REQUIRED', requestId)
     }
@@ -539,7 +547,7 @@ export async function handleTimekeeping(request, env) {
     if (['/api/ponto/daily', '/api/ponto/monthly', '/api/ponto/inconsistencies', '/api/ponto/bank'].includes(path) && request.method === 'GET') {
       const employeeId = cleanText(url.searchParams.get('employeeId'), 120)
       const unitId = cleanText(url.searchParams.get('unitId') || url.searchParams.get('unit'), 120)
-      const employee = actor.role === 'EMPLOYEE' ? await employeeForActor(db, actor) : await employeeById(db, actor, employeeId, unitId)
+      const employee = isConsultor(actor) ? await employeeForActor(db, actor) : await employeeById(db, actor, employeeId, unitId)
       if (!employee || !unitId) return failure(400, 'EMPLOYEE_AND_UNIT_REQUIRED', requestId)
       if (path === '/api/ponto/daily') {
         const date = dateOnly(url.searchParams.get('date'))
@@ -558,7 +566,7 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/corrections' && request.method === 'POST') {
-      if (!roleAllows(actor.role, 'correction.request') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      if (!roleAllows(actor.role, 'correction.request') && !isConsultor(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request); const reason = cleanText(body?.reason, 500); const proposed = body?.proposedAtUtc ? new Date(body.proposedAtUtc).toISOString() : ''
       const event = await db.prepare('SELECT * FROM timekeeping_events WHERE id=?').bind(cleanText(body?.eventId, 120)).first()
       const employee = event ? await employeeById(db, actor, event.employee_id, event.unit_id) : null
@@ -573,15 +581,15 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/corrections' && request.method === 'GET') {
-      if (!roleAllows(actor.role, 'unit.read') && actor.role !== 'EMPLOYEE') return failure(403, 'FORBIDDEN', requestId)
+      if (!roleAllows(actor.role, 'unit.read') && !isConsultor(actor)) return failure(403, 'FORBIDDEN', requestId)
       const status = cleanText(url.searchParams.get('status'), 20).toUpperCase(); const unitId = cleanText(url.searchParams.get('unitId'), 120)
       const rows = await db.prepare(`SELECT c.id, c.event_id, c.requested_at, c.requested_by, c.reason, c.proposed_at_utc, c.status, c.decided_at, c.decided_by, c.decision_reason, e.employee_id, e.unit_id, e.occurred_at_utc, w.display_name AS employee_name FROM timekeeping_corrections c JOIN timekeeping_events e ON e.id=c.event_id JOIN workforce_employees w ON w.id=e.employee_id WHERE (?='' OR c.status=?) AND (?='' OR e.unit_id=?) ORDER BY c.requested_at DESC LIMIT ?`).bind(status, status, unitId, unitId, limitFor(url, 100, 300)).all()
-      const data = (rows.results || []).filter((row) => actor.role === 'EMPLOYEE' ? row.requested_by === actor.id : requireUnit(actor, row.unit_id)).map((row) => ({ id: row.id, eventId: row.event_id, employeeId: row.employee_id, employeeName: row.employee_name, unitId: row.unit_id, originalAtUtc: row.occurred_at_utc, proposedAtUtc: row.proposed_at_utc, requestedAt: row.requested_at, requestedBy: row.requested_by, reason: row.reason, status: row.status, decidedAt: row.decided_at, decidedBy: row.decided_by, decisionReason: row.decision_reason }))
+      const data = (rows.results || []).filter((row) => isConsultor(actor) ? row.requested_by === actor.id : requireUnit(actor, row.unit_id)).map((row) => ({ id: row.id, eventId: row.event_id, employeeId: row.employee_id, employeeName: row.employee_name, unitId: row.unit_id, originalAtUtc: row.occurred_at_utc, proposedAtUtc: row.proposed_at_utc, requestedAt: row.requested_at, requestedBy: row.requested_by, reason: row.reason, status: row.status, decidedAt: row.decided_at, decidedBy: row.decided_by, decisionReason: row.decision_reason }))
       return json(200, { ok: true, data }, requestId)
     }
 
     if (path === '/api/ponto/schedule/sync' && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request); const unitId = cleanText(body?.unitId, 120); const month = monthOnly(body?.month)
       if (!unitId || !month || !requireUnit(actor, unitId)) return failure(400, 'UNIT_AND_MONTH_REQUIRED', requestId)
       const result = await syncSchedule(db, env, actor, unitId, month, requestId)
@@ -637,7 +645,7 @@ export async function handleTimekeeping(request, env) {
 
     const pinConfigure = path.match(/^\/api\/ponto\/pin\/configure(?:\/([^/]+))?$/)
     if (pinConfigure && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request); const employeeId = decodeURIComponent(pinConfigure[1] || cleanText(body?.employeeId, 120)); const employee = await employeeById(db, actor, employeeId)
       if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
       let credential
@@ -652,7 +660,7 @@ export async function handleTimekeeping(request, env) {
 
     const biometricEnroll = path.match(/^\/api\/ponto\/biometrics\/enroll(?:\/([^/]+))?$/)
     if (biometricEnroll && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       if (!env.PONTO_TEMPLATES_KEY) return failure(503, 'BIOMETRIC_KEY_NOT_CONFIGURED', requestId)
       const body = await readJson(request); const employeeId = decodeURIComponent(biometricEnroll[1] || cleanText(body?.employeeId, 120)); const employee = await employeeById(db, actor, employeeId)
       const descriptors = body?.descriptors || (body?.descriptor ? [body.descriptor] : [])
@@ -667,7 +675,7 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/biometrics/revoke' && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request); const employee = await employeeById(db, actor, cleanText(body?.employeeId, 120)); const reason = cleanText(body?.reason, 500)
       if (!employee || !reason) return failure(400, 'EMPLOYEE_AND_REASON_REQUIRED', requestId)
       await db.batch([db.prepare('UPDATE timekeeping_biometric_templates SET revoked_at=?, revoked_by=? WHERE employee_id=? AND revoked_at IS NULL').bind(now(), actor.id, employee.id), await audit(db, { actor, action: 'BIOMETRIC_REVOKE', entityType: 'workforce_employee', entityId: employee.id, requestId, reason, after: { revoked: true } })])
@@ -724,26 +732,36 @@ export async function handleTimekeeping(request, env) {
     }
 
     if (path === '/api/ponto/admin/conflicts/login-email' && request.method === 'GET') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const rows = await db.prepare(`SELECT id, source_id, candidates_json FROM workforce_identity_conflicts WHERE source='PONTO_LOGIN_EMAIL' AND status='OPEN' ORDER BY created_at`).all()
       const data = []
       for (const conflict of rows.results || []) {
         const employees = []
+        let allCandidatesVisible = true
         for (const id of JSON.parse(conflict.candidates_json || '[]')) {
           const employee = await db.prepare('SELECT * FROM workforce_employees WHERE id=?').bind(id).first()
-          if (employee) employees.push({ ...publicEmployee(employee), loginEmail: employee.login_email || undefined, active: employee.status === 'ACTIVE' })
+          if (!employee || !await employeeVisible(db, actor, employee)) {
+            allCandidatesVisible = false
+            continue
+          }
+          employees.push({ ...publicEmployee(employee), loginEmail: employee.login_email || undefined, active: employee.status === 'ACTIVE' })
         }
-        data.push({ id: conflict.id, email: conflict.source_id, count: employees.length, employees })
+        // A Supervisor is never shown part of a cross-unit identity conflict.
+        if (allCandidatesVisible) data.push({ id: conflict.id, email: conflict.source_id, count: employees.length, employees })
       }
       return json(200, { ok: true, data }, requestId)
     }
 
     if (path === '/api/ponto/admin/conflicts/login-email/resolve' && request.method === 'POST') {
-      if (!['HR', 'ADMIN'].includes(actor.role)) return failure(403, 'FORBIDDEN', requestId)
+      if (!canManageWorkforce(actor)) return failure(403, 'FORBIDDEN', requestId)
       const body = await readJson(request); const email = cleanText(body?.email, 240).toLowerCase(); const keepId = cleanText(body?.keepEmployeeId, 120)
       const conflict = await db.prepare(`SELECT * FROM workforce_identity_conflicts WHERE source='PONTO_LOGIN_EMAIL' AND source_id=? AND status='OPEN' LIMIT 1`).bind(email).first()
       const candidates = conflict ? JSON.parse(conflict.candidates_json || '[]') : []
       if (!conflict || !candidates.includes(keepId)) return failure(400, 'INVALID_CONFLICT_RESOLUTION', requestId)
+      for (const candidateId of candidates) {
+        const candidate = await db.prepare('SELECT * FROM workforce_employees WHERE id=?').bind(candidateId).first()
+        if (!candidate || !await employeeVisible(db, actor, candidate)) return failure(403, 'UNIT_FORBIDDEN', requestId)
+      }
       await db.batch([
         db.prepare('UPDATE workforce_employees SET login_email=?, updated_at=? WHERE id=?').bind(email, now(), keepId),
         db.prepare(`UPDATE workforce_identity_conflicts SET status='RESOLVED', resolved_at=?, resolved_by=? WHERE id=?`).bind(now(), actor.id, conflict.id),
@@ -760,4 +778,4 @@ export async function handleTimekeeping(request, env) {
 }
 
 export default { fetch: handleTimekeeping }
-export const __testables = { roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod, csvCell, eventsForWorkDate }
+export const __testables = { normalizeWorkforceRole, roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod, csvCell, eventsForWorkDate }

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -17,21 +17,24 @@ test('readiness fails closed when D1 is unavailable', async () => {
   assert.equal((await response.json()).code, 'DATABASE_UNAVAILABLE')
 })
 
-test('role matrix separates employee, manager, HR, admin and auditor duties', () => {
-  assert.equal(__testables.roleAllows('EMPLOYEE', 'self.punch'), true)
-  assert.equal(__testables.roleAllows('EMPLOYEE', 'unit.read'), false)
+test('role matrix keeps consultor self-service and gives supervisor the former RH/auditor duties', () => {
+  assert.equal(__testables.roleAllows('CONSULTOR', 'self.punch'), true)
+  assert.equal(__testables.roleAllows('CONSULTOR', 'unit.read'), false)
   assert.equal(__testables.roleAllows('MANAGER', 'correction.request'), true)
   assert.equal(__testables.roleAllows('MANAGER', 'correction.approve'), false)
-  assert.equal(__testables.roleAllows('HR', 'period.close'), true)
+  assert.equal(__testables.roleAllows('SUPERVISOR', 'period.close'), true)
+  assert.equal(__testables.roleAllows('SUPERVISOR', 'audit.read'), true)
   assert.equal(__testables.roleAllows('ADMIN', 'device.manage'), true)
-  assert.equal(__testables.roleAllows('AUDITOR', 'audit.read'), true)
-  assert.equal(__testables.roleAllows('AUDITOR', 'period.reopen'), false)
+  assert.equal(__testables.normalizeWorkforceRole('RH'), 'SUPERVISOR')
+  assert.equal(__testables.normalizeWorkforceRole('AUDITOR'), 'SUPERVISOR')
+  assert.equal(__testables.normalizeWorkforceRole('EMPLOYEE'), 'CONSULTOR')
 })
 
-test('manager scope is horizontal and HR/admin scope is organization-wide', () => {
+test('manager and supervisor scopes are horizontal while admin remains organization-wide', () => {
   assert.equal(__testables.requireUnit({ role: 'MANAGER', allowedUnits: ['UNIT_A'] }, 'UNIT_A'), true)
   assert.equal(__testables.requireUnit({ role: 'MANAGER', allowedUnits: ['UNIT_A'] }, 'UNIT_B'), false)
-  assert.equal(__testables.requireUnit({ role: 'HR', allowedUnits: [] }, 'UNIT_B'), true)
+  assert.equal(__testables.requireUnit({ role: 'SUPERVISOR', allowedUnits: ['UNIT_A'] }, 'UNIT_A'), true)
+  assert.equal(__testables.requireUnit({ role: 'SUPERVISOR', allowedUnits: ['UNIT_A'] }, 'UNIT_B'), false)
   assert.equal(__testables.requireUnit({ role: 'ADMIN', allowedUnits: [] }, 'UNIT_B'), true)
 })
 


### PR DESCRIPTION
Unifica RH e Auditor no perfil Supervisor, abaixo de Gerente e limitado às unidades atribuídas no Ponto. Renomeia Employee para Consultor, liberando somente Atendimento e Ponto com escopo estritamente próprio no backend. Mantém aliases de transição para sessões e convites legados.\n\nValidação local: Workforce 19 testes, proxy/navegação 9 testes, typecheck, lint e build aprovados.