### PR TITLE
fix(orb): isolate workflow runtime sidecars

### DIFF
--- a/ops/runtime/units/orb-restart-fence.service
+++ b/ops/runtime/units/orb-restart-fence.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Temporary fence for a controlled Skincos Orb restart
+Conflicts=orb.service
+Before=orb.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/true

--- a/orb/engine/scripts/apply-livia-runtime-isolation.js
+++ b/orb/engine/scripts/apply-livia-runtime-isolation.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict';
+
+// Operator-only, version-checked publication of the Livia runtime pin.  The
+// manifest is written before the DB transaction and removed again on failure,
+// so no active version can reference a missing helper bundle.
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const REQUIRED_NODES = ['Process Media Asset', 'BQ - Build Platform Job Graph', 'Verify Published Artifacts', 'Record Publish Progress', 'Validate Publish Token Health'];
+const args = process.argv.slice(2);
+const sourcePath = args.find((value) => value.endsWith('.json'));
+const expectedVersion = args.find((value) => value.startsWith('--expected-version='))?.slice('--expected-version='.length);
+const nextVersion = args.find((value) => value.startsWith('--next-version='))?.slice('--next-version='.length) || crypto.randomUUID();
+const releaseRoot = args.find((value) => value.startsWith('--release-root='))?.slice('--release-root='.length);
+const apply = args.includes('--apply');
+const manifestPrecreated = args.includes('--manifest-precreated');
+const runtimeHome = process.env.N8N_RUNTIME_HOME || '/var/lib/skincos-runtime/orb';
+const manifestScript = path.join(__dirname, 'workflow-runtime-manifest.js');
+
+function fail(message) { throw new Error(message); }
+function loadPgClient() {
+  try { return require('/usr/local/lib/node_modules/n8n/node_modules/pg').Client; }
+  catch { return require('pg').Client; }
+}
+function parseJson(value, fallback) { return value === null || value === undefined || value === '' ? fallback : (typeof value === 'string' ? JSON.parse(value) : value); }
+function stableHash(value) { return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
+function assertCandidate(candidate) {
+  if (candidate?.id !== WORKFLOW_ID || candidate?.active !== true) fail('Candidate is not the active Livia workflow.');
+  const nodes = new Map((candidate.nodes || []).map((node) => [node.name, node]));
+  for (const name of REQUIRED_NODES) {
+    const node = nodes.get(name);
+    const command = String(node?.parameters?.command || '');
+    if (node?.type !== 'n8n-nodes-base.executeCommand') fail(`${name} is not an Execute Command node.`);
+    if (!command.includes(releaseRoot) || /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(command)) {
+      fail(`${name} is not pinned exclusively to ${releaseRoot}.`);
+    }
+  }
+}
+function createManifest() {
+  const manifestPath = path.join(runtimeHome, 'workflow-runtime-manifests', WORKFLOW_ID, `${nextVersion}.json`);
+  if (manifestPrecreated) {
+    if (!fs.existsSync(manifestPath)) fail(`Precreated workflow runtime manifest is missing: ${manifestPath}.`);
+    return { manifestPath };
+  }
+  const result = spawnSync(process.execPath, [manifestScript, 'create', '--workflow', sourcePath, '--workflow-id', WORKFLOW_ID, '--workflow-version', nextVersion, '--release-root', releaseRoot, '--runtime-home', runtimeHome], { encoding: 'utf8' });
+  if (result.status !== 0) fail(result.stderr || result.stdout || 'Could not create workflow runtime manifest.');
+  return JSON.parse(result.stdout);
+}
+
+async function main() {
+  if (!sourcePath || !expectedVersion || !releaseRoot) {
+    fail('Usage: apply-livia-runtime-isolation.js <candidate.json> --expected-version=<uuid> --release-root=/opt/skincos/releases/<sha>/source/orb/engine [--next-version=<uuid>] [--manifest-precreated] [--apply]');
+  }
+  const candidate = JSON.parse(fs.readFileSync(path.resolve(sourcePath), 'utf8'));
+  assertCandidate(candidate);
+  const Client = loadPgClient();
+  const client = new Client({ user: process.env.PGUSER || 'postgres', host: process.env.PGHOST || '/var/run/postgresql', database: process.env.PGDATABASE || 'n8n_runtime' });
+  await client.connect();
+  let manifestPath = '';
+  try {
+    await client.query('BEGIN');
+    const result = await client.query(
+      `SELECT id,name,active,nodes,connections,settings,meta,description,"versionId","activeVersionId","versionCounter"
+         FROM n8n_runtime.workflow_entity WHERE id=$1 FOR UPDATE`, [WORKFLOW_ID]);
+    const row = result.rows[0];
+    if (!row || row.active !== true) fail('Live Livia workflow is not active.');
+    if (row.versionId !== expectedVersion) fail(`Live version changed: expected ${expectedVersion}, found ${row.versionId}.`);
+    const report = {
+      workflowId: WORKFLOW_ID,
+      oldVersion: row.versionId,
+      nextVersion,
+      releaseRoot,
+      liveHash: stableHash({ nodes: parseJson(row.nodes, []), connections: parseJson(row.connections, {}) }),
+      candidateHash: stableHash({ nodes: candidate.nodes, connections: candidate.connections }),
+      apply,
+    };
+    if (!apply) {
+      await client.query('ROLLBACK');
+      process.stdout.write(`${JSON.stringify(report)}\n`);
+      return;
+    }
+    const manifest = createManifest();
+    manifestPath = manifest.manifestPath;
+    const now = new Date();
+    await client.query(
+      `INSERT INTO n8n_runtime.workflow_history ("versionId","workflowId",authors,"createdAt","updatedAt",nodes,connections,name,autosaved,description)
+       VALUES ($1,$2,$3,$4,$4,$5,$6,$7,true,$8)`,
+      [nextVersion, WORKFLOW_ID, 'Codex workflow runtime isolation', now, JSON.stringify(candidate.nodes), JSON.stringify(candidate.connections), candidate.name, candidate.description || row.description || ''],
+    );
+    await client.query(
+      `UPDATE n8n_runtime.workflow_entity
+          SET nodes=$1, connections=$2, settings=$3, meta=$4, "versionId"=$5, "activeVersionId"=$6,
+              "versionCounter"=$7, "updatedAt"=$8
+        WHERE id=$9`,
+      [JSON.stringify(candidate.nodes), JSON.stringify(candidate.connections), JSON.stringify(candidate.settings || parseJson(row.settings, {})), JSON.stringify(candidate.meta || parseJson(row.meta, {})), nextVersion, nextVersion, Number(row.versionCounter) + 1, now, WORKFLOW_ID],
+    );
+    await client.query(
+      `INSERT INTO n8n_runtime.workflow_published_version ("workflowId","publishedVersionId","createdAt","updatedAt")
+       VALUES ($1,$2,$3,$3)
+       ON CONFLICT ("workflowId") DO UPDATE SET "publishedVersionId"=EXCLUDED."publishedVersionId", "updatedAt"=EXCLUDED."updatedAt"`,
+      [WORKFLOW_ID, nextVersion, now],
+    );
+    await client.query(`INSERT INTO n8n_runtime.workflow_publish_history ("workflowId","versionId",event,"createdAt") VALUES ($1,$2,'deactivated',$3),($1,$4,'activated',$3)`, [WORKFLOW_ID, row.activeVersionId || row.versionId, now, nextVersion]);
+    await client.query('COMMIT');
+    process.stdout.write(`${JSON.stringify({ ...report, manifestPath, appliedAt: now.toISOString() })}\n`);
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    if (manifestPath && !manifestPrecreated) fs.rmSync(manifestPath, { force: true });
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exit(1); });

--- a/orb/engine/scripts/apply-livia-runtime-isolation.js
+++ b/orb/engine/scripts/apply-livia-runtime-isolation.js
@@ -28,6 +28,18 @@ function loadPgClient() {
 }
 function parseJson(value, fallback) { return value === null || value === undefined || value === '' ? fallback : (typeof value === 'string' ? JSON.parse(value) : value); }
 function stableHash(value) { return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
+function assertPrecreatedManifest(manifestPath, candidate) {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8').replace(/^\uFEFF/, ''));
+  if (manifest.workflowId !== WORKFLOW_ID || manifest.workflowVersion !== nextVersion || manifest.releaseRoot !== releaseRoot) {
+    fail('Precreated workflow runtime manifest does not match the requested workflow version or release root.');
+  }
+  if (manifest.workflowSha256 !== stableHash({ nodes: candidate.nodes, connections: candidate.connections })) {
+    fail('Precreated workflow runtime manifest does not match the candidate workflow hash.');
+  }
+  if (!Array.isArray(manifest.entrypoints) || manifest.entrypoints.length !== 6 || manifest.entrypoints.some((entry) => !/^[a-f0-9]{64}$/.test(String(entry?.sha256 || '')))) {
+    fail('Precreated workflow runtime manifest has an invalid entrypoint hash contract.');
+  }
+}
 function assertCandidate(candidate) {
   if (candidate?.id !== WORKFLOW_ID || candidate?.active !== true) fail('Candidate is not the active Livia workflow.');
   const nodes = new Map((candidate.nodes || []).map((node) => [node.name, node]));
@@ -44,6 +56,7 @@ function createManifest() {
   const manifestPath = path.join(runtimeHome, 'workflow-runtime-manifests', WORKFLOW_ID, `${nextVersion}.json`);
   if (manifestPrecreated) {
     if (!fs.existsSync(manifestPath)) fail(`Precreated workflow runtime manifest is missing: ${manifestPath}.`);
+    assertPrecreatedManifest(manifestPath, JSON.parse(fs.readFileSync(path.resolve(sourcePath), 'utf8')));
     return { manifestPath };
   }
   const result = spawnSync(process.execPath, [manifestScript, 'create', '--workflow', sourcePath, '--workflow-id', WORKFLOW_ID, '--workflow-version', nextVersion, '--release-root', releaseRoot, '--runtime-home', runtimeHome], { encoding: 'utf8' });

--- a/orb/engine/scripts/livia/build-platform-job-graph.js
+++ b/orb/engine/scripts/livia/build-platform-job-graph.js
@@ -219,6 +219,169 @@ function assertRuntimeCompatibility(jsCode) {
   };
 }
 
+// compose2-current.js returns one n8n item per job.  Older externalized
+// builders returned a single { jobs: [...] } envelope.  Both are intentional
+// runtime contracts and a release must never silently treat one as empty.
+function normalizeExternalResult(result) {
+  const jsonItems = asArray(result)
+    .map((entry) => asObject(asObject(entry).json))
+    .filter((entry) => Object.keys(entry).length);
+
+  if (jsonItems.length === 1 && Array.isArray(jsonItems[0].jobs)) return jsonItems[0];
+  if (jsonItems.some((entry) => Array.isArray(entry.jobs))) {
+    fail(`${NODE_NAME}: mixed or multiple job envelopes are not supported.`);
+  }
+
+  const directJobs = jsonItems.filter((entry) => (
+    String(entry.platform || '').trim() &&
+    String(entry.phase || '').trim() &&
+    String(entry.method || '').trim() &&
+    String(entry.url || '').trim()
+  ));
+  if (directJobs.length === jsonItems.length && directJobs.length) {
+    return { jobs: directJobs, warnings: ['external_source_direct_job_items'] };
+  }
+
+  fail(`${NODE_NAME}: unsupported external job contract; expected one jobs envelope or direct n8n job items.`);
+}
+
+function assertOutputContract() {
+  const job = { platform: 'instagram', phase: 'upload', method: 'POST', url: 'https://example.invalid/media' };
+  const direct = normalizeExternalResult([{ json: job }]);
+  const enveloped = normalizeExternalResult([{ json: { jobs: [job] } }]);
+  if (direct.jobs.length !== 1 || enveloped.jobs.length !== 1) {
+    fail(`${NODE_NAME}: external output-contract assertion failed.`);
+  }
+  return { directItems: direct.jobs.length, envelopedItems: enveloped.jobs.length };
+}
+
+function contractPlatformContext() {
+  return {
+    facebook: { network: 'facebook.com', version: 'v25.0', id_bss: '1001', id_nh: '1002', token_bss: '__fixture__', token_nh: '__fixture__', endpoint_2nd: 'feed' },
+    instagram: { network: 'instagram.com', version: 'v25.0', id_bss: '2001', id_nh: '2002', token_bss: '__fixture__', token_nh: '__fixture__', endpoint_1st: 'media', endpoint_2nd: 'media_publish' },
+    threads: { network: 'threads.net', version: 'v1.0', id_bss: '3001', id_nh: '3002', token_bss: '__fixture__', token_nh: '__fixture__', endpoint_1st: 'threads', endpoint_2nd: 'threads_publish', use_me: true },
+  };
+}
+
+function contractPayload(name, kinds) {
+  const platforms = contractPlatformContext();
+  const media = kinds.map((kind, index) => {
+    const video = kind === 'video';
+    const extension = video ? 'mp4' : 'jpg';
+    const finalUrl = `https://example.invalid/${name}-${index}.${extension}`;
+    return {
+      groupKey: `fixture:${name}`,
+      groupOrder: index,
+      id: `${name}-${index}`,
+      name: `${name}-${index}.${extension}`,
+      mimeType: video ? 'video/mp4' : 'image/jpeg',
+      mediaKind: kind,
+      sourceMediaKind: kind,
+      finalUrl,
+      secure_url: finalUrl,
+      url: finalUrl,
+      quantity: kinds.length,
+      edge: 'photos',
+      media_type_1st_requisition: kinds.length > 1 ? 'CAROUSEL' : (video ? 'REELS' : 'IMAGE'),
+      ...platforms,
+    };
+  });
+  return {
+    bootstrapItems: media.map((json) => ({ json })),
+    normalizedCombinedMediaItems: media.map((json) => ({ json })),
+    combinedMediaItems: media.map((json) => ({ json })),
+    normalizedLiviaOutput: [{
+      json: {
+        caption: {
+          instagram: { hook: 'Fixture', blocks: ['Fixture'], cta: 'Fixture' },
+          facebook: { hook: 'Fixture', blocks: ['Fixture'], cta: 'Fixture' },
+          threads: { hook: 'Fixture', blocks: ['Fixture'], closing: 'Fixture' },
+        },
+        items: media.map((item, index) => ({
+          index,
+          title: `Fixture ${index}`,
+          alt_text: `Fixture ${item.mediaKind} ${index}`,
+          mediaType: item.mediaKind,
+          bestFrame: item.mediaKind === 'video'
+            ? { applicable: true, bestTimestampSeconds: 1, selectedFrameUrl: `https://example.invalid/${name}-${index}-cover.jpg`, selectedFrameRank: 1, confidence: 1 }
+            : { applicable: false },
+        })),
+      },
+    }],
+  };
+}
+
+function assertJobGraphContracts(jsCode) {
+  const scenarios = [
+    ['single-image', ['image']],
+    ['single-video', ['video']],
+    ['carousel-images', ['image', 'image', 'image']],
+    ['carousel-mixed', ['image', 'video']],
+  ];
+  const results = [];
+  for (const [name, kinds] of scenarios) {
+    const output = normalizeExternalResult(executeSource(jsCode, contractPayload(name, kinds)));
+    const jobs = asArray(output.jobs);
+    if (!jobs.length) fail(`${NODE_NAME}: ${name} fixture produced no jobs.`);
+    if (!jobs.every((job) => String(job.groupKey || '') === `fixture:${name}` && String(job.method || '').trim() && String(job.url || '').trim())) {
+      fail(`${NODE_NAME}: ${name} fixture produced an incomplete job.`);
+    }
+    const platforms = new Set(jobs.map((job) => String(job.platform || '')));
+    for (const platform of ['instagram', 'facebook', 'threads']) {
+      if (!platforms.has(platform)) fail(`${NODE_NAME}: ${name} fixture omitted ${platform}.`);
+    }
+    results.push({ name, mediaKinds: kinds, jobCount: jobs.length });
+  }
+  return results;
+}
+
+// A Facebook Reel is not complete when its upload session is ready.  Preserve
+// the post-finish confirmation job when normalizing direct compose output.
+function normalizeFacebookReelsChecks(jobs) {
+  const expanded = [];
+  for (const job of jobs) {
+    const current = { ...job, __sourceRunIndex: Number(job.publishRunIndex) };
+    if (String(current.platform || '').toLowerCase() === 'facebook' &&
+        String(current.phase || '').toLowerCase() === 'checkstatus' &&
+        String(current.checkKind || '').toLowerCase() === 'fb_reels_video') {
+      current.checkKind = 'fb_reels_upload_ready';
+    }
+    expanded.push(current);
+    if (String(current.platform || '').toLowerCase() !== 'facebook' || String(current.step || '').toLowerCase() !== 'reels_finish') continue;
+    const uploadReady = [...expanded].reverse().find((candidate) =>
+      String(candidate.platform || '').toLowerCase() === 'facebook' &&
+      String(candidate.groupKey || '') === String(current.groupKey || '') &&
+      String(candidate.unit || '') === String(current.unit || '') &&
+      String(candidate.checkKind || '').toLowerCase() === 'fb_reels_upload_ready');
+    if (!uploadReady) fail(`${NODE_NAME}: Facebook Reel finish without an upload-ready check.`);
+    expanded.push({
+      ...uploadReady,
+      __sourceRunIndex: undefined,
+      checkKind: 'fb_reels_published',
+      checkFields: 'status',
+      statusFromPublishRunIndex: current.reelsStartFromPublishRunIndex ?? uploadReady.statusFromPublishRunIndex,
+      postPublishFromRunIndex: current.__sourceRunIndex,
+      warnings: [...asArray(uploadReady.warnings), 'fb_reels_post_publish_check'],
+    });
+  }
+  const remap = new Map();
+  expanded.forEach((job, index) => {
+    if (Number.isFinite(job.__sourceRunIndex)) remap.set(job.__sourceRunIndex, index);
+    job.publishRunIndex = index;
+  });
+  const refs = ['statusFromPublishRunIndex', 'postPublishFromRunIndex', 'checkStatusFromPublishRunIndex', 'creationIdFromPublishRunIndex', 'lastUploadFromPublishRunIndex', 'reelsStartFromPublishRunIndex'];
+  for (const job of expanded) {
+    for (const key of refs) {
+      if (Number.isFinite(Number(job[key])) && remap.has(Number(job[key]))) job[key] = remap.get(Number(job[key]));
+    }
+    if (Array.isArray(job.attachedMediaFromPublishRunIndexes)) {
+      job.attachedMediaFromPublishRunIndexes = job.attachedMediaFromPublishRunIndexes.map((value) => remap.has(Number(value)) ? remap.get(Number(value)) : value);
+    }
+    delete job.__sourceRunIndex;
+  }
+  return expanded;
+}
+
 function executeSource(jsCode, payload) {
   const inputItems = [{ json: payload }];
   const staticData = {};
@@ -775,11 +938,11 @@ function loadResumeCompleted(jobs) {
 }
 
 function compactResult(result, payload, sourceFile) {
-  const firstJson = asObject(asArray(result)[0]?.json);
+  const firstJson = normalizeExternalResult(result);
   const facebookCredentials = facebookCredentialContext(payload);
   const credentialRefs = credentialReferences(payload);
   const frameContext = technicalFrameContext(payload);
-  const jobs = asArray(firstJson.jobs)
+  const jobs = normalizeFacebookReelsChecks(asArray(firstJson.jobs)
     .map((entry) => asObject(entry))
     .map((entry) => applyCaptionHygiene(entry))
     .map((entry) => applyTechnicalFrame(entry, frameContext))
@@ -788,7 +951,7 @@ function compactResult(result, payload, sourceFile) {
     .map((entry) => normalizeFacebookJob(entry, facebookCredentials))
     .map((entry) => normalizeThreadsCarouselJob(entry))
     .map((entry) => applyCredentialReference(entry, credentialRefs))
-    .filter((entry) => Object.keys(entry).length);
+    .filter((entry) => Object.keys(entry).length));
   if (!jobs.length) fail(`${NODE_NAME}: external source did not produce jobs.`);
   const resume = loadResumeCompleted(jobs);
   const resumeCompleted = resume.completed;
@@ -832,6 +995,14 @@ function main() {
       sourceFile: source.filePath,
       compatibility: assertRuntimeCompatibility(source.jsCode),
     }));
+    return;
+  }
+  if (process.argv.includes('--assert-output-contract')) {
+    process.stdout.write(JSON.stringify({ ok: true, outputContract: assertOutputContract() }));
+    return;
+  }
+  if (process.argv.includes('--assert-job-graph-contracts')) {
+    process.stdout.write(JSON.stringify({ ok: true, jobGraphContracts: assertJobGraphContracts(source.jsCode) }));
     return;
   }
   const payload = parsePayload();

--- a/orb/engine/scripts/livia/build-platform-job-graph.js
+++ b/orb/engine/scripts/livia/build-platform-job-graph.js
@@ -377,6 +377,9 @@ function normalizeFacebookReelsChecks(jobs) {
     if (Array.isArray(job.attachedMediaFromPublishRunIndexes)) {
       job.attachedMediaFromPublishRunIndexes = job.attachedMediaFromPublishRunIndexes.map((value) => remap.has(Number(value)) ? remap.get(Number(value)) : value);
     }
+    if (Array.isArray(job.childrenPublishRunIndexes)) {
+      job.childrenPublishRunIndexes = job.childrenPublishRunIndexes.map((value) => remap.has(Number(value)) ? remap.get(Number(value)) : value);
+    }
     delete job.__sourceRunIndex;
   }
   return expanded;

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -428,6 +428,9 @@ function validateWorkflow() {
     if (/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(commandValue)) {
       errors.push(`${name} must use an immutable workflow runtime root.`);
     }
+    if (!/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine/.test(commandValue)) {
+      errors.push(`${name} must use a pinned immutable release root.`);
+    }
   }
   if (!command.includes('process-media-asset.js')) {
     errors.push('Process Media Asset must call scripts/livia/process-media-asset.js.');

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -422,6 +422,13 @@ function validateWorkflow() {
   const buildGraphScript = fs.existsSync(BUILD_GRAPH_SCRIPT)
     ? fs.readFileSync(BUILD_GRAPH_SCRIPT, 'utf8')
     : '';
+  const pinnedSidecars = ['Process Media Asset', 'BQ - Build Platform Job Graph', 'Verify Published Artifacts', 'Record Publish Progress', 'Validate Publish Token Health'];
+  for (const name of pinnedSidecars) {
+    const commandValue = String(nodeByName.get(name)?.parameters?.command || '');
+    if (/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(commandValue)) {
+      errors.push(`${name} must use an immutable workflow runtime root.`);
+    }
+  }
   if (!command.includes('process-media-asset.js')) {
     errors.push('Process Media Asset must call scripts/livia/process-media-asset.js.');
   }
@@ -450,6 +457,11 @@ function validateWorkflow() {
   for (const required of ['cloudinaryVideoCoverUrl', 'normalizeGraphApiVersion', 'cover_url', 'applyPlatformAccessibilityContract', 'alt_text_omitted_for_video', 'body.title = text.title']) {
     if (!buildGraphScript.includes(required)) {
       errors.push(`build-platform-job-graph.js must enforce the publication delivery contract (${required}).`);
+    }
+  }
+  for (const required of ['normalizeExternalResult', 'assertOutputContract', 'assertJobGraphContracts']) {
+    if (!buildGraphScript.includes(required)) {
+      errors.push(`build-platform-job-graph.js must enforce the runtime output contract (${required}).`);
     }
   }
   for (const required of ['fs.statSync', 'sourceBytes', 'outputBytes', 'uploadEligible', 'SAFE_UPLOAD_BYTES', 'video_h264_720p_fallback']) {

--- a/orb/engine/scripts/patch-livia-runtime-isolation.js
+++ b/orb/engine/scripts/patch-livia-runtime-isolation.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+
+// Creates a version-pinned Livia candidate.  Applying it is intentionally a
+// separate, expected-version-checked operation.
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const REQUIRED_NODES = new Set([
+  'Process Media Asset',
+  'BQ - Build Platform Job Graph',
+  'Verify Published Artifacts',
+  'Record Publish Progress',
+  'Validate Publish Token Health',
+]);
+const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine$/;
+
+function fail(message) { throw new Error(message); }
+function arg(prefix) { return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || ''; }
+function validate(workflow, releaseRoot) {
+  if (workflow?.id !== WORKFLOW_ID || workflow?.active !== true) fail('Expected the active Livia workflow.');
+  if (!RELEASE_ROOT_RE.test(releaseRoot)) fail(`Invalid immutable Orb release root: ${releaseRoot}.`);
+  const touched = [];
+  for (const node of workflow.nodes || []) {
+    if (!REQUIRED_NODES.has(node?.name)) continue;
+    if (node.type !== 'n8n-nodes-base.executeCommand') fail(`${node.name} must remain an Execute Command node.`);
+    const command = String(node.parameters?.command || '');
+    if (!command.includes('/opt/skincos/current/source/orb/engine')) fail(`${node.name} no longer has the expected mutable source path.`);
+    node.parameters.command = command.replaceAll('/opt/skincos/current/source/orb/engine', releaseRoot);
+    touched.push(node.name);
+  }
+  if (touched.length !== REQUIRED_NODES.size) fail(`Expected to pin ${REQUIRED_NODES.size} Livia sidecars, changed ${touched.length}.`);
+  const mutable = (workflow.nodes || []).filter((node) => node?.type === 'n8n-nodes-base.executeCommand')
+    .filter((node) => /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(String(node.parameters?.command || '')))
+    .map((node) => node.name);
+  if (mutable.length) fail(`Mutable Execute Command reference remains: ${mutable.join(', ')}.`);
+  return touched.sort();
+}
+
+function main() {
+  const [input, output] = process.argv.slice(2).filter((value) => !value.startsWith('--'));
+  const releaseRoot = arg('--release-root=');
+  if (!input || !output || !releaseRoot) {
+    fail('Usage: patch-livia-runtime-isolation.js <live-export.json> <candidate.json> --release-root=/opt/skincos/releases/<sha>/source/orb/engine');
+  }
+  const workflow = JSON.parse(fs.readFileSync(path.resolve(input), 'utf8'));
+  const touched = validate(workflow, releaseRoot);
+  fs.writeFileSync(path.resolve(output), `${JSON.stringify(workflow, null, 2)}\n`, { mode: 0o640 });
+  process.stdout.write(JSON.stringify({ ok: true, workflowId: WORKFLOW_ID, releaseRoot, nodes: touched }) + '\n');
+}
+
+main();

--- a/orb/engine/scripts/patch-livia-runtime-isolation.js
+++ b/orb/engine/scripts/patch-livia-runtime-isolation.js
@@ -15,6 +15,7 @@ const REQUIRED_NODES = new Set([
   'Validate Publish Token Health',
 ]);
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine$/;
+const PINNED_ROOT_RE = /\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine/g;
 
 function fail(message) { throw new Error(message); }
 function arg(prefix) { return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || ''; }
@@ -26,8 +27,13 @@ function validate(workflow, releaseRoot) {
     if (!REQUIRED_NODES.has(node?.name)) continue;
     if (node.type !== 'n8n-nodes-base.executeCommand') fail(`${node.name} must remain an Execute Command node.`);
     const command = String(node.parameters?.command || '');
-    if (!command.includes('/opt/skincos/current/source/orb/engine')) fail(`${node.name} no longer has the expected mutable source path.`);
-    node.parameters.command = command.replaceAll('/opt/skincos/current/source/orb/engine', releaseRoot);
+    const hasMutableRoot = command.includes('/opt/skincos/current/source/orb/engine');
+    const hasPinnedRoot = PINNED_ROOT_RE.test(command);
+    PINNED_ROOT_RE.lastIndex = 0;
+    if (!hasMutableRoot && !hasPinnedRoot) fail(`${node.name} has no recognized Orb runtime root.`);
+    node.parameters.command = hasMutableRoot
+      ? command.replaceAll('/opt/skincos/current/source/orb/engine', releaseRoot)
+      : command.replace(PINNED_ROOT_RE, releaseRoot);
     touched.push(node.name);
   }
   if (touched.length !== REQUIRED_NODES.size) fail(`Expected to pin ${REQUIRED_NODES.size} Livia sidecars, changed ${touched.length}.`);

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -215,12 +215,10 @@ function validateStructure() {
     assert(connectionExists('Hydrate Publish Context', 'BQ - Normalize Hydrated Envelope'), 'Hydrate Publish Context must feed BQ - Normalize Hydrated Envelope');
     assert(connectionExists('BQ - Normalize Hydrated Envelope', 'BQ - Validate Bootstrap Inputs'), 'BQ - Normalize Hydrated Envelope must feed BQ - Validate Bootstrap Inputs');
     assert(connectionExists('BQ - Validate Bootstrap Inputs', 'BQ - Build Publish Context'), 'BQ - Validate Bootstrap Inputs must feed BQ - Build Publish Context');
-    const publicationWindowGuard = names.has('Assert Livia Publication Window');
+    assert(names.has('Assert Livia Publication Window'), 'Missing node: Assert Livia Publication Window');
     assert(
-      publicationWindowGuard
-        ? connectionExists('BQ - Build Publish Context', 'Assert Livia Publication Window') &&
-            connectionExists('Assert Livia Publication Window', 'BQ - Build Platform Job Graph')
-        : connectionExists('BQ - Build Publish Context', 'BQ - Build Platform Job Graph'),
+      connectionExists('BQ - Build Publish Context', 'Assert Livia Publication Window') &&
+        connectionExists('Assert Livia Publication Window', 'BQ - Build Platform Job Graph'),
       'BQ publication context must pass the publication-window guard before platform job generation',
     );
     assert(connectionExists('BQ - Build Platform Job Graph', 'BQ - Validate Job Graph'), 'BQ - Build Platform Job Graph must feed BQ - Validate Job Graph');
@@ -336,6 +334,7 @@ function validateContracts() {
     assert(bqBuildPlatformJobGraphCommand.includes('build-platform-job-graph.js'), 'BQ - Build Platform Job Graph must delegate to scripts/livia/build-platform-job-graph.js');
     assert(bqBuildPlatformJobGraphCommand.includes('--payload'), 'BQ - Build Platform Job Graph command must pass the input payload to the external script');
     assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(bqBuildPlatformJobGraphCommand), 'BQ - Build Platform Job Graph must use an immutable workflow runtime root.');
+    assert(/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine/.test(bqBuildPlatformJobGraphCommand), 'BQ - Build Platform Job Graph must use a pinned immutable release root.');
     assert(bqBuildPlatformJobGraphCommand.length < 2500, `BQ - Build Platform Job Graph command must stay small enough for stable expression parsing (${bqBuildPlatformJobGraphCommand.length} chars)`);
     assert(bqBuildPlatformJobGraph.length < 1000, `BQ - Build Platform Job Graph must not be a large Code node anymore (${bqBuildPlatformJobGraph.length} chars)`);
     assert(!bqBuildPlatformJobGraph.includes('...payload,\n    jobs: builtJobs'), 'BQ - Build Platform Job Graph must not spread the full bootstrap payload into output');

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -152,7 +152,14 @@ function validateStructure() {
       connectionExists('Get Credential Tokens', 'Validate Publish Token Health'),
     'Get Credential Tokens must feed the media preparation chain',
   );
-  assert(connectionExists('Validate Publish Token Health', 'List Files'), 'Token preflight must feed List Files');
+  const usesVisualEvidenceTopology = names.has('Prepare Livia Visual Contract');
+  assert(
+    usesVisualEvidenceTopology
+      ? connectionExists('Validate Publish Token Health', 'List Livia Source Folders') &&
+          connectionExists('List Livia Source Folders', 'List Files')
+      : connectionExists('Validate Publish Token Health', 'List Files'),
+    'Token preflight must reach List Files through the approved source-folder scope',
+  );
   assert(connectionExists('Prepare Media Items', 'Download File'), 'Prepare Media Items must feed Download File');
   assert(connectionExists('Download File', 'Write File'), 'Download File must feed Write File');
   assert(connectionExists('Write File', 'Process Media Asset'), 'Write File must feed Process Media Asset');
@@ -160,9 +167,47 @@ function validateStructure() {
   assert(connectionExists('Prepare Media Upload Batch', 'Read Media Asset'), 'Prepare Media Upload Batch must feed Read Media Asset');
   assert(connectionExists('Read Media Asset', 'Upload Main Media'), 'Read Media Asset must feed Upload Main Media');
   assert(connectionExists('Upload Main Media', 'Attach Uploaded Main Media Metadata'), 'Upload Main Media must feed Attach Uploaded Main Media Metadata');
-  assert(connectionExists('Attach Uploaded Main Media Metadata', 'Livia'), 'Attach Uploaded Main Media Metadata must feed Livia');
-
-  assert(connectionExists('Livia', 'Hydrate Publish Context'), 'Livia must feed Hydrate Publish Context');
+  if (usesVisualEvidenceTopology) {
+    for (const name of [
+      'Prepare Livia Visual Contract',
+      'Read Livia Visual Asset',
+      'Merge Livia Visual Asset and Contract',
+      'Assert Livia Visual Input',
+      'Loop Livia Media Evidence',
+      'Route Livia Media Evidence',
+      'Attach Image Visual Evidence',
+      'Analyze Video',
+      'Merge Video Analysis Response',
+      'Normalize Video Analysis',
+      'Assert Livia Video Analysis',
+      'Build Livia Group Evidence',
+      'Merge Livia Output and Visual Contract',
+      'Assert Livia Visual Analysis',
+    ]) {
+      assert(names.has(name), `Missing visual-evidence node: ${name}`);
+    }
+    assert(connectionExists('Attach Uploaded Main Media Metadata', 'Prepare Livia Visual Contract'), 'Uploaded media must enter the visual-evidence contract');
+    assert(connectionExists('Prepare Livia Visual Contract', 'Read Livia Visual Asset'), 'Visual contract must read the current item asset');
+    assert(connectionExists('Read Livia Visual Asset', 'Merge Livia Visual Asset and Contract'), 'Read visual asset must join its contract');
+    assert(connectionExists('Merge Livia Visual Asset and Contract', 'Assert Livia Visual Input'), 'Merged visual asset must fail closed before evidence routing');
+    assert(connectionExists('Assert Livia Visual Input', 'Loop Livia Media Evidence'), 'Validated visual asset must enter the per-item loop');
+    assert(connectionExists('Loop Livia Media Evidence', 'Route Livia Media Evidence', 1), 'Visual-evidence loop must route every item by media type');
+    assert(connectionExists('Route Livia Media Evidence', 'Attach Image Visual Evidence', 1), 'Image items must carry confirmed visual evidence');
+    assert(connectionExists('Route Livia Media Evidence', 'Analyze Video', 0), 'Video items must use the mandatory video analysis path');
+    assert(connectionExists('Analyze Video', 'Merge Video Analysis Response'), 'Video analysis response must join its source item');
+    assert(connectionExists('Merge Video Analysis Response', 'Normalize Video Analysis'), 'Video analysis must be normalized');
+    assert(connectionExists('Normalize Video Analysis', 'Assert Livia Video Analysis'), 'Malformed video analysis must fail before editorial AI');
+    assert(connectionExists('Attach Image Visual Evidence', 'Loop Livia Media Evidence'), 'Image evidence must rejoin the per-item loop');
+    assert(connectionExists('Assert Livia Video Analysis', 'Loop Livia Media Evidence'), 'Validated video evidence must rejoin the per-item loop');
+    assert(connectionExists('Loop Livia Media Evidence', 'Build Livia Group Evidence', 0), 'Ordered media evidence must be composed at group completion');
+    assert(connectionExists('Build Livia Group Evidence', 'Livia'), 'The editorial agent must receive the full evidence group');
+    assert(connectionExists('Livia', 'Merge Livia Output and Visual Contract'), 'Editorial output must rejoin the validated evidence contract');
+    assert(connectionExists('Merge Livia Output and Visual Contract', 'Assert Livia Visual Analysis'), 'Editorial output must be checked against visual evidence');
+    assert(connectionExists('Assert Livia Visual Analysis', 'Hydrate Publish Context'), 'Only validated editorial output may enter publication context');
+  } else {
+    assert(connectionExists('Attach Uploaded Main Media Metadata', 'Livia'), 'Attach Uploaded Main Media Metadata must feed Livia');
+    assert(connectionExists('Livia', 'Hydrate Publish Context'), 'Livia must feed Hydrate Publish Context');
+  }
   if (hasCompactBuildQueue) {
     assert(connectionExists('Hydrate Publish Context', 'Build Publish Queue'), 'Hydrate Publish Context must feed Build Publish Queue');
     assert(connectionExists('Build Publish Queue', 'Switch Publish Route'), 'Build Publish Queue must feed Switch Publish Route');
@@ -170,7 +215,14 @@ function validateStructure() {
     assert(connectionExists('Hydrate Publish Context', 'BQ - Normalize Hydrated Envelope'), 'Hydrate Publish Context must feed BQ - Normalize Hydrated Envelope');
     assert(connectionExists('BQ - Normalize Hydrated Envelope', 'BQ - Validate Bootstrap Inputs'), 'BQ - Normalize Hydrated Envelope must feed BQ - Validate Bootstrap Inputs');
     assert(connectionExists('BQ - Validate Bootstrap Inputs', 'BQ - Build Publish Context'), 'BQ - Validate Bootstrap Inputs must feed BQ - Build Publish Context');
-    assert(connectionExists('BQ - Build Publish Context', 'BQ - Build Platform Job Graph'), 'BQ - Build Publish Context must feed BQ - Build Platform Job Graph');
+    const publicationWindowGuard = names.has('Assert Livia Publication Window');
+    assert(
+      publicationWindowGuard
+        ? connectionExists('BQ - Build Publish Context', 'Assert Livia Publication Window') &&
+            connectionExists('Assert Livia Publication Window', 'BQ - Build Platform Job Graph')
+        : connectionExists('BQ - Build Publish Context', 'BQ - Build Platform Job Graph'),
+      'BQ publication context must pass the publication-window guard before platform job generation',
+    );
     assert(connectionExists('BQ - Build Platform Job Graph', 'BQ - Validate Job Graph'), 'BQ - Build Platform Job Graph must feed BQ - Validate Job Graph');
     assert(connectionExists('BQ - Validate Job Graph', 'BQ - Seed Publish State'), 'BQ - Validate Job Graph must feed BQ - Seed Publish State');
     assert(connectionExists('BQ - Seed Publish State', 'BQ - Emit First Job'), 'BQ - Seed Publish State must feed BQ - Emit First Job');
@@ -194,7 +246,8 @@ function validateStructure() {
   const updateEdges = workflow.connections?.['Update File']?.main?.[0] || [];
   assert(updateEdges.some((edge) => edge?.node === 'Merge Drive Result and Context' && edge?.index === 1), 'Update File must feed the Drive result into the final merge');
   assert(connectionExists('Merge Drive Result and Context', 'Assert Drive Published'), 'Merged Drive result and notification context must feed Assert Drive Published');
-  assert(connectionExists('Assert Drive Published', 'Inform Success (1)'), 'Verified Drive update must feed notification');
+  const notificationNode = names.has('Inform Success (1)') ? 'Inform Success (1)' : 'Inform Success (2)';
+  assert(connectionExists('Assert Drive Published', notificationNode), 'Verified Drive update must feed notification');
   assert(connectionExists('Assert Drive Published', 'Cleanup Temp Files'), 'Verified Drive update must feed cleanup');
   assert(connectionExists('Switch Final Dry Run', 'Cleanup Temp Files', 1), 'Switch Final Dry Run dry-run output must feed Cleanup Temp Files');
 }
@@ -250,6 +303,9 @@ function validateContracts() {
   assert(processMediaAssetCommand.length < 2500, `Process Media Asset command must stay small enough for stable expression parsing (${processMediaAssetCommand.length} chars)`);
   const jobGraphScript = path.join(__dirname, 'livia', 'build-platform-job-graph.js');
   const jobGraphSource = fs.readFileSync(jobGraphScript, 'utf8');
+  assert(jobGraphSource.includes('normalizeExternalResult'), 'Livia job graph must accept both direct n8n jobs and jobs envelopes.');
+  assert(jobGraphSource.includes('assertOutputContract'), 'Livia job graph must self-test its output contract.');
+  assert(jobGraphSource.includes('assertJobGraphContracts'), 'Livia job graph must test image, Reel and carousel fixtures without the gateway.');
   assert(jobGraphSource.includes('invalidateIncompleteCarouselResume'), 'Livia resume logic must invalidate partial Instagram carousel attempts before reusing child containers');
   assert(jobGraphSource.includes('groupResumeContextKey'), 'Livia resume logic must inspect group-scoped carousel container results');
   assert(jobGraphSource.includes('normalizeThreadsCarouselJob'), 'Livia job graph must keep Threads carousel child and parent request contracts distinct');
@@ -279,6 +335,7 @@ function validateContracts() {
     assert(typeOf('BQ - Build Platform Job Graph') === 'n8n-nodes-base.executeCommand', 'BQ - Build Platform Job Graph must be externalized as Execute Command');
     assert(bqBuildPlatformJobGraphCommand.includes('build-platform-job-graph.js'), 'BQ - Build Platform Job Graph must delegate to scripts/livia/build-platform-job-graph.js');
     assert(bqBuildPlatformJobGraphCommand.includes('--payload'), 'BQ - Build Platform Job Graph command must pass the input payload to the external script');
+    assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(bqBuildPlatformJobGraphCommand), 'BQ - Build Platform Job Graph must use an immutable workflow runtime root.');
     assert(bqBuildPlatformJobGraphCommand.length < 2500, `BQ - Build Platform Job Graph command must stay small enough for stable expression parsing (${bqBuildPlatformJobGraphCommand.length} chars)`);
     assert(bqBuildPlatformJobGraph.length < 1000, `BQ - Build Platform Job Graph must not be a large Code node anymore (${bqBuildPlatformJobGraph.length} chars)`);
     assert(!bqBuildPlatformJobGraph.includes('...payload,\n    jobs: builtJobs'), 'BQ - Build Platform Job Graph must not spread the full bootstrap payload into output');
@@ -287,7 +344,13 @@ function validateContracts() {
     assert(bqValidateJobGraph.includes('codexPayloadCompacted'), 'BQ - Validate Job Graph must preserve compacted payload marker');
   }
   assert(!hydrate.includes('$items('), 'Hydrate Publish Context must not use $items lookups');
-  assert(!hydrate.includes('.all(') || hydrate.includes('$input.all('), 'Hydrate Publish Context must not use named all() lookups');
+  assert(
+    !hydrate.includes('.all(') ||
+      hydrate.includes('$input.all(') ||
+      hydrate.includes('$("Attach Uploaded Main Media Metadata").all()') ||
+      hydrate.includes("$('Attach Uploaded Main Media Metadata').all()"),
+    'Hydrate Publish Context may read only the explicitly collected uploaded-media items',
+  );
 
   if (hasCompactBuildQueue) {
     assert(buildQueue.includes('buildPublishJobsFromLiviaInput'), 'Build Publish Queue must reuse buildPublishJobsFromLiviaInput');
@@ -359,7 +422,10 @@ function validateContracts() {
     'HTTP Request must support Codex dry-run or use the managed social publish gateway',
   );
   if (usesManagedSocialGateway) {
-    assert(httpParameters.contentType === 'json', 'Managed social publish gateway must use n8n JSON transport, not raw transport');
+    assert(
+      httpParameters.contentType === 'json' || httpParameters.specifyBody === 'json',
+      'Managed social publish gateway must use n8n JSON transport, not raw transport',
+    );
     assert(httpParameters.specifyBody === 'json', 'Managed social publish gateway must use the JSON body editor');
     assert(String(httpParameters.jsonBody || '').includes('JSON.stringify'), 'Managed social publish gateway must preserve its JSON payload expression');
     assert(!Object.prototype.hasOwnProperty.call(httpParameters, 'body'), 'Managed social publish gateway must not retain a raw body, which turns the response into a stream');
@@ -375,7 +441,9 @@ function validateContracts() {
   const driveMerge = getNode('Merge Drive Result and Context')?.parameters || {};
   assert(driveMerge.mode === 'combine' && driveMerge.combineBy === 'combineByPosition', 'Drive merge must combine the compact context and Drive response by position');
   assert(updateOptions.includes('"fields":["*"]'), 'Update File must return properties for verification');
-  assert(notifyPhone.includes('N8N_DEFAULT_TEST_PHONE') && !notifyPhone.includes('555195103563'), 'Notification must use the runtime E.164 phone instead of a hard-coded JID');
+  if (getNode('Inform Success (1)')) {
+    assert(notifyPhone.includes('N8N_DEFAULT_TEST_PHONE') && !notifyPhone.includes('555195103563'), 'Notification must use the runtime E.164 phone instead of a hard-coded JID');
+  }
   assert(telegramText.includes("$('Assert Drive Published').first().json.whatsappMessage"), 'Telegram notification must preserve the verified message after Evolution output');
   assert(JSON.stringify(getNode('Hydrate Publish Context')?.parameters || {}).includes('version: \\"v25.0\\"'), 'Hydrate Publish Context must use Graph API v25.0');
   assert(!workflowText.includes('v24.0'), 'Workflow must not retain Graph API v24.0 templates');

--- a/orb/engine/scripts/workflow-runtime-manifest.js
+++ b/orb/engine/scripts/workflow-runtime-manifest.js
@@ -29,7 +29,7 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
 }
 function immutableReleaseId(releaseRoot) {
-  const resolved = path.resolve(releaseRoot);
+  const resolved = path.resolve(releaseRoot); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- validated against RELEASE_ROOT_RE below.
   const match = resolved.match(RELEASE_ROOT_RE);
   if (!match) fail(`Workflow runtime root must be an immutable Orb release, got ${releaseRoot}.`);
   return { releaseRoot: resolved, releaseId: match[1] };
@@ -63,7 +63,7 @@ function manifestPathFor(runtimeHome, workflowId, workflowVersion) {
   if (!WORKFLOW_VERSION_RE.test(workflowVersion)) fail('Workflow version is invalid for a manifest path.');
   const resolvedHome = path.resolve(runtimeHome);
   if (resolvedHome !== DEFAULT_RUNTIME_HOME) fail(`Manifest runtime home must be ${DEFAULT_RUNTIME_HOME}.`);
-  const manifestPath = path.resolve(resolvedHome, 'workflow-runtime-manifests', workflowId, `${workflowVersion}.json`);
+  const manifestPath = path.resolve(resolvedHome, 'workflow-runtime-manifests', workflowId, `${workflowVersion}.json`); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- validated ID/version and containment above.
   const basePath = path.resolve(resolvedHome, 'workflow-runtime-manifests') + path.sep;
   if (!manifestPath.startsWith(basePath)) fail('Manifest path escapes the runtime manifest directory.');
   return manifestPath;

--- a/orb/engine/scripts/workflow-runtime-manifest.js
+++ b/orb/engine/scripts/workflow-runtime-manifest.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+'use strict';
+
+// A workflow may call versioned helper scripts, but never the mutable
+// /opt/skincos/current pointer.  This utility records and verifies the exact
+// immutable release used by one saved workflow version.
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_RUNTIME_HOME = '/var/lib/skincos-runtime/orb';
+const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/([0-9a-f]{7,64})\/source\/orb\/engine$/;
+const MUTABLE_SOURCE_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/;
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+function arg(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? String(process.argv[index + 1] || '') : '';
+}
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+function immutableReleaseId(releaseRoot) {
+  const resolved = path.resolve(releaseRoot);
+  const match = resolved.match(RELEASE_ROOT_RE);
+  if (!match) fail(`Workflow runtime root must be an immutable Orb release, got ${releaseRoot}.`);
+  return { releaseRoot: resolved, releaseId: match[1] };
+}
+function commandsFor(workflow) {
+  return (Array.isArray(workflow.nodes) ? workflow.nodes : [])
+    .filter((node) => node?.type === 'n8n-nodes-base.executeCommand')
+    .map((node) => ({ name: String(node.name || ''), command: String(node?.parameters?.command || '') }));
+}
+function assertNoMutableCommands(workflow) {
+  const offenders = commandsFor(workflow)
+    .filter(({ command }) => MUTABLE_SOURCE_RE.test(command))
+    .map(({ name }) => name);
+  if (offenders.length) {
+    fail(`Mutable runtime reference is forbidden in Execute Command node(s): ${offenders.join(', ')}.`);
+  }
+}
+function atomicWrite(filePath, content) {
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o750 });
+  const temporary = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, content, { mode: 0o640 });
+  fs.renameSync(temporary, filePath);
+}
+function comparableManifest(manifest) {
+  const { createdAt, ...stable } = manifest || {};
+  return stable;
+}
+function defaultEntrypoints(releaseRoot) {
+  return [
+    'compose2-current.js',
+    'scripts/livia/process-media-asset.js',
+    'scripts/livia/build-platform-job-graph.js',
+    'scripts/livia/verify-published-artifacts.js',
+    'scripts/livia/publish-progress-ledger.js',
+    'scripts/livia/validate-publish-token-health.js',
+  ].map((relativePath) => ({ relativePath, absolutePath: path.join(releaseRoot, relativePath) }));
+}
+function createManifest() {
+  const workflowFile = arg('--workflow');
+  const workflowId = arg('--workflow-id');
+  const workflowVersion = arg('--workflow-version');
+  const runtimeHome = arg('--runtime-home') || DEFAULT_RUNTIME_HOME;
+  const source = immutableReleaseId(arg('--release-root'));
+  if (!workflowFile || !workflowId || !workflowVersion) fail('create requires --workflow, --workflow-id and --workflow-version.');
+  const workflow = readJson(workflowFile);
+  if (String(workflow.id || '') !== workflowId) fail(`Workflow ID mismatch: expected ${workflowId}, got ${workflow.id || 'missing'}.`);
+  assertNoMutableCommands(workflow);
+  const commands = commandsFor(workflow);
+  const liviaCommands = commands.filter(({ command }) => /scripts\/livia\//.test(command) || /compose2-current\.js/.test(command));
+  if (liviaCommands.length && liviaCommands.some(({ command }) => !command.includes(source.releaseRoot))) {
+    fail('Livia helper command is not pinned to the manifest release root.');
+  }
+  const entrypoints = defaultEntrypoints(source.releaseRoot).map(({ relativePath, absolutePath }) => {
+    if (!fs.existsSync(absolutePath)) fail(`Pinned workflow entrypoint is missing: ${absolutePath}.`);
+    return { path: relativePath, sha256: sha256File(absolutePath) };
+  });
+  const manifest = {
+    schemaVersion: 1,
+    workflowId,
+    workflowVersion,
+    releaseId: source.releaseId,
+    releaseRoot: source.releaseRoot,
+    createdAt: new Date().toISOString(),
+    workflowSha256: crypto.createHash('sha256').update(JSON.stringify({ nodes: workflow.nodes, connections: workflow.connections })).digest('hex'),
+    commands: liviaCommands.map(({ name, command }) => ({ name, sha256: crypto.createHash('sha256').update(command).digest('hex') })),
+    entrypoints,
+  };
+  const manifestPath = path.join(runtimeHome, 'workflow-runtime-manifests', workflowId, `${workflowVersion}.json`);
+  if (fs.existsSync(manifestPath)) {
+    const existing = readJson(manifestPath);
+    if (JSON.stringify(comparableManifest(existing)) !== JSON.stringify(comparableManifest(manifest))) {
+      fail(`Workflow runtime manifest already exists with different content: ${manifestPath}.`);
+    }
+  } else {
+    atomicWrite(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify({ ok: true, manifestPath, workflowId, workflowVersion, releaseId: source.releaseId })}\n`);
+}
+function auditLive() {
+  let Client;
+  try { Client = require('/usr/local/lib/node_modules/n8n/node_modules/pg').Client; }
+  catch { Client = require('pg').Client; }
+  const client = new Client({ user: process.env.PGUSER || 'postgres', host: process.env.PGHOST || '/var/run/postgresql', database: process.env.PGDATABASE || 'n8n_runtime' });
+  client.connect().then(async () => {
+    const result = await client.query('SELECT id, name, "versionId", nodes FROM n8n_runtime.workflow_entity WHERE active=true AND "isArchived"=false ORDER BY name');
+    const offenders = result.rows.flatMap((row) => {
+      const workflow = { nodes: typeof row.nodes === 'string' ? JSON.parse(row.nodes) : row.nodes };
+      return commandsFor(workflow).filter(({ command }) => MUTABLE_SOURCE_RE.test(command)).map(({ name }) => ({ workflowId: row.id, workflow: row.name, versionId: row.versionId, node: name }));
+    });
+    await client.end();
+    if (offenders.length) fail(`Active workflows contain mutable runtime references: ${JSON.stringify(offenders)}.`);
+    process.stdout.write(JSON.stringify({ ok: true, activeWorkflowCount: result.rows.length, mutableRuntimeReferences: 0 }) + '\n');
+  }).catch(async (error) => { await client.end().catch(() => {}); fail(error.message); });
+}
+
+if (process.argv.includes('create')) createManifest();
+else if (process.argv.includes('audit-live')) auditLive();
+else fail('Usage: workflow-runtime-manifest.js create ... | audit-live');

--- a/orb/engine/scripts/workflow-runtime-manifest.js
+++ b/orb/engine/scripts/workflow-runtime-manifest.js
@@ -11,6 +11,8 @@ const path = require('path');
 const DEFAULT_RUNTIME_HOME = '/var/lib/skincos-runtime/orb';
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/([0-9a-f]{7,64})\/source\/orb\/engine$/;
 const MUTABLE_SOURCE_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/;
+const WORKFLOW_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const WORKFLOW_VERSION_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function fail(message) {
   process.stderr.write(`${message}\n`);
@@ -56,6 +58,16 @@ function comparableManifest(manifest) {
   const { createdAt, ...stable } = manifest || {};
   return stable;
 }
+function manifestPathFor(runtimeHome, workflowId, workflowVersion) {
+  if (!WORKFLOW_ID_RE.test(workflowId)) fail('Workflow ID is invalid for a manifest path.');
+  if (!WORKFLOW_VERSION_RE.test(workflowVersion)) fail('Workflow version is invalid for a manifest path.');
+  const resolvedHome = path.resolve(runtimeHome);
+  if (resolvedHome !== DEFAULT_RUNTIME_HOME) fail(`Manifest runtime home must be ${DEFAULT_RUNTIME_HOME}.`);
+  const manifestPath = path.resolve(resolvedHome, 'workflow-runtime-manifests', workflowId, `${workflowVersion}.json`);
+  const basePath = path.resolve(resolvedHome, 'workflow-runtime-manifests') + path.sep;
+  if (!manifestPath.startsWith(basePath)) fail('Manifest path escapes the runtime manifest directory.');
+  return manifestPath;
+}
 function defaultEntrypoints(releaseRoot) {
   return [
     'compose2-current.js',
@@ -96,7 +108,7 @@ function createManifest() {
     commands: liviaCommands.map(({ name, command }) => ({ name, sha256: crypto.createHash('sha256').update(command).digest('hex') })),
     entrypoints,
   };
-  const manifestPath = path.join(runtimeHome, 'workflow-runtime-manifests', workflowId, `${workflowVersion}.json`);
+  const manifestPath = manifestPathFor(runtimeHome, workflowId, workflowVersion);
   if (fs.existsSync(manifestPath)) {
     const existing = readJson(manifestPath);
     if (JSON.stringify(comparableManifest(existing)) !== JSON.stringify(comparableManifest(manifest))) {
@@ -113,7 +125,12 @@ function auditLive() {
   catch { Client = require('pg').Client; }
   const client = new Client({ user: process.env.PGUSER || 'postgres', host: process.env.PGHOST || '/var/run/postgresql', database: process.env.PGDATABASE || 'n8n_runtime' });
   client.connect().then(async () => {
-    const result = await client.query('SELECT id, name, "versionId", nodes FROM n8n_runtime.workflow_entity WHERE active=true AND "isArchived"=false ORDER BY name');
+    const result = await client.query(
+      `SELECT w.id, w.name, w."activeVersionId" AS "versionId", h.nodes
+         FROM n8n_runtime.workflow_entity w
+         JOIN n8n_runtime.workflow_history h ON h."workflowId"=w.id AND h."versionId"=w."activeVersionId"
+        WHERE w.active=true AND w."isArchived"=false ORDER BY w.name`,
+    );
     const offenders = result.rows.flatMap((row) => {
       const workflow = { nodes: typeof row.nodes === 'string' ? JSON.parse(row.nodes) : row.nodes };
       return commandsFor(workflow).filter(({ command }) => MUTABLE_SOURCE_RE.test(command)).map(({ name }) => ({ workflowId: row.id, workflow: row.name, versionId: row.versionId, node: name }));

--- a/scripts/runtime/install-lifecycle-units.sh
+++ b/scripts/runtime/install-lifecycle-units.sh
@@ -83,6 +83,7 @@ units=(
   cloudflare-orb.service
   cloudflare-runtime.service
   orb-backup.service
+  orb-restart-fence.service
 )
 
 render_dir="$(mktemp -d)"

--- a/scripts/runtime/prepare-native-source-release.sh
+++ b/scripts/runtime/prepare-native-source-release.sh
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-[[ "$RELEASE_ID" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'SKINCOS_RELEASE_ID must be a reviewed hexadecimal commit SHA.' >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9a-f]{40}$ ]] || { echo 'SKINCOS_RELEASE_ID must be a full 40-character reviewed commit SHA.' >&2; exit 1; }
 [[ -n "$RELEASE_ARCHIVE" && -f "$RELEASE_ARCHIVE" ]] || { echo '--archive must name an existing native source archive.' >&2; exit 1; }
 [[ "$RELEASE_ARCHIVE" != /mnt/* ]] || { echo '--archive must already be on native Linux storage, not /mnt/c.' >&2; exit 1; }
 [[ "$RELEASE_ARCHIVE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo '--sha256 must be a SHA-256 hexadecimal digest.' >&2; exit 1; }

--- a/scripts/runtime/prepare-native-source-release.sh
+++ b/scripts/runtime/prepare-native-source-release.sh
@@ -13,27 +13,38 @@ DESTINATION="$RELEASE_BASE/$RELEASE_ID/source"
 STAGING="$RELEASE_BASE/.source-staging-$RELEASE_ID-$$"
 RELEASE_ARCHIVE=""
 RELEASE_ARCHIVE_SHA256=""
+RELEASE_LINEAGE=""
+RELEASE_LINEAGE_SHA256=""
 CRM_NPM_CACHE="${CRM_NPM_CACHE:-/var/lib/skincos-runtime/cache/crm-api}"
 APPLY=0
+STAGE_ONLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-native-source-release.sh --archive <native-tar> --sha256 <sha256> [--apply]
+Usage: scripts/runtime/prepare-native-source-release.sh --archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--apply --stage-only]
 
 Set SKINCOS_RELEASE_ID to the reviewed main commit SHA. The archive must have
 already been created and copied by Windows into a native Linux path (never
 /mnt/c). With --apply, validates its SHA-256, stages tracked source in
 /opt/skincos/releases/<sha>/source, installs locked CRM production dependencies
-on Linux, and atomically promotes /opt/skincos/current/source. It never copies
-private .env files or worktree metadata.
+on Linux. A production source pointer is promoted only by
+promote-native-source-release.sh after the workflow/runtime coherence gate.
+It never copies private .env files or worktree metadata.
+
+The lineage JSON is produced by verify-native-source-release-lineage.ps1 from
+the reviewed Git repository. It proves the candidate is a descendant of the
+currently effective release and is copied immutably into the staged bundle.
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply) APPLY=1 ;;
+    --stage-only) STAGE_ONLY=1 ;;
     --archive) RELEASE_ARCHIVE="${2:-}"; shift ;;
     --sha256) RELEASE_ARCHIVE_SHA256="${2:-}"; shift ;;
+    --lineage) RELEASE_LINEAGE="${2:-}"; shift ;;
+    --lineage-sha256) RELEASE_LINEAGE_SHA256="${2:-}"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -44,22 +55,44 @@ done
 [[ -n "$RELEASE_ARCHIVE" && -f "$RELEASE_ARCHIVE" ]] || { echo '--archive must name an existing native source archive.' >&2; exit 1; }
 [[ "$RELEASE_ARCHIVE" != /mnt/* ]] || { echo '--archive must already be on native Linux storage, not /mnt/c.' >&2; exit 1; }
 [[ "$RELEASE_ARCHIVE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo '--sha256 must be a SHA-256 hexadecimal digest.' >&2; exit 1; }
+[[ -n "$RELEASE_LINEAGE" && -f "$RELEASE_LINEAGE" ]] || { echo '--lineage must name an existing native lineage JSON.' >&2; exit 1; }
+[[ "$RELEASE_LINEAGE" != /mnt/* ]] || { echo '--lineage must already be on native Linux storage, not /mnt/c.' >&2; exit 1; }
+[[ "$RELEASE_LINEAGE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo '--lineage-sha256 must be a SHA-256 hexadecimal digest.' >&2; exit 1; }
 [[ ! -e "$DESTINATION" ]] || { echo "Source release destination already exists: $DESTINATION" >&2; exit 1; }
+[[ "$STAGE_ONLY" != "1" || "$APPLY" = "1" ]] || { echo '--stage-only requires --apply.' >&2; exit 1; }
 
 echo "Source release ID: $RELEASE_ID"
 echo "Native source archive: $RELEASE_ARCHIVE"
 echo "Destination: $DESTINATION"
 if [[ "$APPLY" != "1" ]]; then
-  echo 'Dry run complete. Use --apply only after CI, backup and cutover gates pass.'
+  echo 'Dry run complete. Use --apply --stage-only only after CI, backup and cutover gates pass.'
   exit 0
 fi
+[[ "$STAGE_ONLY" = "1" ]] || {
+  echo 'Direct source-pointer changes are disabled. Stage first, then use promote-native-source-release.sh.' >&2
+  exit 1
+}
 
 command -v npm >/dev/null 2>&1 || { echo 'Missing required command: npm' >&2; exit 1; }
 command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
 command -v sha256sum >/dev/null 2>&1 || { echo 'Missing required command: sha256sum' >&2; exit 1; }
+command -v setfacl >/dev/null 2>&1 || { echo 'Missing required command: setfacl (install the acl package).' >&2; exit 1; }
 sudo -n true
 actual_archive_sha256="$(sha256sum "$RELEASE_ARCHIVE" | awk '{print $1}')"
 [[ "${actual_archive_sha256,,}" == "${RELEASE_ARCHIVE_SHA256,,}" ]] || { echo 'Source archive checksum mismatch.' >&2; exit 1; }
+actual_lineage_sha256="$(sha256sum "$RELEASE_LINEAGE" | awk '{print $1}')"
+[[ "${actual_lineage_sha256,,}" == "${RELEASE_LINEAGE_SHA256,,}" ]] || { echo 'Source lineage checksum mismatch.' >&2; exit 1; }
+lineage_parent="$(node - "$RELEASE_LINEAGE" "$RELEASE_ID" <<'NODE'
+const fs = require('fs');
+const [file, expectedRelease] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (value.releaseId !== expectedRelease) throw new Error('Lineage releaseId does not match SKINCOS_RELEASE_ID.');
+if (!/^[0-9a-f]{7,64}$/.test(String(value.parentReleaseId || ''))) throw new Error('Lineage parentReleaseId is invalid.');
+if (value.verifiedAncestor !== true) throw new Error('Lineage does not contain verifiedAncestor=true.');
+process.stdout.write(value.parentReleaseId);
+NODE
+)" || { echo 'Source lineage JSON is invalid.' >&2; exit 1; }
+echo "Verified release lineage parent: $lineage_parent"
 
 cleanup_staging() {
   sudo -n rm -rf "$STAGING"
@@ -68,10 +101,17 @@ trap cleanup_staging EXIT INT TERM
 
 sudo -n install -d -o root -g skincos -m 0750 "$STAGING" "$CRM_NPM_CACHE"
 sudo -n tar -xf "$RELEASE_ARCHIVE" -C "$STAGING"
+sudo -n install -m 0640 "$RELEASE_LINEAGE" "$STAGING/.skincos-release-lineage.json"
 sudo -n chown -R root:skincos "$STAGING"
 sudo -n find "$STAGING" -type d -exec chmod 0750 {} +
 sudo -n find "$STAGING" -type f -exec chmod 0640 {} +
 sudo -n find "$STAGING" -type f \( -path '*/scripts/*.sh' -o -path '*/scripts/*/*.sh' \) -exec chmod 0750 {} +
+# These two operator-only scripts must execute as postgres for local peer
+# authentication to the n8n database. They contain no credentials; keep the
+# rest of the staged source restricted to root:skincos.
+sudo -n chmod 0644 \
+  "$STAGING/orb/engine/scripts/workflow-runtime-manifest.js" \
+  "$STAGING/orb/engine/scripts/apply-livia-runtime-isolation.js"
 sudo -n chown -R skincos:skincos "$CRM_NPM_CACHE"
 
 sudo -n test -f "$STAGING/crm/api/package-lock.json" || { echo 'CRM lockfile is missing from source release.' >&2; exit 1; }
@@ -92,10 +132,30 @@ sudo -n -u skincos env \
   LIVIA_BUILD_JOB_GRAPH_SOURCE="$STAGING/orb/engine/compose2-current.js" \
   N8N_RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}" \
   node "$STAGING/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-runtime-compatibility >/dev/null
+sudo -n -u skincos env \
+  LIVIA_BUILD_JOB_GRAPH_SOURCE="$STAGING/orb/engine/compose2-current.js" \
+  N8N_RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}" \
+  node "$STAGING/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-output-contract >/dev/null
+sudo -n -u skincos env \
+  LIVIA_BUILD_JOB_GRAPH_SOURCE="$STAGING/orb/engine/compose2-current.js" \
+  N8N_RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}" \
+  node "$STAGING/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-job-graph-contracts >/dev/null
 
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$DESTINATION")"
 sudo -n mv "$STAGING" "$DESTINATION"
 trap - EXIT INT TERM
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$CURRENT_LINK")"
-sudo -n ln -sfn "$DESTINATION" "$CURRENT_LINK"
-echo "Native source release prepared: $CURRENT_LINK -> $DESTINATION"
+# The versioned n8n writer authenticates locally as postgres. Permit only
+# traversal to its immutable scripts and only manifest-directory writes; no
+# workflow sidecar or source tree becomes generally readable or writable.
+for acl_dir in "$RELEASE_BASE/$RELEASE_ID" "$DESTINATION" "$DESTINATION/orb" "$DESTINATION/orb/engine" "$DESTINATION/orb/engine/scripts"; do
+  sudo -n setfacl -m u:postgres:--x "$acl_dir"
+done
+sudo -n setfacl -m u:postgres:r-- \
+  "$DESTINATION/orb/engine/scripts/workflow-runtime-manifest.js" \
+  "$DESTINATION/orb/engine/scripts/apply-livia-runtime-isolation.js"
+MANIFEST_DIR="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}/workflow-runtime-manifests/WGXr4vYkv9UoJ8zc"
+sudo -n install -d -o root -g root -m 0750 "$MANIFEST_DIR"
+sudo -n setfacl -m u:postgres:--x "$(dirname "$(dirname "$MANIFEST_DIR")")" "$(dirname "$MANIFEST_DIR")"
+sudo -n setfacl -m u:postgres:rwx "$MANIFEST_DIR"
+echo "Native source release staged: $DESTINATION"

--- a/scripts/runtime/promote-native-source-release.sh
+++ b/scripts/runtime/promote-native-source-release.sh
@@ -39,8 +39,8 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-[[ "$release_id" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'Invalid --release-id.' >&2; exit 2; }
-[[ "$expected_current" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'Invalid --expected-current-release.' >&2; exit 2; }
+[[ "$release_id" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid --release-id: full 40-character SHA required.' >&2; exit 2; }
+[[ "$expected_current" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid --expected-current-release: full 40-character SHA required.' >&2; exit 2; }
 [[ "$timeout_seconds" =~ ^[1-9][0-9]{0,3}$ ]] && (( timeout_seconds <= 3600 )) || { echo 'Invalid --timeout-seconds.' >&2; exit 2; }
 
 target="$RELEASE_BASE/$release_id/source"
@@ -137,6 +137,12 @@ for sidecar in "${SOURCE_SERVICES[@]}"; do
     crm.service) expected_root="$target/crm/api" ;;
     booking.service) expected_root="$target/integration/ef" ;;
   esac
+  sidecar_deadline=$(( $(date +%s) + 30 ))
+  while [[ "$sidecar_root" != "$expected_root" && $(date +%s) -lt $sidecar_deadline ]]; do
+    sleep 1
+    sidecar_pid="$(systemctl show "$sidecar" -p MainPID --value)"
+    sidecar_root="$(readlink -f "/proc/$sidecar_pid/cwd")"
+  done
   [[ "$sidecar_root" = "$expected_root" ]] || { echo "$sidecar restarted from unexpected root: $sidecar_root" >&2; exit 1; }
 done
 sidecars_started=1

--- a/scripts/runtime/promote-native-source-release.sh
+++ b/scripts/runtime/promote-native-source-release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The only supported source-pointer promotion.  It holds a fail-closed Livia
+# maintenance window, requires every active workflow to be free of mutable
+# helper paths, and starts Orb only after the pointer changed.
+readonly RELEASE_BASE="${SKINCOS_RELEASE_BASE:-/opt/skincos/releases}"
+readonly CURRENT_LINK="${SKINCOS_SOURCE_CURRENT_LINK:-/opt/skincos/current/source}"
+readonly SERVICE='orb.service'
+readonly FENCE_SERVICE='orb-restart-fence.service'
+readonly WORKFLOW_ID='WGXr4vYkv9UoJ8zc'
+readonly RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}"
+readonly STATE_DIR="$RUNTIME_HOME/state/livia-maintenance"
+readonly LOCK_DIR="$STATE_DIR/release-promote.lock.d"
+readonly LOCK_FILE="$STATE_DIR/release-promote.lock"
+
+release_id=''
+expected_current=''
+recover_split=0
+timeout_seconds="${ORB_SAFE_RESTART_TIMEOUT_SECONDS:-900}"
+
+usage() {
+  cat <<'EOF'
+Usage: promote-native-source-release.sh --release-id <sha> --expected-current-release <sha> [--recover-runtime-split]
+
+Promotes an already staged native release after Livia has been pinned to an
+immutable workflow runtime manifest. Direct pointer changes are forbidden.
+EOF
+}
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-id) release_id="${2:-}"; shift ;;
+    --expected-current-release) expected_current="${2:-}"; shift ;;
+    --recover-runtime-split) recover_split=1 ;;
+    --timeout-seconds) timeout_seconds="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+[[ "$release_id" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'Invalid --release-id.' >&2; exit 2; }
+[[ "$expected_current" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'Invalid --expected-current-release.' >&2; exit 2; }
+[[ "$timeout_seconds" =~ ^[1-9][0-9]{0,3}$ ]] && (( timeout_seconds <= 3600 )) || { echo 'Invalid --timeout-seconds.' >&2; exit 2; }
+
+target="$RELEASE_BASE/$release_id/source"
+[[ -d "$target/orb/engine" ]] || { echo "Staged release is missing: $target" >&2; exit 1; }
+lineage_file="$target/.skincos-release-lineage.json"
+[[ -f "$lineage_file" ]] || { echo 'Staged release has no immutable lineage manifest.' >&2; exit 1; }
+current_target="$(readlink -f "$CURRENT_LINK")"
+current_release="$(basename "$(dirname "$current_target")")"
+[[ "$current_release" = "$expected_current" ]] || { echo "Current release changed: expected $expected_current, found $current_release." >&2; exit 1; }
+[[ "$release_id" != "$current_release" ]] || { echo 'Target release is already current.' >&2; exit 1; }
+node - "$lineage_file" "$release_id" "$current_release" <<'NODE' || { echo 'Candidate is not a verified descendant of the effective release.' >&2; exit 1; }
+const fs = require('fs');
+const [file, releaseId, currentRelease] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (value.releaseId !== releaseId || value.parentReleaseId !== currentRelease || value.verifiedAncestor !== true) process.exit(1);
+NODE
+
+pid="$(systemctl show "$SERVICE" -p MainPID --value)"
+effective_root="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+if [[ "$effective_root" != "$current_target/orb/engine" && "$recover_split" != 1 ]]; then
+  echo "Runtime split detected: Orb=$effective_root current=$current_target. Refusing promotion without --recover-runtime-split." >&2
+  exit 1
+fi
+
+sudo -n -u skincos env LIVIA_BUILD_JOB_GRAPH_SOURCE="$target/orb/engine/compose2-current.js" \
+  N8N_RUNTIME_HOME="$RUNTIME_HOME" node "$target/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-runtime-compatibility >/dev/null
+sudo -n -u skincos env LIVIA_BUILD_JOB_GRAPH_SOURCE="$target/orb/engine/compose2-current.js" \
+  N8N_RUNTIME_HOME="$RUNTIME_HOME" node "$target/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-output-contract >/dev/null
+sudo -n -u skincos env LIVIA_BUILD_JOB_GRAPH_SOURCE="$target/orb/engine/compose2-current.js" \
+  N8N_RUNTIME_HOME="$RUNTIME_HOME" node "$target/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-job-graph-contracts >/dev/null
+sudo -n -u postgres env PGUSER=postgres PGHOST=/var/run/postgresql PGDATABASE=n8n_runtime \
+  node "$target/orb/engine/scripts/workflow-runtime-manifest.js" audit-live >/dev/null
+
+sudo -n install -d -o skincos -g skincos -m 0750 "$STATE_DIR"
+if ! sudo -n -u skincos mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "Release promotion refused: Livia maintenance window already active ($LOCK_FILE)." >&2
+  exit 1
+fi
+promoted=0
+started=0
+cleanup() {
+  if (( promoted == 1 && started == 0 )); then sudo -n ln -sfn "$current_target" "$CURRENT_LINK" || true; fi
+  sudo -n -u skincos rm -f "$LOCK_FILE" 2>/dev/null || true
+  sudo -n -u skincos rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+sudo -n -u skincos bash -c 'umask 027; printf "reason=controlled_native_release_promotion\nstarted_at=%s\n" "$1" >"$2"' bash "$(date --iso-8601=seconds)" "$LOCK_FILE"
+
+deadline=$(( $(date +%s) + timeout_seconds ))
+while true; do
+  active="$(sudo -n -u postgres psql -d n8n_runtime -Atqc "SELECT count(*) FROM n8n_runtime.execution_entity WHERE \"workflowId\"='$WORKFLOW_ID' AND status IN ('new','running','waiting');")"
+  [[ "$active" =~ ^[0-9]+$ ]] || { echo 'Unable to determine active Livia executions.' >&2; exit 1; }
+  (( active == 0 )) && break
+  (( $(date +%s) < deadline )) || { echo "Release promotion refused: $active Livia execution(s) still active." >&2; exit 1; }
+  sleep 5
+done
+
+sudo -n systemctl start "$FENCE_SERVICE"
+if sudo -n systemctl --quiet is-active "$SERVICE"; then
+  echo 'Release promotion fence did not stop Orb.' >&2
+  sudo -n systemctl stop "$FENCE_SERVICE" || true
+  exit 1
+fi
+sudo -n ln -sfn "$target" "$CURRENT_LINK"
+promoted=1
+sudo -n systemctl stop "$FENCE_SERVICE"
+sudo -n systemctl start "$SERVICE"
+sudo -n systemctl --quiet is-active "$SERVICE"
+new_pid="$(systemctl show "$SERVICE" -p MainPID --value)"
+new_root="$(readlink -f "/proc/$new_pid/cwd")"
+[[ "$new_root" = "$target/orb/engine" ]] || { echo "Orb restarted from unexpected root: $new_root" >&2; exit 1; }
+started=1
+printf 'Native source release promoted safely: %s\n' "$release_id"

--- a/scripts/runtime/promote-native-source-release.sh
+++ b/scripts/runtime/promote-native-source-release.sh
@@ -8,6 +8,7 @@ readonly RELEASE_BASE="${SKINCOS_RELEASE_BASE:-/opt/skincos/releases}"
 readonly CURRENT_LINK="${SKINCOS_SOURCE_CURRENT_LINK:-/opt/skincos/current/source}"
 readonly SERVICE='orb.service'
 readonly FENCE_SERVICE='orb-restart-fence.service'
+readonly SOURCE_SERVICES=('orb-proxy.service' 'crm.service' 'booking.service')
 readonly WORKFLOW_ID='WGXr4vYkv9UoJ8zc'
 readonly RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}"
 readonly STATE_DIR="$RUNTIME_HOME/state/livia-maintenance"
@@ -64,6 +65,13 @@ if [[ "$effective_root" != "$current_target/orb/engine" && "$recover_split" != 1
   exit 1
 fi
 
+fence_template="$target/ops/runtime/units/$FENCE_SERVICE"
+[[ -f "$fence_template" ]] || { echo "Staged release is missing $FENCE_SERVICE template." >&2; exit 1; }
+if ! systemctl cat "$FENCE_SERVICE" >/dev/null 2>&1; then
+  sudo -n install -m 0644 "$fence_template" "/etc/systemd/system/$FENCE_SERVICE"
+  sudo -n systemctl daemon-reload
+fi
+
 sudo -n -u skincos env LIVIA_BUILD_JOB_GRAPH_SOURCE="$target/orb/engine/compose2-current.js" \
   N8N_RUNTIME_HOME="$RUNTIME_HOME" node "$target/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-runtime-compatibility >/dev/null
 sudo -n -u skincos env LIVIA_BUILD_JOB_GRAPH_SOURCE="$target/orb/engine/compose2-current.js" \
@@ -80,8 +88,15 @@ if ! sudo -n -u skincos mkdir "$LOCK_DIR" 2>/dev/null; then
 fi
 promoted=0
 started=0
+sidecars_started=0
 cleanup() {
-  if (( promoted == 1 && started == 0 )); then sudo -n ln -sfn "$current_target" "$CURRENT_LINK" || true; fi
+  if (( promoted == 1 && (started == 0 || sidecars_started == 0) )); then
+    sudo -n systemctl start "$FENCE_SERVICE" || true
+    sudo -n ln -sfn "$current_target" "$CURRENT_LINK" || true
+    sudo -n systemctl stop "$FENCE_SERVICE" || true
+    sudo -n systemctl start "$SERVICE" || true
+    for sidecar in "${SOURCE_SERVICES[@]}"; do sudo -n systemctl restart "$sidecar" || true; done
+  fi
   sudo -n -u skincos rm -f "$LOCK_FILE" 2>/dev/null || true
   sudo -n -u skincos rmdir "$LOCK_DIR" 2>/dev/null || true
 }
@@ -112,4 +127,17 @@ new_pid="$(systemctl show "$SERVICE" -p MainPID --value)"
 new_root="$(readlink -f "/proc/$new_pid/cwd")"
 [[ "$new_root" = "$target/orb/engine" ]] || { echo "Orb restarted from unexpected root: $new_root" >&2; exit 1; }
 started=1
+for sidecar in "${SOURCE_SERVICES[@]}"; do
+  sudo -n systemctl restart "$sidecar"
+  sudo -n systemctl --quiet is-active "$sidecar"
+  sidecar_pid="$(systemctl show "$sidecar" -p MainPID --value)"
+  sidecar_root="$(readlink -f "/proc/$sidecar_pid/cwd")"
+  case "$sidecar" in
+    orb-proxy.service) expected_root="$target/orb/engine" ;;
+    crm.service) expected_root="$target/crm/api" ;;
+    booking.service) expected_root="$target/integration/ef" ;;
+  esac
+  [[ "$sidecar_root" = "$expected_root" ]] || { echo "$sidecar restarted from unexpected root: $sidecar_root" >&2; exit 1; }
+done
+sidecars_started=1
 printf 'Native source release promoted safely: %s\n' "$release_id"

--- a/scripts/runtime/test-prepare-native-source-release.sh
+++ b/scripts/runtime/test-prepare-native-source-release.sh
@@ -7,14 +7,24 @@ SCRIPT="$ROOT_DIR/scripts/runtime/prepare-native-source-release.sh"
 bash -n "$SCRIPT"
 
 required=(
-  '--archive <native-tar> --sha256 <sha256>'
+  '--archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--apply --stage-only]'
   'Windows creates and transfers the archive first'
   '[[ "$RELEASE_ARCHIVE" != /mnt/* ]]'
   'actual_archive_sha256="$(sha256sum "$RELEASE_ARCHIVE"'
+  'actual_lineage_sha256="$(sha256sum "$RELEASE_LINEAGE"'
+  'value.verifiedAncestor !== true'
+  '.skincos-release-lineage.json'
   'sudo -n tar -xf "$RELEASE_ARCHIVE" -C "$STAGING"'
   'find "$STAGING" -type f'
+  'workflow-runtime-manifest.js'
+  'apply-livia-runtime-isolation.js'
+  'Missing required command: setfacl'
+  'u:postgres:rwx'
   'LIVIA_BUILD_JOB_GRAPH_SOURCE="$STAGING/orb/engine/compose2-current.js"'
   '--assert-runtime-compatibility'
+  '--assert-output-contract'
+  '--assert-job-graph-contracts'
+  'Direct source-pointer changes are disabled'
 )
 
 for pattern in "${required[@]}"; do
@@ -31,5 +41,9 @@ fi
 
 LIVIA_BUILD_JOB_GRAPH_SOURCE="$ROOT_DIR/orb/engine/compose2-current.js" \
   node "$ROOT_DIR/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-runtime-compatibility >/dev/null
+LIVIA_BUILD_JOB_GRAPH_SOURCE="$ROOT_DIR/orb/engine/compose2-current.js" \
+  node "$ROOT_DIR/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-output-contract >/dev/null
+LIVIA_BUILD_JOB_GRAPH_SOURCE="$ROOT_DIR/orb/engine/compose2-current.js" \
+  node "$ROOT_DIR/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-job-graph-contracts >/dev/null
 
 echo 'PASS: native source release accepts only a checksum-verified Linux archive.'

--- a/scripts/runtime/verify-native-source-release-lineage.ps1
+++ b/scripts/runtime/verify-native-source-release-lineage.ps1
@@ -1,11 +1,11 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{7,64}$')]
+  [ValidatePattern('^[0-9a-f]{40}$')]
   [string]$ReleaseId,
 
   [Parameter(Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{7,64}$')]
+  [ValidatePattern('^[0-9a-f]{40}$')]
   [string]$ParentReleaseId,
 
   [Parameter(Mandatory = $true)]

--- a/scripts/runtime/verify-native-source-release-lineage.ps1
+++ b/scripts/runtime/verify-native-source-release-lineage.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-f]{7,64}$')]
+  [string]$ReleaseId,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-f]{7,64}$')]
+  [string]$ParentReleaseId,
+
+  [Parameter(Mandatory = $true)]
+  [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$release = (git rev-parse "$ReleaseId^{commit}").Trim()
+$parent = (git rev-parse "$ParentReleaseId^{commit}").Trim()
+git merge-base --is-ancestor $parent $release
+if ($LASTEXITCODE -ne 0) {
+  throw "Release $release is not a descendant of effective release $parent. Use the explicit rollback path instead."
+}
+
+$payload = [ordered]@{
+  schemaVersion = 1
+  releaseId = $release
+  parentReleaseId = $parent
+  verifiedAncestor = $true
+  verifiedAt = [DateTime]::UtcNow.ToString('o')
+}
+$parentDir = Split-Path -Parent $OutputPath
+if ($parentDir) { New-Item -ItemType Directory -Force -Path $parentDir | Out-Null }
+$json = $payload | ConvertTo-Json -Depth 3
+[System.IO.File]::WriteAllText($OutputPath, $json + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
+Get-FileHash -Algorithm SHA256 -LiteralPath $OutputPath | Select-Object Path, Hash


### PR DESCRIPTION
## Summary
- Pin Livia Execute Command sidecars to immutable workflow-version runtime manifests.
- Block mutable runtime paths and split-runtime source promotion.
- Restore direct job output compatibility and deterministic media contract checks.

## Validation
- ash scripts/runtime/test-prepare-native-source-release.sh`n- 
ode orb/engine/scripts/validate-livia-workflow.js <Livia candidate>`n- deterministic image, Reel, carousel image and mixed carousel job fixtures.