### PR TITLE
fix(finance): guard canary cleanup after baseline

### DIFF
--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -53,6 +53,7 @@ jobs:
           if (run.conclusion !== 'success' || run.head_sha !== process.env.RELEASE_SHA || run.name !== 'Deploy Finance Worker') process.exit(1);
           NODE
       - name: Validate synthetic-only policy and required bindings
+        id: prerequisites
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -65,6 +66,7 @@ jobs:
           [[ "$CONTROL_KV_ID" =~ ^[0-9a-fA-F]{32}$ ]] || { echo 'Invalid Finance staging control KV id'; exit 1; }
       - name: Capture reversible synthetic grant baseline
         id: baseline
+        if: steps.prerequisites.outcome == 'success'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -74,6 +76,8 @@ jobs:
           [[ "$permission" =~ ^(viewer|operator|manager)$ ]] || { echo 'Synthetic grant is invalid'; exit 1; }
           echo "permission=$permission" >> "$GITHUB_OUTPUT"
       - name: Open deterministic synthetic canary
+        id: canary_open
+        if: steps.baseline.outcome == 'success'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -89,6 +93,7 @@ jobs:
           npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','true',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='true',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='operator' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
       - name: Run authenticated synthetic canary journey
         id: journey
+        if: steps.canary_open.outcome == 'success'
         continue-on-error: true
         env:
           FINANCE_STAGING_CANARY_ACK: "1"
@@ -100,6 +105,7 @@ jobs:
         run: node finance/scripts/staging-synthetic-canary.mjs --report "$RUNNER_TEMP/canary-report.json"
       - name: Run complete import and compensation journey
         id: import
+        if: steps.canary_open.outcome == 'success'
         continue-on-error: true
         env:
           FINANCE_SMOKE_ACK: "1"
@@ -109,13 +115,13 @@ jobs:
           FINANCE_SMOKE_SCOPE_ID: finance-scope-novo-hamburgo
         run: node finance/scripts/staging-import-smoke.mjs --fixture finance/test/fixtures/staging-smoke-import.csv --commit --undo --report "$RUNNER_TEMP/import-report.json"
       - name: Install browser dependencies for isolated shell smoke
-        if: always()
+        if: steps.canary_open.outcome == 'success'
         run: |
           npm --prefix crm/console ci
           npm --prefix crm/console exec -- playwright install --with-deps chromium
       - name: Run isolated Finance shell smoke
         id: ui
-        if: always()
+        if: steps.canary_open.outcome == 'success'
         continue-on-error: true
         env:
           FINANCE_SMOKE_ACK: "1"
@@ -124,7 +130,7 @@ jobs:
           FINANCE_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/finance-ui
         run: node finance/scripts/staging-ui-smoke.mjs
       - name: Merge complete-journey failures into canary report
-        if: always()
+        if: always() && steps.canary_open.outcome == 'success'
         env:
           JOURNEY_OUTCOME: ${{ steps.journey.outcome }}
           IMPORT_OUTCOME: ${{ steps.import.outcome }}
@@ -142,7 +148,7 @@ jobs:
           fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`);
           NODE
       - name: Inject a controlled threshold breach
-        if: always() && inputs.mode == 'abort-drill'
+        if: always() && steps.canary_open.outcome == 'success' && inputs.mode == 'abort-drill'
         run: |
           node - "$RUNNER_TEMP/canary-report.json" <<'NODE'
           const fs = require('fs'); const file = process.argv[2]; let report = {};
@@ -152,7 +158,7 @@ jobs:
           NODE
       - name: Evaluate stop limits
         id: decision
-        if: always()
+        if: always() && steps.canary_open.outcome == 'success'
         run: |
           node finance/scripts/evaluate-canary.mjs --policy ops/module-governance/finance-staging-canary-policy.json --report "$RUNNER_TEMP/canary-report.json" --output "$RUNNER_TEMP/canary-decision.json"
           node - "$RUNNER_TEMP/canary-decision.json" >> "$GITHUB_OUTPUT" <<'NODE'
@@ -160,7 +166,7 @@ jobs:
           console.log(`abort=${decision.ok ? 'false' : 'true'}`);
           NODE
       - name: Kill switch on any breached limit
-        if: always() && steps.decision.outputs.abort == 'true'
+        if: always() && steps.baseline.outcome == 'success' && steps.decision.outputs.abort == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -171,7 +177,7 @@ jobs:
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID" --remote
           npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP;"
       - name: Restore non-enabled staging baseline and synthetic grant
-        if: always()
+        if: always() && steps.baseline.outcome == 'success'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -196,7 +202,7 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
       - name: Fail promotion when a limit was breached
-        if: always() && steps.decision.outputs.abort == 'true'
+        if: always() && steps.baseline.outcome == 'success' && steps.decision.outputs.abort == 'true'
         run: |
           echo 'Canary stop limit breached; kill switch completed and staging baseline was restored.'
           exit 1


### PR DESCRIPTION
## Context
The staging Finance canary run `30465287811` failed closed because the required `FINANCE_SMOKE_PASSWORD` secret name is not configured. It then incorrectly continued into the canary decision/cleanup path without a captured baseline.

## Change
Gate every mutating canary step behind successful prerequisites and baseline capture. Failed preconditions remain auditable but cannot open, disable, or restore the staging cohort.

## Validation
- `node .github/scripts/validate-finance-canary-policy.mjs`
- targeted workflow guard assertions
- `git diff --check`

No production target, user, grant, flag, secret or data was changed.