### PR TITLE
fix(finance): make staging rollback version lookup runnable

### DIFF
--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -164,12 +164,14 @@ jobs:
       - name: Resolve a previously uploaded version for rollback
         if: inputs.operation == 'rollback'
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TARGET: ${{ inputs.target }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
-          FINANCE_VERSION_ID="$(npx --yes wrangler@4.112.0 versions list --config finance/wrangler.toml "${ENV_ARGS[@]}" --json | node -e "const fs=require('fs');const versions=JSON.parse(fs.readFileSync(0,'utf8'));const found=versions.find(x=>x.message===('finance:deploy:'+process.env.RELEASE_SHA));if(!found?.id)process.exit(1);process.stdout.write(found.id)")"
+          FINANCE_VERSION_ID="$(npx --yes wrangler@4.112.0 versions list --config finance/wrangler.toml "${ENV_ARGS[@]}" --json | node -e "const fs=require('fs');const versions=JSON.parse(fs.readFileSync(0,'utf8'));const expected='finance:deploy:'+process.env.RELEASE_SHA;const found=versions.find(x=>(x.message||x.annotations?.['workers/message'])===expected);if(!found?.id)process.exit(1);process.stdout.write(found.id)")"
           [[ -n "$FINANCE_VERSION_ID" ]] || { echo 'No prior Finance version for requested SHA'; exit 1; }
           echo "FINANCE_VERSION_ID=$FINANCE_VERSION_ID" >> "$GITHUB_ENV"
       - name: Deploy only the selected Finance version


### PR DESCRIPTION
Fixes the staging Finance rollback path found by run 30138663286 before version switch. Supplies Cloudflare auth to the rollback lookup and supports the current Wrangler version annotation shape while retaining the immutable SHA selection. No data, flags, grants or production changes. Validation: git diff --check; CI required checks.