### PR TITLE
docs(inventory): record post-803 staging observation

### DIFF
--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -20,8 +20,8 @@ and named human approval; it is frozen independently of the resolved P0 item.
 
 ## Finance staging gate — current status
 
-PR #740 is integrated; follow-up state/evidence PRs #800, #801 and #802 leave
-main at `11bbde1928d8e59e1164ebd64f0c820a740195b0`.
+PR #740 is integrated; follow-up state/evidence PRs #800, #801, #802 and #804
+leave main at `fe0ccbee28ad36e0444937a553a8c11cb48112d8`.
 The offsite drill now has valid D1 retrieval/restore evidence and matching
 PostgreSQL/configuration ciphertext hashes, but a fresh streamed download of
 the two large Drive objects was not captured because the connector exceeded

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -3,7 +3,7 @@
 ## Inventory release reconciliation and `IDENTITY_PII_KEY` audit — 2026-07-25
 
 Fresh source-of-truth check is based on `origin/main`
-`6e6dd5bb97c27fb070a73c4aeae747a986e4bbc9` and the production/staging
+`fe0ccbee28ad36e0444937a553a8c11cb48112d8` and the production/staging
 metadata available at 2026-07-25T03:26Z. PR #787 itself contains only
 `docs/project-state/current-state.md`, `docs/project-state/evidence-ledger.json`
 and `ops/project-orchestration/work-queue.json`; it does not change Inventory,
@@ -48,6 +48,14 @@ retain the previous key until all ciphertexts are re-encrypted and verified.
 The clean current-main `scripts/codex-preflight.sh` run passed with
 `failures=0 warnings=0`. The remaining action is administrative evidence of
 external custody, not another Inventory deploy.
+
+After PR #803, the canonical workflows produced new staging-only evidence for
+the workflow-sync SHA `6e6dd5bb97c27fb070a73c4aeae747a986e4bbc9`: core-all
+preview/staging `30142251628`/`30142271109`, CRM Pages preview/staging
+`30142340101`/`30142359030`, and core-inventory preview/staging
+`30142438522`/`30142457474`. These runs used target `staging` and did not
+publish production. They do not replace the already active `c64ff2…` release;
+the runtime files are unchanged and no new production promotion is required.
 
 ## Offsite restore evidence and next Finance gate — 2026-07-25
 

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,18 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T03:36:00Z",
+      "surface": "github-cloudflare-staging",
+      "scope": "Post-PR-803 staging-only verification and production observation",
+      "state": "staging-current-workflow-sync-production-unchanged",
+      "method": "Canonical preview/staging workflow logs with explicit target and release SHA; production run list; Wrangler deployment status; read-only health probes",
+      "result": "Core-all preview/staging 30142251628/30142271109, CRM Pages preview/staging 30142340101/30142359030 and core-inventory preview/staging 30142438522/30142457474 used SHA 6e6dd5bb97c27fb070a73c4aeae747a986e4bbc9 and target staging. No production target was selected. Production remains Inventory RELEASE_SHA c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d, Worker version 6d7dadc6-7b02-4577-b8b3-d1d4a09cd9ef and Pages deployment e65832a0-5925-4212-b252-2ff20cd08362; /insumos/health and CRM health returned 200.",
+      "limitation": "The staging runs validate workflow-only changes and are not a new production release candidate. No production deploy, migration, flag, grant, user or data mutation was performed.",
+      "release_sha": "c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d",
+      "staging_workflow_sha": "6e6dd5bb97c27fb070a73c4aeae747a986e4bbc9",
+      "runs": [30142251628, 30142271109, 30142340101, 30142359030, 30142438522, 30142457474]
+    },
+    {
       "observed_at": "2026-07-25T03:26:00Z",
       "surface": "github-cloudflare-production-staging",
       "scope": "Inventory candidate reconciliation and IDENTITY_PII_KEY contract",


### PR DESCRIPTION
Atualiza o estado após o merge da PR #804 e registra os previews/staging explícitos do PR #803. Confirma que todos os novos runs foram staging-only, que o Inventory/Pages de produção continuam no RELEASE_SHA c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d, e que health/readiness operacional permanecem saudáveis. Sem deploy de produção, migration, flag, grant, usuário ou dado alterado. Validações: JSON ledger/queue, git diff --check.