### PR TITLE
fix(finance): apply D1 migrations atomically

### DIFF
--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -138,7 +138,18 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
-          npx --yes wrangler@4.112.0 d1 migrations apply "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          # D1 migrations must be atomic: execute each versioned SQL file together with
+          # its journal insert. `d1 migrations apply` splits trigger bodies and can leave
+          # a failed file without a journal entry; `d1 execute --file` imports atomically.
+          npx --yes wrangler@4.114.0 d1 execute "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}" --command 'CREATE TABLE IF NOT EXISTS d1_migrations (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL);'
+          for migration in finance/migrations/*.sql; do
+            name="$(basename "$migration")"
+            applied="$(npx --yes wrangler@4.114.0 d1 execute "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}" --command "SELECT 1 AS applied FROM d1_migrations WHERE name='$name' LIMIT 1;" --json | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));process.stdout.write(x[0]?.results?.[0]?.applied ? 'true' : 'false')")"
+            [[ "$applied" == true ]] && continue
+            batch="$RUNNER_TEMP/finance-migration-${name}"
+            { cat "$migration"; printf "\nINSERT INTO d1_migrations(name) VALUES ('%s');\n" "$name"; } > "$batch"
+            npx --yes wrangler@4.114.0 d1 execute "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}" --file "$batch"
+          done
           if [[ "$BOOTSTRAP_SERVICE_SECRET" == "true" ]]; then
             [[ "$TARGET" == "staging" ]] || { echo 'Finance service-secret bootstrap is staging-only.'; exit 1; }
             [[ -n "${SERVICE_SECRET:-}" ]] || { echo 'Missing FINANCE_SERVICE_AUTH_SECRET.'; exit 1; }

--- a/docs/runbooks/finance-release.md
+++ b/docs/runbooks/finance-release.md
@@ -5,7 +5,7 @@
 1. No primeiro uso de staging, executar `deploy-finance.yml` com `bootstrap_service_secret=true`; nas execuções posteriores, manter esse campo como `false`. O Worker Financeiro deve existir antes de um gateway poder declarar sua service binding.
 2. Depois, publicar somente o gateway pelo `deploy-core-workers.yml`, com `unit=api` e `bootstrap_finance_context=true`; isso instala a service binding e o segredo de contexto sem publicar Inventory. O smoke inicial do Worker usa `FINANCE_STAGING_WORKER_URL`; a verificação pelo gateway ocorre após este passo.
 3. `deploy-finance.yml` em `preview` para o SHA de `main`.
-4. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`.
+4. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`. Cada migration Financeiro é importada junto ao seu registro em `d1_migrations`, de forma atômica; uma falha não deixa schema sem journal.
 5. Conferir `health`, `readiness`, versão, dependências, logs estruturados, alertas e os artefatos `promotion-evidence-finance` e `promotion-evidence-finance-ui`.
 6. Ativar `canary` pelo `module-availability.yml` apenas para atores-piloto; manter `module_enabled=false` até os grants e dados de teste controlados estarem confirmados.
 7. Para produção, usar o mesmo SHA e os dois `staging_run_id`; a aprovação do Environment é manual.


### PR DESCRIPTION
Substitui o executor D1 que fragmentava corpos de trigger por importação atômica de cada migration mais seu journal. Mantém arquivos versionados, D1 exclusivo e pipeline canônico. Sem produção.