### PR TITLE
chore(website): corrigir auditoria de postcss

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10816,9 +10816,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/website/package.json
+++ b/website/package.json
@@ -67,7 +67,7 @@
     "form-data": "4.0.6",
     "ip-address": "10.2.0",
     "js-yaml": "4.2.0",
-    "postcss": "8.5.15",
+    "postcss": "8.5.18",
     "qs": "6.15.2",
     "sharp": "0.35.0",
     "undici": "7.28.0",


### PR DESCRIPTION
## Objetivo

Remover o único bloqueio de auditoria de dependências que impedia a promoção do hotfix de Atendimento.

## Alteração

Atualiza o override de produção de `postcss` de 8.5.15 para 8.5.18, versão posterior ao advisory de path traversal. O lockfile muda somente no pacote correspondente.

## Validação

- `npm ci --ignore-scripts`
- `npm run lint`
- `npm test`
- `npm run build`
- `.github/scripts/npm-audit-gate.mjs website`

Nenhuma mudança de funcionalidade do site.