### PR TITLE
fix(ci): sync staging onboarding mail secrets

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -98,6 +98,12 @@ jobs:
           FINANCE_SERVICE_AUTH_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
           IDENTITY_PII_KEY: ${{ secrets.IDENTITY_PII_KEY }}
           IDENTITY_WORKFORCE_HMAC_KEY: ${{ secrets.IDENTITY_WORKFORCE_HMAC_KEY }}
+          AUTH_RESET_SMTP_HOST: ${{ secrets.AUTH_RESET_SMTP_HOST }}
+          AUTH_RESET_SMTP_PORT: ${{ secrets.AUTH_RESET_SMTP_PORT }}
+          AUTH_RESET_SMTP_USERNAME: ${{ secrets.AUTH_RESET_SMTP_USERNAME }}
+          AUTH_RESET_SMTP_PASSWORD: ${{ secrets.AUTH_RESET_SMTP_PASSWORD }}
+          AUTH_RESET_EMAIL_FROM: ${{ secrets.AUTH_RESET_EMAIL_FROM }}
+          AUTH_RESET_CODE_PEPPER: ${{ secrets.AUTH_RESET_CODE_PEPPER }}
           TARGET: ${{ inputs.target }}
           UNIT: ${{ inputs.unit }}
           BOOTSTRAP_FINANCE_CONTEXT: ${{ inputs.bootstrap_finance_context }}
@@ -122,6 +128,25 @@ jobs:
             for name in IDENTITY_PII_KEY IDENTITY_WORKFORCE_HMAC_KEY; do
               printf '%s' "${!name}" | npx --yes wrangler@3 secret put "$name" --config inventory/wrangler.toml "${env_args[@]}" >/dev/null
             done
+            if [[ "$TARGET" == "staging" ]]; then
+              # Email delivery is optional for ordinary Worker deploys, but a
+              # partial configuration must fail closed. No production mail
+              # secret is ever selected by this staging-only branch.
+              mail_values=("$AUTH_RESET_SMTP_HOST" "$AUTH_RESET_SMTP_USERNAME" "$AUTH_RESET_SMTP_PASSWORD" "$AUTH_RESET_EMAIL_FROM" "$AUTH_RESET_CODE_PEPPER")
+              configured=0
+              for value in "${mail_values[@]}"; do [[ -n "$value" ]] && configured=$((configured + 1)); done
+              if [[ "$configured" == "0" ]]; then
+                echo 'Staging onboarding email transport is not configured; invite/recovery smoke remains blocked.'
+              elif [[ "$configured" != "${#mail_values[@]}" ]]; then
+                echo 'Partial staging onboarding email transport configuration; refusing to deploy.'
+                exit 1
+              else
+                for name in AUTH_RESET_SMTP_HOST AUTH_RESET_SMTP_PORT AUTH_RESET_SMTP_USERNAME AUTH_RESET_SMTP_PASSWORD AUTH_RESET_EMAIL_FROM AUTH_RESET_CODE_PEPPER; do
+                  [[ -n "${!name:-}" ]] || continue
+                  printf '%s' "${!name}" | npx --yes wrangler@3 secret put "$name" --config inventory/wrangler.toml --env staging >/dev/null
+                done
+              fi
+            fi
             npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars "${env_args[@]}"
           fi
           if [[ "$UNIT" == "api" || "$UNIT" == "all" ]]; then


### PR DESCRIPTION
﻿## Objetivo
Desbloquear o transporte de convites/recupera??o do onboarding hier?rquico em staging sem reimplementar a funcionalidade da PR #799.

## Altera??o
- sincroniza os seis segredos `AUTH_RESET_*` do ambiente GitHub `staging` para o Worker Inventory somente quando o alvo ? staging;
- configura??o ausente permanece expl?cita e n?o bloqueia deploy t?cnico, mas mant?m o smoke de convite/recupera??o bloqueado;
- configura??o parcial falha fechada;
- nenhum segredo de produ??o ? selecionado ou reutilizado.

## Seguran?a e escopo
- um ?nico workflow versionado: `.github/workflows/deploy-core-workers.yml`;
- nenhum valor sens?vel foi inclu?do neste PR;
- n?o h? altera??o de produ??o, D1 ou dados de neg?cio;
- o provedor SMTP de staging ainda precisa ser aprovado e configurado separadamente.

## Valida??o
CI deve validar o workflow e os gates can?nicos. Ap?s merge, repetir preview e Workforce/Core staging; o smoke completo s? ser? aprovado ap?s a configura??o do provedor de e-mail de teste.
