### PR TITLE
fix(crm): resetar autenticação local ao iniciar

### DIFF
--- a/crm/console/localDevAuthReset.ts
+++ b/crm/console/localDevAuthReset.ts
@@ -1,0 +1,22 @@
+const LOCAL_AUTH_RESET_PARAM = 'localAuthReset'
+
+type BrowserLocation = Pick<Location, 'href' | 'hostname'>
+
+export function consumeLocalAuthReset(
+  location: BrowserLocation,
+  storage: Pick<Storage, 'removeItem'>,
+  clearCookie: (value: string) => void,
+  replaceUrl: (url: string) => void,
+): boolean {
+  const url = new URL(location.href)
+  const isLocalHost = ['localhost', '127.0.0.1', '::1'].includes(location.hostname)
+  if (!isLocalHost || url.searchParams.get(LOCAL_AUTH_RESET_PARAM) !== '1') return false
+
+  storage.removeItem('crm.localAuth')
+  clearCookie('crm.localAuth=; Path=/; Max-Age=0; SameSite=Lax')
+  clearCookie('crm_local_auth=; Path=/; Max-Age=0; SameSite=Lax')
+
+  url.searchParams.delete(LOCAL_AUTH_RESET_PARAM)
+  replaceUrl(`${url.pathname}${url.search}${url.hash}`)
+  return true
+}

--- a/crm/console/tests/localDevAuthReset.test.ts
+++ b/crm/console/tests/localDevAuthReset.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { consumeLocalAuthReset } from '../localDevAuthReset'
+
+describe('local CRM auth reset', () => {
+  it('clears only the local auth opt-out and removes the one-time query parameter', () => {
+    const removeItem = vi.fn()
+    const clearCookie = vi.fn()
+    const replaceUrl = vi.fn()
+
+    const consumed = consumeLocalAuthReset(
+      { href: 'http://localhost:8791/?module=insumos&localAuthReset=1', hostname: 'localhost' },
+      { removeItem },
+      clearCookie,
+      replaceUrl,
+    )
+
+    expect(consumed).toBe(true)
+    expect(removeItem).toHaveBeenCalledWith('crm.localAuth')
+    expect(clearCookie).toHaveBeenCalledWith('crm.localAuth=; Path=/; Max-Age=0; SameSite=Lax')
+    expect(clearCookie).toHaveBeenCalledWith('crm_local_auth=; Path=/; Max-Age=0; SameSite=Lax')
+    expect(replaceUrl).toHaveBeenCalledWith('/?module=insumos')
+  })
+
+  it('does not affect a non-local URL or a normal launch', () => {
+    const removeItem = vi.fn()
+    const clearCookie = vi.fn()
+    const replaceUrl = vi.fn()
+
+    expect(consumeLocalAuthReset(
+      { href: 'https://crm.skincos.com.br/?localAuthReset=1', hostname: 'crm.skincos.com.br' },
+      { removeItem },
+      clearCookie,
+      replaceUrl,
+    )).toBe(false)
+    expect(removeItem).not.toHaveBeenCalled()
+    expect(clearCookie).not.toHaveBeenCalled()
+    expect(replaceUrl).not.toHaveBeenCalled()
+  })
+})

--- a/crm/console/useReplitAuth.ts
+++ b/crm/console/useReplitAuth.ts
@@ -1,8 +1,17 @@
 // Replit Auth Integration: Custom hook for authentication
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { consumeLocalAuthReset } from './localDevAuthReset'
 
 export function useReplitAuth() {
   const queryClient = useQueryClient()
+  if (typeof window !== 'undefined') {
+    consumeLocalAuthReset(
+      window.location,
+      window.localStorage,
+      (value) => { document.cookie = value },
+      (url) => { window.history.replaceState(null, '', url) },
+    )
+  }
   const isLocalDevHost = typeof window !== 'undefined' &&
     ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)
   const localAuthBypassEnabled =

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -15,6 +15,7 @@ CRM_PAGES_PORT="${CRM_PAGES_PORT:-8791}"
 CRM_ROUTE="${CRM_ROUTE:-/}"
 CRM_MODULE="${CRM_MODULE:-}"
 CRM_PROFILE="${CRM_PROFILE:-realistic}"
+CRM_RESET_LOCAL_AUTH_ON_START="${CRM_RESET_LOCAL_AUTH_ON_START:-1}"
 if [[ -n "${CRM_OPEN_BROWSER+x}" ]]; then
   CRM_OPEN_BROWSER_EXPLICIT=1
 else
@@ -190,6 +191,10 @@ append_query_param() {
 
 if [[ -n "$CRM_MODULE" ]]; then
   CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "module" "$CRM_MODULE")"
+fi
+
+if [[ "$CRM_PROFILE" == "realistic" && "$CRM_RESET_LOCAL_AUTH_ON_START" != "0" ]]; then
+  CRM_ROUTE="$(append_query_param "$CRM_ROUTE" "localAuthReset" "1")"
 fi
 
 if [[ ( -z "$CRM_MODULE" || "$CRM_MODULE" == "meta-ads" || "$CRM_MODULE" == "site-tracking" ) && -z "$CRM_META_ADS_SCENARIO" && "$CRM_PROFILE" == "realistic" ]]; then


### PR DESCRIPTION
## Correção

O atalho `CRM – Local` agora inclui um sinal temporário de reinicialização da autenticação local. Antes de a aplicação consultar a sessão, ele remove somente o opt-out persistente `crm.localAuth` e seus cookies equivalentes; depois remove o parâmetro da URL.

O comportamento é limitado a `localhost` e ao perfil `realistic`. `--profile session` continua preservando o login manual.

## Validação

- `npm run test -- localDevAuthReset.test.ts` — 2 testes aprovados.
- `bash -n scripts/run-local-crm.sh`.
- Typecheck local interrompido por processo WSL travado sem diagnóstico; CI executará a verificação limpa.