### PR TITLE
docs(ops): record Finance staging rollback evidence

### DIFF
--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -17,3 +17,20 @@ rollback/restore and its separate nominal gate remain required before any pilot.
 
 Finance pilot activation remains separately blocked by current staging evidence
 and named human approval; it is frozen independently of the resolved P0 item.
+
+## Finance staging gate — current status
+
+The current-main SHA `8af1d5fe9551891a05a104363043bf3d36fb4ef4` has a successful
+candidate (`30139535704`), preview (`30139561027`) and staging deployment
+(`30139576133`) with Worker version
+`97c7a7da-6a78-44a8-b980-2cc2810df7a0`. A controlled rollback (`30139701809`)
+restored immutable SHA `67ee53843a9a52ad495ab6d67b8cd2b4fac053f9` using Worker
+version `c57fdafc-6045-4eb5-8b38-07ae98d7c256`; health stayed ready and no
+migrations or unrelated modules were touched. The synthetic canary abort drill
+(`30139247054`) also proved the remote kill switch and baseline restoration.
+
+These staging gates are now evidenced, but they do not unlock the pilot. The
+remaining blockers are authenticated import/UI smoke, an external monitor with
+human alert evidence, encrypted offsite backup plus restore for the
+current-main artifact, and named approval. `module_enabled` remains false and
+no real user or unit is enabled.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,55 @@
 # Current state
 
+## Finance staging rollback gate — 2026-07-25
+
+The Finance staging release was re-run from the current `origin/main` SHA
+`8af1d5fe9551891a05a104363043bf3d36fb4ef4`, not from a historical candidate.
+The immutable candidate run `30139535704` and Finance preview run
+`30139561027` passed. Staging run `30139576133` passed with migrations,
+encrypted D1 checkpoint, immutable Worker upload and health smoke. It created
+Worker version `97c7a7da-6a78-44a8-b980-2cc2810df7a0`, whose deployment message
+attests the exact current-main SHA. No production target was selected.
+
+The controlled rollback run `30139701809` restored the known immutable
+predecessor SHA `67ee53843a9a52ad495ab6d67b8cd2b4fac053f9` using preview
+evidence `30138491542`. It resolved and deployed the previously uploaded
+version `c57fdafc-6045-4eb5-8b38-07ae98d7c256` at 100% without applying
+migrations or publishing another module. The staging health endpoint returned
+`200`, `ready=true`, D1 and module-control healthy, and version `67ee…`.
+The rollback workflow elapsed from `02:03:07Z` to `02:05:02Z` (approximately
+115 seconds; this is workflow elapsed time, not a user-visible outage RTO).
+The current staging control state is `module_enabled=false`; no pilot actor or
+unit was enabled.
+
+The canary abort drill `30139247054` is valid synthetic evidence: it opened a
+remote KV canary, ran the authenticated synthetic journey, injected one
+controlled error, recorded `breaches=["errors"]`, executed the kill switch and
+restored the baseline. Its non-zero conclusion is intentional promotion
+interruption. Final remote KV was verified `state=active` and staging D1
+`module_enabled=false`. The earlier run `30139009328` is superseded because
+its KV writes were local rather than remote; PR #796 corrected this and was
+merged before the valid retry.
+
+The scratch restore drill imported the staging Finance D1 export into the
+isolated scratch database `9565bd3b-b9bc-4d7e-95d9-135490a3599e` from export
+SHA-256 `a24db616e94e156c7da5a26a319094b210e7c078a80df11ce0648bea36c9692a`.
+Sanitized counts/checksums matched for audit events (13/468), movements
+(0/0), journal lines (0/0), import batches (0/0), `d1_migrations` (12/407),
+settings (1/19) and grants (1/56). The scratch KV namespace was
+`8024e25c0b3d4eb0a82805bb38781bd4`; its synthetic control flag round-tripped
+with `releaseSha=fdf8cda…` and `syntheticOnly=true`. Finance has no R2 binding
+in its current Wrangler configuration, and no `finance_release_migrations`
+table exists; the journal of record is `d1_migrations`. These are explicit
+scope limitations, not inferred restores.
+
+The scratch D1 and KV resources were temporary staging-only resources and were
+deleted after evidence capture at approximately `2026-07-25T02:07Z` (D1
+`9565bd3b-b9bc-4d7e-95d9-135490a3599e`, KV
+`8024e25c0b3d4eb0a82805bb38781bd4`). Production Finance, flags, grants, users and
+business data remain untouched. Finance pilot remains blocked pending the
+separate authenticated UI/import smoke, external monitor/human alert,
+encrypted offsite backup/restore evidence and named approval.
+
 ## Current Inventory production evidence — 2026-07-25
 
 The deployable release is the explicit immutable `RELEASE_SHA`

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,43 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T02:05:02Z",
+      "surface": "github-cloudflare-staging",
+      "scope": "Finance current-main deploy and immutable rollback",
+      "state": "staging-validated-rollback",
+      "method": "Candidate 30139535704, Finance preview 30139561027, staging deploy 30139576133 and rollback 30139701809; explicit release SHA inputs; Wrangler deployment metadata and /health probe",
+      "result": "Current main SHA 8af1d5fe9551891a05a104363043bf3d36fb4ef4 was deployed as Worker version 97c7a7da-6a78-44a8-b980-2cc2810df7a0. Rollback restored prior immutable SHA 67ee53843a9a52ad495ab6d67b8cd2b4fac053f9 via version c57fdafc-6045-4eb5-8b38-07ae98d7c256 at 100%; health returned 200 and ready=true. No migrations ran during rollback and no other unit was published.",
+      "limitation": "Elapsed workflow time was approximately 115 seconds and is not a user-visible outage RTO. Finance production, users, grants and flags were not touched.",
+      "sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
+      "runs": [30139535704,30139561027,30139576133,30139701809],
+      "rollback": {
+        "sha": "67ee53843a9a52ad495ab6d67b8cd2b4fac053f9",
+        "version": "c57fdafc-6045-4eb5-8b38-07ae98d7c256",
+        "preview_run": 30138491542
+      }
+    },
+    {
+      "observed_at": "2026-07-25T01:50:13Z",
+      "surface": "github-cloudflare-staging",
+      "scope": "Finance synthetic canary abort and kill switch",
+      "state": "validated-controlled-abort",
+      "method": "finance-staging-canary run 30139247054 in abort-drill mode with remote KV writes, synthetic authenticated journey, threshold evaluation and baseline restoration",
+      "result": "One deliberate error breached the errors threshold; the run recorded breaches=[errors], interrupted promotion, executed the kill switch and restored the baseline. Final remote KV was state=active and staging D1 module_enabled=false.",
+      "limitation": "The failed conclusion is expected for an abort drill. No production actor or data was used.",
+      "sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
+      "run": 30139247054
+    },
+    {
+      "observed_at": "2026-07-25T01:56:00Z",
+      "surface": "cloudflare-staging-scratch",
+      "scope": "Finance D1 and KV scratch restore",
+      "state": "validated-destroyed-after-evidence",
+      "method": "Remote D1 export/import, sanitized count/checksum queries and remote KV flag round trip in isolated temporary resources",
+      "result": "D1 export SHA-256 a24db616e94e156c7da5a26a319094b210e7c078a80df11ce0648bea36c9692a restored database 9565bd3b-b9bc-4d7e-95d9-135490a3599e. Counts/checksums matched: audit 13/468, movements 0/0, journal lines 0/0, import batches 0/0, d1_migrations 12/407, settings 1/19 and grants 1/56. KV namespace 8024e25c0b3d4eb0a82805bb38781bd4 round-tripped the synthetic flag.",
+      "limitation": "No R2 binding exists in the Finance configuration and no finance_release_migrations table exists; the journal is d1_migrations. Scratch resources contained no production data and were deleted after capture at approximately 2026-07-25T02:07Z.",
+      "sha": "67ee53843a9a52ad495ab6d67b8cd2b4fac053f9"
+    },
+    {
       "observed_at": "2026-07-25T01:15:00Z",
       "surface": "crm-and-production",
       "scope": "P0 Insumos production promotion and authenticated read-only smoke",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -61,17 +61,21 @@
       "id": "finance-staging-gate",
       "objective": "Close Finance staging gates without enabling production or real users.",
       "priority": 100,
-      "state": "blocked",
-      "dependencies": ["p0-insumos-unit-access"],
+      "state": "partially-validated",
+      "dependencies": [],
       "blockers": [
-        "P0 Insumos real-actor correlation and production gate",
         "authenticated import and UI smoke",
         "external monitor and human alert",
         "encrypted offsite D1 backup",
-        "isolated restore drill"
+        "isolated restore drill for the current-main artifact",
+        "named human approval"
       ],
       "environment": "staging",
-      "permitted_actions": ["none while P0 is blocked and until all Finance staging gates are evidenced"],
+      "permitted_actions": [
+        "staging-only rollback and kill-switch drills",
+        "staging-only scratch restore with synthetic data",
+        "read-only evidence capture"
+      ],
       "required_evidence": [
         "authenticated import and UI smoke",
         "external monitor and human alert",
@@ -83,9 +87,21 @@
       ],
       "done_definition": "All required staging evidence is current; production remains disabled.",
       "next_item": "finance-pilot-approval",
-      "last_verified": "2026-07-24T22:20:00Z",
-      "sha": "1a1a586feaf99ed542f386b245b8b748a03bac4b",
-      "pr": 762
+      "last_verified": "2026-07-25T02:05:02Z",
+      "sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
+      "pr": 762,
+      "evidence": {
+        "candidate_run": 30139535704,
+        "preview_run": 30139561027,
+        "staging_deploy_run": 30139576133,
+        "staging_release_sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
+        "staging_worker_version": "97c7a7da-6a78-44a8-b980-2cc2810df7a0",
+        "rollback_run": 30139701809,
+        "rollback_sha": "67ee53843a9a52ad495ab6d67b8cd2b4fac053f9",
+        "rollback_worker_version": "c57fdafc-6045-4eb5-8b38-07ae98d7c256",
+        "canary_abort_drill": 30139247054,
+        "scratch_restore": "validated; resources destroyed after sanitized evidence"
+      }
     },
     {
       "id": "finance-pilot-approval",


### PR DESCRIPTION
## Escopo\n- registra o deploy do SHA atual da main em staging e o rollback para artefato imutável conhecido;\n- registra canary abort-drill/kill switch remoto e scratch restore sanitizado;\n- atualiza estado, evidence ledger, blockers e fila do orquestrador.\n\n## Segurança\n- staging-only; nenhum deploy, flag, grant, usuário ou dado de produção alterado;\n- scratch D1/KV temporários destruídos após checksums.\n\n## Validação\n- workflows 30139535704, 30139561027, 30139576133 e 30139701809 verdes;\n- canary abort 30139247054 falha intencionalmente após restaurar baseline;\n- health Finance staging 200/ready; git diff --check; JSON parse.\n\nFinance permanece bloqueado para piloto até UI/import smoke, monitor externo/human alert, backup offsite/restore do artefato atual e aprovação nominal.