### PR TITLE
fix(token-vault): restore Livia credential endpoint compatibility

### DIFF
--- a/platform/security/token-vault/src/compat-entry.js
+++ b/platform/security/token-vault/src/compat-entry.js
@@ -1,0 +1,35 @@
+import { handleRequest } from './index.js';
+
+const TOKEN_PREFIX = '/internal/token-vault';
+const LEGACY_TOKEN_METADATA_PATH = '/v1/token-metadata';
+const CANONICAL_TOKEN_LIST_PATH = '/v1/tokens';
+
+function normalizedPath(pathname) {
+  if (pathname === TOKEN_PREFIX) return '/';
+  if (pathname.startsWith(`${TOKEN_PREFIX}/`)) return pathname.slice(TOKEN_PREFIX.length);
+  return pathname;
+}
+
+export function rewriteLegacyTokenMetadataRequest(request) {
+  if (request.method !== 'GET') return request;
+
+  const url = new URL(request.url);
+  if (normalizedPath(url.pathname) !== LEGACY_TOKEN_METADATA_PATH) return request;
+
+  url.pathname = url.pathname.replace(/\/v1\/token-metadata$/, CANONICAL_TOKEN_LIST_PATH);
+  return new Request(url.toString(), {
+    method: 'GET',
+    headers: request.headers,
+    redirect: request.redirect,
+  });
+}
+
+export async function handleCompatRequest(request, env, ctx) {
+  return handleRequest(rewriteLegacyTokenMetadataRequest(request), env, ctx);
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    return handleCompatRequest(request, env, ctx);
+  },
+};

--- a/platform/security/token-vault/tests/compat-entry.test.js
+++ b/platform/security/token-vault/tests/compat-entry.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { rewriteLegacyTokenMetadataRequest } from '../src/compat-entry.js';
+
+test('rewrites the legacy token metadata route to the canonical token list route', () => {
+  const input = new Request(
+    'https://api.skincos.com.br/internal/token-vault/v1/token-metadata?active=true&limit=20',
+    { headers: { Authorization: 'Bearer fixture' } },
+  );
+
+  const output = rewriteLegacyTokenMetadataRequest(input);
+  const url = new URL(output.url);
+
+  assert.equal(url.pathname, '/internal/token-vault/v1/tokens');
+  assert.equal(url.searchParams.get('active'), 'true');
+  assert.equal(url.searchParams.get('limit'), '20');
+  assert.equal(output.headers.get('Authorization'), 'Bearer fixture');
+});
+
+test('leaves the canonical token list route unchanged', () => {
+  const input = new Request('https://api.skincos.com.br/internal/token-vault/v1/tokens?active=true');
+  assert.equal(rewriteLegacyTokenMetadataRequest(input), input);
+});
+
+test('does not rewrite mutating requests', () => {
+  const input = new Request(
+    'https://api.skincos.com.br/internal/token-vault/v1/token-metadata',
+    { method: 'POST' },
+  );
+  assert.equal(rewriteLegacyTokenMetadataRequest(input), input);
+});

--- a/platform/security/token-vault/wrangler.toml
+++ b/platform/security/token-vault/wrangler.toml
@@ -1,5 +1,5 @@
 name = "skincos-token-vault"
-main = "src/index.js"
+main = "src/compat-entry.js"
 compatibility_date = "2026-06-18"
 workers_dev = true
 routes = ["api.skincos.com.br/internal/token-vault/*"]


### PR DESCRIPTION
## Causa
O workflow ativo Livia consulta `GET /internal/token-vault/v1/token-metadata?active=true`, enquanto o Worker canônico expõe apenas `GET /internal/token-vault/v1/tokens`. A divergência faz o nó `Get Credential Tokens` encerrar sem credenciais antes de qualquer análise ou publicação.

## Correção
- adiciona uma entrada retrocompatível que reescreve somente `GET /v1/token-metadata` para o endpoint canônico `/v1/tokens`;
- preserva query string, cabeçalhos e autenticação;
- mantém intactos os endpoints canônicos e não permite alias para operações mutantes;
- configura Wrangler para usar a entrada compatível;
- adiciona testes determinísticos do alias.

## Segurança e escopo
Nenhum token, segredo, workflow, mídia, ledger ou destino social é alterado nesta PR. O contrato continua autenticado e a resposta permanece a mesma do endpoint canônico já utilizado pelo Livia.

## Validação esperada
- `npm --prefix platform/security/token-vault test`
- checks de arquitetura, segurança e deploy do repositório
- após merge: deploy controlado do Token Vault e reteste real do Livia sem reutilizar mídia publicada.