### PR TITLE
test(ops): validar retenção do monitor externo

### DIFF
--- a/ops/observability/scripts/Test-SkincosObservability.ps1
+++ b/ops/observability/scripts/Test-SkincosObservability.ps1
@@ -7,12 +7,17 @@ try {
   $result = & $script -CatalogPath $catalog -StateDirectory $temporary -SuppressHumanNotification
   $doc = $result | ConvertFrom-Json
   if (-not $doc.results -or $doc.monitor -ne 'windows-scheduled-probe') { throw 'monitor output contract missing' }
+  $expiredAt = [DateTime]::UtcNow.AddDays(-31).ToString('o')
+  Add-Content -LiteralPath (Join-Path $temporary 'history.jsonl') -Value (@{generated_at=$expiredAt;results=@()} | ConvertTo-Json -Compress)
+  Add-Content -LiteralPath (Join-Path $temporary 'metrics-history.jsonl') -Value (@{generated_at=$expiredAt;samples=@()} | ConvertTo-Json -Compress)
+  Add-Content -LiteralPath (Join-Path $temporary 'notifications.jsonl') -Value (@{occurred_at=$expiredAt;kind='expired-test'} | ConvertTo-Json -Compress)
   & $script -CatalogPath $catalog -StateDirectory $temporary -ControlledFailure -SuppressHumanNotification | Out-Null
   & $script -CatalogPath $catalog -StateDirectory $temporary -SuppressHumanNotification | Out-Null
   $notifications = Get-Content -LiteralPath (Join-Path $temporary 'notifications.jsonl') | ForEach-Object { $_ | ConvertFrom-Json }
   if (-not ($notifications.kind -contains 'alert') -or -not ($notifications.kind -contains 'resolved')) { throw 'controlled alert and resolution were not recorded' }
   if (-not (Test-Path (Join-Path $temporary 'metrics.prom'))) { throw 'metrics output missing' }
   if ((Get-Content -LiteralPath (Join-Path $temporary 'metrics-history.jsonl')).Count -lt 3) { throw 'metrics retention output missing' }
+  foreach($retainedFile in @('history.jsonl','metrics-history.jsonl','notifications.jsonl')) { if (Select-String -LiteralPath (Join-Path $temporary $retainedFile) -SimpleMatch $expiredAt -Quiet) { throw "retention did not purge expired sample from $retainedFile" } }
   if (-not (Test-Path (Join-Path $temporary 'monitor-health.json'))) { throw 'monitor health output missing' }
   if (-not (Test-Path (Join-Path $temporary 'dashboard.html'))) { throw 'dashboard output missing' }
   Write-Output "Observability monitor test OK ($($doc.results.Count) units)"


### PR DESCRIPTION
## Escopo

Adiciona uma prova de regressao para a retencao de observabilidade: o teste insere amostras com 31 dias em historico, metricas e notificacoes e confirma que o monitor as remove conforme a politica de 30 dias.

Nao altera probes, endpoints, dashboard, configuracao operacional, tokens ou dados pessoais.

## Validacao

- `Test-SkincosObservability.ps1`;
- `npm run observability:validate`;
- `node .github/scripts/validate-architecture.mjs`.