### PR TITLE
ci: consolidar governança e pinagem de Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,45 @@
-# Default owner
+# Fallback. Every active root is explicitly repeated below so ownership changes
+# remain reviewable as the domain map evolves.
 * @jubenitogarcia
 
-# CI / workflows
+# Governance, automation and repository controls
 /.github/ @jubenitogarcia
+/.githooks/ @jubenitogarcia
+/.codex/ @jubenitogarcia
+/docs/ @jubenitogarcia
+/ops/ @jubenitogarcia
+/platform/ @jubenitogarcia
+/scripts/ @jubenitogarcia
+/shared/ @jubenitogarcia
 
-# Public website
+# Active domain roots
+/ads/ @jubenitogarcia
+/api/ @jubenitogarcia
+/booking/ @jubenitogarcia
+/crm/ @jubenitogarcia
+/finance/ @jubenitogarcia
+/integration/ @jubenitogarcia
+/inventory/ @jubenitogarcia
+/messaging/ @jubenitogarcia
+/orb/ @jubenitogarcia
+/social/ @jubenitogarcia
 /website/ @jubenitogarcia
+/workforce/ @jubenitogarcia
 
-# CRM / Pages frontend
-/frontend/ @jubenitogarcia
-
-# Backend services
+# Transitional and data roots remain explicitly owned until their migration ends.
 /backend/ @jubenitogarcia
+/db/ @jubenitogarcia
 
-# Repo hygiene
-/.pre-commit-config.yaml @jubenitogarcia
-/.flake8 @jubenitogarcia
+# Root operational files
+/AGENTS.md @jubenitogarcia
+/CODEX_CONTEXT.md @jubenitogarcia
+/DECISIONS.md @jubenitogarcia
+/TASKS.md @jubenitogarcia
 /.editorconfig @jubenitogarcia
+/.flake8 @jubenitogarcia
+/.gitleaks.toml @jubenitogarcia
+/.pre-commit-config.yaml @jubenitogarcia
 /Makefile @jubenitogarcia
 /README.md @jubenitogarcia
-/docs/ @jubenitogarcia
+/package.json @jubenitogarcia
+/package-lock.json @jubenitogarcia

--- a/.github/governance/environments/production.json
+++ b/.github/governance/environments/production.json
@@ -1,0 +1,8 @@
+{
+  "wait_timer": 0,
+  "reviewers": [],
+  "deployment_branch_policy": {
+    "protected_branches": true,
+    "custom_branch_policies": false
+  }
+}

--- a/.github/governance/environments/staging.json
+++ b/.github/governance/environments/staging.json
@@ -1,0 +1,8 @@
+{
+  "wait_timer": 0,
+  "reviewers": [],
+  "deployment_branch_policy": {
+    "protected_branches": true,
+    "custom_branch_policies": false
+  }
+}

--- a/.github/governance/rulesets/main-enterprise-baseline.json
+++ b/.github/governance/rulesets/main-enterprise-baseline.json
@@ -1,0 +1,42 @@
+{
+  "name": "main-enterprise-baseline",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "CI Smoke (Assert)" },
+          { "context": "Central E2E Smoke" },
+          { "context": "JS/TS Checks (workspace)" },
+          { "context": "Dependency Audit (JS/TS)" },
+          { "context": "Scan for secrets (Gitleaks)" },
+          { "context": "validate", "integration_id": 15368 }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/scripts/validate-github-governance.mjs
+++ b/.github/scripts/validate-github-governance.mjs
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const failures = [];
+const fail = (message) => failures.push(message);
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+const readJson = (relativePath) => JSON.parse(read(relativePath));
+
+const codeowners = read(".github/CODEOWNERS");
+const owner = "@jubenitogarcia";
+const requiredOwnerPaths = fs.readdirSync(root, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name !== ".git")
+  .map((entry) => `/${entry.name}/`)
+  .sort();
+
+if (!/^\*\s+@jubenitogarcia(?:\s|$)/m.test(codeowners)) fail("CODEOWNERS must retain the default repository owner");
+for (const ownerPath of requiredOwnerPaths) {
+  const pattern = new RegExp(`^${ownerPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+${owner}(?:\\s|$)`, "m");
+  if (!pattern.test(codeowners)) fail(`CODEOWNERS is missing ${ownerPath} -> ${owner}`);
+}
+
+const workflowDirectory = path.join(root, ".github/workflows");
+for (const filename of fs.readdirSync(workflowDirectory).filter((name) => /\.ya?ml$/i.test(name))) {
+  const relativePath = path.posix.join(".github/workflows", filename);
+  for (const [index, line] of read(relativePath).split(/\r?\n/).entries()) {
+    const match = line.match(/^\s*(?:-\s*)?uses:\s*([^\s#]+)/);
+    if (!match) continue;
+    const reference = match[1];
+    if (reference.startsWith("./")) continue;
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$/.test(reference)) {
+      fail(`${relativePath}:${index + 1} must pin ${reference} to a full 40-character commit SHA`);
+    }
+  }
+}
+
+const ruleset = readJson(".github/governance/rulesets/main-enterprise-baseline.json");
+if (ruleset.name !== "main-enterprise-baseline" || ruleset.target !== "branch") {
+  fail("main ruleset must declare the canonical name and branch target");
+}
+if (ruleset.enforcement !== "active" || !ruleset.conditions?.ref_name?.include?.includes("~DEFAULT_BRANCH")) {
+  fail("main ruleset must actively target the default branch");
+}
+for (const requiredRule of ["deletion", "non_fast_forward", "pull_request", "required_status_checks"]) {
+  if (!ruleset.rules?.some((rule) => rule.type === requiredRule)) fail(`main ruleset is missing ${requiredRule}`);
+}
+
+for (const environmentName of ["staging", "production"]) {
+  const environment = readJson(`.github/governance/environments/${environmentName}.json`);
+  if (typeof environment.wait_timer !== "number") fail(`${environmentName} environment metadata is invalid`);
+  if (environment.deployment_branch_policy?.protected_branches !== true || environment.deployment_branch_policy?.custom_branch_policies !== false) {
+    fail(`${environmentName} must be restricted to protected branches`);
+  }
+}
+
+if (failures.length) {
+  for (const message of failures) process.stderr.write(`github governance validation failed: ${message}\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write("GitHub governance validation OK.\n");
+}

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -9,8 +9,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - run: node .github/scripts/validate-architecture.mjs
+      - run: node .github/scripts/validate-github-governance.mjs

--- a/.github/workflows/central-e2e-smoke.yml
+++ b/.github/workflows/central-e2e-smoke.yml
@@ -11,10 +11,10 @@ jobs:
     name: Central E2E Smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: 'npm'

--- a/.github/workflows/ci-auto-rerun-transient.yml
+++ b/.github/workflows/ci-auto-rerun-transient.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const run = context.payload.workflow_run;

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (no submodules)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: npm

--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Ensure jq
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload summary artifact
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cloudflare-alerting-apply
           path: /tmp/cloudflare-alerting-apply.summary.json

--- a/.github/workflows/cloudflare-alerting-export.yml
+++ b/.github/workflows/cloudflare-alerting-export.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Ensure jq
         shell: bash
@@ -34,7 +34,7 @@ jobs:
           ls -la
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cloudflare-alerting-export
           path: |

--- a/.github/workflows/cloudflare-audit.yml
+++ b/.github/workflows/cloudflare-audit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run drift audit
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -33,13 +33,13 @@ jobs:
           echo "project=${PROJECT:-skincos}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
       - name: Checkout (for worker wrangler config)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Sync Pages secret (Escala) by environment
         env:
@@ -112,7 +112,7 @@ jobs:
 
       - name: Force redeploy CRM Pages (apply escala secret)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
+++ b/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Force redeploy CRM Pages
         if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.force_redeploy == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Force redeploy CRM Pages (apply secret/env)
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/codex-autonomy-preflight.yml
+++ b/.github/workflows/codex-autonomy-preflight.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run Codex autonomy preflight
         run: scripts/codex-preflight.sh --ci --strict

--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Keep codex PRs up-to-date (update-branch) + label conflicts
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
           script: |

--- a/.github/workflows/deploy-core-workers-reconcile.yml
+++ b/.github/workflows/deploy-core-workers-reconcile.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
@@ -72,7 +72,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: core-workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
@@ -85,7 +85,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: core-workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/deploy-crm-api.yml
+++ b/.github/workflows/deploy-crm-api.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy via SSH
         if: ${{ steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'ssh' }}
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.CRM_API_SSH_HOST }}
           username: ${{ secrets.CRM_API_SSH_USER }}

--- a/.github/workflows/deploy-crm-pages-after-automerge.yml
+++ b/.github/workflows/deploy-crm-pages-after-automerge.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 1
 
       - name: Resolve PR context
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const resolvePr = require('./.github/scripts/resolve_after_automerge_pr.cjs');
@@ -47,7 +47,7 @@ jobs:
       - name: Detect frontend changes
         if: ${{ steps.pr.outputs.eligible == 'true' }}
         id: changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const detectChanges = require('./.github/scripts/detect_pr_file_changes.cjs');
@@ -92,7 +92,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: crm-pages-after-automerge-deploy-${{ steps.pr.outputs.merge_commit_sha }}
           path: deploy-state/crm_pages_after_automerge_sha.txt
@@ -105,13 +105,13 @@ jobs:
 
       - name: Checkout merge commit
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.pr.outputs.merge_commit_sha }}
 
       - name: Setup Node
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -163,7 +163,7 @@ jobs:
 
       - name: Cache Playwright browsers (UI smoke)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.guard.outputs.branch == 'main' && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium
@@ -202,7 +202,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.frontend_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: crm-pages-after-automerge-deploy-${{ steps.pr.outputs.merge_commit_sha }}
           path: deploy-state/crm_pages_after_automerge_sha.txt

--- a/.github/workflows/deploy-crm-pages-reconcile.yml
+++ b/.github/workflows/deploy-crm-pages-reconcile.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
@@ -79,7 +79,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: crm-pages-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
@@ -121,7 +121,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -177,7 +177,7 @@ jobs:
 
       - name: Cache Playwright browsers (UI smoke)
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true' || steps.redeploy.outputs.need == 'true') && vars.ENABLE_PONTO_UI_SMOKE == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium
@@ -216,7 +216,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: crm-pages-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: "npm"

--- a/.github/workflows/deploy-escala-api-reconcile.yml
+++ b/.github/workflows/deploy-escala-api-reconcile.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
@@ -82,7 +82,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: escala-api-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
@@ -95,7 +95,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && (steps.cache.outputs.cache-hit != 'true' || steps.flags.outputs.force == 'true') }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -184,7 +184,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: escala-api-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -47,11 +47,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/deploy-insumos-worker.yml
+++ b/.github/workflows/deploy-insumos-worker.yml
@@ -43,11 +43,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/deploy-social-publisher-worker-reconcile.yml
+++ b/.github/workflows/deploy-social-publisher-worker-reconcile.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
@@ -51,7 +51,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: social-publisher-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/social_publisher_deployed_sha.txt
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: social-publisher-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/social_publisher_deployed_sha.txt

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -57,11 +57,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/deploy-workers-after-automerge.yml
+++ b/.github/workflows/deploy-workers-after-automerge.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 1
 
       - name: Resolve PR context
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const resolvePr = require('./.github/scripts/resolve_after_automerge_pr.cjs');
@@ -47,7 +47,7 @@ jobs:
       - name: Detect worker changes
         if: ${{ steps.pr.outputs.eligible == 'true' }}
         id: changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const detectChanges = require('./.github/scripts/detect_pr_file_changes.cjs');
@@ -91,7 +91,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: workers-after-automerge-deploy-${{ steps.pr.outputs.merge_commit_sha }}
           path: deploy-state/workers_after_automerge_sha.txt
@@ -104,13 +104,13 @@ jobs:
 
       - name: Checkout merge commit
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.pr.outputs.merge_commit_sha }}
 
       - name: Setup Node
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.changes.outputs.workers_changed == 'true' && steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: workers-after-automerge-deploy-${{ steps.pr.outputs.merge_commit_sha }}
           path: deploy-state/workers_after_automerge_sha.txt

--- a/.github/workflows/deploy-workers-reconcile.yml
+++ b/.github/workflows/deploy-workers-reconcile.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
@@ -48,7 +48,7 @@ jobs:
       - name: Restore deploy cache (skip if already deployed)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Save deploy cache
         if: ${{ steps.guard.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: workers-deploy-${{ steps.sha.outputs.sha }}
           path: deploy-state/deployed_sha.txt

--- a/.github/workflows/dispatch-after-automerge-fallback.yml
+++ b/.github/workflows/dispatch-after-automerge-fallback.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch missing after-automerge deploy workflows
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
           script: |

--- a/.github/workflows/escala-api-smoke.yml
+++ b/.github/workflows/escala-api-smoke.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/escala-ui-e2e.yml
+++ b/.github/workflows/escala-ui-e2e.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -37,7 +37,7 @@ jobs:
           npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium

--- a/.github/workflows/insumos-api-slo.yml
+++ b/.github/workflows/insumos-api-slo.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run Insumos API SLO monitor
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/insumos-ui-smoke.yml
+++ b/.github/workflows/insumos-ui-smoke.yml
@@ -25,13 +25,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: "npm"
@@ -42,7 +42,7 @@ jobs:
         working-directory: crm/console
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-chromium
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: insumos-ui-smoke-artifacts
           path: output/playwright/

--- a/.github/workflows/lint-format-static.yml
+++ b/.github/workflows/lint-format-static.yml
@@ -12,7 +12,7 @@ jobs:
     name: JS/TS Checks (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Repository policy checks
         run: |
@@ -23,7 +23,7 @@ jobs:
           bash backend/scripts/ci-no-demo-guard.sh
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: 'npm'
@@ -119,9 +119,9 @@ jobs:
     name: Python Lint & Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/ponto-smoke.yml
+++ b/.github/workflows/ponto-smoke.yml
@@ -15,7 +15,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -16,11 +16,11 @@ jobs:
     name: Scan for secrets (Gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE || '' }}
@@ -29,9 +29,9 @@ jobs:
     name: Dependency Audit (JS/TS)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
 
@@ -66,9 +66,9 @@ jobs:
     name: Pip Audit (Python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           # Semgrep bundles a native semgrep-core executable. Pin a supported
           # Python minor instead of following 3.x to a newly released runtime
@@ -161,7 +161,7 @@ jobs:
           fi
       - name: Upload pip-audit reports (artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pip-audit
           path: pip-audit-*.json
@@ -170,9 +170,9 @@ jobs:
     name: Bandit (Python SAST)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -251,7 +251,7 @@ jobs:
           PY
       - name: Upload Bandit report (artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bandit
           path: bandit.json
@@ -260,9 +260,9 @@ jobs:
     name: Semgrep (SAST)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
       - name: Install Semgrep CLI
@@ -273,6 +273,6 @@ jobs:
         run: semgrep scan --config auto --sarif --output semgrep.sarif
       - name: Upload Semgrep SARIF
         if: ${{ hashFiles('semgrep.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/sync-website-cloudflare-security.yml
+++ b/.github/workflows/sync-website-cloudflare-security.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/test-coverage-quality.yml
+++ b/.github/workflows/test-coverage-quality.yml
@@ -12,9 +12,9 @@ jobs:
     name: Frontend & Website Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.12.0"
           cache: 'npm'
@@ -62,9 +62,9 @@ jobs:
     name: Python Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -81,7 +81,7 @@ jobs:
           cd backend
           python -m pytest tests/unit --cov=config --cov-fail-under=80 --cov-report=xml:coverage.xml --cov-report=term
       - name: Upload coverage.xml
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-coverage
           path: backend/coverage.xml

--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.12.0
           cache: npm
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Python
         if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/docs/operations/github-organization-migration-pending.md
+++ b/docs/operations/github-organization-migration-pending.md
@@ -1,0 +1,18 @@
+# Pendência operacional — migração para GitHub Organization privada
+
+**Estado:** pendente; não faz parte desta PR e não autoriza mover, renomear ou privatizar o repositório atual.
+
+## Objetivo
+
+Migrar `jubenitogarcia/skincos` para uma GitHub Organization e repositório privado sem interromper desenvolvimento, CI, integrações, ambientes ou deploys.
+
+## Pré-requisitos de decisão
+
+1. Nome da Organization, owners independentes e política de recuperação de conta.
+2. Inventário de GitHub Actions, tokens, GitHub Apps, webhooks, dependabot, badges, URLs e integrações Cloudflare/terceiros que referenciam o repositório atual.
+3. Plano para secrets por environment, rulesets, teams e permissões mínimas, incluindo uma segunda pessoa ou função revisora antes de exigir CODEOWNER review.
+4. Janela de migração, comunicação, rollback por redirecionamento GitHub e responsáveis por validar clones, PRs, Actions e integrações externas.
+
+## Critério de conclusão
+
+O desenvolvimento continua no mesmo commit e URLs redirecionadas são verificadas; Actions, environments, secrets e proteções foram recriados/confirmados; nenhuma credencial foi exposta; e uma PR pós-migração comprova clone, CI e operação de ambientes. Até esses pré-requisitos, esta pendência não bloqueia o uso do repositório atual.

--- a/docs/runbooks/github-governance.md
+++ b/docs/runbooks/github-governance.md
@@ -1,0 +1,52 @@
+# Runbook — governança do repositório GitHub
+
+## Fonte reproduzível
+
+- `CODEOWNERS` e `.github/scripts/validate-github-governance.mjs` definem e verificam a ownership local.
+- `.github/governance/rulesets/main-enterprise-baseline.json` é o payload canônico da ruleset da `main`.
+- `.github/governance/environments/{staging,production}.json` são os payloads dos environments; segredos não são versionados.
+
+Os arquivos representam a baseline ativa em 2026-07-23: bloqueio de force-push e exclusão, PR obrigatória, resolução de conversas e checks de CI. A aprovação obrigatória por CODEOWNER permanece desativada porque há apenas um owner humano; ativá-la antes de haver um revisor independente bloquearia o desenvolvimento sem aumentar a segregação real.
+
+## Pré-checagem
+
+Execute em uma branch baseada na `main` e com `gh auth status` válido:
+
+```powershell
+node .github/scripts/validate-github-governance.mjs
+gh api repos/jubenitogarcia/skincos/actions/permissions
+gh api repos/jubenitogarcia/skincos/rulesets
+gh api repos/jubenitogarcia/skincos/environments
+```
+
+Todo `uses:` externo deve apontar para SHA completo de 40 caracteres. Referências locais (`./`) são permitidas. Tags, branches e SHAs curtos bloqueiam CI e não podem ser promovidos à `main`.
+
+## Aplicar ruleset e environments
+
+Use somente após comparar o estado remoto com os arquivos versionados. Para atualizar a ruleset existente, obtenha o ID pelo nome e faça `PUT`; para criar, use `POST` uma única vez.
+
+```powershell
+$ruleset = gh api repos/jubenitogarcia/skincos/rulesets | ConvertFrom-Json | Where-Object name -eq 'main-enterprise-baseline'
+gh api --method PUT "repos/jubenitogarcia/skincos/rulesets/$($ruleset.id)" --input .github/governance/rulesets/main-enterprise-baseline.json
+gh api --method PUT repos/jubenitogarcia/skincos/environments/staging --input .github/governance/environments/staging.json
+gh api --method PUT repos/jubenitogarcia/skincos/environments/production --input .github/governance/environments/production.json
+```
+
+Depois, confirme que staging e produção aceitam somente branches protegidas, que secrets têm nomes e valores distintos por environment, e que nenhuma credencial de produção existe em staging. Nunca registre valores de secrets em Git, logs ou PRs.
+
+## Exigir SHA completo para Actions
+
+Ative somente depois de uma PR com o validador verde e todos os workflows de `main` compatíveis. Preserve as permissões existentes ao atualizar o campo:
+
+```powershell
+$permissions = gh api repos/jubenitogarcia/skincos/actions/permissions | ConvertFrom-Json
+$body = @{ enabled = $permissions.enabled; allowed_actions = $permissions.allowed_actions; sha_pinning_required = $true } | ConvertTo-Json -Compress
+$body | gh api --method PUT repos/jubenitogarcia/skincos/actions/permissions --input -
+gh api repos/jubenitogarcia/skincos/actions/permissions
+```
+
+Aceite: `sha_pinning_required` é `true`; uma execução de CI da `main` inicia sem erro de resolução de Action; o validador continua verde. Rollback: repetir o comando com `sha_pinning_required = $false` somente para restaurar a execução e abrir uma PR corretiva imediata que repine a referência ofensora.
+
+## Revisão periódica
+
+Em cada mudança de workflow, revisar pin, comentário da versão, permissões mínimas, environment usado e caminho de rollback. Mensalmente, comparar ruleset/environments remotos com os arquivos e verificar owners de novos roots. A atualização de SHA ocorre por PR curta, nunca diretamente na `main`.


### PR DESCRIPTION
## Escopo

- atualiza `CODEOWNERS` para todos os roots atuais e adiciona validação automática;
- fixa todas as referências externas de GitHub Actions em SHA completo;
- versiona payloads reproduzíveis para a ruleset da `main` e os environments `staging` e `production`;
- executa a validação de governança no workflow Architecture governance;
- adiciona runbook de aplicação/verificação e pendência isolada da futura migração para Organization privada.

## Segurança e compatibilidade

- 17 referências de Actions foram conferidas contra os commits dos repositórios de origem;
- não foram alterados gatilhos, comandos, secrets, bindings ou deploys dos workflows;
- `sha_pinning_required` remoto permanece `false` durante a PR e só será ativado após merge e confirmação dos gates verdes.

## Validação local

- `git diff --check`;
- `node .github/scripts/validate-github-governance.mjs`;
- `node .github/scripts/validate-architecture.mjs`;
- resolução remota dos 17 SHAs.

## Rollback

Reverter esta PR restaura somente definições de governança e as referências anteriores das Actions. Caso a exigência remota de SHA cause bloqueio inesperado após o merge, o runbook documenta o rollback temporário e a PR corretiva obrigatória.