### PR TITLE
docs(ops): reconcile current Finance evidence

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # TASKS
 
-## P0 operacional — incidente de acesso a Insumos
+## Resolved P0 — incidente de acesso a Insumos
 
 - [x] **P0 — restaurar e estabilizar o acesso por unidade do módulo de Insumos.**
   O ciclo foi concluído em `f30f66e70e0dc949adde5120378509a1c95fe557` e
@@ -10,6 +10,25 @@
   fora do escopo preservada como `403/RBAC_UNIT_DENIED`. A regressão autenticada
   de Atendimento também foi aprovada. Débitos de outros módulos seguem
   independentes deste P0.
+
+## Finance — authoritative reconciliation follow-up (2026-07-29)
+
+- [x] Confirm continuous external observability, a controlled human-alert
+  recovery, historical Finance rollback/kill-switch/scratch-restore evidence,
+  and the merged PR #815 import state machine.
+- [ ] Create a candidate from the then-current `origin/main` and, in a
+  separately authorized staging operation, promote that exact SHA through the
+  canonical Finance Worker/UI preview and staging pipelines. Complete the
+  synthetic authenticated import/UI journey on the same artifact lineage.
+- [ ] Obtain an authorized streaming/provider path for fresh PostgreSQL
+  offsite retrieval, verify integrity, and perform the isolated scratch
+  restore. D1/runtime-config evidence does not close this PostgreSQL gate.
+- [ ] Keep Finance `experimental`; do not enable the module, change grants or
+  start a production pilot until the two preceding gates and named pilot
+  approval are recorded.
+- [ ] Treat production Finance provisioning as a separate approval: create and
+  attest only the isolated Worker, D1, KV, Pages project and environment
+  configuration through the canonical path; do not copy staging identifiers.
 
 ## Controle de Ponto — `codex/admin/workforce-timekeeping-complete`
 

--- a/docs/architecture/module-catalog.json
+++ b/docs/architecture/module-catalog.json
@@ -141,6 +141,15 @@
     {
       "id": "finance",
       "maturity": "experimental",
+      "readiness": {
+        "assessedAt": "2026-07-29T14:02:00Z",
+        "state": "experimental",
+        "integratedImportStateMachine": "PR #815 / 32bf3ebb296ca95e3273bb4fed664480eb5642e5",
+        "stagingBaseline": "Worker and independent UI healthy at 32bf3ebb; module_enabled=false; not a current-main single-SHA release",
+        "provenCapabilities": ["staging rollback", "remote kill switch", "isolated scratch restore", "continuous external monitor and controlled human alert"],
+        "openGates": ["current-main single-SHA preview/staging", "synthetic authenticated import/UI journey", "fresh offsite PostgreSQL retrieval and scratch restore", "named pilot approval"],
+        "production": "not provisioned: skincos-finance Worker, D1, control KV and Finance UI project absent"
+      },
       "owner": { "primary": "@jubenitogarcia", "backup": "unassigned" },
       "dataOwnership": ["Ledger, accounts, obligations, movements, imports, access grants and finance audit trail"],
       "dependencies": { "hard": ["shared"], "optional": ["integration"] },

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -1,87 +1,55 @@
-# Blockers
+# Current blockers
 
-## P0 — Insumos unit access
+## Resolved — Insumos unit access P0
 
-PR #763 remains the source correction; the current closure evidence is the
-immutable release `f30f66e70e0dc949adde5120378509a1c95fe557`, recorded on
-`main` by PR #847/#848. Production Inventory run `30420719000` and CRM Pages
-run `30420793906` completed through the canonical pipelines with checkpoint
-artifact `8711811875`. Controlled synthetic onboarding and authenticated UI
-smokes passed, including canonical-unit access, localStorage reconciliation,
-Atendimento without `UNAUTHORIZED`, and explicit out-of-scope denial
-`403/RBAC_UNIT_DENIED`. All synthetic identities were torn down; no business
-data, real user, grant or flag was changed.
+Insumos is not an executable blocker. The production closure is recorded on
+`main` by PRs #847/#848, using canonical Inventory run `30420719000`, CRM
+Pages run `30420793906`, checkpoint artifact `8711811875`, and sanitized
+synthetic positive/negative unit-scope smokes. Retain rollback evidence, but
+do not reopen this item without a new production symptom.
 
-The P0 queue item can be marked resolved for orchestration purposes, with the
-rollback checkpoints and sanitized evidence retained in the evidence ledger.
-Do not infer that this unlocks Finance production activation: Finance staging
-rollback/restore and its separate nominal gate remain required before any pilot.
+## Finance — staging release evidence is incomplete
 
-Finance pilot activation remains separately blocked by current staging evidence
-and named human approval; it is frozen independently of the resolved P0 item.
+The current Finance staging Worker and independent UI are healthy at
+`32bf3ebb…` (runs `30168445270` and `30168445288`), but current `origin/main`
+is `6963ba04…`; the API and general CRM Pages staging versions differ as well.
+The next technical milestone is therefore a single immutable current-main
+candidate through canonical Finance Worker/UI preview and staging, followed by
+the synthetic authenticated import/UI journey. Until that happens, no staging
+release is eligible for a pilot decision.
 
-## Finance staging gate — current status
+Historical staging evidence remains valid only for the capabilities it tested:
+rollback `30143185583`, remote kill switch
+`30143674681`/`30143742671`, scratch restore and the controlled canary stop.
+The `audit returned 503` in canary `30168648150` was restored and is not a
+current outage: fresh Worker/gateway probes and the continuous monitor are
+healthy. External observability is complete as infrastructure, with a live
+Run-key monitor, dashboard, 30-day retention and recorded human-alert drill.
 
-The fresh offsite retry at 2026-07-25T04:55Z did not close the remaining
-transfer gate. Drive metadata and the four expected objects were visible, but
-the connector's raw PostgreSQL download exceeded its IPC frame limit; the
-private rclone/direct-token attempts could not list or read the folder (403 or
-directory-not-found). No payload, secret, production data or scratch resource
-was changed. Existing local ciphertexts remain manifest-matched only and must
-not be relabeled as a fresh offsite restore.
+## Finance — offsite PostgreSQL recovery remains blocked
 
-The current-main rollback/restore exercise is now complete for candidate SHA
-`b869485b6a33fae5a5dbe504b41660f842fb4ca9`. Worker preview/staging runs
-`30143039262`/`30143051826` promoted it, rollback `30143185583` restored the
-reachable immutable SHA `8af1d5fe9551891a05a104363043bf3d36fb4ef4`, and the
-scratch D1/KV/R2/Worker restore passed its synthetic authenticated journey.
-The UI staging artifact was built from the same candidate (`30143594297`).
-The kill switch was validated against remote KV by `30143674681` and restored
-by `30143742671`; the shell remained healthy while Finance returned 423.
-Scratch resources were destroyed after checksums and functional evidence were
-captured. This is evidence for rollback and recovery, not a production or pilot
-approval. The sanitized private record is retained outside the repository.
+The D1 offsite restore and fresh runtime-config retrieval are valid, but a
+fresh provider-vault retrieval and scratch restoration of the large PostgreSQL
+object is still unproven. The provider connector exceeded its IPC limit and the
+alternate path was unauthorized. An authorized streaming/provider identity is
+required; do not relabel manifest-matched local ciphertext as an offsite
+restore.
 
-PR #740 is integrated; follow-up state/evidence PRs #800, #801, #802, #804,
-#805, #806 and #807 are integrated. Current main is
-`68f88e070629e4077a1a1754b3347e60dc89be18`.
-The offsite drill has valid D1 retrieval/restore evidence and matching
-PostgreSQL/configuration ciphertext hashes. A fresh runtime-config transfer
-was subsequently fetched and decrypted with the versioned restore script; its
-plaintext SHA matched the manifest and the plaintext was destroyed after
-sanitized inspection. The fresh PostgreSQL transfer remains blocked because
-the connector exceeds its IPC limit for the 90,908,667-byte object and the
-alternate provider path lacks authorization. The complete offsite gate
-therefore remains open. No module promotion, flag, grant or production change
-is authorized by this evidence.
+## Finance — production is not provisioned
 
-A follow-up streaming attempt with rclone 1.60.1 reached the same restricted
-Drive vault but was rejected with provider `RATE_LIMIT_EXCEEDED`; it downloaded
-no bytes and changed no state. The next action is to wait for the quota window
-or use an authorized service account, then repeat hash verification and scratch
-restore. This is an external-provider blocker, not a reason to activate
-Finance.
+Read-only Cloudflare queries confirm that production Worker `skincos-finance`
+does not exist. Consequently production D1 `skincos-finance`, a Finance control
+KV namespace, Finance UI Pages project, Worker secret/version/artifact and
+Finance migration are absent. The production API binding targets that missing
+Worker and Core API run `30418523054` failed before upload or smoke. GitHub
+production lacks the Finance-specific D1/KV variable names and backup/service
+secret names required by the canonical workflow; the production release flag
+is disabled. Provisioning these isolated resources needs separate explicit
+production authorization and precedes any production/pilot activation.
 
-The current-main SHA `8af1d5fe9551891a05a104363043bf3d36fb4ef4` has a successful
-candidate (`30139535704`), preview (`30139561027`) and staging deployment
-(`30139576133`) with Worker version
-`97c7a7da-6a78-44a8-b980-2cc2810df7a0`. A controlled rollback (`30139701809`)
-restored immutable SHA `67ee53843a9a52ad495ab6d67b8cd2b4fac053f9` using Worker
-version `c57fdafc-6045-4eb5-8b38-07ae98d7c256`; health stayed ready and no
-migrations or unrelated modules were touched. The synthetic canary abort drill
-(`30139247054`) also proved the remote kill switch and baseline restoration.
+## Pilot decision
 
-These staging gates are now evidenced, but they do not unlock the pilot. The
-remaining blockers are authenticated import/UI smoke, an external monitor with
-human alert evidence, encrypted offsite backup plus restore for the
-current-main artifact, and named approval. `module_enabled` remains false and
-no real user or unit is enabled.
-
-Inventory production is stable on the single reconciled `RELEASE_SHA`
-`c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d`. The additive
-`0017_employee_onboarding.sql` migration is present in the journal with zero
-onboarding payloads; no new promotion is required. `IDENTITY_PII_KEY` exists in
-the staging and production GitHub environments, but external vault/escrow and
-recovery ownership for the generated production key are not evidenced. This is
-an operational security debt and must be closed before onboarding data is
-created or the key is rotated; it does not justify another production deploy.
+`module_enabled` is false and no production actor, grant, flag, secret or data
+may change. A named pilot approval is meaningful only after the current-main
+single-SHA staging journey and the offsite PostgreSQL recovery gate are both
+closed.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,67 @@
 # Current state
 
+## Authoritative Finance reconciliation — 2026-07-29T14:02Z
+
+This entry is the authoritative Finance status for `origin/main`
+`6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b`. Older entries below remain an
+audit trail; they do not prove a later deployment or replace the facts in this
+section.
+
+**Integrated:** PR #815 is merged at `32bf3ebb296ca95e3273bb4fed664480eb5642e5`
+and is an ancestor of the current `main`. Its import state machine is present:
+only a persisted `decision=import` on a valid row contributes to preview and
+commit, a completed batch rejects a new key with `IMPORT_ALREADY_COMMITTED`,
+replaying the same key is idempotent, and undo is compensating/audited.
+
+**Staging:** Finance Worker preview/staging runs `30168426616`/`30168445270`
+and Finance UI runs `30168426575`/`30168445288` attested `32bf3ebb…`. Direct
+reads now return `200`, `ready=true`, healthy D1/module-control dependencies
+and version `32bf3ebb…`; the D1 journal has migrations `0001`–`0012` and
+`finance_settings.module_enabled=false`. The currently deployed Finance
+Worker is immutable version `51bd6fa4-d775-43e4-96c3-6fbe0cec8513`; the
+independent UI Pages deployment also reports source `32bf3eb…`. This is a
+healthy, disabled staging baseline, **not** a current-main single-SHA release:
+the staging API reports `2ba1e0a7…` and the general CRM Pages project reports
+`f30f66e…`.
+
+**Recovery and observability:** staging rollback run `30143185583`, remote-KV
+kill-switch runs `30143674681`/`30143742671`, and the isolated Finance scratch
+restore are valid historical proof of rollback, kill switch and restore. The
+outside-GitHub Windows monitor is currently live through the `SkincosObservability`
+Run-key supervisor; its loopback dashboard `/health` and `/metrics` returned
+`200` at this reconciliation, with 30-day retention and a recorded controlled
+human desktop alert/recovery. This closes the monitor-infrastructure blocker,
+but it does not make a later Finance artifact observed.
+
+The `audit returned 503` canary result in run `30168648150` is historical:
+that run stopped, restored its baseline, and failed the promotion as designed.
+Fresh direct Worker/gateway probes and the continuous monitor currently return
+healthy Finance responses; there is no current observation of that `503`.
+It remains a resilience finding, not a current deployment blocker.
+
+**Production:** direct Cloudflare read-only queries confirm that
+`skincos-finance` does not exist. There is no production `skincos-finance` D1,
+Finance control KV namespace, Finance UI Pages project, Worker secret, Worker
+version, artifact or applied Finance migration. The production API's `FINANCE`
+binding remains configured for that absent Worker; Core API run `30418523054`
+therefore failed before upload/smoke (Cloudflare `10143`). Production API
+`/health` is reachable, while `/readiness` is `404` and `/finance/health` is
+`401`; none is Finance production proof. Production environment configuration
+also lacks the four Finance-specific names required by the canonical workflow:
+`FINANCE_D1_PRODUCTION_ID`, `FINANCE_CONTROL_PRODUCTION_KV_ID`,
+`FINANCE_BACKUP_PASSPHRASE` and `FINANCE_SERVICE_AUTH_SECRET`.
+
+**Open gates:** first create a new immutable candidate from the current main,
+then run the canonical Finance Worker/UI preview and staging paths and complete
+the synthetic authenticated import/UI journey against that one SHA. The
+offsite PostgreSQL recovery gate remains blocked: D1 offsite restoration and
+runtime-config retrieval are evidenced, but the large PostgreSQL object has
+not been freshly retrieved from the provider-separated vault (IPC limit and
+unauthorized alternate path). A named pilot approval follows only after those
+staging gates. Production provisioning is a separate, explicitly authorized
+change; no production resource, flag, grant, user, secret or data was changed
+by this reconciliation.
+
 ## Finance production provision — blocked before workflow dispatch — 2026-07-29T11:21Z
 
 The versioned architecture is unambiguous: the production Finance Worker is

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,20 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-29T14:02:00Z",
+      "surface": "origin-main-github-actions-cloudflare-d1-pages-live-http-and-operator-monitor",
+      "scope": "Authoritative Finance reconciliation",
+      "state": "experimental-staging-baseline-current-main-gate-open",
+      "method": "Fetched origin/main; inspected merged PRs after #815, canonical workflow definitions and recent runs; queried GitHub environment variable/secret names only; made read-only Cloudflare Worker/D1/KV/Pages queries; executed direct health/readiness probes; and inspected the private external-monitor health/metrics without reading secret values or personal data.",
+      "result": "origin/main is 6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b. PR #815 is merged at 32bf3ebb296ca95e3273bb4fed664480eb5642e5 and remains an ancestor. Its Worker/UI preview and staging runs 30168426616/30168445270 and 30168426575/30168445288 attest that SHA. Live staging Finance health/readiness and gateway probes are 200, ready, version 32bf3ebb, D1/module-control healthy, module_enabled=false and the D1 journal contains migrations 0001 through 0012. Direct Workers inspection identifies immutable staging version 51bd6fa4-d775-43e4-96c3-6fbe0cec8513. The historical rollback 30143185583, kill-switch 30143674681/30143742671 and scratch restore remain valid for those tested capabilities. The external Windows monitor is live through its Run-key supervisor with loopback health/metrics 200, 30-day retention and recorded controlled human-alert/recovery evidence. The historical canary audit 503 in 30168648150 is not currently observed by live probes or the monitor.",
+      "limitation": "This is not a current-main single-SHA Finance staging release: staging API reports 2ba1e0a7 and general CRM Pages reports f30f66e while Finance Worker/UI report 32bf3ebb. No synthetic authenticated import/UI journey is evidenced for a current-main candidate. D1 offsite restore and runtime-config retrieval are evidenced, but fresh offsite PostgreSQL retrieval/restoration remains blocked by the connector IPC limit and unauthorized alternate access. Production Finance is absent: direct Cloudflare reads report Worker skincos-finance missing; no Finance production D1/KV/UI/Worker secret/version/artifact/migration exists, and Core API run 30418523054 failed before upload or smoke because its FINANCE binding targets that missing Worker. No production, flag, grant, user, secret, resource or data was changed.",
+      "sha": "6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b",
+      "pr": 815,
+      "runs": [30168426616, 30168445270, 30168426575, 30168445288, 30143185583, 30143674681, 30143742671, 30168648150, 30418523054, 30456978257],
+      "evidence_ref": "C:\\CodexRuntime\\operator\\admin\\skincos\\finance-recovery-drills\\20260725T-current-main-b869485b\\restore-evidence.sanitized.json",
+      "next_action": "Under a separate staging authorization, promote an explicit current-main SHA through canonical Finance Worker/UI preview and staging, then run the controlled synthetic authenticated import/UI journey. Obtain authorized provider streaming before retrying the PostgreSQL offsite restore."
+    },
+    {
       "observed_at": "2026-07-29T11:21:32Z",
       "surface": "github-actions-cloudflare-configuration-and-live-endpoints",
       "scope": "Finance canonical production provision preflight",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,5 +1,7 @@
 {
   "schema": 1,
+  "authoritative_at": "2026-07-29T14:02:00Z",
+  "source_main_sha": "6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b",
   "items": [
     {
       "id": "p0-insumos-unit-access",
@@ -8,124 +10,151 @@
       "state": "resolved",
       "dependencies": [],
       "blockers": [],
-      "environment": "staging",
+      "environment": "production",
       "permitted_actions": [
-        "read-only runtime verification and actor correlation",
-        "record production versions and rollback metadata without publishing",
-        "preserve rollback artifacts",
-        "preserve rollback artifacts and monitor the promoted release"
+        "read-only regression observation",
+        "preserve immutable rollback and sanitized evidence"
+      ],
+      "prohibited_actions": [
+        "reopen the incident without a new observed symptom",
+        "use this resolved incident to authorize Finance activation"
       ],
       "required_evidence": [
-        "PR #763 and functional PR #776 integrated on current main",
-        "current-main candidate manifest and checksum",
-        "Inventory and CRM Pages preview/staging all attest the same current SHA",
-        "positive and negative unit-scope access validation",
-        "synthetic environment journey proving access per authorized unit",
-        "read-only identification of the current CRM actor before production consideration",
-        "production current-version and rollback checkpoint"
+        "PR #763/#776 source lineage",
+        "canonical production runs 30420719000 and 30420793906",
+        "synthetic positive and negative unit-scope journey"
       ],
-      "done_definition": "The unit-access regression is corrected, CI remains green, current-main staging and production prove authorized access for the canonical units, and denied cross-unit/no-unit behavior is covered without business-data mutation.",
-      "next_item": null,
-      "last_verified": "2026-07-29T04:36:09Z",
-      "sha": "f30f66e70e0dc949adde5120378509a1c95fe557",
-      "pr": 763,
+      "done_definition": "Resolved; retained only for audit and regression observation.",
+      "next_item": "finance-current-main-staging-evidence",
+      "last_verified": "2026-07-29T14:02:00Z",
       "evidence": {
-        "historical_inventory_preview_run": 30125747962,
-        "historical_crm_pages_preview_run": 30125749745,
-        "historical_inventory_staging_run": 30125805545,
-        "historical_crm_pages_staging_run": 30125807334,
-        "historical_authenticated_journey_run": 30129792473,
-        "historical_release_sha": "f276919ce6a63b337bd02bd0c3799dbf38f13b97",
-        "missing_functional_merge": "7ba0c11d8a98ff87262b13e268892191120c8544",
-        "historical_fixtures_torn_down": true,
-        "candidate_run": 30135641022,
-        "candidate_source_tree": "b22e897c8a4699f1424b3ee83656016be488ad67",
-        "candidate_source_archive_sha256": "22b9cf2a6845cc2e6348f0e797f69f6c5f89d7b42665bd27460ca8e131d60155",
-        "current_inventory_preview_run": 30135763050,
-        "current_crm_pages_preview_run": 30135762996,
-        "current_inventory_staging_run": 30135788180,
-        "current_crm_pages_staging_run": 30135788135,
-        "current_authenticated_journey_run": 30135863885,
-        "current_pages_url": "https://ca2b2a39.skincos-staging.pages.dev",
-        "current_fixtures_torn_down": true,
-        "production_inventory_run": 30137182608,
-        "production_pages_run": 30137826907,
-        "production_inventory_deployment": "2a71e616-64fc-40ff-8480-5c24fad4497e",
-        "production_inventory_version": "6d7dadc6-7b02-4577-b8b3-d1d4a09cd9ef",
-        "production_pages_deployment": "e65832a0-5925-4212-b252-2ff20cd08362",
-        "production_release_sha": "c64ff2b6655ce9e035a1b3a3840b1d6d809a9c2d",
-        "production_authenticated_smoke": "controlled synthetic onboarding and authenticated UI smokes passed; all synthetic identities were torn down",
-        "production_inventory_run": 30420719000,
-        "production_pages_run": 30420793906,
-        "production_checkpoint_artifact": 8711811875,
-        "production_rbac_scope_smoke": "403/RBAC_UNIT_DENIED for a canonical unit outside the synthetic actor scope"
+        "release_sha": "f30f66e70e0dc949adde5120378509a1c95fe557",
+        "inventory_run": 30420719000,
+        "crm_pages_run": 30420793906,
+        "checkpoint_artifact": 8711811875
       }
     },
     {
-      "id": "finance-staging-gate",
-      "objective": "Close Finance staging gates without enabling production or real users.",
+      "id": "finance-current-main-staging-evidence",
+      "objective": "Create one immutable Finance staging release from current main and prove its synthetic authenticated import/UI journey.",
       "priority": 100,
-      "state": "partially-validated",
+      "state": "ready-for-authorized-staging-operation",
       "dependencies": [],
       "blockers": [
-        "authenticated import and UI smoke",
-        "external monitor and human alert",
-        "fresh offsite PostgreSQL and runtime-config download",
-        "isolated restore drill for the current-main Finance artifact bundle",
-        "named human approval"
+        "current staging Finance Worker/UI attest 32bf3ebb rather than source_main_sha",
+        "no synthetic authenticated import/UI journey attested for a current-main single-SHA artifact"
       ],
       "environment": "staging",
       "permitted_actions": [
-        "staging-only rollback and kill-switch drills",
-        "staging-only scratch restore with synthetic data",
-        "read-only evidence capture"
+        "build a candidate from an explicit current main SHA",
+        "canonical Finance Worker/UI preview and staging promotion",
+        "synthetic authenticated import/UI smoke, canary observation and sanitized evidence capture",
+        "staging-only rollback or kill-switch drill"
+      ],
+      "prohibited_actions": [
+        "production deployment",
+        "module_enabled activation for real users",
+        "production grants, users, flags, secrets, data or resources"
       ],
       "required_evidence": [
-        "authenticated import and UI smoke",
-        "external monitor and human alert",
-        "encrypted offsite D1 backup",
-        "isolated restore drill",
-        "CI",
-        "staging journey",
-        "rollback"
+        "same SHA in Finance Worker and Finance UI preview/staging promotion evidence",
+        "staging migration journal and health/readiness/version evidence",
+        "synthetic authenticated import state-machine and UI journey",
+        "canary thresholds and rollback availability for that candidate"
       ],
-      "done_definition": "All required staging evidence is current; production remains disabled.",
-      "next_item": "finance-pilot-approval",
-      "last_verified": "2026-07-25T03:26:00Z",
-      "sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
-      "pr": 762,
+      "done_definition": "A single immutable current-main Finance artifact lineage is healthy in staging and has passed the controlled synthetic authenticated journey; Finance remains experimental and disabled.",
+      "next_item": "finance-offsite-postgresql-recovery",
+      "last_verified": "2026-07-29T14:02:00Z",
       "evidence": {
-        "candidate_run": 30139535704,
-        "preview_run": 30139561027,
-        "staging_deploy_run": 30139576133,
-        "staging_release_sha": "8af1d5fe9551891a05a104363043bf3d36fb4ef4",
-        "staging_worker_version": "97c7a7da-6a78-44a8-b980-2cc2810df7a0",
-        "rollback_run": 30139701809,
-        "rollback_sha": "67ee53843a9a52ad495ab6d67b8cd2b4fac053f9",
-        "rollback_worker_version": "c57fdafc-6045-4eb5-8b38-07ae98d7c256",
-        "canary_abort_drill": 30139247054,
-        "scratch_restore": "validated; resources destroyed after sanitized evidence"
+        "current_staging_sha": "32bf3ebb296ca95e3273bb4fed664480eb5642e5",
+        "worker_preview_run": 30168426616,
+        "worker_staging_run": 30168445270,
+        "ui_preview_run": 30168426575,
+        "ui_staging_run": 30168445288,
+        "worker_version": "51bd6fa4-d775-43e4-96c3-6fbe0cec8513",
+        "module_enabled": false,
+        "migration_journal": "0001 through 0012"
+      }
+    },
+    {
+      "id": "finance-offsite-postgresql-recovery",
+      "objective": "Prove fresh provider-separated PostgreSQL retrieval and isolated scratch restoration for the Finance recovery gate.",
+      "priority": 99,
+      "state": "blocked-external-provider-access",
+      "dependencies": ["finance-current-main-staging-evidence"],
+      "blockers": [
+        "large PostgreSQL object exceeds the current connector IPC frame limit",
+        "alternate provider path is not authorized"
+      ],
+      "environment": "isolated-scratch",
+      "permitted_actions": [
+        "read-only provider metadata and authorization checks",
+        "authorized streaming download, integrity verification and scratch restore after access is supplied"
+      ],
+      "prohibited_actions": [
+        "treat local manifest-matched ciphertext as a new offsite restore",
+        "production restore or Finance pilot activation"
+      ],
+      "required_evidence": [
+        "fresh offsite PostgreSQL ciphertext retrieval",
+        "integrity verification",
+        "isolated PostgreSQL scratch restore with sanitized count/checksum and functional evidence",
+        "scratch teardown"
+      ],
+      "done_definition": "The provider-separated PostgreSQL object is freshly retrieved, verified and restored in isolation; D1 and runtime-config evidence are retained separately.",
+      "next_item": "finance-pilot-approval",
+      "last_verified": "2026-07-29T14:02:00Z",
+      "evidence": {
+        "d1_offsite_restore": "proven",
+        "runtime_config_fresh_retrieval": "proven",
+        "postgresql_fresh_retrieval": "unproven",
+        "last_retry": "2026-07-25T04:55:00Z"
       }
     },
     {
       "id": "finance-pilot-approval",
-      "objective": "Prepare, not activate, Finance pilot.",
+      "objective": "Prepare, not activate, the Finance pilot package after all staging and recovery gates are current.",
       "priority": 90,
       "state": "blocked",
-      "dependencies": ["finance-staging-gate"],
+      "dependencies": ["finance-current-main-staging-evidence", "finance-offsite-postgresql-recovery"],
       "blockers": [
-        "P0 Insumos production gate",
-        "finance staging gate evidence",
+        "current-main staging journey evidence",
+        "fresh PostgreSQL offsite restore evidence",
         "named human approval"
       ],
       "environment": "production",
-      "permitted_actions": ["none until P0, the Finance staging gate and named approval are complete"],
-      "required_evidence": ["approved package"],
-      "done_definition": "Approval recorded.",
+      "permitted_actions": ["read-only package review and evidence reconciliation"],
+      "prohibited_actions": ["module activation", "grant changes", "cohort activation", "global release"],
+      "required_evidence": ["approved nominal pilot package", "all staging/recovery gates"],
+      "done_definition": "Named approval is recorded; production activation remains a separate explicit command.",
+      "next_item": "finance-production-provision",
+      "last_verified": "2026-07-29T14:02:00Z"
+    },
+    {
+      "id": "finance-production-provision",
+      "objective": "Provision isolated Finance production resources through the canonical guarded workflow path.",
+      "priority": 80,
+      "state": "blocked-requires-production-authorization",
+      "dependencies": ["finance-pilot-approval"],
+      "blockers": [
+        "explicit production authorization",
+        "production Finance Worker, D1, control KV and UI Pages project do not exist",
+        "production Finance environment configuration names are absent"
+      ],
+      "environment": "production",
+      "permitted_actions": ["read-only preflight and provisioning-plan review"],
+      "prohibited_actions": ["unapproved resource creation", "migration", "deploy", "flag/grant/user/data mutation"],
+      "required_evidence": [
+        "isolated production resource inventory",
+        "environment variable/secret names only",
+        "immutable staging lineage",
+        "checkpoint and rollback plan",
+        "explicit production authorization"
+      ],
+      "done_definition": "Resources are separately provisioned and attested before any production promotion; this is not pilot activation.",
       "next_item": null,
-      "last_verified": "2026-07-24T22:20:00Z",
-      "sha": "1a1a586feaf99ed542f386b245b8b748a03bac4b",
-      "pr": 762
+      "last_verified": "2026-07-29T14:02:00Z",
+      "evidence": {"missing_worker": "skincos-finance", "failed_core_api_run": 30418523054}
     }
   ]
 }


### PR DESCRIPTION
## Resumo
- reconcilia o estado do Financeiro somente com evidência de `origin/main`, GitHub, Cloudflare, D1, Pages e monitor externo;
- remove bloqueios obsoletos de observabilidade e do P0 de Insumos, preservando-os como evidência histórica;
- registra o baseline real de staging, a ausência de recursos Financeiro em produção e os gates restantes;
- atualiza `TASKS.md`, estado, ledger, catálogo e fila operacional.

## Limites
- nenhuma flag, grant, usuário, segredo, recurso Cloudflare, dado, staging ou produção foi alterado;
- não há promoção nem deploy nesta PR.

## Validação local
- JSON parsing e `git diff --check`
- arquitetura, governança, topologia, release progressivo, catálogo/maturidade e fronteiras de domínio
- manifestos/guards de staging e PostgreSQL
- catálogo de observabilidade, política de canary e `quality:security`