### PR TITLE
fix(meta-ads): use loopback CRM offer context

### DIFF
--- a/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
+++ b/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
@@ -45,7 +45,7 @@ function assertCandidate(candidate) {
     throw new Error('Candidate still contains a Google Sheets tool.');
   }
   const crm = candidate.nodes.find((node) => node.name === 'CRM Offer Context');
-  if (crm?.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest' || crm?.parameters?.url !== 'https://crm.skincos.com.br/api/atendimento/internal/meta-ads/offer-context?unit={unit}') {
+  if (crm?.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest' || crm?.parameters?.url !== 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit={unit}') {
     throw new Error('Candidate CRM Offer Context tool is incomplete.');
   }
   const target = candidate.connections?.['CRM Offer Context']?.ai_tool?.[0]?.[0];

--- a/orb/engine/scripts/prepare-meta-ads-publish-crm-catalog.js
+++ b/orb/engine/scripts/prepare-meta-ads-publish-crm-catalog.js
@@ -9,7 +9,7 @@ const path = require('path');
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 const CRM_TOOL_NAME = 'CRM Offer Context';
 const CRM_TOOL_ID = 'meta-publish-crm-offer-context';
-const CRM_URL = 'https://crm.skincos.com.br/api/atendimento/internal/meta-ads/offer-context?unit={unit}';
+const CRM_URL = 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit={unit}';
 
 function parseArgs(argv) {
   const values = new Map();

--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -28,7 +28,7 @@ const CODE_SOURCES = Object.freeze({
   'Verify Drive Finalization': 'verify-drive-finalization.js',
 });
 
-const CRM_OFFER_CONTEXT_URL = 'https://crm.skincos.com.br/api/atendimento/internal/meta-ads/offer-context?unit={unit}';
+const CRM_OFFER_CONTEXT_URL = 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit={unit}';
 
 function loadPgClient() {
   try { return require('/usr/local/lib/node_modules/n8n/node_modules/pg').Client; }


### PR DESCRIPTION
Corrige a URL do tool CRM para o endpoint loopback autenticado, que foi validado no serviço nativo. A rota pública ainda passa por uma camada legado e não é usada pelo Orb.