### PR TITLE
feat(finance): establish independent staging release pattern

### DIFF
--- a/.github/workflows/central-e2e-smoke.yml
+++ b/.github/workflows/central-e2e-smoke.yml
@@ -34,6 +34,8 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Start frontend (dev server)
+        env:
+          VITE_FINANCE_MODULE_URL: http://127.0.0.1:5173/finance-module.js
         run: |
           set -euxo pipefail
           cd crm/console

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -1,4 +1,4 @@
-name: Deploy Core Workers (api + insumos)
+name: Deploy Core Worker
 
 on:
   workflow_dispatch:
@@ -9,12 +9,23 @@ on:
         default: staging
         type: choice
         options: [preview, staging, production]
+      unit:
+        description: "Operational unit to publish; use api for gateway-only routing changes"
+        required: true
+        default: all
+        type: choice
+        options: [api, inventory, all]
+      bootstrap_finance_context:
+        description: "Set the Finance service secret in the selected staging API once"
+        required: true
+        default: false
+        type: boolean
       release_sha: { description: "Immutable commit SHA", required: false, type: string }
       preview_run_id: { description: "Required for staging", required: false, type: string }
       staging_run_id: { description: "Required for production", required: false, type: string }
 
 concurrency:
-  group: deploy-core-workers-${{ inputs.target }}
+  group: deploy-core-worker-${{ inputs.unit }}-${{ inputs.target }}
   cancel-in-progress: false
 
 permissions:
@@ -25,12 +36,11 @@ jobs:
   promotion:
     uses: ./.github/workflows/promotion-gate.yml
     with:
-      unit: core-workers
+      unit: core-${{ inputs.unit }}
       target: ${{ inputs.target }}
       release_sha: ${{ inputs.release_sha }}
       preview_run_id: ${{ inputs.preview_run_id }}
       staging_run_id: ${{ inputs.staging_run_id }}
-    secrets: inherit
   deploy:
     needs: promotion
     if: ${{ inputs.target != 'preview' }}
@@ -72,7 +82,7 @@ jobs:
         with:
           node-version: "22.12.0"
 
-      - name: Install worker deps (insumos + api)
+      - name: Install worker deps
         if: ${{ steps.guard.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
@@ -80,37 +90,57 @@ jobs:
           (cd ../api && npm install --no-package-lock --no-audit --no-fund)
         working-directory: inventory
 
-      - name: Deploy Workers (wrangler)
+      - name: Deploy only the selected operational unit
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FINANCE_SERVICE_AUTH_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
+          TARGET: ${{ inputs.target }}
+          UNIT: ${{ inputs.unit }}
+          BOOTSTRAP_FINANCE_CONTEXT: ${{ inputs.bootstrap_finance_context }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
-          if [[ "${{ inputs.target }}" == "staging" ]]; then
+          if [[ "$TARGET" == "staging" ]]; then
             env_args=(--env staging)
             environment_var=(--var "ENVIRONMENT:staging")
           else
             env_args=()
             environment_var=(--var "ENVIRONMENT:production")
           fi
-          npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars "${env_args[@]}"
-          npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars "${env_args[@]}" \
-            --var "APP_VERSION:${{ needs.promotion.outputs.source_sha }}" "${environment_var[@]}"
+          if [[ "$UNIT" == "inventory" || "$UNIT" == "all" ]]; then
+            npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars "${env_args[@]}"
+          fi
+          if [[ "$UNIT" == "api" || "$UNIT" == "all" ]]; then
+            if [[ "$BOOTSTRAP_FINANCE_CONTEXT" == "true" ]]; then
+              [[ "$TARGET" == "staging" ]] || { echo 'Finance context bootstrap is staging-only.'; exit 1; }
+              [[ -n "${FINANCE_SERVICE_AUTH_SECRET:-}" ]] || { echo 'Missing FINANCE_SERVICE_AUTH_SECRET.'; exit 1; }
+              printf '%s' "$FINANCE_SERVICE_AUTH_SECRET" | npx --yes wrangler@3 secret put FINANCE_SERVICE_AUTH_SECRET --config api/wrangler.toml --env staging
+            fi
+            npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars "${env_args[@]}" \
+              --var "APP_VERSION:$RELEASE_SHA" "${environment_var[@]}"
+          fi
 
-      - name: Smoke check API + Inventory Workers (production)
+      - name: Smoke selected core Worker (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/workers_smoke.py \
-            --attempts 5 \
-            --sleep-seconds 6 \
-            --user-agent "Mozilla/5.0 (compatible; CoreWorkerSmoke/1.0)"
+          if [[ "$UNIT" == "api" ]]; then
+            curl --fail --silent --show-error --max-time 15 https://api.skincos.com.br/health >/dev/null
+          else
+            python3 .github/scripts/workers_smoke.py \
+              --attempts 5 \
+              --sleep-seconds 6 \
+              --user-agent "Mozilla/5.0 (compatible; CoreWorkerSmoke/1.0)"
+          fi
+        env:
+          UNIT: ${{ inputs.unit }}
 
       - name: Write staging promotion evidence
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         env:
-          PROMOTION_UNIT: core-workers
+          PROMOTION_UNIT: core-${{ inputs.unit }}
           PROMOTION_TARGET: staging
           PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
@@ -118,7 +148,7 @@ jobs:
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: promotion-evidence-core-workers
+          name: promotion-evidence-core-${{ inputs.unit }}
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -123,6 +123,7 @@ jobs:
         if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
           VITE_BUILD_SHA: ${{ needs.promotion.outputs.source_sha }}
+          VITE_FINANCE_MODULE_URL: ${{ vars.FINANCE_UI_MODULE_URL }}
         run: npm run build
         working-directory: crm/console
 

--- a/.github/workflows/deploy-finance-ui.yml
+++ b/.github/workflows/deploy-finance-ui.yml
@@ -30,7 +30,6 @@ jobs:
       release_sha: ${{ inputs.release_sha }}
       preview_run_id: ${{ inputs.preview_run_id }}
       staging_run_id: ${{ inputs.staging_run_id }}
-    secrets: inherit
   deploy:
     needs: promotion
     if: ${{ inputs.target != 'preview' }}
@@ -72,7 +71,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: ${{ inputs.target == 'production' && vars.FINANCE_UI_PAGES_PROJECT_PRODUCTION || vars.FINANCE_UI_PAGES_PROJECT_STAGING }}
           BRANCH: ${{ inputs.target == 'production' && 'main' || 'staging' }}
-        run: npx --yes wrangler@4.114.0 pages deploy dist-finance --project-name "$PROJECT" --branch "$BRANCH" --commit-hash "${{ needs.promotion.outputs.source_sha }}"
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: npx --yes wrangler@4.114.0 pages deploy dist-finance --project-name "$PROJECT" --branch "$BRANCH" --commit-hash "$RELEASE_SHA"
         working-directory: crm/console
       - name: Write staging promotion evidence
         if: inputs.target == 'staging'

--- a/.github/workflows/deploy-finance-ui.yml
+++ b/.github/workflows/deploy-finance-ui.yml
@@ -1,0 +1,90 @@
+name: Deploy Finance UI artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Target environment
+        required: true
+        type: choice
+        default: staging
+        options: [preview, staging, production]
+      release_sha: { description: Immutable main commit SHA, required: false, type: string }
+      preview_run_id: { description: Required for staging, required: false, type: string }
+      staging_run_id: { description: Required for production, required: false, type: string }
+
+concurrency:
+  group: deploy-finance-ui-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with:
+      unit: finance-ui
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
+    secrets: inherit
+  deploy:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.promotion.outputs.source_sha }}
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: crm/console/package-lock.json
+      - name: Guard isolated Pages project
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ inputs.target == 'production' && vars.FINANCE_UI_PAGES_PROJECT_PRODUCTION || vars.FINANCE_UI_PAGES_PROJECT_STAGING }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PROJECT; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
+      - run: npm ci
+        working-directory: crm/console
+      - name: Build immutable Finance artifact
+        run: |
+          set -euo pipefail
+          npx vite build --config vite.finance.config.ts
+          cat > dist-finance/_headers <<'EOF'
+          /*
+            Access-Control-Allow-Origin: https://crm.skincos.com.br
+            Access-Control-Allow-Methods: GET, HEAD, OPTIONS
+            Cache-Control: no-store
+          EOF
+        working-directory: crm/console
+      - name: Publish only Finance UI
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ inputs.target == 'production' && vars.FINANCE_UI_PAGES_PROJECT_PRODUCTION || vars.FINANCE_UI_PAGES_PROJECT_STAGING }}
+          BRANCH: ${{ inputs.target == 'production' && 'main' || 'staging' }}
+        run: npx --yes wrangler@4.114.0 pages deploy dist-finance --project-name "$PROJECT" --branch "$BRANCH" --commit-hash "${{ needs.promotion.outputs.source_sha }}"
+        working-directory: crm/console
+      - name: Write staging promotion evidence
+        if: inputs.target == 'staging'
+        env:
+          PROMOTION_UNIT: finance-ui
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+      - if: inputs.target == 'staging'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-evidence-finance-ui
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/deploy-finance-ui.yml
+++ b/.github/workflows/deploy-finance-ui.yml
@@ -61,7 +61,7 @@ jobs:
           npx vite build --config vite.finance.config.ts
           cat > dist-finance/_headers <<'EOF'
           /*
-            Access-Control-Allow-Origin: https://crm.skincos.com.br
+            Access-Control-Allow-Origin: *
             Access-Control-Allow-Methods: GET, HEAD, OPTIONS
             Cache-Control: no-store
           EOF

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -19,6 +19,11 @@ on:
         default: deploy
         type: choice
         options: [deploy, rollback]
+      bootstrap_service_secret:
+        description: Set the Finance service secret once before the first staging version upload
+        required: true
+        default: false
+        type: boolean
       staging_run_id:
         description: Required for production; successful Finance staging run for this exact SHA
         required: false
@@ -45,7 +50,6 @@ jobs:
       release_sha: ${{ inputs.release_sha }}
       preview_run_id: ${{ inputs.preview_run_id }}
       staging_run_id: ${{ inputs.staging_run_id }}
-    secrets: inherit
   release:
     needs: promotion
     if: ${{ inputs.target != 'preview' }}
@@ -69,10 +73,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
           CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID }}
-          SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID CONTROL_KV_ID SERVICE_SECRET; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID CONTROL_KV_ID; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
           [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ && "$CONTROL_KV_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Invalid Finance D1 or control KV id'; exit 1; }
       - name: Validate Finance release source
         timeout-minutes: 5
@@ -86,12 +89,13 @@ jobs:
           TARGET: ${{ inputs.target }}
           D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
           CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then
-            sed -i "s/__CONFIGURE_FINANCE_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/$CONTROL_KV_ID/" finance/wrangler.toml
+            sed -i "s/__CONFIGURE_FINANCE_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/$CONTROL_KV_ID/;s/__RELEASE_SHA__/$RELEASE_SHA/g" finance/wrangler.toml
           else
-            sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/" finance/wrangler.toml
+            sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/;s/__RELEASE_SHA__/$RELEASE_SHA/g" finance/wrangler.toml
           fi
       - name: Capture encrypted D1 checkpoint before migrations
         env:
@@ -116,18 +120,47 @@ jobs:
           path: ${{ env.CHECKPOINT }}
           retention-days: 30
           if-no-files-found: error
-      - name: Apply Finance migrations then publish only Finance
+      - name: Apply additive migrations and upload immutable Finance version
+        if: inputs.operation == 'deploy'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
           TARGET: ${{ inputs.target }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+          BOOTSTRAP_SERVICE_SECRET: ${{ inputs.bootstrap_service_secret }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
           npx --yes wrangler@4.112.0 d1 migrations apply "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}"
-          printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
-          npx --yes wrangler@4.112.0 deploy --config finance/wrangler.toml --keep-vars --message "finance:${{ inputs.operation }}:${{ needs.promotion.outputs.source_sha }}" "${ENV_ARGS[@]}"
+          if [[ "$BOOTSTRAP_SERVICE_SECRET" == "true" ]]; then
+            [[ "$TARGET" == "staging" ]] || { echo 'Finance service-secret bootstrap is staging-only.'; exit 1; }
+            [[ -n "${SERVICE_SECRET:-}" ]] || { echo 'Missing FINANCE_SERVICE_AUTH_SECRET.'; exit 1; }
+            printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          fi
+          npx --yes wrangler@4.112.0 secret list --config finance/wrangler.toml "${ENV_ARGS[@]}" --json | node -e "const fs=require('fs');const names=JSON.parse(fs.readFileSync(0,'utf8')).map(x=>x.name);if(!names.includes('FINANCE_SERVICE_AUTH_SECRET')){console.error('FINANCE_SERVICE_AUTH_SECRET must be provisioned before release');process.exit(1)}"
+          WRANGLER_OUTPUT_FILE="$RUNNER_TEMP/finance-upload.jsonl" npx --yes wrangler@4.112.0 versions upload --config finance/wrangler.toml --keep-vars --message "finance:deploy:$RELEASE_SHA" "${ENV_ARGS[@]}"
+          VERSION_ID="$(node -e "const fs=require('fs');const items=fs.readFileSync(process.argv[1],'utf8').trim().split(/\\r?\\n/).map(JSON.parse);const item=items.reverse().find(x=>x.type==='version-upload');if(!item?.version_id)process.exit(1);process.stdout.write(item.version_id)" "$RUNNER_TEMP/finance-upload.jsonl")"
+          echo "FINANCE_VERSION_ID=$VERSION_ID" >> "$GITHUB_ENV"
+      - name: Resolve a previously uploaded version for rollback
+        if: inputs.operation == 'rollback'
+        env:
+          TARGET: ${{ inputs.target }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
+          FINANCE_VERSION_ID="$(npx --yes wrangler@4.112.0 versions list --config finance/wrangler.toml "${ENV_ARGS[@]}" --json | node -e "const fs=require('fs');const versions=JSON.parse(fs.readFileSync(0,'utf8'));const found=versions.find(x=>x.message===('finance:deploy:'+process.env.RELEASE_SHA));if(!found?.id)process.exit(1);process.stdout.write(found.id)")"
+          [[ -n "$FINANCE_VERSION_ID" ]] || { echo 'No prior Finance version for requested SHA'; exit 1; }
+          echo "FINANCE_VERSION_ID=$FINANCE_VERSION_ID" >> "$GITHUB_ENV"
+      - name: Deploy only the selected Finance version
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
+          [[ -n "${FINANCE_VERSION_ID:-}" ]] || { echo 'Finance version was not selected'; exit 1; }
+          npx --yes wrangler@4.112.0 versions deploy "${FINANCE_VERSION_ID}@100%" --yes --config finance/wrangler.toml "${ENV_ARGS[@]}"
       - name: Smoke private Finance Worker through the gateway
         id: smoke
         env:

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [preview, staging, production]
       release_sha:
         description: Immutable main commit to promote or restore
         required: true
@@ -23,6 +23,10 @@ on:
         description: Required for production; successful Finance staging run for this exact SHA
         required: false
         type: string
+      preview_run_id:
+        description: Required for staging; successful Finance preview for this exact SHA
+        required: false
+        type: string
 
 concurrency:
   group: deploy-finance-${{ inputs.target }}
@@ -33,35 +37,32 @@ permissions:
   contents: read
 
 jobs:
+  promotion:
+    uses: ./.github/workflows/promotion-gate.yml
+    with:
+      unit: finance
+      target: ${{ inputs.target }}
+      release_sha: ${{ inputs.release_sha }}
+      preview_run_id: ${{ inputs.preview_run_id }}
+      staging_run_id: ${{ inputs.staging_run_id }}
+    secrets: inherit
   release:
+    needs: promotion
+    if: ${{ inputs.target != 'preview' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ needs.promotion.outputs.source_sha }}
+          fetch-depth: 1
       - name: Verify immutable release
         env:
-          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
-          git cat-file -e "$RELEASE_SHA^{commit}"
-          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
-          git checkout --detach "$RELEASE_SHA"
-      - name: Verify production staging attestation
-        if: inputs.target == 'production'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ inputs.staging_run_id }}
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$RUN_ID" =~ ^[0-9]+$ ]] || { echo 'production requires staging_run_id'; exit 1; }
-          mkdir -p "$RUNNER_TEMP/finance-attestation"
-          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" --name finance-staging-attestation --dir "$RUNNER_TEMP/finance-attestation"
-          node -e "const x=require(process.argv[1]);if(x.target!=='staging'||x.sha!==process.argv[2]||x.health!==200)process.exit(1)" "$RUNNER_TEMP/finance-attestation/attestation.json" "$RELEASE_SHA"
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checked-out source does not match promotion evidence'; exit 1; }
       - name: Guard isolated bindings and secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -92,6 +93,29 @@ jobs:
           else
             sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/" finance/wrangler.toml
           fi
+      - name: Capture encrypted D1 checkpoint before migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+          FINANCE_BACKUP_PASSPHRASE: ${{ secrets.FINANCE_BACKUP_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          [[ -n "${FINANCE_BACKUP_PASSPHRASE:-}" ]] || { echo 'Missing FINANCE_BACKUP_PASSPHRASE'; exit 1; }
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
+          plain="$RUNNER_TEMP/finance-${TARGET}-pre-migration-${GITHUB_SHA}.sql"
+          encrypted="${plain}.gpg"
+          npx --yes wrangler@4.112.0 d1 export "$DB" --remote --output "$plain" --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          printf '%s' "$FINANCE_BACKUP_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --symmetric --cipher-algo AES256 --output "$encrypted" "$plain"
+          rm -f "$plain"
+          echo "CHECKPOINT=$encrypted" >> "$GITHUB_ENV"
+      - name: Upload encrypted D1 checkpoint
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: finance-${{ inputs.target }}-pre-migration-${{ needs.promotion.outputs.source_sha }}
+          path: ${{ env.CHECKPOINT }}
+          retention-days: 30
+          if-no-files-found: error
       - name: Apply Finance migrations then publish only Finance
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -103,7 +127,7 @@ jobs:
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
           npx --yes wrangler@4.112.0 d1 migrations apply "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}"
           printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
-          npx --yes wrangler@4.112.0 deploy --config finance/wrangler.toml --keep-vars --message "finance:${{ inputs.operation }}:${{ inputs.release_sha }}" "${ENV_ARGS[@]}"
+          npx --yes wrangler@4.112.0 deploy --config finance/wrangler.toml --keep-vars --message "finance:${{ inputs.operation }}:${{ needs.promotion.outputs.source_sha }}" "${ENV_ARGS[@]}"
       - name: Smoke private Finance Worker through the gateway
         id: smoke
         env:
@@ -114,16 +138,16 @@ jobs:
           code="$(curl --silent --show-error --output "$RUNNER_TEMP/finance-health.json" --write-out '%{http_code}' "$BASE/finance/health")"
           [[ "$code" == 200 ]] || { cat "$RUNNER_TEMP/finance-health.json"; exit 1; }
           node -e "const x=require(process.argv[1]);if(!x.ok||x.module!=='finance')process.exit(1)" "$RUNNER_TEMP/finance-health.json"
-      - name: Write staging attestation
+      - name: Write staging promotion evidence
         if: inputs.target == 'staging'
         env:
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          mkdir -p "$RUNNER_TEMP/finance-attestation"
-          node -e "require('fs').writeFileSync(process.argv[1],JSON.stringify({target:'staging',sha:process.env.RELEASE_SHA,health:200,createdAt:new Date().toISOString()},null,2))" "$RUNNER_TEMP/finance-attestation/attestation.json"
+          PROMOTION_UNIT: finance
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - if: inputs.target == 'staging'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: finance-staging-attestation
-          path: ${{ runner.temp }}/finance-attestation/attestation.json
+          name: promotion-evidence-finance
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -1,0 +1,129 @@
+name: Deploy Finance Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Isolated environment
+        required: true
+        default: staging
+        type: choice
+        options: [staging, production]
+      release_sha:
+        description: Immutable main commit to promote or restore
+        required: true
+        type: string
+      operation:
+        description: Deploy a release or restore a previous release SHA
+        required: true
+        default: deploy
+        type: choice
+        options: [deploy, rollback]
+      staging_run_id:
+        description: Required for production; successful Finance staging run for this exact SHA
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-finance-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Verify immutable release
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          git cat-file -e "$RELEASE_SHA^{commit}"
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
+          git checkout --detach "$RELEASE_SHA"
+      - name: Verify production staging attestation
+        if: inputs.target == 'production'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.staging_run_id }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RUN_ID" =~ ^[0-9]+$ ]] || { echo 'production requires staging_run_id'; exit 1; }
+          mkdir -p "$RUNNER_TEMP/finance-attestation"
+          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" --name finance-staging-attestation --dir "$RUNNER_TEMP/finance-attestation"
+          node -e "const x=require(process.argv[1]);if(x.target!=='staging'||x.sha!==process.argv[2]||x.health!==200)process.exit(1)" "$RUNNER_TEMP/finance-attestation/attestation.json" "$RELEASE_SHA"
+      - name: Guard isolated bindings and secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
+          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID CONTROL_KV_ID SERVICE_SECRET; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
+          [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ && "$CONTROL_KV_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Invalid Finance D1 or control KV id'; exit 1; }
+      - name: Validate Finance release source
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          npm --prefix finance ci --ignore-scripts
+          npm --prefix finance run check
+          npm --prefix finance test
+      - name: Render only target bindings in ephemeral checkout
+        env:
+          TARGET: ${{ inputs.target }}
+          D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
+          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then
+            sed -i "s/__CONFIGURE_FINANCE_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/$CONTROL_KV_ID/" finance/wrangler.toml
+          else
+            sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/" finance/wrangler.toml
+          fi
+      - name: Apply Finance migrations then publish only Finance
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
+          npx --yes wrangler@4.112.0 d1 migrations apply "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          npx --yes wrangler@4.112.0 deploy --config finance/wrangler.toml --keep-vars --message "finance:${{ inputs.operation }}:${{ inputs.release_sha }}" "${ENV_ARGS[@]}"
+      - name: Smoke private Finance Worker through the gateway
+        id: smoke
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then BASE=https://api.skincos.com.br; else BASE=https://api-staging.skincos.com.br; fi
+          code="$(curl --silent --show-error --output "$RUNNER_TEMP/finance-health.json" --write-out '%{http_code}' "$BASE/finance/health")"
+          [[ "$code" == 200 ]] || { cat "$RUNNER_TEMP/finance-health.json"; exit 1; }
+          node -e "const x=require(process.argv[1]);if(!x.ok||x.module!=='finance')process.exit(1)" "$RUNNER_TEMP/finance-health.json"
+      - name: Write staging attestation
+        if: inputs.target == 'staging'
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/finance-attestation"
+          node -e "require('fs').writeFileSync(process.argv[1],JSON.stringify({target:'staging',sha:process.env.RELEASE_SHA,health:200,createdAt:new Date().toISOString()},null,2))" "$RUNNER_TEMP/finance-attestation/attestation.json"
+      - if: inputs.target == 'staging'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: finance-staging-attestation
+          path: ${{ runner.temp }}/finance-attestation/attestation.json
+          retention-days: 14

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -68,7 +68,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
-          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID }}
           SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
         run: |
           set -euo pipefail
@@ -85,7 +85,7 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           D1_ID: ${{ inputs.target == 'production' && vars.FINANCE_D1_PRODUCTION_ID || vars.FINANCE_D1_STAGING_ID }}
-          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -17,7 +17,11 @@ on:
         description: Runtime state; no artifact is published
         required: true
         type: choice
-        options: [active, maintenance, disabled]
+        options: [active, canary, maintenance, disabled]
+      pilot_actors:
+        description: "CSV of Finance pilot actor IDs; required only for canary"
+        required: false
+        type: string
       message:
         description: User-visible maintenance reason (optional)
         required: false
@@ -53,7 +57,10 @@ jobs:
           MODULE: ${{ inputs.module }}
           STATE: ${{ inputs.state }}
           MESSAGE: ${{ inputs.message }}
+          PILOT_ACTORS: ${{ inputs.pilot_actors }}
         run: |
           set -euo pipefail
-          payload="$(node -e "process.stdout.write(JSON.stringify({state:process.env.STATE,message:process.env.MESSAGE||'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
+          if [[ "$MODULE" != finance && "$STATE" == canary ]]; then echo 'Canary is implemented only for Finance in this workflow.'; exit 1; fi
+          if [[ "$STATE" == canary && -z "${PILOT_ACTORS//[[:space:],]/}" ]]; then echo 'Canary requires at least one pilot actor.'; exit 1; fi
+          payload="$(node -e "process.stdout.write(JSON.stringify({state:process.env.STATE,message:process.env.MESSAGE||'',pilotActors:(process.env.PILOT_ACTORS||'').split(',').map(x=>x.trim()).filter(Boolean),changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
           npx --yes wrangler@4.112.0 kv key put "module-control:$MODULE" "$payload" --namespace-id "$NAMESPACE_ID"

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          NAMESPACE_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          NAMESPACE_ID: ${{ inputs.module == 'finance' && (inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID) || (inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID) }}
         run: |
           set -euo pipefail
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID NAMESPACE_ID; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
@@ -53,7 +53,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          NAMESPACE_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          NAMESPACE_ID: ${{ inputs.module == 'finance' && (inputs.target == 'production' && vars.FINANCE_CONTROL_PRODUCTION_KV_ID || vars.FINANCE_CONTROL_STAGING_KV_ID) || (inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID) }}
           MODULE: ${{ inputs.module }}
           STATE: ${{ inputs.state }}
           MESSAGE: ${{ inputs.message }}

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -1,0 +1,59 @@
+name: Set module availability
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: Module to control
+        required: true
+        type: choice
+        options: [finance, timekeeping]
+      target:
+        description: Isolated environment
+        required: true
+        type: choice
+        options: [staging, production]
+      state:
+        description: Runtime state; no artifact is published
+        required: true
+        type: choice
+        options: [active, maintenance, disabled]
+      message:
+        description: User-visible maintenance reason (optional)
+        required: false
+        type: string
+
+concurrency:
+  group: module-availability-${{ inputs.module }}-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  set-state:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    steps:
+      - name: Guard isolated control store
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NAMESPACE_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID NAMESPACE_ID; do [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }; done
+          [[ "$NAMESPACE_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Invalid module-control KV id'; exit 1; }
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+      - name: Set isolated runtime state
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NAMESPACE_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
+          MODULE: ${{ inputs.module }}
+          STATE: ${{ inputs.state }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          set -euo pipefail
+          payload="$(node -e "process.stdout.write(JSON.stringify({state:process.env.STATE,message:process.env.MESSAGE||'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
+          npx --yes wrangler@4.112.0 kv key put "module-control:$MODULE" "$payload" --namespace-id "$NAMESPACE_ID"

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -3,51 +3,16 @@ import { csrfErrorFor, resolveCrmActor } from '../../shared/crm-auth/worker.js';
 import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
 import { createSignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 
-const financeRateLimitResponse = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
-const digest = async (value) => Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)))).map((item) => item.toString(16).padStart(2, '0')).join('');
+const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
+const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
 
-async function resolveFinanceActor(request, env) {
-    const auth = await resolveCrmActor(request, env);
-    // This bypass exists only when the private runner injects its local-only
-    // Worker binding. Production configuration never defines that binding.
-    if (auth.actor || String(env?.LOCAL_FINANCE_AUTH_BYPASS || '') !== 'true') return auth;
-    const username = String(request.headers.get('x-skincos-local-finance-actor') || env?.LOCAL_FINANCE_ACTOR || '').trim();
-    const csrf = String(env?.LOCAL_FINANCE_CSRF_TOKEN || request.headers.get('x-csrf-token') || 'local-loopback-csrf').trim();
-    if (!username || !csrf) return auth;
-    const allowedModules = String(request.headers.get('x-skincos-local-finance-modules') || env?.LOCAL_FINANCE_ALLOWED_MODULES || '').split(',').map((value) => value.trim()).filter(Boolean);
-    return { actor: { username, role: String(env?.LOCAL_FINANCE_ACTOR_ROLE || 'GESTOR').toUpperCase(), allowedModules }, csrf };
-}
-
-export async function enforceFinanceRateLimit(request, env, actor) {
-    // The production gateway binds RATE_LIMITER as a Durable Object. Local tests
-    // intentionally omit it; production must keep the binding declared in
-    // api/wrangler.toml before Finance is enabled.
-    if (!env?.RATE_LIMITER) return null;
-    const path = new URL(request.url).pathname;
-    const write = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method.toUpperCase());
-    const importWrite = write && path.startsWith('/imports');
-    const limit = importWrite ? 12 : write ? 60 : 240;
-    const bucket = importWrite ? 'import' : write ? 'write' : 'read';
-    const remote = String(request.headers.get('cf-connecting-ip') || '').trim();
-    const actorKey = String(actor?.username || 'anonymous').trim();
-    const identity = await digest(`finance:${actorKey}:${remote || 'no-ip'}`);
-    try {
-        const id = env.RATE_LIMITER.idFromName(`finance:${identity}`);
-        const response = await env.RATE_LIMITER.get(id).fetch(`https://rate-limiter/?key=finance:${bucket}&limit=${limit}&window=60`);
-        const result = await response.json().catch(() => null);
-        if (!response.ok || !result || typeof result.allowed !== 'boolean') return financeRateLimitResponse(503, 'FINANCE_RATE_LIMIT_UNAVAILABLE');
-        if (!result.allowed) return financeRateLimitResponse(429, 'FINANCE_RATE_LIMITED');
-        return null;
-    } catch {
-        // Finance writes fail closed when the configured distributed limiter is
-        // unhealthy; a degraded limiter must not turn into an import flood.
-        return financeRateLimitResponse(503, 'FINANCE_RATE_LIMIT_UNAVAILABLE');
-    }
+export async function forwardFinanceProbe(request, env) {
+    return fetchBoundService(request, env, 'FINANCE', { timeoutMs: 800 });
 }
 
 export async function forwardFinanceToService(request, env, ctx, auth) {
     const secret = String(env?.FINANCE_SERVICE_AUTH_SECRET || '').trim();
-    if (!secret) return financeRateLimitResponse(503, 'FINANCE_SERVICE_IDENTITY_UNAVAILABLE');
+    if (!secret) return gatewayError(503, 'FINANCE_SERVICE_IDENTITY_UNAVAILABLE');
     const headers = new Headers(request.headers);
     headers.delete('cookie');
     headers.delete('x-csrf-token');
@@ -56,16 +21,25 @@ export async function forwardFinanceToService(request, env, ctx, auth) {
         for (const [name, value] of Object.entries(signed)) headers.set(name, value);
         return fetchBoundService(new Request(request, { headers }), env, 'FINANCE', { timeoutMs: 800 });
     } catch {
-        return financeRateLimitResponse(503, 'FINANCE_SERVICE_UNAVAILABLE');
+        return gatewayError(503, 'FINANCE_SERVICE_UNAVAILABLE');
     }
 }
 
-export function createApiGateway({ inventoryHandler, timekeepingHandler, financeDomainHandler = forwardFinanceToService, resolveActor = resolveFinanceActor, rateLimit = enforceFinanceRateLimit } = {}) {
+/**
+ * The gateway owns only the cross-domain envelope: session authentication,
+ * CSRF, correlation and the signed service hand-off. Finance owns every
+ * domain decision (including scope, availability, maintenance and throttling).
+ */
+export function createApiGateway({ inventoryHandler, timekeepingHandler, financeDomainHandler = forwardFinanceToService, resolveActor = resolveCrmActor } = {}) {
     if (typeof inventoryHandler !== 'function') throw new TypeError('inventoryHandler is required');
     return createGatewayHandler({
         inventoryHandler,
         timekeepingHandler,
         financeHandler: async (request, env, ctx) => {
+            // Health and readiness contain no actor or financial data. They stay
+            // available to external monitors while every domain operation uses
+            // the signed authenticated envelope below.
+            if (isOperationalProbe(request)) return forwardFinanceProbe(request, env);
             let auth;
             try {
                 auth = await resolveActor(request, env);
@@ -73,13 +47,11 @@ export function createApiGateway({ inventoryHandler, timekeepingHandler, finance
                 // Identity is required only for the authenticated Finance
                 // capability. Contain an unexpected resolver failure here so
                 // the gateway, Inventory and Workforce mounts remain usable.
-                return financeRateLimitResponse(503, 'IDENTITY_UNAVAILABLE');
+                return gatewayError(503, 'IDENTITY_UNAVAILABLE');
             }
-            if (auth?.unavailable) return financeRateLimitResponse(503, 'IDENTITY_UNAVAILABLE');
+            if (auth?.unavailable) return gatewayError(503, 'IDENTITY_UNAVAILABLE');
             const csrfError = csrfErrorFor(request, auth.csrf);
             if (csrfError) return csrfError;
-            const rateLimitError = await rateLimit(request, env, auth.actor);
-            if (rateLimitError) return rateLimitError;
             return financeDomainHandler(request, env, ctx, auth);
         },
     });

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -1,13 +1,13 @@
-import inventoryWorker from '../../inventory/src/worker.js';
 import { createGatewayHandler } from './router.js';
-import { createFinanceHandler } from '../../finance/api/worker.js';
-import { csrfErrorFor, resolveCrmActor } from '../../shared/crm-auth/worker.js';
+import { csrfErrorFor, resolveIdentityActor } from '../../identity/session/actor.js';
+import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
+import { createSignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 
 const financeRateLimitResponse = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const digest = async (value) => Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)))).map((item) => item.toString(16).padStart(2, '0')).join('');
 
 async function resolveFinanceActor(request, env) {
-    const auth = await resolveCrmActor(request, env);
+    const auth = await resolveIdentityActor(request, env);
     // This bypass exists only when the private runner injects its local-only
     // Worker binding. Production configuration never defines that binding.
     if (auth.actor || String(env?.LOCAL_FINANCE_AUTH_BYPASS || '') !== 'true') return auth;
@@ -45,13 +45,37 @@ export async function enforceFinanceRateLimit(request, env, actor) {
     }
 }
 
-export function createApiGateway({ inventoryHandler, timekeepingHandler, financeDomainHandler = createFinanceHandler(), resolveActor = resolveFinanceActor, rateLimit = enforceFinanceRateLimit } = {}) {
+export async function forwardFinanceToService(request, env, ctx, auth) {
+    const secret = String(env?.FINANCE_SERVICE_AUTH_SECRET || '').trim();
+    if (!secret) return financeRateLimitResponse(503, 'FINANCE_SERVICE_IDENTITY_UNAVAILABLE');
+    const headers = new Headers(request.headers);
+    headers.delete('cookie');
+    headers.delete('x-csrf-token');
+    try {
+        const signed = await createSignedDomainContext({ actor: auth.actor, csrf: auth.csrf, requestId: request.headers.get('x-request-id') }, secret, 'finance');
+        for (const [name, value] of Object.entries(signed)) headers.set(name, value);
+        return fetchBoundService(new Request(request, { headers }), env, 'FINANCE', { timeoutMs: 800 });
+    } catch {
+        return financeRateLimitResponse(503, 'FINANCE_SERVICE_UNAVAILABLE');
+    }
+}
+
+export function createApiGateway({ inventoryHandler, timekeepingHandler, financeDomainHandler = forwardFinanceToService, resolveActor = resolveFinanceActor, rateLimit = enforceFinanceRateLimit } = {}) {
     if (typeof inventoryHandler !== 'function') throw new TypeError('inventoryHandler is required');
     return createGatewayHandler({
         inventoryHandler,
         timekeepingHandler,
         financeHandler: async (request, env, ctx) => {
-            const auth = await resolveActor(request, env);
+            let auth;
+            try {
+                auth = await resolveActor(request, env);
+            } catch {
+                // Identity is required only for the authenticated Finance
+                // capability. Contain an unexpected resolver failure here so
+                // the gateway, Inventory and Workforce mounts remain usable.
+                return financeRateLimitResponse(503, 'IDENTITY_UNAVAILABLE');
+            }
+            if (auth?.unavailable) return financeRateLimitResponse(503, 'IDENTITY_UNAVAILABLE');
             const csrfError = csrfErrorFor(request, auth.csrf);
             if (csrfError) return csrfError;
             const rateLimitError = await rateLimit(request, env, auth.actor);
@@ -64,14 +88,7 @@ export function createApiGateway({ inventoryHandler, timekeepingHandler, finance
 export { createGatewayHandler } from './router.js';
 
 export const handleGatewayRequest = createApiGateway({
-    inventoryHandler: inventoryWorker.fetch.bind(inventoryWorker),
-    timekeepingHandler: async (request, env) => {
-        if (!env.TIMEKEEPING?.fetch) {
-            return new Response(JSON.stringify({ ok: false, error: 'workforce_unavailable' }), {
-                status: 503,
-                headers: { 'content-type': 'application/json; charset=utf-8' },
-            });
-        }
-        return env.TIMEKEEPING.fetch(request);
-    },
+    inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: 800 }),
+    timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', { timeoutMs: 800 }),
+    financeDomainHandler: forwardFinanceToService,
 });

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -1,5 +1,5 @@
 import { createGatewayHandler } from './router.js';
-import { csrfErrorFor, resolveIdentityActor } from '../../identity/session/actor.js';
+import { csrfErrorFor, resolveCrmActor } from '../../shared/crm-auth/worker.js';
 import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
 import { createSignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 
@@ -7,7 +7,7 @@ const financeRateLimitResponse = (status, error) => new Response(JSON.stringify(
 const digest = async (value) => Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)))).map((item) => item.toString(16).padStart(2, '0')).join('');
 
 async function resolveFinanceActor(request, env) {
-    const auth = await resolveIdentityActor(request, env);
+    const auth = await resolveCrmActor(request, env);
     // This bypass exists only when the private runner injects its local-only
     // Worker binding. Production configuration never defines that binding.
     if (auth.actor || String(env?.LOCAL_FINANCE_AUTH_BYPASS || '') !== 'true') return auth;

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createGatewayHandler } from '../src/router.js';
-import { createApiGateway, enforceFinanceRateLimit } from '../src/gateway.js';
+import { createApiGateway, enforceFinanceRateLimit, forwardFinanceToService, handleGatewayRequest } from '../src/gateway.js';
+import { verifySignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
+import { resetBoundServiceResilienceForTest } from '../../shared/service-adapters/cloudflare-service-binding.js';
 
 const calls = [];
 const gateway = createGatewayHandler({
@@ -43,6 +45,45 @@ test('inventory is mounted without retaining the legacy public prefix', async ()
     assert.equal(response.headers.get('x-request-id'), 'inventory-1');
     assert.equal(calls.at(-1).pathname, '/insumos');
     assert.equal(calls.at(-1).search, '?unidade=nh');
+});
+
+test('default gateway reaches Inventory through the explicit service binding', async () => {
+    resetBoundServiceResilienceForTest();
+    let receivedPath = null;
+    const response = await handleGatewayRequest(
+        new Request('https://api.skincos.com.br/inventory/insumos?unidade=nh', { headers: { 'x-request-id': 'inventory-binding-1' } }),
+        { INVENTORY: { fetch: async (request) => { receivedPath = new URL(request.url).pathname; return new Response('inventory-binding-ok'); } } },
+        {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), 'inventory-binding-ok');
+    assert.equal(receivedPath, '/insumos');
+    assert.equal(response.headers.get('x-request-id'), 'inventory-binding-1');
+});
+
+test('an unavailable optional Inventory binding degrades only its route and leaves gateway health operational', async () => {
+    resetBoundServiceResilienceForTest();
+    const inventory = await handleGatewayRequest(new Request('https://api.skincos.com.br/inventory/insumos'), {}, {});
+    assert.equal(inventory.status, 503);
+    assert.equal((await inventory.json()).pendingSynchronization, true);
+    assert.equal(inventory.headers.get('x-skincos-dependency-status'), 'unavailable');
+    const health = await handleGatewayRequest(new Request('https://api.skincos.com.br/health'), {}, {});
+    assert.equal(health.status, 200);
+});
+
+test('a timing-out optional Workforce binding degrades only workforce and opens a circuit', async () => {
+    resetBoundServiceResilienceForTest();
+    const env = { TIMEKEEPING: { fetch: () => new Promise(() => {}) } };
+    const first = await handleGatewayRequest(new Request('https://api.skincos.com.br/api/ponto/health'), env, {});
+    assert.equal(first.status, 503);
+    assert.equal(first.headers.get('x-skincos-sync-state'), 'pending');
+    const second = await handleGatewayRequest(new Request('https://api.skincos.com.br/api/ponto/health'), env, {});
+    assert.equal(second.status, 503);
+    const open = await handleGatewayRequest(new Request('https://api.skincos.com.br/api/ponto/health'), env, {});
+    assert.equal(open.status, 503);
+    assert.equal(open.headers.get('x-skincos-dependency-status'), 'circuit-open');
+    const health = await handleGatewayRequest(new Request('https://api.skincos.com.br/health'), env, {});
+    assert.equal(health.status, 200);
 });
 
 test('workforce owns the canonical public Ponto mount', async () => {
@@ -96,6 +137,35 @@ test('finance gateway passes only an authenticated, CSRF-valid request after the
   const limiter = { idFromName: () => 'finance-limiter', get: () => ({ fetch: async () => new Response(JSON.stringify({ allowed: true }), { headers: { 'content-type': 'application/json' } }) }) };
   const allowed = await gateway(new Request('https://api.skincos.com.br/finance/imports', { method: 'POST', headers: { 'x-csrf-token': 'csrf-ok', 'idempotency-key': 'x' } }), { RATE_LIMITER: limiter }, {});
   assert.equal(allowed.status, 200); assert.equal(seenPath, '/imports');
+});
+
+test('an unavailable Identity resolver is contained to Finance', async () => {
+  let financeCalls = 0;
+  const isolated = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-ok'),
+    resolveActor: async () => ({ actor: null, csrf: null, unavailable: true }),
+    financeDomainHandler: async () => { financeCalls += 1; return new Response('must-not-run'); },
+  });
+  const finance = await isolated(new Request('https://api.skincos.com.br/finance/overview'), {}, {});
+  assert.equal(finance.status, 503);
+  assert.equal((await finance.json()).error, 'IDENTITY_UNAVAILABLE');
+  assert.equal(financeCalls, 0);
+  const inventory = await isolated(new Request('https://api.skincos.com.br/inventory/insumos'), {}, {});
+  assert.equal(inventory.status, 200);
+  assert.equal(await inventory.text(), 'inventory-ok');
+});
+
+test('Finance is reached through an explicit service binding with a short-lived signed actor context', async () => {
+  let received = null;
+  const response = await forwardFinanceToService(new Request('https://api.skincos.com.br/overview', { headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-binding-1' } }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
+    FINANCE: { fetch: async (request) => { received = request; return new Response('finance-binding-ok'); } },
+  }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), 'finance-binding-ok');
+  assert.equal(received.headers.get('cookie'), null);
+  assert.equal(received.headers.get('x-csrf-token'), null);
+  assert.equal((await verifySignedDomainContext(received, 'finance-secret', 'finance')).actor.username, 'pilot');
 });
 
 test('finance rate limits reads, writes and imports in independent buckets', async () => {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createGatewayHandler } from '../src/router.js';
-import { createApiGateway, enforceFinanceRateLimit, forwardFinanceToService, handleGatewayRequest } from '../src/gateway.js';
+import { createApiGateway, forwardFinanceToService, handleGatewayRequest } from '../src/gateway.js';
 import { verifySignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 import { resetBoundServiceResilienceForTest } from '../../shared/service-adapters/cloudflare-service-binding.js';
 
@@ -112,7 +112,7 @@ test('internal paths require a private service identity', async () => {
     assert.equal((await permitted.json()).error, 'internal_route_not_found');
 });
 
-test('finance gateway enforces CSRF before the domain and fails closed when its distributed limiter rejects', async () => {
+test('finance gateway enforces the cross-domain CSRF envelope before forwarding', async () => {
   let domainCalls = 0;
   const rateLimited = createApiGateway({
     inventoryHandler: async () => new Response('inventory'),
@@ -122,20 +122,29 @@ test('finance gateway enforces CSRF before the domain and fails closed when its 
   const csrfDenied = await rateLimited(new Request('https://api.skincos.com.br/finance/accounts', { method: 'POST', headers: { 'idempotency-key': 'x' } }), {}, {});
   assert.equal(csrfDenied.status, 403); assert.equal(domainCalls, 0);
 
-  const limiter = { idFromName: () => 'finance-limiter', get: () => ({ fetch: async () => new Response(JSON.stringify({ allowed: false }), { headers: { 'content-type': 'application/json' } }) }) };
-  const blocked = await rateLimited(new Request('https://api.skincos.com.br/finance/imports', { method: 'POST', headers: { 'x-csrf-token': 'csrf-ok', 'idempotency-key': 'x' } }), { RATE_LIMITER: limiter }, {});
-  assert.equal(blocked.status, 429); assert.equal((await blocked.json()).error, 'FINANCE_RATE_LIMITED'); assert.equal(domainCalls, 0);
+  const allowed = await rateLimited(new Request('https://api.skincos.com.br/finance/imports', { method: 'POST', headers: { 'x-csrf-token': 'csrf-ok', 'idempotency-key': 'x' } }), {}, {});
+  assert.equal(allowed.status, 200); assert.equal(domainCalls, 1);
 });
 
-test('finance gateway passes only an authenticated, CSRF-valid request after the limiter allows it', async () => {
+test('Finance health probes bypass user identity but remain isolated to the Finance binding', async () => {
+  resetBoundServiceResilienceForTest();
+  let receivedPath = null;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/finance/health'), {
+    FINANCE: { fetch: async (request) => { receivedPath = new URL(request.url).pathname; return new Response(JSON.stringify({ ok: true, unit: 'finance' }), { headers: { 'content-type': 'application/json' } }); } },
+  }, {});
+  assert.equal(response.status, 200);
+  assert.equal(receivedPath, '/health');
+  assert.equal((await response.json()).unit, 'finance');
+});
+
+test('finance gateway passes only an authenticated, CSRF-valid request', async () => {
   let seenPath = null;
   const gateway = createApiGateway({
     inventoryHandler: async () => new Response('inventory'),
     financeDomainHandler: async (request) => { seenPath = new URL(request.url).pathname; return new Response('finance-ok'); },
     resolveActor: async () => ({ actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' }),
   });
-  const limiter = { idFromName: () => 'finance-limiter', get: () => ({ fetch: async () => new Response(JSON.stringify({ allowed: true }), { headers: { 'content-type': 'application/json' } }) }) };
-  const allowed = await gateway(new Request('https://api.skincos.com.br/finance/imports', { method: 'POST', headers: { 'x-csrf-token': 'csrf-ok', 'idempotency-key': 'x' } }), { RATE_LIMITER: limiter }, {});
+  const allowed = await gateway(new Request('https://api.skincos.com.br/finance/imports', { method: 'POST', headers: { 'x-csrf-token': 'csrf-ok', 'idempotency-key': 'x' } }), {}, {});
   assert.equal(allowed.status, 200); assert.equal(seenPath, '/imports');
 });
 
@@ -167,18 +176,3 @@ test('Finance is reached through an explicit service binding with a short-lived 
   assert.equal(received.headers.get('x-csrf-token'), null);
   assert.equal((await verifySignedDomainContext(received, 'finance-secret', 'finance')).actor.username, 'pilot');
 });
-
-test('finance rate limits reads, writes and imports in independent buckets', async () => {
-  const limiterRequests = [];
-  const limiter = { idFromName: () => 'finance-limiter', get: () => ({ fetch: async (input) => { limiterRequests.push(String(input)); return new Response(JSON.stringify({ allowed: true }), { headers: { 'content-type': 'application/json' } }); } }) };
-  const env = { RATE_LIMITER: limiter };
-  const actor = { username: 'pilot' };
-  await enforceFinanceRateLimit(new Request('https://api.skincos.com.br/overview'), env, actor);
-  await enforceFinanceRateLimit(new Request('https://api.skincos.com.br/accounts', { method: 'POST' }), env, actor);
-  await enforceFinanceRateLimit(new Request('https://api.skincos.com.br/imports', { method: 'POST' }), env, actor);
-  expectQuery(limiterRequests[0], 'key=finance:read&limit=240');
-  expectQuery(limiterRequests[1], 'key=finance:write&limit=60');
-  expectQuery(limiterRequests[2], 'key=finance:import&limit=12');
-});
-
-function expectQuery(url, expected) { assert.ok(url.includes(expected), `${url} should include ${expected}`); }

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -36,8 +36,16 @@ database_name = "skincos-db"
 database_id = "13e59612-99ba-450e-9014-ddefbee72965"
 
 [[services]]
+binding = "INVENTORY"
+service = "skincos-insumos"
+
+[[services]]
 binding = "TIMEKEEPING"
 service = "skincos-timekeeping"
+
+[[services]]
+binding = "FINANCE"
+service = "skincos-finance"
 
 [[r2_buckets]]
 binding = "BACKUP_BUCKET"
@@ -69,8 +77,16 @@ database_name = "skincos-db-staging"
 database_id = "4bdd7995-ad69-465a-917c-0aab22db5c4e"
 
 [[env.staging.services]]
+binding = "INVENTORY"
+service = "skincos-insumos-staging"
+
+[[env.staging.services]]
 binding = "TIMEKEEPING"
 service = "skincos-timekeeping-staging"
+
+[[env.staging.services]]
+binding = "FINANCE"
+service = "skincos-finance-staging"
 
 [[env.staging.r2_buckets]]
 binding = "BACKUP_BUCKET"

--- a/crm/console/e2e/module-shell-isolation.spec.ts
+++ b/crm/console/e2e/module-shell-isolation.spec.ts
@@ -55,11 +55,11 @@ test('unit selection remains available after the shell loads a module directly',
 
 test('a Finance chunk failure does not take down the shell or another module', async ({ page }) => {
   await mockAuthenticatedShell(page)
-  await page.route('**/FinanceModule.tsx*', async (route) => route.abort('failed'))
+  await page.route('**/finance-module.js*', async (route) => route.abort('failed'))
   await page.goto('/?module=finance')
 
-  await expect(page.getByText('Este módulo está indisponível')).toBeVisible({ timeout: 30_000 })
-  await expect(page.getByText(/falha foi isolada/i)).toBeVisible()
+  await expect(page.getByTestId('finance-remote-unavailable')).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText(/versão independente do Financeiro não pôde ser carregada/i)).toBeVisible()
   await expect(page.getByRole('button', { name: 'Insumos' })).toBeVisible()
 
   // Vite's development error overlay is outside the application shell. Dismiss it

--- a/crm/console/finance-remote/entry.tsx
+++ b/crm/console/finance-remote/entry.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import '../main.css'
+import { FinanceModule } from '../FinanceModule'
+
+export function mount(element: HTMLElement) {
+  const root = createRoot(element)
+  root.render(<FinanceModule />)
+  return () => root.unmount()
+}

--- a/crm/console/modules/RemoteFinanceModule.tsx
+++ b/crm/console/modules/RemoteFinanceModule.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { FinanceModule } from '@/FinanceModule'
+import { Button } from '@/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/card'
 
 type FinanceRemote = { mount: (element: HTMLElement) => void | (() => void) }
 
@@ -7,24 +8,19 @@ type FinanceRemote = { mount: (element: HTMLElement) => void | (() => void) }
 export function RemoteFinanceModule() {
   const container = React.useRef<HTMLDivElement>(null)
   const [failed, setFailed] = React.useState(false)
+  const [retry, setRetry] = React.useState(0)
   const remoteUrl = String(import.meta.env.VITE_FINANCE_MODULE_URL || '').trim()
 
   React.useEffect(() => {
     if (!remoteUrl || !container.current) return
     let disposed = false; let cleanup: void | (() => void)
-    const cssUrl = remoteUrl.replace(/\.js(?:\?.*)?$/, '.css')
-    const stylesheet = document.querySelector<HTMLLinkElement>(`link[data-finance-remote-css="${cssUrl}"]`) || (() => {
-      const link = document.createElement('link')
-      link.rel = 'stylesheet'; link.href = cssUrl; link.dataset.financeRemoteCss = cssUrl
-      document.head.append(link)
-      return link
-    })()
+    setFailed(false)
     import(/* @vite-ignore */ remoteUrl)
       .then((remote: FinanceRemote) => { if (!disposed) cleanup = remote.mount(container.current!) })
       .catch(() => { if (!disposed) setFailed(true) })
-    return () => { disposed = true; cleanup?.(); if (!document.querySelector('[data-finance-remote="true"]')) stylesheet.remove() }
-  }, [remoteUrl])
+    return () => { disposed = true; cleanup?.() }
+  }, [remoteUrl, retry])
 
-  if (!remoteUrl || failed) return <FinanceModule />
+  if (!remoteUrl || failed) return <Card className="border-amber-400/30 bg-slate-950/60 text-white" data-testid="finance-remote-unavailable"><CardHeader><CardTitle>Financeiro indisponível</CardTitle><CardDescription>{remoteUrl ? 'A versão independente do Financeiro não pôde ser carregada. A navegação e os demais módulos continuam disponíveis.' : 'O Financeiro ainda não foi associado a um artefato liberado neste ambiente.'}</CardDescription></CardHeader><CardContent>{remoteUrl && <Button variant="outline" onClick={() => setRetry((value) => value + 1)}>Tentar novamente</Button>}</CardContent></Card>
   return <div ref={container} data-finance-remote="true" aria-busy="true" />
 }

--- a/crm/console/modules/RemoteFinanceModule.tsx
+++ b/crm/console/modules/RemoteFinanceModule.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { FinanceModule } from '@/FinanceModule'
+
+type FinanceRemote = { mount: (element: HTMLElement) => void | (() => void) }
+
+/** Loads an independently published Finance bundle without making it a shell dependency. */
+export function RemoteFinanceModule() {
+  const container = React.useRef<HTMLDivElement>(null)
+  const [failed, setFailed] = React.useState(false)
+  const remoteUrl = String(import.meta.env.VITE_FINANCE_MODULE_URL || '').trim()
+
+  React.useEffect(() => {
+    if (!remoteUrl || !container.current) return
+    let disposed = false; let cleanup: void | (() => void)
+    const cssUrl = remoteUrl.replace(/\.js(?:\?.*)?$/, '.css')
+    const stylesheet = document.querySelector<HTMLLinkElement>(`link[data-finance-remote-css="${cssUrl}"]`) || (() => {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'; link.href = cssUrl; link.dataset.financeRemoteCss = cssUrl
+      document.head.append(link)
+      return link
+    })()
+    import(/* @vite-ignore */ remoteUrl)
+      .then((remote: FinanceRemote) => { if (!disposed) cleanup = remote.mount(container.current!) })
+      .catch(() => { if (!disposed) setFailed(true) })
+    return () => { disposed = true; cleanup?.(); if (!document.querySelector('[data-finance-remote="true"]')) stylesheet.remove() }
+  }, [remoteUrl])
+
+  if (!remoteUrl || failed) return <FinanceModule />
+  return <div ref={container} data-finance-remote="true" aria-busy="true" />
+}

--- a/crm/console/modules/registry.tsx
+++ b/crm/console/modules/registry.tsx
@@ -54,7 +54,7 @@ export const crmModuleRegistry: readonly CrmModuleManifest[] = [
   manifest({ key: 'hr', label: 'RH', icon: '👥', loader: () => import('@/HRModule').then((m) => ({ default: m.HRModule })) }),
   manifest({ key: 'ponto', label: 'Ponto', icon: '⏱️', loader: () => import('@/PontoModule').then((m) => ({ default: m.PontoModule })) }),
   manifest({ key: 'procurement', label: 'Compras', icon: '🛒', loader: () => import('@/ProcurementModule').then((m) => ({ default: m.ProcurementModule })) }),
-  manifest({ key: 'finance', label: 'Financeiro', icon: <img src="/icons/money.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/FinanceModule').then((m) => ({ default: m.FinanceModule })) }),
+  manifest({ key: 'finance', label: 'Financeiro', icon: <img src="/icons/money.png" alt="" aria-hidden className="h-5 w-5" />, loader: () => import('@/modules/RemoteFinanceModule').then((m) => ({ default: m.RemoteFinanceModule })) }),
   manifest({ key: 'products', label: 'Produtos', icon: '📂', loader: () => import('@/ProductCatalog').then((m) => ({ default: m.ProductCatalog })) }),
   manifest({ key: 'pipelines', label: 'Pipelines', icon: '🔀', loader: () => import('@/PipelineManager').then((m) => ({ default: m.PipelineManager })) }),
   manifest({ key: 'lead-scoring', label: 'Lead Scoring', icon: '⭐', loader: () => import('@/LeadScoringSystem').then((m) => ({ default: m.LeadScoringSystem })) }),

--- a/crm/console/vite.finance.config.ts
+++ b/crm/console/vite.finance.config.ts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react'
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+/** Dedicated deployable Finance artifact. The CRM shell loads it by a stable URL. */
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { '@': resolve(import.meta.dirname, '.') }, dedupe: ['react', 'react-dom'] },
+  build: {
+    outDir: 'dist-finance',
+    emptyOutDir: true,
+    lib: { entry: resolve(import.meta.dirname, 'finance-remote/entry.tsx'), formats: ['es'], fileName: 'finance-module' },
+    rollupOptions: { output: { inlineDynamicImports: true } },
+  },
+})

--- a/docs/architecture/finance-foundation-review.md
+++ b/docs/architecture/finance-foundation-review.md
@@ -3,7 +3,7 @@
 ## Correções desta revisão
 
 - O mount `/finance` deixou de entrar no Worker de Inventário, que aplicava uma unidade padrão antes de o Financeiro validar o próprio escopo.
-- A sessão e CSRF continuam sendo CRM, através de `shared/crm-auth`; não há segundo login ou cookie.
+- A sessão e CSRF são responsabilidade de `identity/`, pelo contrato `shared/identity-contract`; não há segundo login ou cookie.
 - Contas operacionais agora têm contas de razão; receitas, despesas e transferências criam débito/crédito em contas distintas e balanceadas.
 - A migration inclui parcelas, relação movimento-tag, candidatos de duplicidade e idempotência vinculada a ator, rota e escopo.
 - O deploy deixou de executar migration Financeiro como efeito colateral de qualquer alteração em Inventário.

--- a/docs/architecture/finance-foundation.md
+++ b/docs/architecture/finance-foundation.md
@@ -2,7 +2,7 @@
 
 ## Fonte de verdade e propriedade
 
-`finance/` é o único dono de movimentos, partidas, importações, conciliação, auditoria e relatórios. O D1 `skincos-db` é acessado pelo gateway em `api.skincos.com.br/finance/*`. `integration/` apenas coleta e normaliza entradas externas; `crm/console` não calcula nem persiste regras financeiras. O gateway chama o handler Financeiro diretamente; ele não encaminha mais `/finance` pelo Worker de Inventário. `shared/crm-auth` é somente a fachada transitória da sessão CRM e delega a validação para Identity; Financeiro recebe apenas o ator autenticado e seus escopos.
+`finance/` é o único dono de movimentos, partidas, importações, conciliação, auditoria e relatórios. O gateway encaminha apenas `/finance/*` por service binding; `crm/console` não calcula nem persiste regras financeiras. `Identity` valida a sessão existente e entrega ao Financeiro somente um ator autenticado e seus escopos por contrato assinado de curta duração. O domínio não lê usuários, hashes, sessões ou D1 de Inventory.
 
 O antigo `backend/apps/actual-server` não é serviço, banco, autenticação ou dependência do Financeiro. Sua licença MIT permite referência seletiva, mas não há código nem estado importado dele.
 

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -1,0 +1,30 @@
+# Deploy independente de módulos CRM
+
+## Contrato operacional
+
+O CRM continua um único Pages/shell visual. As rotas de domínio continuam atrás do gateway, mas Financeiro, Ponto e Atendimento possuem artefato/processo e pipeline próprios. Uma publicação, rollback ou manutenção do domínio não publica o Pages, Inventory ou os demais domínios.
+
+| Módulo | Unidade operacional | Pipeline canônico | Controle sem deploy | Rollback |
+| --- | --- | --- | --- | --- |
+| Financeiro | Worker `skincos-finance` / `skincos-finance-staging` | `deploy-finance.yml` | KV `module-control:finance` | mesmo workflow, `operation=rollback` e SHA já promovido |
+| Ponto | Worker `skincos-timekeeping` / `skincos-timekeeping-staging` | `deploy-timekeeping.yml` | KV `module-control:timekeeping` | versão Worker anterior + checkpoint D1; nunca republicar `api` |
+| Atendimento | processo `CRM_DOMAIN=atendimento` | `deploy-atendimento.yml` | `atendimento-availability.yml` grava o arquivo indicado por `CRM_MODULE_CONTROL_FILE` | mesmo workflow com SHA anterior e comando de rollback dedicado |
+
+O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele resolve a sessão uma vez, remove cookie/CSRF do encaminhamento e entrega ao Worker apenas um contexto de ator HMAC de curta duração. Portanto o Worker financeiro não lê sessão, implementação de Identity ou D1 de Inventory.
+
+## Ordem segura de ativação
+
+1. Criar os dois Workers Financeiro, os dois D1s Financeiro e os dois KVs de controle, sem rota pública.
+2. Configurar `FINANCE_SERVICE_AUTH_SECRET` idêntico apenas entre gateway e Financeiro **no mesmo ambiente**; nunca copiar secret de produção para staging.
+3. Executar Financeiro em staging pelo SHA de `main`, aplicar migrations aditivas, smoke `/finance/health` e guardar a attestation.
+4. Fazer a única publicação de bootstrap do gateway com a nova service binding `FINANCE`, depois promover o mesmo SHA Financeiro. Mudanças seguintes do Financeiro não publicam o gateway.
+5. Configurar o unit/service dedicado do Atendimento, remover seu mount do processo CRM compartilhado e validar health por ambiente. Só então habilitar `ENABLE_ATENDIMENTO_DEPLOY=true`.
+
+## Configuração externa mínima
+
+- GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `MODULE_CONTROL_STAGING_KV_ID`, `MODULE_CONTROL_PRODUCTION_KV_ID` e `FINANCE_SERVICE_AUTH_SECRET`, todos segregados.
+- Cloudflare: criar `skincos-finance` e `skincos-finance-staging` antes do bootstrap do `api`; criar D1/KV separados por ambiente; conceder ao token somente Workers/D1/KV necessários.
+- Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
+- Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.
+
+Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado ou attestation falham explicitamente e não fazem deploy parcial.

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -6,29 +6,29 @@ O CRM continua um único Pages/shell visual. As rotas de domínio continuam atr�
 
 | Módulo | Unidade operacional | Pipeline canônico | Controle sem deploy | Rollback |
 | --- | --- | --- | --- | --- |
-| Financeiro API | Worker `skincos-finance` / `skincos-finance-staging` | `deploy-finance.yml` | KV `module-control:finance` | mesmo workflow, `operation=rollback` e SHA já promovido |
+| Financeiro API | Worker `skincos-finance` / `skincos-finance-staging` | `deploy-finance.yml` | KV `module-control:finance` | `versions deploy` de versão já enviada para o SHA promovido |
 | Financeiro UI | Pages `FINANCE_UI_PAGES_PROJECT_*` | `deploy-finance-ui.yml` | URL estável `VITE_FINANCE_MODULE_URL` no shell | publicar o SHA já promovido pelo mesmo pipeline |
 | Ponto | Worker `skincos-timekeeping` / `skincos-timekeeping-staging` | `deploy-timekeeping.yml` | KV `module-control:timekeeping` | versão Worker anterior + checkpoint D1; nunca republicar `api` |
 | Atendimento | processo `CRM_DOMAIN=atendimento` | `deploy-atendimento.yml` | `atendimento-availability.yml` grava o arquivo indicado por `CRM_MODULE_CONTROL_FILE` | mesmo workflow com SHA anterior e comando de rollback dedicado |
 
-O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele resolve a sessão uma vez, remove cookie/CSRF do encaminhamento e entrega ao Worker apenas um contexto de ator HMAC de curta duração. Portanto o Worker financeiro não lê sessão, implementação de Identity ou D1 de Inventory.
+O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele resolve a sessão uma vez, valida CSRF, remove cookie/CSRF do encaminhamento e entrega ao Worker apenas um contexto de ator HMAC de curta duração. Os probes públicos `/finance/health` e `/finance/readiness` são somente encaminhados, sem ator. Portanto o Worker financeiro não lê sessão, implementação de Identity ou D1 de Inventory; disponibilidade, canary, escopos e regras financeiras pertencem ao domínio Financeiro.
 
 ## Ordem segura de ativação
 
 1. Criar os dois Workers Financeiro, os dois D1s Financeiro, os dois KVs de controle e os dois projetos Pages de UI, sem rota pública.
 2. Configurar `FINANCE_SERVICE_AUTH_SECRET` idêntico apenas entre gateway e Financeiro **no mesmo ambiente**; nunca copiar secret de produção para staging.
 3. Executar o preview imutável, depois Financeiro API e UI em staging pelo mesmo SHA de `main`; o pipeline exporta e cifra checkpoint D1, aplica somente migrations aditivas, smoke `/finance/health` e guarda a evidência de promoção.
-4. Fazer a única publicação de bootstrap do gateway com a nova service binding `FINANCE` e do shell com `VITE_FINANCE_MODULE_URL`; mudanças seguintes do Financeiro não publicam gateway nem CRM Pages.
+4. Fazer uma única publicação de bootstrap do gateway pelo pipeline canônico `deploy-core-workers.yml`, selecionando `unit=api` e `bootstrap_finance_context=true`, com a nova service binding `FINANCE`; no mesmo estágio, executar o primeiro `deploy-finance.yml` com `bootstrap_service_secret=true`. Publicar o shell uma única vez com `VITE_FINANCE_MODULE_URL`. Mudanças seguintes do Financeiro não publicam gateway, Inventory ou CRM Pages.
 5. Configurar o unit/service dedicado do Atendimento, remover seu mount do processo CRM compartilhado e validar health por ambiente. Só então habilitar `ENABLE_ATENDIMENTO_DEPLOY=true`.
 
 ## Configuração externa mínima
 
 - GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `FINANCE_CONTROL_STAGING_KV_ID`, `FINANCE_CONTROL_PRODUCTION_KV_ID`, `FINANCE_UI_PAGES_PROJECT_STAGING`, `FINANCE_UI_PAGES_PROJECT_PRODUCTION`, `FINANCE_SERVICE_AUTH_SECRET` e `FINANCE_BACKUP_PASSPHRASE`, todos segregados.
 - Cloudflare: criar `skincos-finance` e `skincos-finance-staging` antes do bootstrap do `api`; criar D1/KV separados por ambiente; conceder ao token somente Workers/D1/KV necessários.
-- CRM Pages: definir `FINANCE_UI_MODULE_URL` no Environment GitHub para a URL estável `https://skincos-finance-ui-staging.pages.dev/finance-module.js` em staging (e o equivalente produtivo apenas após aprovação). O pipeline canônico de Pages injeta esse valor no build; sem ele o shell usa o fallback local.
+- CRM Pages: definir `FINANCE_UI_MODULE_URL` no Environment GitHub para a URL estável `https://skincos-finance-ui-staging.pages.dev/finance-module.js` em staging (e o equivalente produtivo apenas após aprovação). O pipeline canônico de Pages injeta esse valor no build; sem ele, ou se o bundle falhar, o shell exibe apenas o estado isolado de indisponibilidade — nunca uma cópia local das regras financeiras.
 - Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
 - Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.
 
 Canary é deliberadamente por ator-piloto explícito no KV, não por porcentagem aleatória: o workflow `module-availability.yml` exige `state=canary` e a lista de atores. `maintenance` e `disabled` não publicam artefato. O rollback de código só aceita SHA já promovido; dados não sofrem rollback destrutivo — o checkpoint cifrado é restaurado antes em ambiente isolado e comparado com razão, auditoria, movimentos e lotes.
 
-Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado, checkpoint ou evidência de promoção falham explicitamente e não fazem deploy parcial.
+Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado, checkpoint ou evidência de promoção falham explicitamente e não fazem deploy parcial. O rollback do Worker não recompila nem publica outro módulo: seleciona a versão já associada ao SHA de retorno. O rollback da UI republica somente o bundle construído do SHA previamente promovido, no projeto Pages isolado.

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -23,7 +23,7 @@ O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele
 
 ## Configuração externa mínima
 
-- GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `MODULE_CONTROL_STAGING_KV_ID`, `MODULE_CONTROL_PRODUCTION_KV_ID`, `FINANCE_UI_PAGES_PROJECT_STAGING`, `FINANCE_UI_PAGES_PROJECT_PRODUCTION`, `FINANCE_SERVICE_AUTH_SECRET` e `FINANCE_BACKUP_PASSPHRASE`, todos segregados.
+- GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `FINANCE_CONTROL_STAGING_KV_ID`, `FINANCE_CONTROL_PRODUCTION_KV_ID`, `FINANCE_UI_PAGES_PROJECT_STAGING`, `FINANCE_UI_PAGES_PROJECT_PRODUCTION`, `FINANCE_SERVICE_AUTH_SECRET` e `FINANCE_BACKUP_PASSPHRASE`, todos segregados.
 - Cloudflare: criar `skincos-finance` e `skincos-finance-staging` antes do bootstrap do `api`; criar D1/KV separados por ambiente; conceder ao token somente Workers/D1/KV necessários.
 - Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
 - Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -6,7 +6,8 @@ O CRM continua um único Pages/shell visual. As rotas de domínio continuam atr�
 
 | Módulo | Unidade operacional | Pipeline canônico | Controle sem deploy | Rollback |
 | --- | --- | --- | --- | --- |
-| Financeiro | Worker `skincos-finance` / `skincos-finance-staging` | `deploy-finance.yml` | KV `module-control:finance` | mesmo workflow, `operation=rollback` e SHA já promovido |
+| Financeiro API | Worker `skincos-finance` / `skincos-finance-staging` | `deploy-finance.yml` | KV `module-control:finance` | mesmo workflow, `operation=rollback` e SHA já promovido |
+| Financeiro UI | Pages `FINANCE_UI_PAGES_PROJECT_*` | `deploy-finance-ui.yml` | URL estável `VITE_FINANCE_MODULE_URL` no shell | publicar o SHA já promovido pelo mesmo pipeline |
 | Ponto | Worker `skincos-timekeeping` / `skincos-timekeeping-staging` | `deploy-timekeeping.yml` | KV `module-control:timekeeping` | versão Worker anterior + checkpoint D1; nunca republicar `api` |
 | Atendimento | processo `CRM_DOMAIN=atendimento` | `deploy-atendimento.yml` | `atendimento-availability.yml` grava o arquivo indicado por `CRM_MODULE_CONTROL_FILE` | mesmo workflow com SHA anterior e comando de rollback dedicado |
 
@@ -14,17 +15,19 @@ O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele
 
 ## Ordem segura de ativação
 
-1. Criar os dois Workers Financeiro, os dois D1s Financeiro e os dois KVs de controle, sem rota pública.
+1. Criar os dois Workers Financeiro, os dois D1s Financeiro, os dois KVs de controle e os dois projetos Pages de UI, sem rota pública.
 2. Configurar `FINANCE_SERVICE_AUTH_SECRET` idêntico apenas entre gateway e Financeiro **no mesmo ambiente**; nunca copiar secret de produção para staging.
-3. Executar Financeiro em staging pelo SHA de `main`, aplicar migrations aditivas, smoke `/finance/health` e guardar a attestation.
-4. Fazer a única publicação de bootstrap do gateway com a nova service binding `FINANCE`, depois promover o mesmo SHA Financeiro. Mudanças seguintes do Financeiro não publicam o gateway.
+3. Executar o preview imutável, depois Financeiro API e UI em staging pelo mesmo SHA de `main`; o pipeline exporta e cifra checkpoint D1, aplica somente migrations aditivas, smoke `/finance/health` e guarda a evidência de promoção.
+4. Fazer a única publicação de bootstrap do gateway com a nova service binding `FINANCE` e do shell com `VITE_FINANCE_MODULE_URL`; mudanças seguintes do Financeiro não publicam gateway nem CRM Pages.
 5. Configurar o unit/service dedicado do Atendimento, remover seu mount do processo CRM compartilhado e validar health por ambiente. Só então habilitar `ENABLE_ATENDIMENTO_DEPLOY=true`.
 
 ## Configuração externa mínima
 
-- GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `MODULE_CONTROL_STAGING_KV_ID`, `MODULE_CONTROL_PRODUCTION_KV_ID` e `FINANCE_SERVICE_AUTH_SECRET`, todos segregados.
+- GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `MODULE_CONTROL_STAGING_KV_ID`, `MODULE_CONTROL_PRODUCTION_KV_ID`, `FINANCE_UI_PAGES_PROJECT_STAGING`, `FINANCE_UI_PAGES_PROJECT_PRODUCTION`, `FINANCE_SERVICE_AUTH_SECRET` e `FINANCE_BACKUP_PASSPHRASE`, todos segregados.
 - Cloudflare: criar `skincos-finance` e `skincos-finance-staging` antes do bootstrap do `api`; criar D1/KV separados por ambiente; conceder ao token somente Workers/D1/KV necessários.
 - Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
 - Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.
 
-Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado ou attestation falham explicitamente e não fazem deploy parcial.
+Canary é deliberadamente por ator-piloto explícito no KV, não por porcentagem aleatória: o workflow `module-availability.yml` exige `state=canary` e a lista de atores. `maintenance` e `disabled` não publicam artefato. O rollback de código só aceita SHA já promovido; dados não sofrem rollback destrutivo — o checkpoint cifrado é restaurado antes em ambiente isolado e comparado com razão, auditoria, movimentos e lotes.
+
+Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado, checkpoint ou evidência de promoção falham explicitamente e não fazem deploy parcial.

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -25,6 +25,7 @@ O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele
 
 - GitHub Environments `staging` e `production`: `FINANCE_D1_STAGING_ID`, `FINANCE_D1_PRODUCTION_ID`, `FINANCE_CONTROL_STAGING_KV_ID`, `FINANCE_CONTROL_PRODUCTION_KV_ID`, `FINANCE_UI_PAGES_PROJECT_STAGING`, `FINANCE_UI_PAGES_PROJECT_PRODUCTION`, `FINANCE_SERVICE_AUTH_SECRET` e `FINANCE_BACKUP_PASSPHRASE`, todos segregados.
 - Cloudflare: criar `skincos-finance` e `skincos-finance-staging` antes do bootstrap do `api`; criar D1/KV separados por ambiente; conceder ao token somente Workers/D1/KV necessários.
+- CRM Pages: definir `FINANCE_UI_MODULE_URL` no Environment GitHub para a URL estável `https://skincos-finance-ui-staging.pages.dev/finance-module.js` em staging (e o equivalente produtivo apenas após aprovação). O pipeline canônico de Pages injeta esse valor no build; sem ele o shell usa o fallback local.
 - Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
 - Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.
 

--- a/docs/architecture/module-catalog.json
+++ b/docs/architecture/module-catalog.json
@@ -144,15 +144,15 @@
       "owner": { "primary": "@jubenitogarcia", "backup": "unassigned" },
       "dataOwnership": ["Ledger, accounts, obligations, movements, imports, access grants and finance audit trail"],
       "dependencies": { "hard": ["shared"], "optional": ["integration"] },
-      "services": ["Finance Worker mounted through the API gateway", "CRM Pages finance proxy"],
-      "datastores": ["D1 finance database with finance_settings and finance_access_grants"],
-      "routes": ["api.skincos.com.br/finance/*", "crm /api/finance/*"],
-      "healthChecks": [{ "name": "finance bootstrap gate", "command": "npm run codex:crm:finance-smoke" }],
+    "services": ["Dedicated Finance Worker reached through the API gateway service binding", "Independently published Finance Pages bundle loaded by the CRM shell"],
+    "datastores": ["Dedicated Finance D1 with finance_settings and finance_access_grants", "Dedicated Finance module-control KV per environment"],
+    "routes": ["api.skincos.com.br/finance/*", "api.skincos.com.br/finance/health", "api.skincos.com.br/finance/readiness"],
+    "healthChecks": [{ "name": "Finance Worker health/readiness", "command": "curl --fail https://api-staging.skincos.com.br/finance/readiness" }, { "name": "finance bootstrap gate", "command": "npm run codex:crm:finance-smoke" }],
       "testCommands": ["npm --prefix finance test", "npm run finance:staging:import-smoke", "npm run finance:staging:ui-smoke"],
-      "featureFlag": { "key": "finance_settings.module_enabled", "defaultState": "false", "enforcement": "The API requires an explicit CRM allowedModules grant, a finance_access_grant and module_enabled=true." },
-      "fallback": "Return FINANCE_DISABLED or FINANCE_MODULE_DENIED without exposing data; retain immutable audit data and use the controlled import/recovery runbook.",
+    "featureFlag": { "key": "finance_settings.module_enabled and module-control:finance", "defaultState": "false", "enforcement": "The Finance Worker requires an explicit CRM allowedModules grant, a finance_access_grant and module_enabled=true; its module-control KV can disable, maintain or limit canary actors without publishing the shell." },
+    "fallback": "Return FINANCE_DISABLED, FINANCE_MODULE_DENIED or isolated module maintenance without exposing data; a failed remote bundle renders only the shell unavailable state, while navigation and other modules continue.",
       "slo": { "availability": "99.5% during approved pilot windows", "latency": "p95 <= 1 s for bootstrap and reads", "measurement": "Authenticated staging smoke with explicit acknowledgement" },
-      "rollback": "Set module_enabled=false, remove pilot grants, stop imports, and restore only through the Finance D1 recovery runbook; migrations remain additive."
+    "rollback": "Set module-control to maintenance or disabled, deploy the previously uploaded Finance Worker version and republish only the previous Finance UI SHA; restore D1 only through the Finance recovery runbook. Migrations remain additive."
     },
     {
       "id": "identity",

--- a/docs/runbooks/finance-release.md
+++ b/docs/runbooks/finance-release.md
@@ -2,11 +2,13 @@
 
 ## Ordem obrigatória
 
-1. `deploy-finance.yml` em `preview` para o SHA de `main`.
-2. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`.
-3. Conferir `health`, `readiness`, logs estruturados, alertas e o artefato `promotion-evidence-finance`.
-4. Ativar `canary` pelo `module-availability.yml` apenas para atores-piloto; manter `module_enabled=false` até os grants e dados de teste controlados estarem confirmados.
-5. Para produção, usar o mesmo SHA e os dois `staging_run_id`; a aprovação do Environment é manual.
+1. No primeiro uso de cada ambiente, publicar o gateway uma única vez pelo `deploy-core-workers.yml`, com `unit=api` e `bootstrap_finance_context=true`; isso instala a service binding e o segredo de contexto sem publicar Inventory.
+2. No primeiro uso de cada ambiente, executar `deploy-finance.yml` com `bootstrap_service_secret=true`; nas execuções posteriores, manter esse campo como `false`.
+3. `deploy-finance.yml` em `preview` para o SHA de `main`.
+4. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`.
+5. Conferir `health`, `readiness`, versão, dependências, logs estruturados, alertas e os artefatos `promotion-evidence-finance` e `promotion-evidence-finance-ui`.
+6. Ativar `canary` pelo `module-availability.yml` apenas para atores-piloto; manter `module_enabled=false` até os grants e dados de teste controlados estarem confirmados.
+7. Para produção, usar o mesmo SHA e os dois `staging_run_id`; a aprovação do Environment é manual.
 
 ## Kill switch e manutenção
 
@@ -17,10 +19,11 @@
 ## Rollback e restore
 
 1. Colocar Financeiro em `maintenance`.
-2. Publicar pelo pipeline o SHA anterior que possua evidência de staging; não republicar gateway ou CRM Pages.
-3. Se a correção exigir dados, baixar o checkpoint cifrado do workflow, restaurar primeiro em D1 isolado e comparar contagem/checksum lógico de `finance_audit_events`, `finance_movements`, `finance_journal_lines` e `finance_import_batches` por escopo.
-4. Migrations são somente aditivas. Nunca apagar ledger, auditoria ou idempotência para “voltar”.
-5. Reexecutar smoke de health/readiness e o fluxo piloto antes de tirar a manutenção.
+2. Executar `deploy-finance.yml` com `operation=rollback` e o SHA anterior que possua evidência de staging. O pipeline seleciona a versão Worker já enviada para esse SHA; não recompila nem republica gateway, Inventory ou CRM Pages.
+3. Executar `deploy-finance-ui.yml` com o mesmo SHA anterior se o bundle também precisar retornar; ele publica somente o projeto Pages Financeiro.
+4. Se a correção exigir dados, baixar o checkpoint cifrado do workflow, restaurar primeiro em D1 isolado e comparar contagem/checksum lógico de `finance_audit_events`, `finance_movements`, `finance_journal_lines` e `finance_import_batches` por escopo.
+5. Migrations são somente aditivas. Nunca apagar ledger, auditoria ou idempotência para “voltar”.
+6. Reexecutar smoke de health/readiness e o fluxo piloto antes de tirar a manutenção.
 
 ## Replicação após evidência Financeiro
 

--- a/docs/runbooks/finance-release.md
+++ b/docs/runbooks/finance-release.md
@@ -1,0 +1,27 @@
+# Release, canary e recuperação do Financeiro
+
+## Ordem obrigatória
+
+1. `deploy-finance.yml` em `preview` para o SHA de `main`.
+2. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`.
+3. Conferir `health`, `readiness`, logs estruturados, alertas e o artefato `promotion-evidence-finance`.
+4. Ativar `canary` pelo `module-availability.yml` apenas para atores-piloto; manter `module_enabled=false` até os grants e dados de teste controlados estarem confirmados.
+5. Para produção, usar o mesmo SHA e os dois `staging_run_id`; a aprovação do Environment é manual.
+
+## Kill switch e manutenção
+
+- `maintenance`: responde 503 somente para Financeiro, com `x-skincos-module-state=maintenance`.
+- `disabled`: responde 423 somente para Financeiro; CRM, Inventory, Ponto e navegação continuam disponíveis.
+- `canary`: só os atores explicitamente listados no controle podem alcançar a API; demais usuários recebem 403.
+
+## Rollback e restore
+
+1. Colocar Financeiro em `maintenance`.
+2. Publicar pelo pipeline o SHA anterior que possua evidência de staging; não republicar gateway ou CRM Pages.
+3. Se a correção exigir dados, baixar o checkpoint cifrado do workflow, restaurar primeiro em D1 isolado e comparar contagem/checksum lógico de `finance_audit_events`, `finance_movements`, `finance_journal_lines` e `finance_import_batches` por escopo.
+4. Migrations são somente aditivas. Nunca apagar ledger, auditoria ou idempotência para “voltar”.
+5. Reexecutar smoke de health/readiness e o fluxo piloto antes de tirar a manutenção.
+
+## Replicação após evidência Financeiro
+
+Ponto e Atendimento só recebem o padrão após existirem: um SHA Financeiro promovido até staging, um canary concluído, um rollback de Worker/UI e um restore isolado documentado. A replicação reutiliza: pipeline imutável, health/readiness, estado por KV/controle, checkpoint cifrado e verificação de isolamento de rota. Não copiar grants, bancos, secrets ou atores-piloto do Financeiro.

--- a/finance/package.json
+++ b/finance/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/*.test.mjs",
-    "check": "node --check api/worker.js"
+    "test": "node --test --test-timeout=30000 test/*.test.mjs",
+    "check": "node --check api/worker.js && node --check worker.js"
   },
   "devDependencies": {
     "miniflare": "4.20260722.0"

--- a/finance/package.json
+++ b/finance/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test --test-timeout=30000 test/*.test.mjs",
+    "test": "node --test --test-timeout=180000 test/*.test.mjs",
     "check": "node --check api/worker.js && node --check worker.js"
   },
   "devDependencies": {

--- a/finance/test/edge-worker.test.mjs
+++ b/finance/test/edge-worker.test.mjs
@@ -5,7 +5,9 @@ import { handleFinance } from '../worker.js';
 test('Finance exposes health without a public domain route and honors runtime maintenance', async () => {
   const health = await handleFinance(new Request('https://finance.internal/health'), {}, {});
   assert.equal(health.status, 200);
-  assert.equal((await health.json()).availability.state, 'active');
+  const body = await health.json();
+  assert.equal(body.availability.state, 'active');
+  assert.equal(body.version, 'unreleased');
 
   const maintenance = await handleFinance(new Request('https://finance.internal/overview'), {
     MODULE_CONTROL: { get: async () => ({ state: 'maintenance', message: 'janela' }) },

--- a/finance/test/edge-worker.test.mjs
+++ b/finance/test/edge-worker.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleFinance } from '../worker.js';
+
+test('Finance exposes health without a public domain route and honors runtime maintenance', async () => {
+  const health = await handleFinance(new Request('https://finance.internal/health'), {}, {});
+  assert.equal(health.status, 200);
+  assert.equal((await health.json()).availability.state, 'active');
+
+  const maintenance = await handleFinance(new Request('https://finance.internal/overview'), {
+    MODULE_CONTROL: { get: async () => ({ state: 'maintenance', message: 'janela' }) },
+  }, {});
+  assert.equal(maintenance.status, 503);
+  assert.equal((await maintenance.json()).error, 'MODULE_MAINTENANCE');
+});
+
+test('Finance readiness fails closed when its D1 binding is unavailable', async () => {
+  const readiness = await handleFinance(new Request('https://finance.internal/readiness'), {}, {});
+  assert.equal(readiness.status, 503);
+  const body = await readiness.json();
+  assert.equal(body.ready, false);
+  assert.equal(body.dependencies.d1.state, 'unavailable');
+});

--- a/finance/test/edge-worker.test.mjs
+++ b/finance/test/edge-worker.test.mjs
@@ -21,3 +21,15 @@ test('Finance readiness fails closed when its D1 binding is unavailable', async 
   assert.equal(body.ready, false);
   assert.equal(body.dependencies.d1.state, 'unavailable');
 });
+
+test('Finance canary rejects a non-pilot before domain data is touched', async () => {
+  const encoder = new TextEncoder();
+  const payload = btoa(JSON.stringify({ v: 1, audience: 'finance', issuedAt: Date.now(), actor: { username: 'non-pilot', allowedModules: ['finance'] }, csrf: '' })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  const key = await crypto.subtle.importKey('raw', encoder.encode('test-secret'), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signature = btoa(String.fromCharCode(...new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(payload))))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  const response = await handleFinance(new Request('https://finance.internal/overview', { headers: { 'x-skincos-domain-context': payload, 'x-skincos-domain-signature': signature } }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'test-secret', MODULE_CONTROL: { get: async () => ({ state: 'canary', pilotActors: ['pilot'] }) },
+  }, {});
+  assert.equal(response.status, 403);
+  assert.equal((await response.json()).error, 'FINANCE_CANARY_NOT_GRANTED');
+});

--- a/finance/worker.js
+++ b/finance/worker.js
@@ -1,25 +1,35 @@
 import { createFinanceHandler } from './api/worker.js';
-import { readModuleAvailability, moduleHealthResponse, moduleUnavailableResponse } from '../shared/module-availability/worker.js';
+import { canUseCanary, readModuleAvailability, moduleUnavailableResponse } from '../shared/module-availability/worker.js';
 import { verifySignedDomainContext } from '../shared/service-adapters/signed-domain-context.js';
-import { dependencyState, operationalStatus } from '../shared/observability/contract.js';
+import { dependencyState, operationalLog, operationalStatus } from '../shared/observability/contract.js';
 
 const handler = createFinanceHandler();
 const requestIdFor = (request) => String(request.headers.get('x-request-id') || crypto.randomUUID()).trim();
 const healthPath = (path) => path === '/health' || path === '/readiness';
+async function d1Ready(env) {
+  if (!env?.DB) return false;
+  try { await env.DB.prepare('SELECT 1 AS ready').first(); return true; } catch { return false; }
+}
 
 export async function handleFinance(request, env, ctx) {
   const requestId = requestIdFor(request);
+  const startedAt = Date.now();
   const availability = await readModuleAvailability(env, 'finance');
   const path = new URL(request.url).pathname;
   if (healthPath(path)) {
-    const ready = Boolean(env?.DB) && availability.state === 'active';
-    return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(Boolean(env?.DB)), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status: path === '/readiness' && !ready ? 503 : 200, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
+    const d1 = await d1Ready(env);
+    const ready = d1 && ['active', 'canary'].includes(availability.state);
+    const status = path === '/readiness' && !ready ? 503 : 200;
+    console.log(operationalLog({ domain: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status, route: path }));
+    return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(d1), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
   }
-  if (availability.state !== 'active') return moduleUnavailableResponse('finance', availability, requestId);
+  if (!['active', 'canary'].includes(availability.state)) return moduleUnavailableResponse('finance', availability, requestId);
   const auth = await verifySignedDomainContext(request, String(env?.FINANCE_SERVICE_AUTH_SECRET || ''), 'finance');
   if (!auth) return new Response(JSON.stringify({ ok: false, error: 'SERVICE_IDENTITY_REQUIRED' }), { status: 401, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-request-id': requestId } });
+  if (!canUseCanary(availability, auth.actor)) return new Response(JSON.stringify({ ok: false, error: 'FINANCE_CANARY_NOT_GRANTED', module: 'finance' }), { status: 403, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': 'canary', 'x-request-id': requestId } });
   const response = await handler(request, env, ctx, auth);
   const headers = new Headers(response.headers); headers.set('x-request-id', requestId); headers.set('x-skincos-module-state', availability.state);
+  console.log(operationalLog({ domain: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status: response.status, route: path }));
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 

--- a/finance/worker.js
+++ b/finance/worker.js
@@ -14,14 +14,15 @@ async function d1Ready(env) {
 export async function handleFinance(request, env, ctx) {
   const requestId = requestIdFor(request);
   const startedAt = Date.now();
+  const version = env?.APP_VERSION || env?.VERSION_METADATA?.id || 'unreleased';
   const availability = await readModuleAvailability(env, 'finance');
   const path = new URL(request.url).pathname;
   if (healthPath(path)) {
     const d1 = await d1Ready(env);
     const ready = d1 && ['active', 'canary'].includes(availability.state);
     const status = path === '/readiness' && !ready ? 503 : 200;
-    console.log(operationalLog({ domain: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status, route: path }));
-    return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(d1), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
+    console.log(operationalLog({ domain: 'finance', version, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status, route: path }));
+    return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(d1), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
   }
   if (!['active', 'canary'].includes(availability.state)) return moduleUnavailableResponse('finance', availability, requestId);
   const auth = await verifySignedDomainContext(request, String(env?.FINANCE_SERVICE_AUTH_SECRET || ''), 'finance');
@@ -29,7 +30,7 @@ export async function handleFinance(request, env, ctx) {
   if (!canUseCanary(availability, auth.actor)) return new Response(JSON.stringify({ ok: false, error: 'FINANCE_CANARY_NOT_GRANTED', module: 'finance' }), { status: 403, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': 'canary', 'x-request-id': requestId } });
   const response = await handler(request, env, ctx, auth);
   const headers = new Headers(response.headers); headers.set('x-request-id', requestId); headers.set('x-skincos-module-state', availability.state);
-  console.log(operationalLog({ domain: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status: response.status, route: path }));
+  console.log(operationalLog({ domain: 'finance', version, environment: env?.ENVIRONMENT, requestId, durationMs: Date.now() - startedAt, status: response.status, route: path }));
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 

--- a/finance/worker.js
+++ b/finance/worker.js
@@ -1,0 +1,26 @@
+import { createFinanceHandler } from './api/worker.js';
+import { readModuleAvailability, moduleHealthResponse, moduleUnavailableResponse } from '../shared/module-availability/worker.js';
+import { verifySignedDomainContext } from '../shared/service-adapters/signed-domain-context.js';
+import { dependencyState, operationalStatus } from '../shared/observability/contract.js';
+
+const handler = createFinanceHandler();
+const requestIdFor = (request) => String(request.headers.get('x-request-id') || crypto.randomUUID()).trim();
+const healthPath = (path) => path === '/health' || path === '/readiness';
+
+export async function handleFinance(request, env, ctx) {
+  const requestId = requestIdFor(request);
+  const availability = await readModuleAvailability(env, 'finance');
+  const path = new URL(request.url).pathname;
+  if (healthPath(path)) {
+    const ready = Boolean(env?.DB) && availability.state === 'active';
+    return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version: env?.APP_VERSION, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(Boolean(env?.DB)), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status: path === '/readiness' && !ready ? 503 : 200, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
+  }
+  if (availability.state !== 'active') return moduleUnavailableResponse('finance', availability, requestId);
+  const auth = await verifySignedDomainContext(request, String(env?.FINANCE_SERVICE_AUTH_SECRET || ''), 'finance');
+  if (!auth) return new Response(JSON.stringify({ ok: false, error: 'SERVICE_IDENTITY_REQUIRED' }), { status: 401, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-request-id': requestId } });
+  const response = await handler(request, env, ctx, auth);
+  const headers = new Headers(response.headers); headers.set('x-request-id', requestId); headers.set('x-skincos-module-state', availability.state);
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export default { fetch: handleFinance };

--- a/finance/wrangler.toml
+++ b/finance/wrangler.toml
@@ -1,0 +1,28 @@
+name = "skincos-finance"
+main = "worker.js"
+compatibility_date = "2026-07-23"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "skincos-finance"
+database_id = "__CONFIGURE_FINANCE_D1_ID__"
+migrations_dir = "migrations"
+
+[[kv_namespaces]]
+binding = "MODULE_CONTROL"
+id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
+
+[env.staging]
+name = "skincos-finance-staging"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "skincos-finance-staging"
+database_id = "__CONFIGURE_FINANCE_STAGING_D1_ID__"
+migrations_dir = "migrations"
+
+[[env.staging.kv_namespaces]]
+binding = "MODULE_CONTROL"
+id = "__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__"
+
+# FINANCE_SERVICE_AUTH_SECRET is a secret set separately in production and staging.

--- a/finance/wrangler.toml
+++ b/finance/wrangler.toml
@@ -2,6 +2,10 @@ name = "skincos-finance"
 main = "worker.js"
 compatibility_date = "2026-07-23"
 
+[vars]
+APP_VERSION = "__RELEASE_SHA__"
+ENVIRONMENT = "production"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "skincos-finance"
@@ -14,6 +18,10 @@ id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
 
 [env.staging]
 name = "skincos-finance-staging"
+
+[env.staging.vars]
+APP_VERSION = "__RELEASE_SHA__"
+ENVIRONMENT = "staging"
 
 [[env.staging.d1_databases]]
 binding = "DB"

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -4,13 +4,35 @@
     {
       "id": "core-workers",
       "workflow": ".github/workflows/deploy-core-workers.yml",
-      "concurrencyPrefix": "deploy-core-workers-",
+      "concurrencyPrefix": "deploy-core-worker-",
       "publishes": ["Worker:skincos-api", "Worker:skincos-insumos"],
       "resources": ["api gateway Worker", "inventory Worker", "skincos-db", "skincos-db-staging"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
       "migrationPaths": ["inventory/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {"stagingSupported": true, "financeIncluded": true}
+    },
+    {
+      "id": "finance",
+      "workflow": ".github/workflows/deploy-finance.yml",
+      "concurrencyPrefix": "deploy-finance-",
+      "publishes": ["Worker:skincos-finance", "Worker:skincos-finance-staging"],
+      "resources": ["Finance Worker", "skincos-finance D1", "skincos-finance-staging D1", "Finance module-control KV per environment"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "FINANCE_SERVICE_AUTH_SECRET", "FINANCE_BACKUP_PASSPHRASE"],
+      "migrationPaths": ["finance/migrations"],
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true, "featureFlagDefault": "disabled"}
+    },
+    {
+      "id": "finance-ui",
+      "workflow": ".github/workflows/deploy-finance-ui.yml",
+      "concurrencyPrefix": "deploy-finance-ui-",
+      "publishes": ["Pages:skincos-finance-ui", "Pages:skincos-finance-ui-staging"],
+      "resources": ["Finance Pages bundle", "skincos-finance-ui Pages project", "skincos-finance-ui-staging Pages project"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
+      "migrationPaths": [],
+      "environments": ["preview", "staging", "production"],
+      "promotion": {"stagingSupported": true, "featureFlagDefault": "disabled"}
     },
     {
       "id": "crm-pages",

--- a/shared/domain-boundaries.json
+++ b/shared/domain-boundaries.json
@@ -37,6 +37,34 @@
       "paths": ["shared/module-sdk/**"],
       "consumers": ["*"],
       "owner": "shared"
+    },
+    {
+      "id": "service-binding-adapter-v1",
+      "kind": "adapter",
+      "paths": ["shared/service-adapters/**"],
+      "consumers": ["api", "finance"],
+      "owner": "platform"
+    },
+    {
+      "id": "module-availability-contract-v1",
+      "kind": "contract",
+      "paths": ["shared/module-availability/**"],
+      "consumers": ["finance", "workforce"],
+      "owner": "platform"
+    },
+    {
+      "id": "observability-contract-v1",
+      "kind": "contract",
+      "paths": ["shared/observability/**"],
+      "consumers": ["api", "finance", "workforce"],
+      "owner": "platform"
+    },
+    {
+      "id": "resilience-contract-v1",
+      "kind": "contract",
+      "paths": ["shared/resilience/**"],
+      "consumers": ["shared"],
+      "owner": "platform"
     }
   ],
   "recommendedContracts": [
@@ -57,9 +85,9 @@
     {
       "from": "api",
       "to": "finance",
-      "contractId": "module-sdk-v1",
-      "path": "shared/module-sdk/README.md",
-      "usage": "publish a gateway-to-Finance adapter before importing Finance implementation"
+      "contractId": "service-binding-adapter-v1",
+      "path": "shared/service-adapters/cloudflare-service-binding.js",
+      "usage": "use the service-binding adapter instead of importing Finance implementation"
     },
     {
       "from": "finance",
@@ -78,25 +106,11 @@
   ],
   "legacyDirectImports": [
     {
-      "from": "api/src/gateway.js",
-      "specifier": "../../inventory/src/worker.js",
-      "replacementContractId": "module-sdk-v1",
-      "deadline": "2026-09-30",
-      "reason": "The gateway currently mounts the Inventory Worker implementation while the service-binding adapter is introduced."
-    },
-    {
       "from": "api/workers/index.js",
       "specifier": "../../inventory/src/worker.js",
       "replacementContractId": "module-sdk-v1",
       "deadline": "2026-09-30",
       "reason": "The gateway entrypoint re-exports Inventory runtime classes and must move to a stable service boundary."
-    },
-    {
-      "from": "api/src/gateway.js",
-      "specifier": "../../finance/api/worker.js",
-      "replacementContractId": "module-sdk-v1",
-      "deadline": "2026-09-30",
-      "reason": "Finance remains mounted by the gateway until its independently deployed service adapter is available."
     },
     {
       "from": "crm/console/tests/insumosShareRoutes.test.ts",

--- a/shared/module-availability/package.json
+++ b/shared/module-availability/package.json
@@ -1,0 +1,1 @@
+{ "name": "@skincos/module-availability", "private": true, "type": "module" }

--- a/shared/module-availability/worker.js
+++ b/shared/module-availability/worker.js
@@ -1,5 +1,5 @@
 const CONTROL_KEY_PREFIX = 'module-control:';
-const VALID_STATES = new Set(['active', 'maintenance', 'disabled']);
+const VALID_STATES = new Set(['active', 'canary', 'maintenance', 'disabled']);
 
 function normalize(value) {
   const state = String(value?.state || 'active').trim().toLowerCase();
@@ -7,6 +7,9 @@ function normalize(value) {
     state: VALID_STATES.has(state) ? state : 'active',
     message: String(value?.message || '').trim().slice(0, 240),
     changedAt: String(value?.changedAt || '').trim(),
+    // The allow-list is intentionally explicit: Finance launches only for a
+    // named pilot, never by random percentage on financial mutations.
+    pilotActors: Array.isArray(value?.pilotActors) ? value.pilotActors.map(String).map((item) => item.trim()).filter(Boolean).slice(0, 100) : [],
   };
 }
 
@@ -38,6 +41,10 @@ export function moduleUnavailableResponse(moduleId, availability, requestId) {
       'x-request-id': requestId,
     },
   });
+}
+
+export function canUseCanary(availability, actor) {
+  return availability.state !== 'canary' || availability.pilotActors.includes(String(actor?.username || '').trim());
 }
 
 export function moduleHealthResponse(moduleId, availability, requestId) {

--- a/shared/module-availability/worker.js
+++ b/shared/module-availability/worker.js
@@ -1,0 +1,47 @@
+const CONTROL_KEY_PREFIX = 'module-control:';
+const VALID_STATES = new Set(['active', 'maintenance', 'disabled']);
+
+function normalize(value) {
+  const state = String(value?.state || 'active').trim().toLowerCase();
+  return {
+    state: VALID_STATES.has(state) ? state : 'active',
+    message: String(value?.message || '').trim().slice(0, 240),
+    changedAt: String(value?.changedAt || '').trim(),
+  };
+}
+
+/**
+ * Runtime control is deliberately external to an artifact. A control change
+ * can put one module in maintenance or disable it without redeploying its
+ * Worker or the CRM shell. Missing control is compatible with the initial
+ * rollout and means active; malformed values fail closed into maintenance.
+ */
+export async function readModuleAvailability(env, moduleId) {
+  const store = env?.MODULE_CONTROL;
+  if (!store || typeof store.get !== 'function') return { state: 'active', message: '', changedAt: '', source: 'default' };
+  try {
+    const raw = await store.get(`${CONTROL_KEY_PREFIX}${moduleId}`, 'json');
+    return { ...normalize(raw), source: 'control' };
+  } catch {
+    return { state: 'maintenance', message: 'Controle operacional temporariamente indisponível.', changedAt: '', source: 'unavailable' };
+  }
+}
+
+export function moduleUnavailableResponse(moduleId, availability, requestId) {
+  const error = availability.state === 'disabled' ? 'MODULE_DISABLED' : 'MODULE_MAINTENANCE';
+  return new Response(JSON.stringify({ ok: false, error, module: moduleId, availability }), {
+    status: availability.state === 'disabled' ? 423 : 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-skincos-module-state': availability.state,
+      'x-request-id': requestId,
+    },
+  });
+}
+
+export function moduleHealthResponse(moduleId, availability, requestId) {
+  return new Response(JSON.stringify({ ok: true, module: moduleId, availability }), {
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId },
+  });
+}

--- a/shared/observability/contract.js
+++ b/shared/observability/contract.js
@@ -1,0 +1,18 @@
+export const OBSERVABILITY_CONTRACT_VERSION = 'skincos-observability/v1';
+
+export function dependencyState(available, { required = true, reason = '' } = {}) {
+  return { state: available ? 'healthy' : required ? 'unavailable' : 'degraded', required, ...(reason ? { reason } : {}) };
+}
+
+export function operationalStatus({ unit, version, environment, ready, dependencies, requestId }) {
+  return {
+    ok: Boolean(ready), contractVersion: OBSERVABILITY_CONTRACT_VERSION, unit,
+    version: String(version || 'unknown'), environment: String(environment || 'unknown'), ready: Boolean(ready),
+    dependencies: dependencies || {}, request_id: String(requestId || ''),
+  };
+}
+
+/** Metadata only: callers must never include actors, query strings, payloads or secrets. */
+export function operationalLog({ domain, version, environment, requestId, durationMs, status, route }) {
+  return JSON.stringify({ domain, version: String(version || 'unknown'), environment: String(environment || 'unknown'), request_id: String(requestId || ''), duration_ms: Math.max(0, Number(durationMs || 0)), status: Number(status || 0), route: String(route || '/').split('?')[0] });
+}

--- a/shared/observability/package.json
+++ b/shared/observability/package.json
@@ -1,0 +1,1 @@
+{ "name": "@skincos/observability-contract", "private": true, "type": "module" }

--- a/shared/resilience/dependency.js
+++ b/shared/resilience/dependency.js
@@ -1,0 +1,32 @@
+export class DependencyUnavailableError extends Error {
+  constructor(dependency, reason) { super(`${dependency} is unavailable: ${reason}`); this.name = 'DependencyUnavailableError'; this.dependency = dependency; }
+}
+
+export function createDependencyState() { return new Map(); }
+
+function stateFor(state, dependency) {
+  if (!state.has(dependency)) state.set(dependency, { failures: 0, openUntil: 0 });
+  return state.get(dependency);
+}
+
+function withTimeout(invoke, timeoutMs) {
+  const controller = new AbortController(); let timer;
+  const timeout = new Promise((_, reject) => { timer = setTimeout(() => { controller.abort(); reject(new DependencyUnavailableError('upstream', `timeout after ${timeoutMs}ms`)); }, timeoutMs); });
+  return Promise.race([Promise.resolve().then(() => invoke(controller.signal)), timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Isolates optional domain calls with a short timeout, circuit breaker and explicit degraded result. */
+export async function callOptionalDependency({ dependency, invoke, fallback, timeoutMs = 800, failureThreshold = 2, cooldownMs = 15_000, cache, cacheKey, cacheTtlMs = 0, state = createDependencyState(), now = Date.now }) {
+  const clock = now(); const circuit = stateFor(state, dependency); const cached = cacheKey && cache?.get(cacheKey);
+  const usableCache = cached && cached.expiresAt > clock;
+  const degrade = (mode, error) => ({ mode, pendingSynchronization: true, value: usableCache ? cached.value : fallback({ dependency, mode, error }), error });
+  if (circuit.openUntil > clock) return degrade('circuit-open', new DependencyUnavailableError(dependency, 'circuit open'));
+  try {
+    const value = await withTimeout(invoke, timeoutMs); circuit.failures = 0; circuit.openUntil = 0;
+    if (cacheKey && cache && cacheTtlMs > 0) cache.set(cacheKey, { value, expiresAt: clock + cacheTtlMs });
+    return { mode: 'live', pendingSynchronization: false, value, error: null };
+  } catch (error) {
+    circuit.failures += 1; if (circuit.failures >= failureThreshold) circuit.openUntil = clock + cooldownMs;
+    return degrade('degraded', error instanceof DependencyUnavailableError ? error : new DependencyUnavailableError(dependency, error?.message || 'request failed'));
+  }
+}

--- a/shared/resilience/package.json
+++ b/shared/resilience/package.json
@@ -1,0 +1,1 @@
+{ "name": "@skincos/resilience", "private": true, "type": "module" }

--- a/shared/service-adapters/cloudflare-service-binding.js
+++ b/shared/service-adapters/cloudflare-service-binding.js
@@ -1,0 +1,19 @@
+import { callOptionalDependency, createDependencyState } from '../resilience/dependency.js';
+
+const serviceDependencyState = createDependencyState();
+const safeResponseCache = new Map();
+
+function degradedResponse(bindingName, mode) {
+  return new Response(JSON.stringify({ ok: false, error: 'domain_service_degraded', dependency: bindingName, mode, pendingSynchronization: true }), { status: 503, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-dependency-status': mode, 'x-skincos-sync-state': 'pending' } });
+}
+
+export async function fetchBoundService(request, env, bindingName, { timeoutMs = 800, failureThreshold = 2, cooldownMs = 15_000, cacheTtlMs = 0 } = {}) {
+  const binding = env?.[bindingName]; if (!binding || typeof binding.fetch !== 'function') return degradedResponse(bindingName, 'unavailable');
+  const cacheKey = request.method === 'GET' && cacheTtlMs > 0 ? `${bindingName}:${request.url}` : null;
+  const result = await callOptionalDependency({ dependency: bindingName, state: serviceDependencyState, cache: safeResponseCache, cacheKey, cacheTtlMs, timeoutMs, failureThreshold, cooldownMs, invoke: async (signal) => { const response = await binding.fetch(new Request(request, { signal })); if (response.status >= 500) throw new Error(`upstream status ${response.status}`); return cacheKey ? response.clone() : response; }, fallback: ({ mode }) => degradedResponse(bindingName, mode) });
+  const response = result.mode === 'live' ? result.value : result.value.clone ? result.value.clone() : result.value;
+  const headers = new Headers(response.headers); headers.set('x-skincos-dependency-status', result.mode); headers.set('x-skincos-sync-state', result.pendingSynchronization ? 'pending' : 'current');
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export function resetBoundServiceResilienceForTest() { serviceDependencyState.clear(); safeResponseCache.clear(); }

--- a/shared/service-adapters/package.json
+++ b/shared/service-adapters/package.json
@@ -1,0 +1,1 @@
+{ "name": "@skincos/service-adapters", "private": true, "type": "module" }

--- a/shared/service-adapters/signed-domain-context.js
+++ b/shared/service-adapters/signed-domain-context.js
@@ -1,0 +1,18 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const toBase64Url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+const fromBase64Url = (value) => { const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/'); const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4); return Uint8Array.from(atob(padded), (item) => item.charCodeAt(0)); };
+const safeEqual = (left, right) => { const a = encoder.encode(left || ''); const b = encoder.encode(right || ''); if (a.length !== b.length) return false; let difference = 0; for (let index = 0; index < a.length; index += 1) difference |= a[index] ^ b[index]; return difference === 0; };
+async function sign(secret, payload) { const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']); return toBase64Url(new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(payload)))); }
+
+export async function createSignedDomainContext({ actor, csrf, requestId }, secret, audience, now = Date.now()) {
+  if (!secret || !actor?.username) throw new TypeError('A service identity and authenticated actor are required');
+  const payload = toBase64Url(encoder.encode(JSON.stringify({ v: 1, audience, issuedAt: now, actor, csrf: String(csrf || ''), requestId: String(requestId || '') })));
+  return { 'x-skincos-domain-context': payload, 'x-skincos-domain-signature': await sign(secret, payload) };
+}
+
+export async function verifySignedDomainContext(request, secret, audience, { maxAgeMs = 60_000, now = Date.now() } = {}) {
+  const payload = String(request.headers.get('x-skincos-domain-context') || ''); const received = String(request.headers.get('x-skincos-domain-signature') || '');
+  if (!secret || !payload || !received || !safeEqual(await sign(secret, payload), received)) return null;
+  try { const value = JSON.parse(decoder.decode(fromBase64Url(payload))); if (value?.v !== 1 || value?.audience !== audience || !value?.actor?.username || !Number.isFinite(value?.issuedAt) || Math.abs(now - value.issuedAt) > maxAgeMs) return null; return { actor: value.actor, csrf: String(value.csrf || ''), requestId: String(value.requestId || '') }; } catch { return null; }
+}

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -1,5 +1,7 @@
 import { canonicalEventType, calculateDay, calculatePeriod, isoDateInZone } from './domain.js'
 import { biometricDistance, constantTimeEqual, decryptSensitiveText, decryptTemplate, encryptSensitiveText, encryptTemplate, hashPin, isValidBiometricTemplate, sha256, signHmac, verifyPin } from './security.js'
+import { readModuleAvailability, moduleUnavailableResponse } from '../../shared/module-availability/worker.js'
+import { dependencyState, operationalStatus } from '../../shared/observability/contract.js'
 
 const encoder = new TextEncoder()
 const json = (status, payload, requestId) => new Response(JSON.stringify({ ...payload, requestId }), {
@@ -582,7 +584,8 @@ export async function handleTimekeeping(request, env) {
   const requestId = requestIdFor(request)
   const url = new URL(request.url)
   let path = canonicalPath(url.pathname.replace(/^\/workforce/, ''))
-  if (path === '/health' || path === '/api/ponto/health') return json(200, { ok: true, service: 'workforce-timekeeping', version: env.APP_VERSION || '1.0.0', database: !!env.DB }, requestId)
+  const availability = await readModuleAvailability(env, 'timekeeping')
+  if (path === '/health' || path === '/api/ponto/health') return json(200, { service: 'workforce-timekeeping', database: Boolean(env.DB), ...operationalStatus({ unit: 'timekeeping', version: env.APP_VERSION || '1.0.0', environment: env.ENVIRONMENT, ready: Boolean(env.DB) && availability.state === 'active', requestId, dependencies: { d1: dependencyState(Boolean(env.DB)), schedule: dependencyState(Boolean(env.SCHEDULE), { required: false }), module_control: dependencyState(Boolean(env.MODULE_CONTROL), { required: false }) } }), availability }, requestId)
   if (path === '/readiness' || path === '/api/ponto/readiness') {
     try {
       if (!env.DB) throw new Error('DB_NOT_CONFIGURED')
@@ -591,6 +594,7 @@ export async function handleTimekeeping(request, env) {
     } catch { return json(503, { ok: false, error: 'NOT_READY', code: 'DATABASE_UNAVAILABLE' }, requestId) }
   }
   if (!path.startsWith('/api/ponto')) return json(404, { ok: false, error: 'NOT_FOUND' }, requestId)
+  if (availability.state !== 'active') return moduleUnavailableResponse('timekeeping', availability, requestId)
   if (!env.DB) return json(503, { ok: false, error: 'NOT_READY', code: 'DATABASE_UNAVAILABLE' }, requestId)
   let bodyHash = await sha256('')
   if (!['GET', 'HEAD', 'OPTIONS'].includes(request.method)) {

--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -12,6 +12,10 @@ migrations_dir = "migrations"
 binding = "SCHEDULE"
 service = "skincos-escala-api"
 
+[[kv_namespaces]]
+binding = "MODULE_CONTROL"
+id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
+
 [vars]
 APP_VERSION = "1.0.0"
 APP_ORIGIN = "https://crm.skincos.com.br"
@@ -28,6 +32,10 @@ migrations_dir = "migrations"
 [[env.staging.services]]
 binding = "SCHEDULE"
 service = "skincos-escala-api-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "MODULE_CONTROL"
+id = "__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__"
 
 [env.staging.vars]
 APP_VERSION = "1.0.0"


### PR DESCRIPTION
## Escopo\n- Worker Financeiro isolado, D1/KV de staging e handoff assinado do gateway.\n- Artefato de UI remoto com fallback do shell; pipeline imutável separado.\n- Health/readiness, feature flag, manutenção, canary por ator, rollback e checkpoint cifrado.\n\n## Validação\n- 
pm --prefix api test\n- 
ode --test finance/test/edge-worker.test.mjs\n- 
pm --prefix crm/console run typecheck\n- 
pm --prefix crm/console test (181 testes)\n- build do artefato Financeiro, catálogo e fronteiras.\n\nSem deploy de Worker ou de produção. A PR depende de #737.