### PR TITLE
fix(crm): protect and repair local gestor runtime

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -777,11 +777,15 @@ try {
     console.warn('⚠️  Caixa routes failed to register:', e?.message || String(e))
 }
 
-try {
-    startHarmoniaWorker({ varDir: VAR_DIR })
-    console.log('✅ Harmonia worker initialized')
-} catch (e) {
-    console.warn('⚠️  Harmonia worker failed to start:', e?.message || String(e))
+if (normalizeBoolean(process.env.HARMONIA_WORKER_ENABLED, true)) {
+    try {
+        startHarmoniaWorker({ varDir: VAR_DIR })
+        console.log('✅ Harmonia worker initialized')
+    } catch (e) {
+        console.warn('⚠️  Harmonia worker failed to start:', e?.message || String(e))
+    }
+} else {
+    console.log('ℹ️  Harmonia worker disabled by HARMONIA_WORKER_ENABLED')
 }
 
 // -------------------------------------------------------------
@@ -6949,8 +6953,9 @@ app.use((req, res, next) => {
 
 // CRM Backend API configuration - default port 8099 (separate from frontend on 5000)
 const PORT = process.env.CRM_API_PORT || process.env.PORT || 8099
-app.listen(PORT, '0.0.0.0', () => {
-    console.log(`🚀 CRM Backend API running on http://0.0.0.0:${PORT}`)
+const HOST = process.env.CRM_API_HOST || '0.0.0.0'
+app.listen(PORT, HOST, () => {
+    console.log(`🚀 CRM Backend API running on http://${HOST}:${PORT}`)
     console.log(`📊 Health check: http://localhost:${PORT}/health`)
     console.log(`🎯 API endpoints: http://localhost:${PORT}/api/`)
     console.log(`⚙️  Mode: ${process.env.NODE_ENV || 'development'}`)

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -81,6 +81,9 @@ fi
 if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
   PAGES_BINDING_ARGS+=(--binding "WA_ORCHESTRATOR_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
 fi
+if [[ -n "${LOCAL_ATENDIMENTO_API_TARGET:-}" ]]; then
+  PAGES_BINDING_ARGS+=(--binding "ATENDIMENTO_API_TARGET=${LOCAL_ATENDIMENTO_API_TARGET}")
+fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/
 if [[ -f "$ROOT_DIR/public/_routes.json" ]]; then

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -689,6 +689,9 @@ fi
 if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
   start_whatsapp_orchestrator_local
   export LOCAL_WA_ORCHESTRATOR_API_TARGET="http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}"
+  # Atendimento e Caixa usam o mesmo adaptador CRM local. Sem este alvo, o
+  # Pages dev herda o endpoint remoto e o perfil local recebe 401 do upstream.
+  export LOCAL_ATENDIMENTO_API_TARGET="$LOCAL_WA_ORCHESTRATOR_API_TARGET"
 fi
 
 if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then

--- a/scripts/run-local-whatsapp-orchestrator.sh
+++ b/scripts/run-local-whatsapp-orchestrator.sh
@@ -9,8 +9,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${CRM_LOCAL_WA_ORCHESTRATOR_PORT:-8110}"
 ENV_FILE="${CRM_LOCAL_WA_NATIVE_ENV_FILE:-/etc/skincos/crm-whatsapp.env}"
 CRM_API_ENV_FILE="${CRM_LOCAL_API_NATIVE_ENV_FILE:-/etc/skincos/crm.env}"
-RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-skincos}"
-RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/var/lib/skincos-runtime/crm-local-adapter}"
+RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-admin}"
+# This is an operator-owned QA adapter, never a native service runtime.
+RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/skincos/crm-local-adapter}"
 SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-$RUNTIME_HOME/source}"
 
 if ! sudo -n test -f "$ENV_FILE"; then
@@ -82,6 +83,9 @@ exec sudo -n /usr/bin/env \
   export NODE_ENV=development
   export NO_AUTH=true
   export CRM_LOCAL_NO_AUTH=true
+  # This adapter may read the native database only for local CRM QA. It must
+  # not claim or process native Harmonia work.
+  export HARMONIA_WORKER_ENABLED=false
   export WA_CHANNEL_OWNER_ENFORCED=false
   export WA_ORCHESTRATOR_PROVIDER=evolution
   export CRM_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME"

--- a/scripts/run-local-whatsapp-orchestrator.sh
+++ b/scripts/run-local-whatsapp-orchestrator.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Local-only adapter for the CRM Pages shell. It reuses the Evolution credential
-# from the protected native runtime without copying it into the checkout, Pages
-# bindings, browser, or logs.
+# Local-only adapter for the CRM Pages shell. It reuses protected native
+# runtime configuration without copying it into the checkout, Pages bindings,
+# browser, or logs.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${CRM_LOCAL_WA_ORCHESTRATOR_PORT:-8110}"
 ENV_FILE="${CRM_LOCAL_WA_NATIVE_ENV_FILE:-/etc/skincos/crm-whatsapp.env}"
-RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/mnt/c/CodexRuntime/operator/admin/skincos/whatsapp-local-adapter}"
-RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-$(id -un)}"
-SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-/home/$RUN_AS_USER/.cache/skincos/whatsapp-local-adapter/source}"
+CRM_API_ENV_FILE="${CRM_LOCAL_API_NATIVE_ENV_FILE:-/etc/skincos/crm.env}"
+RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-skincos}"
+RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/var/lib/skincos-runtime/crm-local-adapter}"
+SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-$RUNTIME_HOME/source}"
 
 if ! sudo -n test -f "$ENV_FILE"; then
   echo "[whatsapp-local] Configuração nativa ausente: CRM_LOCAL_WA_NATIVE_ENV_FILE" >&2
@@ -22,8 +23,14 @@ if ! sudo -n test -r "$ENV_FILE"; then
   exit 2
 fi
 
+if ! sudo -n test -r "$CRM_API_ENV_FILE"; then
+  echo "[whatsapp-local] Não foi possível ler o ambiente local da API CRM. Configure CRM_LOCAL_API_NATIVE_ENV_FILE ou a permissão local necessária." >&2
+  exit 2
+fi
+
 export LOCAL_WA_ADAPTER_ROOT="$ROOT_DIR"
 export LOCAL_WA_ADAPTER_ENV_FILE="$ENV_FILE"
+export LOCAL_WA_ADAPTER_CRM_API_ENV_FILE="$CRM_API_ENV_FILE"
 export LOCAL_WA_ADAPTER_PORT="$PORT"
 export LOCAL_WA_ADAPTER_RUNTIME_HOME="$RUNTIME_HOME"
 export LOCAL_WA_ADAPTER_SOURCE_HOME="$SOURCE_HOME"
@@ -34,6 +41,7 @@ export LOCAL_WA_ADAPTER_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
 exec sudo -n /usr/bin/env \
   LOCAL_WA_ADAPTER_ROOT="$LOCAL_WA_ADAPTER_ROOT" \
   LOCAL_WA_ADAPTER_ENV_FILE="$LOCAL_WA_ADAPTER_ENV_FILE" \
+  LOCAL_WA_ADAPTER_CRM_API_ENV_FILE="$LOCAL_WA_ADAPTER_CRM_API_ENV_FILE" \
   LOCAL_WA_ADAPTER_PORT="$LOCAL_WA_ADAPTER_PORT" \
   LOCAL_WA_ADAPTER_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME" \
   LOCAL_WA_ADAPTER_SOURCE_HOME="$LOCAL_WA_ADAPTER_SOURCE_HOME" \
@@ -45,10 +53,19 @@ exec sudo -n /usr/bin/env \
   set -a
   # The file belongs to the native runtime. Never print or persist its values.
   source "$LOCAL_WA_ADAPTER_ENV_FILE"
+  # Atendimento/Financeiro run against the private local PostgreSQL mirror.
+  # Load it inside the privileged bootstrap only; it is never copied into the
+  # checkout, Pages bindings, browser, or logs.
+  source "$LOCAL_WA_ADAPTER_CRM_API_ENV_FILE"
   set +a
 
   : "${EVOLUTION_API_URL:?EVOLUTION_API_URL is required in the native WhatsApp environment}"
   : "${EVOLUTION_API_KEY:?EVOLUTION_API_KEY is required in the native WhatsApp environment}"
+  : "${DATABASE_URL:?DATABASE_URL is required in the native CRM API environment}"
+
+  # Pages deliberately sends an unsigned actor only to this loopback runtime.
+  # Do not inherit production actor keys from the native CRM API environment.
+  unset ATENDIMENTO_ACTOR_HMAC_KEY CAIXA_ACTOR_HMAC_KEY ESCALA_ACTOR_HMAC_KEY CRM_ESCALA_HMAC_KEY
 
   install -d -m 0750 -o "$LOCAL_WA_ADAPTER_RUN_AS_USER" -g "$LOCAL_WA_ADAPTER_RUN_AS_USER" \
     "$LOCAL_WA_ADAPTER_RUNTIME_HOME" "$LOCAL_WA_ADAPTER_RUNTIME_HOME/var" \

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -170,6 +170,10 @@ function Get-CrmLocalReviewRef {
     return $env:CRM_LOCAL_REVIEW_REF.Trim()
 }
 
+function Test-CrmLocalReviewRefExplicit {
+    return -not [string]::IsNullOrWhiteSpace($env:CRM_LOCAL_REVIEW_REF)
+}
+
 function Get-CrmLocalTargetCommit {
     $reviewRef = Get-CrmLocalReviewRef
     & git -C $ProjectRoot fetch origin --prune --quiet
@@ -540,7 +544,7 @@ function Start-CrmPersonaRuntime {
     )
     $targetLiteral = Convert-ToBashLiteral -Value $TargetCommit
     if ($Persona -eq "Gestor") {
-        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_GATE_STRICT=0 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
+        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
             $targetLiteral, `
             (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
             (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
@@ -574,6 +578,10 @@ function Invoke-CrmPersonaAction {
         }
     }
     if ($decision.Action -eq 'restart') {
+        if ($Persona -eq 'Gestor' -and -not (Test-CrmLocalReviewRefExplicit)) {
+            $activeCommit = if ($null -ne $decision.Manifest) { [string]$decision.Manifest.targetCommit } else { 'desconhecida' }
+            throw "CRM – Local (Gestor) já está ativo na revisão $activeCommit. Para proteger alterações locais compartilhadas, a ação padrão não irá substituí-la por origin/main. Informe CRM_LOCAL_REVIEW_REF explicitamente ou pare o runtime após registrar a revisão ativa."
+        }
         Write-Host "[crm-local] Reiniciando ${Persona}: $($decision.Reason)."
         Stop-CrmPersonaRuntime -Persona $Persona
     }

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -544,7 +544,7 @@ function Start-CrmPersonaRuntime {
     )
     $targetLiteral = Convert-ToBashLiteral -Value $TargetCommit
     if ($Persona -eq "Gestor") {
-        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
+        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' VITE_CRM_MAINTENANCE_MODULES=faturamento CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={2} CRM_LOG_FILE={3} bash ./scripts/run-local-crm.sh" -f `
             $targetLiteral, `
             (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
             (Convert-ToBashLiteral -Value $crmGestorPidWsl), `

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -174,6 +174,29 @@ function Test-CrmLocalReviewRefExplicit {
     return -not [string]::IsNullOrWhiteSpace($env:CRM_LOCAL_REVIEW_REF)
 }
 
+function Assert-CrmLocalRevisionReplacementIsExplicit {
+    param(
+        [ValidateSet("Gestor", "Consultor")][string]$Persona,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        $Manifest
+    )
+
+    if ($Persona -ne 'Gestor' -or (Test-CrmLocalReviewRefExplicit) -or $null -eq $Manifest) {
+        return
+    }
+
+    # A failed or incomplete launch at the requested commit is safe to recover.
+    # Block only the destructive case: an actually running Gestor at a distinct
+    # revision would otherwise be replaced by the implicit origin/main target.
+    if (-not (Test-CrmWslPid -PidValue $Manifest.pids.launcher)) {
+        return
+    }
+    $activeCommit = ([string]$Manifest.targetCommit).Trim().ToLowerInvariant()
+    if ($activeCommit -match '^[0-9a-f]{40}$' -and $activeCommit -ne $TargetCommit.ToLowerInvariant()) {
+        throw "CRM – Local (Gestor) já está ativo na revisão $activeCommit. Para proteger alterações locais compartilhadas, a ação padrão não irá substituí-la por origin/main. Informe CRM_LOCAL_REVIEW_REF explicitamente ou pare o runtime após registrar a revisão ativa."
+    }
+}
+
 function Get-CrmLocalTargetCommit {
     $reviewRef = Get-CrmLocalReviewRef
     & git -C $ProjectRoot fetch origin --prune --quiet
@@ -578,10 +601,7 @@ function Invoke-CrmPersonaAction {
         }
     }
     if ($decision.Action -eq 'restart') {
-        if ($Persona -eq 'Gestor' -and -not (Test-CrmLocalReviewRefExplicit)) {
-            $activeCommit = if ($null -ne $decision.Manifest) { [string]$decision.Manifest.targetCommit } else { 'desconhecida' }
-            throw "CRM – Local (Gestor) já está ativo na revisão $activeCommit. Para proteger alterações locais compartilhadas, a ação padrão não irá substituí-la por origin/main. Informe CRM_LOCAL_REVIEW_REF explicitamente ou pare o runtime após registrar a revisão ativa."
-        }
+        Assert-CrmLocalRevisionReplacementIsExplicit -Persona $Persona -TargetCommit $TargetCommit -Manifest $decision.Manifest
         Write-Host "[crm-local] Reiniciando ${Persona}: $($decision.Reason)."
         Stop-CrmPersonaRuntime -Persona $Persona
     }
@@ -616,7 +636,10 @@ function Ensure-CrmGestorForConsultor {
         $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit
         if ($decision.Action -eq 'reuse') { return }
     }
-    if ($decision.Action -eq 'restart') { Stop-CrmPersonaRuntime -Persona Gestor }
+    if ($decision.Action -eq 'restart') {
+        Assert-CrmLocalRevisionReplacementIsExplicit -Persona Gestor -TargetCommit $TargetCommit -Manifest $decision.Manifest
+        Stop-CrmPersonaRuntime -Persona Gestor
+    }
     Start-CrmGestorBackgroundUpdate -TargetCommit $TargetCommit
     $ready = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -TimeoutSeconds 600
     if ($ready.Action -ne 'reuse') {


### PR DESCRIPTION
## Correção do atalho\n- impede que a ação padrão \CRM – Local (Gestor)\ substitua um runtime ativo por \origin/main\ sem uma revisão explícita\n- restaura o gate estrito, removendo o bypass introduzido em #818\n- encaminha Atendimento, Clientes, Faturamento e Procedimentos ao adaptador loopback local\n- carrega a configuração privada da API CRM somente no bootstrap nativo\n\n## Causa diagnosticada\nO atalho executava \ebb1eb38\, que não contém o binding \ATENDIMENTO_API_TARGET\. O gate detectou respostas 401 em quatro módulos e encerrou o launcher; o PowerShell exibiu apenas o wrapper \The WSL command failed with exit code 1\.\n\n## Validação\n- sintaxe PowerShell e bash aprovada\n- build do CRM aprovado em cópia temporária nativa WSL\n- o guard contra substituição foi exercitado: runtime ativo permaneceu no mesmo SHA/PID\n- validação de gate completa em cópia isolada não gerou relatório; não declarada como aprovada\n\nSem merge automático e sem deploy.