### PR TITLE
fix(auth): priorizar e-mail ausente na recuperação

### DIFF
--- a/inventory/src/routes/auth.js
+++ b/inventory/src/routes/auth.js
@@ -652,12 +652,12 @@ export async function handleAuthRoutes({
                 return withCORS(JSON.stringify({ success: false, error: "EMAIL_REQUIRED" }), { status: 400 }, appOrigin);
             }
             try {
-                if (!hasPasswordResetMailerConfig(env) || !resetPepper) {
-                    return withCORS(JSON.stringify({ success: false, error: 'PASSWORD_RECOVERY_UNAVAILABLE' }), { status: 503 }, appOrigin);
-                }
                 const userDb = await d1.getUserByIdentifier(email);
                 if (!userDb?.ativo || normalizeIdentifier(userDb.email) !== email) {
                     return withCORS(JSON.stringify({ success: false, error: 'EMAIL_NOT_REGISTERED' }), { status: 404 }, appOrigin);
+                }
+                if (!hasPasswordResetMailerConfig(env) || !resetPepper) {
+                    return withCORS(JSON.stringify({ success: false, error: 'PASSWORD_RECOVERY_UNAVAILABLE' }), { status: 503 }, appOrigin);
                 }
                 const cooldownSeconds = Math.max(30, toInt(env?.AUTH_RESET_COOLDOWN_SECONDS, 60));
                 const cooldownSince = new Date(Date.now() - cooldownSeconds * 1000).toISOString();


### PR DESCRIPTION
## Correção

A solicitação de recuperação consultava os secrets SMTP antes de verificar se o e-mail informado pertence a uma conta ativa.

No CRM local, os secrets de produção são propositalmente ausentes. Como consequência, um e-mail inexistente recebia `PASSWORD_RECOVERY_UNAVAILABLE` em vez de `EMAIL_NOT_REGISTERED`.

Agora a conta é validada primeiro:
- e-mail não cadastrado: `404 EMAIL_NOT_REGISTERED`;
- conta cadastrada sem mailer configurado: `503 PASSWORD_RECOVERY_UNAVAILABLE`;
- conta cadastrada com mailer configurado: fluxo normal de código.

## Validação

- `npx wrangler deploy --config wrangler.toml --dry-run`
- E2E isolado de autenticação iniciado localmente; CI executará a suíte em ambiente limpo.