### PR TITLE
fix: restaurar YAML dos workflows de promoção

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -20,7 +20,12 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: core-workers, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    with:
+      unit: core-workers
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
     secrets: inherit
   deploy:
     needs: promotion
@@ -102,4 +107,8 @@ jobs:
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with: { name: promotion-evidence-core-workers, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }
+        with:
+          name: promotion-evidence-core-workers
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -20,7 +20,12 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: crm-pages, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    with:
+      unit: crm-pages
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
     secrets: inherit
   deploy:
     needs: promotion
@@ -160,4 +165,8 @@ jobs:
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && inputs.target == 'staging' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with: { name: promotion-evidence-crm-pages, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }
+        with:
+          name: promotion-evidence-crm-pages
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -20,7 +20,12 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: escala-api, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    with:
+      unit: escala-api
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
     secrets: inherit
   deploy:
     needs: promotion
@@ -58,7 +63,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -148,4 +154,8 @@ jobs:
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with: { name: promotion-evidence-escala-api, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }
+        with:
+          name: promotion-evidence-escala-api
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -15,7 +15,12 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: meta-ads-report, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    with:
+      unit: meta-ads-report
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
     secrets: inherit
   deploy:
     needs: promotion
@@ -43,7 +48,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -67,4 +73,8 @@ jobs:
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with: { name: promotion-evidence-meta-ads-report, path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json, retention-days: 14, if-no-files-found: error }
+        with:
+          name: promotion-evidence-meta-ads-report
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -15,7 +15,13 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: social-publisher, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }}, staging_supported: false }
+    with:
+      unit: social-publisher
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
+      staging_supported: false
     secrets: inherit
   deploy:
     needs: promotion
@@ -43,7 +49,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -33,7 +33,12 @@ permissions:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: timekeeping, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }} }
+    with:
+      unit: timekeeping
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
     secrets: inherit
   deploy:
     needs: promotion

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -15,7 +15,13 @@ concurrency:
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
-    with: { unit: public-website-release, target: ${{ inputs.target }}, release_sha: ${{ inputs.release_sha }}, preview_run_id: ${{ inputs.preview_run_id }}, staging_run_id: ${{ inputs.staging_run_id }}, staging_supported: false }
+    with:
+      unit: public-website-release
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
+      staging_supported: false
     secrets: inherit
   deploy:
     needs: promotion
@@ -65,7 +71,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.guard.outputs.skip != 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with: { ref: ${{ needs.promotion.outputs.source_sha }} }
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
 
       - name: Setup Node
         if: ${{ steps.guard.outputs.skip != 'true' }}


### PR DESCRIPTION
Repairs YAML flow mappings that caused GitHub to reject the canonical publisher workflows before any job started. No publisher is dispatched.