### PR TITLE
fix(meta-capi): enforce marketing consent

### DIFF
--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -7,6 +7,7 @@ import { sendBookingNotifications, type PatientGender } from "@/lib/bookingNotif
 import { doctorSlugMatchesQuery } from "@/lib/doctorSlug";
 import { fetchEscalaDaySchedule, personNameMatches } from "@/lib/escalaDb";
 import { issueBookingStatusToken } from "@/lib/bookingSecurity";
+import { META_SCHEDULE_CONTENT_TYPE } from "@/lib/metaEventContracts";
 import { sendMetaServerEvent } from "@/lib/metaConversionsApi";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
 
@@ -559,6 +560,7 @@ export async function POST(request: Request) {
                     fbc: trackingContextResolved?.fbc ?? null,
                 },
                 customData: {
+                    content_type: META_SCHEDULE_CONTENT_TYPE,
                     booking_id: id,
                     unit_slug: unitSlug,
                     doctor_slug: effectiveDoctorSlug,

--- a/website/src/components/BookingFlow.tsx
+++ b/website/src/components/BookingFlow.tsx
@@ -16,6 +16,7 @@ import { doctorSlugFromTeamMember, doctorSlugMatchesQuery, normalizeDoctorSlug }
 import { trackBookingFunnelStep, trackBookingRequestSubmitted } from "@/lib/leadTracking";
 import { setStoredUnitSlug } from "@/lib/unitSelection";
 import { buildTrackingContextFromBrowser, persistAttributionSnapshot } from "@/lib/campaign";
+import { META_SCHEDULE_CONTENT_TYPE } from "@/lib/metaEventContracts";
 import { createMetaEventId, trackMetaStandardEvent } from "@/lib/metaBrowser";
 import TurnstileWidget from "@/components/TurnstileWidget";
 import SmoothAnchorLink from "@/components/SmoothAnchorLink";
@@ -1045,7 +1046,7 @@ export default function BookingFlow() {
             trackMetaStandardEvent(
                 "Schedule",
                 {
-                    content_type: "booking",
+                    content_type: META_SCHEDULE_CONTENT_TYPE,
                     booking_id: json.id,
                     unit_slug: unitSlug,
                     doctor_slug: effectiveDoctor.slug,

--- a/website/src/lib/metaConversionsApi.ts
+++ b/website/src/lib/metaConversionsApi.ts
@@ -35,6 +35,14 @@ type CapiLogWrite = (entry: {
     waClickId?: string | null;
 }) => Promise<void>;
 
+async function writeDeliveryLog(logDelivery: CapiLogWrite | undefined, entry: Parameters<CapiLogWrite>[0]): Promise<void> {
+    try {
+        await logDelivery?.(entry);
+    } catch {
+        // Meta delivery must not make a confirmed booking or WhatsApp redirect fail when D1 auditing is unavailable.
+    }
+}
+
 function normalizeSecret(value: string | null | undefined): string {
     return (value ?? "").trim();
 }
@@ -82,13 +90,30 @@ export async function sendMetaServerEvent(
         logDelivery?: CapiLogWrite;
     } = {},
 ): Promise<{ ok: boolean; skipped?: string; httpStatus?: number | null; responseBody?: string | null; error?: string | null }> {
+    const consent = event.trackingContext?.consent;
+    if (consent?.marketing !== true) {
+        await writeDeliveryLog(options.logDelivery, {
+            channel: "server",
+            eventName: event.eventName,
+            eventId: event.eventId,
+            endpoint: "meta_capi_not_sent_without_marketing_consent",
+            ok: false,
+            httpStatus: null,
+            responseBody: null,
+            errorMessage: "marketing_consent_denied",
+            bookingId: event.bookingId ?? null,
+            waClickId: event.waClickId ?? null,
+        });
+        return { ok: false, skipped: "marketing_consent_denied" };
+    }
+
     const config = await resolveConfig();
     const endpoint = config.pixelId
         ? `https://graph.facebook.com/${config.apiVersion}/${config.pixelId}/events`
         : "meta_capi_not_configured";
 
     if (!config.pixelId || !config.accessToken) {
-        await options.logDelivery?.({
+        await writeDeliveryLog(options.logDelivery, {
             channel: "server",
             eventName: event.eventName,
             eventId: event.eventId,
@@ -101,23 +126,6 @@ export async function sendMetaServerEvent(
             waClickId: event.waClickId ?? null,
         });
         return { ok: false, skipped: "missing_meta_capi_config" };
-    }
-
-    const consent = event.trackingContext?.consent;
-    if (consent?.marketing === false) {
-        await options.logDelivery?.({
-            channel: "server",
-            eventName: event.eventName,
-            eventId: event.eventId,
-            endpoint,
-            ok: false,
-            httpStatus: null,
-            responseBody: null,
-            errorMessage: "marketing_consent_denied",
-            bookingId: event.bookingId ?? null,
-            waClickId: event.waClickId ?? null,
-        });
-        return { ok: false, skipped: "marketing_consent_denied" };
     }
     const eventTime = event.eventTime ?? Math.floor(Date.now() / 1000);
 
@@ -174,7 +182,7 @@ export async function sendMetaServerEvent(
         }
 
         const ok = response.ok;
-        await options.logDelivery?.({
+        await writeDeliveryLog(options.logDelivery, {
             channel: "server",
             eventName: event.eventName,
             eventId: event.eventId,
@@ -201,7 +209,7 @@ export async function sendMetaServerEvent(
             });
         }
 
-        await options.logDelivery?.({
+        await writeDeliveryLog(options.logDelivery, {
             channel: "server",
             eventName: event.eventName,
             eventId: event.eventId,

--- a/website/src/lib/metaEventContracts.ts
+++ b/website/src/lib/metaEventContracts.ts
@@ -1,0 +1,1 @@
+export const META_SCHEDULE_CONTENT_TYPE = "booking";

--- a/website/tests/metaConversionsApi.test.ts
+++ b/website/tests/metaConversionsApi.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TrackingContext } from "../src/lib/attribution";
+import { META_SCHEDULE_CONTENT_TYPE } from "../src/lib/metaEventContracts";
+import {
+    sendMetaServerEvent,
+    type MetaServerEvent,
+} from "../src/lib/metaConversionsApi";
+
+type CapturedMetaEvent = {
+    event_name?: string;
+    event_id?: string;
+    action_source?: string;
+    custom_data: Record<string, unknown>;
+    user_data: {
+        em?: string[];
+        ph?: string[];
+        external_id?: string[];
+        fbp?: string;
+        fbc?: string;
+    };
+};
+
+function acceptedTrackingContext(): TrackingContext {
+    return {
+        capturedAtMs: 1_712_345_678_000,
+        pageUrl: "https://espacofacial.com/agendamento?fbclid=test-fbclid",
+        pagePath: "/agendamento?fbclid=test-fbclid",
+        referrer: null,
+        consent: { analytics: true, marketing: true },
+        params: { fbclid: "test-fbclid" },
+        fbclid: "test-fbclid",
+        fbp: "fb.1.1712345678.browser",
+        fbc: "fb.1.1712345678.test-fbclid",
+        landingUrl: "https://espacofacial.com/agendamento?fbclid=test-fbclid",
+        landingPath: "/agendamento?fbclid=test-fbclid",
+        firstTouch: null,
+        lastTouch: null,
+    };
+}
+
+function scheduleEvent(overrides: Partial<MetaServerEvent> = {}): MetaServerEvent {
+    return {
+        eventName: "Schedule",
+        eventId: "schedule_test_event",
+        eventTime: 1_712_345_678,
+        eventSourceUrl: "https://espacofacial.com/agendamento?fbclid=test-fbclid",
+        userData: {
+            email: "teste.capi@example.invalid",
+            phone: "+55 (51) 99999-0000",
+            externalId: "synthetic-customer-123",
+            clientIpAddress: "203.0.113.5",
+            clientUserAgent: "MetaCapiUnitTest/1.0",
+            fbp: "fb.1.1712345678.browser",
+            fbc: "fb.1.1712345678.test-fbclid",
+        },
+        customData: {
+            content_type: META_SCHEDULE_CONTENT_TYPE,
+            booking_id: "synthetic-booking-123",
+            currency: "BRL",
+        },
+        trackingContext: acceptedTrackingContext(),
+        bookingId: "synthetic-booking-123",
+        ...overrides,
+    };
+}
+
+function setTestSecrets(): () => void {
+    const previous = {
+        pixelId: process.env.META_PIXEL_ID,
+        accessToken: process.env.META_ACCESS_TOKEN,
+        apiVersion: process.env.META_API_VERSION,
+        testEventCode: process.env.META_CAPI_TEST_EVENT_CODE,
+    };
+    process.env.META_PIXEL_ID = "1055784516710042";
+    process.env.META_ACCESS_TOKEN = "test-access-token";
+    process.env.META_API_VERSION = "v22.0";
+    delete process.env.META_CAPI_TEST_EVENT_CODE;
+
+    return () => {
+        if (previous.pixelId === undefined) delete process.env.META_PIXEL_ID;
+        else process.env.META_PIXEL_ID = previous.pixelId;
+        if (previous.accessToken === undefined) delete process.env.META_ACCESS_TOKEN;
+        else process.env.META_ACCESS_TOKEN = previous.accessToken;
+        if (previous.apiVersion === undefined) delete process.env.META_API_VERSION;
+        else process.env.META_API_VERSION = previous.apiVersion;
+        if (previous.testEventCode === undefined) delete process.env.META_CAPI_TEST_EVENT_CODE;
+        else process.env.META_CAPI_TEST_EVENT_CODE = previous.testEventCode;
+    };
+}
+
+test("CAPI is fail-closed when marketing consent is absent or refused", async () => {
+    const restoreSecrets = setTestSecrets();
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    const deliveries: Array<{ errorMessage: string | null; endpoint: string }> = [];
+
+    globalThis.fetch = (async () => {
+        fetchCalls += 1;
+        return new Response("unexpected CAPI request", { status: 500 });
+    }) as typeof fetch;
+
+    try {
+        for (const trackingContext of [null, { ...acceptedTrackingContext(), consent: { analytics: true, marketing: false } }]) {
+            const result = await sendMetaServerEvent(
+                scheduleEvent({ trackingContext }),
+                {
+                    logDelivery: async (entry) => {
+                        deliveries.push({ errorMessage: entry.errorMessage, endpoint: entry.endpoint });
+                    },
+                },
+            );
+            assert.deepEqual(result, { ok: false, skipped: "marketing_consent_denied" });
+        }
+
+        assert.equal(fetchCalls, 0);
+        assert.deepEqual(deliveries, [
+            { errorMessage: "marketing_consent_denied", endpoint: "meta_capi_not_sent_without_marketing_consent" },
+            { errorMessage: "marketing_consent_denied", endpoint: "meta_capi_not_sent_without_marketing_consent" },
+        ]);
+    } finally {
+        globalThis.fetch = originalFetch;
+        restoreSecrets();
+    }
+});
+
+test("accepted Schedule keeps booking content type and hashes identifiers before CAPI delivery", async () => {
+    const restoreSecrets = setTestSecrets();
+    const originalFetch = globalThis.fetch;
+    let capturedPayload: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_input, init) => {
+        capturedPayload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response('{"events_received":1}', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+        const result = await sendMetaServerEvent(scheduleEvent());
+        assert.equal(result.ok, true);
+        const payload = capturedPayload as Record<string, unknown> | null;
+        assert.ok(payload);
+
+        const event = (payload.data as CapturedMetaEvent[])[0];
+        assert.equal(event.event_name, "Schedule");
+        assert.equal(event.event_id, "schedule_test_event");
+        assert.equal(event.action_source, "website");
+        assert.equal(event.custom_data.content_type, "booking");
+        assert.equal(event.user_data.em?.[0], "9e2cd5cb82deac7da5447b32f731280f35152638f0a40312a90abf75f679fcec");
+        assert.equal(event.user_data.ph?.[0], "e3acfc6021fc199bc664eda07074646e0c3505abee84dca49b011db7be878f1b");
+        assert.equal(event.user_data.external_id?.[0], "b337b68d7c27dd68a6b3ff3056c30489871e232f6ebd54439b7e305a97902062");
+        assert.equal(event.user_data.fbp, "fb.1.1712345678.browser");
+        assert.equal(event.user_data.fbc, "fb.1.1712345678.test-fbclid");
+    } finally {
+        globalThis.fetch = originalFetch;
+        restoreSecrets();
+    }
+});
+
+test("CAPI delivery remains successful when audit logging is unavailable", async () => {
+    const restoreSecrets = setTestSecrets();
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+
+    globalThis.fetch = (async () => {
+        fetchCalls += 1;
+        return new Response('{"events_received":1}', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+        const result = await sendMetaServerEvent(scheduleEvent(), {
+            logDelivery: async () => {
+                throw new Error("synthetic D1 audit failure");
+            },
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(fetchCalls, 1);
+    } finally {
+        globalThis.fetch = originalFetch;
+        restoreSecrets();
+    }
+});


### PR DESCRIPTION
## O que mudou
- torna a entrega de eventos CAPI estritamente dependente de consentimento de marketing explícito;
- mantém `Schedule` do navegador e do servidor no mesmo contrato (`content_type: booking`) e no mesmo `event_id`;
- impede uma indisponibilidade de auditoria D1 de afetar um agendamento confirmado ou o redirecionamento para WhatsApp;
- adiciona testes sintéticos para consentimento, hashing/identificadores e auditoria indisponível.

## Motivo
A camada de servidor aceitava contexto de rastreamento ausente. Isso poderia enviar CAPI sem consentimento explícito, em desacordo com a política do site. O `content_type` também precisava estar explícito e uniforme para o evento `Schedule`.

## Escopo e impacto
Apenas o Pixel SKINCOS e os fluxos `Schedule`/`Contact`. Não há mudança de Pixel, token, campanhas, dados de agenda, migrações ou segredos.

## Validação local
- `npm test` — 83 testes aprovados;
- `npm run lint`;
- `npm run typecheck` — build Next.js e TypeScript aprovados.

## Risco, rollback e pré-produção
Risco: alto por envolver consentimento e atribuição, mitigado por falha fechada e por não alterar o caminho de agendamento.

Rollback: reimplantar a versão ativa anterior do Worker (`72b25569-0bdd-42bd-b512-1631ae38998e`) pela esteira canônica; não há migração nem dado persistente para reverter.

Registro pré-produção: validação local concluída em 2026-07-29. A promoção seguirá o gate canônico antes de qualquer teste sintético em produção.