### PR TITLE
fix(meta-ads): evaluate live video replay contract

### DIFF
--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -123,7 +123,7 @@ async function main() {
     }
     const settings = parseJson(workflow.settings, {});
     const structuralDrift = structuralContractDrift(nodes, connections);
-    const videoUploadDrift = videoUploadContractDrift({ ...workflow, nodes, connections });
+    const videoUploadDrift = videoUploadContractDrift({ ...workflow, id: WORKFLOW_ID, nodes, connections });
     const report = {
       workflow_id: WORKFLOW_ID,
       mode: 'read_only',


### PR DESCRIPTION
Fixes the video replay preflight to pass the live workflow identity into the contract validator. Focused test and live read-only preflight against workflow version 807 pass from this revision. No Meta execution in this change.