### PR TITLE
fix(workforce): serialize onboarding manager audits

### DIFF
--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -671,9 +671,12 @@ async function syncIdentityOnboarding(db, body, requestId) {
   }
   const actor = { id: 'identity-service', role: 'ADMIN', email: 'identity-service@internal', allowedUnits: units, name: 'Identity service' }
   statements.push(await audit(db, { actor, action: 'IDENTITY_ONBOARDING_SYNC', entityType: 'workforce_employee', entityId: employeeId, requestId, after: { onboardingId, canonicalEmployeeId, profile, accountStatus, departmentId: department.id, units, managerConfiguredByUnit: Object.fromEntries(Object.entries(managerByUnit).map(([unit, managerId]) => [unit, !!managerId])) } }))
-  if (unresolvedManagerUnits.length) statements.push(await audit(db, { actor, action: 'IDENTITY_ONBOARDING_MANAGER_UNRESOLVED', entityType: 'workforce_employee', entityId: employeeId, requestId, after: { onboardingId, units: unresolvedManagerUnits, resolution: 'MANUAL_REVIEW' } }))
-  if (ambiguousManagerUnits.length) statements.push(await audit(db, { actor, action: 'IDENTITY_ONBOARDING_MANAGER_AMBIGUOUS', entityType: 'workforce_employee', entityId: employeeId, requestId, after: { onboardingId, units: ambiguousManagerUnits, resolution: 'MANUAL_REVIEW' } }))
   await db.batch(statements)
+  // The audit table is hash-chained. Derive every follow-up event only after
+  // the primary onboarding audit has committed, otherwise two events share a
+  // predecessor hash and the D1 trigger correctly rejects the batch.
+  if (unresolvedManagerUnits.length) await (await audit(db, { actor, action: 'IDENTITY_ONBOARDING_MANAGER_UNRESOLVED', entityType: 'workforce_employee', entityId: employeeId, requestId, after: { onboardingId, units: unresolvedManagerUnits, resolution: 'MANUAL_REVIEW' } })).run()
+  if (ambiguousManagerUnits.length) await (await audit(db, { actor, action: 'IDENTITY_ONBOARDING_MANAGER_AMBIGUOUS', entityType: 'workforce_employee', entityId: employeeId, requestId, after: { onboardingId, units: ambiguousManagerUnits, resolution: 'MANUAL_REVIEW' } })).run()
   return { employeeId, canonicalEmployeeId, idempotent: false }
 }
 


### PR DESCRIPTION
Fixes the staging regression introduced by #842: the D1 audit chain rejects two events with the same predecessor hash in one batch. Follow-up manager review audits now commit sequentially after the primary onboarding audit. Tests: Workforce 28/28; git diff --check.