### PR TITLE
fix(meta-ads): validate CRM tool edge

### DIFF
--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -91,7 +91,7 @@ async function main() {
   await client.connect();
   try {
     const result = await client.query(
-      `SELECT active, nodes, settings, "versionId", "activeVersionId", "versionCounter"
+      `SELECT active, nodes, connections, settings, "versionId", "activeVersionId", "versionCounter"
          FROM n8n_runtime.workflow_entity WHERE id = $1`,
       [WORKFLOW_ID],
     );

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 const {
   effectiveResponsesApiEnabled,
@@ -63,4 +65,12 @@ test('replaces the legacy Sheets tool with the authenticated CRM offer-context t
   const updatedSchema = JSON.parse(candidate.nodes.find((node) => node.name === 'OpenAI Chat Model (Agent)').parameters.options.textFormat.textOptions.schema);
   assert.equal(updatedSchema.properties.analysis.properties.spreadsheetPricing, undefined);
   assert.deepEqual(updatedSchema.properties.analysis.properties.crmPricing.properties.source.enum, ['crm', 'none']);
+});
+
+test('preflight loads workflow connections before validating the CRM tool edge', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'scripts', 'validate-meta-ads-publish-preflight.js'),
+    'utf8',
+  );
+  assert.match(source, /SELECT active, nodes, connections, settings,/);
 });


### PR DESCRIPTION
## Context\nThe CRM catalog migration was saved in Orb, but the preflight query omitted the workflow connections column. It therefore treated the valid CRM Offer Context -> Livia i_tool edge as missing.\n\n## Change\n- load connections with the workflow row before evaluating the structural contract\n- add a regression test for the selected field\n\n## Validation\n- 
ode --test orb/engine/tests/meta-ads-publish-preflight.test.js\n- live read-only preflight against workflow version 805 reports the CRM catalog contract synchronized when run from this revision\n\nNo Meta workflow execution or publication is performed.