### PR TITLE
fix(livia): remove mutable verifier wrapper

### DIFF
--- a/docs/project-state/approvals/livia-runtime-repin-c525-20260729.md
+++ b/docs/project-state/approvals/livia-runtime-repin-c525-20260729.md
@@ -1,0 +1,30 @@
+# Livia c525 runtime repin authorization record — 2026-07-29
+
+- **Operator:** `admin`, through the active SKINCOS/Codex task.
+- **Scope:** Livia workflow `WGXr4vYkv9UoJ8zc` only; pin a new historical
+  workflow version to the immutable release
+  `c525f5e1d68829fe4c93197f65d85429a2e0385c`, produced by merged PR #851.
+- **Authorized actions:** re-check for active executions; create a full
+  rollback checkpoint; archive and verify the reviewed descendant; stage it
+  with `--apply --stage-only`; run offline contract checks; create the
+  manifest; publish a version-checked historical repin; and perform read-only
+  health/audit checks.
+- **Explicit exclusions:** `/opt/skincos/current/source`, unrelated workflows,
+  credentials, Drive properties, social destinations and service restarts.
+- **Risk controls:** source archive SHA-256
+  `b60f2001de4768700f6863af527e3755bfdb7d3646afa52956725071f7d1435e`,
+  descendant lineage SHA-256
+  `9ce37392fd63afd687b0d8a0ab7b0bf7c6759e18085ae582228f922463aa7237`,
+  no-active-execution gate, transactional expected-version check, six
+  entrypoint hashes, fail-closed retention guard and immutable rollback
+  checkpoint.
+- **Applied evidence:** workflow version
+  `a1983ff1-4b58-4753-860e-c25dda057f3f` published at
+  `2026-07-29T11:53:04.953Z`; active-manifest SHA-256
+  `a7ced345b16a3538fac5f7dc24135332ac2c2de81bf810744e51352c2989730f`;
+  checkpoint `livia-postpromote-c525f5e1-20260729T085430-0300` index SHA-256
+  `e4eabf9e76bb96c30794a231102466a685d8ce971208dee432fb4b959ac4d60d`.
+
+The authorization does not authorize a synthetic or duplicate social
+publication. A real unpublished Drive item is still required for the final
+end-to-end acceptance journey.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -797,18 +797,24 @@ anteriores e migrations aditivas já aplicadas.
 ## Livia — promoção de bundle isolado 2026-07-29
 
 O workflow Livia (`WGXr4vYkv9UoJ8zc`) está ativo na versão histórica
-`a1983ff1-4b58-4753-860e-c25dda057f3f`, apontando somente para o bundle
-imutável `c525f5e1d68829fe4c93197f65d85429a2e0385c`, produzido do merge da
-PR #851. O ponteiro global não foi alterado. O manifesto ativo tem SHA-256
+`a1983ff1-4b58-4753-860e-c25dda057f3f`, com os cinco sidecars principais
+fixados no bundle imutável `c525f5e1d68829fe4c93197f65d85429a2e0385c`,
+produzido do merge da PR #851. O manifesto ativo tem SHA-256
 `a7ced345b16a3538fac5f7dc24135332ac2c2de81bf810744e51352c2989730f`.
-O schedule diário foi preservado explicitamente como `field: days` às 13:26;
-o audit-live encontrou zero referências mutáveis. Checkpoint pós-promoção:
+O schedule diário foi preservado explicitamente como `field: days` às 13:26.
+Checkpoint pós-promoção:
 `livia-postpromote-c525f5e1-20260729T085430-0300`, índice SHA-256
 `e4eabf9e76bb96c30794a231102466a685d8ce971208dee432fb4b959ac4d60d`.
 
+Uma auditoria posterior encontrou que `Verify Published Artifacts` ainda
+invoca um wrapper externo em `C:\CodexRuntime`, que ignora seu argumento
+versionado e chama `/opt/skincos/current/source`. Portanto, a versão c525 não
+é aceite de isolamento completo: a correção pendente deve reconstruir esse
+comando para chamar diretamente o verificador do bundle, recusar wrappers,
+`--verifier`, DrvFS e ponteiros mutáveis, e publicar uma nova versão histórica.
 O registro de autorização e o runbook versionado especificam a promoção
 `stage-only`, o rollback por nova versão histórica, os probes HTTP e a retenção
 dos bundles referenciados por manifestos. A evidência de publicação real
 continua histórica (execuções 336 e 339); uma publicação posterior só pode ser
-considerada prova da versão ativa se o seu `workflowVersionId` for
-`a1983ff1-4b58-4753-860e-c25dda057f3f` ou um descendente publicado.
+considerada prova da versão corrigida se registrar seu `workflowVersionId`
+publicado e o verificador direto do bundle.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -797,18 +797,18 @@ anteriores e migrations aditivas já aplicadas.
 ## Livia — promoção de bundle isolado 2026-07-29
 
 O workflow Livia (`WGXr4vYkv9UoJ8zc`) está ativo na versão histórica
-`9f7beced-c075-46d1-be78-0e26968e135e`, apontando somente para o bundle
-imutável `f6b8698a450ee2b346ccc93989a365c3455c792d` da PR #837. O ponteiro
-global não foi alterado. O manifesto ativo tem SHA-256
-`4a4fb1d4173021404458eef9b868001fa5cfc33bc21c642d9939f8c2473cfb05`.
+`a1983ff1-4b58-4753-860e-c25dda057f3f`, apontando somente para o bundle
+imutável `c525f5e1d68829fe4c93197f65d85429a2e0385c`, produzido do merge da
+PR #851. O ponteiro global não foi alterado. O manifesto ativo tem SHA-256
+`a7ced345b16a3538fac5f7dc24135332ac2c2de81bf810744e51352c2989730f`.
 O schedule diário foi preservado explicitamente como `field: days` às 13:26;
 o audit-live encontrou zero referências mutáveis. Checkpoint pós-promoção:
-`livia-postpromote-f6b8698a-20260729T112300-0300`, índice SHA-256
-`3cd984dc63e8cef3c1b446cbf15e10dded6b3e588102803795ee5abc97988e4e`.
+`livia-postpromote-c525f5e1-20260729T085430-0300`, índice SHA-256
+`e4eabf9e76bb96c30794a231102466a685d8ce971208dee432fb4b959ac4d60d`.
 
 O registro de autorização e o runbook versionado especificam a promoção
 `stage-only`, o rollback por nova versão histórica, os probes HTTP e a retenção
 dos bundles referenciados por manifestos. A evidência de publicação real
 continua histórica (execuções 336 e 339); uma publicação posterior só pode ser
 considerada prova da versão ativa se o seu `workflowVersionId` for
-`9f7beced-c075-46d1-be78-0e26968e135e` ou um descendente publicado.
+`a1983ff1-4b58-4753-860e-c25dda057f3f` ou um descendente publicado.

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -538,6 +538,18 @@
       "limitation": "The repository record is evidence of the scoped operator authorization and promotion, not a substitute for a pre-promotion staging environment. Historical real publication evidence remains executions 336 and 339; no synthetic social publication was made, and a real active-version journey remains required before closure.",
       "sha": "f6b8698a450ee2b346ccc93989a365c3455c792d",
       "pr": 837
+    },
+    {
+      "observed_at": "2026-07-29T11:53:04.953Z",
+      "surface": "production",
+      "scope": "livia-isolated-runtime-repin-after-pr-851",
+      "state": "production-promoted-post-promotion-audit-pending-real-active-version-journey",
+      "method": "No-active-execution preflight; checksum-verified native archive and descendant lineage; stage-only release preparation; multimodal contract matrix; version-checked manifest and transactional workflow-history publication; audit-live; local http://127.0.0.1:5678/healthz=200 and public https://orb.skincos.com.br/healthz=200",
+      "result": "workflow WGXr4vYkv9UoJ8zc active at a1983ff1-4b58-4753-860e-c25dda057f3f; release c525f5e1d68829fe4c93197f65d85429a2e0385c from PR #851; six entrypoint hashes matched manifest a7ced345b16a3538fac5f7dc24135332ac2c2de81bf810744e51352c2989730f; zero mutable active-runtime references; retention guard rejects cleanup of active bundle",
+      "limitation": "No new social content was available in the date-filtered Drive source folder, so no historical media was reused and no synthetic publication was made. A real production-trigger journey on this active version remains required before closure.",
+      "sha": "c525f5e1d68829fe4c93197f65d85429a2e0385c",
+      "pr": 851,
+      "rollback_checkpoint": "livia-postpromote-c525f5e1-20260729T085430-0300"
     }
   ]
 }

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -529,7 +529,7 @@
       "limitation": "PR/CI/staging pending"
     },
     {
-      "observed_at": "2026-07-29T14:23:15Z",
+      "observed_at": "2026-07-29T11:23:15Z",
       "surface": "production",
       "scope": "livia-isolated-runtime-promotion",
       "state": "production-promoted-post-promotion-audit-pending-real-active-version-journey",
@@ -544,11 +544,21 @@
       "surface": "production",
       "scope": "livia-isolated-runtime-repin-after-pr-851",
       "state": "production-promoted-post-promotion-audit-pending-real-active-version-journey",
-      "method": "No-active-execution preflight; checksum-verified native archive and descendant lineage; stage-only release preparation; multimodal contract matrix; version-checked manifest and transactional workflow-history publication; audit-live; local http://127.0.0.1:5678/healthz=200 and public https://orb.skincos.com.br/healthz=200",
+      "method": "Operator authorization record docs/project-state/approvals/livia-runtime-repin-c525-20260729.md; no-active-execution preflight; checksum-verified native archive and descendant lineage; stage-only release preparation; multimodal contract matrix; version-checked manifest and transactional workflow-history publication; audit-live; local http://127.0.0.1:5678/healthz=200 and public https://orb.skincos.com.br/healthz=200",
       "result": "workflow WGXr4vYkv9UoJ8zc active at a1983ff1-4b58-4753-860e-c25dda057f3f; release c525f5e1d68829fe4c93197f65d85429a2e0385c from PR #851; six entrypoint hashes matched manifest a7ced345b16a3538fac5f7dc24135332ac2c2de81bf810744e51352c2989730f; zero mutable active-runtime references; retention guard rejects cleanup of active bundle",
       "limitation": "No new social content was available in the date-filtered Drive source folder, so no historical media was reused and no synthetic publication was made. A real production-trigger journey on this active version remains required before closure.",
       "sha": "c525f5e1d68829fe4c93197f65d85429a2e0385c",
       "pr": 851,
+      "rollback_checkpoint": "livia-postpromote-c525f5e1-20260729T085430-0300"
+    },
+    {
+      "observed_at": "2026-07-29T12:19:45Z",
+      "surface": "production-runtime-and-isolated-worktree",
+      "scope": "livia-transitive-mutable-verifier-audit",
+      "state": "production-promoted-isolation-noncompliant-remediation-in-progress",
+      "method": "Read-only inspection of active workflow version a1983ff1-4b58-4753-860e-c25dda057f3f, its six-entrypoint manifest and the transitive verifier wrapper; offline candidate reconstruction and deterministic multimedia matrix in an isolated worktree",
+      "result": "The five command roots and manifest hashes were present, but Verify Published Artifacts called C:\\CodexRuntime\\operator\\admin\\skincos\\livia-verify-provider-copy-drift-wrapper.js. That wrapper ignored --verifier and invoked /opt/skincos/current/source, and could accept caption_mismatch. The repaired candidate calls only the pinned release verifier; structural validation, direct/envelope output contract, image/Reel/image-carousel/video-carousel/mixed-carousel matrix, frame-selection and semantic-resume contracts passed without gateway access.",
+      "limitation": "The repaired candidate is not yet integrated or promoted. No social publication, Drive mutation, schedule change, credential change, global pointer change or service restart was performed.",
       "rollback_checkpoint": "livia-postpromote-c525f5e1-20260729T085430-0300"
     }
   ]

--- a/docs/runbooks/livia-isolated-promotion.md
+++ b/docs/runbooks/livia-isolated-promotion.md
@@ -52,6 +52,17 @@ necessária, use somente `scripts/runtime/promote-native-source-release.sh`;
 ele cria a janela de manutenção, aguarda execuções ativas e verifica o CWD do
 Orb. Nunca use `systemctl restart orb.service` diretamente.
 
+### Contrato do verificador
+
+`Verify Published Artifacts` deve chamar diretamente
+`/opt/skincos/releases/<release>/source/orb/engine/scripts/livia/verify-published-artifacts.js`
+via stdin. A promoção deve recusar o candidato se esse comando contiver
+`/opt/skincos/current`, `ORB_ROOT`, `N8N_ROOT`, `/mnt/c`, um wrapper externo,
+ou `--verifier`. Não introduza wrapper para aceitar `caption_mismatch`: uma
+divergência de legenda é falha causal e deve bloquear Drive, notificações e
+cleanup de sucesso até a evidência do provedor ser reconciliada no verificador
+versionado.
+
 ## Rollback de workflow
 
 O rollback é uma nova versão histórica, nunca uma edição do banco nem a

--- a/orb/engine/scripts/apply-livia-runtime-isolation.js
+++ b/orb/engine/scripts/apply-livia-runtime-isolation.js
@@ -11,6 +11,7 @@ const { spawnSync } = require('child_process');
 
 const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
 const REQUIRED_NODES = ['Process Media Asset', 'BQ - Build Platform Job Graph', 'Verify Published Artifacts', 'Record Publish Progress', 'Validate Publish Token Health'];
+const MUTABLE_RUNTIME_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/;
 const args = process.argv.slice(2);
 const sourcePath = args.find((value) => value.endsWith('.json'));
 const expectedVersion = args.find((value) => value.startsWith('--expected-version='))?.slice('--expected-version='.length);
@@ -47,8 +48,11 @@ function assertCandidate(candidate) {
     const node = nodes.get(name);
     const command = String(node?.parameters?.command || '');
     if (node?.type !== 'n8n-nodes-base.executeCommand') fail(`${name} is not an Execute Command node.`);
-    if (!command.includes(releaseRoot) || /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(command)) {
+    if (!command.includes(releaseRoot) || MUTABLE_RUNTIME_RE.test(command)) {
       fail(`${name} is not pinned exclusively to ${releaseRoot}.`);
+    }
+    if (name === 'Verify Published Artifacts' && !command.includes(`${releaseRoot}/scripts/livia/verify-published-artifacts.js`)) {
+      fail('Verify Published Artifacts must invoke the pinned verifier entrypoint directly.');
     }
   }
 }

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -667,6 +667,10 @@ function validateWorkflow() {
   if (!verificationCommand.includes('verify-published-artifacts.js')) {
     errors.push('Verify Published Artifacts must call the external verifier.');
   }
+  if (!/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine\/scripts\/livia\/verify-published-artifacts\.js/.test(verificationCommand) ||
+      /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/.test(verificationCommand)) {
+    errors.push('Verify Published Artifacts must invoke only the pinned immutable verifier without a compatibility wrapper.');
+  }
   const collectCode = String(nodeByName.get('Collect Publish Results')?.parameters?.jsCode || '');
   const processHttpCode = String(nodeByName.get('Process HTTP Publish Result')?.parameters?.jsCode || '');
   if (!processHttpCode.includes('const simulatedRemoteId =') || !processHttpCode.includes('id: simulatedRemoteId')) {

--- a/orb/engine/scripts/patch-livia-runtime-isolation.js
+++ b/orb/engine/scripts/patch-livia-runtime-isolation.js
@@ -17,9 +17,23 @@ const REQUIRED_NODES = new Set([
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine$/;
 const PINNED_ROOT_RE = /\/opt\/skincos\/releases\/[0-9a-f]{7,64}\/source\/orb\/engine/g;
 const SEMANTIC_JOB_KEY_RE = /^livia:v2:[a-f0-9]{64}$/;
+const MUTABLE_RUNTIME_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/;
 
 function fail(message) { throw new Error(message); }
 function arg(prefix) { return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || ''; }
+
+function directVerifierCommand(releaseRoot) {
+  // Keep the verifier inside the workflow-version bundle.  In particular, do
+  // not insert a compatibility wrapper: a wrapper can silently call another
+  // release or turn a provider mismatch into a successful verification.
+  return `={{ (() => {
+  const final = ($json && typeof $json === "object") ? $json : {};
+  function sh(value) {
+    return "'" + String(value).replace(/'/g, "'\\\\''") + "'";
+  }
+  return "set -a; . /etc/skincos/orb-business.env; set +a; printf %s " + sh(JSON.stringify({ final })) + " | node " + sh("${releaseRoot}/scripts/livia/verify-published-artifacts.js") + " --payload -";
+})() }}`;
+}
 
 function patchResumeIdentity(workflow) {
   const nodes = new Map((workflow.nodes || []).map((node) => [node?.name, node]));
@@ -27,6 +41,14 @@ function patchResumeIdentity(workflow) {
   const process = nodes.get('Process HTTP Publish Result');
   if (seed?.type !== 'n8n-nodes-base.code' || process?.type !== 'n8n-nodes-base.code') {
     fail('Livia semantic resume patch requires BQ - Seed Publish State and Process HTTP Publish Result Code nodes.');
+  }
+
+  const seedCode = String(seed.parameters?.jsCode || '');
+  const processCode = String(process.parameters?.jsCode || '');
+  if (seedCode.includes('resumeBySemanticKey') &&
+      seedCode.includes('completedSemanticJobKeys') &&
+      processCode.includes('semanticJobKey: str(source.semanticJobKey')) {
+    return [];
   }
 
   const seedNeedle = `const rawResumeRecords = codexDryRun ? [] : __prAsArray(payload.resumeCompleted);
@@ -79,7 +101,6 @@ for (const entry of resumeRecords) {
 }
 const completedSemanticJobKeys = new Set(resumeRecords.map((entry) => __prStr(entry.semanticJobKey)));
 const pendingJobs = qaAwareJobs.filter((job) => !completedSemanticJobKeys.has(__prStr(job.semanticJobKey)));`;
-  const seedCode = String(seed.parameters?.jsCode || '');
   if (!seedCode.includes(seedNeedle)) {
     fail('Livia semantic resume patch could not find the expected legacy publishRunIndex resume block.');
   }
@@ -87,7 +108,6 @@ const pendingJobs = qaAwareJobs.filter((job) => !completedSemanticJobKeys.has(__
 
   const processNeedle = '    publishRunIndex: source.publishRunIndex,\n    media: {';
   const processReplacement = '    publishRunIndex: source.publishRunIndex,\n    semanticJobKey: str(source.semanticJobKey, ""),\n    media: {';
-  const processCode = String(process.parameters?.jsCode || '');
   if (!processCode.includes(processNeedle)) {
     fail('Livia semantic resume patch could not preserve semanticJobKey in compactResumeRecord.');
   }
@@ -106,15 +126,19 @@ function validate(workflow, releaseRoot) {
     const hasMutableRoot = command.includes('/opt/skincos/current/source/orb/engine');
     const hasPinnedRoot = PINNED_ROOT_RE.test(command);
     PINNED_ROOT_RE.lastIndex = 0;
-    if (!hasMutableRoot && !hasPinnedRoot) fail(`${node.name} has no recognized Orb runtime root.`);
-    node.parameters.command = hasMutableRoot
-      ? command.replaceAll('/opt/skincos/current/source/orb/engine', releaseRoot)
-      : command.replace(PINNED_ROOT_RE, releaseRoot);
+    if (node.name === 'Verify Published Artifacts') {
+      node.parameters.command = directVerifierCommand(releaseRoot);
+    } else {
+      if (!hasMutableRoot && !hasPinnedRoot) fail(`${node.name} has no recognized Orb runtime root.`);
+      node.parameters.command = hasMutableRoot
+        ? command.replaceAll('/opt/skincos/current/source/orb/engine', releaseRoot)
+        : command.replace(PINNED_ROOT_RE, releaseRoot);
+    }
     touched.push(node.name);
   }
   if (touched.length !== REQUIRED_NODES.size) fail(`Expected to pin ${REQUIRED_NODES.size} Livia sidecars, changed ${touched.length}.`);
   const mutable = (workflow.nodes || []).filter((node) => node?.type === 'n8n-nodes-base.executeCommand')
-    .filter((node) => /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(String(node.parameters?.command || '')))
+    .filter((node) => MUTABLE_RUNTIME_RE.test(String(node.parameters?.command || '')))
     .map((node) => node.name);
   if (mutable.length) fail(`Mutable Execute Command reference remains: ${mutable.join(', ')}.`);
   return touched.sort();

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -437,6 +437,8 @@ function validateContracts() {
   assert(commandOf('Cleanup Temp Files').includes('isAllowedCleanupDir'), 'Cleanup Temp Files must delete per-execution asset directories safely');
   assert(verifyCommand.includes('verify-published-artifacts.js'), 'Verify Published Artifacts must call the external verifier');
   assert(verifyCommand.includes('--payload -') && verifyCommand.includes('printf %s'), 'Verifier must receive a bounded payload through stdin');
+  assert(/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine\/scripts\/livia\/verify-published-artifacts\.js/.test(verifyCommand), 'Verifier must invoke the immutable release entrypoint directly');
+  assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/.test(verifyCommand), 'Verifier must not use a mutable root or compatibility wrapper');
   assert(!verifyCommand.includes('Get Credential Tokens') && !verifyCommand.includes('tokenRoot'), 'Verifier must not expose token-vault data in its command line');
   assert(attachVerified.includes('result.ok !== true'), 'Verifier failures must stop final effects');
   assert(assertDrive.includes('appProperties.published'), 'Drive verification must assert published=true');

--- a/orb/engine/scripts/workflow-runtime-manifest.js
+++ b/orb/engine/scripts/workflow-runtime-manifest.js
@@ -10,7 +10,7 @@ const path = require('path');
 
 const DEFAULT_RUNTIME_HOME = '/var/lib/skincos-runtime/orb';
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/([0-9a-f]{7,64})\/source\/orb\/engine$/;
-const MUTABLE_SOURCE_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/;
+const MUTABLE_SOURCE_RE = /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/;
 const WORKFLOW_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 const WORKFLOW_VERSION_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/orb/engine/tests/livia-runtime-isolation.test.js
+++ b/orb/engine/tests/livia-runtime-isolation.test.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const RELEASE = 'c525f5e1d68829fe4c93197f65d85429a2e0385c';
+const RELEASE_ROOT = `/opt/skincos/releases/${RELEASE}/source/orb/engine`;
+const PATCHER = path.resolve(__dirname, '..', 'scripts', 'patch-livia-runtime-isolation.js');
+
+function commandNode(name, command) {
+  return { name, type: 'n8n-nodes-base.executeCommand', parameters: { command } };
+}
+
+function fixture() {
+  const pinned = (entrypoint) => `={{ node '${RELEASE_ROOT}/scripts/livia/${entrypoint}' --payload '{}' }}`;
+  return {
+    id: WORKFLOW_ID,
+    active: true,
+    nodes: [
+      commandNode('Process Media Asset', pinned('process-media-asset.js')),
+      commandNode('BQ - Build Platform Job Graph', `={{ LIVIA_BUILD_JOB_GRAPH_SOURCE='${RELEASE_ROOT}/compose2-current.js' node '${RELEASE_ROOT}/scripts/livia/build-platform-job-graph.js' --payload '{}' }}`),
+      commandNode('Verify Published Artifacts', `={{ node '/mnt/c/CodexRuntime/operator/admin/skincos/livia-verify-provider-copy-drift-wrapper.js' --verifier '${RELEASE_ROOT}/scripts/livia/verify-published-artifacts.js' --payload - }}`),
+      commandNode('Record Publish Progress', pinned('publish-progress-ledger.js')),
+      commandNode('Validate Publish Token Health', pinned('validate-publish-token-health.js')),
+      { name: 'BQ - Seed Publish State', type: 'n8n-nodes-base.code', parameters: { jsCode: 'const resumeBySemanticKey = new Map(); const completedSemanticJobKeys = new Set();' } },
+      { name: 'Process HTTP Publish Result', type: 'n8n-nodes-base.code', parameters: { jsCode: 'const row = { semanticJobKey: str(source.semanticJobKey, "") };' } },
+    ],
+    connections: {},
+  };
+}
+
+test('runtime isolation replaces a mutable verifier wrapper with the pinned entrypoint', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'livia-runtime-isolation-'));
+  try {
+    const input = path.join(temp, 'input.json');
+    const output = path.join(temp, 'output.json');
+    fs.writeFileSync(input, JSON.stringify(fixture()));
+    const result = spawnSync(process.execPath, [PATCHER, input, output, `--release-root=${RELEASE_ROOT}`], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const workflow = JSON.parse(fs.readFileSync(output, 'utf8'));
+    const command = workflow.nodes.find((node) => node.name === 'Verify Published Artifacts').parameters.command;
+    assert.ok(command.includes(`${RELEASE_ROOT}/scripts/livia/verify-published-artifacts.js`));
+    assert.doesNotMatch(command, /\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b|\/opt\/skincos\/current\/source/);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Scope\n\nRemoves the transitive mutable runtime dependency found in the active Livia verifier path.\n\n- Rebuilds **Verify Published Artifacts** to invoke only the version-pinned verifier entrypoint.\n- Rejects /opt/skincos/current, ORB_ROOT, N8N_ROOT, DrvFS, compatibility wrappers and --verifier in candidate, promotion, manifest and QA validation.\n- Makes the semantic-resume patch idempotent for an already modern active workflow.\n- Adds an isolated regression test and records the audit/remediation runbook evidence.\n\nNo workflow, release, schedule, social destination or service was changed by this PR. Promotion remains a separate guarded operation after merge and checks.