### PR TITLE
fix(crm): isolate local runtime and start Timekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Plataforma interna (local) para automações e operações da clínica.
   - sobe o CRM via `Pages Functions` local (`crm/console/scripts/dev_pages.sh`)
   - ativa bypass local de auth apenas em `localhost`
   - preserva os módulos que já suportam leitura real com segurança, como `Escala`
+  - os atalhos `CRM Local`, `Site EF` e `Meta Ads` usam um worktree privado, destacado em `origin/main`. Alterações não integradas no checkout aberto não são carregadas no runtime local.
+  - o primeiro uso do gate local instala o Chromium do Playwright; o CRM não inicia se a smoke obrigatória não puder ser executada.
+  - no perfil genérico, o launcher inicia o `workforce/timekeeping` local, aplica suas migrations e faz o proxy do Ponto assinar requests com uma chave local de teste; nenhum secret de produção é copiado para o ambiente local.
 - Para testar a sessão real sem bypass: `CRM_PROFILE=session npm run crm:local`
 - Para testar `Insumos` sem tocar a produção:
   - `CRM_WITH_INSUMOS=1 npm run crm:local`

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -60,6 +60,12 @@ PAGES_BINDING_ARGS=()
 if [[ -n "${LOCAL_INSUMOS_API_TARGET:-}" ]]; then
   PAGES_BINDING_ARGS+=(--binding "INSUMOS_API_TARGET=${LOCAL_INSUMOS_API_TARGET}")
 fi
+if [[ -n "${PONTO_API_TARGET:-}" ]]; then
+  PAGES_BINDING_ARGS+=(--binding "PONTO_API_TARGET=${PONTO_API_TARGET}")
+fi
+if [[ -n "${PONTO_ACTOR_HMAC_KEY:-}" ]]; then
+  PAGES_BINDING_ARGS+=(--binding "PONTO_ACTOR_HMAC_KEY=${PONTO_ACTOR_HMAC_KEY}")
+fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/
 if [[ -f "$ROOT_DIR/public/_routes.json" ]]; then

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 FRONTEND_DIR="$ROOT_DIR/crm/console"
 BACKEND_DIR="$ROOT_DIR/backend"
+TIMEKEEPING_DIR="$ROOT_DIR/workforce/timekeeping"
 INSUMOS_HELPER="$ROOT_DIR/backend/scripts/insumos.sh"
 INSUMOS_EXPORTER="$ROOT_DIR/backend/scripts/insumos-d1-export.cjs"
 INSUMOS_SEEDER="$ROOT_DIR/backend/scripts/insumos-seed.sh"
@@ -56,6 +57,18 @@ else
   CRM_WITH_INSUMOS=0
 fi
 CRM_INSUMOS_PORT="${CRM_INSUMOS_PORT:-8787}"
+if [[ -n "${CRM_WITH_TIMEKEEPING+x}" ]]; then
+  CRM_WITH_TIMEKEEPING="$CRM_WITH_TIMEKEEPING"
+elif [[ -z "$CRM_MODULE" || "$CRM_MODULE" == "ponto" ]]; then
+  CRM_WITH_TIMEKEEPING=1
+else
+  CRM_WITH_TIMEKEEPING=0
+fi
+CRM_TIMEKEEPING_PORT="${CRM_TIMEKEEPING_PORT:-8801}"
+# Local-only values. Production uses separate Pages and Worker secrets.
+CRM_TIMEKEEPING_ACTOR_KEY="${CRM_TIMEKEEPING_ACTOR_KEY:-test-actor-key-not-secret}"
+CRM_TIMEKEEPING_IDEMPOTENCY_KEY="${CRM_TIMEKEEPING_IDEMPOTENCY_KEY:-test-idempotency-key-not-secret}"
+CRM_TIMEKEEPING_TEMPLATES_KEY="${CRM_TIMEKEEPING_TEMPLATES_KEY:-test-template-key-not-secret}"
 CRM_INSUMOS_SNAPSHOT="${CRM_INSUMOS_SNAPSHOT:-}"
 CRM_REFRESH_INSUMOS_SNAPSHOT="${CRM_REFRESH_INSUMOS_SNAPSHOT:-0}"
 CRM_INSUMOS_SEED_TOKEN="${CRM_INSUMOS_SEED_TOKEN:-dev-seed-token}"
@@ -347,6 +360,53 @@ ensure_frontend_ready() {
   fi
 }
 
+ensure_playwright_chromium() {
+  if [[ "$CRM_GATE_STRICT" != "1" && "$CRM_SMOKE" != "1" ]]; then
+    return 0
+  fi
+
+  echo "[crm-local] Garantindo o Chromium do Playwright para o gate local..."
+  (
+    cd "$FRONTEND_DIR"
+    PLAYWRIGHT_BROWSERS_PATH=0 npm exec playwright install chromium
+  )
+}
+
+ensure_timekeeping_ready() {
+  if [[ ! -d "$TIMEKEEPING_DIR" ]]; then
+    echo "[crm-local] O domínio Workforce/Timekeeping não foi encontrado em $TIMEKEEPING_DIR." >&2
+    exit 1
+  fi
+  if [[ ! -d "$TIMEKEEPING_DIR/node_modules" ]]; then
+    echo "[crm-local] Instalando dependências locais do Timekeeping..."
+    npm --prefix "$TIMEKEEPING_DIR" install
+  fi
+}
+
+start_timekeeping_local() {
+  ensure_timekeeping_ready
+  echo "[crm-local] Aplicando migrations locais do Timekeeping..."
+  (
+    cd "$TIMEKEEPING_DIR"
+    ./node_modules/.bin/wrangler d1 migrations apply skincos-timekeeping --local --config=wrangler.toml
+  ) >>"$LOG_FILE" 2>&1
+
+  echo "[crm-local] Iniciando Workforce/Timekeeping local em :$CRM_TIMEKEEPING_PORT"
+  (
+    cd "$TIMEKEEPING_DIR"
+    ./node_modules/.bin/wrangler dev --local --port "$CRM_TIMEKEEPING_PORT" --config=wrangler.toml \
+      --var "PONTO_ACTOR_HMAC_KEY:$CRM_TIMEKEEPING_ACTOR_KEY" \
+      --var "PONTO_IDEMPOTENCY_KEY:$CRM_TIMEKEEPING_IDEMPOTENCY_KEY" \
+      --var "PONTO_TEMPLATES_KEY:$CRM_TIMEKEEPING_TEMPLATES_KEY"
+  ) >>"$LOG_FILE" 2>&1 &
+  TIMEKEEPING_PID=$!
+
+  if ! wait_for_http "http://127.0.0.1:${CRM_TIMEKEEPING_PORT}/api/ponto/readiness" 90; then
+    echo "[crm-local] Workforce/Timekeeping não respondeu em tempo hábil." >&2
+    exit 1
+  fi
+}
+
 ensure_frontend_dist_ready() {
   if [[ -f "$FRONTEND_DIR/dist/index.html" ]]; then
     return 0
@@ -431,6 +491,9 @@ if [[ "$STOP_ONLY" == "1" ]]; then
   if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
     stop_owned_port_listener "$CRM_INSUMOS_PORT" "insumos"
   fi
+  if [[ "$CRM_WITH_TIMEKEEPING" == "1" ]]; then
+    stop_owned_port_listener "$CRM_TIMEKEEPING_PORT" "workforce-timekeeping"
+  fi
   echo "CRM local finalizado."
   exit 0
 fi
@@ -495,6 +558,7 @@ rotate_current_log
 assert_port_free "$CRM_VITE_PORT" "vite"
 assert_port_free "$CRM_PAGES_PORT" "pages"
 ensure_frontend_ready
+ensure_playwright_chromium
 
 if [[ "$CRM_BUILD_BEFORE_START" == "1" ]]; then
   echo "[crm-local] Gerando build do frontend para alinhar o shell local ao online..."
@@ -509,6 +573,12 @@ if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
   start_insumos_local
 fi
 
+TIMEKEEPING_PID=""
+if [[ "$CRM_WITH_TIMEKEEPING" == "1" ]]; then
+  assert_port_free "$CRM_TIMEKEEPING_PORT" "workforce-timekeeping"
+  start_timekeeping_local
+fi
+
 export VITE_PORT="$CRM_VITE_PORT"
 export PAGES_PORT="$CRM_PAGES_PORT"
 
@@ -518,6 +588,10 @@ if [[ "$CRM_PROFILE" == "realistic" ]]; then
   export LOCAL_AUTH_TEST_USER_ADMIN="${LOCAL_AUTH_TEST_USER_ADMIN:-true}"
   export LOCAL_AUTH_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}"
   export LOCAL_AUTH_NAME="${LOCAL_AUTH_NAME:-Teste CRM Local}"
+  if [[ "$CRM_WITH_TIMEKEEPING" == "1" ]]; then
+    export PONTO_API_TARGET="http://127.0.0.1:${CRM_TIMEKEEPING_PORT}"
+    export PONTO_ACTOR_HMAC_KEY="$CRM_TIMEKEEPING_ACTOR_KEY"
+  fi
   if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
     export ALLOW_DEV_AUTH_BYPASS=true
   fi
@@ -547,6 +621,9 @@ cleanup() {
   fi
   if [[ -n "${INSUMOS_PID:-}" ]]; then
     kill "$INSUMOS_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${TIMEKEEPING_PID:-}" ]]; then
+    kill "$TIMEKEEPING_PID" >/dev/null 2>&1 || true
   fi
   if [[ -f "$PID_FILE" ]]; then
     local tracked_pid

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -135,6 +135,7 @@ function Convert-ToBashLiteral {
 function Invoke-ShortcutWsl {
     param(
         [string]$Command,
+        [string]$WorkingProjectRoot = $ProjectRoot,
         [string[]]$EnvVar = @(),
         [switch]$SkipBootstrapCheck,
         [switch]$SkipNodeCheck,
@@ -144,7 +145,7 @@ function Invoke-ShortcutWsl {
     )
 
     & $wslInvoker `
-        -ProjectRoot $ProjectRoot `
+        -ProjectRoot $WorkingProjectRoot `
         -RepoCommand $Command `
         -EnvVar $EnvVar `
         -SkipBootstrapCheck:$SkipBootstrapCheck `
@@ -156,6 +157,46 @@ function Invoke-ShortcutWsl {
     if ($LASTEXITCODE -ne 0) {
         throw "The WSL command failed with exit code $LASTEXITCODE."
     }
+}
+
+function Resolve-CrmLocalSourceRoot {
+    # CRM Local must never inherit uncommitted product work from the checkout
+    # that happens to invoke the Codex action. Keep a private, detached source
+    # worktree on origin/main instead.
+    $sourceRoot = Join-Path $operatorRuntimeRoot "source\crm-local-main"
+    $sourceParent = Split-Path -Parent $sourceRoot
+
+    if (-not (Test-Path -LiteralPath $sourceRoot)) {
+        New-Item -ItemType Directory -Path $sourceParent -Force | Out-Null
+        & git -C $ProjectRoot fetch origin main | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Não foi possível atualizar origin/main antes de preparar o CRM Local."
+        }
+        & git -C $ProjectRoot worktree add --detach $sourceRoot origin/main | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Não foi possível criar o worktree limpo do CRM Local em '$sourceRoot'."
+        }
+        return $sourceRoot
+    }
+
+    $trackedChanges = @(& git -C $sourceRoot status --porcelain --untracked-files=no)
+    if ($LASTEXITCODE -ne 0) {
+        throw "O worktree privado do CRM Local não está íntegro: '$sourceRoot'."
+    }
+    if ($trackedChanges.Count -gt 0) {
+        throw "O worktree privado do CRM Local contém alterações rastreadas e não será sobrescrito: '$sourceRoot'."
+    }
+
+    & git -C $ProjectRoot fetch origin main | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Não foi possível atualizar origin/main antes de iniciar o CRM Local."
+    }
+    & git -C $sourceRoot checkout --detach origin/main | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Não foi possível alinhar o worktree privado do CRM Local ao origin/main."
+    }
+
+    return $sourceRoot
 }
 
 function Invoke-RepoPowerShellScript {
@@ -329,17 +370,20 @@ function Invoke-ShortcutActionInternal {
         "WebsiteSiteCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:check" }
         "WebsiteReleaseCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:release-check" }
         "CrmLocal" {
-            Invoke-ShortcutWsl -Command ("CRM_BUILD_BEFORE_START=0 CRM_OPEN_BROWSER=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
                 (Convert-ToBashLiteral -Value $crmPidWsl), `
                 (Convert-ToBashLiteral -Value $crmLogWsl))
         }
         "CrmSiteEf" {
-            Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module site-tracking --meta-ads-scenario connected-ready" -f `
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module site-tracking --meta-ads-scenario connected-ready" -f `
                 (Convert-ToBashLiteral -Value $crmPidWsl), `
                 (Convert-ToBashLiteral -Value $crmLogWsl))
         }
         "CrmMetaAds" {
-            Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module meta-ads" -f `
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module meta-ads" -f `
                 (Convert-ToBashLiteral -Value $crmPidWsl), `
                 (Convert-ToBashLiteral -Value $crmLogWsl))
         }
@@ -354,7 +398,8 @@ function Invoke-ShortcutActionInternal {
             Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento.sh --stop" -f `
                 (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
                 (Convert-ToBashLiteral -Value $atendimentoLogWsl))
-            Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
                 (Convert-ToBashLiteral -Value $crmPidWsl), `
                 (Convert-ToBashLiteral -Value $crmLogWsl))
         }


### PR DESCRIPTION
## O que mudou
- O atalho CRM Local passa a executar a partir de um worktree privado destacado em `origin/main`.
- O launcher recompila o frontend, prepara Chromium para o gate e sobe o Workforce/Timekeeping local com migrations.
- O proxy local recebe apenas bindings e chaves de teste locais para o Ponto.

## Causa
O launcher compartilhado usava um checkout divergente e mantinha um lock durante toda a vida do processo. Além disso, a aba Ponto ficava bloqueada pelo gate quando o proxy não tinha `PONTO_ACTOR_HMAC_KEY` nem upstream local.

## Validação
- Build do CRM e orçamento de bundle: aprovado.
- Migrations locais de Insumos e Timekeeping: aprovadas.
- Gate do shell CRM: aprovado (12 módulos, incluindo Ponto).
- `/api/ponto/health`, `/api/ponto/readiness`, `/api/ponto/me` e `/api/ponto/admin/employees`: HTTP 200 no CRM local.