### PR TITLE
fix(release): stamp Pages deployment with promoted SHA

### DIFF
--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -134,8 +134,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PAGES_PROJECT: ${{ steps.guard.outputs.project }}
           BRANCH_NAME: ${{ steps.guard.outputs.branch }}
-          GIT_SHA: ${{ github.sha }}
-          GIT_MESSAGE: ${{ github.event.head_commit.message || github.sha }}
+          # The deployment metadata must identify the immutable artifact that
+          # passed the promotion gate, not the workflow-dispatch ref.
+          GIT_SHA: ${{ needs.promotion.outputs.source_sha }}
+          GIT_MESSAGE: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           PROJECT="${PAGES_PROJECT:-skincos}"


### PR DESCRIPTION
Fixes immutable Pages provenance: the workflow now writes the promotion-gate source SHA to Pages deployment metadata instead of the workflow-dispatch ref. No application code, secrets, flags, grants or data changes.