### PR TITLE
docs(evidence): record Drive quota blocker

### DIFF
--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -27,6 +27,13 @@ the two large Drive objects was not captured because the connector exceeded
 its IPC limit. The complete offsite gate therefore remains open. No module
 promotion, flag, grant or production change is authorized by this evidence.
 
+A follow-up streaming attempt with rclone 1.60.1 reached the same restricted
+Drive vault but was rejected with provider `RATE_LIMIT_EXCEEDED`; it downloaded
+no bytes and changed no state. The next action is to wait for the quota window
+or use an authorized service account, then repeat hash verification and scratch
+restore. This is an external-provider blocker, not a reason to activate
+Finance.
+
 The current-main SHA `8af1d5fe9551891a05a104363043bf3d36fb4ef4` has a successful
 candidate (`30139535704`), preview (`30139561027`) and staging deployment
 (`30139576133`) with Worker version

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -26,6 +26,11 @@ objects through a streaming client, then repeat the Finance-specific artifact
 restore in staging. Do not promote production or activate pilot until both
 evidences and the nominal package are approved.
 
+The first streaming attempt with rclone 1.60.1 was rejected by Google Drive
+with `RATE_LIMIT_EXCEEDED` before any bytes were downloaded. It made no
+external or repository mutation; the blocker is the provider quota window or
+the need for an authorized service-account client.
+
 ## Inventory release-SHA reconciliation — 2026-07-25
 
 The old candidate `cb04cb8b8ca87353c4c672fa5707bf3d36fb4ef4` is not the

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,16 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T03:08:00Z",
+      "surface": "google-drive-offsite-stream",
+      "scope": "Fresh streamed retrieval of large recovery payloads",
+      "state": "blocked-provider-quota",
+      "method": "rclone 1.60.1 using the existing private drive.file config, 10s connect/transfer timeout, one retry and no output of credentials",
+      "result": "The streaming client reached Google Drive but the provider returned RATE_LIMIT_EXCEEDED for drive.googleapis.com/default. No payload was downloaded, decrypted, uploaded or deleted by this attempt.",
+      "limitation": "A fresh auditable download of PostgreSQL and runtime-config remains unproven until the Drive quota window resets or an authorized provider account/streaming client is supplied. No production, D1, flags, grants or Finance users were touched.",
+      "next_action": "Retry from a quota-authorized service account or after the provider quota window resets; preserve the same manifest/key and verify hashes before scratch restore."
+    },
+    {
       "observed_at": "2026-07-25T02:30:32Z",
       "surface": "google-drive-offsite-scratch",
       "scope": "Offsite recovery drill — platform payloads",


### PR DESCRIPTION
## Summary\n- Record the real streaming attempt and provider RATE_LIMIT_EXCEEDED result.\n- Keep the Finance offsite and pilot gates explicit; no payload or production state changed.\n\n## Validation\n- evidence-ledger.json parses\n- git diff --check\n\nNo deploy, data, flag or grant changes.