### PR TITLE
fix(observability): preserve installer process during restart

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -30,9 +30,9 @@ powershell -ExecutionPolicy Bypass -File .\ops\observability\scripts\Install-Ski
 # rollback: Unregister-ScheduledTask -TaskName SkincosObservabilityProbe -Confirm:$false
 ```
 
-O catálogo exige duas leituras consecutivas fora do saudável antes de confirmar um alerta e duas leituras saudáveis antes de confirmá-lo como resolvido. Por unidade, a mensagem de desktop tem cooldown de 15 minutos e expira em 30 segundos. Oscilações de uma única sonda continuam no histórico/métricas, mas não interrompem o operador.
+O catálogo exige duas leituras consecutivas fora do saudável antes de confirmar um alerta e duas leituras saudáveis antes de confirmá-lo como resolvido. Por ambiente e unidade, a mensagem de desktop tem cooldown de 15 minutos e expira em 30 segundos. Oscilações de uma única sonda continuam no histórico/métricas, mas não interrompem o operador. Uma resposta Finance lenta porém HTTP válida é classificada por latência; somente a resposta upstream efetivamente 5xx permanece uma indisponibilidade.
 
-O watchdog usa o mesmo limiar de duas observações stale, mantém estado próprio e serializa o monitor com mutex local. Assim, ele reinicia o dashboard quando necessário sem abrir mensagens repetidas nem perder uma transição confirmável durante invocações simultâneas.
+O watchdog usa o mesmo limiar de duas observações stale, mantém estado próprio e serializa o monitor com mutex local. Assim, ele reinicia o dashboard quando necessário sem abrir mensagens repetidas nem perder uma transição confirmável durante invocações simultâneas. O instalador encerra somente processos do runtime-alvo e nunca seu próprio PID, preservando uma única dupla supervisor/dashboard durante reinstalações.
 
 Uma jornada sintética autenticada exige ator exclusivo de staging, segredo fora do Git e passos sem escrita. Enquanto Identity/Finance não estiverem implantados em staging, o catálogo a mantém desabilitada em vez de reutilizar uma sessão humana.
 

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,29 +1,37 @@
 # Current state
 
-## Observability alert hardening — 2026-07-28T20:48Z
+## Observability alert hardening — 2026-07-29T02:07Z
 
-The active Windows monitor is currently in `operator-run-key` mode and emits a
-desktop `msg.exe` window for every raw health transition. Its private history
-contains 479 such messages since 2026-07-24, primarily Finance staging
-oscillations. Read-only live probes at 20:48Z returned six consecutive 200
-responses for Finance health/readiness and the sampled production API and
-Escala health routes.
-
-An isolated branch based on `origin/main` contains the correction:
-two consecutive non-healthy probes are required before a confirmed alert, two
-healthy probes before resolution, desktop recovery notices are disabled, and
-desktop alerts have a 15-minute per-unit cooldown with a 30-second expiry. The
-Finance health binding deadline is raised to 3 seconds so the monitor can
-classify a slow successful probe as latency degradation rather than a synthetic
-503. Concurrent probes are serialized with a local mutex, and the watchdog now
-uses the same two-run confirmation and cooldown policy. Tests and catalog validation pass. At 20:51Z the reviewed monitor source
-was installed into the private operator runtime after the checkpoint
+The desktop-alert correction is integrated on `main`: PR #833 merged as
+`2ba1e0a74eea8a88a5cdb609ba426c8df2c94261`, and the installer fallback repair
+in PR #836 merged as `34c9baff3978df71402b917449b6971a914b1110`. Both PRs had
+their applicable CI, test and security checks green. The operator runtime was
+reinstalled from a clean worktree at that integrated SHA in
+`operator-run-key` mode at 02:07Z. `installation.json`, the Run key, one
+supervisor plus one dashboard child, and loopback `/health` prove the active
+local runtime; the preserved rollback checkpoint is
 `C:\CodexRuntime\operator\admin\skincos\checkpoints\observability-alert-hardening-20260728T2052Z`.
-The copied catalog/monitor/watchdog hashes match the branch, exactly one
-supervisor is active, and the subsequent 20:52Z probe completed with all six
-enabled units healthy and no transition. No Cloudflare deployment, D1 data or
-production service was changed; the gateway timeout correction is source-only
-until its normal integration and staging release path runs.
+
+The policy requires two consecutive non-healthy probes before an alert and two
+healthy probes before resolution. Desktop recovery notices are disabled,
+desktop alerts have a 15-minute per-unit/environment cooldown, and `msg.exe`
+expires after 30 seconds. The integrated controlled drill produced one desktop
+delivery on its second failure, a persisted recovery with
+`human_notification_delivery=not-applicable`, and a cooldown-suppressed second
+incident. The watchdog/probe mutex and deterministic tests cover concurrent
+invocations and watchdog deduplication. Finance probe requests now have a
+three-second service-binding deadline so a valid slow response is classified as
+latency degradation; genuine Finance 503 responses remain degraded.
+
+Canonical API promotion used preview run `30414699651` and staging run
+`30414749763`, both for immutable SHA `2ba1e0a7…`. Production run `30414808715`
+stopped before upload or smoke: Cloudflare rejected API binding `FINANCE`
+because production Worker `skincos-finance` does not exist (error 10143). Thus
+the API timeout fix is deployed to staging but **not** production; production
+API health remains reachable, but is not proof of this release. No D1 data,
+secrets, bindings, Finance Worker or business data were changed. The remaining
+action needs an explicit production Finance resource/binding decision; do not
+retry the same API promotion until that prerequisite is satisfied.
 
 ## Fresh runtime-config verification — 2026-07-25T05:05Z
 

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -13,6 +13,19 @@
       "base_sha": "f6fc637439618771e3cd3953859fa1875820a832"
     },
     {
+      "observed_at": "2026-07-29T02:07:17Z",
+      "surface": "github-cloudflare-and-windows-observability",
+      "scope": "Integrated desktop alert hardening, canonical API promotion and local runtime reinstallation",
+      "state": "main-integrated-staging-deployed-production-blocked",
+      "method": "PR #833/#836 merge and check metadata; canonical Deploy Core Worker run metadata and failed production log; clean origin/main worktree hash comparison; private runtime installation, process, Run-key, loopback health and controlled-drill readback",
+      "result": "PR #833 merged as 2ba1e0a74eea8a88a5cdb609ba426c8df2c94261 and PR #836 as 34c9baff3978df71402b917449b6971a914b1110, with applicable CI/security checks green. Core API preview 30414699651 and staging 30414749763 succeeded for 2ba1e0a7. The runtime was reinstalled from clean integrated source at 02:07:17Z in operator-run-key mode; one supervisor and one dashboard child were active and loopback health returned ok. The controlled drill recorded one windows-message-delivered alert after its second failure, one resolved record with human_notification_delivery not-applicable, and a subsequent cooldown-suppressed alert. Finance uses a 3-second probe deadline, so a valid slow response is measured as degradation while an actual upstream 503 remains non-healthy.",
+      "limitation": "Production API run 30414808715 failed before Worker upload or smoke because Cloudflare error 10143 reported service binding FINANCE references missing Worker skincos-finance. No binding, secret, Finance Worker, D1 data or business data was changed. Production API health alone does not prove this release.",
+      "release_sha": "2ba1e0a74eea8a88a5cdb609ba426c8df2c94261",
+      "integrated_main_sha": "34c9baff3978df71402b917449b6971a914b1110",
+      "runs": [30414699651, 30414749763, 30414808715],
+      "rollback_checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\checkpoints\\observability-alert-hardening-20260728T2052Z"
+    },
+    {
       "observed_at": "2026-07-25T05:05:34Z",
       "surface": "google-drive-offsite-runtime-config",
       "scope": "Fresh runtime-config ciphertext and scratch decrypt",

--- a/docs/runbooks/external-observability.md
+++ b/docs/runbooks/external-observability.md
@@ -6,7 +6,7 @@ O catálogo em `ops/observability/catalog.json` define os probes. O monitor prim
 
 O estado `healthy` mede somente o endpoint de health e o orçamento de latência. `contract_status: incomplete` ou `partial` significa que a unidade ainda não comprovou todos os campos/health-readiness-dependencies-version exigidos: não é gate de promoção. O alerta humano só é confirmado após duas leituras não saudáveis consecutivas; a recuperação também exige duas leituras saudáveis e fica registrada, sem abrir pop-up.
 
-O instalador registra três tarefas Windows: probe a cada minuto, dashboard local em loopback e watchdog independente a cada dois minutos. Em sessão elevada, elas executam como `SYSTEM` e iniciam no boot; sem elevação, executam como o operador atual, iniciam no logon e continuam automaticamente durante sua sessão. Caso uma política local bloqueie até a criação de tarefas do operador, o instalador registra um supervisor em `HKCU\...\Run`: ele inicia no próximo logon, executa probes a cada minuto e reinicia o dashboard se ele encerrar. O modo efetivo fica em `installation.json`. O dashboard fica somente em `127.0.0.1`, expõe `/`, `/health` e `/metrics` e não depende de Cloudflare ou GitHub. `history.jsonl`, `metrics-history.jsonl` e `notifications.jsonl` retêm 30 dias; nenhum token, payload de negócio ou dado pessoal é gravado.
+O instalador registra três tarefas Windows: probe a cada minuto, dashboard local em loopback e watchdog independente a cada dois minutos. Em sessão elevada, elas executam como `SYSTEM` e iniciam no boot; sem elevação, executam como o operador atual, iniciam no logon e continuam automaticamente durante sua sessão. Caso uma política local bloqueie até a criação de tarefas do operador, o instalador registra um supervisor em `HKCU\...\Run`: ele inicia no próximo logon, executa probes a cada minuto e reinicia o dashboard se ele encerrar. Nesse modo é esperado que as três tarefas estejam ausentes; a prova é `installation.json` com `execution_mode=operator-run-key`, a chave Run, exatamente um supervisor e seu único dashboard filho. O instalador exclui o próprio PID ao encerrar processos anteriores. O dashboard fica somente em `127.0.0.1`, expõe `/`, `/health` e `/metrics` e não depende de Cloudflare ou GitHub. `history.jsonl`, `metrics-history.jsonl` e `notifications.jsonl` retêm 30 dias; nenhum token, payload de negócio ou dado pessoal é gravado.
 
 ## Instalação e rollback
 
@@ -31,6 +31,12 @@ Remove-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Run -N
 ```
 
 O rollback remove apenas o agendamento e a inicialização automática; se o modo `operator-run-key` estiver ativo, encerre o processo supervisor na próxima sessão ou reinicie o Windows. Os arquivos de evidência ficam retidos no runtime privado.
+
+Se a fonte `SkincosObservability` ainda não existir no Windows Application Event
+Log, as tentativas ficam registradas como `event_log_delivery=failed`, mas a
+política de confirmação, o popup com expiração e `notifications.jsonl` continuam
+operacionais. Execute uma reinstalação elevada para registrar a fonte; não
+interprete essa limitação de telemetria como confirmação de entrega humana.
 
 ## Alerta e recuperação controlados
 

--- a/ops/observability/scripts/Install-SkincosObservability.ps1
+++ b/ops/observability/scripts/Install-SkincosObservability.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = 'Stop'; $sourceRoot = Split-Path -Parent $PSScriptRoot;
 function Stop-ExistingSupervisor {
   $managedScripts = @('Start-SkincosObservabilitySupervisor.ps1', 'Serve-SkincosObservabilityDashboard.ps1')
   foreach ($candidate in Get-CimInstance Win32_Process) {
+    if ($candidate.ProcessId -eq $PID) { continue }
     if ($candidate.Name -ne 'powershell.exe' -or -not $candidate.CommandLine -or $candidate.CommandLine -notlike "*$RuntimeDirectory*") { continue }
     if (-not ($managedScripts | Where-Object { $candidate.CommandLine -like "*$_*" })) { continue }
     try { Stop-Process -Id $candidate.ProcessId -Force -ErrorAction Stop } catch {}


### PR DESCRIPTION
## Cause\nThe installer correctly selected the Run-key fallback when Scheduled Tasks were denied, but its scoped process cleanup could match the PowerShell process invoking the installer if that caller command line mentioned a managed script.\n\n## Change\n- Exclude the installer PID from managed-process cleanup.\n- Record actual alert policy, drill, promotion and runtime evidence.\n- Clarify fallback-mode validation and Event Log source limitation.\n\n## Validation\n- PowerShell parser and deterministic monitor policy suite passed.\n- Catalog validation passed.\n- API tests: 16 passed, including slow valid Finance response and genuine upstream failure.\n- Architecture validation passed.\n- Functional installer restart from a caller command line containing the supervisor name preserved the installer and restored one supervisor/dashboard pair.\n\n## Rollout and risk\nNo Cloudflare deployment or data change. The production API promotion remains blocked before upload by missing production Cloudflare Worker skincos-finance (run 30414808715).