### PR TITLE
feat(finance): canary sintético determinístico em staging

### DIFF
--- a/.github/scripts/validate-finance-canary-policy.mjs
+++ b/.github/scripts/validate-finance-canary-policy.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+
+const file = 'ops/module-governance/finance-staging-canary-policy.json';
+const policy = JSON.parse(await readFile(file, 'utf8'));
+const fail = (message) => { throw new Error(`${file}: ${message}`); };
+if (policy.schemaVersion !== 1 || policy.module !== 'finance' || policy.environment !== 'staging') fail('must be schema v1 Finance staging policy');
+if (policy.syntheticOnly !== true) fail('must remain synthetic-only');
+if (!Array.isArray(policy.cohort?.pilotActors) || policy.cohort.pilotActors.length !== 1 || policy.cohort.pilotActors[0] !== 'finance-staging-monitor') fail('must permit only the registered synthetic actor');
+if (!Array.isArray(policy.cohort?.pilotUnits) || policy.cohort.pilotUnits.length !== 1 || policy.cohort.pilotUnits[0] !== 'novo-hamburgo') fail('must permit only Novo Hamburgo staging unit');
+if (!Number.isInteger(policy.cohort?.percentage) || policy.cohort.percentage < 1 || policy.cohort.percentage > 100) fail('percentage must be an integer 1..100');
+for (const key of ['minimumSamples', 'errors', 'p95LatencyMs', 'authenticationFailures', 'journeyFailures', 'dataDivergences', 'auditFailures', 'dependencyFailures']) {
+  if (!Number.isFinite(Number(policy.limits?.[key])) || Number(policy.limits[key]) < 0) fail(`limits.${key} must be non-negative`);
+}
+if (policy.abort?.state !== 'disabled' || policy.abort?.moduleEnabled !== false) fail('abort must disable the module and module_enabled');
+console.log(`Validated Finance synthetic canary policy for ${policy.cohort.pilotActors[0]}.`);

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -29,3 +29,5 @@ jobs:
         run: node .github/scripts/validate-staging-postgres.mjs
       - name: Validate external observability catalog
         run: node scripts/observability/validate-catalog.mjs
+      - name: Validate Finance synthetic canary policy
+        run: node .github/scripts/validate-finance-canary-policy.mjs

--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -1,0 +1,154 @@
+name: Finance synthetic staging canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Immutable Finance SHA already promoted to staging
+        required: true
+        type: string
+      staging_run_id:
+        description: Successful Deploy Finance Worker staging run for this SHA
+        required: true
+        type: string
+      mode:
+        description: Verify the synthetic cohort or exercise the automatic abort path
+        required: true
+        default: verify
+        type: choice
+        options: [verify, abort-drill]
+
+concurrency:
+  group: finance-synthetic-canary-staging
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+      - name: Verify immutable staging promotion evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout does not match release_sha'; exit 1; }
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$STAGING_RUN_ID" > "$RUNNER_TEMP/staging-run.json"
+          node - "$RUNNER_TEMP/staging-run.json" <<'NODE'
+          const fs = require('fs'); const run = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          if (run.conclusion !== 'success' || run.head_sha !== process.env.RELEASE_SHA || run.name !== 'Deploy Finance Worker') process.exit(1);
+          NODE
+      - name: Validate synthetic-only policy and required bindings
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CONTROL_KV_ID: ${{ vars.FINANCE_CONTROL_STAGING_KV_ID }}
+          CANARY_PASSWORD: ${{ secrets.FINANCE_STAGING_CANARY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/validate-finance-canary-policy.mjs
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CONTROL_KV_ID CANARY_PASSWORD; do [[ -n "${!name:-}" ]] || { echo "Missing required staging-only value: $name"; exit 1; }; done
+          [[ "$CONTROL_KV_ID" =~ ^[0-9a-fA-F]{32}$ ]] || { echo 'Invalid Finance staging control KV id'; exit 1; }
+      - name: Capture reversible synthetic grant baseline
+        id: baseline
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          permission="$(npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "SELECT permission FROM finance_access_grants WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo' LIMIT 1;" --json | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const p=x[0]?.results?.[0]?.permission;if(!p)process.exit(1);process.stdout.write(p)")"
+          [[ "$permission" =~ ^(viewer|operator|manager)$ ]] || { echo 'Synthetic grant is invalid'; exit 1; }
+          echo "permission=$permission" >> "$GITHUB_OUTPUT"
+      - name: Open deterministic synthetic canary
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CONTROL_KV_ID: ${{ vars.FINANCE_CONTROL_STAGING_KV_ID }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          node - <<'NODE' > "$RUNNER_TEMP/canary-control.json"
+          const policy = require('./ops/module-governance/finance-staging-canary-policy.json');
+          process.stdout.write(JSON.stringify({ state: 'canary', message: 'Synthetic staging canary only.', pilotActors: policy.cohort.pilotActors, pilotUnits: policy.cohort.pilotUnits, percentage: policy.cohort.percentage, releaseSha: process.env.RELEASE_SHA, syntheticOnly: true, changedAt: new Date().toISOString(), changedBy: process.env.GITHUB_ACTOR }));
+          NODE
+          npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$(cat "$RUNNER_TEMP/canary-control.json")" --namespace-id "$CONTROL_KV_ID"
+          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','true',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='true',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='operator' WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo';"
+      - name: Run authenticated synthetic canary journey
+        id: journey
+        continue-on-error: true
+        env:
+          FINANCE_STAGING_CANARY_ACK: "1"
+          FINANCE_CANARY_BASE_URL: https://api-staging.skincos.com.br
+          FINANCE_CANARY_USERNAME: finance-staging-monitor
+          FINANCE_CANARY_PASSWORD: ${{ secrets.FINANCE_STAGING_CANARY_PASSWORD }}
+          FINANCE_CANARY_SCOPE_ID: finance-scope-novo-hamburgo
+          FINANCE_CANARY_RELEASE_SHA: ${{ inputs.release_sha }}
+        run: node finance/scripts/staging-synthetic-canary.mjs --report "$RUNNER_TEMP/canary-report.json"
+      - name: Inject a controlled threshold breach
+        if: always() && inputs.mode == 'abort-drill'
+        run: |
+          node - "$RUNNER_TEMP/canary-report.json" <<'NODE'
+          const fs = require('fs'); const file = process.argv[2]; let report = {};
+          try { report = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { report = { samples: [] }; }
+          report.errors = Number(report.errors || 0) + 1; report.controlledAbortDrill = true;
+          fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`);
+          NODE
+      - name: Evaluate stop limits
+        id: decision
+        if: always()
+        run: |
+          node finance/scripts/evaluate-canary.mjs --policy ops/module-governance/finance-staging-canary-policy.json --report "$RUNNER_TEMP/canary-report.json" --output "$RUNNER_TEMP/canary-decision.json"
+          node - "$RUNNER_TEMP/canary-decision.json" >> "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require('fs'); const decision = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log(`abort=${decision.ok ? 'false' : 'true'}`);
+          NODE
+      - name: Kill switch on any breached limit
+        if: always() && steps.decision.outputs.abort == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CONTROL_KV_ID: ${{ vars.FINANCE_CONTROL_STAGING_KV_ID }}
+        run: |
+          set -euo pipefail
+          payload="$(node -e "process.stdout.write(JSON.stringify({state:'disabled',message:'Synthetic canary stop limit breached.',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
+          npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID"
+          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP;"
+      - name: Restore non-enabled staging baseline and synthetic grant
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CONTROL_KV_ID: ${{ vars.FINANCE_CONTROL_STAGING_KV_ID }}
+          ORIGINAL_PERMISSION: ${{ steps.baseline.outputs.permission }}
+        run: |
+          set -euo pipefail
+          [[ "$ORIGINAL_PERMISSION" =~ ^(viewer|operator|manager)$ ]] || { echo 'No safe grant baseline available'; exit 1; }
+          payload="$(node -e "process.stdout.write(JSON.stringify({state:'active',message:'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
+          npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID"
+          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='$ORIGINAL_PERMISSION' WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo';"
+      - name: Upload sanitized canary evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: finance-staging-synthetic-canary-${{ inputs.release_sha }}-${{ inputs.mode }}
+          path: |
+            ${{ runner.temp }}/canary-report.json
+            ${{ runner.temp }}/canary-decision.json
+          retention-days: 90
+          if-no-files-found: warn
+      - name: Fail promotion when a limit was breached
+        if: always() && steps.decision.outputs.abort == 'true'
+        run: |
+          echo 'Canary stop limit breached; kill switch completed and staging baseline was restored.'
+          exit 1

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -17,11 +17,7 @@ on:
         description: Runtime state; no artifact is published
         required: true
         type: choice
-        options: [active, canary, maintenance, disabled]
-      pilot_actors:
-        description: "CSV of Finance pilot actor IDs; required only for canary"
-        required: false
-        type: string
+        options: [active, maintenance, disabled]
       message:
         description: User-visible maintenance reason (optional)
         required: false
@@ -57,10 +53,9 @@ jobs:
           MODULE: ${{ inputs.module }}
           STATE: ${{ inputs.state }}
           MESSAGE: ${{ inputs.message }}
-          PILOT_ACTORS: ${{ inputs.pilot_actors }}
         run: |
           set -euo pipefail
-          if [[ "$MODULE" != finance && "$STATE" == canary ]]; then echo 'Canary is implemented only for Finance in this workflow.'; exit 1; fi
-          if [[ "$STATE" == canary && -z "${PILOT_ACTORS//[[:space:],]/}" ]]; then echo 'Canary requires at least one pilot actor.'; exit 1; fi
-          payload="$(node -e "process.stdout.write(JSON.stringify({state:process.env.STATE,message:process.env.MESSAGE||'',pilotActors:(process.env.PILOT_ACTORS||'').split(',').map(x=>x.trim()).filter(Boolean),changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
+          # Canary is intentionally absent here: only finance-staging-canary.yml
+          # can open it after immutable staging evidence and synthetic-only guards.
+          payload="$(node -e "process.stdout.write(JSON.stringify({state:process.env.STATE,message:process.env.MESSAGE||'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
           npx --yes wrangler@4.112.0 kv key put "module-control:$MODULE" "$payload" --namespace-id "$NAMESPACE_ID"

--- a/docs/architecture/independent-module-deploys.md
+++ b/docs/architecture/independent-module-deploys.md
@@ -29,6 +29,14 @@ O gateway somente transporta `/finance/*` e `/api/ponto/*`. Para Financeiro, ele
 - Runtime CRM: criar um unit de Atendimento independente, com porta/health próprios, `CRM_DOMAIN=atendimento`, `CRM_MODULE_CONTROL_FILE` privado e os comandos `CRM_ATENDIMENTO_DEPLOY_COMMAND`, `CRM_ATENDIMENTO_ROLLBACK_COMMAND`, `CRM_ATENDIMENTO_CONTROL_COMMAND`, `CRM_ATENDIMENTO_HEALTH_URL` configurados no Environment GitHub correspondente.
 - Antes de produção: registrar a versão/commit de retorno, confirmar migration somente aditiva, executar smoke de staging do mesmo SHA e aprovar explicitamente o Environment de produção.
 
-Canary é deliberadamente por ator-piloto explícito no KV, não por porcentagem aleatória: o workflow `module-availability.yml` exige `state=canary` e a lista de atores. `maintenance` e `disabled` não publicam artefato. O rollback de código só aceita SHA já promovido; dados não sofrem rollback destrutivo — o checkpoint cifrado é restaurado antes em ambiente isolado e comparado com razão, auditoria, movimentos e lotes.
+Canary do Financeiro é deliberadamente controlado pelo workflow
+`finance-staging-canary.yml`, não pelo controle genérico de disponibilidade. A
+coorte é a interseção de ator em allowlist, unidade permitida, bucket percentual
+determinístico e `releaseSha` igual ao `APP_VERSION` do Worker; qualquer ausência
+falha fechada. Nesta fase é exclusivamente a identidade sintética de staging.
+`maintenance` e `disabled` não publicam artefato. O rollback de código só aceita
+SHA já promovido; dados não sofrem rollback destrutivo — o checkpoint cifrado é
+restaurado antes em ambiente isolado e comparado com razão, auditoria, movimentos
+e lotes.
 
 Nenhum dos workflows novos é acionado por push. Faltas de ID, secret, comando dedicado, checkpoint ou evidência de promoção falham explicitamente e não fazem deploy parcial. O rollback do Worker não recompila nem publica outro módulo: seleciona a versão já associada ao SHA de retorno. O rollback da UI republica somente o bundle construído do SHA previamente promovido, no projeto Pages isolado.

--- a/docs/runbooks/finance-release.md
+++ b/docs/runbooks/finance-release.md
@@ -7,14 +7,28 @@
 3. `deploy-finance.yml` em `preview` para o SHA de `main`.
 4. `deploy-finance.yml` e `deploy-finance-ui.yml` em `staging`, ambos com o mesmo `release_sha` e `preview_run_id`. Cada migration Financeiro é importada junto ao seu registro em `d1_migrations`, de forma atômica; uma falha não deixa schema sem journal.
 5. Conferir `health`, `readiness`, versão, dependências, logs estruturados, alertas e os artefatos `promotion-evidence-finance` e `promotion-evidence-finance-ui`.
-6. Ativar `canary` pelo `module-availability.yml` apenas para atores-piloto; manter `module_enabled=false` até os grants e dados de teste controlados estarem confirmados.
+6. Executar `finance-staging-canary.yml` somente depois do deploy de staging do mesmo SHA. O workflow é o único caminho que abre `canary`: ele exige a evidência do run de staging, aplica allowlist do ator sintético, coorte de unidade, percentual determinístico e SHA do Worker. O `module-availability.yml` não abre canary.
 7. Para produção, usar o mesmo SHA e os dois `staging_run_id`; a aprovação do Environment é manual.
 
 ## Kill switch e manutenção
 
 - `maintenance`: responde 503 somente para Financeiro, com `x-skincos-module-state=maintenance`.
 - `disabled`: responde 423 somente para Financeiro; CRM, Inventory, Ponto e navegação continuam disponíveis.
-- `canary`: só os atores explicitamente listados no controle podem alcançar a API; demais usuários recebem 403.
+- `canary`: exige simultaneamente allowlist, unidade, bucket percentual determinístico e SHA promovido; qualquer campo ausente falha fechado com 403/503. A política atual permite somente `finance-staging-monitor` em `novo-hamburgo` no staging.
+
+## Canary sintético e limites automáticos
+
+`ops/module-governance/finance-staging-canary-policy.json` é validado pelo CI e
+declara os únicos ator e unidade permitidos, além dos limites para erros, p95,
+autenticação, jornada, divergência de dados, auditoria e dependências. O
+workflow registra relatório sanitizado e decisão como artefato por 90 dias.
+
+Ao exceder qualquer limite, o workflow grava `disabled` no KV, define
+`module_enabled=false` antes de restaurar a baseline segura (`active` com a
+feature desligada) e encerra com falha explícita. `mode=abort-drill` injeta uma
+violação de métrica sem indisponibilizar dependências, para comprovar esse
+caminho apenas em staging. Nenhuma dessas execuções altera produção, grants de
+usuários reais ou a coorte de produção.
 
 ## Rollback e restore
 

--- a/docs/runbooks/finance-staging-test-identity.md
+++ b/docs/runbooks/finance-staging-test-identity.md
@@ -14,6 +14,12 @@
 
 A senha não fica no Git, em secret de produção, cookie ou sessão compartilhada. A credencial atual fica cifrada por DPAPI no runtime privado do operador. Cookies emitidos pelo login são host-only para `api-staging.skincos.com.br` e não devem ser enviados a nenhuma origem de produção.
 
+Para o canary automatizado, a mesma senha é copiada apenas para o secret do
+environment GitHub `staging` chamado `FINANCE_STAGING_CANARY_PASSWORD`. Não há
+fallback para secret de repositório ou produção. O workflow
+`finance-staging-canary.yml` fixa o username e o escopo acima e restaura o
+grant `viewer` e `module_enabled=false` mesmo quando a jornada falha.
+
 ## Criação
 
 1. Confirme o alvo com `npx wrangler d1 info skincos-db-staging` e confirme que `finance_settings.module_enabled=false` antes de escrever.

--- a/finance/scripts/evaluate-canary.mjs
+++ b/finance/scripts/evaluate-canary.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Evaluates a sanitized synthetic-canary report.  A failed threshold is data,
+// not an exception: the caller can always execute its kill-switch cleanup.
+import { readFile, writeFile } from 'node:fs/promises';
+
+const value = (name) => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+};
+const policyFile = value('--policy');
+const reportFile = value('--report');
+const outputFile = value('--output');
+if (!policyFile || !reportFile || !outputFile) throw new Error('usage: evaluate-canary.mjs --policy POLICY --report REPORT --output OUTPUT');
+
+const policy = JSON.parse(await readFile(policyFile, 'utf8'));
+let report;
+try { report = JSON.parse(await readFile(reportFile, 'utf8')); } catch { report = { ok: false, samples: [], errors: 1, journeyFailures: 1, reason: 'report_missing' }; }
+const limits = policy.limits || {};
+const samples = Array.isArray(report.samples) ? report.samples : [];
+const timings = samples.map((item) => Number(item.durationMs)).filter(Number.isFinite).sort((a, b) => a - b);
+const p95 = timings.length ? timings[Math.min(timings.length - 1, Math.ceil(timings.length * 0.95) - 1)] : Infinity;
+const measured = {
+  samples: samples.length,
+  p95LatencyMs: p95,
+  errors: Number(report.errors || 0) + (report.ok === false ? 1 : 0),
+  authenticationFailures: Number(report.authenticationFailures || 0),
+  journeyFailures: Number(report.journeyFailures || 0),
+  dataDivergences: Number(report.dataDivergences || 0),
+  auditFailures: Number(report.auditFailures || 0),
+  dependencyFailures: Number(report.dependencyFailures || 0),
+};
+const breaches = [];
+if (measured.samples < Number(limits.minimumSamples || 1)) breaches.push('minimum_samples');
+for (const key of ['errors', 'p95LatencyMs', 'authenticationFailures', 'journeyFailures', 'dataDivergences', 'auditFailures', 'dependencyFailures']) {
+  if (measured[key] > Number(limits[key] ?? 0)) breaches.push(key);
+}
+const decision = { ok: breaches.length === 0, module: policy.module, environment: policy.environment, measured, limits, breaches, evaluatedAt: new Date().toISOString() };
+await writeFile(outputFile, `${JSON.stringify(decision, null, 2)}\n`);
+console.log(JSON.stringify({ ok: decision.ok, breaches: decision.breaches, measured: decision.measured }));

--- a/finance/scripts/staging-synthetic-canary.mjs
+++ b/finance/scripts/staging-synthetic-canary.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// This script is deliberately staging-only. It never prints credentials,
+// cookies, tokens, usernames, request bodies, or synthetic record IDs.
+import { writeFile } from 'node:fs/promises';
+
+const reportFile = process.argv.includes('--report') ? process.argv[process.argv.indexOf('--report') + 1] : '';
+if (!reportFile) throw new Error('--report is required');
+const report = { ok: false, generatedAt: new Date().toISOString(), samples: [], errors: 0, authenticationFailures: 0, journeyFailures: 0, dataDivergences: 0, auditFailures: 0, dependencyFailures: 0 };
+const required = (name) => { const item = String(process.env[name] || '').trim(); if (!item) throw new Error(`${name} is required`); return item; };
+const finish = async (ok, cause) => {
+  report.ok = ok;
+  if (cause) report.failure = String(cause.message || cause).replace(/[\r\n]/g, ' ').slice(0, 180);
+  await writeFile(reportFile, `${JSON.stringify(report, null, 2)}\n`);
+  if (!ok) process.exitCode = 1;
+};
+try {
+  if (process.env.FINANCE_STAGING_CANARY_ACK !== '1') throw new Error('FINANCE_STAGING_CANARY_ACK=1 is required');
+  const baseUrl = required('FINANCE_CANARY_BASE_URL').replace(/\/$/, '');
+  if (baseUrl !== 'https://api-staging.skincos.com.br') throw new Error('canary base URL must be staging gateway');
+  const username = required('FINANCE_CANARY_USERNAME');
+  if (username !== 'finance-staging-monitor') throw new Error('only registered synthetic actor may run canary');
+  const password = required('FINANCE_CANARY_PASSWORD');
+  const scopeId = required('FINANCE_CANARY_SCOPE_ID');
+  if (scopeId !== 'finance-scope-novo-hamburgo') throw new Error('only synthetic Novo Hamburgo scope is allowed');
+  const request = async (name, path, init = {}) => {
+    const started = Date.now();
+    try {
+      const response = await fetch(`${baseUrl}${path}`, { ...init, signal: AbortSignal.timeout(15_000) });
+      report.samples.push({ name, status: response.status, durationMs: Date.now() - started });
+      return response;
+    } catch (cause) {
+      report.samples.push({ name, status: 0, durationMs: Date.now() - started });
+      report.errors += 1; report.dependencyFailures += 1; throw cause;
+    }
+  };
+  const expect = async (name, path, init = {}, status = 200) => {
+    const response = await request(name, path, init);
+    const body = await response.json().catch(() => null);
+    if (response.status !== status) { report.errors += 1; if (status === 200 && response.status === 401) report.authenticationFailures += 1; throw new Error(`${name} returned ${response.status}`); }
+    return body;
+  };
+  const loginResponse = await request('login', '/insumos/auth/login', { method: 'POST', headers: { 'content-type': 'application/json', origin: 'https://crm-staging.skincos.com.br' }, body: JSON.stringify({ username, password }) });
+  const login = await loginResponse.json().catch(() => null);
+  if (loginResponse.status !== 200) { report.authenticationFailures += 1; throw new Error(`login returned ${loginResponse.status}`); }
+  const cookie = (typeof loginResponse.headers.getSetCookie === 'function' ? loginResponse.headers.getSetCookie() : [loginResponse.headers.get('set-cookie') || '']).map((item) => item.split(';', 1)[0]).filter(Boolean).join('; ');
+  if (!cookie || !login?.csrfToken) { report.authenticationFailures += 1; throw new Error('synthetic staging login did not issue session'); }
+  const headers = { cookie, origin: 'https://crm-staging.skincos.com.br', 'x-csrf-token': login.csrfToken };
+  const expectedSha = required('FINANCE_CANARY_RELEASE_SHA');
+  if (!/^[0-9a-f]{40}$/.test(expectedSha)) throw new Error('FINANCE_CANARY_RELEASE_SHA must be a full SHA');
+  const health = await expect('health', '/finance/health', { headers: { origin: 'https://crm-staging.skincos.com.br' } });
+  if (health.version !== expectedSha) { report.dependencyFailures += 1; throw new Error('Finance Worker version does not match canary SHA'); }
+  const bootstrap = await expect('bootstrap', `/finance/bootstrap?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  if (bootstrap.moduleEnabled !== true || bootstrap.canAccess !== true || !Array.isArray(bootstrap.grants) || bootstrap.grants.length !== 1 || bootstrap.grants[0]?.scope_id !== scopeId || bootstrap.grants[0]?.unit_slug !== 'novo-hamburgo' || bootstrap.grants[0]?.permission !== 'operator') throw new Error('synthetic canary scope or grant mismatch');
+  const readiness = await expect('readiness', '/finance/readiness', { headers: { origin: 'https://crm-staging.skincos.com.br' } });
+  if (!readiness.ready || readiness.dependencies?.d1?.state !== 'healthy') { report.dependencyFailures += 1; throw new Error('Finance dependency is not ready'); }
+  await expect('accounts', `/finance/accounts?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  await expect('categories', `/finance/categories?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  const nonce = `canary-${Date.now()}`;
+  const tag = await expect('synthetic-audit-create', `/finance/tags?scopeId=${encodeURIComponent(scopeId)}`, {
+    method: 'POST', headers: { ...headers, 'content-type': 'application/json', 'idempotency-key': `${nonce}:create` }, body: JSON.stringify({ name: nonce }),
+  }, 201);
+  const tagId = String(tag.tag?.id || '').trim();
+  if (!tagId) { report.auditFailures += 1; throw new Error('synthetic audit probe did not return an identifier'); }
+  const archived = await expect('synthetic-audit-compensate', `/finance/tags/${encodeURIComponent(tagId)}/archive?scopeId=${encodeURIComponent(scopeId)}`, {
+    method: 'POST', headers: { ...headers, 'content-type': 'application/json', 'idempotency-key': `${nonce}:archive` }, body: JSON.stringify({ reason: 'Synthetic canary compensation' }),
+  }, 201);
+  if (archived.active !== false) { report.dataDivergences += 1; throw new Error('synthetic canary compensation did not archive its record'); }
+  const audit = await expect('audit', `/finance/audit?scopeId=${encodeURIComponent(scopeId)}&entityType=tag&entityId=${encodeURIComponent(tagId)}`, { headers });
+  if (Number(audit.total || 0) < 2) { report.auditFailures += 1; throw new Error('synthetic canary audit trail is incomplete'); }
+  const denied = await request('cross-unit-denied', '/finance/accounts?scopeId=finance-scope-barra-shopping-sul', { headers });
+  if (denied.status !== 403) { report.journeyFailures += 1; throw new Error('cross-unit access was not denied'); }
+  // The only write is a synthetic tag and its compensating archive; no real
+  // actor, unit, financial movement, import or personal scope is touched.
+  report.ok = true;
+  await finish(true);
+} catch (cause) {
+  if (!report.journeyFailures && !report.authenticationFailures && !report.dependencyFailures) report.journeyFailures += 1;
+  await finish(false, cause);
+}

--- a/finance/test/edge-worker.test.mjs
+++ b/finance/test/edge-worker.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { handleFinance } from '../worker.js';
+import { canaryBucket, canUseCanary } from '../../shared/module-availability/worker.js';
 
 test('Finance exposes health without a public domain route and honors runtime maintenance', async () => {
   const health = await handleFinance(new Request('https://finance.internal/health'), {}, {});
@@ -30,8 +31,24 @@ test('Finance canary rejects a non-pilot before domain data is touched', async (
   const key = await crypto.subtle.importKey('raw', encoder.encode('test-secret'), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
   const signature = btoa(String.fromCharCode(...new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(payload))))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
   const response = await handleFinance(new Request('https://finance.internal/overview', { headers: { 'x-skincos-domain-context': payload, 'x-skincos-domain-signature': signature } }), {
-    FINANCE_SERVICE_AUTH_SECRET: 'test-secret', MODULE_CONTROL: { get: async () => ({ state: 'canary', pilotActors: ['pilot'] }) },
+    APP_VERSION: 'a'.repeat(40), FINANCE_SERVICE_AUTH_SECRET: 'test-secret', MODULE_CONTROL: { get: async () => ({ state: 'canary', pilotActors: ['pilot'], pilotUnits: ['novo-hamburgo'], percentage: 100, releaseSha: 'a'.repeat(40), syntheticOnly: true }) },
   }, {});
   assert.equal(response.status, 403);
   assert.equal((await response.json()).error, 'FINANCE_CANARY_NOT_GRANTED');
+});
+
+test('Finance canary requires actor allowlist, unit cohort and deterministic percentage', () => {
+  const availability = { state: 'canary', pilotActors: ['pilot'], pilotUnits: ['novo-hamburgo'], percentage: 100 };
+  assert.equal(canUseCanary(availability, { username: 'pilot', allowedUnits: ['novo-hamburgo'] }), true);
+  assert.equal(canUseCanary(availability, { username: 'pilot', allowedUnits: ['barra-shopping-sul'] }), false);
+  assert.equal(canUseCanary({ ...availability, percentage: 0 }, { username: 'pilot', allowedUnits: ['novo-hamburgo'] }), false);
+  assert.equal(canaryBucket('pilot'), canaryBucket('pilot'));
+});
+
+test('Finance canary fails closed when its selected artifact is not the promoted SHA', async () => {
+  const response = await handleFinance(new Request('https://finance.internal/overview'), {
+    APP_VERSION: 'b'.repeat(40), MODULE_CONTROL: { get: async () => ({ state: 'canary', pilotActors: ['pilot'], pilotUnits: ['novo-hamburgo'], percentage: 100, releaseSha: 'a'.repeat(40) }) },
+  }, {});
+  assert.equal(response.status, 503);
+  assert.equal((await response.json()).error, 'FINANCE_CANARY_VERSION_MISMATCH');
 });

--- a/finance/worker.js
+++ b/finance/worker.js
@@ -25,6 +25,9 @@ export async function handleFinance(request, env, ctx) {
     return new Response(JSON.stringify({ ...operationalStatus({ unit: 'finance', version, environment: env?.ENVIRONMENT, ready, requestId, dependencies: { d1: dependencyState(d1), module_control: dependencyState(Boolean(env?.MODULE_CONTROL), { required: false }) } }), availability }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId } });
   }
   if (!['active', 'canary'].includes(availability.state)) return moduleUnavailableResponse('finance', availability, requestId);
+  if (availability.state === 'canary' && availability.releaseSha !== version) {
+    return new Response(JSON.stringify({ ok: false, error: 'FINANCE_CANARY_VERSION_MISMATCH', module: 'finance' }), { status: 503, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': 'canary', 'x-request-id': requestId } });
+  }
   const auth = await verifySignedDomainContext(request, String(env?.FINANCE_SERVICE_AUTH_SECRET || ''), 'finance');
   if (!auth) return new Response(JSON.stringify({ ok: false, error: 'SERVICE_IDENTITY_REQUIRED' }), { status: 401, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-request-id': requestId } });
   if (!canUseCanary(availability, auth.actor)) return new Response(JSON.stringify({ ok: false, error: 'FINANCE_CANARY_NOT_GRANTED', module: 'finance' }), { status: 403, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': 'canary', 'x-request-id': requestId } });

--- a/ops/module-governance/finance-staging-canary-policy.json
+++ b/ops/module-governance/finance-staging-canary-policy.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "module": "finance",
+  "environment": "staging",
+  "syntheticOnly": true,
+  "cohort": {
+    "pilotActors": ["finance-staging-monitor"],
+    "pilotUnits": ["novo-hamburgo"],
+    "percentage": 100
+  },
+  "limits": {
+    "minimumSamples": 1,
+    "errors": 0,
+    "p95LatencyMs": 1000,
+    "authenticationFailures": 0,
+    "journeyFailures": 0,
+    "dataDivergences": 0,
+    "auditFailures": 0,
+    "dependencyFailures": 0
+  },
+  "abort": {
+    "state": "disabled",
+    "moduleEnabled": false,
+    "rollback": "Keep the current immutable artifact, block Finance at module-control and restore module_enabled=false. Code rollback remains an explicit follow-up only when the diagnosed fault is artifact-specific."
+  }
+}

--- a/shared/module-availability/worker.js
+++ b/shared/module-availability/worker.js
@@ -1,5 +1,12 @@
 const CONTROL_KEY_PREFIX = 'module-control:';
 const VALID_STATES = new Set(['active', 'canary', 'maintenance', 'disabled']);
+const MAX_CANARY_ACTORS = 100;
+const MAX_CANARY_UNITS = 20;
+
+const list = (value, max) => Array.isArray(value)
+  ? value.map(String).map((item) => item.trim()).filter(Boolean).slice(0, max)
+  : [];
+const percentage = (value) => Number.isFinite(Number(value)) ? Math.max(0, Math.min(100, Math.floor(Number(value)))) : 0;
 
 function normalize(value) {
   const state = String(value?.state || 'active').trim().toLowerCase();
@@ -7,9 +14,13 @@ function normalize(value) {
     state: VALID_STATES.has(state) ? state : 'active',
     message: String(value?.message || '').trim().slice(0, 240),
     changedAt: String(value?.changedAt || '').trim(),
-    // The allow-list is intentionally explicit: Finance launches only for a
-    // named pilot, never by random percentage on financial mutations.
-    pilotActors: Array.isArray(value?.pilotActors) ? value.pilotActors.map(String).map((item) => item.trim()).filter(Boolean).slice(0, 100) : [],
+    // A canary is conjunctive: named actor, named unit, deterministic bucket
+    // and promoted source identity must all agree. Missing fields fail closed.
+    pilotActors: list(value?.pilotActors, MAX_CANARY_ACTORS),
+    pilotUnits: list(value?.pilotUnits, MAX_CANARY_UNITS),
+    percentage: percentage(value?.percentage),
+    releaseSha: String(value?.releaseSha || '').trim().toLowerCase(),
+    syntheticOnly: value?.syntheticOnly === true,
   };
 }
 
@@ -43,8 +54,22 @@ export function moduleUnavailableResponse(moduleId, availability, requestId) {
   });
 }
 
+export function canaryBucket(actorId) {
+  // FNV-1a is stable across Worker isolates. It is a cohort selector, not a
+  // security primitive; authorization remains the explicit allow-list.
+  let hash = 0x811c9dc5;
+  for (const char of String(actorId || '')) { hash ^= char.codePointAt(0); hash = Math.imul(hash, 0x01000193); }
+  return (hash >>> 0) % 10_000;
+}
+
 export function canUseCanary(availability, actor) {
-  return availability.state !== 'canary' || availability.pilotActors.includes(String(actor?.username || '').trim());
+  if (availability.state !== 'canary') return true;
+  const username = String(actor?.username || '').trim();
+  const units = Array.isArray(actor?.allowedUnits) ? actor.allowedUnits.map(String).map((unit) => unit.trim()) : [];
+  if (!username || !availability.pilotActors.includes(username)) return false;
+  if (!availability.pilotUnits.length || !availability.pilotUnits.some((unit) => units.includes(unit))) return false;
+  if (!availability.percentage) return false;
+  return canaryBucket(username) < availability.percentage * 100;
 }
 
 export function moduleHealthResponse(moduleId, availability, requestId) {


### PR DESCRIPTION
## Escopo\n- torna canary Financeiro exclusivo de inance-staging-canary.yml, sem rota manual genérica\n- exige SHA já implantado em staging, ator sintético, unidade, percentual determinístico e versão do Worker\n- aplica limites fail-closed para erro, p95, autenticação, jornada, auditoria, divergência e dependências\n- executa kill switch e restaura baseline segura; inclui abort drill controlado\n\n## Segurança\n- somente staging; sem produção, usuários reais ou grants persistentes\n- evidências sanitizadas ficam como artifact por 90 dias\n\n## Validação local\n- 
ode --test finance/test/edge-worker.test.mjs\n- 
pm --prefix finance run check\n- validadores de arquitetura, promoção, topologia e política\n- Prettier nos workflows\n\n
pm --prefix finance test excedeu 120s sem saída neste worktree; o teste focado passou.