### PR TITLE
fix: restore parsable promotion publishers

### DIFF
--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -53,6 +53,9 @@ for (const retiredPath of catalog.retiredWorkflowPaths ?? []) {
 for (const filename of workflowFiles) {
   const relativePath = path.posix.join(".github/workflows", filename);
   const source = read(relativePath);
+  if (/:\s*\{[^\r\n}]*\$\{\{/.test(source)) {
+    fail(`${relativePath} uses a GitHub expression inside a compact YAML map; use a block mapping so GitHub can parse the workflow.`);
+  }
   const publishingLines = source.split(/\r?\n/).filter((line) => publishPattern.test(line) && !/(--local|--dry-run)/i.test(line));
   if (publishingLines.length && !canonicalPaths.has(relativePath)) fail(`non-canonical publisher found: ${relativePath}`);
 }

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -102,7 +102,10 @@ jobs:
 
       - name: Write staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
-        env: { PROMOTION_UNIT: core-workers, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        env:
+          PROMOTION_UNIT: core-workers
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -160,7 +160,10 @@ jobs:
             --user-agent "Mozilla/5.0 (compatible; PontoSmoke/1.0)"
       - name: Write staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && inputs.target == 'staging' }}
-        env: { PROMOTION_UNIT: crm-pages, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        env:
+          PROMOTION_UNIT: crm-pages
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' && inputs.target == 'staging' }}

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -149,7 +149,10 @@ jobs:
           node workforce/schedule/scripts/smoke.mjs
       - name: Write staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
-        env: { PROMOTION_UNIT: escala-api, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        env:
+          PROMOTION_UNIT: escala-api
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -68,7 +68,10 @@ jobs:
           npx --yes wrangler@3 deploy --config ads/meta/apps/report-ingest-worker/wrangler.toml --keep-vars "${env_args[@]}"
       - name: Write staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
-        env: { PROMOTION_UNIT: meta-ads-report, PROMOTION_TARGET: staging, PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }} }
+        env:
+          PROMOTION_UNIT: meta-ads-report
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Upload staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}


### PR DESCRIPTION
## Context\n\nRepairs the remaining GitHub Actions YAML parsing errors introduced by the immutable-promotion merge. The failed main runs had zero jobs and therefore performed no deployment.\n\n## Changes\n\n- converts expression-bearing compact env maps to standard YAML blocks;\n- makes topology CI reject this unsafe YAML form going forward.\n\n## Validation\n\n- 
ode .github/scripts/validate-deploy-topology.mjs\n- parse all 38 workflow YAML files with PyYAML\n- git diff --check\n\nNo workflow dispatch, migration, deployment, or production action was performed.