### PR TITLE
fix(crm): restore strict local gestor validation

### DIFF
--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -81,6 +81,9 @@ fi
 if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
   PAGES_BINDING_ARGS+=(--binding "WA_ORCHESTRATOR_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
 fi
+if [[ -n "${LOCAL_ATENDIMENTO_API_TARGET:-}" ]]; then
+  PAGES_BINDING_ARGS+=(--binding "ATENDIMENTO_API_TARGET=${LOCAL_ATENDIMENTO_API_TARGET}")
+fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/
 if [[ -f "$ROOT_DIR/public/_routes.json" ]]; then

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -689,6 +689,9 @@ fi
 if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
   start_whatsapp_orchestrator_local
   export LOCAL_WA_ORCHESTRATOR_API_TARGET="http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}"
+  # Atendimento e Caixa usam o mesmo adaptador CRM local. Sem este alvo, o
+  # Pages dev herda o endpoint remoto e o perfil local recebe 401 do upstream.
+  export LOCAL_ATENDIMENTO_API_TARGET="$LOCAL_WA_ORCHESTRATOR_API_TARGET"
 fi
 
 if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then

--- a/scripts/run-local-whatsapp-orchestrator.sh
+++ b/scripts/run-local-whatsapp-orchestrator.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Local-only adapter for the CRM Pages shell. It reuses the Evolution credential
-# from the protected native runtime without copying it into the checkout, Pages
-# bindings, browser, or logs.
+# Local-only adapter for the CRM Pages shell. It reuses protected native
+# runtime configuration without copying it into the checkout, Pages bindings,
+# browser, or logs.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${CRM_LOCAL_WA_ORCHESTRATOR_PORT:-8110}"
 ENV_FILE="${CRM_LOCAL_WA_NATIVE_ENV_FILE:-/etc/skincos/crm-whatsapp.env}"
-RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/mnt/c/CodexRuntime/operator/admin/skincos/whatsapp-local-adapter}"
-RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-$(id -un)}"
-SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-/home/$RUN_AS_USER/.cache/skincos/whatsapp-local-adapter/source}"
+CRM_API_ENV_FILE="${CRM_LOCAL_API_NATIVE_ENV_FILE:-/etc/skincos/crm.env}"
+RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-skincos}"
+RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/var/lib/skincos-runtime/crm-local-adapter}"
+SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-$RUNTIME_HOME/source}"
 
 if ! sudo -n test -f "$ENV_FILE"; then
   echo "[whatsapp-local] Configuração nativa ausente: CRM_LOCAL_WA_NATIVE_ENV_FILE" >&2
@@ -22,8 +23,14 @@ if ! sudo -n test -r "$ENV_FILE"; then
   exit 2
 fi
 
+if ! sudo -n test -r "$CRM_API_ENV_FILE"; then
+  echo "[whatsapp-local] Não foi possível ler o ambiente local da API CRM. Configure CRM_LOCAL_API_NATIVE_ENV_FILE ou a permissão local necessária." >&2
+  exit 2
+fi
+
 export LOCAL_WA_ADAPTER_ROOT="$ROOT_DIR"
 export LOCAL_WA_ADAPTER_ENV_FILE="$ENV_FILE"
+export LOCAL_WA_ADAPTER_CRM_API_ENV_FILE="$CRM_API_ENV_FILE"
 export LOCAL_WA_ADAPTER_PORT="$PORT"
 export LOCAL_WA_ADAPTER_RUNTIME_HOME="$RUNTIME_HOME"
 export LOCAL_WA_ADAPTER_SOURCE_HOME="$SOURCE_HOME"
@@ -34,6 +41,7 @@ export LOCAL_WA_ADAPTER_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
 exec sudo -n /usr/bin/env \
   LOCAL_WA_ADAPTER_ROOT="$LOCAL_WA_ADAPTER_ROOT" \
   LOCAL_WA_ADAPTER_ENV_FILE="$LOCAL_WA_ADAPTER_ENV_FILE" \
+  LOCAL_WA_ADAPTER_CRM_API_ENV_FILE="$LOCAL_WA_ADAPTER_CRM_API_ENV_FILE" \
   LOCAL_WA_ADAPTER_PORT="$LOCAL_WA_ADAPTER_PORT" \
   LOCAL_WA_ADAPTER_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME" \
   LOCAL_WA_ADAPTER_SOURCE_HOME="$LOCAL_WA_ADAPTER_SOURCE_HOME" \
@@ -45,10 +53,19 @@ exec sudo -n /usr/bin/env \
   set -a
   # The file belongs to the native runtime. Never print or persist its values.
   source "$LOCAL_WA_ADAPTER_ENV_FILE"
+  # Atendimento/Financeiro run against the private local PostgreSQL mirror.
+  # Load it inside the privileged bootstrap only; it is never copied into the
+  # checkout, Pages bindings, browser, or logs.
+  source "$LOCAL_WA_ADAPTER_CRM_API_ENV_FILE"
   set +a
 
   : "${EVOLUTION_API_URL:?EVOLUTION_API_URL is required in the native WhatsApp environment}"
   : "${EVOLUTION_API_KEY:?EVOLUTION_API_KEY is required in the native WhatsApp environment}"
+  : "${DATABASE_URL:?DATABASE_URL is required in the native CRM API environment}"
+
+  # Pages deliberately sends an unsigned actor only to this loopback runtime.
+  # Do not inherit production actor keys from the native CRM API environment.
+  unset ATENDIMENTO_ACTOR_HMAC_KEY CAIXA_ACTOR_HMAC_KEY ESCALA_ACTOR_HMAC_KEY CRM_ESCALA_HMAC_KEY
 
   install -d -m 0750 -o "$LOCAL_WA_ADAPTER_RUN_AS_USER" -g "$LOCAL_WA_ADAPTER_RUN_AS_USER" \
     "$LOCAL_WA_ADAPTER_RUNTIME_HOME" "$LOCAL_WA_ADAPTER_RUNTIME_HOME/var" \

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -540,7 +540,7 @@ function Start-CrmPersonaRuntime {
     )
     $targetLiteral = Convert-ToBashLiteral -Value $TargetCommit
     if ($Persona -eq "Gestor") {
-        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_GATE_STRICT=0 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
+        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' VITE_CRM_MAINTENANCE_MODULES=faturamento CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
             $targetLiteral, `
             (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
             (Convert-ToBashLiteral -Value $crmGestorPidWsl), `


### PR DESCRIPTION
## Correção\n- restaura o gate estrito do CRM Local (Gestor), removendo o bypass introduzido em #818\n- encaminha as rotas de Atendimento/Clientes ao adaptador loopback local\n- carrega a configuração privada da API CRM somente no bootstrap nativo\n\n## Validação\n- ação \CRM – Local (Gestor)\ executada contra este branch\n- gate local: 13/13 módulos aprovados\n- Clientes, Atendimento, Faturamento e Procedimentos: 0 erros de API e console\n- validação sintática PowerShell e bash aprovada\n\nSem deploy de produção.