### PR TITLE
fix(livia): bind resume progress to semantic media contract

### DIFF
--- a/orb/engine/scripts/livia/build-platform-job-graph.js
+++ b/orb/engine/scripts/livia/build-platform-job-graph.js
@@ -316,6 +316,7 @@ function assertJobGraphContracts(jsCode) {
     ['single-image', ['image']],
     ['single-video', ['video']],
     ['carousel-images', ['image', 'image', 'image']],
+    ['carousel-videos', ['video', 'video', 'video']],
     ['carousel-mixed', ['image', 'video']],
   ];
   const results = [];
@@ -333,6 +334,28 @@ function assertJobGraphContracts(jsCode) {
     results.push({ name, mediaKinds: kinds, jobCount: jobs.length });
   }
   return results;
+}
+
+function assertResumeIdentityContracts() {
+  const base = {
+    groupKey: 'fixture:resume',
+    groupOrder: 0,
+    platform: 'instagram',
+    unit: 'bss',
+    phase: 'upload',
+    step: 'default_upload',
+    publishRunIndex: 3,
+    media: { id: 'fixture-video', mediaKind: 'video', finalUrl: 'https://example.invalid/video.mp4', groupOrder: 0 },
+    text: { caption: 'Legenda aprovada', selectedFrameUrl: 'https://example.invalid/cover-a.jpg' },
+    jsonRequest: { video_url: 'https://example.invalid/video.mp4', caption: 'Legenda aprovada', cover_url: 'https://example.invalid/cover-a.jpg' },
+  };
+  const first = semanticJobKey(base);
+  const reordered = semanticJobKey({ ...base, publishRunIndex: 99, attempt: 2, waitSeconds: 30 });
+  const changedCaption = semanticJobKey({ ...base, text: { ...base.text, caption: 'Legenda editorial diferente' }, jsonRequest: { ...base.jsonRequest, caption: 'Legenda editorial diferente' } });
+  const changedFrame = semanticJobKey({ ...base, text: { ...base.text, selectedFrameUrl: 'https://example.invalid/cover-b.jpg' }, jsonRequest: { ...base.jsonRequest, cover_url: 'https://example.invalid/cover-b.jpg' } });
+  if (first !== reordered) fail(`${NODE_NAME}: sequential queue ordering changed semantic resume identity.`);
+  if (first === changedCaption || first === changedFrame) fail(`${NODE_NAME}: editorial content change did not invalidate durable resume identity.`);
+  return { stableAcrossQueueReorder: true, captionChangeInvalidates: true, frameChangeInvalidates: true };
 }
 
 // A Facebook Reel is not complete when its upload session is ready.  Preserve
@@ -973,6 +996,87 @@ function normalizeThreadsCarouselJob(job) {
   return current;
 }
 
+// publishRunIndex is deliberately *not* a resume identity. It is rebuilt when
+// Facebook Reel status checks are expanded and is only valid inside one queue.
+// A durable record must instead bind the exact editorial and provider contract
+// to the media that produced it.
+const RESUME_VOLATILE_KEYS = new Set([
+  'publishRunIndex', 'statusFromPublishRunIndex', 'postPublishFromRunIndex',
+  'checkStatusFromPublishRunIndex', 'creationIdFromPublishRunIndex',
+  'lastUploadFromPublishRunIndex', 'reelsStartFromPublishRunIndex',
+  'attempt', 'maxAttempts', 'waitSeconds', 'recoveryAttempt', 'remoteId',
+  'permalink', 'lastStatusCode', 'lastResponseBody', 'codexDryRun', 'warnings',
+]);
+const RESUME_SECRET_KEY = /(access[_-]?token|authorization|api[_-]?key|client[_-]?secret|password|cookie|credential)/i;
+
+function canonicalResumeValue(value, key = '') {
+  if (RESUME_VOLATILE_KEYS.has(key) || RESUME_SECRET_KEY.test(key)) return undefined;
+  if (Array.isArray(value)) return value.map((entry) => canonicalResumeValue(entry)).filter((entry) => entry !== undefined);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort()
+      .map((entryKey) => [entryKey, canonicalResumeValue(value[entryKey], entryKey)])
+      .filter(([, entryValue]) => entryValue !== undefined));
+  }
+  return value === undefined || value === null ? undefined : value;
+}
+
+function semanticJobKey(job) {
+  const current = asObject(job);
+  const media = asObject(current.media);
+  const phase = String(current.phase || '').trim().toLowerCase();
+  const mediaId = String(media.id || current.mediaId || '').trim() ||
+    (['publish', 'checkstatus', 'uploadcontainer'].includes(phase) ? '__group__' : '');
+  const contract = canonicalResumeValue({
+    schema: 'livia-resume-v2',
+    groupKey: String(current.groupKey || '').trim(),
+    groupOrder: Number.isFinite(Number(current.groupOrder)) ? Number(current.groupOrder) : undefined,
+    platform: String(current.platform || '').trim().toLowerCase(),
+    unit: normalizeUnit(current.unit),
+    phase,
+    step: String(current.step || '').trim().toLowerCase(),
+    checkKind: String(current.checkKind || '').trim().toLowerCase(),
+    checkFields: String(current.checkFields || '').trim().toLowerCase(),
+    method: String(current.method || asObject(current.httpRequest).method || '').trim().toUpperCase(),
+    endpoint: String(current.url || asObject(current.httpRequest).url || '').trim(),
+    media: {
+      id: mediaId,
+      sourceMediaKind: String(media.sourceMediaKind || media.mediaKind || current.sourceMediaKind || current.mediaKind || '').trim().toLowerCase(),
+      finalUrl: String(media.finalUrl || media.secure_url || media.url || current.finalUrl || '').trim(),
+      groupOrder: Number.isFinite(Number(media.groupOrder || current.groupOrder)) ? Number(media.groupOrder || current.groupOrder) : undefined,
+    },
+    text: asObject(current.text),
+    request: asObject(current.jsonRequest || current.requestBody || asObject(current.httpRequest).body),
+    resumeDependencies: asObject(current.resumeDependencies),
+  });
+  if (!contract.groupKey || !contract.platform || !contract.unit || !contract.phase || !contract.step || !contract.media.id) {
+    fail(`${NODE_NAME}: semantic resume identity is incomplete for ${contract.platform || 'unknown'}/${contract.unit || 'unknown'} ${contract.phase || 'unknown'}/${contract.step || 'unknown'}.`);
+  }
+  return `livia:v2:${crypto.createHash('sha256').update(JSON.stringify(contract)).digest('hex')}`;
+}
+
+function assignSemanticJobKeys(jobs) {
+  const refs = ['statusFromPublishRunIndex', 'postPublishFromRunIndex', 'checkStatusFromPublishRunIndex', 'creationIdFromPublishRunIndex', 'lastUploadFromPublishRunIndex', 'reelsStartFromPublishRunIndex'];
+  const baseKeys = jobs.map((job) => semanticJobKey({ ...job, resumeDependencies: {} }));
+  const seen = new Set();
+  return jobs.map((job) => {
+    const dependencies = {};
+    for (const ref of refs) {
+      const index = Number(job[ref]);
+      if (Number.isInteger(index) && baseKeys[index]) dependencies[ref.replace(/PublishRunIndex$/, '')] = baseKeys[index];
+    }
+    for (const ref of ['attachedMediaFromPublishRunIndexes', 'childrenPublishRunIndexes']) {
+      if (!Array.isArray(job[ref])) continue;
+      dependencies[ref.replace(/PublishRunIndexes$/, '')] = job[ref]
+        .map((value) => baseKeys[Number(value)])
+        .filter(Boolean);
+    }
+    const key = semanticJobKey({ ...job, resumeDependencies: dependencies });
+    if (seen.has(key)) fail(`${NODE_NAME}: duplicate semantic resume identity for distinct provider jobs.`);
+    seen.add(key);
+    return { ...job, semanticJobKey: key };
+  });
+}
+
 function resumeContextKey(job) {
   const current = asObject(job);
   const media = asObject(current.media);
@@ -1059,15 +1163,19 @@ function loadResumeCompleted(jobs) {
       }
       const rows = asArray(ledger.completed)
         .map((entry) => asObject(entry))
-        .filter((entry) => Number.isInteger(Number(entry.publishRunIndex)) && Object.keys(asObject(entry.lastResponseBody)).length);
+        .filter((entry) => /^livia:v2:[a-f0-9]{64}$/.test(String(entry.semanticJobKey || '')) && Object.keys(asObject(entry.lastResponseBody)).length);
       completed.push(...rows);
     }
   }
-  const byRun = new Map();
-  for (const row of completed) byRun.set(Number(row.publishRunIndex), row);
+  const allowedKeys = new Set(jobs.map((job) => String(job.semanticJobKey || '')));
+  const bySemanticKey = new Map();
+  for (const row of completed) {
+    const key = String(row.semanticJobKey || '');
+    if (allowedKeys.has(key)) bySemanticKey.set(key, row);
+  }
   return invalidateIncompleteCarouselResume(
     jobs,
-    [...byRun.values()].sort((left, right) => Number(left.publishRunIndex) - Number(right.publishRunIndex)),
+    jobs.map((job) => bySemanticKey.get(String(job.semanticJobKey || ''))).filter(Boolean),
   );
 }
 
@@ -1076,7 +1184,7 @@ function compactResult(result, payload, sourceFile) {
   const facebookCredentials = facebookCredentialContext(payload);
   const credentialRefs = credentialReferences(payload);
   const frameContext = technicalFrameContext(payload);
-  const jobs = normalizeFacebookReelsChecks(asArray(firstJson.jobs)
+  const jobs = assignSemanticJobKeys(normalizeFacebookReelsChecks(asArray(firstJson.jobs)
     .map((entry) => asObject(entry))
     .map((entry) => applyCaptionHygiene(entry))
     .map((entry) => applyTechnicalFrame(entry, frameContext))
@@ -1085,7 +1193,7 @@ function compactResult(result, payload, sourceFile) {
     .map((entry) => normalizeFacebookJob(entry, facebookCredentials))
     .map((entry) => normalizeThreadsCarouselJob(entry))
     .map((entry) => applyCredentialReference(entry, credentialRefs))
-    .filter((entry) => Object.keys(entry).length));
+    .filter((entry) => Object.keys(entry).length)));
   if (!jobs.length) fail(`${NODE_NAME}: external source did not produce jobs.`);
   const resume = loadResumeCompleted(jobs);
   const resumeCompleted = resume.completed;
@@ -1140,6 +1248,7 @@ function main() {
       ok: true,
       jobGraphContracts: assertJobGraphContracts(source.jsCode),
       frameSelectionContracts: assertFrameSelectionContracts(),
+      resumeIdentityContracts: assertResumeIdentityContracts(),
     }));
     return;
   }

--- a/orb/engine/scripts/livia/publish-progress-ledger.js
+++ b/orb/engine/scripts/livia/publish-progress-ledger.js
@@ -90,27 +90,35 @@ function recordOne(value) {
   if (!Object.keys(record).length || record.codexDryRun === true) {
     return { recorded: false, reason: record.codexDryRun === true ? 'dry_run' : 'empty' };
   }
-  const runIndex = Number(record.publishRunIndex);
-  if (!Number.isInteger(runIndex) || runIndex < 0) {
-    throw new Error('Livia publish progress requires a non-negative publishRunIndex.');
+  const semanticJobKey = str(record.semanticJobKey);
+  if (!/^livia:v2:[a-f0-9]{64}$/.test(semanticJobKey)) {
+    throw new Error('Livia publish progress requires a semanticJobKey (livia:v2 SHA-256); publishRunIndex is not a durable identity.');
   }
   if (!asObject(record.lastResponseBody).id && !asObject(record.lastResponseBody).post_id && !asObject(record.lastResponseBody).video_id) {
-    throw new Error(`Livia publish progress requires a provider identifier for run ${runIndex}.`);
+    throw new Error(`Livia publish progress requires a provider identifier for semantic job ${semanticJobKey}.`);
   }
 
   const context = contextFor(record);
   const filePath = ledgerPath(context.key);
   const ledger = loadLedger(filePath, context);
-  const completed = ledger.completed.filter((entry) => Number(entry.publishRunIndex) !== runIndex);
+  const completed = ledger.completed.filter((entry) => str(asObject(entry).semanticJobKey) !== semanticJobKey);
   completed.push({ ...record, recordedAt: new Date().toISOString() });
-  completed.sort((left, right) => Number(left.publishRunIndex) - Number(right.publishRunIndex));
+  completed.sort((left, right) => str(left.semanticJobKey).localeCompare(str(right.semanticJobKey)));
   ledger.completed = completed;
   ledger.updatedAt = new Date().toISOString();
   writeLedger(filePath, ledger);
-  return { recorded: true, key: context.key, completedCount: completed.length, publishRunIndex: runIndex };
+  return { recorded: true, key: context.key, completedCount: completed.length, semanticJobKey };
 }
 
 function main() {
+  if (process.argv.includes('--assert-contract')) {
+    const source = fs.readFileSync(__filename, 'utf8');
+    if (!source.includes('semanticJobKey') || !source.includes('filter((entry) => str(asObject(entry).semanticJobKey) !== semanticJobKey)')) {
+      throw new Error('Livia ledger resume contract is not semantic-key based.');
+    }
+    process.stdout.write(`${JSON.stringify({ ok: true, resumeIdentity: 'semanticJobKey', legacyIndexOnlyResume: false })}\n`);
+    return;
+  }
   const payload = readPayload();
   const rows = Array.isArray(payload) ? payload : [payload];
   const results = rows.map(recordOne);

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -528,8 +528,11 @@ function validateWorkflow() {
       errors.push(`BQ - Seed Publish State must protect manual execution (${required}).`);
     }
   }
-  for (const required of ['resumeRecords', 'resumeByRun', 'completedRunIndexes']) {
+  for (const required of ['resumeRecords', 'resumeBySemanticKey', 'completedSemanticJobKeys']) {
     if (!bqSeedCode.includes(required)) errors.push(`BQ - Seed Publish State must restore durable publish progress (${required}).`);
+  }
+  if (bqSeedCode.includes('completedRunIndexes')) {
+    errors.push('BQ - Seed Publish State must not use publishRunIndex as a durable resume identity.');
   }
   if (!String(nodeByName.get('BQ - Validate Job Graph')?.parameters?.jsCode || '').includes('resumeCompleted: asArray(payload.resumeCompleted)')) {
     errors.push('BQ - Validate Job Graph must preserve durable completed jobs for BQ - Seed Publish State.');
@@ -551,7 +554,7 @@ function validateWorkflow() {
   const progressScript = fs.existsSync(PUBLISH_PROGRESS_LEDGER_SCRIPT)
     ? fs.readFileSync(PUBLISH_PROGRESS_LEDGER_SCRIPT, 'utf8')
     : '';
-  for (const required of ['livia-publish-ledger', 'codexDryRun === true', 'publishRunIndex', "'__group__'"]) {
+  for (const required of ['livia-publish-ledger', 'codexDryRun === true', 'semanticJobKey', "'__group__'"]) {
     if (!progressScript.includes(required)) errors.push(`publish-progress-ledger.js must preserve safe resume semantics (${required}).`);
   }
   for (const name of ['Verify Published Artifacts', 'Attach Verified Publish Artifacts', 'Switch Final Dry Run', 'Merge Drive Result and Context', 'Assert Drive Published', 'Cleanup Temp Files']) {

--- a/orb/engine/scripts/patch-livia-runtime-isolation.js
+++ b/orb/engine/scripts/patch-livia-runtime-isolation.js
@@ -16,9 +16,85 @@ const REQUIRED_NODES = new Set([
 ]);
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine$/;
 const PINNED_ROOT_RE = /\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine/g;
+const SEMANTIC_JOB_KEY_RE = /^livia:v2:[a-f0-9]{64}$/;
 
 function fail(message) { throw new Error(message); }
 function arg(prefix) { return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || ''; }
+
+function patchResumeIdentity(workflow) {
+  const nodes = new Map((workflow.nodes || []).map((node) => [node?.name, node]));
+  const seed = nodes.get('BQ - Seed Publish State');
+  const process = nodes.get('Process HTTP Publish Result');
+  if (seed?.type !== 'n8n-nodes-base.code' || process?.type !== 'n8n-nodes-base.code') {
+    fail('Livia semantic resume patch requires BQ - Seed Publish State and Process HTTP Publish Result Code nodes.');
+  }
+
+  const seedNeedle = `const rawResumeRecords = codexDryRun ? [] : __prAsArray(payload.resumeCompleted);
+const resumeRecords = rawResumeRecords
+  .map((entry) => __prAsObject(entry))
+  .filter((entry) => Number.isInteger(Number(entry.publishRunIndex)) && Object.keys(__prAsObject(entry.lastResponseBody)).length);
+const resumeByRun = {};
+for (const entry of resumeRecords) {
+  resumeByRun[__prStr(entry.publishRunIndex)] = {
+    statusCode: entry.lastStatusCode || 200,
+    body: __prAsObject(entry.lastResponseBody),
+  };
+}
+const completedRunIndexes = new Set(resumeRecords.map((entry) => __prStr(entry.publishRunIndex)));
+const pendingJobs = qaAwareJobs.filter((job) => !completedRunIndexes.has(__prStr(job.publishRunIndex)));`;
+  const seedReplacement = `const rawResumeRecords = codexDryRun ? [] : __prAsArray(payload.resumeCompleted);
+const jobsBySemanticKey = new Map();
+for (const job of qaAwareJobs) {
+  const semanticJobKey = __prStr(job.semanticJobKey, "");
+  if (!/^livia:v2:[a-f0-9]{64}$/.test(semanticJobKey)) {
+    throw new Error("BQ - Seed Publish State: job sem semanticJobKey válido; bloqueando antes do gateway.");
+  }
+  if (jobsBySemanticKey.has(semanticJobKey)) {
+    throw new Error("BQ - Seed Publish State: semanticJobKey duplicado; bloqueando antes do gateway.");
+  }
+  jobsBySemanticKey.set(semanticJobKey, job);
+}
+const resumeBySemanticKey = new Map();
+for (const rawEntry of rawResumeRecords.map((entry) => __prAsObject(entry))) {
+  const semanticJobKey = __prStr(rawEntry.semanticJobKey, "");
+  if (!/^livia:v2:[a-f0-9]{64}$/.test(semanticJobKey)) continue;
+  if (!jobsBySemanticKey.has(semanticJobKey)) continue;
+  if (!Object.keys(__prAsObject(rawEntry.lastResponseBody)).length) continue;
+  resumeBySemanticKey.set(semanticJobKey, rawEntry);
+}
+const resumeRecords = qaAwareJobs
+  .map((job) => {
+    const record = resumeBySemanticKey.get(__prStr(job.semanticJobKey));
+    return record ? __prRemoveNulls({ ...record, publishRunIndex: job.publishRunIndex, semanticJobKey: job.semanticJobKey }) : null;
+  })
+  .filter(Boolean);
+const resumeByRun = {};
+for (const entry of resumeRecords) {
+  // This map serves only intra-execution dependency references. The durable
+  // lookup above is exclusively semanticJobKey based.
+  resumeByRun[__prStr(entry.publishRunIndex)] = {
+    statusCode: entry.lastStatusCode || 200,
+    body: __prAsObject(entry.lastResponseBody),
+  };
+}
+const completedSemanticJobKeys = new Set(resumeRecords.map((entry) => __prStr(entry.semanticJobKey)));
+const pendingJobs = qaAwareJobs.filter((job) => !completedSemanticJobKeys.has(__prStr(job.semanticJobKey)));`;
+  const seedCode = String(seed.parameters?.jsCode || '');
+  if (!seedCode.includes(seedNeedle)) {
+    fail('Livia semantic resume patch could not find the expected legacy publishRunIndex resume block.');
+  }
+  seed.parameters.jsCode = seedCode.replace(seedNeedle, seedReplacement);
+
+  const processNeedle = '    publishRunIndex: source.publishRunIndex,\n    media: {';
+  const processReplacement = '    publishRunIndex: source.publishRunIndex,\n    semanticJobKey: str(source.semanticJobKey, ""),\n    media: {';
+  const processCode = String(process.parameters?.jsCode || '');
+  if (!processCode.includes(processNeedle)) {
+    fail('Livia semantic resume patch could not preserve semanticJobKey in compactResumeRecord.');
+  }
+  process.parameters.jsCode = processCode.replace(processNeedle, processReplacement);
+  return ['BQ - Seed Publish State', 'Process HTTP Publish Result'];
+}
+
 function validate(workflow, releaseRoot) {
   if (workflow?.id !== WORKFLOW_ID || workflow?.active !== true) fail('Expected the active Livia workflow.');
   if (!RELEASE_ROOT_RE.test(releaseRoot)) fail(`Invalid immutable Orb release root: ${releaseRoot}.`);
@@ -51,9 +127,10 @@ function main() {
     fail('Usage: patch-livia-runtime-isolation.js <live-export.json> <candidate.json> --release-root=/opt/skincos/releases/<sha>/source/orb/engine');
   }
   const workflow = JSON.parse(fs.readFileSync(path.resolve(input), 'utf8'));
+  const semanticResumeNodes = patchResumeIdentity(workflow);
   const touched = validate(workflow, releaseRoot);
   fs.writeFileSync(path.resolve(output), `${JSON.stringify(workflow, null, 2)}\n`, { mode: 0o640 });
-  process.stdout.write(JSON.stringify({ ok: true, workflowId: WORKFLOW_ID, releaseRoot, nodes: touched }) + '\n');
+  process.stdout.write(JSON.stringify({ ok: true, workflowId: WORKFLOW_ID, releaseRoot, nodes: touched, semanticResumeNodes }) + '\n');
 }
 
 main();

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -304,6 +304,8 @@ function validateContracts() {
   assert(jobGraphSource.includes('normalizeExternalResult'), 'Livia job graph must accept both direct n8n jobs and jobs envelopes.');
   assert(jobGraphSource.includes('assertOutputContract'), 'Livia job graph must self-test its output contract.');
   assert(jobGraphSource.includes('assertJobGraphContracts'), 'Livia job graph must test image, Reel and carousel fixtures without the gateway.');
+  assert(jobGraphSource.includes('semanticJobKey'), 'Livia job graph must derive a semantic durable resume identity.');
+  assert(jobGraphSource.includes('assertResumeIdentityContracts'), 'Livia job graph must prove queue-index changes do not alter resume identity.');
   assert(jobGraphSource.includes('invalidateIncompleteCarouselResume'), 'Livia resume logic must invalidate partial Instagram carousel attempts before reusing child containers');
   assert(jobGraphSource.includes('groupResumeContextKey'), 'Livia resume logic must inspect group-scoped carousel container results');
   assert(jobGraphSource.includes('normalizeThreadsCarouselJob'), 'Livia job graph must keep Threads carousel child and parent request contracts distinct');
@@ -399,10 +401,13 @@ function validateContracts() {
   assert(processHttp.includes('const simulatedRemoteId ='), 'Process HTTP Publish Result must create a synthetic ID during Codex dry-run');
   assert(processHttp.includes('id: simulatedRemoteId'), 'Codex dry-run response body must include a synthetic Graph-compatible ID');
   assert(processHttp.includes('compactResumeRecord'), 'Process HTTP Publish Result must emit a sanitized durable progress record');
+  assert(processHttp.includes('semanticJobKey: str(source.semanticJobKey'), 'Process HTTP Publish Result must preserve semanticJobKey in durable progress records');
   assert(processHttp.includes('facebook_static_photo_already_posted_recovery'), 'Process HTTP Publish Result must recover an already-published Facebook static photo without duplicating it');
-  assert(codeOf('BQ - Seed Publish State').includes('resumeRecords'), 'BQ - Seed Publish State must restore durable completed jobs before retrying');
+  assert(codeOf('BQ - Seed Publish State').includes('resumeBySemanticKey'), 'BQ - Seed Publish State must restore durable completed jobs by semantic identity');
+  assert(codeOf('BQ - Seed Publish State').includes('completedSemanticJobKeys'), 'BQ - Seed Publish State must not use sequential indexes as durable resume keys');
   assert(codeOf('BQ - Validate Job Graph').includes('resumeCompleted: asArray(payload.resumeCompleted)'), 'BQ - Validate Job Graph must preserve durable completed jobs');
   assert(commandOf('Record Publish Progress').includes('publish-progress-ledger.js'), 'Record Publish Progress must call the private runtime ledger script');
+  assert(!codeOf('BQ - Seed Publish State').includes('completedRunIndexes'), 'BQ - Seed Publish State must not use publishRunIndex as a durable resume identity');
   assert(collect.includes('buildFinalCollectorRows'), 'Collect Publish Results must reuse buildFinalCollectorRows');
   assert(collect.includes('buildPublishVerificationTargets'), 'Collect Publish Results must produce provider verification targets');
   assert(collect.includes('mediaKindFor'), 'Collect Publish Results must resolve image, video, and carousel delivery separately');
@@ -538,7 +543,7 @@ function validateManualDryRunFixture() {
   if (getNode('Build Publish Queue')) return;
 
   const seedCode = codeOf('BQ - Seed Publish State');
-  const executeSeed = (mode, id) => {
+  const executeSeed = (mode, id, payload = { jobs: [{ platform: 'instagram', publishRunIndex: 0, semanticJobKey: 'livia:v2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }], codexPayloadCompacted: true }) => {
     const fn = new Function(
       '$input',
       '$json',
@@ -552,7 +557,7 @@ function validateManualDryRunFixture() {
     );
     return fn(
       { all: () => [] },
-      { jobs: [{ platform: 'instagram', publishRunIndex: 0 }], codexPayloadCompacted: true },
+      payload,
       { id, mode },
       () => ({}),
       () => [],
@@ -567,6 +572,21 @@ function validateManualDryRunFixture() {
   assert(manual?.[0]?.json?.codexDryRun === true, 'Manual seed fixture must default to codexDryRun=true');
   assert(manual?.[0]?.json?.firstJob?.codexDryRun === true, 'Manual seed fixture must decorate the first job as dry-run');
   assert(trigger?.[0]?.json?.codexDryRun === false, 'Trigger seed fixture must preserve production behavior by default');
+
+  const semanticJobKey = 'livia:v2:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const job = { platform: 'instagram', publishRunIndex: 0, semanticJobKey };
+  const matching = executeSeed('trigger', 'semantic-match', {
+    jobs: [job],
+    codexPayloadCompacted: true,
+    resumeCompleted: [{ ...job, publishRunIndex: 99, lastResponseBody: { id: 'provider-object' } }],
+  });
+  const mismatched = executeSeed('trigger', 'semantic-mismatch', {
+    jobs: [job],
+    codexPayloadCompacted: true,
+    resumeCompleted: [{ ...job, semanticJobKey: 'livia:v2:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc', lastResponseBody: { id: 'stale-provider-object' } }],
+  });
+  assert(matching?.[0]?.json?.recoveryFinal === true, 'Matching semantic progress must be resumable regardless of its historical queue index');
+  assert(mismatched?.[0]?.json?.firstJob?.semanticJobKey === semanticJobKey, 'Mismatched semantic progress must not suppress a current provider job');
 }
 
 validateStructure();


### PR DESCRIPTION
## Causa\nA retomada usava publishRunIndex como identidade durável, permitindo reutilizar resposta de um job com legenda/capa editorial distinta.\n\n## Correção\n- chave semântica SHA-256 por contrato de mídia/editorial/provider\n- ledger e seed retomam apenas por semanticJobKey\n- índices permanecem apenas para dependências internas\n- matriz offline inclui imagem, Reel, carrossel de imagens, vídeos e misto\n\n## Validação\n- replay offline 337, 338 e 339 sem gateway\n- validação estrutural e contratos negativos\n