### PR TITLE
chore(staging): add isolated postgres role template

### DIFF
--- a/.github/scripts/validate-staging-postgres.mjs
+++ b/.github/scripts/validate-staging-postgres.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const bootstrap = fs.readFileSync(path.join(root, 'platform/staging/postgresql/bootstrap.sql'), 'utf8');
+const runner = fs.readFileSync(path.join(root, 'scripts/staging/postgresql-roles.mjs'), 'utf8');
+const errors = [];
+const roles = ['identity', 'inventory', 'finance'];
+for (const domain of roles) {
+  if (!bootstrap.includes(`skincos_staging_${domain}_owner NOLOGIN NOINHERIT`)) errors.push(`${domain} owner role must be NOLOGIN NOINHERIT`);
+  if (!bootstrap.includes(`skincos_staging_${domain}_runtime NOLOGIN NOINHERIT`)) errors.push(`${domain} runtime role must be NOLOGIN NOINHERIT`);
+  if (!bootstrap.includes(`CREATE SCHEMA IF NOT EXISTS ${domain}`)) errors.push(`${domain} schema is missing`);
+}
+if (!bootstrap.includes('REVOKE ALL ON DATABASE skincos_staging FROM PUBLIC')) errors.push('PUBLIC database access must be revoked');
+if (!runner.includes('SKINCOS_STAGING_POSTGRES_APPLY') || !runner.includes('PG_STAGING_ADMIN_URL')) errors.push('PostgreSQL application must require acknowledgement and external admin credentials');
+if (/password\s*=|postgresql:\/\/[^$]/i.test(`${bootstrap}\n${runner}`)) errors.push('PostgreSQL files must not contain credentials');
+const result = spawnSync(process.execPath, [path.join(root, 'scripts/staging/postgresql-roles.mjs')], { encoding: 'utf8' });
+if (result.status !== 0 || !result.stdout.includes('"mode": "plan"')) errors.push('PostgreSQL roles command must default to a non-mutating plan');
+if (errors.length) {
+  errors.forEach((error) => console.error(`staging PostgreSQL validation failed: ${error}`));
+  process.exit(1);
+}
+console.log('Staging PostgreSQL role template and guard validated.');

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -25,3 +25,5 @@ jobs:
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards
         run: node .github/scripts/validate-staging-scripts.mjs
+      - name: Validate staging PostgreSQL role template
+        run: node .github/scripts/validate-staging-postgres.mjs

--- a/docs/runbooks/staging-postgresql-roles.md
+++ b/docs/runbooks/staging-postgresql-roles.md
@@ -1,0 +1,18 @@
+# Papéis PostgreSQL do staging isolado
+
+O template cria somente papéis `NOLOGIN NOINHERIT`, banco isolado e schemas `identity`, `inventory` e `finance`. Não cria senha, login, pool, grant de produto ou migration de domínio.
+
+Primeiro, valide o plano sem conexão:
+
+```bash
+node scripts/staging/postgresql-roles.mjs
+```
+
+Na janela aprovada, obtenha a URL administrativa de staging exclusivamente pelo gerenciador de segredos e aplique:
+
+```bash
+SKINCOS_STAGING_POSTGRES_APPLY=1 PG_STAGING_ADMIN_URL="$PG_STAGING_ADMIN_URL" \
+  node scripts/staging/postgresql-roles.mjs --apply
+```
+
+O comando não registra a URL, usuário ou senha. Login roles por serviço devem ser criadas em PRs de cutover próprias, mapeadas ao papel de runtime do domínio e limitadas a TLS, pool e timeouts revisados. Uma mudança de Identity, Inventory ou Financeiro não pode ser aplicada com o mesmo login administrativo.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "staging:reconcile": "node ./scripts/staging/reconcile.mjs",
     "staging:teardown": "node ./scripts/staging/teardown.mjs",
     "staging:scripts:validate": "node ./.github/scripts/validate-staging-scripts.mjs",
+    "staging:postgres:roles": "node ./scripts/staging/postgresql-roles.mjs",
+    "staging:postgres:validate": "node ./.github/scripts/validate-staging-postgres.mjs",
     "domain-boundaries:validate": "node ./.github/scripts/validate-domain-boundaries.mjs",
     "api:test": "npm --prefix api test",
     "booking:test": "npm --prefix booking test",

--- a/platform/staging/postgresql/bootstrap.sql
+++ b/platform/staging/postgresql/bootstrap.sql
@@ -1,0 +1,33 @@
+\set ON_ERROR_STOP on
+
+SELECT 'CREATE ROLE skincos_staging_owner NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_owner') \gexec
+SELECT 'CREATE ROLE skincos_staging_migrator NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_migrator') \gexec
+SELECT 'CREATE ROLE skincos_staging_identity_owner NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_identity_owner') \gexec
+SELECT 'CREATE ROLE skincos_staging_inventory_owner NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_inventory_owner') \gexec
+SELECT 'CREATE ROLE skincos_staging_finance_owner NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_finance_owner') \gexec
+SELECT 'CREATE ROLE skincos_staging_identity_runtime NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_identity_runtime') \gexec
+SELECT 'CREATE ROLE skincos_staging_inventory_runtime NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_inventory_runtime') \gexec
+SELECT 'CREATE ROLE skincos_staging_finance_runtime NOLOGIN NOINHERIT' WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'skincos_staging_finance_runtime') \gexec
+
+GRANT skincos_staging_identity_owner, skincos_staging_inventory_owner, skincos_staging_finance_owner TO skincos_staging_migrator;
+SELECT 'CREATE DATABASE skincos_staging OWNER skincos_staging_owner' WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'skincos_staging') \gexec
+
+\connect skincos_staging
+REVOKE ALL ON DATABASE skincos_staging FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+CREATE SCHEMA IF NOT EXISTS identity AUTHORIZATION skincos_staging_identity_owner;
+CREATE SCHEMA IF NOT EXISTS inventory AUTHORIZATION skincos_staging_inventory_owner;
+CREATE SCHEMA IF NOT EXISTS finance AUTHORIZATION skincos_staging_finance_owner;
+
+GRANT CONNECT ON DATABASE skincos_staging TO skincos_staging_migrator, skincos_staging_identity_runtime, skincos_staging_inventory_runtime, skincos_staging_finance_runtime;
+GRANT USAGE ON SCHEMA identity TO skincos_staging_identity_runtime;
+GRANT USAGE ON SCHEMA inventory TO skincos_staging_inventory_runtime;
+GRANT USAGE ON SCHEMA finance TO skincos_staging_finance_runtime;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE skincos_staging_identity_owner IN SCHEMA identity GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO skincos_staging_identity_runtime;
+ALTER DEFAULT PRIVILEGES FOR ROLE skincos_staging_inventory_owner IN SCHEMA inventory GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO skincos_staging_inventory_runtime;
+ALTER DEFAULT PRIVILEGES FOR ROLE skincos_staging_finance_owner IN SCHEMA finance GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO skincos_staging_finance_runtime;
+
+-- Login roles, passwords, TLS connection strings and pool configuration are
+-- intentionally absent. Create login credentials in the approved secret manager
+-- only when a domain runtime has its own reviewed cutover PR.

--- a/platform/staging/postgresql/validate.sql
+++ b/platform/staging/postgresql/validate.sql
@@ -1,0 +1,16 @@
+\set ON_ERROR_STOP on
+
+WITH expected(rolname) AS (
+  VALUES
+    ('skincos_staging_owner'), ('skincos_staging_migrator'),
+    ('skincos_staging_identity_owner'), ('skincos_staging_inventory_owner'), ('skincos_staging_finance_owner'),
+    ('skincos_staging_identity_runtime'), ('skincos_staging_inventory_runtime'), ('skincos_staging_finance_runtime')
+)
+SELECT CASE WHEN EXISTS (
+  SELECT 1 FROM expected e LEFT JOIN pg_roles r USING (rolname)
+  WHERE r.rolname IS NULL OR r.rolcanlogin OR r.rolinherit
+) THEN 'invalid' ELSE 'ok' END;
+
+SELECT COUNT(*)
+FROM pg_namespace
+WHERE nspname IN ('identity', 'inventory', 'finance');

--- a/scripts/staging/postgresql-roles.mjs
+++ b/scripts/staging/postgresql-roles.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { root } from './lib.mjs';
+
+const argv = process.argv.slice(2);
+const apply = argv.includes('--apply');
+if (!apply) {
+  console.log(JSON.stringify({ mode: 'plan', target: 'PostgreSQL staging only', creates: ['NOLOGIN owner roles', 'NOLOGIN runtime roles', 'NOLOGIN migrator role', 'isolated database and schemas'], credentials: 'not created' }, null, 2));
+  process.exit(0);
+}
+if (process.env.SKINCOS_STAGING_POSTGRES_APPLY !== '1') throw new Error('Refusing PostgreSQL mutation. Use SKINCOS_STAGING_POSTGRES_APPLY=1 only in an approved staging change window.');
+if (!process.env.PG_STAGING_ADMIN_URL) throw new Error('PG_STAGING_ADMIN_URL is required and must be supplied by the approved secret manager.');
+const bootstrap = path.join(root, 'platform/staging/postgresql/bootstrap.sql');
+const validate = path.join(root, 'platform/staging/postgresql/validate.sql');
+execFileSync('psql', ['--set', 'ON_ERROR_STOP=1', '--dbname', process.env.PG_STAGING_ADMIN_URL, '--file', bootstrap], { stdio: 'inherit' });
+const output = execFileSync('psql', ['--tuples-only', '--no-align', '--dbname', process.env.PG_STAGING_ADMIN_URL, '--file', validate], { encoding: 'utf8' });
+const lines = output.trim().split('\n').map((line) => line.trim()).filter(Boolean);
+if (lines[0] !== 'ok' || lines[1] !== '3') throw new Error('PostgreSQL staging role validation failed');
+console.log(JSON.stringify({ mode: 'applied', target: 'PostgreSQL staging only', credentials: 'not created' }, null, 2));


### PR DESCRIPTION
## What changed
- Adds an idempotent PostgreSQL staging-only role and schema template for Identity, Inventory and Finance.
- Adds an opt-in runner requiring a secret-manager supplied staging admin connection URL.
- Adds CI validation that roles are NOLOGIN/NOINHERIT, PUBLIC access is revoked, and the default mode is non-mutating.

## Scope
No PostgreSQL connection, role, grant, credential, pool, migration or runtime change is executed by this PR. It contains no hostnames, IDs, usernames or passwords.

## Validation
- npm run staging:manifest:validate
- npm run staging:scripts:validate
- npm run staging:postgres:validate
- npm run staging:postgres:roles
- node .github/scripts/validate-architecture.mjs
- git diff --check