### PR TITLE
feat(auth): cadastro somente por convite autorizado

### DIFF
--- a/crm/console/AuthScreen.tsx
+++ b/crm/console/AuthScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { CircleCheck, Eye, EyeOff, KeyRound, Mail, ShieldCheck, UserRound } from 'lucide-react'
 import { Card, CardHeader, CardContent, CardDescription } from '@/card'
 import { Input } from '@/input'
@@ -20,7 +20,7 @@ const normalizeInviteToken = (token: string) => token.replace(/\s+/g, '').trim()
 const normalizeDisplayName = (name: string) => name.trim().replace(/\s+/g, ' ')
 
 export function AuthScreen() {
-    const { signIn, signUp, requestPasswordReset, verifyPasswordResetCode, resetPassword, loading } = useAuth()
+    const { signIn, signUp, previewSignupInvite, requestPasswordReset, verifyPasswordResetCode, resetPassword, loading } = useAuth()
     const [mode, setMode] = useState<'signin' | 'signup' | 'recovery-request' | 'recovery-code' | 'recovery-password'>('signin')
     const [form, setForm] = useState<FormState>({ name: '', email: '', password: '', inviteToken: '', code: '', passwordConfirmation: '' })
     const [resetGrant, setResetGrant] = useState('')
@@ -28,6 +28,9 @@ export function AuthScreen() {
     const [isVisible, setIsVisible] = useState(false)
     const [showPassword, setShowPassword] = useState(false)
     const [capsLock, setCapsLock] = useState(false)
+    const [inviteEmailLocked, setInviteEmailLocked] = useState(false)
+    const handledInviteFragment = useRef(false)
+    const initialModeEffect = useRef(true)
     const currentYear = new Date().getFullYear()
 
     useEffect(() => {
@@ -35,15 +38,34 @@ export function AuthScreen() {
     }, [])
 
     useEffect(() => {
+        if (handledInviteFragment.current || typeof window === 'undefined') return
+        const params = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+        const token = normalizeInviteToken(params.get('invite') || '')
+        if (!token) return
+        handledInviteFragment.current = true
+        window.history.replaceState(null, document.title, `${window.location.pathname}${window.location.search}`)
+        setMode('signup')
+        setForm(current => ({ ...current, inviteToken: token }))
+        void previewSignupInvite(token)
+            .then(({ email }) => {
+                setForm(current => ({ ...current, email }))
+                setInviteEmailLocked(true)
+            })
+            .catch((err: any) => setError(err?.message || 'Não foi possível validar o convite.'))
+    }, [previewSignupInvite])
+
+    useEffect(() => {
         setError(null)
         setShowPassword(false)
         if (mode === 'recovery-request') setResetGrant('')
         setForm(f => {
             const next = { ...f, password: '', passwordConfirmation: '', code: '' }
-            if (mode === 'signin') {
+            if (mode === 'signin' && !initialModeEffect.current) {
                 next.name = ''
                 next.inviteToken = ''
+                setInviteEmailLocked(false)
             }
+            initialModeEffect.current = false
             return next
         })
     }, [mode])
@@ -52,6 +74,7 @@ export function AuthScreen() {
         if (error) setError(null)
         const { name, value } = e.target
         const nextValue = name === 'inviteToken' ? normalizeInviteToken(value) : name === 'code' ? value.replace(/\D/g, '').slice(0, 6) : value
+        if (name === 'inviteToken') setInviteEmailLocked(false)
         setForm(f => ({ ...f, [name]: nextValue }))
     }
 
@@ -192,7 +215,7 @@ export function AuthScreen() {
                                     {mode === 'signin' ? 'Acessar CRM' : mode === 'signup' ? 'Criar conta com convite' : mode === 'recovery-request' ? 'Recuperar senha' : mode === 'recovery-code' ? 'Validar código' : 'Definir nova senha'}
                                 </h2>
                                 <CardDescription className="mt-2 text-sm text-slate-400">
-                                    {mode === 'signin' ? 'Use seu email corporativo e senha cadastrada.' : mode === 'signup' ? 'O token define automaticamente perfil, unidades e módulos.' : mode === 'recovery-request' ? 'Informe o e-mail cadastrado para receber um código.' : mode === 'recovery-code' ? 'Digite o código enviado ao seu e-mail.' : 'Escolha uma senha nova e segura.'}
+                                    {mode === 'signin' ? 'Use seu email corporativo e senha cadastrada.' : mode === 'signup' ? 'O convite pessoal define o e-mail, perfil, unidades e módulos.' : mode === 'recovery-request' ? 'Informe o e-mail cadastrado para receber um código.' : mode === 'recovery-code' ? 'Digite o código enviado ao seu e-mail.' : 'Escolha uma senha nova e segura.'}
                                 </CardDescription>
                             </div>
 
@@ -265,6 +288,7 @@ export function AuthScreen() {
                                             autoComplete={mode === 'signin' ? 'username' : 'email'}
                                             spellCheck={false}
                                             required
+                                            readOnly={mode === 'signup' && inviteEmailLocked}
                                             aria-invalid={(mode === 'signup' && !!identifier && !signupEmailValid) || (recoveryMode && !!identifier && !recoveryEmailValid)}
                                             aria-describedby={mode === 'signup' || recoveryMode ? 'auth-email-help' : undefined}
                                             className={fieldChrome}
@@ -272,7 +296,7 @@ export function AuthScreen() {
                                     </div>
                                     {(mode === 'signup' || mode === 'recovery-request') && (
                                         <p id="auth-email-help" className={`text-xs leading-relaxed ${identifier && !(mode === 'signup' ? signupEmailValid : recoveryEmailValid) ? 'text-amber-200' : 'text-slate-500'}`}>
-                                            {mode === 'signup' ? 'Use o email corporativo que receberá acesso ao CRM.' : 'Se não houver e-mail cadastrado, informe um gestor.'}
+                                            {mode === 'signup' ? inviteEmailLocked ? 'Este convite é pessoal e está vinculado a este e-mail.' : 'Use exatamente o email corporativo que recebeu o convite.' : 'Se não houver e-mail cadastrado, informe um gestor.'}
                                         </p>
                                     )}
                                 </div>}
@@ -297,7 +321,7 @@ export function AuthScreen() {
                                             />
                                         </div>
                                         <p id="auth-token-help" className="text-xs leading-relaxed text-slate-500">
-                                            Espaços colados junto com o token são removidos automaticamente. O convite herda o escopo definido na administração.
+                                            Espaços colados junto com o token são removidos automaticamente. Convites são pessoais, de uso único e herdam o escopo definido pelo gestor.
                                         </p>
                                     </div>
                                 )}

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -10,6 +10,7 @@ import { LoadingPercentText } from '@/LoadingPattern'
 
 type Invite = {
   id: string
+  inviteeEmail?: string
   tokenHint?: string
   role?: string
   allowedUnits?: string[]
@@ -117,18 +118,17 @@ export function UsersModule() {
 
   const isAuthed = !!me?.user?.username
   const role = String(me?.user?.role || '').trim().toUpperCase()
-  const canManageInvites = role === 'GESTOR'
-  const inviteRoleOptions = role === 'GESTOR'
-    ? ['CONSULTOR', 'SUPERVISOR', 'GERENTE', 'GESTOR']
-    : ['CONSULTOR', 'SUPERVISOR', 'GERENTE']
+  const inviteRoleOptions = ['CONSULTOR', 'SUPERVISOR', 'GERENTE']
 
   const allowedUnits = Array.isArray(me?.user?.allowedUnits) ? me!.user!.allowedUnits!.filter(Boolean) : []
+  const allowedModules = Array.isArray(me?.user?.allowedModules) ? me!.user!.allowedModules!.filter(Boolean) : []
+  const canManageInvites = role === 'GESTOR' && allowedUnits.length > 0 && allowedModules.length > 0
 
   const unidadeOptions = React.useMemo(() => {
     const fromHealth = Array.isArray(health?.unidades) ? health!.unidades!.filter(Boolean) : []
     const base = fromHealth.length ? fromHealth : ['novo-hamburgo', 'barra-shopping-sul']
     const filtered = allowedUnits.length ? base.filter((u) => allowedUnits.includes(u)) : base
-    return filtered.length ? filtered : base
+    return filtered
   }, [allowedUnits.join('|'), Array.isArray(health?.unidades) ? health!.unidades!.join('|') : ''])
 
   React.useEffect(() => {
@@ -174,14 +174,12 @@ export function UsersModule() {
   const [invitesLoading, setInvitesLoading] = React.useState(false)
   const [invites, setInvites] = React.useState<Invite[]>([])
   const [inviteRole, setInviteRole] = React.useState<string>('CONSULTOR')
-  const [inviteMaxUses, setInviteMaxUses] = React.useState<string>('1')
   const [inviteExpiresInDays, setInviteExpiresInDays] = React.useState<string>('30')
   const [inviteAllowedUnits, setInviteAllowedUnits] = React.useState<string>('')
   const [inviteAllowedModules, setInviteAllowedModules] = React.useState<string>('')
+  const [inviteeEmail, setInviteeEmail] = React.useState<string>('')
   const [inviteNote, setInviteNote] = React.useState<string>('')
   const [inviteCreateLoading, setInviteCreateLoading] = React.useState(false)
-  const [inviteTokenOnce, setInviteTokenOnce] = React.useState<string | null>(null)
-  const [inviteTokenHint, setInviteTokenHint] = React.useState<string | null>(null)
 
   const parseUnitsInput = React.useCallback((raw: string) => {
     const s = String(raw || '').trim()
@@ -209,46 +207,42 @@ export function UsersModule() {
 
   React.useEffect(() => {
     if (!inviteOpen) return
-    setInviteTokenOnce(null)
-    setInviteTokenHint(null)
+    setInviteeEmail('')
     setInviteNote('')
     setInviteRole((cur) => (inviteRoleOptions.includes(cur) ? cur : 'CONSULTOR'))
     setInviteAllowedUnits((cur) => {
       if (cur.trim()) return cur
       return allowedUnits.length ? allowedUnits.join(',') : ''
     })
-    setInviteAllowedModules((cur) => (cur.trim() ? cur : ''))
+    setInviteAllowedModules((cur) => (cur.trim() ? cur : allowedModules.join(',')))
     void loadInvites()
-  }, [allowedUnits.join('|'), inviteOpen, inviteRoleOptions.join('|'), loadInvites])
+  }, [allowedModules.join('|'), allowedUnits.join('|'), inviteOpen, inviteRoleOptions.join('|'), loadInvites])
 
   const createInvite = React.useCallback(async () => {
     if (!isAuthed || !canManageInvites) return
     setInviteCreateLoading(true)
-    setInviteTokenOnce(null)
-    setInviteTokenHint(null)
     try {
-      const maxUses = Math.max(1, Math.min(50, parseInt(inviteMaxUses, 10) || 1))
       const expiresInDays = Math.max(1, Math.min(365, parseInt(inviteExpiresInDays, 10) || 30))
       const allowed = parseUnitsInput(inviteAllowedUnits)
       const allowedModules = parseUnitsInput(inviteAllowedModules)
-      const out = await insumosApiJson<{ success?: boolean; data?: Invite; token?: string }>(
+      const email = inviteeEmail.trim().toLowerCase()
+      if (!/^\S+@\S+\.\S+$/.test(email)) throw new Error('Informe o e-mail corporativo do destinatário.')
+      if (!allowed.length || !allowedModules.length) throw new Error('Selecione pelo menos uma unidade e um módulo.')
+      const out = await insumosApiJson<{ success?: boolean; data?: Invite; delivery?: string }>(
         `/admin/invites?${new URLSearchParams({ unidade }).toString()}`,
         {
           method: 'POST',
           csrfToken,
           retryOnCsrf: refreshCsrf,
-          body: { role: inviteRole, maxUses, expiresInDays, allowedUnits: allowed, allowedModules, note: inviteNote }
+          body: { email, role: inviteRole, maxUses: 1, expiresInDays, allowedUnits: allowed, allowedModules, note: inviteNote }
         }
       )
-      const token = out?.token ? String(out.token) : null
-      const hint = (out as any)?.data?.tokenHint ? String((out as any).data.tokenHint) : null
-      if (token) {
-        setInviteTokenOnce(token)
-        setInviteTokenHint(hint)
-        toast.success('Token gerado')
+      if (out?.success) {
+        toast.success(`Convite enviado para ${email}`)
+        setInviteeEmail('')
         void loadInvites()
       } else {
-        toast.error('Não foi possível gerar o token.')
+        toast.error('Não foi possível enviar o convite.')
       }
     } catch (e: any) {
       toast.error(e?.message || 'Falha ao gerar token.')
@@ -260,8 +254,8 @@ export function UsersModule() {
     csrfToken,
     inviteAllowedModules,
     inviteAllowedUnits,
+    inviteeEmail,
     inviteExpiresInDays,
-    inviteMaxUses,
     inviteNote,
     inviteRole,
     isAuthed,
@@ -326,7 +320,7 @@ export function UsersModule() {
             <CardTitle className="text-white text-sm">Convites</CardTitle>
           </CardHeader>
           <CardContent className="text-sm text-blue-100/70">
-            Esta aba está em evolução. Por enquanto, ela concentra a geração de tokens de acesso para criação de conta.
+            Convites pessoais definem e-mail, papel, unidades e módulos antes da criação da conta.
           </CardContent>
         </Card>
       </div>
@@ -336,8 +330,7 @@ export function UsersModule() {
         onOpenChange={(open) => {
           setInviteOpen(open)
           if (!open) {
-            setInviteTokenOnce(null)
-            setInviteTokenHint(null)
+            setInviteeEmail('')
           }
         }}
       >
@@ -345,7 +338,7 @@ export function UsersModule() {
           <DialogHeader>
             <DialogTitle className="text-white">Convites de acesso</DialogTitle>
             <DialogDescription className="text-blue-100/70">
-              Gere um token para criação de conta (por segurança, o token é mostrado apenas uma vez).
+              Envie um convite pessoal, de uso único, para o e-mail corporativo autorizado.
             </DialogDescription>
           </DialogHeader>
 
@@ -370,18 +363,18 @@ export function UsersModule() {
                   </Select>
                 </div>
                 <div>
-                  <div className="text-xs text-blue-200/70 mb-1">Usos</div>
-                  <Input value={inviteMaxUses} onChange={(e) => setInviteMaxUses(e.target.value)} type="number" min={1} max={50} />
+                  <div className="text-xs text-blue-200/70 mb-1">Expira em (dias)</div>
+                  <Input value={inviteExpiresInDays} onChange={(e) => setInviteExpiresInDays(e.target.value)} type="number" min={1} max={365} />
                 </div>
               </div>
 
 	              <div className="grid grid-cols-2 gap-2">
 	                <div>
-	                  <div className="text-xs text-blue-200/70 mb-1">Expira em (dias)</div>
-	                  <Input value={inviteExpiresInDays} onChange={(e) => setInviteExpiresInDays(e.target.value)} type="number" min={1} max={365} />
+	                  <div className="text-xs text-blue-200/70 mb-1">E-mail corporativo</div>
+	                  <Input value={inviteeEmail} onChange={(e) => setInviteeEmail(e.target.value)} type="email" autoComplete="email" placeholder="nome@empresa.com" />
 	                </div>
 	                <div>
-	                  <div className="text-xs text-blue-200/70 mb-1">Unidades (opcional)</div>
+	                  <div className="text-xs text-blue-200/70 mb-1">Unidades permitidas</div>
 	                  <Input
 	                    value={inviteAllowedUnits}
 	                    onChange={(e) => setInviteAllowedUnits(e.target.value)}
@@ -391,11 +384,11 @@ export function UsersModule() {
 	              </div>
 
 	              <div>
-	                <div className="text-xs text-blue-200/70 mb-1">Módulos (opcional)</div>
+	                <div className="text-xs text-blue-200/70 mb-1">Módulos permitidos</div>
 	                <Input
 	                  value={inviteAllowedModules}
 	                  onChange={(e) => setInviteAllowedModules(e.target.value)}
-	                  placeholder="vazio = todos • ex: insumos, status, users"
+	                  placeholder="ex: insumos, status, users"
 	                />
 	              </div>
 
@@ -410,49 +403,23 @@ export function UsersModule() {
                   onClick={() => void createInvite()}
                   disabled={!isAuthed || inviteCreateLoading}
                 >
-                  {inviteCreateLoading ? 'Gerando…' : 'Gerar token'}
+                  {inviteCreateLoading ? 'Enviando…' : 'Enviar convite'}
                 </Button>
                 <Button variant="secondary" onClick={() => void loadInvites()} disabled={!isAuthed || invitesLoading}>
                   {invitesLoading ? 'Atualizando…' : 'Atualizar'}
                 </Button>
               </div>
 
-              {inviteTokenOnce ? (
-                <div className="rounded-xl border border-white/10 bg-black/20 p-3 space-y-2">
-                  <div className="text-sm text-blue-50 font-semibold">
-                    Token gerado {inviteTokenHint ? <span className="text-blue-200/70 font-normal">({inviteTokenHint})</span> : null}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Input value={inviteTokenOnce} readOnly className="font-mono" />
-                    <Button
-                      variant="outline"
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(inviteTokenOnce)
-                          toast.success('Copiado.')
-                        } catch (e: any) {
-                          toast.error(e?.message || 'Não foi possível copiar.')
-                        }
-                      }}
-                    >
-                      Copiar
-                    </Button>
-                  </div>
-                  <div className="text-xs text-blue-200/60">
-                    Envie este token ao usuário. Ele deve usar na tela “Criar Conta”.
-                  </div>
-                </div>
-              ) : null}
-
               <div className="rounded-xl border border-white/10 bg-black/10 p-3">
                 <div className="flex items-center justify-between gap-2">
-                  <div className="text-sm text-blue-50 font-semibold">Tokens recentes</div>
+                  <div className="text-sm text-blue-50 font-semibold">Convites recentes</div>
                   <div className="text-xs text-blue-200/60">{invites.length} itens</div>
                 </div>
                 <div className="mt-2 overflow-auto max-h-[40vh] rounded-lg border border-white/10">
                   <table className="min-w-full text-sm">
                     <thead className="bg-black/30 text-blue-100/80">
                       <tr>
+                        <th className="text-left p-2">E-mail</th>
                         <th className="text-left p-2">Token</th>
                         <th className="text-left p-2">Role</th>
                         <th className="text-left p-2">Usos</th>
@@ -463,6 +430,7 @@ export function UsersModule() {
                     <tbody className="divide-y divide-white/5">
                       {invites.map((it) => (
                         <tr key={it.id} className="hover:bg-white/5">
+                          <td className="p-2 text-blue-50">{it.inviteeEmail || '-'}</td>
                           <td className="p-2 font-mono text-blue-50">{it.tokenHint || it.id.slice(0, 8)}</td>
                           <td className="p-2 text-blue-100/80">{String(it.role || '')}</td>
                           <td className="p-2 text-blue-100/70">
@@ -483,11 +451,11 @@ export function UsersModule() {
                       ))}
                       {!invites.length ? (
                         <tr>
-                          <td className="p-2 text-blue-100/70" colSpan={5}>
+                          <td className="p-2 text-blue-100/70" colSpan={6}>
                             {invitesLoading ? (
                               <LoadingPercentText label="Carregando" showPercent={false} />
                             ) : (
-                              'Sem tokens.'
+                              'Sem convites.'
                             )}
                           </td>
                         </tr>

--- a/crm/console/contexts.tsx
+++ b/crm/console/contexts.tsx
@@ -35,6 +35,7 @@ interface AuthContextValue {
   initProgress: number
   signIn: (email: string, password: string) => Promise<void>
   signUp: (name: string, email: string, password: string, inviteToken: string) => Promise<void>
+  previewSignupInvite: (inviteToken: string) => Promise<{ email: string; expiresAt: string }>
   requestPasswordReset: (email: string) => Promise<{ expiresAt: string }>
   verifyPasswordResetCode: (email: string, code: string) => Promise<{ resetGrant: string; expiresAt: string }>
   resetPassword: (resetGrant: string, password: string) => Promise<void>
@@ -140,6 +141,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       : code === 'TOKEN_REVOKED' ? 'Token revogado.'
       : code === 'TOKEN_EXPIRED' ? 'Token expirado.'
       : code === 'TOKEN_EXHAUSTED' ? 'Token já foi utilizado.'
+      : code === 'INVITE_EMAIL_MISMATCH' ? 'Este convite foi emitido para outro e-mail.'
+      : code === 'INVITE_SCOPE_INVALID' ? 'Este convite não possui permissões válidas. Solicite outro ao gestor.'
+      : code === 'INVITE_MIGRATION_REQUIRED' ? 'O cadastro por convite está sendo atualizado. Tente novamente em instantes.'
       : code === 'EMAIL_TAKEN' ? 'Este email já está cadastrado.'
       : code === 'PASSWORD_TOO_SHORT' ? 'Use uma senha com pelo menos 12 caracteres.'
       : code === 'EMAIL_INVALID' ? 'Email inválido.'
@@ -240,6 +244,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  const previewSignupInvite = async (inviteToken: string) => {
+    const res = await fetchWithTimeout(
+      '/api/auth/invite/preview',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ token: inviteToken.trim() })
+      },
+      15000
+    ).catch((e: any) => {
+      if (e?.name === 'AbortError') throw new Error('Tempo limite ao validar o convite. Tente novamente.')
+      throw e
+    })
+    const json: any = readJson(await res.text())
+    if (!res.ok) throw new Error(friendlySignupError(res.status, json))
+    const email = String(json?.email || '').trim().toLowerCase()
+    if (!email) throw new Error('O convite não contém um e-mail válido.')
+    return { email, expiresAt: String(json?.expiresAt || '') }
+  }
+
   const passwordResetRequest = async (path: string, body: Record<string, string>) => {
     const res = await fetchWithTimeout(
       path,
@@ -334,6 +359,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     initProgress,
     signIn,
     signUp,
+    previewSignupInvite,
     requestPasswordReset,
     verifyPasswordResetCode,
     resetPassword,

--- a/crm/console/e2e/login.spec.ts
+++ b/crm/console/e2e/login.spec.ts
@@ -44,7 +44,7 @@ test.describe('auth', () => {
     await page.getByRole('tab', { name: /Criar conta/i }).click()
     await expect(page.locator('#auth-name')).toBeVisible()
     await expect(page.locator('#auth-inviteToken')).toBeVisible()
-    await expect(page.getByText(/escopo definido na administração/i)).toBeVisible()
+    await expect(page.getByText(/escopo definido pelo gestor/i)).toBeVisible()
     await expect(page.getByRole('button', { name: 'Criar conta' })).toBeDisabled()
     await page.fill('#auth-name', 'Ana Souza')
     await page.fill('#auth-email', 'email-invalido')
@@ -58,6 +58,22 @@ test.describe('auth', () => {
     await page.fill('#auth-password', '123456789012')
     await expect(page.getByText(/Dados prontos/i)).toBeVisible()
     await expect(page.getByRole('button', { name: 'Criar conta' })).toBeEnabled()
+  })
+
+  test('opens a personal invitation from a URL fragment and locks its email', async ({ page }) => {
+    await page.route('**/api/auth/me', route => route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'Not authenticated' }) }))
+    await page.route('**/api/auth/invite/preview', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, email: 'ana@empresa.com', expiresAt: '2026-08-20T12:00:00.000Z' }),
+    }))
+
+    await page.goto('/#invite=ABCD1234EFGH5678IJKL9012')
+    await expect(page.getByRole('heading', { name: 'Criar conta com convite' })).toBeVisible()
+    await expect(page.locator('#auth-email')).toHaveValue('ana@empresa.com')
+    await expect(page.locator('#auth-email')).toHaveAttribute('readonly', '')
+    await expect(page.locator('#auth-inviteToken')).toHaveValue('ABCD1234EFGH5678IJKL9012')
+    await expect(page.getByText(/convite é pessoal e está vinculado/i)).toBeVisible()
+    await expect(page).not.toHaveURL(/#invite=/)
   })
 
   test('recovery validates the email code before allowing a new password', async ({ page }) => {

--- a/inventory/migrations/0016_personal_invites.sql
+++ b/inventory/migrations/0016_personal_invites.sql
@@ -1,0 +1,16 @@
+-- Personal, single-use CRM invitations. Existing generic invitations remain revoked.
+
+ALTER TABLE crm_invites ADD COLUMN invitee_email TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_crm_invites_invitee_email
+  ON crm_invites(invitee_email, revoked, expires_at);
+
+-- Existing bearer tokens must not remain usable after invitation becomes nominal.
+UPDATE crm_invites
+SET revoked = 1
+WHERE invitee_email IS NULL OR TRIM(invitee_email) = '';
+
+-- Prevent concurrent signups through separate invitations from creating duplicate email identities.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_users_email_unique
+  ON crm_users(LOWER(email))
+  WHERE email IS NOT NULL AND TRIM(email) <> '';

--- a/inventory/src/invitePolicy.js
+++ b/inventory/src/invitePolicy.js
@@ -1,0 +1,38 @@
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const INVITABLE_ROLES = ['CONSULTOR', 'SUPERVISOR', 'GERENTE'];
+
+export function normalizeInviteEmail(value) {
+  const email = String(value || '').trim().toLowerCase();
+  return EMAIL_RE.test(email) ? email : '';
+}
+
+export function normalizeInviteScope(value) {
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[,;|]/g)
+      : [];
+  return [...new Set(raw.map((item) => String(item || '').trim()).filter(Boolean))];
+}
+
+export function hasRequiredInviteScope({ allowedUnits, allowedModules }) {
+  return normalizeInviteScope(allowedUnits).length > 0 && normalizeInviteScope(allowedModules).length > 0;
+}
+
+export function validateInviteDelegation({ actorRole, targetRole, actorAllowedUnits, actorAllowedModules, allowedUnits, allowedModules }) {
+  if (String(actorRole || '').trim().toUpperCase() !== 'GESTOR') return 'RBAC_DENIED';
+  if (!INVITABLE_ROLES.includes(String(targetRole || '').trim().toUpperCase())) return 'ROLE_DENIED';
+
+  const actorUnits = normalizeInviteScope(actorAllowedUnits);
+  const actorModules = normalizeInviteScope(actorAllowedModules);
+  const nextUnits = normalizeInviteScope(allowedUnits);
+  const nextModules = normalizeInviteScope(allowedModules);
+
+  if (!nextUnits.length) return 'INVITE_UNITS_REQUIRED';
+  if (!nextModules.length) return 'INVITE_MODULES_REQUIRED';
+  if (!actorUnits.length || !actorModules.length) return 'INVITER_SCOPE_REQUIRED';
+  if (nextUnits.some((unit) => !actorUnits.includes(unit))) return 'INVITE_UNITS_DENIED';
+  if (nextModules.some((moduleKey) => !actorModules.includes(moduleKey))) return 'INVITE_MODULES_DENIED';
+  return null;
+}

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -2,9 +2,11 @@
 
 import { restoreBackupPayload } from '../services/backup.js';
 import { resolveCrmTables } from '../d1Store.js';
+import { sendAccountInviteEmail } from '../smtpMailer.js';
+import { normalizeInviteEmail, normalizeInviteScope, validateInviteDelegation } from '../invitePolicy.js';
 
 const ROLE_ADMIN = ['ADMIN', 'GESTOR', 'GERENTE'];
-const ROLE_INVITES = ['ADMIN', 'GESTOR'];
+const ROLE_INVITES = ['GESTOR'];
 const PASSWORD_MIN_LENGTH = 12;
 
 function slugifyCategory(value) {
@@ -153,6 +155,7 @@ function publicInvite(row) {
   const allowedModules = normalizeAllowedModules(row.allowed_modules_json || row.allowedModulesJson || '');
   return {
     id: row.id,
+    inviteeEmail: row.invitee_email || row.inviteeEmail || '',
     tokenHint: row.token_hint || row.tokenHint || '',
     role: normalizeRole(row.role || 'CONSULTOR'),
     allowedUnits,
@@ -193,14 +196,6 @@ async function sha256Hex(input) {
   return Array.from(new Uint8Array(hash))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
-}
-
-function canIssueRole({ actorRole, targetRole }) {
-  const actor = normalizeRole(actorRole);
-  const target = normalizeRole(targetRole);
-  if (actor === 'ADMIN') return true;
-  if (actor === 'GESTOR') return target !== 'ADMIN';
-  return false;
 }
 
 export async function handleAdminRoutes({
@@ -252,6 +247,7 @@ export async function handleAdminRoutes({
   const { usersTable, invitesTable } = await resolveCrmTables(env);
   const usersHasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
   const invitesHasModules = await tableHasColumn(env, invitesTable, 'allowed_modules_json');
+  const invitesHasInviteeEmail = await tableHasColumn(env, invitesTable, 'invitee_email');
 
   // GET /admin/categories
   if (url.pathname === '/admin/categories' && request.method === 'GET') {
@@ -410,7 +406,7 @@ export async function handleAdminRoutes({
       const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
       const where = includeRevoked ? '' : 'WHERE revoked = 0';
       const rows = await env.DB.prepare(
-        `SELECT id, token_hint, role, allowed_units_json${invitesHasModules ? ', allowed_modules_json' : ''}, max_uses, uses_count, expires_at, revoked, note, created_by, created_at
+        `SELECT id, token_hint, role, allowed_units_json${invitesHasModules ? ', allowed_modules_json' : ''}${invitesHasInviteeEmail ? ', invitee_email' : ''}, max_uses, uses_count, expires_at, revoked, note, created_by, created_at
          FROM ${invitesTable}
          ${where}
          ORDER BY created_at DESC
@@ -431,19 +427,48 @@ export async function handleAdminRoutes({
       if (!ROLE_INVITES.includes(normalizeRole(auth?.user?.role))) {
         return withCORS(JSON.stringify({ success: false, error: 'Sem permissão', code: 'RBAC_DENIED' }), { status: 403 }, appOrigin);
       }
+      if (!invitesHasModules || !invitesHasInviteeEmail) {
+        return withCORS(JSON.stringify({ success: false, error: 'Migração de convites pendente', code: 'INVITE_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
+      }
       const body = await request.json().catch(() => ({}));
-      const role = normalizeRole(body.role || 'OPERADOR');
-      const allowedUnits = normalizeAllowedUnits(body.allowedUnits);
-      const allowedModules = normalizeAllowedModules(body.allowedModules ?? body.allowed_modules ?? body.modules ?? body.scopes);
-      const maxUses = Math.max(1, Math.min(50, parseInt(String(body.maxUses ?? '1'), 10) || 1));
+      const inviteeEmail = normalizeInviteEmail(body.email ?? body.inviteeEmail);
+      const role = normalizeRole(body.role || 'CONSULTOR');
+      const allowedUnits = normalizeInviteScope(body.allowedUnits);
+      const allowedModules = normalizeInviteScope(body.allowedModules ?? body.allowed_modules ?? body.modules ?? body.scopes);
+      const requestedMaxUses = body.maxUses === undefined ? 1 : Number.parseInt(String(body.maxUses), 10);
+      const maxUses = 1;
       const expiresInDays = body.expiresInDays === null || body.expiresInDays === undefined
         ? 30
         : Math.max(1, Math.min(365, parseInt(String(body.expiresInDays), 10) || 30));
       const note = String(body.note || '').trim().slice(0, 200);
 
-      if (!canIssueRole({ actorRole: auth?.user?.role, targetRole: role })) {
-        return withCORS(JSON.stringify({ success: false, error: 'Não permitido criar token para esta hierarquia', code: 'ROLE_DENIED' }), { status: 403 }, appOrigin);
+      if (!inviteeEmail) {
+        return withCORS(JSON.stringify({ success: false, error: 'Informe um e-mail corporativo válido', code: 'INVITEE_EMAIL_INVALID' }), { status: 400 }, appOrigin);
       }
+      if (requestedMaxUses !== 1) return withCORS(JSON.stringify({ success: false, error: 'Convites são pessoais e de uso único', code: 'INVITE_SINGLE_USE_REQUIRED' }), { status: 400 }, appOrigin);
+      const policyError = validateInviteDelegation({
+        actorRole: auth?.user?.role,
+        targetRole: role,
+        actorAllowedUnits: auth?.user?.allowedUnits,
+        actorAllowedModules: auth?.user?.allowedModules,
+        allowedUnits,
+        allowedModules,
+      });
+      if (policyError) {
+        const policyMessages = {
+          RBAC_DENIED: 'Somente gestores podem emitir convites.',
+          ROLE_DENIED: 'O gestor só pode convidar papéis abaixo de gestor.',
+          INVITE_UNITS_REQUIRED: 'Selecione ao menos uma unidade para o convite.',
+          INVITE_MODULES_REQUIRED: 'Selecione ao menos um módulo para o convite.',
+          INVITER_SCOPE_REQUIRED: 'Seu próprio acesso precisa ter unidades e módulos definidos antes de emitir convites.',
+          INVITE_UNITS_DENIED: 'O convite contém uma unidade fora do seu escopo.',
+          INVITE_MODULES_DENIED: 'O convite contém um módulo fora do seu escopo.',
+        };
+        return withCORS(JSON.stringify({ success: false, error: policyMessages[policyError] || 'Convite não permitido.', code: policyError }), { status: policyError === 'RBAC_DENIED' || policyError === 'ROLE_DENIED' || policyError.endsWith('_DENIED') ? 403 : 400 }, appOrigin);
+      }
+
+      const existingUser = await env.DB.prepare(`SELECT username FROM ${usersTable} WHERE LOWER(email) = LOWER(?) LIMIT 1`).bind(inviteeEmail).first();
+      if (existingUser?.username) return withCORS(JSON.stringify({ success: false, error: 'Este e-mail já está cadastrado', code: 'EMAIL_TAKEN' }), { status: 409 }, appOrigin);
 
       const token = randomInviteToken();
       const tokenHash = await sha256Hex(token);
@@ -452,45 +477,21 @@ export async function handleAdminRoutes({
       const createdAt = new Date().toISOString();
       const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
 
-      if (invitesHasModules) {
-        await env.DB.prepare(
-          `INSERT INTO ${invitesTable}
-           (id, token_hash, token_hint, role, allowed_units_json, allowed_modules_json, max_uses, uses_count, expires_at, revoked, note, created_by, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?)`
-        )
-          .bind(
-            id,
-            tokenHash,
-            tokenHint,
-            role,
-            JSON.stringify(allowedUnits),
-            JSON.stringify(allowedModules),
-            maxUses,
-            expiresAt,
-            note,
-            String(auth?.user?.username || ''),
-            createdAt
-          )
-          .run();
-      } else {
-        await env.DB.prepare(
-          `INSERT INTO ${invitesTable}
-           (id, token_hash, token_hint, role, allowed_units_json, max_uses, uses_count, expires_at, revoked, note, created_by, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?)`
-        )
-          .bind(
-            id,
-            tokenHash,
-            tokenHint,
-            role,
-            JSON.stringify(allowedUnits),
-            maxUses,
-            expiresAt,
-            note,
-            String(auth?.user?.username || ''),
-            createdAt
-          )
-          .run();
+      await env.DB.prepare(
+        `INSERT INTO ${invitesTable}
+         (id, token_hash, token_hint, invitee_email, role, allowed_units_json, allowed_modules_json, max_uses, uses_count, expires_at, revoked, note, created_by, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 1, 0, ?, 0, ?, ?, ?)`
+      )
+        .bind(id, tokenHash, tokenHint, inviteeEmail, role, JSON.stringify(allowedUnits), JSON.stringify(allowedModules), expiresAt, note, String(auth?.user?.username || ''), createdAt)
+        .run();
+
+      try {
+        await sendAccountInviteEmail({ env, to: inviteeEmail, token, expiresAt, appUrl: String(env?.AUTH_INVITE_APP_URL || appOrigin) });
+      } catch (mailError) {
+        await env.DB.prepare(`UPDATE ${invitesTable} SET revoked = 1 WHERE id = ? AND uses_count = 0`).bind(id).run();
+        const reason = String(mailError?.message || mailError || 'SMTP_ERROR_UNKNOWN').replace(/[\r\n]+/g, ' ').slice(0, 160);
+        console.error(JSON.stringify({ event: 'AUTH_INVITE_EMAIL_FAILED', invite_id: id, reason }));
+        return withCORS(JSON.stringify({ success: false, error: 'EMAIL_DELIVERY_FAILED' }), { status: 503 }, appOrigin);
       }
 
       try {
@@ -506,13 +507,14 @@ export async function handleAdminRoutes({
           entityId: id,
           unidade: '',
           before: null,
-          after: { role, allowedUnits, allowedModules, maxUses, expiresAt, tokenHint, note }
+          after: { inviteeEmail, role, allowedUnits, allowedModules, maxUses, expiresAt, tokenHint, note, delivery: 'smtp' }
         });
       } catch { }
 
       const invite = publicInvite({
         id,
         token_hint: tokenHint,
+        invitee_email: inviteeEmail,
         role,
         allowed_units_json: JSON.stringify(allowedUnits),
         allowed_modules_json: invitesHasModules ? JSON.stringify(allowedModules) : null,
@@ -525,8 +527,7 @@ export async function handleAdminRoutes({
         created_at: createdAt,
       });
 
-      // IMPORTANT: token is returned only once at creation time
-      return withCORS(JSON.stringify({ success: true, data: invite, token }), { status: 201 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: invite, delivery: 'smtp' }), { status: 201 }, appOrigin);
     } catch (err) {
       const msg = String(err?.message || err);
       if (/UNIQUE constraint failed: (?:insumos_invites|crm_invites)\.token_hash/i.test(msg)) {
@@ -546,7 +547,7 @@ export async function handleAdminRoutes({
       if (!id) return withCORS(JSON.stringify({ success: false, error: 'ID_REQUIRED' }), { status: 400 }, appOrigin);
 
       const existing = await env.DB.prepare(
-        `SELECT id, role, token_hint, allowed_units_json${invitesHasModules ? ', allowed_modules_json' : ''}, max_uses, uses_count, expires_at, revoked, note, created_by, created_at
+        `SELECT id, role, token_hint, allowed_units_json${invitesHasModules ? ', allowed_modules_json' : ''}${invitesHasInviteeEmail ? ', invitee_email' : ''}, max_uses, uses_count, expires_at, revoked, note, created_by, created_at
          FROM ${invitesTable} WHERE id = ? LIMIT 1`
       )
         .bind(id)
@@ -628,6 +629,9 @@ export async function handleAdminRoutes({
   // POST /admin/users
   if (url.pathname === '/admin/users' && request.method === 'POST') {
     try {
+      if (normalizeRole(auth?.user?.role) !== 'ADMIN' || String(env?.ALLOW_ADMIN_USER_PROVISIONING || '').trim().toLowerCase() !== 'true') {
+        return withCORS(JSON.stringify({ success: false, error: 'Criação direta desabilitada. Use um convite autorizado.', code: 'INVITE_REQUIRED' }), { status: 403 }, appOrigin);
+      }
       const body = await request.json().catch(() => ({}));
       const username = String(body.username || '').trim();
       const displayName = String(body.displayName || '').trim();
@@ -729,6 +733,9 @@ export async function handleAdminRoutes({
       const email = body.email !== undefined ? String(body.email || '').trim() : null;
       const displayName = body.displayName !== undefined ? String(body.displayName || '').trim() : null;
       const role = body.role !== undefined ? normalizeRole(body.role || 'CONSULTOR') : null;
+      if (role !== null && normalizeRole(auth?.user?.role) !== 'ADMIN') {
+        return withCORS(JSON.stringify({ success: false, error: 'Somente o provisionamento administrativo pode alterar hierarquia.', code: 'ROLE_MANAGEMENT_DENIED' }), { status: 403 }, appOrigin);
+      }
       const photoUrl = body.photoUrl !== undefined ? String(body.photoUrl || '') : null;
       const allowedUnits = body.allowedUnits !== undefined ? JSON.stringify(normalizeAllowedUnits(body.allowedUnits)) : null;
       const allowedModules = body.allowedModules !== undefined ? JSON.stringify(normalizeAllowedModules(body.allowedModules)) : null;

--- a/inventory/src/routes/auth.js
+++ b/inventory/src/routes/auth.js
@@ -3,6 +3,7 @@
 
 import { resolveCrmTables } from '../d1Store.js';
 import { hasPasswordResetMailerConfig, sendPasswordResetEmail } from '../smtpMailer.js';
+import { hasRequiredInviteScope, normalizeInviteEmail } from '../invitePolicy.js';
 
 export async function handleAuthRoutes({
     request,
@@ -270,6 +271,7 @@ export async function handleAuthRoutes({
 	        const { usersTable, invitesTable, passwordResetsTable } = await resolveCrmTables(env);
 	        const usersHasModules = await tableHasColumn(usersTable, 'allowed_modules_json');
 	        const invitesHasModules = await tableHasColumn(invitesTable, 'allowed_modules_json');
+	        const invitesHasInviteeEmail = await tableHasColumn(invitesTable, 'invitee_email');
 
         const sha256Hex = async (input) => {
 	            const data = new TextEncoder().encode(String(input || ''));
@@ -495,7 +497,30 @@ export async function handleAuthRoutes({
             }
         }
 
-        // POST /auth/register (invite-based signup)
+        // POST /auth/invite/preview - validates a personal invitation without consuming it.
+        if (url.pathname === "/auth/invite/preview" && request.method === "POST") {
+            const body = await request.json().catch(() => ({}));
+            const inviteToken = String(body.token || body.invite || body.inviteToken || '').trim();
+            if (!inviteToken) return withCORS(JSON.stringify({ success: false, error: 'TOKEN_REQUIRED' }), { status: 400 }, appOrigin);
+            if (!invitesHasModules || !invitesHasInviteeEmail) return withCORS(JSON.stringify({ success: false, error: 'INVITE_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
+            try {
+                const invite = await env.DB.prepare(
+                    `SELECT invitee_email, allowed_units_json, allowed_modules_json, max_uses, uses_count, expires_at, revoked
+                     FROM ${invitesTable} WHERE token_hash = ? LIMIT 1`
+                ).bind(await sha256Hex(inviteToken)).first();
+                if (!invite) return withCORS(JSON.stringify({ success: false, error: 'TOKEN_INVALID' }), { status: 401 }, appOrigin);
+                if (Number(invite.revoked || 0)) return withCORS(JSON.stringify({ success: false, error: 'TOKEN_REVOKED' }), { status: 403 }, appOrigin);
+                if (Number(invite.max_uses || 0) !== 1 || Number(invite.uses_count || 0) !== 0) return withCORS(JSON.stringify({ success: false, error: 'TOKEN_EXHAUSTED' }), { status: 403 }, appOrigin);
+                const expiresAt = String(invite.expires_at || '');
+                if (!expiresAt || !Number.isFinite(new Date(expiresAt).getTime()) || Date.now() >= new Date(expiresAt).getTime()) return withCORS(JSON.stringify({ success: false, error: 'TOKEN_EXPIRED' }), { status: 403 }, appOrigin);
+                if (!hasRequiredInviteScope({ allowedUnits: normalizeAllowedUnits(invite.allowed_units_json), allowedModules: normalizeAllowedModules(invite.allowed_modules_json) })) return withCORS(JSON.stringify({ success: false, error: 'INVITE_SCOPE_INVALID' }), { status: 403 }, appOrigin);
+                return withCORS(JSON.stringify({ success: true, email: String(invite.invitee_email || ''), expiresAt }), { status: 200 }, appOrigin);
+            } catch (err) {
+                return withCORS(JSON.stringify({ success: false, error: err.message || String(err) }), { status: 500 }, appOrigin);
+            }
+        }
+
+        // POST /auth/register (personal, single-use invite-based signup)
         if ((url.pathname === "/auth/register" || url.pathname === "/auth/signup") && request.method === "POST") {
             try {
                 if (!env?.DB) {
@@ -503,7 +528,7 @@ export async function handleAuthRoutes({
                 }
                 const body = await request.json().catch(() => ({}));
                 const name = String(body.name || '').trim();
-                const email = String(body.email || body.username || '').trim();
+                const email = normalizeInviteEmail(body.email || body.username || '');
                 const password = String(body.password || body.senha || '').toString();
                 const inviteToken = String(body.token || body.invite || body.inviteToken || '').trim();
 
@@ -523,8 +548,12 @@ export async function handleAuthRoutes({
                 const inviteHash = await sha256Hex(inviteToken);
                 const now = new Date().toISOString();
 
+                if (!usersHasModules || !invitesHasModules || !invitesHasInviteeEmail) {
+                    return withCORS(JSON.stringify({ success: false, error: "INVITE_MIGRATION_REQUIRED" }), { status: 503 }, appOrigin);
+                }
+
                 const invite = await env.DB.prepare(
-                    `SELECT id, role, allowed_units_json${invitesHasModules ? ', allowed_modules_json' : ''}, max_uses, uses_count, expires_at, revoked
+                    `SELECT id, invitee_email, role, allowed_units_json, allowed_modules_json, max_uses, uses_count, expires_at, revoked
                      FROM ${invitesTable}
                      WHERE token_hash = ?
                      LIMIT 1`
@@ -540,7 +569,7 @@ export async function handleAuthRoutes({
                 }
                 const maxUses = Math.max(1, parseInt(String(invite.max_uses || 1), 10) || 1);
                 const usesCount = Math.max(0, parseInt(String(invite.uses_count || 0), 10) || 0);
-                if (usesCount >= maxUses) {
+                if (maxUses !== 1 || usesCount !== 0) {
                     return withCORS(JSON.stringify({ success: false, error: "TOKEN_EXHAUSTED" }), { status: 403 }, appOrigin);
                 }
                 const expiresAt = invite.expires_at ? String(invite.expires_at) : '';
@@ -549,6 +578,9 @@ export async function handleAuthRoutes({
                     if (Number.isFinite(exp) && Date.now() > exp) {
                         return withCORS(JSON.stringify({ success: false, error: "TOKEN_EXPIRED" }), { status: 403 }, appOrigin);
                     }
+                }
+                if (normalizeInviteEmail(invite.invitee_email) !== email) {
+                    return withCORS(JSON.stringify({ success: false, error: "INVITE_EMAIL_MISMATCH" }), { status: 403 }, appOrigin);
                 }
 
                 const existing = await d1.getUserByIdentifier(email);
@@ -564,55 +596,39 @@ export async function handleAuthRoutes({
 
                 const role = normalizeRole(invite.role || 'CONSULTOR');
                 const allowedUnits = normalizeAllowedUnits(invite.allowed_units_json || '');
-                const allowedModules = invitesHasModules ? normalizeAllowedModules(invite.allowed_modules_json || '') : [];
-                const hash = await hashPassword(password);
-
-                if (usersHasModules) {
-                    await env.DB.prepare(
-                        `INSERT INTO ${usersTable}
-                         (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`
-                    )
-                        .bind(
-                            candidate,
-                            email,
-                            name,
-                            hash,
-                            role,
-                            '',
-                            JSON.stringify(allowedUnits),
-                            JSON.stringify(allowedModules),
-                            now,
-                            now
-                        )
-                        .run();
-                } else {
-                    await env.DB.prepare(
-                        `INSERT INTO ${usersTable}
-                         (username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`
-                    )
-                        .bind(
-                            candidate,
-                            email,
-                            name,
-                            hash,
-                            role,
-                            '',
-                            JSON.stringify(allowedUnits),
-                            now,
-                            now
-                        )
-                        .run();
+                const allowedModules = normalizeAllowedModules(invite.allowed_modules_json || '');
+                if (!hasRequiredInviteScope({ allowedUnits, allowedModules })) {
+                    return withCORS(JSON.stringify({ success: false, error: "INVITE_SCOPE_INVALID" }), { status: 403 }, appOrigin);
                 }
-
-                await env.DB.prepare(
+                const hash = await hashPassword(password);
+                const currentTime = new Date().toISOString();
+                const registration = env.DB.prepare(
+                    `INSERT INTO ${usersTable}
+                     (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
+                     SELECT ?, invitee_email, ?, ?, role, '', allowed_units_json, allowed_modules_json, 1, ?, ?
+                     FROM ${invitesTable}
+                     WHERE token_hash = ?
+                       AND invitee_email = ?
+                       AND revoked = 0
+                       AND max_uses = 1
+                       AND uses_count = 0
+                       AND expires_at > ?`
+                ).bind(candidate, name, hash, now, now, inviteHash, email, currentTime);
+                const consume = env.DB.prepare(
                     `UPDATE ${invitesTable}
-                     SET uses_count = uses_count + 1
-                     WHERE id = ?`
-                )
-                    .bind(invite.id)
-                    .run();
+                     SET uses_count = 1
+                     WHERE token_hash = ?
+                       AND invitee_email = ?
+                       AND revoked = 0
+                       AND max_uses = 1
+                       AND uses_count = 0
+                       AND expires_at > ?
+                       AND changes() = 1`
+                ).bind(inviteHash, email, currentTime);
+                const changed = await env.DB.batch([registration, consume]);
+                if (!changed?.[0]?.meta?.changes || !changed?.[1]?.meta?.changes) {
+                    return withCORS(JSON.stringify({ success: false, error: "TOKEN_EXHAUSTED" }), { status: 409 }, appOrigin);
+                }
 
                 const userDb = await d1.getUserByUsername(candidate);
                 const user = userDb

--- a/inventory/src/smtpMailer.js
+++ b/inventory/src/smtpMailer.js
@@ -53,7 +53,7 @@ async function command(writer, reader, state, text, accepted) {
   return expect(reader, state, accepted);
 }
 
-export function hasPasswordResetMailerConfig(env) {
+export function hasAuthMailerConfig(env) {
   return Boolean(
     String(env?.AUTH_RESET_SMTP_HOST || '').trim() &&
     String(env?.AUTH_RESET_SMTP_USERNAME || '').trim() &&
@@ -62,12 +62,14 @@ export function hasPasswordResetMailerConfig(env) {
   );
 }
 
-export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
-  if (!hasPasswordResetMailerConfig(env)) throw new Error('AUTH_RESET_EMAIL_NOT_CONFIGURED');
+export const hasPasswordResetMailerConfig = hasAuthMailerConfig;
+
+async function sendAuthEmail({ env, to, subject, text, html }) {
+  if (!hasAuthMailerConfig(env)) throw new Error('AUTH_EMAIL_NOT_CONFIGURED');
 
   const recipient = cleanEmail(to);
   const from = cleanEmail(env.AUTH_RESET_EMAIL_FROM);
-  if (!recipient || !from) throw new Error('AUTH_RESET_EMAIL_INVALID');
+  if (!recipient || !from) throw new Error('AUTH_EMAIL_INVALID');
 
   const hostname = String(env.AUTH_RESET_SMTP_HOST).trim();
   const port = Math.max(1, Number.parseInt(String(env.AUTH_RESET_SMTP_PORT || '465'), 10) || 465);
@@ -105,10 +107,6 @@ export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
     await command(writer, reader, state, `RCPT TO:<${recipient}>`, [250, 251]);
     await command(writer, reader, state, 'DATA', [354]);
 
-    const expiry = new Date(expiresAt).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', timeZone: 'America/Sao_Paulo' });
-    const subject = 'Código para redefinir sua senha — Espaço Facial CRM';
-    const text = `Seu código de recuperação é: ${code}\n\nEle expira às ${expiry}. Se você não solicitou esta alteração, ignore esta mensagem.`;
-    const html = `<p>Seu código de recuperação é:</p><p style="font-size:28px;font-weight:700;letter-spacing:6px">${code}</p><p>Ele expira às ${expiry}. Se você não solicitou esta alteração, ignore esta mensagem.</p>`;
     const message = [
       `From: Espaço Facial CRM <${from}>`,
       `To: <${recipient}>`,
@@ -136,4 +134,36 @@ export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
     try { reader.releaseLock(); } catch {}
     try { socket.close(); } catch {}
   }
+}
+
+export async function sendPasswordResetEmail({ env, to, code, expiresAt }) {
+  const expiry = new Date(expiresAt).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', timeZone: 'America/Sao_Paulo' });
+  return sendAuthEmail({
+    env,
+    to,
+    subject: 'Código para redefinir sua senha — Espaço Facial CRM',
+    text: `Seu código de recuperação é: ${code}\n\nEle expira às ${expiry}. Se você não solicitou esta alteração, ignore esta mensagem.`,
+    html: `<p>Seu código de recuperação é:</p><p style="font-size:28px;font-weight:700;letter-spacing:6px">${code}</p><p>Ele expira às ${expiry}. Se você não solicitou esta alteração, ignore esta mensagem.</p>`
+  });
+}
+
+export async function sendAccountInviteEmail({ env, to, token, expiresAt, appUrl }) {
+  let baseUrl = 'https://crm.skincos.com.br';
+  try {
+    const candidate = new URL(String(appUrl || baseUrl).trim());
+    if (candidate.protocol === 'https:' || candidate.protocol === 'http:') {
+      baseUrl = candidate.toString().replace(/\/+$/, '');
+    }
+  } catch {
+    // Keep the production CRM URL when an optional local override is malformed.
+  }
+  const inviteUrl = `${baseUrl}/#invite=${encodeURIComponent(String(token || ''))}`;
+  const expiry = new Date(expiresAt).toLocaleDateString('pt-BR', { dateStyle: 'medium', timeZone: 'America/Sao_Paulo' });
+  return sendAuthEmail({
+    env,
+    to,
+    subject: 'Convite para criar sua conta — Espaço Facial CRM',
+    text: `Você foi convidado(a) para acessar o Espaço Facial CRM.\n\nCrie sua conta pelo link abaixo:\n${inviteUrl}\n\nEste convite é pessoal, vale até ${expiry} e só pode ser usado uma vez. Se você não esperava este convite, ignore esta mensagem.`,
+    html: `<p>Você foi convidado(a) para acessar o Espaço Facial CRM.</p><p><a href="${inviteUrl}">Criar minha conta</a></p><p>Este convite é pessoal, vale até ${expiry} e só pode ser usado uma vez.</p><p>Se você não esperava este convite, ignore esta mensagem.</p>`
+  });
 }

--- a/inventory/src/worker.js
+++ b/inventory/src/worker.js
@@ -1228,6 +1228,7 @@ export default {
                 '/auth/login',
                 '/auth/register',
                 '/auth/signup',
+                '/auth/invite/preview',
                 '/auth/password/request',
                 '/auth/password/verify',
                 '/auth/password/reset',
@@ -1311,7 +1312,7 @@ export default {
             if (!u) return false;
             if (String(u.role || '').toUpperCase() === 'ADMIN') return true;
             const allowed = Array.isArray(u.allowedUnits) ? u.allowedUnits.filter(Boolean) : [];
-            if (!allowed.length) return true;
+            if (!allowed.length) return false;
             return allowed.includes(unit);
         };
 
@@ -1324,7 +1325,7 @@ export default {
             if (!u || !moduleKey) return false;
             if (String(u.role || '').toUpperCase() === 'ADMIN') return true; // override
             const allowed = getAllowedModules(u);
-            if (!allowed.length) return true; // compat: no list means "ALL"
+            if (!allowed.length) return false;
             return allowed.includes(String(moduleKey));
         };
 

--- a/inventory/src/worker.js
+++ b/inventory/src/worker.js
@@ -1056,15 +1056,23 @@ export default {
         // The bypass therefore requires both the dev-only Worker flag and the
         // marker emitted exclusively by the localhost Pages proxy.
         const devBypassActive = devBypassEnabled && proxiedLocalDevAuth;
+        // Keep the Insumos proxy aligned with the Pages local-auth identity.
+        // The local launcher deliberately exercises the Gestor path, including
+        // invite delegation. It therefore needs explicit scopes; an ADMIN with
+        // empty scopes would correctly be denied by the invitation policy.
         const devBypassUser = devBypassActive
             ? {
                 username: 'dev',
                 displayName: 'Dev Local',
-                email: 'dev@local',
-                role: 'ADMIN',
+                email: 'dev@local.test',
+                role: 'GESTOR',
                 ativo: true,
-                allowedUnits: [],
-                allowedModules: [],
+                allowedUnits: UNIDADES,
+                allowedModules: [
+                    'users', 'insumos', 'atendimento', 'ponto', 'faturamento',
+                    'procedimentos', 'leads', 'dashboard', 'conversa',
+                    'ai-automation', 'meta-ads', 'site-tracking', 'escala-profissionais',
+                ],
             }
             : null;
         const auditToken = String(env?.INSUMOS_AUDIT_TOKEN || '').trim();

--- a/inventory/tests/invitePolicy.test.mjs
+++ b/inventory/tests/invitePolicy.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hasRequiredInviteScope, normalizeInviteEmail, validateInviteDelegation } from '../src/invitePolicy.js';
+
+test('normalizes the recipient email and requires both scopes', () => {
+  assert.equal(normalizeInviteEmail(' Ana.Souza@Empresa.com '), 'ana.souza@empresa.com');
+  assert.equal(normalizeInviteEmail('not-an-email'), '');
+  assert.equal(hasRequiredInviteScope({ allowedUnits: ['novo-hamburgo'], allowedModules: ['insumos'] }), true);
+  assert.equal(hasRequiredInviteScope({ allowedUnits: [], allowedModules: ['insumos'] }), false);
+  assert.equal(hasRequiredInviteScope({ allowedUnits: ['novo-hamburgo'], allowedModules: [] }), false);
+});
+
+test('only scoped gestores can delegate lower roles within their own access', () => {
+  const base = {
+    actorRole: 'GESTOR',
+    actorAllowedUnits: ['novo-hamburgo', 'barra-shopping-sul'],
+    actorAllowedModules: ['users', 'insumos', 'status'],
+    allowedUnits: ['novo-hamburgo'],
+    allowedModules: ['insumos'],
+  };
+
+  assert.equal(validateInviteDelegation({ ...base, targetRole: 'CONSULTOR' }), null);
+  assert.equal(validateInviteDelegation({ ...base, targetRole: 'GESTOR' }), 'ROLE_DENIED');
+  assert.equal(validateInviteDelegation({ ...base, targetRole: 'ADMIN' }), 'ROLE_DENIED');
+  assert.equal(validateInviteDelegation({ ...base, targetRole: 'GERENTE', allowedUnits: ['unidade-nao-permitida'] }), 'INVITE_UNITS_DENIED');
+  assert.equal(validateInviteDelegation({ ...base, targetRole: 'SUPERVISOR', allowedModules: ['meta-ads'] }), 'INVITE_MODULES_DENIED');
+  assert.equal(validateInviteDelegation({ ...base, actorAllowedModules: [], targetRole: 'CONSULTOR' }), 'INVITER_SCOPE_REQUIRED');
+});


### PR DESCRIPTION
## Cadastro por convite autorizado

Implementa convites nominais, de uso único, vinculados ao e-mail corporativo e com escopos obrigatórios.

- somente Gestor cria ou revoga convites para papéis inferiores;
- cadastro valida e consome o convite atomicamente;
- SMTP envia o link em fragmento e revoga o convite se a entrega falhar;
- criação direta permanece bloqueada, exceto provisionamento administrativo explícito;
- o atalho local usa um Gestor com escopos explícitos, permitindo validar o módulo Usuários.

A rotina de deploy de Workers já aplica as migrations D1 antes do Worker.

Validação: testes de política de convite, sintaxe dos Workers, typecheck e lint direcionados, além de E2E do fluxo de convite/recuperação.