### PR TITLE
fix(ci): stop auxiliary Pages redeploy dispatch

### DIFF
--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   sync:
@@ -70,17 +69,3 @@ jobs:
           set -euo pipefail
           printf "%s" "$INTEGRATIONS_ENCRYPTION_SECRET" | npx --yes wrangler@4 secret put INTEGRATIONS_ENCRYPTION_SECRET --config social/publisher/wrangler.toml >/dev/null
           echo "Set secret INTEGRATIONS_ENCRYPTION_SECRET for social-publisher worker."
-
-      - name: Force redeploy CRM Pages (apply secret/env)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "deploy-crm-pages-reconcile.yml",
-              ref: "main",
-              inputs: { force: "true" },
-            })
-            core.info("Dispatched deploy-crm-pages-reconcile.yml with force=true")


### PR DESCRIPTION
Removes the obsolete dispatch to deploy-crm-pages-reconcile.yml and its actions:write permission. Secret synchronization remains; Pages publication stays exclusively in deploy-crm-pages.yml. No application or data changes.