### PR TITLE
fix(crm): ativar módulo Clientes online

### DIFF
--- a/crm/console/moduleAvailability.ts
+++ b/crm/console/moduleAvailability.ts
@@ -13,6 +13,7 @@ export const DEFAULT_UNLOCKED_MODULE_KEYS = [
   'insumos',
   'conversa',
   'atendimento',
+  'clientes',
   'caixa',
   'faturamento',
   'procedimentos',

--- a/crm/console/tests/moduleAvailability.test.ts
+++ b/crm/console/tests/moduleAvailability.test.ts
@@ -9,10 +9,12 @@ describe('module availability', () => {
       expect(unlocked.has(key)).toBe(false)
     }
     expect(unlocked.has('atendimento')).toBe(true)
+    expect(unlocked.has('clientes')).toBe(true)
   })
 
   it('keeps the modules available for local development validation', () => {
     const unlocked = unlockedModuleKeys('insumos', false)
+    expect(unlocked.has('clientes')).toBe(true)
     expect(unlocked.has('caixa')).toBe(true)
     expect(unlocked.has('meta-ads')).toBe(true)
   })


### PR DESCRIPTION
## Mudança\nLibera a aba **Clientes** em crm.skincos.com.br.\n\n## Causa\nO módulo já estava implementado e autorizado para gestores/admins, mas estava ausente da lista de módulos liberados no CRM online.\n\n## Segurança\nA alteração não amplia RBAC: Clientes permanece disponível apenas para perfis GESTOR e ADMIN.\n\n## Validação\n- itest run tests/moduleAvailability.test.ts tests/crmRoleAccess.test.ts (12 testes)\n- 
pm run build no CRM console\n