### PR TITLE
fix(meta-ads): isolate video upload replay sessions

### DIFF
--- a/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
+++ b/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
+const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
 const args = new Set(process.argv.slice(2));
 const sourcePath = [...args].find((value) => value.endsWith('.json'));
 const expectedVersion = [...args].find((value) => value.startsWith('--expected-version='))?.slice('--expected-version='.length);
@@ -50,6 +51,7 @@ function assertCandidate(candidate) {
   }
   const target = candidate.connections?.['CRM Offer Context']?.ai_tool?.[0]?.[0];
   if (target?.node !== 'Livia' || target?.type !== 'ai_tool') throw new Error('Candidate CRM Offer Context is not connected to Livia.');
+  validateVideoUploadReplay(candidate);
 }
 
 async function main() {

--- a/orb/engine/scripts/patch-meta-ads-video-transfer-replay.js
+++ b/orb/engine/scripts/patch-meta-ads-video-transfer-replay.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
+const VIDEO_START_NODE = 'Prepare Video Upload Starts';
+
+function findNode(workflow, name) {
+  const node = workflow?.nodes?.find((entry) => entry.name === name);
+  if (!node || node.type !== 'n8n-nodes-base.code') throw new Error(`Expected Code node: ${name}`);
+  return node;
+}
+
+function replaceExactly(source, from, to, label) {
+  if (!source.includes(from)) throw new Error(`Video upload patch anchor missing: ${label}`);
+  return source.replace(from, to);
+}
+
+function validate(workflow) {
+  if (workflow?.id !== WORKFLOW_ID || workflow?.active !== false) throw new Error('Expected the inactive Meta Ads Publish workflow.');
+  const code = String(findNode(workflow, VIDEO_START_NODE).parameters?.jsCode || '');
+  const required = [
+    'video-start:v5:',
+    'checksumSha256',
+    'file_checksum: checksumSha256',
+    'normalizacao sem checksum SHA-256 valido',
+  ];
+  const missing = required.filter((value) => !code.includes(value));
+  if (missing.length || code.includes('video-start:v4:')) {
+    throw new Error(`Video upload replay contract is incomplete: ${[...missing, ...(code.includes('video-start:v4:') ? ['video-start:v4'] : [])].join(', ')}`);
+  }
+  return true;
+}
+
+function transform(workflow) {
+  const candidate = structuredClone(workflow);
+  if (candidate?.id !== WORKFLOW_ID || candidate?.active !== false) throw new Error('Expected the inactive Meta Ads Publish workflow.');
+  const node = findNode(candidate, VIDEO_START_NODE);
+  let code = String(node.parameters?.jsCode || '');
+  if (code.includes('video-start:v5:')) {
+    validate(candidate);
+    return candidate;
+  }
+  code = replaceExactly(
+    code,
+    "const normalizedFile = text(processing.normalized_file || video.normalized_file);\n    if (!runId || !fileSize || !normalizedFile) throw new Error(`Video ${video.id} sem run_id, tamanho ou caminho normalizado.`);",
+    "const normalizedFile = text(processing.normalized_file || video.normalized_file);\n    const checksumSha256 = text(processing.output_checksum_sha256 || video.output_checksum_sha256);\n    if (!runId || !fileSize || !normalizedFile) throw new Error(`Video ${video.id} sem run_id, tamanho ou caminho normalizado.`);\n    if (!/^[a-f0-9]{64}$/i.test(checksumSha256)) throw new Error(`Video ${video.id} normalizacao sem checksum SHA-256 valido.`);",
+    'normalized checksum',
+  );
+  code = replaceExactly(
+    code,
+    "checksum_sha256: text(processing.output_checksum_sha256 || video.output_checksum_sha256),",
+    'checksum_sha256: checksumSha256,',
+    'normalized checksum output',
+  );
+  code = replaceExactly(
+    code,
+    "operation_key: `video-start:v4:${stableHash([runId, accountId, tokenId, apiVersion, video.id, sourceFingerprint, VIDEO_NORMALIZATION_CONTRACT_REVISION].map(text).join('|'))}`",
+    "operation_key: `video-start:v5:${stableHash([runId, accountId, tokenId, apiVersion, video.id, sourceFingerprint, checksumSha256, fileSize, VIDEO_NORMALIZATION_CONTRACT_REVISION].map(text).join('|'))}`",
+    'video start operation key',
+  );
+  code = replaceExactly(
+    code,
+    "file_checksum: text(processing.output_checksum_sha256 || video.output_checksum_sha256),",
+    'file_checksum: checksumSha256,',
+    'gateway file checksum',
+  );
+  node.parameters.jsCode = code;
+  validate(candidate);
+  return candidate;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const input = args.find((value) => value.startsWith('--input='))?.slice('--input='.length);
+  const output = args.find((value) => value.startsWith('--output='))?.slice('--output='.length);
+  if (!input || !output) throw new Error('Usage: node patch-meta-ads-video-transfer-replay.js --input=<workflow.json> --output=<workflow.json>');
+  const candidate = transform(JSON.parse(fs.readFileSync(path.resolve(input), 'utf8')));
+  fs.writeFileSync(path.resolve(output), `${JSON.stringify(candidate, null, 2)}\n`);
+  console.log(JSON.stringify({ workflow_id: candidate.id, patched_node: VIDEO_START_NODE, output: path.resolve(output) }));
+}
+
+if (require.main === module) main();
+
+module.exports = { VIDEO_START_NODE, transform, validate };

--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -6,6 +6,7 @@ const path = require('path');
 const {
   manualExecutionAuditState,
 } = require('./lib/meta-ads-publish-execution-semantics');
+const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 const CODE_SOURCES = Object.freeze({
@@ -53,7 +54,7 @@ function structuralContractDrift(nodes, connections) {
     drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_tool_missing' });
   } else {
     if (crm.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest') drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_wrong_type' });
-    if (crm.parameters?.method !== 'GET' || crm.parameters?.url !== CRM_OFFER_CONTEXT_URL) drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_request_mismatch' });
+    if ((crm.parameters?.method && crm.parameters.method !== 'GET') || crm.parameters?.url !== CRM_OFFER_CONTEXT_URL) drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_request_mismatch' });
     if (crm.parameters?.authentication !== 'genericCredentialType' || crm.parameters?.genericAuthType !== 'httpBearerAuth' || !crm.credentials?.httpBearerAuth?.id) {
       drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_credential_missing' });
     }
@@ -77,6 +78,15 @@ function structuralContractDrift(nodes, connections) {
     drift.push({ contract: 'commercial_offer_source', reason: 'livia_schema_invalid' });
   }
   return drift;
+}
+
+function videoUploadContractDrift(workflow) {
+  try {
+    validateVideoUploadReplay(workflow);
+    return [];
+  } catch (error) {
+    return [{ contract: 'video_upload_replay', reason: String(error.message || error) }];
+  }
 }
 
 async function main() {
@@ -113,6 +123,7 @@ async function main() {
     }
     const settings = parseJson(workflow.settings, {});
     const structuralDrift = structuralContractDrift(nodes, connections);
+    const videoUploadDrift = videoUploadContractDrift({ ...workflow, nodes, connections });
     const report = {
       workflow_id: WORKFLOW_ID,
       mode: 'read_only',
@@ -124,6 +135,8 @@ async function main() {
       code_source_drift: drift,
       crm_catalog_contract_synchronized: structuralDrift.length === 0,
       crm_catalog_contract_drift: structuralDrift,
+      video_upload_contract_synchronized: videoUploadDrift.length === 0,
+      video_upload_contract_drift: videoUploadDrift,
       manual_execution_audit: manualExecutionAuditState(settings),
       manual_execution_note: settings.saveManualExecutions === true
         ? 'Manual executions are retained for later inspection.'
@@ -132,7 +145,7 @@ async function main() {
       service_restarts_performed: false,
     };
     console.log(JSON.stringify(report, null, 2));
-    if (drift.length || structuralDrift.length) process.exitCode = 1;
+    if (drift.length || structuralDrift.length || videoUploadDrift.length) process.exitCode = 1;
   } finally {
     await client.end();
   }

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -10,6 +10,7 @@ const {
   manualExecutionAuditState,
 } = require('../scripts/lib/meta-ads-publish-execution-semantics');
 const { CRM_TOOL_NAME, CRM_URL, transform } = require('../scripts/prepare-meta-ads-publish-crm-catalog');
+const { transform: patchVideoUploadReplay } = require('../scripts/patch-meta-ads-video-transfer-replay');
 
 test('Responses API uses the n8n 1.3 default when the stored parameter is absent', () => {
   assert.equal(effectiveResponsesApiEnabled({ typeVersion: 1.3, parameters: {} }), true);
@@ -73,4 +74,30 @@ test('preflight loads workflow connections before validating the CRM tool edge',
     'utf8',
   );
   assert.match(source, /SELECT active, nodes, connections, settings,/);
+});
+
+test('video upload replay key includes normalized bytes and rejects the legacy v4 key', () => {
+  const workflow = {
+    id: 'eFJhFg79lyaycjlm',
+    active: false,
+    nodes: [{
+      name: 'Prepare Video Upload Starts',
+      type: 'n8n-nodes-base.code',
+      parameters: {
+        jsCode: [
+          "const normalizedFile = text(processing.normalized_file || video.normalized_file);",
+          "    if (!runId || !fileSize || !normalizedFile) throw new Error(`Video ${video.id} sem run_id, tamanho ou caminho normalizado.`);",
+          "checksum_sha256: text(processing.output_checksum_sha256 || video.output_checksum_sha256),",
+          "operation_key: `video-start:v4:${stableHash([runId, accountId, tokenId, apiVersion, video.id, sourceFingerprint, VIDEO_NORMALIZATION_CONTRACT_REVISION].map(text).join('|'))}`",
+          "file_checksum: text(processing.output_checksum_sha256 || video.output_checksum_sha256),",
+        ].join('\n'),
+      },
+    }],
+  };
+  const candidate = patchVideoUploadReplay(workflow);
+  const code = candidate.nodes[0].parameters.jsCode;
+  assert.match(code, /video-start:v5:/);
+  assert.match(code, /checksumSha256, fileSize/);
+  assert.match(code, /checksum SHA-256 valido/);
+  assert.doesNotMatch(code, /video-start:v4:/);
 });


### PR DESCRIPTION
## Objetivo\nEvita que uma nova normalização de vídeo reutilize uma sessão/chunk parcial com a mesma chave idempotente.\n\n## Alteração\n- inclui checksum SHA-256 e tamanho normalizado na chave de start v5\n- exige checksum de saída antes de iniciar upload\n- o apply versionado e o preflight passam a validar o contrato v5\n- aceita o GET implícito do n8n no nó CRM (equivalente ao GET explícito)\n\n## Risco e rollback\nWorkflow permanece inativo até o teste manual autorizado. Rollback: checkpoint privado da versão 806 e release nativa atual.\n\n## Validação\n- node --test orb/engine/tests/meta-ads-publish-preflight.test.js\n- transformação da exportação viva 806\n- apply dry-run com versão esperada 806\n\nSem execução Meta nesta PR.