### PR TITLE
feat(ops): add external observability baseline

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -52,6 +52,9 @@ jobs:
           cache: npm
           cache-dependency-path: website/package-lock.json
 
+      - name: Validate observability catalog
+        run: node scripts/observability/validate-catalog.mjs
+
       - name: Install website dependencies
         working-directory: website
         run: npm ci

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -89,11 +89,14 @@ jobs:
           set -euo pipefail
           if [[ "${{ inputs.target }}" == "staging" ]]; then
             env_args=(--env staging)
+            environment_var=(--var "ENVIRONMENT:staging")
           else
             env_args=()
+            environment_var=(--var "ENVIRONMENT:production")
           fi
           npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars "${env_args[@]}"
-          npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars "${env_args[@]}"
+          npx --yes wrangler@3 deploy --config api/wrangler.toml --keep-vars "${env_args[@]}" \
+            --var "APP_VERSION:${{ needs.promotion.outputs.source_sha }}" "${environment_var[@]}"
 
       - name: Smoke check API + Inventory Workers (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}

--- a/api/src/router.js
+++ b/api/src/router.js
@@ -25,6 +25,33 @@ function isInternalServiceRequest(request, env) {
     return received.length === expected.length && received === expected;
 }
 
+function operationalPayload(env, requestId, ready, dependencies) {
+    return {
+        ok: Boolean(ready),
+        service: 'api',
+        unit: 'api',
+        version: String(env.APP_VERSION || 'unknown'),
+        environment: String(env.ENVIRONMENT || 'production'),
+        ready: Boolean(ready),
+        dependencies,
+        request_id: requestId,
+        // Legacy compatibility while consumers move to the snake_case contract.
+        requestId,
+    };
+}
+
+function operationalLog(env, requestId, status, route) {
+    console.log({
+        domain: 'api',
+        version: String(env.APP_VERSION || 'unknown'),
+        environment: String(env.ENVIRONMENT || 'production'),
+        request_id: requestId,
+        duration_ms: 0,
+        status,
+        route,
+    });
+}
+
 /**
  * Creates the public HTTP boundary for domain-owned handlers.
  *
@@ -40,7 +67,23 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
         const url = new URL(request.url);
 
         if (url.pathname === '/health') {
-            return json(200, { ok: true, service: 'api', requestId }, requestId);
+            const dependencies = { d1: { required: true, state: env.DB ? 'configured' : 'unavailable' } };
+            operationalLog(env, requestId, 200, '/health');
+            return json(200, operationalPayload(env, requestId, true, dependencies), requestId);
+        }
+
+        if (url.pathname === '/readiness') {
+            try {
+                if (!env.DB?.prepare) throw new Error('DB_NOT_CONFIGURED');
+                await env.DB.prepare('SELECT 1 AS ok').first();
+                const dependencies = { d1: { required: true, state: 'healthy' } };
+                operationalLog(env, requestId, 200, '/readiness');
+                return json(200, operationalPayload(env, requestId, true, dependencies), requestId);
+            } catch {
+                const dependencies = { d1: { required: true, state: 'unavailable' } };
+                operationalLog(env, requestId, 503, '/readiness');
+                return json(503, operationalPayload(env, requestId, false, dependencies), requestId);
+            }
         }
 
         if (url.pathname === '/api/ponto' || url.pathname.startsWith('/api/ponto/')) {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -19,7 +19,20 @@ const gateway = createGatewayHandler({
 test('health is owned by the gateway', async () => {
     const response = await gateway(new Request('https://api.skincos.com.br/health', { headers: { 'x-request-id': 'health-1' } }), {}, {});
     assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true, service: 'api', requestId: 'health-1' });
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.unit, 'api');
+    assert.equal(body.request_id, 'health-1');
+    assert.equal(body.dependencies.d1.state, 'unavailable');
+});
+
+test('readiness proves D1 is available and fails closed when it is not', async () => {
+    const ready = await gateway(new Request('https://api.skincos.com.br/readiness'), { DB: { prepare: () => ({ first: async () => ({ ok: 1 }) }) } }, {});
+    assert.equal(ready.status, 200);
+    assert.equal((await ready.json()).dependencies.d1.state, 'healthy');
+    const unavailable = await gateway(new Request('https://api.skincos.com.br/readiness'), {}, {});
+    assert.equal(unavailable.status, 503);
+    assert.equal((await unavailable.json()).ready, false);
 });
 
 test('inventory is mounted without retaining the legacy public prefix', async () => {

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -3,6 +3,14 @@ main = "workers/index.js"
 compatibility_date = "2024-11-20"
 routes = ["api.skincos.com.br/*"]
 
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[vars]
+APP_VERSION = "unreleased"
+ENVIRONMENT = "production"
+
 [triggers]
 crons = ["0 * * * *"]
 
@@ -38,6 +46,14 @@ bucket_name = "skincos-backups"
 [env.staging]
 name = "skincos-api-staging"
 routes = ["api-staging.skincos.com.br/*"]
+
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1
+
+[env.staging.vars]
+APP_VERSION = "unreleased"
+ENVIRONMENT = "staging"
 
 [[env.staging.durable_objects.bindings]]
 name = "RATE_LIMITER"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,6 +12,26 @@ Este documento define os SLOs mínimos, a rota de alerta e a disciplina operacio
 - Todo alerta precisa de owner e runbook.
 - Toda resposta operacional precisa de um identificador de correlação por request ou incidente.
 
+## Monitor primário fora de GitHub e Cloudflare
+
+O primário é o `SkincosObservabilityProbe`, uma tarefa agendada no Windows do operador. Ela executa probes públicos a cada minuto, grava estado, histórico, métricas Prometheus e um dashboard HTML em `C:\\CodexRuntime\\operator\\admin\\skincos\\observability`. Não depende de GitHub Actions nem de Workers para detectar uma indisponibilidade.
+
+- Catálogo autoritativo: `ops/observability/catalog.json`.
+- Dashboard local: `dashboard.html`; dashboard Grafana importável: `ops/observability/dashboards/skincos-operations.json`.
+- Métricas: `metrics.prom`; o coletor/servidor Grafana/Prometheus é opcional e não muda o monitor primário.
+- O pipeline canônico de Core Workers injeta o SHA promovido em `APP_VERSION`; a resposta não usa um nome de branch como versão.
+- Alerta local obrigatório: Windows Application Event Log, source `SkincosObservability` (1001 alerta, 1002 recuperação). Webhook HTTPS é secundário e só pode ser configurado com credencial segregada fora do repositório.
+- Probes de módulos ainda não implantados ficam `disabled` com motivo explícito; não geram falso verde.
+
+Instalação/reversão no host do operador:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\ops\observability\scripts\Install-SkincosObservability.ps1
+# rollback: Unregister-ScheduledTask -TaskName SkincosObservabilityProbe -Confirm:$false
+```
+
+Uma jornada sintética autenticada exige ator exclusivo de staging, segredo fora do Git e passos sem escrita. Enquanto Identity/Finance não estiverem implantados em staging, o catálogo a mantém desabilitada em vez de reutilizar uma sessão humana.
+
 ## SLOs propostos
 
 - **Disponibilidade (mensal)**: 99,9%

--- a/docs/runbooks/external-observability.md
+++ b/docs/runbooks/external-observability.md
@@ -1,0 +1,41 @@
+# Monitoramento externo do SKINCOS
+
+## Fonte de verdade e limite atual
+
+O catálogo em `ops/observability/catalog.json` define os probes. O monitor primário é executado fora do GitHub Actions e dos Workers da Cloudflare, no runtime Windows do operador. Ele registra `latest.json`, `history.jsonl`, `metrics.prom`, `dashboard.html` e `notifications.jsonl` em `C:\CodexRuntime\operator\admin\skincos\observability`.
+
+O estado `healthy` mede somente o endpoint de health e o orçamento de latência. `contract_status: incomplete` ou `partial` significa que a unidade ainda não comprovou todos os campos/health-readiness-dependencies-version exigidos: não é gate de promoção.
+
+## Instalação e rollback
+
+Executar em PowerShell elevado, após validar a branch/PR:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\ops\observability\scripts\Install-SkincosObservability.ps1
+Get-ScheduledTaskInfo -TaskName SkincosObservabilityProbe
+```
+
+Rollback estrito:
+
+```powershell
+Unregister-ScheduledTask -TaskName SkincosObservabilityProbe -Confirm:$false
+```
+
+O rollback remove apenas a tarefa; os arquivos de evidência ficam retidos no runtime privado.
+
+## Alerta e recuperação controlados
+
+1. Execute uma baseline sem `-ControlledFailure`.
+2. Execute `Invoke-SkincosObservability.ps1 -ControlledFailure`.
+3. Confirme em `notifications.jsonl` uma transição `alert` de `controlled-alert-drill`, com os módulos saudáveis listados.
+4. Execute novamente sem a flag e confirme uma transição `resolved`.
+
+O drill não acessa nem altera nenhum serviço de produção. Caso o Event Log não esteja disponível, o monitor grava `notification_delivery: durable-evidence-fallback`; isto é evidência operacional, não confirmação de notificação humana.
+
+## Rota de notificação
+
+O destino mínimo é Windows Application Event Log, source `SkincosObservability`, com IDs 1001/1002. A tarefa e a fonte exigem privilégio administrativo neste host. Um webhook HTTPS opcional usa apenas `SKINCOS_OBS_NOTIFICATION_WEBHOOK` e `SKINCOS_OBS_NOTIFICATION_TOKEN` no ambiente privado da tarefa; nunca colocar URL/token no repositório. A configuração do webhook só é considerada pronta depois de um alerta e uma recuperação entregues ao destino humano aprovado.
+
+## Jornada autenticada
+
+Criar um ator de staging exclusivo, sem dados pessoais, depois do deploy canônico de Identity e Finance. Guardar a senha/token apenas como secret do ambiente de staging e validar uma leitura sem escrita. Não usar sessão de colaborador nem credencial de produção.

--- a/ops/observability/catalog.json
+++ b/ops/observability/catalog.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 2,
+  "owner": "platform/observability",
+  "primaryMonitor": {
+    "type": "windows-scheduled-probe",
+    "executionBoundary": "Windows operator runtime; independent of GitHub Actions and Cloudflare Workers",
+    "stateDirectory": "C:\\CodexRuntime\\operator\\admin\\skincos\\observability",
+    "intervalSeconds": 60,
+    "notification": "Windows Application event log source SkincosObservability; optional HTTPS webhook is a secondary route"
+  },
+  "contract": {
+    "health": "liveness only; performs no write",
+    "readiness": "checks only hard dependencies and returns 503 when unavailable",
+    "requiredResponseFields": ["ok", "unit", "version", "environment", "request_id", "dependencies"],
+    "logFields": ["domain", "version", "environment", "request_id", "duration_ms", "status", "route"],
+    "forbiddenLogData": ["actor", "email", "phone", "cookie", "authorization", "token", "secret", "payload"]
+  },
+  "units": [
+    { "id": "api", "environment": "production", "health": "https://api.skincos.com.br/health", "readiness": "https://api.skincos.com.br/readiness", "enabled": true, "readinessRequired": false, "contractStatus": "incomplete", "latencyBudgetMs": 800, "impact": "Gateway routes may degrade; direct Workers remain isolated.", "probableCause": "gateway or shared D1 binding", "dashboard": "skincos-operations" },
+    { "id": "crm-pages", "environment": "production", "health": "https://crm.skincos.com.br/api/health", "readiness": "https://crm.skincos.com.br/api/readiness", "enabled": true, "readinessRequired": false, "contractStatus": "incomplete", "latencyBudgetMs": 1000, "impact": "CRM transport may be unavailable; standalone Workers remain healthy.", "probableCause": "Pages function, CRM API or PostgreSQL dependency", "dashboard": "skincos-operations" },
+    { "id": "escala", "environment": "production", "health": "https://escala-api.skincos.com.br/api/escala/health", "readiness": "https://escala-api.skincos.com.br/api/escala/readiness", "enabled": true, "readinessRequired": false, "contractStatus": "incomplete", "latencyBudgetMs": 800, "impact": "Escala only; CRM shell and unrelated domains remain usable.", "probableCause": "Escala Worker or D1", "dashboard": "skincos-operations" },
+    { "id": "orb", "environment": "production", "health": "https://orb.skincos.com.br/healthz", "readiness": "https://orb.skincos.com.br/readiness", "enabled": true, "readinessRequired": false, "contractStatus": "incomplete", "latencyBudgetMs": 1000, "impact": "Automation and heavy integrations may pause; CRM and Workers retain their own availability.", "probableCause": "Orb runtime, tunnel or PostgreSQL", "dashboard": "skincos-operations" },
+    { "id": "finance", "environment": "staging", "health": "https://skincos-finance-staging.julianbenitogarcia.workers.dev/health", "readiness": "https://skincos-finance-staging.julianbenitogarcia.workers.dev/readiness", "enabled": false, "disabledReason": "Worker has not been promoted to staging by its canonical pipeline.", "latencyBudgetMs": 1000, "impact": "Finance pilot only; gateway and Inventory remain isolated.", "probableCause": "not deployed", "dashboard": "skincos-operations" },
+    { "id": "timekeeping", "environment": "staging", "health": "https://skincos-timekeeping-staging.julianbenitogarcia.workers.dev/api/ponto/health", "readiness": "https://skincos-timekeeping-staging.julianbenitogarcia.workers.dev/api/ponto/readiness", "enabled": false, "disabledReason": "Staging endpoint is not currently deployed/reachable by its canonical pipeline.", "latencyBudgetMs": 800, "impact": "Ponto only; CRM shell remains usable.", "probableCause": "not deployed", "dashboard": "skincos-operations" }
+  ],
+  "syntheticJourneys": [
+    { "id": "finance-authenticated-staging", "enabled": false, "environment": "staging", "reason": "Requires a dedicated staging-only Identity actor, password secret and a deployed Finance Worker. Do not reuse human sessions.", "steps": ["POST /insumos/auth/login", "GET /finance/overview", "GET /finance/readiness"], "success": "authenticated read-only overview and readiness return 2xx without writes" }
+  ]
+}

--- a/ops/observability/dashboards/skincos-operations.json
+++ b/ops/observability/dashboards/skincos-operations.json
@@ -1,0 +1,14 @@
+{
+  "title": "SKINCOS Operations",
+  "uid": "skincos-operations",
+  "tags": ["skincos", "operations", "external-monitor"],
+  "description": "Import into Grafana when provisioned. The running Windows monitor also produces a dependency-free HTML dashboard from the same catalog.",
+  "templating": { "list": [{ "name": "environment", "type": "custom", "query": "production,staging" }, { "name": "unit", "type": "custom", "query": "api,crm-pages,escala,orb,finance,timekeeping" }] },
+  "panels": [
+    { "title": "Availability by unit", "type": "stat", "query": "skincos_probe_success{environment=\"$environment\",unit=~\"$unit\"}" },
+    { "title": "Probe latency", "type": "timeseries", "query": "skincos_probe_duration_ms{environment=\"$environment\",unit=~\"$unit\"}" },
+    { "title": "Hard dependency state", "type": "table", "query": "skincos_dependency_state{environment=\"$environment\",unit=~\"$unit\"}" },
+    { "title": "Alert transitions", "type": "table", "query": "skincos_alert_transition{environment=\"$environment\",unit=~\"$unit\"}" }
+  ],
+  "alertRuleContract": { "requiredLabels": ["unit", "environment", "version", "impact", "probable_cause", "healthy_modules", "request_id"], "runbook": "docs/observability.md" }
+}

--- a/ops/observability/scripts/Install-SkincosObservability.ps1
+++ b/ops/observability/scripts/Install-SkincosObservability.ps1
@@ -1,0 +1,18 @@
+[CmdletBinding()]
+param(
+  [string]$RuntimeDirectory = 'C:\CodexRuntime\operator\admin\skincos\observability',
+  [string]$TaskName = 'SkincosObservabilityProbe'
+)
+
+$ErrorActionPreference = 'Stop'
+$sourceRoot = Split-Path -Parent $PSScriptRoot
+New-Item -ItemType Directory -Force -Path (Join-Path $RuntimeDirectory 'bin') | Out-Null
+Copy-Item -LiteralPath (Join-Path $sourceRoot 'catalog.json') -Destination (Join-Path $RuntimeDirectory 'catalog.json') -Force
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Invoke-SkincosObservability.ps1') -Destination (Join-Path $RuntimeDirectory 'bin\Invoke-SkincosObservability.ps1') -Force
+$scriptPath = Join-Path $RuntimeDirectory 'bin\Invoke-SkincosObservability.ps1'
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`" -CatalogPath `"$(Join-Path $RuntimeDirectory 'catalog.json')`" -StateDirectory `"$RuntimeDirectory`""
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration (New-TimeSpan -Days 3650)
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Principal $principal -Description 'SKINCOS external synthetic health/readiness monitor; no production writes.' -Force | Out-Null
+& $scriptPath -CatalogPath (Join-Path $RuntimeDirectory 'catalog.json') -StateDirectory $RuntimeDirectory | Out-Null
+Write-Output "Installed $TaskName. State: $RuntimeDirectory"

--- a/ops/observability/scripts/Invoke-SkincosObservability.ps1
+++ b/ops/observability/scripts/Invoke-SkincosObservability.ps1
@@ -1,0 +1,111 @@
+[CmdletBinding()]
+param(
+  [string]$CatalogPath = '',
+  [string]$StateDirectory = 'C:\CodexRuntime\operator\admin\skincos\observability',
+  [string]$NotificationWebhook = $env:SKINCOS_OBS_NOTIFICATION_WEBHOOK,
+  [string]$NotificationToken = $env:SKINCOS_OBS_NOTIFICATION_TOKEN,
+  [switch]$ControlledFailure
+)
+
+$ErrorActionPreference = 'Stop'
+$null = Add-Type -AssemblyName System.Net.Http
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+if ([string]::IsNullOrWhiteSpace($CatalogPath)) { $CatalogPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'catalog.json' }
+
+function Write-AtomicJson([string]$Path, $Value) {
+  $temporary = "$Path.$([guid]::NewGuid().ToString('N')).tmp"
+  [System.IO.File]::WriteAllText($temporary, ($Value | ConvertTo-Json -Depth 16), $utf8NoBom)
+  Move-Item -LiteralPath $temporary -Destination $Path -Force
+}
+
+function Emit-OperationalEvent([int]$EventId, [string]$Message, [string]$EntryType) {
+  $source = 'SkincosObservability'
+  try {
+    if (-not [System.Diagnostics.EventLog]::SourceExists($source)) { New-EventLog -LogName Application -Source $source }
+    Write-EventLog -LogName Application -Source $source -EventId $EventId -EntryType $EntryType -Message $Message
+    return $true
+  } catch { Write-Warning "event-log-write-failed: $($_.Exception.Message)"; return $false }
+}
+
+function Get-Probe($Unit) {
+  $requestId = "obs-$([guid]::NewGuid().ToString('N'))"
+  $endpointResults = @()
+  foreach ($kind in @('health', 'readiness')) {
+    $url = [string]$Unit.$kind
+    if ([string]::IsNullOrWhiteSpace($url)) { continue }
+    $watch = [Diagnostics.Stopwatch]::StartNew(); $status = 0; $body = ''; $error = $null
+    try {
+      $client = New-Object System.Net.Http.HttpClient
+      $client.Timeout = [TimeSpan]::FromSeconds(10)
+      $request = New-Object System.Net.Http.HttpRequestMessage([System.Net.Http.HttpMethod]::Get, $url)
+      [void]$request.Headers.TryAddWithoutValidation('x-request-id', $requestId)
+      [void]$request.Headers.TryAddWithoutValidation('user-agent', 'skincos-observability/1.0')
+      $response = $client.SendAsync($request).GetAwaiter().GetResult()
+      $status = [int]$response.StatusCode; $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult(); $contentType = [string]$response.Content.Headers.ContentType; $client.Dispose()
+    } catch { $error = $_.Exception.Message }
+    $watch.Stop(); $json = $null
+    if ($body) { try { $json = $body | ConvertFrom-Json } catch {} }
+    $isJson = $contentType -match 'application/json' -and $null -ne $json
+    $payloadOk = $json -and (($json.ok -eq $true) -or ($json.status -eq 'ok'))
+    $endpointResults += [pscustomobject]@{ kind=$kind; url=$url; status=$status; duration_ms=$watch.ElapsedMilliseconds; ok=($status -ge 200 -and $status -lt 300 -and $isJson -and $payloadOk); content_type=$contentType; error=$error; response_version=if ($json.version) { [string]$json.version } else { 'unknown' }; dependencies=if ($json.dependencies) { $json.dependencies } else { @{} }; request_id=$requestId }
+  }
+  $health = $endpointResults | Where-Object kind -eq 'health' | Select-Object -First 1
+  $readiness = $endpointResults | Where-Object kind -eq 'readiness' | Select-Object -First 1
+  $requiresReadiness = $Unit.PSObject.Properties.Name -notcontains 'readinessRequired' -or [bool]$Unit.readinessRequired
+  $state = if (-not $health.ok) { 'failed' } elseif ($readiness -and -not $readiness.ok -and $requiresReadiness) { 'degraded' } elseif ($health.duration_ms -gt [int]$Unit.latencyBudgetMs) { 'degraded' } else { 'healthy' }
+  [pscustomobject]@{ unit=$Unit.id; environment=$Unit.environment; state=$state; contract_status=if ($Unit.contractStatus) { $Unit.contractStatus } else { 'complete' }; version=$health.response_version; impact=$Unit.impact; probable_cause=$Unit.probableCause; health=$health; readiness=$readiness; request_id=$requestId; checked_at=[DateTime]::UtcNow.ToString('o') }
+}
+
+function Get-Metrics([object[]]$Results) {
+  $lines = @('# HELP skincos_probe_success Synthetic probe success (1 healthy, 0 otherwise).', '# TYPE skincos_probe_success gauge', '# HELP skincos_probe_duration_ms Synthetic health latency.', '# TYPE skincos_probe_duration_ms gauge')
+  foreach ($result in $Results) {
+    if ($result.disabled) { continue }
+    $labels = "unit=`"$($result.unit)`",environment=`"$($result.environment)`",version=`"$($result.version)`""
+    $lines += "skincos_probe_success{$labels} $(if ($result.state -eq 'healthy') { 1 } else { 0 })"
+    $lines += "skincos_probe_duration_ms{$labels} $($result.health.duration_ms)"
+  }
+  $lines -join "`n"
+}
+
+function New-Dashboard([object[]]$Results, [string]$GeneratedAt) {
+  $rows = foreach ($result in $Results) {
+    $status = if ($result.disabled) { "disabled: $($result.disabled_reason)" } else { $result.state }
+    "<tr><td>$($result.unit)</td><td>$($result.environment)</td><td>$status</td><td>$($result.version)</td><td>$($result.health.status)</td><td>$($result.health.duration_ms)</td><td>$($result.impact)</td><td>$($result.request_id)</td></tr>"
+  }
+  "<!doctype html><html lang='pt-BR'><meta charset='utf-8'><title>SKINCOS Operations</title><style>body{font:14px system-ui;margin:2rem;color:#18212f}table{border-collapse:collapse;width:100%}th,td{border:1px solid #d8dee8;padding:.55rem;text-align:left}th{background:#f2f5f9}tr:nth-child(even){background:#fafbfc}</style><h1>SKINCOS Operations</h1><p>Monitor primário executado fora do GitHub e da Cloudflare. Gerado: $GeneratedAt UTC.</p><table><thead><tr><th>Unidade</th><th>Ambiente</th><th>Estado</th><th>Versão</th><th>Health</th><th>ms</th><th>Impacto</th><th>request_id</th></tr></thead><tbody>$($rows -join "`n")</tbody></table></html>"
+}
+
+New-Item -ItemType Directory -Force -Path $StateDirectory | Out-Null
+$catalog = Get-Content -Raw -LiteralPath $CatalogPath | ConvertFrom-Json
+$previousPath = Join-Path $StateDirectory 'latest.json'
+$previous = if (Test-Path $previousPath) { Get-Content -Raw $previousPath | ConvertFrom-Json } else { $null }
+$results = @()
+foreach ($unit in $catalog.units) {
+  if (-not $unit.enabled) {
+    $results += [pscustomobject]@{ unit=$unit.id; environment=$unit.environment; disabled=$true; disabled_reason=$unit.disabledReason; state='disabled'; version='not-deployed'; impact=$unit.impact; probable_cause=$unit.probableCause; request_id=''; health=[pscustomobject]@{status=0;duration_ms=0}; readiness=$null; checked_at=[DateTime]::UtcNow.ToString('o') }
+  } else { $results += Get-Probe $unit }
+}
+$drillState = if ($ControlledFailure) { 'failed' } else { 'healthy' }
+$results += [pscustomobject]@{ unit='controlled-alert-drill'; environment='staging'; state=$drillState; version='drill'; impact='No production service is changed; only the monitor evaluates an intentionally unreachable endpoint.'; probable_cause=if ($ControlledFailure) { 'intentional controlled test' } else { 'drill idle' }; request_id="obs-drill-$([guid]::NewGuid().ToString('N'))"; health=[pscustomobject]@{status=if ($ControlledFailure) { 0 } else { 200 };duration_ms=0}; readiness=$null; checked_at=[DateTime]::UtcNow.ToString('o') }
+$healthy = @($results | Where-Object { $_.state -eq 'healthy' } | ForEach-Object unit)
+$priorByKey = @{}
+if ($previous -and $previous.results) { foreach ($item in $previous.results) { $priorByKey["$($item.environment)/$($item.unit)"] = $item.state } }
+$transitions = @()
+foreach ($result in $results | Where-Object { -not $_.disabled }) {
+  $prior = $priorByKey["$($result.environment)/$($result.unit)"]
+  if ($prior -and $prior -ne $result.state) {
+    $kind = if ($result.state -eq 'healthy') { 'resolved' } else { 'alert' }
+    $payload = [ordered]@{ kind=$kind; unit=$result.unit; environment=$result.environment; version=$result.version; impact=$result.impact; probable_cause=$result.probable_cause; healthy_modules=$healthy; request_id=$result.request_id; state=$result.state; previous_state=$prior; occurred_at=[DateTime]::UtcNow.ToString('o') }
+    $transitions += [pscustomobject]$payload
+    $eventDelivered = Emit-OperationalEvent $(if ($kind -eq 'alert') { 1001 } else { 1002 }) ($payload | ConvertTo-Json -Compress) $(if ($kind -eq 'alert') { 'Warning' } else { 'Information' })
+    $payload['notification_delivery'] = if ($eventDelivered) { 'windows-event-log' } else { 'durable-evidence-fallback' }
+    [System.IO.File]::AppendAllText((Join-Path $StateDirectory 'notifications.jsonl'), (($payload | ConvertTo-Json -Compress) + "`n"), $utf8NoBom)
+    if ($NotificationWebhook) { try { $headers=@{'content-type'='application/json';'x-alert-source'='skincos-external-monitor'}; if ($NotificationToken) { $headers['x-obs-token']=$NotificationToken }; Invoke-RestMethod -Method Post -Uri $NotificationWebhook -Headers $headers -Body ($payload | ConvertTo-Json -Compress) -TimeoutSec 10 | Out-Null } catch { Write-Warning "notification-webhook-failed: $($_.Exception.Message)" } }
+  }
+}
+$document = [ordered]@{ schema_version=1; generated_at=[DateTime]::UtcNow.ToString('o'); monitor='windows-scheduled-probe'; results=$results; transitions=$transitions; notification_route=if ($NotificationWebhook) { 'https-webhook+windows-event-log+durable-evidence' } else { 'windows-event-log-with-durable-evidence-fallback' } }
+Write-AtomicJson $previousPath $document
+[System.IO.File]::AppendAllText((Join-Path $StateDirectory 'history.jsonl'), (($document | ConvertTo-Json -Depth 16 -Compress) + "`n"), $utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $StateDirectory 'metrics.prom'), (Get-Metrics $results), $utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $StateDirectory 'dashboard.html'), (New-Dashboard $results $document.generated_at), $utf8NoBom)
+$document | ConvertTo-Json -Depth 16

--- a/ops/observability/scripts/Test-SkincosObservability.ps1
+++ b/ops/observability/scripts/Test-SkincosObservability.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+$temporary = Join-Path $env:TEMP "skincos-observability-test-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Force -Path $temporary | Out-Null
+try {
+  $script = Join-Path $PSScriptRoot 'Invoke-SkincosObservability.ps1'
+  $catalog = Join-Path (Split-Path -Parent $PSScriptRoot) 'catalog.json'
+  $result = & $script -CatalogPath $catalog -StateDirectory $temporary
+  $doc = $result | ConvertFrom-Json
+  if (-not $doc.results -or $doc.monitor -ne 'windows-scheduled-probe') { throw 'monitor output contract missing' }
+  if (-not (Test-Path (Join-Path $temporary 'metrics.prom'))) { throw 'metrics output missing' }
+  if (-not (Test-Path (Join-Path $temporary 'dashboard.html'))) { throw 'dashboard output missing' }
+  Write-Output "Observability monitor test OK ($($doc.results.Count) units)"
+} finally { if (Test-Path $temporary) { Remove-Item -LiteralPath $temporary -Recurse -Force } }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "observability:validate": "node scripts/observability/validate-catalog.mjs",
     "architecture:validate": "node ./.github/scripts/validate-architecture.mjs && node ./.github/scripts/validate-module-catalog.mjs && node ./.github/scripts/validate-domain-boundaries.mjs",
     "module-catalog:validate": "node ./.github/scripts/validate-module-catalog.mjs",
     "module-maturity:validate": "node ./.github/scripts/validate-module-maturity.mjs",

--- a/scripts/observability/validate-catalog.mjs
+++ b/scripts/observability/validate-catalog.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+
+const catalog = JSON.parse(fs.readFileSync(new URL('../../ops/observability/catalog.json', import.meta.url), 'utf8'));
+const errors = [];
+const required = ['id', 'environment', 'health', 'readiness', 'latencyBudgetMs', 'impact', 'probableCause', 'dashboard'];
+
+if (catalog.schemaVersion !== 2) errors.push('schemaVersion must be 2');
+if (catalog.primaryMonitor?.type !== 'windows-scheduled-probe') errors.push('primary monitor must remain independent from GitHub and Cloudflare');
+if (!Array.isArray(catalog.units) || catalog.units.length === 0) errors.push('units must not be empty');
+for (const unit of catalog.units || []) {
+  for (const field of required) if (unit[field] === undefined || unit[field] === '') errors.push(`${unit.id || '<unknown>'}: missing ${field}`);
+  if (!['production', 'staging'].includes(unit.environment)) errors.push(`${unit.id}: environment must be production or staging`);
+  if (typeof unit.enabled !== 'boolean') errors.push(`${unit.id}: enabled must be boolean`);
+  if (!unit.enabled && !unit.disabledReason) errors.push(`${unit.id}: disabled unit must explain disabledReason`);
+  if (!Number.isInteger(unit.latencyBudgetMs) || unit.latencyBudgetMs < 1) errors.push(`${unit.id}: latencyBudgetMs must be positive integer`);
+}
+for (const journey of catalog.syntheticJourneys || []) {
+  if (!journey.id || !journey.environment || typeof journey.enabled !== 'boolean') errors.push('synthetic journey is incomplete');
+  if (!journey.enabled && !journey.reason) errors.push(`${journey.id}: disabled journey must state reason`);
+}
+if (errors.length) {
+  console.error(`observability catalog validation failed:\n- ${errors.join('\n- ')}`);
+  process.exit(1);
+}
+console.log(`Observability catalog validation OK (${catalog.units.length} units; ${(catalog.syntheticJourneys || []).length} synthetic journeys).`);


### PR DESCRIPTION
## Observabilidade externa e contrato operacional

- adiciona catálogo versionado, validação em CI, métricas Prometheus e dashboard HTML/Grafana para o monitor primário fora de GitHub/Cloudflare;
- adiciona health/readiness estruturados, correlação e logs metadata-only ao gateway API;
- ativa logs Workers e propaga o SHA promovido para `APP_VERSION` no pipeline canônico de Core Workers;
- documenta instalação, rollback, jornada sintética autenticada e drill de alerta/recuperação.

## Evidência local/runtime

- `npm --prefix api test` (9 testes): passou.
- `npm run observability:validate`: passou.
- `Invoke-SkincosObservability.ps1`: monitor e dashboard gerados no runtime privado.
- drill controlado: `controlled-alert-drill` registrou `alert` e depois `resolved`; os serviços de produção permaneceram sem alterações.
- `wrangler deploy --dry-run --config api/wrangler.toml --env staging`: passou; nenhum deploy foi publicado.

## Limites verificados

A sessão atual não tem privilégio para registrar a tarefa `SkincosObservabilityProbe` nem a fonte Windows Event Log. O monitor foi provisionado e executado manualmente; a ativação recorrente e a entrega humana por webhook/Event Log permanecem bloqueadas pelo runbook. Financeiro e Ponto staging continuam `disabled` no catálogo porque ainda não foram implantados pelo pipeline canônico. Nenhuma credencial, segredo ou sessão humana foi adicionada.