### PR TITLE
feat(crm): add local consultor shortcut

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -21,6 +21,11 @@ icon = "run"
 command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action LocalMenu"
 
 [[actions]]
+name = "CRM – Consultor (Ponto)"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmConsultor"
+
+[[actions]]
 name = "EF App"
 icon = "run"
 command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action EfAppMenu"

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -44,6 +44,7 @@ import type { SiteTrackingHeaderState } from '@/siteTrackingTypes'
 import { dispatchAtendimentoHeaderAction, subscribeAtendimentoHeaderState } from '@/atendimentoHeaderBridge'
 import type { AtendimentoHeaderState } from '@/atendimentoHeaderBridge'
 import { hasCrmModuleAccess } from '@/crmRoleAccess'
+import { canManagePonto } from '@/pontoAccess'
 import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, ClipboardList, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Stethoscope, WalletCards, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
@@ -374,14 +375,7 @@ export default function AppFunctionalNeatlab() {
 
     const allowedModulesKey = Array.isArray(user?.allowedModules) ? user.allowedModules.join('|') : ''
     const roleKey = String(user?.role || '').trim().toUpperCase()
-    const isLocalDev = import.meta.env.DEV && (window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost')
-    const devEmail = String(user?.email || '').trim().toLowerCase()
-    const pontoCanAdmin =
-        roleKey === 'GESTOR' ||
-        roleKey === 'GERENTE' ||
-        roleKey === 'SUPERVISOR' ||
-        roleKey === 'ADMIN' ||
-        (isLocalDev && devEmail.endsWith('@local.test'))
+    const pontoCanAdmin = canManagePonto(roleKey)
     const hasModuleAccess = React.useCallback(
         (moduleKey: string) => {
             return hasCrmModuleAccess(roleKey, user?.allowedModules, moduleKey)

--- a/crm/console/localAuthProfile.ts
+++ b/crm/console/localAuthProfile.ts
@@ -1,0 +1,4 @@
+/** The local launcher uses true by default so its normal test account is Gestor. */
+export function isLocalTestUserAdmin(value: unknown): boolean {
+  return String(value ?? 'true').trim().toLowerCase() !== 'false'
+}

--- a/crm/console/localDevAuthReset.ts
+++ b/crm/console/localDevAuthReset.ts
@@ -13,6 +13,10 @@ export function consumeLocalAuthReset(
   if (!isLocalHost || url.searchParams.get(LOCAL_AUTH_RESET_PARAM) !== '1') return false
 
   storage.removeItem('crm.localAuth')
+  storage.removeItem('crm.localRole')
+  storage.removeItem('crm.localEmail')
+  storage.removeItem('crm.localUser')
+  storage.removeItem('crm.localName')
   clearCookie('crm.localAuth=; Path=/; Max-Age=0; SameSite=Lax')
   clearCookie('crm_local_auth=; Path=/; Max-Age=0; SameSite=Lax')
 

--- a/crm/console/pontoAccess.ts
+++ b/crm/console/pontoAccess.ts
@@ -1,0 +1,6 @@
+const PONTO_MANAGEMENT_ROLES = new Set(['GESTOR', 'GERENTE', 'SUPERVISOR', 'ADMIN'])
+
+/** UI policy only. The Ponto API must authorize every operation independently. */
+export function canManagePonto(role: unknown): boolean {
+  return PONTO_MANAGEMENT_ROLES.has(String(role || '').trim().toUpperCase())
+}

--- a/crm/console/tests/crmLocalTestUserAccess.test.ts
+++ b/crm/console/tests/crmLocalTestUserAccess.test.ts
@@ -26,4 +26,24 @@ describe('local CRM test user', () => {
     expect(user.role).toBe('CONSULTOR')
     expect(user.allowedModules).toEqual(['atendimento', 'ponto'])
   })
+
+  it('keeps the synthetic Consultor identity stable for local validation', () => {
+    const user = getLocalDevAuthUser(context({
+      LOCAL_AUTH_TEST_USER_ADMIN: 'false',
+      LOCAL_AUTH_ROLE: 'CONSULTOR',
+      LOCAL_AUTH_EMAIL: 'consultor.local@local.test',
+      LOCAL_AUTH_USERNAME: 'consultor-local',
+      LOCAL_AUTH_NAME: 'Consultor Local',
+      LOCAL_AUTH_ALLOWED_MODULES: 'atendimento,ponto',
+    }))
+
+    expect(user).toMatchObject({
+      id: 'consultor-local',
+      username: 'consultor-local',
+      email: 'consultor.local@local.test',
+      displayName: 'Consultor Local',
+      role: 'CONSULTOR',
+      allowedModules: ['atendimento', 'ponto'],
+    })
+  })
 })

--- a/crm/console/tests/localAuthProfile.test.ts
+++ b/crm/console/tests/localAuthProfile.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isLocalTestUserAdmin } from '../localAuthProfile'
+
+describe('local auth profile', () => {
+  it('keeps the default local test account privileged', () => {
+    expect(isLocalTestUserAdmin(undefined)).toBe(true)
+    expect(isLocalTestUserAdmin('true')).toBe(true)
+  })
+
+  it('lets a local role-specific shortcut disable the privileged fallback', () => {
+    expect(isLocalTestUserAdmin('false')).toBe(false)
+    expect(isLocalTestUserAdmin('FALSE')).toBe(false)
+  })
+})

--- a/crm/console/tests/localDevAuthReset.test.ts
+++ b/crm/console/tests/localDevAuthReset.test.ts
@@ -1,39 +1,37 @@
 import { describe, expect, it, vi } from 'vitest'
 import { consumeLocalAuthReset } from '../localDevAuthReset'
 
-describe('local CRM auth reset', () => {
-  it('clears only the local auth opt-out and removes the one-time query parameter', () => {
-    const removeItem = vi.fn()
-    const clearCookie = vi.fn()
-    const replaceUrl = vi.fn()
-
-    const consumed = consumeLocalAuthReset(
-      { href: 'http://localhost:8791/?module=insumos&localAuthReset=1', hostname: 'localhost' },
-      { removeItem },
-      clearCookie,
-      replaceUrl,
-    )
-
-    expect(consumed).toBe(true)
-    expect(removeItem).toHaveBeenCalledWith('crm.localAuth')
-    expect(clearCookie).toHaveBeenCalledWith('crm.localAuth=; Path=/; Max-Age=0; SameSite=Lax')
-    expect(clearCookie).toHaveBeenCalledWith('crm_local_auth=; Path=/; Max-Age=0; SameSite=Lax')
-    expect(replaceUrl).toHaveBeenCalledWith('/?module=insumos')
-  })
-
-  it('does not affect a non-local URL or a normal launch', () => {
+describe('local auth reset', () => {
+  it('clears every local persona override before opening the requested module', () => {
     const removeItem = vi.fn()
     const clearCookie = vi.fn()
     const replaceUrl = vi.fn()
 
     expect(consumeLocalAuthReset(
-      { href: 'https://crm.skincos.com.br/?localAuthReset=1', hostname: 'crm.skincos.com.br' },
+      { href: 'http://localhost:8791/?module=ponto&localAuthReset=1', hostname: 'localhost' },
       { removeItem },
       clearCookie,
       replaceUrl,
+    )).toBe(true)
+
+    expect(removeItem.mock.calls.map(([key]) => key)).toEqual([
+      'crm.localAuth',
+      'crm.localRole',
+      'crm.localEmail',
+      'crm.localUser',
+      'crm.localName',
+    ])
+    expect(replaceUrl).toHaveBeenCalledWith('/?module=ponto')
+  })
+
+  it('does not clear browser state outside localhost', () => {
+    const removeItem = vi.fn()
+    expect(consumeLocalAuthReset(
+      { href: 'https://crm.skincos.com.br/?localAuthReset=1', hostname: 'crm.skincos.com.br' },
+      { removeItem },
+      vi.fn(),
+      vi.fn(),
     )).toBe(false)
     expect(removeItem).not.toHaveBeenCalled()
-    expect(clearCookie).not.toHaveBeenCalled()
-    expect(replaceUrl).not.toHaveBeenCalled()
   })
 })

--- a/crm/console/tests/pontoAccess.test.ts
+++ b/crm/console/tests/pontoAccess.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { canManagePonto } from '../pontoAccess'
+
+describe('Ponto management navigation policy', () => {
+  it.each(['GESTOR', 'GERENTE', 'SUPERVISOR', 'ADMIN'])('allows the %s role to use management actions', (role) => {
+    expect(canManagePonto(role)).toBe(true)
+  })
+
+  it.each(['CONSULTOR', 'EMPLOYEE', 'unknown', ''])('keeps %s out of management actions', (role) => {
+    expect(canManagePonto(role)).toBe(false)
+  })
+})

--- a/crm/console/useReplitAuth.ts
+++ b/crm/console/useReplitAuth.ts
@@ -1,6 +1,7 @@
 // Replit Auth Integration: Custom hook for authentication
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { consumeLocalAuthReset } from './localDevAuthReset'
+import { isLocalTestUserAdmin } from './localAuthProfile'
 
 export function useReplitAuth() {
   const queryClient = useQueryClient()
@@ -18,7 +19,7 @@ export function useReplitAuth() {
     !!import.meta.env.DEV &&
     isLocalDevHost &&
     String(localStorage.getItem('crm.localAuth') || 'on').toLowerCase() !== 'off'
-  const localTestUserAdmin = String(import.meta.env.VITE_LOCAL_TEST_USER_ADMIN || 'true').trim().toLowerCase() !== 'false'
+  const localTestUserAdmin = isLocalTestUserAdmin(import.meta.env.VITE_LOCAL_AUTH_TEST_USER_ADMIN)
   const localRoleRaw = localTestUserAdmin
     ? 'GESTOR'
     : String(localStorage.getItem('crm.localRole') || import.meta.env.VITE_LOCAL_AUTH_ROLE || 'GESTOR').trim().toUpperCase()

--- a/crm/console/vite.config.ts
+++ b/crm/console/vite.config.ts
@@ -1151,6 +1151,11 @@ function attachDevMiddleware(server: any) {
 }
 
 export default defineConfig({
+  define: {
+    // .dev.vars is intentionally not a Vite .env file. Inject this non-secret
+    // local-only flag so the client fallback matches the Pages auth persona.
+    'import.meta.env.VITE_LOCAL_AUTH_TEST_USER_ADMIN': JSON.stringify(String(localTestUserAdmin)),
+  },
   plugins: [
     tailwindcss(),
     react(),

--- a/scripts/install-shared-codex-shortcuts.ps1
+++ b/scripts/install-shared-codex-shortcuts.ps1
@@ -96,6 +96,7 @@ $shortcuts = @(
     @{ Name = "Workspace"; Action = "WorkspaceMenu"; Description = "Menu de bootstrap, validacao, WSL e GitHub do workspace Skincos." },
     @{ Name = "Contexto"; Action = "ContextMenu"; Description = "Menu de status, contexto e bootstrap de thread do Skincos." },
     @{ Name = "Local"; Action = "LocalMenu"; Description = "Menu de website, CRM e stack local principal do Skincos." },
+    @{ Name = "CRM – Consultor (Ponto)"; Action = "CrmConsultor"; Description = "Abre o CRM local com a persona sintética de Consultor no módulo Ponto." },
     @{ Name = "EF App"; Action = "EfAppMenu"; Description = "Menu das automacoes do app.espacofacial.com.br." },
     @{ Name = "Orb"; Action = "OrbMenu"; Description = "Menu do runtime live do orb/n8n e utilitarios de suporte." }
 )

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -23,6 +23,7 @@ param(
         "WebsiteSiteCheck",
         "WebsiteReleaseCheck",
         "CrmLocal",
+        "CrmConsultor",
         "CrmSiteEf",
         "CrmMetaAds",
         "CrmAtendimento",
@@ -371,7 +372,19 @@ function Invoke-ShortcutActionInternal {
         "WebsiteReleaseCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:release-check" }
         "CrmLocal" {
             $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
+                (Convert-ToBashLiteral -Value $crmPidWsl), `
+                (Convert-ToBashLiteral -Value $crmLogWsl))
+        }
+        "CrmConsultor" {
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            # The runtime manifest proves ownership before --stop can terminate
+            # anything. Starting from a clean local shell avoids reusing the
+            # Gestor process or stale browser persona overrides.
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
+                (Convert-ToBashLiteral -Value $crmPidWsl), `
+                (Convert-ToBashLiteral -Value $crmLogWsl))
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_ROUTE='/?localAuthReset=1' CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module ponto" -f `
                 (Convert-ToBashLiteral -Value $crmPidWsl), `
                 (Convert-ToBashLiteral -Value $crmLogWsl))
         }
@@ -580,6 +593,7 @@ function Show-CrmMenu {
             -Title "Local > CRM" `
             -Options @(
                 (New-MenuOption -Label "CRM Local" -Action "CrmLocal"),
+                (New-MenuOption -Label "CRM – Consultor (Ponto)" -Action "CrmConsultor"),
                 (New-MenuOption -Label "CRM Site EF" -Action "CrmSiteEf"),
                 (New-MenuOption -Label "CRM Meta Ads" -Action "CrmMetaAds"),
                 (New-MenuOption -Label "CRM Atendimento" -Action "CrmAtendimento"),


### PR DESCRIPTION
## What changed
- Adds the Codex App and Start Menu shortcut for a local synthetic Consultor in Ponto.
- Keeps the standard local test account as Gestor and clears stale browser persona overrides.
- Removes local e-mail based Ponto management access and covers the role policy with tests.

## Validation
- npm run typecheck
- npm run lint
- npm run test (136 tests)
- npm run build