### PR TITLE
docs(meta-ads): close final operational audit

### DIFF
--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -47,17 +47,16 @@
   historical worktrees and are not cleanup targets for unrelated tasks.
 - The production workflow is intentionally inactive/manual. Its current live
   version is `830` (`b22ba74a-4fc9-428e-aa4e-41aebfd5b3f0`); the Token Vault
-  production deployment is `beba53d9-67f3-495b-a002-5dc579463c29`. WhatsApp
-  notification uses the private loopback Evolution configuration and a
-  synthetic isolated send reached `DELIVERY_ACK`; Telegram is unchanged.
-  Historical audit closed 46 evidenced pre-stage runs and leaves exactly three
-  staged runs in `reconciliation_required`, documented in
+  production deployment is `beba53d9-67f3-495b-a002-5dc579463c29`. A current
+  isolated Evolution test reached `DELIVERY_ACK`; Telegram remains independent.
+  The historical journal has 110 terminal runs and zero active locks or
+  `reconciliation_required` rows; see
   `orb/engine/docs/meta-ads-publish-historical-run-audit-2026-07-29.md`.
-- The native Orb source release currently resolves to
-  `71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, which predates PR #840. The
-  n8n definition and Worker are reconciled, but the runtime source release is
-  not yet `main`; promote it only through the native release gate with an
-  explicit production authorization and a rollback checkpoint.
+- The native Orb source release resolves to the current `main` merge
+  `a32cf1a9034ccd4872cfbde1ae089e56355300c4` (PR #854). Its immutable archive,
+  verified descendant lineage from `0c0a4fa0f4c2d0b432d449c0ba154e093b3ffe89`,
+  and rollback evidence are private under
+  `C:\CodexRuntime\operator\admin\skincos\native-promotions\`.
 - PR #674 (`codex/admin/github-codex-autonomy`) remains a deliberate draft for
   the optional GitHub autonomy broker; it is not part of the production
   runtime and has no deployment dependency.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -452,8 +452,8 @@
 - Impact: the notification has bounded timeout/retries and can be tested with
   a synthetic message without invoking the commercial workflow or Meta. Runs
   without staging are closed only when operations prove no activation; staged
-  runs remain `reconciliation_required` until a read-only Graph lookup is
-  recorded.
+  runs are closed only after a recorded read-only Graph lookup establishes the
+  physical resource state.
 
 ## 2026-07-29 - Promote native Orb source only through a lineage-checked release
 
@@ -471,3 +471,14 @@
   The preparer grants `postgres` read/traverse access only to the immutable
   Meta Ads preflight surface, so the peer-authenticated audit can validate all
   49 Code nodes without exposing writable source or credentials.
+
+## 2026-07-29 - Close Meta Ads audit only from terminal external evidence
+
+- Decision: close the three historical staged runs only after their physical
+  ads were read from Graph and found `ARCHIVED`; retain the original journal
+  records, append a readback event and use `rolled_back` rather than deletion.
+- Why: a staged job alone is insufficient to infer whether an ad was active,
+  absent or safely recoverable.
+- Impact: the journal now has no active/reconciliation state, while the full
+  audit trail remains available. A current isolated WhatsApp delivery test must
+  reach provider `DELIVERY_ACK`; HTTP acceptance alone is not closure evidence.

--- a/TASKS.md
+++ b/TASKS.md
@@ -36,14 +36,13 @@
 - [x] Reconciliar e versionar o contrato do `Meta Ads – Publish` (workflow,
   fontes dos Code nodes, Token Vault, migrations, preflight e testes) pela PR
   #840; a execução manual 333 concluiu o lote comercial final.
-- [ ] **P1 — concluir as três reconciliações Meta Ads restantes, somente após
-  lookup Graph em modo leitura.** Em 2026-07-29, 46 runs históricos foram
-  encerrados com evento de auditoria e os três que tinham job staged foram
-  corretamente marcados `reconciliation_required`: `map_9c175ce1ed571ccd158ef509`,
-  `map_d4162ea2a7e9660512796dcb` e `map_7464107b2ee04e0cab6a27cf`. O operador
-  Meta Ads deve identificar o recurso físico por operation/resource key e
-  registrar decisão de rollback ou ativação autorizada; não excluir nem mudar
-  recursos por suposição. A entrega WhatsApp foi comprovada isoladamente por
+- [x] **P1 — reconciliar as três pendências Meta Ads por lookup Graph somente
+  leitura.** Em 2026-07-29 os recursos dos runs
+  `map_9c175ce1ed571ccd158ef509`, `map_d4162ea2a7e9660512796dcb` e
+  `map_7464107b2ee04e0cab6a27cf` foram comprovadamente `ARCHIVED` e seus jobs
+  foram fechados como `rolled_back`, com evento imutável de readback. Não houve
+  mutação na Meta; o journal ficou com 110 runs terminais, zero locks ativos e
+  zero `reconciliation_required`. A entrega WhatsApp isolada atingiu
   `DELIVERY_ACK`; Telegram permaneceu independente.
 - [x] **P1 — promover o source release nativo do Orb até o `main` que contém as
   PRs #840 e #844.** Em 2026-07-29 o ponteiro foi promovido de
@@ -55,6 +54,12 @@
   iniciar execução comercial. O workflow permaneceu inativo/manual na versão
   830. A regra de ACL do preparador foi ampliada e testada para que o preflight
   peer-authenticated consiga ler os 49 Code nodes em releases futuros.
+- [x] **P1 — realinhar a release nativa após a integração da PR #854.** O
+  release `a32cf1a9034ccd4872cfbde1ae089e56355300c4` foi promovido por troca
+  atômica a partir de `0c0a4fa0f4c2d0b432d449c0ba154e093b3ffe89`, com archive,
+  lineage, preflight e rollback privados. Orb, proxy, CRM e Booking usam esse
+  mesmo SHA; healths local e públicos, audit-live e preflight Meta Ads passaram
+  sem iniciar execução comercial.
 - [ ] Decide whether draft PR #674 should graduate from the optional GitHub
   autonomy-broker experiment; it is isolated and not deployed.
 

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -818,3 +818,33 @@ dos bundles referenciados por manifestos. A evidência de publicação real
 continua histórica (execuções 336 e 339); uma publicação posterior só pode ser
 considerada prova da versão corrigida se registrar seu `workflowVersionId`
 publicado e o verificador direto do bundle.
+
+## Meta Ads Publish — encerramento operacional 2026-07-29
+
+A execução manual comercial `333` terminou `success` e concluiu
+idempotentemente o run `map_f6a59341d6dace99d70f5533` (o registro preserva a
+origem física na execução `331`). Stage, ativação, Drive, readback, conclusão e
+notificação Telegram foram executados; o teste isolado posterior da Evolution
+foi persistido com `DELIVERY_ACK`. Os anúncios ativos confirmados no Ads Manager
+são `120247386191180157`/criativo `1011986138341232` (BarraShoppingSul) e
+`120247386191560157`/criativo `1400344355311942` (Novo Hamburgo). O contrato
+live conserva `WHATSAPP_MESSAGE` com `https://api.whatsapp.com/send`; os URLs
+de agendamento continuam referências por unidade.
+
+O workflow `eFJhFg79lyaycjlm` está inativo/manual, versão `830`, versão runtime
+`b22ba74a-4fc9-428e-aa4e-41aebfd5b3f0`, schema SHA-256
+`87e82f8d7c89afbe97b6057d1a417013a37e7a2b6227ba14315c4e869e7ce62f`; o
+preflight somente leitura confirmou as 49 fontes sincronizadas e zero mutação
+Meta. O Token Vault está 100% no
+deployment `b24fc28a-ce09-4978-8fc0-ea40561bbb8c`, versão
+`beba53d9-67f3-495b-a002-5dc579463c29`, com D1, token e chave de cifragem
+saudáveis. O journal tem 52 `completed`, 54 `failed`, 3 `rolled_back` e 1
+`calibration_archived`, sem locks ativos, jobs não terminais ou
+`reconciliation_required`.
+
+O source nativo do Orb foi promovido por release descendente de
+`0c0a4fa0f4c2d0b432d449c0ba154e093b3ffe89` para
+`a32cf1a9034ccd4872cfbde1ae089e56355300c4` (merge PR #854). Orb, proxy, CRM
+e Booking usam esse SHA e os health checks local/público são 200. O archive,
+checksum, lineage e rollback permanecem privados em
+`C:\CodexRuntime\operator\admin\skincos\native-promotions\a32cf1a9034ccd4872cfbde1ae089e56355300c4`.

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -552,6 +552,18 @@
       "rollback_checkpoint": "livia-postpromote-c525f5e1-20260729T085430-0300"
     },
     {
+      "observed_at": "2026-07-29T12:50:00Z",
+      "surface": "production-meta-ads-token-vault-orb-and-evolution",
+      "scope": "Meta Ads Publish final operational closure",
+      "state": "closed-with-current-evidence",
+      "method": "Read-only n8n/PostgreSQL execution inspection, Token Vault health and D1 journal queries, current Ads Manager status view, workflow preflight/audit-live, native release pointer/PID/health inspection, and isolated Evolution delivery-status query.",
+      "result": "Execution 333 is success and its idempotent run map_f6a59341d6dace99d70f5533 is completed. Workflow is inactive/manual at version 830 with 49 synchronized sources. Both expected ads are active. Journal has 52 completed, 54 failed, 3 rolled_back and 1 calibration_archived runs, zero active locks, terminal jobs only and no reconciliation_required. Evolution isolated notification reached DELIVERY_ACK. Orb/proxy/CRM/Booking execute native release a32cf1a9034ccd4872cfbde1ae089e56355300c4; Token Vault is healthy on deployment beba53d9-67f3-495b-a002-5dc579463c29.",
+      "limitation": "The Ads Manager view confirms current delivery state; the CTA/handoff evidence remains the persisted Graph readback from the completed commercial run plus the live versioned destination contract. No commercial execution or Meta mutation was performed during this audit.",
+      "sha": "a32cf1a9034ccd4872cfbde1ae089e56355300c4",
+      "pr": 854,
+      "rollback_checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\native-promotions\\a32cf1a9034ccd4872cfbde1ae089e56355300c4"
+    },
+    {
       "observed_at": "2026-07-29T12:19:45Z",
       "surface": "production-runtime-and-isolated-worktree",
       "scope": "livia-transitive-mutable-verifier-audit",

--- a/orb/engine/docs/meta-ads-publish-historical-run-audit-2026-07-29.md
+++ b/orb/engine/docs/meta-ads-publish-historical-run-audit-2026-07-29.md
@@ -18,7 +18,7 @@ ativação, pausa, rollback ou exclusão de recurso Meta.
 | `failed_execution_error` | 6 | A execução n8n correspondente terminou em `error`; não houve staging ou ativação. Estado atualizado para `failed`. |
 | `abandoned_after_creative_before_stage` | 7 | Há `create_creative` concluído, mas não há job, `stage_batch` ou ativação. Estado atualizado para `failed`; possíveis criativos ficam apenas para auditoria futura de órfãos, sem autorização de exclusão. |
 | `abandoned_before_stage` | 33 | Sem staging/ativação e sem evidência de execução resumível. Inclui uploads parciais, falhas pré-criativo e tentativas sem operação. Estado atualizado para `failed`. |
-| `reconciliation_required` | 3 | Há job staged e/ou `stage_batch` concluído, mas nenhuma ativação. Mantido para lookup Graph somente leitura antes de qualquer decisão. |
+| `rolled_back_after_graph_readback` | 3 | Lookup Graph somente leitura encontrou o anúncio físico `ARCHIVED`; evento de readback foi gravado e jobs/runs foram fechados como `rolled_back`, sem mutação Meta. |
 
 ### `failed_execution_error` (6)
 
@@ -53,23 +53,24 @@ ativação, pausa, rollback ou exclusão de recurso Meta.
 `map_3aad73dc83808d2c607a5349`, `map_eb77e6bd8d937da867358b3c`,
 `map_6092f48cd6942488052a434b`.
 
-### Casos que permanecem em `reconciliation_required` (3)
+### Casos encerrados por readback Graph (3)
 
-| Run | Evidência persistida | Responsável | Próximo passo |
-| --- | --- | --- | --- |
-| `map_9c175ce1ed571ccd158ef509` | 1 job staged; `create_creative` e `stage_batch` concluídos; sem `activate_batch`. | Operador Meta Ads | Lookup Graph somente leitura por resource/operation key; registrar se há anúncio físico e decidir ativar ou rollback com autorização. |
-| `map_d4162ea2a7e9660512796dcb` | 1 job staged; `stage_batch` concluído; sem `activate_batch`. | Operador Meta Ads | Mesmo procedimento. |
-| `map_7464107b2ee04e0cab6a27cf` | 1 job staged; `stage_batch` concluído; sem `activate_batch`. | Operador Meta Ads | Mesmo procedimento. |
+| Run | Evidência de readback | Decisão |
+| --- | --- | --- |
+| `map_9c175ce1ed571ccd158ef509` | anúncio `120247362451810157` e criativo `1628576642171208` retornaram `ARCHIVED`. | `rolled_back` com evento `historical_graph_readback_archived_v1`. |
+| `map_d4162ea2a7e9660512796dcb` | anúncio `120247362589160157` e criativo `1628576642171208` retornaram `ARCHIVED`. | `rolled_back` com evento `historical_graph_readback_archived_v1`. |
+| `map_7464107b2ee04e0cab6a27cf` | anúncio `120247362613520157` e criativo `1028746516559170` retornaram `ARCHIVED`. | `rolled_back` com evento `historical_graph_readback_archived_v1`. |
 
 ## Contagem confirmada depois da reconciliação
 
 - `calibration_archived`: 1
 - `completed`: 52
 - `failed`: 54
-- `reconciliation_required`: 3
+- `rolled_back`: 3
 - locks ativos: 0
-- eventos de auditoria gravados: 49
+- `reconciliation_required`: 0
+- jobs não terminais: 0
 
-Os três casos restantes não podem ser encerrados sem a evidência externa
-específica indicada acima. Não há execução comercial em andamento e esta
-auditoria não alterou anúncios, campanhas, conjuntos ou criativos.
+Não há execução comercial em andamento. A reconciliação adicionou somente
+evidência ao journal; não criou, ativou, pausou, arquivou ou excluiu recursos
+na Meta.

--- a/orb/engine/docs/meta-ads-publish-operations.md
+++ b/orb/engine/docs/meta-ads-publish-operations.md
@@ -97,16 +97,20 @@ e uma declaração clara sobre o que não foi validado em produção.
   `https://api.whatsapp.com/send`; as URLs de agendamento permanecem apenas
   como referência por unidade.
 - A definição atualmente viva é a versão `830`
-  (`b22ba74a-4fc9-428e-aa4e-41aebfd5b3f0`), inativa/manual. Ela foi aplicada
+  (`b22ba74a-4fc9-428e-aa4e-41aebfd5b3f0`; schema SHA-256
+  `87e82f8d7c89afbe97b6057d1a417013a37e7a2b6227ba14315c4e869e7ce62f`),
+  inativa/manual. Ela foi aplicada
   versionadamente a partir da exportação canônica; o checkpoint privado da
   versão `825` permanece como rollback operacional.
   O Token Vault ativo é o deployment
   `beba53d9-67f3-495b-a002-5dc579463c29`; o checkpoint privado anterior é o
   rollback operacional.
-- O source release nativo do Orb ainda é
-  `71ec3a8f63bd8fcaa6861ad1487baf6f1e1be59a`, anterior à PR #840. O preflight
-  canônico pode validar a definição viva sem mutação, mas não substitui a
-  promoção versionada desse release; trate-a como um gate operacional separado.
+- O source release nativo do Orb está em
+  `a32cf1a9034ccd4872cfbde1ae089e56355300c4` (merge da PR #854), descendente
+  do release `0c0a4fa0f4c2d0b432d449c0ba154e093b3ffe89`. A promoção usou
+  archive verificável, lineage, drenagem e troca atômica; Orb, proxy, CRM e
+  Booking executam essa mesma release. Rollback permanece uma nova promoção
+  descendente/revertida a partir do checkpoint privado.
 - O run final tem Drive verificado, stage/activate completos e nenhum lock
   ativo. Telegram foi preservado como ramo independente. A notificação
   WhatsApp passou a usar HTTP direto para a Evolution no loopback, com instância
@@ -116,9 +120,9 @@ e uma declaração clara sobre o que não foi validado em produção.
   mensagem sintética e devolveu `DELIVERY_ACK`. Isso comprova entrega pelo
   provedor, não leitura humana.
 - A auditoria histórica está em
-  `docs/meta-ads-publish-historical-run-audit-2026-07-29.md`. Ela gravou um
-  evento imutável por run, encerrou 46 runs comprovadamente sem staging como
-  `failed` e deixou três runs staged em `reconciliation_required`. Não houve
-  ativação, rollback, exclusão ou consulta Graph nessa auditoria. Antes de
-  qualquer ação sobre esses três, o responsável Meta Ads deve fazer lookup
-  Graph somente leitura e registrar uma decisão explícita.
+  `docs/meta-ads-publish-historical-run-audit-2026-07-29.md`. Os três runs
+  anteriormente staged receberam lookup Graph somente leitura, com anúncios
+  comprovadamente `ARCHIVED`, e foram fechados como `rolled_back` com evento
+  imutável. O estado atual é 110 runs terminais, zero locks ativos, jobs não
+  terminais e `reconciliation_required`; nenhuma ação Meta foi feita na
+  reconciliação.

--- a/orb/engine/scripts/inspect-meta-ads-publish-version-alignment.js
+++ b/orb/engine/scripts/inspect-meta-ads-publish-version-alignment.js
@@ -134,7 +134,11 @@ async function main() {
       version_counter: Number(row.versionCounter),
       current_version_id: row.versionId,
       active_version_id: row.activeVersionId,
-      version_aligned: row.versionId === row.activeVersionId,
+      // Inactive workflows execute their current definition; activeVersionId is
+      // intentionally null and must not be reported as configuration drift.
+      version_aligned: row.active === true
+        ? row.versionId === row.activeVersionId
+        : executionSummary.version_id === row.versionId,
       manual_execution_audit: manualExecutionAuditState(parseJson(row.settings, {})),
       execution_version_id: executionSummary.version_id,
       execution: executionSummary,

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -34,6 +34,15 @@ test('execution version follows current for inactive workflows and published ver
   assert.deepEqual(executionSummaryForWorkflow({ active: true, activeVersionId: 'published' }, current, history), history[0]);
 });
 
+test('version alignment treats an inactive workflow current definition as authoritative', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'scripts', 'inspect-meta-ads-publish-version-alignment.js'),
+    'utf8',
+  );
+  assert.match(source, /row\.active === true/);
+  assert.match(source, /executionSummary\.version_id === row\.versionId/);
+});
+
 test('manual execution retention is reported without assuming execution data exists', () => {
   assert.equal(manualExecutionAuditState({ saveManualExecutions: true }), 'persisted');
   assert.equal(manualExecutionAuditState({ saveManualExecutions: false }), 'not_persisted');


### PR DESCRIPTION
## Summary
- records live final audit evidence and historical journal closure
- fixes inactive workflow version-alignment reporting
- updates Meta Ads runbook, project state, tasks, decisions and evidence ledger

## Validation
- targeted Meta Ads/Token Vault suites (37 passing)
- source synchronization check
- live read-only preflight/audit, Token Vault health and D1 journal checks
- no Meta mutation or commercial execution