### PR TITLE
fix(token-vault): restore Livia social gateway

### DIFF
--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -2,6 +2,7 @@ import {
   handleMetaAdsPublishRequest,
   isMetaAdsPublishPath,
 } from './meta-ads-publish.js';
+import { handleSocialPublishOperation } from './social-publish.js';
 
 const TOKEN_PREFIX = '/internal/token-vault';
 const JSON_HEADERS = {
@@ -43,16 +44,23 @@ export async function handleRequest(request, env) {
       });
     }
 
+    if (request.method === 'POST' && pathname === '/v1/social-publish/operations') {
+      return handleSocialPublishOperation({ request, env, requestId, decryptToken, writeAudit });
+    }
+
     if (request.method === 'GET' && pathname === '/v1/tokens') {
+      if (auth.role !== 'admin') return adminOnly(requestId);
       return listTokens(url, env, requestId);
     }
 
     if (request.method === 'POST' && pathname === '/v1/tokens') {
+      if (auth.role !== 'admin') return adminOnly(requestId);
       return createToken(request, env, requestId);
     }
 
     const patchMatch = pathname.match(/^\/v1\/tokens\/([^/]+)$/);
     if (request.method === 'PATCH' && patchMatch) {
+      if (auth.role !== 'admin') return adminOnly(requestId);
       return patchToken(decodeURIComponent(patchMatch[1]), request, env, requestId);
     }
 
@@ -67,6 +75,10 @@ export async function handleRequest(request, env) {
       { status: 500 },
     );
   }
+}
+
+function adminOnly(requestId) {
+  return json({ ok: false, error: 'admin_credential_required', requestId }, { status: 403 });
 }
 
 function normalizePath(pathname) {
@@ -337,20 +349,22 @@ async function serializeToken(row, env) {
 function authorizeRequest(request, env) {
   if (safeString(env.REQUIRE_AUTH || 'true') !== 'true') return { ok: true };
 
-  const configuredToken = safeString(env.TOKEN_VAULT_API_TOKEN);
-  if (!configuredToken) return { ok: false, status: 500, reason: 'missing_worker_secret' };
+  const adminToken = safeString(env.TOKEN_VAULT_API_TOKEN);
+  const operationalToken = safeString(env.TOKEN_VAULT_N8N_API_TOKEN);
+  if (!adminToken && !operationalToken) return { ok: false, status: 500, reason: 'missing_worker_secret' };
 
   const headerName = safeString(env.WORKER_AUTH_HEADER_NAME || 'Authorization') || 'Authorization';
   const scheme = safeString(env.WORKER_AUTH_SCHEME || 'Bearer') || 'Bearer';
   const authHeader = safeString(request.headers.get(headerName));
   if (!authHeader) return { ok: false, status: 401, reason: 'missing_auth_header' };
 
-  const expected = `${scheme} ${configuredToken}`.trim();
-  if (!constantTimeEqual(authHeader, expected)) {
-    return { ok: false, status: 401, reason: 'invalid_auth_header' };
+  if (adminToken && constantTimeEqual(authHeader, `${scheme} ${adminToken}`.trim())) {
+    return { ok: true, role: 'admin' };
   }
-
-  return { ok: true };
+  if (operationalToken && constantTimeEqual(authHeader, `${scheme} ${operationalToken}`.trim())) {
+    return { ok: true, role: 'operational' };
+  }
+  return { ok: false, status: 401, reason: 'invalid_auth_header' };
 }
 
 async function encryptToken(token, env) {

--- a/platform/security/token-vault/src/social-publish.js
+++ b/platform/security/token-vault/src/social-publish.js
@@ -1,0 +1,177 @@
+const PLATFORM_HOSTS = {
+  facebook: new Set(['graph.facebook.com', 'rupload.facebook.com']),
+  instagram: new Set(['graph.instagram.com']),
+  threads: new Set(['graph.threads.net']),
+};
+
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'HEAD']);
+const FORBIDDEN_KEYS = /^(access_token|token|fbToken|igToken|thToken|authorization|secret)$/i;
+
+export async function handleSocialPublishOperation({ request, env, requestId, decryptToken, writeAudit }) {
+  const body = await readJson(request);
+  const platform = text(body?.platform).toLowerCase();
+  const unit = normalizeUnit(body?.unit);
+  const operation = text(body?.operation || body?.step || body?.phase).toLowerCase();
+  const method = text(body?.method || body?.request?.method || 'POST').toUpperCase();
+  const target = text(body?.url || body?.request?.url);
+
+  if (!PLATFORM_HOSTS[platform]) return response({ ok: false, error: 'invalid_platform', requestId }, 400);
+  if (!unit) return response({ ok: false, error: 'invalid_unit', requestId }, 400);
+  if (!operation || !/^[a-z0-9_:-]{1,80}$/.test(operation)) {
+    return response({ ok: false, error: 'invalid_operation', requestId }, 400);
+  }
+  if (!ALLOWED_METHODS.has(method)) return response({ ok: false, error: 'method_not_allowed', requestId }, 405);
+
+  let url;
+  try {
+    url = new URL(target);
+  } catch {
+    return response({ ok: false, error: 'invalid_target_url', requestId }, 400);
+  }
+  if (url.protocol !== 'https:' || !PLATFORM_HOSTS[platform].has(url.hostname.toLowerCase()) || !allowedPath(platform, url)) {
+    return response({ ok: false, error: 'target_not_allowed', requestId }, 403);
+  }
+
+  const credential = await resolveCredential(env, platform, unit);
+  if (!credential) return response({ ok: false, error: 'credential_not_found', platform, unit, requestId }, 404);
+  const accessToken = await decryptToken(credential.token_ciphertext, env);
+
+  const query = sanitizeObject(body?.query || body?.params || body?.request?.query);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+  }
+  url.searchParams.delete('access_token');
+
+  const headers = new Headers(sanitizeObject(body?.headers || body?.requestHeaders || body?.request?.headers));
+  headers.delete('authorization');
+  let payload = sanitizeObject(body?.body || body?.jsonRequest || body?.requestBody || body?.request?.body);
+  if (url.hostname.toLowerCase() === 'rupload.facebook.com') {
+    headers.set('Authorization', `OAuth ${accessToken}`);
+  } else if (method === 'GET' || method === 'HEAD') {
+    url.searchParams.set('access_token', accessToken);
+  } else {
+    payload = { ...payload, access_token: accessToken };
+    headers.set('content-type', 'application/json');
+  }
+
+  const upstream = await fetch(url.toString(), {
+    method,
+    headers,
+    body: ['GET', 'HEAD'].includes(method) ? undefined : JSON.stringify(payload),
+  });
+  const raw = await upstream.text();
+  let upstreamBody;
+  try {
+    upstreamBody = JSON.parse(raw);
+  } catch {
+    upstreamBody = raw ? { text: raw.slice(0, 4000) } : {};
+  }
+  const cleanBody = sanitizeValue(upstreamBody);
+
+  await writeAudit(env, {
+    tokenId: credential.id,
+    event: 'social.operation',
+    provider: platform,
+    unit: credential.unit,
+    tokenType: credential.token_type,
+    status: upstream.ok ? 'ok' : 'error',
+    requestId,
+    metadata: {
+      operation,
+      method,
+      host: url.hostname,
+      path: url.pathname,
+      upstream_status: upstream.status,
+    },
+  });
+
+  const envelope = isObject(cleanBody) ? cleanBody : { data: cleanBody };
+  return response({
+    ...envelope,
+    _gateway: {
+      ok: upstream.ok,
+      operation,
+      platform,
+      unit,
+      upstream_status: upstream.status,
+      requestId,
+    },
+  }, upstream.ok ? 200 : upstream.status);
+}
+
+function allowedPath(platform, url) {
+  const path = url.pathname;
+  if (url.hostname.toLowerCase() === 'rupload.facebook.com') return /^\/video-upload\//.test(path);
+  if (platform === 'threads') return /^\/v1\.0\/(?:me|\d+)(?:\/(?:threads|threads_publish))?$/.test(path);
+  if (platform === 'instagram') return /^\/v25\.0\/\d+(?:\/(?:media|media_publish))?$/.test(path);
+  return /^\/v25\.0\/\d+(?:\/(?:feed|photos|videos|video_reels))?$/.test(path);
+}
+
+async function resolveCredential(env, provider, unit) {
+  const rows = (await env.TOKEN_VAULT_DB.prepare(
+    `SELECT id, provider, unit, external_account_id, token_type, token_ciphertext, metadata_json
+       FROM credential_tokens
+      WHERE provider = ? AND active = 1
+      ORDER BY updated_at DESC`,
+  ).bind(provider).all()).results || [];
+  const matching = rows.filter((row) => normalizeUnit(row.unit || parseMetadata(row.metadata_json)?.legacy_columns?.Unit) === unit);
+  if (provider !== 'facebook') return matching[0] || null;
+  return matching.find((row) => {
+    const metadata = parseMetadata(row.metadata_json);
+    return metadata.purpose !== 'meta_ads_publish' && !metadata.meta_ads_publish;
+  }) || null;
+}
+
+function sanitizeObject(value) {
+  const cleaned = sanitizeValue(value);
+  return isObject(cleaned) ? cleaned : {};
+}
+
+function sanitizeValue(value) {
+  if (Array.isArray(value)) return value.map(sanitizeValue);
+  if (!isObject(value)) return value;
+  const out = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (FORBIDDEN_KEYS.test(key)) continue;
+    out[key] = sanitizeValue(entry);
+  }
+  return out;
+}
+
+function normalizeUnit(value) {
+  const compact = text(value).toLowerCase().replace(/[\s_-]+/g, '');
+  if (compact === 'bss' || compact === 'barrashoppingsul') return 'bss';
+  if (compact === 'nh' || compact === 'novohamburgo') return 'nh';
+  return '';
+}
+
+function parseMetadata(value) {
+  try {
+    return JSON.parse(value || '{}');
+  } catch {
+    return {};
+  }
+}
+
+async function readJson(request) {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+function response(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  });
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function text(value) {
+  return String(value ?? '').trim();
+}

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -4,6 +4,7 @@ import { handleRequest } from '../src/index.js';
 
 const encoder = new TextEncoder();
 const TEST_API_TOKEN = ['unit', 'auth', 'token'].join('-');
+const TEST_OPERATIONAL_TOKEN = ['unit', 'operational', 'token'].join('-');
 const TEST_ENCRYPTION_KEY = ['unit', 'encryption', 'key', 'with', 'enough', 'length'].join('-');
 const THREADS_TOKEN = ['threads', 'fixture', 'token'].join('-');
 const FACEBOOK_TOKEN = ['facebook', 'fixture', 'token'].join('-');
@@ -73,6 +74,7 @@ function env(db) {
   return {
     TOKEN_VAULT_DB: db,
     TOKEN_VAULT_API_TOKEN: TEST_API_TOKEN,
+    TOKEN_VAULT_N8N_API_TOKEN: TEST_OPERATIONAL_TOKEN,
     TOKEN_VAULT_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
     REQUIRE_AUTH: 'true',
     WORKER_AUTH_HEADER_NAME: 'Authorization',
@@ -82,6 +84,10 @@ function env(db) {
 
 function authHeaders() {
   return { Authorization: `Bearer ${TEST_API_TOKEN}` };
+}
+
+function operationalAuthHeaders() {
+  return { Authorization: `Bearer ${TEST_OPERATIONAL_TOKEN}` };
 }
 
 async function encryptForSeed(token, secret) {
@@ -111,6 +117,56 @@ test('health validates configured bindings and secrets', async () => {
   assert.equal(response.status, 200);
   assert.equal(body.ok, true);
   assert.equal(body.checks.d1, true);
+});
+
+test('routes social publication requests to the fail-closed gateway', async () => {
+  const db = new FakeDb();
+  const response = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        platform: 'unsupported',
+        unit: 'bss',
+        operation: 'preflight_contract_probe',
+        method: 'GET',
+        url: 'https://graph.instagram.com/v25.0/1',
+      }),
+    }),
+    env(db),
+  );
+  const body = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(body.error, 'invalid_platform');
+});
+
+test('operational credential can call the social gateway but not list token material', async () => {
+  const db = new FakeDb();
+  const socialResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+      method: 'POST',
+      headers: { ...operationalAuthHeaders(), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        platform: 'unsupported',
+        unit: 'bss',
+        operation: 'preflight_contract_probe',
+        method: 'GET',
+        url: 'https://graph.instagram.com/v25.0/1',
+      }),
+    }),
+    env(db),
+  );
+  assert.equal(socialResponse.status, 400);
+  assert.equal((await socialResponse.json()).error, 'invalid_platform');
+
+  const tokensResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/tokens?active=true', {
+      headers: operationalAuthHeaders(),
+    }),
+    env(db),
+  );
+  assert.equal(tokensResponse.status, 403);
+  assert.equal((await tokensResponse.json()).error, 'admin_credential_required');
 });
 
 test('lists decrypted provider tokens with compatibility fields', async () => {

--- a/platform/security/token-vault/tests/social-publish.test.js
+++ b/platform/security/token-vault/tests/social-publish.test.js
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleSocialPublishOperation } from '../src/social-publish.js';
+
+const SECRET_TOKEN = 'fixture-secret-token';
+
+class Statement {
+  constructor(rows) {
+    this.rows = rows;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async all() {
+    return { results: this.rows.filter((row) => row.provider === this.values[0]) };
+  }
+}
+
+function context(overrides = {}) {
+  const audits = [];
+  return {
+    requestId: 'req-test',
+    env: {
+      TOKEN_VAULT_DB: {
+        prepare() {
+          return new Statement([{
+            id: 'ig_nh',
+            provider: 'instagram',
+            unit: 'Novo Hamburgo',
+            external_account_id: '123',
+            token_type: 'long_lived_access_token',
+            token_ciphertext: 'encrypted',
+            metadata_json: '{}',
+          }]);
+        },
+      },
+    },
+    decryptToken: async () => SECRET_TOKEN,
+    writeAudit: async (_env, entry) => audits.push(entry),
+    audits,
+    ...overrides,
+  };
+}
+
+test('social gateway injects token upstream and never returns it', async () => {
+  const originalFetch = globalThis.fetch;
+  let upstreamUrl = '';
+  let upstreamBody = '';
+  globalThis.fetch = async (url, options) => {
+    upstreamUrl = String(url);
+    upstreamBody = String(options.body || '');
+    return new Response(JSON.stringify({ id: 'container-1', access_token: SECRET_TOKEN }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  try {
+    const ctx = context();
+    const request = new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        platform: 'instagram',
+        unit: 'nh',
+        operation: 'media_create',
+        method: 'POST',
+        url: 'https://graph.instagram.com/v25.0/123/media',
+        body: { image_url: 'https://example.com/image.jpg', access_token: 'leaked-input' },
+      }),
+    });
+    const response = await handleSocialPublishOperation({ request, ...ctx });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.match(upstreamBody, new RegExp(SECRET_TOKEN));
+    assert.equal(upstreamUrl.includes(SECRET_TOKEN), false);
+    assert.equal(JSON.stringify(body).includes(SECRET_TOKEN), false);
+    assert.equal(JSON.stringify(body).includes('leaked-input'), false);
+    assert.equal(ctx.audits.length, 1);
+    assert.equal(JSON.stringify(ctx.audits).includes(SECRET_TOKEN), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('social gateway rejects arbitrary hosts before credential lookup', async () => {
+  const ctx = context();
+  const request = new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      platform: 'instagram',
+      unit: 'nh',
+      operation: 'media_create',
+      url: 'https://example.com/v25.0/123/media',
+    }),
+  });
+  const response = await handleSocialPublishOperation({ request, ...ctx });
+  assert.equal(response.status, 403);
+  assert.equal((await response.json()).error, 'target_not_allowed');
+});
+
+test('social gateway never falls back to a Meta Ads Facebook credential', async () => {
+  let fetched = false;
+  const ctx = context({
+    env: {
+      TOKEN_VAULT_DB: {
+        prepare() {
+          return new Statement([{
+            id: 'facebook_bss_meta_ads',
+            provider: 'facebook',
+            unit: 'BarraShoppingSul',
+            external_account_id: '123',
+            token_type: 'long_lived_access_token',
+            token_ciphertext: 'encrypted',
+            metadata_json: JSON.stringify({ purpose: 'meta_ads_publish' }),
+          }]);
+        },
+      },
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetched = true;
+    return new Response('{}', { status: 200 });
+  };
+  try {
+    const response = await handleSocialPublishOperation({
+      request: new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'facebook',
+          unit: 'bss',
+          operation: 'photo_create',
+          method: 'POST',
+          url: 'https://graph.facebook.com/v25.0/123/photos',
+        }),
+      }),
+      ...ctx,
+    });
+    assert.equal(response.status, 404);
+    assert.equal((await response.json()).error, 'credential_not_found');
+    assert.equal(fetched, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('social gateway accepts every Livia provider route, including the Facebook Reel upload chain', async () => {
+  const rows = [
+    { id: 'fb_nh', provider: 'facebook', unit: 'Novo Hamburgo', external_account_id: '123', token_type: 'long_lived_access_token', token_ciphertext: 'encrypted', metadata_json: '{}' },
+    { id: 'ig_nh', provider: 'instagram', unit: 'Novo Hamburgo', external_account_id: '123', token_type: 'long_lived_access_token', token_ciphertext: 'encrypted', metadata_json: '{}' },
+    { id: 'th_nh', provider: 'threads', unit: 'Novo Hamburgo', external_account_id: '123', token_type: 'long_lived_access_token', token_ciphertext: 'encrypted', metadata_json: '{}' },
+  ];
+  const ctx = context({ env: { TOKEN_VAULT_DB: { prepare() { return new Statement(rows); } } } });
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url: String(url), method: options.method, authorization: options.headers.get('authorization') });
+    return new Response(JSON.stringify({ id: 'provider-object' }), { status: 200 });
+  };
+  try {
+    const requests = [
+      ['facebook', 'POST', 'https://graph.facebook.com/v25.0/123/photos'],
+      ['facebook', 'POST', 'https://graph.facebook.com/v25.0/123/video_reels?upload_phase=start'],
+      ['facebook', 'POST', 'https://rupload.facebook.com/video-upload/v25.0/987'],
+      ['facebook', 'GET', 'https://graph.facebook.com/v25.0/987?fields=status'],
+      ['instagram', 'POST', 'https://graph.instagram.com/v25.0/123/media'],
+      ['instagram', 'POST', 'https://graph.instagram.com/v25.0/123/media_publish'],
+      ['instagram', 'GET', 'https://graph.instagram.com/v25.0/987?fields=status'],
+      ['threads', 'POST', 'https://graph.threads.net/v1.0/me/threads'],
+      ['threads', 'POST', 'https://graph.threads.net/v1.0/me/threads_publish'],
+      ['threads', 'GET', 'https://graph.threads.net/v1.0/987?fields=id'],
+    ];
+    for (const [platform, method, url] of requests) {
+      const response = await handleSocialPublishOperation({
+        request: new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ platform, unit: 'nh', operation: 'livia_contract_probe', method, url }),
+        }),
+        ...ctx,
+      });
+      assert.equal(response.status, 200, `${platform} ${method} ${url}`);
+    }
+    assert.equal(calls.length, requests.length);
+    assert.equal(calls[2].authorization, `OAuth ${SECRET_TOKEN}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## What changed

Restores the social publication gateway required by Livia while retaining PR #866's legacy metadata compatibility. The Worker now accepts the operational runtime credential only for operational routes, keeps token listing administrative, and rejects Facebook Meta Ads credentials as social-publish fallbacks.

## Why

A pre-production probe found that the current Token Vault bundle returned 404 not_found for Livia's required POST /v1/social-publish/operations route. That would have allowed a real run to reach media processing and then fail before publication.

## Validation

- 
pm test in platform/security/token-vault — 39 passing
- 
ode --check for the Worker entrypoint and restored gateway
- wrangler versions upload --dry-run --keep-vars`n
The diff is limited to Token Vault's Livia social gateway and its tests.