### PR TITLE
fix(finance): separar p95 do Worker da autenticação

### DIFF
--- a/docs/runbooks/finance-release.md
+++ b/docs/runbooks/finance-release.md
@@ -19,8 +19,11 @@
 ## Canary sintético e limites automáticos
 
 `ops/module-governance/finance-staging-canary-policy.json` é validado pelo CI e
-declara os únicos ator e unidade permitidos, além dos limites para erros, p95,
-autenticação, jornada, divergência de dados, auditoria e dependências. O
+declara os únicos ator e unidade permitidos, além dos limites para erros, p95 do
+Financeiro, falha de autenticação, jornada, divergência de dados, auditoria e
+dependências. A duração de login é registrada separadamente: não é usada no p95
+do Worker Financeiro, mas uma falha de autenticação continua interrompendo a
+promoção. O
 workflow registra relatório sanitizado e decisão como artefato por 90 dias.
 
 Ao exceder qualquer limite, o workflow grava `disabled` no KV, define

--- a/finance/scripts/evaluate-canary.mjs
+++ b/finance/scripts/evaluate-canary.mjs
@@ -17,11 +17,18 @@ let report;
 try { report = JSON.parse(await readFile(reportFile, 'utf8')); } catch { report = { ok: false, samples: [], errors: 1, journeyFailures: 1, reason: 'report_missing' }; }
 const limits = policy.limits || {};
 const samples = Array.isArray(report.samples) ? report.samples : [];
-const timings = samples.map((item) => Number(item.durationMs)).filter(Number.isFinite).sort((a, b) => a - b);
+// Authentication is measured and reported separately. Its cold-start/network
+// cost must not be mistaken for Finance Worker latency or cause an unrelated
+// Identity/gateway delay to trigger a Finance artifact rollback.
+const financeSamples = samples.filter((item) => item?.name !== 'login');
+const timings = financeSamples.map((item) => Number(item.durationMs)).filter(Number.isFinite).sort((a, b) => a - b);
+const loginDuration = samples.find((item) => item?.name === 'login')?.durationMs;
 const p95 = timings.length ? timings[Math.min(timings.length - 1, Math.ceil(timings.length * 0.95) - 1)] : Infinity;
 const measured = {
   samples: samples.length,
+  financeSamples: financeSamples.length,
   p95LatencyMs: p95,
+  authenticationLatencyMs: Number.isFinite(Number(loginDuration)) ? Number(loginDuration) : null,
   errors: Number(report.errors || 0) + (report.ok === false ? 1 : 0),
   authenticationFailures: Number(report.authenticationFailures || 0),
   journeyFailures: Number(report.journeyFailures || 0),

--- a/finance/test/canary-evaluator.test.mjs
+++ b/finance/test/canary-evaluator.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+test('canary evaluator separates authentication cold-start from Finance p95 latency', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'finance-canary-'));
+  const policy = join(directory, 'policy.json'); const report = join(directory, 'report.json'); const output = join(directory, 'decision.json');
+  await writeFile(policy, JSON.stringify({ module: 'finance', environment: 'staging', limits: { minimumSamples: 1, errors: 0, p95LatencyMs: 1000, authenticationFailures: 0, journeyFailures: 0, dataDivergences: 0, auditFailures: 0, dependencyFailures: 0 } }));
+  await writeFile(report, JSON.stringify({ ok: true, samples: [{ name: 'login', durationMs: 2500 }, { name: 'health', durationMs: 100 }, { name: 'bootstrap', durationMs: 450 }], errors: 0, authenticationFailures: 0, journeyFailures: 0, dataDivergences: 0, auditFailures: 0, dependencyFailures: 0 }));
+  execFileSync(process.execPath, [fileURLToPath(new URL('../scripts/evaluate-canary.mjs', import.meta.url)), '--policy', policy, '--report', report, '--output', output]);
+  const decision = JSON.parse(await readFile(output, 'utf8'));
+  assert.equal(decision.ok, true); assert.equal(decision.measured.p95LatencyMs, 450); assert.equal(decision.measured.authenticationLatencyMs, 2500);
+});


### PR DESCRIPTION
O canary continua bloqueando falha de autenticação, mas passa a medir a duração de login separadamente do p95 do Worker Financeiro. Isso evita que o cold start de Identity/gateway acione rollback de um artefato Financeiro saudável. Inclui teste do avaliador.