### PR TITLE
fix(workforce): configure staging module control KV

### DIFF
--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -51,6 +51,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           D1_ID: ${{ inputs.target == 'production' && vars.TIMEKEEPING_D1_PRODUCTION_ID || vars.TIMEKEEPING_D1_STAGING_ID }}
+          MODULE_CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
           PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
@@ -60,10 +61,11 @@ jobs:
           TIMEKEEPING_BACKUP_PASSPHRASE: ${{ secrets.TIMEKEEPING_BACKUP_PASSPHRASE }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY TIMEKEEPING_BACKUP_PASSPHRASE; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID MODULE_CONTROL_KV_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY TIMEKEEPING_BACKUP_PASSPHRASE; do
             [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }
           done
           [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo "Invalid Timekeeping D1 id"; exit 1; }
+          [[ "$MODULE_CONTROL_KV_ID" =~ ^[0-9a-fA-F]{32}$ ]] || { echo "Invalid module-control KV id"; exit 1; }
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
@@ -98,12 +100,16 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           D1_ID: ${{ inputs.target == 'production' && vars.TIMEKEEPING_D1_PRODUCTION_ID || vars.TIMEKEEPING_D1_STAGING_ID }}
+          MODULE_CONTROL_KV_ID: ${{ inputs.target == 'production' && vars.MODULE_CONTROL_PRODUCTION_KV_ID || vars.MODULE_CONTROL_STAGING_KV_ID }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "production" ]]; then
             sed -i "s/__CONFIGURE_TIMEKEEPING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
+            sed -i "s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/$MODULE_CONTROL_KV_ID/" workforce/timekeeping/wrangler.toml
+            ! grep -q '__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__' workforce/timekeeping/wrangler.toml || { echo 'Unresolved production module-control KV placeholder'; exit 1; }
           else
             sed -i "s/__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
+            ! grep -q '__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__' workforce/timekeeping/wrangler.toml || { echo 'Unresolved staging module-control KV placeholder'; exit 1; }
           fi
 
       - name: Capture encrypted D1 checkpoint

--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -35,7 +35,7 @@ service = "skincos-escala-api-staging"
 
 [[env.staging.kv_namespaces]]
 binding = "MODULE_CONTROL"
-id = "__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__"
+id = "e69fe06b6abc46eca4f4c00198d078f2"
 
 [env.staging.vars]
 APP_VERSION = "1.0.0"


### PR DESCRIPTION
Corrige exclusivamente o bloqueio de staging do Workforce.

- cria e configura namespace KV exclusivo de staging para `MODULE_CONTROL`;
- remove o placeholder de staging da configuração canônica;
- adiciona guard de ID KV no deploy e injeta somente o binding de produção quando a variável própria existir;
- mantém ambientes isolados: staging não referencia recursos de produção e produção falha fechado sem variável própria.

Validação: `npm --prefix workforce/timekeeping test`, `npm run architecture:validate`, e inspeção remota dos bindings/variáveis sem valores sensíveis.

Nenhuma alteração de produção.