### PR TITLE
fix(deploy): apply D1 migrations remotely

### DIFF
--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -56,9 +56,11 @@ jobs:
           corepack enable
           corepack prepare pnpm@9.15.4 --activate
 
-      - name: Install backend workspace deps
+      - name: Install Worker dependencies
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        run: pnpm -C backend install --frozen-lockfile
+        run: |
+          npm --prefix api ci
+          pnpm -C inventory install --frozen-lockfile
 
       - name: Sync password-recovery secrets (optional)
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -78,7 +80,7 @@ jobs:
             local name="$1"
             local value="$2"
             if [[ -n "$value" && "$value" != "__KEEP_EXISTING__" ]]; then
-              printf '%s' "$value" | pnpm -C ../backend -F @skincos/insumos-worker exec wrangler secret put "$name" --config wrangler.toml
+              printf '%s' "$value" | ./node_modules/.bin/wrangler secret put "$name" --config wrangler.toml
             fi
           }
           put_secret AUTH_RESET_SMTP_HOST "$AUTH_RESET_SMTP_HOST"

--- a/backend/scripts/cloudflare-workers.sh
+++ b/backend/scripts/cloudflare-workers.sh
@@ -94,7 +94,7 @@ deploy_insumos() {
   pushd "$ROOT_DIR/inventory" >/dev/null
   # Auth and schema changes must fail closed: never deploy a Worker that expects
   # columns the remote D1 database does not yet have.
-  local d1_args=(--config wrangler.toml)
+  local d1_args=(--config wrangler.toml --remote)
   if [[ -n "${ENV_NAME:-}" ]]; then
     d1_args+=(--env "$ENV_NAME")
   fi


### PR DESCRIPTION
Corrige a implantação do D1/Workers para que migrations sejam aplicadas explicitamente no banco remoto. Atualiza também a instalação dos pacotes reais api e inventory e a sincronização de secrets para usar o Wrangler de inventory, removendo o filtro pnpm obsoleto. Evidência antes da correção: 0014 e 0015 estavam pendentes no D1 remoto; ambas foram aplicadas com sucesso e uma nova listagem retornou No migrations to apply.