### PR TITLE
docs(meta-ads): record closure audit evidence

### DIFF
--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -40,9 +40,22 @@
 
 ## Preserved independent work
 
-- `codex/admin/meta-ads-publish-production-audit` contains uncommitted product
-  work for the Meta Ads publish journal. It is intentionally isolated from the
-  completed architecture/runtime program and must be reviewed in its own task.
+- The canonical `Meta Ads – Publish` contract was integrated by PR #840
+  (`11417df9e362f82337882a4b57e87c98b1a21547`). Its tracked workflow export,
+  Code-node sources, Token Vault gateway, migration, preflight and tests are
+  the source of truth. The older `meta-ads-*` worktrees remain operator-owned
+  historical worktrees and are not cleanup targets for unrelated tasks.
+- The production workflow is intentionally inactive/manual. Its current live
+  version is `825` (`4ec178e3-bc9d-4ed6-b481-eb9015777b2e`); the Token Vault
+  production deployment is `beba53d9-67f3-495b-a002-5dc579463c29`. A final
+  historical journal reconciliation and WhatsApp-notification delivery check
+  remain tracked in `TASKS.md`; do not treat execution success alone as their
+  proof.
+- The native Orb source release currently resolves to
+  `71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, which predates PR #840. The
+  n8n definition and Worker are reconciled, but the runtime source release is
+  not yet `main`; promote it only through the native release gate with an
+  explicit production authorization and a rollback checkpoint.
 - PR #674 (`codex/admin/github-codex-autonomy`) remains a deliberate draft for
   the optional GitHub autonomy broker; it is not part of the production
   runtime and has no deployment dependency.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -423,3 +423,18 @@
 - Decision: own Controle de Ponto in `workforce/timekeeping`, expose it only through the public `api` gateway and use its D1 as the sole operational persistence.
 - Why: the CRM-local JSON backend could not provide durable concurrency, canonical employee identity, period snapshots or enforceable cross-unit authorization.
 - Impact: CRM is a same-origin client/proxy; legacy JSON is import-only, corrections preserve original events, Escala links require explicit aliases, and staging must pass before the guarded production workflow can run.
+
+## 2026-07-29 - Make the Meta Ads publish contract singular and manual
+
+- Decision: treat the tracked Meta Ads workflow export, all mapped Code-node
+  sources, the Token Vault gateway, contract revision, migration, preflight and
+  regression tests as one atomic contract. Production changes use a
+  version-checked workflow apply and a separately versioned Worker deployment.
+- Why: direct editor changes and independent worktrees had allowed the live
+  workflow, gateway and repository to drift, causing a previously successful
+  path to regress on a later manual run.
+- Impact: `Meta Ads – Publish` remains inactive and manual; `WHATSAPP_MESSAGE`
+  is paired only with the WhatsApp handoff URL, while unit appointment URLs are
+  retained as references. A run is not considered closed merely because n8n is
+  green: Drive, journal, locks, readback and notification delivery each need
+  explicit evidence.

--- a/TASKS.md
+++ b/TASKS.md
@@ -29,9 +29,24 @@
 
 - [ ] Confirm or reauthorize the `Google Calendar (Skincos)` credential for the exact scopes required by the inactive clinic Orb workflows.
 - [ ] Provide `GOOGLE_CALENDAR_ID`, approved test data and a non-production-safe validation window before enabling a workflow that can create a real calendar event or booking.
-- [ ] Review and finish the independent Meta Ads publish-journal work in
-  `codex/admin/meta-ads-publish-production-audit`; do not mix it into runtime
-  cleanup commits.
+- [x] Reconciliar e versionar o contrato do `Meta Ads – Publish` (workflow,
+  fontes dos Code nodes, Token Vault, migrations, preflight e testes) pela PR
+  #840; a execução manual 333 concluiu o lote comercial final.
+- [ ] **P1 — reconciliar os runs históricos não terminais do journal Meta Ads e
+  validar a entrega da notificação WhatsApp.** A auditoria de 2026-07-29 não
+  encontrou lock ativo nem pendência no run final `map_f6a59341d6dace99d70f5533`,
+  mas encontrou registros antigos em `acquired`/`processing`/`staged` e um
+  retorno de erro do nó WhatsApp na execução 333. Antes de alterar qualquer
+  registro, mapear os recursos Meta de cada run, decidir compensação ou
+  conclusão idempotente e registrar evidência de entrega; não reenviar
+  notificação nem apagar journal por suposição.
+- [ ] **P1 — promover o source release nativo do Orb até o `main` que contém a
+  PR #840.** O serviço ainda executa o release
+  `71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, anterior ao contrato canônico.
+  O workflow n8n e o Token Vault já estão sincronizados, mas a promoção do
+  release inclui superfícies além do Meta Ads e exige checkpoint, validação
+  pré-produção e autorização explícita de produção. Após a promoção, repetir o
+  preflight a partir do release ativo e registrar o SHA/rollback.
 - [ ] Decide whether draft PR #674 should graduate from the optional GitHub
   autonomy-broker experiment; it is isolated and not deployed.
 

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,38 @@
 # Current state
 
+## Meta Ads Publish closure audit — 2026-07-29T03:00Z
+
+PR #840 merged the canonical workflow and Token Vault contract as
+`11417df9e362f82337882a4b57e87c98b1a21547`; its required checks were green.
+The live workflow `eFJhFg79lyaycjlm` is inactive/manual at version `825`
+(`4ec178e3-bc9d-4ed6-b481-eb9015777b2e`) and the Token Vault production Worker
+is deployment `beba53d9-67f3-495b-a002-5dc579463c29`. The live preflight is
+green and confirms synchronized sources/contracts without a Meta mutation.
+
+The native Orb service source release still resolves to
+`71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, an ancestor that predates PR #840.
+The preflight was intentionally run read-only from the canonical source against
+the live n8n database, so it proves workflow-definition synchronization but not
+that the runtime release itself is at `main`. Native promotion is a separately
+tracked, explicitly authorized production gate.
+
+Manual execution `333` is persisted as `success` (2026-07-28T13:33:57-03:00
+to 13:38:07-03:00). It resumed and completed journal run
+`map_f6a59341d6dace99d70f5533`: visual grouping, video upload, creative
+validation/readback, staging, activation, Drive finalization and completion all
+recorded success. The resulting active ads are BarraShoppingSul
+`120247386191180157` (creative `1011986138341232`) and Novo Hamburgo
+`120247386191560157` (creative `1400344355311942`). The persisted contract is
+WhatsApp / `WHATSAPP_MESSAGE` with `https://api.whatsapp.com/send`; booking
+URLs are retained as unit references and not used as a conflicting destination.
+
+This is not a global journal closure: final-run locks are released and no
+active lock exists, but the production journal still has historical nonterminal
+`acquired`, `processing` and `staged` rows. Telegram notification delivery was
+recorded; the WhatsApp notification node returned an error. Both are tracked as
+P1 in `TASKS.md` and must be reconciled with idempotent readback before this
+workstream can be archived.
+
 ## Observability alert hardening — 2026-07-29T02:23Z
 
 The desktop-alert correction is integrated on `main`: PR #833 merged as

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,21 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-29T03:00:00Z",
+      "surface": "meta-ads-publish-live-n8n-token-vault-github",
+      "scope": "Final closure audit of Meta Ads – Publish",
+      "state": "production-partially-closed-journal-reconciliation-open",
+      "method": "Read-only Orb workflow/execution/health inspection; PostgreSQL execution 333 node-result audit; remote Token Vault D1 SELECTs; Worker version metadata; GitHub PR #840 and origin/main ancestry; targeted worktree/temp inventory",
+      "result": "Workflow eFJhFg79lyaycjlm is inactive/manual at live version 825 (4ec178e3-bc9d-4ed6-b481-eb9015777b2e). Manual execution 333 is persisted success and completed run map_f6a59341d6dace99d70f5533 after resuming it idempotently. Two active journal jobs were created once: BarraShoppingSul ad 120247386191180157 / creative 1011986138341232 and Novo Hamburgo ad 120247386191560157 / creative 1400344355311942. Stage, activate, creative readback, Drive verification and run completion are completed; final-run locks and all unexpired locks are absent. Contract readback records OUTCOME_LEADS, WhatsApp destination, WHATSAPP_MESSAGE and api.whatsapp.com/send. PR #840 merged as 11417df9e362f82337882a4b57e87c98b1a21547 with required checks green; active Token Vault Worker version is 64.",
+      "limitation": "The execution's Telegram notification succeeded, but its WhatsApp notification node returned an error. The journal also retains historical nonterminal acquired/processing/staged records. The native Orb source release remains 71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a, before PR #840; the live preflight therefore proved n8n-definition synchronization from canonical source, not full runtime-release parity with main. No journal rows, locks, ads, creatives or notifications were mutated during this audit; those records and the release promotion require separately evidenced gates before a global archive claim.",
+      "workflow_id": "eFJhFg79lyaycjlm",
+      "execution_id": 333,
+      "run_id": "map_f6a59341d6dace99d70f5533",
+      "pr": 840,
+      "merge_commit": "11417df9e362f82337882a4b57e87c98b1a21547",
+      "token_vault_worker_version": 64
+    },
+    {
       "observed_at": "2026-07-28T20:48:44Z",
       "surface": "windows-observability-and-public-health",
       "scope": "Desktop alert flood investigation and local hardening candidate",

--- a/orb/engine/docs/meta-ads-publish-operations.md
+++ b/orb/engine/docs/meta-ads-publish-operations.md
@@ -83,3 +83,32 @@ versiona o journal, operações e locks idempotentes já usados pelo gateway.
 Uma correção está pronta somente quando há: causa baseada em execução/runtime,
 teste que reproduz o cenário, fontes sincronizadas com o live, preflight verde
 e uma declaração clara sobre o que não foi validado em produção.
+
+## Evidência de encerramento — 2026-07-29
+
+- A última execução comercial bem-sucedida é a manual `333`, concluída em
+  2026-07-28T16:38:07Z. Ela concluiu o run idempotente
+  `map_f6a59341d6dace99d70f5533`, iniciado na execução `331` e retomado pela
+  `333` sem recriar recursos.
+- O lote criou e ativou um anúncio por unidade: BarraShoppingSul
+  `120247386191180157` / criativo `1011986138341232` e Novo Hamburgo
+  `120247386191560157` / criativo `1400344355311942`. O readback da execução
+  confirmou o contrato `OUTCOME_LEADS` + `WHATSAPP_MESSAGE` e o handoff
+  `https://api.whatsapp.com/send`; as URLs de agendamento permanecem apenas
+  como referência por unidade.
+- A definição atualmente viva é a versão `825`
+  (`4ec178e3-bc9d-4ed6-b481-eb9015777b2e`), inativa/manual. Ela foi aplicada a
+  partir da fonte integrada na PR #840 (`11417df9e362f82337882a4b57e87c98b1a21547`).
+  O Token Vault ativo é o deployment
+  `beba53d9-67f3-495b-a002-5dc579463c29`; o checkpoint privado anterior é o
+  rollback operacional.
+- O source release nativo do Orb ainda é
+  `71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, anterior à PR #840. O preflight
+  canônico pode validar a definição viva sem mutação, mas não substitui a
+  promoção versionada desse release; trate-a como um gate operacional separado.
+- O run final tem Drive verificado, stage/activate completos, nenhum lock e
+  nenhum estado `reconciliation_required`. Contudo, a notificação Telegram foi
+  confirmada e a notificação WhatsApp retornou erro; além disso, existem runs
+  históricos não terminais no journal. Eles são uma pendência operacional
+  separada e bloqueiam declarar o fechamento global do journal até a
+  reconciliação idempotente documentada em `TASKS.md`.


### PR DESCRIPTION
## Summary\n- record the final Meta Ads Publish execution, workflow, Token Vault, and rollback evidence\n- distinguish the completed commercial batch from unresolved historical journal and notification work\n- track native Orb source-release drift explicitly instead of implying parity with main\n\n## Validation\n- 
ode --test orb/engine/tests/meta-ads-publish-preflight.test.js\n- 
pm --prefix platform/security/token-vault test\n- 
ode orb/engine/scripts/sync-meta-ads-publish-sources.js check\n- live read-only Meta Ads Publish preflight\n\nNo workflow, Worker, journal, ad, creative, lock, or notification mutation is included.