### PR TITLE
fix(insumos): fail closed without authorized unit

### DIFF
--- a/crm/console/InsumosModule.tsx
+++ b/crm/console/InsumosModule.tsx
@@ -673,7 +673,9 @@ export function InsumosModule() {
     [unidade, user?.allowedUnits, user?.role],
   )
   const allowedUnits = unitAccess.allowedUnits
-  const canUseApi = serviceReady && unitAccessReady && (!isAuthed || unitAccess.hasAuthorizedUnit)
+  // Inventory data is never public: until identity is resolved, and whenever
+  // the actor has no authorized unit, fail closed without issuing data calls.
+  const canUseApi = serviceReady && unitAccessReady && isAuthed && unitAccess.hasAuthorizedUnit
 
   const isManagerRole = ['GESTOR', 'GERENTE'].includes(String(user?.role || '').toUpperCase())
 


### PR DESCRIPTION
## P0 scope\n- blocks all Inventory data calls until authenticated identity and unit authorization are established\n- preserves ADMIN global override through esolveInsumosUnitAccess\n- keeps non-ADMIN empty unit lists fail-closed\n\n## Validation\n- git diff --check\n- targeted Playwright command attempted locally but this worktree lacks the complete Playwright runtime; canonical E2E runs in CI\n\nNo deploy or production change.