### PR TITLE
refactor(crm): modularize shell loading

### DIFF
--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -1,10 +1,11 @@
 // Combined NEATLAB layout + full functionality exposure
-import React, { useState, Suspense, lazy, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import { ContextDebugger } from './ContextDebugger'
-import { ErrorBoundary } from '@/ErrorBoundary'
+import { ModuleHost } from '@/modules/ModuleHost'
+import { crmModuleByKey, crmModuleRegistry, moduleAvailability } from '@/modules/registry'
 import { NotificationProvider, useAuth, useNotifications } from '@/contexts'
 import { isOnlineCrmRuntime, unlockedModuleKeys } from '@/moduleAvailability'
-import { LoadingPercentText, LoadingScreen } from '@/LoadingPattern'
+import { LoadingScreen } from '@/LoadingPattern'
 import { AuthScreen } from '@/AuthScreen'
 import { Card, CardContent, CardHeader, CardTitle } from '@/card'
 import { Button } from '@/button'
@@ -46,7 +47,7 @@ import { dispatchAtendimentoHeaderAction, subscribeAtendimentoHeaderState } from
 import type { AtendimentoHeaderState } from '@/atendimentoHeaderBridge'
 import { hasCrmModuleAccess } from '@/crmRoleAccess'
 import { canManagePonto } from '@/pontoAccess'
-import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, ClipboardList, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Stethoscope, WalletCards, X } from 'lucide-react'
+import { BarChart3, CalendarX2, CheckCircle2, ChevronDown, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
 const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
@@ -230,150 +231,7 @@ async function insumosApiJson<T>(
     throw new Error(err.error || err.message || `HTTP ${res.status}`)
 }
 
-// Key functional modules
-const LeadsManager = lazy(() => import('@/LeadsManager').then(m => ({ default: m.LeadsManager })))
-const NotificationCenter = lazy(() => import('@/NotificationCenter').then(m => ({ default: m.NotificationCenter })))
-const ReportsDashboard = lazy(() => import('@/ReportsDashboard').then(m => ({ default: m.ReportsDashboard })))
-const ConversaModule = lazy(() => import('@/ConversaModule').then(m => ({ default: m.ConversaModule })))
-const AtendimentoModule = lazy(() => import('@/AtendimentoModule').then(m => ({ default: m.AtendimentoModule })))
-const CaixaModule = lazy(() => import('@/CaixaModule').then(m => ({ default: m.CaixaModule })))
-const ClientCommercialModule = lazy(() => import('@/ClientCommercialModule').then(m => ({ default: m.ClientCommercialModule })))
-const MetaCampaignControlCenter = lazy(() => import('@/MetaCampaignControlCenter').then(m => ({ default: m.MetaCampaignControlCenter })))
-const MetaCommandCenter = lazy(() => import('@/MetaCommandCenter').then(m => ({ default: m.MetaCommandCenter })))
-const MetaSyncMonitor = lazy(() => import('@/MetaSyncMonitor').then(m => ({ default: m.MetaSyncMonitor })))
-const MetaSentimentMonitor = lazy(() => import('@/MetaSentimentMonitor').then(m => ({ default: m.MetaSentimentMonitor })))
-const InstagramStudioPro = lazy(() => import('@/InstagramStudioPro').then(m => ({ default: m.InstagramStudioPro })))
-const ThreadsStudio = lazy(() => import('@/ThreadsStudio').then(m => ({ default: m.ThreadsStudio })))
-const SocialNetworksStudio = lazy(() => import('@/SocialNetworksStudio').then(m => ({ default: m.SocialNetworksStudio })))
-const MetaPagesReviewStudio = lazy(() => import('@/MetaPagesReviewStudio').then(m => ({ default: m.MetaPagesReviewStudio })))
-const WorkflowEngine = lazy(() => import('@/WorkflowEngine').then(m => ({ default: m.WorkflowEngine })))
-const ProjectManagement = lazy(() => import('@/ProjectManagement').then(m => ({ default: m.ProjectManagement })))
-const KanbanBoard = lazy(() => import('@/KanbanBoard').then(m => ({ default: m.KanbanBoard })))
-const RichTaskManager = lazy(() => import('@/RichTaskManager').then(m => ({ default: m.RichTaskManager })))
-const TerritoriesManager = lazy(() => import('@/TerritoriesManager').then(m => ({ default: m.TerritoriesManager })))
-const QuotesManager = lazy(() => import('@/QuotesManager').then(m => ({ default: m.QuotesManager })))
-const WebFormsManager = lazy(() => import('@/WebFormsManager').then(m => ({ default: m.WebFormsManager })))
-const EmailTemplatesManager = lazy(() => import('@/EmailTemplatesManager').then(m => ({ default: m.EmailTemplatesManager })))
-const FieldsManager = lazy(() => import('@/FieldsManager').then(m => ({ default: m.FieldsManager })))
-const CustomObjectsManager = lazy(() => import('@/CustomObjectsManager').then(m => ({ default: m.CustomObjectsManager })))
-const PermissionsManager = lazy(() => import('@/PermissionsManager').then(m => ({ default: m.PermissionsManager })))
-const ROIDashboard = lazy(() => import('@/ROIDashboard').then(m => ({ default: m.ROIDashboard })))
-const AIAutomationHub = lazy(() => import('@/AIAutomationHub').then(m => ({ default: m.AIAutomationHub })))
-const AgentDashboard = lazy(() => import('@/AgentDashboard').then(m => ({ default: m.AgentDashboard })))
-const PerformanceCoaching = lazy(() => import('@/PerformanceCoaching').then(m => ({ default: m.PerformanceCoaching })))
-const PerformanceAlerts = lazy(() => import('@/PerformanceAlerts').then(m => ({ default: m.PerformanceAlerts })))
-const BackupRecoveryCenter = lazy(() => import('@/BackupRecoveryCenter').then(m => ({ default: m.BackupRecoveryCenter })))
-const SystemMonitoring = lazy(() => import('@/SystemMonitoring').then(m => ({ default: m.SystemMonitoring })))
-const AssetManagement = lazy(() => import('@/AssetManagement').then(m => ({ default: m.AssetManagement })))
-const ManufacturingModule = lazy(() => import('@/ManufacturingModule').then(m => ({ default: m.ManufacturingModule })))
-const HRModule = lazy(() => import('@/HRModule').then(m => ({ default: m.HRModule })))
-const ProcurementModule = lazy(() => import('@/ProcurementModule').then(m => ({ default: m.ProcurementModule })))
-const Financeiro = lazy(() => import('@/FinanceModule').then(m => ({ default: m.FinanceModule })))
-const ProductCatalog = lazy(() => import('@/ProductCatalog').then(m => ({ default: m.ProductCatalog })))
-const PipelineManager = lazy(() => import('@/PipelineManager').then(m => ({ default: m.PipelineManager })))
-const LeadScoringSystem = lazy(() => import('@/LeadScoringSystem').then(m => ({ default: m.LeadScoringSystem })))
-const WebhooksIntegrationsHub = lazy(() => import('@/WebhooksIntegrationsHub').then(m => ({ default: m.WebhooksIntegrationsHub })))
-const MultiCompanyManagement = lazy(() => import('@/MultiCompanyManagement').then(m => ({ default: m.MultiCompanyManagement })))
-const APIExplorer = lazy(() => import('@/APIExplorer').then(m => ({ default: m.APIExplorer })))
-const Relatorios = lazy(() => import('@/ReportsDashboard').then(m => ({ default: m.ReportsDashboard })))
-const NotificationTester = lazy(() => import('@/NotificationTester').then(m => ({ default: m.NotificationTester })))
-const CapabilitiesCenter = lazy(() => import('@/CapabilitiesCenter').then(m => ({ default: m.CapabilitiesCenter })))
-const JobsCenter = lazy(() => import('@/JobsCenter').then(m => ({ default: m.JobsCenter })))
-const UnitMonitor = lazy(() => import('@/UnitMonitor').then(m => ({ default: m.UnitMonitor })))
-const InsumosModule = lazy(() => import('@/InsumosModule').then(m => ({ default: m.InsumosModule })))
-const FaturamentoModule = lazy(() => import('@/FaturamentoModule').then(m => ({ default: m.FaturamentoModule })))
-const ProcedimentosModule = lazy(() => import('@/ProcedimentosModule').then(m => ({ default: m.ProcedimentosModule })))
-const UsersModule = lazy(() => import('@/UsersModule').then(m => ({ default: m.UsersModule })))
-const SystemStatusModule = lazy(() => import('@/SystemStatusModule').then(m => ({ default: m.SystemStatusModule })))
-const PontoModule = lazy(() => import('@/PontoModule').then(m => ({ default: m.PontoModule })))
-const EscalaProfissionaisModule = lazy(() => import('@/EscalaProfissionaisModule').then(m => ({ default: m.EscalaProfissionaisModule })))
-const SiteTrackingModule = lazy(() => import('@/SiteTrackingModule').then(m => ({ default: m.SiteTrackingModule })))
-
-// TODO: Add remaining modules if needed
-
-const modules: { key: string; label: string; icon: React.ReactNode; component: React.ReactNode }[] = [
-    { key: 'capabilities', label: 'Plataforma', icon: '🧭', component: <CapabilitiesCenter /> },
-    { key: 'jobs', label: 'Execuções', icon: '🏃', component: <JobsCenter /> },
-    { key: 'status', label: 'Status', icon: '📡', component: <SystemStatusModule /> },
-    { key: 'unit-monitor', label: 'Unit Monitor', icon: '📹', component: <UnitMonitor /> },
-    {
-        key: 'insumos',
-        label: 'Insumos',
-        icon: <img src="/icons/insumos-icon-192.svg" alt="" aria-hidden className="h-5 w-5" />,
-        component: <InsumosModule />
-    },
-    { key: 'users', label: 'Usuários', icon: '👤', component: <UsersModule /> },
-    { key: 'dashboard', label: 'Analítica', icon: <img src="/icons/chart.png" alt="" aria-hidden className="h-5 w-5" />, component: <ReportsDashboard /> },
-    { key: 'leads', label: 'Leads', icon: '💎', component: <LeadsManager /> },
-    { key: 'clientes', label: 'Clientes', icon: '👥', component: <ClientCommercialModule /> },
-    { key: 'notifications', label: 'Notificações', icon: '🔔', component: <NotificationCenter /> },
-    { key: 'conversa', label: 'Conversa', icon: '💬', component: <ConversaModule /> },
-    {
-        key: 'atendimento',
-        label: 'Atendimento',
-        icon: (
-            <span className="relative inline-flex h-5 w-5 items-center justify-center text-sky-100" aria-hidden>
-                <Stethoscope className="absolute h-4 w-4 -translate-x-1 translate-y-0.5" />
-                <ClipboardList className="absolute h-3.5 w-3.5 translate-x-1 -translate-y-0.5 text-emerald-200" />
-            </span>
-        ),
-        component: <AtendimentoModule />
-    },
-    { key: 'caixa', label: 'Caixa', icon: '💰', component: <CaixaModule /> },
-    {
-        key: 'faturamento',
-        label: 'Faturamento',
-        icon: <WalletCards className="h-5 w-5 text-emerald-100" aria-hidden />,
-        component: <FaturamentoModule />
-    },
-    {
-        key: 'procedimentos',
-        label: 'Procedimentos',
-        icon: <ClipboardList className="h-5 w-5 text-sky-100" aria-hidden />,
-        component: <ProcedimentosModule />
-    },
-    { key: 'escala-profissionais', label: 'Escala', icon: '🗓️', component: <EscalaProfissionaisModule /> },
-    { key: 'site-tracking', label: 'Site EF', icon: '📍', component: <SiteTrackingModule /> },
-    { key: 'meta-ads', label: 'Meta Ads', icon: '📢', component: <MetaCampaignControlCenter /> },
-    { key: 'meta-command', label: 'Meta Command', icon: '🧭', component: <MetaCommandCenter /> },
-    { key: 'meta-sync', label: 'Meta Sync', icon: '🔄', component: <MetaSyncMonitor /> },
-    { key: 'meta-sentiment', label: 'Sentimento', icon: '🧠', component: <MetaSentimentMonitor /> },
-    { key: 'meta-pages-review', label: 'Meta Review', icon: '🧪', component: <MetaPagesReviewStudio /> },
-    { key: 'instagram-studio', label: 'Redes Sociais', icon: '🌐', component: <SocialNetworksStudio /> },
-    { key: 'threads-studio', label: 'Threads', icon: '🧵', component: <ThreadsStudio /> },
-    { key: 'workflow', label: 'Workflows', icon: '⚙️', component: <WorkflowEngine /> },
-    { key: 'projects', label: 'Projetos', icon: '📁', component: <ProjectManagement /> },
-    { key: 'kanban', label: 'Kanban', icon: '🗂️', component: <KanbanBoard type="tasks" title="Quadro Kanban" description="Gestão visual de tarefas" /> },
-    { key: 'tasks', label: 'Tarefas', icon: '✅', component: <RichTaskManager /> },
-    { key: 'territories', label: 'Territórios', icon: '🗺️', component: <TerritoriesManager /> },
-    { key: 'quotes', label: 'Cotações', icon: '💬', component: <QuotesManager /> },
-    { key: 'web-forms', label: 'Forms', icon: '📝', component: <WebFormsManager /> },
-    { key: 'email-templates', label: 'Templates', icon: '✉️', component: <EmailTemplatesManager /> },
-    { key: 'fields', label: 'Campos', icon: '🧩', component: <FieldsManager objectType="customer" objectName="Cliente" /> },
-    { key: 'permissions', label: 'Permissões', icon: '🔑', component: <PermissionsManager /> },
-    { key: 'custom-objects', label: 'Objetos', icon: '🛠️', component: <CustomObjectsManager /> },
-    { key: 'roi', label: 'ROI', icon: '📈', component: <ROIDashboard /> },
-    { key: 'ai-automation', label: 'AI Automação', icon: '🤖', component: <AIAutomationHub /> },
-    { key: 'agent-dashboard', label: 'Agentes', icon: '🧑‍💼', component: <AgentDashboard /> },
-    { key: 'coaching', label: 'Coaching', icon: '🎯', component: <PerformanceCoaching /> },
-    { key: 'alerts', label: 'Alertas', icon: <img src="/icons/emergency.png" alt="" aria-hidden className="h-5 w-5" />, component: <PerformanceAlerts /> },
-    { key: 'backup-recovery', label: 'Backup', icon: '💾', component: <BackupRecoveryCenter /> },
-    { key: 'system-monitoring', label: 'Monitoramento', icon: '🖥️', component: <SystemMonitoring /> },
-    { key: 'assets', label: 'Ativos', icon: '📦', component: <AssetManagement /> },
-    { key: 'manufacturing', label: 'Fabricação', icon: '🏭', component: <ManufacturingModule /> },
-    { key: 'hr', label: 'RH', icon: '👥', component: <HRModule /> },
-    { key: 'ponto', label: 'Ponto', icon: '⏱️', component: <PontoModule /> },
-    { key: 'procurement', label: 'Compras', icon: '🛒', component: <ProcurementModule /> },
-    { key: 'finance', label: 'Financeiro', icon: <img src="/icons/money.png" alt="" aria-hidden className="h-5 w-5" />, component: <Financeiro /> },
-    { key: 'products', label: 'Produtos', icon: '📂', component: <ProductCatalog /> },
-    { key: 'pipelines', label: 'Pipelines', icon: '🔀', component: <PipelineManager /> },
-    { key: 'lead-scoring', label: 'Lead Scoring', icon: '⭐', component: <LeadScoringSystem /> },
-    { key: 'webhooks', label: 'Webhooks', icon: '🔌', component: <WebhooksIntegrationsHub /> },
-    { key: 'companies', label: 'Empresas', icon: '🏢', component: <MultiCompanyManagement /> },
-    { key: 'notifications-test', label: 'Notif. Tester', icon: '🔔', component: <NotificationTester /> },
-    { key: 'api', label: 'API', icon: '🧪', component: <APIExplorer /> },
-    { key: 'reports', label: 'Relatórios', icon: <img src="/icons/chart.png" alt="" aria-hidden className="h-5 w-5" />, component: <Relatorios /> },
-]
+const modules = crmModuleRegistry
 
 export default function AppFunctionalNeatlab() {
     const { isAuthenticated, user, signOut, initializing, initProgress } = useAuth()
@@ -841,6 +699,10 @@ export default function AppFunctionalNeatlab() {
         () => permittedModulesSorted.filter((m) => UNLOCKED_MODULE_KEYS.has(m.key)),
         [UNLOCKED_MODULE_KEYS, permittedModulesSorted]
     )
+
+    const moduleAccessContext = useMemo(() => ({ role: roleKey, allowedModules: user?.allowedModules, enabledModuleKeys: UNLOCKED_MODULE_KEYS, financeEnabled }), [UNLOCKED_MODULE_KEYS, financeEnabled, roleKey, user?.allowedModules])
+    const activeModuleManifest = crmModuleByKey.get(active)
+    const activeModuleAvailability = activeModuleManifest ? moduleAvailability(activeModuleManifest, moduleAccessContext) : { available: false, reason: 'O módulo solicitado não está registrado.' }
 
     React.useEffect(() => {
         if (!hasModuleAccess(active)) {
@@ -2382,32 +2244,10 @@ export default function AppFunctionalNeatlab() {
 
                             <div className={`relative z-10 min-w-0 ${active === 'conversa' ? 'flex h-full min-h-0 flex-col' : active === 'site-tracking' ? 'max-w-full overflow-x-hidden' : ''}`}>
                                 <div className="hidden">{search}</div>
-                                <ErrorBoundary>
-                                    <Suspense fallback={
-                                        <div className="glass-morphism rounded-2xl p-8 border border-white/20 animate-pulse">
-                                            <div className="space-y-1">
-                                                <LoadingPercentText label="Carregando módulo" className="text-white/90" showPercent={false} />
-                                                <div className="text-blue-300/60 text-sm">Preparando interface empresarial</div>
-                                            </div>
-                                        </div>
-                                    }>
-                                    <div className={`animate-fade-in ${active === 'conversa' ? 'flex h-full min-h-0 flex-col' : ''}`}>
-                                        {mountedModuleKeys
-                                            .map((key) => permittedModulesSorted.find((m) => m.key === key))
-                                            .filter((m) => Boolean(m) && UNLOCKED_MODULE_KEYS.has((m as any).key))
-                                            .map((m) => {
-                                                const moduleEntry = m as (typeof modules)[number]
-                                                const isActive = moduleEntry.key === active
-                                                return (
-                                                    <div key={moduleEntry.key} hidden={!isActive} className={active === 'conversa' ? 'h-full min-h-0' : active === 'site-tracking' ? 'min-w-0 max-w-full overflow-x-hidden' : undefined}>
-                                                        {moduleEntry.component}
-                                                    </div>
-                                                )
-                                            })}
-                                    </div>
-                                    </Suspense>
-                                    <ContextDebugger />
-                                </ErrorBoundary>
+                                <div className={`animate-fade-in ${active === 'conversa' ? 'flex h-full min-h-0 flex-col' : ''}`}>
+                                    {activeModuleManifest ? <div className={active === 'conversa' ? 'h-full min-h-0' : active === 'site-tracking' ? 'min-w-0 max-w-full overflow-x-hidden' : undefined}><ModuleHost manifest={activeModuleManifest} availability={activeModuleAvailability} onReturnToNavigation={() => selectModule(permittedUnlockedModules[0]?.key || DEFAULT_MODULE_KEY)} /></div> : null}
+                                </div>
+                                <ContextDebugger />
                             </div>
                         </main>
                     </div>

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -233,6 +233,15 @@ async function insumosApiJson<T>(
 
 const modules = crmModuleRegistry
 
+function configuredMaintenanceModuleKeys(): Set<string> {
+    return new Set(
+        String(import.meta.env.VITE_CRM_MAINTENANCE_MODULES || '')
+            .split(',')
+            .map((key) => key.trim())
+            .filter((key) => crmModuleByKey.has(key)),
+    )
+}
+
 export default function AppFunctionalNeatlab() {
     const { isAuthenticated, user, signOut, initializing, initProgress } = useAuth()
 
@@ -356,9 +365,9 @@ export default function AppFunctionalNeatlab() {
 	    const [active, setActive] = useState<string>(() => {
 		        try {
 		            const requested = new URLSearchParams(window.location.search).get('module') || new URLSearchParams(window.location.search).get('tab')
-		            if (requested && UNLOCKED_MODULE_KEYS.has(requested) && modules.some((module) => module.key === requested)) {
-		                return requested
-		            }
+            if (requested && crmModuleByKey.has(requested)) {
+                return requested
+            }
 		            const saved = localStorage.getItem('app.activeModule')
 		            const candidate = saved || DEFAULT_MODULE_KEY
 		            return UNLOCKED_MODULE_KEYS.has(candidate) ? candidate : DEFAULT_MODULE_KEY
@@ -376,9 +385,9 @@ export default function AppFunctionalNeatlab() {
 		    const mountedModuleKeys = useMemo(() => [active], [active])
 
 	    React.useEffect(() => {
-	        if (UNLOCKED_MODULE_KEYS.has(active)) return
-	        setActive(DEFAULT_MODULE_KEY)
-	    }, [DEFAULT_MODULE_KEY, UNLOCKED_MODULE_KEYS, active])
+        if (crmModuleByKey.has(active)) return
+        setActive(DEFAULT_MODULE_KEY)
+    }, [DEFAULT_MODULE_KEY, active])
         const [search, setSearch] = useState('')
         const [conversaHeaderState, setConversaHeaderState] = useState<ConversaHeaderState | null>(null)
         const [atendimentoHeaderState, setAtendimentoHeaderState] = useState<AtendimentoHeaderState | null>(null)
@@ -700,16 +709,17 @@ export default function AppFunctionalNeatlab() {
         [UNLOCKED_MODULE_KEYS, permittedModulesSorted]
     )
 
-    const moduleAccessContext = useMemo(() => ({ role: roleKey, allowedModules: user?.allowedModules, enabledModuleKeys: UNLOCKED_MODULE_KEYS, financeEnabled }), [UNLOCKED_MODULE_KEYS, financeEnabled, roleKey, user?.allowedModules])
+    const maintenanceModuleKeys = useMemo(configuredMaintenanceModuleKeys, [])
+    const moduleAccessContext = useMemo(() => ({ role: roleKey, allowedModules: user?.allowedModules, enabledModuleKeys: UNLOCKED_MODULE_KEYS, maintenanceModuleKeys, financeEnabled }), [UNLOCKED_MODULE_KEYS, financeEnabled, maintenanceModuleKeys, roleKey, user?.allowedModules])
     const activeModuleManifest = crmModuleByKey.get(active)
-    const activeModuleAvailability = activeModuleManifest ? moduleAvailability(activeModuleManifest, moduleAccessContext) : { available: false, reason: 'O módulo solicitado não está registrado.' }
-
-    React.useEffect(() => {
-        if (!hasModuleAccess(active)) {
-            const next = permittedUnlockedModules[0]?.key || null
-            if (next && next !== active) setActive(next)
-        }
-    }, [active, hasModuleAccess, permittedUnlockedModules])
+    const activeModuleAvailability = activeModuleManifest ? moduleAvailability(activeModuleManifest, moduleAccessContext) : { available: false, state: 'unreleased' as const, reason: 'O módulo solicitado não está registrado.' }
+    const availableModuleKeys = useMemo(
+        () => crmModuleRegistry
+            .filter((manifest) => permittedUnlockedModules.some((entry) => entry.key === manifest.key))
+            .filter((manifest) => moduleAvailability(manifest, moduleAccessContext).available)
+            .map((manifest) => manifest.key),
+        [moduleAccessContext, permittedUnlockedModules],
+    )
 
     const filteredModules = useMemo(
         () =>
@@ -2245,7 +2255,7 @@ export default function AppFunctionalNeatlab() {
                             <div className={`relative z-10 min-w-0 ${active === 'conversa' ? 'flex h-full min-h-0 flex-col' : active === 'site-tracking' ? 'max-w-full overflow-x-hidden' : ''}`}>
                                 <div className="hidden">{search}</div>
                                 <div className={`animate-fade-in ${active === 'conversa' ? 'flex h-full min-h-0 flex-col' : ''}`}>
-                                    {activeModuleManifest ? <div className={active === 'conversa' ? 'h-full min-h-0' : active === 'site-tracking' ? 'min-w-0 max-w-full overflow-x-hidden' : undefined}><ModuleHost manifest={activeModuleManifest} availability={activeModuleAvailability} onReturnToNavigation={() => selectModule(permittedUnlockedModules[0]?.key || DEFAULT_MODULE_KEY)} /></div> : null}
+                                    {activeModuleManifest ? <div className={active === 'conversa' ? 'h-full min-h-0' : active === 'site-tracking' ? 'min-w-0 max-w-full overflow-x-hidden' : undefined}><ModuleHost manifest={activeModuleManifest} availability={activeModuleAvailability} onReturnToNavigation={() => selectModule(active === DEFAULT_MODULE_KEY ? (availableModuleKeys.find((key) => key !== active) || DEFAULT_MODULE_KEY) : DEFAULT_MODULE_KEY)} /></div> : null}
                                 </div>
                                 <ContextDebugger />
                             </div>

--- a/crm/console/e2e/module-shell-isolation.spec.ts
+++ b/crm/console/e2e/module-shell-isolation.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, type Page } from '@playwright/test'
+
+async function mockAuthenticatedShell(page: Page, allowedModules: string[] = ['finance']) {
+  await page.route('**/api/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, success: true, data: [], total: 0, summary: {}, rankings: {}, monthly: [], units: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }] }),
+    })
+  })
+  await page.route('**/api/auth/me**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        user: {
+          username: 'shell-e2e',
+          email: 'shell-e2e@staging.invalid',
+          role: 'GESTOR',
+          allowedUnits: ['novo-hamburgo'],
+          allowedModules,
+        },
+      }),
+    })
+  })
+  await page.route('**/api/finance/bootstrap**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, moduleEnabled: true, canAccess: true }) })
+  })
+}
+
+test('direct URLs retain an isolated maintenance state and keep other modules reachable', async ({ page }) => {
+  await mockAuthenticatedShell(page)
+  await page.goto('/?module=atendimento')
+
+  await expect(page.getByTestId('module-unavailable')).toBeVisible()
+  await expect(page.getByText('Atendimento em manutenção', { exact: true })).toBeVisible()
+  await expect(page.getByText(/navegação e os demais módulos continuam disponíveis/i)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Voltar aos módulos' }).click()
+  await expect(page).toHaveURL(/module=insumos/)
+})
+
+test('unit selection remains available after the shell loads a module directly', async ({ page }) => {
+  await mockAuthenticatedShell(page)
+  await page.goto('/?module=insumos')
+
+  const unitPicker = page.getByRole('combobox').first()
+  await expect(unitPicker).toBeVisible({ timeout: 30_000 })
+  await unitPicker.click()
+  await page.getByRole('option', { name: 'Barra Shopping Sul' }).click()
+  await expect(unitPicker).toContainText('Barra Shopping Sul')
+})
+
+test('a Finance chunk failure does not take down the shell or another module', async ({ page }) => {
+  await mockAuthenticatedShell(page)
+  await page.route('**/FinanceModule.tsx*', async (route) => route.abort('failed'))
+  await page.goto('/?module=finance')
+
+  await expect(page.getByText('Este módulo está indisponível')).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText(/falha foi isolada/i)).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Insumos' })).toBeVisible()
+
+  // Vite's development error overlay is outside the application shell. Dismiss it
+  // before exercising the navigation that remains available in the real bundle.
+  const closeDevOverlay = page.locator('#close-overlay')
+  if (await closeDevOverlay.isVisible().catch(() => false)) await closeDevOverlay.click()
+  await page.getByRole('button', { name: 'Insumos' }).click()
+  await expect(page).toHaveURL(/module=insumos/)
+  await expect(page.getByRole('heading', { name: 'Insumos' })).toBeVisible({ timeout: 30_000 })
+})

--- a/crm/console/e2e/module-shell-isolation.spec.ts
+++ b/crm/console/e2e/module-shell-isolation.spec.ts
@@ -30,6 +30,7 @@ async function mockAuthenticatedShell(page: Page, allowedModules: string[] = ['f
 }
 
 test('direct URLs retain an isolated maintenance state and keep other modules reachable', async ({ page }) => {
+  test.skip(process.env.E2E_MODULE_MAINTENANCE_KEY !== 'atendimento', 'Requires VITE_CRM_MAINTENANCE_MODULES=atendimento in the test server.')
   await mockAuthenticatedShell(page)
   await page.goto('/?module=atendimento')
 

--- a/crm/console/modules/ModuleHost.tsx
+++ b/crm/console/modules/ModuleHost.tsx
@@ -7,7 +7,7 @@ import type { CrmModuleManifest, ModuleAvailability } from './types'
 type BoundaryProps = { moduleKey: string; children: ReactNode; onReturnToNavigation: () => void; onRetry: () => void }
 type BoundaryState = { error: boolean }
 
-class ModuleErrorBoundary extends Component<BoundaryProps, BoundaryState> {
+export class ModuleErrorBoundary extends Component<BoundaryProps, BoundaryState> {
   state: BoundaryState = { error: false }
   static getDerivedStateFromError() { return { error: true } }
   componentDidCatch(_error: Error, _errorInfo: ErrorInfo) {
@@ -23,7 +23,8 @@ class ModuleErrorBoundary extends Component<BoundaryProps, BoundaryState> {
 }
 
 function ModuleUnavailable({ manifest, availability, onReturnToNavigation }: { manifest: CrmModuleManifest; availability: ModuleAvailability; onReturnToNavigation: () => void }) {
-  return <Card className="border-white/15 bg-slate-950/60 text-white"><CardHeader><CardTitle>{manifest.fallback.unavailableLabel}</CardTitle><CardDescription>{availability.reason || 'O acesso a este módulo não está disponível neste ambiente.'}</CardDescription></CardHeader><CardContent><Button variant="outline" onClick={onReturnToNavigation}>Voltar aos módulos</Button></CardContent></Card>
+  const title = availability.state === 'maintenance' ? `${manifest.label} em manutenção` : manifest.fallback.unavailableLabel
+  return <Card className="border-white/15 bg-slate-950/60 text-white" data-testid="module-unavailable"><CardHeader><CardTitle>{title}</CardTitle><CardDescription>{availability.reason || 'O acesso a este módulo não está disponível neste ambiente.'}</CardDescription></CardHeader><CardContent><Button variant="outline" onClick={onReturnToNavigation}>Voltar aos módulos</Button></CardContent></Card>
 }
 
 export function ModuleHost({ manifest, availability, onReturnToNavigation }: { manifest: CrmModuleManifest; availability: ModuleAvailability; onReturnToNavigation: () => void }) {

--- a/crm/console/modules/ModuleHost.tsx
+++ b/crm/console/modules/ModuleHost.tsx
@@ -1,0 +1,34 @@
+import React, { Component, Suspense, useMemo, useState } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { Button } from '@/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
+import type { CrmModuleManifest, ModuleAvailability } from './types'
+
+type BoundaryProps = { moduleKey: string; children: ReactNode; onReturnToNavigation: () => void; onRetry: () => void }
+type BoundaryState = { error: boolean }
+
+class ModuleErrorBoundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { error: false }
+  static getDerivedStateFromError() { return { error: true } }
+  componentDidCatch(_error: Error, _errorInfo: ErrorInfo) {
+    console.error(JSON.stringify({ level: 'error', scope: 'crm-module', module: this.props.moduleKey, event: 'render_failed' }))
+  }
+  componentDidUpdate(previous: BoundaryProps) {
+    if (previous.moduleKey !== this.props.moduleKey && this.state.error) this.setState({ error: false })
+  }
+  render() {
+    if (!this.state.error) return this.props.children
+    return <Card className="border-amber-400/30 bg-slate-950/60 text-white"><CardHeader><CardTitle>Este módulo está indisponível</CardTitle><CardDescription>A falha foi isolada. A navegação e os demais módulos continuam disponíveis.</CardDescription></CardHeader><CardContent className="flex flex-wrap gap-3"><Button onClick={() => { this.setState({ error: false }); this.props.onRetry() }}>Tentar novamente</Button><Button variant="outline" onClick={this.props.onReturnToNavigation}>Voltar aos módulos</Button></CardContent></Card>
+  }
+}
+
+function ModuleUnavailable({ manifest, availability, onReturnToNavigation }: { manifest: CrmModuleManifest; availability: ModuleAvailability; onReturnToNavigation: () => void }) {
+  return <Card className="border-white/15 bg-slate-950/60 text-white"><CardHeader><CardTitle>{manifest.fallback.unavailableLabel}</CardTitle><CardDescription>{availability.reason || 'O acesso a este módulo não está disponível neste ambiente.'}</CardDescription></CardHeader><CardContent><Button variant="outline" onClick={onReturnToNavigation}>Voltar aos módulos</Button></CardContent></Card>
+}
+
+export function ModuleHost({ manifest, availability, onReturnToNavigation }: { manifest: CrmModuleManifest; availability: ModuleAvailability; onReturnToNavigation: () => void }) {
+  const [retry, setRetry] = useState(0)
+  const EntryPoint = useMemo(() => React.lazy(() => retry > 0 ? Promise.resolve().then(manifest.loader) : manifest.loader()), [manifest.loader, retry])
+  if (!availability.available) return <ModuleUnavailable manifest={manifest} availability={availability} onReturnToNavigation={onReturnToNavigation} />
+  return <ModuleErrorBoundary moduleKey={manifest.key} onReturnToNavigation={onReturnToNavigation} onRetry={() => setRetry((value) => value + 1)}><Suspense fallback={<div className="glass-morphism rounded-2xl border border-white/20 p-8" role="status"><div className="text-white/90">{manifest.fallback.loadingLabel}</div><div className="mt-1 text-sm text-blue-300/60">Carregamento isolado do módulo {manifest.label}.</div></div>}><EntryPoint /></Suspense></ModuleErrorBoundary>
+}

--- a/crm/console/modules/registry.tsx
+++ b/crm/console/modules/registry.tsx
@@ -67,8 +67,9 @@ export const crmModuleRegistry: readonly CrmModuleManifest[] = [
 
 export const crmModuleByKey = new Map(crmModuleRegistry.map((entry) => [entry.key, entry]))
 export function moduleAvailability(manifestEntry: CrmModuleManifest, context: ModuleAccessContext): ModuleAvailability {
-  if (!context.enabledModuleKeys.has(manifestEntry.key)) return { available: false, reason: 'Este módulo ainda não foi liberado neste ambiente.' }
-  if (manifestEntry.key === 'finance' && !context.financeEnabled) return { available: false, reason: 'Financeiro aguarda liberação operacional e escopo explícito.' }
-  if (!hasCrmModuleAccess(context.role, context.allowedModules, manifestEntry.key)) return { available: false, reason: 'Você não possui a permissão necessária para este módulo.' }
-  return { available: true }
+  if (!context.enabledModuleKeys.has(manifestEntry.key)) return { available: false, state: 'unreleased', reason: 'Este módulo ainda não foi liberado neste ambiente.' }
+  if (manifestEntry.key === 'finance' && !context.financeEnabled) return { available: false, state: 'unreleased', reason: 'Financeiro aguarda liberação operacional e escopo explícito.' }
+  if (!hasCrmModuleAccess(context.role, context.allowedModules, manifestEntry.key)) return { available: false, state: 'forbidden', reason: 'Você não possui a permissão necessária para este módulo.' }
+  if (context.maintenanceModuleKeys?.has(manifestEntry.key)) return { available: false, state: 'maintenance', reason: 'Este módulo está em manutenção programada. A navegação e os demais módulos continuam disponíveis.' }
+  return { available: true, state: 'available' }
 }

--- a/crm/console/modules/registry.tsx
+++ b/crm/console/modules/registry.tsx
@@ -1,0 +1,74 @@
+import { ClipboardList, Stethoscope, WalletCards } from 'lucide-react'
+import { hasCrmModuleAccess } from '@/crmRoleAccess'
+import type { CrmModuleManifest, ModuleAccessContext, ModuleAvailability } from './types'
+
+const fallbackFor = (label: string) => ({ loadingLabel: `Carregando ${label}`, unavailableLabel: `${label} indisponível` })
+const manifest = (entry: Omit<CrmModuleManifest, 'permissions' | 'fallback'>): CrmModuleManifest => ({ ...entry, permissions: [`module.${entry.key}.access`], fallback: fallbackFor(entry.label) })
+
+/** Declarative boundary for every CRM module: permissions, lazy entrypoint and fallbacks. */
+export const crmModuleRegistry: readonly CrmModuleManifest[] = [
+  manifest({ key: 'capabilities', label: 'Plataforma', icon: '🧭', loader: () => import('@/CapabilitiesCenter').then((m) => ({ default: m.CapabilitiesCenter })) }),
+  manifest({ key: 'jobs', label: 'Execuções', icon: '🏃', loader: () => import('@/JobsCenter').then((m) => ({ default: m.JobsCenter })) }),
+  manifest({ key: 'status', label: 'Status', icon: '📡', loader: () => import('@/SystemStatusModule').then((m) => ({ default: m.SystemStatusModule })) }),
+  manifest({ key: 'unit-monitor', label: 'Unit Monitor', icon: '📹', loader: () => import('@/UnitMonitor').then((m) => ({ default: m.UnitMonitor })) }),
+  manifest({ key: 'insumos', label: 'Insumos', icon: <img src="/icons/insumos-icon-192.svg" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/InsumosModule').then((m) => ({ default: m.InsumosModule })) }),
+  manifest({ key: 'users', label: 'Usuários', icon: '👤', loader: () => import('@/UsersModule').then((m) => ({ default: m.UsersModule })) }),
+  manifest({ key: 'dashboard', label: 'Analítica', icon: <img src="/icons/chart.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/ReportsDashboard').then((m) => ({ default: m.ReportsDashboard })) }),
+  manifest({ key: 'leads', label: 'Leads', icon: '💎', loader: () => import('@/LeadsManager').then((m) => ({ default: m.LeadsManager })) }),
+  manifest({ key: 'clientes', label: 'Clientes', icon: '👥', loader: () => import('@/ClientCommercialModule').then((m) => ({ default: m.ClientCommercialModule })) }),
+  manifest({ key: 'notifications', label: 'Notificações', icon: '🔔', loader: () => import('@/NotificationCenter').then((m) => ({ default: m.NotificationCenter })) }),
+  manifest({ key: 'conversa', label: 'Conversa', icon: '💬', loader: () => import('@/ConversaModule').then((m) => ({ default: m.ConversaModule })) }),
+  manifest({ key: 'atendimento', label: 'Atendimento', icon: <span className="relative inline-flex h-5 w-5 items-center justify-center text-sky-100" aria-hidden><Stethoscope className="absolute h-4 w-4 -translate-x-1 translate-y-0.5" /><ClipboardList className="absolute h-3.5 w-3.5 translate-x-1 -translate-y-0.5 text-emerald-200" /></span>, loader: () => import('@/AtendimentoModule').then((m) => ({ default: m.AtendimentoModule })) }),
+  manifest({ key: 'caixa', label: 'Caixa', icon: '💰', loader: () => import('@/CaixaModule').then((m) => ({ default: m.CaixaModule })) }),
+  manifest({ key: 'faturamento', label: 'Faturamento', icon: <WalletCards className="h-5 w-5 text-emerald-100" aria-hidden />, loader: () => import('@/FaturamentoModule').then((m) => ({ default: m.FaturamentoModule })) }),
+  manifest({ key: 'procedimentos', label: 'Procedimentos', icon: <ClipboardList className="h-5 w-5 text-sky-100" aria-hidden />, loader: () => import('@/ProcedimentosModule').then((m) => ({ default: m.ProcedimentosModule })) }),
+  manifest({ key: 'escala-profissionais', label: 'Escala', icon: '🗓️', loader: () => import('@/EscalaProfissionaisModule').then((m) => ({ default: m.EscalaProfissionaisModule })) }),
+  manifest({ key: 'site-tracking', label: 'Site EF', icon: '📍', loader: () => import('@/SiteTrackingModule').then((m) => ({ default: m.SiteTrackingModule })) }),
+  manifest({ key: 'meta-ads', label: 'Meta Ads', icon: '📢', loader: () => import('@/MetaCampaignControlCenter').then((m) => ({ default: m.MetaCampaignControlCenter })) }),
+  manifest({ key: 'meta-command', label: 'Meta Command', icon: '🧭', loader: () => import('@/MetaCommandCenter').then((m) => ({ default: m.MetaCommandCenter })) }),
+  manifest({ key: 'meta-sync', label: 'Meta Sync', icon: '🔄', loader: () => import('@/MetaSyncMonitor').then((m) => ({ default: m.MetaSyncMonitor })) }),
+  manifest({ key: 'meta-sentiment', label: 'Sentimento', icon: '🧠', loader: () => import('@/MetaSentimentMonitor').then((m) => ({ default: m.MetaSentimentMonitor })) }),
+  manifest({ key: 'meta-pages-review', label: 'Meta Review', icon: '🧪', loader: () => import('@/MetaPagesReviewStudio').then((m) => ({ default: m.MetaPagesReviewStudio })) }),
+  manifest({ key: 'instagram-studio', label: 'Redes Sociais', icon: '🌐', loader: () => import('@/SocialNetworksStudio').then((m) => ({ default: m.SocialNetworksStudio })) }),
+  manifest({ key: 'threads-studio', label: 'Threads', icon: '🧵', loader: () => import('@/ThreadsStudio').then((m) => ({ default: m.ThreadsStudio })) }),
+  manifest({ key: 'workflow', label: 'Workflows', icon: '⚙️', loader: () => import('@/WorkflowEngine').then((m) => ({ default: m.WorkflowEngine })) }),
+  manifest({ key: 'projects', label: 'Projetos', icon: '📁', loader: () => import('@/ProjectManagement').then((m) => ({ default: m.ProjectManagement })) }),
+  manifest({ key: 'kanban', label: 'Kanban', icon: '🗂️', loader: () => import('@/KanbanBoard').then((m) => ({ default: () => <m.KanbanBoard type="tasks" title="Quadro Kanban" description="Gestão visual de tarefas" /> })) }),
+  manifest({ key: 'tasks', label: 'Tarefas', icon: '✅', loader: () => import('@/RichTaskManager').then((m) => ({ default: m.RichTaskManager })) }),
+  manifest({ key: 'territories', label: 'Territórios', icon: '🗺️', loader: () => import('@/TerritoriesManager').then((m) => ({ default: m.TerritoriesManager })) }),
+  manifest({ key: 'quotes', label: 'Cotações', icon: '💬', loader: () => import('@/QuotesManager').then((m) => ({ default: m.QuotesManager })) }),
+  manifest({ key: 'web-forms', label: 'Forms', icon: '📝', loader: () => import('@/WebFormsManager').then((m) => ({ default: m.WebFormsManager })) }),
+  manifest({ key: 'email-templates', label: 'Templates', icon: '✉️', loader: () => import('@/EmailTemplatesManager').then((m) => ({ default: m.EmailTemplatesManager })) }),
+  manifest({ key: 'fields', label: 'Campos', icon: '🧩', loader: () => import('@/FieldsManager').then((m) => ({ default: () => <m.FieldsManager objectType="customer" objectName="Cliente" /> })) }),
+  manifest({ key: 'permissions', label: 'Permissões', icon: '🔑', loader: () => import('@/PermissionsManager').then((m) => ({ default: m.PermissionsManager })) }),
+  manifest({ key: 'custom-objects', label: 'Objetos', icon: '🛠️', loader: () => import('@/CustomObjectsManager').then((m) => ({ default: m.CustomObjectsManager })) }),
+  manifest({ key: 'roi', label: 'ROI', icon: '📈', loader: () => import('@/ROIDashboard').then((m) => ({ default: m.ROIDashboard })) }),
+  manifest({ key: 'ai-automation', label: 'AI Automação', icon: '🤖', loader: () => import('@/AIAutomationHub').then((m) => ({ default: m.AIAutomationHub })) }),
+  manifest({ key: 'agent-dashboard', label: 'Agentes', icon: '🧑‍💼', loader: () => import('@/AgentDashboard').then((m) => ({ default: m.AgentDashboard })) }),
+  manifest({ key: 'coaching', label: 'Coaching', icon: '🎯', loader: () => import('@/PerformanceCoaching').then((m) => ({ default: m.PerformanceCoaching })) }),
+  manifest({ key: 'alerts', label: 'Alertas', icon: <img src="/icons/emergency.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/PerformanceAlerts').then((m) => ({ default: m.PerformanceAlerts })) }),
+  manifest({ key: 'backup-recovery', label: 'Backup', icon: '💾', loader: () => import('@/BackupRecoveryCenter').then((m) => ({ default: m.BackupRecoveryCenter })) }),
+  manifest({ key: 'system-monitoring', label: 'Monitoramento', icon: '🖥️', loader: () => import('@/SystemMonitoring').then((m) => ({ default: m.SystemMonitoring })) }),
+  manifest({ key: 'assets', label: 'Ativos', icon: '📦', loader: () => import('@/AssetManagement').then((m) => ({ default: m.AssetManagement })) }),
+  manifest({ key: 'manufacturing', label: 'Fabricação', icon: '🏭', loader: () => import('@/ManufacturingModule').then((m) => ({ default: m.ManufacturingModule })) }),
+  manifest({ key: 'hr', label: 'RH', icon: '👥', loader: () => import('@/HRModule').then((m) => ({ default: m.HRModule })) }),
+  manifest({ key: 'ponto', label: 'Ponto', icon: '⏱️', loader: () => import('@/PontoModule').then((m) => ({ default: m.PontoModule })) }),
+  manifest({ key: 'procurement', label: 'Compras', icon: '🛒', loader: () => import('@/ProcurementModule').then((m) => ({ default: m.ProcurementModule })) }),
+  manifest({ key: 'finance', label: 'Financeiro', icon: <img src="/icons/money.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/FinanceModule').then((m) => ({ default: m.FinanceModule })) }),
+  manifest({ key: 'products', label: 'Produtos', icon: '📂', loader: () => import('@/ProductCatalog').then((m) => ({ default: m.ProductCatalog })) }),
+  manifest({ key: 'pipelines', label: 'Pipelines', icon: '🔀', loader: () => import('@/PipelineManager').then((m) => ({ default: m.PipelineManager })) }),
+  manifest({ key: 'lead-scoring', label: 'Lead Scoring', icon: '⭐', loader: () => import('@/LeadScoringSystem').then((m) => ({ default: m.LeadScoringSystem })) }),
+  manifest({ key: 'webhooks', label: 'Webhooks', icon: '🔌', loader: () => import('@/WebhooksIntegrationsHub').then((m) => ({ default: m.WebhooksIntegrationsHub })) }),
+  manifest({ key: 'companies', label: 'Empresas', icon: '🏢', loader: () => import('@/MultiCompanyManagement').then((m) => ({ default: m.MultiCompanyManagement })) }),
+  manifest({ key: 'notifications-test', label: 'Notif. Tester', icon: '🔔', loader: () => import('@/NotificationTester').then((m) => ({ default: m.NotificationTester })) }),
+  manifest({ key: 'api', label: 'API', icon: '🧪', loader: () => import('@/APIExplorer').then((m) => ({ default: m.APIExplorer })) }),
+  manifest({ key: 'reports', label: 'Relatórios', icon: <img src="/icons/chart.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/ReportsDashboard').then((m) => ({ default: m.ReportsDashboard })) }),
+]
+
+export const crmModuleByKey = new Map(crmModuleRegistry.map((entry) => [entry.key, entry]))
+export function moduleAvailability(manifestEntry: CrmModuleManifest, context: ModuleAccessContext): ModuleAvailability {
+  if (!context.enabledModuleKeys.has(manifestEntry.key)) return { available: false, reason: 'Este módulo ainda não foi liberado neste ambiente.' }
+  if (manifestEntry.key === 'finance' && !context.financeEnabled) return { available: false, reason: 'Financeiro aguarda liberação operacional e escopo explícito.' }
+  if (!hasCrmModuleAccess(context.role, context.allowedModules, manifestEntry.key)) return { available: false, reason: 'Você não possui a permissão necessária para este módulo.' }
+  return { available: true }
+}

--- a/crm/console/modules/types.ts
+++ b/crm/console/modules/types.ts
@@ -1,11 +1,14 @@
 import type { ComponentType, ReactNode } from 'react'
 
-export type ModuleAvailability = { available: boolean; reason?: string }
+export type ModuleAvailabilityState = 'available' | 'unreleased' | 'maintenance' | 'forbidden'
+
+export type ModuleAvailability = { available: boolean; state: ModuleAvailabilityState; reason?: string }
 
 export type ModuleAccessContext = {
   role: unknown
   allowedModules: unknown
   enabledModuleKeys: ReadonlySet<string>
+  maintenanceModuleKeys?: ReadonlySet<string>
   financeEnabled: boolean
 }
 

--- a/crm/console/modules/types.ts
+++ b/crm/console/modules/types.ts
@@ -1,0 +1,19 @@
+import type { ComponentType, ReactNode } from 'react'
+
+export type ModuleAvailability = { available: boolean; reason?: string }
+
+export type ModuleAccessContext = {
+  role: unknown
+  allowedModules: unknown
+  enabledModuleKeys: ReadonlySet<string>
+  financeEnabled: boolean
+}
+
+export type CrmModuleManifest = {
+  key: string
+  label: string
+  icon: ReactNode
+  permissions: readonly string[]
+  loader: () => Promise<{ default: ComponentType }>
+  fallback: { loadingLabel: string; unavailableLabel: string }
+}

--- a/crm/console/tests/moduleRegistry.test.ts
+++ b/crm/console/tests/moduleRegistry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { crmModuleRegistry, moduleAvailability } from '../modules/registry'
+import { ModuleErrorBoundary } from '../modules/ModuleHost'
 
 describe('CRM module registry', () => {
   it('gives every module a manifest, lazy entrypoint, permission and isolated states', () => {
@@ -18,7 +19,21 @@ describe('CRM module registry', () => {
     const atendimento = crmModuleRegistry.find((entry) => entry.key === 'atendimento')!
     const finance = crmModuleRegistry.find((entry) => entry.key === 'finance')!
     const enabled = new Set(['atendimento', 'finance'])
-    expect(moduleAvailability(atendimento, { role: 'GESTOR', allowedModules: [], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: true })
-    expect(moduleAvailability(finance, { role: 'GESTOR', allowedModules: ['finance'], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: false, reason: 'Financeiro aguarda liberação operacional e escopo explícito.' })
+    expect(moduleAvailability(atendimento, { role: 'GESTOR', allowedModules: [], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: true, state: 'available' })
+    expect(moduleAvailability(finance, { role: 'GESTOR', allowedModules: ['finance'], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: false, state: 'unreleased', reason: 'Financeiro aguarda liberação operacional e escopo explícito.' })
+  })
+
+  it('keeps maintenance isolated from access, release and other modules', () => {
+    const atendimento = crmModuleRegistry.find((entry) => entry.key === 'atendimento')!
+    const insumos = crmModuleRegistry.find((entry) => entry.key === 'insumos')!
+    const enabled = new Set(['atendimento', 'insumos'])
+    const maintenance = new Set(['atendimento'])
+
+    expect(moduleAvailability(atendimento, { role: 'GESTOR', allowedModules: [], enabledModuleKeys: enabled, maintenanceModuleKeys: maintenance, financeEnabled: false })).toEqual({ available: false, state: 'maintenance', reason: 'Este módulo está em manutenção programada. A navegação e os demais módulos continuam disponíveis.' })
+    expect(moduleAvailability(insumos, { role: 'GESTOR', allowedModules: [], enabledModuleKeys: enabled, maintenanceModuleKeys: maintenance, financeEnabled: false })).toEqual({ available: true, state: 'available' })
+  })
+
+  it('turns a rendering exception into an isolated module recovery state', () => {
+    expect(ModuleErrorBoundary.getDerivedStateFromError(new Error('synthetic render failure'))).toEqual({ error: true })
   })
 })

--- a/crm/console/tests/moduleRegistry.test.ts
+++ b/crm/console/tests/moduleRegistry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { crmModuleRegistry, moduleAvailability } from '../modules/registry'
+
+describe('CRM module registry', () => {
+  it('gives every module a manifest, lazy entrypoint, permission and isolated states', () => {
+    const keys = crmModuleRegistry.map((entry) => entry.key)
+    expect(new Set(keys).size).toBe(keys.length)
+    expect(keys.length).toBeGreaterThan(50)
+    for (const entry of crmModuleRegistry) {
+      expect(entry.permissions).toContain(`module.${entry.key}.access`)
+      expect(entry.loader).toBeTypeOf('function')
+      expect(entry.fallback.loadingLabel).toContain(entry.label)
+      expect(entry.fallback.unavailableLabel).toContain(entry.label)
+    }
+  })
+
+  it('isolates an unavailable module without making another module unavailable', () => {
+    const atendimento = crmModuleRegistry.find((entry) => entry.key === 'atendimento')!
+    const finance = crmModuleRegistry.find((entry) => entry.key === 'finance')!
+    const enabled = new Set(['atendimento', 'finance'])
+    expect(moduleAvailability(atendimento, { role: 'GESTOR', allowedModules: [], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: true })
+    expect(moduleAvailability(finance, { role: 'GESTOR', allowedModules: ['finance'], enabledModuleKeys: enabled, financeEnabled: false })).toEqual({ available: false, reason: 'Financeiro aguarda liberação operacional e escopo explícito.' })
+  })
+})

--- a/crm/console/tests/moduleRegistry.test.ts
+++ b/crm/console/tests/moduleRegistry.test.ts
@@ -34,6 +34,6 @@ describe('CRM module registry', () => {
   })
 
   it('turns a rendering exception into an isolated module recovery state', () => {
-    expect(ModuleErrorBoundary.getDerivedStateFromError(new Error('synthetic render failure'))).toEqual({ error: true })
+    expect(ModuleErrorBoundary.getDerivedStateFromError()).toEqual({ error: true })
   })
 })

--- a/docs/architecture/crm-shell-module-registry.md
+++ b/docs/architecture/crm-shell-module-registry.md
@@ -1,0 +1,15 @@
+# Shell lógico do CRM e módulos carregados sob demanda
+
+O shell em `crm/console/App.tsx` conserva autenticação, seleção de unidade,
+navegação, permissões de navegação, layout e contexto de cabeçalho. Os módulos
+são declarados em `crm/console/modules/registry.tsx` com identificador, rótulo,
+permissão, entrypoint lazy, fallback e estado de indisponibilidade.
+
+`ModuleHost` cria uma fronteira de runtime por módulo. Falha de renderização ou
+de chunk é limitada ao módulo ativo, oferece recuperação e mantém a navegação e
+os demais módulos disponíveis. A autorização de dados continua nos backends.
+
+Não há Module Federation, carregamento remoto ou deploy independente de bundles
+nesta fase. Antes de evoluir a publicação independente, staging deve provar a
+navegação entre Atendimento e Insumos, uma falha simulada de import e o retorno
+pela barra lateral sem recarregar o shell.


### PR DESCRIPTION
## Alterações

- substitui o registro manual de módulos do `App.tsx` por manifestos tipados e um module registry;
- adiciona carregamento lazy por entrypoint, permissões de navegação, fallback e estado de indisponibilidade por módulo;
- isola falhas de renderização e de chunk no `ModuleHost`, preservando navegação e os demais módulos;
- documenta o gate de staging e mantém a arquitetura sem Module Federation ou carregamento remoto.

## Validação

- `npm run typecheck`
- `npm test` — 181 testes
- `npm run lint` — sem erros (avisos legados existentes)
- `npm run build` — orçamento de bundle aprovado
- `npm run architecture:validate`
- validação renderizada local: Atendimento e Insumos carregados sem erros de console.

Não houve deploy. A validação em staging continua necessária antes de qualquer evolução para publicação independente.