### PR TITLE
fix(finance): preserve audit reads in staging canary

### DIFF
--- a/.github/scripts/validate-finance-canary-policy.mjs
+++ b/.github/scripts/validate-finance-canary-policy.mjs
@@ -6,7 +6,7 @@ const policy = JSON.parse(await readFile(file, 'utf8'));
 const fail = (message) => { throw new Error(`${file}: ${message}`); };
 if (policy.schemaVersion !== 1 || policy.module !== 'finance' || policy.environment !== 'staging') fail('must be schema v1 Finance staging policy');
 if (policy.syntheticOnly !== true) fail('must remain synthetic-only');
-if (!Array.isArray(policy.cohort?.pilotActors) || policy.cohort.pilotActors.length !== 1 || policy.cohort.pilotActors[0] !== 'finance-staging-monitor') fail('must permit only the registered synthetic actor');
+if (!Array.isArray(policy.cohort?.pilotActors) || policy.cohort.pilotActors.length !== 1 || policy.cohort.pilotActors[0] !== 'finance-staging-smoke') fail('must permit only the dedicated synthetic smoke actor');
 if (!Array.isArray(policy.cohort?.pilotUnits) || policy.cohort.pilotUnits.length !== 1 || policy.cohort.pilotUnits[0] !== 'novo-hamburgo') fail('must permit only Novo Hamburgo staging unit');
 if (!Number.isInteger(policy.cohort?.percentage) || policy.cohort.percentage < 1 || policy.cohort.percentage > 100) fail('percentage must be an integer 1..100');
 for (const key of ['minimumSamples', 'errors', 'p95LatencyMs', 'authenticationFailures', 'journeyFailures', 'dataDivergences', 'auditFailures', 'dependencyFailures']) {

--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -54,7 +54,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CONTROL_KV_ID: ${{ vars.FINANCE_CONTROL_STAGING_KV_ID }}
-          CANARY_PASSWORD: ${{ secrets.FINANCE_STAGING_CANARY_PASSWORD }}
+          CANARY_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
         run: |
           set -euo pipefail
           node .github/scripts/validate-finance-canary-policy.mjs
@@ -67,7 +67,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          permission="$(npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "SELECT permission FROM finance_access_grants WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo' LIMIT 1;" --json | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const p=x[0]?.results?.[0]?.permission;if(!p)process.exit(1);process.stdout.write(p)")"
+          permission="$(npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "SELECT permission FROM finance_access_grants WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo' LIMIT 1;" --json | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const p=x[0]?.results?.[0]?.permission;if(!p)process.exit(1);process.stdout.write(p)")"
           [[ "$permission" =~ ^(viewer|operator|manager)$ ]] || { echo 'Synthetic grant is invalid'; exit 1; }
           echo "permission=$permission" >> "$GITHUB_OUTPUT"
       - name: Open deterministic synthetic canary
@@ -83,15 +83,15 @@ jobs:
           process.stdout.write(JSON.stringify({ state: 'canary', message: 'Synthetic staging canary only.', pilotActors: policy.cohort.pilotActors, pilotUnits: policy.cohort.pilotUnits, percentage: policy.cohort.percentage, releaseSha: process.env.RELEASE_SHA, syntheticOnly: true, changedAt: new Date().toISOString(), changedBy: process.env.GITHUB_ACTOR }));
           NODE
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$(cat "$RUNNER_TEMP/canary-control.json")" --namespace-id "$CONTROL_KV_ID" --remote
-          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','true',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='true',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='operator' WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo';"
+          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','true',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='true',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='operator' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
       - name: Run authenticated synthetic canary journey
         id: journey
         continue-on-error: true
         env:
           FINANCE_STAGING_CANARY_ACK: "1"
           FINANCE_CANARY_BASE_URL: https://api-staging.skincos.com.br
-          FINANCE_CANARY_USERNAME: finance-staging-monitor
-          FINANCE_CANARY_PASSWORD: ${{ secrets.FINANCE_STAGING_CANARY_PASSWORD }}
+          FINANCE_CANARY_USERNAME: finance-staging-smoke
+          FINANCE_CANARY_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
           FINANCE_CANARY_SCOPE_ID: finance-scope-novo-hamburgo
           FINANCE_CANARY_RELEASE_SHA: ${{ inputs.release_sha }}
         run: node finance/scripts/staging-synthetic-canary.mjs --report "$RUNNER_TEMP/canary-report.json"
@@ -136,7 +136,7 @@ jobs:
           [[ "$ORIGINAL_PERMISSION" =~ ^(viewer|operator|manager)$ ]] || { echo 'No safe grant baseline available'; exit 1; }
           payload="$(node -e "process.stdout.write(JSON.stringify({state:'active',message:'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID" --remote
-          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='$ORIGINAL_PERMISSION' WHERE username='finance-staging-monitor' AND scope_id='finance-scope-novo-hamburgo';"
+          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='$ORIGINAL_PERMISSION' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
       - name: Upload sanitized canary evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -6,6 +6,17 @@ import { createSignedDomainContext } from '../../shared/service-adapters/signed-
 const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
+const FINANCE_AUDIT_READ_TIMEOUT_MS = 3_000;
+
+function financeServiceTimeout(request) {
+    // Audit is an authenticated, read-only, paginated D1 query.  It must have
+    // the same bounded observation window as health/readiness so a legitimate
+    // slow audit lookup is not turned into a fabricated gateway 503.  Writes
+    // and all other Finance routes retain the short 800 ms dependency budget.
+    return request.method === 'GET' && new URL(request.url).pathname === '/audit'
+        ? FINANCE_AUDIT_READ_TIMEOUT_MS
+        : 800;
+}
 
 export async function forwardFinanceProbe(request, env) {
     // This route is read-only and is itself evaluated by the external monitor's
@@ -23,7 +34,7 @@ export async function forwardFinanceToService(request, env, ctx, auth) {
     try {
         const signed = await createSignedDomainContext({ actor: auth.actor, csrf: auth.csrf, requestId: request.headers.get('x-request-id') }, secret, 'finance');
         for (const [name, value] of Object.entries(signed)) headers.set(name, value);
-        return fetchBoundService(new Request(request, { headers }), env, 'FINANCE', { timeoutMs: 800 });
+        return fetchBoundService(new Request(request, { headers }), env, 'FINANCE', { timeoutMs: financeServiceTimeout(request) });
     } catch {
         return gatewayError(503, 'FINANCE_SERVICE_UNAVAILABLE');
     }

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -158,6 +158,28 @@ test('Finance health probes still classify a genuine upstream failure as unavail
   assert.equal((await response.json()).error, 'domain_service_degraded');
 });
 
+test('Finance audit read preserves a slow successful binding response without widening write timeouts', async () => {
+  resetBoundServiceResilienceForTest();
+  const auditStartedAt = Date.now();
+  const audit = await forwardFinanceToService(new Request('https://api.skincos.com.br/audit?scopeId=finance-scope-novo-hamburgo', {
+    headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-audit-timeout' },
+  }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
+    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 1_050)); return new Response(JSON.stringify({ ok: true, total: 2 }), { headers: { 'content-type': 'application/json' } }); } },
+  }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
+  assert.equal(audit.status, 200);
+  assert.ok(Date.now() - auditStartedAt >= 1_000);
+
+  resetBoundServiceResilienceForTest();
+  const write = await forwardFinanceToService(new Request('https://api.skincos.com.br/tags?scopeId=finance-scope-novo-hamburgo', {
+    method: 'POST', headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-write-timeout' },
+  }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
+    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 1_050)); return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }); } },
+  }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
+  assert.equal(write.status, 503);
+});
+
 test('finance gateway passes only an authenticated, CSRF-valid request', async () => {
   let seenPath = null;
   const gateway = createApiGateway({

--- a/docs/runbooks/finance-staging-test-identity.md
+++ b/docs/runbooks/finance-staging-test-identity.md
@@ -2,40 +2,44 @@
 
 ## Identidade e owner
 
-`finance-staging-monitor` é uma identidade sintética, exclusiva de staging e propriedade de `@skincos/finance`; `admin` é o operador responsável pela execução e pela guarda da credencial. Ela usa o login real `POST /insumos/auth/login` e a sessão assinada consumida pelo gateway em `/finance/*`.
+`finance-staging-smoke` é a identidade sintética exclusiva de staging para o smoke e canary Financeiro. Ela é propriedade de `@skincos/finance`; `admin` é o operador responsável pela execução, rotação e teardown. `finance-staging-monitor` permanece somente como identidade `viewer` do monitor e nunca é reutilizada pelo smoke. A identidade usa o login real `POST /insumos/auth/login` e a sessão assinada consumida pelo gateway em `/finance/*`.
 
-- banco: somente `skincos-db-staging`; nunca consultar ou escrever `skincos-db`;
-- e-mail sintético: `finance-staging-monitor@staging.invalid`;
+- bancos: conta somente em `skincos-db-staging` e grant somente em `skincos-finance-staging`; nunca consultar ou escrever os equivalentes produtivos;
+- e-mail sintético: `finance-staging-smoke@staging.invalid`;
 - papel: `CONSULTOR`;
 - módulos: somente `finance`;
-- unidade e grant: somente `finance-scope-novo-hamburgo`, permissão `viewer`;
-- pessoal, BarraShoppingSul, administrador, importação e mutações: negados;
+- unidade e grant: somente `finance-scope-novo-hamburgo`, permissão `operator`, o mínimo necessário para importar e desfazer;
+- pessoal, BarraShoppingSul, administrador e qualquer mutação fora da importação/compensação sintética controlada: negados;
 - a flag `finance_settings.module_enabled` permanece `false` fora de uma janela de smoke aprovada.
 
 A senha não fica no Git, em secret de produção, cookie ou sessão compartilhada. A credencial atual fica cifrada por DPAPI no runtime privado do operador. Cookies emitidos pelo login são host-only para `api-staging.skincos.com.br` e não devem ser enviados a nenhuma origem de produção.
 
-Para o canary automatizado, a mesma senha é copiada apenas para o secret do
-environment GitHub `staging` chamado `FINANCE_STAGING_CANARY_PASSWORD`. Não há
-fallback para secret de repositório ou produção. O workflow
-`finance-staging-canary.yml` fixa o username e o escopo acima e restaura o
-grant `viewer` e `module_enabled=false` mesmo quando a jornada falha.
+O segredo fica somente no environment GitHub `staging` como
+`FINANCE_SMOKE_PASSWORD`; os nomes não secretos necessários pela jornada usam
+o prefixo `FINANCE_SMOKE_` e nunca têm fallback de repositório ou produção. O
+workflow `finance-staging-canary.yml` fixa username e escopo e sempre restaura
+`module_enabled=false` e o grant pré-existente. Expiração operacional máxima:
+sete dias; renovar exige rotação e novo registro de evidência. Ao encerrar o
+marco, execute `revoke` e remova os valores `FINANCE_SMOKE_*` que não forem
+necessários para outro exercício aprovado.
 
 ## Criação
 
-1. Confirme o alvo com `npx wrangler d1 info skincos-db-staging` e confirme que `finance_settings.module_enabled=false` antes de escrever.
+1. Confirme os alvos `skincos-db-staging` e `skincos-finance-staging` e confirme que `finance_settings.module_enabled=false` antes de escrever.
 2. Gere uma senha aleatória de ao menos 24 caracteres e mantenha-a apenas no cofre/armazenamento privado do operador.
 3. Gere SQL em arquivo privado; o comando não se conecta à Cloudflare nem imprime senha/hash:
 
 ```powershell
-$env:FINANCE_STAGING_IDENTITY_ACK = '1'
-$env:FINANCE_STAGING_TEST_PASSWORD = '<segredo privado>'
-node .\finance\scripts\staging-test-identity-sql.mjs create --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\provision.sql
+$env:FINANCE_SMOKE_IDENTITY_ACK = '1'
+$env:FINANCE_SMOKE_PASSWORD = '<segredo privado>'
+node .\finance\scripts\staging-smoke-identity-sql.mjs provision --expires-at '<UTC ISO-8601>' --core-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\core-provision.sql --finance-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\finance-provision.sql
 ```
 
 4. Execute exclusivamente contra staging, valide o login real e apague o SQL após registrar a evidência privada:
 
 ```bash
-npx wrangler d1 execute skincos-db-staging --remote --file /mnt/c/CodexRuntime/operator/admin/skincos/finance-staging-identity/provision.sql
+npx wrangler d1 execute skincos-db-staging --remote --file /mnt/c/CodexRuntime/operator/admin/skincos/finance-staging-smoke/core-provision.sql
+npx wrangler d1 execute skincos-finance-staging --remote --file /mnt/c/CodexRuntime/operator/admin/skincos/finance-staging-smoke/finance-provision.sql
 ```
 
 Se a segunda inserção falhar, execute imediatamente `revoke` abaixo. Não ligue a feature flag como parte da criação.
@@ -45,19 +49,19 @@ Se a segunda inserção falhar, execute imediatamente `revoke` abaixo. Não ligu
 Rotação exige nova senha privada e incrementa `session_version`, invalidando todas as sessões anteriores:
 
 ```powershell
-$env:FINANCE_STAGING_IDENTITY_ACK = '1'
-$env:FINANCE_STAGING_TEST_PASSWORD = '<nova senha privada>'
-node .\finance\scripts\staging-test-identity-sql.mjs rotate --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\rotate.sql
+$env:FINANCE_SMOKE_IDENTITY_ACK = '1'
+$env:FINANCE_SMOKE_PASSWORD = '<nova senha privada>'
+node .\finance\scripts\staging-smoke-identity-sql.mjs rotate --expires-at '<UTC ISO-8601>' --core-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\core-rotate.sql --finance-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\finance-rotate.sql
 ```
 
 Revogação é imediata: desativa a conta, incrementa `session_version` e remove todos os grants Financeiro. Não requer senha.
 
 ```powershell
-$env:FINANCE_STAGING_IDENTITY_ACK = '1'
-node .\finance\scripts\staging-test-identity-sql.mjs revoke --output C:\CodexRuntime\operator\admin\skincos\finance-staging-identity\revoke.sql
+$env:FINANCE_SMOKE_IDENTITY_ACK = '1'
+node .\finance\scripts\staging-smoke-identity-sql.mjs revoke --expires-at '<UTC ISO-8601>' --core-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\core-revoke.sql --finance-output C:\CodexRuntime\operator\admin\skincos\finance-staging-smoke\finance-revoke.sql
 ```
 
-Execute o arquivo gerado com o mesmo comando Wrangler restrito a `skincos-db-staging`. Depois confirme que login retorna `403`, o bootstrap não possui grants e `module_enabled` permanece `false`.
+Execute cada arquivo somente no D1 indicado. Depois confirme que login retorna `403`, o bootstrap não possui grants e `module_enabled` permanece `false`.
 
 ## Evidência mínima
 

--- a/finance/scripts/staging-smoke-identity-sql.mjs
+++ b/finance/scripts/staging-smoke-identity-sql.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Produces staging-only SQL in explicitly chosen private paths. It never
+// connects to Cloudflare or writes credential material to stdout.
+import { pbkdf2Sync, randomBytes } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const [action] = process.argv.slice(2);
+const value = (flag) => {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? String(process.argv[index + 1] || '').trim() : '';
+};
+const coreOutput = value('--core-output');
+const financeOutput = value('--finance-output');
+const expiresAt = value('--expires-at');
+const password = String(process.env.FINANCE_SMOKE_PASSWORD || '');
+const username = 'finance-staging-smoke';
+const scopeId = 'finance-scope-novo-hamburgo';
+const technicalActor = '@skincos/finance-smoke';
+
+if (!['provision', 'rotate', 'revoke'].includes(action) || !coreOutput || !financeOutput || !expiresAt) {
+  throw new Error('Usage: FINANCE_SMOKE_IDENTITY_ACK=1 [FINANCE_SMOKE_PASSWORD=<private>] node finance/scripts/staging-smoke-identity-sql.mjs provision|rotate|revoke --expires-at <ISO-8601> --core-output <private.sql> --finance-output <private.sql>');
+}
+if (process.env.FINANCE_SMOKE_IDENTITY_ACK !== '1') throw new Error('FINANCE_SMOKE_IDENTITY_ACK=1 is required');
+if (!Number.isFinite(Date.parse(expiresAt))) throw new Error('--expires-at must be ISO-8601');
+if (['provision', 'rotate'].includes(action) && password.length < 24) throw new Error('FINANCE_SMOKE_PASSWORD must contain at least 24 characters');
+
+const quote = (item) => `'${String(item).replaceAll("'", "''")}'`;
+const now = new Date().toISOString();
+const json = (item) => quote(JSON.stringify(item));
+const base64url = (item) => item.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+const passwordHash = () => {
+  const salt = randomBytes(16);
+  const derived = pbkdf2Sync(password, salt, 100_000, 32, 'sha256');
+  return `pbkdf2_sha256$100000$${base64url(salt)}$${base64url(derived)}`;
+};
+const audit = (actionName, before, after) => `INSERT INTO audit_log(ts,actor,role,action,entity,entity_id,unidade,idempotency_key,before_json,after_json) VALUES(${quote(now)},${quote(technicalActor)},'SYSTEM',${quote(actionName)},'crm_users',${quote(username)},'novo-hamburgo',${quote(`finance-smoke:${action}:${now}`)},${json(before)},${json(after)});`;
+const financeAudit = (actionName, before, after) => `INSERT INTO finance_audit_events(id,scope_id,actor,action,entity_type,entity_id,request_id,before_json,after_json,created_at) VALUES(${quote(`finance-smoke-${action}-${randomBytes(8).toString('hex')}`)},${quote(scopeId)},${quote(technicalActor)},${quote(actionName)},'finance_access_grant',${quote(username)},${quote(`finance-smoke:${action}:${now}`)},${json(before)},${json(after)},${quote(now)});`;
+
+let coreSql;
+let financeSql;
+const baseline = { username, environment: 'staging', expiresAt, allowedUnits: ['novo-hamburgo'], allowedModules: ['finance'] };
+if (action === 'provision') {
+  coreSql = [
+    'BEGIN IMMEDIATE;',
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'CONSULTOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1);`,
+    audit('FINANCE_SMOKE_IDENTITY_PROVISIONED', null, { ...baseline, active: true }),
+    'COMMIT;',
+  ].join('\n');
+  financeSql = [
+    'BEGIN IMMEDIATE;',
+    `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-smoke-operator-nh')},${quote(username)},${quote(scopeId)},'operator',${quote(now)},${quote(technicalActor)});`,
+    financeAudit('FINANCE_SMOKE_GRANT_PROVISIONED', null, { ...baseline, permission: 'operator' }),
+    'COMMIT;',
+  ].join('\n');
+} else if (action === 'rotate') {
+  coreSql = [
+    'BEGIN IMMEDIATE;',
+    `UPDATE crm_users SET password_hash=${quote(passwordHash())},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`,
+    audit('FINANCE_SMOKE_IDENTITY_ROTATED', { active: true }, { ...baseline, active: true }),
+    'COMMIT;',
+  ].join('\n');
+  financeSql = [
+    'BEGIN IMMEDIATE;',
+    financeAudit('FINANCE_SMOKE_GRANT_ROTATION_CONFIRMED', { permission: 'operator' }, { ...baseline, permission: 'operator' }),
+    'COMMIT;',
+  ].join('\n');
+} else {
+  coreSql = [
+    'BEGIN IMMEDIATE;',
+    `UPDATE crm_users SET ativo=0,session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)};`,
+    audit('FINANCE_SMOKE_IDENTITY_REVOKED', { active: true }, { ...baseline, active: false }),
+    'COMMIT;',
+  ].join('\n');
+  financeSql = [
+    'BEGIN IMMEDIATE;',
+    `DELETE FROM finance_access_grants WHERE username=${quote(username)};`,
+    financeAudit('FINANCE_SMOKE_GRANT_REVOKED', { permission: 'operator' }, { ...baseline, permission: null }),
+    'COMMIT;',
+  ].join('\n');
+}
+
+for (const [file, sql] of [[coreOutput, coreSql], [financeOutput, financeSql]]) {
+  const target = resolve(file);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${sql}\n`, { mode: 0o600 });
+}
+console.log(JSON.stringify({ ok: true, action, username, scopeId, environment: 'staging', expiresAt, coreOutput: resolve(coreOutput), financeOutput: resolve(financeOutput) }));

--- a/finance/scripts/staging-synthetic-canary.mjs
+++ b/finance/scripts/staging-synthetic-canary.mjs
@@ -18,7 +18,7 @@ try {
   const baseUrl = required('FINANCE_CANARY_BASE_URL').replace(/\/$/, '');
   if (baseUrl !== 'https://api-staging.skincos.com.br') throw new Error('canary base URL must be staging gateway');
   const username = required('FINANCE_CANARY_USERNAME');
-  if (username !== 'finance-staging-monitor') throw new Error('only registered synthetic actor may run canary');
+  if (username !== 'finance-staging-smoke') throw new Error('only dedicated synthetic smoke actor may run canary');
   const password = required('FINANCE_CANARY_PASSWORD');
   const scopeId = required('FINANCE_CANARY_SCOPE_ID');
   if (scopeId !== 'finance-scope-novo-hamburgo') throw new Error('only synthetic Novo Hamburgo scope is allowed');

--- a/ops/module-governance/finance-staging-canary-policy.json
+++ b/ops/module-governance/finance-staging-canary-policy.json
@@ -4,7 +4,7 @@
   "environment": "staging",
   "syntheticOnly": true,
   "cohort": {
-    "pilotActors": ["finance-staging-monitor"],
+    "pilotActors": ["finance-staging-smoke"],
     "pilotUnits": ["novo-hamburgo"],
     "percentage": 100
   },


### PR DESCRIPTION
## Objetivo
Corrige o `503` do canary Financeiro em staging sem ampliar timeout de escrita e separa o ator de smoke do usuário viewer do monitor.

## Mudança
- `/finance/audit` recebe timeout de leitura limitado a 3 s; demais rotas Financeiro mantêm 800 ms.
- Canary passa a usar somente `finance-staging-smoke` e `FINANCE_SMOKE_PASSWORD` no environment `staging`.
- Gerador privado, auditável e com rotação/revogação cria SQL separado para Identity D1 e Finance D1.

## Risco e rollback
- Somente gateway, workflow e documentação. Reverter este commit restaura a política anterior; nenhum deploy, flag, grant ou dado foi alterado por esta PR.

## Validação local
- `npm --prefix api test`
- `npm --prefix finance run check`
- `npm --prefix finance test`
- validação de política do canary, arquitetura/fronteiras e `git diff --check`