### PR TITLE
governance: require restore evidence for maturity gates

### DIFF
--- a/.github/scripts/validate-module-maturity.mjs
+++ b/.github/scripts/validate-module-maturity.mjs
@@ -7,7 +7,7 @@ const states = ['experimental', 'staging', 'pilot', 'operational', 'critical'];
 const errors = []; const fail = (message) => errors.push(message);
 if (catalog.schemaVersion !== 2) fail('module catalog schemaVersion must be 2');
 if (JSON.stringify(catalog.maturityModel?.states) !== JSON.stringify(states)) fail('catalog must declare the official maturity states in order');
-if (evidence.schemaVersion !== 1) fail('promotion evidence schemaVersion must be 1');
+if (evidence.schemaVersion !== 2) fail('promotion evidence schemaVersion must be 2');
 for (const state of states) if (!Array.isArray(evidence.criteria?.[state]) || evidence.criteria[state].length === 0) fail(`missing criteria for ${state}`);
 for (const module of catalog.modules ?? []) {
   if (!states.includes(module.maturity)) { fail(`${module.id} has non-official maturity ${module.maturity}`); continue; }
@@ -16,6 +16,21 @@ for (const module of catalog.modules ?? []) {
   if (!record) { fail(`${module.id} at ${module.maturity} lacks reviewed promotion evidence`); continue; }
   for (const criterion of required) if (typeof record[criterion] !== 'string' || record[criterion].trim().length < 8) fail(`${module.id} at ${module.maturity} lacks ${criterion} evidence`);
   if (module.maturity !== 'experimental' && record.state !== module.maturity) fail(`${module.id} evidence state must match catalog maturity`);
+  if (['operational', 'critical'].includes(module.maturity)) {
+    const proof = record.recoveryProof;
+    if (!proof || typeof proof !== 'object' || Array.isArray(proof)) {
+      fail(`${module.id} at ${module.maturity} lacks structured recoveryProof`);
+      continue;
+    }
+    for (const field of ['drillId', 'scope', 'evidenceRef', 'restoredAt', 'dataChecks', 'functionalCheck']) {
+      if (typeof proof[field] !== 'string' || proof[field].trim().length < 8) fail(`${module.id} recoveryProof lacks ${field}`);
+    }
+    if (!Number.isFinite(proof.rtoSeconds) || proof.rtoSeconds <= 0) fail(`${module.id} recoveryProof lacks a measured rtoSeconds`);
+    if (module.maturity === 'critical') {
+      if (proof.offsite !== true) fail(`${module.id} critical recoveryProof must attest an offsite restore`);
+      if (typeof proof.keyEscrowRef !== 'string' || proof.keyEscrowRef.trim().length < 8) fail(`${module.id} critical recoveryProof lacks keyEscrowRef`);
+    }
+  }
 }
 if (errors.length) { for (const error of errors) console.error(`module maturity validation failed: ${error}`); process.exit(1); }
 console.log(`Module maturity validation OK (${catalog.modules.length} modules).`);

--- a/docs/audits/recovery-drill-2026-07-23.md
+++ b/docs/audits/recovery-drill-2026-07-23.md
@@ -36,3 +36,19 @@ fechado.
    a DPAPI local é apenas camada transitória.
 4. Repetir o exercício recuperando D1, PostgreSQL, R2 e configuração desse
    cofre externo e anexar `recoveryProof` ao módulo candidato.
+
+## Atualização de cofre externo — 2026-07-24
+
+O drill `20260724T0620Z` criou novos exports somente leitura de D1,
+PostgreSQL e configuração nativa, cifrou-os com AES-256-CBC + HMAC-SHA-256 e
+os enviou a um Google Drive privado. A chave foi criada no runtime privado,
+protegida por DPAPI e registrada separadamente como Environment Secret no
+GitHub Actions; hashes
+e metadados sanitizados estão na evidência privada do operador.
+
+O upload externo e a separação de fornecedor estão comprovados. A recuperação
+por download ainda não é evidência válida: a autorização OAuth `drive.file` do
+cliente de restore ficou pendente, portanto não houve import D1, restore
+PostgreSQL, extração de configuração, validação de checksum nem medição nova de
+RPO/RTO a partir do Drive. O gate permanece fechado, e esta atualização não
+promove nenhum módulo.

--- a/docs/audits/recovery-drill-2026-07-23.md
+++ b/docs/audits/recovery-drill-2026-07-23.md
@@ -46,9 +46,33 @@ protegida por DPAPI e registrada separadamente como Environment Secret no
 GitHub Actions; hashes
 e metadados sanitizados estão na evidência privada do operador.
 
-O upload externo e a separação de fornecedor estão comprovados. A recuperação
-por download ainda não é evidência válida: a autorização OAuth `drive.file` do
-cliente de restore ficou pendente, portanto não houve import D1, restore
-PostgreSQL, extração de configuração, validação de checksum nem medição nova de
-RPO/RTO a partir do Drive. O gate permanece fechado, e esta atualização não
-promove nenhum módulo.
+O upload externo e a separação de fornecedor estão comprovados. Em
+`20260725T-offsite-restore-current-main`, o cliente com escopo `drive.file`
+recuperou o ciphertext D1 do Drive. Os ciphertexts PostgreSQL e configuração
+já presentes no runtime privado foram conferidos byte-a-byte contra o
+manifesto do mesmo cofre e restaurados no scratch privado; a transferência
+fresh desses dois arquivos não foi rebaixada a prova nesta execução porque o
+conector raw excede o limite IPC. A verificação HMAC, os três hashes plaintext
+e a validação funcional passaram para os arquivos restaurados:
+
+- D1: 58 tabelas, 16 migrations (última `0016_personal_invites.sql`), zero
+  violações de FK; Financeiro com 3 scopes, 2 grants, 1 setting, 0 movimentos,
+  0 lançamentos e 12 migrations de release.
+- PostgreSQL: restore custom dump em banco isolado, 58 tabelas, 43 workflows,
+  246 executions e 44 credentials; restore em 25,643 s.
+- Configuração: tar legível com 33 entradas e SHA-256 idêntico; o restore
+  criptográfico levou 0,479 s (D1 0,637 s).
+
+O scratch e os arquivos plaintext foram destruídos após a validação; resta apenas
+`C:\CodexRuntime\operator\admin\skincos\offsite-recovery\20260725T-current-main-offsite-restore-evidence.sanitized.json`.
+Isto fecha a prova técnica offsite de D1 e a prova criptográfica/funcional local
+dos outros dois payloads; o restore offsite de PostgreSQL/configuração ainda
+precisa de uma captura de download auditável para fechar o conjunto. Ela
+não é `recoveryProof` do módulo Financeiro: não restaura o bundle/Worker do
+Financeiro nem aprova piloto, e `module_enabled` permanece desligado.
+
+O snapshot tinha 76.272,151 s de idade no momento do restore; isso é uma
+observação do exercício, não um RPO de produção. Permanece P1 a migração do
+cofre para Shared Drive com conta de serviço/owner corporativo e o escrow em KMS
+externo ao GitHub; a chave atual está separada como Environment Secret de
+`recovery` e protegida por DPAPI no runtime privado.

--- a/docs/audits/recovery-drill-2026-07-23.md
+++ b/docs/audits/recovery-drill-2026-07-23.md
@@ -1,0 +1,38 @@
+# Recovery drill — 2026-07-23
+
+Escopo: `skincos-db` (D1), `n8n_runtime` (PostgreSQL), configuração nativa do
+runtime e transporte cifrado em R2. Evidência privada, sem conteúdo pessoal ou
+segredos: `C:\CodexRuntime\operator\admin\skincos\recovery-drills\20260723T223442Z`.
+
+| Item | Resultado comprovado |
+| --- | --- |
+| D1 | export de 13 MB; scratch com 58 tabelas, 57 contagens consultáveis idênticas (`_cf_KV` é reservada), zero violações de FK, 16 migrations e leitura de Inventory; re-export SHA-256 idêntico. |
+| D1 a partir do backup cifrado | download R2, decriptação, criação/import em scratch e leitura de migrations concluídos em **18,203 s**; 19.096 queries importadas. |
+| PostgreSQL | `pg_dump` online de 91 MB sem parar Orb; restore de 58 tabelas em scratch em **16,170 s**; contagens e checksums lógicos idênticos e leitura de workflows/executions/credentials aprovada. |
+| Configuração/R2 | arquivo de `/etc/skincos` e units selecionadas cifrado com AES-256, enviado/recuperado no R2 de staging; SHA-256 do arquivo restaurado idêntico e conteúdo do tar legível. |
+| Limitação D1 | `PRAGMA integrity_check` é bloqueado pelo provedor (`SQLITE_AUTH`); o drill usou `foreign_key_check`, esquema, contagens, checksum de export e leitura funcional. |
+| Limpeza | os dois scratch D1 e o scratch PostgreSQL foram removidos; SQL, dump, SQLite e chaves temporárias em texto claro foram removidos. |
+
+Na observação de RPO às `2026-07-24T01:53:33Z`, o snapshot D1 tinha 1.083 s,
+o dump PostgreSQL 396 s e o archive de configuração 146 s. Esses números são
+observações do exercício, não SLOs de produção.
+
+## Decisão
+
+O exercício satisfaz prova técnica local/same-provider de backup, restore,
+checksum e teste funcional para os escopos acima. Ele **não** satisfaz a
+política empresarial de offsite: `skincos-backups-staging` pertence à mesma
+conta Cloudflare e a chave está protegida apenas por DPAPI local, sem escrow
+externo. Por isso não há módulo promovido e o gate de maturidade permanece
+fechado.
+
+## P0 para fechar o gate
+
+1. Selecionar e provisionar cofre em fornecedor distinto, com retenção
+   imutável e conta empresarial do Skincos.
+2. Criar role de gravação limitada ao prefixo de backup, separada das roles de
+   deploy e restore, e registrar seus owners.
+3. Guardar a chave de recuperação em KMS/Vault externo com escrow break-glass;
+   a DPAPI local é apenas camada transitória.
+4. Repetir o exercício recuperando D1, PostgreSQL, R2 e configuração desse
+   cofre externo e anexar `recoveryProof` ao módulo candidato.

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,17 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T02:30:32Z",
+      "surface": "google-drive-offsite-scratch",
+      "scope": "Offsite recovery drill — platform payloads",
+      "state": "d1-offsite-proven-pg-config-local-match",
+      "method": "Restricted drive.file retrieval, HMAC verification, restore-offsite-archive.ps1, isolated SQLite/PostgreSQL scratch, count/checksum/functional checks and explicit scratch destruction",
+      "result": "D1 ciphertext was retrieved from the provider-separated Drive vault and restored with 58 tables, 16 migrations, zero foreign-key violations and Finance counts (3 scopes, 2 grants, 1 setting, 0 movements, 0 journal entries, 12 release migrations). PostgreSQL and runtime configuration ciphertexts in the private runtime matched the same Drive manifest byte-for-byte and restored with 58 tables/43 workflows/246 executions/44 credentials and 33 tar entries. Plaintext hashes matched the manifest; PostgreSQL restore measured 25.643 seconds.",
+      "limitation": "A fresh raw download of the large PostgreSQL and configuration objects exceeded the connector IPC limit in this execution, so their offsite transfer remains a technical gate. This is not Finance recoveryProof, does not restore a Worker or frontend bundle and does not promote the module. Scratch and plaintexts were destroyed; only sanitized private evidence remains.",
+      "key_id": "offsite-20260724-v1",
+      "evidence_ref": "C:\\CodexRuntime\\operator\\admin\\skincos\\offsite-recovery\\20260725T-current-main-offsite-restore-evidence.sanitized.json"
+    },
+    {
       "observed_at": "2026-07-25T02:15:00Z",
       "surface": "github-cloudflare-production",
       "scope": "Inventory definitive release SHA reconciliation",

--- a/docs/runbooks/backup-and-restore-policy.md
+++ b/docs/runbooks/backup-and-restore-policy.md
@@ -18,6 +18,53 @@ origem devem ser contas/roles diferentes. A chave precisa de escrow fora do
 fornecedor de armazenamento, com procedimento break-glass auditável. Segredos
 e dados pessoais nunca entram no repositório nem na evidência versionada.
 
+## Implementação do cofre externo
+
+O cofre externo é um diretório privado em Google Drive, fora da conta
+Cloudflare e do host PostgreSQL. Seu ID, o arquivo de configuração do cliente
+e os logs de transferência ficam exclusivamente em
+`C:\CodexRuntime\operator\admin\skincos\offsite-recovery\`, com ACL para
+`SYSTEM` e o operador. O repositório guarda apenas estes contratos:
+
+- a origem usa a credencial de leitura do fornecedor (Cloudflare ou role de
+  backup PostgreSQL), nunca a credencial do Drive;
+- o cliente do Drive deve usar o escopo `drive.file`, para enxergar somente os
+  arquivos que ele próprio criou; uma conta de serviço em Shared Drive é a
+  substituição obrigatória antes de classificar o cofre como corporativo;
+- os objetos são ciphertexts e manifestos sanitizados. O Drive não recebe
+  dumps, configuração, chaves ou tokens em claro;
+- a chave de 32 bytes permanece protegida por DPAPI no runtime privado. Uma
+  cópia do material de recuperação fica como GitHub Actions Environment Secret
+  no environment `recovery`, separado do Drive e da Cloudflare; ela não pode
+  existir como secret genérico do repositório;
+- cada rotação cria um `keyId` novo e um Secret de escrow novo antes do primeiro
+  upload. Chaves anteriores permanecem por `retenção + 30 dias`; revogação,
+  suspeita de exposição ou perda de operador força rotação imediata.
+
+`scripts/recovery/new-offsite-recovery-key.ps1` cria a chave privada;
+`protect-offsite-archive.ps1` cifra arquivos grandes em streaming com
+AES-256-CBC + HMAC-SHA-256 (encrypt-then-MAC); e
+`restore-offsite-archive.ps1` verifica o HMAC antes de decriptar em scratch.
+Os scripts nunca contêm IDs, chaves, contas ou destinos.
+
+## Retenção, acesso e auditoria
+
+- Manter 35 pontos diários e 12 mensais; qualquer exclusão requer a retenção
+  equivalente no cofre e registro de auditoria. Nunca usar `sync --delete`.
+- Antes de promover um arquivo, comparar SHA-256 do ciphertext local com o
+  remoto e registrar `keyId`, hash, tamanho, timestamps e operador em evidência
+  sanitizada. O hash do plaintext fica somente na evidência privada.
+- O acesso normal tem somente upload/listagem no prefixo de backup. Download e
+  decriptação são break-glass: registrar incidente, owner, motivo, escopo,
+  hora, `keyId` e hash; restaurar em scratch sem rotas, bindings ou secrets de
+  produção; e destruir o scratch após validação.
+- O escrow é exercitado a cada trimestre: um administrador autorizado usa o
+  Secret de recuperação em ambiente isolado, valida seu fingerprint e registra
+  a evidência sem revelar a chave. O GitHub Secret não é usado por aplicações.
+- Falha de upload, hash, escrow, retenção ou restore bloqueia promoção e abre
+  alerta P0 para Platform. Acesso de emergência não autoriza sobrescrever a
+  origem nem restaurar sobre produção.
+
 ## Procedimento de restore
 
 1. Suspender somente as escritas do domínio afetado e registrar o bookmark ou
@@ -39,11 +86,21 @@ restauração, testes de dados e funcional, e RTO medido. `critical` exige ainda
 prova de restauração offsite e referência de escrow da chave. Uma referência
 sem esses campos falha o check `module-maturity:validate`.
 
-## Situação transitória em 2026-07-23
+## Situação e gate em 2026-07-24
 
 O exercício `20260723T223442Z` comprovou D1, PostgreSQL e configuração em
-scratch, com ciphertext no R2 de staging. Esse bucket é Cloudflare e a chave
-está apenas em DPAPI do operador; portanto **não é cópia offsite nem escrow**.
-Nenhum módulo pode usar esse exercício para avançar a `operational` ou
-`critical`. A provisão do cofre externo, role de backup segregada e escrow é
-P0 antes de qualquer promoção.
+scratch, com ciphertext no R2 de staging. Ele permanece uma prova útil de
+restore local/same-provider, mas não de offsite.
+
+Em `20260724T0620Z`, um cofre Google Drive privado recebeu ciphertexts novos
+de D1, PostgreSQL e configuração, com AES-256-CBC + HMAC-SHA-256 e escrow de
+chave separado em GitHub Actions. A cópia satisfaz separação de fornecedor e
+de material criptográfico, mas **a restauração a partir do Drive ainda não foi
+aceita como prova**: a autorização OAuth de escopo restrito do cliente de
+recovery está pendente. Não há `recoveryProof` novo, promoção ou alteração de
+produção até que o download do cofre, a restauração scratch, os checksums, a
+jornada funcional e a destruição do scratch sejam registrados.
+
+Também permanece P1 a migração desse cofre privado para Shared Drive com conta
+de serviço e owner corporativo; isso evita dependência de uma conta humana sem
+rebaixar o gate técnico atual.

--- a/docs/runbooks/backup-and-restore-policy.md
+++ b/docs/runbooks/backup-and-restore-policy.md
@@ -1,0 +1,49 @@
+# Política de backup e restauração
+
+Esta política é obrigatória para qualquer mudança de maturidade. Um backup não
+substitui uma restauração testada; evidência local, endpoint saudável ou deploy
+anterior não qualificam um módulo para `operational`.
+
+## Controles obrigatórios
+
+| Dado | RPO alvo | RTO alvo | Retenção | Cópia e criptografia | Owner |
+| --- | ---: | ---: | --- | --- | --- |
+| D1 por domínio | 15 min | 30 min | 35 dias + mensal por 12 meses | export cifrado AES-256, destino primário e cofre de outro fornecedor | owner do domínio + Platform |
+| PostgreSQL por domínio | 15 min | 30 min | 35 dias + mensal por 12 meses | dump consistente cifrado AES-256, destino primário e cofre de outro fornecedor | owner do serviço + Platform |
+| R2 e configurações | 24 h, ou antes de alteração | 60 min | 90 dias | inventário de objetos e arquivo de configuração cifrados; cópia fora da conta Cloudflare | Platform |
+| Estados operacionais (filas, DLQ, outbox, bindings) | 15 min | 60 min | 35 dias | export versionado, cifrado e reconciliável | owner do módulo |
+
+As credenciais de escrita do destino, a chave de criptografia e o acesso à
+origem devem ser contas/roles diferentes. A chave precisa de escrow fora do
+fornecedor de armazenamento, com procedimento break-glass auditável. Segredos
+e dados pessoais nunca entram no repositório nem na evidência versionada.
+
+## Procedimento de restore
+
+1. Suspender somente as escritas do domínio afetado e registrar o bookmark ou
+   timestamp de recuperação.
+2. Recuperar o ciphertext em ambiente scratch isolado e verificar a assinatura
+   ou SHA-256 antes de decriptar.
+3. Restaurar sem binding, rota, segredo ou fila de produção.
+4. Comparar esquema, contagens, checksum de conteúdo e integridade referencial;
+   executar uma jornada de leitura/escrita segura do domínio.
+5. Medir RPO e RTO do início da recuperação ao teste funcional; anexar o
+   identificador de evidência privada e destruir o scratch ao final.
+6. Só então avaliar o corte, com rollback documentado e aprovação explícita.
+
+## Gate de maturidade
+
+O CI exige `recoveryProof` estruturado para estados `operational` e `critical`.
+Ele deve conter id do drill, escopo, referência de evidência, timestamp da
+restauração, testes de dados e funcional, e RTO medido. `critical` exige ainda
+prova de restauração offsite e referência de escrow da chave. Uma referência
+sem esses campos falha o check `module-maturity:validate`.
+
+## Situação transitória em 2026-07-23
+
+O exercício `20260723T223442Z` comprovou D1, PostgreSQL e configuração em
+scratch, com ciphertext no R2 de staging. Esse bucket é Cloudflare e a chave
+está apenas em DPAPI do operador; portanto **não é cópia offsite nem escrow**.
+Nenhum módulo pode usar esse exercício para avançar a `operational` ou
+`critical`. A provisão do cofre externo, role de backup segregada e escrow é
+P0 antes de qualquer promoção.

--- a/docs/runbooks/backup-and-restore-policy.md
+++ b/docs/runbooks/backup-and-restore-policy.md
@@ -94,12 +94,23 @@ restore local/same-provider, mas não de offsite.
 
 Em `20260724T0620Z`, um cofre Google Drive privado recebeu ciphertexts novos
 de D1, PostgreSQL e configuração, com AES-256-CBC + HMAC-SHA-256 e escrow de
-chave separado em GitHub Actions. A cópia satisfaz separação de fornecedor e
-de material criptográfico, mas **a restauração a partir do Drive ainda não foi
-aceita como prova**: a autorização OAuth de escopo restrito do cliente de
-recovery está pendente. Não há `recoveryProof` novo, promoção ou alteração de
-produção até que o download do cofre, a restauração scratch, os checksums, a
-jornada funcional e a destruição do scratch sejam registrados.
+chave separado em GitHub Actions. Em `20260725T-offsite-restore-current-main`,
+o cliente `drive.file` recuperou o ciphertext D1 e validou-o no scratch. Os
+ciphertexts PostgreSQL e configuração presentes no runtime privado coincidem
+byte-a-byte com o manifesto do Drive e foram restaurados no mesmo scratch; a
+captura de download fresh desses dois arquivos não foi considerada prova nesta
+execução porque o conector raw excede o limite IPC. Os resultados restaurados
+foram D1 com 58 tabelas/16 migrations/zero FK violations, PostgreSQL com 58
+tabelas e configuração com 33 entradas. O restore PostgreSQL mediu 25,643 s; o
+scratch e os plaintexts foram destruídos após a jornada funcional. A prova
+sanitizada está no runtime privado do operador.
+
+Este restore fecha a prova técnica offsite de D1 e a prova criptográfica/
+funcional local dos outros payloads; o download auditável de PostgreSQL e
+configuração ainda é gate técnico. Também não
+cria `recoveryProof` de nenhum módulo nem promove o Financeiro: bundle/Worker,
+flags, grants e smoke autenticado do Financeiro continuam gates separados, e
+`module_enabled` permanece desligado.
 
 Também permanece P1 a migração desse cofre privado para Shared Drive com conta
 de serviço e owner corporativo; isso evita dependência de uma conta humana sem

--- a/ops/module-governance/promotion-evidence.json
+++ b/ops/module-governance/promotion-evidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "purpose": "Reviewed evidence required before a module may advance its official maturity state. References identify runbooks, tests or immutable evidence; they never contain secrets or personal data.",
   "criteria": {
     "experimental": ["permissions", "tests", "featureFlag", "fallback", "documentation"],

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -1,0 +1,18 @@
+# Cifragem e recuperação offsite
+
+Estes comandos manipulam somente arquivos privados em runtime. Eles não
+conhecem destino, credencial, chave ou identificador de ambiente; esses dados
+ficam no cofre privado do operador e em um escrow externo.
+
+- `new-offsite-recovery-key.ps1` cria uma chave de 32 bytes protegida por DPAPI
+  do operador e informa apenas o fingerprint para auditoria.
+- `protect-offsite-archive.ps1` cifra um arquivo em streaming com AES-256-CBC
+  e HMAC-SHA-256 (encrypt-then-MAC), produzindo hashes de origem e ciphertext.
+- `restore-offsite-archive.ps1` verifica o HMAC antes de abrir o conteúdo e
+  escreve atomically apenas no scratch explicitamente escolhido.
+
+O processo de operação está em
+`docs/runbooks/backup-and-restore-policy.md`. A rotação cria um novo `keyId`,
+registra o material no escrow externo antes de qualquer backup e mantém a
+chave anterior até o fim da retenção acrescido do RTO. Não copie o arquivo de
+chave, o ciphertext, dumps ou manifests operacionais para o repositório.

--- a/scripts/recovery/new-offsite-recovery-key.ps1
+++ b/scripts/recovery/new-offsite-recovery-key.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$KeyPath,
+    [Parameter(Mandatory)][string]$KeyId,
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
+$parent = Split-Path -Parent $KeyPath
+if (-not $parent) { throw 'KeyPath must include a parent directory.' }
+if ((Test-Path -LiteralPath $KeyPath) -and -not $Force) { throw "Key file already exists: $KeyPath" }
+New-Item -ItemType Directory -Force -Path $parent | Out-Null
+
+$key = New-Object byte[] 32
+$rng = [Security.Cryptography.RandomNumberGenerator]::Create()
+try { $rng.GetBytes($key) } finally { $rng.Dispose() }
+$protected = [Security.Cryptography.ProtectedData]::Protect(
+    $key,
+    [Text.Encoding]::UTF8.GetBytes('SKINCOS offsite recovery key v1'),
+    [Security.Cryptography.DataProtectionScope]::CurrentUser
+)
+
+@{
+    schemaVersion = 1
+    keyId = $KeyId
+    createdAtUtc = [DateTime]::UtcNow.ToString('o')
+    protection = 'DPAPI CurrentUser'
+    protectedKey = [Convert]::ToBase64String($protected)
+} | ConvertTo-Json -Depth 3 | ForEach-Object {
+    [IO.File]::WriteAllText($KeyPath, $_, [Text.UTF8Encoding]::new($false))
+}
+
+& icacls.exe $KeyPath /inheritance:r /grant:r '*S-1-5-18:F' "*$([Security.Principal.WindowsIdentity]::GetCurrent().User.Value):F" /Q | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to restrict key file ACL.' }
+
+$sha = [Security.Cryptography.SHA256]::Create()
+try { $fingerprint = $sha.ComputeHash($key) } finally { $sha.Dispose() }
+Write-Output "key_id=$KeyId"
+Write-Output "key_fingerprint=$(([BitConverter]::ToString($fingerprint) -replace '-', '').ToLowerInvariant())"

--- a/scripts/recovery/protect-offsite-archive.ps1
+++ b/scripts/recovery/protect-offsite-archive.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$InputPath,
+    [Parameter(Mandatory)][string]$OutputPath,
+    [Parameter(Mandatory)][string]$KeyPath,
+    [Parameter(Mandatory)][string]$KeyId
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
+$magic = [Text.Encoding]::ASCII.GetBytes("SKINCOS-OFFSITE-ARCHIVE-V1`n")
+$entropy = [Text.Encoding]::UTF8.GetBytes('SKINCOS offsite recovery key v1')
+
+function Get-RecoveryKey([string]$path) {
+    $record = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    if ($record.schemaVersion -ne 1 -or [string]::IsNullOrWhiteSpace($record.protectedKey)) { throw 'Invalid protected recovery key record.' }
+    return [Security.Cryptography.ProtectedData]::Unprotect(
+        [Convert]::FromBase64String([string]$record.protectedKey), $entropy,
+        [Security.Cryptography.DataProtectionScope]::CurrentUser
+    )
+}
+function Derive-Key([byte[]]$master, [string]$label) {
+    $h = [Security.Cryptography.HMACSHA256]::new($master)
+    try { return $h.ComputeHash([Text.Encoding]::UTF8.GetBytes($label)) } finally { $h.Dispose() }
+}
+
+if (-not (Test-Path -LiteralPath $InputPath -PathType Leaf)) { throw "Input file not found: $InputPath" }
+$outputParent = Split-Path -Parent $OutputPath
+if (-not $outputParent) { throw 'OutputPath must include a parent directory.' }
+New-Item -ItemType Directory -Force -Path $outputParent | Out-Null
+$partial = "$OutputPath.partial"
+Remove-Item -LiteralPath $partial -Force -ErrorAction SilentlyContinue
+
+$master = Get-RecoveryKey $KeyPath
+$encKey = Derive-Key $master 'SKINCOS offsite AES-256 encryption v1'
+$macKey = Derive-Key $master 'SKINCOS offsite HMAC-SHA-256 v1'
+$iv = New-Object byte[] 16
+$rng = [Security.Cryptography.RandomNumberGenerator]::Create()
+try {
+    $rng.GetBytes($iv)
+    $aes = [Security.Cryptography.Aes]::Create()
+    $aes.KeySize = 256; $aes.Mode = [Security.Cryptography.CipherMode]::CBC; $aes.Padding = [Security.Cryptography.PaddingMode]::PKCS7
+    $aes.Key = $encKey; $aes.IV = $iv
+    $input = [IO.File]::OpenRead($InputPath)
+    $output = [IO.File]::Create($partial)
+    try {
+        $output.Write($magic, 0, $magic.Length); $output.Write($iv, 0, $iv.Length)
+        $crypto = [Security.Cryptography.CryptoStream]::new($output, $aes.CreateEncryptor(), [Security.Cryptography.CryptoStreamMode]::Write, $true)
+        try { $input.CopyTo($crypto); $crypto.FlushFinalBlock() } finally { $crypto.Dispose() }
+    } finally { $input.Dispose(); $output.Dispose(); $aes.Dispose() }
+    $hmac = [Security.Cryptography.HMACSHA256]::new($macKey)
+    try {
+        $stream = [IO.File]::OpenRead($partial)
+        try { $tag = $hmac.ComputeHash($stream) } finally { $stream.Dispose() }
+    } finally { $hmac.Dispose() }
+    $append = [IO.File]::Open($partial, [IO.FileMode]::Append)
+    try { $append.Write($tag, 0, $tag.Length) } finally { $append.Dispose() }
+    Move-Item -LiteralPath $partial -Destination $OutputPath -Force
+} finally {
+    $rng.Dispose()
+    [Array]::Clear($master, 0, $master.Length); [Array]::Clear($encKey, 0, $encKey.Length); [Array]::Clear($macKey, 0, $macKey.Length)
+    Remove-Item -LiteralPath $partial -Force -ErrorAction SilentlyContinue
+}
+
+$inputHash = (Get-FileHash -LiteralPath $InputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+$cipherHash = (Get-FileHash -LiteralPath $OutputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+@{ schemaVersion=1; keyId=$KeyId; algorithm='AES-256-CBC+HMAC-SHA-256'; sourceSha256=$inputHash; ciphertextSha256=$cipherHash; createdAtUtc=[DateTime]::UtcNow.ToString('o') } | ConvertTo-Json -Compress

--- a/scripts/recovery/restore-offsite-archive.ps1
+++ b/scripts/recovery/restore-offsite-archive.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$InputPath,
+    [Parameter(Mandatory)][string]$OutputPath,
+    [Parameter(Mandatory)][string]$KeyPath
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
+$magic = [Text.Encoding]::ASCII.GetBytes("SKINCOS-OFFSITE-ARCHIVE-V1`n")
+$entropy = [Text.Encoding]::UTF8.GetBytes('SKINCOS offsite recovery key v1')
+
+function Get-RecoveryKey([string]$path) {
+    $record = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    if ($record.schemaVersion -ne 1 -or [string]::IsNullOrWhiteSpace($record.protectedKey)) { throw 'Invalid protected recovery key record.' }
+    return [Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String([string]$record.protectedKey), $entropy, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+}
+function Derive-Key([byte[]]$master, [string]$label) { $h = [Security.Cryptography.HMACSHA256]::new($master); try { return $h.ComputeHash([Text.Encoding]::UTF8.GetBytes($label)) } finally { $h.Dispose() } }
+function Test-FixedTime([byte[]]$a, [byte[]]$b) { if ($a.Length -ne $b.Length) { return $false }; $d=0; for($i=0;$i -lt $a.Length;$i++){ $d = $d -bor ($a[$i] -bxor $b[$i]) }; return $d -eq 0 }
+
+if (-not (Test-Path -LiteralPath $InputPath -PathType Leaf)) { throw "Ciphertext not found: $InputPath" }
+$length = (Get-Item -LiteralPath $InputPath).Length
+$headerLength = $magic.Length + 16
+if ($length -le ($headerLength + 32)) { throw 'Ciphertext is too short.' }
+$master = Get-RecoveryKey $KeyPath; $encKey = Derive-Key $master 'SKINCOS offsite AES-256 encryption v1'; $macKey = Derive-Key $master 'SKINCOS offsite HMAC-SHA-256 v1'
+$partial = "$OutputPath.partial"
+$cipherPayload = "$OutputPath.cipher.partial"
+Remove-Item -LiteralPath $partial -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $cipherPayload -Force -ErrorAction SilentlyContinue
+try {
+    $contentLength = $length - 32
+    $hmac = [Security.Cryptography.HMACSHA256]::new($macKey)
+    try {
+        $in = [IO.File]::OpenRead($InputPath)
+        try {
+            $buffer = New-Object byte[] 1048576; $remaining=$contentLength
+            while($remaining -gt 0){ $read=$in.Read($buffer,0,[Math]::Min($buffer.Length,$remaining)); if($read -le 0){throw 'Unexpected end of ciphertext.'}; [void]$hmac.TransformBlock($buffer,0,$read,$null,0); $remaining -= $read }
+            [void]$hmac.TransformFinalBlock(@(),0,0); $expected=$hmac.Hash
+            $tag=New-Object byte[] 32; if($in.Read($tag,0,32) -ne 32){throw 'Ciphertext tag is missing.'}
+            if(-not (Test-FixedTime $expected $tag)){throw 'Ciphertext integrity verification failed.'}
+        } finally { $in.Dispose() }
+    } finally { $hmac.Dispose() }
+    $source=[IO.File]::OpenRead($InputPath); $payload=[IO.File]::Create($cipherPayload)
+    try {
+        $remaining=$contentLength; $buffer=New-Object byte[] 1048576
+        while($remaining -gt 0) { $read=$source.Read($buffer,0,[Math]::Min($buffer.Length,$remaining)); if($read -le 0){throw 'Unexpected end of ciphertext.'}; $payload.Write($buffer,0,$read); $remaining-=$read }
+    } finally { $source.Dispose(); $payload.Dispose() }
+    $in=[IO.File]::OpenRead($cipherPayload); $out=[IO.File]::Create($partial)
+    try {
+        $actualMagic=New-Object byte[] $magic.Length; if($in.Read($actualMagic,0,$actualMagic.Length) -ne $actualMagic.Length -or -not (Test-FixedTime $actualMagic $magic)){throw 'Unknown ciphertext format.'}
+        $iv=New-Object byte[] 16; if($in.Read($iv,0,16) -ne 16){throw 'Ciphertext IV is missing.'}
+        $aes=[Security.Cryptography.Aes]::Create(); $aes.KeySize=256; $aes.Mode=[Security.Cryptography.CipherMode]::CBC; $aes.Padding=[Security.Cryptography.PaddingMode]::PKCS7; $aes.Key=$encKey; $aes.IV=$iv
+        try { $crypto=[Security.Cryptography.CryptoStream]::new($in,$aes.CreateDecryptor(),[Security.Cryptography.CryptoStreamMode]::Read,$true); try { $crypto.CopyTo($out) } finally { $crypto.Dispose() } } finally { $aes.Dispose() }
+    } finally { $in.Dispose(); $out.Dispose() }
+    Move-Item -LiteralPath $partial -Destination $OutputPath -Force
+} finally { [Array]::Clear($master,0,$master.Length); [Array]::Clear($encKey,0,$encKey.Length); [Array]::Clear($macKey,0,$macKey.Length); Remove-Item -LiteralPath $partial -Force -ErrorAction SilentlyContinue; Remove-Item -LiteralPath $cipherPayload -Force -ErrorAction SilentlyContinue }
+
+@{ schemaVersion=1; plaintextSha256=(Get-FileHash -LiteralPath $OutputPath -Algorithm SHA256).Hash.ToLowerInvariant(); restoredAtUtc=[DateTime]::UtcNow.ToString('o') } | ConvertTo-Json -Compress

--- a/scripts/recovery/test-offsite-archive.ps1
+++ b/scripts/recovery/test-offsite-archive.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param([Parameter(Mandatory)][string]$ScratchRoot)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+New-Item -ItemType Directory -Force -Path $ScratchRoot | Out-Null
+$source = Join-Path $ScratchRoot 'source.bin'
+$key = Join-Path $ScratchRoot 'key.dpapi.json'
+$cipher = Join-Path $ScratchRoot 'source.skba'
+$restored = Join-Path $ScratchRoot 'restored.bin'
+[IO.File]::WriteAllBytes($source, [byte[]](1..255))
+
+& (Join-Path $PSScriptRoot 'new-offsite-recovery-key.ps1') -KeyPath $key -KeyId 'selftest' | Out-Null
+& (Join-Path $PSScriptRoot 'protect-offsite-archive.ps1') -InputPath $source -OutputPath $cipher -KeyPath $key -KeyId 'selftest' | Out-Null
+& (Join-Path $PSScriptRoot 'restore-offsite-archive.ps1') -InputPath $cipher -OutputPath $restored -KeyPath $key | Out-Null
+if ((Get-FileHash $source -Algorithm SHA256).Hash -ne (Get-FileHash $restored -Algorithm SHA256).Hash) { throw 'Archive round trip checksum mismatch.' }
+
+$tampered = Join-Path $ScratchRoot 'tampered.skba'; Copy-Item -LiteralPath $cipher -Destination $tampered
+$stream = [IO.File]::Open($tampered, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite)
+try { $stream.Seek(32, [IO.SeekOrigin]::Begin) | Out-Null; $byte=$stream.ReadByte(); $stream.Seek(32, [IO.SeekOrigin]::Begin) | Out-Null; $stream.WriteByte($byte -bxor 1) } finally { $stream.Dispose() }
+$tamperRejected = $false
+try { & (Join-Path $PSScriptRoot 'restore-offsite-archive.ps1') -InputPath $tampered -OutputPath (Join-Path $ScratchRoot 'tampered.out') -KeyPath $key | Out-Null } catch { $tamperRejected = $_.Exception.Message -match 'integrity' }
+if (-not $tamperRejected) { throw 'Tampered archive was not rejected.' }
+Write-Output 'offsite archive self-test passed'


### PR DESCRIPTION
﻿## What changed

- Adds the enterprise backup/restore policy and a sanitized recovery-drill report.
- Requires structured `recoveryProof` with measured RTO before a module can be marked `operational` or `critical`; critical also requires offsite and key-escrow attestations.
- Records the real D1, PostgreSQL and encrypted runtime-configuration drill without placing data or secrets in Git.

## Why

A healthy endpoint or a local backup is not sufficient evidence for a maturity promotion. The CI contract keeps that gate closed until restore evidence is reviewed.

## Validation

- `npm run architecture:validate`
- `npm run module-maturity:validate`
- Real scratch restore: D1 58 tables/16 migrations/0 FK violations; PostgreSQL 58 tables and 25.643 s; configuration archive 33 entries.
- Sanitized evidence retained privately under the operator runtime; scratch and plaintexts destroyed.

## Operational limitation

The Google Drive `drive.file` client fetched and validated the D1 ciphertext. PostgreSQL and runtime-configuration ciphertexts in the private operator runtime match the Drive manifest byte-for-byte and were restored, but a fresh raw download of those two large files exceeded the connector IPC limit in this execution. Their offsite download remains a technical gate. Shared Drive/service-account ownership and an external KMS escrow also remain P1. No module is promoted and Finance `module_enabled` stays false.
