### PR TITLE
docs(finance): identidade técnica exclusiva de staging

### DIFF
--- a/docs/runbooks/finance-staging-test-identity.md
+++ b/docs/runbooks/finance-staging-test-identity.md
@@ -1,0 +1,58 @@
+# Identidade técnica do Financeiro em staging
+
+## Identidade e owner
+
+`finance-staging-monitor` é uma identidade sintética, exclusiva de staging e propriedade de `@skincos/finance`; `admin` é o operador responsável pela execução e pela guarda da credencial. Ela usa o login real `POST /insumos/auth/login` e a sessão assinada consumida pelo gateway em `/finance/*`.
+
+- banco: somente `skincos-db-staging`; nunca consultar ou escrever `skincos-db`;
+- e-mail sintético: `finance-staging-monitor@staging.invalid`;
+- papel: `CONSULTOR`;
+- módulos: somente `finance`;
+- unidade e grant: somente `finance-scope-novo-hamburgo`, permissão `viewer`;
+- pessoal, BarraShoppingSul, administrador, importação e mutações: negados;
+- a flag `finance_settings.module_enabled` permanece `false` fora de uma janela de smoke aprovada.
+
+A senha não fica no Git, em secret de produção, cookie ou sessão compartilhada. A credencial atual fica cifrada por DPAPI no runtime privado do operador. Cookies emitidos pelo login são host-only para `api-staging.skincos.com.br` e não devem ser enviados a nenhuma origem de produção.
+
+## Criação
+
+1. Confirme o alvo com `npx wrangler d1 info skincos-db-staging` e confirme que `finance_settings.module_enabled=false` antes de escrever.
+2. Gere uma senha aleatória de ao menos 24 caracteres e mantenha-a apenas no cofre/armazenamento privado do operador.
+3. Gere SQL em arquivo privado; o comando não se conecta à Cloudflare nem imprime senha/hash:
+
+```powershell
+$env:FINANCE_STAGING_IDENTITY_ACK = '1'
+$env:FINANCE_STAGING_TEST_PASSWORD = '<segredo privado>'
+node .\finance\scripts\staging-test-identity-sql.mjs create --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\provision.sql
+```
+
+4. Execute exclusivamente contra staging, valide o login real e apague o SQL após registrar a evidência privada:
+
+```bash
+npx wrangler d1 execute skincos-db-staging --remote --file /mnt/c/CodexRuntime/operator/admin/skincos/finance-staging-identity/provision.sql
+```
+
+Se a segunda inserção falhar, execute imediatamente `revoke` abaixo. Não ligue a feature flag como parte da criação.
+
+## Rotação e revogação
+
+Rotação exige nova senha privada e incrementa `session_version`, invalidando todas as sessões anteriores:
+
+```powershell
+$env:FINANCE_STAGING_IDENTITY_ACK = '1'
+$env:FINANCE_STAGING_TEST_PASSWORD = '<nova senha privada>'
+node .\finance\scripts\staging-test-identity-sql.mjs rotate --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\rotate.sql
+```
+
+Revogação é imediata: desativa a conta, incrementa `session_version` e remove todos os grants Financeiro. Não requer senha.
+
+```powershell
+$env:FINANCE_STAGING_IDENTITY_ACK = '1'
+node .\finance\scripts\staging-test-identity-sql.mjs revoke --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\revoke.sql
+```
+
+Execute o arquivo gerado com o mesmo comando Wrangler restrito a `skincos-db-staging`. Depois confirme que login retorna `403`, o bootstrap não possui grants e `module_enabled` permanece `false`.
+
+## Evidência mínima
+
+Registrar somente no runtime privado: horário, SHA, alvo lógico, resultado do login, escopo/permiteção, resultado do bootstrap e resultado da revogação/rotação. Não registrar senha, hash, cookie, CSRF, e-mail real, URL assinada ou dados financeiros.

--- a/finance/scripts/staging-test-identity-sql.mjs
+++ b/finance/scripts/staging-test-identity-sql.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Generates sensitive SQL only into an explicitly chosen private operator path.
+// It never connects to Cloudflare and never prints a password or its hash.
+import { pbkdf2Sync, randomBytes } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const [action] = process.argv.slice(2);
+const outputIndex = process.argv.indexOf('--output');
+const output = outputIndex >= 0 ? String(process.argv[outputIndex + 1] || '').trim() : '';
+const password = String(process.env.FINANCE_STAGING_TEST_PASSWORD || '');
+const username = 'finance-staging-monitor';
+const scopeId = 'finance-scope-novo-hamburgo';
+const quote = (value) => `'${String(value).replaceAll("'", "''")}'`;
+
+if (!['create', 'rotate', 'revoke'].includes(action) || !output) {
+  throw new Error('Usage: FINANCE_STAGING_TEST_PASSWORD=<private> node finance/scripts/staging-test-identity-sql.mjs create|rotate|revoke --output <private.sql>');
+}
+if (process.env.FINANCE_STAGING_IDENTITY_ACK !== '1') throw new Error('FINANCE_STAGING_IDENTITY_ACK=1 is required');
+if (['create', 'rotate'].includes(action) && password.length < 24) throw new Error('FINANCE_STAGING_TEST_PASSWORD must contain at least 24 characters');
+
+const now = new Date().toISOString();
+const base64url = (value) => value.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+const passwordHash = () => {
+  const salt = randomBytes(16);
+  const derived = pbkdf2Sync(password, salt, 100_000, 32, 'sha256');
+  return `pbkdf2_sha256$100000$${base64url(salt)}$${base64url(derived)}`;
+};
+
+let sql;
+if (action === 'create') {
+  sql = [
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-monitor@staging.invalid')},${quote('Finance staging monitor (synthetic)')},${quote(passwordHash())},'CONSULTOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},0);`,
+    `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-monitor-viewer-nh')},${quote(username)},${quote(scopeId)},'viewer',${quote(now)},${quote('@skincos/finance')});`,
+  ].join('\n');
+} else if (action === 'rotate') {
+  sql = `UPDATE crm_users SET password_hash=${quote(passwordHash())},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`;
+} else {
+  // Invalidate the session before removing the grant. Either completed statement denies Finance access.
+  sql = [
+    `UPDATE crm_users SET ativo=0,session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)};`,
+    `DELETE FROM finance_access_grants WHERE username=${quote(username)};`,
+  ].join('\n');
+}
+
+mkdirSync(dirname(resolve(output)), { recursive: true });
+writeFileSync(resolve(output), `${sql}\n`, { mode: 0o600 });
+console.log(JSON.stringify({ ok: true, action, username, scopeId, environment: 'staging', output: resolve(output) }));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "crm:local:finance:status": "bash ./scripts/run-local-finance.sh --status",
     "crm:local:finance:ports": "bash ./scripts/run-local-finance.sh --ports",
     "finance:migrate:staging": "bash ./finance/scripts/apply-d1-migrations.sh --remote --env staging --adopt-existing-schema",
+    "finance:staging:test-identity:sql": "node ./finance/scripts/staging-test-identity-sql.mjs",
     "finance:staging:import-smoke": "node ./finance/scripts/staging-import-smoke.mjs",
     "finance:staging:ui-smoke": "node ./finance/scripts/staging-ui-smoke.mjs",
     "codex:shared:setup": "powershell -ExecutionPolicy Bypass -File .\\scripts\\setup-shared-codex-workspace.ps1",


### PR DESCRIPTION
## Escopo

Define e operacionaliza a identidade sintética `finance-staging-monitor` para staging:

- gerador de SQL que não imprime senha ou hash e exige confirmação explícita;
- conta com papel CONSULTOR, módulo Financeiro, uma unidade e grant viewer;
- runbook de criação, rotação, revogação imediata e owner;
- documentação da guarda privada de credenciais e da proibição de produção.

A identidade foi criada apenas no D1 de staging e validada pelo login real e bootstrap Financeiro, com a flag do módulo ainda desligada.

## Validação

- geração local do SQL com verificação de que a senha não aparece em claro;
- `node --check finance/scripts/staging-test-identity-sql.mjs`;
- D1 remoto de staging: conta, escopo e grant mínimos;
- login real e cookie host-only de staging; bootstrap 200 com `module_enabled=false`;
- `npm --prefix finance test` iniciou, mas o worktree limpo não possuía `miniflare`; `npm ci` excedeu o limite local. A CI executa a suíte completa.