### PR TITLE
chore(staging): version reproducible foundation manifest

### DIFF
--- a/.github/scripts/validate-staging-manifest.mjs
+++ b/.github/scripts/validate-staging-manifest.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const manifestPath = path.join(root, 'platform/staging/manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const errors = [];
+const fail = (message) => errors.push(message);
+const expectedDomains = ['finance', 'identity', 'inventory'];
+const requiredBindings = ['DB', 'DATA_BUCKET', 'EVENT_QUEUE', 'FLAGS'];
+const prohibitedKey = /(?:account|database|namespace|zone|version|deployment)_?id/i;
+const prohibitedValue = /(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32}|https?:\/\/|\.workers\.dev|skincos\.com\.br)/i;
+
+function scan(value, location = 'manifest') {
+  if (Array.isArray(value)) return value.forEach((item, index) => scan(item, `${location}[${index}]`));
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      if (key === '$schema') continue;
+      if (prohibitedKey.test(key)) fail(`${location}.${key} must not contain a remote resource identifier`);
+      scan(nested, `${location}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === 'string' && prohibitedValue.test(value)) fail(`${location} must not contain a remote identifier or route`);
+}
+
+if (manifest.schemaVersion !== 1) fail('schemaVersion must be 1');
+if (manifest.environment !== 'staging') fail('environment must be staging');
+if (manifest.safety?.customRoutesAllowed !== false) fail('custom routes must remain disabled');
+if (manifest.safety?.productionDataAllowed !== false) fail('production data must remain prohibited');
+if (manifest.safety?.defaultFeatureFlags?.module_enabled !== false) fail('module_enabled must default to false');
+if (manifest.safety?.requiredApplyAcknowledgement !== 'SKINCOS_STAGING_APPLY=1') fail('apply acknowledgement must be explicit');
+
+const domains = manifest.domains || [];
+if (domains.map((domain) => domain.id).sort().join(',') !== expectedDomains.join(',')) fail('domains must be exactly finance, identity and inventory');
+for (const domain of domains) {
+  for (const field of ['owner', 'worker', 'd1', 'kv', 'r2', 'queue', 'deadLetterQueue']) if (!domain[field]) fail(`${domain.id}.${field} is required`);
+  if (domain.queue === domain.deadLetterQueue) fail(`${domain.id} source queue and DLQ must be distinct`);
+  if (domain.bindings?.slice().sort().join(',') !== requiredBindings.slice().sort().join(',')) fail(`${domain.id} must declare only the standard isolated bindings`);
+  if (JSON.stringify(domain.secretNames) !== JSON.stringify(['STAGING_CONTROL_TOKEN'])) fail(`${domain.id} must declare only the secret name, never a value`);
+}
+
+for (const resource of ['worker', 'd1', 'kv', 'r2', 'queue', 'deadLetterQueue']) {
+  const values = domains.map((domain) => domain[resource]);
+  if (new Set(values).size !== values.length) fail(`${resource} names must be unique by domain`);
+}
+if ((manifest.postgresql?.domains || []).map((domain) => domain.id).sort().join(',') !== expectedDomains.join(',')) fail('PostgreSQL roles must exist for every isolated domain');
+
+scan(manifest);
+if (errors.length) {
+  errors.forEach((error) => console.error(`staging manifest validation failed: ${error}`));
+  process.exit(1);
+}
+console.log(`Staging manifest validation OK (${domains.length} isolated domains, no remote identifiers).`);

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -21,3 +21,5 @@ jobs:
         run: node .github/scripts/validate-module-catalog.mjs && node .github/scripts/validate-module-maturity.mjs
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
+      - name: Validate reproducible staging manifest
+        run: node .github/scripts/validate-staging-manifest.mjs

--- a/docs/audits/staging-foundation-source-audit-2026-07-24.md
+++ b/docs/audits/staging-foundation-source-audit-2026-07-24.md
@@ -1,0 +1,32 @@
+# Auditoria de fontes da fundação de staging — 2026-07-24
+
+## Baseline
+
+- Base auditada: `origin/main` em `4f152750`.
+- Nenhum recurso remoto, segredo, flag, grant, usuário ou dado foi alterado nesta auditoria.
+- Este documento registra somente nomes lógicos e commits. IDs, URLs de Workers, versões de deploy, dumps e valores de segredo são deliberadamente excluídos.
+
+## Implementações ainda fora da main
+
+| Fonte local | Commit | Conteúdo aproveitável | Estado nesta integração |
+| --- | --- | --- | --- |
+| `codex/admin/staging-isolation` | `34d26afb` | Worker de controle, D1/KV/R2/Queue/DLQ por domínio, inventário e bootstrap PostgreSQL | Extrair somente contrato lógico, guardas e templates sem IDs; não fazer cherry-pick do commit. |
+| `codex/admin/staging-domain-migration` | `e1ce8fdc` | journal de migração, scripts de reconciliação e rollback de sombra | Extrair em PR posterior apenas scripts parametrizados e migrations de journal; não importar dados nem nomes de recursos existentes. |
+| `codex/admin/postgres-staging-hardening` | `953a95fc` | papéis PostgreSQL e validações de staging, junto com mudanças de runtime CRM | Extrair em PR posterior apenas SQL de roles e validação; manter o runtime CRM fora deste escopo. |
+| `codex/admin/finance-independent-pattern-shell` | `865daad1` | Worker/Pages independentes do Financeiro e artefatos de frontend | Fora de escopo: contém runtime e frontend, além de `crm/console/dist-finance/` não rastreado e descartável. |
+
+Os commits acima permanecem preservados como snapshots recuperáveis. Nenhum deles é considerado prova de que a infraestrutura exista ou esteja saudável remotamente.
+
+## Estado que já está na main
+
+- Há configurações e workflows de staging legados para CRM Pages, API/Inventory, Escala e Ponto.
+- `docs/staging.md` ainda descreve a branch `staging` como linha de desenvolvimento. Isso diverge do modelo de promoção imutável e será corrigido no runbook de bootstrap, sem reativar deploys legados.
+- Financeiro possui evidência de staging no gateway e Pages, mas não um Worker de fundação independente promovido por esta auditoria.
+
+## Limites e ordem segura de integração
+
+1. Manifesto lógico e guardas de segredo/identificador (esta PR).
+2. Templates, bootstrap, teardown protegido e Worker de controle, todos com execução remota opt-in.
+3. Roles PostgreSQL, journal e reconciliação parametrizada, sem corte de tráfego ou cópia de dados.
+
+Cada etapa deve ser revisada e validada em CI antes da próxima. Provisionamento remoto só poderá acontecer em uma janela aprovada, com estado gerado fora do repositório e feature flags desligadas.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "architecture:validate": "node ./.github/scripts/validate-architecture.mjs && node ./.github/scripts/validate-module-catalog.mjs && node ./.github/scripts/validate-domain-boundaries.mjs",
     "module-catalog:validate": "node ./.github/scripts/validate-module-catalog.mjs",
     "module-maturity:validate": "node ./.github/scripts/validate-module-maturity.mjs",
+    "staging:manifest:validate": "node ./.github/scripts/validate-staging-manifest.mjs",
     "domain-boundaries:validate": "node ./.github/scripts/validate-domain-boundaries.mjs",
     "api:test": "npm --prefix api test",
     "booking:test": "npm --prefix booking test",

--- a/platform/staging/manifest.json
+++ b/platform/staging/manifest.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "./manifest.schema.json",
+  "schemaVersion": 1,
+  "environment": "staging",
+  "purpose": "reproducible, non-production isolation foundation",
+  "owners": {
+    "operational": "@skincos/platform",
+    "identity": "@skincos/identity",
+    "inventory": "@skincos/inventory",
+    "finance": "@skincos/finance"
+  },
+  "safety": {
+    "customRoutesAllowed": false,
+    "productionDataAllowed": false,
+    "defaultFeatureFlags": {
+      "module_enabled": false
+    },
+    "requiredApplyAcknowledgement": "SKINCOS_STAGING_APPLY=1",
+    "privateStateDirectoryVariable": "SKINCOS_STAGING_STATE_DIR"
+  },
+  "pages": [
+    {
+      "logicalId": "crm-shell",
+      "projectName": "skincos-staging",
+      "owner": "@skincos/crm",
+      "purpose": "isolated CRM shell preview",
+      "bindings": []
+    }
+  ],
+  "domains": [
+    {
+      "id": "identity",
+      "owner": "@skincos/identity",
+      "worker": "skincos-identity-staging-foundation",
+      "d1": "skincos-identity-staging",
+      "kv": "SKINCOS_IDENTITY_STAGING_FLAGS",
+      "r2": "skincos-identity-staging-data",
+      "queue": "skincos-identity-events-staging",
+      "deadLetterQueue": "skincos-identity-events-dlq-staging",
+      "bindings": ["DB", "FLAGS", "DATA_BUCKET", "EVENT_QUEUE"],
+      "secretNames": ["STAGING_CONTROL_TOKEN"]
+    },
+    {
+      "id": "inventory",
+      "owner": "@skincos/inventory",
+      "worker": "skincos-inventory-staging-foundation",
+      "d1": "skincos-inventory-staging",
+      "kv": "SKINCOS_INVENTORY_STAGING_FLAGS",
+      "r2": "skincos-inventory-staging-data",
+      "queue": "skincos-inventory-events-staging",
+      "deadLetterQueue": "skincos-inventory-events-dlq-staging",
+      "bindings": ["DB", "FLAGS", "DATA_BUCKET", "EVENT_QUEUE"],
+      "secretNames": ["STAGING_CONTROL_TOKEN"]
+    },
+    {
+      "id": "finance",
+      "owner": "@skincos/finance",
+      "worker": "skincos-finance-staging-foundation",
+      "d1": "skincos-finance-staging",
+      "kv": "SKINCOS_FINANCE_STAGING_FLAGS",
+      "r2": "skincos-finance-staging-data",
+      "queue": "skincos-finance-events-staging",
+      "deadLetterQueue": "skincos-finance-events-dlq-staging",
+      "bindings": ["DB", "FLAGS", "DATA_BUCKET", "EVENT_QUEUE"],
+      "secretNames": ["STAGING_CONTROL_TOKEN"]
+    }
+  ],
+  "postgresql": {
+    "database": "skincos_staging",
+    "ownerRole": "skincos_staging_owner",
+    "migrationRole": "skincos_staging_migrator",
+    "domains": [
+      { "id": "identity", "schema": "identity", "ownerRole": "skincos_staging_identity_owner", "runtimeRole": "skincos_staging_identity_runtime" },
+      { "id": "inventory", "schema": "inventory", "ownerRole": "skincos_staging_inventory_owner", "runtimeRole": "skincos_staging_inventory_runtime" },
+      { "id": "finance", "schema": "finance", "ownerRole": "skincos_staging_finance_owner", "runtimeRole": "skincos_staging_finance_runtime" }
+    ]
+  }
+}

--- a/platform/staging/manifest.schema.json
+++ b/platform/staging/manifest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SKINCOS reproducible staging manifest",
+  "type": "object",
+  "required": ["schemaVersion", "environment", "owners", "safety", "pages", "domains", "postgresql"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "environment": { "const": "staging" },
+    "domains": { "type": "array", "minItems": 3 },
+    "pages": { "type": "array", "minItems": 1 }
+  }
+}


### PR DESCRIPTION
## What changed
- Adds a versioned logical inventory for the isolated Identity, Inventory and Finance staging foundation.
- Adds CI validation that rejects remote IDs, URLs, custom routes, enabled module flags and undeclared secrets.
- Records the local/worktree source audit without importing runtime, data or secrets.

## Why
The previous foundation exists only in local commits and contains environment-specific identifiers. This extracts the reproducible contract while preserving separation from private state.

## Validation
- npm run staging:manifest:validate (WSL Ubuntu-24.04)
- node .github/scripts/validate-architecture.mjs (WSL Ubuntu-24.04)
- git diff --check (PowerShell)

No deploy, remote resource mutation, migration, grant, flag or secret change is included.