### PR TITLE
chore(orb): add isolated n8n release qualification guards

### DIFF
--- a/docs/operations/orb-n8n-release-qualification.md
+++ b/docs/operations/orb-n8n-release-qualification.md
@@ -1,0 +1,24 @@
+# Qualificação de release Orb/n8n
+
+Este pacote é preparatório. Ele não instala, atualiza, promove, reinicia, executa migration nem acessa o runtime de produção.
+
+## Uso permitido
+
+Execute o auditor somente em um staging marcado explicitamente e em um diretório Linux privado fora de `/opt`, `/etc` e `/var/lib`:
+
+```bash
+N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging \
+N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES \
+N8N_AUDIT_ROOT=/tmp/n8n-release-audit \
+ops/runtime/n8n-security/audit-release-baseline.sh 2.32.5
+```
+
+Compare versões por meio de seus `summary.json`. A comparação de advisories não comprova alcançabilidade; cada item crítico requer uma matriz separada de origem, pré-condição, superfície externa, workflow e evidência de teste negativo.
+
+## Gate de promoção
+
+Uma promoção futura requer, além deste inventário: release estável oficial, checksum fixado, staging completo, backup/restauração comprovados, migrations reversíveis por restauração, regressão OAuth, MCP somente leitura, quatro serviços e bloqueio público de MCP. Qualquer vulnerabilidade crítica com caminho alcançável ou não descartado bloqueia a promoção.
+
+## Inventário
+
+O inventário mantém somente `n8n-nodes-evolution-api-en`, a variante observada como gerenciada. A variante legada em português e `n8n-nodes-python` ficam explicitamente excluídas; a reintrodução exige evidência de uso, qualificação isolada e revisão humana.

--- a/ops/runtime/n8n-security/audit-release-baseline.sh
+++ b/ops/runtime/n8n-security/audit-release-baseline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")" && pwd)
+INVENTORY="$ROOT/community-packages.json"
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+info() { printf 'INFO: %s\n' "$*"; }
+
+[[ $# -eq 1 ]] || die 'usage: audit-release-baseline.sh <n8n-version>'
+version=$1
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die 'invalid n8n version.'
+[[ "${N8N_UPGRADE_ENV:-}" == staging && "${N8N_EXPECTED_ENV:-}" == staging ]] || die 'audit is staging-only.'
+[[ "${N8N_STAGING_MARKER:-}" == orb-n8n-staging ]] || die 'staging marker is absent or invalid.'
+[[ "${N8N_AUDIT_APPLY:-}" == YES ]] || die 'refused: set N8N_AUDIT_APPLY=YES for an isolated fixture.'
+audit_root=${N8N_AUDIT_ROOT:-}
+[[ -n "$audit_root" && "$audit_root" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
+[[ "$audit_root" != /opt/* && "$audit_root" != /var/lib/* && "$audit_root" != /etc/* ]] || die 'audit root must not be a runtime or production configuration path.'
+[[ "$(node -p process.platform)" == linux && "$(node -p process.arch)" == x64 ]] || die 'expected linux/x64.'
+expected_node=${N8N_AUDIT_NODE_VERSION:-v22.23.1}
+expected_npm=${N8N_AUDIT_NPM_VERSION:-10.9.8}
+[[ "$(node --version)" == "$expected_node" ]] || die "Node mismatch: expected $expected_node."
+[[ "$(npm --version)" == "$expected_npm" ]] || die "npm mismatch: expected $expected_npm."
+[[ -f "$INVENTORY" ]] || die 'community inventory is missing.'
+
+workdir="$audit_root/n8n-$version"
+in_progress="$workdir.in-progress.$$"
+[[ ! -e "$workdir" && ! -e "$in_progress" ]] || die 'refusing to overwrite evidence.'
+mkdir -p "$in_progress/components"
+
+node --input-type=module - "$INVENTORY" "$in_progress" "$version" <<'NODE'
+import fs from 'node:fs';
+import path from 'node:path';
+const [inventoryPath, root, n8nVersion] = process.argv.slice(2);
+const inventory = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+const packages = [{ key: 'runtime-n8n', name: 'n8n', version: n8nVersion }, ...inventory.packages]
+  .map((item) => ({ ...item, key: item.key ?? `community-${item.name.replace(/[^a-z0-9]+/gi, '_')}` }));
+for (const item of packages) {
+  const component = path.join(root, 'components', item.key);
+  fs.mkdirSync(component, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(component, 'package.json'), `${JSON.stringify({ private: true, name: `skincos-release-audit-${item.key}`, version: '0.0.0', dependencies: { [item.name]: item.version } }, null, 2)}\n`, { mode: 0o600 });
+}
+fs.writeFileSync(path.join(root, 'components.json'), `${JSON.stringify(packages, null, 2)}\n`, { mode: 0o600 });
+NODE
+
+while IFS=$'\t' read -r key name component_version; do
+  component="$in_progress/components/$key"
+  (
+    cd "$component"
+    npm install --package-lock-only --ignore-scripts --omit=optional
+    ci_log=$(mktemp)
+    if ! npm ci --ignore-scripts --omit=optional >"$ci_log" 2>&1; then
+      if ! grep -q 'ENOTEMPTY' "$ci_log"; then cat "$ci_log" >&2; rm -f "$ci_log"; exit 1; fi
+      rm -rf -- "$component/node_modules"
+      npm ci --ignore-scripts --omit=optional
+    fi
+    rm -f "$ci_log"
+    npm audit --omit=optional --json > audit.json || audit_exit=$?
+    : "${audit_exit:=0}"
+    node --input-type=module - "$key" "$name" "$component_version" "$audit_exit" <<'NODE'
+import fs from 'node:fs';
+const [component, directPackage, directVersion, auditExit] = process.argv.slice(2);
+const audit = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+const highCritical = Object.values(audit.vulnerabilities ?? {}).filter((item) => ['high', 'critical'].includes(item.severity)).map((item) => ({
+  component, direct_package: directPackage, direct_version: directVersion, package: item.name, severity: item.severity,
+  direct: Boolean(item.isDirect), range: item.range, effects: item.effects ?? [], fix_available: item.fixAvailable ?? false,
+  via: (item.via ?? []).map((via) => typeof via === 'string' ? { package: via } : ({ source: via.source, title: via.title, url: via.url, severity: via.severity, range: via.range }))
+}));
+fs.writeFileSync('summary.json', `${JSON.stringify({ component, direct_package: directPackage, direct_version: directVersion, audit_exit: Number(auditExit), counts: audit.metadata?.vulnerabilities ?? {}, high_critical: highCritical }, null, 2)}\n`, { mode: 0o600 });
+NODE
+  )
+done < <(node --input-type=module - "$in_progress/components.json" <<'NODE'
+import fs from 'node:fs';
+for (const item of JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))) console.log([item.key, item.name, item.version].join('\t'));
+NODE
+)
+
+node --input-type=module - "$in_progress" <<'NODE'
+import fs from 'node:fs'; import path from 'node:path';
+const root = process.argv[2];
+const components = JSON.parse(fs.readFileSync(path.join(root, 'components.json'), 'utf8')).map(({ key }) => JSON.parse(fs.readFileSync(path.join(root, 'components', key, 'summary.json'), 'utf8')));
+const high_critical = components.flatMap((component) => component.high_critical);
+const report = { schema_version: 1, fixture_scope: 'Synthetic dependency-only audit. It never reads runtime configuration, data, credentials, database, workflows, or production paths.', node: process.version, npm: process.env.npm_config_user_agent ?? 'npm/unknown', platform: `${process.platform}/${process.arch}`, install_flags: ['--ignore-scripts', '--omit=optional'], n8n_version: components.find((item) => item.component === 'runtime-n8n').direct_version, components: components.map(({ component, direct_package, direct_version, counts }) => ({ component, direct_package, direct_version, counts })), high_critical };
+fs.writeFileSync(path.join(root, 'summary.json'), `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+NODE
+mv "$in_progress" "$workdir"
+info "dependency audit completed: $workdir/summary.json"

--- a/ops/runtime/n8n-security/community-packages.json
+++ b/ops/runtime/n8n-security/community-packages.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "purpose": "Community-node inventory for isolated n8n release qualification. This file is not a production installer or promotion manifest.",
+  "packages": [
+    { "name": "@cloudconvert/n8n-nodes-cloudconvert", "version": "1.0.2" },
+    { "name": "n8n-nodes-browserless", "version": "1.1.3" },
+    { "name": "n8n-nodes-cloudinary", "version": "0.2.1" },
+    { "name": "n8n-nodes-evolution-api-en", "version": "1.0.2" },
+    { "name": "n8n-nodes-evolution-tools", "version": "0.1.10" },
+    { "name": "n8n-nodes-mcp", "version": "0.1.37" },
+    { "name": "n8n-nodes-meta-publisher", "version": "0.15.1" },
+    { "name": "n8n-nodes-run-node-with-credentials-x", "version": "0.4.1" },
+    { "name": "n8n-nodes-websocket", "version": "1.0.1" }
+  ],
+  "excluded_packages": [
+    {
+      "name": "n8n-nodes-evolution-api",
+      "reason": "Portuguese legacy package is not the installed/original managed package; retain only the English package observed in use."
+    },
+    {
+      "name": "n8n-nodes-python",
+      "reason": "No workflow reference was observed in the read-only runtime inventory."
+    }
+  ]
+}

--- a/ops/runtime/n8n-security/compare-release-baselines.mjs
+++ b/ops/runtime/n8n-security/compare-release-baselines.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const paths = process.argv.slice(2);
+if (paths.length < 2) throw new Error('usage: compare-release-baselines.mjs <summary.json> <summary.json> [...]');
+const reports = paths.map((path) => ({ path, report: JSON.parse(fs.readFileSync(path, 'utf8')) }));
+const keyOf = (item) => `${item.package}|${item.via.map((via) => via.source ?? via.url ?? via.package ?? '').join(',')}`;
+const keys = new Set(reports.flatMap(({ report }) => report.high_critical.map(keyOf)));
+const result = {
+  schema_version: 1,
+  scope: 'Package presence and advisories only. Reachability and exploitability require separate evidence.',
+  releases: reports.map(({ path, report }) => ({ path, n8n_version: report.n8n_version, component_count: report.components.length, high_critical_count: report.high_critical.length })),
+  findings: [...keys].sort().map((key) => ({ key, releases: reports.map(({ report }) => ({ n8n_version: report.n8n_version, finding: report.high_critical.find((item) => keyOf(item) === key) ?? null })) }))
+};
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/ops/runtime/n8n-security/tests/test-release-baseline.sh
+++ b/ops/runtime/n8n-security/tests/test-release-baseline.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+
+if N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" "$ROOT/audit-release-baseline.sh" 2.32.5; then
+  echo 'expected production environment refusal' >&2; exit 1
+fi
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=wrong N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" "$ROOT/audit-release-baseline.sh" 2.32.5; then
+  echo 'expected marker refusal' >&2; exit 1
+fi
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/lib/skincos "$ROOT/audit-release-baseline.sh" 2.32.5; then
+  echo 'expected production path refusal' >&2; exit 1
+fi
+node --input-type=module - "$ROOT/community-packages.json" <<'NODE'
+import fs from 'node:fs';
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (manifest.packages.some(({ name }) => name === 'n8n-nodes-evolution-api')) throw new Error('legacy Evolution package must remain excluded');
+if (!manifest.packages.some(({ name }) => name === 'n8n-nodes-evolution-api-en')) throw new Error('managed Evolution English package missing');
+NODE
+echo 'release baseline guard tests passed'


### PR DESCRIPTION
## Scope\n\nSafe preparation only: isolated dependency baseline tooling, managed community-node inventory, guard tests, and release-qualification documentation.\n\nNo runtime artifact, version manifest, migration, service action, production configuration, workflow, credential, or deployment is included.\n\n## Validation\n\n- ash -n ops/runtime/n8n-security/audit-release-baseline.sh\n- ash ops/runtime/n8n-security/tests/test-release-baseline.sh\n- Staging-only, marker, and protected-path refusal coverage\n\n## Security boundary\n\nThe auditor requires an explicit staging environment and writes only a private synthetic fixture outside /opt, /etc, and /var/lib.