### PR TITLE
fix(insumos): grant fixture runtime module scope

### DIFF
--- a/inventory/scripts/insumosStagingRbacFixtures.mjs
+++ b/inventory/scripts/insumosStagingRbacFixtures.mjs
@@ -63,7 +63,9 @@ if (action === 'provision') {
   const statements = [];
   for (const scenario of fixtures.scenarios) {
     statements.push(`DELETE FROM crm_users WHERE username = ${sql(scenario.username)};`);
-    statements.push(`INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(scenario.username)}, ${sql(scenario.email)}, ${sql(`Synthetic Insumos RBAC ${scenario.id}`)}, ${sql(passwordHash(scenario.password))}, ${sql(scenario.role)}, '', ${sql(JSON.stringify(scenario.allowedUnits))}, ${sql(JSON.stringify(['inventory']))}, 1, ${sql(now)}, ${sql(now)}, 0);`);
+    // `insumos` is the runtime module permission enforced by the Inventory
+    // Worker. `inventory` is a domain label, not an authorization scope.
+    statements.push(`INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(scenario.username)}, ${sql(scenario.email)}, ${sql(`Synthetic Insumos RBAC ${scenario.id}`)}, ${sql(passwordHash(scenario.password))}, ${sql(scenario.role)}, '', ${sql(JSON.stringify(scenario.allowedUnits))}, ${sql(JSON.stringify(['insumos']))}, 1, ${sql(now)}, ${sql(now)}, 0);`);
     statements.push(audit('STAGING_SYNTHETIC_IDENTITY_PROVISIONED', scenario.username, { runId, scope: scenario.allowedUnits, role: scenario.role }));
   }
   writeFileSync(sqlPath, `${statements.join('\n')}\n`, { mode: 0o600 });

--- a/inventory/tests/insumosStagingRbacFixtures.test.mjs
+++ b/inventory/tests/insumosStagingRbacFixtures.test.mjs
@@ -19,9 +19,12 @@ test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
     assert.equal(data.environment, 'staging');
     assert.equal(data.scenarios.length, 6);
     assert.deepEqual(data.scenarios.find((item) => item.id === 'alias').allowedUnits, ['NH']);
-    assert.match(readFileSync(sql, 'utf8'), /STAGING_SYNTHETIC_IDENTITY_PROVISIONED/);
-    assert.doesNotMatch(readFileSync(sql, 'utf8'), /BEGIN TRANSACTION|COMMIT;/);
-    assert.doesNotMatch(readFileSync(sql, 'utf8'), /api\.skincos\.com\.br/);
+    const statement = readFileSync(sql, 'utf8');
+    assert.match(statement, /STAGING_SYNTHETIC_IDENTITY_PROVISIONED/);
+    assert.match(statement, /\["insumos"\]/);
+    assert.doesNotMatch(statement, /\["inventory"\]/);
+    assert.doesNotMatch(statement, /BEGIN TRANSACTION|COMMIT;/);
+    assert.doesNotMatch(statement, /api\.skincos\.com\.br/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Scope\n- gives staging-only synthetic RBAC identities the runtime insumos module scope\n- prevents the inventory domain label from being used as an authorization grant\n\n## Validation\n- 
ode --test inventory/tests/insumosStagingRbacFixtures.test.mjs (WSL)\n- git diff --check\n\nNo deployment or production data change.