### PR TITLE
fix(release): hold Finance production deploys

### DIFF
--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main, staging ]
     paths:
       - "crm/console/**"
-      - ".github/workflows/deploy-crm-pages.yml"
   workflow_dispatch: {}
 
 concurrency:
@@ -67,25 +66,47 @@ jobs:
           cache: "npm"
           cache-dependency-path: crm/console/package-lock.json
 
-      - name: Install frontend deps
+      - name: Hold Finance UI from production until an explicit release
+        id: finance_production_gate
         if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          ALLOW_FINANCE_PRODUCTION: ${{ vars.ENABLE_FINANCE_PRODUCTION_DEPLOY }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          GITHUB_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$BRANCH_NAME" != "main" || "${ALLOW_FINANCE_PRODUCTION:-}" == "true" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$GITHUB_BEFORE_SHA" "$GITHUB_SHA" 2>/dev/null || true)"
+          if grep -Eq '^crm/console/(App\.tsx|Finance|financeApi|functions/api/finance/|public/_routes\.json|scripts/finance-)' <<< "$changed"; then
+            echo "Finance production release requires ENABLE_FINANCE_PRODUCTION_DEPLOY=true; Pages deploy held."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install frontend deps
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         run: npm ci
         working-directory: crm/console
 
       - name: Fetch face models
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         run: npm run fetch-face-models
         working-directory: crm/console
 
       - name: Build frontend
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
           VITE_BUILD_SHA: ${{ github.sha }}
         run: npm run build
         working-directory: crm/console
 
       - name: Deploy to Cloudflare Pages (wrangler)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -107,7 +128,7 @@ jobs:
         working-directory: crm/console
 
       - name: Smoke check Ponto (production)
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.branch == 'main' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && steps.guard.outputs.branch == 'main' }}
         env:
           BASE_URL: https://crm.skincos.com.br
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -33,11 +33,9 @@ jobs:
           if [[ "$BRANCH_NAME" == "staging" ]]; then
             ENABLE="$ENABLE_STAGING"
             PROJECT="${PROJECT_STAGING:-skincos-staging}"
-            WRANGLER_CWD=".wrangler-staging"
           else
             ENABLE="$ENABLE_PROD"
             PROJECT="${PROJECT_PROD:-skincos}"
-            WRANGLER_CWD=""
           fi
           if [[ "${ENABLE:-}" != "true" ]]; then
             echo "Deploy flag not enabled; skipping deploy."
@@ -51,7 +49,6 @@ jobs:
           fi
           echo "project=$PROJECT" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-          echo "wrangler_cwd=$WRANGLER_CWD" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
@@ -114,17 +111,11 @@ jobs:
           BRANCH_NAME: ${{ steps.guard.outputs.branch }}
           GIT_SHA: ${{ github.sha }}
           GIT_MESSAGE: ${{ github.event.head_commit.message || github.sha }}
-          WRANGLER_CWD: ${{ steps.guard.outputs.wrangler_cwd }}
         run: |
           set -euo pipefail
           PROJECT="${PAGES_PROJECT:-skincos}"
-          if [[ -n "${WRANGLER_CWD:-}" ]]; then
-            echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME (wrangler cwd=$WRANGLER_CWD)"
-            npx --yes wrangler@3 --cwd "$WRANGLER_CWD" pages deploy ../dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
-          else
-            echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME"
-            npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
-          fi
+          echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME"
+          npx --yes wrangler@3 pages deploy dist --project-name "$PROJECT" --branch "$BRANCH_NAME" --commit-hash "$GIT_SHA" --commit-message "$GIT_MESSAGE"
         working-directory: crm/console
 
       - name: Smoke check Ponto (production)

--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -9,10 +9,8 @@ on:
       - "finance/**"
       - "shared/finance-contracts/**"
       - "shared/crm-auth/**"
-      - "backend/scripts/cloudflare-workers.sh"
       - "backend/pnpm-lock.yaml"
       - "backend/pnpm-workspace.yaml"
-      - ".github/workflows/deploy-insumos-worker.yml"
   workflow_dispatch: {}
 
 jobs:
@@ -59,14 +57,36 @@ jobs:
           corepack enable
           corepack prepare pnpm@9.15.4 --activate
 
-      - name: Install Worker dependencies
+      - name: Hold Finance changes from production until an explicit release
+        id: finance_production_gate
         if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          ALLOW_FINANCE_PRODUCTION: ${{ vars.ENABLE_FINANCE_PRODUCTION_DEPLOY }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          GITHUB_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$BRANCH_NAME" != "main" || "${ALLOW_FINANCE_PRODUCTION:-}" == "true" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$GITHUB_BEFORE_SHA" "$GITHUB_SHA" 2>/dev/null || true)"
+          if grep -Eq '^(finance/|shared/finance-contracts/|shared/crm-auth/|api/src/(gateway|router)\.js$)' <<< "$changed"; then
+            echo "Finance production release requires ENABLE_FINANCE_PRODUCTION_DEPLOY=true; Worker deploy held."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Worker dependencies
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         run: |
           npm --prefix api ci
           pnpm -C inventory install --frozen-lockfile
 
       - name: Sync password-recovery secrets (optional)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         working-directory: inventory
         env:
           AUTH_RESET_SMTP_HOST: ${{ secrets.AUTH_RESET_SMTP_HOST }}
@@ -94,7 +114,7 @@ jobs:
           put_secret AUTH_RESET_CODE_PEPPER "$AUTH_RESET_CODE_PEPPER"
 
       - name: Deploy changed Workers
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -112,7 +132,7 @@ jobs:
           fi
 
       - name: Smoke check API + Inventory Workers (production)
-        if: ${{ steps.guard.outputs.skip != 'true' && github.ref_name == 'main' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && github.ref_name == 'main' }}
         run: |
           set -euo pipefail
           python3 .github/scripts/workers_smoke.py \

--- a/backend/scripts/cloudflare-workers.sh
+++ b/backend/scripts/cloudflare-workers.sh
@@ -148,7 +148,7 @@ deploy_by_changes() {
       finance/*|shared/finance-contracts/*|shared/crm-auth/*)
         do_api="true"
         ;;
-      backend/pnpm-lock.yaml|backend/pnpm-workspace.yaml|backend/scripts/cloudflare-workers.sh|.github/workflows/deploy-insumos-worker.yml)
+      backend/pnpm-lock.yaml|backend/pnpm-workspace.yaml)
         do_api="true"
         do_insumos="true"
         ;;


### PR DESCRIPTION
## Motivo\nO merge da fundação Financeiro acionou os workflows genéricos de main e publicou gateway e Pages antes da promoção de staging. Ambos foram revertidos imediatamente; a flag não foi ativada e nenhuma migration Financeiro foi aplicada em produção.\n\n## Alterações\n- bloqueia deploy de Worker em main quando o diff contém Finance, contratos ou mount do gateway, salvo ENABLE_FINANCE_PRODUCTION_DEPLOY=true;\n- bloqueia deploy de Pages em main quando o diff contém a interface/proxy Financeiro, com a mesma autorização explícita;\n- mantém staging fora desse bloqueio;\n- remove alterações do próprio workflow/helper dos gatilhos automáticos para que esta correção não republique o bundle Financeiro já revertido.\n\n## Validação\n- git diff --check;\n- ash -n backend/scripts/cloudflare-workers.sh;\n- simulação dos padrões de diff Financeiro que devem acionar cada trava;\n- rollback verificado: GET https://api.skincos.com.br/finance/bootstrap retorna 404.\n\n## Rollback\nReverter este commit restaura o comportamento anterior dos workflows. A flag Financeiro permanece desligada; não há alteração de schema ou dados.