### PR TITLE
docs(ops): reconcile Inventory release SHA evidence

### DIFF
--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -34,3 +34,12 @@ remaining blockers are authenticated import/UI smoke, an external monitor with
 human alert evidence, encrypted offsite backup plus restore for the
 current-main artifact, and named approval. `module_enabled` remains false and
 no real user or unit is enabled.
+
+Inventory production is stable on the single reconciled `RELEASE_SHA`
+`c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d`. The additive
+`0017_employee_onboarding.sql` migration is present in the journal with zero
+onboarding payloads; no new promotion is required. `IDENTITY_PII_KEY` exists in
+the staging and production GitHub environments, but external vault/escrow and
+recovery ownership for the generated production key are not evidenced. This is
+an operational security debt and must be closed before onboarding data is
+created or the key is rotated; it does not justify another production deploy.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,36 @@
 # Current state
 
+## Inventory release-SHA reconciliation — 2026-07-25
+
+The old candidate `cb04cb8b8ca87353c4c672fa5707bf3d36fb4ef4` is not the
+authorized production SHA: the delta to `c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d`
+contains the additive Identity onboarding migration and runtime compatibility
+changes. The production release therefore correctly used the newer immutable
+SHA `c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d`.
+
+The delta from `c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d` to the current main
+`d006157297c02e2a7bace9fcd1abad654b546d06` contains only workflow/preflight,
+Finance canary/rollback, orchestration and evidence-documentation changes:
+`.github/workflows/*`, `scripts/codex-preflight.sh`,
+`docs/project-state/*` and `ops/project-orchestration/work-queue.json`. It
+contains no Inventory/Identity/CRM frontend runtime, migration, binding or
+deployable Pages artifact change. `c64ff2…` remains the single authorized
+`RELEASE_SHA`; no new Inventory/Pages promotion is required.
+
+The exact production workflow inputs prove the same release lineage: Inventory
+run `30137182608` used `RELEASE_SHA=c64ff2…` and staging predecessor
+`30135788180`; Pages run `30137826907` stamped `GIT_SHA=c64ff2…`. Active
+production resources are Inventory deployment
+`2a71e616-64fc-40ff-8480-5c24fad4497e` / Worker version
+`6d7dadc6-7b02-4577-b8b3-d1d4a09cd9ef` and Pages deployment
+`e65832a0-5925-4212-b252-2ff20cd08362`, source `c64ff2…`.
+
+The Inventory promotion did apply the additive
+`0017_employee_onboarding.sql` migration. A current read-only D1 query finds
+the journal row and zero onboarding rows / zero encrypted-email or phone rows;
+`d1 migrations list` now reports no pending migrations. This supersedes the
+earlier wording that the promotion had no migrations to apply.
+
 ## Finance staging rollback gate — 2026-07-25
 
 The Finance staging release was re-run from the current `origin/main` SHA
@@ -62,11 +93,14 @@ candidate, preview and staging runs (`30135641022`, `30135763050`,
 `30135790724` is not release evidence.
 
 `IDENTITY_PII_KEY` was classified as case 3 after read-only schema and source
-review: the compatibility path is present, but production D1 has no
-`crm_employee_onboarding` or `crm_identity_sessions` tables and no encrypted
-payload was evidenced. A new CSPRNG value was provisioned only to the GitHub
-`production` environment on 2026-07-25T00:40:42Z; the value is not stored or
-printed here. No production data, user, grant or feature flag was changed.
+review. The additive `crm_employee_onboarding` table now exists, but production
+D1 has zero onboarding rows and zero encrypted personal-email/phone payloads;
+`crm_identity_sessions` is absent. A fresh CSPRNG value was provisioned only to
+the GitHub `production` environment on 2026-07-25T00:40:42Z; the value is not
+stored or printed here. The staging and production secret names are present,
+but an external vault/escrow record for the generated production key is not
+evidenced and remains an operational security debt. No production user, grant
+or feature flag was changed.
 
 The clean preflight from an archive of current `origin/main`
 `cb658ad1e25413c2a307c846c9be99d1207eabb5` completed with
@@ -76,7 +110,8 @@ secrets and variables, workflow inventory and live health endpoints.
 ### Production promotion and checkpoints
 
 * Inventory/Core Workers: canonical run `30137182608`, explicit checkout and
-  `RELEASE_SHA` `c64ff2b`; migration step reported no pending migrations. The
+  `RELEASE_SHA` `c64ff2b`; migration `0017_employee_onboarding.sql` applied
+  successfully, and a subsequent read-only check reports no pending migrations. The
   active deployment is `2a71e616-64fc-40ff-8480-5c24fad4497e`, Worker version
   `6d7dadc6-7b02-4577-b8b3-d1d4a09cd9ef` (version 5135), at 100% traffic.
 * CRM Pages: canonical corrected run `30137826907`, explicit checkout and

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,39 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T02:15:00Z",
+      "surface": "github-cloudflare-production",
+      "scope": "Inventory definitive release SHA reconciliation",
+      "state": "production-stable-single-release",
+      "method": "Git diff/name-status between cb04cb8b8ca87353c4c672fa5707bf2d5a9fcecb, c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d and current main d006157297c02e2a7bace9fcd1abad654b546d06; production workflow log 30137182608; Pages run 30137826907; live health probes and read-only D1 journal/count query",
+      "result": "cb04 is superseded by runtime Identity onboarding changes in the c64 delta. The c64-to-current-main delta contains only workflow/preflight, Finance, orchestration and evidence-documentation files, with no Inventory/Identity/CRM runtime, migration, binding or Pages artifact change. c64 remains the unique authorized RELEASE_SHA. Inventory run 30137182608 explicitly used c64 and Pages run 30137826907 stamped c64; active Worker 6d7dadc6-7b02-4577-b8b3-d1d4a09cd9ef and Pages deployment e65832a0-5925-4212-b252-2ff20cd08362 correspond to that release. Inventory health is HTTP 200/ready=true; CRM health is HTTP 200.",
+      "limitation": "Readiness/version/dependencies are authentication-protected and returned 401 without a session; health and deployment metadata are the available public evidence. No new deploy was run.",
+      "release_sha": "c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d",
+      "runs": [30137182608,30137826907]
+    },
+    {
+      "observed_at": "2026-07-25T02:15:00Z",
+      "surface": "cloudflare-production-d1",
+      "scope": "Inventory migration and onboarding data verification",
+      "state": "migration-applied-zero-payload",
+      "method": "Production workflow log plus read-only wrangler d1 migrations list and SELECT COUNT query",
+      "result": "Run 30137182608 applied additive migration 0017_employee_onboarding.sql. Current D1 journal contains that migration; d1 migrations list reports no pending migrations; onboarding rows, encrypted-email rows and encrypted-phone rows are all zero. No data was written by the verification query.",
+      "limitation": "The migration is part of the already deployed c64 release and was not re-run in this audit.",
+      "release_sha": "c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d",
+      "run": 30137182608
+    },
+    {
+      "observed_at": "2026-07-25T02:15:00Z",
+      "surface": "github-environments-and-source",
+      "scope": "IDENTITY_PII_KEY contract re-audit",
+      "state": "present-zero-production-payload-external-escrow-unproven",
+      "method": "Source inspection of Inventory/Identity AES-GCM adapters, deploy-core-workers workflow, secret-name metadata for staging and production, and read-only production D1 counts",
+      "result": "The workflow reads IDENTITY_PII_KEY from the environment-scoped secret and forwards it to the Inventory Worker. Both Inventory encryption and Identity decryption derive a SHA-256 32-byte AES-GCM key; ciphertext format is v1.<base64url-12-byte-IV>.<base64url-ciphertext>. Production and staging secret names exist. Production onboarding payload count is zero.",
+      "limitation": "The generated production value is intentionally not read or logged. An external authorized vault/escrow source and recovery owner are not evidenced; do not rotate or copy the key until that control is established.",
+      "secret_names": ["IDENTITY_PII_KEY"],
+      "environment_scopes": ["staging", "production"]
+    },
+    {
       "observed_at": "2026-07-25T02:05:02Z",
       "surface": "github-cloudflare-staging",
       "scope": "Finance current-main deploy and immutable rollback",


### PR DESCRIPTION
## Escopo\n- reconcilia cb04, c64 e a main atual;\n- confirma c64 como único RELEASE_SHA autorizado para Inventory e Pages;\n- corrige a evidência da migration 0017, que foi aplicada no deploy e hoje não tem pendências;\n- registra o contrato de IDENTITY_PII_KEY e o débito de escrow externo sem expor o valor.\n\n## Evidência\n- Inventory production run 30137182608 (release_sha c64);\n- Pages production run 30137826907 (GIT_SHA c64);\n- D1: migration journal 0017, zero onboarding payloads, zero alterações na consulta;\n- health Inventory 200/ready=true e CRM health 200.\n\nNenhum deploy, secret, usuário, grant, flag ou dado foi alterado nesta PR.