### PR TITLE
feat(crm): run gestor and consultor local concurrently

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -21,6 +21,11 @@ icon = "run"
 command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action LocalMenu"
 
 [[actions]]
+name = "CRM – Local (Gestor)"
+icon = "run"
+command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmLocal"
+
+[[actions]]
 name = "CRM – Consultor (Ponto)"
 icon = "run"
 command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmConsultor"

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -66,6 +66,9 @@ fi
 if [[ -n "${PONTO_ACTOR_HMAC_KEY:-}" ]]; then
   PAGES_BINDING_ARGS+=(--binding "PONTO_ACTOR_HMAC_KEY=${PONTO_ACTOR_HMAC_KEY}")
 fi
+if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
+  PAGES_BINDING_ARGS+=(--binding "WA_ORCHESTRATOR_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
+fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/
 if [[ -f "$ROOT_DIR/public/_routes.json" ]]; then

--- a/scripts/install-shared-codex-shortcuts.ps1
+++ b/scripts/install-shared-codex-shortcuts.ps1
@@ -96,6 +96,7 @@ $shortcuts = @(
     @{ Name = "Workspace"; Action = "WorkspaceMenu"; Description = "Menu de bootstrap, validacao, WSL e GitHub do workspace Skincos." },
     @{ Name = "Contexto"; Action = "ContextMenu"; Description = "Menu de status, contexto e bootstrap de thread do Skincos." },
     @{ Name = "Local"; Action = "LocalMenu"; Description = "Menu de website, CRM e stack local principal do Skincos." },
+    @{ Name = "CRM – Local (Gestor)"; Action = "CrmLocal"; Description = "Inicia o CRM Gestor local e os serviços compartilhados." },
     @{ Name = "CRM – Consultor (Ponto)"; Action = "CrmConsultor"; Description = "Abre o CRM local com a persona sintética de Consultor no módulo Ponto." },
     @{ Name = "EF App"; Action = "EfAppMenu"; Description = "Menu das automacoes do app.espacofacial.com.br." },
     @{ Name = "Orb"; Action = "OrbMenu"; Description = "Menu do runtime live do orb/n8n e utilitarios de suporte." }

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -8,6 +8,7 @@ TIMEKEEPING_DIR="$ROOT_DIR/workforce/timekeeping"
 INSUMOS_HELPER="$ROOT_DIR/backend/scripts/insumos.sh"
 INSUMOS_EXPORTER="$ROOT_DIR/backend/scripts/insumos-d1-export.cjs"
 INSUMOS_SEEDER="$ROOT_DIR/backend/scripts/insumos-seed.sh"
+WHATSAPP_ORCHESTRATOR_HELPER="$ROOT_DIR/scripts/run-local-whatsapp-orchestrator.sh"
 
 CRM_HOST="${CRM_HOST:-127.0.0.1}"
 CRM_VITE_PORT="${CRM_VITE_PORT:-5173}"
@@ -58,6 +59,8 @@ else
   CRM_WITH_INSUMOS=0
 fi
 CRM_INSUMOS_PORT="${CRM_INSUMOS_PORT:-8787}"
+CRM_WITH_WHATSAPP="${CRM_WITH_WHATSAPP:-0}"
+CRM_WA_ORCHESTRATOR_PORT="${CRM_WA_ORCHESTRATOR_PORT:-8110}"
 if [[ -n "${CRM_WITH_TIMEKEEPING+x}" ]]; then
   CRM_WITH_TIMEKEEPING="$CRM_WITH_TIMEKEEPING"
 elif [[ -z "$CRM_MODULE" || "$CRM_MODULE" == "ponto" ]]; then
@@ -108,6 +111,9 @@ Opções:
   --insumos-snapshot FILE        Faz seed local do Insumos com este snapshot JSON
   --refresh-insumos-snapshot     Exporta um snapshot novo do D1 remoto antes do seed
   --insumos-seed-token TOKEN     Token local usado para /admin/seed (default: dev-seed-token)
+  --with-whatsapp                Inicia o adaptador local do WhatsApp
+  --without-whatsapp             Não inicia o adaptador local do WhatsApp (default)
+  --whatsapp-port PORT           Porta do adaptador WhatsApp local (default: 8110)
   CRM_LOCAL_LOG_LEVEL=LEVEL      Nível dos runtimes locais: warn (default), info, debug, error ou none
   CRM_BROWSER_DIAGNOSTICS_LOG=FILE Arquivo privado para diagnósticos conhecidos do Chromium durante smokes
   --smoke                        Roda uma smoke local do módulo após subir o CRM
@@ -150,6 +156,9 @@ while [[ $# -gt 0 ]]; do
     --insumos-snapshot) shift; CRM_INSUMOS_SNAPSHOT="$1" ;;
     --refresh-insumos-snapshot) CRM_REFRESH_INSUMOS_SNAPSHOT=1 ;;
     --insumos-seed-token) shift; CRM_INSUMOS_SEED_TOKEN="$1" ;;
+    --with-whatsapp) CRM_WITH_WHATSAPP=1 ;;
+    --without-whatsapp) CRM_WITH_WHATSAPP=0 ;;
+    --whatsapp-port) shift; CRM_WA_ORCHESTRATOR_PORT="$1" ;;
     --smoke) CRM_SMOKE=1 ;;
     --exit-after-smoke) CRM_EXIT_AFTER_SMOKE=1 ;;
     --headed-smoke) CRM_SMOKE_HEADED=1 ;;
@@ -490,10 +499,33 @@ start_insumos_local() {
   fi
 }
 
+start_whatsapp_orchestrator_local() {
+  if [[ ! -x "$WHATSAPP_ORCHESTRATOR_HELPER" ]]; then
+    echo "[crm-local] Adaptador WhatsApp local não está executável: $WHATSAPP_ORCHESTRATOR_HELPER" >&2
+    exit 1
+  fi
+  echo "[crm-local] Iniciando adaptador local do WhatsApp em :$CRM_WA_ORCHESTRATOR_PORT"
+  (
+    CRM_LOCAL_WA_ORCHESTRATOR_PORT="$CRM_WA_ORCHESTRATOR_PORT" \
+      LOCAL_AUTH_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}" \
+      LOCAL_AUTH_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}" \
+      "$WHATSAPP_ORCHESTRATOR_HELPER"
+  ) >>"$LOG_FILE" 2>&1 &
+  WHATSAPP_ORCHESTRATOR_PID=$!
+
+  if ! wait_for_http "http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}/health" 60; then
+    echo "[crm-local] Adaptador local do WhatsApp não respondeu em tempo hábil." >&2
+    exit 1
+  fi
+}
+
 if [[ "$STOP_ONLY" == "1" ]]; then
   stop_existing
   stop_owned_port_listener "$CRM_VITE_PORT" "vite"
   stop_owned_port_listener "$CRM_PAGES_PORT" "pages"
+  if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
+    stop_owned_port_listener "$CRM_WA_ORCHESTRATOR_PORT" "whatsapp"
+  fi
   if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
     stop_owned_port_listener "$CRM_INSUMOS_PORT" "insumos"
   fi
@@ -557,6 +589,9 @@ if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
     echo "Snapshot Insumos: $CRM_INSUMOS_SNAPSHOT"
   fi
 fi
+if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
+  echo "WhatsApp local: http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}"
+fi
 echo "Log: $LOG_FILE"
 echo ""
 
@@ -564,6 +599,9 @@ stop_existing
 rotate_current_log
 assert_port_free "$CRM_VITE_PORT" "vite"
 assert_port_free "$CRM_PAGES_PORT" "pages"
+if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
+  assert_port_free "$CRM_WA_ORCHESTRATOR_PORT" "whatsapp"
+fi
 ensure_frontend_ready
 ensure_playwright_chromium
 
@@ -575,6 +613,7 @@ else
 fi
 
 INSUMOS_PID=""
+WHATSAPP_ORCHESTRATOR_PID=""
 if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
   assert_port_free "$CRM_INSUMOS_PORT" "insumos"
   start_insumos_local
@@ -606,6 +645,11 @@ else
   export LOCAL_AUTH_BYPASS=false
 fi
 
+if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
+  start_whatsapp_orchestrator_local
+  export LOCAL_WA_ORCHESTRATOR_API_TARGET="http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}"
+fi
+
 if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
   export LOCAL_INSUMOS_API_TARGET="http://127.0.0.1:${CRM_INSUMOS_PORT}"
 fi
@@ -631,6 +675,9 @@ cleanup() {
   fi
   if [[ -n "${TIMEKEEPING_PID:-}" ]]; then
     kill "$TIMEKEEPING_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${WHATSAPP_ORCHESTRATOR_PID:-}" ]]; then
+    kill "$WHATSAPP_ORCHESTRATOR_PID" >/dev/null 2>&1 || true
   fi
   if [[ -f "$PID_FILE" ]]; then
     local tracked_pid

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -24,6 +24,7 @@ param(
         "WebsiteReleaseCheck",
         "CrmLocal",
         "CrmConsultor",
+        "CrmConsultorStop",
         "CrmSiteEf",
         "CrmMetaAds",
         "CrmAtendimento",
@@ -161,10 +162,15 @@ function Invoke-ShortcutWsl {
 }
 
 function Resolve-CrmLocalSourceRoot {
+    param(
+        [ValidateSet("Gestor", "Consultor")]
+        [string]$Persona = "Gestor"
+    )
+
     # CRM Local must never inherit uncommitted product work from the checkout
-    # that happens to invoke the Codex action. Keep a private, detached source
-    # worktree on origin/main instead.
-    $sourceRoot = Join-Path $operatorRuntimeRoot "source\crm-local-main"
+    # that happens to invoke the Codex action. Each persona gets an isolated,
+    # detached origin/main worktree so Pages state and local auth never clash.
+    $sourceRoot = Join-Path $operatorRuntimeRoot ("source\crm-local-{0}-main" -f $Persona.ToLowerInvariant())
     $sourceParent = Split-Path -Parent $sourceRoot
 
     if (-not (Test-Path -LiteralPath $sourceRoot)) {
@@ -198,6 +204,23 @@ function Resolve-CrmLocalSourceRoot {
     }
 
     return $sourceRoot
+}
+
+function Assert-GestorSharedServices {
+    param([string]$WorkingProjectRoot)
+
+    Invoke-ShortcutWsl -WorkingProjectRoot $WorkingProjectRoot -SkipBootstrapCheck -Command @'
+for endpoint in \
+  http://127.0.0.1:8791/api/auth/me \
+  http://127.0.0.1:8787/insumos/health \
+  http://127.0.0.1:8801/api/ponto/readiness \
+  http://127.0.0.1:8110/health; do
+  if ! curl -fsS --max-time 5 "$endpoint" >/dev/null; then
+    echo "[crm-consultor] O CRM Local (Gestor) não está pronto em $endpoint. Inicie CRM – Local antes do Consultor." >&2
+    exit 1
+  fi
+done
+'@
 }
 
 function Invoke-RepoPowerShellScript {
@@ -264,8 +287,10 @@ $websiteLog = Join-Path $logRoot "website-local-dev.log"
 $websitePort = Join-Path $tmpRoot "website-local-dev.port"
 $sharedRoot = Split-Path (Split-Path $ProjectRoot -Parent) -Parent
 $websiteSourceRoot = Join-Path $sharedRoot "Worktrees\skincos\shared\website-local-main"
-$crmPid = Join-Path $tmpRoot "crm-local-dev.pid"
-$crmLog = Join-Path $logRoot "crm-local-dev.log"
+$crmGestorPid = Join-Path $tmpRoot "crm-local-gestor.pid"
+$crmGestorLog = Join-Path $logRoot "crm-local-gestor.log"
+$crmConsultorPid = Join-Path $tmpRoot "crm-local-consultor.pid"
+$crmConsultorLog = Join-Path $logRoot "crm-local-consultor.log"
 $atendimentoPid = Join-Path $tmpRoot "crm-atendimento-local.pid"
 $atendimentoLog = Join-Path $logRoot "crm-atendimento-local.log"
 $efAppStateRoot = Join-Path $localStateRoot "espacofacial-app"
@@ -282,8 +307,10 @@ $tmpRootWsl = Convert-WindowsPathToWsl -Path $tmpRoot
 $websitePidWsl = Convert-WindowsPathToWsl -Path $websitePid
 $websiteLogWsl = Convert-WindowsPathToWsl -Path $websiteLog
 $websitePortWsl = Convert-WindowsPathToWsl -Path $websitePort
-$crmPidWsl = Convert-WindowsPathToWsl -Path $crmPid
-$crmLogWsl = Convert-WindowsPathToWsl -Path $crmLog
+$crmGestorPidWsl = Convert-WindowsPathToWsl -Path $crmGestorPid
+$crmGestorLogWsl = Convert-WindowsPathToWsl -Path $crmGestorLog
+$crmConsultorPidWsl = Convert-WindowsPathToWsl -Path $crmConsultorPid
+$crmConsultorLogWsl = Convert-WindowsPathToWsl -Path $crmConsultorLog
 $atendimentoPidWsl = Convert-WindowsPathToWsl -Path $atendimentoPid
 $atendimentoLogWsl = Convert-WindowsPathToWsl -Path $atendimentoLog
 $efAppOutputRootWsl = Convert-WindowsPathToWsl -Path $efAppOutputRoot
@@ -371,34 +398,35 @@ function Invoke-ShortcutActionInternal {
         "WebsiteSiteCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:check" }
         "WebsiteReleaseCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:release-check" }
         "CrmLocal" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh" -f `
+                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
         }
         "CrmConsultor" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
-            # The runtime manifest proves ownership before --stop can terminate
-            # anything. Starting from a clean local shell avoids reusing the
-            # Gestor process or stale browser persona overrides.
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_ROUTE='/?localAuthReset=1' CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module ponto" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Consultor
+            Assert-GestorSharedServices -WorkingProjectRoot $crmLocalSourceRoot
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 PONTO_API_TARGET=http://127.0.0.1:8801 PONTO_ACTOR_HMAC_KEY=test-actor-key-not-secret LOCAL_INSUMOS_API_TARGET=http://127.0.0.1:8787 LOCAL_WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:8110 CRM_ROUTE='/?localAuthReset=1' CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module ponto" -f `
+                (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmConsultorLogWsl))
+        }
+        "CrmConsultorStop" {
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Consultor
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
+                (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmConsultorLogWsl))
         }
         "CrmSiteEf" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
             Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module site-tracking --meta-ads-scenario connected-ready" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
+                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
         }
         "CrmMetaAds" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
             Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module meta-ads" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
+                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
         }
         "CrmAtendimento" {
             Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento.sh" -f `
@@ -408,13 +436,10 @@ function Invoke-ShortcutActionInternal {
         "CrmAtendimentoMirrorStatus" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-status" }
         "CrmAtendimentoMirrorSync" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-sync -- --apply" }
         "CrmLocalStop" {
-            Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento.sh --stop" -f `
-                (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
-                (Convert-ToBashLiteral -Value $atendimentoLogWsl))
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
-                (Convert-ToBashLiteral -Value $crmPidWsl), `
-                (Convert-ToBashLiteral -Value $crmLogWsl))
+            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
+            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --stop" -f `
+                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
+                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
         }
         "CrmMemory" { Invoke-ShortcutWsl -Command "bash ./scripts/codex-memory-crm.sh" }
         "CrmSiteSmoke" { Invoke-ShortcutWsl -Command "npm run codex:crm:site-smoke" }
@@ -592,14 +617,15 @@ function Show-CrmMenu {
         $selection = Read-MenuSelection `
             -Title "Local > CRM" `
             -Options @(
-                (New-MenuOption -Label "CRM Local" -Action "CrmLocal"),
+                (New-MenuOption -Label "CRM – Local (Gestor)" -Action "CrmLocal"),
                 (New-MenuOption -Label "CRM – Consultor (Ponto)" -Action "CrmConsultor"),
+                (New-MenuOption -Label "CRM – Consultor Stop" -Action "CrmConsultorStop"),
                 (New-MenuOption -Label "CRM Site EF" -Action "CrmSiteEf"),
                 (New-MenuOption -Label "CRM Meta Ads" -Action "CrmMetaAds"),
                 (New-MenuOption -Label "CRM Atendimento" -Action "CrmAtendimento"),
                 (New-MenuOption -Label "CRM Atendimento - Status do Clone" -Action "CrmAtendimentoMirrorStatus"),
                 (New-MenuOption -Label "CRM Atendimento - Atualizar Clone" -Action "CrmAtendimentoMirrorSync"),
-                (New-MenuOption -Label "CRM Local Stop" -Action "CrmLocalStop"),
+                (New-MenuOption -Label "CRM Local (Gestor) Stop" -Action "CrmLocalStop"),
                 (New-MenuOption -Label "CRM Memory" -Action "CrmMemory"),
                 (New-MenuOption -Label "CRM Site Smoke" -Action "CrmSiteSmoke"),
                 (New-MenuOption -Label "CRM Meta Ads Smoke" -Action "CrmMetaAdsSmoke"),


### PR DESCRIPTION
## Summary
- run Gestor and Consultor CRM shells independently on 8791 and 8792
- keep shared Insumos, WhatsApp and Timekeeping services owned by Gestor
- isolate worktrees, PID/log files and stop actions by persona

## Validation
- PowerShell parser and Bash syntax passed
- Gestor local smoke reached auth, Insumos, Timekeeping health and readiness

The full dual-persona launch requires this commit on main because launchers intentionally bootstrap clean origin/main worktrees.