### PR TITLE
ci(release): archive immutable candidates and validate controls

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "sourceBranch": "main",
+  "stages": ["preview", "staging", "pilot", "canary", "production"],
+  "stagePredecessor": {"staging": "preview", "pilot": "staging", "canary": "pilot", "production": "canary"},
+  "controls": {
+    "immutableSource": "release-source-<sha> artifact and source SHA reachable from main",
+    "featureFlag": "module-specific flag remains disabled until the approved stage",
+    "killSwitch": "a documented per-unit switch must stop new promotion and the module fallback must remain available",
+    "rollback": "redeploy the previous attested SHA through the canonical publisher; migrations remain additive",
+    "automaticInterruption": "a stage may not advance when error, latency, or journey evidence exceeds policy"
+  },
+  "criticalUnits": {
+    "core-workers": {"featureFlag": "deployment gate ENABLE_CORE_WORKERS_DEPLOY", "killSwitch": "RELEASE_KILL_SWITCH_CORE_WORKERS", "rollback": "previous staging-attested SHA", "pilotCanary": "blocked: dual Worker version affinity and external SLO evidence are not configured"},
+    "crm-pages": {"featureFlag": "Finance module_enabled plus ENABLE_FINANCE_PRODUCTION_DEPLOY", "killSwitch": "finance_settings.module_enabled=false", "rollback": "previous Pages deployment or previous staging-attested SHA", "pilotCanary": "blocked: Pages traffic steering and pilot cohort configuration are not configured"},
+    "escala-api": {"featureFlag": "deployment gate ENABLE_ESCALA_API_DEPLOY", "killSwitch": "RELEASE_KILL_SWITCH_ESCALA_API", "rollback": "previous staging-attested SHA", "pilotCanary": "blocked: Worker gradual routing and external SLO evidence are not configured"},
+    "timekeeping": {"featureFlag": "environment deploy gate and Ponto operational flag", "killSwitch": "RELEASE_KILL_SWITCH_TIMEKEEPING", "rollback": "previous staging-attested SHA with additive-migration compatibility", "pilotCanary": "blocked: Worker gradual routing, network-context pilot cohort and external SLO evidence are not configured"},
+    "meta-ads-report": {"featureFlag": "META_ADS_REPORT_MODE", "killSwitch": "RELEASE_KILL_SWITCH_META_ADS_REPORT", "rollback": "previous staging-attested SHA", "pilotCanary": "blocked: job-level canary and external ingestion journey evidence are not configured"}
+  }
+}

--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+const policy = JSON.parse(read(".github/governance/progressive-release-policy.json"));
+const catalog = JSON.parse(read("platform/deploy/operational-units.json"));
+const failures = [];
+const fail = (message) => failures.push(message);
+
+if (policy.schemaVersion !== 1 || policy.sourceBranch !== "main") fail("policy must use main as its only release source");
+if (JSON.stringify(policy.stages) !== JSON.stringify(["preview", "staging", "pilot", "canary", "production"])) fail("policy stages must be preview, staging, pilot, canary, production in order");
+for (const [stage, predecessor] of Object.entries({ staging: "preview", pilot: "staging", canary: "pilot", production: "canary" })) {
+  if (policy.stagePredecessor?.[stage] !== predecessor) fail(`${stage} must require ${predecessor} evidence`);
+}
+for (const [unit, control] of Object.entries(policy.criticalUnits ?? {})) {
+  if (!catalog.units.some((entry) => entry.id === unit)) fail(`${unit} is not in the operational-unit catalog`);
+  for (const key of ["featureFlag", "killSwitch", "rollback", "pilotCanary"]) if (!control[key] || typeof control[key] !== "string") fail(`${unit} must declare ${key}`);
+}
+const candidate = read(".github/workflows/prepare-release-candidate.yml");
+for (const required of ["branches: [main]", "git merge-base --is-ancestor", "git archive --format=tar.gz", "sourceArchiveSha256", "release-source-${{ steps.release.outputs.source_sha }}"]) {
+  if (!candidate.includes(required)) fail(`release candidate workflow is missing ${required}`);
+}
+const gate = read(".github/workflows/promotion-gate.yml");
+for (const required of ["release_sha", "Verify predecessor evidence", "promotion-evidence.mjs verify", "source_sha"]) if (!gate.includes(required)) fail(`immutable promotion gate is missing ${required}`);
+if (failures.length) {
+  for (const message of failures) process.stderr.write(`progressive release validation failed: ${message}\n`);
+  process.exitCode = 1;
+} else process.stdout.write("Progressive release policy validation OK.\n");

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -16,3 +16,4 @@ jobs:
       - run: node .github/scripts/validate-architecture.mjs
       - run: node .github/scripts/validate-github-governance.mjs
       - run: node .github/scripts/validate-deploy-topology.mjs
+      - run: node .github/scripts/validate-progressive-release.mjs

--- a/.github/workflows/prepare-release-candidate.yml
+++ b/.github/workflows/prepare-release-candidate.yml
@@ -1,0 +1,60 @@
+name: Prepare immutable release candidate
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Full commit SHA already reachable from main (defaults to the dispatch SHA)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-release-candidate-${{ inputs.release_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  archive:
+    name: Archive immutable source and release identity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+      - name: Resolve a commit already promoted to main
+        id: release
+        env:
+          REQUESTED_SHA: ${{ inputs.release_sha }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          release_sha="${REQUESTED_SHA:-$EVENT_SHA}"
+          [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::release_sha must be a full commit SHA"; exit 1; }
+          git fetch --no-tags origin main
+          git cat-file -e "$release_sha^{commit}"
+          git merge-base --is-ancestor "$release_sha" origin/main || { echo "::error::$release_sha is not reachable from origin/main"; exit 1; }
+          echo "source_sha=$release_sha" >> "$GITHUB_OUTPUT"
+      - name: Archive and attest source
+        env:
+          RELEASE_SHA: ${{ steps.release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-candidate
+          git archive --format=tar.gz --prefix="skincos-${RELEASE_SHA}/" "$RELEASE_SHA" > release-candidate/source.tar.gz
+          sha256sum release-candidate/source.tar.gz | awk '{print $1}' > release-candidate/source.sha256
+          export SOURCE_TREE="$(git rev-parse "${RELEASE_SHA}^{tree}")"
+          node - <<'NODE'
+          const fs = require("fs");
+          fs.writeFileSync("release-candidate/release.json", `${JSON.stringify({schemaVersion: 1, sourceSha: process.env.RELEASE_SHA, sourceTree: process.env.SOURCE_TREE, sourceArchiveSha256: fs.readFileSync("release-candidate/source.sha256", "utf8").trim(), createdAt: new Date().toISOString()}, null, 2)}\n`);
+          NODE
+      - name: Upload release candidate evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-source-${{ steps.release.outputs.source_sha }}
+          path: release-candidate/
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -38,8 +38,13 @@ jobs:
             exit 1
           fi
           source_sha="${REQUESTED_SHA:-$GITHUB_SHA}"
+          git fetch --no-tags origin main
           git fetch --no-tags --depth=1 origin "$source_sha"
           git cat-file -e "$source_sha^{commit}"
+          git merge-base --is-ancestor "$source_sha" origin/main || {
+            echo "::error::$source_sha is not reachable from origin/main."
+            exit 1
+          }
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
       - name: Block unsupported staging target
         if: ${{ inputs.target == 'staging' && !inputs.staging_supported }}

--- a/docs/runbooks/immutable-promotion.md
+++ b/docs/runbooks/immutable-promotion.md
@@ -2,8 +2,8 @@
 
 ## Regra
 
-Cada publisher canônico usa `.github/workflows/promotion-gate.yml`. A cadeia é
-`preview -> staging -> production` para o mesmo `release_sha` (commit Git de
+Cada publisher canônico usa `.github/workflows/promotion-gate.yml`. A cadeia
+alvo é `preview -> staging -> piloto -> canary -> production` para o mesmo `release_sha` (commit Git de
 40 caracteres, portanto imutável). O gate publica evidência de preview e exige
 o `preview_run_id` correspondente antes de staging; após um staging bem-sucedido,
 o workflow publica `promotion-evidence-<unit>` e produção exige tanto o
@@ -13,15 +13,21 @@ O job de produção faz checkout do SHA atestado, nunca do HEAD atual da `main`.
 As configurações, bindings e secrets continuam sendo selecionados exclusivamente
 pelo environment do destino.
 
+Todo push na `main` também cria `release-source-<SHA>`: tarball, SHA-256 e
+identidade da árvore Git. Esse job somente arquiva a fonte; ele não publica
+código, não altera feature flags e não cria deployment.
+
 ## Operação
 
 1. Execute o publisher da unidade com `target=preview`; registre o run id e o
    SHA exibido no artefato de evidência.
 2. Execute `target=staging`, com `release_sha` e `preview_run_id`. Não use uma
    branch ou SHA diferente.
-3. Depois da validação funcional de staging, execute `target=production`, com
-   o mesmo `release_sha` e `staging_run_id`. A aprovação do environment de
-   produção continua obrigatória.
+3. Piloto e canary só podem ser abertos depois de staging e com o mesmo SHA,
+   cada um com sua evidência, feature flag e kill switch armado.
+4. Depois da validação do canary, execute `target=production`, com o mesmo
+   `release_sha` e evidência válida do estágio anterior. A aprovação do
+   environment de produção continua obrigatória.
 
 Não use `workflow_dispatch` nesta mudança. Esta PR altera apenas o mecanismo.
 
@@ -36,6 +42,12 @@ Não use `workflow_dispatch` nesta mudança. Esta PR altera apenas o mecanismo.
   existir.
 - O runtime nativo já usa releases em `/opt/skincos/releases/<sha>`; a falta é
   um host de staging isolado, não uma segunda forma de publicar produção.
+- O contrato versionado em
+  `.github/governance/progressive-release-policy.json` registra flags, kill
+  switches, rollback e os bloqueios de piloto/canary de cada unidade crítica.
+  Sem environments `preview`, `pilot`, `canary`, coorte e fonte externa de
+  SLO/jornada, esses estágios ficam bloqueados explicitamente: nunca há
+  fallback para produção integral.
 
 ## Evidência e rollback
 
@@ -43,3 +55,6 @@ Não use `workflow_dispatch` nesta mudança. Esta PR altera apenas o mecanismo.
 timestamp, sem secrets. Preserve o run de staging com a evidência de smoke e o
 SHA anterior. Rollback continua pelo publisher canônico usando o SHA anterior
 que já tenha evidência de staging válida; migrations permanecem aditivas.
+Falha de erro, latência ou jornada interrompe a promoção: não avance o SHA nem
+altere a flag. Para canary já exposto, aplique o rollback canônico para o SHA
+atestado anterior e desligue a feature flag do módulo quando houver uma.


### PR DESCRIPTION
## Entrega segura\n\n- gera em cada merge na main somente um artefato auditável elease-source-<SHA> (fonte, árvore Git e SHA-256);\n- exige que o SHA de promoção seja alcançável pela main;\n- registra e valida por CI o contrato de preview, staging, piloto, canary, produção, flag, kill switch, rollback e interrupção;\n- mantém piloto/canary fail-closed até existir environment, coorte e observabilidade externa — sem fallback para produção.\n\n## Validação\n\n- 
ode .github/scripts/validate-progressive-release.mjs\n- 
ode .github/scripts/validate-deploy-topology.mjs\n- 
ode .github/scripts/validate-github-governance.mjs\n- parse de 39 workflows YAML\n- git diff --check\n\nNenhum workflow_dispatch, deploy, migration, feature flag remota ou ação de produção foi executada.