### PR TITLE
fix(atendimento): serializar inicialização do schema

### DIFF
--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -74,6 +74,56 @@ test('scopes atendimento router access by consuming module', () => {
     assert.equal(canAccessAtendimento(faturamentoActor, '/management/catalog', 'GET'), false)
 })
 
+test('initializes Atendimento schema once when concurrent reads arrive', async () => {
+    let transactions = 0
+    const fakePool = createFakePool([
+        (sql) => {
+            if (sql === 'begin') transactions += 1
+            return null
+        },
+        (sql) => sql.includes('select slug, name from crm_atendimento.units order by name') && {
+            rows: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }], rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.professionals') && { rows: [], rowCount: 0 },
+        (sql) => sql.includes('from crm_atendimento.procedures') && { rows: [], rowCount: 0 },
+    ])
+    const store = createAtendimentoStore({ pool: fakePool })
+
+    await Promise.all([
+        store.references({ role: 'GESTOR' }),
+        store.references({ role: 'GESTOR' }),
+        store.references({ role: 'GESTOR' }),
+    ])
+
+    assert.equal(transactions, 1)
+})
+
+test('retries Atendimento schema initialization after a transient failure', async () => {
+    let firstMigration = true
+    let transactions = 0
+    const fakePool = createFakePool([
+        (sql) => {
+            if (sql === 'begin') transactions += 1
+            if (sql.includes('create extension if not exists pgcrypto') && firstMigration) {
+                firstMigration = false
+                throw new Error('transient migration failure')
+            }
+            return null
+        },
+        (sql) => sql.includes('select slug, name from crm_atendimento.units order by name') && {
+            rows: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }], rowCount: 1,
+        },
+        (sql) => sql.includes('from crm_atendimento.professionals') && { rows: [], rowCount: 0 },
+        (sql) => sql.includes('from crm_atendimento.procedures') && { rows: [], rowCount: 0 },
+    ])
+    const store = createAtendimentoStore({ pool: fakePool })
+
+    await assert.rejects(() => store.references({ role: 'GESTOR' }), /transient migration failure/)
+    await store.references({ role: 'GESTOR' })
+
+    assert.equal(transactions, 2)
+})
+
 test('rejects a direct non-manager attempt to replace the persisted consultant before any write', async () => {
     const queries = []
     const fakePool = createFakePool([

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -2655,10 +2655,20 @@ async function queryIdentityReviewQueue(pgPool, query = {}) {
 
 export function createAtendimentoStore(options = {}) {
     const pgPool = options.pool || createAtendimentoPool(options.databaseUrl)
+    let readinessPromise = null
 
     async function ensureReady() {
         requirePool(pgPool)
-        await withPgTransaction(pgPool, migrateAtendimento)
+        if (!readinessPromise) {
+            readinessPromise = withPgTransaction(pgPool, migrateAtendimento)
+                .catch((error) => {
+                    // Do not cache a failed initialization: an operator may repair the
+                    // database state and the next request must be allowed to retry.
+                    readinessPromise = null
+                    throw error
+                })
+        }
+        await readinessPromise
     }
 
     return {


### PR DESCRIPTION
## Causa raiz

Cada endpoint de Atendimento executava a migração DDL em `ensureReady()`. O frontend abre referências, overview, atendimentos e catálogo em paralelo; essas transações adquiriam locks em ordens conflitantes e o PostgreSQL encerrava algumas com deadlock, retornando `500 INTERNAL_ERROR`.

O incidente também revelou sete tabelas legadas com proprietário `postgres`, enquanto o serviço usa o papel `skincos`; isso bloqueava a criação idempotente de índices e produzia `500` constantes. A propriedade foi reparada diretamente no banco de runtime, com checkpoint e evento de auditoria, sem alterar dados de atendimento.

## Correção

- Compartilha uma única promise de inicialização por instância do store.
- Mantém retry após falha, sem cachear inicialização malsucedida.
- Não altera RBAC, dados de usuários, unidades ou comportamento funcional dos endpoints.

## Usuários potencialmente afetados

Qualquer usuário do módulo Atendimento no primeiro carregamento após reinício/deploy, especialmente telas que disparam as consultas paralelas.

## Validação

- `node --test server/atendimento/__tests__/*.test.js` — 100 testes aprovados.
- Novos testes cobrem inicialização concorrente única e retry após falha transitória.
- Todas as verificações obrigatórias de CI passaram no merge commit.
- O promotor nativo validou o archive por SHA-256 e instalou dependências bloqueadas sem vulnerabilidades de produção.

## Staging e produção

- A fundação de staging nativo ainda não está provisionada; portanto não há evidência a alegar de um smoke nativo em staging.
- Em razão do incidente ativo, a promoção controlada ocorreu após CI integral, backup com restauração verificada e dry-run do promotor nativo.
- Produção: release `53c126722a0ba399c4f18d9ad83a1b45c07ea083`; health local e público saudáveis; smoke autenticado carregou as movimentações e uma atualização deliberada sem `UNAUTHORIZED`, 401, 500 ou erros de console.

## Rollback

Reapontar `/opt/skincos/current/source` para o release anterior, reiniciar somente `crm.service` e repetir os health checks local/público. Não houve migração de dados de negócio nesta publicação.
