### PR TITLE
fix(crm): grant local test user Gestor access

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Plataforma interna (local) para automações e operações da clínica.
 ### Auth local (sem login manual)
 - Em `localhost`, o bypass de auth **só é ativado com flag explícita** (`LOCAL_AUTH_BYPASS=true` ou `VITE_LOCAL_AUTH_BYPASS=true`).
 - Para habilitar bypass no frontend local: `VITE_LOCAL_AUTH_BYPASS=true npm run dev`.
+- Com o bypass local, a conta de teste é `GESTOR` por padrão e acessa todos os módulos ativos. Para validar um perfil restrito, use `LOCAL_AUTH_TEST_USER_ADMIN=false` junto de `LOCAL_AUTH_ROLE=<perfil>`.
 - Overrides úteis (frontend local): `VITE_LOCAL_AUTH_ROLE`, `VITE_LOCAL_AUTH_EMAIL`, `VITE_LOCAL_AUTH_NAME`.
 - Em Pages Functions local (`npm run dev:pages`), `requireCrmUser` só faz bypass em `localhost` quando a flag acima estiver ativa.
 - No CRM API local (`crm/api/server.js`), o stub de sessão dev exige `NO_AUTH=true` (não é mais default).

--- a/crm/console/.dev.vars.example
+++ b/crm/console/.dev.vars.example
@@ -9,6 +9,9 @@ ESCALA_API_TARGET=https://escala-api.skincos.com.br
 AUTH_PATH_PREFIX=/insumos/auth
 LOCAL_AUTH_BYPASS=false
 LOCAL_AUTH_ROLE=GESTOR
+# Local test account defaults to Gestor and can access every active module.
+# Set false only while deliberately validating a restricted local role.
+LOCAL_AUTH_TEST_USER_ADMIN=true
 LOCAL_AUTH_EMAIL=dev@local.test
 LOCAL_AUTH_NAME=Dev Local
 LOCAL_ESCALA_MOCK=false

--- a/crm/console/functions/_lib/crmAuth.ts
+++ b/crm/console/functions/_lib/crmAuth.ts
@@ -95,16 +95,22 @@ export function isLocalDevAuthBypassEnabled(context: any): boolean {
 
 export function getLocalDevAuthUser(context: any): CrmAuthUser {
   const env = context?.env || {}
-  const role = normalizeRole(env.LOCAL_AUTH_ROLE || env.DEV_AUTH_ROLE || 'GESTOR') || 'GESTOR'
+  // The local launcher represents one privileged test account. Keep it aligned
+  // with the Gestor experience so every active CRM module can be exercised
+  // locally. Role-specific local tests can opt out explicitly.
+  const localTestUserAdmin = parseBoolean(env.LOCAL_AUTH_TEST_USER_ADMIN) !== false
+  const role = localTestUserAdmin
+    ? 'GESTOR'
+    : (normalizeRole(env.LOCAL_AUTH_ROLE || env.DEV_AUTH_ROLE || 'GESTOR') || 'GESTOR')
   const email = String(env.LOCAL_AUTH_EMAIL || env.DEV_AUTH_EMAIL || 'dev@local.test').trim() || 'dev@local.test'
   const username = String(env.LOCAL_AUTH_USERNAME || email.split('@')[0] || 'dev').trim() || 'dev'
   const displayName = String(env.LOCAL_AUTH_NAME || env.DEV_AUTH_NAME || 'Dev Local').trim() || 'Dev Local'
   const allowedUnits =
     parseList(env.LOCAL_AUTH_ALLOWED_UNITS) ||
     parseList(env.DEV_AUTH_ALLOWED_UNITS)
-  const allowedModules =
-    parseList(env.LOCAL_AUTH_ALLOWED_MODULES) ||
-    parseList(env.DEV_AUTH_ALLOWED_MODULES)
+  const allowedModules = localTestUserAdmin
+    ? undefined
+    : (parseList(env.LOCAL_AUTH_ALLOWED_MODULES) || parseList(env.DEV_AUTH_ALLOWED_MODULES))
 
   return {
     id: username,

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -48,6 +48,7 @@ upsert_non_secret_dev_var() {
 
 upsert_non_secret_dev_var "LOCAL_AUTH_BYPASS" "${LOCAL_AUTH_BYPASS:-false}"
 upsert_non_secret_dev_var "LOCAL_AUTH_ROLE" "${LOCAL_AUTH_ROLE:-GESTOR}"
+upsert_non_secret_dev_var "LOCAL_AUTH_TEST_USER_ADMIN" "${LOCAL_AUTH_TEST_USER_ADMIN:-true}"
 upsert_non_secret_dev_var "LOCAL_AUTH_EMAIL" "${LOCAL_AUTH_EMAIL:-dev@local.test}"
 upsert_non_secret_dev_var "LOCAL_AUTH_NAME" "${LOCAL_AUTH_NAME:-Dev Local}"
 ensure_dev_var "ESCALA_API_TARGET" "https://escala-api.skincos.com.br"

--- a/crm/console/tests/crmLocalTestUserAccess.test.ts
+++ b/crm/console/tests/crmLocalTestUserAccess.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { getLocalDevAuthUser } from '../functions/_lib/crmAuth'
+
+function context(env: Record<string, string | undefined>) {
+  return { env }
+}
+
+describe('local CRM test user', () => {
+  it('uses Gestor and no module restriction by default', () => {
+    const user = getLocalDevAuthUser(context({
+      LOCAL_AUTH_ROLE: 'CONSULTOR',
+      LOCAL_AUTH_ALLOWED_MODULES: 'atendimento,ponto',
+    }))
+
+    expect(user.role).toBe('GESTOR')
+    expect(user.allowedModules).toBeUndefined()
+  })
+
+  it('permits an explicit opt-out for restricted-role checks', () => {
+    const user = getLocalDevAuthUser(context({
+      LOCAL_AUTH_TEST_USER_ADMIN: 'false',
+      LOCAL_AUTH_ROLE: 'CONSULTOR',
+      LOCAL_AUTH_ALLOWED_MODULES: 'atendimento,ponto',
+    }))
+
+    expect(user.role).toBe('CONSULTOR')
+    expect(user.allowedModules).toEqual(['atendimento', 'ponto'])
+  })
+})

--- a/crm/console/useReplitAuth.ts
+++ b/crm/console/useReplitAuth.ts
@@ -9,7 +9,10 @@ export function useReplitAuth() {
     !!import.meta.env.DEV &&
     isLocalDevHost &&
     String(localStorage.getItem('crm.localAuth') || 'on').toLowerCase() !== 'off'
-  const localRoleRaw = String(localStorage.getItem('crm.localRole') || import.meta.env.VITE_LOCAL_AUTH_ROLE || 'GESTOR').trim().toUpperCase()
+  const localTestUserAdmin = String(import.meta.env.VITE_LOCAL_TEST_USER_ADMIN || 'true').trim().toLowerCase() !== 'false'
+  const localRoleRaw = localTestUserAdmin
+    ? 'GESTOR'
+    : String(localStorage.getItem('crm.localRole') || import.meta.env.VITE_LOCAL_AUTH_ROLE || 'GESTOR').trim().toUpperCase()
   const localRole = localRoleRaw === 'ADMIN' ? 'GESTOR' : (localRoleRaw === 'OPERADOR' ? 'INJETOR' : localRoleRaw)
   const localEmail = String(localStorage.getItem('crm.localEmail') || import.meta.env.VITE_LOCAL_AUTH_EMAIL || 'dev@local.test')
   const localUsername = String(localStorage.getItem('crm.localUser') || localEmail.split('@')[0] || 'dev')

--- a/crm/console/vite.config.ts
+++ b/crm/console/vite.config.ts
@@ -83,8 +83,13 @@ const apiProxyTarget =
 
 const localAuthBypassEnabled =
   parseBooleanEnv(envValue('VITE_LOCAL_AUTH_BYPASS', 'LOCAL_AUTH_BYPASS')) ?? false
+// The standard local account exercises the full Gestor surface. Set this to
+// false only when intentionally validating a restricted profile locally.
+const localTestUserAdmin =
+  parseBooleanEnv(envValue('VITE_LOCAL_AUTH_TEST_USER_ADMIN', 'LOCAL_AUTH_TEST_USER_ADMIN')) ?? true
 const localAuthRole = (() => {
   const raw = String(envValue('VITE_LOCAL_AUTH_ROLE', 'LOCAL_AUTH_ROLE') || 'GESTOR').trim().toUpperCase()
+  if (localTestUserAdmin) return 'GESTOR'
   if (raw === 'ADMIN') return 'GESTOR'
   if (raw === 'OPERADOR') return 'INJETOR'
   return raw || 'GESTOR'
@@ -102,7 +107,7 @@ const localAuthAllowedUnits = String(
   .map((item) => item.trim())
   .filter(Boolean)
 const localAuthAllowedModules = String(
-  envValue('VITE_LOCAL_AUTH_ALLOWED_MODULES', 'LOCAL_AUTH_ALLOWED_MODULES') || '',
+  localTestUserAdmin ? '' : (envValue('VITE_LOCAL_AUTH_ALLOWED_MODULES', 'LOCAL_AUTH_ALLOWED_MODULES') || ''),
 ).trim()
   .split(',')
   .map((item) => item.trim())

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -515,6 +515,7 @@ export PAGES_PORT="$CRM_PAGES_PORT"
 if [[ "$CRM_PROFILE" == "realistic" ]]; then
   export LOCAL_AUTH_BYPASS=true
   export LOCAL_AUTH_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
+  export LOCAL_AUTH_TEST_USER_ADMIN="${LOCAL_AUTH_TEST_USER_ADMIN:-true}"
   export LOCAL_AUTH_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}"
   export LOCAL_AUTH_NAME="${LOCAL_AUTH_NAME:-Teste CRM Local}"
   if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then


### PR DESCRIPTION
## Alteração\n- a conta padrão do bypass local passa a ser explicitamente Gestor, sem restrição de módulos\n- o comportamento fica alinhado entre Pages Functions, Vite e o launcher CRM local\n- perfis restritos continuam testáveis com LOCAL_AUTH_TEST_USER_ADMIN=false\n\n## Validação\n- itest run tests/crmLocalTestUserAccess.test.ts tests/crmRoleAccess.test.ts (4 passed)\n- 
pm ci (sem vulnerabilidades novas)\n- typecheck/lint/build local interrompidos por bloqueio de I/O p9_client_rpc no worktree Windows/WSL; CI Linux cobre os gates completos.