### PR TITLE
fix(crm): restaurar dados e travar módulos online

### DIFF
--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -3,6 +3,7 @@ import React, { useState, Suspense, lazy, useMemo } from 'react'
 import { ContextDebugger } from './ContextDebugger'
 import { ErrorBoundary } from '@/ErrorBoundary'
 import { NotificationProvider, useAuth, useNotifications } from '@/contexts'
+import { isOnlineCrmRuntime, unlockedModuleKeys } from '@/moduleAvailability'
 import { LoadingPercentText, LoadingScreen } from '@/LoadingPattern'
 import { AuthScreen } from '@/AuthScreen'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
@@ -444,10 +445,10 @@ export default function AppFunctionalNeatlab() {
 	        }
 	    }, [loadProfile, profileCurrentPassword, profileDisplayName, profileEmail, profileNewPassword])
 
-		    const UNLOCKED_MODULE_KEYS = useMemo(
-                () => new Set([DEFAULT_MODULE_KEY, 'insumos', 'conversa', 'atendimento', 'caixa', 'clientes', 'faturamento', 'procedimentos', 'unit-monitor', 'instagram-studio', 'meta-pages-review', 'meta-ads', 'site-tracking', 'escala-profissionais', 'ponto', 'finance']),
-		        [DEFAULT_MODULE_KEY]
-		    )
+	    const UNLOCKED_MODULE_KEYS = useMemo(
+	        () => unlockedModuleKeys(DEFAULT_MODULE_KEY, isOnlineCrmRuntime(window.location.hostname)),
+	        [DEFAULT_MODULE_KEY]
+	    )
 	    const [sidebarHover, setSidebarHover] = useState(false)
 	    React.useEffect(() => {
 	        if (!Array.isArray(user?.allowedModules) || !user.allowedModules.map(String).includes('finance')) { setFinanceEnabled(false); return }

--- a/crm/console/moduleAvailability.ts
+++ b/crm/console/moduleAvailability.ts
@@ -1,0 +1,35 @@
+const ONLINE_DISABLED_MODULE_KEYS = new Set([
+  'caixa',
+  'faturamento',
+  'meta-ads',
+  'meta-pages-review',
+  'procedimentos',
+  'instagram-studio',
+  'site-tracking',
+  'unit-monitor',
+])
+
+export const DEFAULT_UNLOCKED_MODULE_KEYS = [
+  'insumos',
+  'conversa',
+  'atendimento',
+  'caixa',
+  'faturamento',
+  'procedimentos',
+  'unit-monitor',
+  'instagram-studio',
+  'meta-pages-review',
+  'meta-ads',
+  'site-tracking',
+  'escala-profissionais',
+] as const
+
+export function unlockedModuleKeys(defaultModuleKey: string, isOnline: boolean): Set<string> {
+  const candidates = [defaultModuleKey, ...DEFAULT_UNLOCKED_MODULE_KEYS]
+  return new Set(candidates.filter((key) => !isOnline || !ONLINE_DISABLED_MODULE_KEYS.has(key)))
+}
+
+export function isOnlineCrmRuntime(hostname: string): boolean {
+  const host = String(hostname || '').trim().toLowerCase()
+  return host !== 'localhost' && host !== '127.0.0.1' && host !== '::1'
+}

--- a/crm/console/tests/moduleAvailability.test.ts
+++ b/crm/console/tests/moduleAvailability.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isOnlineCrmRuntime, unlockedModuleKeys } from '../moduleAvailability'
+
+describe('module availability', () => {
+  it('keeps experimental modules locked in every online CRM runtime', () => {
+    const unlocked = unlockedModuleKeys('insumos', true)
+
+    for (const key of ['caixa', 'faturamento', 'meta-ads', 'meta-pages-review', 'procedimentos', 'instagram-studio', 'site-tracking', 'unit-monitor']) {
+      expect(unlocked.has(key)).toBe(false)
+    }
+    expect(unlocked.has('atendimento')).toBe(true)
+  })
+
+  it('keeps the modules available for local development validation', () => {
+    const unlocked = unlockedModuleKeys('insumos', false)
+    expect(unlocked.has('caixa')).toBe(true)
+    expect(unlocked.has('meta-ads')).toBe(true)
+  })
+
+  it('distinguishes local loopback from online hosts', () => {
+    expect(isOnlineCrmRuntime('localhost')).toBe(false)
+    expect(isOnlineCrmRuntime('127.0.0.1')).toBe(false)
+    expect(isOnlineCrmRuntime('crm.skincos.com.br')).toBe(true)
+    expect(isOnlineCrmRuntime('preview.pages.dev')).toBe(true)
+  })
+})

--- a/crm/console/wrangler.toml
+++ b/crm/console/wrangler.toml
@@ -8,6 +8,7 @@ binding = "SHARE_BUCKET"
 bucket_name = "skincos-share"
 
 [env.production.vars]
+ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"
 INSUMOS_API_TARGET = "https://api.skincos.com.br"
 ESCALA_API_TARGET = "https://escala-api.skincos.com.br"
 REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET = "true"


### PR DESCRIPTION
## Correção de produção

- direciona o proxy de Atendimento para o CRM nativo em cs-api.skincos.com.br;
- bloqueia Caixa, Faturamento, Meta Ads, Meta Review, Procedimentos, Redes Sociais, EF Site e Unit Monitor nos hosts online;
- mantém esses módulos disponíveis somente no desenvolvimento local.

## Causa

A Pages não tinha ATENDIMENTO_API_TARGET; o fallback apontava para o Worker de Insumos, enquanto a rota crm-api.skincos.com.br está obsoleta. A origem correta foi verificada em produção.

## Validação

- Vitest: moduleAvailability + atendimentoProxy (11 testes)
- typecheck
- build