### PR TITLE
fix(auth): pass STARTTLS as Cloudflare socket option

### DIFF
--- a/inventory/src/smtpMailer.js
+++ b/inventory/src/smtpMailer.js
@@ -74,7 +74,10 @@ export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
   const username = String(env.AUTH_RESET_SMTP_USERNAME).trim();
   const password = String(env.AUTH_RESET_SMTP_PASSWORD);
   const { connect } = await import('cloudflare:sockets');
-  let socket = connect({ hostname, port, secureTransport: port === 465 ? 'on' : 'starttls' });
+  let socket = connect(
+    { hostname, port },
+    { secureTransport: port === 465 ? 'on' : 'starttls' }
+  );
   let writer = socket.writable.getWriter();
   let reader = socket.readable.getReader();
   let state = { buffer: '', lines: [] };


### PR DESCRIPTION
Corrige a chamada de cloudflare:sockets: secureTransport pertence ao segundo argumento de connect, não ao objeto de endereço. O erro sanitizado observado em produção era: secureTransport socket option must be set to starttls for startTls to be used. Validado com node --check e Wrangler dry-run; o aceite final será o envio SMTP real após deploy.