### PR TITLE
fix(insumos): corrige RBAC por unidade

### DIFF
--- a/crm/console/InsumosModule.tsx
+++ b/crm/console/InsumosModule.tsx
@@ -61,6 +61,7 @@ import { useInsumosInventoryMutationsController } from '@/useInsumosInventoryMut
 import { useInsumosMovementsController } from '@/useInsumosMovementsController'
 import { useInsumosQuickLookupController } from '@/useInsumosQuickLookupController'
 import { useInsumosQuickOperationsController } from '@/useInsumosQuickOperationsController'
+import { resolveInsumosUnitAccess } from '@/insumosUnitAccess'
 import {
   CANONICAL_TIPOS_UNIDADE,
   brToIsoDate,
@@ -273,6 +274,7 @@ export function InsumosModule() {
   const [authLoading, setAuthLoading] = React.useState(true)
   const [healthLoaded, setHealthLoaded] = React.useState(false)
   const [authLoaded, setAuthLoaded] = React.useState(false)
+  const [unitAccessReady, setUnitAccessReady] = React.useState(false)
   const [overviewLoaded, setOverviewLoaded] = React.useState(false)
   const [insumosLoaded, setInsumosLoaded] = React.useState(false)
   const [movLoaded, setMovLoaded] = React.useState(false)
@@ -660,13 +662,18 @@ export function InsumosModule() {
     return () => observer.disconnect()
   }, [])
 
-  const canUseApi = Boolean(
+  const serviceReady = Boolean(
     typeof health?.ready === 'boolean'
       ? health.ready
       : (typeof health?.dbConfigured === 'boolean' ? health.dbConfigured : health?.ok)
   )
   const isAuthed = !!user?.username
-  const allowedUnits = Array.isArray(user?.allowedUnits) ? user!.allowedUnits!.filter(Boolean) : []
+  const unitAccess = React.useMemo(
+    () => resolveInsumosUnitAccess({ role: user?.role, allowedUnits: user?.allowedUnits, savedUnit: unidade }),
+    [unidade, user?.allowedUnits, user?.role],
+  )
+  const allowedUnits = unitAccess.allowedUnits
+  const canUseApi = serviceReady && unitAccessReady && (!isAuthed || unitAccess.hasAuthorizedUnit)
 
   const isManagerRole = ['GESTOR', 'GERENTE'].includes(String(user?.role || '').toUpperCase())
 
@@ -1787,10 +1794,8 @@ export function InsumosModule() {
   }, [])
 
   const unidadeOptions = React.useMemo(() => {
-    if (!allowedUnits.length) return allUnidades
-    const filtered = allUnidades.filter((u) => allowedUnits.includes(u))
-    return filtered.length ? filtered : allUnidades
-  }, [allUnidades.join('|'), allowedUnits.join('|')])
+    return resolveInsumosUnitAccess({ role: user?.role, allowedUnits, savedUnit: unidade, availableUnits: allUnidades }).visibleUnits
+  }, [allUnidades.join('|'), allowedUnits.join('|'), unidade, user?.role])
 
   const unidadeLabel = React.useCallback((u: string) => {
     return String(u || '')
@@ -1799,6 +1804,17 @@ export function InsumosModule() {
       .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
       .join(' ')
   }, [])
+
+  const selectAuthorizedUnit = React.useCallback((value: string) => {
+    const requested = resolveInsumosUnitAccess({ role: user?.role, allowedUnits, savedUnit: value, availableUnits: allUnidades })
+    if (!requested.requestedUnit || !requested.visibleUnits.includes(requested.requestedUnit)) return
+    setUnidade(requested.requestedUnit)
+    try {
+      window.localStorage.setItem(INSUMOS_UNIT_KEY, requested.requestedUnit)
+    } catch {
+      // Request gating remains authoritative if persistence is unavailable.
+    }
+  }, [INSUMOS_UNIT_KEY, allUnidades, allowedUnits, user?.role])
 
 	  const applyShareToForm = React.useCallback((payload: SharePayload & { id?: string }) => {
 	    setCreateOpen(true)
@@ -2214,6 +2230,7 @@ export function InsumosModule() {
 
   const loadMe = React.useCallback(async () => {
     setAuthLoading(true)
+    setUnitAccessReady(false)
     try {
       const out = await apiJson<{ success?: boolean; user?: InsumosUser; csrfToken?: string }>('/auth/me')
       setUser(out?.user || null)
@@ -2226,6 +2243,23 @@ export function InsumosModule() {
       setAuthLoading(false)
     }
   }, [])
+
+  React.useEffect(() => {
+    if (!authLoaded) return
+    if (!isAuthed) {
+      setUnitAccessReady(true)
+      return
+    }
+    const next = resolveInsumosUnitAccess({ role: user?.role, allowedUnits: user?.allowedUnits, savedUnit: unidade })
+    if (next.selectedUnit && next.selectedUnit !== unidade) setUnidade(next.selectedUnit)
+    try {
+      if (next.selectedUnit) window.localStorage.setItem(INSUMOS_UNIT_KEY, next.selectedUnit)
+      else window.localStorage.removeItem(INSUMOS_UNIT_KEY)
+    } catch {
+      // Storage reconciliation is best-effort; request gating remains fail-closed.
+    }
+    setUnitAccessReady(true)
+  }, [INSUMOS_UNIT_KEY, authLoaded, isAuthed, unidade, user?.allowedUnits, user?.role])
 
   const loadProxyStatus = React.useCallback(async () => {
     try {
@@ -2306,7 +2340,7 @@ export function InsumosModule() {
         return
       }
       if (issueUnit && issueUnit !== unidade) {
-        setUnidade(issueUnit)
+        selectAuthorizedUnit(issueUnit)
       }
 
       if (issueCode === 'DUPLICATE_BARCODE' && codigo) {
@@ -2368,7 +2402,7 @@ export function InsumosModule() {
 
       toast.error('Insumo não encontrado para edição rápida.')
     },
-    [isAuthed, lookupInsumosByCodigo, openEditDialog, unidade]
+    [isAuthed, lookupInsumosByCodigo, openEditDialog, selectAuthorizedUnit, unidade]
   )
 
   const loadInsumosPaged = React.useCallback(
@@ -2661,7 +2695,7 @@ export function InsumosModule() {
     setOverviewCustomFrom,
     setOverviewCustomTo,
     setOverviewPeriod,
-    setSelectedUnit: setUnidade,
+    setSelectedUnit: selectAuthorizedUnit,
     showOverviewLoadingProgress,
     status: headerStatus,
     storageKey: INSUMOS_UNIT_KEY,
@@ -3838,6 +3872,11 @@ export function InsumosModule() {
           }}
         />
       ) : null}
+      {authLoaded && isAuthed && unitAccessReady && !unitAccess.hasAuthorizedUnit ? (
+        <div className="rounded-xl border border-amber-300/30 bg-amber-950/40 px-4 py-3 text-sm text-amber-100">
+          Seu acesso ao Insumos ainda não possui uma unidade autorizada. Solicite a configuração de acesso; nenhuma consulta foi enviada.
+        </div>
+      ) : null}
       <DragDropContext onDragStart={onDragStartLayout} onDragEnd={onDragEndLayout}>
       <InsumosInventoryDialog
         open={insumosListModalOpen}
@@ -4398,7 +4437,9 @@ export function InsumosModule() {
               isAuthed={isAuthed}
               rows={movementRows}
               emptyContent={
-                movLoadError && !movLoading && isAuthed ? (
+                unitAccessReady && isAuthed && !unitAccess.hasAuthorizedUnit ? (
+                  <span className="text-amber-100">Aguardando configuração de acesso por unidade.</span>
+                ) : movLoadError && !movLoading && isAuthed ? (
                   <span className="text-red-200">
                     Erro ao carregar movimentações ({movLoadError.status || 'erro'}
                     {movLoadError.code ? `/${movLoadError.code}` : ''}): {movLoadError.message}

--- a/crm/console/e2e/insumos-circuit-breaker.spec.ts
+++ b/crm/console/e2e/insumos-circuit-breaker.spec.ts
@@ -35,7 +35,7 @@ test.describe('insumos', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             success: true,
-            user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] },
+            user: { username: 'e2e', role: 'GESTOR', allowedUnits: ['novo-hamburgo'] },
             csrfToken: 'e2e'
           })
         })
@@ -72,7 +72,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: ['novo-hamburgo'] } })
       })
     })
 

--- a/crm/console/e2e/insumos-edit-modal-policy.spec.ts
+++ b/crm/console/e2e/insumos-edit-modal-policy.spec.ts
@@ -29,7 +29,7 @@ test.describe('insumos', () => {
           contentType: 'application/json',
           body: JSON.stringify({
             success: true,
-            user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] },
+            user: { username: 'e2e', role: 'GESTOR', allowedUnits: ['novo-hamburgo'] },
             csrfToken: 'e2e'
           })
         })
@@ -87,7 +87,7 @@ test.describe('insumos', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: [] } })
+        body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits: ['novo-hamburgo'] } })
       })
     })
 

--- a/crm/console/e2e/insumos-unit-rbac.spec.ts
+++ b/crm/console/e2e/insumos-unit-rbac.spec.ts
@@ -3,7 +3,8 @@ import { test, expect } from '@playwright/test'
 async function mockInsumos(page: import('@playwright/test').Page, allowedUnits: string[], requests: string[]) {
   await page.route('**/api/insumos/**', async (route) => {
     const path = new URL(route.request().url()).pathname
-    if (!path.endsWith('/health') && !path.endsWith('/auth/me')) requests.push(route.request().url())
+    const isControlRequest = path.endsWith('/health') || path.endsWith('/auth/me') || path.endsWith('/_proxy-status') || path.endsWith('/prefs')
+    if (!isControlRequest) requests.push(route.request().url())
     if (path.endsWith('/health')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, ready: true, dbConfigured: true, unidades: ['novo-hamburgo', 'barra-shopping-sul'] }) })
     }

--- a/crm/console/e2e/insumos-unit-rbac.spec.ts
+++ b/crm/console/e2e/insumos-unit-rbac.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+async function mockInsumos(page: import('@playwright/test').Page, allowedUnits: string[], requests: string[]) {
+  await page.route('**/api/insumos/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.endsWith('/health') && !path.endsWith('/auth/me')) requests.push(route.request().url())
+    if (path.endsWith('/health')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, ready: true, dbConfigured: true, unidades: ['novo-hamburgo', 'barra-shopping-sul'] }) })
+    }
+    if (path.endsWith('/auth/me')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, user: { username: 'e2e', role: 'GESTOR', allowedUnits }, csrfToken: 'e2e' }) })
+    }
+    if (path.includes('/movimentacoes')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, movimentos: [], resumo: { totalMovimentacoes: 0 } }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: [], resumo: { total: 0 } }) })
+  })
+  await page.route('**/api/auth/me**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ user: { username: 'e2e', role: 'GESTOR', allowedUnits } }) }))
+}
+
+test.describe('Insumos unit RBAC', () => {
+  test('reconciles a stale local unit before movement requests', async ({ page }) => {
+    const requests: string[] = []
+    await page.addInitScript(() => localStorage.setItem('skincos.insumos.unidade.v1', 'Novo Hamburgo'))
+    await mockInsumos(page, ['BSS'], requests)
+
+    await page.goto('/?insumos=1')
+    await page.getByRole('button', { name: 'Insumos', exact: true }).click()
+    await page.waitForTimeout(1800)
+
+    const movementRequests = requests.filter((url) => url.includes('/movimentacoes'))
+    expect(movementRequests.length).toBeGreaterThan(0)
+    expect(movementRequests.every((url) => new URL(url).searchParams.get('unidade') === 'barra-shopping-sul')).toBe(true)
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('skincos.insumos.unidade.v1'))).toBe('barra-shopping-sul')
+  })
+
+  test('does not send Insumos data requests for a user without units', async ({ page }) => {
+    const requests: string[] = []
+    await mockInsumos(page, [], requests)
+
+    await page.goto('/?insumos=1')
+    await page.getByRole('button', { name: 'Insumos', exact: true }).click()
+    await expect(page.getByText(/ainda não possui uma unidade autorizada/i)).toBeVisible({ timeout: 10000 })
+    await page.waitForTimeout(900)
+
+    expect(requests).toEqual([])
+  })
+})

--- a/crm/console/insumosUnitAccess.ts
+++ b/crm/console/insumosUnitAccess.ts
@@ -1,0 +1,20 @@
+import {
+  CANONICAL_UNIT_SCOPES,
+  normalizeAllowedUnits,
+  normalizeUnitScope,
+} from '../../shared/identity-contract/index.js'
+
+export function resolveInsumosUnitAccess(input: {
+  role?: string | null
+  allowedUnits?: unknown
+  savedUnit?: string | null
+  availableUnits?: string[]
+}) {
+  const isAdmin = String(input.role || '').trim().toUpperCase() === 'ADMIN'
+  const available = normalizeAllowedUnits(input.availableUnits || CANONICAL_UNIT_SCOPES)
+  const allowedUnits = normalizeAllowedUnits(input.allowedUnits)
+  const visibleUnits = isAdmin ? available : available.filter((unit) => allowedUnits.includes(unit))
+  const requestedUnit = normalizeUnitScope(input.savedUnit)
+  const selectedUnit = requestedUnit && visibleUnits.includes(requestedUnit) ? requestedUnit : (visibleUnits[0] || '')
+  return { allowedUnits, visibleUnits, requestedUnit, selectedUnit, hasAuthorizedUnit: visibleUnits.length > 0, isAdmin }
+}

--- a/crm/console/tests/insumosUnitAccess.test.ts
+++ b/crm/console/tests/insumosUnitAccess.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveInsumosUnitAccess } from '../insumosUnitAccess'
+
+describe('Insumos unit access reconciliation', () => {
+  it('keeps Novo Hamburgo-only users within Novo Hamburgo', () => {
+    expect(resolveInsumosUnitAccess({ role: 'GESTOR', allowedUnits: ['NH'], savedUnit: 'barra-shopping-sul' })).toMatchObject({
+      allowedUnits: ['novo-hamburgo'], visibleUnits: ['novo-hamburgo'], selectedUnit: 'novo-hamburgo', hasAuthorizedUnit: true,
+    })
+  })
+
+  it('reconciles legacy saved storage to Barra Shopping Sul', () => {
+    expect(resolveInsumosUnitAccess({ role: 'GESTOR', allowedUnits: ['BarraShoppingSul'], savedUnit: 'Novo Hamburgo' })).toMatchObject({
+      visibleUnits: ['barra-shopping-sul'], selectedUnit: 'barra-shopping-sul', hasAuthorizedUnit: true,
+    })
+    expect(resolveInsumosUnitAccess({ role: 'GESTOR', allowedUnits: ['BSS'], savedUnit: 'unidade-invalida' })).toMatchObject({
+      visibleUnits: ['barra-shopping-sul'], selectedUnit: 'barra-shopping-sul', hasAuthorizedUnit: true,
+    })
+  })
+
+  it('supports both scopes, user changes in the same browser, empty scopes, and ADMIN', () => {
+    expect(resolveInsumosUnitAccess({ role: 'GESTOR', allowedUnits: ['novo-hamburgo', 'BSS'], savedUnit: 'BSS' })).toMatchObject({
+      visibleUnits: ['novo-hamburgo', 'barra-shopping-sul'], selectedUnit: 'barra-shopping-sul', hasAuthorizedUnit: true,
+    })
+    expect(resolveInsumosUnitAccess({ role: 'GESTOR', allowedUnits: [], savedUnit: 'novo-hamburgo' })).toMatchObject({
+      visibleUnits: [], selectedUnit: '', hasAuthorizedUnit: false,
+    })
+    expect(resolveInsumosUnitAccess({ role: 'ADMIN', allowedUnits: [], savedUnit: 'BSS' })).toMatchObject({
+      visibleUnits: ['novo-hamburgo', 'barra-shopping-sul'], selectedUnit: 'barra-shopping-sul', hasAuthorizedUnit: true,
+    })
+  })
+})

--- a/identity/routes/auth.js
+++ b/identity/routes/auth.js
@@ -4,6 +4,7 @@
 import { resolveIdentityTables } from '../store/d1.js';
 import { hasPasswordResetMailerConfig, sendPasswordResetEmail } from '../notifications/smtpMailer.js';
 import { hasRequiredInviteScope, normalizeInviteEmail } from '../policy/invitePolicy.js';
+import { normalizeAllowedUnits } from '../../shared/identity-contract/index.js';
 
 export async function handleAuthRoutes({
     request,
@@ -225,21 +226,6 @@ export async function handleAuthRoutes({
     };
 	    if (d1?.enabled) {
 	        const normalizeRole = (role) => String(role || 'CONSULTOR').trim().toUpperCase();
-	        const normalizeAllowedUnits = (value) => {
-	            if (!value) return [];
-	            if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
-	            if (typeof value === 'string') {
-	                const s = value.trim();
-	                if (!s) return [];
-	                try {
-	                    const parsed = JSON.parse(s);
-	                    if (Array.isArray(parsed)) return parsed.map(String).map((x) => x.trim()).filter(Boolean);
-	                } catch {}
-	                return s.split(/[,;|]/g).map((x) => String(x || '').trim()).filter(Boolean);
-	            }
-	            return [];
-	        };
-
 	        const normalizeAllowedModules = (value) => {
 	            if (!value) return [];
 	            if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
@@ -605,7 +591,7 @@ export async function handleAuthRoutes({
                 const registration = env.DB.prepare(
                     `INSERT INTO ${usersTable}
                      (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-                     SELECT ?, invitee_email, ?, ?, role, '', allowed_units_json, allowed_modules_json, 1, ?, ?
+                     SELECT ?, invitee_email, ?, ?, role, '', ?, ?, 1, ?, ?
                      FROM ${invitesTable}
                      WHERE token_hash = ?
                        AND invitee_email = ?
@@ -613,7 +599,7 @@ export async function handleAuthRoutes({
                        AND max_uses = 1
                        AND uses_count = 0
                        AND expires_at > ?`
-                ).bind(candidate, name, hash, now, now, inviteHash, email, currentTime);
+                ).bind(candidate, name, hash, JSON.stringify(allowedUnits), JSON.stringify(allowedModules), now, now, inviteHash, email, currentTime);
                 const consume = env.DB.prepare(
                     `UPDATE ${invitesTable}
                      SET uses_count = 1

--- a/identity/store/d1.js
+++ b/identity/store/d1.js
@@ -1,4 +1,4 @@
-import { toAuthenticatedActor } from '../../shared/identity-contract/index.js';
+import { normalizeAllowedUnits, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
 
 const toInt = (value, fallback = 0) => {
   const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
@@ -58,7 +58,7 @@ function toIdentityUser(row) {
     email: row.email || '',
     role: row.role || 'CONSULTOR',
     photoUrl: row.photo_url || '',
-    allowedUnits: parseScopes(row.allowed_units_json),
+    allowedUnits: normalizeAllowedUnits(row.allowed_units_json),
     allowedModules: parseScopes(row.allowed_modules_json),
     ativo: toInt(row.ativo, 1) === 1,
     createdAt: row.created_at || null,

--- a/identity/test/actor-contract.test.mjs
+++ b/identity/test/actor-contract.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { toAuthenticatedActor } from '../../shared/identity-contract/index.js';
+import { hasUnitScopeAccess, normalizeAllowedUnits, normalizeUnitScope, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
 import { isCurrentSessionVersion, resolveIdentityActor } from '../session/actor.js';
 
 test('Identity publishes a stable actor with scoped permissions and compatibility aliases', () => {
@@ -14,6 +14,22 @@ test('Identity publishes a stable actor with scoped permissions and compatibilit
   assert.deepEqual(actor.allowedModules, ['finance']);
   assert.equal(isCurrentSessionVersion({ sv: 4 }, { sessionVersion: 4 }), true);
   assert.equal(isCurrentSessionVersion({ sv: 3 }, { sessionVersion: 4 }), false);
+});
+
+test('Identity canonicalizes known unit aliases and keeps unknown or empty scopes fail-closed', () => {
+  assert.equal(normalizeUnitScope('NH'), 'novo-hamburgo');
+  assert.equal(normalizeUnitScope('Novo Hamburgo'), 'novo-hamburgo');
+  assert.equal(normalizeUnitScope('novohamburgo'), 'novo-hamburgo');
+  assert.equal(normalizeUnitScope('BSS'), 'barra-shopping-sul');
+  assert.equal(normalizeUnitScope('Barra Shopping Sul'), 'barra-shopping-sul');
+  assert.equal(normalizeUnitScope('BarraShoppingSul'), 'barra-shopping-sul');
+  assert.equal(normalizeUnitScope('unidade-invalida'), '');
+  assert.deepEqual(normalizeAllowedUnits(['NH', 'novo-hamburgo', 'BSS']), ['novo-hamburgo', 'barra-shopping-sul']);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['NH'] }, 'novo-hamburgo'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['BSS'] }, 'novo-hamburgo'), false);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: [] }, 'novo-hamburgo'), false);
+  assert.equal(hasUnitScopeAccess({ role: 'ADMIN', allowedUnits: [] }, 'barra-shopping-sul'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'ADMIN', allowedUnits: [] }, 'unidade-invalida'), false);
 });
 
 test('Identity accepts the existing signed session payload without changing its cookie format', async () => {

--- a/inventory/scripts/repairUserInsumosUnits.mjs
+++ b/inventory/scripts/repairUserInsumosUnits.mjs
@@ -1,0 +1,46 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { normalizeAllowedUnits, unknownUnitScopes } from '../../shared/identity-contract/index.js';
+
+const TARGET_UNITS = ['novo-hamburgo', 'barra-shopping-sul'];
+const INVENTORY_CONFIG = fileURLToPath(new URL('../wrangler.toml', import.meta.url));
+const sql = (value) => `'${String(value ?? '').replace(/'/g, "''")}'`;
+const subjectId = (value) => createHash('sha256').update(String(value || '')).digest('hex').slice(0, 12);
+
+export function planExplicitUserUnitRepair(row) {
+  if (!row) return { ok: false, reason: 'USER_NOT_FOUND' };
+  const raw = row.allowed_units_json ?? '';
+  if (unknownUnitScopes(raw).length) return { ok: false, reason: 'UNKNOWN_UNIT_SCOPE', subject: subjectId(row.username) };
+  if (normalizeAllowedUnits(raw).length) return { ok: false, reason: 'NON_EMPTY_SCOPE_REQUIRES_REVIEW', subject: subjectId(row.username) };
+  return { ok: true, subject: subjectId(row.username), before: JSON.stringify([]), after: JSON.stringify(TARGET_UNITS) };
+}
+
+export function buildExplicitUserUnitRepairSql(username, plan, now = new Date().toISOString()) {
+  const after = JSON.stringify({ allowedUnits: TARGET_UNITS, repair: 'explicit-user-insumos-units' });
+  return `BEGIN;
+UPDATE crm_users SET allowed_units_json=${sql(plan.after)}, updated_at=${sql(now)} WHERE username=${sql(username)} AND COALESCE(allowed_units_json, '') IN ('', '[]');
+INSERT INTO audit_log (ts, actor, role, action, entity, entity_id, unidade, ip, user_agent, idempotency_key, before_json, after_json)
+SELECT ${sql(now)}, 'system:unit-scope-repair', 'SYSTEM', 'IDENTITY_UNIT_SCOPE_GRANTED', 'crm_users', ${sql(username)}, '', '', '', '', ${sql(JSON.stringify({ allowedUnits: [] }))}, ${sql(after)} WHERE changes()=1;
+COMMIT;`;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const usernameIndex = argv.indexOf('--username');
+  const username = usernameIndex >= 0 ? String(argv[usernameIndex + 1] || '').trim() : '';
+  const apply = argv.includes('--apply');
+  if (!username) throw new Error('USERNAME_REQUIRED: use --username <canonical-username>.');
+  const database = process.env.INVENTORY_D1_DATABASE || 'skincos-db';
+  const environment = process.env.INVENTORY_D1_ENV || '';
+  const command = `SELECT username, role, ativo, allowed_units_json, allowed_modules_json, session_version FROM crm_users WHERE LOWER(username)=LOWER(${sql(username)}) LIMIT 1`;
+  const envArgs = environment ? ['--env', environment] : [];
+  const output = execFileSync('npx', ['--yes', 'wrangler@4.114.0', 'd1', 'execute', database, '--remote', '--config', INVENTORY_CONFIG, ...envArgs, '--command', command, '--json'], { encoding: 'utf8' });
+  const row = JSON.parse(output)[0]?.results?.[0] || null;
+  const plan = planExplicitUserUnitRepair(row);
+  if (!plan.ok) throw new Error(plan.reason);
+  if (apply) execFileSync('npx', ['--yes', 'wrangler@4.114.0', 'd1', 'execute', database, '--remote', '--config', INVENTORY_CONFIG, ...envArgs, '--command', buildExplicitUserUnitRepairSql(username, plan), '--json'], { encoding: 'utf8' });
+  console.log(JSON.stringify({ mode: apply ? 'applied' : 'dry-run', ...plan, role: row.role, active: row.ativo, allowedModulesConfigured: Array.isArray(JSON.parse(row.allowed_modules_json || '[]')) && JSON.parse(row.allowed_modules_json || '[]').includes('insumos'), sessionVersion: row.session_version }, null, 2));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/inventory/scripts/unitScopeRepair.mjs
+++ b/inventory/scripts/unitScopeRepair.mjs
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { normalizeAllowedUnits, unknownUnitScopes } from '../../shared/identity-contract/index.js';
+
+const TARGET_UNITS = ['novo-hamburgo', 'barra-shopping-sul'];
+const INVENTORY_CONFIG = fileURLToPath(new URL('../wrangler.toml', import.meta.url));
+
+const subjectId = (value) => createHash('sha256').update(String(value || '')).digest('hex').slice(0, 12);
+const sql = (value) => `'${String(value ?? '').replace(/'/g, "''")}'`;
+
+export function planAliasNormalization(rows) {
+  const normalize = [];
+  const review = [];
+  for (const row of rows || []) {
+    const raw = row?.allowed_units_json ?? '';
+    const units = normalizeAllowedUnits(raw);
+    const unknown = unknownUnitScopes(raw);
+    const rawItems = typeof raw === 'string' && raw.trim() ? (() => { try { const parsed = JSON.parse(raw); return Array.isArray(parsed) ? parsed : [raw]; } catch { return raw.split(/[,;|]/g); } })() : [];
+    const currentJson = JSON.stringify(rawItems.map(String).map((item) => item.trim()).filter(Boolean));
+    const nextJson = JSON.stringify(units);
+    const subject = subjectId(row?.username);
+    if (!rawItems.length) {
+      review.push({ subject, reason: 'EMPTY_SCOPE' });
+    } else if (unknown.length) {
+      review.push({ subject, reason: 'UNKNOWN_UNIT', unknownCount: unknown.length });
+    } else if (currentJson !== nextJson) {
+      // Keep the raw stored value as the optimistic-concurrency predicate. This
+      // also supports legacy comma-delimited rows, whose JSON rendering differs.
+      normalize.push({ username: String(row.username), subject, before: currentJson, beforeRaw: String(raw), after: nextJson });
+    }
+  }
+  return { normalize, review };
+}
+
+export function buildAliasNormalizationSql(item, now = new Date().toISOString()) {
+  const audit = JSON.stringify({ allowedUnits: JSON.parse(item.after), repair: 'canonical-alias-normalization' });
+  return `BEGIN;
+UPDATE crm_users SET allowed_units_json=${sql(item.after)}, updated_at=${sql(now)} WHERE username=${sql(item.username)} AND COALESCE(allowed_units_json, '')=${sql(item.beforeRaw ?? item.before)};
+INSERT INTO audit_log (ts, actor, role, action, entity, entity_id, unidade, ip, user_agent, idempotency_key, before_json, after_json)
+SELECT ${sql(now)}, 'system:unit-scope-repair', 'SYSTEM', 'IDENTITY_UNIT_SCOPE_NORMALIZED', 'crm_users', ${sql(item.username)}, '', '', '', '', ${sql(JSON.stringify({ allowedUnits: JSON.parse(item.before) }))}, ${sql(audit)} WHERE changes()=1;
+COMMIT;`;
+}
+
+function runWrangler(args) {
+  return execFileSync('npx', ['--yes', 'wrangler@4.114.0', ...args], { encoding: 'utf8' });
+}
+
+function parsedD1(command, database, environment) {
+  const args = ['d1', 'execute', database, '--remote', '--config', INVENTORY_CONFIG, '--command', command, '--json'];
+  if (environment) args.push('--env', environment);
+  const output = runWrangler(args);
+  return JSON.parse(output)[0]?.results || [];
+}
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const apply = args.has('--apply');
+  const database = process.env.INVENTORY_D1_DATABASE || 'skincos-db';
+  const environment = process.env.INVENTORY_D1_ENV || '';
+  const rows = parsedD1('SELECT username, allowed_units_json FROM crm_users ORDER BY username', database, environment);
+  const plan = planAliasNormalization(rows);
+  for (const item of plan.normalize) {
+    if (apply) parsedD1(buildAliasNormalizationSql(item), database, environment);
+  }
+  console.log(JSON.stringify({ mode: apply ? 'applied' : 'dry-run', database, normalized: plan.normalize.map(({ subject }) => ({ subject })), review: plan.review }, null, 2));
+  if (!apply) console.log('Run again with --apply only after reviewing the pseudonymous plan. Empty scopes are never changed.');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/inventory/src/d1Store.js
+++ b/inventory/src/d1Store.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { normalizeAllowedUnits as normalizeCanonicalAllowedUnits } from '../../shared/identity-contract/index.js';
 
 function toInt(v, fallback = 0) {
   const n = typeof v === 'number' ? v : parseInt(String(v ?? ''), 10);
@@ -1866,17 +1867,7 @@ function safeJsonParse(raw, fallback) {
 }
 
 function normalizeAllowedUnits(value) {
-  if (!value) return [];
-  if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
-  if (typeof value === 'string') {
-    const parsed = safeJsonParse(value, null);
-    if (Array.isArray(parsed)) return parsed.map(String).map((s) => s.trim()).filter(Boolean);
-    return value
-      .split(/[,;|]/g)
-      .map((s) => String(s || '').trim())
-      .filter(Boolean);
-  }
-  return [];
+  return normalizeCanonicalAllowedUnits(value);
 }
 
 function normalizeAllowedModules(value) {

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -4,6 +4,7 @@ import { restoreBackupPayload } from '../services/backup.js';
 import { resolveCrmTables } from '../d1Store.js';
 import { sendAccountInviteEmail } from '../smtpMailer.js';
 import { normalizeInviteEmail, normalizeInviteScope, validateInviteDelegation } from '../invitePolicy.js';
+import { normalizeAllowedUnits as normalizeCanonicalAllowedUnits, unknownUnitScopes } from '../../../shared/identity-contract/index.js';
 
 const ROLE_ADMIN = ['ADMIN', 'GESTOR', 'GERENTE'];
 const ROLE_INVITES = ['GESTOR'];
@@ -31,18 +32,11 @@ function normalizeRole(role) {
 }
 
 function normalizeAllowedUnits(value) {
-  if (!value) return [];
-  if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
-  if (typeof value === 'string') {
-    const s = value.trim();
-    if (!s) return [];
-    try {
-      const parsed = JSON.parse(s);
-      if (Array.isArray(parsed)) return parsed.map(String).map((x) => x.trim()).filter(Boolean);
-    } catch { }
-    return s.split(/[,;|]/g).map((x) => String(x || '').trim()).filter(Boolean);
-  }
-  return [];
+  return normalizeCanonicalAllowedUnits(value);
+}
+
+function invalidUnitScopes(value) {
+  return unknownUnitScopes(value);
 }
 
 function normalizeAllowedModules(value) {
@@ -433,7 +427,9 @@ export async function handleAdminRoutes({
       const body = await request.json().catch(() => ({}));
       const inviteeEmail = normalizeInviteEmail(body.email ?? body.inviteeEmail);
       const role = normalizeRole(body.role || 'CONSULTOR');
-      const allowedUnits = normalizeInviteScope(body.allowedUnits);
+      const invalidUnits = invalidUnitScopes(body.allowedUnits);
+      if (invalidUnits.length) return withCORS(JSON.stringify({ success: false, error: 'Unidade inválida', code: 'UNIT_INVALID' }), { status: 400 }, appOrigin);
+      const allowedUnits = normalizeAllowedUnits(body.allowedUnits);
       const allowedModules = normalizeInviteScope(body.allowedModules ?? body.allowed_modules ?? body.modules ?? body.scopes);
       const requestedMaxUses = body.maxUses === undefined ? 1 : Number.parseInt(String(body.maxUses), 10);
       const maxUses = 1;
@@ -637,6 +633,8 @@ export async function handleAdminRoutes({
       const displayName = String(body.displayName || '').trim();
       const email = String(body.email || '').trim();
       const role = normalizeRole(body.role || 'CONSULTOR');
+      const invalidUnits = invalidUnitScopes(body.allowedUnits);
+      if (invalidUnits.length) return withCORS(JSON.stringify({ success: false, error: 'UNIT_INVALID' }), { status: 400 }, appOrigin);
       const allowedUnits = normalizeAllowedUnits(body.allowedUnits);
       const allowedModules = normalizeAllowedModules(body.allowedModules ?? body.allowed_modules ?? body.modules ?? body.scopes);
       const ativo = body.ativo === false ? 0 : 1;
@@ -737,6 +735,9 @@ export async function handleAdminRoutes({
         return withCORS(JSON.stringify({ success: false, error: 'Somente o provisionamento administrativo pode alterar hierarquia.', code: 'ROLE_MANAGEMENT_DENIED' }), { status: 403 }, appOrigin);
       }
       const photoUrl = body.photoUrl !== undefined ? String(body.photoUrl || '') : null;
+      if (body.allowedUnits !== undefined && invalidUnitScopes(body.allowedUnits).length) {
+        return withCORS(JSON.stringify({ success: false, error: 'UNIT_INVALID' }), { status: 400 }, appOrigin);
+      }
       const allowedUnits = body.allowedUnits !== undefined ? JSON.stringify(normalizeAllowedUnits(body.allowedUnits)) : null;
       const allowedModules = body.allowedModules !== undefined ? JSON.stringify(normalizeAllowedModules(body.allowedModules)) : null;
       const ativo = body.ativo === undefined ? null : (body.ativo ? 1 : 0);

--- a/inventory/src/worker.js
+++ b/inventory/src/worker.js
@@ -31,6 +31,7 @@ import {
     d1ListInsumosPaged,
     d1ListInsumosOptions,
 } from './d1Store.js';
+import { hasUnitScopeAccess, normalizeUnitScope } from '../../shared/identity-contract/index.js';
 
 const MAX_PROFILE_PHOTO_URL_CHARS = 45000;
 
@@ -49,20 +50,6 @@ function safeJsonParse(raw) {
     }
 }
 
-function slugifyUnidade(value) {
-    const s0 = String(value || '').trim().toLowerCase();
-    if (!s0) return '';
-    if (s0 === '*' || s0 === 'all' || s0 === 'todas') return '*';
-    if (s0 === 'novo-hamburgo' || s0 === 'novohamburgo' || s0 === 'novo hamburgo' || s0 === 'nh') return 'novo-hamburgo';
-    if (s0 === 'barra-shopping-sul' || s0 === 'barrashoppingsul' || s0 === 'barra shopping sul' || s0 === 'bss') return 'barra-shopping-sul';
-    const s = s0
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-    return s;
-}
-
 function getInsumosConfig(env) {
     const unidadesRaw = String(env?.UNIDADES || '').trim();
     const unidades = unidadesRaw
@@ -70,8 +57,8 @@ function getInsumosConfig(env) {
             new Set(
                 unidadesRaw
                     .split(/[,;|]/g)
-                    .map((u) => slugifyUnidade(u))
-                    .filter((u) => u && u !== '*')
+                    .map((u) => normalizeUnitScope(u))
+                    .filter(Boolean)
             )
         )
         : DEFAULT_UNIDADES;
@@ -81,9 +68,9 @@ function getInsumosConfig(env) {
     const unidadeHeaders = {};
     if (unitHeadersParsed && typeof unitHeadersParsed === 'object') {
         for (const [k, v] of Object.entries(unitHeadersParsed)) {
-            const slug = slugifyUnidade(k);
+            const slug = normalizeUnitScope(k);
             const key = String(v || '').toLowerCase().trim();
-            if (slug && slug !== '*' && key) unidadeHeaders[slug] = key;
+            if (slug && key) unidadeHeaders[slug] = key;
         }
     }
 
@@ -954,7 +941,7 @@ async function enqueueNotificationsRefresh(env, unidade) {
 async function refreshNotificationsSnapshotInD1({ env, unidade }) {
     if (!env?.DB) return;
     const config = getInsumosConfig(env);
-    const unit = unidade ? slugifyUnidade(unidade) : null;
+    const unit = unidade ? normalizeUnitScope(unidade) : null;
     const unidades = unit ? [unit] : config.unidades;
 
     for (const u of unidades) {
@@ -1038,7 +1025,10 @@ export default {
             // ignore
         }
         const defaultUnidade = UNIDADES[0] || 'novo-hamburgo';
-        const unidade = slugifyUnidade(url.searchParams.get('unidade') || '') || defaultUnidade;
+        const unidadeParam = String(url.searchParams.get('unidade') || '').trim();
+        const normalizedRequestedUnit = normalizeUnitScope(unidadeParam);
+        const invalidRequestedUnit = !!unidadeParam && !normalizedRequestedUnit;
+        const unidade = normalizedRequestedUnit || defaultUnidade;
         const cookies = parseCookies(request.headers.get('cookie') || '');
         const ip = getClientIp(request);
         const userAgent = getUserAgent(request);
@@ -1132,6 +1122,14 @@ export default {
             else console.log(serializedPayload);
             return res;
         };
+
+        if (invalidRequestedUnit) {
+            return withCORS(
+                JSON.stringify({ success: false, error: 'Unidade inválida', code: 'UNIT_INVALID' }),
+                { status: 400 },
+                appOrigin
+            );
+        }
 
         const enforceRateLimit = async (kind) => {
             if (!env.RATE_LIMITER) return { allowed: true };
@@ -1313,13 +1311,7 @@ export default {
             return sessionUser;
         };
 
-        const hasUnitAccess = (u, unit) => {
-            if (!u) return false;
-            if (String(u.role || '').toUpperCase() === 'ADMIN') return true;
-            const allowed = Array.isArray(u.allowedUnits) ? u.allowedUnits.filter(Boolean) : [];
-            if (!allowed.length) return false;
-            return allowed.includes(unit);
-        };
+        const hasUnitAccess = (u, unit) => !!u && hasUnitScopeAccess(u, unit);
 
         const getAllowedModules = (u) => {
             const raw = Array.isArray(u?.allowedModules) ? u.allowedModules : [];

--- a/inventory/tests/identity-compatibility.test.mjs
+++ b/inventory/tests/identity-compatibility.test.mjs
@@ -19,7 +19,7 @@ test('Inventory keeps the existing auth mount through the registered Identity ad
             if (sql.includes('sqlite_master')) return { type: 'table' };
             if (sql.includes('FROM crm_users')) return {
               username: 'existing-user', display_name: 'Existing User', role: 'CONSULTOR', ativo: 1,
-              allowed_units_json: '["novo-hamburgo"]', allowed_modules_json: '["inventory"]', session_version: 0,
+              allowed_units_json: '["NH"]', allowed_modules_json: '["inventory"]', session_version: 0,
             };
             return null;
           },
@@ -31,5 +31,6 @@ test('Inventory keeps the existing auth mount through the registered Identity ad
 
   const user = await store.getUserByUsername('existing-user');
   assert.equal(user.username, 'existing-user');
+  assert.deepEqual(user.allowedUnits, ['novo-hamburgo']);
   assert.deepEqual(user.allowedModules, ['inventory']);
 });

--- a/inventory/tests/unitRbac.test.mjs
+++ b/inventory/tests/unitRbac.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hasUnitScopeAccess } from '../../shared/identity-contract/index.js';
+
+test('Inventory RBAC accepts only the canonical scope for a one-unit actor', () => {
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['novo-hamburgo'] }, 'novo-hamburgo'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['novo-hamburgo'] }, 'barra-shopping-sul'), false);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['barra-shopping-sul'] }, 'barra-shopping-sul'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['barra-shopping-sul'] }, 'novo-hamburgo'), false);
+});
+
+test('Inventory RBAC supports both canonical scopes, aliases at Identity input, and preserves denial', () => {
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['NH', 'BSS'] }, 'novo-hamburgo'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['NH', 'BSS'] }, 'barra-shopping-sul'), true);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: [] }, 'novo-hamburgo'), false);
+  assert.equal(hasUnitScopeAccess({ role: 'GESTOR', allowedUnits: ['novo-hamburgo'] }, 'invalida'), false);
+  assert.equal(hasUnitScopeAccess({ role: 'ADMIN', allowedUnits: [] }, 'novo-hamburgo'), true);
+});

--- a/inventory/tests/unitScopeRepair.test.mjs
+++ b/inventory/tests/unitScopeRepair.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildAliasNormalizationSql, planAliasNormalization } from '../scripts/unitScopeRepair.mjs';
+import { planExplicitUserUnitRepair } from '../scripts/repairUserInsumosUnits.mjs';
+
+test('alias repair only canonicalizes recognized aliases and reports empty or unknown rows', () => {
+  const plan = planAliasNormalization([
+    { username: 'alias', allowed_units_json: '["NH","Barra Shopping Sul"]' },
+    { username: 'empty', allowed_units_json: '[]' },
+    { username: 'unknown', allowed_units_json: '["unidade-estranha"]' },
+  ]);
+  assert.equal(plan.normalize.length, 1);
+  assert.equal(plan.review.length, 2);
+  const sql = buildAliasNormalizationSql(plan.normalize[0], '2026-07-24T00:00:00.000Z');
+  assert.match(sql, /IDENTITY_UNIT_SCOPE_NORMALIZED/);
+  assert.match(sql, /audit_log/);
+
+  const delimited = planAliasNormalization([{ username: 'delimited', allowed_units_json: 'NH;BSS' }]).normalize[0];
+  assert.match(buildAliasNormalizationSql(delimited), /COALESCE\(allowed_units_json, ''\)='NH;BSS'/);
+});
+
+test('explicit repair is limited to an empty known scope and is auditable', () => {
+  const plan = planExplicitUserUnitRepair({ username: 'target', allowed_units_json: '[]' });
+  assert.deepEqual(plan, { ok: true, subject: plan.subject, before: '[]', after: '["novo-hamburgo","barra-shopping-sul"]' });
+  assert.equal(planExplicitUserUnitRepair({ username: 'other', allowed_units_json: '["novo-hamburgo"]' }).reason, 'NON_EMPTY_SCOPE_REQUIRES_REVIEW');
+  assert.equal(planExplicitUserUnitRepair({ username: 'other', allowed_units_json: '["unknown"]' }).reason, 'UNKNOWN_UNIT_SCOPE');
+});

--- a/shared/identity-contract/index.js
+++ b/shared/identity-contract/index.js
@@ -1,5 +1,59 @@
 export const IDENTITY_ACTOR_CONTRACT_VERSION = 'identity-actor/v1';
 
+// Unit scopes are closed: persisted and RBAC-facing values are only these slugs.
+export const CANONICAL_UNIT_SCOPES = Object.freeze(['novo-hamburgo', 'barra-shopping-sul']);
+const CANONICAL_UNIT_SCOPE_SET = new Set(CANONICAL_UNIT_SCOPES);
+
+function scopeItems(value) {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  const raw = value.trim();
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.map(String).map((item) => item.trim()).filter(Boolean);
+  } catch {
+    // Legacy delimited rows remain readable until their explicit repair.
+  }
+  return raw.split(/[,;|]/g).map((item) => item.trim()).filter(Boolean);
+}
+
+export function normalizeUnitScope(value) {
+  const key = String(value || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '');
+  if (key === 'novohamburgo' || key === 'nh') return 'novo-hamburgo';
+  if (key === 'barrashoppingsul' || key === 'bss') return 'barra-shopping-sul';
+  return '';
+}
+
+export function normalizeAllowedUnits(value) {
+  const units = [];
+  for (const item of scopeItems(value)) {
+    const canonical = normalizeUnitScope(item);
+    if (canonical && !units.includes(canonical)) units.push(canonical);
+  }
+  return units;
+}
+
+export function unknownUnitScopes(value) {
+  return scopeItems(value).filter((item) => !normalizeUnitScope(item));
+}
+
+export function isCanonicalUnitScope(value) {
+  return CANONICAL_UNIT_SCOPE_SET.has(String(value || '').trim());
+}
+
+export function hasUnitScopeAccess({ role, allowedUnits }, requestedUnit) {
+  const unit = normalizeUnitScope(requestedUnit);
+  if (!unit) return false;
+  if (String(role || '').trim().toUpperCase() === 'ADMIN') return true;
+  return normalizeAllowedUnits(allowedUnits).includes(unit);
+}
+
 const asList = (value) => Array.isArray(value)
   ? [...new Set(value.map(String).map((item) => item.trim()).filter(Boolean))]
   : [];
@@ -10,7 +64,7 @@ const asList = (value) => Array.isArray(value)
  */
 export function toAuthenticatedActor(user) {
   if (!user?.username) return null;
-  const units = asList(user.allowedUnits);
+  const units = normalizeAllowedUnits(user.allowedUnits);
   const modules = asList(user.allowedModules);
   const permissions = asList(user.permissions);
   return Object.freeze({


### PR DESCRIPTION
## Causa raiz

O Worker de Inventory aplicava RBAC contra `allowedUnits` sem normalização canônica. Registros legados com aliases poderiam falhar na comparação. A investigação no D1 de produção também encontrou três perfis ativos com escopo de unidade vazio; dois são GESTOR e, por serem não-ADMIN, recebem corretamente `RBAC_UNIT_DENIED`.

O request histórico `a2047e799b471ab8` não está recuperável: a configuração do Worker não mantém Workers Logs históricos e o log estruturado não registra ator ou escopos. Nenhum dado pessoal foi exposto. O endpoint é o Worker `skincos-insumos` (produção ativa `6104273d-a14c-4a84-8bb1-889a681969dc`); a tabela é `crm_users` no D1 `skincos-db`.

## Dados x código

- Dados: escopo vazio é uma configuração incompleta e continua negado. O reparo explícito não amplia módulos, não toca `session_version` e exige o usuário canônico informado pelo operador.
- Código: Identity, convites, criação/edição, `/auth/me`, Inventory e UI agora usam os mesmos slugs fechados: `novo-hamburgo` e `barra-shopping-sul`.

## Correção

- Normalizador único aceita NH/BSS, nomes e slugs legados; valores desconhecidos são rejeitados nas escritas e bloqueados em RBAC.
- ADMIN preserva override global; não-ADMIN com lista vazia continua sem acesso.
- A UI reconcilia `skincos.insumos.unidade.v1` antes das consultas, mostra somente unidades permitidas e evita requests quando não há unidade autorizada.
- Scripts idempotentes: aliases reconhecidos podem ser normalizados com auditoria; escopos vazios só são reportados; reparo individual exige `--username` e `--apply` explícitos.

## Potencialmente afetados

Perfis não-ADMIN com `allowed_units_json` vazio ou aliases reconhecidos. O dry-run atual encontrou três escopos vazios e nenhum alias para normalizar. Não houve alteração de dados em produção.

## Validação

- `inventory: npm test` — 7 testes aprovados.
- `identity: node --test test/*.test.mjs` — 3 testes aprovados.
- Frontend: 12 testes Vitest aprovados; typecheck e lint executados no runtime WSL.
- `npm run architecture:validate`, catálogo de observabilidade e `node --check inventory/src/worker.js` aprovados.
- Dry-run remoto do reparo não escreveu no D1 e reportou somente escopos vazios.

O E2E headless e o smoke autenticado em staging permanecem pendentes: o Vite local travou por uma instalação parcial em DrvFS e a promoção para staging exige um SHA já em `main`, mais a evidência do preview predecessor. Esta PR não declara staging aprovado.

## Rollback

Reverter o commit `7ee1b3fd`. Nenhuma migration automática é executada. Qualquer execução futura dos scripts fica registrada em `audit_log` e pode ser revertida para o JSON anterior indicado no evento.

## Staging pendente

Após merge e preview aprovado, executar o pipeline canônico de preview -> staging para Inventory e CRM Pages e rodar smoke autenticado com: usuário de uma unidade, usuário de ambas e tentativa deliberada em unidade não autorizada. Não promover produção nesta etapa.