### PR TITLE
fix(auth): release SMTP streams before STARTTLS

### DIFF
--- a/inventory/src/smtpMailer.js
+++ b/inventory/src/smtpMailer.js
@@ -88,10 +88,10 @@ export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
     if (port !== 465) {
       await command(writer, reader, state, 'STARTTLS', [220]);
       if (typeof socket.startTls !== 'function') throw new Error('SMTP_STARTTLS_UNAVAILABLE');
-      const secured = await Promise.resolve(socket.startTls());
-      if (!secured?.writable || !secured?.readable) throw new Error('SMTP_STARTTLS_FAILED');
       writer.releaseLock();
       reader.releaseLock();
+      const secured = await Promise.resolve(socket.startTls());
+      if (!secured?.writable || !secured?.readable) throw new Error('SMTP_STARTTLS_FAILED');
       socket = secured;
       writer = secured.writable.getWriter();
       reader = secured.readable.getReader();


### PR DESCRIPTION
Libera os locks do reader/writer do socket SMTP antes de chamar startTls, como exige a API cloudflare:sockets. A ordem anterior causava This WritableStream is currently locked to a writer no smoke real. Validado com node --check e Wrangler dry-run; aceite final por envio real após deploy.