### PR TITLE
fix(workforce): preserve fail-closed onboarding account state

### DIFF
--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -131,6 +131,17 @@ function publicEmployee(row) {
   return row ? { id: row.id, employeeId: row.canonical_employee_id, name: row.display_name, email: row.login_email || null, status: row.status, accessState, terminatedAt: row.terminated_at || null } : null
 }
 
+// `status` is retained for timekeeping compatibility, but onboarding account
+// state is authoritative. A generic employee edit must never turn a pending
+// or invited account operational merely by changing the legacy status column.
+function isOperationalEmployee(row) {
+  return normalizeAccountState(row?.access_state || (row?.status === 'ACTIVE' ? 'ACTIVE' : row?.status === 'TERMINATED' ? 'TERMINATED' : 'SUSPENDED')) === 'ACTIVE'
+}
+
+function identityOnboardingId(row) {
+  try { return cleanText(JSON.parse(String(row?.metadata_json || '{}'))?.identityOnboardingId, 120) } catch { return '' }
+}
+
 const profilePrivateFields = ['cpf', 'mobilePhone', 'pis', 'rgNumber', 'rgIssuer', 'rgIssuerState', 'rgIssuedAt', 'motherName', 'fatherName', 'zipCode', 'street', 'addressNumber', 'addressComplement', 'neighborhood']
 const profilePublicFields = ['socialName', 'personalEmail', 'groupName', 'departmentName', 'managerEmployeeId', 'managerCpf', 'admittedAt', 'dismissedAt', 'birthPlace', 'educationLevel', 'city', 'state']
 const profileSelfPublicFields = ['socialName', 'personalEmail', 'birthPlace', 'educationLevel', 'city', 'state']
@@ -892,7 +903,17 @@ export async function handleTimekeeping(request, env) {
       const employee = await employeeById(db, actor, decodeURIComponent(employeeMatch[1]))
       if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
       const body = request.method === 'PATCH' ? await readJson(request) : {}
-      const status = request.method === 'DELETE' || body?.active === false ? 'TERMINATED' : 'ACTIVE'
+      // Account state for an Identity-originated employee can only transition
+      // through the signed Identity service route, which records the saga and
+      // preserves the fail-closed access_state contract.
+      if (identityOnboardingId(employee) && (request.method === 'DELETE' || body?.active !== undefined)) return failure(409, 'IDENTITY_ONBOARDING_STATUS_MANAGED', requestId)
+      const status = request.method === 'DELETE'
+        ? 'TERMINATED'
+        : body?.active === false
+          ? 'TERMINATED'
+          : body?.active === true
+            ? 'ACTIVE'
+            : employee.status
       const email = body?.loginEmail === undefined ? employee.login_email : cleanText(body.loginEmail, 240).toLowerCase() || null
       const name = body?.name === undefined ? employee.display_name : cleanText(body.name, 180)
       if (!name) return failure(400, 'INVALID_EMPLOYEE', requestId)
@@ -913,7 +934,7 @@ export async function handleTimekeeping(request, env) {
       if (isTerminal && (body.descriptor !== undefined || body.template !== undefined || body.pin === undefined)) return failure(400, 'TERMINAL_PIN_REQUIRED', requestId)
       let employee = isTerminal ? await employeeForTerminal(db, actor, body.employeeCode) : isConsultor(actor) ? await employeeForActor(db, actor) : await employeeById(db, actor, cleanText(body.employeeId, 120))
       if (!employee) return failure(404, 'EMPLOYEE_NOT_LINKED', requestId)
-      if (employee.status !== 'ACTIVE') return failure(409, 'EMPLOYEE_NOT_ACTIVE', requestId)
+      if (!isOperationalEmployee(employee)) return failure(409, 'EMPLOYEE_NOT_ACTIVE', requestId)
       const occurredAt = isTerminal ? now() : body.occurredAt ? new Date(body.occurredAt).toISOString() : now()
       const unitId = isTerminal ? actor.allowedUnits[0] : cleanText(body.unitId || body.unit, 120)
       const initialWorkDate = isoDateInZone(occurredAt, 'America/Sao_Paulo')
@@ -1229,4 +1250,4 @@ export async function handleTimekeeping(request, env) {
 }
 
 export default { fetch: handleTimekeeping }
-export const __testables = { normalizeWorkforceRole, roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod, csvCell, eventsForWorkDate, isFacePunchEnabled, verifyPunchCredential, profileInput, profileDocumentStatus, normalizeNetworks, ipInNetwork, locationEvidence, normalizePresenceMode, normalizeNetworkPolicy, identityServiceAuthorized, normalizedDepartmentKey, publicEmployee, syncIdentityOnboardingStatus }
+export const __testables = { normalizeWorkforceRole, roleAllows, requireUnit, canonicalEventType, calculateDay, calculatePeriod, csvCell, eventsForWorkDate, isFacePunchEnabled, verifyPunchCredential, profileInput, profileDocumentStatus, normalizeNetworks, ipInNetwork, locationEvidence, normalizePresenceMode, normalizeNetworkPolicy, identityServiceAuthorized, normalizedDepartmentKey, publicEmployee, isOperationalEmployee, identityOnboardingId, syncIdentityOnboardingStatus }

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -105,6 +105,16 @@ test('Workforce never presents pending or invited onboarding as operational', ()
   assert.equal(invited.status, 'LEAVE')
 })
 
+test('onboarding access state remains authoritative for operational timekeeping', () => {
+  assert.equal(__testables.isOperationalEmployee({ status: 'ACTIVE', access_state: 'PENDING_ACCESS' }), false)
+  assert.equal(__testables.isOperationalEmployee({ status: 'ACTIVE', access_state: 'INVITED' }), false)
+  assert.equal(__testables.isOperationalEmployee({ status: 'ACTIVE', access_state: 'SUSPENDED' }), false)
+  assert.equal(__testables.isOperationalEmployee({ status: 'ACTIVE', access_state: 'ACTIVE' }), true)
+  assert.equal(__testables.isOperationalEmployee({ status: 'ACTIVE' }), true)
+  assert.equal(__testables.identityOnboardingId({ metadata_json: JSON.stringify({ identityOnboardingId: 'onb-1' }) }), 'onb-1')
+  assert.equal(__testables.identityOnboardingId({ metadata_json: '{invalid' }), '')
+})
+
 test('CSV cells neutralize formulas and follow CSV quote escaping', () => {
   assert.equal(__testables.csvCell('=HYPERLINK("https://invalid.example")'), '"\'=HYPERLINK(""https://invalid.example"")"')
   assert.equal(__testables.csvCell('Pessoa "Teste"'), '"Pessoa ""Teste"""')


### PR DESCRIPTION
## Causa\nA rota genérica de funcionário podia alterar o status técnico sem respeitar ccess_state de registros originados pelo onboarding; o registro de ponto avaliava apenas esse status legado.\n\n## Correção\n- torna ccess_state a condição operacional para registro de ponto;\n- impede mudanças genéricas de ativo/terminação para empregados gerenciados pelo onboarding Identity;\n- preserva o status existente em PATCH sem alteração explícita de ativo;\n- adiciona regressões para PENDING_ACCESS, INVITED e SUSPENDED.\n\n## Segurança\nMantém o fluxo assinado Identity → Workforce como única fronteira de transição do onboarding, sem ampliar escopo ou acesso.\n\n## Validação\n
pm --prefix workforce/timekeeping test (27 testes) e git diff --check.\n\nSem deploy de produção.