### PR TITLE
fix(crm): reduce Chromium background diagnostics

### DIFF
--- a/crm/console/scripts/crm-local-smoke.cjs
+++ b/crm/console/scripts/crm-local-smoke.cjs
@@ -151,8 +151,12 @@ async function main() {
         '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-features=Translate,BackForwardCache',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-sync',
+        '--no-first-run',
         '--mute-audio',
-        ...(HEADED ? [] : ['--disable-gpu']),
+        ...(HEADED ? [] : ['--disable-gpu', '--use-angle=swiftshader']),
       ],
     })
 

--- a/crm/console/scripts/meta-ads-local-smoke.cjs
+++ b/crm/console/scripts/meta-ads-local-smoke.cjs
@@ -46,8 +46,12 @@ async function main() {
         '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-features=Translate,BackForwardCache',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-sync',
+        '--no-first-run',
         '--mute-audio',
-        ...(HEADED ? [] : ['--disable-gpu']),
+        ...(HEADED ? [] : ['--disable-gpu', '--use-angle=swiftshader']),
       ],
     })
     context = await browser.newContext({

--- a/crm/console/scripts/site-tracking-local-smoke.cjs
+++ b/crm/console/scripts/site-tracking-local-smoke.cjs
@@ -46,8 +46,12 @@ async function main() {
         '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-features=Translate,BackForwardCache',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-sync',
+        '--no-first-run',
         '--mute-audio',
-        ...(HEADED ? [] : ['--disable-gpu']),
+        ...(HEADED ? [] : ['--disable-gpu', '--use-angle=swiftshader']),
       ],
     })
     context = await browser.newContext({


### PR DESCRIPTION
﻿## Altera??o

Reduz diagn?sticos externos do Chromium nos smokes locais ao desabilitar rede de fundo, atualiza??o de componentes, sincroniza??o e first-run. Mant?m GPU desabilitada e usa renderiza??o software no modo headless.

## Valida??o

- `node --check` nos tr?s scripts de smoke
- `git diff --check`
