### PR TITLE
fix(finance): compensar tag sintética no canary

### DIFF
--- a/finance/api/worker.js
+++ b/finance/api/worker.js
@@ -150,7 +150,10 @@ export function createFinanceHandler() {
       if (registrationLifecycleMatch && request.method === 'POST') { requireScope(true); const [, collection, entityId, action] = registrationLifecycleMatch; const payload = await body(); const result = await mutate(payload, async () => {
         const table = { accounts: 'finance_accounts', categories: 'finance_categories', payees: 'finance_payees', tags: 'finance_tags', 'cost-centers': 'finance_cost_centers' }[collection]; const entityType = { accounts: 'account', categories: 'category', payees: 'payee', tags: 'tag', 'cost-centers': 'costCenter' }[collection];
         const record = await scoped(table, entityId); if (!record) throw new FinanceContractError('NOT_FOUND', 'Cadastro não encontrado.');
-        const active = action === 'restore' ? 1 : 0; const changed = Number(record.active) !== active; const statements = [env.DB.prepare(`UPDATE ${table} SET active=?,updated_at=? WHERE id=? AND scope_id=?`).bind(active, now(), entityId, scopeId)];
+        const active = action === 'restore' ? 1 : 0; const changed = Number(record.active) !== active; const lifecycleUpdate = collection === 'tags'
+          ? env.DB.prepare(`UPDATE finance_tags SET active=? WHERE id=? AND scope_id=?`).bind(active, entityId, scopeId)
+          : env.DB.prepare(`UPDATE ${table} SET active=?,updated_at=? WHERE id=? AND scope_id=?`).bind(active, now(), entityId, scopeId);
+        const statements = [lifecycleUpdate];
         if (record.ledger_account_id) statements.push(env.DB.prepare(`UPDATE finance_ledger_accounts SET active=? WHERE id=? AND scope_id=?`).bind(active, record.ledger_account_id, scopeId));
         statements.push(auditStatement(`${entityType.replace(/([A-Z])/g, '_$1').toUpperCase()}_${action === 'restore' ? 'RESTORED' : 'ARCHIVED'}`, entityType, entityId, { active: Number(record.active) }, { active }));
         return { data: { ok: true, id: entityId, active: Boolean(active), changed }, statements };

--- a/finance/test/d1-integration.test.mjs
+++ b/finance/test/d1-integration.test.mjs
@@ -100,6 +100,17 @@ test('D1 local: registrations are archived instead of deleted and stay isolated 
   const audit = await request(ctx.env, ctx.actor, `/audit?scopeId=${scopeNh}&entityId=${archived.id}&entityType=account`); assert.equal(audit.body.events.some((event) => event.action === 'ACCOUNT_ARCHIVED'), true); assert.equal(audit.body.events.some((event) => event.action === 'ACCOUNT_RESTORED'), true);
 });
 
+test('D1 local: a synthetic tag can be archived with an auditable compensation', async (t) => {
+  const ctx = await fixture(); t.after(() => ctx.mf.dispose()); await grant(ctx.DB, 'pilot', scopeNh);
+  const created = await request(ctx.env, ctx.actor, `/tags?scopeId=${scopeNh}`, { method: 'POST', key: 'synthetic-tag-create', body: { name: 'Synthetic canary tag' } });
+  assert.equal(created.response.status, 201, JSON.stringify(created.body));
+  const tagId = created.body.tag.id;
+  const archived = await request(ctx.env, ctx.actor, `/tags/${tagId}/archive?scopeId=${scopeNh}`, { method: 'POST', key: 'synthetic-tag-archive', body: {} });
+  assert.equal(archived.response.status, 201, JSON.stringify(archived.body)); assert.equal(archived.body.active, false);
+  const audit = await request(ctx.env, ctx.actor, `/audit?scopeId=${scopeNh}&entityId=${tagId}&entityType=tag`);
+  assert.equal(audit.body.events.some((event) => event.action === 'TAG_CREATED'), true); assert.equal(audit.body.events.some((event) => event.action === 'TAG_ARCHIVED'), true);
+});
+
 test('D1 local: reconciliation lines, exact suggestions and confirmations are scoped, balanced and auditable', async (t) => {
   const ctx = await fixture(); t.after(() => ctx.mf.dispose()); await grant(ctx.DB, 'pilot', scopeNh); await grant(ctx.DB, 'pilot', scopeBss);
   const bank = await account(ctx.env, ctx.actor, scopeNh, 'Banco conciliado', 'reconciliation-bank'); const income = await category(ctx.env, ctx.actor, scopeNh, 'Receita conciliada', 'income', 'reconciliation-income'); const expense = await category(ctx.env, ctx.actor, scopeNh, 'Despesa conciliada', 'expense', 'reconciliation-expense');


### PR DESCRIPTION
Corrige a compensação de tags: inance_tags não possui updated_at, portanto o arquivamento agora atualiza apenas ctive.\n\nInclui teste D1 para criação, arquivamento e auditoria da tag sintética usada pelo canary. Nenhum deploy ou alteração de produção nesta PR.