### PR TITLE
docs(recovery): record offsite streaming blocker

### DIFF
--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -20,6 +20,14 @@ and named human approval; it is frozen independently of the resolved P0 item.
 
 ## Finance staging gate — current status
 
+The fresh offsite retry at 2026-07-25T04:55Z did not close the remaining
+transfer gate. Drive metadata and the four expected objects were visible, but
+the connector's raw PostgreSQL download exceeded its IPC frame limit; the
+private rclone/direct-token attempts could not list or read the folder (403 or
+directory-not-found). No payload, secret, production data or scratch resource
+was changed. Existing local ciphertexts remain manifest-matched only and must
+not be relabeled as a fresh offsite restore.
+
 The current-main rollback/restore exercise is now complete for candidate SHA
 `b869485b6a33fae5a5dbe504b41660f842fb4ca9`. Worker preview/staging runs
 `30143039262`/`30143051826` promoted it, rollback `30143185583` restored the

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,25 @@
 # Current state
 
+## Offsite retrieval retry — 2026-07-25T04:55Z
+
+The provider-separated Drive folder and four recovery objects remain present
+and accessible by metadata: `20260724T0620Z-manifest.json`, D1, PostgreSQL and
+runtime-config ciphertexts. A fresh connector download of the PostgreSQL object
+returned a provider file reference, but a raw fetch exceeded the connector IPC
+frame limit (121,214,224 bytes versus 67,108,864). A second direct streaming
+attempt using the private `drive.file` rclone credential could not list the
+folder, and the direct API token path returned HTTP 403. No bytes were written,
+decrypted, restored, uploaded or deleted by these attempts; temporary private
+credential copies and the empty output file were removed.
+
+The local encrypted ciphertexts still match the prior manifest evidence, but
+that is not a fresh offsite transfer. Consequently the Finance backup gate is
+still **unproven** for PostgreSQL/runtime-config transfer. Do not promote or
+activate Finance on this evidence. The smallest safe resolution is an
+authorized Drive service account or provider-approved streaming path that can
+retrieve the two large objects in chunks, followed by hash verification and a
+scratch restore.
+
 ## Orchestrator continuation audit — 2026-07-25T04:44Z
 
 The attached production-cycle instructions were re-read and reconciled against

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,16 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-25T04:55:00Z",
+      "surface": "google-drive-offsite-stream",
+      "scope": "Fresh PostgreSQL/runtime-config retrieval retry",
+      "state": "blocked-provider-transfer",
+      "method": "Drive folder metadata/list, connector download reference, raw connector fetch attempt, private rclone drive.file listing and direct token range probe; temporary private artifacts removed",
+      "result": "The provider folder and manifest/D1/PostgreSQL/runtime-config objects are visible by metadata. Connector download returned a provider file reference, but raw retrieval exceeded the 64 MiB IPC frame limit (121214224 bytes). rclone could not list the restricted folder and the direct API path returned HTTP 403 at byte zero. No bytes were written, decrypted, restored, uploaded or deleted by this retry.",
+      "limitation": "The local encrypted PostgreSQL/runtime-config copies still match the prior manifest, but this retry does not prove a fresh offsite transfer. Finance backup/recovery and pilot gates remain open.",
+      "next_action": "Use an authorized provider-approved service account or chunked streaming client with access to the recovery folder, then hash and scratch-restore both objects."
+    },
+    {
       "observed_at": "2026-07-25T04:44:28Z",
       "surface": "git-github-cloudflare-production",
       "scope": "Continuation audit of attached Inventory/Identity/Finance production-cycle instructions",


### PR DESCRIPTION
## Summary\n- record fresh Drive metadata and streaming attempts\n- preserve the IPC/provider transfer limitation as an open Finance gate\n- document that no payload, secret, production data or scratch resource changed\n\n## Safety\nDocumentation/evidence only.\n\n## Validation\n- jq empty docs/project-state/evidence-ledger.json\n- npm run architecture:validate\n- npm run observability:validate\n- npm run module-maturity:validate\n- npm run staging:manifest:validate\n- npm run staging:scripts:validate\n- git diff --check