### PR TITLE
fix(crm): liberar Ponto para todos os usuários

### DIFF
--- a/crm/console/crmRoleAccess.ts
+++ b/crm/console/crmRoleAccess.ts
@@ -11,6 +11,10 @@ export function hasCrmModuleAccess(role: unknown, allowedModules: unknown, modul
   const key = String(moduleKey || '').trim()
   const roleKey = String(role || '').trim().toUpperCase()
   if (!key) return false
+  // Every authenticated CRM user can access the self-service timekeeping area.
+  // Data and administrative operations remain authorized by the Ponto proxy and
+  // Workforce service; this function only governs sidebar navigation.
+  if (key === 'ponto') return true
   if (roleKey === 'GESTOR' || roleKey === 'ADMIN') return true
   if (roleKey === 'CONSULTOR' || roleKey === 'EMPLOYEE') return CONSULTOR_MODULE_KEYS.has(key)
   if (key === 'escala-profissionais') return roleKey === 'GERENTE'

--- a/crm/console/tests/crmRoleAccess.test.ts
+++ b/crm/console/tests/crmRoleAccess.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { hasCrmModuleAccess } from '../crmRoleAccess'
 
 describe('CRM role module navigation', () => {
-  it('limits Consultor to Atendimento and Ponto even without an allowedModules list', () => {
+  it('keeps Consultor limited to Atendimento and Ponto even without an allowedModules list', () => {
     expect(hasCrmModuleAccess('CONSULTOR', [], 'atendimento')).toBe(true)
     expect(hasCrmModuleAccess('CONSULTOR', [], 'ponto')).toBe(true)
     expect(hasCrmModuleAccess('CONSULTOR', [], 'faturamento')).toBe(false)
@@ -13,5 +13,23 @@ describe('CRM role module navigation', () => {
     expect(hasCrmModuleAccess('EMPLOYEE', [], 'atendimento')).toBe(true)
     expect(hasCrmModuleAccess('EMPLOYEE', [], 'ponto')).toBe(true)
     expect(hasCrmModuleAccess('EMPLOYEE', [], 'users')).toBe(false)
+  })
+
+  it.each([
+    ['ADMIN'],
+    ['GESTOR'],
+    ['GERENTE'],
+    ['SUPERVISOR'],
+    ['CONSULTOR'],
+    ['EMPLOYEE'],
+    ['custom-authenticated-role'],
+  ])('always exposes Ponto to the authenticated %s role even when it is not assigned', (role) => {
+    expect(hasCrmModuleAccess(role, ['insumos'], 'ponto')).toBe(true)
+  })
+
+  it('does not use Ponto visibility to broaden any other module', () => {
+    expect(hasCrmModuleAccess('SUPERVISOR', ['insumos'], 'atendimento')).toBe(false)
+    expect(hasCrmModuleAccess('CONSULTOR', ['insumos'], 'users')).toBe(false)
+    expect(hasCrmModuleAccess('custom-authenticated-role', ['insumos'], 'users')).toBe(false)
   })
 })

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -64,6 +64,18 @@ describe('Ponto CRM proxy', () => {
     expect(actor.role).toBe('CONSULTOR')
   })
 
+  it('blocks a Consultor from administrative routes before forwarding upstream', async () => {
+    ;(getInsumosUser as Mock).mockResolvedValue({ id: 'consultor-1', email: 'consultor@example.test', role: 'CONSULTOR', allowedUnits: ['UNIT_A'] })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await onRequest(context('/api/ponto/admin/employees'))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: 'FORBIDDEN' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('adds a unique replay nonce to protected mutations', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }))
     vi.stubGlobal('fetch', fetchMock)


### PR DESCRIPTION
## Resumo

Libera a aba **Ponto** para qualquer usuário autenticado do CRM, inclusive quando `allowedModules` não contém `ponto`.

## Segurança

A alteração afeta somente a navegação. O proxy continua bloqueando `/api/ponto/admin/*` para Consultor, e o Workforce mantém escopo próprio por funcionário e unidade.

## Validação

- `crm/console`: typecheck e lint aprovados
- 125 testes Vitest aprovados
- build de produção aprovado dentro do orçamento de bundles
- `workforce/timekeeping`: 19 testes aprovados

Inclui regressão que confirma `403` antes de encaminhar uma rota administrativa de Ponto para uma sessão de Consultor.