### PR TITLE
fix(ci): align Ponto smoke workflow arguments

### DIFF
--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -103,7 +103,6 @@ jobs:
           .github/scripts/ponto_smoke.py \
             --attempts 5 \
             --sleep-seconds 5 \
-            --require-proxy-token-configured \
             --require-actor-key-configured \
             --user-agent "Mozilla/5.0 (compatible; PontoSmoke/1.0)"
 
@@ -173,7 +172,6 @@ jobs:
           .github/scripts/ponto_smoke.py \
             --attempts 15 \
             --sleep-seconds 10 \
-            --require-proxy-token-configured \
             --require-actor-key-configured \
             --user-agent "Mozilla/5.0 (compatible; PontoSmoke/1.0)"
 


### PR DESCRIPTION
Remove a opção obsoleta require-proxy-token-configured das duas execuções do workflow de reconciliação do CRM Pages. O script atual valida targetConfigured e actorKeyConfigured; a opção removida causava erro de argumento e era mascarada por continue-on-error. Validado: help do script e contrato estático do workflow.