### PR TITLE
fix(atendimento): complete Google Sheets import audit values

### DIFF
--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -124,6 +124,43 @@ test('retries Atendimento schema initialization after a transient failure', asyn
     assert.equal(transactions, 2)
 })
 
+test('imports source rows with one actor value for both audit columns', async () => {
+    const queries = []
+    const fakePool = createFakePool([
+        (sql, params) => {
+            queries.push({ sql, params })
+            if (sql.startsWith('insert into crm_atendimento.units(')) {
+                return { rows: [{ id: 'unit-1', slug: 'novo-hamburgo', name: 'Novo Hamburgo' }], rowCount: 1 }
+            }
+            if (sql.startsWith('insert into crm_atendimento.procedures(')) {
+                return { rows: [{ id: 'procedure-1', name: 'Botox' }], rowCount: 1 }
+            }
+            if (sql.startsWith('insert into crm_atendimento.attendances(')) {
+                return { rows: [{ id: 'attendance-1', inserted: true }], rowCount: 1 }
+            }
+            return null
+        },
+    ])
+    const store = createAtendimentoStore({ pool: fakePool })
+
+    const result = await store.importRecords({
+        records: [{
+            unitSlug: 'novo-hamburgo', unitName: 'Novo Hamburgo', date: '2026-07-24',
+            clientName: 'Cliente', procedureName: 'Botox', code: '#0699', quantity: 1,
+            discount: false, otherValue: 0, roundValue: false, value: 699,
+            injectorName: '', consultantName: '', observation: '',
+            sourceSheetId: 'sheet-1', sourceTab: 'Novo Hamburgo', sourceRow: 3,
+        }],
+        cache: { procedures: [], professionals: [], procedureCodes: [], schedules: [] },
+        actor: { id: 'google-sheet-import', role: 'GESTOR' },
+    })
+
+    assert.deepEqual(result, { dryRun: false, records: 1, inserted: 1, updated: 0, skipped: 0 })
+    const write = queries.find(({ sql }) => sql.startsWith('insert into crm_atendimento.attendances('))
+    assert.match(write.sql, /values \(\$1,\$2,\$3,\$4,\$5,\$6,\$7,\$8,\$9,\$10,\$11,\$12,\$13,\$14,\$15,\$16,\$17,\$18,\$19,\$19\)/)
+    assert.equal(write.params.at(-1), 'google-sheet-import')
+})
+
 test('rejects a direct non-manager attempt to replace the persisted consultant before any write', async () => {
     const queries = []
     const fakePool = createFakePool([

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -3654,7 +3654,7 @@ export function createAtendimentoStore(options = {}) {
                             unit_id, service_date, client_name, procedure_id, code, quantity,
                             discount, other_value, round_value, value, injector_id, consultant_id, injector_source_name, consultant_source_name,
                             observation, source_sheet_id, source_tab, source_row, created_by, updated_by
-                        ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$18)
+                        ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$19)
                         on conflict(source_sheet_id, source_tab, source_row) where source_sheet_id is not null and source_tab is not null and source_row is not null
                         do update set
                             unit_id = excluded.unit_id,


### PR DESCRIPTION
## What changed

Fixes the Atendimento Google Sheets import SQL so both audit fields receive the import actor.

## Root cause

The insert listed 20 target columns but supplied 19 values, causing live imports to roll back.

## Validation

- Added a regression test for the import audit values.
- crm/api npm test: 132 passed.