### PR TITLE
ci: promover unidades por evidência imutável

### DIFF
--- a/.github/scripts/promotion-evidence.mjs
+++ b/.github/scripts/promotion-evidence.mjs
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const [mode, file] = process.argv.slice(2);
+const required = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing ${name}`);
+  return value;
+};
+
+if (mode === "write") {
+  const evidence = {
+    schemaVersion: 1,
+    unit: required("PROMOTION_UNIT"),
+    target: required("PROMOTION_TARGET"),
+    sourceSha: required("PROMOTION_SOURCE_SHA"),
+    sourceTree: required("PROMOTION_SOURCE_TREE"),
+    runId: required("GITHUB_RUN_ID"),
+    repository: required("GITHUB_REPOSITORY"),
+    createdAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(evidence, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(evidence)}\n`);
+} else if (mode === "verify") {
+  const evidence = JSON.parse(fs.readFileSync(file, "utf8"));
+  const expectedUnit = required("PROMOTION_UNIT");
+  const expectedTarget = required("PROMOTION_EXPECTED_TARGET");
+  const expectedSha = process.env.PROMOTION_EXPECTED_SHA;
+  if (evidence.schemaVersion !== 1 || evidence.unit !== expectedUnit || evidence.target !== expectedTarget || !/^[0-9a-f]{40}$/i.test(evidence.sourceSha) || !/^[0-9a-f]{40}$/i.test(evidence.sourceTree)) {
+    throw new Error("promotion evidence has an invalid identity or stage");
+  }
+  if (expectedSha && evidence.sourceSha !== expectedSha) throw new Error("promotion evidence SHA differs from requested release SHA");
+  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `source_sha=${evidence.sourceSha}\nsource_tree=${evidence.sourceTree}\n`);
+  process.stdout.write(`Promotion evidence verified for ${evidence.unit} ${evidence.sourceSha} from ${evidence.target}.\n`);
+} else {
+  throw new Error("usage: promotion-evidence.mjs write|verify <file>");
+}

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -20,8 +20,8 @@ for (const control of catalog.externalPublisherControls ?? []) {
   }
 }
 for (const unit of catalog.units ?? []) {
-  if (!unit.id || !Array.isArray(unit.resources) || !Array.isArray(unit.publishes) || !Array.isArray(unit.secrets) || !Array.isArray(unit.migrationPaths) || !Array.isArray(unit.environments)) {
-    fail("every operational unit needs id, publishes, resources, secrets, migrationPaths and environments");
+  if (!unit.id || !unit.promotion || typeof unit.promotion.stagingSupported !== "boolean" || !Array.isArray(unit.resources) || !Array.isArray(unit.publishes) || !Array.isArray(unit.secrets) || !Array.isArray(unit.migrationPaths) || !Array.isArray(unit.environments)) {
+    fail("every operational unit needs promotion, publishes, resources, secrets, migrationPaths and environments");
     continue;
   }
   for (const resource of unit.publishes) {
@@ -43,6 +43,7 @@ for (const unit of catalog.units ?? []) {
   if (/^\s{2}(push|schedule|pull_request_target|workflow_run|repository_dispatch):/m.test(source)) fail(`${unit.id} has an automatic publish trigger`);
   if (!/^concurrency:/m.test(source) || !source.includes(unit.concurrencyPrefix)) fail(`${unit.id} must serialize by unit and environment`);
   if (!/^\s+environment:/m.test(source)) fail(`${unit.id} must select a GitHub environment`);
+  if (!source.includes("promotion-gate.yml") || !source.includes("release_sha") || !source.includes("staging_run_id")) fail(`${unit.id} must use the immutable promotion gate`);
 }
 
 for (const retiredPath of catalog.retiredWorkflowPaths ?? []) {

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -8,14 +8,23 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [preview, staging, production]
+      release_sha: { description: "Immutable commit SHA", required: false, type: string }
+      preview_run_id: { description: "Required for staging", required: false, type: string }
+      staging_run_id: { description: "Required for production", required: false, type: string }
 
 concurrency:
   group: deploy-core-workers-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: core-workers, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     permissions:
@@ -45,6 +54,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -83,3 +94,12 @@ jobs:
             --attempts 5 \
             --sleep-seconds 6 \
             --user-agent "Mozilla/5.0 (compatible; CoreWorkerSmoke/1.0)"
+
+      - name: Write staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        env: { PROMOTION_UNIT: core-workers, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Upload staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with: { name: promotion-evidence-core-workers, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -8,14 +8,23 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [preview, staging, production]
+      release_sha: { description: "Immutable commit SHA", required: false, type: string }
+      preview_run_id: { description: "Required for staging", required: false, type: string }
+      staging_run_id: { description: "Required for production", required: false, type: string }
 
 concurrency:
   group: deploy-crm-pages-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: crm-pages, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     permissions:
@@ -59,6 +68,7 @@ jobs:
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
           fetch-depth: 2
 
       - name: Setup Node
@@ -103,7 +113,7 @@ jobs:
       - name: Build frontend
         if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
-          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: npm run build
         working-directory: crm/console
 
@@ -143,3 +153,11 @@ jobs:
             --sleep-seconds 10 \
             --allow-ponto-disabled \
             --user-agent "Mozilla/5.0 (compatible; PontoSmoke/1.0)"
+      - name: Write staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && inputs.target == 'staging' }}
+        env: { PROMOTION_UNIT: crm-pages, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Upload staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with: { name: promotion-evidence-crm-pages, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -8,14 +8,23 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [preview, staging, production]
+      release_sha: { description: "Immutable commit SHA", required: false, type: string }
+      preview_run_id: { description: "Required for staging", required: false, type: string }
+      staging_run_id: { description: "Required for production", required: false, type: string }
 
 concurrency:
   group: deploy-escala-api-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: escala-api, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     permissions:
@@ -49,6 +58,7 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -131,3 +141,11 @@ jobs:
         run: |
           set -euo pipefail
           node workforce/schedule/scripts/smoke.mjs
+      - name: Write staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        env: { PROMOTION_UNIT: escala-api, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Upload staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with: { name: promotion-evidence-escala-api, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -1,16 +1,27 @@
 name: Deploy Meta Ads Report Worker
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target: { description: Target stage, required: true, default: preview, type: choice, options: [preview, staging, production] }
+      release_sha: { description: Immutable commit SHA, required: false, type: string }
+      preview_run_id: { description: Required for staging, required: false, type: string }
+      staging_run_id: { description: Required for production, required: false, type: string }
 
 concurrency:
-  group: deploy-meta-ads-report-production
+  group: deploy-meta-ads-report-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: meta-ads-report, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.target }}
     permissions:
       contents: read
 
@@ -32,6 +43,7 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -46,4 +58,13 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          npx --yes wrangler@3 deploy --config ads/meta/apps/report-ingest-worker/wrangler.toml --keep-vars
+          if [[ "${{ inputs.target }}" == "staging" ]]; then env_args=(--env staging); else env_args=(); fi
+          npx --yes wrangler@3 deploy --config ads/meta/apps/report-ingest-worker/wrangler.toml --keep-vars "${env_args[@]}"
+      - name: Write staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        env: { PROMOTION_UNIT: meta-ads-report, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Upload staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with: { name: promotion-evidence-meta-ads-report, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -1,16 +1,27 @@
 name: Deploy Social Publisher Worker
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target: { description: Target stage, required: true, default: preview, type: choice, options: [preview, staging, production] }
+      release_sha: { description: Immutable commit SHA, required: false, type: string }
+      preview_run_id: { description: Required for staging, required: false, type: string }
+      staging_run_id: { description: Required for production, required: false, type: string }
 
 concurrency:
-  group: deploy-social-publisher-production
+  group: deploy-social-publisher-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: social-publisher, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }}, staging_supported: false }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.target }}
     permissions:
       contents: read
 
@@ -32,6 +43,7 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -8,7 +8,15 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [preview, staging, production]
+      release_sha:
+        description: Immutable commit SHA
+        required: false
+        type: string
+      preview_run_id:
+        description: Required for staging
+        required: false
+        type: string
       staging_run_id:
         description: Required for production - successful staging run id for this exact commit
         required: false
@@ -23,32 +31,16 @@ permissions:
   contents: read
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: timekeeping, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    secrets: inherit
   deploy:
-    if: github.ref == 'refs/heads/main'
+    needs: promotion
+    if: ${{ github.ref == 'refs/heads/main' && inputs.target != 'preview' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     steps:
-      - name: Verify production staging attestation
-        if: inputs.target == 'production'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          STAGING_RUN_ID: ${{ inputs.staging_run_id }}
-          EXPECTED_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          [[ "$STAGING_RUN_ID" =~ ^[0-9]+$ ]] || { echo "Production requires a numeric staging_run_id"; exit 1; }
-          mkdir -p "$RUNNER_TEMP/staging-attestation"
-          gh run download "$STAGING_RUN_ID" --repo "$GITHUB_REPOSITORY" --name timekeeping-staging-attestation --dir "$RUNNER_TEMP/staging-attestation"
-          node - "$RUNNER_TEMP/staging-attestation/attestation.json" "$EXPECTED_SHA" <<'NODE'
-          const fs = require('fs')
-          const [file, expectedSha] = process.argv.slice(2)
-          const value = JSON.parse(fs.readFileSync(file, 'utf8'))
-          if (value.target !== 'staging' || value.sha !== expectedSha || value.health !== 200 || value.readiness !== 200) {
-            console.error('Staging attestation does not match this production commit')
-            process.exit(1)
-          }
-          NODE
-
       - name: Guard target and credentials
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -69,7 +61,7 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
-          ref: main
+          ref: ${{ needs.promotion.outputs.source_sha }}
           fetch-depth: 1
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
@@ -88,7 +80,7 @@ jobs:
       - name: Verify checked-out source identity
         run: |
           set -euo pipefail
-          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo "Checkout SHA mismatch"; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "${{ needs.promotion.outputs.source_sha }}" ]] || { echo "Checkout SHA mismatch"; exit 1; }
 
       - name: Test release source
         run: |
@@ -202,17 +194,20 @@ jobs:
             node -e "const p=JSON.parse(require('fs').readFileSync(process.argv[1])); if(!p.ok) process.exit(1)" "$body"
           done
 
-      - name: Write staging attestation
+      - name: Write staging promotion evidence
         if: inputs.target == 'staging'
+        env:
+          PROMOTION_UNIT: timekeeping
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
-          mkdir -p "$RUNNER_TEMP/timekeeping-staging-attestation"
-          node -e "require('fs').writeFileSync(process.argv[1], JSON.stringify({target:'staging',sha:process.env.GITHUB_SHA,runId:process.env.GITHUB_RUN_ID,health:200,readiness:200,createdAt:new Date().toISOString()},null,2))" "$RUNNER_TEMP/timekeeping-staging-attestation/attestation.json"
+          PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
 
-      - name: Upload staging attestation
+      - name: Upload staging promotion evidence
         if: inputs.target == 'staging'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: timekeeping-staging-attestation
-          path: ${{ runner.temp }}/timekeeping-staging-attestation/attestation.json
+          name: promotion-evidence-timekeeping
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -1,16 +1,27 @@
 name: Deploy Website to Cloudflare
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target: { description: Target stage, required: true, default: preview, type: choice, options: [preview, staging, production] }
+      release_sha: { description: Immutable commit SHA, required: false, type: string }
+      preview_run_id: { description: Required for staging, required: false, type: string }
+      staging_run_id: { description: Required for production, required: false, type: string }
 
 concurrency:
-  group: deploy-website-production
+  group: deploy-website-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with: { unit: public-website-release, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }}, staging_supported: false }
+    secrets: inherit
   deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.target }}
     permissions:
       contents: read
     env:
@@ -54,6 +65,7 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -30,9 +30,10 @@ jobs:
         id: identity
         env:
           REQUESTED_SHA: ${{ inputs.release_sha }}
+          PROMOTION_TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
-          if [[ "${{ inputs.target }}" != "preview" && -z "${REQUESTED_SHA:-}" ]]; then
+          if [[ "$PROMOTION_TARGET" != "preview" && -z "${REQUESTED_SHA:-}" ]]; then
             echo "::error::staging and production require the exact release_sha from predecessor evidence."
             exit 1
           fi

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -1,0 +1,81 @@
+name: Immutable promotion gate
+
+on:
+  workflow_call:
+    inputs:
+      unit: { required: true, type: string }
+      target: { required: true, type: string }
+      release_sha: { required: false, type: string, default: "" }
+      preview_run_id: { required: false, type: string, default: "" }
+      staging_run_id: { required: false, type: string, default: "" }
+      staging_supported: { required: false, type: boolean, default: true }
+    outputs:
+      source_sha:
+        value: ${{ jobs.gate.outputs.source_sha }}
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      source_sha: ${{ steps.identity.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+      - name: Resolve immutable source identity
+        id: identity
+        env:
+          REQUESTED_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.target }}" != "preview" && -z "${REQUESTED_SHA:-}" ]]; then
+            echo "::error::staging and production require the exact release_sha from predecessor evidence."
+            exit 1
+          fi
+          source_sha="${REQUESTED_SHA:-$GITHUB_SHA}"
+          git fetch --no-tags --depth=1 origin "$source_sha"
+          git cat-file -e "$source_sha^{commit}"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - name: Block unsupported staging target
+        if: ${{ inputs.target == 'staging' && !inputs.staging_supported }}
+        run: |
+          echo "::error::This unit has no isolated staging binding. Provision it before any promotion."
+          exit 1
+      - name: Verify predecessor evidence
+        if: ${{ inputs.target != 'preview' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREDECESSOR_RUN_ID: ${{ inputs.target == 'staging' && inputs.preview_run_id || inputs.staging_run_id }}
+          EXPECTED_TARGET: ${{ inputs.target == 'staging' && 'preview' || 'staging' }}
+          PROMOTION_UNIT: ${{ inputs.unit }}
+          PROMOTION_EXPECTED_TARGET: ${{ inputs.target == 'staging' && 'preview' || 'staging' }}
+          PROMOTION_EXPECTED_SHA: ${{ steps.identity.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo "::error::A numeric predecessor run id is required."; exit 1; }
+          mkdir -p "$RUNNER_TEMP/promotion-evidence"
+          gh run download "$PREDECESSOR_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "promotion-evidence-${PROMOTION_UNIT}" --dir "$RUNNER_TEMP/promotion-evidence"
+          node .github/scripts/promotion-evidence.mjs verify "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Write preview evidence
+        if: ${{ inputs.target == 'preview' }}
+        env:
+          PROMOTION_UNIT: ${{ inputs.unit }}
+          PROMOTION_TARGET: preview
+          PROMOTION_SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
+          PROMOTION_SOURCE_TREE: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tree="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")"
+          PROMOTION_SOURCE_TREE="$tree" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - name: Upload preview evidence
+        if: ${{ inputs.target == 'preview' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-evidence-${{ inputs.unit }}
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/docs/runbooks/immutable-promotion.md
+++ b/docs/runbooks/immutable-promotion.md
@@ -1,0 +1,45 @@
+# Promoção imutável por unidade operacional
+
+## Regra
+
+Cada publisher canônico usa `.github/workflows/promotion-gate.yml`. A cadeia é
+`preview -> staging -> production` para o mesmo `release_sha` (commit Git de
+40 caracteres, portanto imutável). O gate publica evidência de preview e exige
+o `preview_run_id` correspondente antes de staging; após um staging bem-sucedido,
+o workflow publica `promotion-evidence-<unit>` e produção exige tanto o
+`staging_run_id` quanto o mesmo `release_sha`.
+
+O job de produção faz checkout do SHA atestado, nunca do HEAD atual da `main`.
+As configurações, bindings e secrets continuam sendo selecionados exclusivamente
+pelo environment do destino.
+
+## Operação
+
+1. Execute o publisher da unidade com `target=preview`; registre o run id e o
+   SHA exibido no artefato de evidência.
+2. Execute `target=staging`, com `release_sha` e `preview_run_id`. Não use uma
+   branch ou SHA diferente.
+3. Depois da validação funcional de staging, execute `target=production`, com
+   o mesmo `release_sha` e `staging_run_id`. A aprovação do environment de
+   produção continua obrigatória.
+
+Não use `workflow_dispatch` nesta mudança. Esta PR altera apenas o mecanismo.
+
+## Cobertura e bloqueios explícitos
+
+- Core Workers (inclui Inventory e Financeiro), CRM Pages (inclui Financeiro),
+  Escala, Ponto e Meta Ads Report têm staging configurado e podem cumprir a
+  cadeia quando seus secrets e aprovações estiverem presentes.
+- Social Publisher, Website e runtime nativo foram convertidos para o mesmo
+  contrato, mas staging falha explicitamente até que recebam recursos isolados.
+  Eles não podem ir para produção por esse pipeline enquanto esse bloqueio
+  existir.
+- O runtime nativo já usa releases em `/opt/skincos/releases/<sha>`; a falta é
+  um host de staging isolado, não uma segunda forma de publicar produção.
+
+## Evidência e rollback
+
+`promotion-evidence-<unit>` contém unidade, estágio, SHA, árvore Git, run e
+timestamp, sem secrets. Preserve o run de staging com a evidência de smoke e o
+SHA anterior. Rollback continua pelo publisher canônico usando o SHA anterior
+que já tenha evidência de staging válida; migrations permanecem aditivas.

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -9,7 +9,8 @@
       "resources": ["api gateway Worker", "inventory Worker", "skincos-db", "skincos-db-staging"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
       "migrationPaths": ["inventory/migrations"],
-      "environments": ["staging", "production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true, "financeIncluded": true}
     },
     {
       "id": "crm-pages",
@@ -19,7 +20,8 @@
       "resources": ["Cloudflare Pages skincos", "Cloudflare Pages skincos-staging", "crm console"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
       "migrationPaths": [],
-      "environments": ["staging", "production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true, "financeIncluded": true}
     },
     {
       "id": "escala-api",
@@ -29,7 +31,8 @@
       "resources": ["Escala Worker", "skincos-escala", "skincos-escala-staging"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "ESCALA_ACTOR_HMAC_KEY"],
       "migrationPaths": ["workforce/schedule/migrations-d1"],
-      "environments": ["staging", "production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true}
     },
     {
       "id": "timekeeping",
@@ -39,37 +42,41 @@
       "resources": ["Timekeeping Worker", "skincos-timekeeping", "skincos-timekeeping-staging"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "PONTO_ACTOR_HMAC_KEY", "PONTO_IDEMPOTENCY_KEY", "PONTO_TEMPLATES_KEY", "PONTO_NETWORK_CONTEXT_KEY"],
       "migrationPaths": ["workforce/timekeeping/migrations"],
-      "environments": ["staging", "production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true}
     },
     {
       "id": "social-publisher",
       "workflow": ".github/workflows/deploy-social-publisher-worker.yml",
-      "concurrencyPrefix": "deploy-social-publisher-production",
+      "concurrencyPrefix": "deploy-social-publisher-",
       "publishes": ["Worker:skincos-social-publisher"],
       "resources": ["Social Publisher Worker"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
       "migrationPaths": [],
-      "environments": ["production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": false, "blocker": "Dedicated Social Publisher bindings, R2 and Durable Object namespace are not provisioned for staging."}
     },
     {
       "id": "meta-ads-report",
       "workflow": ".github/workflows/deploy-meta-ads-report-worker.yml",
-      "concurrencyPrefix": "deploy-meta-ads-report-production",
+      "concurrencyPrefix": "deploy-meta-ads-report-",
       "publishes": ["Worker:skincos-meta-ads-performance-report"],
       "resources": ["Meta Ads Report Worker", "skincos-meta-ads-performance-report", "skincos-meta-ads-performance-report-staging"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
       "migrationPaths": ["ads/meta/apps/report-ingest-worker/migrations"],
-      "environments": ["production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true}
     },
     {
       "id": "public-website-release",
       "workflow": ".github/workflows/deploy-website-cloudflare.yml",
-      "concurrencyPrefix": "deploy-website-production",
+      "concurrencyPrefix": "deploy-website-",
       "publishes": ["Worker:espacofacial", "Worker:skincos-legal-hub", "Worker:esfa-redirector"],
       "resources": ["Espaco Facial Worker", "SKINCOS legal hub Worker", "esfa redirect Worker", "espacofacial-booking D1"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_SECURITY_API_TOKEN"],
       "migrationPaths": ["website/migrations"],
-      "environments": ["production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": false, "blocker": "Dedicated Website, booking D1, legal hub and redirect routes are not provisioned for staging."}
     },
     {
       "id": "native-runtime",
@@ -79,7 +86,8 @@
       "resources": ["orb", "orb-proxy", "messaging-whatsapp", "crm", "booking", "cloudflare-orb", "cloudflare-runtime", "PostgreSQL n8n_runtime"],
       "secrets": ["/etc/skincos"],
       "migrationPaths": ["orb/engine/db/migrations", "crm/api/server/atendimento/migrations", "booking/migrations"],
-      "environments": ["production"]
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": false, "blocker": "Native runtime has immutable releases but no isolated native staging host; production remains operator-gated."}
     }
   ],
   "nonPublishingSurfaces": [


### PR DESCRIPTION
## Objetivo
Finalizar o contrato de promoção imutável para os publishers canônicos, sem executar preview remoto, staging ou produção nesta PR.

## Fluxo
`preview -> staging -> production` usa o mesmo `release_sha`.
- preview publica evidência de identidade após os checks de PR;
- staging exige o `preview_run_id` e o mesmo SHA;
- produção exige `staging_run_id`, `release_sha` e faz checkout do SHA atestado, não do HEAD da main.

## Cobertura
Core/Inventory/Financeiro, CRM Pages/Financeiro, Escala, Ponto e Meta Ads têm staging configurado. Social, Website e runtime nativo agora falham explicitamente no estágio de staging até que recursos isolados sejam provisionados; produção fica bloqueada.

## Validação local
- topology, governance e architecture validators;
- `promotion-evidence.mjs` write/verify com SHA sintético;
- `git diff --check`.

Nenhum `workflow_dispatch`, deploy, migration remota ou mudança de produção foi executado.