### PR TITLE
test(finance): complete canonical staging canary

### DIFF
--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: 22
       - name: Verify immutable staging promotion evidence
         env:
           GH_TOKEN: ${{ github.token }}
@@ -95,6 +98,49 @@ jobs:
           FINANCE_CANARY_SCOPE_ID: finance-scope-novo-hamburgo
           FINANCE_CANARY_RELEASE_SHA: ${{ inputs.release_sha }}
         run: node finance/scripts/staging-synthetic-canary.mjs --report "$RUNNER_TEMP/canary-report.json"
+      - name: Run complete import and compensation journey
+        id: import
+        continue-on-error: true
+        env:
+          FINANCE_SMOKE_ACK: "1"
+          FINANCE_SMOKE_BASE_URL: https://api-staging.skincos.com.br
+          FINANCE_SMOKE_USERNAME: finance-staging-smoke
+          FINANCE_SMOKE_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
+          FINANCE_SMOKE_SCOPE_ID: finance-scope-novo-hamburgo
+        run: node finance/scripts/staging-import-smoke.mjs --fixture finance/test/fixtures/staging-smoke-import.csv --commit --undo --report "$RUNNER_TEMP/import-report.json"
+      - name: Install browser dependencies for isolated shell smoke
+        if: always()
+        run: |
+          npm --prefix crm/console ci
+          npm --prefix crm/console exec -- playwright install --with-deps chromium
+      - name: Run isolated Finance shell smoke
+        id: ui
+        if: always()
+        continue-on-error: true
+        env:
+          FINANCE_SMOKE_ACK: "1"
+          FINANCE_SMOKE_USERNAME: finance-staging-smoke
+          FINANCE_SMOKE_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
+          FINANCE_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/finance-ui
+        run: node finance/scripts/staging-ui-smoke.mjs
+      - name: Merge complete-journey failures into canary report
+        if: always()
+        env:
+          JOURNEY_OUTCOME: ${{ steps.journey.outcome }}
+          IMPORT_OUTCOME: ${{ steps.import.outcome }}
+          UI_OUTCOME: ${{ steps.ui.outcome }}
+        run: |
+          node - "$RUNNER_TEMP/canary-report.json" <<'NODE'
+          const fs = require('fs'); const file = process.argv[2]; let report = {};
+          try { report = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { report = { samples: [] }; }
+          const failed = Object.entries({ journey: process.env.JOURNEY_OUTCOME, import: process.env.IMPORT_OUTCOME, ui: process.env.UI_OUTCOME }).filter(([, outcome]) => outcome !== 'success').map(([name]) => name);
+          if (failed.length) {
+            report.errors = Number(report.errors || 0) + failed.length;
+            report.journeyFailures = Number(report.journeyFailures || 0) + failed.length;
+            report.completeJourneyFailures = failed;
+          }
+          fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`);
+          NODE
       - name: Inject a controlled threshold breach
         if: always() && inputs.mode == 'abort-drill'
         run: |
@@ -145,6 +191,8 @@ jobs:
           path: |
             ${{ runner.temp }}/canary-report.json
             ${{ runner.temp }}/canary-decision.json
+            ${{ runner.temp }}/import-report.json
+            ${{ runner.temp }}/finance-ui/finance-staging-ui.json
           retention-days: 90
           if-no-files-found: warn
       - name: Fail promotion when a limit was breached

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
-// Controlled staging-only import probe. Credentials are supplied only by the
-// operator environment; no password, cookie, or production default is kept in
-// this repository. It stages one normalized source by default; commit and undo
-// need explicit arguments and identifiers from the controlled staging window.
-import { readFile } from 'node:fs/promises';
+// Controlled staging-only import journey. It creates only synthetic reference
+// records, compensates the imported movement, and archives its references.
+import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 const required = (name) => {
@@ -28,14 +26,15 @@ const sourceType = arg('--source', 'generic');
 if (!['generic', 'moneywiz', 'ef-caixa'].includes(sourceType)) throw new Error('--source must be generic, moneywiz, or ef-caixa');
 const fixture = arg('--fixture');
 if (!fixture) throw new Error('--fixture is required');
+const reportFile = arg('--report');
 const commitRequested = process.argv.includes('--commit');
 const undoRequested = process.argv.includes('--undo');
 if (undoRequested && !commitRequested) throw new Error('--undo requires --commit');
+const nonce = `finance-staging-smoke-${Date.now()}`;
 
-const deadline = (signal) => {
+const deadline = () => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('request timeout')), timeoutMs);
-  signal?.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
   return { signal: controller.signal, done: () => clearTimeout(timer) };
 };
 async function request(path, init = {}) {
@@ -57,70 +56,120 @@ const loginBody = await json(login);
 const setCookies = typeof login.headers.getSetCookie === 'function' ? login.headers.getSetCookie() : [login.headers.get('set-cookie') || ''];
 const cookie = setCookies.map((value) => value.split(';', 1)[0]).filter(Boolean).join('; ');
 if (!cookie || !loginBody.csrfToken) throw new Error('staging auth did not issue session and CSRF cookies');
-
-const raw = await readFile(resolve(fixture), 'utf8');
-const payload = sourceType === 'ef-caixa'
-  ? { filename: 'staging-ef-smoke.json', sourceType, efCaixa: JSON.parse(raw) }
-  : { filename: `staging-${sourceType}-smoke.csv`, sourceType, csv: raw, encoding: 'utf-8' };
-const key = `staging-import-smoke:${sourceType}:${scopeId}:${Date.now()}`;
-const staged = await request(`/finance/imports?scopeId=${encodeURIComponent(scopeId)}`, {
-  method: 'POST',
-  headers: {
-    'content-type': 'application/json', cookie, origin: 'https://crm-staging.skincos.com.br',
-    'x-csrf-token': loginBody.csrfToken, 'idempotency-key': key,
-  },
-  body: JSON.stringify(payload),
-});
-const body = await json(staged);
-const batchId = String(body.batchId || '').trim();
-if (!batchId) throw new Error('staging did not return batchId');
 const authHeaders = (idempotencyKey) => ({ 'content-type': 'application/json', cookie, origin: 'https://crm-staging.skincos.com.br', 'x-csrf-token': loginBody.csrfToken, ...(idempotencyKey ? { 'idempotency-key': idempotencyKey } : {}) });
-const loadBatch = async () => json(await request(`/finance/imports/${encodeURIComponent(batchId)}?scopeId=${encodeURIComponent(scopeId)}`, { headers: authHeaders() }));
+const key = `staging-import-smoke:${sourceType}:${scopeId}:${nonce}`;
+const created = [];
+const createRegistration = async (collection, value, idempotencyKey) => {
+  const response = await request(`/finance/${collection}?scopeId=${encodeURIComponent(scopeId)}`, {
+    method: 'POST', headers: authHeaders(idempotencyKey), body: JSON.stringify(value),
+  });
+  const createdBody = await json(response);
+  const entity = collection === 'accounts' ? createdBody.account : createdBody.category;
+  if (!entity?.id) throw new Error(`staging did not create synthetic ${collection}`);
+  created.push({ collection, id: entity.id });
+  return entity;
+};
+const cleanup = async () => {
+  const results = [];
+  for (const entity of [...created].reverse()) {
+    const response = await request(`/finance/${entity.collection}/${encodeURIComponent(entity.id)}/archive?scopeId=${encodeURIComponent(scopeId)}`, {
+      method: 'POST', headers: authHeaders(`${key}:cleanup:${entity.collection}:${entity.id}`), body: JSON.stringify({ reason: 'Controlled staging smoke cleanup' }),
+    });
+    const archived = await json(response);
+    if (archived.active !== false) throw new Error(`synthetic ${entity.collection} cleanup was not confirmed`);
+    results.push(entity.collection);
+  }
+  return results;
+};
 const stateSummary = (loaded) => {
   const counts = {};
   for (const row of loaded.rows || []) counts[`${row.status}:${row.decision}`] = (counts[`${row.status}:${row.decision}`] || 0) + 1;
   return { batchStatus: loaded.batch?.status || null, rows: counts, decisions: (loaded.decisions || []).length };
 };
-const result = { ok: true, sourceType, status: staged.status, batchId, alreadyStaged: Boolean(body.alreadyStaged), analysis: body.analysis ? { sourceType: body.analysis.sourceType, rows: Number(body.analysis.rows?.length || 0) } : null };
-let loaded = await loadBatch();
-result.before = stateSummary(loaded);
-if (commitRequested) {
-  if (body.alreadyStaged) throw new Error(`batch ${batchId} already exists; refusing to mutate a deduplicated import`);
-  if (loaded.batch?.status !== 'staged') throw new Error(`batch ${batchId} is not staged (${loaded.batch?.status || 'unknown'}); refusing commit`);
-  const candidate = (loaded.rows || []).find((row) => row.status === 'valid');
-  if (!candidate) throw new Error(`no valid import row after staging: ${JSON.stringify(stateSummary(loaded))}`);
-  const defaultAccountId = required('FINANCE_SMOKE_DEFAULT_ACCOUNT_ID');
-  const incomeCategoryId = required('FINANCE_SMOKE_INCOME_CATEGORY_ID');
-  const expenseCategoryId = required('FINANCE_SMOKE_EXPENSE_CATEGORY_ID');
-  const decision = await request(`/finance/imports/${encodeURIComponent(batchId)}/decisions?scopeId=${encodeURIComponent(scopeId)}`, {
-    method: 'POST', headers: authHeaders(`${key}:decision`),
-    body: JSON.stringify({ rowId: candidate.id, decision: 'import' }),
+const result = { ok: false, sourceType, scope: 'synthetic-novo-hamburgo' };
+
+try {
+  const raw = (await readFile(resolve(fixture), 'utf8')).replaceAll('__SMOKE_NONCE__', nonce);
+  const payload = sourceType === 'ef-caixa'
+    ? { filename: 'staging-ef-smoke.json', sourceType, efCaixa: JSON.parse(raw) }
+    : { filename: `staging-${sourceType}-smoke.csv`, sourceType, csv: raw, encoding: 'utf-8' };
+  const staged = await request(`/finance/imports?scopeId=${encodeURIComponent(scopeId)}`, {
+    method: 'POST', headers: authHeaders(key), body: JSON.stringify(payload),
   });
-  const decisionBody = await json(decision);
-  loaded = await loadBatch();
-  const persisted = (loaded.rows || []).find((row) => row.id === candidate.id);
-  if (!persisted || persisted.status !== 'valid' || persisted.decision !== 'import') throw new Error(`import decision did not persist: ${JSON.stringify(stateSummary(loaded))}`);
-  const preview = await request(`/finance/imports/${encodeURIComponent(batchId)}/preview?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:preview`), body: '{}' });
-  const previewBody = await json(preview);
-  if (Number(previewBody.ready || 0) < 1) throw new Error(`no approved rows after explicit decision: ${JSON.stringify({ decision: decisionBody.decision?.decision || null, state: stateSummary(loaded), preview: { ready: Number(previewBody.ready || 0), summary: previewBody.summary || {} } })}`);
-  const commitPayload = { defaultAccountId, incomeCategoryId, expenseCategoryId };
-  const commit = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
-  const commitBody = await json(commit);
-  loaded = await loadBatch();
-  const committedRows = (loaded.rows || []).filter((row) => row.status === 'committed' && row.movement_id);
-  if (loaded.batch?.status !== 'committed' || !committedRows.length) throw new Error(`commit did not produce committed rows: ${JSON.stringify(stateSummary(loaded))}`);
-  const replay = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
-  const replayBody = await json(replay);
-  if (!replayBody.replayed) throw new Error('repeat commit did not replay the original operation');
-  result.decision = { status: decision.status, rowId: candidate.id, persisted: true };
-  result.preview = { status: preview.status, ready: Number(previewBody.ready || 0) };
-  result.commit = { status: commit.status, operationId: commitBody.operationId || null, committed: Number(commitBody.committed || 0), replayed: Boolean(replayBody.replayed) };
-  result.afterCommit = stateSummary(loaded);
-  if (undoRequested) {
-    const undo = await request(`/finance/imports/${encodeURIComponent(batchId)}/undo?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
-    const undoBody = await json(undo);
+  const stagedBody = await json(staged);
+  const batchId = String(stagedBody.batchId || '').trim();
+  if (!batchId) throw new Error('staging did not return batchId');
+  const loadBatch = async () => json(await request(`/finance/imports/${encodeURIComponent(batchId)}?scopeId=${encodeURIComponent(scopeId)}`, { headers: authHeaders() }));
+  result.stage = { status: staged.status, alreadyStaged: Boolean(stagedBody.alreadyStaged), rows: Number(stagedBody.analysis?.rows?.length || 0) };
+  let loaded = await loadBatch();
+  result.before = stateSummary(loaded);
+  if (commitRequested) {
+    if (stagedBody.alreadyStaged) throw new Error('synthetic import unexpectedly reused a previous batch');
+    if (loaded.batch?.status !== 'staged') throw new Error(`batch is not staged (${loaded.batch?.status || 'unknown'}); refusing commit`);
+    const analyzed = await request(`/finance/imports/${encodeURIComponent(batchId)}/analyze?scopeId=${encodeURIComponent(scopeId)}`, {
+      method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(payload),
+    });
+    const analysisBody = await json(analyzed);
+    if (!analysisBody.analysis?.rows?.length) throw new Error('import analyze did not return rows');
+    result.analyze = { status: analyzed.status, rows: Number(analysisBody.analysis.rows.length) };
     loaded = await loadBatch();
-    result.undo = { status: undo.status, operationId: undoBody.operationId || null, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch?.status || null, movementsCompensated: (loaded.rows || []).filter((row) => row.movement_id).length };
+    const candidate = (loaded.rows || []).find((row) => row.status === 'valid');
+    if (!candidate) throw new Error(`no valid import row after staging: ${JSON.stringify(stateSummary(loaded))}`);
+    const account = await createRegistration('accounts', { name: `Conta sintética ${nonce}`, type: 'bank', currency: 'BRL', openingBalanceMinor: 0 }, `${key}:account`);
+    const income = await createRegistration('categories', { name: `Receita sintética ${nonce}`, direction: 'income' }, `${key}:income`);
+    const expense = await createRegistration('categories', { name: `Despesa sintética ${nonce}`, direction: 'expense' }, `${key}:expense`);
+    const decision = await request(`/finance/imports/${encodeURIComponent(batchId)}/decisions?scopeId=${encodeURIComponent(scopeId)}`, {
+      method: 'POST', headers: authHeaders(`${key}:decision`), body: JSON.stringify({ rowId: candidate.id, decision: 'import' }),
+    });
+    await json(decision);
+    loaded = await loadBatch();
+    const persisted = (loaded.rows || []).find((row) => row.id === candidate.id);
+    if (!persisted || persisted.status !== 'valid' || persisted.decision !== 'import') throw new Error(`import decision did not persist: ${JSON.stringify(stateSummary(loaded))}`);
+    const preview = await request(`/finance/imports/${encodeURIComponent(batchId)}/preview?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:preview`), body: '{}' });
+    const previewBody = await json(preview);
+    if (Number(previewBody.ready || 0) < 1) throw new Error('no approved rows after explicit decision');
+    const commitPayload = { defaultAccountId: account.id, incomeCategoryId: income.id, expenseCategoryId: expense.id };
+    const commit = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
+    const commitBody = await json(commit);
+    loaded = await loadBatch();
+    const committedRows = (loaded.rows || []).filter((row) => row.status === 'committed' && row.movement_id);
+    if (loaded.batch?.status !== 'committed' || !committedRows.length) throw new Error(`commit did not produce committed rows: ${JSON.stringify(stateSummary(loaded))}`);
+    const replay = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
+    const replayBody = await json(replay);
+    if (!replayBody.replayed) throw new Error('repeat commit did not replay the original operation');
+    const conflict = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify({ ...commitPayload, expenseCategoryId: income.id }) });
+    const conflictBody = await conflict.json().catch(() => null);
+    if (conflict.status !== 409 || conflictBody?.error !== 'IDEMPOTENCY_CONFLICT') throw new Error(`incompatible second confirmation did not conflict: ${conflict.status}`);
+    const audit = await request(`/finance/audit?scopeId=${encodeURIComponent(scopeId)}&entityType=import_batch&entityId=${encodeURIComponent(batchId)}`, { headers: authHeaders() });
+    const auditBody = await json(audit);
+    if (Number(auditBody.total || 0) < 2) throw new Error('import audit trail is incomplete');
+    result.decision = { status: decision.status, persisted: true };
+    result.preview = { status: preview.status, ready: Number(previewBody.ready || 0) };
+    result.commit = { status: commit.status, committed: Number(commitBody.committed || 0), replayed: Boolean(replayBody.replayed), conflictStatus: conflict.status };
+    result.audit = { status: audit.status, events: Number(auditBody.total || 0) };
+    result.afterCommit = stateSummary(loaded);
+    if (undoRequested) {
+      const undo = await request(`/finance/imports/${encodeURIComponent(batchId)}/undo?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
+      const undoBody = await json(undo);
+      loaded = await loadBatch();
+      if (loaded.batch?.status !== 'undone') throw new Error('import undo did not reach the compensated state');
+      result.undo = { status: undo.status, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch.status, movementsCompensated: (loaded.rows || []).filter((row) => row.movement_id).length };
+    }
   }
+  result.ok = true;
+} catch (error) {
+  result.error = String(error?.message || error).replace(/[\r\n]/g, ' ').slice(0, 180);
+  throw error;
+} finally {
+  let cleanupFailure = null;
+  try {
+    if (created.length) result.cleanup = await cleanup();
+  } catch (error) {
+    cleanupFailure = error;
+    result.cleanupError = String(error?.message || error).replace(/[\r\n]/g, ' ').slice(0, 180);
+  }
+  if (reportFile) await writeFile(resolve(reportFile), `${JSON.stringify(result, null, 2)}\n`);
+  if (cleanupFailure) throw cleanupFailure;
 }
+
 console.log(JSON.stringify(result));

--- a/finance/test/fixtures/staging-smoke-import.csv
+++ b/finance/test/fixtures/staging-smoke-import.csv
@@ -1,0 +1,2 @@
+Data;Descrição;Valor;Conta;Categoria;Moeda;Observação;Identificador Externo
+01/07/2026;Importação sintética de staging;125,00;Conta sintética;Receita sintética;BRL;Dado removível;__SMOKE_NONCE__


### PR DESCRIPTION
Scope: executes the complete synthetic Finance import, idempotency, audit, undo and archive journey inside the canonical staging canary; adds the isolated CRM Finance shell smoke to the same fail-closed decision. Safety: no production paths, credentials, real users or permanent grants; any failed journey restores the disabled baseline. Validation: finance test/check, canary policy validation and git diff --check.