### PR TITLE
fix(ci): grant promotion gate evidence access

### DIFF
--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -43,6 +43,7 @@ for (const unit of catalog.units ?? []) {
   if (/^\s{2}(push|schedule|pull_request_target|workflow_run|repository_dispatch):/m.test(source)) fail(`${unit.id} has an automatic publish trigger`);
   if (!/^concurrency:/m.test(source) || !source.includes(unit.concurrencyPrefix)) fail(`${unit.id} must serialize by unit and environment`);
   if (!/^\s+environment:/m.test(source)) fail(`${unit.id} must select a GitHub environment`);
+  if (!/^permissions:\r?\n\s+actions:\s+read\r?\n\s+contents:\s+read/m.test(source)) fail(`${unit.id} must grant the promotion gate actions: read and contents: read`);
   if (!source.includes("promotion-gate.yml") || !source.includes("release_sha") || !source.includes("staging_run_id")) fail(`${unit.id} must use the immutable promotion gate`);
 }
 

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -17,6 +17,10 @@ concurrency:
   group: deploy-core-workers-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -17,6 +17,10 @@ concurrency:
   group: deploy-crm-pages-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -17,6 +17,10 @@ concurrency:
   group: deploy-escala-api-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -12,6 +12,10 @@ concurrency:
   group: deploy-meta-ads-report-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -12,6 +12,10 @@ concurrency:
   group: deploy-social-publisher-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -12,6 +12,10 @@ concurrency:
   group: deploy-website-${{ inputs.target }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml


### PR DESCRIPTION
## Correção\n\nO preview manual #58 falhou antes de jobs porque os callers do gate reutilizável não concediam ctions: read, necessário para verificar evidência de promoção.\n\n- concede apenas ctions: read e contents: read nos publishers;\n- CI passa a exigir essas permissões mínimas.\n\n## Segurança\n\nNenhum deploy foi executado: o preview falhou em startup, antes de jobs. Esta PR não executa workflow dispatch, migration nem publicação.