### PR TITLE
feat(meta-ads): reconcile canonical publish source

### DIFF
--- a/orb/engine/.gitignore
+++ b/orb/engine/.gitignore
@@ -65,3 +65,5 @@ workflows/*.current*.json
 workflows/*.live*.json
 # Snapshots are temporary; only the four tracked clinic workflow baselines are versioned.
 workflows/*.json
+# The inactive Meta Ads Publish definition is the reviewed control-plane source.
+!workflows/meta-ads-publish.current.json

--- a/orb/engine/docs/meta-ads-publish-operations.md
+++ b/orb/engine/docs/meta-ads-publish-operations.md
@@ -21,6 +21,40 @@ arquivos em `workflow-src/meta-ads-publish/`.
    nomes de nodes ou por uma aba antiga do navegador.
 3. Para runtime, valide `/var/lib/skincos-runtime/orb` e os serviços finais; o
    `Orb Validate` é a verificação ampla após alterações de infraestrutura.
+4. A definição rastreada é `workflows/meta-ads-publish.current.json`. Ela é
+   uma exportação sanitizada: não inclui execução, pin data, contadores nem
+   versão runtime. Cada um dos 49 Code nodes tem uma fonte em
+   `workflow-src/meta-ads-publish/`, listada uma única vez em
+   `scripts/lib/meta-ads-publish-code-sources.js`.
+
+## Sincronização e rollback
+
+1. Exporte o workflow vivo para o checkpoint privado com
+   `node scripts/export-meta-ads-publish-live.js`.
+2. Gere a definição revisável com
+   `node scripts/export-meta-ads-publish-canonical.js <checkpoint>/workflow.live.json workflows/meta-ads-publish.current.json`
+   e extraia/compare todos os Code nodes com
+   `node scripts/sync-meta-ads-publish-sources.js check`.
+3. Aplique uma alteração somente a partir da definição canônica, com
+   `apply-meta-ads-publish-workflow-snapshot.js`, usando a versão viva esperada;
+   o script recusa workflows ativos e mudanças concorrentes.
+4. Para rollback, use o checkpoint privado anterior como candidato, confirme a
+   versão viva atual e execute o mesmo apply versionado. Nunca copie código do
+   editor, de um worktree antigo ou de uma execução para a produção.
+
+O Token Vault é uma superfície separada: o arquivo canônico é
+`platform/security/token-vault/src/meta-ads-publish.js`. Antes de promover uma
+versão do Worker, execute seus testes e registre o ID/ETag retornado pelo
+Wrangler; depois compare a versão de produção e rode o preflight do workflow.
+O Worker declara a mesma `WORKFLOW_CONTRACT_REVISION` que `Build Jobs`,
+`Validate Meta Creative Payload` e `Build Meta API Params From Vault`. Este
+último nó falha fechado se a capacidade recebida divergir; uma alteração de
+contrato exige atualizar os quatro produtores/consumidores, a definição
+canônica, o checkpoint de run e o preflight na mesma revisão.
+
+Antes do primeiro deploy em um ambiente, aplique as migrations do Token Vault
+com `npm run d1:migrate`. A migration `0002_meta_ads_publish_journal.sql`
+versiona o journal, operações e locks idempotentes já usados pelo gateway.
 
 ## Regras que evitam recorrência
 

--- a/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
+++ b/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
@@ -9,6 +9,7 @@ const path = require('path');
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
+const { validate: validateCrmContextPrefetch } = require('./patch-meta-ads-crm-context-prefetch');
 const args = new Set(process.argv.slice(2));
 const sourcePath = [...args].find((value) => value.endsWith('.json'));
 const expectedVersion = [...args].find((value) => value.startsWith('--expected-version='))?.slice('--expected-version='.length);
@@ -45,12 +46,18 @@ function assertCandidate(candidate) {
   if (!Array.isArray(candidate.nodes) || candidate.nodes.some((node) => node.type === 'n8n-nodes-base.googleSheetsTool')) {
     throw new Error('Candidate still contains a Google Sheets tool.');
   }
-  const crm = candidate.nodes.find((node) => node.name === 'CRM Offer Context');
-  if (crm?.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest' || crm?.parameters?.url !== 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit={unit}') {
-    throw new Error('Candidate CRM Offer Context tool is incomplete.');
+  validateCrmContextPrefetch(candidate);
+  const codeByName = (name) => String(candidate.nodes.find((node) => node.name === name)?.parameters?.jsCode || '');
+  const revision = (code) => /const\s+WORKFLOW_CONTRACT_REVISION\s*=\s*'([^']+)'/.exec(code)?.[1] || '';
+  const buildRevision = revision(codeByName('Build Jobs'));
+  const validatorRevision = revision(codeByName('Validate Meta Creative Payload'));
+  const gatewayRevision = revision(codeByName('Build Meta API Params From Vault'));
+  if (!buildRevision || buildRevision !== validatorRevision || buildRevision !== gatewayRevision) {
+    throw new Error('Candidate Meta Ads Publish workflow contract revisions are inconsistent.');
   }
-  const target = candidate.connections?.['CRM Offer Context']?.ai_tool?.[0]?.[0];
-  if (target?.node !== 'Livia' || target?.type !== 'ai_tool') throw new Error('Candidate CRM Offer Context is not connected to Livia.');
+  if (!/gatewayContractRevision !== WORKFLOW_CONTRACT_REVISION/.test(codeByName('Build Meta API Params From Vault'))) {
+    throw new Error('Candidate does not fail closed on Token Vault workflow contract revision drift.');
+  }
   validateVideoUploadReplay(candidate);
 }
 

--- a/orb/engine/scripts/export-meta-ads-publish-canonical.js
+++ b/orb/engine/scripts/export-meta-ads-publish-canonical.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+// Converts a private, live n8n export into the tracked workflow definition.
+// Runtime execution state and version counters deliberately stay out of Git.
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
+const [inputPath, outputPath] = process.argv.slice(2);
+
+if (!inputPath || !outputPath) {
+  throw new Error('Usage: node export-meta-ads-publish-canonical.js <live-export.json> <canonical-workflow.json>');
+}
+
+const live = JSON.parse(fs.readFileSync(path.resolve(inputPath), 'utf8'));
+if (live.id !== WORKFLOW_ID) throw new Error('Unexpected workflow id.');
+if (live.active !== false) throw new Error('Refusing to export an active workflow.');
+if (!Array.isArray(live.nodes) || !live.nodes.length || !live.connections || typeof live.connections !== 'object') {
+  throw new Error('Live workflow is structurally incomplete.');
+}
+
+const canonical = {
+  id: live.id,
+  name: live.name,
+  active: false,
+  nodes: live.nodes,
+  connections: live.connections,
+  settings: live.settings || {},
+  meta: live.meta || {},
+  description: live.description || '',
+};
+
+fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+fs.writeFileSync(path.resolve(outputPath), `${JSON.stringify(canonical, null, 2)}\n`);
+console.log(JSON.stringify({
+  workflow_id: canonical.id,
+  nodes: canonical.nodes.length,
+  output: path.resolve(outputPath),
+  omitted: ['staticData', 'pinData', 'versionId', 'activeVersionId', 'versionCounter', 'updatedAt'],
+}, null, 2));

--- a/orb/engine/scripts/patch-meta-ads-crm-context-prefetch.js
+++ b/orb/engine/scripts/patch-meta-ads-crm-context-prefetch.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+'use strict';
+
+// Moves the CRM catalog lookup out of the AI sub-node. n8n's HTTP Request Tool
+// does not reliably execute a loopback authenticated URL on this runtime,
+// while the normal HTTP Request node does. The model still receives only the
+// CRM result that belongs to each destination and never a spreadsheet.
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
+const CRM_URL = 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context';
+const PREPARE_NODE = 'Prepare CRM Offer Context Requests';
+const FETCH_NODE = 'Fetch CRM Offer Context';
+const ATTACH_NODE = 'Attach CRM Offer Context';
+const LIVIA_NODE = 'Livia';
+const INPUT_NODE = 'Prepare Media Upload Plan';
+
+const PREPARE_CODE = `function text(value) { return String(value ?? '').trim(); }
+function unitSlug(destinationGroup) {
+  const normalized = text(destinationGroup).toLocaleLowerCase('pt-BR').replace(/[^a-z0-9]+/g, '');
+  if (normalized === 'barrashoppingsul') return 'barra-shopping-sul';
+  if (normalized === 'novohamburgo') return 'novo-hamburgo';
+  throw new Error(\`Destino CRM desconhecido: \${text(destinationGroup) || 'vazio'}.\`);
+}
+
+return $input.all().flatMap((item) => {
+  const job = item.json || {};
+  const jobKey = text(job.job_key);
+  const groupKey = text(job.group_key);
+  const destinations = Array.isArray(job.destinations) ? job.destinations : [];
+  if (!jobKey || !groupKey || !destinations.length) throw new Error('Prepare CRM Offer Context Requests exige job_key, group_key e destinos.');
+  const seen = new Set();
+  return destinations.map((destination) => {
+    const destinationGroup = text(destination?.destination_group);
+    const crmUnit = unitSlug(destinationGroup);
+    if (seen.has(crmUnit)) throw new Error(\`Destino CRM duplicado em \${jobKey}: \${crmUnit}.\`);
+    seen.add(crmUnit);
+    return {
+      json: {
+        job_key: jobKey,
+        group_key: groupKey,
+        crm_unit: crmUnit,
+        crm_destination_group: destinationGroup,
+        crm_source_job: job,
+      },
+      binary: item.binary || {},
+      pairedItem: item.pairedItem,
+    };
+  });
+});`;
+
+const ATTACH_CODE = `function text(value) { return String(value ?? '').trim(); }
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  return Number((Array.isArray(paired) ? paired[0]?.item : paired?.item) ?? fallback);
+}
+
+const requests = $items('${PREPARE_NODE}') || [];
+const buckets = new Map();
+for (const [index, item] of $input.all().entries()) {
+  const request = requests[pairedIndex(item, index)];
+  if (!request?.json) throw new Error(\`CRM Offer Context sem request correlacionado; index=\${index}.\`);
+  const meta = request.json;
+  const jobKey = text(meta.job_key);
+  const groupKey = text(meta.group_key);
+  const crmUnit = text(meta.crm_unit);
+  const sourceJob = meta.crm_source_job;
+  if (!jobKey || !groupKey || !crmUnit || !sourceJob) throw new Error('CRM Offer Context retornou contexto incompleto.');
+  const bucket = buckets.get(jobKey) || { job: sourceJob, group_key: groupKey, contexts: {}, binary: request.binary || {} };
+  if (bucket.group_key !== groupKey || bucket.contexts[crmUnit]) throw new Error(\`CRM Offer Context duplicado ou divergente em \${jobKey}.\`);
+  bucket.contexts[crmUnit] = item.json || {};
+  buckets.set(jobKey, bucket);
+}
+
+return [...buckets.entries()].map(([jobKey, bucket]) => {
+  const expected = Array.isArray(bucket.job.destinations) ? bucket.job.destinations.length : 0;
+  if (!expected || Object.keys(bucket.contexts).length !== expected) {
+    throw new Error(\`Cobertura CRM incompleta em \${jobKey}; expected=\${expected} completed=\${Object.keys(bucket.contexts).length}.\`);
+  }
+  return {
+    json: {
+      ...bucket.job,
+      crm_offer_context_version: '1',
+      crm_offer_contexts: bucket.contexts,
+    },
+    binary: bucket.binary,
+  };
+});`;
+
+function clone(value) { return JSON.parse(JSON.stringify(value)); }
+function nodeByName(workflow, name) { return workflow.nodes.find((node) => node.name === name); }
+
+function nodeDefinitions(credentialId, credentialName) {
+  return [
+    { id: 'meta-publish-prepare-crm-offer-context', name: PREPARE_NODE, type: 'n8n-nodes-base.code', typeVersion: 2, position: [7360, 1376], parameters: { jsCode: PREPARE_CODE } },
+    {
+      id: 'meta-publish-fetch-crm-offer-context', name: FETCH_NODE, type: 'n8n-nodes-base.httpRequest', typeVersion: 4.3, position: [7584, 1376],
+      parameters: {
+        url: `={{ '${CRM_URL}?unit=' + encodeURIComponent($json.crm_unit) }}`,
+        authentication: 'genericCredentialType', genericAuthType: 'httpBearerAuth', options: { timeout: 20000 },
+      },
+      credentials: { httpBearerAuth: { id: credentialId, name: credentialName } },
+    },
+    { id: 'meta-publish-attach-crm-offer-context', name: ATTACH_NODE, type: 'n8n-nodes-base.code', typeVersion: 2, position: [7808, 1376], parameters: { jsCode: ATTACH_CODE } },
+  ];
+}
+
+function validate(workflow) {
+  const nodes = Array.isArray(workflow?.nodes) ? workflow.nodes : [];
+  const connections = workflow?.connections || {};
+  if (nodes.some((node) => node.type === 'n8n-nodes-base.googleSheetsTool' || node.name === 'Knowledge' || node.name === 'CRM Offer Context')) throw new Error('Legacy commercial source node is still present.');
+  const prepare = nodeByName(workflow, PREPARE_NODE);
+  const fetch = nodeByName(workflow, FETCH_NODE);
+  const attach = nodeByName(workflow, ATTACH_NODE);
+  if (!prepare?.parameters?.jsCode?.includes('unitSlug') || !attach?.parameters?.jsCode?.includes('crm_offer_contexts')) throw new Error('CRM prefetch code nodes are incomplete.');
+  if (fetch?.type !== 'n8n-nodes-base.httpRequest' || fetch.parameters?.authentication !== 'genericCredentialType' || fetch.parameters?.genericAuthType !== 'httpBearerAuth' || !fetch.credentials?.httpBearerAuth?.id || !String(fetch.parameters?.url || '').includes(CRM_URL)) throw new Error('CRM prefetch HTTP request is incomplete.');
+  const inputTargets = connections?.[INPUT_NODE]?.main?.[0] || [];
+  const prepareTargets = connections?.[PREPARE_NODE]?.main?.[0] || [];
+  const fetchTargets = connections?.[FETCH_NODE]?.main?.[0] || [];
+  const attachTargets = connections?.[ATTACH_NODE]?.main?.[0] || [];
+  if (!inputTargets.some((edge) => edge.node === PREPARE_NODE) || !prepareTargets.some((edge) => edge.node === FETCH_NODE) || !fetchTargets.some((edge) => edge.node === ATTACH_NODE) || !attachTargets.some((edge) => edge.node === LIVIA_NODE)) {
+    throw new Error('CRM prefetch graph is not connected to Livia.');
+  }
+  const livia = nodeByName(workflow, LIVIA_NODE);
+  const prompt = String(livia?.parameters?.text || '');
+  const system = String(livia?.parameters?.options?.systemMessage || '');
+  if (!prompt.includes('crm_offer_contexts') || !system.includes('consultado automaticamente pelo workflow')) throw new Error('Livia CRM context prompt is incomplete.');
+  return true;
+}
+
+function transform(workflow, { credentialId, credentialName }) {
+  if (workflow?.id !== WORKFLOW_ID || workflow.active !== false) throw new Error('Expected an inactive Meta Ads Publish export.');
+  if (!credentialId || !credentialName) throw new Error('CRM bearer credential is required.');
+  const candidate = clone(workflow);
+  candidate.nodes = candidate.nodes.filter((node) => !['CRM Offer Context', PREPARE_NODE, FETCH_NODE, ATTACH_NODE].includes(node.name));
+  candidate.nodes.push(...nodeDefinitions(credentialId, credentialName));
+  delete candidate.connections['CRM Offer Context'];
+  const existing = candidate.connections?.[INPUT_NODE]?.main?.[0] || [];
+  candidate.connections[INPUT_NODE] = { main: [existing.filter((edge) => edge.node !== LIVIA_NODE).concat([{ node: PREPARE_NODE, type: 'main', index: 0 }])] };
+  candidate.connections[PREPARE_NODE] = { main: [[{ node: FETCH_NODE, type: 'main', index: 0 }]] };
+  candidate.connections[FETCH_NODE] = { main: [[{ node: ATTACH_NODE, type: 'main', index: 0 }]] };
+  candidate.connections[ATTACH_NODE] = { main: [[{ node: LIVIA_NODE, type: 'main', index: 0 }]] };
+  const livia = nodeByName(candidate, LIVIA_NODE);
+  let prompt = String(livia.parameters.text || '');
+  if (!prompt.includes('crm_offer_contexts')) {
+    prompt = prompt.replace(
+      '  destinations: $json.destinations || [],',
+      '  destinations: $json.destinations || [],\n  crm_offer_contexts: $json.crm_offer_contexts || {},',
+    );
+    if (!prompt.includes('crm_offer_contexts')) prompt += '\ncrm_offer_contexts: $json.crm_offer_contexts || {}';
+  }
+  livia.parameters.text = prompt;
+  const crmInstruction = '- O catálogo comercial do CRM foi consultado automaticamente pelo workflow para cada unidade de destino.\n- Use somente os dados presentes em `crm_offer_contexts` para preço, oferta, parcelamento, condição e vigência.\n- Se o CRM não retornar uma oferta, não use preço ou condição que não esteja inequívoca na mídia.';
+  let systemMessage = String(livia.parameters?.options?.systemMessage || '');
+  systemMessage = systemMessage.replace(/- Consulte `CRM Offer Context`[\s\S]*?inequívoca na mídia\./, crmInstruction);
+  if (!systemMessage.includes('consultado automaticamente pelo workflow')) systemMessage += `\n${crmInstruction}`;
+  systemMessage = systemMessage.replace('`crmPricing` deve refletir apenas o que vier do CRM, quando ele for consultado.', '`crmPricing` deve refletir apenas o que vier de `crm_offer_contexts`.');
+  livia.parameters.options.systemMessage = systemMessage;
+  validate(candidate);
+  return candidate;
+}
+
+function main() {
+  const [input, output, credentialId, credentialName] = process.argv.slice(2);
+  if (!input || !output || !credentialId || !credentialName) throw new Error('Usage: node patch-meta-ads-crm-context-prefetch.js <input.json> <output.json> <credential-id> <credential-name>');
+  const candidate = transform(JSON.parse(fs.readFileSync(path.resolve(input), 'utf8')), { credentialId, credentialName });
+  fs.writeFileSync(path.resolve(output), `${JSON.stringify(candidate, null, 2)}\n`);
+  console.log(JSON.stringify({ workflow_id: candidate.id, crm_source: 'prefetched_http_request', output: path.resolve(output) }));
+}
+
+if (require.main === module) main();
+
+module.exports = { CRM_URL, PREPARE_NODE, FETCH_NODE, ATTACH_NODE, transform, validate };

--- a/orb/engine/scripts/sync-meta-ads-publish-sources.js
+++ b/orb/engine/scripts/sync-meta-ads-publish-sources.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { CODE_SOURCES } = require('./lib/meta-ads-publish-code-sources');
 
 const moduleRoot = path.resolve(__dirname, '..');
 const workflowArg = process.argv.slice(2).find((value) => value.startsWith('--workflow='));
@@ -10,26 +11,6 @@ const workflowPath = workflowArg
   ? path.resolve(workflowArg.slice('--workflow='.length))
   : path.join(moduleRoot, 'workflows', 'meta-ads-publish.current.json');
 const sourceRoot = path.join(moduleRoot, 'workflow-src', 'meta-ads-publish');
-
-const CODE_SOURCES = Object.freeze({
-  'Build Meta API Params From Vault': 'build-meta-api-params-from-vault.js',
-  'Build Meta Account Inventory Requests': 'build-meta-inventory-requests.js',
-  'Build Payload': 'build-payload.js',
-  'Prepare Publish Run': 'prepare-publish-run.js',
-  'Restore Publish Groups': 'restore-publish-groups.js',
-  'Prepare Gateway Uploads': 'prepare-gateway-uploads.js',
-  'Normalize Gateway Upload': 'normalize-gateway-upload.js',
-  'Build Jobs': 'build-jobs.js',
-  'Validate Meta Creative Payload': 'validate-meta-creative-payload.js',
-  'Prepare Creative Operation': 'prepare-creative-operation.js',
-  'Attach Creative Result': 'attach-creative-result.js',
-  'Attach Advantage+ Verification': 'attach-advantage-plus-verification.js',
-  'Build Stage Batch': 'build-stage-batch.js',
-  'Build Activate Batch': 'build-activate-batch.js',
-  'Build Drive Finalization': 'build-drive-finalization.js',
-  'Prepare Drive Read': 'prepare-drive-read.js',
-  'Verify Drive Finalization': 'verify-drive-finalization.js',
-});
 
 function readWorkflow() {
   return JSON.parse(fs.readFileSync(workflowPath, 'utf8'));

--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -6,30 +6,15 @@ const path = require('path');
 const {
   manualExecutionAuditState,
 } = require('./lib/meta-ads-publish-execution-semantics');
+const { CODE_SOURCES } = require('./lib/meta-ads-publish-code-sources');
 const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
+const {
+  CRM_URL: CRM_OFFER_CONTEXT_URL,
+  FETCH_NODE: CRM_FETCH_NODE,
+  validate: validateCrmContextPrefetch,
+} = require('./patch-meta-ads-crm-context-prefetch');
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
-const CODE_SOURCES = Object.freeze({
-  'Build Meta API Params From Vault': 'build-meta-api-params-from-vault.js',
-  'Build Meta Account Inventory Requests': 'build-meta-inventory-requests.js',
-  'Build Payload': 'build-payload.js',
-  'Prepare Publish Run': 'prepare-publish-run.js',
-  'Restore Publish Groups': 'restore-publish-groups.js',
-  'Prepare Gateway Uploads': 'prepare-gateway-uploads.js',
-  'Normalize Gateway Upload': 'normalize-gateway-upload.js',
-  'Build Jobs': 'build-jobs.js',
-  'Validate Meta Creative Payload': 'validate-meta-creative-payload.js',
-  'Prepare Creative Operation': 'prepare-creative-operation.js',
-  'Attach Creative Result': 'attach-creative-result.js',
-  'Attach Advantage+ Verification': 'attach-advantage-plus-verification.js',
-  'Build Stage Batch': 'build-stage-batch.js',
-  'Build Activate Batch': 'build-activate-batch.js',
-  'Build Drive Finalization': 'build-drive-finalization.js',
-  'Prepare Drive Read': 'prepare-drive-read.js',
-  'Verify Drive Finalization': 'verify-drive-finalization.js',
-});
-
-const CRM_OFFER_CONTEXT_URL = 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit={unit}';
 
 function loadPgClient() {
   try { return require('/usr/local/lib/node_modules/n8n/node_modules/pg').Client; }
@@ -49,22 +34,19 @@ function structuralContractDrift(nodes, connections) {
   const drift = [];
   const sheets = nodes.filter((node) => node.type === 'n8n-nodes-base.googleSheetsTool');
   if (sheets.length) drift.push({ contract: 'commercial_offer_source', reason: 'google_sheets_tool_present', nodes: sheets.map((node) => node.name) });
-  const crm = nodes.find((node) => node.name === 'CRM Offer Context');
-  if (!crm) {
-    drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_tool_missing' });
-  } else {
-    if (crm.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest') drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_wrong_type' });
-    if ((crm.parameters?.method && crm.parameters.method !== 'GET') || crm.parameters?.url !== CRM_OFFER_CONTEXT_URL) drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_request_mismatch' });
-    if (crm.parameters?.authentication !== 'genericCredentialType' || crm.parameters?.genericAuthType !== 'httpBearerAuth' || !crm.credentials?.httpBearerAuth?.id) {
-      drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_credential_missing' });
-    }
-    const target = connections?.['CRM Offer Context']?.ai_tool?.[0]?.[0];
-    if (target?.node !== 'Livia' || target?.type !== 'ai_tool') drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_not_connected_to_livia' });
+  const crmFetch = nodes.find((node) => node.name === CRM_FETCH_NODE);
+  if (!crmFetch || crmFetch.type !== 'n8n-nodes-base.httpRequest' || crmFetch.parameters?.authentication !== 'genericCredentialType' || crmFetch.parameters?.genericAuthType !== 'httpBearerAuth' || !crmFetch.credentials?.httpBearerAuth?.id || !String(crmFetch.parameters?.url || '').includes(CRM_OFFER_CONTEXT_URL)) {
+    drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_prefetch_request_invalid' });
+  }
+  try {
+    validateCrmContextPrefetch({ id: WORKFLOW_ID, active: false, nodes, connections });
+  } catch (error) {
+    drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_prefetch_graph_invalid', detail: String(error.message || error) });
   }
   const livia = nodes.find((node) => node.name === 'Livia');
   const systemMessage = String(livia?.parameters?.options?.systemMessage || '');
   const prompt = String(livia?.parameters?.text || '');
-  if (!livia || !systemMessage.includes('CRM Offer Context') || !prompt.includes('crmPricing') || /Knowledge|planilha|spreadsheetPricing/i.test(`${systemMessage}\n${prompt}`)) {
+  if (!livia || !systemMessage.includes('consultado automaticamente pelo workflow') || !prompt.includes('crmPricing') || !prompt.includes('crm_offer_contexts') || /Knowledge|planilha|spreadsheetPricing|CRM Offer Context/i.test(`${systemMessage}\n${prompt}`)) {
     drift.push({ contract: 'commercial_offer_source', reason: 'livia_crm_prompt_contract_missing' });
   }
   const model = nodes.find((node) => node.name === 'OpenAI Chat Model (Agent)');
@@ -87,6 +69,40 @@ function videoUploadContractDrift(workflow) {
   } catch (error) {
     return [{ contract: 'video_upload_replay', reason: String(error.message || error) }];
   }
+}
+
+function codeConstant(code, name) {
+  const match = new RegExp(`const\\s+${name}\\s*=\\s*'([^']+)'`).exec(String(code || ''));
+  return match ? match[1] : '';
+}
+
+function creativeContractDrift(nodes) {
+  const buildJobs = String(nodes.find((node) => node.name === 'Build Jobs')?.parameters?.jsCode || '');
+  const validator = String(nodes.find((node) => node.name === 'Validate Meta Creative Payload')?.parameters?.jsCode || '');
+  const gatewayParams = String(nodes.find((node) => node.name === 'Build Meta API Params From Vault')?.parameters?.jsCode || '');
+  const drift = [];
+  const buildRevision = codeConstant(buildJobs, 'WORKFLOW_CONTRACT_REVISION');
+  const validatorRevision = codeConstant(validator, 'WORKFLOW_CONTRACT_REVISION');
+  const gatewayRevision = codeConstant(gatewayParams, 'WORKFLOW_CONTRACT_REVISION');
+  if (!buildRevision || buildRevision !== validatorRevision || buildRevision !== gatewayRevision) {
+    drift.push({ contract: 'creative_payload', reason: 'workflow_contract_revision_mismatch', build_jobs: buildRevision, validator: validatorRevision, gateway_params: gatewayRevision });
+  }
+  if (!/capabilities\)\.workflow_contract_revision/.test(gatewayParams) || !/gatewayContractRevision !== WORKFLOW_CONTRACT_REVISION/.test(gatewayParams)) {
+    drift.push({ contract: 'creative_payload', reason: 'gateway_contract_revision_gate_missing' });
+  }
+  if (codeConstant(buildJobs, 'DEFAULT_CTA_TYPE') !== 'BOOK_NOW' || codeConstant(buildJobs, 'WHATSAPP_CTA_TYPE') !== 'WHATSAPP_MESSAGE' || codeConstant(validator, 'REQUIRED_CTA') !== 'BOOK_NOW' || codeConstant(validator, 'WHATSAPP_CTA') !== 'WHATSAPP_MESSAGE') {
+    drift.push({ contract: 'creative_payload', reason: 'cta_contract_mismatch' });
+  }
+  if (codeConstant(buildJobs, 'OUTCOME_LEADS_CTA_TYPE') !== 'LEARN_MORE' || codeConstant(validator, 'OUTCOME_LEADS_CTA') !== 'LEARN_MORE' || !/function ctaTypeForDestination\(/.test(buildJobs) || !/function expectedFlexibleCta\(/.test(validator)) {
+    drift.push({ contract: 'creative_payload', reason: 'objective_aware_cta_contract_mismatch' });
+  }
+  if (!/const currentEntries = currentItems/.test(buildJobs) || !/if \(currentEntries\.length\) return currentEntries/.test(buildJobs)) {
+    drift.push({ contract: 'creative_payload', reason: 'current_build_payload_precedence_missing' });
+  }
+  if (!/source_url:\s*toHttps\(sourceUrl\)/.test(buildJobs) || !/creative_source_url_missing/.test(validator) || !/creative_source_url_primary_link_mismatch/.test(validator)) {
+    drift.push({ contract: 'creative_payload', reason: 'source_url_contract_mismatch' });
+  }
+  return drift;
 }
 
 async function main() {
@@ -124,6 +140,7 @@ async function main() {
     const settings = parseJson(workflow.settings, {});
     const structuralDrift = structuralContractDrift(nodes, connections);
     const videoUploadDrift = videoUploadContractDrift({ ...workflow, id: WORKFLOW_ID, nodes, connections });
+    const creativeDrift = creativeContractDrift(nodes);
     const report = {
       workflow_id: WORKFLOW_ID,
       mode: 'read_only',
@@ -137,6 +154,8 @@ async function main() {
       crm_catalog_contract_drift: structuralDrift,
       video_upload_contract_synchronized: videoUploadDrift.length === 0,
       video_upload_contract_drift: videoUploadDrift,
+      creative_payload_contract_synchronized: creativeDrift.length === 0,
+      creative_payload_contract_drift: creativeDrift,
       manual_execution_audit: manualExecutionAuditState(settings),
       manual_execution_note: settings.saveManualExecutions === true
         ? 'Manual executions are retained for later inspection.'
@@ -145,7 +164,7 @@ async function main() {
       service_restarts_performed: false,
     };
     console.log(JSON.stringify(report, null, 2));
-    if (drift.length || structuralDrift.length || videoUploadDrift.length) process.exitCode = 1;
+    if (drift.length || structuralDrift.length || videoUploadDrift.length || creativeDrift.length) process.exitCode = 1;
   } finally {
     await client.end();
   }

--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -71,8 +71,20 @@ function videoUploadContractDrift(workflow) {
   }
 }
 
+const CONTRACT_CONSTANT_PATTERNS = Object.freeze({
+  WORKFLOW_CONTRACT_REVISION: /const\s+WORKFLOW_CONTRACT_REVISION\s*=\s*'([^']+)'/,
+  DEFAULT_CTA_TYPE: /const\s+DEFAULT_CTA_TYPE\s*=\s*'([^']+)'/,
+  WHATSAPP_CTA_TYPE: /const\s+WHATSAPP_CTA_TYPE\s*=\s*'([^']+)'/,
+  REQUIRED_CTA: /const\s+REQUIRED_CTA\s*=\s*'([^']+)'/,
+  WHATSAPP_CTA: /const\s+WHATSAPP_CTA\s*=\s*'([^']+)'/,
+  OUTCOME_LEADS_CTA_TYPE: /const\s+OUTCOME_LEADS_CTA_TYPE\s*=\s*'([^']+)'/,
+  OUTCOME_LEADS_CTA: /const\s+OUTCOME_LEADS_CTA\s*=\s*'([^']+)'/,
+});
+
 function codeConstant(code, name) {
-  const match = new RegExp(`const\\s+${name}\\s*=\\s*'([^']+)'`).exec(String(code || ''));
+  const pattern = CONTRACT_CONSTANT_PATTERNS[name];
+  if (!pattern) return '';
+  const match = pattern.exec(String(code || ''));
   return match ? match[1] : '';
 }
 

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -11,6 +11,15 @@ const {
 } = require('../scripts/lib/meta-ads-publish-execution-semantics');
 const { CRM_TOOL_NAME, CRM_URL, transform } = require('../scripts/prepare-meta-ads-publish-crm-catalog');
 const { transform: patchVideoUploadReplay } = require('../scripts/patch-meta-ads-video-transfer-replay');
+const { CODE_SOURCES } = require('../scripts/lib/meta-ads-publish-code-sources');
+
+test('tracks every live Meta Ads Publish Code node in one shared source map', () => {
+  assert.equal(Object.keys(CODE_SOURCES).length, 49);
+  assert.equal(CODE_SOURCES['Build Jobs'], 'build-jobs.js');
+  assert.equal(CODE_SOURCES['Validate Visual Grouping'], 'validate-visual-grouping.js');
+  assert.equal(CODE_SOURCES['Prepare CRM Offer Context Requests'], 'prepare-crm-offer-context-requests.js');
+  assert.equal(CODE_SOURCES['Attach CRM Offer Context'], 'attach-crm-offer-context.js');
+});
 
 test('Responses API uses the n8n 1.3 default when the stored parameter is absent', () => {
   assert.equal(effectiveResponsesApiEnabled({ typeVersion: 1.3, parameters: {} }), true);
@@ -74,6 +83,16 @@ test('preflight loads workflow connections before validating the CRM tool edge',
     'utf8',
   );
   assert.match(source, /SELECT active, nodes, connections, settings,/);
+  assert.match(source, /gateway_contract_revision_gate_missing/);
+});
+
+test('gateway parameters reject a Token Vault contract revision mismatch before publication', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'workflow-src', 'meta-ads-publish', 'build-meta-api-params-from-vault.js'),
+    'utf8',
+  );
+  assert.match(source, /const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta'/);
+  assert.match(source, /gatewayContractRevision !== WORKFLOW_CONTRACT_REVISION/);
 });
 
 test('video upload replay key includes normalized bytes and rejects the legacy v4 key', () => {

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -84,6 +84,7 @@ test('preflight loads workflow connections before validating the CRM tool edge',
   );
   assert.match(source, /SELECT active, nodes, connections, settings,/);
   assert.match(source, /gateway_contract_revision_gate_missing/);
+  assert.doesNotMatch(source, /new RegExp\(/);
 });
 
 test('gateway parameters reject a Token Vault contract revision mismatch before publication', () => {

--- a/orb/engine/workflow-src/meta-ads-publish/aggregate-media-upload-results.js
+++ b/orb/engine/workflow-src/meta-ads-publish/aggregate-media-upload-results.js
@@ -1,0 +1,128 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+const plans = $items('Prepare Media Upload Plan') || [];
+const planByJob = new Map();
+for (const item of plans) {
+  const plan = item.json?.media_upload_plan || {};
+  const jobKey = text(plan.job_key || item.json?.job_key);
+  if (!jobKey) throw new Error('Aggregate Media Upload Results encontrou plano sem job_key.');
+  if (planByJob.has(jobKey)) throw new Error(`Plano de upload duplicado para ${jobKey}.`);
+  planByJob.set(jobKey, clone(plan));
+}
+if (!planByJob.size) throw new Error('Aggregate Media Upload Results sem planos de upload.');
+
+const buckets = new Map([...planByJob.keys()].map((jobKey) => [jobKey, {
+  image_uploads: [],
+  video_uploads: [],
+  image_skips: [],
+  video_skips: [],
+  seen: new Set(),
+  receiptsByKey: new Map(),
+}]));
+
+for (const item of $input.all()) {
+  const receipt = item.json || {};
+  const jobKey = text(receipt.job_key);
+  const bucket = buckets.get(jobKey);
+  if (!bucket) throw new Error(`Resultado de upload nao correlacionado; job_key=${jobKey || 'vazio'}.`);
+
+  const resultKind = text(receipt.upload_result_kind);
+  if (resultKind === 'image_skipped') {
+    bucket.image_skips.push(clone(receipt));
+    continue;
+  }
+  if (resultKind === 'video_skipped') {
+    bucket.video_skips.push(clone(receipt));
+    continue;
+  }
+
+  const uploadKind = text(receipt.upload_kind);
+  const accountId = text(receipt._gateway_account_id || receipt.account_id);
+  const sourceFileId = text(receipt.source_file_id);
+  if (!accountId || !sourceFileId) {
+    throw new Error(`Resultado de upload incompleto em ${jobKey}; account_id/source_file_id ausente.`);
+  }
+  const dedupeKey = [uploadKind, accountId, sourceFileId].join('::');
+  if (bucket.seen.has(dedupeKey)) {
+    const previous = bucket.receiptsByKey.get(dedupeKey) || {};
+    // Polling a video until it is ready can surface the exact same terminal
+    // receipt more than once through the loop/merge graph. It is safe to
+    // collapse only an identical ready receipt; any different video result
+    // remains an ambiguity and stops publication.
+    const identicalReadyVideo = uploadKind === 'video' &&
+      text(previous.video_id) === text(receipt.video_id) &&
+      text(previous.video_status).toLowerCase() === 'ready' &&
+      text(receipt.video_status).toLowerCase() === 'ready' &&
+      previous.ready === true && receipt.ready === true;
+    if (identicalReadyVideo) continue;
+    throw new Error(`Resultado de upload duplicado em ${jobKey}; key=${dedupeKey}.`);
+  }
+  bucket.seen.add(dedupeKey);
+  bucket.receiptsByKey.set(dedupeKey, clone(receipt));
+
+  if (uploadKind === 'image' || uploadKind === 'video_thumbnail') {
+    const imageEntries = Object.values(receipt.images || {});
+    if (!imageEntries.length || !imageEntries.some((entry) => text(entry?.hash))) {
+      throw new Error(`Upload de imagem sem hash em ${jobKey}; kind=${uploadKind}.`);
+    }
+    bucket.image_uploads.push(clone(receipt));
+    continue;
+  }
+  if (uploadKind === 'video') {
+    if (!text(receipt.video_id) || text(receipt.video_status).toLowerCase() !== 'ready' || receipt.ready !== true) {
+      throw new Error(`Video ainda nao ready em ${jobKey}; status=${text(receipt.video_status) || 'vazio'}.`);
+    }
+    bucket.video_uploads.push(clone(receipt));
+    continue;
+  }
+  throw new Error(`Tipo de resultado de upload desconhecido em ${jobKey}; kind=${uploadKind || 'vazio'}.`);
+}
+
+const outputs = [];
+for (const [jobKey, plan] of planByJob.entries()) {
+  const bucket = buckets.get(jobKey);
+  const expectedImages = Number(plan.expected?.images || 0);
+  const expectedVideos = Number(plan.expected?.videos || 0);
+  const completedImages = bucket.image_uploads.length;
+  const completedVideos = bucket.video_uploads.length;
+  const imageSkipped = expectedImages === 0;
+  const videoSkipped = expectedVideos === 0;
+
+  if (imageSkipped ? bucket.image_skips.length !== 1 : bucket.image_skips.length !== 0) {
+    throw new Error(`Marcador de imagem invalido em ${jobKey}; expected=${expectedImages} markers=${bucket.image_skips.length}.`);
+  }
+  if (videoSkipped ? bucket.video_skips.length !== 1 : bucket.video_skips.length !== 0) {
+    throw new Error(`Marcador de video invalido em ${jobKey}; expected=${expectedVideos} markers=${bucket.video_skips.length}.`);
+  }
+  if (completedImages !== expectedImages || completedVideos !== expectedVideos) {
+    throw new Error(`Uploads incompletos em ${jobKey}; expected_images=${expectedImages} completed_images=${completedImages} expected_videos=${expectedVideos} completed_videos=${completedVideos}.`);
+  }
+
+  outputs.push({
+    json: {
+      media_upload_envelope_version: '2',
+      job_key: jobKey,
+      group_key: text(plan.group_key),
+      media_mode: text(plan.media_mode),
+      expected: {
+        images: expectedImages,
+        videos: expectedVideos,
+        static_images: Number(plan.expected?.static_images || 0),
+        video_thumbnails: Number(plan.expected?.video_thumbnails || 0),
+      },
+      completed: { images: completedImages, videos: completedVideos },
+      image_uploads: bucket.image_uploads,
+      video_uploads: bucket.video_uploads,
+      skipped: { images: imageSkipped, videos: videoSkipped },
+      skip_reasons: {
+        images: imageSkipped ? 'no_media_of_type' : '',
+        videos: videoSkipped ? 'no_media_of_type' : '',
+      },
+      ready: true,
+    },
+  });
+}
+
+return outputs;

--- a/orb/engine/workflow-src/meta-ads-publish/assemble-job-inputs.js
+++ b/orb/engine/workflow-src/meta-ads-publish/assemble-job-inputs.js
@@ -1,0 +1,93 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+function parseJsonObject(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function unwrapAi(value) {
+  const json = object(value);
+  if (json.output && typeof json.output === 'object') return clone(json.output);
+  const parsedOutput = parseJsonObject(json.output);
+  if (parsedOutput) return parsedOutput.output && typeof parsedOutput.output === 'object' && Object.keys(parsedOutput).length === 1
+    ? clone(parsedOutput.output)
+    : clone(parsedOutput);
+  return clone(json);
+}
+
+const jobs = ($items('Build Payload') || [])
+  .map((item) => item.json || {})
+  .filter((job) => text(job.job_key) && !text(job.error));
+if (!jobs.length) throw new Error('Assemble Job Inputs sem jobs validos do Build Payload.');
+
+const jobsByKey = new Map(jobs.map((job) => [text(job.job_key), job]));
+const jobsByGroup = new Map(jobs.map((job) => [text(job.group_key), text(job.job_key)]));
+const envelopesByJob = new Map();
+const aiCandidates = [];
+
+for (const item of $input.all()) {
+  const json = item.json || {};
+  if (text(json.media_upload_envelope_version) === '2') {
+    const jobKey = text(json.job_key);
+    if (!jobsByKey.has(jobKey)) throw new Error(`Envelope de midia nao correlacionado; job_key=${jobKey || 'vazio'}.`);
+    if (envelopesByJob.has(jobKey)) throw new Error(`Envelope de midia duplicado para ${jobKey}.`);
+    envelopesByJob.set(jobKey, clone(json));
+    continue;
+  }
+  const ai = unwrapAi(json);
+  if (Object.keys(object(ai.creative_override)).length) aiCandidates.push({ raw: json, ai });
+}
+
+const aiByJob = new Map();
+const unmapped = [];
+for (const candidate of aiCandidates) {
+  const directKey = text(candidate.ai.job_key || candidate.raw.job_key);
+  const groupKey = text(candidate.ai.group_key || candidate.raw.group_key);
+  const resolved = jobsByKey.has(directKey)
+    ? directKey
+    : jobsByGroup.get(groupKey) || (jobs.length === 1 && aiCandidates.length === 1 ? text(jobs[0].job_key) : '');
+  if (!resolved) {
+    unmapped.push({ has_job_key: Boolean(directKey), has_group_key: Boolean(groupKey) });
+    continue;
+  }
+  if (aiByJob.has(resolved)) throw new Error(`Respostas Livia conflitantes para ${resolved}.`);
+  const job = jobsByKey.get(resolved);
+  if (groupKey && groupKey !== text(job.group_key)) throw new Error(`group_key da Livia diverge em ${resolved}.`);
+  aiByJob.set(resolved, clone(candidate.ai));
+}
+
+if (unmapped.length) throw new Error(`Resposta Livia nao correlacionada; count=${unmapped.length}.`);
+
+return jobs.map((job) => {
+  const jobKey = text(job.job_key);
+  const envelope = envelopesByJob.get(jobKey);
+  const ai = aiByJob.get(jobKey);
+  if (!envelope) throw new Error(`Envelope de midia ausente para ${jobKey}.`);
+  if (!ai) throw new Error(`Resposta Livia ausente para ${jobKey}.`);
+  if (text(envelope.group_key) !== text(job.group_key)) throw new Error(`group_key do envelope diverge em ${jobKey}.`);
+  if (envelope.ready !== true) throw new Error(`Envelope de midia nao ready para ${jobKey}.`);
+  return {
+    json: {
+      job_input_assembly_version: '2',
+      job_key: jobKey,
+      group_key: text(job.group_key),
+      media_mode: text(job.media_mode),
+      media_upload_envelope: envelope,
+      ai_output: ai,
+      assembly_diagnostics: {
+        media_ready: true,
+        image_upload_count: list(envelope.image_uploads).length,
+        video_upload_count: list(envelope.video_uploads).length,
+        ai_correlated: true,
+      },
+    },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/attach-crm-offer-context.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-crm-offer-context.js
@@ -1,0 +1,37 @@
+function text(value) { return String(value ?? '').trim(); }
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  return Number((Array.isArray(paired) ? paired[0]?.item : paired?.item) ?? fallback);
+}
+
+const requests = $items('Prepare CRM Offer Context Requests') || [];
+const buckets = new Map();
+for (const [index, item] of $input.all().entries()) {
+  const request = requests[pairedIndex(item, index)];
+  if (!request?.json) throw new Error(`CRM Offer Context sem request correlacionado; index=${index}.`);
+  const meta = request.json;
+  const jobKey = text(meta.job_key);
+  const groupKey = text(meta.group_key);
+  const crmUnit = text(meta.crm_unit);
+  const sourceJob = meta.crm_source_job;
+  if (!jobKey || !groupKey || !crmUnit || !sourceJob) throw new Error('CRM Offer Context retornou contexto incompleto.');
+  const bucket = buckets.get(jobKey) || { job: sourceJob, group_key: groupKey, contexts: {}, binary: request.binary || {} };
+  if (bucket.group_key !== groupKey || bucket.contexts[crmUnit]) throw new Error(`CRM Offer Context duplicado ou divergente em ${jobKey}.`);
+  bucket.contexts[crmUnit] = item.json || {};
+  buckets.set(jobKey, bucket);
+}
+
+return [...buckets.entries()].map(([jobKey, bucket]) => {
+  const expected = Array.isArray(bucket.job.destinations) ? bucket.job.destinations.length : 0;
+  if (!expected || Object.keys(bucket.contexts).length !== expected) {
+    throw new Error(`Cobertura CRM incompleta em ${jobKey}; expected=${expected} completed=${Object.keys(bucket.contexts).length}.`);
+  }
+  return {
+    json: {
+      ...bucket.job,
+      crm_offer_context_version: '1',
+      crm_offer_contexts: bucket.contexts,
+    },
+    binary: bucket.binary,
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/attach-task-runner-health.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-task-runner-health.js
@@ -1,0 +1,27 @@
+function pairedIndex(item, fallback) {
+  const paired = item && item.pairedItem;
+  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);
+  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);
+  return Number(fallback);
+}
+
+const prepared = $items('Prepare Publish Run') || [];
+return $input.all().map((item, index) => {
+  const sourceIndex = pairedIndex(item, index);
+  const source = prepared[sourceIndex] || prepared[index];
+  if (!source || !source.json) {
+    throw new Error(`Task Runner health sem item correlacionado de Prepare Publish Run; index=${index}.`);
+  }
+  return {
+    json: {
+      ...source.json,
+      task_runner_health: {
+        ok: true,
+        endpoint: 'loopback',
+        checked_at: new Date().toISOString(),
+      },
+    },
+    binary: source.binary || {},
+    pairedItem: { item: sourceIndex },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/attach-video-analysis.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-video-analysis.js
@@ -1,0 +1,2 @@
+const main = $items('Attach Video Main') || [];
+return $input.all().map((item, index) => ({ json: main[index]?.json || {}, binary: { data: main[index]?.binary?.data, analysis: item.binary?.analysis } }));

--- a/orb/engine/workflow-src/meta-ads-publish/attach-video-main.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-video-main.js
@@ -1,0 +1,2 @@
+const metadata = $items('Attach Video Transcript') || [];
+return $input.all().map((item, index) => ({ json: metadata[index]?.json || {}, binary: { data: item.binary?.data } }));

--- a/orb/engine/workflow-src/meta-ads-publish/attach-video-staging-context.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-video-staging-context.js
@@ -1,0 +1,18 @@
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  return Number((Array.isArray(paired) ? paired[0]?.item : paired?.item) ?? fallback);
+}
+
+const sourceItems = $items('Is Video?') || [];
+
+return $input.all().map((item, index) => {
+  const result = item.json || {};
+  if (Number(result.exitCode) !== 0 || result.error) {
+    throw new Error(`Nao foi possivel preparar o diretorio temporario do video: ${result.stderr || result.error || 'comando sem detalhes'}`);
+  }
+  const source = sourceItems[pairedIndex(item, index)];
+  if (!source?.json?.media_staging?.input_file || !source?.json?.media_staging?.base_dir) {
+    throw new Error('Contexto de staging de video ausente apos preparar o diretorio.');
+  }
+  return { json: source.json, binary: source.binary, pairedItem: source.pairedItem };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/attach-video-thumbnail.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-video-thumbnail.js
@@ -1,0 +1,2 @@
+const prior = $items('Attach Video Analysis') || [];
+return $input.all().map((item, index) => ({ json: prior[index]?.json || {}, binary: { data: prior[index]?.binary?.data, analysis: prior[index]?.binary?.analysis, thumbnail: item.binary?.thumbnail } }));

--- a/orb/engine/workflow-src/meta-ads-publish/attach-video-transcript.js
+++ b/orb/engine/workflow-src/meta-ads-publish/attach-video-transcript.js
@@ -1,0 +1,8 @@
+let audioSources = [];
+try { audioSources = $items('Video Has Audio?', 0) || []; } catch { audioSources = []; }
+return $input.all().map((item, index) => {
+  const response = item.json || {};
+  const source = response.media_processing ? response : (audioSources[index]?.json || {});
+  const transcript = String(response.text || response.transcript || '').trim();
+  return { json: { ...source, media_processing: { ...(source.media_processing || {}), transcript, transcription_status: transcript ? 'completed' : (source.media_processing?.has_audio ? 'failed_non_blocking' : 'not_applicable') } } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/build-jobs.js
+++ b/orb/engine/workflow-src/meta-ads-publish/build-jobs.js
@@ -4,11 +4,15 @@ const CALIBRATION_FILE_PREFIXES = ['[TEST-VIDEO-ONLY]', '[TEST-CAROUSEL]'];
 // Build Jobs and the downstream quality gate must advance together. This
 // prevents a stale n8n node definition from quietly accepting a payload whose
 // destination contract was added by a newer workflow revision.
-const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v12_native_carousel_route';
-// Website Lead ad sets with dynamic creative reject BOOK_NOW. A replacement
-// must, however, preserve the destination contract of its source ad: message
-// campaigns require WHATSAPP_MESSAGE and the WhatsApp URL.
-const DEFAULT_CTA_TYPE = 'LEARN_MORE';
+// Increment this whenever a persisted creative body becomes incompatible. The
+// resume path deliberately reuses an existing mutation body, so the revision
+// is a hard boundary rather than merely descriptive metadata.
+const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';
+// The CTA is selected from the live campaign objective. Meta rejects BOOK_NOW
+// on dynamic OUTCOME_LEADS ad sets, while the other website contracts retain
+// the booking CTA. WhatsApp remains a URL destination, not a CTA policy.
+const DEFAULT_CTA_TYPE = 'BOOK_NOW';
+const OUTCOME_LEADS_CTA_TYPE = 'LEARN_MORE';
 const WHATSAPP_CTA_TYPE = 'WHATSAPP_MESSAGE';
 const RATIO_PRIORITY = ['4x5', '3x4', '2x1', '9x16'];
 const TEMPORAL_GUARD_FRESH_DAYS = 7;
@@ -170,7 +174,14 @@ function configuredDestinationKind(destinationMeta) {
   return '';
 }
 
-function resolveDestinationContract(job, destinationMeta) {
+function ctaTypeForDestination(destinationMeta, usesWhatsAppDestination) {
+  if (usesWhatsAppDestination) return WHATSAPP_CTA_TYPE;
+  return safeString(destinationMeta && destinationMeta.campaign_objective).toUpperCase() === 'OUTCOME_LEADS'
+    ? OUTCOME_LEADS_CTA_TYPE
+    : DEFAULT_CTA_TYPE;
+}
+
+function resolveDestinationContract(job, destinationMeta, verifiedWebsiteUrl = '') {
   const configuredKind = configuredDestinationKind(destinationMeta);
   const configuredWhatsAppUrl = toHttps(destinationMeta && destinationMeta.whatsapp_destination_url);
   const scopedContracts = safeArray(job && job.source_ads)
@@ -183,6 +194,21 @@ function resolveDestinationContract(job, destinationMeta) {
     return { ok: false, error: 'destination_contract_conflict', configured_kind: configuredKind, observed_kinds: observedKinds };
   }
   const kind = configuredKind || (observedKinds.length === 1 ? observedKinds[0] : '');
+  // A unit-specific landing-page mapping is an explicit Token Vault
+  // destination configuration. It is sufficient evidence for a website
+  // destination when legacy rows omit destination_type and no source creative
+  // is available in the ad inventory response.
+  const websiteUrl = toHttps(verifiedWebsiteUrl);
+  if (!kind && websiteUrl && !isWhatsAppHostname(websiteUrl)) {
+    return {
+      ok: true,
+      kind: 'website',
+      link_url: websiteUrl,
+      source: 'token_vault_landing_page_mapping',
+      configured_kind: configuredKind,
+      observed_source_ad_count: scopedContracts.length,
+    };
+  }
   if (!kind) {
     return {
       ok: false,
@@ -587,26 +613,6 @@ const ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES = Object.freeze({
   image_animation: 'Animacao de imagem',
   site_extensions: 'Extensoes do site',
 });
-const VIDEO_ADVANTAGE_PLUS_MAIN_FEATURES = Object.freeze({
-  add_text_overlay: 'Adicionar sobreposicoes',
-  music_generation: 'Adicionar musica',
-  pac_relaxation: 'Midia flexivel',
-  adapt_to_placement: 'Adaptar layout ao posicionamento',
-  video_filtering: 'Retoques e efeitos de video',
-  text_optimizations: 'Melhorias no texto',
-});
-const VIDEO_ADVANTAGE_PLUS_ESSENTIAL_FEATURES = Object.freeze({
-  inline_comment: 'Comentarios relevantes',
-  enhance_cta: 'Aprimorar CTA',
-});
-const VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES = Object.freeze({
-  reveal_details_over_time: 'Revelar detalhes ao longo do tempo',
-  show_destination_blurbs: 'Mostrar detalhes do destino',
-  video_highlights: 'Destaques automaticos de video',
-  site_extensions: 'Extensoes do site',
-  video_auto_crop: 'Recorte automatico de video',
-  video_uncrop: 'Expansao automatica de video',
-});
 const ADVANTAGE_PLUS_BASELINE_FEATURES = [
   'add_text_overlay',
   'image_touchups',
@@ -619,18 +625,15 @@ const ADVANTAGE_PLUS_BASELINE_FEATURES = [
   'image_animation',
 ];
 const ADVANTAGE_PLUS_CONDITIONAL_FEATURES = ['music_generation', 'pac_relaxation', 'site_extensions'];
-const VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES = [
-  'add_text_overlay',
-  'adapt_to_placement',
-  'video_filtering',
-  'text_optimizations',
-  'inline_comment',
-  'enhance_cta',
-  'reveal_details_over_time',
-  'show_destination_blurbs',
-  'video_highlights',
-];
-const VIDEO_ADVANTAGE_PLUS_CONDITIONAL_FEATURES = ['music_generation', 'pac_relaxation', 'site_extensions', 'video_auto_crop', 'video_uncrop'];
+// Token Vault is the canonical Graph boundary. Video-only creatives must use
+// the same allowlisted feature keys it validates for every creative; prior
+// video-specific keys (adapt_to_placement/video_filtering/etc.) were rejected
+// before reaching Graph and cannot be treated as a publish fallback.
+const VIDEO_ADVANTAGE_PLUS_MAIN_FEATURES = ADVANTAGE_PLUS_MAIN_FEATURES;
+const VIDEO_ADVANTAGE_PLUS_ESSENTIAL_FEATURES = ADVANTAGE_PLUS_ESSENTIAL_FEATURES;
+const VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES = ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES;
+const VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES = ADVANTAGE_PLUS_BASELINE_FEATURES;
+const VIDEO_ADVANTAGE_PLUS_CONDITIONAL_FEATURES = ADVANTAGE_PLUS_CONDITIONAL_FEATURES;
 
 function parseApiVersionMajor(version) {
   const match = safeString(version).match(/^v?(\d+)/i);
@@ -662,7 +665,7 @@ function normalizeSiteLinks(list) {
   return out;
 }
 
-function buildAdvantagePlusRequest({ apiVersion, siteLinks, musicEligible, pacEligible, mediaMode }) {
+function buildAdvantagePlusRequest({ apiVersion, siteLinks, musicEligible, pacEligible, mediaMode, sourceUrl }) {
   if (parseApiVersionMajor(apiVersion) < 25) {
     throw new Error(`Advantage+ Creative completo exige Marketing API v25.0; recebido ${safeString(apiVersion) || 'vazio'}.`);
   }
@@ -673,16 +676,10 @@ function buildAdvantagePlusRequest({ apiVersion, siteLinks, musicEligible, pacEl
   const essentialFeatures = videoOnly ? VIDEO_ADVANTAGE_PLUS_ESSENTIAL_FEATURES : ADVANTAGE_PLUS_ESSENTIAL_FEATURES;
   const supplementalFeatures = videoOnly
     ? VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES
-    : (hasVideo
-        ? { ...ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES, video_auto_crop: VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES.video_auto_crop, video_uncrop: VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES.video_uncrop }
-        : ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES);
+    : ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES;
   const desiredFeatures = videoOnly
     ? [...VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES, ...VIDEO_ADVANTAGE_PLUS_CONDITIONAL_FEATURES]
-    : [
-        ...ADVANTAGE_PLUS_BASELINE_FEATURES,
-        ...ADVANTAGE_PLUS_CONDITIONAL_FEATURES,
-        ...(hasVideo ? ['video_auto_crop', 'video_uncrop'] : []),
-      ];
+    : [...ADVANTAGE_PLUS_BASELINE_FEATURES, ...ADVANTAGE_PLUS_CONDITIONAL_FEATURES];
   const creativeFeaturesSpec = {};
   const eligibleFeatures = [...baselineFeatures];
   const skippedFeatures = [];
@@ -765,12 +762,15 @@ function buildAdvantagePlusRequest({ apiVersion, siteLinks, musicEligible, pacEl
       })),
     },
     creativeFeaturesSpec,
-    creativeSourcingSpec: siteLinksEligible
-      ? { site_links_spec: siteLinks.map((link) => ({
+    creativeSourcingSpec: removeEmptyFields({
+      source_url: toHttps(sourceUrl),
+      ...(siteLinksEligible
+        ? { site_links_spec: siteLinks.map((link) => ({
             site_link_title: safeString(link.site_link_title || link.title),
             site_link_url: toHttps(link.site_link_url || link.url),
           })) }
-      : {},
+        : {}),
+    }),
   };
 }
 
@@ -877,12 +877,23 @@ function safeWarnings(jobWarnings, extraWarnings) {
 }
 
 function getBuildPayloadEntries() {
-  let items = [];
-  try { items = $items('Restore Publish Groups') || []; } catch (error) { items = []; }
-  if (!items.some((item) => safeString(item && item.json && item.json.job_key))) {
-    items = $('Build Payload').all();
-  }
-  return items
+  // A restored run contains a historical snapshot. It is a valid fallback
+  // only when there is no current Build Payload. Prefer the current graph so
+  // live placement/campaign facts (including the CTA policy) cannot be
+  // silently replaced by a stale resume record.
+  let currentItems = [];
+  try { currentItems = $('Build Payload').all(); } catch (error) { currentItems = []; }
+  const currentEntries = currentItems
+    .map((item) => ({
+      json: item.json || {},
+      binary: item.binary || {},
+    }))
+    .filter((entry) => entry.json && safeString(entry.json.job_key));
+  if (currentEntries.length) return currentEntries;
+
+  let restoredItems = [];
+  try { restoredItems = $items('Restore Publish Groups') || []; } catch (error) { restoredItems = []; }
+  return restoredItems
     .map((item) => ({
       json: item.json || {},
       binary: item.binary || {},
@@ -1577,6 +1588,18 @@ function persistedResumeJobs() {
   return [...unique.values()];
 }
 
+function isCurrentCtaResumeContract(row) {
+  const feed = asObject(asObject(row).creativePayload && asObject(row).creativePayload.asset_feed_spec);
+  const ctaTypes = safeArray(feed.call_to_action_types)
+    .map((value) => safeString(value).toUpperCase())
+    .filter(Boolean);
+  const destination = asObject(row.destination_meta);
+  const expected = safeString(destination.campaign_objective).toUpperCase() === 'OUTCOME_LEADS'
+    ? OUTCOME_LEADS_CTA_TYPE
+    : DEFAULT_CTA_TYPE;
+  return ctaTypes.length === 1 && ctaTypes[0] === expected;
+}
+
 const persistedJobs = persistedResumeJobs();
 const resumeJobs = persistedJobs.filter((job) => {
   const row = asObject(job);
@@ -1587,6 +1610,7 @@ const resumeJobs = persistedJobs.filter((job) => {
     (kind === 'website' || kind === 'whatsapp') &&
     Boolean(linkUrl) &&
     (kind !== 'whatsapp' || isWhatsAppHostname(linkUrl)) &&
+    isCurrentCtaResumeContract(row) &&
     isCurrentVideoOnlyResumeContract(row) &&
     isCurrentCarouselResumeContract(row);
 });
@@ -2035,7 +2059,28 @@ for (const entry of jobEntries) {
       continue;
     }
 
-    const destinationContract = resolveDestinationContract(job, destinationMeta);
+    const allowedLinkHosts = safeArray(destinationMeta.allowed_link_hosts || gatewayConfig && gatewayConfig.allowed_link_hosts);
+    const creativeGroupKey = safeString(job.creative_group_key || job.group_key);
+    const landingPage = resolveLandingPage(destinationMeta, gatewayConfig, creativeGroupKey, allowedLinkHosts);
+    if (!landingPage.ok) {
+      outputs.push({
+        json: {
+          error: 'A landing page especifica da campanha nao esta pronta no Token Vault.',
+          upstream_node: 'Build Jobs',
+          upstream_error: landingPage.error,
+          debug: {
+            job_key: safeString(job.job_key),
+            creative_group_key: creativeGroupKey,
+            destination_group: safeString(destinationMeta.destination_group),
+            configured_keys: landingPage.configured_keys || [],
+            rejected_hostname: landingPage.rejected_hostname || '',
+          },
+        },
+      });
+      continue;
+    }
+
+    const destinationContract = resolveDestinationContract(job, destinationMeta, landingPage.url);
     if (!destinationContract.ok) {
       outputs.push({
         json: {
@@ -2054,6 +2099,21 @@ for (const entry of jobEntries) {
       continue;
     }
     const usesWhatsAppDestination = destinationContract.kind === 'whatsapp';
+    if (!usesWhatsAppDestination && mediaMode !== 'carousel' && !safeString(destinationMeta.campaign_objective)) {
+      outputs.push({
+        json: {
+          error: 'O objetivo efetivo da campanha nao foi retornado pelo inventario Meta; lote bloqueado antes de criar o criativo.',
+          upstream_node: 'Build Jobs',
+          upstream_error: 'campaign_objective_missing',
+          debug: {
+            job_key: safeString(job.job_key),
+            destination_group: safeString(destinationMeta.destination_group),
+            destination_adset_id_present: Boolean(safeString(destinationMeta.destination_adset_id)),
+          },
+        },
+      });
+      continue;
+    }
     if (mediaMode === 'carousel' && (!carouselNativeAdsetId || !carouselNativeVerified || !carouselNativeRouteActive)) {
       outputs.push({
         json: {
@@ -2078,9 +2138,8 @@ for (const entry of jobEntries) {
       resolvedAdsetId = carouselNativeAdsetId;
       if (carouselNativeCampaignId) resolvedCampaignId = carouselNativeCampaignId;
     }
-    const ctaTypes = [usesWhatsAppDestination ? WHATSAPP_CTA_TYPE : DEFAULT_CTA_TYPE];
+    const ctaTypes = [ctaTypeForDestination(destinationMeta, usesWhatsAppDestination)];
     const requestedRawSiteLinks = safeArray(overrides.site_links || overrides.siteLinks || ai.site_links || ai.siteLinks);
-    const allowedLinkHosts = safeArray(destinationMeta.allowed_link_hosts || gatewayConfig && gatewayConfig.allowed_link_hosts);
     const siteLinks = normalizeSiteLinks(requestedRawSiteLinks);
     const rejectedSiteLinks = siteLinks.filter((link) => !isAllowedLinkUrl(link.url, allowedLinkHosts));
     if (rejectedSiteLinks.length) {
@@ -2115,26 +2174,6 @@ for (const entry of jobEntries) {
     const normalizedBodies = aiBodies;
     const normalizedTitles = aiTitles;
     const normalizedDescriptions = aiDescriptions;
-
-    const creativeGroupKey = safeString(job.creative_group_key || job.group_key);
-    const landingPage = resolveLandingPage(destinationMeta, gatewayConfig, creativeGroupKey, allowedLinkHosts);
-    if (!landingPage.ok) {
-      outputs.push({
-        json: {
-          error: 'A landing page especifica da campanha nao esta pronta no Token Vault.',
-          upstream_node: 'Build Jobs',
-          upstream_error: landingPage.error,
-          debug: {
-            job_key: safeString(job.job_key),
-            creative_group_key: creativeGroupKey,
-            destination_group: safeString(destinationMeta.destination_group),
-            configured_keys: landingPage.configured_keys || [],
-            rejected_hostname: landingPage.rejected_hostname || '',
-          },
-        },
-      });
-      continue;
-    }
 
     const schedulingLandingPageUrl = landingPage.url;
     const primaryLinkUrl = usesWhatsAppDestination ? destinationContract.link_url : schedulingLandingPageUrl;
@@ -2318,6 +2357,7 @@ for (const entry of jobEntries) {
       // that Meta preserves the full labelled placement contract.
       pacEligible: mediaMode !== 'carousel' && orderedAssets.length > 1 && mixedPlacementRules.length > 1,
       mediaMode,
+      sourceUrl: primaryLinkUrl,
     });
 
     const creativeRootExtras = removeEmptyFields({

--- a/orb/engine/workflow-src/meta-ads-publish/build-meta-api-params-from-vault.js
+++ b/orb/engine/workflow-src/meta-ads-publish/build-meta-api-params-from-vault.js
@@ -12,10 +12,17 @@ const SAFE_LANDING_PAGE_BY_DESTINATION = Object.freeze({
   barrashoppingsul: 'https://espacofacial.com/agendamento?unit=barrashoppingsul',
   novohamburgo: 'https://espacofacial.com/agendamento?unit=novo-hamburgo',
 });
+const SAFE_WHATSAPP_DESTINATION_URL = 'https://api.whatsapp.com/send';
+const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';
 
 const root = $input.first()?.json || {};
 if (root.ok !== true || root.ready !== true) {
   throw new Error(`Meta Publish gateway nao esta pronto: ${JSON.stringify(root.invalid || root.error || {})}`);
+}
+
+const gatewayContractRevision = safeString(asObject(root.capabilities).workflow_contract_revision);
+if (gatewayContractRevision !== WORKFLOW_CONTRACT_REVISION) {
+  throw new Error(`Meta Publish gateway com revisao de contrato divergente: esperado ${WORKFLOW_CONTRACT_REVISION}, recebido ${gatewayContractRevision || 'ausente'}.`);
 }
 
 // The workflow and the Token Vault must evolve as one contract. Verify the
@@ -88,7 +95,10 @@ const rows = destinations.map((entry) => {
       campaign_objective: safeString(item.campaign_objective),
       optimization_goal: safeString(item.optimization_goal),
       destination_type: safeString(item.destination_type).toUpperCase(),
-      whatsapp_destination_url: safeString(item.whatsapp_destination_url),
+      // The effective destination type is read from the live ad set. This
+      // endpoint is the only fallback when a legacy Token Vault row omits its
+      // explicit WhatsApp handoff URL; it is corroborated by the source ads.
+      whatsapp_destination_url: safeString(item.whatsapp_destination_url || SAFE_WHATSAPP_DESTINATION_URL),
       carousel_native_campaign_id: safeString(item.carousel_native_campaign_id),
       carousel_native_adset_id: safeString(item.carousel_native_adset_id),
       carousel_native_adset_verified: item.carousel_native_adset_verified === true,

--- a/orb/engine/workflow-src/meta-ads-publish/build-payload.js
+++ b/orb/engine/workflow-src/meta-ads-publish/build-payload.js
@@ -1849,9 +1849,11 @@ for (const group of groupedCreatives) {
       landing_page_validation: deepClone(destination.landing_page_validation || {}),
       placement_eligibility: deepClone(placementCheck || {}),
       freshness_window_days: Number(destination.freshness_window_days || 7),
-      campaign_objective: safeString(destination.campaign_objective),
-      optimization_goal: safeString(destination.optimization_goal),
-      destination_type: safeString(destination.destination_type).toUpperCase(),
+      // Live ad-set data wins over an optional Token Vault metadata mirror.
+      // In particular, OUTCOME_LEADS dynamic creatives cannot stage BOOK_NOW.
+      campaign_objective: safeString(placementCheck && placementCheck.campaign_objective || destination.campaign_objective).toUpperCase(),
+      optimization_goal: safeString(placementCheck && placementCheck.optimization_goal || destination.optimization_goal).toUpperCase(),
+      destination_type: safeString(placementCheck && placementCheck.destination_type || destination.destination_type).toUpperCase(),
       whatsapp_destination_url: safeString(destination.whatsapp_destination_url),
       carousel_native_campaign_id: safeString(destination.carousel_native_campaign_id),
       carousel_native_adset_id: safeString(destination.carousel_native_adset_id),

--- a/orb/engine/workflow-src/meta-ads-publish/build-resume-jobs-checkpoint.js
+++ b/orb/engine/workflow-src/meta-ads-publish/build-resume-jobs-checkpoint.js
@@ -1,0 +1,21 @@
+function text(value) { return String(value ?? '').trim(); }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+const jobs = $input.all().map((item) => clone(item.json || {}));
+if (!jobs.length) throw new Error('Build Resume Jobs Checkpoint recebeu zero jobs validados.');
+
+const runIds = [...new Set(jobs.map((job) => text(job.run_id)).filter(Boolean))];
+if (runIds.length !== 1) throw new Error(`Build Resume Jobs Checkpoint recebeu run_ids inconsistentes: ${JSON.stringify(runIds)}`);
+
+return [{
+  json: {
+    run_id: runIds[0],
+    checkpoint_request: {
+      status: 'processing',
+      // Store the exact validated mutation bodies before the first Graph write.
+      // A retry must never ask the generative copy agent to recreate them.
+      summary: { resume_jobs: jobs },
+      error: {},
+    },
+  },
+}];

--- a/orb/engine/workflow-src/meta-ads-publish/classify-media.js
+++ b/orb/engine/workflow-src/meta-ads-publish/classify-media.js
@@ -1,0 +1,29 @@
+function text(value) { return String(value ?? '').trim(); }
+function safe(value) { return text(value).replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 80); }
+return $input.all().map((item, index) => {
+  const json = item.json || {};
+  const binary = item.binary?.data;
+  const mime = text(binary?.mimeType || json.mimeType).toLowerCase();
+  const mediaType = mime.startsWith('video/') ? 'video' : mime.startsWith('image/') ? 'image' : '';
+  if (!mediaType) throw new Error(`MIME nao suportado em ${json.id || index}: ${mime}.`);
+  if (mediaType === 'video' && !['video/mp4', 'video/quicktime'].includes(mime)) throw new Error(`Video deve ser MP4 ou MOV: ${mime}.`);
+  const sourceId = safe(json.id) || `media_${index + 1}`;
+  const executionId = safe($execution.id) || 'manual';
+  const ext = mime === 'video/quicktime' ? 'mov' : mediaType === 'video' ? 'mp4' : (text(binary?.fileExtension) || 'jpg').replace(/[^A-Za-z0-9]/g, '');
+  // This location is writable from the Orb service namespace. The following
+  // staging node creates baseDir before Read/Write Files receives inputFile.
+  const baseDir = `/tmp/meta-ads-publish/${executionId}/${sourceId}`;
+  const inputFile = `${baseDir}/source.${ext}`;
+  const outputDir = `${baseDir}/processed`;
+  const processorPayload = { input_file: inputFile, output_dir: outputDir, source_file_id: text(json.id), execution_id: executionId, mime_type: mime };
+  return {
+    json: {
+      ...json,
+      mimeType: mime,
+      media_type: mediaType,
+      media_staging: { base_dir: baseDir, input_file: inputFile, output_dir: outputDir },
+      processor_payload_b64: mediaType === 'video' ? Buffer.from(JSON.stringify(processorPayload), 'utf8').toString('base64') : '',
+    },
+    binary: item.binary,
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/emit-no-image-upload.js
+++ b/orb/engine/workflow-src/meta-ads-publish/emit-no-image-upload.js
@@ -1,0 +1,16 @@
+return $input.all().map((item) => {
+  const plan = item.json?.media_upload_plan || {};
+  if (Number(plan.expected?.images || 0) !== 0) {
+    throw new Error(`Emit No Image Upload recebeu plano com uploads esperados; job_key=${plan.job_key || ''}.`);
+  }
+  return {
+    json: {
+      job_key: String(plan.job_key || item.json?.job_key || ''),
+      group_key: String(plan.group_key || item.json?.group_key || ''),
+      media_mode: String(plan.media_mode || item.json?.media_mode || ''),
+      upload_result_kind: 'image_skipped',
+      skipped: true,
+      reason: 'no_media_of_type',
+    },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/emit-no-video-upload.js
+++ b/orb/engine/workflow-src/meta-ads-publish/emit-no-video-upload.js
@@ -1,0 +1,16 @@
+return $input.all().map((item) => {
+  const plan = item.json?.media_upload_plan || {};
+  if (Number(plan.expected?.videos || 0) !== 0) {
+    throw new Error(`Emit No Video Upload recebeu plano com uploads esperados; job_key=${plan.job_key || ''}.`);
+  }
+  return {
+    json: {
+      job_key: String(plan.job_key || item.json?.job_key || ''),
+      group_key: String(plan.group_key || item.json?.group_key || ''),
+      media_mode: String(plan.media_mode || item.json?.media_mode || ''),
+      upload_result_kind: 'video_skipped',
+      skipped: true,
+      reason: 'no_media_of_type',
+    },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/normalize-video-chunk-transfer.js
+++ b/orb/engine/workflow-src/meta-ads-publish/normalize-video-chunk-transfer.js
@@ -1,0 +1,24 @@
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);
+  return Number(paired?.item ?? fallback);
+}
+const prepared = $items('Prepare Video Chunk Transfer') || [];
+return $input.all().map((item, index) => {
+  const sourceIndex = pairedIndex(item, index);
+  const state = prepared[sourceIndex]?.json || {};
+  const response = item.json || {};
+  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Transferencia de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);
+  const result = response.operation.result || {};
+  const start = Number(result.start_offset);
+  const end = Number(result.end_offset);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < Number(state.start_offset) || end < start) throw new Error('Meta retornou offsets de video invalidos.');
+  return { json: {
+    ...state,
+    start_offset: start,
+    end_offset: end,
+    transfer_count: Number(state.transfer_count || 0) + 1,
+    last_transfer_operation_key: response.operation.operation_key,
+    upload_bytes_complete: start === end,
+  } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/normalize-video-finish.js
+++ b/orb/engine/workflow-src/meta-ads-publish/normalize-video-finish.js
@@ -1,0 +1,8 @@
+function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }
+const prepared = $items('Prepare Video Finish') || [];
+return $input.all().map((item, index) => {
+  const state = prepared[pairedIndex(item, index)]?.json || {};
+  const response = item.json || {};
+  if (response.ok !== true || response.operation?.status !== 'completed' || response.operation?.result?.success !== true) throw new Error(`Finish de video nao confirmado: ${JSON.stringify(response)}`);
+  return { json: { ...state, finish_operation_key: response.operation.operation_key, status_attempt: 0 } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/normalize-video-status.js
+++ b/orb/engine/workflow-src/meta-ads-publish/normalize-video-status.js
@@ -1,0 +1,44 @@
+function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function isNineBySixteen(widthValue, heightValue) {
+  const width = Number(widthValue);
+  const height = Number(heightValue);
+  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;
+}
+const prepared = $items('Prepare Video Status') || [];
+return $input.all().map((item, index) => {
+  const state = prepared[pairedIndex(item, index)]?.json || {};
+  const response = item.json || {};
+  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Consulta de status de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);
+  const result = response.operation.result || {};
+  const status = String(result.video_status || '').toLowerCase();
+  if (['error', 'failed', 'expired'].includes(status)) throw new Error(`Processamento Meta do video falhou: ${status}.`);
+  const thumbnailCandidates = list(result.thumbnails && result.thumbnails.data);
+  const preferredThumbnail = thumbnailCandidates.find((thumbnail) => thumbnail && thumbnail.is_preferred === true) || thumbnailCandidates[0] || {};
+  const videoWidth = Number(state.video_width || 0);
+  const videoHeight = Number(state.video_height || 0);
+  const thumbnailWidth = Number(preferredThumbnail.width || 0);
+  const thumbnailHeight = Number(preferredThumbnail.height || 0);
+  if (status === 'ready' && (!isNineBySixteen(videoWidth, videoHeight) || !isNineBySixteen(thumbnailWidth, thumbnailHeight))) {
+    throw new Error(`Video Audience Network rewarded precisa permanecer em 9:16 na Meta; video=${videoWidth}x${videoHeight}, miniatura=${thumbnailWidth}x${thumbnailHeight}.`);
+  }
+  return { json: {
+    ...state,
+    video_id: String(result.id || state.video_id),
+    video_status: status,
+    ready: result.ready === true || status === 'ready',
+    thumbnails: result.thumbnails || {},
+    video_width: videoWidth,
+    video_height: videoHeight,
+    video_aspect_ratio: '9x16',
+    video_recommended_aspect_ratio: '9x16',
+    preferred_thumbnail_width: thumbnailWidth,
+    preferred_thumbnail_height: thumbnailHeight,
+    preferred_thumbnail_aspect_ratio: status === 'ready' ? '9x16' : '',
+    status_operation_key: response.operation.operation_key,
+    upload_kind: 'video',
+    role: 'vertical_video',
+    ratio: '9x16',
+    replayed: response.replayed === true,
+  } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/normalize-video-upload-start.js
+++ b/orb/engine/workflow-src/meta-ads-publish/normalize-video-upload-start.js
@@ -1,0 +1,37 @@
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);
+  return Number(paired?.item ?? fallback);
+}
+const prepared = $items('Prepare Video Upload Starts') || [];
+return $input.all().map((item, index) => {
+  const sourceIndex = pairedIndex(item, index);
+  const source = prepared[sourceIndex]?.json || {};
+  const response = item.json || {};
+  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Inicio de upload de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);
+  const result = response.operation.result || {};
+  if (!result.upload_session_id || !result.video_id) throw new Error('Inicio de upload sem sessao ou video_id.');
+  const semanticReplay = response.semantic_replay === true;
+  const replayCompletionOffset = Number(source.file_size || 0);
+  if (semanticReplay && (!Number.isSafeInteger(replayCompletionOffset) || replayCompletionOffset <= 0)) {
+    throw new Error('Replay semantico de video sem tamanho normalizado valido.');
+  }
+  return { json: {
+    ...source,
+    upload_session_id: String(result.upload_session_id),
+    video_id: String(result.video_id),
+    // A semantic replay is selected only from resume_jobs whose video was
+    // already validated as ready. Do not reopen an old chunk session against
+    // a newly normalized temporary file; jump to the idempotent finish/status
+    // checks for the same persisted video_id.
+    start_offset: semanticReplay ? replayCompletionOffset : Number(result.start_offset),
+    end_offset: semanticReplay ? replayCompletionOffset : Number(result.end_offset),
+    upload_generation: 1,
+    transfer_count: 0,
+    start_operation_key: response.operation.operation_key,
+    replayed_start: response.replayed === true,
+    semantic_replay_video_id: response.replayed === true ? String(result.video_id) : '',
+    semantic_replay_ready: semanticReplay,
+    upload_bytes_complete: semanticReplay,
+  } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/parse-processed-video.js
+++ b/orb/engine/workflow-src/meta-ads-publish/parse-processed-video.js
@@ -1,0 +1,17 @@
+function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }
+function isNineBySixteen(widthValue, heightValue) {
+  const width = Number(widthValue);
+  const height = Number(heightValue);
+  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;
+}
+const sourceItems = $items('Write Video Source') || [];
+return $input.all().map((item, index) => {
+  const value = item.json || {};
+  if (Number(value.exitCode) !== 0 || value.error) throw new Error(`Processamento de video falhou: ${value.stderr || value.error}`);
+  let processing;
+  try { processing = JSON.parse(String(value.stdout || '{}')); } catch { throw new Error('Saida do processador de video invalida.'); }
+  if (processing.ok !== true || !processing.normalized_file || !processing.contact_sheet_file || !processing.thumbnail_file) throw new Error(`Processamento de video incompleto: ${JSON.stringify(processing)}`);
+  if (!isNineBySixteen(processing.width, processing.height)) throw new Error(`Video vertical precisa ser 9:16 apos normalizacao; recebido ${processing.width}x${processing.height}.`);
+  const source = sourceItems[pairedIndex(item, index)]?.json || {};
+  return { json: { ...source, media_processing: { ...processing, output_dir: source.media_staging?.output_dir, aspect_ratio: '9x16', recommended_aspect_ratio: '9x16', transcript: '', transcription_status: processing.has_audio ? 'pending' : 'not_applicable' } } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/parse-video-slice.js
+++ b/orb/engine/workflow-src/meta-ads-publish/parse-video-slice.js
@@ -1,0 +1,8 @@
+return $input.all().map((item) => {
+  const value = item.json || {};
+  if (Number(value.exitCode) !== 0 || value.error) throw new Error(`Falha ao fatiar video: ${value.stderr || value.error}`);
+  let parsed;
+  try { parsed = JSON.parse(String(value.stdout || '{}')); } catch { throw new Error('Saida do fatiador de video invalida.'); }
+  if (!parsed.chunk_file || !parsed.state) throw new Error('Fatiador nao retornou chunk_file/state.');
+  return { json: parsed };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-creative-fallback-1.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-creative-fallback-1.js
@@ -1,0 +1,70 @@
+const ATTEMPT = 1;
+const OPTIONAL_REMOVAL_PRIORITY = ['pac_relaxation', 'music_generation', 'video_highlights', 'video_filtering', 'adapt_to_placement', 'add_text_overlay'];
+
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+function key(value) { return text(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+function stable(value) { if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`; if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stable(value[name])}`).join(',')}}`; return JSON.stringify(value); }
+function stableHash(value) { let hash = 2166136261; for (const char of text(value)) { hash ^= char.charCodeAt(0); hash = Math.imul(hash, 16777619); } return (hash >>> 0).toString(36); }
+function unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }
+function responseSucceeded(response) {
+  return response.ok === true && response.operation && response.operation.status === 'completed' && text(response.operation.result && response.operation.result.id);
+}
+function responseText(response) {
+  try { return JSON.stringify(response || {}).toLowerCase(); }
+  catch { return text(response).toLowerCase(); }
+}
+function chooseRemoval(features, response) {
+  const available = OPTIONAL_REMOVAL_PRIORITY.filter((feature) => Object.prototype.hasOwnProperty.call(features, feature));
+  const detail = responseText(response);
+  const indicated = available.find((feature) => detail.includes(feature));
+  if (indicated) return indicated;
+  // A generic Meta rejection can still be an enhancement incompatibility, but
+  // structural payload errors (such as an invalid asset feed) must never be
+  // hidden by stripping arbitrary optional features.
+  return /(creative[ _-]?feature|advantage\+?|enhancement|text[ _-]?overlay|music|pac[ _-]?relaxation|video[ _-]?(filtering|highlights?)|adapt[ _-]?to[ _-]?placement)/.test(detail)
+    ? (available[0] || '')
+    : '';
+}
+function markRemoved(groups, feature, reason) {
+  const out = clone(object(groups));
+  for (const group of ['main', 'essential', 'supplemental']) {
+    out[group] = list(out[group]).map((entry) => text(entry && entry.api_key) === feature
+      ? { ...entry, requested: false, status: 'fallback_removed', reason }
+      : entry);
+  }
+  return out;
+}
+
+return $input.all().map((item, index) => {
+  const merged = object(item.json);
+  const response = { ok: merged.ok, replayed: merged.replayed, operation: merged.operation, requestId: merged.requestId, detail: merged.detail, error: merged.error };
+  const source = { ...merged };
+  for (const field of ['ok', 'replayed', 'operation', 'requestId', 'detail', 'error']) delete source[field];
+  const succeeded = responseSucceeded(response);
+  const resolvedCreativeId = succeeded ? text(response.operation.result.id) : '';
+  if (succeeded) {
+    return { json: { ...source, creative_id: resolvedCreativeId, creative_fallback_attempts: list(source.creative_fallback_attempts), gateway_request: { action: 'get_creative', operation_key: key(`fallback-read-${ATTEMPT}:${source.run_id}:${resolvedCreativeId}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), object_id: resolvedCreativeId } }, binary: item.binary, pairedItem: { item: index } };
+  }
+  const payload = clone(object(source.creativePayload));
+  const features = object(object(payload.degrees_of_freedom_spec).creative_features_spec);
+  const removedFeature = chooseRemoval(features, response);
+  if (!removedFeature) throw new Error(`Create AdCreative falhou por erro estrutural ou nao mapeado; fallback de Advantage+ nao aplicado em ${source.job_key || index}.`);
+  delete features[removedFeature];
+  const payloadHash = stableHash(stable(payload));
+  const fallbackReason = `meta_create_failed_fallback_${ATTEMPT}`;
+  const removed = unique([...list(source.advantage_plus_fallback_removed_features), removedFeature]);
+  const requested = unique(list(source.advantage_plus_requested_features).filter((feature) => feature !== removedFeature));
+  return {
+    json: {
+      ...source, creativePayload: payload, advantage_plus_requested_features: requested,
+      advantage_plus_feature_groups: markRemoved(source.advantage_plus_feature_groups, removedFeature, fallbackReason),
+      advantage_plus_fallback_removed_features: removed,
+      advantage_plus_fallback_reasons: { ...object(source.advantage_plus_fallback_reasons), [removedFeature]: fallbackReason },
+      creative_fallback_attempts: [...list(source.creative_fallback_attempts), { attempt: ATTEMPT, removed_feature: removedFeature, reason: fallbackReason }],
+      gateway_request: { action: 'create_creative', operation_key: key(`creative:v2:${payloadHash}:${source.run_id}:${source.destination_group}:fallback_${ATTEMPT}:${removedFeature}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), payload },
+    }, binary: item.binary, pairedItem: { item: index },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-creative-fallback-2.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-creative-fallback-2.js
@@ -1,0 +1,54 @@
+const ATTEMPT = 2;
+const OPTIONAL_REMOVAL_PRIORITY = ['music_generation', 'pac_relaxation', 'video_highlights', 'video_filtering', 'adapt_to_placement', 'add_text_overlay'];
+
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+function key(value) { return text(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+function stable(value) { if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`; if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stable(value[name])}`).join(',')}}`; return JSON.stringify(value); }
+function stableHash(value) { let hash = 2166136261; for (const char of text(value)) { hash ^= char.charCodeAt(0); hash = Math.imul(hash, 16777619); } return (hash >>> 0).toString(36); }
+function unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }
+function responseSucceeded(response) { return response.ok === true && response.operation && response.operation.status === 'completed' && text(response.operation.result && response.operation.result.id); }
+function responseText(response) { try { return JSON.stringify(response || {}).toLowerCase(); } catch { return text(response).toLowerCase(); } }
+function chooseRemoval(features, response) {
+  const available = OPTIONAL_REMOVAL_PRIORITY.filter((feature) => Object.prototype.hasOwnProperty.call(features, feature));
+  const detail = responseText(response);
+  const indicated = available.find((feature) => detail.includes(feature));
+  if (indicated) return indicated;
+  return /(creative[ _-]?feature|advantage\+?|enhancement|text[ _-]?overlay|music|pac[ _-]?relaxation|video[ _-]?(filtering|highlights?)|adapt[ _-]?to[ _-]?placement)/.test(detail) ? (available[0] || '') : '';
+}
+function markRemoved(groups, feature, reason) {
+  const out = clone(object(groups));
+  for (const group of ['main', 'essential', 'supplemental']) out[group] = list(out[group]).map((entry) => text(entry && entry.api_key) === feature ? { ...entry, requested: false, status: 'fallback_removed', reason } : entry);
+  return out;
+}
+
+return $input.all().map((item, index) => {
+  const merged = object(item.json);
+  const response = { ok: merged.ok, replayed: merged.replayed, operation: merged.operation, requestId: merged.requestId, detail: merged.detail, error: merged.error };
+  const source = { ...merged };
+  for (const field of ['ok', 'replayed', 'operation', 'requestId', 'detail', 'error']) delete source[field];
+  const succeeded = responseSucceeded(response);
+  const resolvedCreativeId = succeeded ? text(response.operation.result.id) : '';
+  if (succeeded) return { json: { ...source, creative_id: resolvedCreativeId, creative_fallback_attempts: list(source.creative_fallback_attempts), gateway_request: { action: 'get_creative', operation_key: key(`fallback-read-${ATTEMPT}:${source.run_id}:${resolvedCreativeId}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), object_id: resolvedCreativeId } }, binary: item.binary, pairedItem: { item: index } };
+  const payload = clone(object(source.creativePayload));
+  const features = object(object(payload.degrees_of_freedom_spec).creative_features_spec);
+  const removedFeature = chooseRemoval(features, response);
+  if (!removedFeature) throw new Error(`Create AdCreative falhou por erro estrutural ou nao mapeado apos fallbacks seletivos em ${source.job_key || index}.`);
+  delete features[removedFeature];
+  const payloadHash = stableHash(stable(payload));
+  const fallbackReason = `meta_create_failed_fallback_${ATTEMPT}`;
+  const removed = unique([...list(source.advantage_plus_fallback_removed_features), removedFeature]);
+  const requested = unique(list(source.advantage_plus_requested_features).filter((feature) => feature !== removedFeature));
+  return {
+    json: {
+      ...source, creativePayload: payload, advantage_plus_requested_features: requested,
+      advantage_plus_feature_groups: markRemoved(source.advantage_plus_feature_groups, removedFeature, fallbackReason),
+      advantage_plus_fallback_removed_features: removed,
+      advantage_plus_fallback_reasons: { ...object(source.advantage_plus_fallback_reasons), [removedFeature]: fallbackReason },
+      creative_fallback_attempts: [...list(source.creative_fallback_attempts), { attempt: ATTEMPT, removed_feature: removedFeature, reason: fallbackReason }],
+      gateway_request: { action: 'create_creative', operation_key: key(`creative:v2:${payloadHash}:${source.run_id}:${source.destination_group}:fallback_${ATTEMPT}:${removedFeature}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), payload },
+    }, binary: item.binary, pairedItem: { item: index },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-crm-offer-context-requests.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-crm-offer-context-requests.js
@@ -1,0 +1,33 @@
+function text(value) { return String(value ?? '').trim(); }
+function unitSlug(destinationGroup) {
+  const normalized = text(destinationGroup).toLocaleLowerCase('pt-BR').replace(/[^a-z0-9]+/g, '');
+  if (normalized === 'barrashoppingsul') return 'barra-shopping-sul';
+  if (normalized === 'novohamburgo') return 'novo-hamburgo';
+  throw new Error(`Destino CRM desconhecido: ${text(destinationGroup) || 'vazio'}.`);
+}
+
+return $input.all().flatMap((item) => {
+  const job = item.json || {};
+  const jobKey = text(job.job_key);
+  const groupKey = text(job.group_key);
+  const destinations = Array.isArray(job.destinations) ? job.destinations : [];
+  if (!jobKey || !groupKey || !destinations.length) throw new Error('Prepare CRM Offer Context Requests exige job_key, group_key e destinos.');
+  const seen = new Set();
+  return destinations.map((destination) => {
+    const destinationGroup = text(destination?.destination_group);
+    const crmUnit = unitSlug(destinationGroup);
+    if (seen.has(crmUnit)) throw new Error(`Destino CRM duplicado em ${jobKey}: ${crmUnit}.`);
+    seen.add(crmUnit);
+    return {
+      json: {
+        job_key: jobKey,
+        group_key: groupKey,
+        crm_unit: crmUnit,
+        crm_destination_group: destinationGroup,
+        crm_source_job: job,
+      },
+      binary: item.binary || {},
+      pairedItem: item.pairedItem,
+    };
+  });
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-media-upload-plan.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-media-upload-plan.js
@@ -1,0 +1,68 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+function normalizeMediaMode(value, imageCount, videoCount) {
+  const mode = text(value);
+  if (mode === 'static_only' || mode === 'static_group') return 'static_only';
+  if (mode === 'mixed' || mode === 'mixed_group') return 'mixed';
+  if (mode === 'video_only') return 'video_only';
+  if (mode === 'carousel') return 'carousel';
+  if (imageCount > 0 && videoCount > 0) return 'mixed';
+  if (videoCount > 0) return 'video_only';
+  return 'static_only';
+}
+
+return $input.all().map((item) => {
+  const group = item.json || {};
+  const jobKey = text(group.job_key);
+  const groupKey = text(group.group_key);
+  const images = list(group.imagens);
+  const videos = list(group.videos);
+  if (!jobKey || !groupKey) throw new Error('Prepare Media Upload Plan exige job_key e group_key.');
+
+  const accounts = new Map();
+  for (const destination of list(group.destinations)) {
+    const accountId = text(destination.destination_ad_account_id || destination.account_id).replace(/^act_/, '');
+    if (!accountId) throw new Error(`Destino sem account_id em ${jobKey}.`);
+    accounts.set(accountId, accountId);
+  }
+  if (!accounts.size) throw new Error(`Prepare Media Upload Plan sem contas de destino em ${jobKey}.`);
+
+  const mediaMode = normalizeMediaMode(group.media_mode, images.length, videos.length);
+  const modeIsValid =
+    (mediaMode === 'static_only' && images.length > 0 && videos.length === 0) ||
+    (mediaMode === 'mixed' && images.length > 0 && videos.length > 0) ||
+    (mediaMode === 'video_only' && images.length === 0 && videos.length > 0) ||
+    (mediaMode === 'carousel' && images.length >= 2 && images.length <= 10 && videos.length === 0);
+  if (!modeIsValid) {
+    throw new Error(`Contrato de media_mode inconsistente em ${jobKey}: mode=${mediaMode} images=${images.length} videos=${videos.length}.`);
+  }
+
+  const accountCount = accounts.size;
+  const staticImageOperations = images.length * accountCount;
+  const thumbnailOperations = videos.length * accountCount;
+  const videoOperations = videos.length * accountCount;
+  const expectedImageOperations = staticImageOperations + thumbnailOperations;
+
+  return {
+    json: {
+      ...group,
+      media_mode: mediaMode,
+      media_upload_plan: {
+        version: '2',
+        job_key: jobKey,
+        group_key: groupKey,
+        media_mode: mediaMode,
+        destination_accounts: [...accounts.keys()],
+        expected: {
+          images: expectedImageOperations,
+          videos: videoOperations,
+          static_images: staticImageOperations,
+          video_thumbnails: thumbnailOperations,
+        },
+      },
+    },
+    binary: clone(item.binary || {}),
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-video-chunk-transfer.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-video-chunk-transfer.js
@@ -1,0 +1,34 @@
+function pairedIndex(item, fallback) {
+  const paired = item?.pairedItem;
+  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);
+  return Number(paired?.item ?? fallback);
+}
+function key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+const sliced = $items('Parse Video Slice') || [];
+return $input.all().map((item, index) => {
+  const sourceIndex = pairedIndex(item, index);
+  const slice = sliced[sourceIndex]?.json || {};
+  const state = slice.state || {};
+  if (!item.binary?.data) throw new Error('Chunk lido sem binario data.');
+  return {
+    json: {
+      ...state,
+      chunk_file: slice.chunk_file,
+      chunk_size: Number(slice.chunk_size),
+      gateway_request: {
+        action: 'transfer_video_chunk',
+        operation_key: key(`video-transfer:${state.run_id}:${state.account_id}:${state.source_file_id}:${state.upload_session_id}:${state.start_offset}`),
+        token_id: state.token_id,
+        account_id: state.account_id,
+        api_version: state.api_version,
+        source_file_id: state.source_file_id,
+        upload_session_id: state.upload_session_id,
+        start_offset: Number(state.start_offset),
+        file_name: `video-${state.start_offset}.part`,
+        file_checksum: state.checksum_sha256,
+        semantic_replay_video_id: state.semantic_replay_video_id || undefined,
+      },
+    },
+    binary: { data: item.binary.data },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-video-chunk.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-video-chunk.js
@@ -1,0 +1,17 @@
+function text(value) { return String(value ?? '').trim(); }
+return $input.all().map((item) => {
+  const state = item.json || {};
+  const start = Number(state.start_offset);
+  const end = Number(state.end_offset);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end <= start || end - start > 16 * 1024 * 1024) {
+    throw new Error(`Offsets de chunk invalidos ou acima de 16 MiB: ${start}-${end}.`);
+  }
+  const payload = {
+    input_file: text(state.normalized_file),
+    output_dir: `${text(state.output_dir)}/chunks_${text(state.account_id)}_${text(state.upload_session_id)}`,
+    start_offset: start,
+    end_offset: end,
+    state,
+  };
+  return { json: { ...state, chunk_payload_b64: Buffer.from(JSON.stringify(payload), 'utf8').toString('base64') } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-video-finish.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-video-finish.js
@@ -1,0 +1,16 @@
+function key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+return $input.all().map((item) => {
+  const state = item.json || {};
+  if (Number(state.start_offset) !== Number(state.end_offset)) throw new Error('Finish solicitado antes do upload completo.');
+  return { json: { ...state, gateway_request: {
+    action: 'finish_video_upload',
+    operation_key: key(`video-finish:${state.run_id}:${state.account_id}:${state.source_file_id}:${state.upload_session_id}`),
+    token_id: state.token_id,
+    account_id: state.account_id,
+    api_version: state.api_version,
+    source_file_id: state.source_file_id,
+    upload_session_id: state.upload_session_id,
+    title: state.source_file_name,
+    semantic_replay_video_id: state.semantic_replay_video_id || undefined,
+  } } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-video-status.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-video-status.js
@@ -1,0 +1,15 @@
+function key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+return $input.all().map((item) => {
+  const state = item.json || {};
+  const attempt = Number(state.status_attempt || 0) + 1;
+  if (attempt > 60) throw new Error(`Video ${state.video_id} nao ficou ready apos 60 consultas.`);
+  return { json: { ...state, status_attempt: attempt, gateway_request: {
+    action: 'get_video_status',
+    operation_key: key(`video-status:${state.run_id}:${state.account_id}:${state.video_id}:${attempt}`),
+    token_id: state.token_id,
+    account_id: state.account_id,
+    api_version: state.api_version,
+    object_id: state.video_id,
+    source_file_id: state.source_file_id,
+  } } };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-video-upload-starts.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-video-upload-starts.js
@@ -1,0 +1,109 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function isNineBySixteen(widthValue, heightValue) {
+  const width = Number(widthValue);
+  const height = Number(heightValue);
+  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;
+}
+function stableHash(value) {
+  let hash = 2166136261;
+  for (const char of text(value)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+const VIDEO_NORMALIZATION_CONTRACT_REVISION = 'video9x16_h264_aac_v1';
+
+function resumableVideoId(group, accountId, sourceFileId) {
+  let restored = [];
+  try { restored = $items('Restore Publish Groups') || []; } catch (error) { restored = []; }
+  const candidates = restored
+    .flatMap((entry) => list(entry?.json?.resume_jobs))
+    .filter((job) => text(job.account_id || job.destination_ad_account_id).replace(/^act_/, '') === accountId)
+    .filter((job) => text(job.asset_ids?.vertical_video) === sourceFileId)
+    .filter((job) => text(job.video_status).toLowerCase() === 'ready')
+    .map((job) => text(job.video_id))
+    .filter((value) => /^\d{5,30}$/.test(value));
+  const unique = [...new Set(candidates)];
+  return unique.length === 1 ? unique[0] : '';
+}
+
+const outputs = [];
+for (const item of $input.all()) {
+  const group = item.json || {};
+  const runId = text(group.run_id);
+  for (const video of list(group.videos)) {
+    const inventory = list(group.media_inventory).find((entry) => text(entry.source_file_id || entry.id) === text(video.id));
+    const processing = inventory?.media_processing || video.media_processing || {};
+    const fileSize = Number(processing.output_bytes || video.output_bytes || item.binary?.[video.binary_key]?.fileSize || 0);
+    const normalizedFile = text(processing.normalized_file || video.normalized_file);
+    const checksumSha256 = text(processing.output_checksum_sha256 || video.output_checksum_sha256);
+    if (!runId || !fileSize || !normalizedFile) throw new Error(`Video ${video.id} sem run_id, tamanho ou caminho normalizado.`);
+    if (!/^[a-f0-9]{64}$/i.test(checksumSha256)) throw new Error(`Video ${video.id} normalizacao sem checksum SHA-256 valido.`);
+    const width = Number(processing.width || video.width || 0);
+    const height = Number(processing.height || video.height || 0);
+    if (!isNineBySixteen(width, height)) throw new Error(`Video ${video.id} nao esta em 9:16 apos normalizacao: ${width}x${height}.`);
+    const batchFile = list(group.batch_files).find((entry) => text(entry.id) === text(video.id)) || {};
+    const sourceFingerprint = text(
+      video.md5_checksum || inventory?.source_md5_checksum || batchFile.md5_checksum ||
+      [video.id, video.modified_time || batchFile.modified_time, video.size || batchFile.size].map(text).join('|')
+    );
+    if (!sourceFingerprint) throw new Error(`Video ${video.id} sem fingerprint estavel do arquivo fonte.`);
+    // Destinations may represent different units that publish through the
+    // same ad account. Video upload is account-scoped, just like image
+    // upload, so starting it once per destination creates duplicate videos
+    // and violates the aggregate's exact-count contract.
+    const accounts = new Map();
+    for (const destination of list(group.destinations)) {
+      const accountId = text(destination.destination_ad_account_id || destination.account_id).replace(/^act_/, '');
+      const tokenId = text(destination.token_id);
+      const apiVersion = text(destination.destination_api_version || destination.api_version || 'v25.0');
+      if (!accountId || !tokenId) throw new Error(`Destino de video incompleto em ${group.job_key}.`);
+      accounts.set(accountId, { accountId, tokenId, apiVersion });
+    }
+    for (const { accountId, tokenId, apiVersion } of accounts.values()) {
+      const resumeVideoId = resumableVideoId(group, accountId, text(video.id));
+      outputs.push({ json: {
+        run_id: runId,
+        job_key: text(group.job_key),
+        source_file_id: text(video.id),
+        source_file_name: text(video.original_name || video.name),
+        normalized_file: normalizedFile,
+        output_dir: text(processing.output_dir || normalizedFile.replace(/\/[^/]+$/, '')),
+        file_size: fileSize,
+        video_width: width,
+        video_height: height,
+        video_aspect_ratio: '9x16',
+        video_recommended_aspect_ratio: '9x16',
+        checksum_sha256: checksumSha256,
+        source_fingerprint: sourceFingerprint,
+        normalization_contract_revision: VIDEO_NORMALIZATION_CONTRACT_REVISION,
+        account_id: accountId,
+        _gateway_account_id: accountId,
+        token_id: tokenId,
+        api_version: apiVersion,
+        gateway_request: {
+          action: 'start_video_upload',
+          // A prior workflow revision used only the normalized asset identity.
+          // Token, Graph version and normalized byte count are part of the
+          // gateway request hash, so omit them here and a replay can collide
+          // with a record produced by the old request shape. Keep the v3 key
+          // stable for exact replays, yet distinct for every semantic request.
+          operation_key: `video-start:v5:${stableHash([runId, accountId, tokenId, apiVersion, video.id, sourceFingerprint, checksumSha256, fileSize, VIDEO_NORMALIZATION_CONTRACT_REVISION].map(text).join('|'))}`,
+          token_id: tokenId,
+          account_id: accountId,
+          api_version: apiVersion,
+          source_file_id: text(video.id),
+          file_size: fileSize,
+          file_checksum: checksumSha256,
+          source_fingerprint: sourceFingerprint,
+          normalization_contract_revision: VIDEO_NORMALIZATION_CONTRACT_REVISION,
+          resume_video_id: resumeVideoId || undefined,
+        },
+      } });
+    }
+  }
+}
+return outputs;

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-visual-grouping-batch.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-visual-grouping-batch.js
@@ -1,0 +1,142 @@
+function text(value) {
+  return String(value ?? '').trim();
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function object(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function mediaTypeOf(source, binaryData) {
+  const mime = text(source.media_processing?.mime_type || source.mimeType || binaryData?.mimeType).toLowerCase();
+  if (mime.startsWith('video/')) return 'video';
+  if (mime.startsWith('image/')) return 'image';
+  return '';
+}
+
+function dimensionsOf(source, binaryData) {
+  const processing = object(source.media_processing);
+  return {
+    width: Number(processing.width || source.width || binaryData?.width || 0),
+    height: Number(processing.height || source.height || binaryData?.height || 0),
+  };
+}
+
+const rawInputItems = $input.all();
+if (!rawInputItems.length) throw new Error('Prepare Visual Grouping Batch recebeu zero midias.');
+
+// A folder is a queue, not a batch forever. Keep an older unpublished asset
+// out of a newly delivered set when a clear temporal gap proves it belongs to
+// a previous intake. Deferred files stay untouched in Drive for their own
+// future batch; nothing is silently marked published or discarded.
+const COHORT_MAX_GAP_MS = 2 * 60 * 60 * 1000;
+const dated = rawInputItems.map((item, original_index) => ({
+  item,
+  original_index,
+  modified_ms: Date.parse(text(item?.json?.modifiedTime || item?.json?.modified_time || '')),
+}));
+const datedSorted = dated.slice().sort((left, right) => (Number.isFinite(right.modified_ms) ? right.modified_ms : -Infinity) - (Number.isFinite(left.modified_ms) ? left.modified_ms : -Infinity));
+const selectedEntries = [];
+let previousModified = null;
+for (const entry of datedSorted) {
+  if (!Number.isFinite(entry.modified_ms)) { selectedEntries.push(entry); continue; }
+  if (previousModified !== null && previousModified - entry.modified_ms > COHORT_MAX_GAP_MS) break;
+  selectedEntries.push(entry);
+  previousModified = entry.modified_ms;
+}
+const selectedIndexes = new Set(selectedEntries.map((entry) => entry.original_index));
+const inputEntries = dated.filter((entry) => selectedIndexes.has(entry.original_index));
+const deferredEntries = dated.filter((entry) => !selectedIndexes.has(entry.original_index));
+if (!inputEntries.length) throw new Error('Prepare Visual Grouping Batch nao encontrou midias no coorte atual.');
+
+const anyVideo = inputEntries.some(({ item }) => {
+  const source = item?.json || {};
+  return mediaTypeOf(source, item?.binary?.data) === 'video';
+});
+// Four or more static pieces are ambiguous until the vision pass says whether
+// they are placement variants or an ordered story. Version 3 makes that
+// decision explicit; the old three-image and mixed-media contracts remain
+// unchanged.
+const version = inputEntries.length >= 4 ? '3' : anyVideo ? '2' : '1';
+const media = [];
+const binary = {};
+const seenDriveIds = new Set();
+
+for (const [batchIndex, entryWithIndex] of inputEntries.entries()) {
+  const item = entryWithIndex.item;
+  const itemIndex = entryWithIndex.original_index;
+  const source = item?.json || {};
+  const driveId = text(source.id || source.drive_id);
+  const data = item?.binary?.data;
+  const mediaType = mediaTypeOf(source, data);
+  if (!driveId) throw new Error(`Midia ${itemIndex + 1} sem id do Google Drive.`);
+  if (seenDriveIds.has(driveId)) throw new Error(`Midia duplicada no lote visual: ${driveId}.`);
+  if (!['image', 'video'].includes(mediaType)) throw new Error(`Arquivo ${driveId} possui MIME nao suportado.`);
+
+  const analysisBinary = mediaType === 'video' ? item?.binary?.analysis : data;
+  if (!analysisBinary || !text(analysisBinary.mimeType).toLowerCase().startsWith('image/')) {
+    throw new Error(`Midia ${driveId} sem representacao visual de imagem para o agente.`);
+  }
+  if (mediaType === 'video') {
+    if (!data || !text(data.mimeType).toLowerCase().startsWith('video/')) throw new Error(`Video ${driveId} sem binario normalizado.`);
+    if (!item?.binary?.thumbnail || !text(item.binary.thumbnail.mimeType).toLowerCase().startsWith('image/')) {
+      throw new Error(`Video ${driveId} sem miniatura limpa.`);
+    }
+  }
+
+  seenDriveIds.add(driveId);
+  const ordinal = batchIndex + 1;
+  const mediaRef = version === '2'
+    ? `MEDIA_${String(ordinal).padStart(3, '0')}`
+    : `IMG_${String(ordinal).padStart(3, '0')}`;
+  const analysisKey = `analysis_${String(ordinal).padStart(3, '0')}`;
+  const dimensions = dimensionsOf(source, data);
+  const processing = object(source.media_processing);
+  const entry = {
+    media_ref: mediaRef,
+    image_ref: version === '1' ? mediaRef : undefined,
+    ordinal,
+    media_type: mediaType,
+    mime_type: text(processing.mime_type || data?.mimeType || source.mimeType),
+    width: dimensions.width,
+    height: dimensions.height,
+    duration_seconds: mediaType === 'video' ? Number(processing.duration_seconds || 0) : 0,
+    has_audio: mediaType === 'video' ? Boolean(processing.has_audio) : false,
+    transcript: mediaType === 'video' ? text(processing.transcript) : '',
+    analysis_binary_key: analysisKey,
+    source_item_index: itemIndex,
+    source_file_id: driveId,
+    drive_reference: { id: driveId, modified_time: text(source.modifiedTime || source.modified_time) },
+  };
+  media.push(entry);
+  binary[analysisKey] = clone(analysisBinary);
+}
+
+return [{
+  json: {
+    visual_grouping_batch_version: version,
+    grouping_contract: version === '2'
+      ? 'mixed_media_four_roles'
+      : version === '3'
+        ? 'static_placement_or_carousel'
+        : 'legacy_three_images',
+    input_count: media.length,
+    deferred_media_count: deferredEntries.length,
+    deferred_media_reason: deferredEntries.length ? 'outside_current_drive_intake_cohort' : '',
+    contains_video: anyVideo,
+    required_roles: version === '2'
+      ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video']
+      : version === '3'
+        ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video', 'carousel_card']
+        : ['feed', 'banner', 'stories'],
+    media,
+    images: version === '1' ? media : undefined,
+  },
+  // Only image representations are forwarded to the vision model. Raw video
+  // and upload thumbnails remain on Prepare Media Inventory and are restored
+  // after the model output has passed the exact-coverage gate.
+  binary,
+}];

--- a/orb/engine/workflow-src/meta-ads-publish/restore-persisted-resume-jobs.js
+++ b/orb/engine/workflow-src/meta-ads-publish/restore-persisted-resume-jobs.js
@@ -1,0 +1,14 @@
+function text(value) { return String(value ?? '').trim(); }
+
+const checkpoint = $input.first()?.json || {};
+if (checkpoint.ok !== true || !checkpoint.run || text(checkpoint.run.id) !== text($items('Build Resume Jobs Checkpoint')[0]?.json?.run_id)) {
+  throw new Error(`Persist Resume Jobs falhou: ${JSON.stringify(checkpoint.error || checkpoint)}`);
+}
+
+const jobs = $items('Validate Meta Creative Payload') || [];
+if (!jobs.length) throw new Error('Restore Persisted Resume Jobs nao encontrou jobs validados.');
+
+return jobs.map((item) => ({
+  json: item.json || {},
+  binary: item.binary,
+}));

--- a/orb/engine/workflow-src/meta-ads-publish/validate-meta-creative-payload.js
+++ b/orb/engine/workflow-src/meta-ads-publish/validate-meta-creative-payload.js
@@ -24,9 +24,12 @@ const REQUIRED_VIDEO_ONLY_REWARDED_AUDIENCE_NETWORK_POSITIONS = ['rewarded_video
 const REQUIRED_VIDEO_ONLY_WHATSAPP_POSITIONS = ['status'];
 const REQUIRED_HORIZONTAL_PLATFORMS = ['facebook'];
 const REQUIRED_HORIZONTAL_FACEBOOK_POSITIONS = ['search'];
-const REQUIRED_CTA = 'LEARN_MORE';
+// OUTCOME_LEADS dynamic creatives reject BOOK_NOW at staging. The expected
+// CTA comes from the live campaign objective carried by destination_meta.
+const REQUIRED_CTA = 'BOOK_NOW';
+const OUTCOME_LEADS_CTA = 'LEARN_MORE';
 const WHATSAPP_CTA = 'WHATSAPP_MESSAGE';
-const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v12_native_carousel_route';
+const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';
 const ALLOWED_ADVANTAGE_PLUS_FEATURES = new Set([
   'add_text_overlay',
   'image_touchups',
@@ -40,11 +43,6 @@ const ALLOWED_ADVANTAGE_PLUS_FEATURES = new Set([
   'show_destination_blurbs',
   'image_animation',
   'site_extensions',
-  'adapt_to_placement',
-  'video_filtering',
-  'video_highlights',
-  'video_auto_crop',
-  'video_uncrop',
 ]);
 const FORBIDDEN_ADVANTAGE_PLUS_FEATURES = new Set([
   'image_template',
@@ -58,6 +56,14 @@ function safeString(value) { return String(value ?? '').trim(); }
 function safeArray(value) { return Array.isArray(value) ? value : []; }
 function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
 function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+function expectedFlexibleCta(source, destinationKind) {
+  if (destinationKind === 'whatsapp') return WHATSAPP_CTA;
+  const destination = asObject(source.destination_meta);
+  return safeString(destination.campaign_objective || source.destination_campaign_objective).toUpperCase() === 'OUTCOME_LEADS'
+    ? OUTCOME_LEADS_CTA
+    : REQUIRED_CTA;
+}
 
 function restoredRunContext() {
   let groups = [];
@@ -358,11 +364,13 @@ function validateAdvantagePlus(payload, source, hosts) {
   }
 
   const sourcing = asObject(payload.creative_sourcing_spec);
-  // Meta accepts the scheduling landing page in asset_feed_spec.link_urls.  Do
-  // not add creative_sourcing_spec.source_url unless Meta site extensions are
-  // configured: it was rejected by this account's creative endpoint.
+  // Token Vault and Meta must receive exactly the same HTTPS landing page in
+  // the asset feed and the sourcing spec. This prevents a later redirect or
+  // fallback from silently changing the commercial destination.
   const sourceUrl = safeString(sourcing.source_url);
-  assert(!sourceUrl, 'creative_source_url_forbidden_without_site_extensions', {});
+  assert(Boolean(sourceUrl), 'creative_source_url_missing', {});
+  if (destinationContractKind(source) === 'whatsapp') assert(isWhatsAppUrl(sourceUrl), 'creative_source_url_whatsapp_invalid', {});
+  else validateUrl(sourceUrl, hosts, 'creative_source_url');
 
   const siteLinks = safeArray(sourcing.site_links_spec);
   assert(siteLinks.length === 0 || (siteLinks.length >= 2 && siteLinks.length <= 4), 'site_links_count_invalid', { count: siteLinks.length });
@@ -478,6 +486,17 @@ return $input.all().map((item) => {
   const legacyCarousel = isCarousel && Object.keys(asObject(story.link_data)).length > 0;
   const hosts = allowedHosts(source);
   const destinationKind = destinationContractKind(source);
+  // This value is also checked inside validateAdvantagePlus(), but the main
+  // payload contract needs it in this scope to prove that Token Vault receives
+  // the same destination as the primary asset-feed link. Native carousels are
+  // deliberately exempt because their approved contract forbids a sourcing
+  // spec altogether.
+  const sourceUrl = safeString(asObject(payload.creative_sourcing_spec).source_url);
+  if (!isCarousel) {
+    assert(Boolean(sourceUrl), 'creative_source_url_missing', {});
+    if (destinationKind === 'whatsapp') assert(isWhatsAppUrl(sourceUrl), 'creative_source_url_whatsapp_invalid', {});
+    else validateUrl(sourceUrl, hosts, 'creative_source_url');
+  }
   assert(safeString(payload.name), 'creative_name_missing', {});
   assert(safeString(story.page_id) === safeString(source.page_id), 'creative_page_id_mismatch', {});
   assert(legacyCarousel || Object.keys(feed).length > 0, 'asset_feed_spec_required', {});
@@ -530,17 +549,20 @@ return $input.all().map((item) => {
     ? validateNativeCarousel(story, source, hosts, destinationKind)
     : validateCarouselFeed(feed, story, source, hosts, destinationKind)) : null;
   if (!isCarousel) assert(linkUrls.length === 1, 'link_url_count_invalid', { actual: linkUrls.length });
-  const primaryLink = isCarousel ? carouselValidation.primaryLink : validateUrl(linkUrls[0] && linkUrls[0].website_url, hosts, 'primary_link');
+  const primaryLink = isCarousel ? carouselValidation.primaryLink : destinationKind === 'whatsapp'
+    ? (assert(isWhatsAppUrl(linkUrls[0] && linkUrls[0].website_url), 'primary_link_whatsapp_required', {}), safeString(linkUrls[0] && linkUrls[0].website_url))
+    : validateUrl(linkUrls[0] && linkUrls[0].website_url, hosts, 'primary_link');
+  if (!isCarousel) assert(sourceUrl === primaryLink, 'creative_source_url_primary_link_mismatch', {});
   const whatsappDestination = destinationKind === 'whatsapp';
   if (isCarousel && whatsappDestination) assert(isWhatsAppUrl(primaryLink), 'carousel_primary_link_whatsapp_required', {});
   if (isCarousel && !whatsappDestination) assert(!isWhatsAppUrl(primaryLink), 'carousel_primary_link_whatsapp_forbidden', {});
   if (whatsappDestination && !isCarousel) {
-    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === WHATSAPP_CTA, 'cta_must_be_whatsapp_message', { value: ctas });
+    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === expectedFlexibleCta(source, destinationKind), 'cta_type_incompatible_with_campaign_objective', { value: ctas });
     assert(isWhatsAppUrl(primaryLink), 'primary_link_whatsapp_required', {});
     const schedulingUrl = validateUrl(source.scheduling_landing_page_url, hosts, 'scheduling_landing_page');
     assert(!isWhatsAppUrl(schedulingUrl), 'scheduling_landing_page_whatsapp_forbidden', {});
   } else if (!isCarousel) {
-    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === REQUIRED_CTA, 'cta_must_be_learn_more', { value: ctas });
+    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === expectedFlexibleCta(source, destinationKind), 'cta_type_incompatible_with_campaign_objective', { value: ctas });
     assert(!isWhatsAppUrl(primaryLink), 'primary_link_whatsapp_forbidden', {});
     assert(primaryLink === safeString(source.landing_page_url), 'primary_link_landing_page_mismatch', {});
   }

--- a/orb/engine/workflow-src/meta-ads-publish/validate-meta-placement-eligibility.js
+++ b/orb/engine/workflow-src/meta-ads-publish/validate-meta-placement-eligibility.js
@@ -1,0 +1,91 @@
+function text(value) { return String(value ?? '').trim().toLowerCase(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function values(targeting, configuredKey, effectiveKey) {
+  const effective = list(targeting[effectiveKey]).map(text).filter(Boolean);
+  return effective.length ? effective : list(targeting[configuredKey]).map(text).filter(Boolean);
+}
+function includesAny(actual, expected) { return expected.some((value) => actual.includes(value)); }
+function missing(actual, expected) { return expected.filter((value) => !actual.includes(value)); }
+
+const failures = [];
+const outputs = [];
+const KNOWN_FACEBOOK_POSITIONS = new Set(['feed', 'marketplace', 'instream_video', 'instream_reel', 'story', 'search', 'facebook_reels', 'fb_reels', 'facebook_reels_overlay', 'notification']);
+const KNOWN_INSTAGRAM_POSITIONS = new Set(['stream', 'story', 'reels', 'explore', 'explore_home']);
+const KNOWN_AUDIENCE_NETWORK_POSITIONS = new Set(['classic', 'rewarded_video']);
+const KNOWN_WHATSAPP_POSITIONS = new Set(['status']);
+for (const item of $input.all()) {
+  const root = object(item.json);
+  if (root.ok !== true) throw new Error(`Meta placement preflight sem inventario valido: ${JSON.stringify(root.error || root.detail || {})}`);
+  const checks = list(root.placement_checks);
+  if (!checks.length) throw new Error('Meta placement preflight nao recebeu adsets para validar.');
+  const normalizedChecks = [];
+
+  for (const entry of checks) {
+    const targeting = object(entry && entry.targeting);
+    const publishers = values(targeting, 'publisher_platforms', 'effective_publisher_platforms');
+    const facebook = values(targeting, 'facebook_positions', 'effective_facebook_positions');
+    const instagram = values(targeting, 'instagram_positions', 'effective_instagram_positions');
+    const audienceNetwork = values(targeting, 'audience_network_positions', 'effective_audience_network_positions');
+    const whatsapp = values(targeting, 'whatsapp_positions', 'effective_whatsapp_positions');
+    const problems = [];
+
+    problems.push(...missing(publishers, ['facebook', 'instagram', 'audience_network', 'whatsapp']).map((value) => `publisher:${value}`));
+    if (!includesAny(facebook, ['instream_video', 'instream_reel'])) problems.push('facebook:instream_video');
+    if (!facebook.includes('story')) problems.push('facebook:story');
+    if (!includesAny(facebook, ['facebook_reels', 'fb_reels'])) problems.push('facebook:facebook_reels');
+    if (!facebook.includes('facebook_reels_overlay')) problems.push('facebook:facebook_reels_overlay');
+    if (!facebook.includes('feed')) problems.push('facebook:feed');
+    if (!facebook.includes('search')) problems.push('facebook:search');
+    if (!facebook.includes('notification')) problems.push('facebook:notification');
+    problems.push(...missing(instagram, ['story', 'reels']).map((value) => `instagram:${value}`));
+    if (!instagram.includes('stream')) problems.push('instagram:stream');
+    if (!audienceNetwork.includes('classic')) problems.push('audience_network:classic');
+    if (!audienceNetwork.includes('rewarded_video')) problems.push('audience_network:rewarded_video');
+    if (!whatsapp.some((value) => value.includes('status'))) problems.push('whatsapp:status');
+    problems.push(...facebook.filter((value) => !KNOWN_FACEBOOK_POSITIONS.has(value)).map((value) => `facebook:unsupported:${value}`));
+    problems.push(...instagram.filter((value) => !KNOWN_INSTAGRAM_POSITIONS.has(value)).map((value) => `instagram:unsupported:${value}`));
+    problems.push(...audienceNetwork.filter((value) => !KNOWN_AUDIENCE_NETWORK_POSITIONS.has(value)).map((value) => `audience_network:unsupported:${value}`));
+    problems.push(...whatsapp.filter((value) => !KNOWN_WHATSAPP_POSITIONS.has(value)).map((value) => `whatsapp:unsupported:${value}`));
+
+    if (problems.length) {
+      failures.push({
+        destination_group: String(entry && entry.destination_group || ''),
+        adset_id_present: Boolean(String(entry && entry.adset_id || '')),
+        missing_effective_placements: problems,
+      });
+    }
+
+    normalizedChecks.push({
+      ...entry,
+      advantage_plus_eligibility: {
+        instagram_static_image_music: publishers.includes('instagram') && includesAny(instagram, ['story', 'reels', 'stream']),
+        instagram_video_music: publishers.includes('instagram') && includesAny(instagram, ['story', 'reels', 'stream']),
+        effective_instagram_positions: instagram,
+        effective_publisher_platforms: publishers,
+      },
+    });
+  }
+
+  outputs.push({
+    ...item,
+    json: {
+      ...root,
+      placement_checks: normalizedChecks,
+      placement_preflight: {
+        status: 'ok',
+        checked_adsets: checks.length,
+        required_vertical_crop: '90x160',
+        required_horizontal_crop: '191x100',
+        required_horizontal_placement: 'facebook:search',
+        required_mixed_video_placement: 'audience_network:rewarded_video',
+      },
+    },
+  });
+}
+
+if (failures.length) {
+  throw new Error(`Meta placement preflight bloqueou o lote: ${JSON.stringify(failures)}`);
+}
+
+return outputs;

--- a/orb/engine/workflow-src/meta-ads-publish/validate-visual-grouping.js
+++ b/orb/engine/workflow-src/meta-ads-publish/validate-visual-grouping.js
@@ -1,0 +1,275 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+function parseObject(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try { const parsed = JSON.parse(value); return object(parsed); } catch { return null; }
+}
+function unwrapAgent(value) {
+  const root = object(value);
+  const direct = parseObject(root.output);
+  if (direct) return object(direct.output) && Object.keys(object(direct.output)).length ? direct.output : direct;
+  return object(root.output) && Object.keys(object(root.output)).length ? root.output : root;
+}
+function token(value) {
+  return text(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+function fnv64(value) {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  for (const char of String(value)) {
+    hash = BigInt.asUintN(64, hash ^ BigInt(char.codePointAt(0)));
+    hash = BigInt.asUintN(64, hash * prime);
+  }
+  return hash.toString(36).toUpperCase();
+}
+function normalizeOfferFingerprint(raw) {
+  const source = object(raw);
+  const procedures = list(source.procedures)
+    .map((entry) => object(entry))
+    .map((entry) => ({ key: token(entry.key), quantity: token(entry.quantity), unit: token(entry.unit) }))
+    .filter((entry) => entry.key)
+    .sort((left, right) => `${left.key}:${left.quantity}:${left.unit}`.localeCompare(`${right.key}:${right.quantity}:${right.unit}`));
+  const payment_terms = [...new Set(list(source.payment_terms).map(token).filter(Boolean))].sort();
+  const condition_terms = [...new Set(list(source.condition_terms).map(token).filter(Boolean))].sort();
+  const price_amount_cents = Math.max(0, Math.trunc(Number(source.price_amount_cents || 0)));
+  const price_qualifier = ['fixed', 'from'].includes(token(source.price_qualifier)) ? token(source.price_qualifier) : 'unknown';
+  const validity = token(source.validity);
+  const evidence = list(source.evidence).map(text).filter(Boolean).slice(0, 8);
+  const canonical_key = [
+    'v1',
+    `p=${procedures.map((entry) => `${entry.key}:${entry.quantity || 'unknown'}:${entry.unit || 'unknown'}`).join('+') || 'unknown'}`,
+    `price=${price_amount_cents}:${price_qualifier}`,
+    `pay=${payment_terms.join('+') || 'none'}`,
+    `cond=${condition_terms.join('+') || 'none'}`,
+    `valid=${validity || 'none'}`,
+  ].join('|');
+  const replacement_eligible = Number(source.confidence) >= 0.9 && procedures.length > 0 &&
+    procedures.every((entry) => entry.quantity && entry.unit) && price_amount_cents > 0 &&
+    price_qualifier !== 'unknown' && evidence.length > 0;
+  return {
+    version: 'v1', confidence: Number(source.confidence || 0), procedures, price_amount_cents,
+    price_qualifier, payment_terms, condition_terms, validity, evidence, canonical_key,
+    tag: replacement_eligible ? `[OFV1:${fnv64(canonical_key)}]` : '',
+    replacement_eligible,
+    status: replacement_eligible ? 'verified' : 'unverified',
+  };
+}
+function sourceItems() {
+  try { const items = $items('Prepare Media Inventory') || []; if (items.length) return items; } catch {}
+  try { return $items('Download File') || []; } catch { return []; }
+}
+
+const prepared = ($items('Prepare Visual Grouping Batch') || [])[0];
+const version = text(prepared?.json?.visual_grouping_batch_version || '1');
+const manifest = list(prepared?.json?.media).length ? list(prepared.json.media) : list(prepared?.json?.images);
+if (!manifest.length) throw new Error('Validate Visual Grouping nao encontrou o manifesto original.');
+
+const result = unwrapAgent($input.first()?.json || {});
+const groups = list(result.groups);
+let assignments = list(result.assignments);
+if (!groups.length || !assignments.length) throw new Error(`Agente visual retornou estrutura vazia: ${JSON.stringify(result).slice(0, 1000)}`);
+
+const groupByKey = new Map();
+for (const rawGroup of groups) {
+  const group = object(rawGroup);
+  const key = text(group.group_key).toUpperCase();
+  const confidence = Number(group.confidence);
+  if (!/^VISUAL_GROUP_[0-9]{2,}$/.test(key)) throw new Error(`Chave de grupo visual invalida: ${text(group.group_key)}.`);
+  if (!Number.isFinite(confidence) || confidence < 0.75 || confidence > 1) throw new Error(`Confianca de grupo insuficiente em ${key}: ${group.confidence}.`);
+  const offerFingerprint = normalizeOfferFingerprint(group.offer_fingerprint);
+  if (!object(group.offer_fingerprint) || !Array.isArray(group.offer_fingerprint.procedures)) {
+    throw new Error(`offer_fingerprint ausente ou invalido em ${key}.`);
+  }
+  const mediaMode = text(group.media_mode).toLowerCase();
+  if (version === '3' && mediaMode && !['static_only', 'carousel', 'mixed', 'video_only'].includes(mediaMode)) {
+    throw new Error(`media_mode visual invalido em ${key}: ${text(group.media_mode)}.`);
+  }
+  const normalizedGroup = {
+    group_key: key,
+    visual_concept: text(group.visual_concept),
+    confidence,
+    evidence: list(group.evidence).map(text).filter(Boolean),
+    offer_fingerprint: offerFingerprint,
+    media_mode: version === '3' ? mediaMode : '',
+  };
+  if (groupByKey.has(key)) {
+    // The Responses adapter can repeat a complete group verbatim. It carries
+    // no new classification information, so collapse only an exact normalized
+    // duplicate; any material disagreement stays fail-closed.
+    if (JSON.stringify(groupByKey.get(key)) !== JSON.stringify(normalizedGroup)) {
+      throw new Error(`Grupo visual conflitante: ${key}.`);
+    }
+    continue;
+  }
+  groupByKey.set(key, normalizedGroup);
+}
+
+const manifestByRef = new Map(manifest.map((entry) => [text(entry.media_ref || entry.image_ref), entry]));
+// Some multimodal adapters serialize only the first assignment despite having
+// produced one high-confidence, explicitly sequential carousel group. This is
+// a response-shape defect, not permission to guess membership: recover only
+// when the model itself states carousel/sequence, every item is an image, and
+// the group is the sole, high-confidence explanation of the entire batch.
+const soleGroup = groupByKey.size === 1 ? [...groupByKey.values()][0] : null;
+const carouselNarrative = /carrossel|sequ[êe]ncia/i.test(`${soleGroup?.visual_concept || ''} ${(soleGroup?.evidence || []).join(' ')}`);
+const partialCarouselAssignmentFallback = version === '3' && assignments.length < manifest.length &&
+  soleGroup && soleGroup.confidence >= 0.9 && carouselNarrative &&
+  manifest.length >= 2 && manifest.length <= 10 && manifest.every((entry) => text(entry.media_type || 'image') === 'image') &&
+  assignments.every((entry) => text(object(entry).group_key).toUpperCase() === soleGroup.group_key);
+if (partialCarouselAssignmentFallback) {
+  assignments = manifest
+    .slice()
+    .sort((left, right) => Number(left.ordinal || 0) - Number(right.ordinal || 0))
+    .map((entry, index) => ({
+      media_ref: text(entry.media_ref || entry.image_ref), media_type: 'image', group_key: soleGroup.group_key,
+      role: 'carousel_card', ratio: text(entry.ratio || '4x5'), carousel_card_index: index + 1,
+      confidence: soleGroup.confidence, evidence: soleGroup.evidence,
+    }));
+  soleGroup.media_mode = 'carousel';
+}
+const assignmentByRef = new Map();
+const supportedRatios = new Set(['1x1', '2x1', '3x4', '4x5', '9x16']);
+const legacyRole = (ratio) => ratio === '2x1' ? 'banner' : ratio === '9x16' ? 'stories' : 'feed';
+const v2RoleFor = (mediaType, ratio) => mediaType === 'video' ? (ratio === '9x16' ? 'vertical_video' : '')
+  : ratio === '2x1' ? 'banner_image' : ratio === '9x16' ? 'vertical_image' : ['1x1', '3x4', '4x5'].includes(ratio) ? 'feed_image' : '';
+
+for (const rawAssignment of assignments) {
+  const assignment = object(rawAssignment);
+  const mediaRef = text(assignment.media_ref || assignment.image_ref);
+  const manifestEntry = manifestByRef.get(mediaRef);
+  const groupKey = text(assignment.group_key).toUpperCase();
+  const ratio = text(assignment.ratio).toLowerCase();
+  const mediaType = text(assignment.media_type || manifestEntry?.media_type || 'image').toLowerCase();
+  const declaredRole = text(assignment.role || assignment.slot).toLowerCase();
+  const confidence = Number(assignment.confidence);
+  if (!manifestEntry) throw new Error(`Agente visual retornou referencia desconhecida: ${mediaRef}.`);
+  if (assignmentByRef.has(mediaRef)) throw new Error(`Midia atribuida mais de uma vez: ${mediaRef}.`);
+  if (!groupByKey.has(groupKey)) throw new Error(`Midia ${mediaRef} referencia grupo inexistente: ${groupKey}.`);
+  if (mediaType !== text(manifestEntry.media_type || 'image')) throw new Error(`Tipo de midia divergente em ${mediaRef}.`);
+  if (!supportedRatios.has(ratio)) throw new Error(`Proporcao visual nao suportada para ${mediaRef}: ${ratio}.`);
+  const carouselGroup = version === '3' && groupByKey.get(groupKey)?.media_mode === 'carousel';
+  const expectedRole = carouselGroup
+    ? (mediaType === 'image' ? 'carousel_card' : '')
+    : version === '2' ? v2RoleFor(mediaType, ratio) : legacyRole(ratio);
+  if (!expectedRole) throw new Error(`Papel sem mapeamento para ${mediaType}/${ratio} em ${mediaRef}.`);
+  // Group membership is the visual model's responsibility. The media role is
+  // not: it is mechanically determined by type and aspect ratio. Normalize
+  // an occasional model label error (for example, 2:1 called feed_image)
+  // instead of rejecting a group whose visual association is otherwise sound.
+  const role = expectedRole;
+  if (!Number.isFinite(confidence) || confidence < 0.75 || confidence > 1) throw new Error(`Confianca insuficiente para ${mediaRef}: ${assignment.confidence}.`);
+  const evidence = list(assignment.evidence).map(text).filter(Boolean);
+  const forbiddenEvidence = [text(manifestEntry.source_file_id), text(manifestEntry.source_json?.name)].filter(Boolean);
+  if (evidence.some((entry) => forbiddenEvidence.some((forbidden) => entry.toLowerCase().includes(forbidden.toLowerCase())))) {
+    throw new Error(`Nome ou id de arquivo usado como evidencia em ${mediaRef}.`);
+  }
+  const carouselCardIndex = carouselGroup ? Number(assignment.carousel_card_index) : 0;
+  if (carouselGroup && (!Number.isInteger(carouselCardIndex) || carouselCardIndex < 1 || carouselCardIndex > 10)) {
+    throw new Error(`carousel_card_index invalido para ${mediaRef}.`);
+  }
+  assignmentByRef.set(mediaRef, { media_ref: mediaRef, media_type: mediaType, group_key: groupKey, ratio, role, carousel_card_index: carouselCardIndex, declared_role: declaredRole, confidence, evidence });
+}
+
+const missing = [...manifestByRef.keys()].filter((ref) => !assignmentByRef.has(ref));
+if (missing.length || assignmentByRef.size !== manifestByRef.size) {
+  throw new Error(`Agrupamento visual nao cobriu o lote exatamente uma vez. missing=${JSON.stringify(missing)} expected=${manifestByRef.size} assigned=${assignmentByRef.size}`);
+}
+const groupMediaModes = new Map();
+for (const groupKey of groupByKey.keys()) {
+  const groupAssignments = [...assignmentByRef.values()].filter((entry) => entry.group_key === groupKey);
+  const declaredMode = groupByKey.get(groupKey)?.media_mode;
+  const inferCarousel = version === '3' && !declaredMode &&
+    groupAssignments.length >= 2 && groupAssignments.length <= 10 &&
+    groupAssignments.every((entry) => entry.media_type === 'image');
+  const carouselMode = version === '3' && (declaredMode === 'carousel' || inferCarousel);
+  if (inferCarousel) {
+    // The model already proved membership visually. Older model responses may
+    // omit the new v3 field; retain the intake sequence rather than falling
+    // back to filename parsing or silently treating five cards as placements.
+    groupAssignments.sort((left, right) => Number(manifestByRef.get(left.media_ref)?.ordinal || 0) - Number(manifestByRef.get(right.media_ref)?.ordinal || 0))
+      .forEach((entry, index) => {
+        entry.role = 'carousel_card';
+        entry.carousel_card_index = index + 1;
+      });
+  }
+  const roles = groupAssignments.map((entry) => entry.role);
+  const requiredRoles = carouselMode
+    ? ['carousel_card']
+    : version === '3' && declaredMode === 'mixed'
+      ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video']
+    : version === '3' && declaredMode === 'video_only'
+      ? ['vertical_video']
+    : version === '2'
+    ? (roles.length === 1 && roles[0] === 'vertical_video'
+      ? ['vertical_video']
+      : ['feed_image', 'banner_image', 'vertical_image', 'vertical_video'])
+    : ['feed', 'banner', 'stories'];
+  const missingRoles = requiredRoles.filter((role) => !roles.includes(role));
+  const duplicateRoles = carouselMode ? [] : [...new Set(roles.filter((role, index) => roles.indexOf(role) !== index))];
+  const cardIndices = carouselMode ? groupAssignments.map((entry) => entry.carousel_card_index).sort((a, b) => a - b) : [];
+  const contiguousCards = carouselMode && cardIndices.length >= 2 && cardIndices.length <= 10 && cardIndices.every((value, index) => value === index + 1);
+  if (missingRoles.length || duplicateRoles.length || (carouselMode ? !contiguousCards : groupAssignments.length !== requiredRoles.length)) {
+    throw new Error(`Grupo visual incompleto ou ambiguo ${groupKey}. missing_roles=${JSON.stringify(missingRoles)} duplicate_roles=${JSON.stringify(duplicateRoles)} media=${groupAssignments.length}`);
+  }
+  groupMediaModes.set(groupKey, carouselMode
+    ? 'carousel'
+    : version === '3' && declaredMode === 'mixed'
+      ? 'mixed_group'
+    : version === '3' && declaredMode === 'video_only'
+      ? 'video_only'
+    : version !== '2'
+    ? 'static_group'
+    : requiredRoles.length === 1 ? 'video_only' : 'mixed_group');
+}
+
+const originals = sourceItems();
+const outputs = [];
+for (const entry of manifest) {
+  const mediaRef = text(entry.media_ref || entry.image_ref);
+  const assignment = assignmentByRef.get(mediaRef);
+  const group = groupByKey.get(assignment.group_key);
+  const original = originals[Number(entry.source_item_index)];
+  if (!original) throw new Error(`Midia original ausente para ${mediaRef}.`);
+  const binary = clone(original.binary || {});
+  if (!binary.data) throw new Error(`Binario principal ausente para ${mediaRef}.`);
+  if (assignment.media_type === 'video' && (!binary.thumbnail || !binary.analysis)) throw new Error(`Artefatos processados ausentes para ${mediaRef}.`);
+  outputs.push({
+    json: {
+      ...clone(object(original.json)),
+      visual_grouping: {
+        version,
+        strategy: 'ai_visual_global',
+        media_ref: mediaRef,
+        image_ref: version === '1' ? mediaRef : undefined,
+        media_type: assignment.media_type,
+        role: assignment.role,
+        slot: version === '1' ? assignment.role : assignment.role.replace(/_image$|_video$/, ''),
+        group_key: assignment.group_key,
+        media_mode: groupMediaModes.get(assignment.group_key),
+        visual_concept: group.visual_concept,
+        ratio: assignment.ratio,
+        confidence: assignment.confidence,
+        evidence: assignment.evidence,
+        group_confidence: group.confidence,
+        group_evidence: group.evidence,
+        offer_fingerprint: clone(group.offer_fingerprint),
+        carousel_card_index: assignment.carousel_card_index || undefined,
+        carousel_card_order_source: version === '3' && !text(group.media_mode)
+          ? 'intake_sequence_fallback_after_visual_membership'
+          : (assignment.carousel_card_index ? 'visual_agent' : undefined),
+      },
+    },
+    binary,
+  });
+}
+
+return outputs;

--- a/orb/engine/workflows/meta-ads-publish.current.json
+++ b/orb/engine/workflows/meta-ads-publish.current.json
@@ -1,0 +1,3494 @@
+{
+  "id": "eFJhFg79lyaycjlm",
+  "name": "Meta Ads – Publish",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {
+        "jsCode": "const DEFAULT_AD_STATUS = 'ACTIVE';\nconst CALIBRATION_AD_STATUS = 'PAUSED';\nconst CALIBRATION_FILE_PREFIXES = ['[TEST-VIDEO-ONLY]', '[TEST-CAROUSEL]'];\n// Build Jobs and the downstream quality gate must advance together. This\n// prevents a stale n8n node definition from quietly accepting a payload whose\n// destination contract was added by a newer workflow revision.\n// Increment this whenever a persisted creative body becomes incompatible. The\n// resume path deliberately reuses an existing mutation body, so the revision\n// is a hard boundary rather than merely descriptive metadata.\nconst WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';\n// The CTA is selected from the live campaign objective. Meta rejects BOOK_NOW\n// on dynamic OUTCOME_LEADS ad sets, while the other website contracts retain\n// the booking CTA. WhatsApp remains a URL destination, not a CTA policy.\nconst DEFAULT_CTA_TYPE = 'BOOK_NOW';\nconst OUTCOME_LEADS_CTA_TYPE = 'LEARN_MORE';\nconst WHATSAPP_CTA_TYPE = 'WHATSAPP_MESSAGE';\nconst RATIO_PRIORITY = ['4x5', '3x4', '2x1', '9x16'];\nconst TEMPORAL_GUARD_FRESH_DAYS = 7;\nconst VERTICAL_CROP_KEY = '90x160';\nconst HORIZONTAL_CROP_KEY = '191x100';\nconst FEED_FOUR_BY_FIVE_CROP_KEY = '400x500';\nconst VERTICAL_PUBLISHER_PLATFORMS = ['facebook', 'instagram', 'audience_network', 'whatsapp'];\nconst VERTICAL_FACEBOOK_POSITIONS = ['instream_video', 'story', 'facebook_reels'];\nconst VERTICAL_INSTAGRAM_POSITIONS = ['story', 'reels'];\nconst VERTICAL_AUDIENCE_NETWORK_POSITIONS = ['classic'];\nconst VERTICAL_WHATSAPP_POSITIONS = ['status'];\nconst VERTICAL_REWARDED_VIDEO_PLATFORMS = ['audience_network'];\nconst VERTICAL_REWARDED_VIDEO_POSITIONS = ['rewarded_video'];\nconst VIDEO_ONLY_SOCIAL_PLATFORMS = ['facebook', 'instagram'];\nconst VIDEO_ONLY_NETWORK_PLATFORMS = ['audience_network', 'whatsapp'];\nconst VIDEO_ONLY_FACEBOOK_POSITIONS = ['feed', 'instream_video', 'story', 'search', 'facebook_reels', 'facebook_reels_overlay', 'notification'];\nconst VIDEO_ONLY_INSTAGRAM_POSITIONS = ['stream', 'story', 'reels'];\nconst VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS = ['classic', 'rewarded_video'];\nconst VIDEO_ONLY_WHATSAPP_POSITIONS = ['status'];\n\nfunction safeString(value) {\n  return String(value ?? '').trim();\n}\n\nfunction calibrationMarkerForJob(job) {\n  const assets = [\n    ...safeArray(job && job.media_inventory),\n    ...safeArray(job && job.videos),\n    ...safeArray(job && job.imagens),\n    ...safeArray(job && job.arquivos),\n  ];\n  return assets.reduce((marker, asset) => {\n    if (marker) return marker;\n    const name = safeString(asset && (asset.original_name || asset.name || asset.file_name));\n    return CALIBRATION_FILE_PREFIXES.find((prefix) => name.toUpperCase().startsWith(prefix)) || '';\n  }, '');\n}\n\nfunction calibrationAdName(value, marker) {\n  const name = safeString(value);\n  const prefix = safeString(marker) || CALIBRATION_FILE_PREFIXES[0];\n  if (name.toUpperCase().startsWith(prefix)) return name.slice(0, 255);\n  return `${prefix} ${name || 'Media calibration'}`.slice(0, 255);\n}\n\nfunction toHttps(url) {\n  const value = safeString(url);\n  return value ? value.replace(/^http:\\/\\//i, 'https://') : '';\n}\n\nfunction deepClone(value) {\n  return value == null ? value : JSON.parse(JSON.stringify(value));\n}\n\nfunction safeArray(value) {\n  return Array.isArray(value) ? value : [];\n}\n\nfunction normalizeMediaMode(value, job) {\n  const mode = safeString(value);\n  if (mode === 'static_only' || mode === 'static_group') return 'static_only';\n  if (mode === 'mixed' || mode === 'mixed_group') return 'mixed';\n  if (mode === 'video_only') return 'video_only';\n  if (mode === 'carousel') return 'carousel';\n  if (safeArray(job && job.videos).length && safeArray(job && job.imagens).length) return 'mixed';\n  if (safeArray(job && job.videos).length) return 'video_only';\n  return 'static_only';\n}\n\nfunction asObject(value) {\n  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};\n}\n\nfunction normalizeLookupKey(value) {\n  return safeString(value).toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '');\n}\nfunction buildMetaConfigLookup() {\n  const map = new Map();\n  let rows = [];\n  try { rows = $items('Build Meta API Params From Vault') || []; } catch (error) { rows = []; }\n  for (const item of rows) {\n    const row = (item && item.json) || {};\n    const keys = [row.destination_group, row.row_number, row.destination_row_number, row.page_id, row.instagram_user_id, row.adset_id, row.account_id && row.destination_group ? `${row.account_id}:${row.destination_group}` : ''];\n    for (const key of keys) {\n      const normalized = normalizeLookupKey(key);\n      if (normalized && !map.has(normalized)) map.set(normalized, deepClone(row));\n    }\n  }\n  return map;\n}\nconst __metaConfigLookup = buildMetaConfigLookup();\nfunction metaConfigForDestination(destinationMeta) {\n  const keys = [destinationMeta.destination_group, destinationMeta.destination_row_number, destinationMeta.destination_page_id, destinationMeta.destination_instagram_user_id, destinationMeta.destination_adset_id, destinationMeta.destination_ad_account_id && destinationMeta.destination_group ? `${destinationMeta.destination_ad_account_id}:${destinationMeta.destination_group}` : ''];\n  for (const key of keys) {\n    const config = __metaConfigLookup.get(normalizeLookupKey(key));\n    if (config) return config;\n  }\n  return null;\n}\n\nfunction parseHttpsHostname(value) {\n  const url = toHttps(value);\n  const match = /^https:\\/\\/([^\\/?#\\s:@]+)(?::\\d+)?(?:[\\/?#]|$)/i.exec(url);\n  const hostname = safeString(match && match[1]).replace(/\\.$/, '').toLowerCase();\n  if (!hostname || hostname.includes('..')) return '';\n  return /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i.test(hostname) ? hostname : '';\n}\n\nfunction isAllowedLinkUrl(value, configuredHosts) {\n  const hostname = parseHttpsHostname(value);\n  if (!hostname) return false;\n  const allowed = new Set([\n    'api.whatsapp.com',\n    'wa.me',\n    'espacofacial.com',\n    'www.espacofacial.com',\n    ...safeArray(configuredHosts).map((host) => safeString(host).toLowerCase()),\n  ]);\n  return [...allowed].some((host) => hostname === host || hostname.endsWith(`.${host}`));\n}\n\nfunction safeHostname(value) {\n  return parseHttpsHostname(value);\n}\n\nfunction isWhatsAppHostname(value) {\n  const hostname = parseHttpsHostname(value);\n  return hostname === 'wa.me' || hostname === 'api.whatsapp.com' || hostname.endsWith('.whatsapp.com');\n}\n\nfunction contractFromSourceAd(ad) {\n  const creative = asObject(ad && ad.creative);\n  const feed = asObject(creative.asset_feed_spec);\n  const story = asObject(creative.object_story_spec);\n  const linkData = asObject(story.link_data);\n  const storyCta = asObject(linkData.call_to_action);\n  const ctaType = safeString(\n    safeArray(feed.call_to_action_types)[0] || storyCta.type\n  ).toUpperCase();\n  const linkUrl = toHttps(\n    safeArray(feed.link_urls)[0] && safeArray(feed.link_urls)[0].website_url ||\n    asObject(storyCta.value).link ||\n    linkData.link\n  );\n  if (!ctaType || !linkUrl) return null;\n  if (ctaType === WHATSAPP_CTA_TYPE && isWhatsAppHostname(linkUrl)) {\n    return { kind: 'whatsapp', cta_type: WHATSAPP_CTA_TYPE, link_url: linkUrl };\n  }\n  if (!isWhatsAppHostname(linkUrl)) {\n    return { kind: 'website', cta_type: ctaType, link_url: linkUrl };\n  }\n  return null;\n}\n\nfunction configuredDestinationKind(destinationMeta) {\n  const value = safeString(destinationMeta && destinationMeta.destination_type).toUpperCase();\n  if (/WHATSAPP|MESSAG/.test(value)) return 'whatsapp';\n  if (/WEBSITE|WEB|SITE/.test(value)) return 'website';\n  return '';\n}\n\nfunction ctaTypeForDestination(destinationMeta, usesWhatsAppDestination) {\n  if (usesWhatsAppDestination) return WHATSAPP_CTA_TYPE;\n  return safeString(destinationMeta && destinationMeta.campaign_objective).toUpperCase() === 'OUTCOME_LEADS'\n    ? OUTCOME_LEADS_CTA_TYPE\n    : DEFAULT_CTA_TYPE;\n}\n\nfunction resolveDestinationContract(job, destinationMeta, verifiedWebsiteUrl = '') {\n  const configuredKind = configuredDestinationKind(destinationMeta);\n  const configuredWhatsAppUrl = toHttps(destinationMeta && destinationMeta.whatsapp_destination_url);\n  const scopedContracts = safeArray(job && job.source_ads)\n    .filter((ad) => safeString(ad && ad.adset_id) === safeString(destinationMeta && destinationMeta.destination_adset_id))\n    .map(contractFromSourceAd)\n    .filter(Boolean);\n  const observedKinds = uniqueStrings(scopedContracts.map((contract) => contract.kind));\n\n  if (configuredKind && observedKinds.length && (observedKinds.length !== 1 || observedKinds[0] !== configuredKind)) {\n    return { ok: false, error: 'destination_contract_conflict', configured_kind: configuredKind, observed_kinds: observedKinds };\n  }\n  const kind = configuredKind || (observedKinds.length === 1 ? observedKinds[0] : '');\n  // A unit-specific landing-page mapping is an explicit Token Vault\n  // destination configuration. It is sufficient evidence for a website\n  // destination when legacy rows omit destination_type and no source creative\n  // is available in the ad inventory response.\n  const websiteUrl = toHttps(verifiedWebsiteUrl);\n  if (!kind && websiteUrl && !isWhatsAppHostname(websiteUrl)) {\n    return {\n      ok: true,\n      kind: 'website',\n      link_url: websiteUrl,\n      source: 'token_vault_landing_page_mapping',\n      configured_kind: configuredKind,\n      observed_source_ad_count: scopedContracts.length,\n    };\n  }\n  if (!kind) {\n    return {\n      ok: false,\n      error: observedKinds.length > 1 ? 'destination_contract_ambiguous' : 'destination_contract_unverified',\n      configured_kind: configuredKind,\n      observed_kinds: observedKinds,\n    };\n  }\n  if (kind === 'website') {\n    return {\n      ok: true,\n      kind,\n      source: configuredKind ? 'gateway_destination_type' : 'source_adset_creative',\n      configured_kind: configuredKind,\n      observed_source_ad_count: scopedContracts.length,\n    };\n  }\n  if (configuredKind === 'whatsapp') {\n    if (!isWhatsAppHostname(configuredWhatsAppUrl)) {\n      return {\n        ok: false,\n        error: 'destination_whatsapp_url_config_missing_or_invalid',\n        configured_kind: configuredKind,\n        observed_kinds: observedKinds,\n      };\n    }\n    return {\n      ok: true,\n      kind,\n      link_url: configuredWhatsAppUrl,\n      source: scopedContracts.length ? 'gateway_destination_contract_and_source_adset_creative' : 'gateway_destination_contract',\n      configured_kind: configuredKind,\n      observed_source_ad_count: scopedContracts.length,\n    };\n  }\n  const whatsappUrls = uniqueStrings(scopedContracts\n    .filter((contract) => contract.kind === 'whatsapp')\n    .map((contract) => contract.link_url));\n  if (whatsappUrls.length !== 1) {\n    return {\n      ok: false,\n      error: whatsappUrls.length > 1 ? 'destination_whatsapp_link_ambiguous' : 'destination_whatsapp_link_unverified',\n      configured_kind: configuredKind,\n      observed_kinds: observedKinds,\n    };\n  }\n  return {\n    ok: true,\n    kind,\n    link_url: whatsappUrls[0],\n    source: configuredKind ? 'gateway_destination_type_and_source_adset_creative' : 'source_adset_creative',\n    configured_kind: configuredKind,\n    observed_source_ad_count: scopedContracts.length,\n  };\n}\n\nfunction publicDestinationContract(contract) {\n  return {\n    kind: safeString(contract && contract.kind),\n    source: safeString(contract && contract.source),\n    configured_kind: safeString(contract && contract.configured_kind),\n    observed_source_ad_count: Number(contract && contract.observed_source_ad_count || 0),\n    link_host: safeHostname(contract && contract.link_url),\n  };\n}\n\n// Keep the contract beside the final Graph payload as well as beside its\n// resolution metadata. n8n may persist only selected Code-node fields after a\n// manual resume; reconstructing from the payload prevents that persistence\n// shape from stripping the fail-closed destination gate.\nfunction primaryLinkFromCreativePayload(payload) {\n  const story = asObject(asObject(payload).object_story_spec);\n  const videoCta = asObject(asObject(story.video_data).call_to_action);\n  const feed = asObject(asObject(payload).asset_feed_spec);\n  const feedLink = asObject(safeArray(feed.link_urls)[0]).website_url;\n  const linkData = asObject(story.link_data);\n  return toHttps(asObject(videoCta.value).link || feedLink || asObject(linkData.call_to_action).value?.link || linkData.link);\n}\n\nfunction ensureOutputDestinationContract(output) {\n  const row = asObject(output && output.json);\n  if (safeString(row.error)) return;\n  const linkUrl = primaryLinkFromCreativePayload(row.creativePayload);\n  const inferredKind = isWhatsAppHostname(linkUrl) ? 'whatsapp' : 'website';\n  const existing = asObject(row.destination_contract);\n  const kind = safeString(existing.kind).toLowerCase() || inferredKind;\n  if (kind !== 'whatsapp' && kind !== 'website') {\n    throw new Error('Build Jobs gerou contrato de destino invalido para ' + safeString(row.job_key) + '.');\n  }\n  if (kind === 'whatsapp' && !isWhatsAppHostname(linkUrl)) {\n    throw new Error('Build Jobs perdeu URL WhatsApp no payload final para ' + safeString(row.job_key) + '.');\n  }\n  if (kind === 'website' && (!linkUrl || isWhatsAppHostname(linkUrl))) {\n    throw new Error('Build Jobs perdeu landing page web no payload final para ' + safeString(row.job_key) + '.');\n  }\n  row.workflow_contract_revision = WORKFLOW_CONTRACT_REVISION;\n  row.destination_contract = {\n    kind,\n    source: safeString(existing.source) || 'final_graph_payload',\n    configured_kind: safeString(existing.configured_kind),\n    observed_source_ad_count: Number(existing.observed_source_ad_count || 0),\n    link_host: safeHostname(linkUrl),\n  };\n}\n\nfunction uniqueStrings(values) {\n  const out = [];\n  const seen = new Set();\n\n  for (const value of safeArray(values)) {\n    const normalized = safeString(value);\n    if (!normalized) continue;\n    const key = normalized.toLowerCase();\n    if (seen.has(key)) continue;\n    seen.add(key);\n    out.push(normalized);\n  }\n\n  return out;\n}\n\nfunction uniqueObjectsBy(values, getKey) {\n  const out = [];\n  const seen = new Set();\n\n  for (const value of safeArray(values)) {\n    const key = safeString(getKey(value));\n    if (!key || seen.has(key)) continue;\n    seen.add(key);\n    out.push(value);\n  }\n\n  return out;\n}\n\nfunction normalizeKey(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '_')\n    .replace(/_+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toUpperCase();\n}\n\nfunction normalizeCompactKey(value) {\n  return normalizeKey(value).replace(/_/g, '');\n}\n\nfunction detectRatio(value) {\n  const name = safeString(value).toLowerCase();\n  if (/(^|[^a-z0-9])2x1([^a-z0-9]|$)/i.test(name)) return '2x1';\n  if (/(^|[^a-z0-9])3x4([^a-z0-9]|$)/i.test(name)) return '3x4';\n  if (/(^|[^a-z0-9])4x5([^a-z0-9]|$)/i.test(name)) return '4x5';\n  if (/(^|[^a-z0-9])9x16([^a-z0-9]|$)/i.test(name)) return '9x16';\n  if (/(^|[^a-z0-9])1x1([^a-z0-9]|$)/i.test(name)) return '1x1';\n  if (/(^|[^a-z0-9])16x9([^a-z0-9]|$)/i.test(name)) return '16x9';\n  return '';\n}\n\nfunction detectRatioFromLabelName(labelName) {\n  const normalized = normalizeKey(labelName);\n\n  if (normalized.includes('IMAGE_1')) return '3x4';\n  if (normalized.includes('IMAGE_2')) return '2x1';\n  if (normalized.includes('IMAGE_3')) return '9x16';\n  if (normalized.includes('9X16')) return '9x16';\n  if (normalized.includes('16X9')) return '16x9';\n  if (normalized.includes('4X5')) return '4x5';\n  if (normalized.includes('3X4')) return '3x4';\n  if (normalized.includes('2X1')) return '2x1';\n  if (normalized.includes('1X1')) return '1x1';\n\n  return '';\n}\n\nfunction inferRatioFromImageCrops(imageCrops) {\n  const cropKeys = Object.keys(imageCrops || {}).map((key) => safeString(key));\n  const cropMap = {\n    '191x100': '2x1',\n    '100x100': '3x4',\n    '400x500': '4x5',\n    '300x400': '3x4',\n    '600x750': '4x5',\n    '768x1024': '3x4',\n    '90x160': '9x16',\n    '160x90': '16x9',\n    '1080x1920': '9x16',\n    '1920x1080': '16x9',\n    '1080x1080': '1x1',\n    '1200x628': '2x1',\n  };\n\n  for (const key of cropKeys) {\n    if (cropMap[key]) return cropMap[key];\n  }\n\n  return '';\n}\n\nfunction inferRatioFromRule(rule, creativeImages) {\n  const customization = rule && rule.customization_spec ? rule.customization_spec : {};\n  const imageLabel = rule && rule.image_label ? rule.image_label : {};\n  const ratioFromLabel = detectRatioFromLabelName(imageLabel.name);\n  if (ratioFromLabel) return ratioFromLabel;\n\n  const imageLabelId = safeString(imageLabel.id);\n  const creativeImage = safeArray(creativeImages).find((image) =>\n    safeArray(image && image.adlabels).some((label) => safeString(label && label.id) === imageLabelId)\n  );\n  const ratioFromCrop = inferRatioFromImageCrops(creativeImage && creativeImage.image_crops ? creativeImage.image_crops : {});\n  if (ratioFromCrop) return ratioFromCrop;\n\n  const allPositions = [\n    ...safeArray(customization.publisher_platforms),\n    ...safeArray(customization.facebook_positions),\n    ...safeArray(customization.instagram_positions),\n    ...safeArray(customization.audience_network_positions),\n    ...safeArray(customization.messenger_positions),\n  ].map((value) => safeString(value).toLowerCase());\n\n  if (allPositions.some((value) => ['story', 'stories', 'reels', 'facebook_reels', 'instagram_reels'].includes(value))) {\n    return '9x16';\n  }\n\n  if (allPositions.includes('search')) {\n    return '2x1';\n  }\n\n  if (allPositions.some((value) =>\n    [\n      'feed',\n      'stream',\n      'explore',\n      'explore_home',\n      'marketplace',\n      'notification',\n      'instream_video',\n      'video_feeds',\n      'right_hand_column',\n      'facebook_feed',\n      'instagram_stream',\n    ].includes(value)\n  )) {\n    return '3x4';\n  }\n\n  return '';\n}\n\nfunction buildReplacementPlanForAd(ad, mediaInventoryByRatio) {\n  const creative = ad && ad.creative ? ad.creative : {};\n  const assetFeed = creative.asset_feed_spec || {};\n  const rules = safeArray(assetFeed.asset_customization_rules);\n  const creativeImages = safeArray(assetFeed.images);\n  const plan = [];\n\n  for (const rule of rules) {\n    const ratio = inferRatioFromRule(rule, creativeImages);\n    if (!ratio) continue;\n\n    const mediaItem = mediaInventoryByRatio.get(ratio);\n    if (!mediaItem) continue;\n\n    plan.push({\n      ad_id: safeString(ad.id),\n      ad_name: safeString(ad.name),\n      creative_id: safeString(creative.id),\n      ratio,\n      binary_key: safeString(mediaItem.binary_key),\n      new_image_drive_id: safeString(mediaItem.id),\n      new_image_name: safeString(mediaItem.name),\n      target_image_label_id: safeString(rule && rule.image_label && rule.image_label.id),\n      target_image_label_name: safeString(rule && rule.image_label && rule.image_label.name),\n      rule_priority: rule && rule.priority != null ? rule.priority : null,\n      inferred_from_positions: true,\n    });\n  }\n\n  return uniqueObjectsBy(plan, (item) =>\n    [item.ad_id, item.ratio, item.target_image_label_id || item.target_image_label_name].join('::')\n  );\n}\n\nfunction hasCreativeAsset(asset) {\n  return Boolean(safeString(asset && asset.hash) || safeString(asset && asset.url));\n}\n\nfunction parseJsonObject(value) {\n  if (typeof value !== 'string') return null;\n\n  const text = value.trim();\n  if (!text) return null;\n\n  try {\n    const parsed = JSON.parse(text);\n    return parsed && typeof parsed === 'object' ? parsed : null;\n  } catch {\n    return null;\n  }\n}\n\nfunction unwrapAi(json) {\n  if (!json || typeof json !== 'object') return deepClone(json || {});\n  if (json.output && typeof json.output === 'object') return deepClone(json.output);\n\n  const parsedOutput = parseJsonObject(json.output);\n  if (parsedOutput) {\n    if (parsedOutput.output && typeof parsedOutput.output === 'object' && Object.keys(parsedOutput).length === 1) {\n      return deepClone(parsedOutput.output);\n    }\n\n    return deepClone(parsedOutput);\n  }\n\n  return deepClone(json || {});\n}\n\nfunction normalizeTextAssets(list, maxItems) {\n  const out = [];\n  const seen = new Set();\n\n  for (const entry of safeArray(list)) {\n    const text = safeString(typeof entry === 'string' ? entry : entry && entry.text);\n    if (!text) continue;\n\n    const key = text.toLowerCase();\n    if (seen.has(key)) continue;\n\n    seen.add(key);\n    out.push({ text });\n    if (out.length >= maxItems) break;\n  }\n\n  return out;\n}\n\nfunction mergeTextAssets(primaryList, fallbackList, maxItems) {\n  return normalizeTextAssets([\n    ...safeArray(primaryList),\n    ...safeArray(fallbackList),\n  ], maxItems);\n}\n\nfunction extractUrlCandidate(value) {\n  if (typeof value === 'string') return safeString(value);\n\n  if (value && typeof value === 'object') {\n    if (typeof value.website_url === 'string') return safeString(value.website_url);\n    if (typeof value.url === 'string') return safeString(value.url);\n    if (typeof value.href === 'string') return safeString(value.href);\n\n    if (value.website_url && typeof value.website_url === 'object') {\n      if (typeof value.website_url.url === 'string') return safeString(value.website_url.url);\n      if (typeof value.website_url.href === 'string') return safeString(value.website_url.href);\n    }\n  }\n\n  return '';\n}\n\nfunction isValidWebsiteUrl(url) {\n  return Boolean(parseHttpsHostname(url));\n}\n\nfunction removeEmptyFields(value) {\n  if (Array.isArray(value)) {\n    return value.map(removeEmptyFields).filter((item) => item !== undefined && item !== null && item !== '');\n  }\n  if (value && typeof value === 'object') {\n    const out = {};\n    for (const [key, inner] of Object.entries(value)) {\n      const cleaned = removeEmptyFields(inner);\n      const emptyObject = cleaned && typeof cleaned === 'object' && !Array.isArray(cleaned) && Object.keys(cleaned).length === 0;\n      const emptyArray = Array.isArray(cleaned) && cleaned.length === 0;\n      if (cleaned !== undefined && cleaned !== null && cleaned !== '' && !emptyObject && !emptyArray) {\n        out[key] = cleaned;\n      }\n    }\n    return out;\n  }\n  return value;\n}\n\nconst ADVANTAGE_PLUS_SITE_LINKS_MIN = 2;\nconst ADVANTAGE_PLUS_SITE_LINKS_MAX = 4;\nconst ADVANTAGE_PLUS_MAIN_FEATURES = Object.freeze({\n  add_text_overlay: 'Adicionar sobreposicoes',\n  music_generation: 'Adicionar musica',\n  pac_relaxation: 'Midia flexivel',\n  image_touchups: 'Retoques visuais',\n  text_optimizations: 'Melhorias no texto',\n});\nconst ADVANTAGE_PLUS_ESSENTIAL_FEATURES = Object.freeze({\n  inline_comment: 'Comentarios relevantes',\n  enhance_cta: 'Aprimorar CTA',\n  image_brightness_and_contrast: 'Ajustar brilho e contraste',\n});\nconst ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES = Object.freeze({\n  reveal_details_over_time: 'Revelar detalhes ao longo do tempo',\n  show_destination_blurbs: 'Mostrar detalhes do destino',\n  image_animation: 'Animacao de imagem',\n  site_extensions: 'Extensoes do site',\n});\nconst ADVANTAGE_PLUS_BASELINE_FEATURES = [\n  'add_text_overlay',\n  'image_touchups',\n  'text_optimizations',\n  'inline_comment',\n  'enhance_cta',\n  'image_brightness_and_contrast',\n  'reveal_details_over_time',\n  'show_destination_blurbs',\n  'image_animation',\n];\nconst ADVANTAGE_PLUS_CONDITIONAL_FEATURES = ['music_generation', 'pac_relaxation', 'site_extensions'];\n// Token Vault is the canonical Graph boundary. Video-only creatives must use\n// the same allowlisted feature keys it validates for every creative; prior\n// video-specific keys (adapt_to_placement/video_filtering/etc.) were rejected\n// before reaching Graph and cannot be treated as a publish fallback.\nconst VIDEO_ADVANTAGE_PLUS_MAIN_FEATURES = ADVANTAGE_PLUS_MAIN_FEATURES;\nconst VIDEO_ADVANTAGE_PLUS_ESSENTIAL_FEATURES = ADVANTAGE_PLUS_ESSENTIAL_FEATURES;\nconst VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES = ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES;\nconst VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES = ADVANTAGE_PLUS_BASELINE_FEATURES;\nconst VIDEO_ADVANTAGE_PLUS_CONDITIONAL_FEATURES = ADVANTAGE_PLUS_CONDITIONAL_FEATURES;\n\nfunction parseApiVersionMajor(version) {\n  const match = safeString(version).match(/^v?(\\d+)/i);\n  return match ? Number(match[1]) : 0;\n}\n\nfunction normalizeSiteLinks(list) {\n  const out = [];\n  const seen = new Set();\n  for (const entry of safeArray(list)) {\n    const title = safeString(\n      typeof entry === 'string'\n        ? ''\n        : entry && (entry.title || entry.site_link_title || entry.name || entry.label)\n    );\n    const url = safeString(extractUrlCandidate(entry));\n    if (!title || !/^https:\\/\\//i.test(url) || !isValidWebsiteUrl(url)) continue;\n    const key = title.toLowerCase() + '::' + url.toLowerCase();\n    if (seen.has(key)) continue;\n    seen.add(key);\n    out.push({\n      title,\n      url,\n      site_link_title: title,\n      site_link_url: url,\n    });\n    if (out.length >= ADVANTAGE_PLUS_SITE_LINKS_MAX) break;\n  }\n  return out;\n}\n\nfunction buildAdvantagePlusRequest({ apiVersion, siteLinks, musicEligible, pacEligible, mediaMode, sourceUrl }) {\n  if (parseApiVersionMajor(apiVersion) < 25) {\n    throw new Error(`Advantage+ Creative completo exige Marketing API v25.0; recebido ${safeString(apiVersion) || 'vazio'}.`);\n  }\n  const videoOnly = mediaMode === 'video_only';\n  const hasVideo = videoOnly || mediaMode === 'mixed';\n  const baselineFeatures = videoOnly ? VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES : ADVANTAGE_PLUS_BASELINE_FEATURES;\n  const mainFeatures = videoOnly ? VIDEO_ADVANTAGE_PLUS_MAIN_FEATURES : ADVANTAGE_PLUS_MAIN_FEATURES;\n  const essentialFeatures = videoOnly ? VIDEO_ADVANTAGE_PLUS_ESSENTIAL_FEATURES : ADVANTAGE_PLUS_ESSENTIAL_FEATURES;\n  const supplementalFeatures = videoOnly\n    ? VIDEO_ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES\n    : ADVANTAGE_PLUS_SUPPLEMENTAL_FEATURES;\n  const desiredFeatures = videoOnly\n    ? [...VIDEO_ADVANTAGE_PLUS_BASELINE_FEATURES, ...VIDEO_ADVANTAGE_PLUS_CONDITIONAL_FEATURES]\n    : [...ADVANTAGE_PLUS_BASELINE_FEATURES, ...ADVANTAGE_PLUS_CONDITIONAL_FEATURES];\n  const creativeFeaturesSpec = {};\n  const eligibleFeatures = [...baselineFeatures];\n  const skippedFeatures = [];\n  const skipReasons = {};\n  for (const feature of baselineFeatures) {\n    creativeFeaturesSpec[feature] = { enroll_status: 'OPT_IN' };\n  }\n\n  if (musicEligible) {\n    creativeFeaturesSpec.music_generation = { enroll_status: 'OPT_IN' };\n    eligibleFeatures.push('music_generation');\n  } else {\n    skippedFeatures.push('music_generation');\n    skipReasons.music_generation = 'adset_without_eligible_instagram_static_image_placement';\n  }\n\n  if (!videoOnly && pacEligible) {\n    creativeFeaturesSpec.pac_relaxation = { enroll_status: 'OPT_IN' };\n    eligibleFeatures.push('pac_relaxation');\n  } else {\n    skippedFeatures.push('pac_relaxation');\n    skipReasons.pac_relaxation = videoOnly\n      ? 'video_only_pac_relaxation_requires_separate_calibration'\n      : 'multiple_ratios_or_explicit_placement_rules_missing';\n  }\n\n  if (hasVideo) {\n    // Asset-feed video has no supported per-placement crop field. Live paused\n    // calibration with video_auto_crop=OPT_IN was acknowledged by Graph, but\n    // Ads Manager still rendered the exact 1080x1920 source as \"Original\".\n    // Keep those verified 9:16 pixels authoritative instead of allowing Meta\n    // to silently crop or generatively expand the source.\n    skippedFeatures.push('video_auto_crop', 'video_uncrop');\n    skipReasons.video_auto_crop = 'exact_9x16_source_already_satisfies_recommended_format_and_live_opt_in_calibration_kept_ads_manager_label_original';\n    skipReasons.video_uncrop = 'disabled_to_preserve_verified_9x16_source_without_silent_expansion';\n  }\n\n  const siteLinksEligible = siteLinks.length >= ADVANTAGE_PLUS_SITE_LINKS_MIN;\n  if (siteLinksEligible) {\n    creativeFeaturesSpec.site_extensions = { enroll_status: 'OPT_IN' };\n    eligibleFeatures.push('site_extensions');\n  } else {\n    skippedFeatures.push('site_extensions');\n    skipReasons.site_extensions = 'fewer_than_two_valid_site_links';\n  }\n\n  return {\n    featureKeyMode: 'add_text_overlay',\n    desiredFeatures,\n    requestedFeatures: Object.keys(creativeFeaturesSpec),\n    eligibleFeatures,\n    skippedFeatures,\n    skipReasons,\n    siteLinksEligible,\n    siteLinks: deepClone(siteLinks),\n    featureGroups: {\n      main: Object.entries(mainFeatures).map(([apiKey, label]) => ({\n        api_key: apiKey,\n        label,\n        requested: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey),\n        eligible: eligibleFeatures.includes(apiKey),\n        status: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey) ? 'requested' : 'ineligible',\n        reason: skipReasons[apiKey] || '',\n      })),\n      essential: Object.entries(essentialFeatures).map(([apiKey, label]) => ({\n        api_key: apiKey,\n        label,\n        requested: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey),\n        eligible: eligibleFeatures.includes(apiKey),\n        status: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey) ? 'requested' : 'ineligible',\n        reason: skipReasons[apiKey] || '',\n      })),\n      supplemental: Object.entries(supplementalFeatures).map(([apiKey, label]) => ({\n        api_key: apiKey,\n        label,\n        requested: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey),\n        eligible: eligibleFeatures.includes(apiKey),\n        status: Object.prototype.hasOwnProperty.call(creativeFeaturesSpec, apiKey) ? 'requested' : 'ineligible',\n        reason: skipReasons[apiKey] || '',\n      })),\n    },\n    creativeFeaturesSpec,\n    creativeSourcingSpec: removeEmptyFields({\n      source_url: toHttps(sourceUrl),\n      ...(siteLinksEligible\n        ? { site_links_spec: siteLinks.map((link) => ({\n            site_link_title: safeString(link.site_link_title || link.title),\n            site_link_url: toHttps(link.site_link_url || link.url),\n          })) }\n        : {}),\n    }),\n  };\n}\n\nfunction resolveLandingPage(destinationMeta, gatewayConfig, creativeGroupKey, allowedHosts) {\n  const map = asObject(destinationMeta.landing_pages_by_creative_group || gatewayConfig && gatewayConfig.landing_pages_by_creative_group);\n  const normalizedGroup = normalizeKey(creativeGroupKey);\n  const exactMatches = Object.entries(map).filter(([key]) => normalizeKey(key) === normalizedGroup);\n  const defaultMatches = Object.entries(map).filter(([key]) => ['DEFAULT', 'ALL'].includes(normalizeKey(key)) || safeString(key) === '*');\n  const uniqueUrls = uniqueStrings(Object.values(map));\n  const matches = exactMatches.length\n    ? exactMatches\n    : defaultMatches.length\n      ? defaultMatches\n      : uniqueUrls.length === 1\n        ? [Object.entries(map).find(([, value]) => safeString(value) === uniqueUrls[0])]\n        : [];\n  if (matches.length !== 1) {\n    return {\n      ok: false,\n      error: matches.length ? 'landing_page_mapping_ambiguous' : 'landing_page_mapping_missing',\n      configured_keys: Object.keys(map).map(normalizeKey).filter(Boolean),\n    };\n  }\n  const url = safeString(matches[0][1]);\n  if (!/^https:\\/\\//i.test(url) || !isAllowedLinkUrl(url, allowedHosts) || isWhatsAppHostname(url)) {\n    return {\n      ok: false,\n      error: isWhatsAppHostname(url) ? 'landing_page_redirects_to_whatsapp' : 'landing_page_invalid_or_not_allowed',\n      rejected_hostname: safeHostname(url) || 'invalid',\n    };\n  }\n  return {\n    ok: true,\n    url,\n    source: 'token_vault.landing_pages_by_creative_group',\n    configured_key: matches[0][0],\n  };\n}\n\nfunction isMusicEligible(placementEligibility) {\n  const eligibility = asObject(placementEligibility && placementEligibility.advantage_plus_eligibility);\n  if (eligibility.instagram_static_image_music === true) return true;\n  const targeting = asObject(placementEligibility && placementEligibility.targeting);\n  const publishers = safeArray(targeting.effective_publisher_platforms || targeting.publisher_platforms).map((value) => safeString(value).toLowerCase());\n  const instagram = safeArray(targeting.effective_instagram_positions || targeting.instagram_positions).map((value) => safeString(value).toLowerCase());\n  return publishers.includes('instagram') && instagram.some((value) => ['story', 'reels', 'stream'].includes(value));\n}\n\nfunction placementValues(placementEligibility, key) {\n  const targeting = asObject(placementEligibility && placementEligibility.targeting);\n  const effectiveKey = `effective_${key}`;\n  const values = safeArray(targeting[effectiveKey]).length ? targeting[effectiveKey] : targeting[key];\n  return safeArray(values).map((value) => safeString(value).toLowerCase()).filter(Boolean);\n}\n\nfunction videoOnlyPlacementContract(placementEligibility) {\n  const publishers = placementValues(placementEligibility, 'publisher_platforms');\n  const facebook = placementValues(placementEligibility, 'facebook_positions');\n  const instagram = placementValues(placementEligibility, 'instagram_positions');\n  const audienceNetwork = placementValues(placementEligibility, 'audience_network_positions');\n  const whatsapp = placementValues(placementEligibility, 'whatsapp_positions');\n  const required = {\n    publisher_platforms: VERTICAL_PUBLISHER_PLATFORMS,\n    facebook_positions: VIDEO_ONLY_FACEBOOK_POSITIONS,\n    instagram_positions: VIDEO_ONLY_INSTAGRAM_POSITIONS,\n    audience_network_positions: VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS,\n    whatsapp_positions: VIDEO_ONLY_WHATSAPP_POSITIONS,\n  };\n  const actual = { publisher_platforms: publishers, facebook_positions: facebook, instagram_positions: instagram, audience_network_positions: audienceNetwork, whatsapp_positions: whatsapp };\n  const missing = Object.fromEntries(Object.entries(required)\n    .map(([key, expected]) => [key, expected.filter((value) => !actual[key].includes(value))])\n    .filter(([, values]) => values.length));\n  const unsupported = {\n    facebook_positions: facebook.filter((value) => !VIDEO_ONLY_FACEBOOK_POSITIONS.includes(value)),\n    instagram_positions: instagram.filter((value) => !VIDEO_ONLY_INSTAGRAM_POSITIONS.includes(value)),\n    audience_network_positions: audienceNetwork.filter((value) => !VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS.includes(value)),\n    whatsapp_positions: whatsapp.filter((value) => !VIDEO_ONLY_WHATSAPP_POSITIONS.includes(value)),\n  };\n  const hasUnsupported = Object.values(unsupported).some((values) => values.length);\n  return {\n    ok: !Object.keys(missing).length && !hasUnsupported,\n    required,\n    actual,\n    missing,\n    unsupported,\n    // Messenger remains permitted on the ad set, but it is deliberately not\n    // represented here because the effective targeting exposes no Messenger\n    // sub-position that can be bound by an asset customization rule.\n    ignored_publishers: publishers.filter((value) => !VERTICAL_PUBLISHER_PLATFORMS.includes(value)),\n  };\n}\n\n\nfunction createLabel(seed, type, index) {\n  const base = normalizeKey(seed).toLowerCase().slice(0, 24) || 'asset';\n  return { name: ['placement_asset', base, type, index].join('_') };\n}\n\nfunction safeWarnings(jobWarnings, extraWarnings) {\n  return [\n    ...safeArray(jobWarnings),\n    ...safeArray(extraWarnings),\n  ];\n}\n\nfunction getBuildPayloadEntries() {\n  // A restored run contains a historical snapshot. It is a valid fallback\n  // only when there is no current Build Payload. Prefer the current graph so\n  // live placement/campaign facts (including the CTA policy) cannot be\n  // silently replaced by a stale resume record.\n  let currentItems = [];\n  try { currentItems = $('Build Payload').all(); } catch (error) { currentItems = []; }\n  const currentEntries = currentItems\n    .map((item) => ({\n      json: item.json || {},\n      binary: item.binary || {},\n    }))\n    .filter((entry) => entry.json && safeString(entry.json.job_key));\n  if (currentEntries.length) return currentEntries;\n\n  let restoredItems = [];\n  try { restoredItems = $items('Restore Publish Groups') || []; } catch (error) { restoredItems = []; }\n  return restoredItems\n    .map((item) => ({\n      json: item.json || {},\n      binary: item.binary || {},\n    }))\n    .filter((entry) => entry.json && safeString(entry.json.job_key));\n}\n\nfunction getBuildPayloadErrorEntries() {\n  return $('Build Payload')\n    .all()\n    .map((item) => ({\n      json: item.json || {},\n      binary: item.binary || {},\n    }))\n    .filter((entry) => entry.json && safeString(entry.json.error));\n}\n\nfunction buildFileToJob(jobEntries) {\n  const fileToJob = new Map();\n\n  for (const entry of jobEntries) {\n    const job = entry.json || {};\n    for (const media of [...safeArray(job.imagens), ...safeArray(job.videos)]) {\n      const imageName = safeString(media.name);\n      const originalName = safeString(media.original_name);\n      const ratio = safeString(media.proporcao || detectRatio(imageName || originalName));\n\n      const payload = {\n        job_key: safeString(job.job_key),\n        ratio,\n        role: safeString(media.role),\n        media_type: safeString(media.media_type || 'image'),\n        source_file_id: safeString(media.id),\n        source_file_name: imageName || originalName,\n        carousel_card_index: Number(media.carousel_card_index || 0),\n        upload_key: safeString(media.role) === 'carousel_card'\n          ? `carousel_card_${Number(media.carousel_card_index || 0)}`\n          : ratio,\n      };\n\n      if (imageName) fileToJob.set(normalizeKey(imageName), payload);\n      if (originalName) fileToJob.set(normalizeKey(originalName), payload);\n    }\n  }\n\n  return fileToJob;\n}\n\nfunction buildUploadedByJob(inputItems, fileToJob) {\n  const uploadItems = inputItems.map((item) => item.json || {});\n\n  const uploadedByJob = new Map();\n  const targetFor = (jobKey, accountId) => {\n    if (!jobKey || !accountId) return null;\n    if (!uploadedByJob.has(jobKey)) uploadedByJob.set(jobKey, new Map());\n    const byAccount = uploadedByJob.get(jobKey);\n    if (!byAccount.has(accountId)) byAccount.set(accountId, {});\n    return byAccount.get(accountId);\n  };\n\n  for (const item of uploadItems) {\n    if (item.video_id && item.upload_kind === 'video') {\n      const target = targetFor(safeString(item.job_key), safeString(item._gateway_account_id || item.account_id));\n      if (target) target.vertical_video = {\n        media_type: 'video', role: 'vertical_video', ratio: '9x16', video_id: safeString(item.video_id),\n        video_status: safeString(item.video_status), ready: item.ready === true,\n        width: Number(item.video_width || 0), height: Number(item.video_height || 0),\n        aspect_ratio: safeString(item.video_aspect_ratio),\n        recommended_aspect_ratio: safeString(item.video_recommended_aspect_ratio),\n        preferred_thumbnail_width: Number(item.preferred_thumbnail_width || 0),\n        preferred_thumbnail_height: Number(item.preferred_thumbnail_height || 0),\n        preferred_thumbnail_aspect_ratio: safeString(item.preferred_thumbnail_aspect_ratio),\n        source_file_id: safeString(item.source_file_id), source_file_name: safeString(item.source_file_name),\n        checksum_sha256: safeString(item.checksum_sha256), operation_key: safeString(item.status_operation_key),\n      };\n      continue;\n    }\n    for (const [filename, meta] of Object.entries(item.images || {})) {\n      const normalizedFilename = normalizeKey(filename);\n      // Gateway receipts retain their parent job_key, but do not retain the\n      // carousel card ordinal. Rehydrate the original media contract by the\n      // returned filename before choosing a target key. Otherwise every card\n      // collapses under its aspect ratio (for example, five 4:5 cards) and\n      // the strict carousel completeness guard correctly rejects the batch.\n      const mappedRef = fileToJob.get(normalizedFilename);\n      if (safeString(item.job_key) && mappedRef && safeString(mappedRef.job_key) !== safeString(item.job_key)) {\n        throw new Error(`Upload gateway retornou arquivo correlacionado a outro job: ${safeString(item.job_key)}.`);\n      }\n      const fileRef = mappedRef\n        ? {\n          ...mappedRef,\n          job_key: safeString(item.job_key) || safeString(mappedRef.job_key),\n          ratio: safeString(item.ratio) || safeString(mappedRef.ratio),\n          role: safeString(item.role) || safeString(mappedRef.role),\n          media_type: item.upload_kind === 'video_thumbnail' ? 'video_thumbnail' : safeString(mappedRef.media_type || 'image'),\n          source_file_id: safeString(item.source_file_id) || safeString(mappedRef.source_file_id),\n          source_file_name: safeString(item.source_file_name) || safeString(mappedRef.source_file_name),\n        }\n        : safeString(item.job_key)\n          ? { job_key: safeString(item.job_key), ratio: safeString(item.ratio), role: safeString(item.role), media_type: item.upload_kind === 'video_thumbnail' ? 'video_thumbnail' : 'image', source_file_id: safeString(item.source_file_id), source_file_name: safeString(item.source_file_name) }\n          : null;\n      if (!fileRef || !fileRef.job_key) continue;\n\n      const accountId = safeString(item._gateway_account_id || item.account_id);\n      if (!accountId) continue;\n      const target = targetFor(fileRef.job_key, accountId);\n      const targetKey = item.upload_kind === 'video_thumbnail'\n        ? 'vertical_video_thumbnail'\n        : (fileRef.upload_key || fileRef.ratio || detectRatio(filename));\n      target[targetKey] = {\n        ratio: fileRef.ratio || detectRatio(filename),\n        role: fileRef.role,\n        media_type: fileRef.media_type,\n        original_filename: safeString(filename),\n        source_file_id: fileRef.source_file_id,\n        source_file_name: fileRef.source_file_name,\n        carousel_card_index: Number(fileRef.carousel_card_index || 0),\n        hash: safeString(meta && meta.hash),\n        url: toHttps(meta && meta.url),\n        width: Number(meta && meta.width),\n        height: Number(meta && meta.height),\n      };\n    }\n  }\n\n  return uploadedByJob;\n}\n\nfunction buildFallbackUploadPool(inputItems) {\n  const uploadItems = inputItems\n    .map((item) => item.json || {})\n    .filter((json) => json.images && typeof json.images === 'object');\n\n  const pool = [];\n  const seen = new Set();\n\n  for (const item of uploadItems) {\n    for (const [filename, meta] of Object.entries(item.images || {})) {\n      const hash = safeString(meta && meta.hash);\n      const url = toHttps(meta && meta.url);\n      if (!hash && !url) continue;\n\n      const ratio = safeString(detectRatio(filename));\n      const dedupeKey = [hash, url, ratio].join('::');\n      if (seen.has(dedupeKey)) continue;\n      seen.add(dedupeKey);\n\n      pool.push({\n        ratio,\n        original_filename: safeString(filename),\n        source_file_id: '',\n        source_file_name: safeString(filename),\n        hash,\n        url,\n        width: Number(meta && meta.width),\n        height: Number(meta && meta.height),\n      });\n    }\n  }\n\n  return pool;\n}\n\nfunction buildAiByJob(inputItems, jobEntries) {\n  // This node receives a Merge containing Livia output plus image/video upload\n  // receipts.  Upload receipts also carry job_key, so job_key alone is never\n  // evidence of an AI response.  Treat only a parsed creative_override as copy.\n  const aiItems = inputItems\n    .map((item, input_index) => ({ item: item.json || {}, input_index }))\n    .map(({ item, input_index }) => ({ item, ai: unwrapAi(item), input_index }))\n    .filter(({ ai }) => Object.keys(asObject(ai.creative_override)).length > 0);\n\n  const jobsByKey = new Map();\n  const jobsBySourceName = new Map(jobEntries.map((entry) => [normalizeKey(entry.json.source_ad_name), safeString(entry.json.job_key)]));\n  const jobsByGroupKey = new Map(jobEntries.map((entry) => [normalizeKey(entry.json.group_key), safeString(entry.json.job_key)]));\n\n  for (const entry of jobEntries) {\n    const key = safeString(entry.json && entry.json.job_key);\n    if (!key) continue;\n    jobsByKey.set(key, key);\n    jobsByKey.set(normalizeKey(key), key);\n  }\n\n  const aiByJob = new Map();\n  const unmappedInputIndexes = [];\n  const conflictingJobKeys = new Set();\n\n  for (const { item, ai, input_index } of aiItems) {\n    const directKey = safeString(ai.job_key || item.job_key);\n    const aiSourceName = safeString(ai.source_ad_name || item.source_ad_name);\n    const aiGroupKey = safeString(ai.group_key || ai.nome_base || item.group_key);\n    const resolvedJobKey =\n      jobsByKey.get(directKey) ||\n      jobsByKey.get(normalizeKey(directKey)) ||\n      jobsBySourceName.get(normalizeKey(aiSourceName)) ||\n      jobsByGroupKey.get(normalizeKey(aiGroupKey)) ||\n      (jobEntries.length === 1 && aiItems.length === 1 ? safeString(jobEntries[0].json.job_key) : '');\n\n    if (!resolvedJobKey) {\n      unmappedInputIndexes.push(input_index);\n      continue;\n    }\n    if (aiByJob.has(resolvedJobKey)) {\n      conflictingJobKeys.add(resolvedJobKey);\n      continue;\n    }\n    aiByJob.set(resolvedJobKey, ai);\n  }\n\n  return {\n    aiByJob,\n    diagnostics: {\n      candidate_count: aiItems.length,\n      mapped_job_keys: [...aiByJob.keys()],\n      unmapped_candidate_count: unmappedInputIndexes.length,\n      conflicting_job_keys: [...conflictingJobKeys],\n    },\n  };\n}\n\nfunction buildOrderedAssets(job, uploaded) {\n  if (safeString(job && job.media_mode) === 'carousel') {\n    return safeArray(job.carousel_cards || job.imagens)\n      .slice()\n      .sort((left, right) => Number(left.carousel_card_index || 0) - Number(right.carousel_card_index || 0))\n      .map((card) => uploaded[`carousel_card_${Number(card.carousel_card_index || 0)}`])\n      .filter(Boolean);\n  }\n  const requiredRatios = safeArray(job.required_ratios).length ? safeArray(job.required_ratios) : RATIO_PRIORITY;\n  const ordered = requiredRatios.map((ratio) => uploaded[ratio]).filter(Boolean);\n  if (ordered.length) return ordered;\n  return RATIO_PRIORITY.map((ratio) => uploaded[ratio]).filter(Boolean);\n}\n\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\n\nfunction buildCenteredCrop(widthValue, heightValue, targetWidth, targetHeight) {\n  const width = Math.trunc(Number(widthValue));\n  const height = Math.trunc(Number(heightValue));\n  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;\n\n  const targetRatio = targetWidth / targetHeight;\n  const sourceRatio = width / height;\n  if (Math.abs(sourceRatio - targetRatio) < 0.000001) {\n    return [[0, 0], [width, height]];\n  }\n\n  // Meta evaluates image_crops against the exact integer ratio encoded in the\n  // crop key.  Rounding only one edge can produce a crop such as 1731x906 for\n  // 191x100, which looks correct locally but is rejected by the creative API.\n  // When the source is large enough, retain the largest centred crop whose\n  // dimensions are an exact integer multiple of the requested ratio.\n  const exactScale = Math.floor(Math.min(width / targetWidth, height / targetHeight));\n  if (exactScale >= 1) {\n    const cropWidth = targetWidth * exactScale;\n    const cropHeight = targetHeight * exactScale;\n    const left = Math.max(0, Math.floor((width - cropWidth) / 2));\n    const top = Math.max(0, Math.floor((height - cropHeight) / 2));\n    return [[left, top], [left + cropWidth, top + cropHeight]];\n  }\n\n  if (sourceRatio > targetRatio) {\n    const cropWidth = Math.max(1, Math.round(height * targetRatio));\n    const left = Math.max(0, Math.floor((width - cropWidth) / 2));\n    return [[left, 0], [Math.min(width, left + cropWidth), height]];\n  }\n\n  const cropHeight = Math.max(1, Math.round(width / targetRatio));\n  const top = Math.max(0, Math.floor((height - cropHeight) / 2));\n  return [[0, top], [width, Math.min(height, top + cropHeight)]];\n}\n\nfunction buildImageCrops(asset) {\n  const ratio = safeString(asset && asset.ratio);\n  if (ratio === '4x5') {\n    const crop = buildCenteredCrop(asset && asset.width, asset && asset.height, 4, 5);\n    return crop ? { [FEED_FOUR_BY_FIVE_CROP_KEY]: crop } : undefined;\n  }\n  if (ratio === '9x16') {\n    const crop = buildCenteredCrop(asset && asset.width, asset && asset.height, 9, 16);\n    return crop ? { [VERTICAL_CROP_KEY]: crop } : undefined;\n  }\n  if (ratio === '2x1') {\n    const crop = buildCenteredCrop(asset && asset.width, asset && asset.height, 191, 100);\n    return crop ? { [HORIZONTAL_CROP_KEY]: crop } : undefined;\n  }\n  return undefined;\n}\n\nfunction buildSourceAssetFallback(job, preferredAd) {\n  const sourceAds = safeArray(job.source_ads);\n  const sourceAd =\n    preferredAd ||\n    sourceAds.find((ad) => safeString(ad && ad.id) === safeString(job.source_ad_id)) ||\n    sourceAds[0] ||\n    null;\n\n  if (!sourceAd || !sourceAd.creative || typeof sourceAd.creative !== 'object') return null;\n\n  const creative = sourceAd.creative;\n  const assetImages = safeArray(creative.asset_feed_spec && creative.asset_feed_spec.images);\n  const candidateFromAssetFeed = assetImages.find((image) =>\n    Boolean(safeString(image && image.hash) || safeString(image && image.url))\n  ) || null;\n\n  const hash = safeString((candidateFromAssetFeed && candidateFromAssetFeed.hash) || creative.image_hash);\n  const url = toHttps((candidateFromAssetFeed && candidateFromAssetFeed.url) || creative.image_url || creative.thumbnail_url);\n  if (!hash && !url) return null;\n\n  const preferredRatio = safeString(safeArray(job.required_ratios)[0]) || '3x4';\n\n  return {\n    ratio: preferredRatio,\n    original_filename: safeString(sourceAd.name || job.source_ad_name || 'source_fallback'),\n    source_file_id: safeString(sourceAd.id),\n    source_file_name: safeString(sourceAd.name || job.source_ad_name || 'source_fallback'),\n    hash,\n    url,\n  };\n}\n\nfunction buildMediaInventoryByRatio(job) {\n  const inventory = new Map();\n  const candidates = safeArray(job.media_inventory).length ? safeArray(job.media_inventory) : safeArray(job.imagens);\n\n  for (const item of candidates) {\n    const ratio = safeString(item.ratio || item.proporcao || detectRatio(item.name || item.original_name));\n    if (!ratio || inventory.has(ratio)) continue;\n    inventory.set(ratio, {\n      id: safeString(item.id),\n      name: safeString(item.name || item.original_name),\n      binary_key: safeString(item.binary_key || `data_${ratio.replace(/[^a-zA-Z0-9]+/g, '_')}`),\n    });\n  }\n\n  return inventory;\n}\n\nfunction buildDestinationAliases(destinationGroup) {\n  const aliases = new Set();\n  const normalized = normalizeKey(destinationGroup);\n  const compact = normalizeCompactKey(destinationGroup);\n  if (normalized) aliases.add(normalized);\n  if (compact) aliases.add(compact);\n\n  if (/BARRA.*SHOPPING.*SUL|BARRASHOPPINGSUL/i.test(normalized)) {\n    aliases.add('BARRASHOPPINGSUL');\n    aliases.add('BARRA_SHOPPING_SUL');\n    aliases.add('BSS');\n  }\n\n  if (/NOVO.*HAMBURGO|NOVOHAMBURGO/i.test(normalized)) {\n    aliases.add('NOVOHAMBURGO');\n    aliases.add('NOVO_HAMBURGO');\n    aliases.add('NH');\n  }\n\n  return [...aliases];\n}\n\nfunction normalizeNameSegment(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '')\n    .toLowerCase();\n}\n\nfunction buildCanonicalAdName(sourceAdName, destinationGroup, offerFingerprintTag) {\n  const source = safeString(sourceAdName).replace(/\\s*\\[OFV1:[A-Z0-9]+\\]/ig, '').trim();\n  const destination = safeString(destinationGroup);\n  const tag = safeString(offerFingerprintTag);\n  const tagToken = tag ? `[${tag}]` : '';\n  const preserveTag = (name) => {\n    const normalizedName = safeString(name);\n    if (!tagToken) return normalizedName.slice(0, 255);\n    if (!normalizedName) return tagToken.slice(0, 255);\n    const availableNameLength = Math.max(0, 255 - tagToken.length - 1);\n    return `${normalizedName.slice(0, availableNameLength).trimEnd()} ${tagToken}`.trim();\n  };\n\n  if (!source) return preserveTag(destination);\n  if (!destination) return preserveTag(source);\n\n  const sourceParts = source\n    .split('|')\n    .map((part) => safeString(part))\n    .filter(Boolean);\n\n  if (!sourceParts.length) return preserveTag(destination);\n\n  const lastPart = sourceParts[sourceParts.length - 1];\n  const canonical = normalizeNameSegment(lastPart) === normalizeNameSegment(destination)\n    ? sourceParts.join(' | ')\n    : [...sourceParts, destination].join(' | ');\n  // The offer tag is a replacement-safety guard, not decorative metadata.\n  // Trim the descriptive prefix first so the tag survives the Meta name cap.\n  return preserveTag(canonical);\n}\n\nfunction buildVariantAdName(canonicalAdName, variantSuffix, offerFingerprintTag) {\n  const base = safeString(canonicalAdName).replace(/\\s*\\[OFV1:[A-Z0-9]+\\]/ig, '').trim();\n  const suffix = safeString(variantSuffix);\n  const tag = safeString(offerFingerprintTag);\n  const tagToken = tag ? `[${tag}]` : '';\n  const fixedTail = [suffix, tagToken].filter(Boolean).join(' ');\n  if (!fixedTail) return base.slice(0, 255);\n  if (!base) return fixedTail.slice(0, 255);\n  const availableBaseLength = Math.max(0, 255 - fixedTail.length - 1);\n  return `${base.slice(0, availableBaseLength).trimEnd()} ${fixedTail}`.trim();\n}\n\nfunction parseMetaTimestamp(value) {\n  const raw = safeString(value);\n  if (!raw) return NaN;\n  const normalized = raw.replace(/([+-]\\d{2})(\\d{2})$/, '$1:$2');\n  const ms = Date.parse(normalized);\n  return Number.isFinite(ms) ? ms : NaN;\n}\n\nfunction isoFromMs(ms) {\n  return Number.isFinite(ms) ? new Date(ms).toISOString() : '';\n}\n\nfunction buildTemporalCandidateInfo(ad, freshnessCutoffMs) {\n  const creative = ad && ad.creative && typeof ad.creative === 'object' ? ad.creative : {};\n  const candidates = [\n    { field: 'updated_time', value: safeString(ad && ad.updated_time), ms: parseMetaTimestamp(ad && ad.updated_time) },\n    { field: 'created_time', value: safeString(ad && ad.created_time), ms: parseMetaTimestamp(ad && ad.created_time) },\n    { field: 'creative.updated_time', value: safeString(creative.updated_time), ms: parseMetaTimestamp(creative.updated_time) },\n    { field: 'creative.created_time', value: safeString(creative.created_time), ms: parseMetaTimestamp(creative.created_time) },\n  ].filter((entry) => Number.isFinite(entry.ms));\n\n  candidates.sort((left, right) => right.ms - left.ms);\n  const latest = candidates[0] || null;\n  const hasKnownTime = Boolean(latest);\n  const isFresh = Boolean(hasKnownTime && latest.ms >= freshnessCutoffMs);\n\n  return {\n    created_time: safeString(ad && ad.created_time),\n    updated_time: safeString(ad && ad.updated_time),\n    creative_created_time: safeString(creative.created_time),\n    creative_updated_time: safeString(creative.updated_time),\n    candidate_last_mutation_field: latest ? latest.field : '',\n    candidate_last_mutation_time: latest ? latest.value : '',\n    candidate_last_mutation_iso: latest ? isoFromMs(latest.ms) : '',\n    candidate_last_mutation_ms: latest ? latest.ms : null,\n    has_known_time: hasKnownTime,\n    is_fresh: isFresh,\n    freshness_cutoff: isoFromMs(freshnessCutoffMs),\n    freshness_window_days: TEMPORAL_GUARD_FRESH_DAYS,\n  };\n}\n\nfunction compareRankedCandidates(left, right) {\n  if (left.temporal.is_fresh !== right.temporal.is_fresh) return left.temporal.is_fresh ? 1 : -1;\n  if (!left.temporal.is_fresh && left.temporal.has_known_time !== right.temporal.has_known_time) {\n    return left.temporal.has_known_time ? -1 : 1;\n  }\n\n  const scoreDiff = right.score - left.score;\n  if (scoreDiff) return scoreDiff;\n\n  const leftTime = Number.isFinite(left.temporal.candidate_last_mutation_ms) ? left.temporal.candidate_last_mutation_ms : Number.MAX_SAFE_INTEGER;\n  const rightTime = Number.isFinite(right.temporal.candidate_last_mutation_ms) ? right.temporal.candidate_last_mutation_ms : Number.MAX_SAFE_INTEGER;\n  return leftTime - rightTime;\n}\n\nfunction summarizeAd(ad, score, reasons, temporal) {\n  const temporalInfo = temporal || buildTemporalCandidateInfo(ad, Date.now() - TEMPORAL_GUARD_FRESH_DAYS * 24 * 60 * 60 * 1000);\n  return {\n    ad_id: safeString(ad && ad.id),\n    ad_name: safeString(ad && ad.name),\n    adset_id: safeString(ad && ad.adset_id),\n    campaign_id: safeString(ad && ad.campaign_id),\n    page_id: safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.page_id),\n    instagram_user_id: safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.instagram_user_id),\n    created_time: temporalInfo.created_time,\n    updated_time: temporalInfo.updated_time,\n    creative_created_time: temporalInfo.creative_created_time,\n    creative_updated_time: temporalInfo.creative_updated_time,\n    candidate_last_mutation_time: temporalInfo.candidate_last_mutation_time,\n    candidate_last_mutation_iso: temporalInfo.candidate_last_mutation_iso,\n    temporal_has_known_time: temporalInfo.has_known_time,\n    temporal_is_fresh: temporalInfo.is_fresh,\n    score,\n    reasons,\n  };\n}\n\nfunction hasHardDestinationMismatch(ad, destinationMeta) {\n  const adsetId = safeString(ad && ad.adset_id);\n  const pageId = safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.page_id);\n  const instagramUserId = safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.instagram_user_id);\n  const destinationAdsetId = safeString(destinationMeta.destination_adset_id);\n  const destinationPageId = safeString(destinationMeta.destination_page_id);\n  const destinationInstagramUserId = safeString(destinationMeta.destination_instagram_user_id);\n\n  return Boolean(\n    (destinationAdsetId && adsetId && adsetId !== destinationAdsetId) ||\n    (destinationPageId && pageId && pageId !== destinationPageId) ||\n    (destinationInstagramUserId && instagramUserId && instagramUserId !== destinationInstagramUserId)\n  );\n}\n\nfunction scoreSourceAdForDestination(ad, destinationMeta, aliases, preferredIds, temporalInfo) {\n  const reasons = [];\n  let score = 0;\n\n  if (hasHardDestinationMismatch(ad, destinationMeta)) {\n    return { score: 0, reasons: ['destination_id_mismatch'] };\n  }\n\n  const adId = safeString(ad && ad.id);\n  const adsetId = safeString(ad && ad.adset_id);\n  const campaignId = safeString(ad && ad.campaign_id);\n  const pageId = safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.page_id);\n  const instagramUserId = safeString(ad && ad.creative && ad.creative.object_story_spec && ad.creative.object_story_spec.instagram_user_id);\n  const adNameKey = normalizeKey(ad && ad.name);\n  const adNameCompact = normalizeCompactKey(ad && ad.name);\n\n  if (preferredIds.has(adId)) {\n    if (temporalInfo && temporalInfo.is_fresh) {\n      reasons.push('selected_ad_id_fresh_ignored');\n    } else {\n      score += 500;\n      reasons.push('selected_ad_id');\n    }\n  }\n\n  if (adsetId && adsetId === safeString(destinationMeta.destination_adset_id)) {\n    score += 1000;\n    reasons.push('adset_id');\n  }\n\n  if (campaignId && campaignId === safeString(destinationMeta.destination_campaign_id)) {\n    score += 220;\n    reasons.push('campaign_id');\n  }\n\n  if (pageId && pageId === safeString(destinationMeta.destination_page_id)) {\n    score += 160;\n    reasons.push('page_id');\n  }\n\n  if (instagramUserId && instagramUserId === safeString(destinationMeta.destination_instagram_user_id)) {\n    score += 160;\n    reasons.push('instagram_user_id');\n  }\n\n  for (const alias of aliases) {\n    if (!alias) continue;\n    if (adNameKey.includes(alias) || adNameCompact.includes(alias.replace(/_/g, ''))) {\n      score += 120;\n      reasons.push(`alias:${alias}`);\n      break;\n    }\n  }\n\n  return {\n    score,\n    reasons,\n  };\n}\n\nfunction createExpandedJobKey(parentJobKey, destinationMeta) {\n  return [\n    safeString(parentJobKey),\n    normalizeKey(destinationMeta.destination_group || destinationMeta.destination_row_number || 'DEST')\n  ].filter(Boolean).join('__');\n}\n\nfunction expandAssembledInputs(items, jobs) {\n  const jobByKey = new Map(jobs.map((entry) => [safeString(entry.json && entry.json.job_key), entry.json || {}]));\n  const assemblies = new Map();\n  const expanded = [];\n\n  for (const item of items) {\n    const assembly = item.json || {};\n    if (safeString(assembly.job_input_assembly_version) !== '2') {\n      throw new Error('Build Jobs aceita somente itens produzidos por Assemble Job Inputs v2.');\n    }\n    const jobKey = safeString(assembly.job_key);\n    const job = jobByKey.get(jobKey);\n    if (!job) throw new Error(`Build Jobs recebeu assembly nao correlacionado; job_key=${jobKey || 'vazio'}.`);\n    if (assemblies.has(jobKey)) throw new Error(`Build Jobs recebeu assembly duplicado para ${jobKey}.`);\n    const envelope = asObject(assembly.media_upload_envelope);\n    const ai = asObject(assembly.ai_output);\n    if (safeString(envelope.media_upload_envelope_version) !== '2' || envelope.ready !== true) {\n      throw new Error(`Envelope de midia invalido em ${jobKey}.`);\n    }\n    if (safeString(envelope.job_key) !== jobKey || safeString(envelope.group_key) !== safeString(job.group_key)) {\n      throw new Error(`Envelope de midia diverge do Build Payload em ${jobKey}.`);\n    }\n    if (!Object.keys(asObject(ai.creative_override)).length) {\n      throw new Error(`Assembly sem creative_override valido em ${jobKey}.`);\n    }\n    assemblies.set(jobKey, assembly);\n    for (const receipt of [...safeArray(envelope.image_uploads), ...safeArray(envelope.video_uploads)]) {\n      expanded.push({ json: deepClone(receipt) });\n    }\n    expanded.push({ json: deepClone(ai) });\n  }\n\n  for (const jobKey of jobByKey.keys()) {\n    if (!assemblies.has(jobKey)) throw new Error(`Assembly ausente para ${jobKey}.`);\n  }\n  return expanded;\n}\n\nconst assembledInputItems = $input.all();\nconst jobEntries = getBuildPayloadEntries();\nconst buildPayloadErrors = getBuildPayloadErrorEntries();\n\nfunction isCurrentVideoOnlyResumeContract(row) {\n  const mediaMode = normalizeMediaMode(row && row.media_mode, row || {});\n  if (mediaMode !== 'video_only') return true;\n  const feed = asObject(asObject(row && row.creativePayload).asset_feed_spec);\n  const rules = safeArray(feed.asset_customization_rules);\n  if (safeArray(feed.images).length || safeArray(feed.videos).length !== 1 || rules.length !== 2) return false;\n  const labelsFrom = (assets) => safeArray(assets).map((asset) => safeString(asset && asset.adlabels && asset.adlabels[0] && asset.adlabels[0].name)).filter(Boolean);\n  const bodyLabels = labelsFrom(feed.bodies);\n  const titleLabels = labelsFrom(feed.titles);\n  const descriptionLabels = labelsFrom(feed.descriptions);\n  if ([bodyLabels, titleLabels, descriptionLabels].some((labels) => labels.length !== 5 || new Set(labels).size !== 5)) return false;\n  const hasExpectedLabels = (rule) => safeString(rule && rule.video_label && rule.video_label.name) === 'vertical_video' &&\n    bodyLabels.includes(safeString(rule && rule.body_label && rule.body_label.name)) &&\n    titleLabels.includes(safeString(rule && rule.title_label && rule.title_label.name)) &&\n    descriptionLabels.includes(safeString(rule && rule.description_label && rule.description_label.name)) &&\n    !safeString(rule && rule.image_label && rule.image_label.name);\n  const mainRule = rules.find((rule) => {\n    const spec = asObject(rule && rule.customization_spec);\n    return safeArray(spec.publisher_platforms).map(safeString).sort().join(',') === 'audience_network,facebook,instagram,whatsapp' &&\n      safeArray(spec.audience_network_positions).map(safeString).join(',') === 'classic';\n  });\n  const rewardedRule = rules.find((rule) => {\n    const spec = asObject(rule && rule.customization_spec);\n    return safeArray(spec.publisher_platforms).map(safeString).join(',') === 'audience_network' &&\n      safeArray(spec.audience_network_positions).map(safeString).join(',') === 'rewarded_video';\n  });\n  return Boolean(mainRule && rewardedRule && hasExpectedLabels(mainRule) && hasExpectedLabels(rewardedRule) &&\n    safeString(mainRule.body_label && mainRule.body_label.name) !== safeString(rewardedRule.body_label && rewardedRule.body_label.name) &&\n    safeString(mainRule.title_label && mainRule.title_label.name) !== safeString(rewardedRule.title_label && rewardedRule.title_label.name) &&\n    safeString(mainRule.description_label && mainRule.description_label.name) !== safeString(rewardedRule.description_label && rewardedRule.description_label.name));\n}\n\nfunction isCurrentCarouselResumeContract(row) {\n  const mediaMode = normalizeMediaMode(row && row.media_mode, row || {});\n  if (mediaMode !== 'carousel') return true;\n  const payload = asObject(row && row.creativePayload);\n  const story = asObject(payload.object_story_spec);\n  const feed = asObject(payload.asset_feed_spec);\n  const formats = safeArray(feed.ad_formats).map((value) => safeString(value).toUpperCase()).filter(Boolean);\n  const images = safeArray(feed.images);\n  const carousels = safeArray(feed.carousels);\n  const cards = safeArray(asObject(carousels[0]).child_attachments);\n  if (Object.keys(asObject(story.link_data)).length || formats.length !== 1 || formats[0] !== 'CAROUSEL' ||\n      images.length < 2 || images.length > 10 || carousels.length !== 1 || cards.length !== images.length ||\n      asObject(carousels[0]).multi_share_optimized !== false) return false;\n  const labelsFrom = (assets) => new Set(safeArray(assets).flatMap((asset) => safeArray(asset && asset.adlabels).map((label) => safeString(label && label.name))).filter(Boolean));\n  const imageLabels = labelsFrom(images);\n  const bodyLabels = labelsFrom(feed.bodies);\n  const titleLabels = labelsFrom(feed.titles);\n  const descriptionLabels = labelsFrom(feed.descriptions);\n  const linkLabels = labelsFrom(feed.link_urls);\n  const ctaTypes = safeArray(feed.call_to_action_types).map((value) => safeString(value).toUpperCase()).filter(Boolean);\n  if (ctaTypes.length !== 1 || !ctaTypes[0] || safeArray(feed.call_to_actions).length) return false;\n  return cards.every((card) => {\n    const child = asObject(card);\n    return imageLabels.has(safeString(asObject(child.image_label).name)) &&\n      bodyLabels.has(safeString(asObject(child.body_label).name)) &&\n      titleLabels.has(safeString(asObject(child.title_label).name)) &&\n      descriptionLabels.has(safeString(asObject(child.description_label).name)) &&\n      linkLabels.has(safeString(asObject(child.link_url_label).name)) &&\n      !safeString(asObject(child.call_to_action_type_label).name);\n  });\n}\n\nfunction persistedResumeJobs() {\n  let restored = [];\n  try { restored = $items('Restore Publish Groups') || []; } catch (error) { restored = []; }\n  const jobs = restored.flatMap((item) => safeArray(item && item.json && item.json.resume_jobs));\n  const unique = new Map();\n  for (const job of jobs) {\n    const key = safeString(job && job.job_key);\n    if (key && !unique.has(key)) unique.set(key, deepClone(job));\n  }\n  return [...unique.values()];\n}\n\nfunction isCurrentCtaResumeContract(row) {\n  const feed = asObject(asObject(row).creativePayload && asObject(row).creativePayload.asset_feed_spec);\n  const ctaTypes = safeArray(feed.call_to_action_types)\n    .map((value) => safeString(value).toUpperCase())\n    .filter(Boolean);\n  const destination = asObject(row.destination_meta);\n  const expected = safeString(destination.campaign_objective).toUpperCase() === 'OUTCOME_LEADS'\n    ? OUTCOME_LEADS_CTA_TYPE\n    : DEFAULT_CTA_TYPE;\n  return ctaTypes.length === 1 && ctaTypes[0] === expected;\n}\n\nconst persistedJobs = persistedResumeJobs();\nconst resumeJobs = persistedJobs.filter((job) => {\n  const row = asObject(job);\n  const contract = asObject(row.destination_contract);\n  const kind = safeString(contract.kind).toLowerCase();\n  const linkUrl = primaryLinkFromCreativePayload(row.creativePayload);\n  return safeString(row.workflow_contract_revision) === WORKFLOW_CONTRACT_REVISION &&\n    (kind === 'website' || kind === 'whatsapp') &&\n    Boolean(linkUrl) &&\n    (kind !== 'whatsapp' || isWhatsAppHostname(linkUrl)) &&\n    isCurrentCtaResumeContract(row) &&\n    isCurrentVideoOnlyResumeContract(row) &&\n    isCurrentCarouselResumeContract(row);\n});\nif (persistedJobs.length && !resumeJobs.length && !assembledInputItems.length) {\n  throw new Error('Build Jobs recusou resume_jobs incompativeis com o contrato de midia atual sem entradas suficientes para reconstruir com seguranca.');\n}\nif (resumeJobs.length === persistedJobs.length && resumeJobs.length) {\n  return resumeJobs.map((job) => ({ json: job }));\n}\n\nif (!jobEntries.length) {\n  const rootError = buildPayloadErrors[0] && buildPayloadErrors[0].json ? buildPayloadErrors[0].json : null;\n  return [{\n    json: rootError\n      ? {\n          error: 'Build Payload falhou antes de gerar jobs.',\n          upstream_node: 'Build Payload',\n          upstream_error: safeString(rootError.error),\n          upstream_debug: deepClone(rootError.debug || {}),\n          debug: {\n            input_count: assembledInputItems.length,\n            build_payload_item_count: $('Build Payload').all().length,\n          },\n        }\n      : {\n          error: 'Nenhum job do Build Payload foi encontrado no input do Build Jobs.',\n          debug: {\n            input_count: assembledInputItems.length,\n            build_payload_item_count: $('Build Payload').all().length,\n          },\n        },\n  }];\n}\n\nconst inputItems = expandAssembledInputs(assembledInputItems, jobEntries);\nconst fileToJob = buildFileToJob(jobEntries);\nconst uploadedByJob = buildUploadedByJob(inputItems, fileToJob);\nconst aiCorrelation = buildAiByJob(inputItems, jobEntries);\nconst aiByJob = aiCorrelation.aiByJob;\nfunction buildDestinationClaimKey(destinationMeta) {\n  return safeString(destinationMeta && destinationMeta.destination_adset_id) ||\n    safeString(destinationMeta && destinationMeta.destination_campaign_id) ||\n    normalizeKey(destinationMeta && destinationMeta.destination_group) ||\n    'SEM_DESTINO';\n}\n\nconst claimedReplacementAdIdsByDestination = new Map();\n\nconst outputs = [];\n\nfor (const entry of jobEntries) {\n  const job = entry.json || {};\n  const uploadedByAccount = uploadedByJob.get(job.job_key) || new Map();\n  const ai = aiByJob.get(job.job_key) || {};\n  const mediaInventoryByRatio = buildMediaInventoryByRatio(job);\n  const baseWarnings = [];\n\n  const rawDestinations = safeArray(job.destinations);\n  if (!rawDestinations.length) {\n    outputs.push({\n      json: {\n        error: 'Nenhum destino explicito foi encontrado para o grupo.',\n        upstream_node: 'Build Jobs',\n        upstream_error: 'destination_required',\n        debug: { job_key: safeString(job.job_key) },\n      },\n    });\n    continue;\n  }\n\n  const destinationsToProcess = rawDestinations;\n\n  const resolvedDestinations = destinationsToProcess.map((destination) => ({\n    destination_group: safeString(destination.destination_group),\n    destination_row_number: safeString(destination.destination_row_number || destination.row_number),\n    destination_campaign_id: safeString(destination.destination_campaign_id || destination.campaign_id),\n    destination_ad_account_id: safeString(destination.destination_ad_account_id || destination.account_id),\n    destination_page_id: safeString(destination.destination_page_id || destination.page_id),\n    destination_instagram_user_id: safeString(destination.destination_instagram_user_id || destination.instagram_user_id),\n    destination_adset_id: safeString(destination.destination_adset_id || destination.adset_id),\n    destination_api_version: safeString(destination.destination_api_version || destination.api_version || 'v25.0'),\n    token_id: safeString(destination.token_id),\n    allowed_link_hosts: safeArray(destination.allowed_link_hosts),\n    landing_pages_by_creative_group: deepClone(destination.landing_pages_by_creative_group || {}),\n    landing_page_validation: deepClone(destination.landing_page_validation || {}),\n    placement_eligibility: deepClone(destination.placement_eligibility || {}),\n    freshness_window_days: Number(destination.freshness_window_days || TEMPORAL_GUARD_FRESH_DAYS),\n    campaign_objective: safeString(destination.campaign_objective),\n    optimization_goal: safeString(destination.optimization_goal),\n    destination_type: safeString(destination.destination_type).toUpperCase(),\n    whatsapp_destination_url: toHttps(destination.whatsapp_destination_url),\n    carousel_native_campaign_id: safeString(destination.carousel_native_campaign_id),\n    carousel_native_adset_id: safeString(destination.carousel_native_adset_id),\n    carousel_native_adset_verified: destination.carousel_native_adset_verified === true,\n    carousel_native_route_active: destination.carousel_native_route_active === true,\n    config_revision: safeString(destination.config_revision || job.config_revision),\n    destination_id_source: safeString(destination.destination_id_source || 'build_payload'),\n    suffix_hint: safeString(destination.suffix_hint || job.suffix_hint),\n  }));\n\n  for (const destinationMeta of resolvedDestinations) {\n    const aliases = buildDestinationAliases(destinationMeta.destination_group);\n    const destinationClaimKey = buildDestinationClaimKey(destinationMeta);\n    if (!claimedReplacementAdIdsByDestination.has(destinationClaimKey)) {\n      claimedReplacementAdIdsByDestination.set(destinationClaimKey, new Set());\n    }\n    const claimedReplacementAdIds = claimedReplacementAdIdsByDestination.get(destinationClaimKey);\n    const mediaMode = normalizeMediaMode(job.media_mode, job);\n    const calibrationMarker = calibrationMarkerForJob(job);\n    // Calibration is deliberately limited to the two media contracts that\n    // need Ads Manager preview evidence. It never substitutes an ad.\n    const calibrationMode = Boolean(calibrationMarker) && ['video_only', 'carousel'].includes(mediaMode);\n    const requestedReplaceExistingRaw =\n      safeString(job.action) === 'replace_existing' || Boolean(job.should_replace_existing);\n    const requestedReplaceExisting = requestedReplaceExistingRaw && !calibrationMode;\n    const desiredAdStatus = calibrationMode ? CALIBRATION_AD_STATUS : DEFAULT_AD_STATUS;\n    if (!['static_only', 'mixed', 'video_only', 'carousel'].includes(mediaMode)) {\n      outputs.push({ json: { error: 'Modo de midia invalido.', upstream_node: 'Build Jobs', upstream_error: 'media_mode_invalid', debug: { job_key: safeString(job.job_key), media_mode: mediaMode } } });\n      continue;\n    }\n    const videoOnlyPlacement = mediaMode === 'video_only'\n      ? videoOnlyPlacementContract(destinationMeta.placement_eligibility)\n      : null;\n    if (videoOnlyPlacement && !videoOnlyPlacement.ok) {\n      outputs.push({\n        json: {\n          error: 'O ad set possui posicionamento de video unico sem regra de personalizacao mapeada.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'video_only_placement_contract_invalid',\n          debug: {\n            job_key: safeString(job.job_key),\n            destination_group: safeString(destinationMeta.destination_group),\n            missing: videoOnlyPlacement.missing,\n            unsupported: videoOnlyPlacement.unsupported,\n          },\n        },\n      });\n      continue;\n    }\n    // A complete mixed group is one physical creative and one physical ad. Its\n    // image and video variants are selected by placement rules inside the\n    // asset feed, so replacement remains the same one-ad idempotent operation\n    // used for a static-only group. Missing offer evidence still creates a new\n    // ad; it never broadens the candidate search.\n    const expectedOfferFingerprint = asObject(job.offer_fingerprint);\n    const offerFingerprintTag = safeString(expectedOfferFingerprint.tag).toUpperCase();\n    const offerFingerprintReplacementEligible =\n      expectedOfferFingerprint.replacement_eligible === true &&\n      /^OFV1:[A-Z0-9]+$/.test(offerFingerprintTag);\n    const shouldReplaceExisting = requestedReplaceExisting && offerFingerprintReplacementEligible;\n\n    const preferredIds = new Set(\n      shouldReplaceExisting\n        ? uniqueStrings(safeArray(job.selected_ad_ids))\n        : []\n    );\n    const matchedScoreByAdId = new Map(\n      safeArray(job.matched_ads)\n        .map((item) => [safeString(item && item.ad_id), Number(item && item.score) || 0])\n        .filter(([adId]) => Boolean(adId))\n    );\n    const matchedIds = new Set([...matchedScoreByAdId.keys()]);\n    const offerMatchStatusByAdId = new Map(\n      safeArray(job.matched_ads)\n        .map((item) => [safeString(item && item.ad_id), safeString(item && item.offer_match_status)])\n        .filter(([adId]) => Boolean(adId))\n    );\n\n    const inRunClaimExcludedAdIds = shouldReplaceExisting\n      ? uniqueStrings(safeArray(job.source_ads).map((ad) => safeString(ad && ad.id)).filter((adId) => claimedReplacementAdIds.has(adId)))\n      : [];\n\n    const offerExcludedCandidateIds = shouldReplaceExisting\n      ? uniqueStrings(safeArray(job.source_ads)\n          .map((ad) => safeString(ad && ad.id))\n          .filter((adId) => adId && offerMatchStatusByAdId.get(adId) !== 'exact'))\n      : [];\n\n    const candidateSourceAds = shouldReplaceExisting\n      ? safeArray(job.source_ads).filter((ad) => {\n          const adId = safeString(ad && ad.id);\n          if (claimedReplacementAdIds.has(adId)) return false;\n          // Build Payload is the only component allowed to prove offer\n          // equivalence. A source ad cannot become replaceable merely because\n          // it shares a campaign, destination, product, or legacy job_key.\n          if (offerMatchStatusByAdId.get(adId) !== 'exact') return false;\n          return preferredIds.has(adId) || matchedIds.has(adId);\n        })\n      : [];\n\n    const freshnessWindowDays = Math.max(1, Math.min(90, Number(destinationMeta.freshness_window_days || TEMPORAL_GUARD_FRESH_DAYS)));\n    const freshnessCutoffMs = Date.now() - freshnessWindowDays * 24 * 60 * 60 * 1000;\n    const rankedCandidates = shouldReplaceExisting\n      ? candidateSourceAds\n          .map((ad) => {\n            const temporal = buildTemporalCandidateInfo(ad, freshnessCutoffMs);\n            const scored = scoreSourceAdForDestination(ad, destinationMeta, aliases, preferredIds, temporal);\n            const matchScore = Number(matchedScoreByAdId.get(safeString(ad && ad.id)) || 0);\n            if (matchScore > 0) {\n              scored.score += Math.min(matchScore, 750);\n              scored.reasons.push('match_score:' + matchScore);\n            }\n            if (temporal.is_fresh) {\n              scored.reasons.push('temporal_guard:fresh_candidate_excluded');\n            } else if (!temporal.has_known_time) {\n              scored.reasons.push('temporal_guard:unknown_time_fallback');\n            } else {\n              scored.reasons.push('temporal_guard:past_candidate');\n            }\n            return {\n              ad,\n              temporal,\n              ...scored,\n            };\n          })\n          .filter((entry) => entry.score > 0)\n          .sort(compareRankedCandidates)\n      : [];\n\n    const knownPastCandidates = rankedCandidates.filter((entry) => !entry.temporal.is_fresh && entry.temporal.has_known_time);\n    const unknownTimeFallbackCandidates = rankedCandidates.filter((entry) => !entry.temporal.is_fresh && !entry.temporal.has_known_time);\n    const freshCandidates = rankedCandidates.filter((entry) => entry.temporal.is_fresh);\n    const eligibleCandidates = knownPastCandidates.length ? knownPastCandidates : unknownTimeFallbackCandidates;\n    const chosenEntry = shouldReplaceExisting && eligibleCandidates[0]\n      ? eligibleCandidates[0]\n      : null;\n    const chosenAd = chosenEntry ? chosenEntry.ad : null;\n    const temporalGuard = {\n      freshness_window_days: freshnessWindowDays,\n      freshness_cutoff: isoFromMs(freshnessCutoffMs),\n      candidate_count: rankedCandidates.length,\n      eligible_past_candidate_count: eligibleCandidates.length,\n      known_past_candidate_count: knownPastCandidates.length,\n      unknown_time_fallback_candidate_count: unknownTimeFallbackCandidates.length,\n      fresh_candidate_count: freshCandidates.length,\n      excluded_fresh_candidate_ids: freshCandidates.map((entry) => safeString(entry.ad && entry.ad.id)).filter(Boolean),\n      chosen_ad_id: safeString(chosenAd && chosenAd.id),\n      chosen_ad_name: safeString(chosenAd && chosenAd.name),\n      candidate_last_mutation_time: chosenEntry ? chosenEntry.temporal.candidate_last_mutation_time : '',\n      candidate_last_mutation_iso: chosenEntry ? chosenEntry.temporal.candidate_last_mutation_iso : '',\n      reason: !offerFingerprintReplacementEligible\n        ? 'offer_fingerprint_unverified'\n        : chosenEntry\n        ? (chosenEntry.temporal.has_known_time ? 'past_candidate_selected' : 'unknown_time_fallback_selected')\n        : (freshCandidates.length ? 'all_matching_candidates_are_fresh' : 'no_matching_candidate'),\n    };\n\n    // A requested replacement only proceeds when an unambiguous, old target\n    // exists. Recent candidates and an empty match set are both normal reasons\n    // to create a separate ad in the configured ad set, never to block a valid\n    // publication batch or overwrite a protected ad.\n    const replacementFallsBackToNewAd = requestedReplaceExisting && !chosenAd;\n    const temporalGuardRequiresNewAd = replacementFallsBackToNewAd && freshCandidates.length > 0;\n\n    const carouselNativeAdsetId = safeString(destinationMeta.carousel_native_adset_id || metaConfigForDestination(destinationMeta) && metaConfigForDestination(destinationMeta).carousel_native_adset_id);\n    const carouselNativeCampaignId = safeString(destinationMeta.carousel_native_campaign_id || metaConfigForDestination(destinationMeta) && metaConfigForDestination(destinationMeta).carousel_native_campaign_id);\n    const carouselNativeVerified = destinationMeta.carousel_native_adset_verified === true || metaConfigForDestination(destinationMeta) && metaConfigForDestination(destinationMeta).carousel_native_adset_verified === true;\n    const carouselNativeRouteActive = destinationMeta.carousel_native_route_active === true || metaConfigForDestination(destinationMeta) && metaConfigForDestination(destinationMeta).carousel_native_route_active === true;\n    const carouselCandidateUsesNativeRoute = safeString(chosenAd && chosenAd.adset_id) === carouselNativeAdsetId;\n    let action = shouldReplaceExisting && !replacementFallsBackToNewAd\n      ? 'replace_existing'\n      : 'create_new';\n\n    // A legacy flexible ad set cannot be rewritten into a native carousel.\n    // Until a native-route ad itself becomes an eligible replacement target,\n    // publish a separate active ad in the verified native route instead.\n    if (mediaMode === 'carousel' && action === 'replace_existing' && !carouselCandidateUsesNativeRoute) {\n      action = 'create_new';\n    }\n\n    const offerReplacementGuard = {\n      required: true,\n      requested_replace_existing: requestedReplaceExistingRaw,\n      expected_status: safeString(expectedOfferFingerprint.status || (offerFingerprintReplacementEligible ? 'verified' : 'unverified')),\n      expected_tag: offerFingerprintTag,\n      replacement_eligible: offerFingerprintReplacementEligible,\n      exact_candidate_count: candidateSourceAds.length,\n      excluded_candidate_ids: offerExcludedCandidateIds,\n      selected_candidate_offer_match_status: chosenAd\n        ? safeString(offerMatchStatusByAdId.get(safeString(chosenAd.id)))\n        : '',\n      reason: calibrationMode\n        ? 'calibration_forces_create_new_paused'\n        : (action === 'replace_existing'\n        ? 'exact_eligible_candidate_selected'\n        : (!offerFingerprintReplacementEligible\n          ? 'offer_fingerprint_unverified'\n          : (freshCandidates.length ? 'all_exact_candidates_are_fresh' : 'offer_fingerprint_mismatch'))),\n    };\n\n    let scopedReplacementPlan = action === 'replace_existing'\n      ? safeArray(job.replacement_plan).filter((item) =>\n          safeString(item.ad_id) === safeString(chosenAd && chosenAd.id)\n        )\n      : [];\n\n    if (action === 'replace_existing' && !scopedReplacementPlan.length && chosenAd) {\n      scopedReplacementPlan = buildReplacementPlanForAd(chosenAd, mediaInventoryByRatio);\n    }\n\n    if (action === 'replace_existing' && !scopedReplacementPlan.length) {\n      outputs.push({\n        json: {\n          error: 'replace_existing foi bloqueado porque o plano de substituicao nao pode ser construido com seguranca.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'replacement_plan_missing',\n          debug: {\n            job_key: safeString(job.job_key),\n            destination_group: safeString(destinationMeta.destination_group),\n            chosen_ad_id: safeString(chosenAd && chosenAd.id),\n          },\n        },\n      });\n      continue;\n    }\n\n    const chosenScore = chosenEntry ? chosenEntry.score : 0;\n    const chosenReasons = chosenEntry ? chosenEntry.reasons : [];\n\n    const warnings = [];\n    let resolvedAdsetId = safeString(destinationMeta.destination_adset_id);\n    const resolvedSourceAdId = action === 'replace_existing'\n      ? safeString(chosenAd && chosenAd.id)\n      : '';\n    const resolvedApiVersion = safeString(destinationMeta.destination_api_version || 'v25.0');\n    const resolvedAccountId = safeString(destinationMeta.destination_ad_account_id);\n    const resolvedPageId = safeString(destinationMeta.destination_page_id);\n    const resolvedInstagramUserId = safeString(destinationMeta.destination_instagram_user_id);\n    let resolvedCampaignId = safeString(destinationMeta.destination_campaign_id);\n    const gatewayConfig = metaConfigForDestination(destinationMeta);\n    const resolvedTokenId = safeString(destinationMeta.token_id || gatewayConfig && gatewayConfig.token_id);\n    const uploaded = uploadedByAccount.get(resolvedAccountId) || {};\n    const orderedAssets = buildOrderedAssets(job, uploaded).filter(hasCreativeAsset);\n    const requiresVideo = mediaMode === 'mixed' || mediaMode === 'video_only';\n    const requiresStaticImages = mediaMode === 'mixed' || mediaMode === 'static_only' || mediaMode === 'carousel';\n    const carouselCards = safeArray(job.carousel_cards || job.imagens)\n      .slice()\n      .sort((left, right) => Number(left.carousel_card_index || 0) - Number(right.carousel_card_index || 0));\n    const expectedStaticAssetCount = mediaMode === 'carousel'\n      ? carouselCards.length\n      : safeArray(job.required_ratios).length;\n    const uploadedVideo = asObject(uploaded.vertical_video);\n    const uploadedVideoThumbnail = asObject(uploaded.vertical_video_thumbnail);\n    const videoGeometryValid = isNineBySixteen(uploadedVideo.width, uploadedVideo.height)\n      && safeString(uploadedVideo.aspect_ratio) === '9x16'\n      && safeString(uploadedVideo.recommended_aspect_ratio) === '9x16'\n      && isNineBySixteen(uploadedVideo.preferred_thumbnail_width, uploadedVideo.preferred_thumbnail_height)\n      && safeString(uploadedVideo.preferred_thumbnail_aspect_ratio) === '9x16';\n    if (requiresStaticImages && (orderedAssets.length !== expectedStaticAssetCount || (mediaMode === 'carousel' ? orderedAssets.length < 2 : orderedAssets.length < 3))) {\n      outputs.push({\n        json: {\n          error: 'Upload gateway incompleto ou sem correlacao estrita por nome, ratio e conta.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'strict_upload_mapping_failed',\n          debug: {\n            job_key: safeString(job.job_key),\n            account_id: resolvedAccountId,\n            required_ratios: mediaMode === 'carousel' ? carouselCards.map((card) => `carousel_card_${card.carousel_card_index}`) : deepClone(job.required_ratios || []),\n            resolved_ratios: orderedAssets.map((asset) => safeString(asset.ratio)),\n          },\n        },\n      });\n      continue;\n    }\n    if (requiresVideo && (!safeString(uploadedVideo.video_id) || uploadedVideo.ready !== true || safeString(uploadedVideo.video_status) !== 'ready' || !safeString(uploadedVideoThumbnail.hash) || !videoGeometryValid)) {\n      outputs.push({\n        json: {\n          error: 'Upload de video ou miniatura incompleto antes da criacao do creative.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'strict_video_upload_mapping_failed',\n          debug: {\n            job_key: safeString(job.job_key), account_id: resolvedAccountId,\n            video_id: safeString(uploadedVideo.video_id), video_status: safeString(uploadedVideo.video_status),\n            video_ready: uploadedVideo.ready === true, thumbnail_hash_present: Boolean(safeString(uploadedVideoThumbnail.hash)),\n            video_dimensions: `${Number(uploadedVideo.width || 0)}x${Number(uploadedVideo.height || 0)}`,\n            thumbnail_dimensions: `${Number(uploadedVideo.preferred_thumbnail_width || 0)}x${Number(uploadedVideo.preferred_thumbnail_height || 0)}`,\n            required_aspect_ratio: '9x16',\n          },\n        },\n      });\n      continue;\n    }\n    if (!requiresStaticImages && orderedAssets.length) {\n      outputs.push({ json: { error: 'Video unico nao pode carregar imagens estaticas no mesmo job.', upstream_node: 'Build Jobs', upstream_error: 'video_only_contains_images', debug: { job_key: safeString(job.job_key), image_count: orderedAssets.length } } });\n      continue;\n    }\n\n    if (!orderedAssets.length) warnings.push('Nenhum asset enviado foi associado a este job.');\n    if (!resolvedAccountId) warnings.push('destination_ad_account_id ausente.');\n    if (!resolvedPageId) warnings.push('destination_page_id ausente.');\n    if (!resolvedCampaignId) warnings.push('destination_campaign_id ausente.');\n    if (!resolvedApiVersion) warnings.push('destination_api_version ausente.');\n    if (!resolvedTokenId) warnings.push('token_id opaco do gateway ausente para o destino.');\n    if (action === 'create_new' && !resolvedAdsetId) warnings.push(`Job ${job.job_key} sem destination_adset_id para create_new.`);\n    if (action === 'replace_existing' && !resolvedSourceAdId) warnings.push('source_ad_id ausente para replace_existing.');\n    if (calibrationMode) warnings.push('Marcador de calibracao detectado: sera criado um anuncio novo PAUSED e nenhuma substituicao sera permitida.');\n    if (temporalGuardRequiresNewAd) warnings.push(`Janela de ${freshnessWindowDays} dias protegeu ${freshCandidates.length} anuncio(s) recente(s); sera criado um novo anuncio ${desiredAdStatus} sem substituir os existentes.`);\n    if (replacementFallsBackToNewAd && !temporalGuardRequiresNewAd) warnings.push(`Nenhum candidato com oferta comercial comprovadamente identica foi localizado para substituicao; sera criado um novo anuncio ${desiredAdStatus} sem substituir anuncios existentes.`);\n    if (requestedReplaceExisting && !offerFingerprintReplacementEligible) warnings.push(`replace_existing foi convertido para create_new ${desiredAdStatus} porque a oferta comercial nao possui fingerprint comprovado.`);\n\n    const overrides = deepClone(ai.creative_override || {});\n    const analysis = deepClone(ai.analysis || {});\n    const videoFrame = deepClone(ai.video_frame || {\n      bestTimestamp: '',\n      bestTimestampSeconds: 0,\n      selectedFrameUrl: '',\n      selectedFrameRank: 0,\n      reason: '',\n      confidence: 0,\n      candidates: [],\n    });\n\n    const aiBodies = normalizeTextAssets(overrides.bodies, 5);\n    const aiTitles = normalizeTextAssets(overrides.titles, 5);\n    const aiDescriptions = normalizeTextAssets(overrides.descriptions, 5);\n\n    const aiCorrelationConflict = aiCorrelation.diagnostics.conflicting_job_keys.includes(safeString(job.job_key));\n    const aiOutputUnmapped = !aiByJob.has(job.job_key) && aiCorrelation.diagnostics.unmapped_candidate_count > 0;\n    if (aiCorrelationConflict || aiOutputUnmapped || !aiByJob.has(job.job_key) || aiBodies.length !== 5 || aiTitles.length !== 5 || aiDescriptions.length !== 5) {\n      const upstreamError = aiCorrelationConflict\n        ? 'ai_output_conflict'\n        : aiOutputUnmapped\n          ? 'ai_output_unmapped'\n          : 'ai_copy_contract_failed';\n      outputs.push({\n        json: {\n          error: upstreamError === 'ai_output_unmapped'\n            ? 'A resposta estruturada da IA nao pode ser correlacionada com seguranca ao job.'\n            : upstreamError === 'ai_output_conflict'\n              ? 'Mais de uma resposta estruturada da IA foi correlacionada ao mesmo job.'\n              : 'A saida estruturada da IA nao atende ao contrato exato de 5 bodies, 5 titles e 5 descriptions.',\n          upstream_node: 'Build Jobs',\n          upstream_error: upstreamError,\n          debug: {\n            job_key: safeString(job.job_key),\n            ai_output_found: aiByJob.has(job.job_key),\n            body_count: aiBodies.length,\n            title_count: aiTitles.length,\n            description_count: aiDescriptions.length,\n            ai_candidate_count: aiCorrelation.diagnostics.candidate_count,\n            ai_unmapped_candidate_count: aiCorrelation.diagnostics.unmapped_candidate_count,\n            ai_conflicting_job_keys: deepClone(aiCorrelation.diagnostics.conflicting_job_keys),\n          },\n        },\n      });\n      continue;\n    }\n\n    const allowedLinkHosts = safeArray(destinationMeta.allowed_link_hosts || gatewayConfig && gatewayConfig.allowed_link_hosts);\n    const creativeGroupKey = safeString(job.creative_group_key || job.group_key);\n    const landingPage = resolveLandingPage(destinationMeta, gatewayConfig, creativeGroupKey, allowedLinkHosts);\n    if (!landingPage.ok) {\n      outputs.push({\n        json: {\n          error: 'A landing page especifica da campanha nao esta pronta no Token Vault.',\n          upstream_node: 'Build Jobs',\n          upstream_error: landingPage.error,\n          debug: {\n            job_key: safeString(job.job_key),\n            creative_group_key: creativeGroupKey,\n            destination_group: safeString(destinationMeta.destination_group),\n            configured_keys: landingPage.configured_keys || [],\n            rejected_hostname: landingPage.rejected_hostname || '',\n          },\n        },\n      });\n      continue;\n    }\n\n    const destinationContract = resolveDestinationContract(job, destinationMeta, landingPage.url);\n    if (!destinationContract.ok) {\n      outputs.push({\n        json: {\n          error: 'O contrato de destino do ad set nao foi comprovado; lote bloqueado antes de qualquer mutacao Meta.',\n          upstream_node: 'Build Jobs',\n          upstream_error: destinationContract.error,\n          debug: {\n            job_key: safeString(job.job_key),\n            destination_group: safeString(destinationMeta.destination_group),\n            destination_adset_id_present: Boolean(safeString(destinationMeta.destination_adset_id)),\n            configured_kind: safeString(destinationContract.configured_kind),\n            observed_kinds: deepClone(destinationContract.observed_kinds || []),\n          },\n        },\n      });\n      continue;\n    }\n    const usesWhatsAppDestination = destinationContract.kind === 'whatsapp';\n    if (!usesWhatsAppDestination && mediaMode !== 'carousel' && !safeString(destinationMeta.campaign_objective)) {\n      outputs.push({\n        json: {\n          error: 'O objetivo efetivo da campanha nao foi retornado pelo inventario Meta; lote bloqueado antes de criar o criativo.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'campaign_objective_missing',\n          debug: {\n            job_key: safeString(job.job_key),\n            destination_group: safeString(destinationMeta.destination_group),\n            destination_adset_id_present: Boolean(safeString(destinationMeta.destination_adset_id)),\n          },\n        },\n      });\n      continue;\n    }\n    if (mediaMode === 'carousel' && (!carouselNativeAdsetId || !carouselNativeVerified || !carouselNativeRouteActive)) {\n      outputs.push({\n        json: {\n          error: 'O conjunto de anuncios atual exige criativo flexivel e nao renderiza o contrato de carrossel no Ads Manager; lote bloqueado antes de qualquer mutacao Meta.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'carousel_requires_verified_native_adset',\n          debug: {\n            job_key: safeString(job.job_key),\n            destination_group: safeString(destinationMeta.destination_group),\n            current_destination_adset_id: safeString(destinationMeta.destination_adset_id),\n            carousel_native_adset_id_present: Boolean(carouselNativeAdsetId),\n            carousel_native_adset_verified: carouselNativeVerified,\n            carousel_native_route_active: carouselNativeRouteActive,\n            required_configuration: ['carousel_native_adset_id', 'carousel_native_adset_verified=true', 'carousel_native_route_active=true'],\n            observed_graph_errors: ['flexible_creative_required', '100/1443048'],\n          },\n        },\n      });\n      continue;\n    }\n    if (mediaMode === 'carousel') {\n      resolvedAdsetId = carouselNativeAdsetId;\n      if (carouselNativeCampaignId) resolvedCampaignId = carouselNativeCampaignId;\n    }\n    const ctaTypes = [ctaTypeForDestination(destinationMeta, usesWhatsAppDestination)];\n    const requestedRawSiteLinks = safeArray(overrides.site_links || overrides.siteLinks || ai.site_links || ai.siteLinks);\n    const siteLinks = normalizeSiteLinks(requestedRawSiteLinks);\n    const rejectedSiteLinks = siteLinks.filter((link) => !isAllowedLinkUrl(link.url, allowedLinkHosts));\n    if (rejectedSiteLinks.length) {\n      outputs.push({\n        json: {\n          error: 'A IA retornou site_links fora da allowlist de hosts.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'site_link_host_not_allowed',\n          debug: { job_key: safeString(job.job_key), rejected_count: rejectedSiteLinks.length },\n        },\n      });\n      continue;\n    }\n    if (requestedRawSiteLinks.length && siteLinks.length < ADVANTAGE_PLUS_SITE_LINKS_MIN) {\n      warnings.push('Advantage+ site links recebidos da IA, mas menos de 2 links HTTPS validos restaram apos a sanitizacao; site_extensions sera omitido.');\n    }\n    if (requestedRawSiteLinks.length > ADVANTAGE_PLUS_SITE_LINKS_MAX) {\n      warnings.push('Advantage+ site links acima do limite; apenas os 4 primeiros links validos serao considerados.');\n    }\n\n    const sourceAdName = safeString(\n      job.source_ad_name_base ||\n      job.source_ad_name ||\n      ai.source_ad_name ||\n      job.nome_base ||\n      (action === 'replace_existing' && chosenAd && chosenAd.name) ||\n      'Duplicated Ad'\n    );\n    const canonicalAdName = buildCanonicalAdName(sourceAdName, destinationMeta.destination_group, offerFingerprintTag);\n    const finalAdName = calibrationMode ? calibrationAdName(canonicalAdName, calibrationMarker) : canonicalAdName;\n\n    const normalizedBodies = aiBodies;\n    const normalizedTitles = aiTitles;\n    const normalizedDescriptions = aiDescriptions;\n\n    const schedulingLandingPageUrl = landingPage.url;\n    const primaryLinkUrl = usesWhatsAppDestination ? destinationContract.link_url : schedulingLandingPageUrl;\n    const safeLinkUrls = [{ website_url: primaryLinkUrl }];\n    const adMutationPayload = {\n      name: finalAdName || sourceAdName,\n      status: desiredAdStatus,\n      creative: {\n        creative_id: '',\n      },\n      ...(resolvedAdsetId ? { adset_id: resolvedAdsetId } : {}),\n    };\n    const useFlexibleCreative = orderedAssets.length >= 3 && mediaMode !== 'carousel';\n\n    const imageLabels = orderedAssets.map((asset) => ({ name: asset.ratio === '2x1' ? 'banner_image' : asset.ratio === '9x16' ? 'vertical_image' : 'feed_image' }));\n    const videoLabel = { name: 'vertical_video' };\n    // The destination campaign requires a flexible creative envelope. Carousel\n    // cards therefore live in asset_feed_spec.carousels (rather than a legacy\n    // object_story_spec.link_data payload), where each ordered card receives\n    // its own labels even if every image has the same aspect ratio.\n    const carouselImageLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName, 'carousel_image', index + 1));\n    const carouselBodyLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName, 'carousel_body', index + 1));\n    const carouselTitleLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName, 'carousel_title', index + 1));\n    const carouselDescriptionLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName, 'carousel_description', index + 1));\n    const carouselLinkLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName, 'carousel_link', index + 1));\n  const bodyRuleLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName + '_' + asset.ratio, 'body_rule', index + 1));\n  const titleRuleLabels = orderedAssets.map((asset, index) => createLabel(sourceAdName + '_' + asset.ratio, 'title_rule', index + 1));\n  const descriptionRuleLabels = normalizedDescriptions.map((asset, index) => createLabel(sourceAdName, 'description_rule', index + 1));\n  // In a placement-customized video feed Meta applies every unlabelled text\n  // asset to every rule. Give every variant its own label and bind one exact\n  // variant to each of the two video scopes. The remaining variants stay\n  // preserved in the feed but never form a multi-asset rule.\n  const videoOnlyBodyLabels = normalizedBodies.map((asset, index) => createLabel(sourceAdName, 'video_body_rule', index + 1));\n  const videoOnlyTitleLabels = normalizedTitles.map((asset, index) => createLabel(sourceAdName, 'video_title_rule', index + 1));\n  const videoOnlyDescriptionLabels = normalizedDescriptions.map((asset, index) => createLabel(sourceAdName, 'video_description_rule', index + 1));\n\n    const imageAssets = orderedAssets.map((asset, index) => ({\n      hash: safeString(asset.hash) || undefined,\n      url: safeString(asset.hash) ? undefined : toHttps(asset.url),\n      image_crops: buildImageCrops(asset),\n      adlabels: [imageLabels[index]],\n    }));\n\n    const verticalAsset = orderedAssets.find((asset) => safeString(asset && asset.ratio) === '9x16');\n    if (mediaMode !== 'carousel' && verticalAsset && !buildImageCrops(verticalAsset)) {\n      outputs.push({\n        json: {\n          error: 'A arte vertical nao possui dimensoes validas para calcular o corte recomendado 9:16.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'vertical_crop_dimensions_missing',\n          debug: {\n            job_key: safeString(job.job_key),\n            ratio: '9x16',\n            width_present: Number(verticalAsset.width) > 0,\n            height_present: Number(verticalAsset.height) > 0,\n          },\n        },\n      });\n      continue;\n    }\n\n    const horizontalAsset = orderedAssets.find((asset) => safeString(asset && asset.ratio) === '2x1');\n    if (mediaMode !== 'carousel' && horizontalAsset && !buildImageCrops(horizontalAsset)) {\n      outputs.push({\n        json: {\n          error: 'A arte horizontal nao possui dimensoes validas para calcular o corte recomendado 1,91:1.',\n          upstream_node: 'Build Jobs',\n          upstream_error: 'horizontal_crop_dimensions_missing',\n          debug: {\n            job_key: safeString(job.job_key),\n            ratio: '2x1',\n            meta_crop_key: HORIZONTAL_CROP_KEY,\n            width_present: Number(horizontalAsset.width) > 0,\n            height_present: Number(horizontalAsset.height) > 0,\n          },\n        },\n      });\n      continue;\n    }\n\n  const bodyAssets = normalizedBodies.map((asset, index) => ({\n    text: safeString(asset.text),\n    adlabels: mediaMode === 'video_only' ? [videoOnlyBodyLabels[index]] : bodyRuleLabels,\n  }));\n\n  const titleAssets = normalizedTitles.map((asset, index) => ({\n    text: safeString(asset.text).slice(0, 80),\n    adlabels: mediaMode === 'video_only' ? [videoOnlyTitleLabels[index]] : titleRuleLabels,\n  }));\n\n  const descriptionAssets = normalizedDescriptions.map((asset, index) => ({\n    text: safeString(asset.text),\n    adlabels: mediaMode === 'video_only' ? [videoOnlyDescriptionLabels[index]] : [descriptionRuleLabels[index]],\n    }));\n\n    const feedIndex = orderedAssets.findIndex((asset) => !['2x1', '9x16'].includes(asset.ratio));\n    const bannerIndex = orderedAssets.findIndex((asset) => asset.ratio === '2x1');\n    const verticalIndex = orderedAssets.findIndex((asset) => asset.ratio === '9x16');\n    const staticPlacementRules = [\n      {\n        customization_spec: { publisher_platforms: ['facebook', 'instagram'], facebook_positions: ['feed', 'marketplace'], instagram_positions: ['stream', 'explore'] },\n        image_label: imageLabels[feedIndex], body_label: bodyRuleLabels[feedIndex], title_label: titleRuleLabels[feedIndex], description_label: descriptionRuleLabels[0], priority: 1,\n      },\n      {\n        customization_spec: { publisher_platforms: ['facebook'], facebook_positions: ['search'] },\n        image_label: imageLabels[bannerIndex], body_label: bodyRuleLabels[bannerIndex], title_label: titleRuleLabels[bannerIndex], description_label: descriptionRuleLabels[1], priority: 2,\n      },\n      {\n        customization_spec: { publisher_platforms: ['facebook', 'instagram'], facebook_positions: ['story', 'facebook_reels'], instagram_positions: ['story', 'reels'] },\n        image_label: imageLabels[verticalIndex],\n        body_label: bodyRuleLabels[verticalIndex], title_label: titleRuleLabels[verticalIndex], description_label: descriptionRuleLabels[2], priority: 3,\n      },\n    ];\n\n    // A mixed group is a placement-customized vertical variation, never a\n    // second standalone video ad. The image is deliberately assigned to every\n    // requested vertical surface except rewarded video; the uploaded video is\n    // constrained to Audience Network rewarded video only.\n    const mixedPlacementRules = mediaMode === 'mixed' ? [\n      staticPlacementRules[0],\n      staticPlacementRules[1],\n      {\n        customization_spec: {\n          publisher_platforms: VERTICAL_PUBLISHER_PLATFORMS,\n          facebook_positions: VERTICAL_FACEBOOK_POSITIONS,\n          instagram_positions: VERTICAL_INSTAGRAM_POSITIONS,\n          audience_network_positions: VERTICAL_AUDIENCE_NETWORK_POSITIONS,\n          whatsapp_positions: VERTICAL_WHATSAPP_POSITIONS,\n        },\n        image_label: imageLabels[verticalIndex],\n        body_label: bodyRuleLabels[verticalIndex], title_label: titleRuleLabels[verticalIndex], description_label: descriptionRuleLabels[2], priority: 3,\n      },\n      {\n        customization_spec: {\n          publisher_platforms: VERTICAL_REWARDED_VIDEO_PLATFORMS,\n          audience_network_positions: VERTICAL_REWARDED_VIDEO_POSITIONS,\n        },\n        video_label: videoLabel,\n        body_label: bodyRuleLabels[verticalIndex], title_label: titleRuleLabels[verticalIndex], description_label: descriptionRuleLabels[3], priority: 4,\n      },\n    ] : staticPlacementRules;\n\n    // Meta requires at least two customization rules when placement\n    // personalization is enabled, and each rule may receive only one text\n    // asset of each type. The labels select one of the five preserved variants\n    // for each scope instead of letting every global variant match both rules.\n    const videoOnlyPlacementRules = mediaMode === 'video_only' ? [\n      {\n        customization_spec: {\n          publisher_platforms: VERTICAL_PUBLISHER_PLATFORMS,\n          facebook_positions: VIDEO_ONLY_FACEBOOK_POSITIONS,\n          instagram_positions: VIDEO_ONLY_INSTAGRAM_POSITIONS,\n          audience_network_positions: VERTICAL_AUDIENCE_NETWORK_POSITIONS,\n          whatsapp_positions: VIDEO_ONLY_WHATSAPP_POSITIONS,\n        },\n        video_label: videoLabel,\n        body_label: videoOnlyBodyLabels[0],\n        title_label: videoOnlyTitleLabels[0],\n        description_label: videoOnlyDescriptionLabels[0],\n        priority: 1,\n      },\n      {\n        customization_spec: {\n          publisher_platforms: VERTICAL_REWARDED_VIDEO_PLATFORMS,\n          audience_network_positions: VERTICAL_REWARDED_VIDEO_POSITIONS,\n        },\n        video_label: videoLabel,\n        body_label: videoOnlyBodyLabels[1],\n        title_label: videoOnlyTitleLabels[1],\n        description_label: videoOnlyDescriptionLabels[1],\n        priority: 2,\n      },\n    ] : [];\n\n    const advantagePlusRequest = buildAdvantagePlusRequest({\n      apiVersion: resolvedApiVersion,\n      siteLinks,\n      musicEligible: isMusicEligible(destinationMeta.placement_eligibility),\n      // pac_relaxation is represented by Ads Manager as \"Mídia flexível\".\n      // It remains disabled for video_only until a dedicated calibration proves\n      // that Meta preserves the full labelled placement contract.\n      pacEligible: mediaMode !== 'carousel' && orderedAssets.length > 1 && mixedPlacementRules.length > 1,\n      mediaMode,\n      sourceUrl: primaryLinkUrl,\n    });\n\n    const creativeRootExtras = removeEmptyFields({\n      degrees_of_freedom_spec: {\n        creative_features_spec: deepClone(advantagePlusRequest.creativeFeaturesSpec),\n      },\n      creative_sourcing_spec: deepClone(advantagePlusRequest.creativeSourcingSpec),\n    });\n\n    const staticCreativePayload = useFlexibleCreative\n      ? removeEmptyFields({\n          name: finalAdName || sourceAdName,\n          object_story_spec: {\n            page_id: String(resolvedPageId),\n            instagram_user_id: resolvedInstagramUserId ? String(resolvedInstagramUserId) : undefined,\n          },\n          asset_feed_spec: {\n            ad_formats: ['SINGLE_IMAGE'],\n            optimization_type: 'PLACEMENT',\n            images: imageAssets,\n            bodies: bodyAssets,\n            titles: titleAssets,\n            descriptions: descriptionAssets,\n            link_urls: safeLinkUrls,\n            call_to_action_types: ctaTypes,\n            asset_customization_rules: staticPlacementRules,\n          },\n          ...creativeRootExtras,\n        })\n      : removeEmptyFields({\n          name: finalAdName || sourceAdName,\n          object_story_spec: {\n            page_id: String(resolvedPageId),\n            instagram_user_id: resolvedInstagramUserId ? String(resolvedInstagramUserId) : undefined,\n            link_data: {\n              link: primaryLinkUrl,\n              message: safeString(bodyAssets[0] && bodyAssets[0].text),\n              name: safeString(titleAssets[0] && titleAssets[0].text).slice(0, 80),\n              description: safeString(descriptionAssets[0] && descriptionAssets[0].text),\n              image_hash: safeString(imageAssets[0] && imageAssets[0].hash) || undefined,\n              picture: safeString(imageAssets[0] && imageAssets[0].hash)\n                ? undefined\n                : toHttps(orderedAssets[0] && orderedAssets[0].url),\n              call_to_action: {\n                type: ctaTypes[0] || DEFAULT_CTA_TYPE,\n                value: { link: primaryLinkUrl },\n              },\n            },\n          },\n          ...creativeRootExtras,\n        });\n\n    // Native carousel is deliberately isolated in a verified manual-placement\n    // ad set. Do not add asset_feed_spec or Advantage+ root extras here: Meta\n    // accepts the native link-data contract, while the flexible and hybrid\n    // envelopes either fail validation or render a broken carousel preview.\n    const carouselCreativePayload = mediaMode === 'carousel' ? removeEmptyFields({\n      name: finalAdName || sourceAdName,\n      object_story_spec: {\n        page_id: String(resolvedPageId),\n        instagram_user_id: resolvedInstagramUserId ? String(resolvedInstagramUserId) : undefined,\n        link_data: {\n          link: primaryLinkUrl,\n          message: safeString(normalizedBodies[0] && normalizedBodies[0].text),\n          call_to_action: {\n            type: ctaTypes[0] || DEFAULT_CTA_TYPE,\n            value: { link: primaryLinkUrl },\n          },\n          child_attachments: orderedAssets.map((asset, index) => removeEmptyFields({\n            link: primaryLinkUrl,\n            image_hash: safeString(asset.hash) || undefined,\n            picture: safeString(asset.hash) ? undefined : toHttps(asset.url),\n            name: safeString(normalizedTitles[index % normalizedTitles.length] && normalizedTitles[index % normalizedTitles.length].text).slice(0, 80),\n            description: safeString(normalizedDescriptions[index % normalizedDescriptions.length] && normalizedDescriptions[index % normalizedDescriptions.length].text),\n          })),\n          multi_share_end_card: false,\n          multi_share_optimized: false,\n        },\n      },\n    }) : null;\n\n    const mixedCreativePayload = mediaMode === 'mixed' ? removeEmptyFields({\n      name: finalAdName || sourceAdName,\n      object_story_spec: {\n        page_id: String(resolvedPageId),\n        instagram_user_id: resolvedInstagramUserId ? String(resolvedInstagramUserId) : undefined,\n      },\n      asset_feed_spec: {\n        // Meta accepts exactly one ad format per asset_feed_spec (1885374),\n        // while SINGLE_VIDEO rejects labelled image assets (1885718).\n        // AUTOMATIC_FORMAT is the single flexible envelope that can carry the\n        // image and video inventory together; placement rules still make the\n        // vertical video exclusive to rewarded video.\n        ad_formats: ['AUTOMATIC_FORMAT'],\n        optimization_type: 'PLACEMENT',\n        images: imageAssets,\n        videos: [{\n          video_id: safeString(uploadedVideo.video_id),\n          thumbnail_hash: safeString(uploadedVideoThumbnail.hash),\n          adlabels: [videoLabel],\n        }],\n        bodies: bodyAssets,\n        titles: titleAssets,\n        descriptions: descriptionAssets,\n        link_urls: safeLinkUrls,\n        call_to_action_types: ctaTypes,\n        asset_customization_rules: mixedPlacementRules,\n      },\n      ...creativeRootExtras,\n    }) : null;\n\n    const videoCreativePayload = mediaMode === 'video_only' ? removeEmptyFields({\n      name: `${finalAdName || sourceAdName} [VIDEO]`,\n      object_story_spec: {\n        page_id: String(resolvedPageId),\n        instagram_user_id: resolvedInstagramUserId ? String(resolvedInstagramUserId) : undefined,\n      },\n      asset_feed_spec: {\n        ad_formats: ['SINGLE_VIDEO'],\n        optimization_type: 'PLACEMENT',\n        videos: [{\n          video_id: safeString(uploadedVideo.video_id),\n          thumbnail_hash: safeString(uploadedVideoThumbnail.hash),\n          adlabels: [videoLabel],\n        }],\n        bodies: bodyAssets,\n        titles: titleAssets,\n        descriptions: descriptionAssets,\n        link_urls: safeLinkUrls,\n        call_to_action_types: ctaTypes,\n        asset_customization_rules: videoOnlyPlacementRules,\n      },\n      ...creativeRootExtras,\n    }) : null;\n\n    const creativeVariants = [\n      ...(mediaMode === 'static_only' ? [{\n        media_variant: 'static_flexible',\n        name_suffix: '[STATIC]',\n        creativePayload: staticCreativePayload,\n        assetIds: Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.source_file_id)])),\n        assetNames: Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.source_file_name || asset.original_filename)])),\n        assetHashes: Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.hash)])),\n        assetUrls: Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, toHttps(asset.url)])),\n        orderedRatios: orderedAssets.map((asset) => safeString(asset.ratio)),\n        requiredMediaRoles: ['feed_image', 'banner_image', 'vertical_image'],\n        advantagePlusEnabled: true,\n      }] : []),\n      ...(mediaMode === 'carousel' ? [{\n        media_variant: 'carousel',\n        name_suffix: '',\n        creativePayload: carouselCreativePayload,\n        carousel_render_contract: 'native_link_data',\n        assetIds: Object.fromEntries(carouselCards.map((card) => [`carousel_card_${card.carousel_card_index}`, safeString(card.id)])),\n        assetNames: Object.fromEntries(carouselCards.map((card) => [`carousel_card_${card.carousel_card_index}`, safeString(card.original_name || card.name)])),\n        assetHashes: Object.fromEntries(orderedAssets.map((asset, index) => [`carousel_card_${index + 1}`, safeString(asset.hash)])),\n        assetUrls: Object.fromEntries(orderedAssets.map((asset, index) => [`carousel_card_${index + 1}`, toHttps(asset.url)])),\n        orderedRatios: orderedAssets.map((asset) => safeString(asset.ratio)),\n        requiredMediaRoles: ['carousel_card'],\n        advantagePlusEnabled: false,\n      }] : []),\n      ...(mediaMode === 'mixed' ? [{\n        media_variant: 'mixed_flexible',\n        name_suffix: '',\n        creativePayload: mixedCreativePayload,\n        assetIds: {\n          ...Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.source_file_id)])),\n          vertical_video: safeString(safeArray(job.videos)[0] && safeArray(job.videos)[0].id),\n        },\n        assetNames: {\n          ...Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.source_file_name || asset.original_filename)])),\n          vertical_video: safeString(safeArray(job.videos)[0] && (safeArray(job.videos)[0].original_name || safeArray(job.videos)[0].name)),\n        },\n        assetHashes: {\n          ...Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, safeString(asset.hash)])),\n          vertical_video: safeString(uploadedVideo.video_id),\n          vertical_video_thumbnail: safeString(uploadedVideoThumbnail.hash),\n        },\n        assetUrls: Object.fromEntries(orderedAssets.map((asset) => [asset.ratio, toHttps(asset.url)])),\n        orderedRatios: [...orderedAssets.map((asset) => safeString(asset.ratio)), '9x16_video'],\n        requiredMediaRoles: ['feed_image', 'banner_image', 'vertical_image', 'vertical_video'],\n        advantagePlusEnabled: true,\n      }] : []),\n      ...(mediaMode === 'video_only' ? [{\n        media_variant: 'video_single',\n        name_suffix: '[VIDEO]',\n        creativePayload: videoCreativePayload,\n        assetIds: Object.fromEntries(safeArray(job.videos).map((video) => ['vertical_video', safeString(video.id)])),\n        assetNames: Object.fromEntries(safeArray(job.videos).map((video) => ['vertical_video', safeString(video.original_name || video.name)])),\n        assetHashes: { vertical_video: safeString(uploadedVideo.video_id), vertical_video_thumbnail: safeString(uploadedVideoThumbnail.hash) },\n        assetUrls: {},\n        orderedRatios: ['9x16_video'],\n        requiredMediaRoles: ['vertical_video'],\n        advantagePlusEnabled: true,\n      }] : []),\n    ];\n\n    const readyToCreateCreative = Boolean(\n      resolvedTokenId &&\n      resolvedAccountId &&\n      resolvedPageId &&\n      resolvedApiVersion &&\n      (requiresStaticImages ? orderedAssets.length : safeString(uploadedVideo.video_id))\n    );\n\n    const readyToCreateAd = action === 'create_new'\n      ? Boolean(resolvedTokenId && resolvedAccountId && resolvedAdsetId && resolvedApiVersion && (requiresStaticImages ? orderedAssets.length : safeString(uploadedVideo.video_id)))\n      : false;\n\n    const readyToReplaceAd = Boolean(\n      resolvedTokenId && action === 'replace_existing' && resolvedSourceAdId && resolvedApiVersion &&\n      (requiresStaticImages ? orderedAssets.length : safeString(uploadedVideo.video_id))\n    );\n\n    if (readyToReplaceAd) {\n      claimedReplacementAdIds.add(resolvedSourceAdId);\n    }\n\n    for (const variant of creativeVariants) {\n      // Only distinct physical variants receive a suffix. A mixed creative is\n      // intentionally the one canonical ad for its group and destination.\n      const variantAdName = variant.name_suffix\n        ? buildVariantAdName(finalAdName || sourceAdName, variant.name_suffix, offerFingerprintTag)\n        : (finalAdName || sourceAdName);\n      const variantAdPayload = { ...adMutationPayload, name: variantAdName };\n      const reportedAdvantage = advantagePlusRequest;\n      variant.creativePayload.name = variantAdName;\n      outputs.push({\n      json: {\n        parent_job_key: safeString(job.job_key),\n        job_key: `${createExpandedJobKey(job.job_key, destinationMeta)}:${variant.media_variant}`,\n\n        action,\n        match_status: action === 'replace_existing'\n          ? 'destination_replace'\n          : (temporalGuardRequiresNewAd\n            ? 'temporal_guard_create_new'\n            : (replacementFallsBackToNewAd\n              ? (offerFingerprintReplacementEligible ? 'offer_fingerprint_create_new' : 'offer_fingerprint_unverified_create_new')\n              : safeString(job.match_status || 'no_match'))),\n        should_create_new_ad: action === 'create_new',\n        should_replace_existing: action === 'replace_existing',\n\n        source_ad_id: resolvedSourceAdId,\n        source_ad_name: sourceAdName,\n        source_ad_texts: deepClone(job.source_ad_texts || {}),\n\n        group_key: safeString(job.group_key),\n        offer_group_key: safeString(job.offer_group_key || job.offer_key || job.group_key),\n        creative_group_key: safeString(job.creative_group_key || job.group_key),\n        logical_creative_group_key: safeString(job.creative_group_key || job.group_key),\n        media_mode: mediaMode,\n        media_variant: variant.media_variant,\n        grouping_discriminator: safeString(job.grouping_discriminator),\n        grouping_strategy: safeString(job.grouping_strategy),\n        nome_base: safeString(job.nome_base),\n        product_key: safeString(job.product_key),\n        suffix_hint: safeString(job.suffix_hint),\n        offer_fingerprint: deepClone(expectedOfferFingerprint),\n        offer_replacement_guard: deepClone(offerReplacementGuard),\n\n        analysis,\n        video_frame: videoFrame,\n\n        destination_group: safeString(destinationMeta.destination_group),\n        destination_row_number: safeString(destinationMeta.destination_row_number),\n        destination_campaign_id: resolvedCampaignId,\n        destination_ad_account_id: resolvedAccountId,\n        destination_page_id: resolvedPageId,\n        destination_instagram_user_id: resolvedInstagramUserId,\n        destination_adset_id: resolvedAdsetId,\n        destination_api_version: resolvedApiVersion,\n        destination_id_source: safeString(destinationMeta.destination_id_source),\n\n        destination_meta: deepClone(destinationMeta),\n        destinations: [deepClone(destinationMeta)],\n        all_destinations: deepClone(resolvedDestinations),\n\n        account_id: safeString(resolvedAccountId),\n        api_version: safeString(resolvedApiVersion),\n        page_id: safeString(resolvedPageId),\n        instagram_user_id: safeString(resolvedInstagramUserId),\n        row_number: safeString(destinationMeta.destination_row_number),\n        token_id: resolvedTokenId,\n        run_id: safeString(job.run_id),\n        batch_fingerprint: safeString(job.batch_fingerprint),\n        workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,\n        config_revision: safeString(destinationMeta.config_revision || job.config_revision),\n        allowed_link_hosts: deepClone(allowedLinkHosts),\n        landing_page_url: primaryLinkUrl,\n        scheduling_landing_page_url: schedulingLandingPageUrl,\n        destination_mode: usesWhatsAppDestination\n          ? (action === 'replace_existing' ? 'whatsapp_message_preserved_from_source_ad' : 'whatsapp_message_inferred_from_adset')\n          : 'website_leads',\n        destination_contract: publicDestinationContract(destinationContract),\n        landing_page_source: landingPage.source,\n        landing_page_configured_key: landingPage.configured_key,\n        desired_final_status: desiredAdStatus,\n        calibration_mode: calibrationMode,\n        calibration_marker: calibrationMode ? calibrationMarker : '',\n        carousel_render_contract: safeString(variant.carousel_render_contract),\n\n        creativePayload: variant.creativePayload,\n        advantage_plus_request: {\n          desired_features: deepClone(reportedAdvantage.desiredFeatures),\n          requested_features: deepClone(reportedAdvantage.requestedFeatures),\n          eligible_features: deepClone(reportedAdvantage.eligibleFeatures),\n          skipped_features: deepClone(reportedAdvantage.skippedFeatures),\n          skip_reasons: deepClone(reportedAdvantage.skipReasons),\n          feature_key_mode: safeString(reportedAdvantage.featureKeyMode),\n          site_links: deepClone(reportedAdvantage.siteLinks),\n          site_extensions_enabled: Boolean(reportedAdvantage.siteLinksEligible),\n          landing_page_source: landingPage.source,\n          requested_at_api_version: resolvedApiVersion,\n          feature_groups: deepClone(reportedAdvantage.featureGroups),\n        },\n        advantage_plus_feature_groups: deepClone(reportedAdvantage.featureGroups),\n        advantage_plus_effective_report: {\n          status: 'pending_graph_readback',\n          evidence_source: 'request_only',\n          main: deepClone(reportedAdvantage.featureGroups.main),\n          essential: deepClone(reportedAdvantage.featureGroups.essential),\n          supplemental: deepClone(reportedAdvantage.featureGroups.supplemental),\n          graph_acknowledged_features: [],\n          ui_confirmed_features: [],\n          rejected_features: [],\n          ineligible_features: deepClone(reportedAdvantage.skippedFeatures),\n          ui_confirmation_required: true,\n        },\n        advantage_plus_requested_features: deepClone(reportedAdvantage.requestedFeatures),\n        advantage_plus_eligible_features: deepClone(reportedAdvantage.eligibleFeatures),\n        advantage_plus_skipped_features: deepClone(reportedAdvantage.skippedFeatures),\n        advantage_plus_skip_reasons: deepClone(reportedAdvantage.skipReasons),\n        advantage_plus_final_features: deepClone(reportedAdvantage.requestedFeatures),\n        advantage_plus_applied_features: [],\n        advantage_plus_removed_features: [],\n        advantage_plus_feature_key_mode: safeString(reportedAdvantage.featureKeyMode),\n        advantage_plus_site_links: deepClone(reportedAdvantage.siteLinks),\n        site_links_requested_count: safeArray(reportedAdvantage.siteLinks).length,\n        site_links_applied: [],\n        advantage_plus_verification: {\n          status: 'pending',\n          requested_features: deepClone(reportedAdvantage.requestedFeatures),\n          eligible_features: deepClone(reportedAdvantage.eligibleFeatures),\n          skipped_features: deepClone(reportedAdvantage.skippedFeatures),\n          skip_reasons: deepClone(reportedAdvantage.skipReasons),\n          site_links_requested_count: safeArray(reportedAdvantage.siteLinks).length,\n          site_extensions_requested: Boolean(reportedAdvantage.siteLinksEligible),\n          landing_page_source: landingPage.source,\n          requested_at_api_version: resolvedApiVersion,\n          graph_acknowledgement_is_not_ui_confirmation: true,\n        },\n\n        adPayload: deepClone(variantAdPayload),\n\n        updateAdPayload: deepClone(variantAdPayload),\n\n        asset_ids: variant.assetIds,\n        asset_names: variant.assetNames,\n        asset_hashes: variant.assetHashes,\n        asset_urls: variant.assetUrls,\n        ordered_asset_ratios: variant.orderedRatios,\n        required_media_roles: variant.requiredMediaRoles,\n        video_id: safeString(uploadedVideo.video_id),\n        video_status: safeString(uploadedVideo.video_status),\n        video_thumbnail_hash: safeString(uploadedVideoThumbnail.hash),\n        video_width: Number(uploadedVideo.width || 0),\n        video_height: Number(uploadedVideo.height || 0),\n        video_aspect_ratio: safeString(uploadedVideo.aspect_ratio),\n        video_recommended_aspect_ratio: safeString(uploadedVideo.recommended_aspect_ratio),\n        video_thumbnail_width: Number(uploadedVideo.preferred_thumbnail_width || 0),\n        video_thumbnail_height: Number(uploadedVideo.preferred_thumbnail_height || 0),\n        video_thumbnail_aspect_ratio: safeString(uploadedVideo.preferred_thumbnail_aspect_ratio),\n\n        readyToCreateCreative,\n        readyToCreateAd,\n        readyToReplaceAd,\n\n        creative_mode: variant.media_variant === 'video_single'\n          ? 'video_single_asset_feed'\n          : (variant.media_variant === 'carousel'\n            ? 'native_carousel_link_data'\n          : (variant.media_variant === 'mixed_flexible'\n            ? 'mixed_flexible'\n            : (action === 'replace_existing' || useFlexibleCreative ? 'flexible_required' : 'single_image'))),\n        creative_quality_status: variant.media_variant === 'video_single'\n          ? 'video_single_asset_feed_payload_prepared'\n          : (variant.media_variant === 'carousel'\n            ? 'native_carousel_payload_prepared'\n          : (variant.media_variant === 'mixed_flexible'\n            ? 'mixed_flexible_payload_prepared'\n            : (useFlexibleCreative ? 'flexible_payload_prepared' : 'single_image_payload_prepared'))),\n        creative_quality_requirements: {\n          require_asset_feed_spec: variant.media_variant === 'video_single' || (variant.media_variant !== 'carousel' && (action === 'replace_existing' || useFlexibleCreative)),\n          min_images: variant.media_variant === 'carousel' ? carouselCards.length : (variant.media_variant === 'video_single' ? 0 : (action === 'replace_existing' || useFlexibleCreative ? 3 : 1)),\n          min_videos: variant.media_variant === 'mixed_flexible' ? 1 : (variant.media_variant === 'video_single' ? 1 : 0),\n          min_bodies: variant.media_variant === 'video_single' ? 5 : (action === 'replace_existing' || useFlexibleCreative ? 5 : 1),\n          min_titles: variant.media_variant === 'video_single' ? 5 : (action === 'replace_existing' || useFlexibleCreative ? 5 : 1),\n          min_descriptions: 5,\n        },\n        allow_fallback_creative: false,\n        blocked_before_update: false,\n\n        matched_ads: rankedCandidates.slice(0, 10).map((entry) => summarizeAd(entry.ad, entry.score, entry.reasons, entry.temporal)),\n        selected_ad_ids: resolvedSourceAdId ? [resolvedSourceAdId] : [],\n        selected_ads: resolvedSourceAdId ? [summarizeAd(chosenAd, chosenScore, chosenReasons, chosenEntry ? chosenEntry.temporal : null)] : [],\n        replacement_plan: deepClone(scopedReplacementPlan),\n\n        related_ids: {\n          ...deepClone(job.related_ids || {}),\n          selected_ad_ids: resolvedSourceAdId ? [resolvedSourceAdId] : [],\n          replacement_ad_ids: uniqueStrings(scopedReplacementPlan.map((item) => item.ad_id)),\n          replacement_creative_ids: uniqueStrings(scopedReplacementPlan.map((item) => item.creative_id)),\n          destination_campaign_ids: uniqueStrings([destinationMeta.destination_campaign_id]),\n          destination_adset_ids: uniqueStrings([destinationMeta.destination_adset_id]),\n          destination_page_ids: uniqueStrings([destinationMeta.destination_page_id]),\n          destination_instagram_user_ids: uniqueStrings([destinationMeta.destination_instagram_user_id]),\n          destination_ad_account_ids: uniqueStrings([destinationMeta.destination_ad_account_id]),\n        },\n\n        destination_match_debug: {\n          aliases,\n          preferred_ids: [...preferredIds],\n          in_run_claim_key: destinationClaimKey,\n          in_run_claimed_ad_ids: [...claimedReplacementAdIds],\n          in_run_claim_excluded_ad_ids: inRunClaimExcludedAdIds,\n          offer_fingerprint: {\n            status: safeString(expectedOfferFingerprint.status),\n            tag: offerFingerprintTag,\n            replacement_eligible: offerFingerprintReplacementEligible,\n            exact_candidate_count: candidateSourceAds.length,\n            excluded_candidate_ids: offerExcludedCandidateIds,\n          },\n          candidate_count: candidateSourceAds.length,\n          ranked_candidates: rankedCandidates.slice(0, 10).map((entry) => summarizeAd(entry.ad, entry.score, entry.reasons, entry.temporal)),\n          chosen_ad_id: resolvedSourceAdId,\n          chosen_ad_name: safeString(chosenAd && chosenAd.name),\n          replacement_plan_count: scopedReplacementPlan.length,\n          replacement_plan_built_from_creative: !safeArray(job.replacement_plan).some((item) => safeString(item.ad_id) === resolvedSourceAdId) && scopedReplacementPlan.length > 0,\n          temporal_guard: temporalGuard,\n          destination_contract: publicDestinationContract(destinationContract),\n        },\n\n        warnings: safeWarnings(safeWarnings(job.warnings, baseWarnings), warnings),\n      },\n      binary: deepClone(entry.binary || {}),\n    });\n    }\n  }\n}\n\nif (!outputs.length) {\n  throw new Error(`Build Jobs terminou sem outputs. debug=${JSON.stringify({\n    inputCount: inputItems.length,\n    buildPayloadCount: jobEntries.length,\n    uploadedByJobKeys: [...uploadedByJob.keys()],\n    aiByJobKeys: [...aiByJob.keys()],\n  })}`);\n}\n\nfor (const output of outputs) ensureOutputDestinationContract(output);\n\nconst outputErrors = outputs.filter((item) => safeString(item && item.json && item.json.error));\nif (outputErrors.length) {\n  throw new Error(`Build Jobs bloqueou o lote antes de qualquer mutacao Meta. errors=${JSON.stringify(outputErrors.map((item) => item.json))}`);\n}\n\nreturn outputs;\n"
+      },
+      "id": "a80bbf9d-8e2a-4d2e-aa18-78eb1407c0b9",
+      "name": "Build Jobs",
+      "type": "n8n-nodes-base.code",
+      "position": [
+        8304,
+        1272
+      ],
+      "retryOnFail": true,
+      "typeVersion": 2,
+      "maxTries": 3,
+      "waitBetweenTries": 5000
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "7d3f07ca-fca2-49c8-acf9-91387cc084b1",
+      "name": "Create AdCreative",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        9648,
+        1568
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 20000,
+      "typeVersion": 4.3,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "resource": "fileFolder",
+        "searchMethod": "query",
+        "queryString": "=(mimeType contains 'image/' or mimeType = 'video/mp4' or mimeType = 'video/quicktime') and not properties has {key = 'published' and value = 'true'} and trashed = false",
+        "returnAll": true,
+        "filter": {
+          "folderId": {
+            "__rl": true,
+            "mode": "id",
+            "value": "1z15HKnEXN5gWuwHndMQGNYXm-Wsiq5da"
+          }
+        },
+        "options": {
+          "fields": [
+            "*"
+          ]
+        }
+      },
+      "id": "b2b7d119-cf13-4d01-bb74-910aa205526c",
+      "name": "Search File",
+      "type": "n8n-nodes-base.googleDrive",
+      "position": [
+        -2848,
+        1252
+      ],
+      "retryOnFail": true,
+      "typeVersion": 3,
+      "waitBetweenTries": 3000,
+      "maxTries": 3,
+      "credentials": {
+        "googleDriveOAuth2Api": {
+          "id": "jO1yl4X4hfN2kBxd",
+          "name": "Google Cloud - Drive"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "request",
+              "value": "={{ JSON.stringify($json.gateway_request) }}"
+            },
+            {
+              "parameterType": "formBinaryData",
+              "name": "file",
+              "inputDataFieldName": "data"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "16b40bc2-6e80-47ba-ba35-fb7e7fde03cf",
+      "name": "Upload File",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        6688,
+        1000
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "typeVersion": 4.2,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "download",
+        "fileId": {
+          "__rl": true,
+          "mode": "id",
+          "value": "={{ $json.id }}"
+        },
+        "options": {}
+      },
+      "id": "c73cb783-7c49-467f-b067-396a7e1ed4a7",
+      "name": "Download File",
+      "type": "n8n-nodes-base.googleDrive",
+      "position": [
+        -2624,
+        1252
+      ],
+      "retryOnFail": true,
+      "typeVersion": 3,
+      "waitBetweenTries": 3000,
+      "maxTries": 3,
+      "credentials": {
+        "googleDriveOAuth2Api": {
+          "id": "jO1yl4X4hfN2kBxd",
+          "name": "Google Cloud - Drive"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "model": {
+          "__rl": true,
+          "value": "gpt-5.6-luna",
+          "mode": "list",
+          "cachedResultName": "gpt-5.6-luna"
+        },
+        "builtInTools": {},
+        "options": {
+          "textFormat": {
+            "textOptions": {
+              "type": "json_schema",
+              "name": "meta_ads_publish",
+              "schema": "{\n  \"type\": \"object\",\n  \"additionalProperties\": false,\n  \"required\": [\n    \"job_key\",\n    \"group_key\",\n    \"source_ad_name\",\n    \"analysis\",\n    \"creative_override\"\n  ],\n  \"properties\": {\n    \"source_ad_name\": {\n      \"type\": \"string\",\n      \"minLength\": 1\n    },\n    \"analysis\": {\n      \"type\": \"object\",\n      \"additionalProperties\": false,\n      \"required\": [\n        \"content_type\",\n        \"detected_procedures\",\n        \"adsPricing\",\n        \"crmPricing\",\n        \"notes\"\n      ],\n      \"properties\": {\n        \"content_type\": {\n          \"type\": \"string\",\n          \"enum\": [\n            \"image\",\n            \"video\",\n            \"mixed\",\n            \"unknown\"\n          ]\n        },\n        \"detected_procedures\": {\n          \"type\": \"array\",\n          \"maxItems\": 10,\n          \"items\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"name\",\n              \"evidence\"\n            ],\n            \"properties\": {\n              \"name\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 120\n              },\n              \"evidence\": {\n                \"type\": \"array\",\n                \"minItems\": 1,\n                \"maxItems\": 10,\n                \"items\": {\n                  \"type\": \"string\",\n                  \"minLength\": 1,\n                  \"maxLength\": 200\n                }\n              }\n            }\n          }\n        },\n        \"adsPricing\": {\n          \"type\": \"object\",\n          \"additionalProperties\": false,\n          \"required\": [\n            \"value\",\n            \"offer\",\n            \"source\"\n          ],\n          \"properties\": {\n            \"value\": {\n              \"type\": \"string\",\n              \"maxLength\": 120\n            },\n            \"offer\": {\n              \"type\": \"string\",\n              \"maxLength\": 180\n            },\n            \"source\": {\n              \"type\": \"string\",\n              \"enum\": [\n                \"media\",\n                \"none\"\n              ]\n            }\n          }\n        },\n        \"notes\": {\n          \"type\": \"string\",\n          \"maxLength\": 500\n        },\n        \"crmPricing\": {\n          \"type\": \"object\",\n          \"additionalProperties\": false,\n          \"required\": [\n            \"value\",\n            \"offer\",\n            \"source\"\n          ],\n          \"properties\": {\n            \"value\": {\n              \"type\": \"string\",\n              \"maxLength\": 120\n            },\n            \"offer\": {\n              \"type\": \"string\",\n              \"maxLength\": 180\n            },\n            \"source\": {\n              \"type\": \"string\",\n              \"enum\": [\n                \"crm\",\n                \"none\"\n              ]\n            }\n          }\n        }\n      }\n    },\n    \"creative_override\": {\n      \"type\": \"object\",\n      \"additionalProperties\": false,\n      \"required\": [\n        \"bodies\",\n        \"titles\",\n        \"descriptions\",\n        \"site_links\"\n      ],\n      \"properties\": {\n        \"bodies\": {\n          \"type\": \"array\",\n          \"minItems\": 5,\n          \"maxItems\": 5,\n          \"items\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"text\"\n            ],\n            \"properties\": {\n              \"text\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 240\n              }\n            }\n          }\n        },\n        \"titles\": {\n          \"type\": \"array\",\n          \"minItems\": 5,\n          \"maxItems\": 5,\n          \"items\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"text\"\n            ],\n            \"properties\": {\n              \"text\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 40\n              }\n            }\n          }\n        },\n        \"descriptions\": {\n          \"type\": \"array\",\n          \"minItems\": 5,\n          \"maxItems\": 5,\n          \"items\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"text\"\n            ],\n            \"properties\": {\n              \"text\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 60\n              }\n            }\n          }\n        },\n        \"site_links\": {\n          \"type\": \"array\",\n          \"minItems\": 0,\n          \"maxItems\": 4,\n          \"items\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"title\",\n              \"url\"\n            ],\n            \"properties\": {\n              \"title\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 80\n              },\n              \"url\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"maxLength\": 500,\n                \"pattern\": \"^https://.+\"\n              }\n            }\n          }\n        }\n      }\n    },\n    \"job_key\": {\n      \"type\": \"string\",\n      \"minLength\": 1\n    },\n    \"group_key\": {\n      \"type\": \"string\",\n      \"minLength\": 1\n    }\n  }\n}"
+            }
+          }
+        }
+      },
+      "id": "c8d0afca-6e56-4e2a-83e8-c7935cf30331",
+      "name": "OpenAI Chat Model (Agent)",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "position": [
+        7360,
+        1688
+      ],
+      "retryOnFail": true,
+      "typeVersion": 1.3,
+      "waitBetweenTries": 5000,
+      "credentials": {
+        "openAiApi": {
+          "id": "d5x9D1q8y2QXDeUD",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "retrieve-as-tool",
+        "toolName": "documents",
+        "toolDescription": "Contexto da marca Espaço Facial: benefícios, diferenciais, tom de voz, mensagens anteriores e orientações seguras de comunicação.",
+        "tableName": {
+          "__rl": true,
+          "mode": "list",
+          "value": "documents",
+          "cachedResultName": "documents"
+        },
+        "topK": 6,
+        "options": {}
+      },
+      "id": "6404e851-c259-4534-88c5-0b72ae237037",
+      "name": "Documents",
+      "type": "@n8n/n8n-nodes-langchain.vectorStoreSupabase",
+      "position": [
+        7488,
+        1688
+      ],
+      "typeVersion": 1.1,
+      "credentials": {
+        "supabaseApi": {
+          "id": "4Qk1QXPbz4tLJvF9",
+          "name": "Supabase account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "6fb82d7b-d670-41ca-9c51-cddd9ecda563",
+      "name": "Embeddings OpenAI",
+      "type": "@n8n/n8n-nodes-langchain.embeddingsOpenAi",
+      "position": [
+        7568,
+        1896
+      ],
+      "retryOnFail": true,
+      "typeVersion": 1.2,
+      "waitBetweenTries": 5000,
+      "credentials": {
+        "openAiApi": {
+          "id": "d5x9D1q8y2QXDeUD",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "numberInputs": 3
+      },
+      "id": "e204ebb1-bfb1-4d13-83cd-df63cc5c9913",
+      "name": "Merge (1)",
+      "type": "n8n-nodes-base.merge",
+      "position": [
+        2432,
+        1360
+      ],
+      "retryOnFail": true,
+      "typeVersion": 3.2,
+      "waitBetweenTries": 5000
+    },
+    {
+      "parameters": {},
+      "id": "0e200cdf-a264-48bc-8953-f5f6345a9a19",
+      "name": "Merge (2)",
+      "type": "n8n-nodes-base.merge",
+      "position": [
+        7856,
+        1272
+      ],
+      "retryOnFail": true,
+      "typeVersion": 3.2,
+      "waitBetweenTries": 5000
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/inventory' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "d7c1fcbb-be4d-4ba3-8f16-5db1f18d2baa",
+      "name": "Meta List Ads",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        1920,
+        1736
+      ],
+      "retryOnFail": false,
+      "typeVersion": 4.2,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const inputItems = $input.all();\n\nconst SLOT_CONFIG = [\n  // Feed uses 4:5 when that exact source asset exists. Other accepted source\n  // aspects remain valid fallbacks and must not be cropped merely to invent 4:5.\n  { slot: 'feed', acceptedRatios: ['4x5', '3x4', '1x1'] },\n  { slot: 'banner', acceptedRatios: ['2x1'] },\n  { slot: 'stories', acceptedRatios: ['9x16'] },\n];\n\nconst RATIO_ORDER = {\n  '1x1': 1,\n  '2x1': 2,\n  '4x5': 3,\n  '3x4': 4,\n  '9x16': 5,\n  '16x9': 6,\n};\n\nconst CREATIVE_TYPES = new Set([\n  'estatico',\n  'estatic',\n  'static',\n  'video',\n  'carrossel',\n]);\n\nconst KNOWN_OFFER_TYPES = new Set([\n  'price',\n  'regular',\n  'sessao',\n  'sessoes',\n  'desconto',\n  'brinde',\n  'procedimento_gratis',\n  'procedimento',\n  'clube_anual',\n  'combo',\n  'parcelado',\n  'avista',\n]);\n\nfunction isCreativeTypePart(part) {\n  return CREATIVE_TYPES.has(safeString(part).toLowerCase());\n}\n\nfunction isRatioPart(part) {\n  return Boolean(detectRatio(part));\n}\n\nfunction findLastIndex(values, predicate) {\n  for (let i = safeArray(values).length - 1; i >= 0; i--) {\n    if (predicate(values[i], i)) return i;\n  }\n  return -1;\n}\n\nfunction safeString(value) {\n  return String(value ?? '').trim();\n}\n\nfunction deepClone(value) {\n  return value == null ? value : JSON.parse(JSON.stringify(value));\n}\n\nfunction normalizeText(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9_]+/g, ' ')\n    .replace(/\\s+/g, ' ')\n    .trim()\n    .toUpperCase();\n}\n\nfunction normalizeKey(value) {\n  return normalizeText(value).replace(/\\s+/g, '_');\n}\n\nfunction normalizeLandingPageKey(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '_')\n    .replace(/_+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toUpperCase();\n}\n\nfunction normalizeCompactKey(value) {\n  return normalizeText(value).replace(/\\s+/g, '');\n}\n\nfunction safeArray(value) {\n  return Array.isArray(value) ? value : [];\n}\n\nfunction uniqueStrings(values) {\n  const out = [];\n  const seen = new Set();\n\n  for (const value of safeArray(values)) {\n    const normalized = safeString(value);\n    if (!normalized) continue;\n\n    const key = normalized.toLowerCase();\n    if (seen.has(key)) continue;\n\n    seen.add(key);\n    out.push(normalized);\n  }\n\n  return out;\n}\n\nfunction uniqueObjectsBy(values, getKey) {\n  const out = [];\n  const seen = new Set();\n\n  for (const value of safeArray(values)) {\n    const key = safeString(getKey(value));\n    if (!key || seen.has(key)) continue;\n    seen.add(key);\n    out.push(value);\n  }\n\n  return out;\n}\n\nfunction cleanupBrokenFileName(name) {\n  return safeString(name)\n    .normalize('NFC')\n    .replace(/(\\.jpg|\\.jpeg|\\.png|\\.webp)+$/i, (match) => {\n      const extMatch = match.match(/\\.(jpg|jpeg|png|webp)/i);\n      return extMatch ? extMatch[0].toLowerCase() : match.toLowerCase();\n    })\n    .replace(/(jpg|jpeg|png|webp)(2x1|3x4|4x5|9x16|1x1|16x9)(\\.(jpg|jpeg|png|webp))$/i, '__$2$3');\n}\n\nfunction stripExtension(name) {\n  return safeString(name).replace(/\\.[^.]+$/, '').trim();\n}\n\nfunction detectRatio(value) {\n  const text = safeString(value).toLowerCase();\n\n  const patterns = [\n    { ratio: '9x16', regex: /(?:^|[^a-z0-9])9x16(?:[^a-z0-9]|$)/i },\n    { ratio: '16x9', regex: /(?:^|[^a-z0-9])16x9(?:[^a-z0-9]|$)/i },\n    { ratio: '4x5', regex: /(?:^|[^a-z0-9])4x5(?:[^a-z0-9]|$)/i },\n    { ratio: '3x4', regex: /(?:^|[^a-z0-9])3x4(?:[^a-z0-9]|$)/i },\n    { ratio: '2x1', regex: /(?:^|[^a-z0-9])2x1(?:[^a-z0-9]|$)/i },\n    { ratio: '1x1', regex: /(?:^|[^a-z0-9])1x1(?:[^a-z0-9]|$)/i },\n  ];\n\n  for (const entry of patterns) {\n    if (entry.regex.test(text)) return entry.ratio;\n  }\n\n  return '';\n}\n\nfunction parseFriendlyOrientationName(value) {\n  const normalized = stripExtension(cleanupBrokenFileName(value))\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, ' ')\n    .replace(/\\s+/g, ' ')\n    .trim()\n    .toLowerCase();\n  const match = normalized.match(/^(wide|horizontal|vertical|square|quadrado)(?:\\s+(.+))?$/i);\n  if (!match) return null;\n\n  const orientation = match[1].toLowerCase();\n  const groupLabel = safeString(match[2] || 'default');\n  const ratioByOrientation = {\n    wide: '2x1',\n    horizontal: '2x1',\n    vertical: '9x16',\n    square: '1x1',\n    quadrado: '1x1',\n  };\n  const semanticLabel = /^\\d+$|^v\\d+$/i.test(groupLabel)\n    ? `creative_set_${groupLabel}`\n    : groupLabel;\n\n  return {\n    orientation,\n    ratio: ratioByOrientation[orientation],\n    group_label: groupLabel,\n    logical_base_name: semanticLabel,\n    group_key: `FRIENDLY_${normalizeKey(groupLabel) || 'DEFAULT'}`,\n  };\n}\n\nfunction detectSuffixHint(value) {\n  const parts = splitStructuredParts(value);\n\n  if (parts.includes('generic')) return 'generic';\n\n  return 'campaign';\n}\n\nfunction removeSuffixHint(value) {\n  return safeString(value)\n    .replace(/(?:[\\s_-]+)(generic|campaign)$/i, '')\n    .replace(/[_-]+$/g, '')\n    .trim();\n}\n\nfunction stripFileDecorations(name) {\n  const cleaned = cleanupBrokenFileName(name);\n  const parts = splitStructuredParts(cleaned);\n\n  const ratioIndex = findLastIndex(parts, isRatioPart);\n\n  // Se achou proporção, tudo depois dela é formato, versão ou campanha.\n  if (ratioIndex > 0) {\n    return parts.slice(0, ratioIndex).join('__').trim();\n  }\n\n  return parts\n    .filter((part) => !isCreativeTypePart(part))\n    .filter((part) => !isRatioPart(part))\n    .filter((part) => part !== 'generic' && part !== 'campaign')\n    .filter((part) => !/^v\\d+$/i.test(part))\n    .join('__')\n    .trim();\n}\n\nfunction splitStructuredParts(name) {\n  const cleaned = cleanupBrokenFileName(name);\n  const withoutExt = stripExtension(cleaned);\n\n  const normalized = withoutExt\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9_]+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toLowerCase();\n\n  return normalized\n    .split(/__+/)\n    .map((part) =>\n      safeString(part)\n        .replace(/^_+|_+$/g, '')\n        .replace(/_+/g, '_')\n        .toLowerCase()\n    )\n    .filter(Boolean);\n}\n\nfunction parseStructuredCreativeName(name) {\n  const parts = splitStructuredParts(name);\n  if (parts.length < 4) return null;\n\n  const suffix_hint = detectSuffixHint(name);\n\n  const formatIndex = findLastIndex(parts, isRatioPart);\n  if (formatIndex < 0) return null;\n\n  const format = parts[formatIndex];\n\n  const prefixParts = parts.slice(0, formatIndex);\n  const tailParts = parts.slice(formatIndex + 1);\n\n  const creative_type =\n    tailParts.find((part) => isCreativeTypePart(part)) || '';\n\n  const version =\n    tailParts.find((part) => /^v\\d+$/i.test(part)) || '';\n\n  const campaign_key = tailParts\n    .filter((part) => !isCreativeTypePart(part))\n    .filter((part) => part !== 'generic' && part !== 'campaign')\n    .filter((part) => !/^v\\d+$/i.test(part))\n    .join('__');\n\n  if (prefixParts.length < 2) return null;\n\n  let offerIndex = -1;\n\n  for (let i = 1; i < prefixParts.length; i++) {\n    if (KNOWN_OFFER_TYPES.has(prefixParts[i])) {\n      offerIndex = i;\n      break;\n    }\n  }\n\n  if (offerIndex === -1) {\n    offerIndex = Math.max(1, prefixParts.length - 3);\n  }\n\n  const productKeyParts = prefixParts.slice(0, offerIndex);\n  const remainder = prefixParts.slice(offerIndex);\n\n  if (!productKeyParts.length || !remainder.length) return null;\n\n  const offer_type = remainder[0] || '';\n  const offer_detail = remainder[1] || '';\n  const payment_term = remainder.slice(2).join('__');\n\n  const product_key = productKeyParts.join('__');\n\n  const offer_key = [\n    product_key,\n    offer_type,\n    offer_detail,\n    payment_term,\n  ].filter(Boolean).join('__');\n\n  const format_key = [\n    offer_key,\n    format,\n    creative_type,\n  ].filter(Boolean).join('__');\n\n  return {\n    raw_name: name,\n    base_name: removeSuffixHint(stripFileDecorations(name)),\n    normalized: parts.join('__'),\n\n    product_key,\n    item_key: '',\n    presentation: '',\n    area: '',\n\n    offer_type,\n    offer_detail,\n    payment_term,\n\n    format,\n    creative_type,\n    version,\n    campaign_key,\n\n    offer_key,\n    format_key,\n    full_key: format_key,\n\n    suffix_hint,\n  };\n}\n\nfunction inferProductFamily(value) {\n  const text = normalizeText(value).replace(/_/g, ' ');\n\n  if (text.includes('BIOESTIMULADOR') && text.includes('COLAGENO')) {\n    return 'bioestimulador_colageno';\n  }\n\n  if (text.includes('BIOESTIMULADOR')) {\n    return 'bioestimulador';\n  }\n\n  if (text.includes('BOTOX') || text.includes('TOXINA')) {\n    return 'botox';\n  }\n\n  if (text.includes('PREENCHIMENTO') && text.includes('LABIAL')) {\n    return 'preenchimento_labial';\n  }\n\n  if (text.includes('PREENCHIMENTO')) {\n    return 'preenchimento';\n  }\n\n  if (text.includes('LAVIEEN')) {\n    return 'lavieen';\n  }\n\n  if (text.includes('SCULPTRA')) {\n    return 'sculptra';\n  }\n\n  if (text.includes('RADIESSE')) {\n    return 'radiesse';\n  }\n\n  if (text.includes('ELLEVA')) {\n    return 'elleva';\n  }\n\n  return '';\n}\n\nfunction inferOfferMarkers(value) {\n  const text = normalizeText(value).replace(/_/g, ' ');\n  const markers = new Set();\n\n  if (text.includes('PRICE') || text.includes('PRECO') || text.includes('A PARTIR') || /R\\D*\\d+/i.test(safeString(value))) {\n    markers.add('price');\n  }\n\n  if (text.includes('SESSAO') || text.includes('SESSOES')) markers.add('sessao');\n  if (text.includes('AVISTA') || text.includes('PIX')) markers.add('avista');\n  if (text.includes('10X') || text.includes('PARCELADO') || text.includes('CARTAO')) markers.add('parcelado');\n  if (text.includes('2X1')) markers.add('2x1');\n  if (text.includes('BRINDE')) markers.add('brinde');\n  if (text.includes('COMBO')) markers.add('combo');\n  if (text.includes('REGULAR')) markers.add('regular');\n\n  return [...markers];\n}\n\nfunction scoreOfferMarkerFit(groupMarkers, adMarkers) {\n  const groupSet = new Set(safeArray(groupMarkers));\n  const adSet = new Set(safeArray(adMarkers));\n\n  let score = 0;\n  const reasons = [];\n\n  for (const marker of groupSet) {\n    if (adSet.has(marker)) {\n      score += 25;\n      reasons.push(`marcador compartilhado: ${marker}`);\n    }\n  }\n\n  // PIX é uma boa aproximação para \"à vista\".\n  if (groupSet.has('avista') && adSet.has('avista')) {\n    score += 15;\n    reasons.push('pagamento à vista/PIX compatível');\n  }\n\n  // Penaliza anúncios antigos com mecânica muito diferente.\n  const hardConflicts = ['2x1', 'brinde', 'combo'];\n\n  for (const marker of hardConflicts) {\n    if (!groupSet.has(marker) && adSet.has(marker)) {\n      score -= 45;\n      reasons.push(`penalidade por mecânica diferente: ${marker}`);\n    }\n  }\n\n  if (groupSet.has('avista') && adSet.has('parcelado') && !adSet.has('avista')) {\n    score -= 15;\n    reasons.push('pagamento diferente: parcelado vs à vista');\n  }\n\n  return { score, reasons };\n}\n\nfunction fingerprintToken(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '_')\n    .replace(/_+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toLowerCase();\n}\n\nfunction fingerprintTag(value) {\n  const match = /\\[OFV1:([A-Z0-9]+)\\]/i.exec(safeString(value));\n  return match ? `OFV1:${safeString(match[1]).toUpperCase()}` : '';\n}\n\nfunction canonicalOfferFingerprint({ procedures, price_amount_cents, price_qualifier, payment_terms, condition_terms, validity }) {\n  return [\n    'v1',\n    `p=${safeArray(procedures).map((entry) => `${fingerprintToken(entry.key)}:${fingerprintToken(entry.quantity) || 'unknown'}:${fingerprintToken(entry.unit) || 'unknown'}`).sort().join('+') || 'unknown'}`,\n    `price=${Math.max(0, Math.trunc(Number(price_amount_cents || 0)))}:${['fixed', 'from'].includes(fingerprintToken(price_qualifier)) ? fingerprintToken(price_qualifier) : 'unknown'}`,\n    `pay=${safeArray(payment_terms).map(fingerprintToken).filter(Boolean).sort().join('+') || 'none'}`,\n    `cond=${safeArray(condition_terms).map(fingerprintToken).filter(Boolean).sort().join('+') || 'none'}`,\n    `valid=${fingerprintToken(validity) || 'none'}`,\n  ].join('|');\n}\n\nfunction normalizedOfferFingerprint(raw) {\n  const source = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};\n  const procedures = safeArray(source.procedures)\n    .map((entry) => entry && typeof entry === 'object' ? entry : {})\n    .map((entry) => ({ key: fingerprintToken(entry.key), quantity: fingerprintToken(entry.quantity), unit: fingerprintToken(entry.unit) }))\n    .filter((entry) => entry.key);\n  const price_amount_cents = Math.max(0, Math.trunc(Number(source.price_amount_cents || 0)));\n  const price_qualifier = ['fixed', 'from'].includes(fingerprintToken(source.price_qualifier)) ? fingerprintToken(source.price_qualifier) : 'unknown';\n  const payment_terms = safeArray(source.payment_terms).map(fingerprintToken).filter(Boolean);\n  const condition_terms = safeArray(source.condition_terms).map(fingerprintToken).filter(Boolean);\n  const validity = fingerprintToken(source.validity);\n  const evidence = safeArray(source.evidence).map(safeString).filter(Boolean);\n  const replacement_eligible = source.replacement_eligible === true && Number(source.confidence) >= 0.9 &&\n    procedures.length > 0 && procedures.every((entry) => entry.quantity && entry.unit) &&\n    price_amount_cents > 0 && price_qualifier !== 'unknown' && evidence.length > 0;\n  return {\n    ...source,\n    procedures, price_amount_cents, price_qualifier, payment_terms, condition_terms, validity, evidence,\n    canonical_key: canonicalOfferFingerprint({ procedures, price_amount_cents, price_qualifier, payment_terms, condition_terms, validity }),\n    tag: fingerprintTag(source.tag) || safeString(source.tag),\n    replacement_eligible,\n    status: replacement_eligible ? 'verified' : 'unverified',\n  };\n}\n\nfunction centsFromText(value) {\n  const match = /R\\$\\s*([0-9]{1,6})(?:[\\.,]([0-9]{1,2}))?/i.exec(safeString(value));\n  if (!match) return 0;\n  return Number(match[1]) * 100 + Number((match[2] || '0').padEnd(2, '0').slice(0, 2));\n}\n\nfunction legacyOfferFingerprint(ad) {\n  const search = buildAdSearchText(ad);\n  const tag = fingerprintTag(ad && ad.name) || fingerprintTag(search);\n  if (tag) return { status: 'tagged', tag, replacement_eligible: true, source: 'internal_ad_name_tag' };\n  const normalized = normalizeText(search).replace(/_/g, ' ');\n  const procedures = [];\n  const botox = /(?:BOTOX|TOXINA)[^0-9]{0,32}([0-9]{1,3})\\s*(UI|U)\\b/i.exec(normalized);\n  if (botox) procedures.push({ key: 'botox', quantity: botox[1], unit: botox[2].toLowerCase() === 'u' ? 'ui' : botox[2].toLowerCase() });\n  const filler = /PREENCHIMENTO(?:\\s+LABIAL)?[^0-9]{0,40}([0-9]+(?:[\\.,][0-9]+)?)\\s*(ML)\\b/i.exec(normalized);\n  if (filler) procedures.push({ key: /PREENCHIMENTO\\s+LABIAL/i.test(normalized) ? 'preenchimento_labial' : 'preenchimento', quantity: filler[1].replace(',', '.'), unit: filler[2].toLowerCase() });\n  const price_amount_cents = centsFromText(search);\n  const price_qualifier = /A\\s+PARTIR\\s+DE/i.test(normalized) ? 'from' : price_amount_cents ? 'fixed' : 'unknown';\n  const payment_terms = [\n    ...(normalized.match(/\\b([0-9]{1,2})X\\b/g) || []).map((entry) => `parcelado_${entry.toLowerCase()}`),\n    ...(normalized.includes('PIX') ? ['pix'] : []),\n    ...(normalized.includes('A VISTA') ? ['avista'] : []),\n  ];\n  const condition_terms = ['COMBO', 'BRINDE', 'DESCONTO'].filter((term) => normalized.includes(term)).map((term) => term.toLowerCase());\n  const validityMatch = /(?:VALID[AO]\\s+DE\\s+)?([0-3]?[0-9]\\s*(?:A|ATE)\\s*[0-3]?[0-9](?:\\/[0-1]?[0-9](?:\\/[0-9]{2,4})?)?)/i.exec(normalized);\n  const validity = validityMatch ? fingerprintToken(validityMatch[1]) : '';\n  const fingerprint = normalizedOfferFingerprint({\n    confidence: procedures.length && price_amount_cents ? 1 : 0,\n    procedures, price_amount_cents, price_qualifier, payment_terms, condition_terms, validity,\n    evidence: procedures.length && price_amount_cents ? ['creative_text_reconstructed'] : [],\n    replacement_eligible: procedures.length > 0 && procedures.every((entry) => entry.quantity && entry.unit) && price_amount_cents > 0,\n  });\n  return { ...fingerprint, source: 'creative_text_reconstructed' };\n}\n\nfunction compareOfferFingerprints(expectedRaw, candidateRaw) {\n  const expected = normalizedOfferFingerprint(expectedRaw);\n  const candidate = candidateRaw && candidateRaw.status === 'tagged'\n    ? candidateRaw\n    : normalizedOfferFingerprint(candidateRaw);\n  if (!expected.replacement_eligible) return { status: 'offer_fingerprint_unverified', expected, candidate };\n  if (candidate.status === 'tagged') {\n    const expectedTag = fingerprintTag(expected.tag) || safeString(expected.tag).replace(/^\\[|\\]$/g, '');\n    return candidate.tag && candidate.tag === expectedTag\n      ? { status: 'exact', source: 'internal_ad_name_tag', expected, candidate }\n      : { status: 'offer_fingerprint_mismatch', source: 'internal_ad_name_tag', expected, candidate };\n  }\n  if (!candidate.replacement_eligible) return { status: 'offer_fingerprint_unverified', expected, candidate };\n  return candidate.canonical_key === expected.canonical_key\n    ? { status: 'exact', source: 'legacy_creative_text', expected, candidate }\n    : { status: 'offer_fingerprint_mismatch', source: 'legacy_creative_text', expected, candidate };\n}\n\nfunction parseStructuredCreativeNameFromText(text) {\n  const direct = parseStructuredCreativeName(text);\n  if (direct) return direct;\n\n  const normalized = safeString(text)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9_]+/g, '_')\n    .replace(/_+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toLowerCase();\n\n  if (!normalized) return null;\n\n  const candidates = normalized.match(/([a-z0-9_]+(?:__[a-z0-9_]+){5,})/g) || [];\n\n  for (const candidate of candidates) {\n    const parsed = parseStructuredCreativeName(candidate);\n    if (parsed) return parsed;\n  }\n\n  return null;\n}\n\nconst stopWords = new Set([\n  'A', 'AS', 'O', 'OS', 'DE', 'DA', 'DO', 'DAS', 'DOS', 'E', 'EM', 'NO', 'NA', 'NOS', 'NAS',\n  'PARA', 'POR', 'COM', 'SEM', 'UM', 'UMA', 'UNS', 'UMAS',\n  'CAMPAIGN', 'CAMPANHA', 'AD', 'ADS', 'LEAD', 'LEADS', 'WA', 'WHATSAPP',\n  'ANUNCIO', 'ANUNCIOS', 'CONJUNTO', 'ADSET', 'CRIATIVO', 'CRIATIVOS', 'COPY',\n  'ESPACO', 'FACIAL', 'BARRASHOPPINGSUL', 'NOVO', 'HAMBURGO',\n  'MES', 'CONSUMIDOR', 'OFERTA', 'EXCLUSIVO', 'EXCLUSIVA', 'TEMPO', 'LIMITADO',\n  'REGULAR', 'BRINDE', 'DESCONTO', 'PROCEDIMENTO', 'GRATIS',\n  'PADRAO', 'PIX', 'ESTATICO', 'ESTATIC', 'STATIC', 'VIDEO', 'CARROSSEL',\n  'GENERIC',\n]);\n\nfunction tokenize(value) {\n  return normalizeText(value)\n    .replace(/_/g, ' ')\n    .split(' ')\n    .map((token) => token.trim())\n    .filter((token) => token && token.length > 2 && !stopWords.has(token) && !/^\\d+$/.test(token));\n}\n\nfunction extractCreativeTexts(ad) {\n  const creative = ad && ad.creative ? ad.creative : {};\n  const assetFeed = creative.asset_feed_spec || {};\n  const storySpec = creative.object_story_spec || {};\n  const linkData = storySpec.link_data || {};\n\n  return {\n    titles: uniqueStrings([\n      ...safeArray(assetFeed.titles).map((item) => item && item.text),\n      creative.title,\n      linkData.name,\n    ]),\n    bodies: uniqueStrings([\n      ...safeArray(assetFeed.bodies).map((item) => item && item.text),\n      creative.body,\n      linkData.message,\n    ]),\n    descriptions: uniqueStrings([\n      ...safeArray(assetFeed.descriptions).map((item) => item && item.text),\n      linkData.description,\n    ]),\n  };\n}\n\nfunction buildAdSearchText(ad) {\n  const texts = extractCreativeTexts(ad);\n  return [\n    safeString(ad && ad.name),\n    ...texts.titles,\n    ...texts.bodies,\n    ...texts.descriptions,\n  ].join(' ');\n}\n\nfunction detectRatioFromLabelName(labelName) {\n  const normalized = normalizeText(labelName);\n\n  if (normalized.includes('IMAGE 1') || normalized.includes('IMAGE_1')) return '3x4';\n  if (normalized.includes('IMAGE 2') || normalized.includes('IMAGE_2')) return '2x1';\n  if (normalized.includes('IMAGE 3') || normalized.includes('IMAGE_3')) return '9x16';\n\n  if (normalized.includes('9X16')) return '9x16';\n  if (normalized.includes('16X9')) return '16x9';\n  if (normalized.includes('4X5')) return '4x5';\n  if (normalized.includes('3X4')) return '3x4';\n  if (normalized.includes('2X1')) return '2x1';\n  if (normalized.includes('1X1')) return '1x1';\n\n  return '';\n}\n\nfunction inferRatioFromImageCrops(imageCrops) {\n  const cropKeys = Object.keys(imageCrops || {}).map((key) => safeString(key));\n\n  const cropMap = {\n    '191x100': '2x1',\n    '100x100': '3x4',\n    '400x500': '4x5',\n    '300x400': '3x4',\n    '600x750': '4x5',\n    '768x1024': '3x4',\n    '90x160': '9x16',\n    '160x90': '16x9',\n    '1080x1920': '9x16',\n    '1920x1080': '16x9',\n    '1080x1080': '1x1',\n    '1200x628': '2x1',\n  };\n\n  for (const key of cropKeys) {\n    if (cropMap[key]) return cropMap[key];\n  }\n\n  return '';\n}\n\nfunction inferRatioFromRule(rule, creativeImages) {\n  const customization = rule && rule.customization_spec ? rule.customization_spec : {};\n  const imageLabel = rule && rule.image_label ? rule.image_label : {};\n  const labelName = safeString(imageLabel.name);\n\n  const ratioFromLabel = detectRatioFromLabelName(labelName);\n  if (ratioFromLabel) return ratioFromLabel;\n\n  const imageId = safeString(imageLabel.id);\n  const creativeImage = safeArray(creativeImages).find((img) =>\n    safeArray(img && img.adlabels).some((label) => safeString(label && label.id) === imageId)\n  );\n  const ratioFromCrop = inferRatioFromImageCrops(creativeImage && creativeImage.image_crops ? creativeImage.image_crops : {});\n  if (ratioFromCrop) return ratioFromCrop;\n\n  const allPositions = [\n    ...safeArray(customization.publisher_platforms),\n    ...safeArray(customization.facebook_positions),\n    ...safeArray(customization.instagram_positions),\n    ...safeArray(customization.audience_network_positions),\n    ...safeArray(customization.messenger_positions),\n  ].map((value) => safeString(value).toLowerCase());\n\n  if (allPositions.some((value) => ['story', 'stories', 'reels', 'facebook_reels', 'instagram_reels'].includes(value))) {\n    return '9x16';\n  }\n\n  if (allPositions.includes('search')) {\n    return '2x1';\n  }\n\n  if (allPositions.some((value) =>\n    [\n      'feed',\n      'stream',\n      'explore',\n      'explore_home',\n      'marketplace',\n      'notification',\n      'instream_video',\n      'video_feeds',\n      'right_hand_column',\n      'facebook_feed',\n      'instagram_stream',\n    ].includes(value)\n  )) {\n    return '3x4';\n  }\n\n  return '';\n}\n\nfunction binaryKeyForRatio(ratio) {\n  return `data_${safeString(ratio).replace(/[^a-zA-Z0-9]+/g, '_')}`;\n}\n\nfunction binaryKeyForRole(role) {\n  return `data_${safeString(role).replace(/[^a-zA-Z0-9]+/g, '_')}`;\n}\n\nfunction ratioToSlot(ratio) {\n  const normalizedRatio = safeString(ratio);\n  const config = SLOT_CONFIG.find((entry) => entry.acceptedRatios.includes(normalizedRatio));\n  return config ? config.slot : '';\n}\n\nfunction preferredRatiosForSlot(slot) {\n  const config = SLOT_CONFIG.find((entry) => entry.slot === slot);\n  return config ? config.acceptedRatios : [];\n}\n\nfunction getRequiredRatiosForGroup(group) {\n  const selectedRatios = [];\n\n  for (const config of SLOT_CONFIG) {\n    const match = safeArray(group.imagens).find((image) => config.acceptedRatios.includes(safeString(image.proporcao)));\n    if (!match) return [];\n    selectedRatios.push(safeString(match.proporcao));\n  }\n\n  return selectedRatios;\n}\n\nfunction pickMediaItemForTargetRatio(targetRatio, mediaInventoryByRatio) {\n  const exact = mediaInventoryByRatio.get(safeString(targetRatio));\n  if (exact) return exact;\n\n  const targetSlot = ratioToSlot(targetRatio);\n  if (!targetSlot) return null;\n\n  for (const mediaItem of mediaInventoryByRatio.values()) {\n    if (ratioToSlot(mediaItem && mediaItem.proporcao) === targetSlot) {\n      return mediaItem;\n    }\n  }\n\n  return null;\n}\n\nfunction buildReplacementPlanForAd(ad, mediaInventoryByRatio) {\n  const creative = ad && ad.creative ? ad.creative : {};\n  const assetFeed = creative.asset_feed_spec || {};\n  const rules = safeArray(assetFeed.asset_customization_rules);\n  const creativeImages = safeArray(assetFeed.images);\n\n  const plan = [];\n\n  for (const rule of rules) {\n    const targetRatio = inferRatioFromRule(rule, creativeImages);\n    if (!targetRatio) continue;\n\n    const mediaItem = pickMediaItemForTargetRatio(targetRatio, mediaInventoryByRatio);\n    if (!mediaItem) continue;\n\n    plan.push({\n      ad_id: safeString(ad.id),\n      ad_name: safeString(ad.name),\n      creative_id: safeString(creative.id),\n      ratio: safeString(mediaItem.proporcao),\n      target_ratio: safeString(targetRatio),\n      replacement_slot: ratioToSlot(mediaItem.proporcao) || ratioToSlot(targetRatio),\n      binary_key: safeString(mediaItem.binary_key),\n      new_image_drive_id: safeString(mediaItem.id),\n      new_image_name: safeString(mediaItem.name),\n      target_image_label_id: safeString(rule && rule.image_label && rule.image_label.id),\n      target_image_label_name: safeString(rule && rule.image_label && rule.image_label.name),\n      rule_priority: rule && rule.priority != null ? rule.priority : null,\n      inferred_from_positions: true,\n      ratio_was_adapted: safeString(mediaItem.proporcao) !== safeString(targetRatio),\n    });\n  }\n\n  return uniqueObjectsBy(plan, (item) =>\n    [item.ad_id, item.target_ratio, item.target_image_label_id || item.target_image_label_name].join('::')\n  );\n}\n\nfunction buildMatchDecision(groupMeta, adMeta) {\n  const reasons = [];\n  let match_level = 'none';\n  let score = 0;\n\n  if (\n    groupMeta?.offer_key &&\n    adMeta?.parsed_naming?.offer_key &&\n    groupMeta.offer_key === adMeta.parsed_naming.offer_key\n  ) {\n    match_level = 'offer_key_exact';\n    score = 1000;\n    reasons.push('offer_key exata');\n  } else if (\n    groupMeta?.product_key &&\n    adMeta?.parsed_naming?.product_key &&\n    groupMeta.product_key === adMeta.parsed_naming.product_key &&\n    groupMeta.offer_type === adMeta.parsed_naming.offer_type &&\n    groupMeta.offer_detail === adMeta.parsed_naming.offer_detail\n  ) {\n    match_level = 'product_plus_offer';\n    score = 800;\n    reasons.push('product_key + offer_type + offer_detail');\n  } else if (\n    groupMeta?.product_key &&\n    adMeta?.parsed_naming?.product_key &&\n    groupMeta.product_key === adMeta.parsed_naming.product_key\n  ) {\n    match_level = 'product_only';\n    score = 600;\n    reasons.push('product_key exata');\n  } else if (\n    groupMeta?.product_family &&\n    adMeta?.product_family &&\n    groupMeta.product_family === adMeta.product_family\n  ) {\n    match_level = 'product_family_offer_fit';\n    score = 420;\n    reasons.push(`familia de produto compatível: ${groupMeta.product_family}`);\n  } else if (\n    groupMeta?.product_family &&\n    adMeta?.product_family &&\n    (\n      groupMeta.product_family.includes(adMeta.product_family) ||\n      adMeta.product_family.includes(groupMeta.product_family)\n    )\n  ) {\n    match_level = 'product_family_soft';\n    score = 320;\n    reasons.push(`familia de produto aproximada: ${groupMeta.product_family} ~ ${adMeta.product_family}`);\n  }\n\n  const markerFit = scoreOfferMarkerFit(groupMeta.offer_markers, adMeta.offer_markers);\n  score += markerFit.score;\n  reasons.push(...markerFit.reasons);\n\n  const groupTokenSet = new Set(groupMeta.tokens || []);\n  const sharedTokens = safeArray(adMeta.tokens).filter((token) => groupTokenSet.has(token));\n  let textScore = sharedTokens.length * 6;\n\n  if (groupMeta.compact_name && adMeta.compact_name && adMeta.compact_name.includes(groupMeta.compact_name)) textScore += 12;\n  if (groupMeta.normalized_name && adMeta.normalized_name && adMeta.normalized_name.includes(groupMeta.normalized_name)) textScore += 8;\n\n  const exactTokenMatch =\n    safeArray(groupMeta.tokens).length > 0 &&\n    safeArray(groupMeta.tokens).every((token) => safeArray(adMeta.tokens).includes(token));\n\n  if (exactTokenMatch) textScore += 10;\n\n  const exactNameMatch = Boolean(groupMeta.normalized_name && adMeta.normalized_name === groupMeta.normalized_name);\n  if (exactNameMatch) textScore += 20;\n\n  if (match_level === 'none' && textScore > 0) {\n    match_level = 'text_fallback';\n    score = textScore;\n    reasons.push('fallback textual');\n  } else {\n    score += textScore;\n    if (textScore > 0) reasons.push(`reforco textual ${textScore}`);\n  }\n\n  return {\n    match_level,\n    score,\n    reasons,\n    shared_tokens: sharedTokens,\n    exact_name_match: exactNameMatch,\n    exact_token_match: exactTokenMatch,\n  };\n}\n\nfunction buildSourceAdTexts(sourceAd) {\n  if (!sourceAd) {\n    return { titles: [], bodies: [], descriptions: [] };\n  }\n  return extractCreativeTexts(sourceAd);\n}\n\nfunction createJobKey(parts) {\n  return normalizeKey(parts.filter(Boolean).join('__'));\n}\n\nfunction inferUnitKey(value) {\n  const text = normalizeText(value).replace(/_/g, ' ');\n  const compact = text.replace(/\\s+/g, '');\n\n  if (\n    compact.includes('BARRASHOPPINGSUL') ||\n    text.includes('BARRA SHOPPING SUL') ||\n    /(?:^|\\s)BSS(?:\\s|$)/.test(text)\n  ) {\n    return 'bss';\n  }\n\n  if (\n    text.includes('NOVO HAMBURGO') ||\n    /(?:^|\\s)NH(?:\\s|$)/.test(text)\n  ) {\n    return 'nh';\n  }\n\n  return '';\n}\n\nfunction buildAdUnitSearchText(matchedAd) {\n  const source = matchedAd && matchedAd.source_ad ? matchedAd.source_ad : {};\n  const adset = source.adset || {};\n  const campaign = source.campaign || {};\n\n  return [\n    matchedAd && matchedAd.ad_name,\n    source.name,\n    adset.name,\n    campaign.name,\n  ].join(' ');\n}\n\nfunction buildDestinationUnitSearchText(destination) {\n  return [\n    destination && destination.destination_group,\n    destination && destination.group,\n    destination && destination.name,\n    destination && destination.adset_name,\n    destination && destination.destination_adset_name,\n    destination && destination.page_name,\n    destination && destination.row_number,\n  ].join(' ');\n}\n\nfunction selectBestAdsByDestination(selectedAds, destinations) {\n  const ordered = safeArray(selectedAds)\n    .slice()\n    .sort((a, b) => b.score - a.score || safeString(a.ad_name).localeCompare(safeString(b.ad_name)));\n\n  const remaining = ordered.slice();\n  const chosen = [];\n  const destinationUnits = uniqueStrings(\n    safeArray(destinations)\n      .map((destination) => inferUnitKey(buildDestinationUnitSearchText(destination)))\n      .filter(Boolean)\n  );\n\n  for (const destinationUnit of destinationUnits) {\n    const bestIndex = remaining.findIndex((ad) => inferUnitKey(buildAdUnitSearchText(ad)) === destinationUnit);\n\n    if (bestIndex >= 0) {\n      chosen.push(remaining[bestIndex]);\n      remaining.splice(bestIndex, 1);\n    }\n  }\n\n  if (chosen.length) return chosen;\n\n  const maxAds = Math.max(1, destinationUnits.length || safeArray(destinations).length || 1);\n  return ordered.slice(0, maxAds);\n}\n\nfunction limitSelectedAdsForSafety(selectedAds, destinations) {\n  const ordered = safeArray(selectedAds)\n    .slice()\n    .sort((a, b) => b.score - a.score || safeString(a.ad_name).localeCompare(safeString(b.ad_name)));\n\n  if (!ordered.length) return [];\n\n  const firstLevel = safeString(ordered[0].match_level);\n  const broadLevels = new Set(['product_only', 'product_family_offer_fit', 'product_family_soft', 'text_fallback']);\n\n  if (safeArray(destinations).length > 1) {\n    return selectBestAdsByDestination(ordered, destinations);\n  }\n\n  if (broadLevels.has(firstLevel)) {\n    return ordered.slice(0, 1);\n  }\n\n  return ordered.slice(0, Math.min(3, ordered.length));\n}\n\nfunction isDriveItem(item) {\n  return Boolean(\n    safeString(item?.id) &&\n    safeString(item?.name) &&\n    !Object.prototype.hasOwnProperty.call(item || {}, 'row_number') &&\n    !Object.prototype.hasOwnProperty.call(item || {}, 'data') &&\n    !Object.prototype.hasOwnProperty.call(item || {}, 'creative')\n  );\n}\n\nfunction isDestinationItem(item) {\n  return Boolean(\n    Object.prototype.hasOwnProperty.call(item || {}, 'row_number') &&\n    Object.prototype.hasOwnProperty.call(item || {}, 'destination_group') &&\n    (\n      Object.prototype.hasOwnProperty.call(item || {}, 'account_id') ||\n      Object.prototype.hasOwnProperty.call(item || {}, 'page_id') ||\n      Object.prototype.hasOwnProperty.call(item || {}, 'instagram_user_id') ||\n      Object.prototype.hasOwnProperty.call(item || {}, 'campaign_id') ||\n      Object.prototype.hasOwnProperty.call(item || {}, 'adset_id')\n    )\n  );\n}\n\nfunction flattenDataEntries(items) {\n  const out = [];\n\n  for (const item of safeArray(items)) {\n    const data = item && item.data;\n    if (!Array.isArray(data)) continue;\n\n    for (const entry of data) {\n      if (entry && typeof entry === 'object' && !Array.isArray(entry)) {\n        out.push(entry);\n      }\n    }\n  }\n\n  return out;\n}\n\nfunction buildCreativeGrouping(nameContext) {\n  const parsed = nameContext && nameContext.parsed_naming ? nameContext.parsed_naming : null;\n  const logicalBaseName = safeString(nameContext && nameContext.logical_base_name);\n  const offerKey = parsed && safeString(parsed.offer_key) ? safeString(parsed.offer_key) : '';\n  const campaignKey = parsed && safeString(parsed.campaign_key) ? safeString(parsed.campaign_key) : '';\n  const version = parsed && safeString(parsed.version) ? safeString(parsed.version) : '';\n  const discriminatorParts = uniqueStrings([campaignKey, version]);\n  const groupingDiscriminator = discriminatorParts.join('__');\n\n  if (offerKey && groupingDiscriminator) {\n    return {\n      offer_group_key: normalizeKey(offerKey),\n      creative_group_key: normalizeKey([offerKey, groupingDiscriminator].filter(Boolean).join('__')),\n      grouping_discriminator: groupingDiscriminator,\n      grouping_strategy: 'offer_key_plus_campaign_or_version',\n    };\n  }\n\n  if (offerKey) {\n    return {\n      offer_group_key: normalizeKey(offerKey),\n      creative_group_key: normalizeKey(offerKey),\n      grouping_discriminator: '',\n      grouping_strategy: 'offer_key_only',\n    };\n  }\n\n  return {\n    offer_group_key: normalizeKey(logicalBaseName),\n    creative_group_key: normalizeKey(logicalBaseName),\n    grouping_discriminator: '',\n    grouping_strategy: 'logical_base_name',\n  };\n}\n\nfunction buildNameContext(name) {\n  const rawName = safeString(name).normalize('NFC');\n  const cleanedName = cleanupBrokenFileName(rawName);\n  const friendlyOrientation = parseFriendlyOrientationName(cleanedName);\n  const ratio = detectRatio(cleanedName) || safeString(friendlyOrientation && friendlyOrientation.ratio);\n  const rawBaseWithoutExt = stripExtension(cleanedName);\n  const suffix_hint = detectSuffixHint(rawBaseWithoutExt);\n  const logicalBaseWithSuffix = rawBaseWithoutExt;\n  const logicalBaseName = friendlyOrientation\n    ? safeString(friendlyOrientation.logical_base_name)\n    : stripFileDecorations(cleanedName);\n  const parsedNaming = friendlyOrientation ? null : parseStructuredCreativeName(cleanedName);\n\n  const effectiveSuffixHint =\n    safeString(parsedNaming && parsedNaming.suffix_hint) ||\n    suffix_hint;\n\n  const grouping = friendlyOrientation\n    ? {\n        offer_group_key: normalizeKey(logicalBaseName),\n        creative_group_key: safeString(friendlyOrientation.group_key),\n        grouping_discriminator: safeString(friendlyOrientation.group_label),\n        grouping_strategy: 'friendly_orientation_plus_set',\n      }\n    : buildCreativeGrouping({\n        logical_base_name: logicalBaseName,\n        parsed_naming: parsedNaming ? deepClone(parsedNaming) : null,\n      });\n\n  return {\n    raw_name: rawName,\n    cleaned_name: cleanedName,\n    ratio,\n    suffix_hint: effectiveSuffixHint,\n    logical_base_name: logicalBaseName,\n    logical_base_with_suffix: logicalBaseWithSuffix,\n    friendly_orientation: friendlyOrientation ? deepClone(friendlyOrientation) : null,\n    parsed_naming: parsedNaming ? deepClone(parsedNaming) : null,\n    offer_group_key: grouping.offer_group_key,\n    creative_group_key: grouping.creative_group_key,\n    grouping_discriminator: grouping.grouping_discriminator,\n    grouping_strategy: grouping.grouping_strategy,\n    group_key: grouping.creative_group_key,\n  };\n}\n\nfunction buildEffectiveNameContext(json, name) {\n  const visual = json && typeof json.visual_grouping === 'object' && !Array.isArray(json.visual_grouping)\n    ? json.visual_grouping\n    : null;\n  if (!visual || safeString(visual.strategy) !== 'ai_visual_global') return buildNameContext(name);\n\n  const groupKey = normalizeKey(visual.group_key);\n  const ratio = safeString(visual.ratio).toLowerCase();\n  const visualConcept = safeString(visual.visual_concept) || groupKey;\n  if (!groupKey || !ratio) return buildNameContext(name);\n\n  return {\n    raw_name: safeString(name).normalize('NFC'),\n    cleaned_name: cleanupBrokenFileName(name),\n    ratio,\n    suffix_hint: 'campaign',\n    logical_base_name: visualConcept,\n    logical_base_with_suffix: visualConcept,\n    friendly_orientation: null,\n    parsed_naming: null,\n    offer_group_key: normalizeKey(visualConcept) || groupKey,\n    creative_group_key: groupKey,\n    grouping_discriminator: groupKey,\n    grouping_strategy: 'ai_visual_global',\n    group_key: groupKey,\n    visual_grouping: deepClone(visual),\n  };\n}\n\nfunction registerBinaryBucket(map, key, payload) {\n  if (!key) return;\n  if (!map.has(key)) map.set(key, []);\n  map.get(key).push(payload);\n}\n\nfunction sortCandidatesForSlot(candidates, slot, preferredSuffixHint) {\n  const preferredRatios = preferredRatiosForSlot(slot);\n\n  return safeArray(candidates).slice().sort((left, right) => {\n    const leftBinary = left.binary_found ? 1 : 0;\n    const rightBinary = right.binary_found ? 1 : 0;\n    if (leftBinary !== rightBinary) return rightBinary - leftBinary;\n\n    const leftSuffix = safeString(left.suffix_hint) === safeString(preferredSuffixHint) ? 1 : 0;\n    const rightSuffix = safeString(right.suffix_hint) === safeString(preferredSuffixHint) ? 1 : 0;\n    if (leftSuffix !== rightSuffix) return rightSuffix - leftSuffix;\n\n    const leftRatioOrder = preferredRatios.indexOf(safeString(left.proporcao));\n    const rightRatioOrder = preferredRatios.indexOf(safeString(right.proporcao));\n    if (leftRatioOrder !== rightRatioOrder) {\n      return (leftRatioOrder === -1 ? 999 : leftRatioOrder) - (rightRatioOrder === -1 ? 999 : rightRatioOrder);\n    }\n\n    const leftGlobalOrder = RATIO_ORDER[safeString(left.proporcao)] || 999;\n    const rightGlobalOrder = RATIO_ORDER[safeString(right.proporcao)] || 999;\n    if (leftGlobalOrder !== rightGlobalOrder) return leftGlobalOrder - rightGlobalOrder;\n\n    return safeString(left.name).localeCompare(safeString(right.name));\n  });\n}\n\nfunction chooseBestBinaryRef(candidates, preferredFileName, preferredSuffixHint) {\n  const normalizedPreferredFile = normalizeKey(cleanupBrokenFileName(preferredFileName));\n\n  return safeArray(candidates)\n    .slice()\n    .sort((left, right) => {\n      const leftExact = normalizeKey(cleanupBrokenFileName(left.fileName)) === normalizedPreferredFile ? 1 : 0;\n      const rightExact = normalizeKey(cleanupBrokenFileName(right.fileName)) === normalizedPreferredFile ? 1 : 0;\n      if (leftExact !== rightExact) return rightExact - leftExact;\n\n      const leftSuffix = safeString(left.suffix_hint) === safeString(preferredSuffixHint) ? 1 : 0;\n      const rightSuffix = safeString(right.suffix_hint) === safeString(preferredSuffixHint) ? 1 : 0;\n      if (leftSuffix !== rightSuffix) return rightSuffix - leftSuffix;\n\n      return safeString(left.fileName).localeCompare(safeString(right.fileName));\n    })[0] || null;\n}\n\nfunction pickResolvedBinary(binaryState, group, image) {\n  const driveMatch = binaryState.byDriveId.get(safeString(image.id)) || null;\n  if (driveMatch) return driveMatch;\n  const exactKey = normalizeKey(cleanupBrokenFileName(image.name || image.original_name));\n  const exactMatch = binaryState.byExactName.get(exactKey) || null;\n  if (exactMatch) return exactMatch;\n\n  const fallbackKey = `${group.group_key}::${image.proporcao}`;\n  const bucket = binaryState.byGroupAndRatio.get(fallbackKey) || [];\n  return chooseBestBinaryRef(bucket, image.name || image.original_name, group.suffix_hint);\n}\n\nfunction buildFailure(debug, message) {\n  throw new Error(`${message} | debug=${JSON.stringify(debug)}`);\n}\n\nconst allJson = inputItems.map((item) => (item && item.json ? item.json : item || {}));\nconst driveItems = allJson.filter(isDriveItem);\nconst destinations = allJson.filter(isDestinationItem);\nconst flattenedData = flattenDataEntries(allJson);\nconst placementChecks = allJson.flatMap((item) => safeArray(item && item.placement_checks));\n\nfunction placementCheckForDestination(destination) {\n  const adsetId = safeString(destination && (destination.adset_id || destination.destination_adset_id));\n  const group = normalizeCompactKey(destination && destination.destination_group);\n  return placementChecks.find((entry) => safeString(entry && entry.adset_id) === adsetId) ||\n    placementChecks.find((entry) => normalizeCompactKey(entry && entry.destination_group) === group) ||\n    null;\n}\n\nconst sourceAds = uniqueObjectsBy(\n  flattenedData.filter((item) =>\n    safeString(item.id) &&\n    safeString(item.name) &&\n    safeString(item.adset_id) &&\n    safeString(item.campaign_id) &&\n    item.creative\n  ),\n  (item) => safeString(item.id)\n);\n\nconst binaryState = {\n  byDriveId: new Map(),\n  byExactName: new Map(),\n  byGroupAndRatio: new Map(),\n};\n\nfor (const item of inputItems) {\n  const itemJson = item && item.json ? item.json : {};\n  const binaryData = item?.binary?.data;\n  const fileName = safeString(binaryData?.fileName || itemJson.name);\n  if (!binaryData || !fileName) continue;\n  const context = buildEffectiveNameContext(itemJson, itemJson.name || fileName);\n  const payload = {\n    data: deepClone(binaryData),\n    thumbnail: deepClone(item?.binary?.thumbnail || null),\n    analysis: deepClone(item?.binary?.analysis || null),\n    fileName,\n    source_file_id: safeString(itemJson.id),\n    media_type: safeString(itemJson.visual_grouping?.media_type || (safeString(binaryData.mimeType).startsWith('video/') ? 'video' : 'image')),\n    role: safeString(itemJson.visual_grouping?.role),\n    group_key: context.group_key,\n    offer_group_key: context.offer_group_key,\n    creative_group_key: context.creative_group_key,\n    grouping_discriminator: context.grouping_discriminator,\n    grouping_strategy: context.grouping_strategy,\n    ratio: context.ratio,\n    suffix_hint: context.suffix_hint,\n  };\n  if (payload.source_file_id) binaryState.byDriveId.set(payload.source_file_id, payload);\n  binaryState.byExactName.set(normalizeKey(cleanupBrokenFileName(fileName)), payload);\n  registerBinaryBucket(binaryState.byGroupAndRatio, `${context.group_key}::${context.ratio}`, payload);\n}\n\nconst groups = new Map();\n\nfor (const json of driveItems) {\n  const id = safeString(json.id);\n  const nameContext = buildEffectiveNameContext(json, json.name);\n\n  if (!id || !nameContext.cleaned_name || !nameContext.ratio) continue;\n\n  if (!groups.has(nameContext.group_key)) {\n    const visualOfferFingerprint = normalizedOfferFingerprint(nameContext.visual_grouping?.offer_fingerprint);\n    groups.set(nameContext.group_key, {\n      nome_base: nameContext.logical_base_name,\n      group_key: nameContext.group_key,\n      offer_group_key: nameContext.offer_group_key,\n      creative_group_key: nameContext.creative_group_key,\n      grouping_discriminator: nameContext.grouping_discriminator,\n      grouping_strategy: nameContext.grouping_strategy,\n      normalized_name: normalizeText(nameContext.logical_base_name),\n      compact_name: normalizeCompactKey(nameContext.logical_base_name),\n      tokens: tokenize(nameContext.logical_base_name),\n      product_family: inferProductFamily(nameContext.logical_base_name || nameContext.cleaned_name),\n      offer_markers: inferOfferMarkers(nameContext.logical_base_name),\n      offer_fingerprint: visualOfferFingerprint,\n      parsed_naming: nameContext.parsed_naming ? deepClone(nameContext.parsed_naming) : null,\n      product_key: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.product_key) : '',\n      item_key: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.item_key) : '',\n      presentation: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.presentation) : '',\n      area: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.area) : '',\n      offer_type: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.offer_type) : '',\n      offer_detail: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.offer_detail) : '',\n      payment_term: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.payment_term) : '',\n      offer_key: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.offer_key) : '',\n      format: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.format) : '',\n      creative_type: nameContext.parsed_naming ? safeString(nameContext.parsed_naming.creative_type) : '',\n      suffix_hints_found: [],\n      candidates_by_slot: {\n        feed: [],\n        banner: [],\n        stories: [],\n      },\n      // Carousel cards intentionally share an aspect ratio. Their sequence is\n      // visual-model evidence, never an inference from the Drive filename.\n      carousel_candidates: [],\n      video_candidates: [],\n      all_candidates: [],\n    });\n  }\n\n  const currentGroup = groups.get(nameContext.group_key);\n  const currentFingerprint = normalizedOfferFingerprint(nameContext.visual_grouping?.offer_fingerprint);\n  if (currentFingerprint.canonical_key !== currentGroup.offer_fingerprint.canonical_key) {\n    return buildFailure({ group_key: nameContext.group_key }, 'As midias do mesmo grupo visual retornaram offer_fingerprint divergente.');\n  }\n  const mediaType = safeString(json.visual_grouping?.media_type || (safeString(json.mimeType || json.mime_type).toLowerCase().startsWith('video/') ? 'video' : 'image')).toLowerCase();\n  const role = safeString(json.visual_grouping?.role || (mediaType === 'video' ? 'vertical_video' : '')).toLowerCase();\n  const slot = mediaType === 'image' ? ratioToSlot(nameContext.ratio) : '';\n  const binaryRef = pickResolvedBinary(binaryState, currentGroup, {\n    name: nameContext.cleaned_name,\n    original_name: json.name,\n    proporcao: nameContext.ratio,\n  });\n\n  const candidate = {\n    id,\n    name: nameContext.cleaned_name,\n    original_name: safeString(json.name).normalize('NFC'),\n    mime_type: safeString(json.mimeType || json.mime_type),\n    md5_checksum: safeString(json.md5Checksum || json.md5_checksum),\n    modified_time: safeString(json.modifiedTime || json.modified_time),\n    size: safeString(json.size),\n    media_type: mediaType,\n    role,\n    output_checksum_sha256: safeString(json.media_processing?.output_checksum_sha256),\n    thumbnail_checksum_sha256: safeString(json.media_processing?.thumbnail_checksum_sha256),\n    duration_seconds: Number(json.media_processing?.duration_seconds || 0),\n    media_processing: deepClone(json.media_processing || {}),\n    proporcao: nameContext.ratio,\n    slot,\n    carousel_card_index: Number(json.visual_grouping?.carousel_card_index || 0),\n    extension: safeString(nameContext.cleaned_name).match(/(\\.[^.]+)$/)?.[1] || '',\n    binary_found: Boolean(binaryRef && binaryRef.data),\n    suffix_hint: nameContext.suffix_hint,\n  };\n\n  currentGroup.all_candidates.push(candidate);\n\n  if (nameContext.suffix_hint) {\n    currentGroup.suffix_hints_found.push(nameContext.suffix_hint);\n  }\n\n  if (mediaType === 'video') {\n    currentGroup.video_candidates.push(candidate);\n  } else if (role === 'carousel_card') {\n    currentGroup.carousel_candidates.push(candidate);\n  } else if (slot) {\n    currentGroup.candidates_by_slot[slot].push(candidate);\n  }\n}\n\nconst requiresVideo = driveItems.some((item) => safeString(item.visual_grouping?.media_type || item.mimeType || item.mime_type).toLowerCase().includes('video'));\n\nconst candidateGroupDebug = [];\nconst groupedCreatives = [];\n\nfor (const group of groups.values()) {\n  const suffixCounts = group.suffix_hints_found.reduce((acc, hint) => {\n    acc[hint] = (acc[hint] || 0) + 1;\n    return acc;\n  }, {});\n\n  const suffix_hint =\n    (suffixCounts.generic || 0) > (suffixCounts.campaign || 0) ? 'generic'\n    : (suffixCounts.campaign || 0) > (suffixCounts.generic || 0) ? 'campaign'\n    : safeString(group.suffix_hints_found[0]);\n\n  group.suffix_hint = suffix_hint;\n\n  const carouselCandidates = safeArray(group.carousel_candidates).slice().sort((left, right) =>\n    Number(left.carousel_card_index || 0) - Number(right.carousel_card_index || 0)\n  );\n  if (carouselCandidates.length) {\n    const expectedIndices = carouselCandidates.map((_, index) => index + 1);\n    const receivedIndices = carouselCandidates.map((candidate) => Number(candidate.carousel_card_index || 0));\n    const carouselValid =\n      group.all_candidates.length === carouselCandidates.length &&\n      group.video_candidates.length === 0 &&\n      carouselCandidates.length >= 2 && carouselCandidates.length <= 10 &&\n      receivedIndices.every((value, index) => value === expectedIndices[index]);\n    group.imagens = carouselCandidates.map((image, index) => ({\n      id: image.id,\n      name: image.name,\n      original_name: image.original_name,\n      proporcao: image.proporcao,\n      extension: image.extension,\n      binary_key: `data_carousel_card_${index + 1}`,\n      mime_type: image.mime_type,\n      md5_checksum: image.md5_checksum,\n      modified_time: image.modified_time,\n      size: image.size,\n      media_type: 'image',\n      role: 'carousel_card',\n      carousel_card_index: index + 1,\n    }));\n    group.carousel_cards = deepClone(group.imagens);\n    group.videos = [];\n    group.media_mode = 'carousel';\n    group.required_media_roles = ['carousel_card'];\n    group.available_ratios = uniqueStrings(group.all_candidates.map((candidate) => candidate.proporcao));\n    group.required_ratios = [];\n    group.grupo_completo = carouselValid;\n    group.missing_ratios = carouselValid ? [] : ['carousel_cards:2..10_contiguous'];\n    group.duplicate_ratios = {};\n    candidateGroupDebug.push({\n      group_key: group.group_key,\n      offer_group_key: group.offer_group_key,\n      creative_group_key: group.creative_group_key,\n      grouping_discriminator: group.grouping_discriminator,\n      grouping_strategy: group.grouping_strategy,\n      nome_base: group.nome_base,\n      suffix_hint,\n      ratios_found: group.available_ratios,\n      required_ratios: [],\n      media_mode: group.media_mode,\n      required_media_roles: group.required_media_roles,\n      carousel_card_count: carouselCandidates.length,\n      carousel_card_indices: receivedIndices,\n      missing_ratios: group.missing_ratios,\n      duplicate_ratios: group.duplicate_ratios,\n      videos_found: [],\n      slot_candidates: {},\n    });\n    if (group.grupo_completo) groupedCreatives.push(group);\n    continue;\n  }\n\n  const selectedImages = [];\n  const duplicate_ratios = {};\n\n  for (const config of SLOT_CONFIG) {\n    const candidates = sortCandidatesForSlot(group.candidates_by_slot[config.slot], config.slot, suffix_hint);\n    if (candidates.length > 1) {\n      duplicate_ratios[config.slot] = candidates.map((candidate) => safeString(candidate.proporcao));\n    }\n    if (candidates[0]) {\n      selectedImages.push(candidates[0]);\n    }\n  }\n\n  selectedImages.sort((left, right) =>\n    (RATIO_ORDER[safeString(left.proporcao)] || 999) - (RATIO_ORDER[safeString(right.proporcao)] || 999)\n  );\n\n  group.imagens = selectedImages.map((image) => ({\n    id: image.id,\n    name: image.name,\n    original_name: image.original_name,\n    proporcao: image.proporcao,\n    extension: image.extension,\n    binary_key: binaryKeyForRatio(image.proporcao),\n    mime_type: image.mime_type,\n    md5_checksum: image.md5_checksum,\n    modified_time: image.modified_time,\n    size: image.size,\n    media_type: 'image',\n    role: image.slot === 'feed' ? 'feed_image' : image.slot === 'banner' ? 'banner_image' : 'vertical_image',\n  }));\n\n  const selectedVideos = group.video_candidates.filter((candidate) => candidate.role === 'vertical_video' && candidate.proporcao === '9x16');\n  group.videos = selectedVideos.slice(0, 1).map((video) => ({\n    id: video.id,\n    name: video.name,\n    original_name: video.original_name,\n    proporcao: video.proporcao,\n    role: 'vertical_video',\n    media_type: 'video',\n    binary_key: binaryKeyForRole('vertical_video'),\n    thumbnail_binary_key: 'thumbnail_vertical_video',\n    mime_type: video.mime_type,\n    md5_checksum: video.md5_checksum,\n    output_checksum_sha256: video.output_checksum_sha256,\n    thumbnail_checksum_sha256: video.thumbnail_checksum_sha256,\n    duration_seconds: video.duration_seconds,\n    media_processing: deepClone(video.media_processing || {}),\n    modified_time: video.modified_time,\n    size: video.size,\n  }));\n\n  const hasCompleteStaticSet = group.imagens.length === SLOT_CONFIG.length;\n  const hasSingleVerticalVideo = group.videos.length === 1;\n  group.media_mode = hasCompleteStaticSet && hasSingleVerticalVideo\n    ? 'mixed'\n    : !group.imagens.length && hasSingleVerticalVideo\n      ? 'video_only'\n      : 'static_only';\n  group.required_media_roles = group.media_mode === 'mixed'\n    ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video']\n    : group.media_mode === 'video_only'\n      ? ['vertical_video']\n      : ['feed_image', 'banner_image', 'vertical_image'];\n  group.available_ratios = uniqueStrings(group.all_candidates.map((candidate) => candidate.proporcao));\n  group.required_ratios = group.media_mode === 'video_only' ? [] : getRequiredRatiosForGroup(group);\n  group.grupo_completo = group.media_mode === 'mixed'\n    ? hasCompleteStaticSet && hasSingleVerticalVideo\n    : group.media_mode === 'video_only'\n      ? hasSingleVerticalVideo\n      : !requiresVideo && hasCompleteStaticSet;\n  group.missing_ratios = group.media_mode === 'video_only' ? [] : SLOT_CONFIG\n    .filter((config) => !group.imagens.some((image) => config.acceptedRatios.includes(safeString(image.proporcao))))\n    .map((config) => config.acceptedRatios.join('|'));\n  group.duplicate_ratios = duplicate_ratios;\n  if (group.video_candidates.length > 1) group.duplicate_ratios.vertical_video = group.video_candidates.map((candidate) => candidate.original_name);\n  if ((requiresVideo || group.video_candidates.length) && group.videos.length !== 1) group.missing_ratios.push('vertical_video:9x16');\n\n  candidateGroupDebug.push({\n    group_key: group.group_key,\n    offer_group_key: group.offer_group_key,\n    creative_group_key: group.creative_group_key,\n    grouping_discriminator: group.grouping_discriminator,\n    grouping_strategy: group.grouping_strategy,\n    nome_base: group.nome_base,\n    suffix_hint,\n    ratios_found: group.available_ratios,\n    required_ratios: group.required_ratios,\n    media_mode: group.media_mode,\n    required_media_roles: group.required_media_roles,\n    missing_ratios: group.missing_ratios,\n    duplicate_ratios: group.duplicate_ratios,\n    videos_found: group.video_candidates.map((candidate) => `${candidate.proporcao}:${candidate.original_name}`),\n    slot_candidates: Object.fromEntries(\n      Object.entries(group.candidates_by_slot).map(([slot, list]) => [\n        slot,\n        safeArray(list).map((candidate) => `${candidate.proporcao}:${candidate.original_name}`),\n      ])\n    ),\n  });\n\n  if (group.grupo_completo) {\n    groupedCreatives.push(group);\n  }\n}\n\nif (!driveItems.length) {\n  return buildFailure({\n    drive_items_found: 0,\n    destinations_found: destinations.length,\n    candidate_groups_built: groups.size,\n    complete_groups_found: groupedCreatives.length,\n    groups: candidateGroupDebug,\n  }, 'Nenhum item de Drive foi encontrado no Merge de entrada.');\n}\n\nif (!groupedCreatives.length) {\n  return buildFailure({\n    drive_items_found: driveItems.length,\n    destinations_found: destinations.length,\n    candidate_groups_built: groups.size,\n    complete_groups_found: 0,\n    groups: candidateGroupDebug,\n  }, 'Nenhum grupo completo foi montado.');\n}\n\nconst incompleteGroups = candidateGroupDebug.filter((candidate) => safeArray(candidate.missing_ratios).length);\nconst duplicateGroups = candidateGroupDebug.filter((candidate) => Object.keys(candidate.duplicate_ratios || {}).length);\nif (incompleteGroups.length || duplicateGroups.length || groupedCreatives.length !== groups.size) {\n  return buildFailure({\n    drive_items_found: driveItems.length,\n    destinations_found: destinations.length,\n    candidate_groups_built: groups.size,\n    complete_groups_found: groupedCreatives.length,\n    incomplete_groups: incompleteGroups,\n    duplicate_groups: duplicateGroups,\n    groups: candidateGroupDebug,\n  }, 'O lote inteiro foi bloqueado porque existem grupos incompletos ou slots duplicados.');\n}\n\nconst batchFiles = driveItems\n  .map((item) => ({\n    id: safeString(item.id),\n    name: safeString(item.name),\n    md5_checksum: safeString(item.md5Checksum || item.md5_checksum),\n    modified_time: safeString(item.modifiedTime || item.modified_time),\n    size: safeString(item.size),\n    media_type: safeString(item.visual_grouping?.media_type || (safeString(item.mimeType || item.mime_type).startsWith('video/') ? 'video' : 'image')),\n    checksum_sha256: safeString(item.media_processing?.output_checksum_sha256),\n  }))\n  .sort((left, right) => left.id.localeCompare(right.id));\nconst configRevisions = uniqueStrings(destinations.map((destination) => destination.config_revision));\nif (configRevisions.length !== 1) {\n  return buildFailure({ config_revisions: configRevisions }, 'Os destinos nao compartilham a mesma revisao de configuracao do gateway.');\n}\n\nconst normalizedSourceAds = sourceAds.map((ad) => {\n  const searchText = buildAdSearchText(ad);\n  const parsedNaming = parseStructuredCreativeNameFromText(searchText);\n\n  return {\n    raw: deepClone(ad),\n    id: safeString(ad.id),\n    name: safeString(ad.name),\n    normalized_name: normalizeText(ad.name),\n    compact_name: normalizeCompactKey(ad.name),\n    tokens: tokenize(searchText),\n    product_family: inferProductFamily(searchText),\n    offer_markers: inferOfferMarkers(searchText),\n    search_text: searchText,\n    extracted_texts: extractCreativeTexts(ad),\n    parsed_naming: parsedNaming ? deepClone(parsedNaming) : null,\n    offer_fingerprint: legacyOfferFingerprint(ad),\n  };\n});\n\nconst outputs = [];\n\nfor (const group of groupedCreatives) {\n  const binary = {};\n  const warnings = [];\n  const media_inventory = [];\n\n  for (const image of group.imagens) {\n    const binaryRef = pickResolvedBinary(binaryState, group, image);\n    const binaryKey = safeString(image.binary_key) || binaryKeyForRatio(image.proporcao);\n\n    media_inventory.push({\n      id: image.id,\n      source_file_id: image.id,\n      name: image.name,\n      original_name: image.original_name,\n      media_type: 'image',\n      role: image.role,\n      carousel_card_index: Number(image.carousel_card_index || 0),\n      proporcao: image.proporcao,\n      binary_key: binaryKey,\n      checksum_sha256: safeString(image.output_checksum_sha256 || image.md5_checksum),\n      has_binary: Boolean(binaryRef && binaryRef.data),\n    });\n\n    if (binaryRef && binaryRef.data) {\n      binary[binaryKey] = deepClone(binaryRef.data);\n    } else {\n      warnings.push(`Binario nao encontrado para ${image.original_name || image.name}`);\n    }\n  }\n\n  for (const video of safeArray(group.videos)) {\n    const binaryRef = pickResolvedBinary(binaryState, group, video);\n    const binaryKey = binaryKeyForRole('vertical_video');\n    media_inventory.push({\n      id: video.id,\n      source_file_id: video.id,\n      name: video.name,\n      original_name: video.original_name,\n      media_type: 'video',\n      role: 'vertical_video',\n      proporcao: '9x16',\n      binary_key: binaryKey,\n      thumbnail_binary_key: 'thumbnail_vertical_video',\n      source_md5_checksum: video.md5_checksum,\n      source_size: video.size,\n      checksum_sha256: video.output_checksum_sha256,\n      thumbnail_checksum_sha256: video.thumbnail_checksum_sha256,\n      duration_seconds: video.duration_seconds,\n      media_processing: deepClone(video.media_processing || {}),\n      has_binary: Boolean(binaryRef?.data),\n      has_thumbnail: Boolean(binaryRef?.thumbnail),\n    });\n    if (binaryRef?.data) binary[binaryKey] = deepClone(binaryRef.data);\n    else warnings.push(`Binario de video nao encontrado para ${video.original_name || video.name}`);\n    if (binaryRef?.thumbnail) binary.thumbnail_vertical_video = deepClone(binaryRef.thumbnail);\n    else warnings.push(`Miniatura de video nao encontrada para ${video.original_name || video.name}`);\n  }\n\n  const ratiosWithBinary = uniqueStrings(\n    media_inventory.filter((item) => item.has_binary).map((item) => item.proporcao)\n  );\n\n  for (const ratio of group.required_ratios) {\n    if (!ratiosWithBinary.includes(ratio)) {\n      warnings.push(`Binario ausente para a proporcao ${ratio} em ${group.nome_base}`);\n    }\n  }\n\n  const mediaInventoryByRatio = new Map(\n    media_inventory.map((item) => [safeString(item.proporcao), item])\n  );\n\n  const matchedAds = normalizedSourceAds\n    .map((ad) => {\n      const decision = buildMatchDecision(group, ad);\n      const offerDecision = compareOfferFingerprints(group.offer_fingerprint, ad.offer_fingerprint);\n      return {\n        ad_id: ad.id,\n        ad_name: ad.name,\n        score: decision.score,\n        match_level: decision.match_level,\n        match_reasons: decision.reasons,\n        shared_tokens: decision.shared_tokens,\n        exact_name_match: decision.exact_name_match,\n        exact_token_match: decision.exact_token_match,\n        parsed_naming_found: Boolean(ad.parsed_naming),\n        parsed_offer_key: ad.parsed_naming ? ad.parsed_naming.offer_key : '',\n        parsed_product_key: ad.parsed_naming ? ad.parsed_naming.product_key : '',\n        offer_match_status: offerDecision.status,\n        offer_match_source: offerDecision.source || '',\n        offer_fingerprint: deepClone(ad.offer_fingerprint),\n        source_ad: deepClone(ad.raw),\n        source_ad_texts: deepClone(ad.extracted_texts),\n      };\n    })\n    .filter((item) => item.score > 0)\n    .sort((a, b) => b.score - a.score || a.ad_name.localeCompare(b.ad_name));\n\n  const replacementMatchedAds = matchedAds.filter((item) => item.offer_match_status === 'exact');\n  const bestStructured = replacementMatchedAds.find((item) => item.match_level !== 'text_fallback');\n  let selectedAds = [];\n\n  if (bestStructured) {\n    const structuredPriority = {\n      offer_key_exact: 6,\n      product_plus_offer: 5,\n      product_only: 4,\n      product_family_offer_fit: 3,\n      product_family_soft: 2,\n      text_fallback: 1,\n      none: 0,\n    };\n\n    const bestLevelScore = structuredPriority[bestStructured.match_level] || 0;\n    selectedAds = replacementMatchedAds.filter((item) => (structuredPriority[item.match_level] || 0) === bestLevelScore);\n\n    if (selectedAds.length > 1) {\n      const topStructuredScore = selectedAds[0].score;\n      selectedAds = selectedAds.filter((item) => item.score >= topStructuredScore - 10);\n    }\n  } else {\n    const topScore = replacementMatchedAds.length ? replacementMatchedAds[0].score : 0;\n    selectedAds = replacementMatchedAds.filter((item) => {\n      if (item.exact_name_match) return true;\n      if (item.exact_token_match && item.score >= 12) return true;\n      if (topScore > 0 && item.score >= Math.max(12, topScore - 4)) return true;\n      return false;\n    });\n  }\n\n  selectedAds = limitSelectedAdsForSafety(selectedAds, destinations);\n\n  if (!group.parsed_naming) {\n    warnings.push(`Nome do criativo fora do padrao estruturado: ${group.nome_base}`);\n  }\n\n  if (!selectedAds.length) {\n    warnings.push(`Nenhum anuncio substituivel com oferta comercial identica encontrado para ${group.nome_base}; ${group.offer_fingerprint.replacement_eligible ? 'offer_fingerprint_mismatch' : 'offer_fingerprint_unverified'}.`);\n  }\n\n  if (selectedAds.length > 3) {\n    warnings.push(`Match amplo para ${group.nome_base}: ${selectedAds.length} anuncios selecionados`);\n  }\n\n  const primaryMatchedAd = selectedAds.length ? selectedAds[0] : null;\n  const matchStatus = primaryMatchedAd ? primaryMatchedAd.match_level : 'no_match';\n\n  const replaceEligibleLevels = group.suffix_hint === 'campaign'\n    ? ['offer_key_exact', 'product_plus_offer', 'product_only', 'product_family_offer_fit']\n    : ['offer_key_exact'];\n\n  const shouldReplaceExisting =\n    group.offer_fingerprint.replacement_eligible === true &&\n    Boolean(primaryMatchedAd) &&\n    replaceEligibleLevels.includes(matchStatus) &&\n    primaryMatchedAd.score >= 380;\n\n  const selectedAdsForReplace = shouldReplaceExisting ? selectedAds : [];\n  const primarySelectedAd = shouldReplaceExisting ? primaryMatchedAd : null;\n\n  const replacementPlan = shouldReplaceExisting\n    ? selectedAdsForReplace.flatMap((matched) =>\n        buildReplacementPlanForAd(matched.source_ad, mediaInventoryByRatio)\n      )\n    : [];\n\n  const selectedAdIds = uniqueStrings(selectedAdsForReplace.map((item) => item.ad_id));\n\n  if (shouldReplaceExisting && selectedAdsForReplace.length && !replacementPlan.length) {\n    warnings.push(`Foram encontrados anuncios para ${group.nome_base}, mas nenhuma regra de substituicao pode ser inferida`);\n  }\n\n  const replacementRatiosCovered = uniqueStrings(replacementPlan.map((item) => item.ratio));\n  for (const ratio of group.required_ratios) {\n    if (shouldReplaceExisting && !replacementRatiosCovered.includes(ratio)) {\n      warnings.push(`Nenhum destino de substituicao inferido para a proporcao ${ratio} em ${group.nome_base}`);\n    }\n  }\n\n  const sourceAd = primarySelectedAd ? primarySelectedAd.source_ad : null;\n  const sourceAdTexts = primaryMatchedAd\n    ? buildSourceAdTexts(primaryMatchedAd.source_ad)\n    : { titles: [], bodies: [], descriptions: [] };\n\n  const sourceAdNameOriginal = primaryMatchedAd\n    ? safeString(primaryMatchedAd.ad_name)\n    : '';\n\n  const sourceAdNameBase = safeString(group.nome_base);\n\n  const sourceAdNameReference =\n    sourceAdNameBase ||\n    sourceAdNameOriginal;\n\n  const action = shouldReplaceExisting ? 'replace_existing' : 'create_new';\n\n  const resolvedDestinations = destinations.map((destination) => {\n    const destinationCampaignId = safeString(destination.campaign_id || destination.destination_campaign_id);\n    const destinationAdsetId = safeString(destination.adset_id || destination.destination_adset_id);\n    const placementCheck = placementCheckForDestination(destination);\n\n    const destinationWarnings = [\n      ...(destinationCampaignId ? [] : ['Campaign ID nao encontrado para o destination atual.']),\n      ...(destinationAdsetId ? [] : ['AdSet ID nao encontrado para o destination atual.']),\n    ];\n\n    return {\n      destination_group: safeString(destination.destination_group),\n      destination_row_number: safeString(destination.row_number || destination.destination_row_number),\n      destination_campaign_id: destinationCampaignId,\n      destination_ad_account_id: safeString(destination.account_id || destination.destination_ad_account_id),\n      destination_page_id: safeString(destination.page_id || destination.destination_page_id),\n      destination_instagram_user_id: safeString(destination.instagram_user_id || destination.destination_instagram_user_id),\n      destination_adset_id: destinationAdsetId,\n      destination_api_version: safeString(destination.api_version || destination.destination_api_version || 'v25.0'),\n      token_id: safeString(destination.token_id),\n      allowed_link_hosts: safeArray(destination.allowed_link_hosts),\n      landing_pages_by_creative_group: deepClone(destination.landing_pages_by_creative_group || {}),\n      landing_page_validation: deepClone(destination.landing_page_validation || {}),\n      placement_eligibility: deepClone(placementCheck || {}),\n      freshness_window_days: Number(destination.freshness_window_days || 7),\n      // Live ad-set data wins over an optional Token Vault metadata mirror.\n      // In particular, OUTCOME_LEADS dynamic creatives cannot stage BOOK_NOW.\n      campaign_objective: safeString(placementCheck && placementCheck.campaign_objective || destination.campaign_objective).toUpperCase(),\n      optimization_goal: safeString(placementCheck && placementCheck.optimization_goal || destination.optimization_goal).toUpperCase(),\n      destination_type: safeString(placementCheck && placementCheck.destination_type || destination.destination_type).toUpperCase(),\n      whatsapp_destination_url: safeString(destination.whatsapp_destination_url),\n      carousel_native_campaign_id: safeString(destination.carousel_native_campaign_id),\n      carousel_native_adset_id: safeString(destination.carousel_native_adset_id),\n      carousel_native_adset_verified: destination.carousel_native_adset_verified === true,\n      carousel_native_route_active: destination.carousel_native_route_active === true,\n      config_revision: safeString(destination.config_revision),\n      destination_id_source: 'token_vault',\n      suffix_hint: group.suffix_hint,\n      warnings: destinationWarnings,\n    };\n  });\n\n  for (const destination of resolvedDestinations) {\n    const landingPages = destination.landing_pages_by_creative_group && typeof destination.landing_pages_by_creative_group === 'object'\n      ? destination.landing_pages_by_creative_group\n      : {};\n    const exactLandingKeys = Object.keys(landingPages)\n      .filter((key) => normalizeLandingPageKey(key) === normalizeLandingPageKey(group.creative_group_key));\n    const defaultLandingKeys = Object.keys(landingPages)\n      .filter((key) => ['DEFAULT', 'ALL'].includes(normalizeLandingPageKey(key)) || safeString(key) === '*');\n    const uniqueLandingUrls = uniqueStrings(Object.values(landingPages));\n    const matchingLandingKeys = exactLandingKeys.length\n      ? exactLandingKeys\n      : defaultLandingKeys.length\n        ? defaultLandingKeys\n        : uniqueLandingUrls.length === 1\n          ? [Object.keys(landingPages).find((key) => safeString(landingPages[key]) === uniqueLandingUrls[0])]\n          : [];\n    if (matchingLandingKeys.length !== 1) {\n      buildFailure({\n        creative_group_key: group.creative_group_key,\n        destination_group: destination.destination_group,\n        configured_landing_page_keys: Object.keys(landingPages).map(normalizeLandingPageKey),\n      }, matchingLandingKeys.length\n        ? 'Landing page ambigua para o grupo criativo; lote bloqueado antes de upload e IA.'\n        : 'Landing page ausente para o grupo criativo e sem fallback seguro do destino; lote bloqueado antes de upload e IA.');\n    }\n  }\n\n  for (const destination of resolvedDestinations) {\n    warnings.push(...safeArray(destination.warnings));\n  }\n\n  if (\n    resolvedDestinations.length > 1 &&\n    sourceAdNameOriginal &&\n    sourceAdNameOriginal.includes('|')\n  ) {\n    warnings.push(\n      `source_ad_name original continha unidade e foi neutralizado para evitar duplicacao por destino: ${sourceAdNameOriginal}`\n    );\n  }\n\n  if (!resolvedDestinations.length) {\n    warnings.push(`Nenhum destino foi reconhecido no input para ${group.nome_base}`);\n  }\n\n  const primaryDestination = resolvedDestinations.length === 1 ? resolvedDestinations[0] : {};\n  const primaryDestinationStrategy = resolvedDestinations.length === 1 ? 'single_destination_only' : 'destinations_array_only';\n  const jobKey = createJobKey([group.group_key, group.suffix_hint || 'base']);\n\n  outputs.push({\n    json: {\n      job_key: jobKey,\n      action,\n      match_status: matchStatus,\n      should_create_new_ad: action === 'create_new',\n      should_replace_existing: action === 'replace_existing',\n\n      nome_base: group.nome_base,\n      group_key: group.group_key,\n      offer_group_key: group.offer_group_key,\n      creative_group_key: group.creative_group_key,\n      grouping_discriminator: group.grouping_discriminator,\n      grouping_strategy: group.grouping_strategy,\n      product_key: group.product_key,\n      product_family: group.product_family,\n      offer_markers: group.offer_markers,\n      offer_fingerprint: deepClone(group.offer_fingerprint),\n      suffix_hint: group.suffix_hint,\n\n      source_ad_id: sourceAd ? safeString(sourceAd.id) : '',\n      source_ad_name: sourceAdNameReference,\n      source_ad_name_base: sourceAdNameBase,\n      source_ad_name_original: sourceAdNameOriginal,\n      source_ad_texts: sourceAdTexts,\n\n      naming: {\n        parsed: Boolean(group.parsed_naming),\n        product_key: group.product_key,\n        item_key: group.item_key,\n        presentation: group.presentation,\n        area: group.area,\n        offer_type: group.offer_type,\n        offer_detail: group.offer_detail,\n        payment_term: group.payment_term,\n        offer_key: group.offer_key,\n        format: group.format,\n        creative_type: group.creative_type,\n        campaign_key: group.parsed_naming ? safeString(group.parsed_naming.campaign_key) : '',\n        creative_group_key: group.creative_group_key,\n        offer_group_key: group.offer_group_key,\n        grouping_discriminator: group.grouping_discriminator,\n        grouping_strategy: group.grouping_strategy,\n        product_family: group.product_family,\n        offer_markers: group.offer_markers,\n        offer_fingerprint: deepClone(group.offer_fingerprint),\n        suffix_hint: group.suffix_hint,\n      },\n\n      imagens: deepClone(group.imagens),\n      carousel_cards: deepClone(group.carousel_cards || []),\n      videos: deepClone(group.videos),\n      media_mode: group.media_mode,\n      required_media_roles: deepClone(group.required_media_roles),\n      available_ratios: group.available_ratios,\n      required_ratios: group.required_ratios,\n      missing_ratios: group.missing_ratios,\n      grupo_completo: group.grupo_completo,\n      media_inventory,\n\n      destinations: resolvedDestinations.map((destination) => ({\n        destination_group: destination.destination_group,\n        destination_row_number: destination.destination_row_number,\n        destination_campaign_id: destination.destination_campaign_id,\n        destination_ad_account_id: destination.destination_ad_account_id,\n        destination_page_id: destination.destination_page_id,\n        destination_instagram_user_id: destination.destination_instagram_user_id,\n        destination_adset_id: destination.destination_adset_id,\n        destination_api_version: destination.destination_api_version,\n        token_id: destination.token_id,\n        allowed_link_hosts: destination.allowed_link_hosts,\n        landing_pages_by_creative_group: destination.landing_pages_by_creative_group,\n        landing_page_validation: destination.landing_page_validation,\n        placement_eligibility: destination.placement_eligibility,\n        freshness_window_days: destination.freshness_window_days,\n        campaign_objective: destination.campaign_objective,\n        optimization_goal: destination.optimization_goal,\n        destination_type: destination.destination_type,\n        whatsapp_destination_url: destination.whatsapp_destination_url,\n        carousel_native_campaign_id: destination.carousel_native_campaign_id,\n        carousel_native_adset_id: destination.carousel_native_adset_id,\n        carousel_native_adset_verified: destination.carousel_native_adset_verified,\n        carousel_native_route_active: destination.carousel_native_route_active,\n        config_revision: destination.config_revision,\n        destination_id_source: destination.destination_id_source,\n        suffix_hint: destination.suffix_hint,\n        warnings: destination.warnings,\n      })),\n\n      destinations_count: resolvedDestinations.length,\n      destination_groups: uniqueStrings(resolvedDestinations.map((d) => d.destination_group)),\n      primary_destination_strategy: primaryDestinationStrategy,\n      primary_destination_available: resolvedDestinations.length === 1,\n\n      destination_group: safeString(primaryDestination.destination_group),\n      destination_row_number: safeString(primaryDestination.destination_row_number),\n      destination_campaign_id: safeString(primaryDestination.destination_campaign_id),\n      destination_ad_account_id: safeString(primaryDestination.destination_ad_account_id),\n      destination_page_id: safeString(primaryDestination.destination_page_id),\n      destination_instagram_user_id: safeString(primaryDestination.destination_instagram_user_id),\n      destination_adset_id: safeString(primaryDestination.destination_adset_id),\n      destination_api_version: safeString(primaryDestination.destination_api_version),\n\n      account_id: safeString(primaryDestination.destination_ad_account_id),\n      api_version: safeString(primaryDestination.destination_api_version),\n      page_id: safeString(primaryDestination.destination_page_id),\n      instagram_user_id: safeString(primaryDestination.destination_instagram_user_id),\n      row_number: safeString(primaryDestination.destination_row_number),\n\n      matched_ads: matchedAds.map((item) => ({\n        ad_id: item.ad_id,\n        ad_name: item.ad_name,\n        score: item.score,\n        match_level: item.match_level,\n        match_reasons: item.match_reasons,\n        shared_tokens: item.shared_tokens,\n        exact_name_match: item.exact_name_match,\n        exact_token_match: item.exact_token_match,\n        parsed_naming_found: item.parsed_naming_found,\n        parsed_offer_key: item.parsed_offer_key,\n        parsed_product_key: item.parsed_product_key,\n        offer_match_status: item.offer_match_status,\n        offer_match_source: item.offer_match_source,\n        created_time: safeString(item.source_ad && item.source_ad.created_time),\n        updated_time: safeString(item.source_ad && item.source_ad.updated_time),\n        creative_created_time: safeString(item.source_ad && item.source_ad.creative && item.source_ad.creative.created_time),\n        creative_updated_time: safeString(item.source_ad && item.source_ad.creative && item.source_ad.creative.updated_time),\n      })),\n\n      selected_ad_ids: selectedAdIds,\n      selected_ads: selectedAdsForReplace.map((item) => ({\n        ad_id: item.ad_id,\n        ad_name: item.ad_name,\n        score: item.score,\n        match_level: item.match_level,\n        parsed_offer_key: item.parsed_offer_key,\n        parsed_product_key: item.parsed_product_key,\n        offer_match_status: item.offer_match_status,\n        created_time: safeString(item.source_ad && item.source_ad.created_time),\n        updated_time: safeString(item.source_ad && item.source_ad.updated_time),\n        creative_created_time: safeString(item.source_ad && item.source_ad.creative && item.source_ad.creative.created_time),\n        creative_updated_time: safeString(item.source_ad && item.source_ad.creative && item.source_ad.creative.updated_time),\n      })),\n\n      replacement_plan: deepClone(replacementPlan),\n\n      related_ids: {\n        drive_file_ids: uniqueStrings([...group.imagens, ...safeArray(group.videos)].map((media) => media.id)),\n        matched_ad_ids: uniqueStrings(matchedAds.map((item) => item.ad_id)),\n        selected_ad_ids: selectedAdIds,\n        replacement_ad_ids: uniqueStrings(replacementPlan.map((item) => item.ad_id)),\n        replacement_creative_ids: uniqueStrings(replacementPlan.map((item) => item.creative_id)),\n        destination_campaign_ids: uniqueStrings(resolvedDestinations.map((item) => item.destination_campaign_id)),\n        destination_adset_ids: uniqueStrings(resolvedDestinations.map((item) => item.destination_adset_id)),\n        destination_page_ids: uniqueStrings(resolvedDestinations.map((item) => item.destination_page_id)),\n        destination_instagram_user_ids: uniqueStrings(resolvedDestinations.map((item) => item.destination_instagram_user_id)),\n        destination_ad_account_ids: uniqueStrings(resolvedDestinations.map((item) => item.destination_ad_account_id)),\n      },\n\n      source_ads: deepClone(sourceAds),\n      batch_files: deepClone(batchFiles),\n      config_revision: configRevisions[0],\n\n      debug_grouping: {\n        drive_items_in_group: group.all_candidates.length,\n        creative_group_key: group.creative_group_key,\n        offer_group_key: group.offer_group_key,\n        grouping_discriminator: group.grouping_discriminator,\n        grouping_strategy: group.grouping_strategy,\n        candidate_groups_built: groups.size,\n        complete_groups_found: groupedCreatives.length,\n        incomplete_groups: candidateGroupDebug.filter((candidate) => safeArray(candidate.missing_ratios).length),\n        selected_ratios: group.imagens.map((image) => image.proporcao),\n        selected_media_roles: [...group.imagens, ...safeArray(group.videos)].map((media) => media.role),\n        available_ratios: group.available_ratios,\n        missing_ratios: group.missing_ratios,\n        duplicate_ratios: group.duplicate_ratios,\n        suffix_hints_found: uniqueStrings(group.suffix_hints_found),\n        destinations_found_in_input: destinations.length,\n      },\n\n      warnings: uniqueStrings(warnings),\n    },\n    binary: deepClone(binary),\n  });\n}\n\nif (!outputs.length) {\n  return buildFailure({\n    drive_items_found: driveItems.length,\n    destinations_found: destinations.length,\n    candidate_groups_built: groups.size,\n    complete_groups_found: groupedCreatives.length,\n    groups: candidateGroupDebug,\n  }, 'Nenhum grupo completo foi montado.');\n}\n\nreturn outputs;\n"
+      },
+      "id": "91555de4-d8bd-4e20-9744-8ad99c68a5cb",
+      "name": "Build Payload",
+      "type": "n8n-nodes-base.code",
+      "position": [
+        2656,
+        1376
+      ],
+      "retryOnFail": false,
+      "typeVersion": 2
+    },
+    {
+      "parameters": {},
+      "id": "65432ac8-75c1-43f4-9cfc-d146eead9d16",
+      "name": "When clicking ‘Execute workflow’",
+      "type": "n8n-nodes-base.manualTrigger",
+      "position": [
+        -3072,
+        1448
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "jsCode": "const MAX_BODY_LENGTH = 240;\nconst MAX_TITLE_LENGTH = 40;\nconst MAX_DESCRIPTION_LENGTH = 60;\nconst MIN_IMAGES = 3;\nconst BODY_COUNT = 5;\nconst TITLE_COUNT = 5;\nconst DESCRIPTION_COUNT = 5;\nconst VERTICAL_CROP_KEY = '90x160';\nconst HORIZONTAL_CROP_KEY = '191x100';\nconst FEED_FOUR_BY_FIVE_CROP_KEY = '400x500';\nconst REQUIRED_MIXED_STATIC_VERTICAL_PLATFORMS = ['facebook', 'instagram', 'audience_network', 'whatsapp'];\nconst REQUIRED_MIXED_STATIC_VERTICAL_FACEBOOK_POSITIONS = ['instream_video', 'story', 'facebook_reels'];\nconst REQUIRED_VERTICAL_INSTAGRAM_POSITIONS = ['story', 'reels'];\nconst REQUIRED_MIXED_STATIC_VERTICAL_AUDIENCE_NETWORK_POSITIONS = ['classic'];\nconst REQUIRED_MIXED_STATIC_VERTICAL_WHATSAPP_POSITIONS = ['status'];\nconst REQUIRED_MIXED_VIDEO_PLATFORMS = ['audience_network'];\nconst REQUIRED_MIXED_VIDEO_AUDIENCE_NETWORK_POSITIONS = ['rewarded_video'];\nconst REQUIRED_VIDEO_ONLY_SOCIAL_PLATFORMS = ['facebook', 'instagram'];\nconst REQUIRED_VIDEO_ONLY_NETWORK_PLATFORMS = ['audience_network', 'whatsapp'];\nconst REQUIRED_VIDEO_ONLY_FACEBOOK_POSITIONS = ['feed', 'instream_video', 'story', 'search', 'facebook_reels', 'facebook_reels_overlay', 'notification'];\nconst REQUIRED_VIDEO_ONLY_INSTAGRAM_POSITIONS = ['stream', 'story', 'reels'];\nconst REQUIRED_VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS = ['classic'];\nconst REQUIRED_VIDEO_ONLY_REWARDED_AUDIENCE_NETWORK_POSITIONS = ['rewarded_video'];\nconst REQUIRED_VIDEO_ONLY_WHATSAPP_POSITIONS = ['status'];\nconst REQUIRED_HORIZONTAL_PLATFORMS = ['facebook'];\nconst REQUIRED_HORIZONTAL_FACEBOOK_POSITIONS = ['search'];\n// OUTCOME_LEADS dynamic creatives reject BOOK_NOW at staging. The expected\n// CTA comes from the live campaign objective carried by destination_meta.\nconst REQUIRED_CTA = 'BOOK_NOW';\nconst OUTCOME_LEADS_CTA = 'LEARN_MORE';\nconst WHATSAPP_CTA = 'WHATSAPP_MESSAGE';\nconst WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';\nconst ALLOWED_ADVANTAGE_PLUS_FEATURES = new Set([\n  'add_text_overlay',\n  'image_touchups',\n  'music_generation',\n  'pac_relaxation',\n  'text_optimizations',\n  'inline_comment',\n  'enhance_cta',\n  'image_brightness_and_contrast',\n  'reveal_details_over_time',\n  'show_destination_blurbs',\n  'image_animation',\n  'site_extensions',\n]);\nconst FORBIDDEN_ADVANTAGE_PLUS_FEATURES = new Set([\n  'image_template',\n  'media_type_automation',\n  'show_summary',\n  'audio',\n  ['standard', 'enhancements'].join('_'),\n]);\n\nfunction safeString(value) { return String(value ?? '').trim(); }\nfunction safeArray(value) { return Array.isArray(value) ? value : []; }\nfunction asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\n\nfunction expectedFlexibleCta(source, destinationKind) {\n  if (destinationKind === 'whatsapp') return WHATSAPP_CTA;\n  const destination = asObject(source.destination_meta);\n  return safeString(destination.campaign_objective || source.destination_campaign_objective).toUpperCase() === 'OUTCOME_LEADS'\n    ? OUTCOME_LEADS_CTA\n    : REQUIRED_CTA;\n}\n\nfunction restoredRunContext() {\n  let groups = [];\n  try { groups = $items('Restore Publish Groups') || []; } catch (error) { groups = []; }\n  const runIds = [...new Set(groups.map((item) => safeString(item && item.json && item.json.run_id)).filter(Boolean))];\n  const fingerprints = [...new Set(groups.map((item) => safeString(item && item.json && item.json.batch_fingerprint)).filter(Boolean))];\n  assert(runIds.length <= 1, 'restored_run_id_ambiguous', { count: runIds.length });\n  assert(fingerprints.length <= 1, 'restored_batch_fingerprint_ambiguous', { count: fingerprints.length });\n  return { run_id: runIds[0] || '', batch_fingerprint: fingerprints[0] || '' };\n}\n\nfunction fail(message, detail = {}) {\n  throw new Error(`Meta creative quality gate: ${message} | detail=${JSON.stringify(detail)}`);\n}\n\nfunction assert(condition, message, detail) {\n  if (!condition) fail(message, detail);\n}\n\nfunction sanitize(value) {\n  if (Array.isArray(value)) return value.map(sanitize);\n  if (!value || typeof value !== 'object') return value;\n  const out = {};\n  for (const [key, item] of Object.entries(value)) {\n    if (/^(fbToken|authorization)$/i.test(key)) continue;\n    out[key] = sanitize(item);\n  }\n  return out;\n}\n\nfunction textAssets(value, expected, maxLength, label) {\n  const assets = safeArray(value);\n  assert(assets.length === expected, `${label}_count_invalid`, { expected, actual: assets.length });\n  const normalized = assets.map((entry, index) => {\n    const text = safeString(typeof entry === 'string' ? entry : entry && entry.text).replace(/\\s+/g, ' ');\n    assert(text.length > 0, `${label}_empty`, { index });\n    assert(text.length <= maxLength, `${label}_too_long`, { index, maxLength, actual: text.length });\n    return text.toLowerCase();\n  });\n  assert(new Set(normalized).size === normalized.length, `${label}_duplicates`, {});\n  return assets;\n}\n\nfunction allowedHosts(source) {\n  return new Set([\n    'api.whatsapp.com',\n    'wa.me',\n    'espacofacial.com',\n    'www.espacofacial.com',\n    ...safeArray(source.allowed_link_hosts).map((entry) => safeString(entry).toLowerCase()),\n  ]);\n}\n\nfunction validateUrl(value, hosts, label) {\n  const raw = safeString(value);\n  const match = /^https:\\/\\/([^\\/?#\\s:@]+)(?::\\d+)?(?:[\\/?#]|$)/i.exec(raw);\n  const hostname = safeString(match && match[1]).replace(/\\.$/, '').toLowerCase();\n  assert(Boolean(hostname) && !hostname.includes('..') && /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i.test(hostname), `${label}_invalid`, {});\n  assert([...hosts].some((host) => hostname === host || hostname.endsWith(`.${host}`)), `${label}_host_not_allowed`, { hostname });\n  return raw;\n}\n\nfunction isWhatsAppUrl(value) {\n  const raw = safeString(value);\n  const match = /^https:\\/\\/([^\\/?#\\s:@]+)(?::\\d+)?(?:[\\/?#]|$)/i.exec(raw);\n  const hostname = safeString(match && match[1]).toLowerCase();\n  return hostname === 'wa.me' || hostname === 'api.whatsapp.com' || hostname.endsWith('.whatsapp.com');\n}\n\nfunction destinationContractKind(source) {\n  const kind = safeString(asObject(source.destination_contract).kind).toLowerCase();\n  assert(kind === 'whatsapp' || kind === 'website', 'destination_contract_missing_or_invalid', { kind });\n  return kind;\n}\n\nfunction labelNames(assets) {\n  return new Set(safeArray(assets).flatMap((asset) => safeArray(asset && asset.adlabels).map((label) => safeString(label && label.name))).filter(Boolean));\n}\n\nfunction containsAll(actual, expected) {\n  const values = new Set(safeArray(actual).map((value) => safeString(value).toLowerCase()));\n  return expected.every((value) => values.has(value));\n}\n\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\n\nfunction validateCrop(image, index, cropKey, targetWidth, targetHeight, label) {\n  const crops = asObject(image && image.image_crops);\n  if (!Object.prototype.hasOwnProperty.call(crops, cropKey)) return false;\n  const crop = safeArray(crops[cropKey]);\n  assert(crop.length === 2, `${label}_crop_points_invalid`, { index });\n  const start = safeArray(crop[0]);\n  const end = safeArray(crop[1]);\n  assert(start.length === 2 && end.length === 2, `${label}_crop_coordinates_invalid`, { index });\n  const width = Number(end[0]) - Number(start[0]);\n  const height = Number(end[1]) - Number(start[1]);\n  assert(Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0, `${label}_crop_bounds_invalid`, { index });\n  // Meta may round a crop edge to a whole source pixel.  Comparing the\n  // resulting ratios with only one pixel of tolerance on the longest edge\n  // rejects valid crops such as 1731x906 for the 191x100 placement (the ideal\n  // height is fractional).  Keep the gate narrow, but allow the bounded error\n  // introduced by rounding either coordinate.\n  const expectedRatio = targetWidth / targetHeight;\n  const actualRatio = width / height;\n  const ratioTolerance = Math.max(0.002, 2 / Math.min(width, height));\n  assert(Math.abs(actualRatio - expectedRatio) <= ratioTolerance, `${label}_crop_ratio_invalid`, {\n    index,\n    width,\n    height,\n    expected_ratio: expectedRatio,\n    actual_ratio: actualRatio,\n    ratio_tolerance: ratioTolerance,\n  });\n  return true;\n}\n\nfunction validateVerticalCrop(image, index) {\n  return validateCrop(image, index, VERTICAL_CROP_KEY, 9, 16, 'vertical');\n}\n\nfunction validateHorizontalCrop(image, index) {\n  return validateCrop(image, index, HORIZONTAL_CROP_KEY, 191, 100, 'horizontal');\n}\n\nfunction validateFeedFourByFiveCrop(image, index) {\n  return validateCrop(image, index, FEED_FOUR_BY_FIVE_CROP_KEY, 4, 5, 'feed_four_by_five');\n}\n\nfunction validateVideoOnlyPlacementRules(feed) {\n  const imageLabels = labelNames(feed.images);\n  const videoLabels = labelNames(feed.videos);\n  const bodyLabels = labelNames(feed.bodies);\n  const titleLabels = labelNames(feed.titles);\n  const descriptionLabels = labelNames(feed.descriptions);\n  const rules = safeArray(feed.asset_customization_rules);\n  assert(imageLabels.size === 0, 'video_only_images_forbidden', { actual: imageLabels.size });\n  assert(videoLabels.size === 1 && videoLabels.has('vertical_video'), 'video_only_video_label_invalid', { labels: [...videoLabels] });\n  const exactUniqueLabels = (assets, labels) => safeArray(assets).length === 5 && labels.size === 5 && safeArray(assets).every((asset) => safeArray(asset && asset.adlabels).length === 1);\n  assert(exactUniqueLabels(feed.bodies, bodyLabels), 'video_only_body_labels_invalid', { labels: [...bodyLabels] });\n  assert(exactUniqueLabels(feed.titles, titleLabels), 'video_only_title_labels_invalid', { labels: [...titleLabels] });\n  assert(exactUniqueLabels(feed.descriptions, descriptionLabels), 'video_only_description_labels_invalid', { labels: [...descriptionLabels] });\n  assert(rules.length === 2, 'video_only_placement_rule_count_invalid', { actual: rules.length });\n  const mainRule = asObject(rules[0]);\n  const rewardedRule = asObject(rules[1]);\n  const mainSpec = asObject(mainRule.customization_spec);\n  const rewardedSpec = asObject(rewardedRule.customization_spec);\n  for (const rule of [mainRule, rewardedRule]) {\n    assert(!safeString(rule.image_label && rule.image_label.name), 'video_only_image_label_forbidden', {});\n    assert(safeString(rule.video_label && rule.video_label.name) === 'vertical_video', 'video_only_rule_video_label_invalid', {});\n    assert(bodyLabels.has(safeString(rule.body_label && rule.body_label.name)), 'video_only_rule_body_label_invalid', {});\n    assert(titleLabels.has(safeString(rule.title_label && rule.title_label.name)), 'video_only_rule_title_label_invalid', {});\n    assert(descriptionLabels.has(safeString(rule.description_label && rule.description_label.name)), 'video_only_rule_description_label_invalid', {});\n  }\n  assert(safeString(mainRule.body_label && mainRule.body_label.name) !== safeString(rewardedRule.body_label && rewardedRule.body_label.name), 'video_only_rule_body_label_reused', {});\n  assert(safeString(mainRule.title_label && mainRule.title_label.name) !== safeString(rewardedRule.title_label && rewardedRule.title_label.name), 'video_only_rule_title_label_reused', {});\n  assert(safeString(mainRule.description_label && mainRule.description_label.name) !== safeString(rewardedRule.description_label && rewardedRule.description_label.name), 'video_only_rule_description_label_reused', {});\n  assert(containsAll(mainSpec.publisher_platforms, [...REQUIRED_VIDEO_ONLY_SOCIAL_PLATFORMS, ...REQUIRED_VIDEO_ONLY_NETWORK_PLATFORMS]), 'video_only_publishers_incomplete', {});\n  assert(safeArray(mainSpec.publisher_platforms).length === 4, 'video_only_publishers_not_exclusive', {});\n  assert(containsAll(mainSpec.facebook_positions, REQUIRED_VIDEO_ONLY_FACEBOOK_POSITIONS), 'video_only_facebook_positions_incomplete', {});\n  assert(safeArray(mainSpec.facebook_positions).length === REQUIRED_VIDEO_ONLY_FACEBOOK_POSITIONS.length, 'video_only_facebook_positions_not_exclusive', {});\n  assert(containsAll(mainSpec.instagram_positions, REQUIRED_VIDEO_ONLY_INSTAGRAM_POSITIONS), 'video_only_instagram_positions_incomplete', {});\n  assert(safeArray(mainSpec.instagram_positions).length === REQUIRED_VIDEO_ONLY_INSTAGRAM_POSITIONS.length, 'video_only_instagram_positions_not_exclusive', {});\n  assert(containsAll(mainSpec.audience_network_positions, REQUIRED_VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS), 'video_only_audience_network_positions_incomplete', {});\n  assert(safeArray(mainSpec.audience_network_positions).length === REQUIRED_VIDEO_ONLY_AUDIENCE_NETWORK_POSITIONS.length, 'video_only_audience_network_positions_not_exclusive', {});\n  assert(containsAll(mainSpec.whatsapp_positions, REQUIRED_VIDEO_ONLY_WHATSAPP_POSITIONS), 'video_only_whatsapp_positions_incomplete', {});\n  assert(safeArray(mainSpec.whatsapp_positions).length === REQUIRED_VIDEO_ONLY_WHATSAPP_POSITIONS.length, 'video_only_whatsapp_positions_not_exclusive', {});\n  assert(containsAll(rewardedSpec.publisher_platforms, ['audience_network']) && safeArray(rewardedSpec.publisher_platforms).length === 1, 'video_only_rewarded_publishers_invalid', {});\n  assert(containsAll(rewardedSpec.audience_network_positions, REQUIRED_VIDEO_ONLY_REWARDED_AUDIENCE_NETWORK_POSITIONS) && safeArray(rewardedSpec.audience_network_positions).length === 1, 'video_only_rewarded_positions_invalid', {});\n  assert(!safeArray(rewardedSpec.facebook_positions).length && !safeArray(rewardedSpec.instagram_positions).length && !safeArray(rewardedSpec.whatsapp_positions).length, 'video_only_rewarded_scope_invalid', {});\n  return {\n    feed_four_by_five_rule_count: 0,\n    mixed_static_vertical_rule_count: 0,\n    mixed_video_rewarded_rule_count: 0,\n    video_only_placement_rule_count: 2,\n  };\n}\n\nfunction validatePlacementRules(feed, isVideoOnly = false) {\n  if (isVideoOnly) return validateVideoOnlyPlacementRules(feed);\n  const imageLabels = labelNames(feed.images);\n  const videoLabels = labelNames(feed.videos);\n  const bodyLabels = labelNames(feed.bodies);\n  const titleLabels = labelNames(feed.titles);\n  const descriptionLabels = labelNames(feed.descriptions);\n  const images = safeArray(feed.images);\n  const hasMixedVideo = safeArray(feed.videos).length > 0;\n  const usedDescriptionLabels = new Set();\n  let mixedStaticVerticalRuleCount = 0;\n  let mixedVideoVerticalRuleCount = 0;\n  let verticalLegacyRuleCount = 0;\n  let horizontalRuleCount = 0;\n  let feedFourByFiveRuleCount = 0;\n  for (const [index, rule] of safeArray(feed.asset_customization_rules).entries()) {\n    const image = safeString(rule && rule.image_label && rule.image_label.name);\n    const video = safeString(rule && rule.video_label && rule.video_label.name);\n    const body = safeString(rule && rule.body_label && rule.body_label.name);\n    const title = safeString(rule && rule.title_label && rule.title_label.name);\n    const description = safeString(rule && rule.description_label && rule.description_label.name);\n    assert(Boolean(image || video), 'placement_media_label_missing', { index });\n    if (image) assert(imageLabels.has(image), 'placement_image_label_missing', { index, image });\n    if (video) assert(videoLabels.has(video), 'placement_video_label_missing', { index, video });\n    assert(bodyLabels.has(body), 'placement_body_label_missing', { index, body });\n    assert(titleLabels.has(title), 'placement_title_label_missing', { index, title });\n    assert(descriptionLabels.has(description), 'placement_description_label_missing', { index, description });\n    assert(!usedDescriptionLabels.has(description), 'placement_description_label_reused', { index, description });\n    usedDescriptionLabels.add(description);\n    const creativeImage = images.find((entry) => safeArray(entry && entry.adlabels)\n      .some((label) => safeString(label && label.name) === image));\n    const spec = asObject(rule && rule.customization_spec);\n    if (video) {\n      // The vertical video is not a companion for Stories/Reels. It is the\n      // explicit replacement only for Audience Network rewarded video.\n      assert(!image, 'mixed_video_rule_must_not_include_image_label', { index, image });\n      mixedVideoVerticalRuleCount += 1;\n      assert(containsAll(spec.publisher_platforms, REQUIRED_MIXED_VIDEO_PLATFORMS), 'mixed_video_publishers_incomplete', { index });\n      assert(containsAll(spec.audience_network_positions, REQUIRED_MIXED_VIDEO_AUDIENCE_NETWORK_POSITIONS), 'mixed_video_rewarded_position_missing', { index });\n      assert(safeArray(spec.publisher_platforms).length === REQUIRED_MIXED_VIDEO_PLATFORMS.length, 'mixed_video_publishers_not_exclusive', { index });\n      assert(safeArray(spec.audience_network_positions).length === REQUIRED_MIXED_VIDEO_AUDIENCE_NETWORK_POSITIONS.length, 'mixed_video_positions_not_exclusive', { index });\n      assert(safeArray(spec.facebook_positions).length === 0, 'mixed_video_facebook_position_forbidden', { index });\n      assert(safeArray(spec.instagram_positions).length === 0, 'mixed_video_instagram_position_forbidden', { index });\n      assert(safeArray(spec.whatsapp_positions).length === 0, 'mixed_video_whatsapp_position_forbidden', { index });\n      continue;\n    }\n    const isFeedPlacement = containsAll(spec.publisher_platforms, ['facebook', 'instagram']) &&\n      (containsAll(spec.facebook_positions, ['feed']) || containsAll(spec.instagram_positions, ['stream']));\n    if (creativeImage && isFeedPlacement && validateFeedFourByFiveCrop(creativeImage, index)) {\n      feedFourByFiveRuleCount += 1;\n    }\n    if (creativeImage && validateVerticalCrop(creativeImage, index)) {\n      if (hasMixedVideo) {\n        mixedStaticVerticalRuleCount += 1;\n        assert(containsAll(spec.publisher_platforms, REQUIRED_MIXED_STATIC_VERTICAL_PLATFORMS), 'mixed_static_vertical_publishers_incomplete', { index });\n        assert(containsAll(spec.facebook_positions, REQUIRED_MIXED_STATIC_VERTICAL_FACEBOOK_POSITIONS), 'mixed_static_vertical_facebook_positions_incomplete', { index });\n        assert(containsAll(spec.instagram_positions, REQUIRED_VERTICAL_INSTAGRAM_POSITIONS), 'vertical_instagram_positions_incomplete', { index });\n        assert(containsAll(spec.audience_network_positions, REQUIRED_MIXED_STATIC_VERTICAL_AUDIENCE_NETWORK_POSITIONS), 'mixed_static_vertical_audience_network_positions_incomplete', { index });\n        assert(containsAll(spec.whatsapp_positions, REQUIRED_MIXED_STATIC_VERTICAL_WHATSAPP_POSITIONS), 'mixed_static_vertical_whatsapp_positions_incomplete', { index });\n      } else {\n        verticalLegacyRuleCount += 1;\n      }\n    }\n    if (creativeImage && validateHorizontalCrop(creativeImage, index)) {\n      horizontalRuleCount += 1;\n      assert(containsAll(spec.publisher_platforms, REQUIRED_HORIZONTAL_PLATFORMS), 'horizontal_publishers_incomplete', { index });\n      assert(containsAll(spec.facebook_positions, REQUIRED_HORIZONTAL_FACEBOOK_POSITIONS), 'horizontal_facebook_positions_incomplete', { index });\n    }\n  }\n  if (hasMixedVideo) {\n    assert(mixedStaticVerticalRuleCount === 1, 'mixed_static_vertical_placement_rule_count_invalid', { actual: mixedStaticVerticalRuleCount });\n    assert(mixedVideoVerticalRuleCount === 1, 'mixed_video_rewarded_placement_rule_count_invalid', { actual: mixedVideoVerticalRuleCount });\n  } else {\n    assert(verticalLegacyRuleCount === 1, 'vertical_placement_rule_count_invalid', { actual: verticalLegacyRuleCount });\n  }\n  assert(horizontalRuleCount === 1, 'horizontal_placement_rule_count_invalid', { actual: horizontalRuleCount });\n  assert(usedDescriptionLabels.size === safeArray(feed.asset_customization_rules).length, 'placement_description_rule_count_invalid', {\n    expected: safeArray(feed.asset_customization_rules).length,\n    actual: usedDescriptionLabels.size,\n  });\n  // A 4:5 source carries Meta's explicit 400x500 crop. A 3:4 or 1:1 fallback\n  // deliberately keeps its native aspect, so it has no artificial 4:5 crop.\n  assert(feedFourByFiveRuleCount <= 1, 'feed_four_by_five_placement_rule_count_invalid', { actual: feedFourByFiveRuleCount });\n  return {\n    feed_four_by_five_rule_count: feedFourByFiveRuleCount,\n    mixed_static_vertical_rule_count: mixedStaticVerticalRuleCount,\n    mixed_video_rewarded_rule_count: mixedVideoVerticalRuleCount,\n  };\n}\n\nfunction validateAdvantagePlus(payload, source, hosts) {\n  const legacyBundleKey = ['standard', 'enhancements'].join('_');\n  assert(!Object.prototype.hasOwnProperty.call(payload, legacyBundleKey), 'legacy_enhancement_bundle_forbidden', {});\n  const freedom = asObject(payload.degrees_of_freedom_spec);\n  assert(!Object.prototype.hasOwnProperty.call(freedom, legacyBundleKey), 'legacy_enhancement_bundle_forbidden', {});\n  const features = asObject(freedom.creative_features_spec);\n  const nativeCarousel = safeString(source.media_variant) === 'carousel' &&\n    safeString(source.carousel_render_contract) === 'native_link_data';\n  if (nativeCarousel) {\n    assert(Object.keys(freedom).length === 0, 'native_carousel_advantage_plus_forbidden', {});\n    assert(Object.keys(asObject(payload.creative_sourcing_spec)).length === 0, 'native_carousel_sourcing_spec_forbidden', {});\n    return;\n  }\n  const requested = safeArray(source.advantage_plus_requested_features);\n  assert(Object.keys(features).length > 0, 'advantage_plus_features_missing', {});\n  for (const [feature, config] of Object.entries(features)) {\n    assert(ALLOWED_ADVANTAGE_PLUS_FEATURES.has(feature), 'advantage_plus_feature_not_allowlisted', { feature });\n    assert(!FORBIDDEN_ADVANTAGE_PLUS_FEATURES.has(feature), 'advantage_plus_feature_forbidden', { feature });\n    assert(safeString(config && config.enroll_status).toUpperCase() === 'OPT_IN', 'advantage_plus_feature_not_opted_in', { feature });\n  }\n  for (const feature of requested) {\n    assert(Object.prototype.hasOwnProperty.call(features, feature), 'advantage_plus_requested_feature_missing', { feature });\n  }\n\n  for (const feature of FORBIDDEN_ADVANTAGE_PLUS_FEATURES) {\n    assert(!Object.prototype.hasOwnProperty.call(features, feature), 'advantage_plus_feature_forbidden', { feature });\n  }\n\n  const sourcing = asObject(payload.creative_sourcing_spec);\n  // Token Vault and Meta must receive exactly the same HTTPS landing page in\n  // the asset feed and the sourcing spec. This prevents a later redirect or\n  // fallback from silently changing the commercial destination.\n  const sourceUrl = safeString(sourcing.source_url);\n  assert(Boolean(sourceUrl), 'creative_source_url_missing', {});\n  if (destinationContractKind(source) === 'whatsapp') assert(isWhatsAppUrl(sourceUrl), 'creative_source_url_whatsapp_invalid', {});\n  else validateUrl(sourceUrl, hosts, 'creative_source_url');\n\n  const siteLinks = safeArray(sourcing.site_links_spec);\n  assert(siteLinks.length === 0 || (siteLinks.length >= 2 && siteLinks.length <= 4), 'site_links_count_invalid', { count: siteLinks.length });\n  for (const [index, link] of siteLinks.entries()) {\n    assert(safeString(link && link.site_link_title), 'site_link_title_missing', { index });\n    validateUrl(link && link.site_link_url, hosts, `site_link_${index}`);\n  }\n  const siteExtensions = asObject(features.site_extensions);\n  assert(Boolean(siteLinks.length) === Boolean(safeString(siteExtensions.enroll_status)), 'site_extensions_site_links_mismatch', {});\n}\n\nfunction validateCarouselFeed(feed, story, source, hosts, destinationKind) {\n  assert(Object.keys(asObject(story.link_data)).length === 0, 'carousel_legacy_link_data_forbidden', {});\n  const formats = safeArray(feed.ad_formats).map((value) => safeString(value).toUpperCase()).filter(Boolean);\n  assert(formats.length === 1 && formats[0] === 'CAROUSEL', 'carousel_ad_format_invalid', { formats });\n  const carousels = safeArray(feed.carousels);\n  assert(carousels.length === 1, 'carousel_feed_count_invalid', { actual: carousels.length });\n  const carousel = asObject(carousels[0]);\n  const cards = safeArray(carousel.child_attachments);\n  assert(cards.length >= 2 && cards.length <= 10, 'carousel_card_count_invalid', { actual: cards.length });\n  assert(carousel.multi_share_optimized === false, 'carousel_multi_share_optimized_must_be_false', {});\n  const images = safeArray(feed.images);\n  const bodies = safeArray(feed.bodies);\n  const titles = safeArray(feed.titles);\n  const descriptions = safeArray(feed.descriptions);\n  const links = safeArray(feed.link_urls);\n  assert(images.length === cards.length, 'carousel_image_count_invalid', { expected: cards.length, actual: images.length });\n  assert(bodies.length === cards.length, 'carousel_body_count_invalid', { expected: cards.length, actual: bodies.length });\n  assert(titles.length === cards.length, 'carousel_title_count_invalid', { expected: cards.length, actual: titles.length });\n  assert(descriptions.length === cards.length, 'carousel_description_count_invalid', { expected: cards.length, actual: descriptions.length });\n  assert(links.length === cards.length, 'carousel_link_count_invalid', { expected: cards.length, actual: links.length });\n  const imageLabels = labelNames(images);\n  const bodyLabels = labelNames(bodies);\n  const titleLabels = labelNames(titles);\n  const descriptionLabels = labelNames(descriptions);\n  const linkLabels = labelNames(links);\n  const expectedCta = destinationKind === 'whatsapp' ? WHATSAPP_CTA : REQUIRED_CTA;\n  const ctaTypes = safeArray(feed.call_to_action_types).map((value) => safeString(value).toUpperCase()).filter(Boolean);\n  assert(ctaTypes.length === 1 && ctaTypes[0] === expectedCta, 'carousel_cta_types_invalid', { values: ctaTypes });\n  assert(safeArray(feed.call_to_actions).length === 0, 'carousel_call_to_actions_forbidden', { actual: safeArray(feed.call_to_actions).length });\n  const additionalData = asObject(feed.additional_data);\n  assert(additionalData.multi_share_end_card === false, 'carousel_multi_share_end_card_must_be_false', {});\n  assert(additionalData.is_click_to_message === (destinationKind === 'whatsapp'), 'carousel_click_to_message_flag_invalid', {\n    destination_kind: destinationKind,\n    actual: additionalData.is_click_to_message,\n  });\n  const primaryLink = validateUrl(links[0] && links[0].website_url, hosts, 'carousel_primary_link');\n  for (const [index, card] of cards.entries()) {\n    const child = asObject(card);\n    assert(imageLabels.has(safeString(asObject(child.image_label).name)), 'carousel_card_image_label_invalid', { index });\n    assert(bodyLabels.has(safeString(asObject(child.body_label).name)), 'carousel_card_body_label_invalid', { index });\n    assert(titleLabels.has(safeString(asObject(child.title_label).name)), 'carousel_card_title_label_invalid', { index });\n    assert(descriptionLabels.has(safeString(asObject(child.description_label).name)), 'carousel_card_description_label_invalid', { index });\n    const linkLabel = safeString(asObject(child.link_url_label).name);\n    assert(linkLabels.has(linkLabel), 'carousel_card_link_label_invalid', { index });\n    const linked = links.find((entry) => safeArray(entry && entry.adlabels).some((label) => safeString(label && label.name) === linkLabel));\n    assert(validateUrl(linked && linked.website_url, hosts, `carousel_card_${index}_link`) === primaryLink, 'carousel_card_link_mismatch', { index });\n    assert(!safeString(asObject(child.call_to_action_type_label).name), 'carousel_card_cta_label_forbidden', { index });\n  }\n  const expectedCards = Object.keys(asObject(source.asset_ids)).filter((key) => /^carousel_card_\\d+$/.test(safeString(key))).length;\n  assert(!expectedCards || expectedCards === cards.length, 'carousel_card_asset_count_mismatch', { expected: expectedCards, actual: cards.length });\n  return { primaryLink, card_count: cards.length };\n}\n\nfunction validateNativeCarousel(story, source, hosts, destinationKind) {\n  const linkData = asObject(story.link_data);\n  const cards = safeArray(linkData.child_attachments);\n  assert(cards.length >= 2 && cards.length <= 10, 'carousel_card_count_invalid', { actual: cards.length });\n  assert(linkData.multi_share_optimized === false, 'carousel_multi_share_optimized_must_be_false', {});\n  assert(linkData.multi_share_end_card === false, 'carousel_multi_share_end_card_must_be_false', {});\n  assert(safeString(linkData.message), 'carousel_message_missing', {});\n  const primaryLink = validateUrl(linkData.link, hosts, 'carousel_primary_link');\n  const expectedCta = destinationKind === 'whatsapp' ? WHATSAPP_CTA : REQUIRED_CTA;\n  const cta = asObject(linkData.call_to_action);\n  assert(safeString(cta.type).toUpperCase() === expectedCta, 'carousel_cta_invalid', { value: cta.type });\n  assert(validateUrl(asObject(cta.value).link, hosts, 'carousel_cta_link') === primaryLink, 'carousel_cta_link_mismatch', {});\n  for (const [index, card] of cards.entries()) {\n    const child = asObject(card);\n    assert(safeString(child.image_hash), 'carousel_card_image_hash_missing', { index });\n    assert(safeString(child.name), 'carousel_card_title_missing', { index });\n    assert(safeString(child.description), 'carousel_card_description_missing', { index });\n    assert(validateUrl(child.link, hosts, `carousel_card_${index}_link`) === primaryLink, 'carousel_card_link_mismatch', { index });\n  }\n  const expectedCards = Object.keys(asObject(source.asset_ids)).filter((key) => /^carousel_card_\\d+$/.test(safeString(key))).length;\n  assert(!expectedCards || expectedCards === cards.length, 'carousel_card_asset_count_mismatch', { expected: expectedCards, actual: cards.length });\n  return { primaryLink, card_count: cards.length, render_contract: 'native_link_data' };\n}\n\nreturn $input.all().map((item) => {\n  const source = sanitize(clone(item.json || {}));\n  const restored = restoredRunContext();\n  if (!safeString(source.run_id)) source.run_id = restored.run_id;\n  if (!safeString(source.batch_fingerprint)) source.batch_fingerprint = restored.batch_fingerprint;\n  if (safeString(source.error)) fail('upstream_error', { error: safeString(source.error), upstream: safeString(source.upstream_error) });\n\n  assert(safeString(source.run_id), 'run_id_missing', {});\n  assert(\n    safeString(source.workflow_contract_revision) === WORKFLOW_CONTRACT_REVISION,\n    'workflow_contract_version_skew',\n    { expected: WORKFLOW_CONTRACT_REVISION, received: safeString(source.workflow_contract_revision) },\n  );\n  assert(safeString(source.token_id), 'token_id_missing', {});\n  assert(/^v25\\.0$/.test(safeString(source.api_version)), 'api_version_must_be_v25', { value: source.api_version });\n  assert(/^\\d+$/.test(safeString(source.account_id)), 'account_id_invalid', {});\n  assert(/^\\d+$/.test(safeString(source.page_id)), 'page_id_invalid', {});\n\n  const payload = asObject(source.creativePayload);\n  const story = asObject(payload.object_story_spec);\n  const feed = asObject(payload.asset_feed_spec);\n  const isVideoOnly = safeString(source.media_variant) === 'video_single';\n  const isMixedFlexible = safeString(source.media_variant) === 'mixed_flexible';\n  const isCarousel = safeString(source.media_variant) === 'carousel';\n  const legacyCarousel = isCarousel && Object.keys(asObject(story.link_data)).length > 0;\n  const hosts = allowedHosts(source);\n  const destinationKind = destinationContractKind(source);\n  // This value is also checked inside validateAdvantagePlus(), but the main\n  // payload contract needs it in this scope to prove that Token Vault receives\n  // the same destination as the primary asset-feed link. Native carousels are\n  // deliberately exempt because their approved contract forbids a sourcing\n  // spec altogether.\n  const sourceUrl = safeString(asObject(payload.creative_sourcing_spec).source_url);\n  if (!isCarousel) {\n    assert(Boolean(sourceUrl), 'creative_source_url_missing', {});\n    if (destinationKind === 'whatsapp') assert(isWhatsAppUrl(sourceUrl), 'creative_source_url_whatsapp_invalid', {});\n    else validateUrl(sourceUrl, hosts, 'creative_source_url');\n  }\n  assert(safeString(payload.name), 'creative_name_missing', {});\n  assert(safeString(story.page_id) === safeString(source.page_id), 'creative_page_id_mismatch', {});\n  assert(legacyCarousel || Object.keys(feed).length > 0, 'asset_feed_spec_required', {});\n  if (legacyCarousel) assert(Object.keys(feed).length === 0, 'carousel_legacy_asset_feed_forbidden', {});\n  if (isMixedFlexible || isVideoOnly) {\n    assert(Object.keys(asObject(story.video_data)).length === 0, 'asset_feed_video_object_story_spec_forbidden', {});\n  }\n\n  const images = safeArray(feed.images);\n  if (legacyCarousel) assert(images.length === 0, 'carousel_legacy_images_forbidden', { actual: images.length });\n  else if (isCarousel) assert(images.length >= 2 && images.length <= 10, 'carousel_asset_feed_images_invalid', { actual: images.length });\n  else if (isVideoOnly) assert(images.length === 0, 'video_only_images_forbidden', { actual: images.length });\n  else assert(images.length >= MIN_IMAGES, 'image_count_invalid', { minimum: MIN_IMAGES, actual: images.length });\n  for (const [index, image] of images.entries()) {\n    assert(Boolean(safeString(image && image.hash) || safeString(image && image.url)), 'image_reference_missing', { index });\n    if (safeString(image && image.url)) validateUrl(image.url, hosts, `image_${index}`);\n  }\n  const videos = safeArray(feed.videos);\n  const expectsAssetFeedVideo = isMixedFlexible || isVideoOnly;\n  assert(expectsAssetFeedVideo ? videos.length === 1 : videos.length === 0, expectsAssetFeedVideo ? 'asset_feed_video_count_invalid' : 'unexpected_asset_feed_video', { actual: videos.length });\n  for (const [index, video] of videos.entries()) {\n    assert(/^\\d+$/.test(safeString(video && video.video_id)), 'video_id_invalid', { index });\n    assert(Boolean(safeString(video && video.thumbnail_hash)), 'video_thumbnail_hash_missing', { index });\n  }\n  if (expectsAssetFeedVideo) {\n    assert(safeString(source.video_status).toLowerCase() === 'ready', 'video_not_ready', { video_status: source.video_status });\n    assert(isNineBySixteen(source.video_width, source.video_height), 'video_source_aspect_ratio_invalid', { width: source.video_width, height: source.video_height, required: '9x16' });\n    assert(safeString(source.video_aspect_ratio) === '9x16' && safeString(source.video_recommended_aspect_ratio) === '9x16', 'video_source_aspect_ratio_metadata_invalid', {});\n    assert(isNineBySixteen(source.video_thumbnail_width, source.video_thumbnail_height), 'video_thumbnail_aspect_ratio_invalid', { width: source.video_thumbnail_width, height: source.video_thumbnail_height, required: '9x16' });\n    assert(safeString(source.video_thumbnail_aspect_ratio) === '9x16', 'video_thumbnail_aspect_ratio_metadata_invalid', {});\n    const adFormats = safeArray(feed.ad_formats).map((format) => safeString(format).toUpperCase()).filter(Boolean);\n    if (isMixedFlexible) {\n      // The Graph endpoint rejects a multi-format feed (1885374), and\n      // SINGLE_VIDEO rejects images (1885718). AUTOMATIC_FORMAT is the\n      // supported flexible envelope for mixed labelled inventory.\n      assert(adFormats.length === 1 && adFormats[0] === 'AUTOMATIC_FORMAT', 'mixed_ad_format_must_be_automatic', { formats: safeArray(feed.ad_formats) });\n    } else {\n      assert(adFormats.length === 1 && adFormats[0] === 'SINGLE_VIDEO', 'video_only_ad_format_must_be_single_video', { formats: safeArray(feed.ad_formats) });\n    }\n  }\n  if (!isCarousel) {\n    textAssets(feed.bodies, BODY_COUNT, MAX_BODY_LENGTH, 'bodies');\n    textAssets(feed.titles, TITLE_COUNT, MAX_TITLE_LENGTH, 'titles');\n    textAssets(feed.descriptions, DESCRIPTION_COUNT, MAX_DESCRIPTION_LENGTH, 'descriptions');\n  }\n\n  const ctas = legacyCarousel ? [asObject(story.link_data.call_to_action).type] : safeArray(feed.call_to_action_types);\n  const linkUrls = safeArray(feed.link_urls);\n  const carouselValidation = isCarousel ? (legacyCarousel\n    ? validateNativeCarousel(story, source, hosts, destinationKind)\n    : validateCarouselFeed(feed, story, source, hosts, destinationKind)) : null;\n  if (!isCarousel) assert(linkUrls.length === 1, 'link_url_count_invalid', { actual: linkUrls.length });\n  const primaryLink = isCarousel ? carouselValidation.primaryLink : destinationKind === 'whatsapp'\n    ? (assert(isWhatsAppUrl(linkUrls[0] && linkUrls[0].website_url), 'primary_link_whatsapp_required', {}), safeString(linkUrls[0] && linkUrls[0].website_url))\n    : validateUrl(linkUrls[0] && linkUrls[0].website_url, hosts, 'primary_link');\n  if (!isCarousel) assert(sourceUrl === primaryLink, 'creative_source_url_primary_link_mismatch', {});\n  const whatsappDestination = destinationKind === 'whatsapp';\n  if (isCarousel && whatsappDestination) assert(isWhatsAppUrl(primaryLink), 'carousel_primary_link_whatsapp_required', {});\n  if (isCarousel && !whatsappDestination) assert(!isWhatsAppUrl(primaryLink), 'carousel_primary_link_whatsapp_forbidden', {});\n  if (whatsappDestination && !isCarousel) {\n    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === expectedFlexibleCta(source, destinationKind), 'cta_type_incompatible_with_campaign_objective', { value: ctas });\n    assert(isWhatsAppUrl(primaryLink), 'primary_link_whatsapp_required', {});\n    const schedulingUrl = validateUrl(source.scheduling_landing_page_url, hosts, 'scheduling_landing_page');\n    assert(!isWhatsAppUrl(schedulingUrl), 'scheduling_landing_page_whatsapp_forbidden', {});\n  } else if (!isCarousel) {\n    assert(ctas.length === 1 && safeString(ctas[0]).toUpperCase() === expectedFlexibleCta(source, destinationKind), 'cta_type_incompatible_with_campaign_objective', { value: ctas });\n    assert(!isWhatsAppUrl(primaryLink), 'primary_link_whatsapp_forbidden', {});\n    assert(primaryLink === safeString(source.landing_page_url), 'primary_link_landing_page_mismatch', {});\n  }\n  const placementValidation = isCarousel ? { carousel_card_count: carouselValidation.card_count } : validatePlacementRules(feed, isVideoOnly);\n  validateAdvantagePlus(payload, source, hosts);\n\n  const adPayload = asObject(source.adPayload);\n  assert(safeString(adPayload.name), 'ad_name_missing', {});\n  const adStatus = safeString(adPayload.status).toUpperCase();\n  const calibrationMarker = safeString(source.calibration_marker).toUpperCase();\n  const expectedCalibrationMarker = isCarousel\n    ? '[TEST-CAROUSEL]'\n    : (isVideoOnly ? '[TEST-VIDEO-ONLY]' : '');\n  const isPausedCalibration =\n    source.calibration_mode === true &&\n    Boolean(expectedCalibrationMarker) &&\n    safeString(source.action) === 'create_new' &&\n    calibrationMarker === expectedCalibrationMarker &&\n    safeString(adPayload.name).toUpperCase().startsWith(expectedCalibrationMarker) &&\n    safeString(source.desired_final_status).toUpperCase() === 'PAUSED' &&\n    adStatus === 'PAUSED';\n  assert(\n    adStatus === 'ACTIVE' || isPausedCalibration,\n    'ad_publish_status_invalid',\n    { value: adPayload.status, calibration_mode: source.calibration_mode === true },\n  );\n  const offerFingerprint = asObject(source.offer_fingerprint);\n  const offerReplacementGuard = asObject(source.offer_replacement_guard);\n  const offerTag = safeString(offerFingerprint.tag).toUpperCase();\n  const offerReplacementEligible =\n    offerFingerprint.replacement_eligible === true && /^OFV1:[A-Z0-9]+$/.test(offerTag);\n  // Replacements are materially riskier than creates: the upstream selector\n  // must prove an exact commercial offer, and a verified new offer must leave\n  // its deterministic tag on the ad for future non-heuristic correlation.\n  assert(Object.keys(offerReplacementGuard).length > 0, 'offer_replacement_guard_missing', {});\n  if (safeString(source.action) === 'replace_existing') {\n    assert(offerReplacementEligible, 'replacement_offer_fingerprint_unverified', { status: offerFingerprint.status });\n    assert(safeString(offerReplacementGuard.reason) === 'exact_eligible_candidate_selected', 'replacement_offer_fingerprint_not_exact', {\n      reason: offerReplacementGuard.reason,\n    });\n    assert(safeString(offerReplacementGuard.selected_candidate_offer_match_status) === 'exact', 'replacement_candidate_offer_match_not_exact', {});\n  }\n  if (offerReplacementEligible) {\n    assert(safeString(adPayload.name).toUpperCase().includes(`[${offerTag}]`), 'offer_fingerprint_tag_missing_from_ad_name', { offer_tag: offerTag });\n  }\n  if (safeString(source.action) === 'create_new') {\n    assert(/^\\d+$/.test(safeString(adPayload.adset_id)), 'adset_id_required_for_create', {});\n  }\n\n  return {\n    json: {\n      ...source,\n      creativePayload: payload,\n      creativePayloadFallback: undefined,\n      allow_fallback_creative: false,\n      blocked_before_update: false,\n      meta_creative_validation: {\n        status: 'ok',\n        applied_at: new Date().toISOString(),\n        fallback_available: false,\n        fallback_policy: 'disabled',\n        creative_error_policy: 'fail_fast_before_ad_mutation',\n        ad_mutation_requires_all_creatives: true,\n        image_count: legacyCarousel ? carouselValidation.card_count : images.length,\n        video_count: videos.length,\n        video_status: safeString(source.video_status),\n        video_delivery_aspect_ratio: expectsAssetFeedVideo ? '9x16' : '',\n        video_delivery_format_semantics: safeString(source.media_variant) === 'mixed_flexible'\n          ? 'rewarded_video_recommended_9x16_satisfied_by_exact_original_source'\n          : (expectsAssetFeedVideo ? 'recommended_9x16_satisfied_by_exact_original_source' : ''),\n        vertical_crop_key: VERTICAL_CROP_KEY,\n        media_variant: safeString(source.media_variant || 'static_flexible'),\n        destination_contract_kind: destinationKind,\n        workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,\n        vertical_placement_rule_count: isVideoOnly ? Number(placementValidation.video_only_placement_rule_count || 0) : 1,\n        video_only_placement_rule_count: Number(placementValidation.video_only_placement_rule_count || 0),\n        mixed_static_vertical_rule_count: Number(placementValidation.mixed_static_vertical_rule_count || 0),\n        mixed_video_rewarded_rule_count: Number(placementValidation.mixed_video_rewarded_rule_count || 0),\n        horizontal_crop_key: HORIZONTAL_CROP_KEY,\n        horizontal_placement_rule_count: isVideoOnly ? 0 : 1,\n        feed_four_by_five_placement_rule_count: Number(placementValidation.feed_four_by_five_rule_count || 0),\n        body_count: isCarousel ? 1 : BODY_COUNT,\n        title_count: isCarousel ? carouselValidation.card_count : TITLE_COUNT,\n        description_count: isCarousel ? carouselValidation.card_count : DESCRIPTION_COUNT,\n        carousel_card_count: isCarousel ? carouselValidation.card_count : 0,\n        carousel_render_contract: isCarousel ? carouselValidation.render_contract || 'asset_feed' : '',\n        ad_status: adStatus,\n        calibration_mode: isPausedCalibration,\n        site_links_count: safeArray(asObject(payload.creative_sourcing_spec).site_links_spec).length,\n        advantage_plus_requested_features: safeArray(source.advantage_plus_requested_features),\n        offer_fingerprint: {\n          status: safeString(offerFingerprint.status || 'unverified'),\n          tag: offerTag,\n          replacement_eligible: offerReplacementEligible,\n          replacement_reason: safeString(offerReplacementGuard.reason),\n        },\n      },\n      warnings: safeArray(source.warnings),\n    },\n    binary: item.binary,\n  };\n});\n"
+      },
+      "id": "f0f920f6-65d2-4ad1-836f-6550f0ad1010",
+      "name": "Validate Meta Creative Payload",
+      "type": "n8n-nodes-base.code",
+      "position": [
+        8528,
+        1272
+      ],
+      "retryOnFail": false,
+      "typeVersion": 2
+    },
+    {
+      "parameters": {
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/config' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "1c1fd6c5-dce1-42fe-86f4-e6bfacf2346a",
+      "name": "Get Meta Publish Config",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        1184,
+        1664
+      ],
+      "retryOnFail": false,
+      "typeVersion": 4.3,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "=Analise o conjunto de mídias anexadas e gere uma nova copy para Meta Ads.\n\nRetorne SOMENTE um JSON válido no formato exigido pelo parser.\nNão escreva explicações, comentários, markdown, aspas triplas, observações extras nem texto fora do JSON.\n\nRegras obrigatórias:\n- Mantenha `source_ad_name` exatamente igual ao recebido no input.\n- Use `source_copy_reference` apenas como contexto do anúncio correlacionado do mês anterior.\n- Não copie literalmente a copy anterior. Reescreva a peça com base na nova mídia.\n- Considere todas as mídias anexadas como variações do mesmo criativo.\n- Gere exatamente:\n  - 5 `bodies`\n  - 5 `titles`\n  - 5 `descriptions`\n  - 0 a 4 `site_links` opcionais com `title` e `url` HTTPS\n- Respeite rigorosamente os limites:\n  - cada `body.text` com no máximo 240 caracteres\n  - cada `title.text` com no máximo 40 caracteres\n  - cada `description.text` com no máximo 60 caracteres\n- Não ultrapasse os limites de caracteres em nenhuma hipótese.\n- Prefira linguagem comercial, clara e objetiva.\n- Evite emojis. Só use se forem realmente necessários e sem comprometer o limite.\n- Não invente preços, condições, parcelamentos, brindes, promessas médicas ou garantias de resultado.\n- Se preço, condição ou oferta não estiverem claros na mídia, use apenas o que for seguro e verificável.\n\nA URL principal e o CTA sao controlados pelo workflow a partir do Token Vault; retorne apenas os campos definidos no schema.\n\nPara `analysis`:\n- Identifique o procedimento principal e, se houver, variações relevantes.\n- Em `adsPricing`, use apenas informações visíveis na mídia.\n- Em `crmPricing`, use somente dados retornados pelo catálogo comercial do CRM nesta execução.\n- Em `notes`, seja breve, factual e útil para geração da copy.\n\nItem atual:\n{{ JSON.stringify({\n  job_key: $json.job_key,\n  group_key: $json.group_key,\n  nome_base: $json.nome_base,\n  source_ad_name: $json.source_ad_name,\n  source_copy_reference: $json.source_ad_texts,\n  destination_group: $json.destination_group,\n  destinations: $json.destinations || [],\n  crm_offer_contexts: $json.crm_offer_contexts || {},\n  media_inventory: $json.media_inventory,\n  allowed_link_hosts: $json.destinations?.[0]?.allowed_link_hosts || []\n}) }}\n\nContrato de correlacao deterministica do workflow:\n- Retorne no objeto JSON de nivel raiz os campos `job_key` e `group_key` exatamente como recebidos no item atual.\n- Esses identificadores nao sao texto criativo: nao os traduza, nao os resuma e nao invente valores.\n- Em lotes com mais de um job, a resposta sem esses identificadores sera recusada antes de qualquer mutacao Meta.",
+        "options": {
+          "systemMessage": "Você é um agente multimodal de análise de mídia e geração de copy para Meta Ads da clínica Espaço Facial.\n\nSua tarefa é analisar o conjunto de artes anexadas para um mesmo anúncio e gerar uma nova copy compatível com Meta Ads, obedecendo estritamente o schema de saída.\n\nObjetivo:\n1. Entender o procedimento, a oferta e o apelo comercial com base na nova mídia.\n2. Usar a copy do anúncio anterior apenas como referência de contexto e continuidade.\n3. Gerar uma nova copy coerente com a peça atual, com linguagem comercial clara e segura.\n4. Produzir uma saída pronta para uso em automação, sem necessidade de reescrita manual.\n\nRegras críticas:\n- Retorne somente JSON válido.\n- Preserve `source_ad_name` exatamente como veio no input.\n- Considere todas as mídias anexadas como variações do mesmo criativo.\n- Não invente preços, condições, parcelamentos, brindes, quantidades, regras promocionais ou promessas médicas.\n- Não afirme resultados garantidos, permanentes ou universais.\n- Não faça diagnóstico.\n- Não use linguagem clínica arriscada ou que implique cura, certeza de resultado ou superioridade absoluta.\n- O catálogo comercial do CRM foi consultado automaticamente pelo workflow para cada unidade de destino.\n- Use somente os dados presentes em `crm_offer_contexts` para preço, oferta, parcelamento, condição e vigência.\n- Se o CRM não retornar uma oferta, não use preço ou condição que não esteja inequívoca na mídia.\n- Se uma informação não estiver segura, interrompa a inferência e use formulação neutra; nunca invente dados.\n\nA URL principal e o CTA sao controlados pelo workflow a partir do Token Vault; retorne apenas os campos definidos no schema.\n\nRegras obrigatórias para `creative_override`:\n- Gerar exatamente 5 `bodies`.\n- Gerar exatamente 5 `titles`.\n- Gerar exatamente 5 `descriptions`.\n- Gerar `site_links` como array vazio ou com 2 a 4 links HTTPS permitidos pelo input.\n- Cada `body.text` deve ter no máximo 240 caracteres.\n- Cada `title.text` deve ter no máximo 40 caracteres.\n- cada `description.text` deve ter no máximo 60 caracteres.\n- Nunca ultrapasse esses limites.\n- Escreva textos prontos para anúncio, sem bullets excessivos, sem prefixos do tipo “Título 1” ou “Body 1”.\n- Evite emojis. Use somente se forem indispensáveis e sem comprometer os limites.\n- Não repita variações quase idênticas. As 5 opções devem ter diversidade real de formulação.\n- Não use placeholders como “{{product.name}}”, “nome do cliente”, “sua cidade” ou similares.\n- Não inclua hashtags.\n\n\nRegras para `analysis`:\n- `content_type` deve refletir corretamente o tipo de mídia.\n- `detected_procedures` deve listar apenas procedimentos realmente sustentados pela mídia.\n- Em `evidence`, cite sinais objetivos da arte, como textos visíveis, elementos visuais e oferta mostrada.\n- `adsPricing` deve refletir apenas o que estiver visível na mídia, quando houver.\n- `crmPricing` deve refletir apenas o que vier de `crm_offer_contexts`.\n- `notes` deve ser conciso, factual e útil para orientar a copy.\n\nDireção editorial:\n- Linguagem em português do Brasil.\n- Tom comercial, simples, claro e orientado à conversão.\n- Texto natural, direto e elegante.\n- Priorize compreensão imediata da oferta.\n- Quando houver preço, apresente de forma clara e fiel à mídia.\n- Quando houver CTA visual na arte, incorpore o sentido dele sem copiar mecanicamente.\n\nContrato de correlacao deterministica do workflow:\n- `job_key` e `group_key` devem ser devolvidos no JSON raiz, exatamente como vieram no input.\n- Nunca altere esses identificadores; eles sao usados para correlacionar a copy com a midia.",
+          "maxIterations": 4,
+          "passthroughBinaryImages": true
+        }
+      },
+      "id": "044ae10d-dfaa-4a29-a834-e5b1175da4fc",
+      "name": "Livia",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "position": [
+        7392,
+        1464
+      ],
+      "retryOnFail": false,
+      "typeVersion": 3
+    },
+    {
+      "parameters": {
+        "jsCode": "function safeString(value) { return String(value ?? '').trim(); }\nfunction asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction normalizeCompact(value) {\n  return safeString(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '')\n    .toLowerCase();\n}\n\nconst SAFE_LANDING_PAGE_BY_DESTINATION = Object.freeze({\n  barrashoppingsul: 'https://espacofacial.com/agendamento?unit=barrashoppingsul',\n  novohamburgo: 'https://espacofacial.com/agendamento?unit=novo-hamburgo',\n});\nconst SAFE_WHATSAPP_DESTINATION_URL = 'https://api.whatsapp.com/send';\nconst WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';\n\nconst root = $input.first()?.json || {};\nif (root.ok !== true || root.ready !== true) {\n  throw new Error(`Meta Publish gateway nao esta pronto: ${JSON.stringify(root.invalid || root.error || {})}`);\n}\n\nconst gatewayContractRevision = safeString(asObject(root.capabilities).workflow_contract_revision);\nif (gatewayContractRevision !== WORKFLOW_CONTRACT_REVISION) {\n  throw new Error(`Meta Publish gateway com revisao de contrato divergente: esperado ${WORKFLOW_CONTRACT_REVISION}, recebido ${gatewayContractRevision || 'ausente'}.`);\n}\n\n// The workflow and the Token Vault must evolve as one contract. Verify the\n// complete resumable-video API before any batch work starts, even for a static\n// batch: a missing action is a deployment mismatch, not a media error.\nconst requiredVideoActions = [\n  'start_video_upload',\n  'transfer_video_chunk',\n  'finish_video_upload',\n  'get_video_status',\n];\nconst videoUpload = asObject(asObject(root.capabilities).video_upload);\nconst supportedVideoActions = Array.isArray(videoUpload.supported_actions)\n  ? videoUpload.supported_actions.map(safeString).filter(Boolean)\n  : [];\nconst missingVideoActions = requiredVideoActions.filter((action) => !supportedVideoActions.includes(action));\nif (missingVideoActions.length) {\n  throw new Error(`Meta Publish gateway sem contrato de upload de video: ${missingVideoActions.join(', ')}.`);\n}\nif (Number(videoUpload.max_file_bytes) < 90 * 1024 * 1024 || Number(videoUpload.max_chunk_bytes) < 16 * 1024 * 1024) {\n  throw new Error('Meta Publish gateway declarou limites insuficientes para upload de video.');\n}\n\nconst destinations = Array.isArray(root.destinations) ? root.destinations : [];\nconst required = [\n  'token_id',\n  'api_version',\n  'account_id',\n  'campaign_id',\n  'adset_id',\n  'page_id',\n  'instagram_user_id',\n  'destination_group',\n];\n\nconst rows = destinations.map((entry) => {\n  const item = asObject(entry);\n  const missing = required.filter((key) => !safeString(item[key]));\n  if (missing.length) {\n    throw new Error(`Meta Publish config incompleta em ${item.token_id || item.destination_group || 'destino'}: ${missing.join(', ')}`);\n  }\n  const configuredLandingPages = asObject(item.landing_pages_by_creative_group);\n  const destinationKey = normalizeCompact(item.destination_group);\n  const safeFallbackLandingPage = SAFE_LANDING_PAGE_BY_DESTINATION[destinationKey] || '';\n  if (!Object.keys(configuredLandingPages).length && !safeFallbackLandingPage) {\n    throw new Error(`Meta Publish sem landing page segura para o destino ${safeString(item.destination_group)}.`);\n  }\n  const landingPages = Object.keys(configuredLandingPages).length\n    ? configuredLandingPages\n    : { DEFAULT: safeFallbackLandingPage };\n  return {\n    json: {\n      row_number: item.row_number ?? '',\n      destination_group: safeString(item.destination_group),\n      api_version: safeString(item.api_version || 'v25.0'),\n      account_id: safeString(item.account_id).replace(/^act_/, ''),\n      campaign_id: safeString(item.campaign_id),\n      adset_id: safeString(item.adset_id),\n      page_id: safeString(item.page_id),\n      instagram_user_id: safeString(item.instagram_user_id),\n      token_id: safeString(item.token_id),\n      allowed_link_hosts: Array.isArray(item.allowed_link_hosts) ? item.allowed_link_hosts : [],\n      landing_pages_by_creative_group: landingPages,\n      landing_page_validation: asObject(item.landing_page_validation),\n      freshness_window_days: Number(item.freshness_window_days || 7),\n      // Destination data is intentionally non-secret and lets the publisher\n      // validate the ad-set contract before it creates a new ad. Older Token\n      // Vault rows may omit it; Build Jobs then requires corroboration from an\n      // existing creative in the exact same ad set instead of guessing.\n      campaign_objective: safeString(item.campaign_objective),\n      optimization_goal: safeString(item.optimization_goal),\n      destination_type: safeString(item.destination_type).toUpperCase(),\n      // The effective destination type is read from the live ad set. This\n      // endpoint is the only fallback when a legacy Token Vault row omits its\n      // explicit WhatsApp handoff URL; it is corroborated by the source ads.\n      whatsapp_destination_url: safeString(item.whatsapp_destination_url || SAFE_WHATSAPP_DESTINATION_URL),\n      carousel_native_campaign_id: safeString(item.carousel_native_campaign_id),\n      carousel_native_adset_id: safeString(item.carousel_native_adset_id),\n      carousel_native_adset_verified: item.carousel_native_adset_verified === true,\n      carousel_native_route_active: item.carousel_native_route_active === true,\n      config_revision: safeString(root.config_revision),\n      destination_id_source: 'meta_publish_gateway',\n      secrets_exposed: false,\n    },\n  };\n}).sort((left, right) => Number(left.json.row_number || 0) - Number(right.json.row_number || 0));\n\nif (rows.length < 2) {\n  throw new Error(`Meta Publish gateway precisa de 2 destinos ativos; encontrados ${rows.length}.`);\n}\n\nreturn rows;"
+      },
+      "id": "baf58346-3a8e-47ff-84d6-e75b3904cc0e",
+      "name": "Build Meta API Params From Vault",
+      "type": "n8n-nodes-base.code",
+      "position": [
+        1408,
+        1664
+      ],
+      "typeVersion": 2
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "fileId": {
+          "__rl": true,
+          "value": "={{ $json.id }}",
+          "mode": "id"
+        },
+        "options": {
+          "propertiesUi": {
+            "propertyValues": [
+              {
+                "key": "published",
+                "value": "={{ true }}"
+              },
+              {
+                "key": "meta_ads_published_at",
+                "value": "={{ $json.meta_ads_published_at }}"
+              },
+              {
+                "key": "meta_ads_execution_id",
+                "value": "={{ $json.meta_ads_execution_id }}"
+              },
+              {
+                "key": "meta_ads_creative_group_key",
+                "value": "={{ $json.meta_ads_creative_group_key }}"
+              },
+              {
+                "key": "meta_ads_units",
+                "value": "={{ $json.meta_ads_units }}"
+              },
+              {
+                "key": "meta_ads_ad_ids",
+                "value": "={{ $json.meta_ads_ad_ids }}"
+              },
+              {
+                "key": "meta_ads_creative_ids",
+                "value": "={{ $json.meta_ads_creative_ids }}"
+              },
+              {
+                "key": "meta_ads_run_id",
+                "value": "={{ $json.meta_ads_run_id }}"
+              }
+            ]
+          }
+        }
+      },
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 3,
+      "position": [
+        13456,
+        1448
+      ],
+      "id": "29743e0d-e789-4fbb-a759-c377b6d51ff4",
+      "name": "Update Meta Source File",
+      "retryOnFail": true,
+      "waitBetweenTries": 3000,
+      "maxTries": 3,
+      "credentials": {
+        "googleDriveOAuth2Api": {
+          "id": "jO1yl4X4hfN2kBxd",
+          "name": "Google Cloud - Drive"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "resource": "messages-api",
+        "instanceName": "crm-channel-1",
+        "remoteJid": "5551995103563",
+        "messageText": "={{ $json.event.payload.whatsapp_message }}",
+        "options_message": {}
+      },
+      "type": "n8n-nodes-evolution-api-en.evolutionApi",
+      "typeVersion": 1,
+      "position": [
+        15024,
+        1352
+      ],
+      "id": "e8ac9e77-fbc6-4082-8358-f197ac53cf08",
+      "name": "Inform Meta Publish Success (WhatsApp)",
+      "executeOnce": true,
+      "retryOnFail": false,
+      "credentials": {
+        "evolutionApi": {
+          "id": "bfuWTzZoi8VCYCzE",
+          "name": "Evolution Token"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "chatId": "7893126619",
+        "text": "={{ $json.event.payload.telegram_message }}",
+        "additionalFields": {
+          "appendAttribution": false,
+          "disable_web_page_preview": true,
+          "parse_mode": "HTML"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        15024,
+        1544
+      ],
+      "id": "a64f575a-fcdf-4307-8caa-6f723490fcf9",
+      "name": "Inform Meta Publish Success (Telegram)",
+      "webhookId": "837f6d8f-f5bb-41e6-9323-fb074a1d43c1",
+      "retryOnFail": false,
+      "credentials": {
+        "telegramApi": {
+          "id": "9NlSo0dcxNrKtlWW",
+          "name": "Telegram – @espacofacial_bot"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "b53fe4d3-3d32-4310-b708-f2544ac2b428",
+      "name": "Verify Advantage+ Creative",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        11888,
+        1272
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\nfunction labels(assets) {\n  return new Set(list(assets).flatMap((asset) => list(asset && asset.adlabels).map((label) => text(label && label.name))).filter(Boolean));\n}\nfunction contains(actual, expected) {\n  const values = new Set(list(actual).map(text).filter(Boolean));\n  return expected.every((value) => values.has(value));\n}\nfunction allCarryLabel(assets, label) {\n  return list(assets).length === 5 && list(assets).every((asset) => labels([asset]).has(label));\n}\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0\n    && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\nfunction effectiveWhatsAppStatus(placementItems, source) {\n  const destinationGroup = text(source.destination_group);\n  const adsetId = text(source.destination_adset_id || source.adset_id);\n  const checks = list(placementItems).flatMap((item) => list(object(item && item.json).placement_checks));\n  return checks.some((check) => {\n    const sameDestination = destinationGroup && text(check.destination_group) === destinationGroup;\n    const sameAdset = adsetId && text(check.adset_id) === adsetId;\n    return (sameDestination || sameAdset) && contains(object(check.targeting).effective_whatsapp_positions, ['status']);\n  });\n}\nfunction effectiveVideoOnlyPlacementScope(placementItems, source) {\n  const destinationGroup = text(source.destination_group);\n  const adsetId = text(source.destination_adset_id || source.adset_id);\n  const checks = list(placementItems).flatMap((item) => list(object(item && item.json).placement_checks));\n  return checks.some((check) => {\n    const sameDestination = destinationGroup && text(check.destination_group) === destinationGroup;\n    const sameAdset = adsetId && text(check.adset_id) === adsetId;\n    if (!sameDestination && !sameAdset) return false;\n    const targeting = object(check.targeting);\n    return contains(targeting.effective_publisher_platforms, ['facebook', 'instagram', 'audience_network', 'whatsapp']) &&\n      contains(targeting.effective_facebook_positions, ['feed', 'instream_video', 'story', 'search', 'facebook_reels', 'facebook_reels_overlay', 'notification']) &&\n      contains(targeting.effective_instagram_positions, ['stream', 'story', 'reels']) &&\n      contains(targeting.effective_audience_network_positions, ['classic', 'rewarded_video']) &&\n      contains(targeting.effective_whatsapp_positions, ['status']);\n  });\n}\nfunction verifyMixedCreativeReadback(source, creative, placementItems) {\n  if (text(source.media_variant) !== 'mixed_flexible') return { status: 'not_applicable' };\n  const feed = object(creative.asset_feed_spec);\n  const images = list(feed.images);\n  const videos = list(feed.videos);\n  const imageLabels = labels(images);\n  const videoLabels = labels(videos);\n  const descriptions = list(feed.descriptions);\n  const descriptionLabels = labels(descriptions);\n  const formats = list(feed.ad_formats).map((value) => text(value).toUpperCase()).filter(Boolean);\n  const rules = list(feed.asset_customization_rules);\n  const staticVertical = rules.filter((rule) => text(rule && rule.image_label && rule.image_label.name) === 'vertical_image' && !text(rule && rule.video_label && rule.video_label.name));\n  const videoRewarded = rules.filter((rule) => text(rule && rule.video_label && rule.video_label.name) === 'vertical_video' && !text(rule && rule.image_label && rule.image_label.name));\n  const staticSpec = object(staticVertical[0] && staticVertical[0].customization_spec);\n  const videoSpec = object(videoRewarded[0] && videoRewarded[0].customization_spec);\n  const ruleDescriptionLabels = rules.map((rule) => text(rule && rule.description_label && rule.description_label.name));\n  const videoWidth = Number(source.video_width || 0);\n  const videoHeight = Number(source.video_height || 0);\n  const thumbnailWidth = Number(source.video_thumbnail_width || 0);\n  const thumbnailHeight = Number(source.video_thumbnail_height || 0);\n  // Graph keeps the WhatsApp publisher platform but canonicalizes the sole\n  // supported subposition (Status) by omitting whatsapp_positions. This is\n  // equivalent only when the effective ad-set targeting independently proves\n  // that Status is the available WhatsApp position; otherwise it remains a\n  // fail-closed placement loss.\n  const whatsappScopeNormalized = contains(staticSpec.publisher_platforms, ['whatsapp'])\n    && list(staticSpec.whatsapp_positions).length === 0\n    && effectiveWhatsAppStatus(placementItems, source);\n  const failures = [];\n  if (images.length !== 3 || !contains([...imageLabels], ['feed_image', 'banner_image', 'vertical_image'])) failures.push('mixed_readback_images_invalid');\n  if (videos.length !== 1 || !videoLabels.has('vertical_video')) failures.push('mixed_readback_video_invalid');\n  if (descriptions.length !== 5 || ruleDescriptionLabels.some((label) => !label || !descriptionLabels.has(label)) || new Set(ruleDescriptionLabels).size !== rules.length) failures.push('mixed_readback_description_rules_invalid');\n  if (formats.length !== 1 || formats[0] !== 'AUTOMATIC_FORMAT') failures.push('mixed_readback_ad_format_invalid');\n  if (staticVertical.length !== 1 || !contains(staticSpec.publisher_platforms, ['facebook', 'instagram', 'audience_network', 'whatsapp']) || !contains(staticSpec.facebook_positions, ['instream_video', 'story', 'facebook_reels']) || !contains(staticSpec.instagram_positions, ['story', 'reels']) || !contains(staticSpec.audience_network_positions, ['classic']) || !(contains(staticSpec.whatsapp_positions, ['status']) || whatsappScopeNormalized)) failures.push('mixed_readback_static_vertical_rule_invalid');\n  if (videoRewarded.length !== 1 || !contains(videoSpec.publisher_platforms, ['audience_network']) || !contains(videoSpec.audience_network_positions, ['rewarded_video']) || list(videoSpec.facebook_positions).length || list(videoSpec.instagram_positions).length || list(videoSpec.whatsapp_positions).length) failures.push('mixed_readback_rewarded_video_rule_invalid');\n  if (!isNineBySixteen(videoWidth, videoHeight) || !isNineBySixteen(thumbnailWidth, thumbnailHeight)) failures.push('mixed_rewarded_video_source_not_verified_9x16');\n  if (failures.length) throw new Error(`Mixed creative readback divergiu do contrato de midia: ${JSON.stringify({ creative_id: text(creative.id || source.creative_id), failures })}`);\n  return {\n    status: 'verified',\n    image_count: images.length,\n    video_count: videos.length,\n    static_vertical_rule_count: staticVertical.length,\n    rewarded_video_rule_count: videoRewarded.length,\n    rewarded_video_source_dimensions: `${videoWidth}x${videoHeight}`,\n    rewarded_video_thumbnail_dimensions: `${thumbnailWidth}x${thumbnailHeight}`,\n    rewarded_video_delivery_aspect_ratio: '9x16',\n    rewarded_video_format_status: 'recommended_9x16_satisfied_by_exact_original_source',\n    ads_manager_format_label: 'original',\n    ads_manager_format_label_status: 'exact_9x16_semantic_equivalent_to_recommended',\n    ads_manager_crop_control_semantics: 'original_is_exact_9x16_and_recommended_crop_is_a_no_op',\n    video_auto_crop_calibration: 'graph_acknowledged_opt_in_but_ads_manager_remained_original',\n    graph_video_crop_field_available: false,\n    whatsapp_status_scope: whatsappScopeNormalized ? 'graph_normalized_to_effective_adset_status' : 'explicit',\n  };\n}\nfunction verifyVideoOnlyCreativeReadback(source, creative, placementItems) {\n  if (text(source.media_variant) !== 'video_single') return { status: 'not_applicable' };\n  const feed = object(creative.asset_feed_spec);\n  const images = list(feed.images);\n  const videos = list(feed.videos);\n  const videoLabels = labels(videos);\n  const bodyLabels = labels(feed.bodies);\n  const titleLabels = labels(feed.titles);\n  const descriptionLabels = labels(feed.descriptions);\n  const formats = list(feed.ad_formats).map((value) => text(value).toUpperCase()).filter(Boolean);\n  const rules = list(feed.asset_customization_rules);\n  const placementScopeVerified = effectiveVideoOnlyPlacementScope(placementItems, source);\n  const mainRule = object(rules[0]);\n  const rewardedRule = object(rules[1]);\n  const mainSpec = object(mainRule.customization_spec);\n  const rewardedSpec = object(rewardedRule.customization_spec);\n  const whatsappScopeNormalized = contains(mainSpec.publisher_platforms, ['whatsapp'])\n    && list(mainSpec.whatsapp_positions).length === 0\n    && effectiveWhatsAppStatus(placementItems, source);\n  const failures = [];\n  if (images.length !== 0) failures.push('video_only_readback_images_present');\n  if (videos.length !== 1 || videoLabels.size !== 1 || !videoLabels.has('vertical_video')) failures.push('video_only_readback_video_invalid');\n  if (formats.length !== 1 || formats[0] !== 'SINGLE_VIDEO') failures.push('video_only_readback_ad_format_invalid');\n  const exactlyFiveUnique = (assets, labels) => list(assets).length === 5 && labels.size === 5 && list(assets).every((asset) => list(asset && asset.adlabels).length === 1);\n  if (!exactlyFiveUnique(feed.bodies, bodyLabels)) failures.push('video_only_readback_body_labels_invalid');\n  if (!exactlyFiveUnique(feed.titles, titleLabels)) failures.push('video_only_readback_title_labels_invalid');\n  if (!exactlyFiveUnique(feed.descriptions, descriptionLabels)) failures.push('video_only_readback_description_labels_invalid');\n  const labelsValid = rules.length === 2 && rules.every((rule) => text(rule.video_label && rule.video_label.name) === 'vertical_video' && bodyLabels.has(text(rule.body_label && rule.body_label.name)) && titleLabels.has(text(rule.title_label && rule.title_label.name)) && descriptionLabels.has(text(rule.description_label && rule.description_label.name)) && !text(rule.image_label && rule.image_label.name)) &&\n    text(mainRule.body_label && mainRule.body_label.name) !== text(rewardedRule.body_label && rewardedRule.body_label.name) &&\n    text(mainRule.title_label && mainRule.title_label.name) !== text(rewardedRule.title_label && rewardedRule.title_label.name) &&\n    text(mainRule.description_label && mainRule.description_label.name) !== text(rewardedRule.description_label && rewardedRule.description_label.name);\n  if (!labelsValid) failures.push('video_only_readback_rule_labels_invalid');\n  if (!contains(mainSpec.publisher_platforms, ['facebook', 'instagram', 'audience_network', 'whatsapp']) || list(mainSpec.publisher_platforms).length !== 4) failures.push('video_only_readback_publishers_invalid');\n  if (!contains(mainSpec.facebook_positions, ['feed', 'instream_video', 'story', 'search', 'facebook_reels', 'facebook_reels_overlay', 'notification']) || list(mainSpec.facebook_positions).length !== 7) failures.push('video_only_readback_facebook_positions_invalid');\n  if (!contains(mainSpec.instagram_positions, ['stream', 'story', 'reels']) || list(mainSpec.instagram_positions).length !== 3) failures.push('video_only_readback_instagram_positions_invalid');\n  if (!contains(mainSpec.audience_network_positions, ['classic']) || list(mainSpec.audience_network_positions).length !== 1) failures.push('video_only_readback_audience_network_positions_invalid');\n  if (!(contains(mainSpec.whatsapp_positions, ['status']) || whatsappScopeNormalized)) failures.push('video_only_readback_whatsapp_status_invalid');\n  if (!contains(rewardedSpec.publisher_platforms, ['audience_network']) || list(rewardedSpec.publisher_platforms).length !== 1 || !contains(rewardedSpec.audience_network_positions, ['rewarded_video']) || list(rewardedSpec.audience_network_positions).length !== 1 || list(rewardedSpec.facebook_positions).length || list(rewardedSpec.instagram_positions).length || list(rewardedSpec.whatsapp_positions).length) failures.push('video_only_readback_rewarded_rule_invalid');\n  if (!placementScopeVerified) failures.push('video_only_readback_placement_scope_invalid');\n  if (failures.length) throw new Error(`Video-only creative readback divergiu do contrato: ${JSON.stringify({ creative_id: text(creative.id || source.creative_id), failures })}`);\n  return {\n    status: 'verified',\n    image_count: 0,\n    video_count: 1,\n    body_count: 5,\n    title_count: 5,\n    description_count: 5,\n    placement_rule_count: 2,\n    placement_scope: 'two_explicit_video_rules_match_effective_adset_targeting',\n    whatsapp_status_scope: whatsappScopeNormalized ? 'graph_normalized_to_effective_adset_status' : 'explicit',\n    aspect_ratio_semantics: 'single_uploaded_source_verified_9x16_no_video_crop_field_in_graph_schema',\n  };\n}\nfunction verifyCarouselCreativeReadback(source, creative) {\n  if (text(source.media_variant) !== 'carousel') return { status: 'not_applicable' };\n  const story = object(creative.object_story_spec);\n  const legacy = object(story.link_data);\n  const expectedCards = Object.keys(object(source.asset_ids)).filter((key) => /^carousel_card_\\d+$/.test(text(key))).length;\n  const expectedCta = text(object(source.destination_contract).kind).toLowerCase() === 'whatsapp' ? 'WHATSAPP_MESSAGE' : 'LEARN_MORE';\n  if (Object.keys(legacy).length) {\n    const cards = list(legacy.child_attachments);\n    const failures = [];\n    if (!expectedCards || cards.length !== expectedCards || cards.length < 2 || cards.length > 10) failures.push('carousel_readback_card_count_invalid');\n    if (legacy.multi_share_optimized !== false || legacy.multi_share_end_card !== false) failures.push('carousel_readback_container_invalid');\n    if (text(object(legacy.call_to_action).type).toUpperCase() !== expectedCta) failures.push('carousel_readback_cta_invalid');\n    const links = new Set(cards.map((card) => text(card && card.link)).filter(Boolean));\n    if (links.size !== 1 || text(legacy.link) !== [...links][0]) failures.push('carousel_readback_link_consistency_invalid');\n    for (const card of cards) {\n      if (!text(card && card.image_hash) || !text(card && card.name) || !text(card && card.description)) failures.push('carousel_readback_card_content_invalid');\n    }\n    if (failures.length) throw new Error(`Carousel creative readback divergiu do contrato renderizavel: ${JSON.stringify({ creative_id: text(creative.id || source.creative_id), failures })}`);\n    return { status: 'verified', image_count: cards.length, card_count: cards.length, title_count: cards.length, description_count: cards.length, CTA: expectedCta, render_contract: 'legacy_link_data' };\n  }\n  const feed = object(creative.asset_feed_spec);\n  const images = list(feed.images);\n  const bodies = list(feed.bodies);\n  const titles = list(feed.titles);\n  const descriptions = list(feed.descriptions);\n  const links = list(feed.link_urls);\n  const carousel = object(list(feed.carousels)[0]);\n  const cards = list(carousel.child_attachments);\n  const formats = list(feed.ad_formats).map((value) => text(value).toUpperCase()).filter(Boolean);\n  const imageLabels = labels(images);\n  const bodyLabels = labels(bodies);\n  const titleLabels = labels(titles);\n  const descriptionLabels = labels(descriptions);\n  const linkLabels = labels(links);\n  const ctaTypes = list(feed.call_to_action_types).map((value) => text(value).toUpperCase()).filter(Boolean);\n  const primaryLinks = new Set(links.map((entry) => text(entry && entry.website_url)).filter(Boolean));\n  const additionalData = object(feed.additional_data);\n  const failures = [];\n  if (formats.length !== 1 || formats[0] !== 'CAROUSEL') failures.push('carousel_readback_ad_format_invalid');\n  if (list(feed.carousels).length !== 1 || carousel.multi_share_optimized !== false) failures.push('carousel_readback_container_invalid');\n  if (!expectedCards || cards.length !== expectedCards || cards.length < 2 || cards.length > 10) failures.push('carousel_readback_card_count_invalid');\n  if ([images, bodies, titles, descriptions, links].some((assets) => assets.length !== cards.length)) failures.push('carousel_readback_asset_count_invalid');\n  if (ctaTypes.length !== 1 || ctaTypes[0] !== expectedCta || list(feed.call_to_actions).length) failures.push('carousel_readback_cta_invalid');\n  if (additionalData.multi_share_end_card !== false || additionalData.is_click_to_message !== (expectedCta === 'WHATSAPP_MESSAGE')) {\n    failures.push('carousel_readback_click_to_message_invalid');\n  }\n  if (primaryLinks.size !== 1) failures.push('carousel_readback_link_consistency_invalid');\n  for (const card of cards) {\n    const child = object(card);\n    if (!imageLabels.has(text(object(child.image_label).name)) ||\n      !bodyLabels.has(text(object(child.body_label).name)) ||\n      !titleLabels.has(text(object(child.title_label).name)) ||\n      !descriptionLabels.has(text(object(child.description_label).name)) ||\n      !linkLabels.has(text(object(child.link_url_label).name)) ||\n      text(object(child.call_to_action_type_label).name)) failures.push('carousel_readback_card_labels_invalid');\n  }\n  if (failures.length) throw new Error(`Carousel creative readback divergiu do contrato renderizavel: ${JSON.stringify({ creative_id: text(creative.id || source.creative_id), failures })}`);\n  return {\n    status: 'verified',\n    image_count: images.length,\n    card_count: cards.length,\n    title_count: titles.length,\n    description_count: descriptions.length,\n    CTA: ctaTypes[0],\n    child_cta_labels: 'absent_by_contract',\n    render_contract: 'asset_feed',\n  };\n}\nfunction updateFeatureGroup(groups, reportedOptIn, removedOrIneligible, notReported) {\n  return list(groups).map((entry) => {\n    const feature = text(entry && entry.api_key);\n    const requested = entry && entry.requested === true;\n    if (!requested) return { ...entry, status: 'ineligible' };\n    if (reportedOptIn.includes(feature)) return { ...entry, status: 'graph_acknowledged' };\n    if (removedOrIneligible.includes(feature)) return { ...entry, status: 'rejected_or_ineligible' };\n    if (notReported.includes(feature)) return { ...entry, status: 'not_reported' };\n    return { ...entry, status: 'unknown' };\n  });\n}\nfunction buildEffectiveReport(source, reportedOptIn, removedOrIneligible, notReported, evidenceSource) {\n  const groups = object(source.advantage_plus_feature_groups);\n  return {\n    status: evidenceSource === 'graph_readback'\n      ? (removedOrIneligible.length || notReported.length ? 'inconclusive' : 'graph_acknowledged_ui_unverified')\n      : 'graph_readback_unavailable',\n    evidence_source: evidenceSource,\n    main: updateFeatureGroup(groups.main, reportedOptIn, removedOrIneligible, notReported),\n    essential: updateFeatureGroup(groups.essential, reportedOptIn, removedOrIneligible, notReported),\n    supplemental: updateFeatureGroup(groups.supplemental, reportedOptIn, removedOrIneligible, notReported),\n    graph_acknowledged_features: reportedOptIn,\n    ui_confirmed_features: [],\n    rejected_features: removedOrIneligible,\n    not_reported_features: notReported,\n    ineligible_features: unique(source.advantage_plus_skipped_features),\n    ui_confirmation_required: true,\n    graph_acknowledgement_is_not_ui_confirmation: true,\n  };\n}\n\nconst sources = $items('Attach Creative Result') || [];\nconst placementItems = $items('Validate Meta Placement Eligibility') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const sourceItem = sources[sourceIndex] || {};\n  const source = object(sourceItem.json);\n  const response = object(item.json);\n  const requested = unique(source.advantage_plus_requested_features);\n  if (response.ok !== true || response.operation?.status !== 'completed') {\n    const detail = object(response.detail);\n    return {\n      json: {\n        ...source,\n        advantage_plus_effective_report: buildEffectiveReport(source, [], [], requested, 'none'),\n        advantage_plus_verification: {\n          status: 'unavailable',\n          checked_at: new Date().toISOString(),\n          requested_features: requested,\n          reported_opt_in: [],\n          removed_or_ineligible: [],\n          not_reported: requested,\n          applied_features: [],\n          removed_features: [],\n          graph_acknowledged_features: [],\n          ui_confirmed_features: [],\n          graph_acknowledgement_is_not_ui_confirmation: true,\n          site_links_requested_count: list(source.advantage_plus_site_links).length,\n          site_links_applied: [],\n          error_code: text(detail.code || response.status),\n          error_subcode: text(detail.error_subcode),\n        },\n        warnings: [\n          ...list(source.warnings),\n          'A verificacao informativa do creative Advantage+ nao ficou disponivel; a criacao confirmada foi preservada.',\n        ],\n      },\n      binary: sourceItem.binary || item.binary,\n      pairedItem: { item: sourceIndex },\n    };\n  }\n  const creative = object(response.operation.result);\n  const mixedMediaReadback = verifyMixedCreativeReadback(source, creative, placementItems);\n  const videoOnlyMediaReadback = verifyVideoOnlyCreativeReadback(source, creative, placementItems);\n  const carouselMediaReadback = verifyCarouselCreativeReadback(source, creative);\n  const features = object(object(creative.degrees_of_freedom_spec).creative_features_spec);\n  const reported = Object.keys(features);\n  const reportedOptIn = Object.entries(features)\n    .filter(([, config]) => text(config && config.enroll_status).toUpperCase() === 'OPT_IN')\n    .map(([name]) => name);\n  const removedOrIneligible = requested.filter((feature) => reported.includes(feature) && !reportedOptIn.includes(feature));\n  const notReported = requested.filter((feature) => !reported.includes(feature));\n  const verificationStatus = removedOrIneligible.length || notReported.length ? 'inconclusive' : 'verified';\n  const siteLinks = list(object(creative.creative_sourcing_spec).site_links_spec).map((entry) => ({\n    title: text(entry && (entry.site_link_title || entry.title)),\n    url: text(entry && (entry.site_link_url || entry.url)),\n  })).filter((entry) => entry.title && entry.url);\n  return {\n    json: {\n      ...source,\n      creative_id: text(source.creative_id || creative.id),\n      mixed_media_readback: mixedMediaReadback,\n      video_only_media_readback: videoOnlyMediaReadback,\n      carousel_media_readback: carouselMediaReadback,\n      advantage_plus_effective_report: buildEffectiveReport(\n        source,\n        reportedOptIn,\n        removedOrIneligible,\n        notReported,\n        'graph_readback',\n      ),\n      advantage_plus_applied_features: reportedOptIn,\n      advantage_plus_applied_features_semantics: 'legacy_graph_acknowledged_only',\n      advantage_plus_removed_features: removedOrIneligible,\n      advantage_plus_not_reported_features: notReported,\n      advantage_plus_final_features: reportedOptIn,\n      site_links_applied: siteLinks,\n      advantage_plus_verification: {\n        status: verificationStatus === 'verified' ? 'graph_acknowledged_ui_unverified' : verificationStatus,\n        checked_at: new Date().toISOString(),\n        requested_features: requested,\n        reported_opt_in: reportedOptIn,\n        removed_or_ineligible: removedOrIneligible,\n        not_reported: notReported,\n        applied_features: [],\n        removed_features: removedOrIneligible,\n        graph_acknowledged_features: reportedOptIn,\n        ui_confirmed_features: [],\n        graph_acknowledgement_is_not_ui_confirmation: true,\n        site_links_requested_count: list(source.advantage_plus_site_links).length,\n        site_links_applied: siteLinks,\n        response_id: text(creative.id),\n      },\n      warnings: [\n        ...list(source.warnings),\n        ...(reportedOptIn.length ? [`A Graph API reconheceu ${reportedOptIn.length} enhancements como OPT_IN; isso nao confirma ativacao no Ads Manager.`] : []),\n        ...(removedOrIneligible.length ? [`A Meta reportou enhancements removidos ou inelegiveis: ${removedOrIneligible.join(', ')}`] : []),\n        ...(notReported.length ? [`A Meta nao reportou o estado destes enhancements; o readback e inconclusivo: ${notReported.join(', ')}`] : []),\n      ],\n    },\n    binary: sourceItem.binary || item.binary,\n    pairedItem: { item: sourceIndex },\n  };\n});"
+      },
+      "id": "9efe6643-1c2c-45e6-972c-dd97a475723a",
+      "name": "Attach Advantage+ Verification",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        12112,
+        1272
+      ],
+      "retryOnFail": false
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\n\nconst byAccount = new Map();\nfor (const item of $input.all()) {\n  const row = item.json || {};\n  const accountId = text(row.account_id).replace(/^act_/, '');\n  const tokenId = text(row.token_id);\n  const apiVersion = text(row.api_version || 'v25.0');\n  if (!accountId || !tokenId) throw new Error(`Destino sem account_id/token_id: ${row.destination_group || 'desconhecido'}.`);\n  const key = `${accountId}:${apiVersion}`;\n  if (!byAccount.has(key)) {\n    byAccount.set(key, {\n      token_id: tokenId,\n      account_id: accountId,\n      api_version: apiVersion,\n      destination_groups: [],\n      adsets: [],\n    });\n  }\n  const request = byAccount.get(key);\n  request.destination_groups.push(text(row.destination_group));\n  request.adsets.push({\n    adset_id: text(row.adset_id),\n    destination_group: text(row.destination_group),\n  });\n  request.alternate_token_ids = [\n    ...new Set([...(request.alternate_token_ids || []), tokenId]),\n  ];\n}\n\nreturn [...byAccount.values()].map((request) => ({\n  json: {\n    ...request,\n    destination_groups: [...new Set(request.destination_groups.filter(Boolean))],\n    alternate_token_ids: [...new Set(request.alternate_token_ids || [])],\n    adsets: [...new Map(request.adsets.filter((entry) => entry.adset_id)\n      .map((entry) => [entry.adset_id, entry])).values()],\n  },\n}));"
+      },
+      "id": "meta-publish-build-inventory",
+      "name": "Build Meta Account Inventory Requests",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1632,
+        1736
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\n\n// The run fingerprint must change when the Meta creative contract changes;\n// otherwise a corrected payload collides with a failed operation for the same\n// Drive lot and cannot be retried safely by the idempotency gateway.\nconst PUBLISH_CONTRACT_REVISION = 'creative_payload_v12_carousel_link_data';\n\nconst groups = $input.all().map((item) => item.json || {});\nif (!groups.length) throw new Error('Prepare Publish Run recebeu zero grupos.');\n\nconst revisions = [...new Set(groups.map((group) => text(group.config_revision)).filter(Boolean))];\nif (revisions.length !== 1) throw new Error(`Revisao de configuracao inconsistente: ${JSON.stringify(revisions)}`);\n\nconst byId = new Map();\nfor (const group of groups) {\n  for (const file of list(group.batch_files)) {\n    const id = text(file.id);\n    if (!id) continue;\n    const normalized = {\n      id,\n      name: text(file.name),\n      md5_checksum: text(file.md5_checksum || file.md5Checksum),\n      modified_time: `${text(file.modified_time || file.modifiedTime)}#${PUBLISH_CONTRACT_REVISION}`,\n      size: text(file.size),\n    };\n    const previous = byId.get(id);\n    if (previous && JSON.stringify(previous) !== JSON.stringify(normalized)) {\n      throw new Error(`Metadados divergentes para o arquivo ${id}.`);\n    }\n    byId.set(id, normalized);\n  }\n}\n\nconst files = [...byId.values()].sort((left, right) => left.id.localeCompare(right.id));\nif (!files.length) throw new Error('Prepare Publish Run nao encontrou arquivos para o fingerprint.');\n\nreturn [{\n  json: {\n    config_revision: revisions[0],\n    workflow_execution_id: String($execution.id),\n    files,\n    group_count: groups.length,\n    group_keys: groups.map((group) => text(group.creative_group_key || group.group_key)),\n  },\n}];"
+      },
+      "id": "meta-publish-prepare-run",
+      "name": "Prepare Publish Run",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2880,
+        1376
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-publish-acquire-run",
+      "name": "Acquire Publish Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        3552,
+        1376
+      ],
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\n\nconst gateway = $input.first()?.json || {};\nif (gateway.ok !== true || !gateway.run || !text(gateway.run.id)) {\n  throw new Error(`Acquire Publish Run falhou: ${JSON.stringify(gateway.error || gateway)}`);\n}\nconst run = gateway.run;\nconst resumeJobs = Array.isArray(run.summary?.resume_jobs) ? run.summary.resume_jobs : [];\nif (run.status === 'reconciliation_required') {\n  throw new Error(`Run ${run.id} exige reconciliacao manual antes de continuar.`);\n}\nif (run.status === 'completed' || run.status === 'rolled_back') {\n  throw new Error(`Run ${run.id} ja terminou com status ${run.status}; novos arquivos ou nova revisao sao necessarios.`);\n}\nif (run.status === 'meta_completed_drive_pending') {\n  return [{ json: { resume_drive_only: true, run_id: run.id, run } }];\n}\n\nconst groups = $items('Build Payload') || [];\nreturn groups.map((item) => ({\n  json: {\n    ...(item.json || {}),\n    run_id: run.id,\n    batch_fingerprint: text(run.batch_fingerprint),\n    config_revision: text(run.config_revision),\n    resume_drive_only: false,\n    // Preserve the exact, already-validated mutation bodies on a retry. The\n    // copy agent is intentionally generative, so rebuilding it would change\n    // the request hash while this run must remain idempotent.\n    resume_jobs: resumeJobs,\n  },\n  binary: item.binary,\n}));"
+      },
+      "id": "meta-publish-restore-groups",
+      "name": "Restore Publish Groups",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3776,
+        1376
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-publish-resume-condition",
+              "leftValue": "={{ $json.resume_drive_only }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-publish-resume-route",
+      "name": "Resume Drive Only?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        4000,
+        1376
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction stableHash(value) {\n  // Keep every semantic input in the identity without relying on the\n  // gateway's maximum operation-key length. A long token/run prefix used to\n  // truncate the per-file suffix, making all image uploads look identical.\n  let hash = 2166136261;\n  for (const char of text(value)) {\n    hash ^= char.charCodeAt(0);\n    hash = Math.imul(hash, 16777619);\n  }\n  return (hash >>> 0).toString(36);\n}\nfunction uploadOperationKey(kind, parts) {\n  return `${kind}:v3:${stableHash(parts.map(text).join('|'))}`;\n}\n\nconst outputs = [];\nfor (const item of $input.all()) {\n  const group = item.json || {};\n  const runId = text(group.run_id);\n  if (!runId) throw new Error('Prepare Gateway Uploads sem run_id.');\n  const accounts = new Map();\n  for (const destination of list(group.destinations)) {\n    const accountId = text(destination.destination_ad_account_id || destination.account_id).replace(/^act_/, '');\n    const tokenId = text(destination.token_id);\n    const apiVersion = text(destination.destination_api_version || destination.api_version || 'v25.0');\n    if (!accountId || !tokenId) throw new Error(`Destino incompleto em ${group.job_key}.`);\n    accounts.set(accountId, { accountId, tokenId, apiVersion });\n  }\n  for (const image of list(group.imagens)) {\n    const binaryKey = text(image.binary_key || 'data');\n    const binary = item.binary && item.binary[binaryKey];\n    if (!binary) throw new Error(`Binario ${binaryKey} ausente para ${image.original_name || image.name}.`);\n    for (const account of accounts.values()) {\n      // Keep retry identity stable for the same asset, but do not reuse an\n      // operation created by an earlier request shape (different token,\n      // Graph version or uploaded binary metadata). Token Vault includes\n      // those fields in its request hash and correctly rejects mismatches.\n      const operationKey = uploadOperationKey('upload', [\n        runId,\n        account.accountId,\n        account.tokenId,\n        account.apiVersion,\n        text(binary.fileName),\n        text(binary.fileSize),\n        text(binary.mimeType),\n        text(image.checksum || image.sha256 || image.id),\n      ]);\n      outputs.push({\n        json: {\n          run_id: runId,\n          job_key: text(group.job_key),\n          ratio: text(image.proporcao),\n          role: text(image.role),\n          upload_kind: 'image',\n          source_file_id: text(image.id),\n          source_file_name: text(image.original_name || image.name),\n          account_id: account.accountId,\n          _gateway_account_id: account.accountId,\n          gateway_request: {\n            action: 'upload_image',\n            operation_key: operationKey,\n            token_id: account.tokenId,\n            account_id: account.accountId,\n            api_version: account.apiVersion,\n            file_name: text(image.original_name || image.name),\n          },\n        },\n        binary: { data: binary },\n      });\n    }\n  }\n  for (const video of list(group.videos)) {\n    const binaryKey = text(video.thumbnail_binary_key || 'thumbnail_vertical_video');\n    const binary = item.binary && item.binary[binaryKey];\n    if (!binary) throw new Error(`Miniatura ${binaryKey} ausente para ${video.original_name || video.name}.`);\n    for (const account of accounts.values()) {\n      const operationKey = uploadOperationKey('upload-thumb', [\n        runId,\n        account.accountId,\n        account.tokenId,\n        account.apiVersion,\n        text(binary.fileName),\n        text(binary.fileSize),\n        text(binary.mimeType),\n        text(video.thumbnail_checksum_sha256 || video.output_checksum_sha256 || video.id),\n      ]);\n      const fileName = `${text(video.id).replace(/[^A-Za-z0-9_-]+/g, '_')}__video_thumbnail.jpg`;\n      outputs.push({\n        json: {\n          run_id: runId,\n          job_key: text(group.job_key),\n          ratio: '9x16',\n          role: 'vertical_video',\n          upload_kind: 'video_thumbnail',\n          source_file_id: text(video.id),\n          source_file_name: text(video.original_name || video.name),\n          account_id: account.accountId,\n          _gateway_account_id: account.accountId,\n          gateway_request: {\n            action: 'upload_image',\n            operation_key: operationKey,\n            token_id: account.tokenId,\n            account_id: account.accountId,\n            api_version: account.apiVersion,\n            file_name: fileName,\n          },\n        },\n        binary: { data: binary },\n      });\n    }\n  }\n}\nif (!outputs.length) throw new Error('Prepare Gateway Uploads terminou sem itens.');\nreturn outputs;"
+      },
+      "id": "meta-publish-prepare-uploads",
+      "name": "Prepare Gateway Uploads",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6464,
+        1000
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst prepared = $items('Prepare Gateway Uploads') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const source = (prepared[sourceIndex] || {}).json || {};\n  const response = item.json || {};\n  if (response.ok !== true || response.operation?.status !== 'completed') {\n    throw new Error(`Upload gateway falhou para ${source.source_file_name || source.source_file_id}: ${JSON.stringify(response.detail || response.error || response)}`);\n  }\n  const result = response.operation.result || {};\n  if (!result.images || typeof result.images !== 'object') {\n    throw new Error(`Upload gateway sem images para ${source.source_file_name || source.source_file_id}.`);\n  }\n  return {\n    json: {\n      ...result,\n      _gateway_account_id: source._gateway_account_id,\n      account_id: source.account_id,\n      source_file_id: source.source_file_id,\n      source_file_name: source.source_file_name,\n      ratio: source.ratio,\n      role: source.role,\n      upload_kind: source.upload_kind,\n      job_key: source.job_key,\n      operation_key: response.operation.operation_key,\n      replayed: response.replayed === true,\n    },\n    pairedItem: { item: sourceIndex },\n  };\n});"
+      },
+      "id": "meta-publish-normalize-upload",
+      "name": "Normalize Gateway Upload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6912,
+        1000
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nfunction stable(value) {\n  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;\n  if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stable(value[name])}`).join(',')}}`;\n  return JSON.stringify(value);\n}\nfunction stableHash(value) {\n  let hash = 2166136261;\n  for (const char of text(value)) { hash ^= char.charCodeAt(0); hash = Math.imul(hash, 16777619); }\n  return (hash >>> 0).toString(36);\n}\n\nreturn $input.all().map((item) => {\n  const job = item.json || {};\n  if (!text(job.run_id) || !text(job.token_id) || !job.creativePayload) {\n    throw new Error(`Prepare Creative Operation recebeu job incompleto: ${job.job_key || 'sem-chave'}.`);\n  }\n  const payloadHash = stableHash(stable(job.creativePayload));\n  return {\n    json: {\n      ...job,\n      gateway_request: {\n        action: 'create_creative',\n        operation_key: key(`creative:v2:${payloadHash}:${job.run_id}:${job.destination_group}:${job.media_variant || 'static_flexible'}`),\n        token_id: text(job.token_id),\n        account_id: text(job.account_id),\n        api_version: text(job.api_version || 'v25.0'),\n        payload: job.creativePayload,\n      },\n    },\n    binary: item.binary,\n  };\n});"
+      },
+      "id": "meta-publish-prepare-creative",
+      "name": "Prepare Creative Operation",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        9424,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\n\nreturn $input.all().map((item, index) => {\n  const merged = item.json || {};\n  const response = {\n    ok: merged.ok,\n    replayed: merged.replayed,\n    operation: merged.operation,\n    requestId: merged.requestId,\n    detail: merged.detail,\n    error: merged.error,\n  };\n  const source = { ...merged };\n  for (const field of ['ok', 'replayed', 'operation', 'requestId', 'detail', 'error']) delete source[field];\n  const result = response.operation?.result || {};\n  const creativeId = text(result.id);\n  if (response.ok !== true || response.operation?.status !== 'completed' || !creativeId) {\n    throw new Error(`Create AdCreative gateway falhou em ${source.job_key || index}: ${JSON.stringify(response.detail || response.error || response)}`);\n  }\n  return {\n    json: {\n      ...source,\n      creative_id: creativeId,\n      create_creative_operation_key: text(response.operation.operation_key),\n      create_creative_replayed: response.replayed === true,\n      creative_fallback_attempts: Array.isArray(source.creative_fallback_attempts) ? source.creative_fallback_attempts : [],\n      gateway_request: {\n        action: 'get_creative',\n        operation_key: key(`verify:${source.run_id}:${creativeId}`),\n        token_id: text(source.token_id),\n        account_id: text(source.account_id),\n        api_version: text(source.api_version || 'v25.0'),\n        object_id: creativeId,\n      },\n    },\n    binary: item.binary,\n    pairedItem: { item: index },\n  };\n});"
+      },
+      "id": "meta-publish-attach-creative",
+      "name": "Attach Creative Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        11440,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nfunction targetNameKey(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_'); }\n\nconst inputs = $input.all();\nif (!inputs.length) throw new Error('Build Stage Batch recebeu zero creatives verificados.');\nconst runIds = [...new Set(inputs.map((item) => text(item.json && item.json.run_id)).filter(Boolean))];\nif (runIds.length !== 1) throw new Error(`Build Stage Batch recebeu run_ids inconsistentes: ${JSON.stringify(runIds)}`);\nconst runId = runIds[0];\nconst targets = new Set();\n\nconst jobs = inputs.map((item, index) => {\n  const job = item.json || {};\n  const creativeId = text(job.creative_id);\n  if (!creativeId) throw new Error(`Creative ID ausente no job ${job.job_key || index}.`);\n  const action = text(job.action);\n  if (!['create_new', 'replace_existing'].includes(action)) throw new Error(`Acao invalida no job ${job.job_key || index}.`);\n  const target = action === 'replace_existing'\n    ? `ad:${text(job.source_ad_id)}`\n    // This is an in-memory duplicate detector, not a Meta operation key.\n    // Do not shorten it: static/video names differ in their intentional tail\n    // (`[STATIC]` / `[VIDEO]`) after a common long descriptive prefix.\n    : `adset:${text(job.destination_adset_id)}:name:${targetNameKey(object(job.adPayload).name)}`;\n  if (targets.has(target)) throw new Error(`Target Meta duplicado no mesmo lote: ${target}`);\n  targets.add(target);\n  const desiredStatus = text(job.desired_final_status || object(job.adPayload).status || 'ACTIVE').toUpperCase();\n  if (!['ACTIVE', 'PAUSED'].includes(desiredStatus)) {\n    throw new Error(`Status final invalido no job ${job.job_key || index}: ${desiredStatus}`);\n  }\n  const adPayload = {\n    ...object(job.adPayload),\n    // Commercial jobs stay ACTIVE. Explicit calibration jobs carry PAUSED\n    // through staging and final reconciliation without changing that default.\n    status: desiredStatus,\n    creative: { creative_id: creativeId },\n  };\n  // Updating an existing ad must not resend adset_id.  Meta treats it as an\n  // ad-set mutation and rejects the creative against the campaign objective,\n  // even when the value is unchanged.\n  if (action === 'replace_existing') delete adPayload.adset_id;\n  return {\n    operation_key: key(`ad:${runId}:${job.creative_group_key}:${job.destination_group}:${job.media_variant || 'static_flexible'}`),\n    action,\n    target_ad_id: action === 'replace_existing' ? text(job.source_ad_id) : undefined,\n    token_id: text(job.token_id),\n    account_id: text(job.account_id),\n    api_version: text(job.api_version || 'v25.0'),\n    destination_group: text(job.destination_group),\n    creative_group_key: text(job.creative_group_key || job.group_key),\n    media_variant: text(job.media_variant || 'static_flexible'),\n    creative_id: creativeId,\n    desired_status: desiredStatus,\n    ad_payload: adPayload,\n    files: Object.entries(object(job.asset_ids)).map(([ratio, id]) => ({\n      id: text(id),\n      ratio: text(ratio),\n      name: text(object(job.asset_names)[ratio]),\n    })).filter((file) => file.id),\n  };\n});\n\nreturn [{\n  json: {\n    run_id: runId,\n    stage_operation_key: key(`stage:${runId}`),\n    gateway_request: {\n      action: 'stage_batch',\n      operation_key: key(`stage:${runId}`),\n      jobs,\n    },\n    job_count: jobs.length,\n  },\n}];"
+      },
+      "id": "meta-publish-build-stage",
+      "name": "Build Stage Batch",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        12336,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-publish-stage-batch",
+      "name": "Stage Ad Batch",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        12560,
+        1272
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 15000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\n\nconst response = $input.first()?.json || {};\nif (response.ok !== true || response.operation?.status !== 'completed' || response.operation?.result?.status !== 'staged') {\n  throw new Error(`Stage Ad Batch nao concluiu com seguranca: ${JSON.stringify(response.detail || response.error || response)}`);\n}\nconst stageRequest = $items('Build Stage Batch')[0]?.json || {};\nconst runId = text(stageRequest.run_id);\nconst stageOperationKey = text(response.operation.operation_key || stageRequest.stage_operation_key);\nif (!runId || !stageOperationKey) throw new Error('Build Activate Batch sem run_id ou stage_operation_key.');\n\nreturn [{\n  json: {\n    run_id: runId,\n    stage_operation_key: stageOperationKey,\n    gateway_request: {\n      action: 'activate_batch',\n      operation_key: key(`activate:${runId}`),\n      stage_operation_key: stageOperationKey,\n    },\n  },\n}];"
+      },
+      "id": "meta-publish-build-activate",
+      "name": "Build Activate Batch",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        12784,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-publish-activate-batch",
+      "name": "Activate Ad Batch",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        13008,
+        1272
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 15000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\n\nconst input = $input.first()?.json || {};\nlet runId = text(input.run_id);\nlet jobs = [];\nif (input.resume_drive_only === true) {\n  runId = text(input.run_id || input.run?.id);\n  jobs = list(input.run?.summary?.jobs);\n} else {\n  if (input.ok !== true || input.operation?.status !== 'completed') {\n    throw new Error(`Activate Ad Batch falhou: ${JSON.stringify(input.detail || input.error || input)}`);\n  }\n  const result = input.operation.result || {};\n  if (result.status !== 'meta_completed_drive_pending') {\n    throw new Error(`Activate Ad Batch retornou estado inesperado: ${JSON.stringify(result)}`);\n  }\n  runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id);\n  jobs = list(result.jobs);\n}\nif (!runId || !jobs.length) throw new Error('Build Drive Finalization sem run_id ou jobs persistidos.');\n\nconst byFile = new Map();\nfor (const job of jobs) {\n  for (const file of list(job.files)) {\n    const id = text(file.id);\n    if (!id) continue;\n    if (!byFile.has(id)) byFile.set(id, { id, name: text(file.name), ratio: text(file.ratio), units: [], ad_ids: [], creative_ids: [], groups: [] });\n    const row = byFile.get(id);\n    row.units.push(job.destination_group);\n    row.ad_ids.push(job.ad_id);\n    row.creative_ids.push(job.creative_id);\n    row.groups.push(job.creative_group_key);\n  }\n}\nif (!byFile.size) throw new Error('Build Drive Finalization nao recuperou os arquivos do journal.');\n\nconst publishedAt = new Date().toISOString();\nconst summaries = jobs.map((job) => ({\n  creative_group_key: text(job.creative_group_key),\n  destination_group: text(job.destination_group),\n  action: text(job.action),\n  ad_id: text(job.ad_id),\n  creative_id: text(job.creative_id),\n  created_new: job.created_new === true,\n}));\nconst lines = [\n  'Meta Ads Publish concluido',\n  `Run: ${runId}`,\n  `Jobs Meta: ${summaries.length}`,\n  `Artes: ${byFile.size}`,\n  '',\n  ...summaries.map((job) => `- ${job.creative_group_key} | ${job.destination_group} | ${job.action} | ad ${job.ad_id}`),\n];\nconst message = lines.join('\\n');\n\nreturn [...byFile.values()].map((file) => ({\n  json: {\n    id: file.id,\n    fileName: file.name,\n    ratio: file.ratio,\n    run_id: runId,\n    published: true,\n    meta_ads_published_at: publishedAt,\n    meta_ads_execution_id: String($execution.id),\n    meta_ads_run_id: runId,\n    meta_ads_creative_group_key: unique(file.groups).join(', '),\n    meta_ads_units: unique(file.units).join(', '),\n    meta_ads_ad_ids: unique(file.ad_ids).join(', '),\n    meta_ads_creative_ids: unique(file.creative_ids).join(', '),\n    meta_publish_summary: summaries,\n    whatsapp_message: message,\n    telegram_message: message,\n  },\n}));"
+      },
+      "id": "meta-publish-drive-finalization",
+      "name": "Build Drive Finalization",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        13232,
+        1448
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst expected = $items('Build Drive Finalization') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const source = (expected[sourceIndex] || {}).json || {};\n  return {\n    json: {\n      ...source,\n      drive_update_response: item.json || {},\n      drive_update_had_error: Boolean(item.json && item.json.error),\n    },\n    pairedItem: { item: sourceIndex },\n  };\n});"
+      },
+      "id": "meta-publish-prepare-drive-read",
+      "name": "Prepare Drive Read",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        13680,
+        1448
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://www.googleapis.com/drive/v3/files/{{$json.id}}",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "googleDriveOAuth2Api",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "fields",
+              "value": "id,name,properties"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "meta-publish-read-drive",
+      "name": "Read Meta Source File",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        13904,
+        1448
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": {
+          "id": "jO1yl4X4hfN2kBxd",
+          "name": "Google Cloud - Drive"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst prepared = $items('Prepare Drive Read') || [];\nconst verified = [];\nfor (const [index, item] of $input.all().entries()) {\n  const sourceIndex = pairedIndex(item, index);\n  const expected = (prepared[sourceIndex] || {}).json || {};\n  const actual = item.json || {};\n  const properties = actual.properties || {};\n  const checks = {\n    published: text(properties.published) === 'true',\n    run_id: text(properties.meta_ads_run_id) === text(expected.run_id),\n    groups: text(properties.meta_ads_creative_group_key) === text(expected.meta_ads_creative_group_key),\n  };\n  if (!checks.published || !checks.run_id || !checks.groups) {\n    throw new Error(`Drive readback falhou para ${expected.id}: ${JSON.stringify(checks)}`);\n  }\n  verified.push(expected);\n}\nif (verified.length !== prepared.length) throw new Error(`Drive readback incompleto: ${verified.length}/${prepared.length}.`);\n\nconst first = verified[0];\nreturn [{\n  json: {\n    run_id: text(first.run_id),\n    verified_file_count: verified.length,\n    files: verified.map((item) => ({ id: text(item.id), name: text(item.fileName) })),\n    meta_publish_summary: first.meta_publish_summary,\n    whatsapp_message: text(first.whatsapp_message),\n    telegram_message: text(first.telegram_message),\n    completion_request: {\n      status: 'completed',\n      summary: {\n        verified_file_count: verified.length,\n        jobs: first.meta_publish_summary,\n      },\n    },\n  },\n}];"
+      },
+      "id": "meta-publish-verify-drive",
+      "name": "Verify Drive Finalization",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        14128,
+        1448
+      ]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.completion_request }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "meta-publish-complete-run",
+      "name": "Complete Publish Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        14352,
+        1448
+      ],
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $('Verify Drive Finalization').first().json.run_id + '/events' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ ({ event_key: 'success_notification', payload: { whatsapp_message: $('Verify Drive Finalization').first().json.whatsapp_message, telegram_message: $('Verify Drive Finalization').first().json.telegram_message } }) }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "meta-publish-claim-notification",
+      "name": "Claim Success Notification",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        14576,
+        1448
+      ],
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim().toLowerCase(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction values(targeting, configuredKey, effectiveKey) {\n  const effective = list(targeting[effectiveKey]).map(text).filter(Boolean);\n  return effective.length ? effective : list(targeting[configuredKey]).map(text).filter(Boolean);\n}\nfunction includesAny(actual, expected) { return expected.some((value) => actual.includes(value)); }\nfunction missing(actual, expected) { return expected.filter((value) => !actual.includes(value)); }\n\nconst failures = [];\nconst outputs = [];\nconst KNOWN_FACEBOOK_POSITIONS = new Set(['feed', 'marketplace', 'instream_video', 'instream_reel', 'story', 'search', 'facebook_reels', 'fb_reels', 'facebook_reels_overlay', 'notification']);\nconst KNOWN_INSTAGRAM_POSITIONS = new Set(['stream', 'story', 'reels', 'explore', 'explore_home']);\nconst KNOWN_AUDIENCE_NETWORK_POSITIONS = new Set(['classic', 'rewarded_video']);\nconst KNOWN_WHATSAPP_POSITIONS = new Set(['status']);\nfor (const item of $input.all()) {\n  const root = object(item.json);\n  if (root.ok !== true) throw new Error(`Meta placement preflight sem inventario valido: ${JSON.stringify(root.error || root.detail || {})}`);\n  const checks = list(root.placement_checks);\n  if (!checks.length) throw new Error('Meta placement preflight nao recebeu adsets para validar.');\n  const normalizedChecks = [];\n\n  for (const entry of checks) {\n    const targeting = object(entry && entry.targeting);\n    const publishers = values(targeting, 'publisher_platforms', 'effective_publisher_platforms');\n    const facebook = values(targeting, 'facebook_positions', 'effective_facebook_positions');\n    const instagram = values(targeting, 'instagram_positions', 'effective_instagram_positions');\n    const audienceNetwork = values(targeting, 'audience_network_positions', 'effective_audience_network_positions');\n    const whatsapp = values(targeting, 'whatsapp_positions', 'effective_whatsapp_positions');\n    const problems = [];\n\n    problems.push(...missing(publishers, ['facebook', 'instagram', 'audience_network', 'whatsapp']).map((value) => `publisher:${value}`));\n    if (!includesAny(facebook, ['instream_video', 'instream_reel'])) problems.push('facebook:instream_video');\n    if (!facebook.includes('story')) problems.push('facebook:story');\n    if (!includesAny(facebook, ['facebook_reels', 'fb_reels'])) problems.push('facebook:facebook_reels');\n    if (!facebook.includes('facebook_reels_overlay')) problems.push('facebook:facebook_reels_overlay');\n    if (!facebook.includes('feed')) problems.push('facebook:feed');\n    if (!facebook.includes('search')) problems.push('facebook:search');\n    if (!facebook.includes('notification')) problems.push('facebook:notification');\n    problems.push(...missing(instagram, ['story', 'reels']).map((value) => `instagram:${value}`));\n    if (!instagram.includes('stream')) problems.push('instagram:stream');\n    if (!audienceNetwork.includes('classic')) problems.push('audience_network:classic');\n    if (!audienceNetwork.includes('rewarded_video')) problems.push('audience_network:rewarded_video');\n    if (!whatsapp.some((value) => value.includes('status'))) problems.push('whatsapp:status');\n    problems.push(...facebook.filter((value) => !KNOWN_FACEBOOK_POSITIONS.has(value)).map((value) => `facebook:unsupported:${value}`));\n    problems.push(...instagram.filter((value) => !KNOWN_INSTAGRAM_POSITIONS.has(value)).map((value) => `instagram:unsupported:${value}`));\n    problems.push(...audienceNetwork.filter((value) => !KNOWN_AUDIENCE_NETWORK_POSITIONS.has(value)).map((value) => `audience_network:unsupported:${value}`));\n    problems.push(...whatsapp.filter((value) => !KNOWN_WHATSAPP_POSITIONS.has(value)).map((value) => `whatsapp:unsupported:${value}`));\n\n    if (problems.length) {\n      failures.push({\n        destination_group: String(entry && entry.destination_group || ''),\n        adset_id_present: Boolean(String(entry && entry.adset_id || '')),\n        missing_effective_placements: problems,\n      });\n    }\n\n    normalizedChecks.push({\n      ...entry,\n      advantage_plus_eligibility: {\n        instagram_static_image_music: publishers.includes('instagram') && includesAny(instagram, ['story', 'reels', 'stream']),\n        instagram_video_music: publishers.includes('instagram') && includesAny(instagram, ['story', 'reels', 'stream']),\n        effective_instagram_positions: instagram,\n        effective_publisher_platforms: publishers,\n      },\n    });\n  }\n\n  outputs.push({\n    ...item,\n    json: {\n      ...root,\n      placement_checks: normalizedChecks,\n      placement_preflight: {\n        status: 'ok',\n        checked_adsets: checks.length,\n        required_vertical_crop: '90x160',\n        required_horizontal_crop: '191x100',\n        required_horizontal_placement: 'facebook:search',\n        required_mixed_video_placement: 'audience_network:rewarded_video',\n      },\n    },\n  });\n}\n\nif (failures.length) {\n  throw new Error(`Meta placement preflight bloqueou o lote: ${JSON.stringify(failures)}`);\n}\n\nreturn outputs;"
+      },
+      "id": "meta-publish-validate-placements",
+      "name": "Validate Meta Placement Eligibility",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2208,
+        1736
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-publish-notify-condition",
+              "leftValue": "={{ $json.claimed }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-publish-should-notify",
+      "name": "Should Notify?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        14800,
+        1448
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) {\n  return String(value ?? '').trim();\n}\n\nfunction clone(value) {\n  return value == null ? value : JSON.parse(JSON.stringify(value));\n}\n\nfunction object(value) {\n  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};\n}\n\nfunction mediaTypeOf(source, binaryData) {\n  const mime = text(source.media_processing?.mime_type || source.mimeType || binaryData?.mimeType).toLowerCase();\n  if (mime.startsWith('video/')) return 'video';\n  if (mime.startsWith('image/')) return 'image';\n  return '';\n}\n\nfunction dimensionsOf(source, binaryData) {\n  const processing = object(source.media_processing);\n  return {\n    width: Number(processing.width || source.width || binaryData?.width || 0),\n    height: Number(processing.height || source.height || binaryData?.height || 0),\n  };\n}\n\nconst rawInputItems = $input.all();\nif (!rawInputItems.length) throw new Error('Prepare Visual Grouping Batch recebeu zero midias.');\n\n// A folder is a queue, not a batch forever. Keep an older unpublished asset\n// out of a newly delivered set when a clear temporal gap proves it belongs to\n// a previous intake. Deferred files stay untouched in Drive for their own\n// future batch; nothing is silently marked published or discarded.\nconst COHORT_MAX_GAP_MS = 2 * 60 * 60 * 1000;\nconst dated = rawInputItems.map((item, original_index) => ({\n  item,\n  original_index,\n  modified_ms: Date.parse(text(item?.json?.modifiedTime || item?.json?.modified_time || '')),\n}));\nconst datedSorted = dated.slice().sort((left, right) => (Number.isFinite(right.modified_ms) ? right.modified_ms : -Infinity) - (Number.isFinite(left.modified_ms) ? left.modified_ms : -Infinity));\nconst selectedEntries = [];\nlet previousModified = null;\nfor (const entry of datedSorted) {\n  if (!Number.isFinite(entry.modified_ms)) { selectedEntries.push(entry); continue; }\n  if (previousModified !== null && previousModified - entry.modified_ms > COHORT_MAX_GAP_MS) break;\n  selectedEntries.push(entry);\n  previousModified = entry.modified_ms;\n}\nconst selectedIndexes = new Set(selectedEntries.map((entry) => entry.original_index));\nconst inputEntries = dated.filter((entry) => selectedIndexes.has(entry.original_index));\nconst deferredEntries = dated.filter((entry) => !selectedIndexes.has(entry.original_index));\nif (!inputEntries.length) throw new Error('Prepare Visual Grouping Batch nao encontrou midias no coorte atual.');\n\nconst anyVideo = inputEntries.some(({ item }) => {\n  const source = item?.json || {};\n  return mediaTypeOf(source, item?.binary?.data) === 'video';\n});\n// Four or more static pieces are ambiguous until the vision pass says whether\n// they are placement variants or an ordered story. Version 3 makes that\n// decision explicit; the old three-image and mixed-media contracts remain\n// unchanged.\nconst version = inputEntries.length >= 4 ? '3' : anyVideo ? '2' : '1';\nconst media = [];\nconst binary = {};\nconst seenDriveIds = new Set();\n\nfor (const [batchIndex, entryWithIndex] of inputEntries.entries()) {\n  const item = entryWithIndex.item;\n  const itemIndex = entryWithIndex.original_index;\n  const source = item?.json || {};\n  const driveId = text(source.id || source.drive_id);\n  const data = item?.binary?.data;\n  const mediaType = mediaTypeOf(source, data);\n  if (!driveId) throw new Error(`Midia ${itemIndex + 1} sem id do Google Drive.`);\n  if (seenDriveIds.has(driveId)) throw new Error(`Midia duplicada no lote visual: ${driveId}.`);\n  if (!['image', 'video'].includes(mediaType)) throw new Error(`Arquivo ${driveId} possui MIME nao suportado.`);\n\n  const analysisBinary = mediaType === 'video' ? item?.binary?.analysis : data;\n  if (!analysisBinary || !text(analysisBinary.mimeType).toLowerCase().startsWith('image/')) {\n    throw new Error(`Midia ${driveId} sem representacao visual de imagem para o agente.`);\n  }\n  if (mediaType === 'video') {\n    if (!data || !text(data.mimeType).toLowerCase().startsWith('video/')) throw new Error(`Video ${driveId} sem binario normalizado.`);\n    if (!item?.binary?.thumbnail || !text(item.binary.thumbnail.mimeType).toLowerCase().startsWith('image/')) {\n      throw new Error(`Video ${driveId} sem miniatura limpa.`);\n    }\n  }\n\n  seenDriveIds.add(driveId);\n  const ordinal = batchIndex + 1;\n  const mediaRef = version === '2'\n    ? `MEDIA_${String(ordinal).padStart(3, '0')}`\n    : `IMG_${String(ordinal).padStart(3, '0')}`;\n  const analysisKey = `analysis_${String(ordinal).padStart(3, '0')}`;\n  const dimensions = dimensionsOf(source, data);\n  const processing = object(source.media_processing);\n  const entry = {\n    media_ref: mediaRef,\n    image_ref: version === '1' ? mediaRef : undefined,\n    ordinal,\n    media_type: mediaType,\n    mime_type: text(processing.mime_type || data?.mimeType || source.mimeType),\n    width: dimensions.width,\n    height: dimensions.height,\n    duration_seconds: mediaType === 'video' ? Number(processing.duration_seconds || 0) : 0,\n    has_audio: mediaType === 'video' ? Boolean(processing.has_audio) : false,\n    transcript: mediaType === 'video' ? text(processing.transcript) : '',\n    analysis_binary_key: analysisKey,\n    source_item_index: itemIndex,\n    source_file_id: driveId,\n    drive_reference: { id: driveId, modified_time: text(source.modifiedTime || source.modified_time) },\n  };\n  media.push(entry);\n  binary[analysisKey] = clone(analysisBinary);\n}\n\nreturn [{\n  json: {\n    visual_grouping_batch_version: version,\n    grouping_contract: version === '2'\n      ? 'mixed_media_four_roles'\n      : version === '3'\n        ? 'static_placement_or_carousel'\n        : 'legacy_three_images',\n    input_count: media.length,\n    deferred_media_count: deferredEntries.length,\n    deferred_media_reason: deferredEntries.length ? 'outside_current_drive_intake_cohort' : '',\n    contains_video: anyVideo,\n    required_roles: version === '2'\n      ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video']\n      : version === '3'\n        ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video', 'carousel_card']\n        : ['feed', 'banner', 'stories'],\n    media,\n    images: version === '1' ? media : undefined,\n  },\n  // Only image representations are forwarded to the vision model. Raw video\n  // and upload thumbnails remain on Prepare Media Inventory and are restored\n  // after the model output has passed the exact-coverage gate.\n  binary,\n}];"
+      },
+      "id": "meta-publish-prepare-visual-batch",
+      "name": "Prepare Visual Grouping Batch",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1632,
+        1252
+      ]
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "=Analise todas as {{ $json.input_count }} representacoes visuais como um unico lote. Cada imagem estatica aparece diretamente; cada video aparece apenas como contact sheet 2x2, metadados e transcricao. Use media_ref, nunca nome ou id do arquivo.\n\nContrato: {{ $json.grouping_contract }}\nPapeis obrigatorios: {{ JSON.stringify($json.required_roles) }}\nManifesto:\n{{ JSON.stringify($json.media.map(({ media_ref, media_type, mime_type, width, height, duration_seconds, has_audio, transcript }) => ({ media_ref, media_type, mime_type, width, height, duration_seconds, has_audio, transcript }))) }}\n\nCompare procedimento, oferta, preco, textos e composicao. Atribua cada midia exatamente uma vez e retorne somente o JSON exigido.\n\nPara cada grupo, preencha offer_fingerprint exclusivamente com fatos visiveis na midia. Procedures deve conter cada procedimento e sua quantidade/unidade quando exibida; preco deve ser convertido para centavos. Use price_qualifier=fixed ou from; use unknown e valor 0 quando o preco nao estiver inequivocamente visivel. Liste pagamento, condicoes e vigencia somente quando visiveis; use arrays vazios e validade vazia quando nao houver. A confianca mede a certeza comercial, nao a qualidade visual. Nao use nome ou id de arquivo como evidencia.\n\nContrato adicional v3: quando duas a dez imagens contam a\nmesma narrativa em sequência (por exemplo, cards de uma oferta), defina o\ngrupo como media_mode=\"carousel\" e atribua todas como role=\"carousel_card\".\nInforme carousel_card_index inteiro e contínuo de 1 até N na ordem narrativa\nque aparece visualmente. Não use nomes, IDs ou ordem do Drive. Não classifique\ncomo carousel se forem as três variações de posicionamento da mesma arte; nesse\ncaso use media_mode=\"static_only\" e os papéis feed/banner/stories. Em v3 cada\ngrupo deve obrigatoriamente devolver media_mode: \"carousel\", \"static_only\",\n\"mixed\" ou \"video_only\". Para carousel, carousel_card_index é obrigatório em\ncada assignment; para mixed/video_only, preserve os papéis de mídia vertical\ndo contrato v2. Um carousel não pode conter vídeo, nem cards duplicados, e\nprecisa de 2 a 10 imagens. Ambiguidade ou confiança abaixo de 0,75 deve\nbloquear o lote.",
+        "options": {
+          "systemMessage": "Voce e um agente multimodal de agrupamento de criativos Meta Ads. Ignore completamente nomes e ids de arquivos. Imagens sao mostradas diretamente; videos sao representados por contact sheet, dimensoes, duracao e transcricao, nunca pelo video bruto. Compare todo o lote antes de agrupar por procedimento, oferta, preco, condicao, pessoas, paleta e composicao. Em contrato legado, cada grupo tem feed, banner e stories. Em contrato misto v2, cada grupo tem exatamente feed_image, banner_image, vertical_image e vertical_video; o video deve ser 9x16 e pertencer inequivocamente ao mesmo conceito/oferta. Confiança abaixo de 0.75 deve ser declarada e bloquear o lote, nunca mascarada. Grupos deterministas VISUAL_GROUP_01... pela primeira midia. Nao use nomes como evidencia. Responda somente no schema.\n\nPara cada grupo, preencha offer_fingerprint exclusivamente com fatos visiveis na midia. Procedures deve conter cada procedimento e sua quantidade/unidade quando exibida; preco deve ser convertido para centavos. Use price_qualifier=fixed ou from; use unknown e valor 0 quando o preco nao estiver inequivocamente visivel. Liste pagamento, condicoes e vigencia somente quando visiveis; use arrays vazios e validade vazia quando nao houver. A confianca mede a certeza comercial, nao a qualidade visual. Nao use nome ou id de arquivo como evidencia.\n\nContrato adicional v3: quando duas a dez imagens contam a\nmesma narrativa em sequência (por exemplo, cards de uma oferta), defina o\ngrupo como media_mode=\"carousel\" e atribua todas como role=\"carousel_card\".\nInforme carousel_card_index inteiro e contínuo de 1 até N na ordem narrativa\nque aparece visualmente. Não use nomes, IDs ou ordem do Drive. Não classifique\ncomo carousel se forem as três variações de posicionamento da mesma arte; nesse\ncaso use media_mode=\"static_only\" e os papéis feed/banner/stories. Em v3 cada\ngrupo deve obrigatoriamente devolver media_mode: \"carousel\", \"static_only\",\n\"mixed\" ou \"video_only\". Para carousel, carousel_card_index é obrigatório em\ncada assignment; para mixed/video_only, preserve os papéis de mídia vertical\ndo contrato v2. Um carousel não pode conter vídeo, nem cards duplicados, e\nprecisa de 2 a 10 imagens. Ambiguidade ou confiança abaixo de 0,75 deve\nbloquear o lote.",
+          "maxIterations": 2,
+          "passthroughBinaryImages": true
+        }
+      },
+      "id": "meta-publish-visual-grouping-agent",
+      "name": "Visual Grouping Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 3,
+      "position": [
+        1856,
+        1252
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000
+    },
+    {
+      "parameters": {
+        "model": {
+          "__rl": true,
+          "value": "gpt-5.6-luna",
+          "mode": "list",
+          "cachedResultName": "gpt-5.6-luna"
+        },
+        "builtInTools": {},
+        "options": {
+          "textFormat": {
+            "textOptions": {
+              "type": "json_schema",
+              "name": "meta_ads_visual_grouping",
+              "schema": "{\n  \"type\": \"object\",\n  \"additionalProperties\": false,\n  \"required\": [\n    \"groups\",\n    \"assignments\",\n    \"warnings\"\n  ],\n  \"properties\": {\n    \"groups\": {\n      \"type\": \"array\",\n      \"minItems\": 1,\n      \"items\": {\n        \"type\": \"object\",\n        \"additionalProperties\": false,\n        \"required\": [\n          \"group_key\",\n          \"visual_concept\",\n          \"confidence\",\n          \"evidence\",\n          \"offer_fingerprint\"\n        ],\n        \"properties\": {\n          \"group_key\": {\n            \"type\": \"string\",\n            \"pattern\": \"^VISUAL_GROUP_[0-9]{2,}$\"\n          },\n          \"visual_concept\": {\n            \"type\": \"string\",\n            \"minLength\": 1,\n            \"maxLength\": 160\n          },\n          \"confidence\": {\n            \"type\": \"number\",\n            \"minimum\": 0.75,\n            \"maximum\": 1\n          },\n          \"evidence\": {\n            \"type\": \"array\",\n            \"minItems\": 1,\n            \"maxItems\": 6,\n            \"items\": {\n              \"type\": \"string\",\n              \"minLength\": 1,\n              \"maxLength\": 200\n            }\n          },\n          \"offer_fingerprint\": {\n            \"type\": \"object\",\n            \"additionalProperties\": false,\n            \"required\": [\n              \"confidence\",\n              \"procedures\",\n              \"price_amount_cents\",\n              \"price_qualifier\",\n              \"payment_terms\",\n              \"condition_terms\",\n              \"validity\",\n              \"evidence\"\n            ],\n            \"properties\": {\n              \"confidence\": {\n                \"type\": \"number\",\n                \"minimum\": 0,\n                \"maximum\": 1\n              },\n              \"procedures\": {\n                \"type\": \"array\",\n                \"maxItems\": 6,\n                \"items\": {\n                  \"type\": \"object\",\n                  \"additionalProperties\": false,\n                  \"required\": [\n                    \"key\",\n                    \"quantity\",\n                    \"unit\"\n                  ],\n                  \"properties\": {\n                    \"key\": {\n                      \"type\": \"string\",\n                      \"minLength\": 1,\n                      \"maxLength\": 80\n                    },\n                    \"quantity\": {\n                      \"type\": \"string\",\n                      \"maxLength\": 32\n                    },\n                    \"unit\": {\n                      \"type\": \"string\",\n                      \"maxLength\": 24\n                    }\n                  }\n                }\n              },\n              \"price_amount_cents\": {\n                \"type\": \"integer\",\n                \"minimum\": 0\n              },\n              \"price_qualifier\": {\n                \"type\": \"string\",\n                \"enum\": [\n                  \"fixed\",\n                  \"from\",\n                  \"unknown\"\n                ]\n              },\n              \"payment_terms\": {\n                \"type\": \"array\",\n                \"maxItems\": 8,\n                \"items\": {\n                  \"type\": \"string\",\n                  \"maxLength\": 48\n                }\n              },\n              \"condition_terms\": {\n                \"type\": \"array\",\n                \"maxItems\": 8,\n                \"items\": {\n                  \"type\": \"string\",\n                  \"maxLength\": 48\n                }\n              },\n              \"validity\": {\n                \"type\": \"string\",\n                \"maxLength\": 80\n              },\n              \"evidence\": {\n                \"type\": \"array\",\n                \"minItems\": 1,\n                \"maxItems\": 8,\n                \"items\": {\n                  \"type\": \"string\",\n                  \"minLength\": 1,\n                  \"maxLength\": 200\n                }\n              }\n            }\n          }\n        }\n      }\n    },\n    \"assignments\": {\n      \"type\": \"array\",\n      \"minItems\": 1,\n      \"items\": {\n        \"type\": \"object\",\n        \"additionalProperties\": false,\n        \"required\": [\n          \"media_ref\",\n          \"media_type\",\n          \"group_key\",\n          \"role\",\n          \"ratio\",\n          \"confidence\",\n          \"evidence\"\n        ],\n        \"properties\": {\n          \"media_ref\": {\n            \"type\": \"string\",\n            \"pattern\": \"^(MEDIA|IMG)_[0-9]{3,}$\"\n          },\n          \"media_type\": {\n            \"type\": \"string\",\n            \"enum\": [\n              \"image\",\n              \"video\"\n            ]\n          },\n          \"group_key\": {\n            \"type\": \"string\",\n            \"pattern\": \"^VISUAL_GROUP_[0-9]{2,}$\"\n          },\n          \"role\": {\n            \"type\": \"string\",\n            \"enum\": [\n              \"feed\",\n              \"banner\",\n              \"stories\",\n              \"feed_image\",\n              \"banner_image\",\n              \"vertical_image\",\n              \"vertical_video\"\n            ]\n          },\n          \"ratio\": {\n            \"type\": \"string\",\n            \"enum\": [\n              \"1x1\",\n              \"2x1\",\n              \"3x4\",\n              \"4x5\",\n              \"9x16\"\n            ]\n          },\n          \"confidence\": {\n            \"type\": \"number\",\n            \"minimum\": 0.75,\n            \"maximum\": 1\n          },\n          \"evidence\": {\n            \"type\": \"array\",\n            \"minItems\": 1,\n            \"maxItems\": 6,\n            \"items\": {\n              \"type\": \"string\",\n              \"minLength\": 1,\n              \"maxLength\": 200\n            }\n          }\n        }\n      }\n    },\n    \"warnings\": {\n      \"type\": \"array\",\n      \"maxItems\": 20,\n      \"items\": {\n        \"type\": \"string\",\n        \"maxLength\": 240\n      }\n    }\n  }\n}"
+            }
+          }
+        }
+      },
+      "id": "meta-publish-visual-grouping-model",
+      "name": "OpenAI Vision Model (Grouping)",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1.3,
+      "position": [
+        1928,
+        1476
+      ],
+      "retryOnFail": true,
+      "waitBetweenTries": 5000,
+      "credentials": {
+        "openAiApi": {
+          "id": "d5x9D1q8y2QXDeUD",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\nfunction parseObject(value) {\n  if (value && typeof value === 'object' && !Array.isArray(value)) return value;\n  if (typeof value !== 'string' || !value.trim()) return null;\n  try { const parsed = JSON.parse(value); return object(parsed); } catch { return null; }\n}\nfunction unwrapAgent(value) {\n  const root = object(value);\n  const direct = parseObject(root.output);\n  if (direct) return object(direct.output) && Object.keys(object(direct.output)).length ? direct.output : direct;\n  return object(root.output) && Object.keys(object(root.output)).length ? root.output : root;\n}\nfunction token(value) {\n  return text(value)\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .replace(/[^a-zA-Z0-9]+/g, '_')\n    .replace(/_+/g, '_')\n    .replace(/^_+|_+$/g, '')\n    .toLowerCase();\n}\nfunction fnv64(value) {\n  let hash = 0xcbf29ce484222325n;\n  const prime = 0x100000001b3n;\n  for (const char of String(value)) {\n    hash = BigInt.asUintN(64, hash ^ BigInt(char.codePointAt(0)));\n    hash = BigInt.asUintN(64, hash * prime);\n  }\n  return hash.toString(36).toUpperCase();\n}\nfunction normalizeOfferFingerprint(raw) {\n  const source = object(raw);\n  const procedures = list(source.procedures)\n    .map((entry) => object(entry))\n    .map((entry) => ({ key: token(entry.key), quantity: token(entry.quantity), unit: token(entry.unit) }))\n    .filter((entry) => entry.key)\n    .sort((left, right) => `${left.key}:${left.quantity}:${left.unit}`.localeCompare(`${right.key}:${right.quantity}:${right.unit}`));\n  const payment_terms = [...new Set(list(source.payment_terms).map(token).filter(Boolean))].sort();\n  const condition_terms = [...new Set(list(source.condition_terms).map(token).filter(Boolean))].sort();\n  const price_amount_cents = Math.max(0, Math.trunc(Number(source.price_amount_cents || 0)));\n  const price_qualifier = ['fixed', 'from'].includes(token(source.price_qualifier)) ? token(source.price_qualifier) : 'unknown';\n  const validity = token(source.validity);\n  const evidence = list(source.evidence).map(text).filter(Boolean).slice(0, 8);\n  const canonical_key = [\n    'v1',\n    `p=${procedures.map((entry) => `${entry.key}:${entry.quantity || 'unknown'}:${entry.unit || 'unknown'}`).join('+') || 'unknown'}`,\n    `price=${price_amount_cents}:${price_qualifier}`,\n    `pay=${payment_terms.join('+') || 'none'}`,\n    `cond=${condition_terms.join('+') || 'none'}`,\n    `valid=${validity || 'none'}`,\n  ].join('|');\n  const replacement_eligible = Number(source.confidence) >= 0.9 && procedures.length > 0 &&\n    procedures.every((entry) => entry.quantity && entry.unit) && price_amount_cents > 0 &&\n    price_qualifier !== 'unknown' && evidence.length > 0;\n  return {\n    version: 'v1', confidence: Number(source.confidence || 0), procedures, price_amount_cents,\n    price_qualifier, payment_terms, condition_terms, validity, evidence, canonical_key,\n    tag: replacement_eligible ? `[OFV1:${fnv64(canonical_key)}]` : '',\n    replacement_eligible,\n    status: replacement_eligible ? 'verified' : 'unverified',\n  };\n}\nfunction sourceItems() {\n  try { const items = $items('Prepare Media Inventory') || []; if (items.length) return items; } catch {}\n  try { return $items('Download File') || []; } catch { return []; }\n}\n\nconst prepared = ($items('Prepare Visual Grouping Batch') || [])[0];\nconst version = text(prepared?.json?.visual_grouping_batch_version || '1');\nconst manifest = list(prepared?.json?.media).length ? list(prepared.json.media) : list(prepared?.json?.images);\nif (!manifest.length) throw new Error('Validate Visual Grouping nao encontrou o manifesto original.');\n\nconst result = unwrapAgent($input.first()?.json || {});\nconst groups = list(result.groups);\nlet assignments = list(result.assignments);\nif (!groups.length || !assignments.length) throw new Error(`Agente visual retornou estrutura vazia: ${JSON.stringify(result).slice(0, 1000)}`);\n\nconst groupByKey = new Map();\nfor (const rawGroup of groups) {\n  const group = object(rawGroup);\n  const key = text(group.group_key).toUpperCase();\n  const confidence = Number(group.confidence);\n  if (!/^VISUAL_GROUP_[0-9]{2,}$/.test(key)) throw new Error(`Chave de grupo visual invalida: ${text(group.group_key)}.`);\n  if (!Number.isFinite(confidence) || confidence < 0.75 || confidence > 1) throw new Error(`Confianca de grupo insuficiente em ${key}: ${group.confidence}.`);\n  const offerFingerprint = normalizeOfferFingerprint(group.offer_fingerprint);\n  if (!object(group.offer_fingerprint) || !Array.isArray(group.offer_fingerprint.procedures)) {\n    throw new Error(`offer_fingerprint ausente ou invalido em ${key}.`);\n  }\n  const mediaMode = text(group.media_mode).toLowerCase();\n  if (version === '3' && mediaMode && !['static_only', 'carousel', 'mixed', 'video_only'].includes(mediaMode)) {\n    throw new Error(`media_mode visual invalido em ${key}: ${text(group.media_mode)}.`);\n  }\n  const normalizedGroup = {\n    group_key: key,\n    visual_concept: text(group.visual_concept),\n    confidence,\n    evidence: list(group.evidence).map(text).filter(Boolean),\n    offer_fingerprint: offerFingerprint,\n    media_mode: version === '3' ? mediaMode : '',\n  };\n  if (groupByKey.has(key)) {\n    // The Responses adapter can repeat a complete group verbatim. It carries\n    // no new classification information, so collapse only an exact normalized\n    // duplicate; any material disagreement stays fail-closed.\n    if (JSON.stringify(groupByKey.get(key)) !== JSON.stringify(normalizedGroup)) {\n      throw new Error(`Grupo visual conflitante: ${key}.`);\n    }\n    continue;\n  }\n  groupByKey.set(key, normalizedGroup);\n}\n\nconst manifestByRef = new Map(manifest.map((entry) => [text(entry.media_ref || entry.image_ref), entry]));\n// Some multimodal adapters serialize only the first assignment despite having\n// produced one high-confidence, explicitly sequential carousel group. This is\n// a response-shape defect, not permission to guess membership: recover only\n// when the model itself states carousel/sequence, every item is an image, and\n// the group is the sole, high-confidence explanation of the entire batch.\nconst soleGroup = groupByKey.size === 1 ? [...groupByKey.values()][0] : null;\nconst carouselNarrative = /carrossel|sequ[êe]ncia/i.test(`${soleGroup?.visual_concept || ''} ${(soleGroup?.evidence || []).join(' ')}`);\nconst partialCarouselAssignmentFallback = version === '3' && assignments.length < manifest.length &&\n  soleGroup && soleGroup.confidence >= 0.9 && carouselNarrative &&\n  manifest.length >= 2 && manifest.length <= 10 && manifest.every((entry) => text(entry.media_type || 'image') === 'image') &&\n  assignments.every((entry) => text(object(entry).group_key).toUpperCase() === soleGroup.group_key);\nif (partialCarouselAssignmentFallback) {\n  assignments = manifest\n    .slice()\n    .sort((left, right) => Number(left.ordinal || 0) - Number(right.ordinal || 0))\n    .map((entry, index) => ({\n      media_ref: text(entry.media_ref || entry.image_ref), media_type: 'image', group_key: soleGroup.group_key,\n      role: 'carousel_card', ratio: text(entry.ratio || '4x5'), carousel_card_index: index + 1,\n      confidence: soleGroup.confidence, evidence: soleGroup.evidence,\n    }));\n  soleGroup.media_mode = 'carousel';\n}\nconst assignmentByRef = new Map();\nconst supportedRatios = new Set(['1x1', '2x1', '3x4', '4x5', '9x16']);\nconst legacyRole = (ratio) => ratio === '2x1' ? 'banner' : ratio === '9x16' ? 'stories' : 'feed';\nconst v2RoleFor = (mediaType, ratio) => mediaType === 'video' ? (ratio === '9x16' ? 'vertical_video' : '')\n  : ratio === '2x1' ? 'banner_image' : ratio === '9x16' ? 'vertical_image' : ['1x1', '3x4', '4x5'].includes(ratio) ? 'feed_image' : '';\n\nfor (const rawAssignment of assignments) {\n  const assignment = object(rawAssignment);\n  const mediaRef = text(assignment.media_ref || assignment.image_ref);\n  const manifestEntry = manifestByRef.get(mediaRef);\n  const groupKey = text(assignment.group_key).toUpperCase();\n  const ratio = text(assignment.ratio).toLowerCase();\n  const mediaType = text(assignment.media_type || manifestEntry?.media_type || 'image').toLowerCase();\n  const declaredRole = text(assignment.role || assignment.slot).toLowerCase();\n  const confidence = Number(assignment.confidence);\n  if (!manifestEntry) throw new Error(`Agente visual retornou referencia desconhecida: ${mediaRef}.`);\n  if (assignmentByRef.has(mediaRef)) throw new Error(`Midia atribuida mais de uma vez: ${mediaRef}.`);\n  if (!groupByKey.has(groupKey)) throw new Error(`Midia ${mediaRef} referencia grupo inexistente: ${groupKey}.`);\n  if (mediaType !== text(manifestEntry.media_type || 'image')) throw new Error(`Tipo de midia divergente em ${mediaRef}.`);\n  if (!supportedRatios.has(ratio)) throw new Error(`Proporcao visual nao suportada para ${mediaRef}: ${ratio}.`);\n  const carouselGroup = version === '3' && groupByKey.get(groupKey)?.media_mode === 'carousel';\n  const expectedRole = carouselGroup\n    ? (mediaType === 'image' ? 'carousel_card' : '')\n    : version === '2' ? v2RoleFor(mediaType, ratio) : legacyRole(ratio);\n  if (!expectedRole) throw new Error(`Papel sem mapeamento para ${mediaType}/${ratio} em ${mediaRef}.`);\n  // Group membership is the visual model's responsibility. The media role is\n  // not: it is mechanically determined by type and aspect ratio. Normalize\n  // an occasional model label error (for example, 2:1 called feed_image)\n  // instead of rejecting a group whose visual association is otherwise sound.\n  const role = expectedRole;\n  if (!Number.isFinite(confidence) || confidence < 0.75 || confidence > 1) throw new Error(`Confianca insuficiente para ${mediaRef}: ${assignment.confidence}.`);\n  const evidence = list(assignment.evidence).map(text).filter(Boolean);\n  const forbiddenEvidence = [text(manifestEntry.source_file_id), text(manifestEntry.source_json?.name)].filter(Boolean);\n  if (evidence.some((entry) => forbiddenEvidence.some((forbidden) => entry.toLowerCase().includes(forbidden.toLowerCase())))) {\n    throw new Error(`Nome ou id de arquivo usado como evidencia em ${mediaRef}.`);\n  }\n  const carouselCardIndex = carouselGroup ? Number(assignment.carousel_card_index) : 0;\n  if (carouselGroup && (!Number.isInteger(carouselCardIndex) || carouselCardIndex < 1 || carouselCardIndex > 10)) {\n    throw new Error(`carousel_card_index invalido para ${mediaRef}.`);\n  }\n  assignmentByRef.set(mediaRef, { media_ref: mediaRef, media_type: mediaType, group_key: groupKey, ratio, role, carousel_card_index: carouselCardIndex, declared_role: declaredRole, confidence, evidence });\n}\n\nconst missing = [...manifestByRef.keys()].filter((ref) => !assignmentByRef.has(ref));\nif (missing.length || assignmentByRef.size !== manifestByRef.size) {\n  throw new Error(`Agrupamento visual nao cobriu o lote exatamente uma vez. missing=${JSON.stringify(missing)} expected=${manifestByRef.size} assigned=${assignmentByRef.size}`);\n}\nconst groupMediaModes = new Map();\nfor (const groupKey of groupByKey.keys()) {\n  const groupAssignments = [...assignmentByRef.values()].filter((entry) => entry.group_key === groupKey);\n  const declaredMode = groupByKey.get(groupKey)?.media_mode;\n  const inferCarousel = version === '3' && !declaredMode &&\n    groupAssignments.length >= 2 && groupAssignments.length <= 10 &&\n    groupAssignments.every((entry) => entry.media_type === 'image');\n  const carouselMode = version === '3' && (declaredMode === 'carousel' || inferCarousel);\n  if (inferCarousel) {\n    // The model already proved membership visually. Older model responses may\n    // omit the new v3 field; retain the intake sequence rather than falling\n    // back to filename parsing or silently treating five cards as placements.\n    groupAssignments.sort((left, right) => Number(manifestByRef.get(left.media_ref)?.ordinal || 0) - Number(manifestByRef.get(right.media_ref)?.ordinal || 0))\n      .forEach((entry, index) => {\n        entry.role = 'carousel_card';\n        entry.carousel_card_index = index + 1;\n      });\n  }\n  const roles = groupAssignments.map((entry) => entry.role);\n  const requiredRoles = carouselMode\n    ? ['carousel_card']\n    : version === '3' && declaredMode === 'mixed'\n      ? ['feed_image', 'banner_image', 'vertical_image', 'vertical_video']\n    : version === '3' && declaredMode === 'video_only'\n      ? ['vertical_video']\n    : version === '2'\n    ? (roles.length === 1 && roles[0] === 'vertical_video'\n      ? ['vertical_video']\n      : ['feed_image', 'banner_image', 'vertical_image', 'vertical_video'])\n    : ['feed', 'banner', 'stories'];\n  const missingRoles = requiredRoles.filter((role) => !roles.includes(role));\n  const duplicateRoles = carouselMode ? [] : [...new Set(roles.filter((role, index) => roles.indexOf(role) !== index))];\n  const cardIndices = carouselMode ? groupAssignments.map((entry) => entry.carousel_card_index).sort((a, b) => a - b) : [];\n  const contiguousCards = carouselMode && cardIndices.length >= 2 && cardIndices.length <= 10 && cardIndices.every((value, index) => value === index + 1);\n  if (missingRoles.length || duplicateRoles.length || (carouselMode ? !contiguousCards : groupAssignments.length !== requiredRoles.length)) {\n    throw new Error(`Grupo visual incompleto ou ambiguo ${groupKey}. missing_roles=${JSON.stringify(missingRoles)} duplicate_roles=${JSON.stringify(duplicateRoles)} media=${groupAssignments.length}`);\n  }\n  groupMediaModes.set(groupKey, carouselMode\n    ? 'carousel'\n    : version === '3' && declaredMode === 'mixed'\n      ? 'mixed_group'\n    : version === '3' && declaredMode === 'video_only'\n      ? 'video_only'\n    : version !== '2'\n    ? 'static_group'\n    : requiredRoles.length === 1 ? 'video_only' : 'mixed_group');\n}\n\nconst originals = sourceItems();\nconst outputs = [];\nfor (const entry of manifest) {\n  const mediaRef = text(entry.media_ref || entry.image_ref);\n  const assignment = assignmentByRef.get(mediaRef);\n  const group = groupByKey.get(assignment.group_key);\n  const original = originals[Number(entry.source_item_index)];\n  if (!original) throw new Error(`Midia original ausente para ${mediaRef}.`);\n  const binary = clone(original.binary || {});\n  if (!binary.data) throw new Error(`Binario principal ausente para ${mediaRef}.`);\n  if (assignment.media_type === 'video' && (!binary.thumbnail || !binary.analysis)) throw new Error(`Artefatos processados ausentes para ${mediaRef}.`);\n  outputs.push({\n    json: {\n      ...clone(object(original.json)),\n      visual_grouping: {\n        version,\n        strategy: 'ai_visual_global',\n        media_ref: mediaRef,\n        image_ref: version === '1' ? mediaRef : undefined,\n        media_type: assignment.media_type,\n        role: assignment.role,\n        slot: version === '1' ? assignment.role : assignment.role.replace(/_image$|_video$/, ''),\n        group_key: assignment.group_key,\n        media_mode: groupMediaModes.get(assignment.group_key),\n        visual_concept: group.visual_concept,\n        ratio: assignment.ratio,\n        confidence: assignment.confidence,\n        evidence: assignment.evidence,\n        group_confidence: group.confidence,\n        group_evidence: group.evidence,\n        offer_fingerprint: clone(group.offer_fingerprint),\n        carousel_card_index: assignment.carousel_card_index || undefined,\n        carousel_card_order_source: version === '3' && !text(group.media_mode)\n          ? 'intake_sequence_fallback_after_visual_membership'\n          : (assignment.carousel_card_index ? 'visual_agent' : undefined),\n      },\n    },\n    binary,\n  });\n}\n\nreturn outputs;"
+      },
+      "id": "meta-publish-validate-visual-grouping",
+      "name": "Validate Visual Grouping",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2208,
+        1252
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\n\nconst jobs = $input.all().map((item) => clone(item.json || {}));\nif (!jobs.length) throw new Error('Build Resume Jobs Checkpoint recebeu zero jobs validados.');\n\nconst runIds = [...new Set(jobs.map((job) => text(job.run_id)).filter(Boolean))];\nif (runIds.length !== 1) throw new Error(`Build Resume Jobs Checkpoint recebeu run_ids inconsistentes: ${JSON.stringify(runIds)}`);\n\nreturn [{\n  json: {\n    run_id: runIds[0],\n    checkpoint_request: {\n      status: 'processing',\n      // Store the exact validated mutation bodies before the first Graph write.\n      // A retry must never ask the generative copy agent to recreate them.\n      summary: { resume_jobs: jobs },\n      error: {},\n    },\n  },\n}];"
+      },
+      "id": "meta-publish-build-resume-checkpoint",
+      "name": "Build Resume Jobs Checkpoint",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        8752,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.checkpoint_request }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "meta-publish-persist-resume-jobs",
+      "name": "Persist Resume Jobs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        8976,
+        1272
+      ],
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\n\nconst checkpoint = $input.first()?.json || {};\nif (checkpoint.ok !== true || !checkpoint.run || text(checkpoint.run.id) !== text($items('Build Resume Jobs Checkpoint')[0]?.json?.run_id)) {\n  throw new Error(`Persist Resume Jobs falhou: ${JSON.stringify(checkpoint.error || checkpoint)}`);\n}\n\nconst jobs = $items('Validate Meta Creative Payload') || [];\nif (!jobs.length) throw new Error('Restore Persisted Resume Jobs nao encontrou jobs validados.');\n\nreturn jobs.map((item) => ({\n  json: item.json || {},\n  binary: item.binary,\n}));"
+      },
+      "id": "meta-publish-restore-resume-jobs",
+      "name": "Restore Persisted Resume Jobs",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        9200,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const ATTEMPT = 1;\nconst OPTIONAL_REMOVAL_PRIORITY = ['pac_relaxation', 'music_generation', 'video_highlights', 'video_filtering', 'adapt_to_placement', 'add_text_overlay'];\n\nfunction text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nfunction stable(value) { if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`; if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stable(value[name])}`).join(',')}}`; return JSON.stringify(value); }\nfunction stableHash(value) { let hash = 2166136261; for (const char of text(value)) { hash ^= char.charCodeAt(0); hash = Math.imul(hash, 16777619); } return (hash >>> 0).toString(36); }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\nfunction responseSucceeded(response) {\n  return response.ok === true && response.operation && response.operation.status === 'completed' && text(response.operation.result && response.operation.result.id);\n}\nfunction responseText(response) {\n  try { return JSON.stringify(response || {}).toLowerCase(); }\n  catch { return text(response).toLowerCase(); }\n}\nfunction chooseRemoval(features, response) {\n  const available = OPTIONAL_REMOVAL_PRIORITY.filter((feature) => Object.prototype.hasOwnProperty.call(features, feature));\n  const detail = responseText(response);\n  const indicated = available.find((feature) => detail.includes(feature));\n  if (indicated) return indicated;\n  // A generic Meta rejection can still be an enhancement incompatibility, but\n  // structural payload errors (such as an invalid asset feed) must never be\n  // hidden by stripping arbitrary optional features.\n  return /(creative[ _-]?feature|advantage\\+?|enhancement|text[ _-]?overlay|music|pac[ _-]?relaxation|video[ _-]?(filtering|highlights?)|adapt[ _-]?to[ _-]?placement)/.test(detail)\n    ? (available[0] || '')\n    : '';\n}\nfunction markRemoved(groups, feature, reason) {\n  const out = clone(object(groups));\n  for (const group of ['main', 'essential', 'supplemental']) {\n    out[group] = list(out[group]).map((entry) => text(entry && entry.api_key) === feature\n      ? { ...entry, requested: false, status: 'fallback_removed', reason }\n      : entry);\n  }\n  return out;\n}\n\nreturn $input.all().map((item, index) => {\n  const merged = object(item.json);\n  const response = { ok: merged.ok, replayed: merged.replayed, operation: merged.operation, requestId: merged.requestId, detail: merged.detail, error: merged.error };\n  const source = { ...merged };\n  for (const field of ['ok', 'replayed', 'operation', 'requestId', 'detail', 'error']) delete source[field];\n  const succeeded = responseSucceeded(response);\n  const resolvedCreativeId = succeeded ? text(response.operation.result.id) : '';\n  if (succeeded) {\n    return { json: { ...source, creative_id: resolvedCreativeId, creative_fallback_attempts: list(source.creative_fallback_attempts), gateway_request: { action: 'get_creative', operation_key: key(`fallback-read-${ATTEMPT}:${source.run_id}:${resolvedCreativeId}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), object_id: resolvedCreativeId } }, binary: item.binary, pairedItem: { item: index } };\n  }\n  const payload = clone(object(source.creativePayload));\n  const features = object(object(payload.degrees_of_freedom_spec).creative_features_spec);\n  const removedFeature = chooseRemoval(features, response);\n  if (!removedFeature) throw new Error(`Create AdCreative falhou por erro estrutural ou nao mapeado; fallback de Advantage+ nao aplicado em ${source.job_key || index}.`);\n  delete features[removedFeature];\n  const payloadHash = stableHash(stable(payload));\n  const fallbackReason = `meta_create_failed_fallback_${ATTEMPT}`;\n  const removed = unique([...list(source.advantage_plus_fallback_removed_features), removedFeature]);\n  const requested = unique(list(source.advantage_plus_requested_features).filter((feature) => feature !== removedFeature));\n  return {\n    json: {\n      ...source, creativePayload: payload, advantage_plus_requested_features: requested,\n      advantage_plus_feature_groups: markRemoved(source.advantage_plus_feature_groups, removedFeature, fallbackReason),\n      advantage_plus_fallback_removed_features: removed,\n      advantage_plus_fallback_reasons: { ...object(source.advantage_plus_fallback_reasons), [removedFeature]: fallbackReason },\n      creative_fallback_attempts: [...list(source.creative_fallback_attempts), { attempt: ATTEMPT, removed_feature: removedFeature, reason: fallbackReason }],\n      gateway_request: { action: 'create_creative', operation_key: key(`creative:v2:${payloadHash}:${source.run_id}:${source.destination_group}:fallback_${ATTEMPT}:${removedFeature}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), payload },\n    }, binary: item.binary, pairedItem: { item: index },\n  };\n});"
+      },
+      "id": "meta-prepare-creative-fallback-1",
+      "name": "Prepare Creative Fallback 1",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        10096,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const ATTEMPT = 2;\nconst OPTIONAL_REMOVAL_PRIORITY = ['music_generation', 'pac_relaxation', 'video_highlights', 'video_filtering', 'adapt_to_placement', 'add_text_overlay'];\n\nfunction text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nfunction stable(value) { if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`; if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stable(value[name])}`).join(',')}}`; return JSON.stringify(value); }\nfunction stableHash(value) { let hash = 2166136261; for (const char of text(value)) { hash ^= char.charCodeAt(0); hash = Math.imul(hash, 16777619); } return (hash >>> 0).toString(36); }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\nfunction responseSucceeded(response) { return response.ok === true && response.operation && response.operation.status === 'completed' && text(response.operation.result && response.operation.result.id); }\nfunction responseText(response) { try { return JSON.stringify(response || {}).toLowerCase(); } catch { return text(response).toLowerCase(); } }\nfunction chooseRemoval(features, response) {\n  const available = OPTIONAL_REMOVAL_PRIORITY.filter((feature) => Object.prototype.hasOwnProperty.call(features, feature));\n  const detail = responseText(response);\n  const indicated = available.find((feature) => detail.includes(feature));\n  if (indicated) return indicated;\n  return /(creative[ _-]?feature|advantage\\+?|enhancement|text[ _-]?overlay|music|pac[ _-]?relaxation|video[ _-]?(filtering|highlights?)|adapt[ _-]?to[ _-]?placement)/.test(detail) ? (available[0] || '') : '';\n}\nfunction markRemoved(groups, feature, reason) {\n  const out = clone(object(groups));\n  for (const group of ['main', 'essential', 'supplemental']) out[group] = list(out[group]).map((entry) => text(entry && entry.api_key) === feature ? { ...entry, requested: false, status: 'fallback_removed', reason } : entry);\n  return out;\n}\n\nreturn $input.all().map((item, index) => {\n  const merged = object(item.json);\n  const response = { ok: merged.ok, replayed: merged.replayed, operation: merged.operation, requestId: merged.requestId, detail: merged.detail, error: merged.error };\n  const source = { ...merged };\n  for (const field of ['ok', 'replayed', 'operation', 'requestId', 'detail', 'error']) delete source[field];\n  const succeeded = responseSucceeded(response);\n  const resolvedCreativeId = succeeded ? text(response.operation.result.id) : '';\n  if (succeeded) return { json: { ...source, creative_id: resolvedCreativeId, creative_fallback_attempts: list(source.creative_fallback_attempts), gateway_request: { action: 'get_creative', operation_key: key(`fallback-read-${ATTEMPT}:${source.run_id}:${resolvedCreativeId}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), object_id: resolvedCreativeId } }, binary: item.binary, pairedItem: { item: index } };\n  const payload = clone(object(source.creativePayload));\n  const features = object(object(payload.degrees_of_freedom_spec).creative_features_spec);\n  const removedFeature = chooseRemoval(features, response);\n  if (!removedFeature) throw new Error(`Create AdCreative falhou por erro estrutural ou nao mapeado apos fallbacks seletivos em ${source.job_key || index}.`);\n  delete features[removedFeature];\n  const payloadHash = stableHash(stable(payload));\n  const fallbackReason = `meta_create_failed_fallback_${ATTEMPT}`;\n  const removed = unique([...list(source.advantage_plus_fallback_removed_features), removedFeature]);\n  const requested = unique(list(source.advantage_plus_requested_features).filter((feature) => feature !== removedFeature));\n  return {\n    json: {\n      ...source, creativePayload: payload, advantage_plus_requested_features: requested,\n      advantage_plus_feature_groups: markRemoved(source.advantage_plus_feature_groups, removedFeature, fallbackReason),\n      advantage_plus_fallback_removed_features: removed,\n      advantage_plus_fallback_reasons: { ...object(source.advantage_plus_fallback_reasons), [removedFeature]: fallbackReason },\n      creative_fallback_attempts: [...list(source.creative_fallback_attempts), { attempt: ATTEMPT, removed_feature: removedFeature, reason: fallbackReason }],\n      gateway_request: { action: 'create_creative', operation_key: key(`creative:v2:${payloadHash}:${source.run_id}:${source.destination_group}:fallback_${ATTEMPT}:${removedFeature}`), token_id: text(source.token_id), account_id: text(source.account_id), api_version: text(source.api_version || 'v25.0'), payload },\n    }, binary: item.binary, pairedItem: { item: index },\n  };\n});"
+      },
+      "id": "meta-prepare-creative-fallback-2",
+      "name": "Prepare Creative Fallback 2",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        10768,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-create-adcreative-fallback-1",
+      "name": "Create AdCreative Fallback 1",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        10320,
+        1568
+      ],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 10000,
+      "typeVersion": 4.3,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-create-adcreative-fallback-2",
+      "name": "Create AdCreative Fallback 2",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        10992,
+        1568
+      ],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 10000,
+      "typeVersion": 4.3,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction safe(value) { return text(value).replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 80); }\nreturn $input.all().map((item, index) => {\n  const json = item.json || {};\n  const binary = item.binary?.data;\n  const mime = text(binary?.mimeType || json.mimeType).toLowerCase();\n  const mediaType = mime.startsWith('video/') ? 'video' : mime.startsWith('image/') ? 'image' : '';\n  if (!mediaType) throw new Error(`MIME nao suportado em ${json.id || index}: ${mime}.`);\n  if (mediaType === 'video' && !['video/mp4', 'video/quicktime'].includes(mime)) throw new Error(`Video deve ser MP4 ou MOV: ${mime}.`);\n  const sourceId = safe(json.id) || `media_${index + 1}`;\n  const executionId = safe($execution.id) || 'manual';\n  const ext = mime === 'video/quicktime' ? 'mov' : mediaType === 'video' ? 'mp4' : (text(binary?.fileExtension) || 'jpg').replace(/[^A-Za-z0-9]/g, '');\n  // This location is writable from the Orb service namespace. The following\n  // staging node creates baseDir before Read/Write Files receives inputFile.\n  const baseDir = `/tmp/meta-ads-publish/${executionId}/${sourceId}`;\n  const inputFile = `${baseDir}/source.${ext}`;\n  const outputDir = `${baseDir}/processed`;\n  const processorPayload = { input_file: inputFile, output_dir: outputDir, source_file_id: text(json.id), execution_id: executionId, mime_type: mime };\n  return {\n    json: {\n      ...json,\n      mimeType: mime,\n      media_type: mediaType,\n      media_staging: { base_dir: baseDir, input_file: inputFile, output_dir: outputDir },\n      processor_payload_b64: mediaType === 'video' ? Buffer.from(JSON.stringify(processorPayload), 'utf8').toString('base64') : '',\n    },\n    binary: item.binary,\n  };\n});"
+      },
+      "id": "meta-media-classify",
+      "name": "Classify Media",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -2400,
+        1252
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-media-is-video-condition",
+              "leftValue": "={{ $json.media_type === \"video\" }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-media-is-video",
+      "name": "Is Video?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        -2176,
+        1252
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "write",
+        "fileName": "={{ $json.media_staging.input_file }}",
+        "options": {}
+      },
+      "id": "meta-media-write-video",
+      "name": "Write Video Source",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        -1504,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "executeOnce": false,
+        "command": "=node /var/lib/skincos-runtime/orb/scripts/meta-ads/process-video-asset.js --payload-b64 {{ $json.processor_payload_b64 }}"
+      },
+      "id": "meta-media-process-video",
+      "name": "Process Video Asset",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        -1280,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\nconst sourceItems = $items('Write Video Source') || [];\nreturn $input.all().map((item, index) => {\n  const value = item.json || {};\n  if (Number(value.exitCode) !== 0 || value.error) throw new Error(`Processamento de video falhou: ${value.stderr || value.error}`);\n  let processing;\n  try { processing = JSON.parse(String(value.stdout || '{}')); } catch { throw new Error('Saida do processador de video invalida.'); }\n  if (processing.ok !== true || !processing.normalized_file || !processing.contact_sheet_file || !processing.thumbnail_file) throw new Error(`Processamento de video incompleto: ${JSON.stringify(processing)}`);\n  if (!isNineBySixteen(processing.width, processing.height)) throw new Error(`Video vertical precisa ser 9:16 apos normalizacao; recebido ${processing.width}x${processing.height}.`);\n  const source = sourceItems[pairedIndex(item, index)]?.json || {};\n  return { json: { ...source, media_processing: { ...processing, output_dir: source.media_staging?.output_dir, aspect_ratio: '9x16', recommended_aspect_ratio: '9x16', transcript: '', transcription_status: processing.has_audio ? 'pending' : 'not_applicable' } } };\n});"
+      },
+      "id": "meta-media-parse-video",
+      "name": "Parse Processed Video",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1056,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-media-has-audio-condition",
+              "leftValue": "={{ $json.media_processing.has_audio === true }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-media-has-audio",
+      "name": "Video Has Audio?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        -832,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.media_processing.audio_file }}",
+        "options": {
+          "fileName": "={{ $json.id + \".wav\" }}",
+          "mimeType": "audio/wav",
+          "dataPropertyName": "data"
+        }
+      },
+      "id": "meta-media-read-audio",
+      "name": "Read Video Audio",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        -608,
+        1396
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "audio",
+        "operation": "transcribe",
+        "options": {
+          "language": "pt",
+          "temperature": 0
+        }
+      },
+      "id": "meta-media-transcribe",
+      "name": "Transcribe Video Audio",
+      "type": "@n8n/n8n-nodes-langchain.openAi",
+      "typeVersion": 2.1,
+      "position": [
+        -384,
+        1396
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "d5x9D1q8y2QXDeUD",
+          "name": "OpenAi account"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "let audioSources = [];\ntry { audioSources = $items('Video Has Audio?', 0) || []; } catch { audioSources = []; }\nreturn $input.all().map((item, index) => {\n  const response = item.json || {};\n  const source = response.media_processing ? response : (audioSources[index]?.json || {});\n  const transcript = String(response.text || response.transcript || '').trim();\n  return { json: { ...source, media_processing: { ...(source.media_processing || {}), transcript, transcription_status: transcript ? 'completed' : (source.media_processing?.has_audio ? 'failed_non_blocking' : 'not_applicable') } } };\n});"
+      },
+      "id": "meta-media-attach-transcript",
+      "name": "Attach Video Transcript",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -160,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.media_processing.normalized_file }}",
+        "options": {
+          "fileName": "={{ $json.id + \".mp4\" }}",
+          "mimeType": "video/mp4",
+          "dataPropertyName": "data"
+        }
+      },
+      "id": "meta-media-read-main",
+      "name": "Read Normalized Video",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        64,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const metadata = $items('Attach Video Transcript') || [];\nreturn $input.all().map((item, index) => ({ json: metadata[index]?.json || {}, binary: { data: item.binary?.data } }));"
+      },
+      "id": "meta-media-attach-main",
+      "name": "Attach Video Main",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        288,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.media_processing.contact_sheet_file }}",
+        "options": {
+          "fileName": "={{ $json.id + \"-contact-sheet.jpg\" }}",
+          "mimeType": "image/jpeg",
+          "dataPropertyName": "analysis"
+        }
+      },
+      "id": "meta-media-read-analysis",
+      "name": "Read Video Contact Sheet",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        512,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const main = $items('Attach Video Main') || [];\nreturn $input.all().map((item, index) => ({ json: main[index]?.json || {}, binary: { data: main[index]?.binary?.data, analysis: item.binary?.analysis } }));"
+      },
+      "id": "meta-media-attach-analysis",
+      "name": "Attach Video Analysis",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        736,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.media_processing.thumbnail_file }}",
+        "options": {
+          "fileName": "={{ $json.id + \"-thumbnail.jpg\" }}",
+          "mimeType": "image/jpeg",
+          "dataPropertyName": "thumbnail"
+        }
+      },
+      "id": "meta-media-read-thumbnail",
+      "name": "Read Video Thumbnail",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        960,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const prior = $items('Attach Video Analysis') || [];\nreturn $input.all().map((item, index) => ({ json: prior[index]?.json || {}, binary: { data: prior[index]?.binary?.data, analysis: prior[index]?.binary?.analysis, thumbnail: item.binary?.thumbnail } }));"
+      },
+      "id": "meta-media-attach-thumbnail",
+      "name": "Attach Video Thumbnail",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1184,
+        1324
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "meta-media-inventory",
+      "name": "Prepare Media Inventory",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        1408,
+        1252
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\nfunction stableHash(value) {\n  let hash = 2166136261;\n  for (const char of text(value)) {\n    hash ^= char.charCodeAt(0);\n    hash = Math.imul(hash, 16777619);\n  }\n  return (hash >>> 0).toString(36);\n}\n\nconst VIDEO_NORMALIZATION_CONTRACT_REVISION = 'video9x16_h264_aac_v1';\n\nfunction resumableVideoId(group, accountId, sourceFileId) {\n  let restored = [];\n  try { restored = $items('Restore Publish Groups') || []; } catch (error) { restored = []; }\n  const candidates = restored\n    .flatMap((entry) => list(entry?.json?.resume_jobs))\n    .filter((job) => text(job.account_id || job.destination_ad_account_id).replace(/^act_/, '') === accountId)\n    .filter((job) => text(job.asset_ids?.vertical_video) === sourceFileId)\n    .filter((job) => text(job.video_status).toLowerCase() === 'ready')\n    .map((job) => text(job.video_id))\n    .filter((value) => /^\\d{5,30}$/.test(value));\n  const unique = [...new Set(candidates)];\n  return unique.length === 1 ? unique[0] : '';\n}\n\nconst outputs = [];\nfor (const item of $input.all()) {\n  const group = item.json || {};\n  const runId = text(group.run_id);\n  for (const video of list(group.videos)) {\n    const inventory = list(group.media_inventory).find((entry) => text(entry.source_file_id || entry.id) === text(video.id));\n    const processing = inventory?.media_processing || video.media_processing || {};\n    const fileSize = Number(processing.output_bytes || video.output_bytes || item.binary?.[video.binary_key]?.fileSize || 0);\n    const normalizedFile = text(processing.normalized_file || video.normalized_file);\n    const checksumSha256 = text(processing.output_checksum_sha256 || video.output_checksum_sha256);\n    if (!runId || !fileSize || !normalizedFile) throw new Error(`Video ${video.id} sem run_id, tamanho ou caminho normalizado.`);\n    if (!/^[a-f0-9]{64}$/i.test(checksumSha256)) throw new Error(`Video ${video.id} normalizacao sem checksum SHA-256 valido.`);\n    const width = Number(processing.width || video.width || 0);\n    const height = Number(processing.height || video.height || 0);\n    if (!isNineBySixteen(width, height)) throw new Error(`Video ${video.id} nao esta em 9:16 apos normalizacao: ${width}x${height}.`);\n    const batchFile = list(group.batch_files).find((entry) => text(entry.id) === text(video.id)) || {};\n    const sourceFingerprint = text(\n      video.md5_checksum || inventory?.source_md5_checksum || batchFile.md5_checksum ||\n      [video.id, video.modified_time || batchFile.modified_time, video.size || batchFile.size].map(text).join('|')\n    );\n    if (!sourceFingerprint) throw new Error(`Video ${video.id} sem fingerprint estavel do arquivo fonte.`);\n    // Destinations may represent different units that publish through the\n    // same ad account. Video upload is account-scoped, just like image\n    // upload, so starting it once per destination creates duplicate videos\n    // and violates the aggregate's exact-count contract.\n    const accounts = new Map();\n    for (const destination of list(group.destinations)) {\n      const accountId = text(destination.destination_ad_account_id || destination.account_id).replace(/^act_/, '');\n      const tokenId = text(destination.token_id);\n      const apiVersion = text(destination.destination_api_version || destination.api_version || 'v25.0');\n      if (!accountId || !tokenId) throw new Error(`Destino de video incompleto em ${group.job_key}.`);\n      accounts.set(accountId, { accountId, tokenId, apiVersion });\n    }\n    for (const { accountId, tokenId, apiVersion } of accounts.values()) {\n      const resumeVideoId = resumableVideoId(group, accountId, text(video.id));\n      outputs.push({ json: {\n        run_id: runId,\n        job_key: text(group.job_key),\n        source_file_id: text(video.id),\n        source_file_name: text(video.original_name || video.name),\n        normalized_file: normalizedFile,\n        output_dir: text(processing.output_dir || normalizedFile.replace(/\\/[^/]+$/, '')),\n        file_size: fileSize,\n        video_width: width,\n        video_height: height,\n        video_aspect_ratio: '9x16',\n        video_recommended_aspect_ratio: '9x16',\n        checksum_sha256: checksumSha256,\n        source_fingerprint: sourceFingerprint,\n        normalization_contract_revision: VIDEO_NORMALIZATION_CONTRACT_REVISION,\n        account_id: accountId,\n        _gateway_account_id: accountId,\n        token_id: tokenId,\n        api_version: apiVersion,\n        gateway_request: {\n          action: 'start_video_upload',\n          // A prior workflow revision used only the normalized asset identity.\n          // Token, Graph version and normalized byte count are part of the\n          // gateway request hash, so omit them here and a replay can collide\n          // with a record produced by the old request shape. Keep the v3 key\n          // stable for exact replays, yet distinct for every semantic request.\n          operation_key: `video-start:v5:${stableHash([runId, accountId, tokenId, apiVersion, video.id, sourceFingerprint, checksumSha256, fileSize, VIDEO_NORMALIZATION_CONTRACT_REVISION].map(text).join('|'))}`,\n          token_id: tokenId,\n          account_id: accountId,\n          api_version: apiVersion,\n          source_file_id: text(video.id),\n          file_size: fileSize,\n          file_checksum: checksumSha256,\n          source_fingerprint: sourceFingerprint,\n          normalization_contract_revision: VIDEO_NORMALIZATION_CONTRACT_REVISION,\n          resume_video_id: resumeVideoId || undefined,\n        },\n      } });\n    }\n  }\n}\nreturn outputs;"
+      },
+      "id": "meta-video-start-prepare",
+      "name": "Prepare Video Upload Starts",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        4672,
+        512
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-video-start",
+      "name": "Start Video Upload",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        4896,
+        512
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item?.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  return Number(paired?.item ?? fallback);\n}\nconst prepared = $items('Prepare Video Upload Starts') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const source = prepared[sourceIndex]?.json || {};\n  const response = item.json || {};\n  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Inicio de upload de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);\n  const result = response.operation.result || {};\n  if (!result.upload_session_id || !result.video_id) throw new Error('Inicio de upload sem sessao ou video_id.');\n  const semanticReplay = response.semantic_replay === true;\n  const replayCompletionOffset = Number(source.file_size || 0);\n  if (semanticReplay && (!Number.isSafeInteger(replayCompletionOffset) || replayCompletionOffset <= 0)) {\n    throw new Error('Replay semantico de video sem tamanho normalizado valido.');\n  }\n  return { json: {\n    ...source,\n    upload_session_id: String(result.upload_session_id),\n    video_id: String(result.video_id),\n    // A semantic replay is selected only from resume_jobs whose video was\n    // already validated as ready. Do not reopen an old chunk session against\n    // a newly normalized temporary file; jump to the idempotent finish/status\n    // checks for the same persisted video_id.\n    start_offset: semanticReplay ? replayCompletionOffset : Number(result.start_offset),\n    end_offset: semanticReplay ? replayCompletionOffset : Number(result.end_offset),\n    upload_generation: 1,\n    transfer_count: 0,\n    start_operation_key: response.operation.operation_key,\n    replayed_start: response.replayed === true,\n    semantic_replay_video_id: response.replayed === true ? String(result.video_id) : '',\n    semantic_replay_ready: semanticReplay,\n    upload_bytes_complete: semanticReplay,\n  } };\n});"
+      },
+      "id": "meta-video-start-normalize",
+      "name": "Normalize Video Upload Start",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        5120,
+        512
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nreturn $input.all().map((item) => {\n  const state = item.json || {};\n  const start = Number(state.start_offset);\n  const end = Number(state.end_offset);\n  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end <= start || end - start > 16 * 1024 * 1024) {\n    throw new Error(`Offsets de chunk invalidos ou acima de 16 MiB: ${start}-${end}.`);\n  }\n  const payload = {\n    input_file: text(state.normalized_file),\n    output_dir: `${text(state.output_dir)}/chunks_${text(state.account_id)}_${text(state.upload_session_id)}`,\n    start_offset: start,\n    end_offset: end,\n    state,\n  };\n  return { json: { ...state, chunk_payload_b64: Buffer.from(JSON.stringify(payload), 'utf8').toString('base64') } };\n});"
+      },
+      "id": "meta-video-chunk-prepare",
+      "name": "Prepare Video Chunk",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        5568,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "executeOnce": false,
+        "command": "=node /var/lib/skincos-runtime/orb/scripts/meta-ads/slice-video-chunk.js --payload-b64 {{ $json.chunk_payload_b64 }}"
+      },
+      "id": "meta-video-slice",
+      "name": "Slice Video Chunk",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        5792,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map((item) => {\n  const value = item.json || {};\n  if (Number(value.exitCode) !== 0 || value.error) throw new Error(`Falha ao fatiar video: ${value.stderr || value.error}`);\n  let parsed;\n  try { parsed = JSON.parse(String(value.stdout || '{}')); } catch { throw new Error('Saida do fatiador de video invalida.'); }\n  if (!parsed.chunk_file || !parsed.state) throw new Error('Fatiador nao retornou chunk_file/state.');\n  return { json: parsed };\n});"
+      },
+      "id": "meta-video-slice-parse",
+      "name": "Parse Video Slice",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6016,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.chunk_file }}",
+        "options": {
+          "fileName": "={{ \"video-\" + $json.state.start_offset + \".part\" }}",
+          "mimeType": "application/octet-stream",
+          "dataPropertyName": "data"
+        }
+      },
+      "id": "meta-video-read-chunk",
+      "name": "Read Video Chunk",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        6240,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item?.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  return Number(paired?.item ?? fallback);\n}\nfunction key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nconst sliced = $items('Parse Video Slice') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const slice = sliced[sourceIndex]?.json || {};\n  const state = slice.state || {};\n  if (!item.binary?.data) throw new Error('Chunk lido sem binario data.');\n  return {\n    json: {\n      ...state,\n      chunk_file: slice.chunk_file,\n      chunk_size: Number(slice.chunk_size),\n      gateway_request: {\n        action: 'transfer_video_chunk',\n        operation_key: key(`video-transfer:${state.run_id}:${state.account_id}:${state.source_file_id}:${state.upload_session_id}:${state.start_offset}`),\n        token_id: state.token_id,\n        account_id: state.account_id,\n        api_version: state.api_version,\n        source_file_id: state.source_file_id,\n        upload_session_id: state.upload_session_id,\n        start_offset: Number(state.start_offset),\n        file_name: `video-${state.start_offset}.part`,\n        file_checksum: state.checksum_sha256,\n        semantic_replay_video_id: state.semantic_replay_video_id || undefined,\n      },\n    },\n    binary: { data: item.binary.data },\n  };\n});"
+      },
+      "id": "meta-video-transfer-prepare",
+      "name": "Prepare Video Chunk Transfer",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6464,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "request",
+              "value": "={{ JSON.stringify($json.gateway_request) }}"
+            },
+            {
+              "parameterType": "formBinaryData",
+              "name": "file",
+              "inputDataFieldName": "data"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-video-transfer",
+      "name": "Transfer Video Chunk",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        6688,
+        160
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item?.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  return Number(paired?.item ?? fallback);\n}\nconst prepared = $items('Prepare Video Chunk Transfer') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const state = prepared[sourceIndex]?.json || {};\n  const response = item.json || {};\n  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Transferencia de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);\n  const result = response.operation.result || {};\n  const start = Number(result.start_offset);\n  const end = Number(result.end_offset);\n  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < Number(state.start_offset) || end < start) throw new Error('Meta retornou offsets de video invalidos.');\n  return { json: {\n    ...state,\n    start_offset: start,\n    end_offset: end,\n    transfer_count: Number(state.transfer_count || 0) + 1,\n    last_transfer_operation_key: response.operation.operation_key,\n    upload_bytes_complete: start === end,\n  } };\n});"
+      },
+      "id": "meta-video-transfer-normalize",
+      "name": "Normalize Video Chunk Transfer",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6912,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-video-bytes-complete-condition",
+              "leftValue": "={{ $json.upload_bytes_complete === true }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-video-bytes-complete",
+      "name": "Video Bytes Complete?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        5344,
+        512
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nreturn $input.all().map((item) => {\n  const state = item.json || {};\n  if (Number(state.start_offset) !== Number(state.end_offset)) throw new Error('Finish solicitado antes do upload completo.');\n  return { json: { ...state, gateway_request: {\n    action: 'finish_video_upload',\n    operation_key: key(`video-finish:${state.run_id}:${state.account_id}:${state.source_file_id}:${state.upload_session_id}`),\n    token_id: state.token_id,\n    account_id: state.account_id,\n    api_version: state.api_version,\n    source_file_id: state.source_file_id,\n    upload_session_id: state.upload_session_id,\n    title: state.source_file_name,\n    semantic_replay_video_id: state.semantic_replay_video_id || undefined,\n  } } };\n});"
+      },
+      "id": "meta-video-finish-prepare",
+      "name": "Prepare Video Finish",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        5568,
+        440
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-video-finish",
+      "name": "Finish Video Upload",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        5792,
+        440
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }\nconst prepared = $items('Prepare Video Finish') || [];\nreturn $input.all().map((item, index) => {\n  const state = prepared[pairedIndex(item, index)]?.json || {};\n  const response = item.json || {};\n  if (response.ok !== true || response.operation?.status !== 'completed' || response.operation?.result?.success !== true) throw new Error(`Finish de video nao confirmado: ${JSON.stringify(response)}`);\n  return { json: { ...state, finish_operation_key: response.operation.operation_key, status_attempt: 0 } };\n});"
+      },
+      "id": "meta-video-finish-normalize",
+      "name": "Normalize Video Finish",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6016,
+        440
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function key(value) { return String(value ?? '').trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\nreturn $input.all().map((item) => {\n  const state = item.json || {};\n  const attempt = Number(state.status_attempt || 0) + 1;\n  if (attempt > 60) throw new Error(`Video ${state.video_id} nao ficou ready apos 60 consultas.`);\n  return { json: { ...state, status_attempt: attempt, gateway_request: {\n    action: 'get_video_status',\n    operation_key: key(`video-status:${state.run_id}:${state.account_id}:${state.video_id}:${attempt}`),\n    token_id: state.token_id,\n    account_id: state.account_id,\n    api_version: state.api_version,\n    object_id: state.video_id,\n    source_file_id: state.source_file_id,\n  } } };\n});"
+      },
+      "id": "meta-video-status-prepare",
+      "name": "Prepare Video Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6240,
+        440
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-video-status",
+      "name": "Get Video Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        6464,
+        352
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) { const p = item?.pairedItem; return Number((Array.isArray(p) ? p[0]?.item : p?.item) ?? fallback); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction isNineBySixteen(widthValue, heightValue) {\n  const width = Number(widthValue);\n  const height = Number(heightValue);\n  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 && Math.abs((width / height) - (9 / 16)) <= 0.002;\n}\nconst prepared = $items('Prepare Video Status') || [];\nreturn $input.all().map((item, index) => {\n  const state = prepared[pairedIndex(item, index)]?.json || {};\n  const response = item.json || {};\n  if (response.ok !== true || response.operation?.status !== 'completed') throw new Error(`Consulta de status de video falhou: ${JSON.stringify(response.detail || response.error || response)}`);\n  const result = response.operation.result || {};\n  const status = String(result.video_status || '').toLowerCase();\n  if (['error', 'failed', 'expired'].includes(status)) throw new Error(`Processamento Meta do video falhou: ${status}.`);\n  const thumbnailCandidates = list(result.thumbnails && result.thumbnails.data);\n  const preferredThumbnail = thumbnailCandidates.find((thumbnail) => thumbnail && thumbnail.is_preferred === true) || thumbnailCandidates[0] || {};\n  const videoWidth = Number(state.video_width || 0);\n  const videoHeight = Number(state.video_height || 0);\n  const thumbnailWidth = Number(preferredThumbnail.width || 0);\n  const thumbnailHeight = Number(preferredThumbnail.height || 0);\n  if (status === 'ready' && (!isNineBySixteen(videoWidth, videoHeight) || !isNineBySixteen(thumbnailWidth, thumbnailHeight))) {\n    throw new Error(`Video Audience Network rewarded precisa permanecer em 9:16 na Meta; video=${videoWidth}x${videoHeight}, miniatura=${thumbnailWidth}x${thumbnailHeight}.`);\n  }\n  return { json: {\n    ...state,\n    video_id: String(result.id || state.video_id),\n    video_status: status,\n    ready: result.ready === true || status === 'ready',\n    thumbnails: result.thumbnails || {},\n    video_width: videoWidth,\n    video_height: videoHeight,\n    video_aspect_ratio: '9x16',\n    video_recommended_aspect_ratio: '9x16',\n    preferred_thumbnail_width: thumbnailWidth,\n    preferred_thumbnail_height: thumbnailHeight,\n    preferred_thumbnail_aspect_ratio: status === 'ready' ? '9x16' : '',\n    status_operation_key: response.operation.operation_key,\n    upload_kind: 'video',\n    role: 'vertical_video',\n    ratio: '9x16',\n    replayed: response.replayed === true,\n  } };\n});"
+      },
+      "id": "meta-video-status-normalize",
+      "name": "Normalize Video Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6688,
+        352
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-video-ready-condition",
+              "leftValue": "={{ $json.ready === true }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-video-ready",
+      "name": "Video Ready?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        6912,
+        352
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "meta-video-status-wait",
+      "name": "Wait Video Processing",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [
+        7136,
+        440
+      ],
+      "webhookId": "meta-video-status-wait"
+    },
+    {
+      "parameters": {},
+      "id": "meta-upload-results-merge",
+      "name": "Merge Media Upload Results",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        7136,
+        992
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {
+          "clashHandling": {
+            "values": {
+              "resolveClash": "preferInput2"
+            }
+          }
+        }
+      },
+      "id": "meta-merge-creative-response-0",
+      "name": "Merge Creative Response 0",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        9872,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {
+          "clashHandling": {
+            "values": {
+              "resolveClash": "preferInput2"
+            }
+          }
+        }
+      },
+      "id": "meta-merge-creative-response-1",
+      "name": "Merge Creative Response 1",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        10544,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {
+          "clashHandling": {
+            "values": {
+              "resolveClash": "preferInput2"
+            }
+          }
+        }
+      },
+      "id": "meta-merge-creative-response-2",
+      "name": "Merge Creative Response 2",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        11216,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "executeOnce": false,
+        "command": "=install -d -m 0750 -- \"{{ $json.media_staging.base_dir }}\""
+      },
+      "id": "meta-media-prepare-staging",
+      "name": "Prepare Video Staging Directory",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        -1952,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item?.pairedItem;\n  return Number((Array.isArray(paired) ? paired[0]?.item : paired?.item) ?? fallback);\n}\n\nconst sourceItems = $items('Is Video?') || [];\n\nreturn $input.all().map((item, index) => {\n  const result = item.json || {};\n  if (Number(result.exitCode) !== 0 || result.error) {\n    throw new Error(`Nao foi possivel preparar o diretorio temporario do video: ${result.stderr || result.error || 'comando sem detalhes'}`);\n  }\n  const source = sourceItems[pairedIndex(item, index)];\n  if (!source?.json?.media_staging?.input_file || !source?.json?.media_staging?.base_dir) {\n    throw new Error('Contexto de staging de video ausente apos preparar o diretorio.');\n  }\n  return { json: source.json, binary: source.binary, pairedItem: source.pairedItem };\n});"
+      },
+      "id": "meta-media-attach-staging",
+      "name": "Attach Video Staging Context",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1728,
+        1324
+      ]
+    },
+    {
+      "parameters": {
+        "url": "http://127.0.0.1:5681/health",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "text"
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "meta-publish-runner-health",
+      "name": "Check Task Runner Health",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        3104,
+        1376
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 2000
+    },
+    {
+      "parameters": {
+        "jsCode": "function pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst prepared = $items('Prepare Publish Run') || [];\nreturn $input.all().map((item, index) => {\n  const sourceIndex = pairedIndex(item, index);\n  const source = prepared[sourceIndex] || prepared[index];\n  if (!source || !source.json) {\n    throw new Error(`Task Runner health sem item correlacionado de Prepare Publish Run; index=${index}.`);\n  }\n  return {\n    json: {\n      ...source.json,\n      task_runner_health: {\n        ok: true,\n        endpoint: 'loopback',\n        checked_at: new Date().toISOString(),\n      },\n    },\n    binary: source.binary || {},\n    pairedItem: { item: sourceIndex },\n  };\n});"
+      },
+      "id": "meta-publish-runner-health-attach",
+      "name": "Attach Task Runner Health",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3328,
+        1376
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\n\nfunction normalizeMediaMode(value, imageCount, videoCount) {\n  const mode = text(value);\n  if (mode === 'static_only' || mode === 'static_group') return 'static_only';\n  if (mode === 'mixed' || mode === 'mixed_group') return 'mixed';\n  if (mode === 'video_only') return 'video_only';\n  if (mode === 'carousel') return 'carousel';\n  if (imageCount > 0 && videoCount > 0) return 'mixed';\n  if (videoCount > 0) return 'video_only';\n  return 'static_only';\n}\n\nreturn $input.all().map((item) => {\n  const group = item.json || {};\n  const jobKey = text(group.job_key);\n  const groupKey = text(group.group_key);\n  const images = list(group.imagens);\n  const videos = list(group.videos);\n  if (!jobKey || !groupKey) throw new Error('Prepare Media Upload Plan exige job_key e group_key.');\n\n  const accounts = new Map();\n  for (const destination of list(group.destinations)) {\n    const accountId = text(destination.destination_ad_account_id || destination.account_id).replace(/^act_/, '');\n    if (!accountId) throw new Error(`Destino sem account_id em ${jobKey}.`);\n    accounts.set(accountId, accountId);\n  }\n  if (!accounts.size) throw new Error(`Prepare Media Upload Plan sem contas de destino em ${jobKey}.`);\n\n  const mediaMode = normalizeMediaMode(group.media_mode, images.length, videos.length);\n  const modeIsValid =\n    (mediaMode === 'static_only' && images.length > 0 && videos.length === 0) ||\n    (mediaMode === 'mixed' && images.length > 0 && videos.length > 0) ||\n    (mediaMode === 'video_only' && images.length === 0 && videos.length > 0) ||\n    (mediaMode === 'carousel' && images.length >= 2 && images.length <= 10 && videos.length === 0);\n  if (!modeIsValid) {\n    throw new Error(`Contrato de media_mode inconsistente em ${jobKey}: mode=${mediaMode} images=${images.length} videos=${videos.length}.`);\n  }\n\n  const accountCount = accounts.size;\n  const staticImageOperations = images.length * accountCount;\n  const thumbnailOperations = videos.length * accountCount;\n  const videoOperations = videos.length * accountCount;\n  const expectedImageOperations = staticImageOperations + thumbnailOperations;\n\n  return {\n    json: {\n      ...group,\n      media_mode: mediaMode,\n      media_upload_plan: {\n        version: '2',\n        job_key: jobKey,\n        group_key: groupKey,\n        media_mode: mediaMode,\n        destination_accounts: [...accounts.keys()],\n        expected: {\n          images: expectedImageOperations,\n          videos: videoOperations,\n          static_images: staticImageOperations,\n          video_thumbnails: thumbnailOperations,\n        },\n      },\n    },\n    binary: clone(item.binary || {}),\n  };\n});"
+      },
+      "id": "meta-publish-media-upload-plan",
+      "name": "Prepare Media Upload Plan",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        4224,
+        1072
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-publish-has-images",
+              "leftValue": "={{ Number($json.media_upload_plan?.expected?.images || 0) > 0 }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-publish-has-image-uploads",
+      "name": "Has Images?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        6240,
+        1096
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map((item) => {\n  const plan = item.json?.media_upload_plan || {};\n  if (Number(plan.expected?.images || 0) !== 0) {\n    throw new Error(`Emit No Image Upload recebeu plano com uploads esperados; job_key=${plan.job_key || ''}.`);\n  }\n  return {\n    json: {\n      job_key: String(plan.job_key || item.json?.job_key || ''),\n      group_key: String(plan.group_key || item.json?.group_key || ''),\n      media_mode: String(plan.media_mode || item.json?.media_mode || ''),\n      upload_result_kind: 'image_skipped',\n      skipped: true,\n      reason: 'no_media_of_type',\n    },\n  };\n});"
+      },
+      "id": "meta-publish-no-image-upload",
+      "name": "Emit No Image Upload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6912,
+        1192
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "meta-publish-has-videos",
+              "leftValue": "={{ Number($json.media_upload_plan?.expected?.videos || 0) > 0 }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "meta-publish-has-video-uploads",
+      "name": "Has Videos?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        4448,
+        664
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map((item) => {\n  const plan = item.json?.media_upload_plan || {};\n  if (Number(plan.expected?.videos || 0) !== 0) {\n    throw new Error(`Emit No Video Upload recebeu plano com uploads esperados; job_key=${plan.job_key || ''}.`);\n  }\n  return {\n    json: {\n      job_key: String(plan.job_key || item.json?.job_key || ''),\n      group_key: String(plan.group_key || item.json?.group_key || ''),\n      media_mode: String(plan.media_mode || item.json?.media_mode || ''),\n      upload_result_kind: 'video_skipped',\n      skipped: true,\n      reason: 'no_media_of_type',\n    },\n  };\n});"
+      },
+      "id": "meta-publish-no-video-upload",
+      "name": "Emit No Video Upload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6912,
+        808
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\n\nconst plans = $items('Prepare Media Upload Plan') || [];\nconst planByJob = new Map();\nfor (const item of plans) {\n  const plan = item.json?.media_upload_plan || {};\n  const jobKey = text(plan.job_key || item.json?.job_key);\n  if (!jobKey) throw new Error('Aggregate Media Upload Results encontrou plano sem job_key.');\n  if (planByJob.has(jobKey)) throw new Error(`Plano de upload duplicado para ${jobKey}.`);\n  planByJob.set(jobKey, clone(plan));\n}\nif (!planByJob.size) throw new Error('Aggregate Media Upload Results sem planos de upload.');\n\nconst buckets = new Map([...planByJob.keys()].map((jobKey) => [jobKey, {\n  image_uploads: [],\n  video_uploads: [],\n  image_skips: [],\n  video_skips: [],\n  seen: new Set(),\n  receiptsByKey: new Map(),\n}]));\n\nfor (const item of $input.all()) {\n  const receipt = item.json || {};\n  const jobKey = text(receipt.job_key);\n  const bucket = buckets.get(jobKey);\n  if (!bucket) throw new Error(`Resultado de upload nao correlacionado; job_key=${jobKey || 'vazio'}.`);\n\n  const resultKind = text(receipt.upload_result_kind);\n  if (resultKind === 'image_skipped') {\n    bucket.image_skips.push(clone(receipt));\n    continue;\n  }\n  if (resultKind === 'video_skipped') {\n    bucket.video_skips.push(clone(receipt));\n    continue;\n  }\n\n  const uploadKind = text(receipt.upload_kind);\n  const accountId = text(receipt._gateway_account_id || receipt.account_id);\n  const sourceFileId = text(receipt.source_file_id);\n  if (!accountId || !sourceFileId) {\n    throw new Error(`Resultado de upload incompleto em ${jobKey}; account_id/source_file_id ausente.`);\n  }\n  const dedupeKey = [uploadKind, accountId, sourceFileId].join('::');\n  if (bucket.seen.has(dedupeKey)) {\n    const previous = bucket.receiptsByKey.get(dedupeKey) || {};\n    // Polling a video until it is ready can surface the exact same terminal\n    // receipt more than once through the loop/merge graph. It is safe to\n    // collapse only an identical ready receipt; any different video result\n    // remains an ambiguity and stops publication.\n    const identicalReadyVideo = uploadKind === 'video' &&\n      text(previous.video_id) === text(receipt.video_id) &&\n      text(previous.video_status).toLowerCase() === 'ready' &&\n      text(receipt.video_status).toLowerCase() === 'ready' &&\n      previous.ready === true && receipt.ready === true;\n    if (identicalReadyVideo) continue;\n    throw new Error(`Resultado de upload duplicado em ${jobKey}; key=${dedupeKey}.`);\n  }\n  bucket.seen.add(dedupeKey);\n  bucket.receiptsByKey.set(dedupeKey, clone(receipt));\n\n  if (uploadKind === 'image' || uploadKind === 'video_thumbnail') {\n    const imageEntries = Object.values(receipt.images || {});\n    if (!imageEntries.length || !imageEntries.some((entry) => text(entry?.hash))) {\n      throw new Error(`Upload de imagem sem hash em ${jobKey}; kind=${uploadKind}.`);\n    }\n    bucket.image_uploads.push(clone(receipt));\n    continue;\n  }\n  if (uploadKind === 'video') {\n    if (!text(receipt.video_id) || text(receipt.video_status).toLowerCase() !== 'ready' || receipt.ready !== true) {\n      throw new Error(`Video ainda nao ready em ${jobKey}; status=${text(receipt.video_status) || 'vazio'}.`);\n    }\n    bucket.video_uploads.push(clone(receipt));\n    continue;\n  }\n  throw new Error(`Tipo de resultado de upload desconhecido em ${jobKey}; kind=${uploadKind || 'vazio'}.`);\n}\n\nconst outputs = [];\nfor (const [jobKey, plan] of planByJob.entries()) {\n  const bucket = buckets.get(jobKey);\n  const expectedImages = Number(plan.expected?.images || 0);\n  const expectedVideos = Number(plan.expected?.videos || 0);\n  const completedImages = bucket.image_uploads.length;\n  const completedVideos = bucket.video_uploads.length;\n  const imageSkipped = expectedImages === 0;\n  const videoSkipped = expectedVideos === 0;\n\n  if (imageSkipped ? bucket.image_skips.length !== 1 : bucket.image_skips.length !== 0) {\n    throw new Error(`Marcador de imagem invalido em ${jobKey}; expected=${expectedImages} markers=${bucket.image_skips.length}.`);\n  }\n  if (videoSkipped ? bucket.video_skips.length !== 1 : bucket.video_skips.length !== 0) {\n    throw new Error(`Marcador de video invalido em ${jobKey}; expected=${expectedVideos} markers=${bucket.video_skips.length}.`);\n  }\n  if (completedImages !== expectedImages || completedVideos !== expectedVideos) {\n    throw new Error(`Uploads incompletos em ${jobKey}; expected_images=${expectedImages} completed_images=${completedImages} expected_videos=${expectedVideos} completed_videos=${completedVideos}.`);\n  }\n\n  outputs.push({\n    json: {\n      media_upload_envelope_version: '2',\n      job_key: jobKey,\n      group_key: text(plan.group_key),\n      media_mode: text(plan.media_mode),\n      expected: {\n        images: expectedImages,\n        videos: expectedVideos,\n        static_images: Number(plan.expected?.static_images || 0),\n        video_thumbnails: Number(plan.expected?.video_thumbnails || 0),\n      },\n      completed: { images: completedImages, videos: completedVideos },\n      image_uploads: bucket.image_uploads,\n      video_uploads: bucket.video_uploads,\n      skipped: { images: imageSkipped, videos: videoSkipped },\n      skip_reasons: {\n        images: imageSkipped ? 'no_media_of_type' : '',\n        videos: videoSkipped ? 'no_media_of_type' : '',\n      },\n      ready: true,\n    },\n  });\n}\n\nreturn outputs;"
+      },
+      "id": "meta-publish-aggregate-media-uploads",
+      "name": "Aggregate Media Upload Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        7496,
+        992
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }\n\nfunction parseJsonObject(value) {\n  if (typeof value !== 'string' || !value.trim()) return null;\n  try {\n    const parsed = JSON.parse(value);\n    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;\n  } catch {\n    return null;\n  }\n}\n\nfunction unwrapAi(value) {\n  const json = object(value);\n  if (json.output && typeof json.output === 'object') return clone(json.output);\n  const parsedOutput = parseJsonObject(json.output);\n  if (parsedOutput) return parsedOutput.output && typeof parsedOutput.output === 'object' && Object.keys(parsedOutput).length === 1\n    ? clone(parsedOutput.output)\n    : clone(parsedOutput);\n  return clone(json);\n}\n\nconst jobs = ($items('Build Payload') || [])\n  .map((item) => item.json || {})\n  .filter((job) => text(job.job_key) && !text(job.error));\nif (!jobs.length) throw new Error('Assemble Job Inputs sem jobs validos do Build Payload.');\n\nconst jobsByKey = new Map(jobs.map((job) => [text(job.job_key), job]));\nconst jobsByGroup = new Map(jobs.map((job) => [text(job.group_key), text(job.job_key)]));\nconst envelopesByJob = new Map();\nconst aiCandidates = [];\n\nfor (const item of $input.all()) {\n  const json = item.json || {};\n  if (text(json.media_upload_envelope_version) === '2') {\n    const jobKey = text(json.job_key);\n    if (!jobsByKey.has(jobKey)) throw new Error(`Envelope de midia nao correlacionado; job_key=${jobKey || 'vazio'}.`);\n    if (envelopesByJob.has(jobKey)) throw new Error(`Envelope de midia duplicado para ${jobKey}.`);\n    envelopesByJob.set(jobKey, clone(json));\n    continue;\n  }\n  const ai = unwrapAi(json);\n  if (Object.keys(object(ai.creative_override)).length) aiCandidates.push({ raw: json, ai });\n}\n\nconst aiByJob = new Map();\nconst unmapped = [];\nfor (const candidate of aiCandidates) {\n  const directKey = text(candidate.ai.job_key || candidate.raw.job_key);\n  const groupKey = text(candidate.ai.group_key || candidate.raw.group_key);\n  const resolved = jobsByKey.has(directKey)\n    ? directKey\n    : jobsByGroup.get(groupKey) || (jobs.length === 1 && aiCandidates.length === 1 ? text(jobs[0].job_key) : '');\n  if (!resolved) {\n    unmapped.push({ has_job_key: Boolean(directKey), has_group_key: Boolean(groupKey) });\n    continue;\n  }\n  if (aiByJob.has(resolved)) throw new Error(`Respostas Livia conflitantes para ${resolved}.`);\n  const job = jobsByKey.get(resolved);\n  if (groupKey && groupKey !== text(job.group_key)) throw new Error(`group_key da Livia diverge em ${resolved}.`);\n  aiByJob.set(resolved, clone(candidate.ai));\n}\n\nif (unmapped.length) throw new Error(`Resposta Livia nao correlacionada; count=${unmapped.length}.`);\n\nreturn jobs.map((job) => {\n  const jobKey = text(job.job_key);\n  const envelope = envelopesByJob.get(jobKey);\n  const ai = aiByJob.get(jobKey);\n  if (!envelope) throw new Error(`Envelope de midia ausente para ${jobKey}.`);\n  if (!ai) throw new Error(`Resposta Livia ausente para ${jobKey}.`);\n  if (text(envelope.group_key) !== text(job.group_key)) throw new Error(`group_key do envelope diverge em ${jobKey}.`);\n  if (envelope.ready !== true) throw new Error(`Envelope de midia nao ready para ${jobKey}.`);\n  return {\n    json: {\n      job_input_assembly_version: '2',\n      job_key: jobKey,\n      group_key: text(job.group_key),\n      media_mode: text(job.media_mode),\n      media_upload_envelope: envelope,\n      ai_output: ai,\n      assembly_diagnostics: {\n        media_ready: true,\n        image_upload_count: list(envelope.image_uploads).length,\n        video_upload_count: list(envelope.video_uploads).length,\n        ai_correlated: true,\n      },\n    },\n  };\n});"
+      },
+      "id": "meta-publish-assemble-job-inputs",
+      "name": "Assemble Job Inputs",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        8080,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "amount": 30
+      },
+      "id": "meta-publish-advantage-stabilization-wait",
+      "name": "Wait Advantage+ Stabilization",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [
+        11664,
+        1272
+      ],
+      "webhookId": "meta-publish-advantage-stabilization-wait"
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction unitSlug(destinationGroup) {\n  const normalized = text(destinationGroup).toLocaleLowerCase('pt-BR').replace(/[^a-z0-9]+/g, '');\n  if (normalized === 'barrashoppingsul') return 'barra-shopping-sul';\n  if (normalized === 'novohamburgo') return 'novo-hamburgo';\n  throw new Error(`Destino CRM desconhecido: ${text(destinationGroup) || 'vazio'}.`);\n}\n\nreturn $input.all().flatMap((item) => {\n  const job = item.json || {};\n  const jobKey = text(job.job_key);\n  const groupKey = text(job.group_key);\n  const destinations = Array.isArray(job.destinations) ? job.destinations : [];\n  if (!jobKey || !groupKey || !destinations.length) throw new Error('Prepare CRM Offer Context Requests exige job_key, group_key e destinos.');\n  const seen = new Set();\n  return destinations.map((destination) => {\n    const destinationGroup = text(destination?.destination_group);\n    const crmUnit = unitSlug(destinationGroup);\n    if (seen.has(crmUnit)) throw new Error(`Destino CRM duplicado em ${jobKey}: ${crmUnit}.`);\n    seen.add(crmUnit);\n    return {\n      json: {\n        job_key: jobKey,\n        group_key: groupKey,\n        crm_unit: crmUnit,\n        crm_destination_group: destinationGroup,\n        crm_source_job: job,\n      },\n      binary: item.binary || {},\n      pairedItem: item.pairedItem,\n    };\n  });\n});"
+      },
+      "id": "meta-publish-prepare-crm-offer-context",
+      "name": "Prepare CRM Offer Context Requests",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6688,
+        1464
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{ 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit=' + encodeURIComponent($json.crm_unit) }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "options": {
+          "timeout": 20000
+        }
+      },
+      "id": "meta-publish-fetch-crm-offer-context",
+      "name": "Fetch CRM Offer Context",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        6912,
+        1464
+      ],
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "4r0IbVgjAaSOQREF",
+          "name": "Bearer Auth account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction pairedIndex(item, fallback) {\n  const paired = item?.pairedItem;\n  return Number((Array.isArray(paired) ? paired[0]?.item : paired?.item) ?? fallback);\n}\n\nconst requests = $items('Prepare CRM Offer Context Requests') || [];\nconst buckets = new Map();\nfor (const [index, item] of $input.all().entries()) {\n  const request = requests[pairedIndex(item, index)];\n  if (!request?.json) throw new Error(`CRM Offer Context sem request correlacionado; index=${index}.`);\n  const meta = request.json;\n  const jobKey = text(meta.job_key);\n  const groupKey = text(meta.group_key);\n  const crmUnit = text(meta.crm_unit);\n  const sourceJob = meta.crm_source_job;\n  if (!jobKey || !groupKey || !crmUnit || !sourceJob) throw new Error('CRM Offer Context retornou contexto incompleto.');\n  const bucket = buckets.get(jobKey) || { job: sourceJob, group_key: groupKey, contexts: {}, binary: request.binary || {} };\n  if (bucket.group_key !== groupKey || bucket.contexts[crmUnit]) throw new Error(`CRM Offer Context duplicado ou divergente em ${jobKey}.`);\n  bucket.contexts[crmUnit] = item.json || {};\n  buckets.set(jobKey, bucket);\n}\n\nreturn [...buckets.entries()].map(([jobKey, bucket]) => {\n  const expected = Array.isArray(bucket.job.destinations) ? bucket.job.destinations.length : 0;\n  if (!expected || Object.keys(bucket.contexts).length !== expected) {\n    throw new Error(`Cobertura CRM incompleta em ${jobKey}; expected=${expected} completed=${Object.keys(bucket.contexts).length}.`);\n  }\n  return {\n    json: {\n      ...bucket.job,\n      crm_offer_context_version: '1',\n      crm_offer_contexts: bucket.contexts,\n    },\n    binary: bucket.binary,\n  };\n});"
+      },
+      "id": "meta-publish-attach-crm-offer-context",
+      "name": "Attach CRM Offer Context",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        7136,
+        1464
+      ]
+    }
+  ],
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Search File"
+          },
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Get Meta Publish Config"
+          }
+        ]
+      ]
+    },
+    "Search File": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Download File"
+          }
+        ]
+      ]
+    },
+    "Download File": {
+      "main": [
+        [
+          {
+            "node": "Classify Media",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Visual Grouping Batch": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Visual Grouping Agent"
+          }
+        ]
+      ]
+    },
+    "Visual Grouping Agent": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Validate Visual Grouping"
+          }
+        ]
+      ]
+    },
+    "Validate Visual Grouping": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Merge (1)"
+          }
+        ]
+      ]
+    },
+    "Get Meta Publish Config": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Meta API Params From Vault"
+          }
+        ]
+      ]
+    },
+    "Build Meta API Params From Vault": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 1,
+            "node": "Merge (1)"
+          },
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Meta Account Inventory Requests"
+          }
+        ]
+      ]
+    },
+    "Build Meta Account Inventory Requests": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Meta List Ads"
+          }
+        ]
+      ]
+    },
+    "Meta List Ads": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Validate Meta Placement Eligibility"
+          }
+        ]
+      ]
+    },
+    "Validate Meta Placement Eligibility": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 2,
+            "node": "Merge (1)"
+          }
+        ]
+      ]
+    },
+    "Merge (1)": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Payload"
+          }
+        ]
+      ]
+    },
+    "Build Payload": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Prepare Publish Run"
+          }
+        ]
+      ]
+    },
+    "Prepare Publish Run": {
+      "main": [
+        [
+          {
+            "node": "Check Task Runner Health",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Acquire Publish Run": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Restore Publish Groups"
+          }
+        ]
+      ]
+    },
+    "Restore Publish Groups": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Resume Drive Only?"
+          }
+        ]
+      ]
+    },
+    "Resume Drive Only?": {
+      "main": [
+        [
+          {
+            "node": "Build Drive Finalization",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Media Upload Plan",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Gateway Uploads": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Upload File"
+          }
+        ]
+      ]
+    },
+    "Upload File": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Normalize Gateway Upload"
+          }
+        ]
+      ]
+    },
+    "Normalize Gateway Upload": {
+      "main": [
+        [
+          {
+            "node": "Merge Media Upload Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Livia": {
+      "main": [
+        [
+          {
+            "node": "Merge (2)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge (2)": {
+      "main": [
+        [
+          {
+            "node": "Assemble Job Inputs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Jobs": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Validate Meta Creative Payload"
+          }
+        ]
+      ]
+    },
+    "Validate Meta Creative Payload": {
+      "main": [
+        [
+          {
+            "node": "Build Resume Jobs Checkpoint",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Creative Operation": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 0",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Create AdCreative",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create AdCreative": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 0",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Attach Creative Result": {
+      "main": [
+        [
+          {
+            "node": "Wait Advantage+ Stabilization",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Verify Advantage+ Creative": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Attach Advantage+ Verification"
+          }
+        ]
+      ]
+    },
+    "Attach Advantage+ Verification": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Stage Batch"
+          }
+        ]
+      ]
+    },
+    "Build Stage Batch": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Stage Ad Batch"
+          }
+        ]
+      ]
+    },
+    "Stage Ad Batch": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Activate Batch"
+          }
+        ]
+      ]
+    },
+    "Build Activate Batch": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Activate Ad Batch"
+          }
+        ]
+      ]
+    },
+    "Activate Ad Batch": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Build Drive Finalization"
+          }
+        ]
+      ]
+    },
+    "Build Drive Finalization": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Update Meta Source File"
+          }
+        ]
+      ]
+    },
+    "Update Meta Source File": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Prepare Drive Read"
+          }
+        ]
+      ]
+    },
+    "Prepare Drive Read": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Read Meta Source File"
+          }
+        ]
+      ]
+    },
+    "Read Meta Source File": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Verify Drive Finalization"
+          }
+        ]
+      ]
+    },
+    "Verify Drive Finalization": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Complete Publish Run"
+          }
+        ]
+      ]
+    },
+    "Complete Publish Run": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Claim Success Notification"
+          }
+        ]
+      ]
+    },
+    "Claim Success Notification": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Should Notify?"
+          }
+        ]
+      ]
+    },
+    "Should Notify?": {
+      "main": [
+        [
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Inform Meta Publish Success (WhatsApp)"
+          },
+          {
+            "type": "main",
+            "index": 0,
+            "node": "Inform Meta Publish Success (Telegram)"
+          }
+        ],
+        []
+      ]
+    },
+    "OpenAI Chat Model (Agent)": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Livia",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Vision Model (Grouping)": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Visual Grouping Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Documents": {
+      "ai_tool": [
+        [
+          {
+            "node": "Livia",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Embeddings OpenAI": {
+      "ai_embedding": [
+        [
+          {
+            "node": "Documents",
+            "type": "ai_embedding",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Resume Jobs Checkpoint": {
+      "main": [
+        [
+          {
+            "node": "Persist Resume Jobs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Persist Resume Jobs": {
+      "main": [
+        [
+          {
+            "node": "Restore Persisted Resume Jobs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Restore Persisted Resume Jobs": {
+      "main": [
+        [
+          {
+            "node": "Prepare Creative Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Creative Fallback 1": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Create AdCreative Fallback 1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create AdCreative Fallback 1": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 1",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Prepare Creative Fallback 2": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Create AdCreative Fallback 2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create AdCreative Fallback 2": {
+      "main": [
+        [
+          {
+            "node": "Merge Creative Response 2",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Classify Media": {
+      "main": [
+        [
+          {
+            "node": "Is Video?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Video?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Staging Directory",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Media Inventory",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Write Video Source": {
+      "main": [
+        [
+          {
+            "node": "Process Video Asset",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Video Asset": {
+      "main": [
+        [
+          {
+            "node": "Parse Processed Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Processed Video": {
+      "main": [
+        [
+          {
+            "node": "Video Has Audio?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Video Has Audio?": {
+      "main": [
+        [
+          {
+            "node": "Read Video Audio",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Attach Video Transcript",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Video Audio": {
+      "main": [
+        [
+          {
+            "node": "Transcribe Video Audio",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Transcribe Video Audio": {
+      "main": [
+        [
+          {
+            "node": "Attach Video Transcript",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Video Transcript": {
+      "main": [
+        [
+          {
+            "node": "Read Normalized Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Normalized Video": {
+      "main": [
+        [
+          {
+            "node": "Attach Video Main",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Video Main": {
+      "main": [
+        [
+          {
+            "node": "Read Video Contact Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Video Contact Sheet": {
+      "main": [
+        [
+          {
+            "node": "Attach Video Analysis",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Video Analysis": {
+      "main": [
+        [
+          {
+            "node": "Read Video Thumbnail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Video Thumbnail": {
+      "main": [
+        [
+          {
+            "node": "Attach Video Thumbnail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Video Thumbnail": {
+      "main": [
+        [
+          {
+            "node": "Prepare Media Inventory",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Prepare Media Inventory": {
+      "main": [
+        [
+          {
+            "node": "Prepare Visual Grouping Batch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Upload Starts": {
+      "main": [
+        [
+          {
+            "node": "Start Video Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start Video Upload": {
+      "main": [
+        [
+          {
+            "node": "Normalize Video Upload Start",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Video Upload Start": {
+      "main": [
+        [
+          {
+            "node": "Video Bytes Complete?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Chunk": {
+      "main": [
+        [
+          {
+            "node": "Slice Video Chunk",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Slice Video Chunk": {
+      "main": [
+        [
+          {
+            "node": "Parse Video Slice",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Video Slice": {
+      "main": [
+        [
+          {
+            "node": "Read Video Chunk",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Video Chunk": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Chunk Transfer",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Chunk Transfer": {
+      "main": [
+        [
+          {
+            "node": "Transfer Video Chunk",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Transfer Video Chunk": {
+      "main": [
+        [
+          {
+            "node": "Normalize Video Chunk Transfer",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Video Chunk Transfer": {
+      "main": [
+        [
+          {
+            "node": "Video Bytes Complete?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Video Bytes Complete?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Finish",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Video Chunk",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Finish": {
+      "main": [
+        [
+          {
+            "node": "Finish Video Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Finish Video Upload": {
+      "main": [
+        [
+          {
+            "node": "Normalize Video Finish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Video Finish": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Status": {
+      "main": [
+        [
+          {
+            "node": "Get Video Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Video Status": {
+      "main": [
+        [
+          {
+            "node": "Normalize Video Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Video Status": {
+      "main": [
+        [
+          {
+            "node": "Video Ready?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Video Ready?": {
+      "main": [
+        [
+          {
+            "node": "Merge Media Upload Results",
+            "type": "main",
+            "index": 1
+          }
+        ],
+        [
+          {
+            "node": "Wait Video Processing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Wait Video Processing": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Media Upload Results": {
+      "main": [
+        [
+          {
+            "node": "Aggregate Media Upload Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Creative Response 0": {
+      "main": [
+        [
+          {
+            "node": "Prepare Creative Fallback 1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Creative Response 1": {
+      "main": [
+        [
+          {
+            "node": "Prepare Creative Fallback 2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Creative Response 2": {
+      "main": [
+        [
+          {
+            "node": "Attach Creative Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Video Staging Directory": {
+      "main": [
+        [
+          {
+            "node": "Attach Video Staging Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Video Staging Context": {
+      "main": [
+        [
+          {
+            "node": "Write Video Source",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Task Runner Health": {
+      "main": [
+        [
+          {
+            "node": "Attach Task Runner Health",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach Task Runner Health": {
+      "main": [
+        [
+          {
+            "node": "Acquire Publish Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Media Upload Plan": {
+      "main": [
+        [
+          {
+            "node": "Has Images?",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Has Videos?",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Prepare CRM Offer Context Requests",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Images?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Gateway Uploads",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Emit No Image Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Emit No Image Upload": {
+      "main": [
+        [
+          {
+            "node": "Merge Media Upload Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Videos?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Video Upload Starts",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Emit No Video Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Emit No Video Upload": {
+      "main": [
+        [
+          {
+            "node": "Merge Media Upload Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Aggregate Media Upload Results": {
+      "main": [
+        [
+          {
+            "node": "Merge (2)",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Assemble Job Inputs": {
+      "main": [
+        [
+          {
+            "node": "Build Jobs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Wait Advantage+ Stabilization": {
+      "main": [
+        [
+          {
+            "node": "Verify Advantage+ Creative",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare CRM Offer Context Requests": {
+      "main": [
+        [
+          {
+            "node": "Fetch CRM Offer Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch CRM Offer Context": {
+      "main": [
+        [
+          {
+            "node": "Attach CRM Offer Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach CRM Offer Context": {
+      "main": [
+        [
+          {
+            "node": "Livia",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "timezone": "America/Sao_Paulo",
+    "binaryMode": "separate",
+    "callerPolicy": "workflowsFromSameOwner",
+    "timeSavedMode": "dynamic",
+    "availableInMCP": false,
+    "executionOrder": "v1",
+    "errorWorkflow": "metaAdsPublishErrorV1",
+    "executionTimeout": 1800,
+    "saveDataSuccessExecution": "all",
+    "saveDataErrorExecution": "all",
+    "saveManualExecutions": true,
+    "saveExecutionProgress": true
+  },
+  "meta": {
+    "instanceId": "944572ee8c2e8d51cb844e6e1ba9720294ea16d2b3e1ac5c32173bdb860f95d8",
+    "templateCredsSetupCompleted": true,
+    "codexMetaAdsPublishFinalization": {
+      "appliedAt": "2026-07-09T18:27:36.234Z",
+      "notes": [
+        "Adds post-Meta finalization for Drive published properties and operational notifications.",
+        "Finalizer emits only after every Build Jobs item has a successful Create/Update Ad result.",
+        "Upload File now uses Build Meta API Params From Vault instead of a literal bearer token."
+      ]
+    },
+    "meta_ads_publish_contract": "carousel_v1"
+  },
+  "description": ""
+}

--- a/platform/security/token-vault/migrations/0002_meta_ads_publish_journal.sql
+++ b/platform/security/token-vault/migrations/0002_meta_ads_publish_journal.sql
@@ -1,0 +1,83 @@
+CREATE TABLE IF NOT EXISTS meta_ads_publish_runs (
+  id TEXT PRIMARY KEY,
+  batch_fingerprint TEXT NOT NULL UNIQUE,
+  request_hash TEXT NOT NULL,
+  workflow_execution_id TEXT,
+  config_revision TEXT NOT NULL,
+  status TEXT NOT NULL,
+  files_json TEXT NOT NULL DEFAULT '[]',
+  summary_json TEXT NOT NULL DEFAULT '{}',
+  error_json TEXT NOT NULL DEFAULT '{}',
+  heartbeat_at TEXT NOT NULL,
+  lock_expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_runs_status_updated
+  ON meta_ads_publish_runs(status, updated_at);
+
+CREATE TABLE IF NOT EXISTS meta_ads_publish_jobs (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  operation_key TEXT NOT NULL UNIQUE,
+  request_hash TEXT NOT NULL,
+  destination_group TEXT NOT NULL,
+  creative_group_key TEXT NOT NULL,
+  action TEXT NOT NULL,
+  resource_key TEXT NOT NULL,
+  status TEXT NOT NULL,
+  previous_state_json TEXT NOT NULL DEFAULT '{}',
+  result_json TEXT NOT NULL DEFAULT '{}',
+  error_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY (run_id) REFERENCES meta_ads_publish_runs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_jobs_run_status
+  ON meta_ads_publish_jobs(run_id, status);
+
+CREATE TABLE IF NOT EXISTS meta_ads_publish_operations (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  operation_key TEXT NOT NULL UNIQUE,
+  request_hash TEXT NOT NULL,
+  action TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  result_json TEXT NOT NULL DEFAULT '{}',
+  error_json TEXT NOT NULL DEFAULT '{}',
+  meta_trace_id TEXT,
+  rate_usage_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY (run_id) REFERENCES meta_ads_publish_runs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_operations_run_status
+  ON meta_ads_publish_operations(run_id, status);
+
+CREATE TABLE IF NOT EXISTS meta_ads_publish_locks (
+  resource_key TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  operation_key TEXT NOT NULL,
+  heartbeat_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_locks_expires
+  ON meta_ads_publish_locks(expires_at);
+
+CREATE TABLE IF NOT EXISTS meta_ads_publish_events (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  event_key TEXT NOT NULL,
+  status TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(run_id, event_key),
+  FOREIGN KEY (run_id) REFERENCES meta_ads_publish_runs(id)
+);

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -1,3 +1,8 @@
+import {
+  handleMetaAdsPublishRequest,
+  isMetaAdsPublishPath,
+} from './meta-ads-publish.js';
+
 const TOKEN_PREFIX = '/internal/token-vault';
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -25,6 +30,17 @@ export async function handleRequest(request, env) {
 
     if (request.method === 'GET' && pathname === '/health') {
       return health(env, requestId);
+    }
+
+    if (isMetaAdsPublishPath(pathname)) {
+      return await handleMetaAdsPublishRequest({
+        request,
+        env,
+        requestId,
+        pathname,
+        decryptToken,
+        writeAudit,
+      });
     }
 
     if (request.method === 'GET' && pathname === '/v1/tokens') {

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -1,0 +1,2233 @@
+const PREFIX = '/v1/meta-ads-publish';
+const GRAPH_ORIGIN = 'https://graph.facebook.com';
+const GRAPH_VIDEO_ORIGIN = 'https://graph-video.facebook.com';
+const LOCK_TTL_MS = 30 * 60 * 1000;
+const GRAPH_TIMEOUT_MS = 60 * 1000;
+const MAX_RETRY_WINDOW_MS = 5 * 60 * 1000;
+const MAX_GRAPH_ATTEMPTS = 3;
+const IMAGE_PROPAGATION_SUBCODE = 2446386;
+const CREATIVE_RETRY_SUBCODE = 1487390;
+const IMAGE_PROPAGATION_BASE_DELAY_MS = 15 * 1000;
+const MAX_AD_PAGES = 20;
+const MAX_ADS = 2000;
+const CREATIVE_READ_FIELDS = Object.freeze([
+  'id',
+  'name',
+  'object_story_spec',
+  'asset_feed_spec',
+  'degrees_of_freedom_spec',
+  'creative_sourcing_spec',
+]);
+const ADSET_PLACEMENT_FIELDS = [
+  'id',
+  'campaign{id,objective}',
+  'optimization_goal',
+  'destination_type',
+  'targeting{publisher_platforms,facebook_positions,instagram_positions,audience_network_positions,whatsapp_positions,effective_publisher_platforms,effective_facebook_positions,effective_instagram_positions,effective_audience_network_positions,effective_whatsapp_positions}',
+].join(',');
+const ADSET_READ_FIELDS = [
+  'id',
+  'name',
+  'campaign_id',
+  'status',
+  'billing_event',
+  'optimization_goal',
+  'destination_type',
+  'bid_strategy',
+  'daily_budget',
+  'lifetime_budget',
+  'start_time',
+  'end_time',
+  'attribution_spec',
+  'promoted_object',
+  'targeting',
+].join(',');
+const CAMPAIGN_READ_FIELDS = [
+  'id',
+  'name',
+  'objective',
+  'buying_type',
+  'special_ad_categories',
+  'is_adset_budget_sharing_enabled',
+  'status',
+].join(',');
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 90 * 1024 * 1024;
+const MAX_VIDEO_CHUNK_BYTES = 16 * 1024 * 1024;
+const MAX_MULTIPART_REQUEST_BYTES = MAX_VIDEO_CHUNK_BYTES + 1024 * 1024;
+const MAX_BATCH_JOBS = 50;
+const MAX_LANDING_REDIRECTS = 5;
+const PAUSED_CALIBRATION_CAMPAIGN_OBJECTIVES = new Set(['OUTCOME_ENGAGEMENT', 'OUTCOME_LEADS']);
+const WHATSAPP_HOSTS = new Set(['wa.me', 'api.whatsapp.com']);
+const ALLOWED_CREATIVE_FEATURES = new Set([
+  'add_text_overlay',
+  'image_touchups',
+  'music_generation',
+  'pac_relaxation',
+  'text_optimizations',
+  'inline_comment',
+  'enhance_cta',
+  'image_brightness_and_contrast',
+  'reveal_details_over_time',
+  'show_destination_blurbs',
+  'image_animation',
+  'site_extensions',
+]);
+const FORBIDDEN_CREATIVE_FEATURES = new Set([
+  'image_template',
+  'media_type_automation',
+  'show_summary',
+  'audio',
+  'standard_enhancements',
+]);
+const REQUIRED_CREATIVE_FEATURES = Object.freeze([
+  'add_text_overlay',
+  'image_touchups',
+  'text_optimizations',
+  'inline_comment',
+  'enhance_cta',
+  'image_brightness_and_contrast',
+  'reveal_details_over_time',
+  'show_destination_blurbs',
+  'image_animation',
+]);
+const TERMINAL_RUN_STATES = new Set(['completed', 'rolled_back']);
+const VIDEO_UPLOAD_ACTIONS = Object.freeze([
+  'start_video_upload',
+  'transfer_video_chunk',
+  'finish_video_upload',
+  'get_video_status',
+]);
+// This revision is deliberately returned with the public (non-secret) gateway
+// capabilities.  The workflow rejects a mismatch before it can open a publish
+// run, so a partial rollout cannot silently mix producer, checkpoint and
+// gateway behavior.
+const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v18_live_campaign_cta';
+const MUTATING_ACTIONS = new Set([
+  'upload_image',
+  'start_video_upload',
+  'transfer_video_chunk',
+  'finish_video_upload',
+  'create_creative',
+  'create_campaign',
+  'create_adset',
+  'promote_native_carousel_route',
+  'stage_batch',
+  'activate_batch',
+  'rollback_batch',
+]);
+const ALLOWED_ACTIONS = new Set([
+  'list_ads',
+  'upload_image',
+  ...VIDEO_UPLOAD_ACTIONS,
+  'create_creative',
+  'get_creative',
+  'get_ad',
+  'get_adset',
+  'get_campaign',
+  'create_campaign',
+  'create_adset',
+  'promote_native_carousel_route',
+  'stage_batch',
+  'activate_batch',
+  'rollback_batch',
+]);
+
+const AD_INVENTORY_FIELDS = [
+  'id',
+  'name',
+  'status',
+  'effective_status',
+  'created_time',
+  'updated_time',
+  'adset_id',
+  'campaign_id',
+  'creative{id,name,object_story_spec,asset_feed_spec}',
+  'adset{id,name,campaign_id}',
+  'campaign{id,name}',
+].join(',');
+
+const AD_STATE_FIELDS = [
+  'id',
+  'name',
+  'status',
+  'effective_status',
+  'created_time',
+  'updated_time',
+  'adset_id',
+  'campaign_id',
+  'creative{id,name}',
+].join(',');
+
+export function isMetaAdsPublishPath(pathname) {
+  return pathname === PREFIX || pathname.startsWith(`${PREFIX}/`);
+}
+
+export async function handleMetaAdsPublishRequest(input) {
+  const { request, env, requestId, pathname, decryptToken, writeAudit } = input;
+
+  if (request.method === 'GET' && pathname === `${PREFIX}/config`) {
+    return getConfig(env, requestId);
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/inventory`) {
+    return getInventory({ request, env, requestId, decryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/runs`) {
+    return createOrResumeRun(request, env, requestId);
+  }
+
+  const runMatch = pathname.match(/^\/v1\/meta-ads-publish\/runs\/([^/]+)$/);
+  if (request.method === 'GET' && runMatch) {
+    return getRun(decodeURIComponent(runMatch[1]), env, requestId);
+  }
+  if (request.method === 'PATCH' && runMatch) {
+    return updateRun(decodeURIComponent(runMatch[1]), request, env, requestId);
+  }
+
+  const heartbeatMatch = pathname.match(/^\/v1\/meta-ads-publish\/runs\/([^/]+)\/heartbeat$/);
+  if (request.method === 'POST' && heartbeatMatch) {
+    return heartbeatRun(decodeURIComponent(heartbeatMatch[1]), env, requestId);
+  }
+
+  const eventMatch = pathname.match(/^\/v1\/meta-ads-publish\/runs\/([^/]+)\/events$/);
+  if (request.method === 'POST' && eventMatch) {
+    return claimEvent(decodeURIComponent(eventMatch[1]), request, env, requestId);
+  }
+
+  const operationMatch = pathname.match(/^\/v1\/meta-ads-publish\/runs\/([^/]+)\/operations$/);
+  if (request.method === 'POST' && operationMatch) {
+    return executeOperation({
+      runId: decodeURIComponent(operationMatch[1]),
+      request,
+      env,
+      requestId,
+      decryptToken,
+      writeAudit,
+    });
+  }
+
+  return response({ ok: false, error: 'meta_ads_publish_not_found', requestId }, 404);
+}
+
+async function getInventory({ request, env, requestId, decryptToken, writeAudit }) {
+  const body = await readObject(request);
+  try {
+    const context = {
+      env,
+      runId: 'inventory',
+      operationKey: `inventory:${clean(body.account_id)}`,
+      decryptToken,
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+    };
+    const result = await listAds(body, context);
+    const placementChecks = [];
+    const seenAdsets = new Set();
+    for (const entry of safeArray(body.adsets)) {
+      const adsetId = normalizeNumericId(entry && entry.adset_id, 'adset_id');
+      if (seenAdsets.has(adsetId)) continue;
+      seenAdsets.add(adsetId);
+      placementChecks.push({
+        adset_id: adsetId,
+        destination_group: clean(entry && entry.destination_group),
+        ...await readAdsetPlacements(body, adsetId, context),
+      });
+    }
+    await writeAudit(env, {
+      event: 'meta_ads_publish.inventory',
+      status: 'ok',
+      requestId,
+      metadata: {
+        token_id: clean(body.token_id),
+        account_id: clean(body.account_id),
+        item_count: result.item_count,
+        page_count: result.page_count,
+      },
+    });
+    return response({ ok: true, ...result, placement_checks: placementChecks, rate_usage: context.rateUsage, requestId });
+  } catch (error) {
+    const normalized = normalizeFailure(error);
+    await writeAudit(env, {
+      event: 'meta_ads_publish.inventory',
+      status: 'failed',
+      requestId,
+      metadata: {
+        token_id: clean(body.token_id),
+        account_id: clean(body.account_id),
+        error_class: normalized.classification,
+        code: normalized.code,
+        subcode: normalized.error_subcode,
+        fbtrace_id: normalized.fbtrace_id,
+      },
+    });
+    return response({ ok: false, error: 'meta_inventory_failed', detail: normalized, requestId }, normalized.http_status || 502);
+  }
+}
+
+async function getConfig(env, requestId) {
+  const rows = await dbAll(env,
+    `SELECT id, unit, external_account_id, token_type, expires_at, active,
+            metadata_json, updated_at
+       FROM credential_tokens
+      WHERE provider = 'facebook' AND active = 1
+      ORDER BY unit, external_account_id`,
+  );
+
+  const destinations = [];
+  const landingPageInvalid = [];
+  for (const row of rows) {
+    const metadata = parseObject(row.metadata_json);
+    const config = asObject(metadata.meta_ads_publish);
+    if (!Object.keys(config).length) {
+      continue;
+    }
+    const allowedLinkHosts = normalizeHosts(config.allowed_link_hosts);
+    const landingDefinition = normalizeLandingPageMap(config.landing_pages_by_creative_group, allowedLinkHosts);
+    const landingPageValidation = await validateLandingPagesOnline(landingDefinition.pages, allowedLinkHosts, env);
+    const landingErrors = [...landingDefinition.errors, ...landingPageValidation.errors];
+    if (!Object.keys(landingDefinition.pages).length) landingErrors.push({ error: 'landing_pages_by_creative_group_required' });
+    if (landingErrors.length) {
+      landingPageInvalid.push({
+        token_id: clean(row.id),
+        destination_group: clean(config.destination_group),
+        errors: landingErrors,
+      });
+    }
+    destinations.push({
+      token_id: clean(row.id),
+      unit: clean(row.unit),
+      external_account_id: clean(row.external_account_id),
+      expires_at: nullable(row.expires_at),
+      updated_at: nullable(row.updated_at),
+      row_number: config.row_number ?? '',
+      destination_group: clean(config.destination_group),
+      api_version: normalizeApiVersion(config.api_version || 'v25.0'),
+      account_id: normalizeNumericId(config.account_id, 'account_id'),
+      campaign_id: normalizeNumericId(config.campaign_id, 'campaign_id'),
+      adset_id: normalizeNumericId(config.adset_id, 'adset_id'),
+      page_id: normalizeNumericId(config.page_id, 'page_id'),
+      instagram_user_id: normalizeNumericId(config.instagram_user_id, 'instagram_user_id'),
+      allowed_link_hosts: allowedLinkHosts,
+      landing_pages_by_creative_group: landingDefinition.pages,
+      landing_page_validation: {
+        ok: landingErrors.length === 0,
+        results: landingPageValidation.results,
+      },
+      freshness_window_days: clampInteger(config.freshness_window_days, 7, 1, 90),
+      carousel_native_campaign_id: clean(config.carousel_native_campaign_id),
+      carousel_native_adset_id: clean(config.carousel_native_adset_id),
+      carousel_native_adset_verified: config.carousel_native_adset_verified === true,
+      carousel_native_route_active: config.carousel_native_route_active === true,
+    });
+  }
+
+  const required = [
+    'token_id', 'destination_group', 'api_version', 'account_id', 'campaign_id',
+    'adset_id', 'page_id', 'instagram_user_id',
+  ];
+  const invalid = destinations
+    .map((item) => ({
+      token_id: item.token_id,
+      missing: required.filter((key) => !clean(item[key])),
+    }))
+    .filter((item) => item.missing.length);
+  invalid.push(...landingPageInvalid);
+  const configRevision = await sha256(stableStringify(destinations));
+
+  return response({
+    ok: invalid.length === 0 && destinations.length >= 2,
+    ready: invalid.length === 0 && destinations.length >= 2,
+    count: destinations.length,
+    config_revision: configRevision,
+    destinations,
+    invalid,
+    capabilities: {
+      workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,
+      video_upload: {
+        supported_actions: VIDEO_UPLOAD_ACTIONS,
+        max_file_bytes: MAX_VIDEO_BYTES,
+        max_chunk_bytes: MAX_VIDEO_CHUNK_BYTES,
+      },
+    },
+    secrets_exposed: false,
+    requestId,
+  }, invalid.length || destinations.length < 2 ? 409 : 200);
+}
+
+async function createOrResumeRun(request, env, requestId) {
+  const body = await readObject(request);
+  const configRevision = requireHash(body.config_revision, 'config_revision');
+  const files = normalizeFiles(body.files);
+  if (!files.length) return response({ ok: false, error: 'files_required', requestId }, 400);
+  const batchFingerprint = body.batch_fingerprint
+    ? requireHash(body.batch_fingerprint, 'batch_fingerprint')
+    : await sha256(stableStringify({ configRevision, files }));
+
+  const requestHash = await sha256(stableStringify({ batchFingerprint, configRevision, files }));
+  const existing = await dbFirst(env,
+    `SELECT * FROM meta_ads_publish_runs WHERE batch_fingerprint = ?`,
+    batchFingerprint,
+  );
+  if (existing) {
+    if (clean(existing.request_hash) !== requestHash) {
+      return response({ ok: false, error: 'batch_fingerprint_conflict', requestId }, 409);
+    }
+    return response({ ok: true, replayed: true, run: serializeRun(existing), requestId });
+  }
+
+  const now = nowIso();
+  const runId = `map_${batchFingerprint.slice(0, 24)}`;
+  const expiresAt = new Date(Date.now() + LOCK_TTL_MS).toISOString();
+  await dbRun(env,
+    `INSERT INTO meta_ads_publish_runs (
+      id, batch_fingerprint, request_hash, workflow_execution_id, config_revision,
+      status, files_json, heartbeat_at, lock_expires_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, 'acquired', ?, ?, ?, ?, ?)`,
+    runId,
+    batchFingerprint,
+    requestHash,
+    nullable(body.workflow_execution_id),
+    configRevision,
+    JSON.stringify(files),
+    now,
+    expiresAt,
+    now,
+    now,
+  );
+  await acquireLocks(env, runId, `run:${runId}`, [`batch:${batchFingerprint}`, ...files.map((file) => `drive:${file.id}`)]);
+  const created = await loadRun(env, runId);
+  return response({ ok: true, replayed: false, run: serializeRun(created), requestId }, 201);
+}
+
+async function getRun(runId, env, requestId) {
+  const run = await loadRun(env, runId);
+  if (!run) return response({ ok: false, error: 'run_not_found', requestId }, 404);
+  const jobs = await dbAll(env,
+    `SELECT id, operation_key, destination_group, creative_group_key, action,
+            resource_key, status, previous_state_json, result_json, error_json,
+            created_at, updated_at
+       FROM meta_ads_publish_jobs WHERE run_id = ? ORDER BY created_at, id`,
+    runId,
+  );
+  const operations = await dbAll(env,
+    `SELECT operation_key, action, status, attempt_count, result_json, error_json,
+            meta_trace_id, rate_usage_json, created_at, updated_at
+       FROM meta_ads_publish_operations WHERE run_id = ? ORDER BY created_at, id`,
+    runId,
+  );
+  return response({
+    ok: true,
+    run: serializeRun(run),
+    jobs: jobs.map(serializeJob),
+    operations: operations.map(serializeOperation),
+    requestId,
+  });
+}
+
+async function updateRun(runId, request, env, requestId) {
+  const run = await loadRun(env, runId);
+  if (!run) return response({ ok: false, error: 'run_not_found', requestId }, 404);
+  const body = await readObject(request);
+  const allowedStatuses = new Set([
+    'processing', 'creatives_ready', 'staged', 'meta_completed_drive_pending',
+    'completed', 'failed', 'rolled_back', 'reconciliation_required',
+  ]);
+  const status = clean(body.status);
+  if (!allowedStatuses.has(status)) {
+    return response({ ok: false, error: 'invalid_run_status', requestId }, 400);
+  }
+  const now = nowIso();
+  await dbRun(env,
+    `UPDATE meta_ads_publish_runs
+        SET status = ?, summary_json = ?, error_json = ?, heartbeat_at = ?,
+            lock_expires_at = ?, updated_at = ?
+      WHERE id = ?`,
+    status,
+    limitedJson(body.summary),
+    limitedJson(body.error),
+    now,
+    new Date(Date.now() + LOCK_TTL_MS).toISOString(),
+    now,
+    runId,
+  );
+  if (TERMINAL_RUN_STATES.has(status)) await releaseRunLocks(env, runId);
+  return getRun(runId, env, requestId);
+}
+
+async function heartbeatRun(runId, env, requestId) {
+  const run = await loadRun(env, runId);
+  if (!run) return response({ ok: false, error: 'run_not_found', requestId }, 404);
+  if (TERMINAL_RUN_STATES.has(clean(run.status))) {
+    return response({ ok: false, error: 'run_already_terminal', requestId }, 409);
+  }
+  const now = nowIso();
+  const expiresAt = new Date(Date.now() + LOCK_TTL_MS).toISOString();
+  await dbRun(env,
+    `UPDATE meta_ads_publish_runs SET heartbeat_at = ?, lock_expires_at = ?, updated_at = ? WHERE id = ?`,
+    now, expiresAt, now, runId,
+  );
+  await dbRun(env,
+    `UPDATE meta_ads_publish_locks SET heartbeat_at = ?, expires_at = ?, updated_at = ? WHERE run_id = ?`,
+    now, expiresAt, now, runId,
+  );
+  return response({ ok: true, run_id: runId, heartbeat_at: now, lock_expires_at: expiresAt, requestId });
+}
+
+async function claimEvent(runId, request, env, requestId) {
+  const run = await loadRun(env, runId);
+  if (!run) return response({ ok: false, error: 'run_not_found', requestId }, 404);
+  const body = await readObject(request);
+  const eventKey = requireKey(body.event_key, 'event_key');
+  const existing = await dbFirst(env,
+    `SELECT id, status, payload_json, created_at, updated_at
+       FROM meta_ads_publish_events WHERE run_id = ? AND event_key = ?`,
+    runId, eventKey,
+  );
+  if (existing) {
+    return response({ ok: true, claimed: false, replayed: true, event: serializeEvent(existing), requestId });
+  }
+  const now = nowIso();
+  const id = crypto.randomUUID();
+  await dbRun(env,
+    `INSERT INTO meta_ads_publish_events (id, run_id, event_key, status, payload_json, created_at, updated_at)
+     VALUES (?, ?, ?, 'claimed', ?, ?, ?)`,
+    id, runId, eventKey, limitedJson(body.payload), now, now,
+  );
+  return response({
+    ok: true,
+    claimed: true,
+    replayed: false,
+    event: { id, event_key: eventKey, status: 'claimed', payload: asObject(body.payload) },
+    requestId,
+  }, 201);
+}
+
+async function executeOperation(context) {
+  const { runId, request, env, requestId, decryptToken, writeAudit } = context;
+  const run = await loadRun(env, runId);
+  if (!run) return response({ ok: false, error: 'run_not_found', requestId }, 404);
+  if (TERMINAL_RUN_STATES.has(clean(run.status))) {
+    return response({ ok: false, error: 'run_already_terminal', status: run.status, requestId }, 409);
+  }
+
+  const parsed = await readOperationRequest(request);
+  if (parsed.error) return response({ ok: false, error: parsed.error, requestId }, parsed.status || 400);
+  const body = parsed.body;
+  const action = clean(body.action);
+  if (!ALLOWED_ACTIONS.has(action)) return response({ ok: false, error: 'invalid_action', requestId }, 400);
+  const operationKey = requireKey(body.operation_key, 'operation_key');
+  const requestHash = await sha256(stableStringify(operationHashInput(body, parsed.file)));
+  if (body.request_hash && clean(body.request_hash) !== requestHash) {
+    return response({ ok: false, error: 'request_hash_mismatch', request_hash: requestHash, requestId }, 400);
+  }
+
+  const existing = await dbFirst(env,
+    `SELECT * FROM meta_ads_publish_operations WHERE operation_key = ?`,
+    operationKey,
+  );
+  if (existing) {
+    if (clean(existing.request_hash) !== requestHash) {
+      return response({ ok: false, error: 'operation_key_conflict', requestId }, 409);
+    }
+    if (clean(existing.status) === 'completed') {
+      return response({ ok: true, replayed: true, operation: serializeOperation(existing), requestId });
+    }
+    if (clean(existing.status) === 'in_progress') {
+      return response({ ok: false, error: 'operation_in_progress', operation: serializeOperation(existing), requestId }, 409);
+    }
+  }
+
+  const resources = deriveResourceKeys(action, body);
+  try {
+    await acquireLocks(env, runId, operationKey, resources);
+  } catch (error) {
+    return response({ ok: false, error: clean(error.message) || 'resource_locked', requestId }, 409);
+  }
+
+  const now = nowIso();
+  const operationId = existing?.id || crypto.randomUUID();
+  if (existing) {
+    await dbRun(env,
+      `UPDATE meta_ads_publish_operations
+          SET status = 'in_progress', error_json = '{}', updated_at = ?
+        WHERE id = ?`,
+      now, operationId,
+    );
+  } else {
+    await dbRun(env,
+      `INSERT INTO meta_ads_publish_operations (
+        id, run_id, operation_key, request_hash, action, status, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 'in_progress', ?, ?)`,
+      operationId, runId, operationKey, requestHash, action, now, now,
+    );
+  }
+
+  try {
+    const graphContext = {
+      env,
+      runId,
+      operationKey,
+      action,
+      decryptToken,
+      file: parsed.file,
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+    };
+    const result = await performOperation(action, body, graphContext);
+    const completedAt = nowIso();
+    await dbRun(env,
+      `UPDATE meta_ads_publish_operations
+          SET status = 'completed', attempt_count = ?, result_json = ?, error_json = '{}',
+              meta_trace_id = ?, rate_usage_json = ?, updated_at = ?
+        WHERE id = ?`,
+      graphContext.attempts,
+      limitedJson(result),
+      nullable(graphContext.traceId),
+      limitedJson(graphContext.rateUsage),
+      completedAt,
+      operationId,
+    );
+    await releaseOperationLocks(env, runId, operationKey);
+    await writeAudit(env, {
+      event: `meta_ads_publish.${action}`,
+      status: 'ok',
+      requestId,
+      metadata: { run_id: runId, operation_key: operationKey, attempts: graphContext.attempts },
+    });
+    const saved = await dbFirst(env, `SELECT * FROM meta_ads_publish_operations WHERE id = ?`, operationId);
+    return response({ ok: true, replayed: false, operation: serializeOperation(saved), requestId });
+  } catch (error) {
+    const normalized = normalizeFailure(error);
+    const status = normalized.ambiguous ? 'reconciliation_required' : 'failed';
+    await dbRun(env,
+      `UPDATE meta_ads_publish_operations
+          SET status = ?, attempt_count = attempt_count + 1, error_json = ?,
+              meta_trace_id = ?, updated_at = ?
+        WHERE id = ?`,
+      status,
+      limitedJson(normalized),
+      nullable(normalized.fbtrace_id),
+      nowIso(),
+      operationId,
+    );
+    if (normalized.ambiguous) {
+      await dbRun(env,
+        `UPDATE meta_ads_publish_runs SET status = 'reconciliation_required', error_json = ?, updated_at = ? WHERE id = ?`,
+        limitedJson(normalized), nowIso(), runId,
+      );
+    }
+    await releaseOperationLocks(env, runId, operationKey);
+    await writeAudit(env, {
+      event: `meta_ads_publish.${action}`,
+      status,
+      requestId,
+      metadata: {
+        run_id: runId,
+        operation_key: operationKey,
+        error_class: normalized.classification,
+        code: normalized.code,
+        subcode: normalized.error_subcode,
+        fbtrace_id: normalized.fbtrace_id,
+      },
+    });
+    return response({ ok: false, error: 'meta_operation_failed', detail: normalized, requestId }, normalized.http_status || 502);
+  }
+}
+
+async function performOperation(action, body, context) {
+  if (action === 'list_ads') return listAds(body, context);
+  if (action === 'upload_image') return uploadImage(body, context);
+  if (action === 'start_video_upload') return startVideoUpload(body, context);
+  if (action === 'transfer_video_chunk') return transferVideoChunk(body, context);
+  if (action === 'finish_video_upload') return finishVideoUpload(body, context);
+  if (action === 'get_video_status') return getVideoStatus(body, context);
+  if (action === 'create_creative') return createCreative(body, context);
+  if (action === 'get_creative') return getCreative(body, context);
+  if (action === 'get_ad') return getAd(body, context);
+  if (action === 'get_adset') return getAdset(body, context);
+  if (action === 'get_campaign') return getCampaign(body, context);
+  if (action === 'create_campaign') return createCampaign(body, context);
+  if (action === 'create_adset') return createAdset(body, context);
+  if (action === 'promote_native_carousel_route') return promoteNativeCarouselRoute(body, context);
+  if (action === 'stage_batch') return stageBatch(body, context);
+  if (action === 'activate_batch') return activateBatch(body, context);
+  if (action === 'rollback_batch') return rollbackBatch(body, context);
+  throw failure('invalid_action', { classification: 'permanent', http_status: 400 });
+}
+
+async function listAds(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  let url = graphUrl(auth.apiVersion, `act_${auth.accountId}/ads`, {
+    fields: AD_INVENTORY_FIELDS,
+    limit: '500',
+  });
+  const ads = [];
+  let pages = 0;
+  while (url) {
+    pages += 1;
+    if (pages > MAX_AD_PAGES) throw failure('ad_inventory_page_limit', { classification: 'permanent', http_status: 409 });
+    const result = await graphRequest(url, { method: 'GET' }, auth, context);
+    ads.push(...safeArray(result.body.data));
+    if (ads.length > MAX_ADS) throw failure('ad_inventory_item_limit', { classification: 'permanent', http_status: 409 });
+    url = validatePagingUrl(result.body?.paging?.next, auth.apiVersion);
+  }
+  return { data: ads, page_count: pages, item_count: ads.length, truncated: false };
+}
+
+async function readAdsetPlacements(body, adsetId, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, adsetId, { fields: ADSET_PLACEMENT_FIELDS }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  const adset = asObject(result.body);
+  const campaign = asObject(adset.campaign);
+  return sanitizeGraphValue({
+    targeting: asObject(adset.targeting),
+    // This comes from the live ad set/campaign, not from a manually copied
+    // Token Vault field. Build Jobs uses it to choose a CTA the destination
+    // contract can actually stage.
+    campaign_objective: clean(campaign.objective).toUpperCase(),
+    optimization_goal: clean(adset.optimization_goal).toUpperCase(),
+    destination_type: clean(adset.destination_type).toUpperCase(),
+  });
+}
+
+async function uploadImage(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  if (!(context.file instanceof Blob)) throw failure('image_file_required', { classification: 'permanent', http_status: 400 });
+  if (context.file.size <= 0 || context.file.size > MAX_UPLOAD_BYTES) {
+    throw failure('image_size_invalid', { classification: 'permanent', http_status: 413 });
+  }
+  const form = new FormData();
+  form.append('filename', context.file, clean(body.file_name) || 'creative-image.jpg');
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, `act_${auth.accountId}/adimages`),
+    { method: 'POST', body: form },
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+// Video uploads use Meta's resumable protocol. Keeping it inside the Token
+// Vault preserves the existing token boundary and makes each phase journaled
+// and idempotent by the normal operation-key mechanism.
+async function startVideoUpload(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const fileSize = normalizeVideoFileSize(body.file_size);
+  const form = new FormData();
+  form.append('upload_phase', 'start');
+  form.append('file_size', String(fileSize));
+  const result = await graphRequest(
+    graphVideoUrl(auth.apiVersion, `act_${auth.accountId}/advideos`),
+    { method: 'POST', body: form },
+    auth,
+    context,
+  );
+  return normalizeVideoUploadResponse(result.body, 'start');
+}
+
+async function transferVideoChunk(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  if (!(context.file instanceof Blob)) throw failure('video_chunk_required', { classification: 'permanent', http_status: 400 });
+  if (context.file.size <= 0 || context.file.size > MAX_VIDEO_CHUNK_BYTES) {
+    throw failure('video_chunk_size_invalid', { classification: 'permanent', http_status: 413 });
+  }
+  const uploadSessionId = normalizeUploadSessionId(body.upload_session_id);
+  const startOffset = normalizeVideoOffset(body.start_offset, 'start_offset');
+  const expectedEndOffset = startOffset + context.file.size;
+  if (expectedEndOffset > MAX_VIDEO_BYTES) throw failure('video_offset_invalid', { classification: 'permanent', http_status: 400 });
+  const form = new FormData();
+  form.append('upload_phase', 'transfer');
+  form.append('upload_session_id', uploadSessionId);
+  form.append('start_offset', String(startOffset));
+  form.append('video_file_chunk', context.file, clean(body.file_name) || `video-${startOffset}.part`);
+  const result = await graphRequest(
+    graphVideoUrl(auth.apiVersion, `act_${auth.accountId}/advideos`),
+    { method: 'POST', body: form },
+    auth,
+    context,
+  );
+  const normalized = normalizeVideoUploadResponse(result.body, 'transfer');
+  const returnedStart = normalizeVideoOffset(normalized.start_offset, 'returned_start_offset');
+  const returnedEnd = normalizeVideoOffset(normalized.end_offset, 'returned_end_offset');
+  if (returnedStart < startOffset || returnedStart > expectedEndOffset || returnedEnd < returnedStart || returnedEnd > MAX_VIDEO_BYTES) {
+    throw failure('video_offsets_invalid', { classification: 'permanent', http_status: 502 });
+  }
+  return normalized;
+}
+
+async function finishVideoUpload(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const uploadSessionId = normalizeUploadSessionId(body.upload_session_id);
+  const form = new FormData();
+  form.append('upload_phase', 'finish');
+  form.append('upload_session_id', uploadSessionId);
+  const title = clean(body.title);
+  if (title) form.append('title', title.slice(0, 255));
+  const result = await graphRequest(
+    graphVideoUrl(auth.apiVersion, `act_${auth.accountId}/advideos`),
+    { method: 'POST', body: form },
+    auth,
+    context,
+  );
+  return normalizeVideoUploadResponse(result.body, 'finish');
+}
+
+async function getVideoStatus(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const videoId = normalizeNumericId(body.object_id || body.video_id, 'video_id');
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, videoId, { fields: 'id,status,thumbnails' }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  const value = sanitizeGraphValue(result.body);
+  const videoStatus = clean(value?.status?.video_status || value?.status?.status || value?.video_status).toLowerCase();
+  return { ...value, video_status: videoStatus, ready: videoStatus === 'ready' };
+}
+
+async function createCreative(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const payload = validateCreativePayload(body.payload, context.operationKey);
+  try {
+    const result = await graphRequest(
+      graphUrl(auth.apiVersion, `act_${auth.accountId}/adcreatives`),
+      jsonRequest('POST', payload),
+      auth,
+      context,
+    );
+    return sanitizeGraphValue(result.body);
+  } catch (error) {
+    if (!normalizeFailure(error).ambiguous) throw error;
+    const reconciled = await findCreativeByOperationName(auth, payload.name, context);
+    if (reconciled) return { ...reconciled, reconciled_after_ambiguous_response: true };
+    throw error;
+  }
+}
+
+async function getCreative(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const creativeId = normalizeNumericId(body.object_id, 'object_id');
+  const fields = CREATIVE_READ_FIELDS.join(',');
+  const result = await graphRequest(graphUrl(auth.apiVersion, creativeId, { fields }), { method: 'GET' }, auth, context);
+  return sanitizeGraphValue(result.body);
+}
+
+async function getAd(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const adId = normalizeNumericId(body.object_id, 'object_id');
+  return readAd(auth, adId, context);
+}
+
+async function getAdset(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const adsetId = normalizeNumericId(body.object_id, 'object_id');
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, adsetId, { fields: ADSET_READ_FIELDS }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+async function getCampaign(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const campaignId = normalizeNumericId(body.object_id, 'object_id');
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, campaignId, { fields: CAMPAIGN_READ_FIELDS }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+async function createCampaign(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const payload = validatePausedCampaignPayload(body.payload);
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, `act_${auth.accountId}/campaigns`),
+    { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) },
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+async function createAdset(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const payload = validatePausedAdsetPayload(body.payload);
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, `act_${auth.accountId}/adsets`),
+    jsonRequest('POST', payload),
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+async function promoteNativeCarouselRoute(body, context) {
+  const auth = await resolveGraphAuth(body, context);
+  const payload = validateNativeCarouselRoutePromotion(body.payload);
+  const campaign = await graphRequest(
+    graphUrl(auth.apiVersion, payload.campaign_id, { fields: 'id,name,status' }),
+    { method: 'GET' }, auth, context,
+  );
+  if (!isNativeCarouselRouteName(campaign.body && campaign.body.name)) {
+    throw failure('native_carousel_campaign_name_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  for (const adId of payload.test_ad_ids) {
+    const ad = await readAd(auth, adId, context);
+    if (!clean(ad.name).startsWith('[TEST-CAROUSEL-NATIVE]')) {
+      throw failure('native_carousel_test_ad_name_invalid', { classification: 'permanent', http_status: 400 });
+    }
+    await graphRequest(graphUrl(auth.apiVersion, adId), jsonRequest('POST', { status: 'ARCHIVED' }), auth, context);
+  }
+  for (const adset of payload.adsets) {
+    const current = await graphRequest(
+      graphUrl(auth.apiVersion, adset.id, { fields: 'id,name,status' }),
+      { method: 'GET' }, auth, context,
+    );
+    if (!isNativeCarouselRouteName(current.body && current.body.name)) {
+      throw failure('native_carousel_adset_name_invalid', { classification: 'permanent', http_status: 400 });
+    }
+    await graphRequest(graphUrl(auth.apiVersion, adset.id), jsonRequest('POST', { name: adset.name, status: 'ACTIVE' }), auth, context);
+  }
+  await graphRequest(
+    graphUrl(auth.apiVersion, payload.campaign_id),
+    jsonRequest('POST', { name: payload.campaign_name, status: 'ACTIVE' }),
+    auth,
+    context,
+  );
+  return {
+    campaign_id: payload.campaign_id,
+    campaign_status: 'ACTIVE',
+    adsets: payload.adsets.map((adset) => ({ id: adset.id, name: adset.name, status: 'ACTIVE' })),
+    archived_test_ad_ids: payload.test_ad_ids,
+  };
+}
+
+async function stageBatch(body, context) {
+  const jobs = validateBatchJobs(body.jobs);
+  const staged = [];
+  try {
+    for (const job of jobs) {
+      const auth = await resolveGraphAuth(job, context);
+      const payload = validateAdPayload(job.ad_payload, job.action);
+      payload.status = 'PAUSED';
+      if (job.action === 'replace_existing') {
+        const adId = normalizeNumericId(job.target_ad_id, 'target_ad_id');
+        const previous = await readAd(auth, adId, context);
+        const result = await updateAdWithReconciliation(auth, adId, payload, context);
+        const record = buildStagedRecord(job, adId, previous, result, false);
+        staged.push(record);
+        await upsertJob(context.env, context.runId, record, 'staged');
+      } else {
+        const result = await createAdWithReconciliation(auth, payload, context);
+        const adId = normalizeNumericId(result.id, 'created_ad_id');
+        const record = buildStagedRecord(job, adId, {}, result, true);
+        staged.push(record);
+        await upsertJob(context.env, context.runId, record, 'staged');
+      }
+    }
+  } catch (error) {
+    const rollback = await compensateStaged(staged, context);
+    const normalized = normalizeFailure(error);
+    normalized.compensation = rollback;
+    normalized.ambiguous = normalized.ambiguous || rollback.reconciliation_required;
+    throw Object.assign(new Error(normalized.message || 'stage_batch_failed'), normalized);
+  }
+  await setRunState(context.env, context.runId, 'staged', { jobs: staged.map(stripJobForSummary) });
+  return { status: 'staged', job_count: staged.length, jobs: staged };
+}
+
+async function activateBatch(body, context) {
+  const staged = await loadStagedOperation(body.stage_operation_key, context);
+  const activated = [];
+  try {
+    for (const record of staged.jobs) {
+      const auth = await resolveGraphAuth(record, context);
+      const result = await updateAdWithReconciliation(auth, record.ad_id, { status: 'ACTIVE' }, context);
+      activated.push({ ...record, activation_result: sanitizeGraphValue(result) });
+      await updateJobStatus(context.env, record.operation_key, 'active', { ad_id: record.ad_id });
+    }
+  } catch (error) {
+    const rollback = await compensateStaged(staged.jobs, context);
+    const normalized = normalizeFailure(error);
+    normalized.compensation = rollback;
+    normalized.ambiguous = normalized.ambiguous || rollback.reconciliation_required;
+    throw Object.assign(new Error(normalized.message || 'activate_batch_failed'), normalized);
+  }
+  await setRunState(context.env, context.runId, 'meta_completed_drive_pending', {
+    jobs: activated.map(stripJobForSummary),
+  });
+  return { status: 'meta_completed_drive_pending', job_count: activated.length, jobs: activated };
+}
+
+async function rollbackBatch(body, context) {
+  const staged = await loadStagedOperation(body.stage_operation_key, context);
+  const rollback = await compensateStaged(staged.jobs, context);
+  const status = rollback.reconciliation_required ? 'reconciliation_required' : 'rolled_back';
+  await setRunState(context.env, context.runId, status, rollback);
+  if (rollback.reconciliation_required) {
+    throw failure('rollback_reconciliation_required', {
+      classification: 'ambiguous',
+      ambiguous: true,
+      http_status: 502,
+      compensation: rollback,
+    });
+  }
+  return { status, ...rollback };
+}
+
+async function loadStagedOperation(operationKey, context) {
+  const key = requireKey(operationKey, 'stage_operation_key');
+  const row = await dbFirst(context.env,
+    `SELECT result_json, status, action FROM meta_ads_publish_operations
+      WHERE run_id = ? AND operation_key = ?`,
+    context.runId, key,
+  );
+  if (!row || clean(row.status) !== 'completed' || clean(row.action) !== 'stage_batch') {
+    throw failure('staged_operation_not_found', { classification: 'permanent', http_status: 409 });
+  }
+  const result = parseObject(row.result_json);
+  if (!safeArray(result.jobs).length) throw failure('staged_jobs_missing', { classification: 'permanent', http_status: 409 });
+  return result;
+}
+
+async function compensateStaged(records, context) {
+  const results = [];
+  let reconciliationRequired = false;
+  for (const record of [...records].reverse()) {
+    try {
+      const auth = await resolveGraphAuth(record, context);
+      if (record.created_new) {
+        await updateAdWithReconciliation(auth, record.ad_id, { status: 'PAUSED' }, context);
+        results.push({ ad_id: record.ad_id, action: 'pause_created', ok: true });
+      } else {
+        const payload = previousStatePayload(record.previous_state);
+        await updateAdWithReconciliation(auth, record.ad_id, payload, context);
+        results.push({ ad_id: record.ad_id, action: 'restore_existing', ok: true });
+      }
+      await updateJobStatus(context.env, record.operation_key, 'rolled_back', { ad_id: record.ad_id });
+    } catch (error) {
+      reconciliationRequired = true;
+      const normalized = normalizeFailure(error);
+      results.push({
+        ad_id: record.ad_id,
+        action: record.created_new ? 'pause_created' : 'restore_existing',
+        ok: false,
+        error: normalized,
+      });
+      await updateJobStatus(context.env, record.operation_key, 'reconciliation_required', normalized);
+    }
+  }
+  return { reconciliation_required: reconciliationRequired, results };
+}
+
+async function resolveGraphAuth(body, context) {
+  const tokenId = clean(body.token_id);
+  if (!tokenId) throw failure('token_id_required', { classification: 'permanent', http_status: 400 });
+  const row = await dbFirst(context.env,
+    `SELECT id, provider, active, token_ciphertext, metadata_json
+       FROM credential_tokens WHERE id = ?`,
+    tokenId,
+  );
+  if (!row || row.provider !== 'facebook' || Number(row.active) !== 1) {
+    throw failure('facebook_token_not_available', { classification: 'auth', http_status: 401 });
+  }
+  const metadata = parseObject(row.metadata_json);
+  const config = asObject(metadata.meta_ads_publish);
+  const accountId = normalizeNumericId(body.account_id || config.account_id, 'account_id');
+  const configuredAccount = normalizeNumericId(config.account_id, 'configured_account_id');
+  if (accountId !== configuredAccount) {
+    throw failure('account_not_authorized_for_token', { classification: 'auth', http_status: 403 });
+  }
+  const apiVersion = normalizeApiVersion(body.api_version || config.api_version || 'v25.0');
+  const accessToken = await context.decryptToken(row.token_ciphertext, context.env);
+  const appSecretProof = clean(context.env.META_APP_SECRET)
+    ? await hmacSha256(clean(context.env.META_APP_SECRET), accessToken)
+    : '';
+  return { tokenId, accountId, apiVersion, accessToken, appSecretProof };
+}
+
+async function graphRequest(url, init, auth, context) {
+  let lastFailure;
+  const started = Date.now();
+  for (let attempt = 1; attempt <= MAX_GRAPH_ATTEMPTS; attempt += 1) {
+    context.attempts += 1;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), GRAPH_TIMEOUT_MS);
+    try {
+      const target = appendAppSecretProof(url, auth.appSecretProof);
+      const headers = new Headers(init.headers || {});
+      headers.set('Authorization', `Bearer ${auth.accessToken}`);
+      const graphFetch = context.env.META_GRAPH_FETCH || fetch;
+      const graphResponse = await graphFetch(target, { ...init, headers, signal: controller.signal });
+      const body = await parseGraphBody(graphResponse);
+      const rateUsage = extractRateUsage(graphResponse.headers);
+      context.rateUsage = mergeRateUsage(context.rateUsage, rateUsage);
+      context.traceId = clean(body?.error?.fbtrace_id || context.traceId);
+      const maxUsage = maxRateUsage(rateUsage);
+      if (maxUsage >= 95 && graphResponse.ok) {
+        context.rateUsage.pause_recommended = true;
+      } else if (maxUsage >= 80) {
+        context.rateUsage.warning = true;
+      }
+      if (graphResponse.ok && !body?.error) return { body, status: graphResponse.status, headers: graphResponse.headers };
+
+      const normalized = normalizeMetaError(body, graphResponse.status, graphResponse.headers, context.action);
+      lastFailure = normalized;
+      if (!normalized.retryable || attempt === MAX_GRAPH_ATTEMPTS) throw Object.assign(new Error(normalized.message), normalized);
+      const delay = retryDelayMs(attempt, graphResponse.headers, started, normalized);
+      if (delay <= 0) throw Object.assign(new Error(normalized.message), normalized);
+      await (context.env.META_GRAPH_SLEEP || sleep)(delay);
+    } catch (error) {
+      const normalized = normalizeFailure(error);
+      lastFailure = normalized;
+      if (!normalized.retryable || attempt === MAX_GRAPH_ATTEMPTS) throw Object.assign(new Error(normalized.message), normalized);
+      const delay = retryDelayMs(attempt, null, started);
+      if (delay <= 0) throw Object.assign(new Error(normalized.message), normalized);
+      await (context.env.META_GRAPH_SLEEP || sleep)(delay);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+  throw Object.assign(new Error(lastFailure?.message || 'meta_graph_failed'), lastFailure || {});
+}
+
+async function readAd(auth, adId, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, adId, { fields: AD_STATE_FIELDS }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  return sanitizeGraphValue(result.body);
+}
+
+async function updateAdWithReconciliation(auth, adId, payload, context) {
+  try {
+    const result = await graphRequest(graphUrl(auth.apiVersion, adId), jsonRequest('POST', payload), auth, context);
+    return sanitizeGraphValue(result.body);
+  } catch (error) {
+    if (!normalizeFailure(error).ambiguous) throw error;
+    const current = await readAd(auth, adId, context);
+    if (adStateMatches(current, payload)) return { success: true, id: adId, reconciled_after_ambiguous_response: true };
+    throw error;
+  }
+}
+
+async function createAdWithReconciliation(auth, payload, context) {
+  try {
+    const result = await graphRequest(
+      graphUrl(auth.apiVersion, `act_${auth.accountId}/ads`),
+      jsonRequest('POST', payload),
+      auth,
+      context,
+    );
+    return sanitizeGraphValue(result.body);
+  } catch (error) {
+    if (!normalizeFailure(error).ambiguous) throw error;
+    const found = await findAdByPayload(auth, payload, context);
+    if (found) return { id: found.id, success: true, reconciled_after_ambiguous_response: true };
+    throw error;
+  }
+}
+
+async function findCreativeByOperationName(auth, name, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, `act_${auth.accountId}/adcreatives`, { fields: 'id,name', limit: '100' }),
+    { method: 'GET' }, auth, context,
+  );
+  const matches = safeArray(result.body.data).filter((entry) => clean(entry.name) === clean(name));
+  return matches.length === 1 ? sanitizeGraphValue(matches[0]) : null;
+}
+
+async function findAdByPayload(auth, payload, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, `act_${auth.accountId}/ads`, { fields: AD_STATE_FIELDS, limit: '100' }),
+    { method: 'GET' }, auth, context,
+  );
+  const creativeId = clean(payload?.creative?.creative_id);
+  const matches = safeArray(result.body.data).filter((entry) => (
+    clean(entry.name) === clean(payload.name)
+    && clean(entry.adset_id) === clean(payload.adset_id)
+    && clean(entry.creative?.id) === creativeId
+  ));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function validateCreativePayload(value, operationKey) {
+  const payload = sanitizeGraphValue(asObject(value));
+  const hasStory = Object.keys(asObject(payload.object_story_spec)).length > 0;
+  const hasFeed = Object.keys(asObject(payload.asset_feed_spec)).length > 0;
+  if (!hasStory) {
+    throw failure('flexible_creative_required', { classification: 'permanent', http_status: 400 });
+  }
+  if (hasFeed) return validateFlexibleCreativePayload(payload, operationKey);
+  return validateNativeCarouselCreativePayload(payload, operationKey);
+}
+
+function validateFlexibleCreativePayload(payload, operationKey) {
+  const feed = asObject(payload.asset_feed_spec);
+  const images = safeArray(feed.images);
+  const videos = safeArray(feed.videos);
+  const videoOnly = images.length === 0 && videos.length === 1;
+  const mixed = images.length >= 3 && videos.length === 1;
+  const staticOnly = images.length >= 3 && videos.length === 0;
+  if ((!videoOnly && !mixed && !staticOnly) || safeArray(feed.bodies).length !== 5 || safeArray(feed.titles).length !== 5) {
+    throw failure('creative_quality_gate_failed', { classification: 'permanent', http_status: 400 });
+  }
+  if (safeArray(feed.descriptions).length !== 5) {
+    throw failure('creative_description_count_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const formats = safeArray(feed.ad_formats).map((entry) => clean(entry)).filter(Boolean);
+  const requiredFormat = videoOnly ? 'SINGLE_VIDEO' : mixed ? 'AUTOMATIC_FORMAT' : 'SINGLE_IMAGE';
+  if (formats.length !== 1 || formats[0] !== requiredFormat) {
+    throw failure(videoOnly ? 'video_only_feed_requires_single_video_format' : mixed ? 'mixed_video_feed_requires_automatic_format' : 'static_feed_requires_single_image_format');
+  }
+  if (videos.length > 1) throw failure('creative_video_count_invalid', { classification: 'permanent', http_status: 400 });
+  if (videos.length === 1) {
+    const video = asObject(videos[0]);
+    normalizeNumericId(video.video_id, 'video_id');
+    if (!/^[A-Za-z0-9_-]{16,200}$/.test(clean(video.thumbnail_hash))) throw failure('video_thumbnail_hash_invalid');
+    const labels = safeArray(video.adlabels).map((label) => clean(label?.name)).filter(Boolean);
+    if (labels.length !== 1 || labels[0] !== 'vertical_video') throw failure('video_label_invalid');
+  }
+  if (payload.video_id || asObject(payload.object_story_spec).video_id) throw failure('root_video_id_forbidden');
+
+  const mediaLabels = new Set(images.flatMap((asset) => safeArray(asset?.adlabels).map((label) => clean(label?.name))).filter(Boolean));
+  const videoLabels = new Set(videos.flatMap((asset) => safeArray(asset?.adlabels).map((label) => clean(label?.name))).filter(Boolean));
+  const bodyLabels = new Set(safeArray(feed.bodies).flatMap((asset) => safeArray(asset?.adlabels).map((label) => clean(label?.name))).filter(Boolean));
+  const titleLabels = new Set(safeArray(feed.titles).flatMap((asset) => safeArray(asset?.adlabels).map((label) => clean(label?.name))).filter(Boolean));
+  const descriptionLabels = new Set(safeArray(feed.descriptions).flatMap((asset) => safeArray(asset?.adlabels).map((label) => clean(label?.name))).filter(Boolean));
+  const rules = safeArray(feed.asset_customization_rules);
+  if (!rules.length) throw failure('creative_customization_rules_required');
+  const claimedPlacements = new Set();
+  let videoRuleCount = 0;
+  for (const [index, rule] of rules.entries()) {
+    const imageLabel = clean(rule?.image_label?.name);
+    const videoLabel = clean(rule?.video_label?.name);
+    const bodyLabel = clean(rule?.body_label?.name);
+    const titleLabel = clean(rule?.title_label?.name);
+    const descriptionLabel = clean(rule?.description_label?.name);
+    if (!imageLabel && !videoLabel) throw failure(`creative_rule_media_label_missing:${index}`);
+    if (imageLabel && !mediaLabels.has(imageLabel)) throw failure(`creative_rule_image_label_invalid:${index}`);
+    if (videoLabel && !videoLabels.has(videoLabel)) throw failure(`creative_rule_video_label_invalid:${index}`);
+    if (imageLabel && videoLabel) throw failure(`creative_rule_multiple_media_labels:${index}`);
+    if (!bodyLabels.has(bodyLabel) || !titleLabels.has(titleLabel) || !descriptionLabels.has(descriptionLabel)) {
+      throw failure(`creative_rule_text_label_invalid:${index}`);
+    }
+    if (videoLabel) videoRuleCount += 1;
+    const spec = asObject(rule?.customization_spec);
+    for (const publisher of safeArray(spec.publisher_platforms).map(clean).filter(Boolean)) {
+      const positions = publisher === 'facebook' ? safeArray(spec.facebook_positions)
+        : publisher === 'instagram' ? safeArray(spec.instagram_positions)
+          : publisher === 'audience_network' ? safeArray(spec.audience_network_positions)
+            : publisher === 'whatsapp' ? safeArray(spec.whatsapp_positions) : [];
+      for (const position of positions) {
+        const claim = `${publisher}:${clean(position)}`;
+        if (claimedPlacements.has(claim)) throw failure(`creative_rule_overlap:${index}`);
+        claimedPlacements.add(claim);
+      }
+    }
+  }
+  if (videoOnly && videoRuleCount !== 2) throw failure('creative_video_only_rule_invalid');
+  if (mixed && videoRuleCount !== 1) throw failure('creative_mixed_video_rule_invalid');
+  const ctas = safeArray(feed.call_to_action_types).map((entry) => clean(entry).toUpperCase());
+  if (ctas.length !== 1 || !['BOOK_NOW', 'LEARN_MORE', 'WHATSAPP_MESSAGE'].includes(ctas[0])) {
+    throw failure('creative_cta_type_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const primaryUrl = clean(safeArray(feed.link_urls)[0]?.website_url);
+  const sourceUrl = clean(asObject(payload.creative_sourcing_spec).source_url);
+  let primaryParsed;
+  try { primaryParsed = new URL(primaryUrl); } catch { primaryParsed = null; }
+  const isWhatsAppDestination = Boolean(primaryParsed && primaryParsed.protocol === 'https:' && isWhatsAppHostname(primaryParsed.hostname));
+  const isWebsiteDestination = Boolean(primaryParsed && primaryParsed.protocol === 'https:' && !isWhatsAppDestination && primaryUrl === sourceUrl);
+  if ((ctas[0] === 'WHATSAPP_MESSAGE' && !isWhatsAppDestination) ||
+      (ctas[0] !== 'WHATSAPP_MESSAGE' && !isWebsiteDestination)) {
+    throw failure('creative_landing_page_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const freedom = asObject(payload.degrees_of_freedom_spec);
+  if (Object.prototype.hasOwnProperty.call(freedom, 'standard_enhancements')) {
+    throw failure('standard_enhancements_forbidden', { classification: 'permanent', http_status: 400 });
+  }
+  const features = asObject(freedom.creative_features_spec);
+  for (const [feature, details] of Object.entries(features)) {
+    if (!ALLOWED_CREATIVE_FEATURES.has(feature) || FORBIDDEN_CREATIVE_FEATURES.has(feature)) {
+      throw failure(`creative_feature_forbidden:${feature}`, { classification: 'permanent', http_status: 400 });
+    }
+    if (clean(details && details.enroll_status).toUpperCase() !== 'OPT_IN') {
+      throw failure(`creative_feature_not_opted_in:${feature}`, { classification: 'permanent', http_status: 400 });
+    }
+  }
+  for (const feature of REQUIRED_CREATIVE_FEATURES) {
+    if (!Object.prototype.hasOwnProperty.call(features, feature)) {
+      throw failure(`creative_feature_required:${feature}`, { classification: 'permanent', http_status: 400 });
+    }
+  }
+  const siteLinks = safeArray(asObject(payload.creative_sourcing_spec).site_links_spec);
+  if (Boolean(features.site_extensions) !== (siteLinks.length >= 2 && siteLinks.length <= 4)) {
+    throw failure('creative_site_extensions_mismatch', { classification: 'permanent', http_status: 400 });
+  }
+  const marker = `[sk:${shortKey(operationKey)}]`;
+  const name = clean(payload.name) || 'Meta Ads Publish Creative';
+  payload.name = name.includes(marker) ? name : `${name} ${marker}`.slice(0, 255);
+  delete payload.access_token;
+  return payload;
+}
+
+function validateNativeCarouselCreativePayload(payload, operationKey) {
+  const story = asObject(payload.object_story_spec);
+  const linkData = asObject(story.link_data);
+  const cards = safeArray(linkData.child_attachments);
+  if (!clean(story.page_id) || cards.length < 2 || cards.length > 10) {
+    throw failure('native_carousel_contract_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const sourceUrl = clean(asObject(payload.creative_sourcing_spec).source_url);
+  const rootLink = clean(linkData.link);
+  let parsed;
+  try { parsed = new URL(rootLink); } catch { parsed = null; }
+  const rootCta = asObject(linkData.call_to_action);
+  const ctaType = clean(rootCta.type).toUpperCase();
+  const isWhatsApp = Boolean(parsed && isWhatsAppHostname(parsed.hostname));
+  const isWebsiteBooking = Boolean(parsed && parsed.protocol === 'https:' && !isWhatsApp && rootLink === sourceUrl);
+  if (!parsed || !(ctaType === 'WHATSAPP_MESSAGE' && isWhatsApp) && !(ctaType === 'BOOK_NOW' && isWebsiteBooking)) {
+    throw failure('native_carousel_landing_page_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  if (!['BOOK_NOW', 'WHATSAPP_MESSAGE'].includes(ctaType)) {
+    throw failure('native_carousel_cta_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  for (const [index, rawCard] of cards.entries()) {
+    const card = asObject(rawCard);
+    const cardLink = clean(card.link || rootLink);
+    if (!clean(card.image_hash) || !clean(card.name) || cardLink !== rootLink) {
+      throw failure(`native_carousel_card_${index + 1}_invalid`, { classification: 'permanent', http_status: 400 });
+    }
+    const cardCta = asObject(card.call_to_action);
+    if (Object.keys(cardCta).length && clean(cardCta.type).toUpperCase() !== ctaType) {
+      throw failure(`native_carousel_card_${index + 1}_cta_invalid`, { classification: 'permanent', http_status: 400 });
+    }
+  }
+  if (Object.keys(asObject(payload.degrees_of_freedom_spec)).length) {
+    throw failure('native_carousel_advantage_plus_unsupported', { classification: 'permanent', http_status: 400 });
+  }
+  const marker = `[sk:${shortKey(operationKey)}]`;
+  const name = clean(payload.name) || 'Meta Ads Publish Native Carousel';
+  payload.name = name.includes(marker) ? name : `${name} ${marker}`.slice(0, 255);
+  delete payload.access_token;
+  return payload;
+}
+
+function validatePausedAdsetPayload(value) {
+  const source = asObject(value);
+  const allowed = new Set([
+    'name', 'campaign_id', 'billing_event', 'optimization_goal', 'destination_type', 'bid_strategy',
+    'daily_budget', 'lifetime_budget', 'start_time', 'end_time', 'attribution_spec',
+    'promoted_object', 'targeting', 'status',
+  ]);
+  for (const key of Object.keys(source)) {
+    if (!allowed.has(key)) throw failure(`adset_field_forbidden:${key}`, { classification: 'permanent', http_status: 400 });
+  }
+  const payload = sanitizeGraphValue(source);
+  if (!clean(payload.name) || !clean(payload.campaign_id) || !Object.keys(asObject(payload.targeting)).length) {
+    throw failure('adset_payload_incomplete', { classification: 'permanent', http_status: 400 });
+  }
+  if (clean(payload.status).toUpperCase() !== 'PAUSED') {
+    throw failure('adset_must_be_paused', { classification: 'permanent', http_status: 400 });
+  }
+  if (!clean(payload.billing_event) || !clean(payload.optimization_goal)) {
+    throw failure('adset_delivery_contract_missing', { classification: 'permanent', http_status: 400 });
+  }
+  delete payload.access_token;
+  return payload;
+}
+
+function validatePausedCampaignPayload(value) {
+  const source = asObject(value);
+  const allowed = new Set(['name', 'objective', 'buying_type', 'special_ad_categories', 'is_adset_budget_sharing_enabled', 'status']);
+  for (const key of Object.keys(source)) {
+    if (!allowed.has(key)) throw failure(`campaign_field_forbidden:${key}`, { classification: 'permanent', http_status: 400 });
+  }
+  const payload = sanitizeGraphValue(source);
+  if (!clean(payload.name) || !PAUSED_CALIBRATION_CAMPAIGN_OBJECTIVES.has(clean(payload.objective))) {
+    throw failure('campaign_payload_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  if (clean(payload.status).toUpperCase() !== 'PAUSED') {
+    throw failure('campaign_must_be_paused', { classification: 'permanent', http_status: 400 });
+  }
+  payload.buying_type = clean(payload.buying_type) || 'AUCTION';
+  payload.special_ad_categories = safeArray(payload.special_ad_categories);
+  payload.is_adset_budget_sharing_enabled = Boolean(payload.is_adset_budget_sharing_enabled);
+  delete payload.access_token;
+  return payload;
+}
+
+function isNativeCarouselRouteName(value) {
+  const name = clean(value);
+  return name.startsWith('[TEST-CAROUSEL-NATIVE]') || name.startsWith('[NATIVE-CAROUSEL]');
+}
+
+function validateNativeCarouselRoutePromotion(value) {
+  const source = asObject(value);
+  const allowed = new Set(['campaign_id', 'campaign_name', 'adsets', 'test_ad_ids']);
+  for (const key of Object.keys(source)) {
+    if (!allowed.has(key)) throw failure(`native_carousel_route_field_forbidden:${key}`, { classification: 'permanent', http_status: 400 });
+  }
+  const campaignId = normalizeNumericId(source.campaign_id, 'campaign_id');
+  const campaignName = clean(source.campaign_name);
+  if (!campaignName.startsWith('[NATIVE-CAROUSEL]')) {
+    throw failure('native_carousel_campaign_name_required', { classification: 'permanent', http_status: 400 });
+  }
+  const adsets = safeArray(source.adsets).map((entry, index) => {
+    const adset = asObject(entry);
+    const id = normalizeNumericId(adset.id, `adsets[${index}].id`);
+    const name = clean(adset.name);
+    if (!name.startsWith('[NATIVE-CAROUSEL]')) {
+      throw failure(`native_carousel_adset_name_required:${index}`, { classification: 'permanent', http_status: 400 });
+    }
+    return { id, name };
+  });
+  if (!adsets.length || adsets.length > 10) {
+    throw failure('native_carousel_adset_count_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const testAdIds = [...new Set(safeArray(source.test_ad_ids).map((id) => normalizeNumericId(id, 'test_ad_id')))];
+  if (!testAdIds.length || testAdIds.length > 20) {
+    throw failure('native_carousel_test_ad_count_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  return { campaign_id: campaignId, campaign_name: campaignName, adsets, test_ad_ids: testAdIds };
+}
+
+function validateAdPayload(value, action) {
+  const payload = sanitizeGraphValue(asObject(value));
+  if (!clean(payload.name) || !clean(payload?.creative?.creative_id)) {
+    throw failure('ad_payload_incomplete', { classification: 'permanent', http_status: 400 });
+  }
+  if (action === 'create_new' && !clean(payload.adset_id)) {
+    throw failure('adset_id_required_for_create', { classification: 'permanent', http_status: 400 });
+  }
+  delete payload.access_token;
+  return payload;
+}
+
+function validateBatchJobs(value) {
+  const jobs = safeArray(value);
+  if (!jobs.length || jobs.length > MAX_BATCH_JOBS) {
+    throw failure('batch_job_count_invalid', { classification: 'permanent', http_status: 400 });
+  }
+  const targets = new Set();
+  return jobs.map((raw, index) => {
+    const job = asObject(raw);
+    const action = clean(job.action);
+    if (!['create_new', 'replace_existing'].includes(action)) {
+      throw failure(`job_${index}_action_invalid`, { classification: 'permanent', http_status: 400 });
+    }
+    const operationKey = requireKey(job.operation_key, `jobs[${index}].operation_key`);
+    const resourceKey = action === 'replace_existing'
+      ? `ad:${normalizeNumericId(job.target_ad_id, 'target_ad_id')}`
+      : `adset:${normalizeNumericId(job.ad_payload?.adset_id, 'adset_id')}:name:${shortKey(clean(job.ad_payload?.name))}`;
+    if (targets.has(resourceKey)) {
+      throw failure(`duplicate_batch_target:${resourceKey}`, { classification: 'permanent', http_status: 409 });
+    }
+    targets.add(resourceKey);
+    return {
+      ...sanitizeGraphValue(job),
+      action,
+      operation_key: operationKey,
+      resource_key: resourceKey,
+      destination_group: clean(job.destination_group),
+      creative_group_key: clean(job.creative_group_key),
+    };
+  });
+}
+
+function buildStagedRecord(job, adId, previousState, result, createdNew) {
+  return {
+    operation_key: job.operation_key,
+    token_id: job.token_id,
+    api_version: job.api_version,
+    account_id: job.account_id,
+    destination_group: job.destination_group,
+    creative_group_key: job.creative_group_key,
+    creative_id: clean(job.creative_id || job.ad_payload?.creative?.creative_id),
+    action: job.action,
+    resource_key: job.resource_key,
+    ad_id: adId,
+    created_new: createdNew,
+    files: safeArray(job.files).map((file) => ({
+      id: clean(file && file.id),
+      name: clean(file && file.name),
+      ratio: clean(file && file.ratio),
+    })).filter((file) => file.id),
+    previous_state: sanitizeGraphValue(previousState),
+    stage_result: sanitizeGraphValue(result),
+  };
+}
+
+function previousStatePayload(previous) {
+  const state = asObject(previous);
+  const payload = {
+    name: clean(state.name),
+    status: clean(state.status),
+    creative: clean(state.creative?.id) ? { creative_id: clean(state.creative.id) } : undefined,
+    adset_id: clean(state.adset_id) || undefined,
+  };
+  return removeEmpty(payload);
+}
+
+function adStateMatches(current, intended) {
+  const state = asObject(current);
+  const payload = asObject(intended);
+  if (payload.name && clean(state.name) !== clean(payload.name)) return false;
+  if (payload.status && clean(state.status) !== clean(payload.status)) return false;
+  if (payload.adset_id && clean(state.adset_id) !== clean(payload.adset_id)) return false;
+  if (payload.creative?.creative_id && clean(state.creative?.id) !== clean(payload.creative.creative_id)) return false;
+  return true;
+}
+
+async function upsertJob(env, runId, record, status) {
+  const now = nowIso();
+  const requestHash = await sha256(stableStringify(record));
+  await dbRun(env,
+    `INSERT INTO meta_ads_publish_jobs (
+      id, run_id, operation_key, request_hash, destination_group, creative_group_key,
+      action, resource_key, status, previous_state_json, result_json, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(operation_key) DO UPDATE SET
+      status = excluded.status,
+      previous_state_json = excluded.previous_state_json,
+      result_json = excluded.result_json,
+      updated_at = excluded.updated_at`,
+    crypto.randomUUID(), runId, record.operation_key, requestHash,
+    record.destination_group, record.creative_group_key, record.action, record.resource_key,
+    status, limitedJson(record.previous_state), limitedJson(record), now, now,
+  );
+}
+
+async function updateJobStatus(env, operationKey, status, result) {
+  await dbRun(env,
+    `UPDATE meta_ads_publish_jobs SET status = ?, result_json = ?, updated_at = ? WHERE operation_key = ?`,
+    status, limitedJson(result), nowIso(), operationKey,
+  );
+}
+
+async function setRunState(env, runId, status, summary) {
+  await dbRun(env,
+    `UPDATE meta_ads_publish_runs SET status = ?, summary_json = ?, updated_at = ? WHERE id = ?`,
+    status, limitedJson(summary), nowIso(), runId,
+  );
+}
+
+async function acquireLocks(env, runId, operationKey, resourceKeys) {
+  const keys = [...new Set(safeArray(resourceKeys).map(clean).filter(Boolean))].sort();
+  const now = nowIso();
+  const expiresAt = new Date(Date.now() + LOCK_TTL_MS).toISOString();
+  for (const resourceKey of keys) {
+    const current = await dbFirst(env,
+      `SELECT resource_key, run_id, operation_key, expires_at FROM meta_ads_publish_locks WHERE resource_key = ?`,
+      resourceKey,
+    );
+    if (current && clean(current.run_id) !== runId && Date.parse(current.expires_at) > Date.now()) {
+      throw new Error(`resource_locked:${resourceKey}`);
+    }
+    await dbRun(env,
+      `INSERT INTO meta_ads_publish_locks (
+        resource_key, run_id, operation_key, heartbeat_at, expires_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(resource_key) DO UPDATE SET
+        run_id = excluded.run_id,
+        operation_key = excluded.operation_key,
+        heartbeat_at = excluded.heartbeat_at,
+        expires_at = excluded.expires_at,
+        updated_at = excluded.updated_at
+      WHERE meta_ads_publish_locks.expires_at <= ? OR meta_ads_publish_locks.run_id = ?`,
+      resourceKey, runId, operationKey, now, expiresAt, now, now, now, runId,
+    );
+    const acquired = await dbFirst(env,
+      `SELECT run_id, operation_key FROM meta_ads_publish_locks WHERE resource_key = ?`,
+      resourceKey,
+    );
+    if (!acquired || clean(acquired.run_id) !== runId) throw new Error(`resource_locked:${resourceKey}`);
+  }
+}
+
+async function releaseOperationLocks(env, runId, operationKey) {
+  await dbRun(env,
+    `DELETE FROM meta_ads_publish_locks
+      WHERE run_id = ? AND operation_key = ? AND resource_key NOT LIKE 'batch:%' AND resource_key NOT LIKE 'drive:%'`,
+    runId, operationKey,
+  );
+}
+
+async function releaseRunLocks(env, runId) {
+  await dbRun(env, `DELETE FROM meta_ads_publish_locks WHERE run_id = ?`, runId);
+}
+
+function deriveResourceKeys(action, body) {
+  if (action === 'stage_batch') {
+    return validateBatchJobs(body.jobs).map((job) => job.resource_key);
+  }
+  if (['activate_batch', 'rollback_batch'].includes(action)) return [`run:${clean(body.stage_operation_key)}`];
+  if (action === 'create_creative') return [`creative:${clean(body.account_id)}:${shortKey(body.operation_key)}`];
+  if (action === 'create_campaign') return [`campaign:${clean(body.account_id)}:${shortKey(body.operation_key)}`];
+  if (action === 'create_adset') return [`adset:${clean(body.account_id)}:${shortKey(body.operation_key)}`];
+  if (action === 'upload_image') return [`image:${clean(body.account_id)}:${shortKey(body.operation_key)}`];
+  if (VIDEO_UPLOAD_ACTIONS.includes(action)) {
+    const videoKey = clean(body.video_id || body.object_id || body.upload_session_id || body.source_file_id || body.operation_key);
+    return [`video:${clean(body.account_id)}:${shortKey(videoKey)}`];
+  }
+  return [];
+}
+
+function normalizeMetaError(body, status, headers, action = '') {
+  const error = asObject(body?.error);
+  const code = Number(error.code || 0);
+  const subcode = Number(error.error_subcode || 0);
+  // Meta can acknowledge an ad-image upload before that hash is available to
+  // the adcreative endpoint. It reports this propagation window as code 100,
+  // subcode 2446386 (normally classified as permanent), although retrying the
+  // same idempotent creative request after a short delay succeeds.
+  const propagationRetry = clean(action) === 'create_creative' && code === 100 && subcode === IMAGE_PROPAGATION_SUBCODE;
+  // Meta occasionally returns this generic creative-construction subcode while
+  // explicitly asking the caller to retry. It is safe to retry the same
+  // idempotent operation a bounded number of times; do not generalize this to
+  // other code-100 validation failures.
+  const creativeRetry = clean(action) === 'create_creative' &&
+    code === 100 &&
+    subcode === CREATIVE_RETRY_SUBCODE &&
+    /try again later|tente novamente mais tarde/i.test(clean(error.error_user_msg || error.message));
+  const transient = propagationRetry || creativeRetry || error.is_transient === true || status === 408 || status === 429 || status >= 500;
+  const auth = [190, 102, 10, 200].includes(code) || status === 401 || status === 403;
+  const permanent = auth || (!(propagationRetry || creativeRetry) && code === 100) || (!transient && status >= 400 && status < 500);
+  return {
+    message: redactText(error.error_user_msg || error.message || `Meta Graph HTTP ${status}`),
+    classification: auth ? 'auth' : permanent ? 'permanent' : transient ? 'transient' : 'unknown',
+    retryable: transient && !permanent,
+    propagation_retry: propagationRetry,
+    creative_retry: creativeRetry,
+    ambiguous: false,
+    http_status: status,
+    code,
+    error_subcode: subcode,
+    fbtrace_id: clean(error.fbtrace_id),
+    retry_after_seconds: retryAfterSeconds(headers),
+  };
+}
+
+function normalizeFailure(error) {
+  if (error && typeof error === 'object' && error.classification) {
+    return {
+      message: redactText(error.message || 'meta_operation_failed'),
+      classification: clean(error.classification),
+      retryable: Boolean(error.retryable),
+      ambiguous: Boolean(error.ambiguous),
+      http_status: Number(error.http_status || 502),
+      code: Number(error.code || 0),
+      error_subcode: Number(error.error_subcode || 0),
+      fbtrace_id: clean(error.fbtrace_id),
+      compensation: error.compensation,
+    };
+  }
+  const name = clean(error?.name);
+  const aborted = name === 'AbortError';
+  return {
+    message: aborted ? 'meta_graph_timeout' : redactText(error?.message || 'meta_graph_network_error'),
+    classification: 'transient',
+    retryable: true,
+    ambiguous: true,
+    http_status: 502,
+    code: 0,
+    error_subcode: 0,
+    fbtrace_id: '',
+  };
+}
+
+function failure(message, extra = {}) {
+  return Object.assign(new Error(message), {
+    classification: 'permanent', retryable: false, ambiguous: false, http_status: 400, ...extra,
+  });
+}
+
+function retryDelayMs(attempt, headers, startedAt, failureState = {}) {
+  const elapsed = Date.now() - startedAt;
+  const remaining = MAX_RETRY_WINDOW_MS - elapsed;
+  if (remaining <= 0) return 0;
+  const retryAfter = retryAfterSeconds(headers) * 1000;
+  const propagationBackoff = failureState.propagation_retry === true
+    ? Math.min(60_000, IMAGE_PROPAGATION_BASE_DELAY_MS * (2 ** (attempt - 1)))
+    : 0;
+  const backoff = propagationBackoff || Math.min(30_000, (2 ** (attempt - 1)) * 1000 + Math.floor(Math.random() * 500));
+  return Math.min(remaining, retryAfter || backoff);
+}
+
+function retryAfterSeconds(headers) {
+  const value = Number(headers?.get?.('retry-after') || 0);
+  return Number.isFinite(value) && value > 0 ? Math.min(value, 300) : 0;
+}
+
+function extractRateUsage(headers) {
+  const out = {};
+  for (const name of ['x-business-use-case-usage', 'x-ad-account-usage', 'x-app-usage']) {
+    const raw = clean(headers?.get?.(name));
+    if (!raw) continue;
+    try { out[name] = JSON.parse(raw); } catch { out[name] = { unparsed: true }; }
+  }
+  return out;
+}
+
+function maxRateUsage(value) {
+  let max = 0;
+  if (Array.isArray(value)) {
+    for (const item of value) max = Math.max(max, maxRateUsage(item));
+  } else if (value && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      if (['call_count', 'total_cputime', 'total_time'].includes(key) && Number.isFinite(Number(item))) {
+        max = Math.max(max, Number(item));
+      } else {
+        max = Math.max(max, maxRateUsage(item));
+      }
+    }
+  }
+  return max;
+}
+
+function mergeRateUsage(left, right) {
+  return { ...asObject(left), ...asObject(right) };
+}
+
+function graphUrl(apiVersion, path, query = {}) {
+  const version = normalizeApiVersion(apiVersion);
+  const cleanPath = clean(path).replace(/^\/+/, '');
+  if (!cleanPath || /[^A-Za-z0-9_/-]/.test(cleanPath)) throw failure('invalid_graph_path');
+  const url = new URL(`${GRAPH_ORIGIN}/${version}/${cleanPath}`);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== '') url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+function graphVideoUrl(apiVersion, path) {
+  const version = normalizeApiVersion(apiVersion);
+  const cleanPath = clean(path).replace(/^\/+/, '');
+  if (!cleanPath || /[^A-Za-z0-9_/-]/.test(cleanPath)) throw failure('invalid_graph_video_path');
+  return `${GRAPH_VIDEO_ORIGIN}/${version}/${cleanPath}`;
+}
+
+function validatePagingUrl(value, apiVersion) {
+  const raw = clean(value);
+  if (!raw) return '';
+  const url = new URL(raw);
+  if (url.origin !== GRAPH_ORIGIN || !url.pathname.startsWith(`/${normalizeApiVersion(apiVersion)}/`)) {
+    throw failure('invalid_meta_paging_url', { classification: 'permanent', http_status: 502 });
+  }
+  url.searchParams.delete('access_token');
+  return url.toString();
+}
+
+function appendAppSecretProof(value, proof) {
+  if (!proof) return value;
+  const url = new URL(value);
+  url.searchParams.set('appsecret_proof', proof);
+  return url.toString();
+}
+
+function jsonRequest(method, body) {
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(removeEmpty(sanitizeGraphValue(body))),
+  };
+}
+
+async function parseGraphBody(graphResponse) {
+  const text = await graphResponse.text();
+  if (!text) return {};
+  try { return JSON.parse(text); } catch { return { raw_response: redactText(text.slice(0, 1000)) }; }
+}
+
+function normalizeApiVersion(value) {
+  const version = clean(value || 'v25.0');
+  if (!/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(version)) throw failure('unsupported_api_version');
+  return version;
+}
+
+function normalizeNumericId(value, label) {
+  const id = clean(value).replace(/^act_/, '');
+  if (!/^\d{5,30}$/.test(id)) throw failure(`${label}_invalid`);
+  return id;
+}
+
+function normalizeVideoFileSize(value) {
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size <= 0 || size > MAX_VIDEO_BYTES) {
+    throw failure('video_size_invalid', { classification: 'permanent', http_status: 413 });
+  }
+  return size;
+}
+
+function normalizeUploadSessionId(value) {
+  const id = clean(value);
+  if (!/^\d{5,100}$/.test(id)) throw failure('upload_session_id_invalid');
+  return id;
+}
+
+function normalizeVideoOffset(value, label) {
+  const offset = Number(value);
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > MAX_VIDEO_BYTES) throw failure(`${label}_invalid`);
+  return offset;
+}
+
+function normalizeVideoUploadResponse(value, phase) {
+  const result = sanitizeGraphValue(asObject(value));
+  if (phase === 'start') {
+    normalizeUploadSessionId(result.upload_session_id);
+    normalizeNumericId(result.video_id, 'video_id');
+    normalizeVideoOffset(result.start_offset, 'start_offset');
+    normalizeVideoOffset(result.end_offset, 'end_offset');
+  } else if (phase === 'transfer') {
+    normalizeVideoOffset(result.start_offset, 'start_offset');
+    normalizeVideoOffset(result.end_offset, 'end_offset');
+  } else if (result.success !== true && clean(result.success) !== 'true') {
+    throw failure('video_finish_not_confirmed', { classification: 'permanent', http_status: 502 });
+  }
+  return result;
+}
+
+function normalizeHosts(value) {
+  return [...new Set(safeArray(value).map((entry) => clean(entry).toLowerCase()).filter((entry) => /^[a-z0-9.-]+$/.test(entry)))];
+}
+
+function isAllowedHostname(hostname, allowedHosts) {
+  const normalized = clean(hostname).replace(/\.$/, '').toLowerCase();
+  return normalizeHosts(allowedHosts).some((host) => normalized === host || normalized.endsWith(`.${host}`));
+}
+
+function isWhatsAppHostname(hostname) {
+  const normalized = clean(hostname).replace(/\.$/, '').toLowerCase();
+  return WHATSAPP_HOSTS.has(normalized) || normalized.endsWith('.whatsapp.com');
+}
+
+function parseLandingUrl(value, allowedHosts) {
+  try {
+    const url = new URL(clean(value));
+    if (isWhatsAppHostname(url.hostname)) {
+      return { ok: false, error: 'landing_page_whatsapp_forbidden', hostname: url.hostname };
+    }
+    if (url.protocol !== 'https:' || url.username || url.password || !isAllowedHostname(url.hostname, allowedHosts)) {
+      return { ok: false, error: 'landing_page_invalid_or_not_allowed', hostname: clean(url.hostname) || 'invalid' };
+    }
+    url.hash = '';
+    return { ok: true, url: url.toString(), hostname: url.hostname };
+  } catch {
+    return { ok: false, error: 'landing_page_url_invalid', hostname: 'invalid' };
+  }
+}
+
+function normalizeLandingPageMap(value, allowedHosts) {
+  const pages = {};
+  const errors = [];
+  const seen = new Set();
+  for (const [rawKey, rawUrl] of Object.entries(asObject(value))) {
+    const key = clean(rawKey);
+    const normalizedKey = key.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+    if (!key || key.length > 200 || !normalizedKey || seen.has(normalizedKey)) {
+      errors.push({ key: key.slice(0, 200), error: seen.has(normalizedKey) ? 'landing_page_key_duplicate' : 'landing_page_key_invalid' });
+      continue;
+    }
+    seen.add(normalizedKey);
+    const parsed = parseLandingUrl(rawUrl, allowedHosts);
+    if (!parsed.ok) {
+      errors.push({ key, error: parsed.error, hostname: parsed.hostname });
+      continue;
+    }
+    pages[key] = parsed.url;
+  }
+  return { pages, errors };
+}
+
+async function validateLandingPagesOnline(pages, allowedHosts, env) {
+  const results = {};
+  const errors = [];
+  for (const [key, configuredUrl] of Object.entries(asObject(pages))) {
+    let currentUrl = configuredUrl;
+    let redirectCount = 0;
+    let completed = false;
+    try {
+      while (redirectCount <= MAX_LANDING_REDIRECTS) {
+        const parsed = parseLandingUrl(currentUrl, allowedHosts);
+        if (!parsed.ok) {
+          errors.push({ key, error: parsed.error, hostname: parsed.hostname });
+          break;
+        }
+        const landingFetch = env.LANDING_PAGE_FETCH || fetch;
+        const pageResponse = await landingFetch(parsed.url, {
+          method: 'GET',
+          redirect: 'manual',
+          headers: { 'User-Agent': 'Skincos-Meta-Ads-Preflight/1.0', Range: 'bytes=0-0' },
+        });
+        const location = clean(pageResponse.headers.get('location'));
+        if (pageResponse.status >= 300 && pageResponse.status < 400 && location) {
+          if (pageResponse.body && typeof pageResponse.body.cancel === 'function') await pageResponse.body.cancel();
+          redirectCount += 1;
+          if (redirectCount > MAX_LANDING_REDIRECTS) {
+            errors.push({ key, error: 'landing_page_redirect_limit_exceeded' });
+            break;
+          }
+          currentUrl = new URL(location, parsed.url).toString();
+          continue;
+        }
+        if (pageResponse.body && typeof pageResponse.body.cancel === 'function') await pageResponse.body.cancel();
+        if (pageResponse.status < 200 || pageResponse.status >= 400) {
+          errors.push({ key, error: 'landing_page_http_error', status: pageResponse.status });
+          break;
+        }
+        results[key] = {
+          ok: true,
+          final_url: parsed.url,
+          final_hostname: parsed.hostname,
+          redirect_count: redirectCount,
+          status: pageResponse.status,
+        };
+        completed = true;
+        break;
+      }
+      if (!completed && !errors.some((entry) => entry.key === key)) {
+        errors.push({ key, error: 'landing_page_validation_incomplete' });
+      }
+    } catch (error) {
+      errors.push({ key, error: 'landing_page_fetch_failed', detail: redactText(error && error.message) });
+    }
+  }
+  return { results, errors };
+}
+
+function normalizeFiles(value) {
+  const files = safeArray(value);
+  if (files.length > 300) throw failure('too_many_files', { http_status: 413 });
+  const seen = new Set();
+  return files.map((entry) => {
+    const file = asObject(entry);
+    const id = clean(file.id);
+    const name = clean(file.name);
+    if (!id || !name || seen.has(id)) throw failure('invalid_or_duplicate_file');
+    seen.add(id);
+    return {
+      id,
+      name,
+      md5_checksum: clean(file.md5_checksum || file.md5Checksum),
+      modified_time: clean(file.modified_time || file.modifiedTime),
+      size: clean(file.size),
+    };
+  }).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+async function readOperationRequest(request) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > MAX_MULTIPART_REQUEST_BYTES) return { error: 'request_too_large', status: 413 };
+  const contentType = clean(request.headers.get('content-type')).toLowerCase();
+  if (contentType.includes('multipart/form-data')) {
+    try {
+      const form = await request.formData();
+      const body = JSON.parse(clean(form.get('request')) || '{}');
+      const file = form.get('file');
+      return { body: asObject(body), file: file instanceof Blob ? file : null };
+    } catch {
+      return { error: 'invalid_multipart_payload', status: 400 };
+    }
+  }
+  return { body: await readObject(request), file: null };
+}
+
+function operationHashInput(body, file) {
+  const copy = sanitizeGraphValue({ ...body });
+  delete copy.request_hash;
+  if (clean(copy.action) === 'start_video_upload') {
+    // The source fingerprint and normalization contract identify a semantic
+    // replay. Encoder metadata may change the normalized byte count.
+    delete copy.file_size;
+    delete copy.file_checksum;
+    delete copy.resume_video_id;
+  }
+  if (['transfer_video_chunk', 'finish_video_upload'].includes(clean(copy.action))) {
+    delete copy.semantic_replay_video_id;
+  }
+  return {
+    ...copy,
+    file: file instanceof Blob ? { size: file.size, type: file.type, name: file.name || '' } : null,
+  };
+}
+
+function deriveRunFiles(row) {
+  return parseArray(row.files_json);
+}
+
+function serializeRun(row) {
+  return {
+    id: row.id,
+    batch_fingerprint: row.batch_fingerprint,
+    workflow_execution_id: row.workflow_execution_id,
+    config_revision: row.config_revision,
+    status: row.status,
+    files: deriveRunFiles(row),
+    summary: parseObject(row.summary_json),
+    error: parseObject(row.error_json),
+    heartbeat_at: row.heartbeat_at,
+    lock_expires_at: row.lock_expires_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function serializeJob(row) {
+  return {
+    id: row.id,
+    operation_key: row.operation_key,
+    destination_group: row.destination_group,
+    creative_group_key: row.creative_group_key,
+    action: row.action,
+    resource_key: row.resource_key,
+    status: row.status,
+    previous_state: parseObject(row.previous_state_json),
+    result: parseObject(row.result_json),
+    error: parseObject(row.error_json),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function serializeOperation(row) {
+  return {
+    operation_key: row.operation_key,
+    action: row.action,
+    status: row.status,
+    attempt_count: Number(row.attempt_count || 0),
+    result: parseObject(row.result_json),
+    error: parseObject(row.error_json),
+    fbtrace_id: nullable(row.meta_trace_id),
+    rate_usage: parseObject(row.rate_usage_json),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function serializeEvent(row) {
+  return {
+    id: row.id,
+    status: row.status,
+    payload: parseObject(row.payload_json),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function stripJobForSummary(record) {
+  return {
+    operation_key: record.operation_key,
+    destination_group: record.destination_group,
+    creative_group_key: record.creative_group_key,
+    action: record.action,
+    ad_id: record.ad_id,
+    creative_id: record.creative_id,
+    created_new: record.created_new,
+    files: safeArray(record.files),
+  };
+}
+
+function sanitizeGraphValue(value) {
+  if (Array.isArray(value)) return value.map(sanitizeGraphValue);
+  if (!value || typeof value !== 'object') return value;
+  const out = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (/^(access_token|token|fbToken|authorization)$/i.test(key)) continue;
+    out[key] = sanitizeGraphValue(item);
+  }
+  return out;
+}
+
+function removeEmpty(value) {
+  if (Array.isArray(value)) return value.map(removeEmpty).filter((item) => item !== undefined && item !== null && item !== '');
+  if (!value || typeof value !== 'object') return value;
+  const out = {};
+  for (const [key, item] of Object.entries(value)) {
+    const cleaned = removeEmpty(item);
+    if (cleaned === undefined || cleaned === null || cleaned === '') continue;
+    if (Array.isArray(cleaned) && cleaned.length === 0) continue;
+    if (cleaned && typeof cleaned === 'object' && !Array.isArray(cleaned) && Object.keys(cleaned).length === 0) continue;
+    out[key] = cleaned;
+  }
+  return out;
+}
+
+async function loadRun(env, runId) {
+  return dbFirst(env, `SELECT * FROM meta_ads_publish_runs WHERE id = ?`, runId);
+}
+
+async function dbFirst(env, sql, ...values) {
+  return env.TOKEN_VAULT_DB.prepare(sql).bind(...values).first();
+}
+
+async function dbAll(env, sql, ...values) {
+  const result = await env.TOKEN_VAULT_DB.prepare(sql).bind(...values).all();
+  return result.results || [];
+}
+
+async function dbRun(env, sql, ...values) {
+  return env.TOKEN_VAULT_DB.prepare(sql).bind(...values).run();
+}
+
+async function readObject(request) {
+  try { return asObject(await request.json()); } catch { return {}; }
+}
+
+function response(data, status = 200) {
+  return new Response(JSON.stringify(sanitizeGraphValue(data)), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+async function sha256(value) {
+  const bytes = new TextEncoder().encode(String(value));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacSha256(secret, value) {
+  const key = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function limitedJson(value) {
+  const serialized = JSON.stringify(sanitizeGraphValue(value || {}));
+  if (serialized.length > 1_000_000) throw failure('journal_payload_too_large', { http_status: 413 });
+  return serialized;
+}
+
+function parseObject(value) {
+  try { return asObject(typeof value === 'string' ? JSON.parse(value || '{}') : value); } catch { return {}; }
+}
+
+function parseArray(value) {
+  try {
+    const parsed = typeof value === 'string' ? JSON.parse(value || '[]') : value;
+    return safeArray(parsed);
+  } catch { return []; }
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function nullable(value) {
+  return clean(value) || null;
+}
+
+function requireHash(value, label) {
+  const hash = clean(value).toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(hash)) throw failure(`${label}_invalid`);
+  return hash;
+}
+
+function requireKey(value, label) {
+  const key = clean(value);
+  if (!/^[A-Za-z0-9_.:-]{8,200}$/.test(key)) throw failure(`${label}_invalid`);
+  return key;
+}
+
+function shortKey(value) {
+  const text = clean(value).replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+  return text.slice(0, 12) || 'unknown';
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? Math.max(min, Math.min(max, parsed)) : fallback;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function redactText(value) {
+  return clean(value)
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]')
+    .replace(/[A-Za-z0-9_-]{80,}/g, '[REDACTED]')
+    .slice(0, 1000);
+}
+
+export const __test = Object.freeze({
+  acquireLocks,
+  createOrResumeRun,
+  creativeReadFields: CREATIVE_READ_FIELDS,
+  campaignReadFields: CAMPAIGN_READ_FIELDS,
+  adsetPlacementFields: ADSET_PLACEMENT_FIELDS,
+  adsetReadFields: ADSET_READ_FIELDS,
+  graphRequest,
+  graphVideoUrl,
+  getVideoStatus,
+  maxRateUsage,
+  normalizeApiVersion,
+  normalizeUploadSessionId,
+  normalizeVideoFileSize,
+  normalizeVideoOffset,
+  normalizeVideoUploadResponse,
+  normalizeMetaError,
+  retryDelayMs,
+  normalizeLandingPageMap,
+  operationHashInput,
+  startVideoUpload,
+  transferVideoChunk,
+  finishVideoUpload,
+  videoUploadActions: VIDEO_UPLOAD_ACTIONS,
+  parseLandingUrl,
+  previousStatePayload,
+  sanitizeGraphValue,
+  stageBatch,
+  stableStringify,
+  validateAdPayload,
+  validatePausedCampaignPayload,
+  validatePausedAdsetPayload,
+  validateNativeCarouselRoutePromotion,
+  validateBatchJobs,
+  validateCreativePayload,
+  validateLandingPagesOnline,
+  validatePagingUrl,
+  updateAdWithReconciliation,
+});

--- a/platform/security/token-vault/tests/meta-ads-publish.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish.test.js
@@ -1,0 +1,680 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  __test,
+  handleMetaAdsPublishRequest,
+} from '../src/meta-ads-publish.js';
+
+class ConfigStatement {
+  constructor(rows) {
+    this.rows = rows;
+  }
+
+  bind() {
+    return this;
+  }
+
+  async all() {
+    return { results: this.rows };
+  }
+}
+
+class ConfigDb {
+  constructor(rows) {
+    this.rows = rows;
+  }
+
+  prepare(sql) {
+    assert.match(sql, /FROM credential_tokens/);
+    return new ConfigStatement(this.rows);
+  }
+}
+
+function configRow(id, unit, rowNumber) {
+  return {
+    id,
+    unit,
+    external_account_id: '123456789',
+    token_type: 'long_lived_access_token',
+    expires_at: null,
+    active: 1,
+    updated_at: '2026-07-10T00:00:00.000Z',
+    metadata_json: JSON.stringify({
+      meta_ads_publish: {
+        row_number: rowNumber,
+        destination_group: unit,
+        api_version: 'v25.0',
+        account_id: '123456789',
+        campaign_id: '223456789',
+        adset_id: String(323456780 + rowNumber),
+        page_id: String(423456780 + rowNumber),
+        instagram_user_id: String(523456780 + rowNumber),
+        carousel_native_campaign_id: '723456789',
+        carousel_native_adset_id: String(823456780 + rowNumber),
+        carousel_native_adset_verified: true,
+        carousel_native_route_active: true,
+        allowed_link_hosts: ['espacofacial.com'],
+        landing_pages_by_creative_group: {
+          BOTOX_35UI_PRICE_DOSE_AVISTA_ANIVERSARIO_7_ANOS: 'https://espacofacial.com/campanhas/aniversario-7-anos/botox',
+        },
+      },
+    }),
+  };
+}
+
+test('config exposes metadata and opaque token ids without token material', async () => {
+  const env = { TOKEN_VAULT_DB: new ConfigDb([
+    configRow('facebook_barra', 'BarraShoppingSul', 1),
+    configRow('facebook_nh', 'Novo Hamburgo', 2),
+  ]), LANDING_PAGE_FETCH: async () => new Response('', { status: 200 }) };
+  const result = await handleMetaAdsPublishRequest({
+    request: new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config'),
+    env,
+    requestId: 'test-request',
+    pathname: '/v1/meta-ads-publish/config',
+    decryptToken: async () => { throw new Error('must not decrypt config'); },
+    writeAudit: async () => {},
+  });
+  const body = await result.json();
+  assert.equal(result.status, 200);
+  assert.equal(body.ready, true);
+  assert.equal(body.destinations.length, 2);
+  assert.equal(body.destinations[0].token_id, 'facebook_barra');
+  assert.equal(JSON.stringify(body).includes('access_token'), false);
+  assert.equal(JSON.stringify(body).includes('token_ciphertext'), false);
+  assert.equal(body.destinations[0].landing_page_validation.ok, true);
+  assert.equal(body.destinations[0].carousel_native_adset_verified, true);
+  assert.equal(body.destinations[0].carousel_native_route_active, true);
+  assert.equal(body.destinations[0].landing_pages_by_creative_group.BOTOX_35UI_PRICE_DOSE_AVISTA_ANIVERSARIO_7_ANOS, 'https://espacofacial.com/campanhas/aniversario-7-anos/botox');
+  assert.match(body.config_revision, /^[a-f0-9]{64}$/);
+  assert.equal(body.capabilities.workflow_contract_revision, 'meta_destination_contract_v18_live_campaign_cta');
+  assert.deepEqual(body.capabilities.video_upload.supported_actions, __test.videoUploadActions);
+  assert.equal(body.capabilities.video_upload.max_file_bytes, 90 * 1024 * 1024);
+  assert.equal(body.capabilities.video_upload.max_chunk_bytes, 16 * 1024 * 1024);
+});
+
+function flexibleStaticFeed() {
+  const label = (prefix, index) => ({ name: `${prefix}_${index}` });
+  return {
+    ad_formats: ['SINGLE_IMAGE'],
+    images: [
+      { hash: 'a', adlabels: [{ name: 'feed_image' }] },
+      { hash: 'b', adlabels: [{ name: 'banner_image' }] },
+      { hash: 'c', adlabels: [{ name: 'vertical_image' }] },
+    ],
+    bodies: Array.from({ length: 5 }, (_, index) => ({ text: `body-${index}`, adlabels: [label('body', index)] })),
+    titles: Array.from({ length: 5 }, (_, index) => ({ text: `title-${index}`, adlabels: [label('title', index)] })),
+    descriptions: Array.from({ length: 5 }, (_, index) => ({ text: `description-${index}`, adlabels: [label('description', index)] })),
+    link_urls: [{ website_url: 'https://espacofacial.com/campanhas/botox' }],
+    call_to_action_types: ['BOOK_NOW'],
+    asset_customization_rules: [
+      { image_label: { name: 'feed_image' }, body_label: label('body', 0), title_label: label('title', 0), description_label: label('description', 0), customization_spec: { publisher_platforms: ['facebook'], facebook_positions: ['feed'] } },
+      { image_label: { name: 'banner_image' }, body_label: label('body', 1), title_label: label('title', 1), description_label: label('description', 1), customization_spec: { publisher_platforms: ['facebook'], facebook_positions: ['search'] } },
+      { image_label: { name: 'vertical_image' }, body_label: label('body', 2), title_label: label('title', 2), description_label: label('description', 2), customization_spec: { publisher_platforms: ['instagram'], instagram_positions: ['story'] } },
+    ],
+  };
+}
+
+function requiredCreativeFeatures() {
+  return Object.fromEntries([
+    'add_text_overlay', 'image_touchups', 'text_optimizations', 'inline_comment',
+    'enhance_cta', 'image_brightness_and_contrast', 'reveal_details_over_time',
+    'show_destination_blurbs', 'image_animation', 'music_generation', 'pac_relaxation',
+  ].map((feature) => [feature, { enroll_status: 'OPT_IN' }]));
+}
+
+test('flexible creative quality gate requires 3 images, 5 bodies, 5 titles and 5 descriptions', () => {
+  const payload = {
+    name: 'Botox',
+    object_story_spec: { page_id: '123456789' },
+    asset_feed_spec: flexibleStaticFeed(),
+    creative_sourcing_spec: { source_url: 'https://espacofacial.com/campanhas/botox' },
+    degrees_of_freedom_spec: {
+      creative_features_spec: requiredCreativeFeatures(),
+    },
+  };
+  const validated = __test.validateCreativePayload(payload, 'creative:group:unit');
+  assert.match(validated.name, /\[sk:creativegrou\]/);
+  assert.throws(
+    () => __test.validateCreativePayload({ ...payload, asset_feed_spec: { ...payload.asset_feed_spec, titles: [{ text: 'one' }] } }, 'creative:bad'),
+    /creative_quality_gate_failed/,
+  );
+});
+
+test('flexible creative quality gate accepts an explicit WhatsApp destination', () => {
+  const payload = {
+    name: 'Botox WhatsApp',
+    object_story_spec: { page_id: '123456789' },
+    asset_feed_spec: {
+      ...flexibleStaticFeed(),
+      link_urls: [{ website_url: 'https://api.whatsapp.com/send' }],
+      call_to_action_types: ['WHATSAPP_MESSAGE'],
+    },
+    creative_sourcing_spec: { source_url: 'https://api.whatsapp.com/send' },
+    degrees_of_freedom_spec: { creative_features_spec: requiredCreativeFeatures() },
+  };
+  assert.doesNotThrow(() => __test.validateCreativePayload(payload, 'creative:whatsapp:unit'));
+});
+
+test('video-only flexible creative accepts the labeled 9:16 contract', () => {
+  const label = (prefix, index) => ({ name: `${prefix}_${index}` });
+  const payload = {
+    name: 'Video vertical',
+    object_story_spec: { page_id: '123456789' },
+    asset_feed_spec: {
+      ad_formats: ['SINGLE_VIDEO'],
+      optimization_type: 'PLACEMENT',
+      videos: [{ video_id: '123456789', thumbnail_hash: 'thumbhash0123456789', adlabels: [{ name: 'vertical_video' }] }],
+      bodies: Array.from({ length: 5 }, (_, index) => ({ text: `body-${index}`, adlabels: [label('body', index)] })),
+      titles: Array.from({ length: 5 }, (_, index) => ({ text: `title-${index}`, adlabels: [label('title', index)] })),
+      descriptions: Array.from({ length: 5 }, (_, index) => ({ text: `description-${index}`, adlabels: [label('description', index)] })),
+      link_urls: [{ website_url: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' }],
+      call_to_action_types: ['BOOK_NOW'],
+      asset_customization_rules: [
+        { video_label: { name: 'vertical_video' }, body_label: label('body', 0), title_label: label('title', 0), description_label: label('description', 0), customization_spec: { publisher_platforms: ['facebook'], facebook_positions: ['feed'] } },
+        { video_label: { name: 'vertical_video' }, body_label: label('body', 1), title_label: label('title', 1), description_label: label('description', 1), customization_spec: { publisher_platforms: ['audience_network'], audience_network_positions: ['rewarded_video'] } },
+      ],
+    },
+    creative_sourcing_spec: { source_url: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' },
+    degrees_of_freedom_spec: { creative_features_spec: requiredCreativeFeatures() },
+  };
+  assert.doesNotThrow(() => __test.validateCreativePayload(payload, 'creative:video:unit'));
+});
+
+test('native carousel contract accepts labeled card attachments and rejects flexible-only fields', () => {
+  const payload = {
+    name: '[TEST-CAROUSEL-NATIVE] Restylane',
+    object_story_spec: {
+      page_id: '123456789',
+      instagram_actor_id: '987654321',
+      link_data: {
+        link: 'https://espacofacial.com/agendamento?unit=barrashoppingsul',
+        message: 'Conheça as etapas do procedimento.',
+        call_to_action: { type: 'BOOK_NOW', value: { link: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' } },
+        child_attachments: [
+          { image_hash: 'image-one', name: 'Etapa 1', link: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' },
+          { image_hash: 'image-two', name: 'Etapa 2', link: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' },
+        ],
+      },
+    },
+    creative_sourcing_spec: { source_url: 'https://espacofacial.com/agendamento?unit=barrashoppingsul' },
+  };
+  const validated = __test.validateCreativePayload(payload, 'creative:native:unit');
+  assert.match(validated.name, /\[sk:creativenati\]/);
+  assert.throws(
+    () => __test.validateCreativePayload({ ...payload, degrees_of_freedom_spec: { creative_features_spec: {} } }, 'creative:native:bad'),
+    /native_carousel_advantage_plus_unsupported/,
+  );
+  const whatsapp = structuredClone(payload);
+  whatsapp.object_story_spec.link_data.link = 'https://api.whatsapp.com/send';
+  whatsapp.object_story_spec.link_data.call_to_action = { type: 'WHATSAPP_MESSAGE', value: { link: 'https://api.whatsapp.com/send' } };
+  whatsapp.object_story_spec.link_data.child_attachments.forEach((card) => { card.link = 'https://api.whatsapp.com/send'; });
+  delete whatsapp.creative_sourcing_spec;
+  assert.doesNotThrow(() => __test.validateCreativePayload(whatsapp, 'creative:native:whatsapp'));
+});
+
+test('landing page validation rejects redirects to WhatsApp before any Meta operation', async () => {
+  const definition = __test.normalizeLandingPageMap({
+    BOTOX_CAMPAIGN: 'https://espacofacial.com/campanhas/botox',
+  }, ['espacofacial.com']);
+  assert.deepEqual(definition.errors, []);
+  const validation = await __test.validateLandingPagesOnline(definition.pages, ['espacofacial.com'], {
+    LANDING_PAGE_FETCH: async () => new Response('', {
+      status: 302,
+      headers: { location: 'https://wa.me/5551995103563' },
+    }),
+  });
+  assert.equal(validation.results.BOTOX_CAMPAIGN, undefined);
+  assert.equal(validation.errors[0].error, 'landing_page_whatsapp_forbidden');
+});
+
+test('creative gateway rejects legacy or catalog-only enhancement keys', () => {
+  const payload = {
+    name: 'Botox',
+    object_story_spec: { page_id: '123456789' },
+    asset_feed_spec: flexibleStaticFeed(),
+    creative_sourcing_spec: { source_url: 'https://espacofacial.com/campanhas/botox' },
+    degrees_of_freedom_spec: {
+      creative_features_spec: {
+        media_type_automation: { enroll_status: 'OPT_IN' },
+      },
+    },
+  };
+  assert.throws(() => __test.validateCreativePayload(payload, 'creative:legacy'), /creative_feature_forbidden:media_type_automation/);
+});
+
+test('creative readback requests only fields supported by the Graph creative object', () => {
+  assert.equal(__test.creativeReadFields.includes('created_time'), false);
+  assert.equal(__test.creativeReadFields.includes('updated_time'), false);
+  assert.equal(__test.creativeReadFields.includes('asset_feed_spec'), true);
+  assert.equal(__test.creativeReadFields.includes('degrees_of_freedom_spec'), true);
+});
+
+test('video upload gateway uses Graph Video phases and enforces the chunk contract', async () => {
+  const calls = [];
+  const { context } = gatewayContext(async (url, init) => {
+    const parsed = new URL(url);
+    const form = init.body;
+    calls.push({ host: parsed.host, path: parsed.pathname, phase: form.get('upload_phase'), startOffset: form.get('start_offset') });
+    if (form.get('upload_phase') === 'start') return jsonResponse({ upload_session_id: '123456', video_id: '987654321', start_offset: '0', end_offset: '1024' });
+    if (form.get('upload_phase') === 'transfer') return jsonResponse({ start_offset: '0', end_offset: '1024' });
+    return jsonResponse({ success: true });
+  });
+  context.action = 'start_video_upload';
+  const start = await __test.startVideoUpload({ token_id: 'facebook_barra', account_id: '123456789', api_version: 'v25.0', file_size: 1024 }, context);
+  assert.equal(start.video_id, '987654321');
+  context.action = 'transfer_video_chunk';
+  context.file = new Blob([new Uint8Array(1024)], { type: 'video/mp4' });
+  await __test.transferVideoChunk({ token_id: 'facebook_barra', account_id: '123456789', api_version: 'v25.0', upload_session_id: '123456', start_offset: 0, file_name: 'creative.mp4' }, context);
+  context.action = 'finish_video_upload';
+  await __test.finishVideoUpload({ token_id: 'facebook_barra', account_id: '123456789', api_version: 'v25.0', upload_session_id: '123456' }, context);
+  assert.deepEqual(calls.map((call) => call.phase), ['start', 'transfer', 'finish']);
+  assert.ok(calls.every((call) => call.host === 'graph-video.facebook.com' && call.path === '/v25.0/act_123456789/advideos'));
+  assert.throws(() => __test.normalizeVideoFileSize(91 * 1024 * 1024), /video_size_invalid/);
+  await assert.rejects(
+    () => __test.transferVideoChunk({ token_id: 'facebook_barra', account_id: '123456789', api_version: 'v25.0', upload_session_id: '123456', start_offset: 0 }, { ...context, file: new Blob([new Uint8Array(16 * 1024 * 1024 + 1)]) }),
+    /video_chunk_size_invalid/,
+  );
+});
+
+test('video upload actions stay part of the gateway capability contract', () => {
+  assert.deepEqual(__test.videoUploadActions, ['start_video_upload', 'transfer_video_chunk', 'finish_video_upload', 'get_video_status']);
+});
+
+test('adset placement readback requests effective WhatsApp and vertical placement fields', () => {
+  assert.match(__test.adsetPlacementFields, /campaign\{id,objective\}/);
+  assert.match(__test.adsetPlacementFields, /optimization_goal/);
+  assert.match(__test.adsetPlacementFields, /effective_whatsapp_positions/);
+  assert.match(__test.adsetPlacementFields, /effective_facebook_positions/);
+  assert.match(__test.adsetPlacementFields, /effective_instagram_positions/);
+  assert.match(__test.adsetPlacementFields, /effective_audience_network_positions/);
+});
+
+test('native-carousel calibration ad sets are constrained to paused, explicit delivery payloads', () => {
+  const payload = {
+    name: '[TEST-CAROUSEL-NATIVE] BSS',
+    campaign_id: '123456789',
+    status: 'PAUSED',
+    billing_event: 'IMPRESSIONS',
+    optimization_goal: 'CONVERSATIONS',
+    targeting: { publisher_platforms: ['facebook', 'instagram'] },
+  };
+  assert.equal(__test.validatePausedAdsetPayload(payload).status, 'PAUSED');
+  assert.throws(() => __test.validatePausedAdsetPayload({ ...payload, status: 'ACTIVE' }), /adset_must_be_paused/);
+  assert.throws(() => __test.validatePausedAdsetPayload({ ...payload, account_id: 'forbidden' }), /adset_field_forbidden:account_id/);
+  assert.match(__test.adsetReadFields, /promoted_object/);
+  assert.match(__test.adsetReadFields, /destination_type/);
+});
+
+test('native-carousel calibration campaigns are limited to paused supported objectives', () => {
+  const payload = {
+    name: '[TEST-CAROUSEL-NATIVE] BSS',
+    objective: 'OUTCOME_ENGAGEMENT',
+    buying_type: 'AUCTION',
+    special_ad_categories: [],
+    status: 'PAUSED',
+  };
+  assert.equal(__test.validatePausedCampaignPayload(payload).objective, 'OUTCOME_ENGAGEMENT');
+  assert.equal(__test.validatePausedCampaignPayload({ ...payload, objective: 'OUTCOME_LEADS' }).objective, 'OUTCOME_LEADS');
+  assert.throws(() => __test.validatePausedCampaignPayload({ ...payload, objective: 'OUTCOME_SALES' }), /campaign_payload_invalid/);
+  assert.throws(() => __test.validatePausedCampaignPayload({ ...payload, status: 'ACTIVE' }), /campaign_must_be_paused/);
+});
+
+test('campaign calibration readback requests the delivery contract fields', () => {
+  assert.match(__test.campaignReadFields, /objective/);
+  assert.match(__test.campaignReadFields, /is_adset_budget_sharing_enabled/);
+});
+
+test('native carousel promotion can only activate explicitly named routes', () => {
+  const payload = {
+    campaign_id: '123456789',
+    campaign_name: '[NATIVE-CAROUSEL] WhatsApp',
+    adsets: [{ id: '223456789', name: '[NATIVE-CAROUSEL] BSS' }],
+    test_ad_ids: ['323456789'],
+  };
+  assert.equal(__test.validateNativeCarouselRoutePromotion(payload).adsets.length, 1);
+  assert.throws(
+    () => __test.validateNativeCarouselRoutePromotion({ ...payload, campaign_name: 'Campaign' }),
+    /native_carousel_campaign_name_required/,
+  );
+  assert.throws(
+    () => __test.validateNativeCarouselRoutePromotion({ ...payload, test_ad_ids: [] }),
+    /native_carousel_test_ad_count_invalid/,
+  );
+});
+
+test('batch validation rejects duplicate replacement targets', () => {
+  const job = {
+    operation_key: 'job:barra:botox:1',
+    action: 'replace_existing',
+    target_ad_id: '120246883241450157',
+    destination_group: 'BarraShoppingSul',
+    creative_group_key: 'botox-v1',
+    token_id: 'facebook_barra',
+    account_id: '123456789',
+    api_version: 'v25.0',
+    ad_payload: {
+      name: 'Botox | BarraShoppingSul',
+      creative: { creative_id: '1024340013785371' },
+    },
+  };
+  assert.throws(() => __test.validateBatchJobs([job, { ...job, operation_key: 'job:barra:botox:2' }]), /duplicate_batch_target/);
+});
+
+test('error classification retries only transient Meta failures', () => {
+  const permanent = __test.normalizeMetaError({ error: { code: 100, message: 'Invalid parameter' } }, 400, new Headers());
+  assert.equal(permanent.classification, 'permanent');
+  assert.equal(permanent.retryable, false);
+
+  const transient = __test.normalizeMetaError({ error: { code: 2, is_transient: true, message: 'Temporary' } }, 500, new Headers());
+  assert.equal(transient.classification, 'transient');
+  assert.equal(transient.retryable, true);
+});
+
+test('fresh ad-image propagation is retried only for creative creation', () => {
+  const errorBody = {
+    error: {
+      code: 100,
+      error_subcode: 2446386,
+      message: 'Selected image is not available yet',
+    },
+  };
+  const creativeFailure = __test.normalizeMetaError(errorBody, 400, new Headers(), 'create_creative');
+  assert.equal(creativeFailure.classification, 'transient');
+  assert.equal(creativeFailure.retryable, true);
+  assert.equal(creativeFailure.propagation_retry, true);
+  assert.equal(__test.retryDelayMs(1, new Headers(), Date.now(), creativeFailure), 15_000);
+  assert.equal(__test.retryDelayMs(2, new Headers(), Date.now(), creativeFailure), 30_000);
+
+  const unrelatedFailure = __test.normalizeMetaError(errorBody, 400, new Headers(), 'get_ad');
+  assert.equal(unrelatedFailure.classification, 'permanent');
+  assert.equal(unrelatedFailure.retryable, false);
+  assert.equal(unrelatedFailure.propagation_retry, false);
+});
+
+test('Meta generic retry-later creative failure is retried only for creative creation', () => {
+  const errorBody = {
+    error: {
+      code: 100,
+      error_subcode: 1487390,
+      error_user_msg: 'Ocorreu um erro. Tente novamente mais tarde',
+    },
+  };
+  const creativeFailure = __test.normalizeMetaError(errorBody, 400, new Headers(), 'create_creative');
+  assert.equal(creativeFailure.classification, 'transient');
+  assert.equal(creativeFailure.retryable, true);
+  assert.equal(creativeFailure.creative_retry, true);
+
+  const unrelatedFailure = __test.normalizeMetaError(errorBody, 400, new Headers(), 'get_ad');
+  assert.equal(unrelatedFailure.classification, 'permanent');
+  assert.equal(unrelatedFailure.retryable, false);
+  assert.equal(unrelatedFailure.creative_retry, false);
+});
+
+test('creative creation waits for fresh image hashes and succeeds without duplicating the operation', async () => {
+  let attempts = 0;
+  const delays = [];
+  const context = {
+    action: 'create_creative',
+    attempts: 0,
+    rateUsage: {},
+    traceId: '',
+    env: {
+      META_GRAPH_FETCH: async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          return new Response(JSON.stringify({
+            error: {
+              code: 100,
+              error_subcode: 2446386,
+              message: 'Selected image is not available yet',
+            },
+          }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ id: 'creative-accepted' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      META_GRAPH_SLEEP: async (delay) => delays.push(delay),
+    },
+  };
+
+  const result = await __test.graphRequest(
+    'https://graph.facebook.com/v25.0/act_123/adcreatives',
+    { method: 'POST', body: '{}' },
+    { accessToken: 'test-token', appSecretProof: '' },
+    context,
+  );
+
+  assert.equal(result.body.id, 'creative-accepted');
+  assert.equal(attempts, 3);
+  assert.equal(context.attempts, 3);
+  assert.deepEqual(delays, [15_000, 30_000]);
+});
+
+test('pagination accepts only the official Graph host and current API version', () => {
+  const valid = __test.validatePagingUrl('https://graph.facebook.com/v25.0/act_123/ads?after=cursor&access_token=secret', 'v25.0');
+  assert.equal(valid.includes('access_token'), false);
+  assert.throws(() => __test.validatePagingUrl('https://example.com/v25.0/act_123/ads', 'v25.0'), /invalid_meta_paging_url/);
+  assert.throws(() => __test.validatePagingUrl('https://graph.facebook.com/v24.0/act_123/ads', 'v25.0'), /invalid_meta_paging_url/);
+});
+
+test('sanitizer strips token fields recursively', () => {
+  const sanitized = __test.sanitizeGraphValue({
+    id: '1',
+    access_token: 'secret',
+    nested: { token: 'secret', authorization: 'secret', keep: true },
+  });
+  assert.deepEqual(sanitized, { id: '1', nested: { keep: true } });
+});
+
+test('rollback payload restores mutable ad state', () => {
+  assert.deepEqual(__test.previousStatePayload({
+    name: 'Old ad',
+    status: 'PAUSED',
+    adset_id: '323456789',
+    creative: { id: '623456789' },
+  }), {
+    name: 'Old ad',
+    status: 'PAUSED',
+    adset_id: '323456789',
+    creative: { creative_id: '623456789' },
+  });
+});
+
+class GatewayStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async first() {
+    if (this.sql.includes('FROM credential_tokens')) return this.db.credential;
+    if (this.sql.includes('FROM meta_ads_publish_locks')) return null;
+    if (this.sql.includes('FROM meta_ads_publish_operations')) return null;
+    return null;
+  }
+
+  async all() {
+    return { results: [] };
+  }
+
+  async run() {
+    this.db.statements.push({ sql: this.sql, values: this.values });
+    return { success: true };
+  }
+}
+
+class GatewayDb {
+  constructor() {
+    this.statements = [];
+    this.credential = {
+      id: 'facebook_barra',
+      provider: 'facebook',
+      active: 1,
+      token_ciphertext: 'encrypted',
+      metadata_json: JSON.stringify({ meta_ads_publish: { account_id: '123456789', api_version: 'v25.0' } }),
+    };
+  }
+
+  prepare(sql) {
+    return new GatewayStatement(this, sql);
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function gatewayContext(fetchImpl) {
+  const db = new GatewayDb();
+  return {
+    db,
+    context: {
+      env: {
+        TOKEN_VAULT_DB: db,
+        META_GRAPH_FETCH: fetchImpl,
+        META_GRAPH_SLEEP: async () => {},
+      },
+      runId: 'run-test',
+      operationKey: 'stage:run-test',
+      decryptToken: async () => 'fixture-secret',
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+    },
+  };
+}
+
+function replacementJob(adId, operationKey) {
+  return {
+    operation_key: operationKey,
+    action: 'replace_existing',
+    target_ad_id: adId,
+    token_id: 'facebook_barra',
+    account_id: '123456789',
+    api_version: 'v25.0',
+    destination_group: `unit-${adId}`,
+    creative_group_key: `group-${adId}`,
+    creative_id: `9${adId}`,
+    ad_payload: {
+      name: `New ad ${adId}`,
+      status: 'PAUSED',
+      creative: { creative_id: `9${adId}` },
+      adset_id: '323456789',
+    },
+    files: [{ id: `drive-${adId}`, name: `${adId}.jpg`, ratio: '4x5' }],
+  };
+}
+
+test('stage batch compensates earlier ads when a later permanent mutation fails', async () => {
+  const calls = [];
+  const { context } = gatewayContext(async (url, init) => {
+    const parsed = new URL(url);
+    calls.push({ path: parsed.pathname, method: init.method, body: init.body ? JSON.parse(init.body) : null });
+    if (init.method === 'GET') {
+      const adId = parsed.pathname.split('/').pop();
+      return jsonResponse({ id: adId, name: `Old ad ${adId}`, status: 'ACTIVE', adset_id: '323456789', creative: { id: `8${adId}` } });
+    }
+    if (parsed.pathname.endsWith('/22222')) {
+      return jsonResponse({ error: { code: 100, message: 'Invalid parameter', is_transient: false } }, 400);
+    }
+    return jsonResponse({ success: true });
+  });
+
+  let caught;
+  try {
+    await __test.stageBatch({ jobs: [replacementJob('11111', 'job:one1'), replacementJob('22222', 'job:two2')] }, context);
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(caught);
+  assert.equal(caught.classification, 'permanent');
+  assert.equal(caught.compensation.reconciliation_required, false);
+  assert.equal(caught.compensation.results.length, 1);
+  const firstAdPosts = calls.filter((call) => call.path.endsWith('/11111') && call.method === 'POST');
+  assert.equal(firstAdPosts.length, 2);
+  assert.equal(firstAdPosts[1].body.name, 'Old ad 11111');
+  assert.equal(firstAdPosts[1].body.creative.creative_id, '811111');
+});
+
+test('ambiguous update timeout reconciles by reading the final ad state', async () => {
+  let calls = 0;
+  const intended = {
+    name: 'Intended ad',
+    status: 'PAUSED',
+    adset_id: '323456789',
+    creative: { creative_id: '923456789' },
+  };
+  const { context } = gatewayContext(async (url, init) => {
+    calls += 1;
+    if (init.method === 'POST') throw new TypeError('network disconnected after request');
+    return jsonResponse({
+      id: '120246883241450157',
+      name: intended.name,
+      status: intended.status,
+      adset_id: intended.adset_id,
+      creative: { id: intended.creative.creative_id },
+    });
+  });
+  const result = await __test.updateAdWithReconciliation(
+    { accountId: '123456789', apiVersion: 'v25.0', accessToken: 'fixture-secret', appSecretProof: '' },
+    '120246883241450157',
+    intended,
+    context,
+  );
+  assert.equal(result.reconciled_after_ambiguous_response, true);
+  assert.equal(calls, 4);
+});
+
+class LockStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) { this.values = values; return this; }
+
+  async first() {
+    const lock = this.db.locks.get(this.values[0]);
+    return lock ? { ...lock } : null;
+  }
+
+  async run() {
+    if (this.sql.includes('INSERT INTO meta_ads_publish_locks')) {
+      const [resourceKey, runId, operationKey, heartbeatAt, expiresAt] = this.values;
+      const current = this.db.locks.get(resourceKey);
+      if (!current || Date.parse(current.expires_at) <= Date.now() || current.run_id === runId) {
+        this.db.locks.set(resourceKey, {
+          resource_key: resourceKey,
+          run_id: runId,
+          operation_key: operationKey,
+          heartbeat_at: heartbeatAt,
+          expires_at: expiresAt,
+        });
+      }
+    }
+    return { success: true };
+  }
+}
+
+test('resource locks reject concurrent runs targeting the same ad', async () => {
+  const db = { locks: new Map(), prepare(sql) { return new LockStatement(this, sql); } };
+  const env = { TOKEN_VAULT_DB: db };
+  await __test.acquireLocks(env, 'run-one', 'operation-one', ['ad:120246883241450157']);
+  await assert.rejects(
+    () => __test.acquireLocks(env, 'run-two', 'operation-two', ['ad:120246883241450157']),
+    /resource_locked/,
+  );
+});


### PR DESCRIPTION
﻿## What
- versions the inactive `Meta Ads - Publish` workflow as a sanitized canonical definition and maps all 49 live Code nodes to tracked sources
- ports the validated Meta Ads Token Vault gateway, idempotency journal migration and tests into `platform/security/token-vault`
- makes the Token Vault/workflow contract revision explicit and fail-closed
- adds guarded export, sync, apply, rollback and live-drift preflight paths

## Validation
- `orb/engine`: source sync check, syntax checks, `node --test tests/meta-ads-publish-preflight.test.js` (8 passing)
- `platform/security/token-vault`: `npm test` (31 passing)
- read-only D1 migration listing confirms no pending production migrations
- workflow apply dry-run against live version 824 completed without mutation

## Rollout
After merge: deploy the Token Vault Worker, apply the version-checked inactive workflow snapshot, then run the live read-only preflight. No Meta publication or workflow activation is included.
