### PR TITLE
fix(website): add isolated staging promotion path

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -25,7 +25,7 @@ jobs:
       release_sha: ${{ inputs.release_sha }}
       preview_run_id: ${{ inputs.preview_run_id }}
       staging_run_id: ${{ inputs.staging_run_id }}
-      staging_supported: false
+      staging_supported: true
     secrets: inherit
   deploy:
     needs: promotion
@@ -34,33 +34,6 @@ jobs:
     environment: ${{ inputs.target }}
     permissions:
       contents: read
-    env:
-      NEXT_PUBLIC_META_PIXEL_ID: ${{ secrets.NEXT_PUBLIC_META_PIXEL_ID != '' && secrets.NEXT_PUBLIC_META_PIXEL_ID || secrets.META_PIXEL_ID }}
-      META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-      META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
-      AGENDA_SYNC_TOKEN: ${{ secrets.AGENDA_SYNC_TOKEN }}
-      TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
-      CADASTRO_WHEEL_SECRET: ${{ secrets.CADASTRO_WHEEL_SECRET }}
-      TITAN_SMTP_HOST: ${{ secrets.TITAN_SMTP_HOST }}
-      TITAN_SMTP_PORT: ${{ secrets.TITAN_SMTP_PORT }}
-      TITAN_SMTP_USER_BARRA: ${{ secrets.TITAN_SMTP_USER_BARRA }}
-      TITAN_SMTP_PASS_BARRA: ${{ secrets.TITAN_SMTP_PASS_BARRA }}
-      TITAN_SMTP_USER_NH: ${{ secrets.TITAN_SMTP_USER_NH }}
-      TITAN_SMTP_PASS_NH: ${{ secrets.TITAN_SMTP_PASS_NH }}
-      BOOKING_EMAIL_FROM: ${{ secrets.BOOKING_EMAIL_FROM }}
-      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-      BOOKING_EMAIL_WEBHOOK_URL: ${{ secrets.BOOKING_EMAIL_WEBHOOK_URL }}
-      BOOKING_EMAIL_WEBHOOK_SECRET: ${{ secrets.BOOKING_EMAIL_WEBHOOK_SECRET }}
-      BOOKING_WHATSAPP_WEBHOOK_URL: ${{ secrets.BOOKING_WHATSAPP_WEBHOOK_URL }}
-      BOOKING_WHATSAPP_WEBHOOK_SECRET: ${{ secrets.BOOKING_WHATSAPP_WEBHOOK_SECRET }}
-      BOOKING_WEBHOOK_URL: ${{ secrets.BOOKING_WEBHOOK_URL }}
-      BOOKING_WEBHOOK_SECRET: ${{ secrets.BOOKING_WEBHOOK_SECRET }}
-      TRACKING_DASHBOARD_TOKEN: ${{ secrets.TRACKING_DASHBOARD_TOKEN }}
-      BOOKING_EMAIL_LOGO_URL: ${{ secrets.BOOKING_EMAIL_LOGO_URL }}
-      BOOKING_EMAIL_AMBASSADOR_MALE_IMAGE_URL: ${{ secrets.BOOKING_EMAIL_AMBASSADOR_MALE_IMAGE_URL }}
-      BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL: ${{ secrets.BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL }}
-      INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
-
     steps:
       - name: Guard Cloudflare deploy secrets
         id: guard
@@ -109,7 +82,7 @@ jobs:
         run: npm run lint
 
       - name: Sync worker secrets (optional)
-        if: ${{ steps.guard.outputs.skip != 'true' && (env.NEXT_PUBLIC_META_PIXEL_ID != '' || env.META_PIXEL_ID != '' || env.META_ACCESS_TOKEN != '' || env.AGENDA_SYNC_TOKEN != '' || env.TURNSTILE_SECRET_KEY != '' || env.CADASTRO_WHEEL_SECRET != '' || env.TITAN_SMTP_HOST != '' || env.TITAN_SMTP_PORT != '' || env.TITAN_SMTP_USER_BARRA != '' || env.TITAN_SMTP_PASS_BARRA != '' || env.TITAN_SMTP_USER_NH != '' || env.TITAN_SMTP_PASS_NH != '' || env.BOOKING_EMAIL_FROM != '' || env.RESEND_API_KEY != '' || env.BOOKING_EMAIL_WEBHOOK_URL != '' || env.BOOKING_EMAIL_WEBHOOK_SECRET != '' || env.BOOKING_WHATSAPP_WEBHOOK_URL != '' || env.BOOKING_WHATSAPP_WEBHOOK_SECRET != '' || env.BOOKING_WEBHOOK_URL != '' || env.BOOKING_WEBHOOK_SECRET != '' || env.TRACKING_DASHBOARD_TOKEN != '' || env.BOOKING_EMAIL_LOGO_URL != '' || env.BOOKING_EMAIL_AMBASSADOR_MALE_IMAGE_URL != '' || env.BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL != '' || env.INSTAGRAM_SYNC_TOKEN != '') }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         continue-on-error: true
         working-directory: website
         run: |
@@ -154,33 +127,66 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_META_PIXEL_ID: ${{ secrets.NEXT_PUBLIC_META_PIXEL_ID != '' && secrets.NEXT_PUBLIC_META_PIXEL_ID || secrets.META_PIXEL_ID }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
+          AGENDA_SYNC_TOKEN: ${{ secrets.AGENDA_SYNC_TOKEN }}
+          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+          CADASTRO_WHEEL_SECRET: ${{ secrets.CADASTRO_WHEEL_SECRET }}
+          TITAN_SMTP_HOST: ${{ secrets.TITAN_SMTP_HOST }}
+          TITAN_SMTP_PORT: ${{ secrets.TITAN_SMTP_PORT }}
+          TITAN_SMTP_USER_BARRA: ${{ secrets.TITAN_SMTP_USER_BARRA }}
+          TITAN_SMTP_PASS_BARRA: ${{ secrets.TITAN_SMTP_PASS_BARRA }}
+          TITAN_SMTP_USER_NH: ${{ secrets.TITAN_SMTP_USER_NH }}
+          TITAN_SMTP_PASS_NH: ${{ secrets.TITAN_SMTP_PASS_NH }}
+          BOOKING_EMAIL_FROM: ${{ secrets.BOOKING_EMAIL_FROM }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          BOOKING_EMAIL_WEBHOOK_URL: ${{ secrets.BOOKING_EMAIL_WEBHOOK_URL }}
+          BOOKING_EMAIL_WEBHOOK_SECRET: ${{ secrets.BOOKING_EMAIL_WEBHOOK_SECRET }}
+          BOOKING_WHATSAPP_WEBHOOK_URL: ${{ secrets.BOOKING_WHATSAPP_WEBHOOK_URL }}
+          BOOKING_WHATSAPP_WEBHOOK_SECRET: ${{ secrets.BOOKING_WHATSAPP_WEBHOOK_SECRET }}
+          BOOKING_WEBHOOK_URL: ${{ secrets.BOOKING_WEBHOOK_URL }}
+          BOOKING_WEBHOOK_SECRET: ${{ secrets.BOOKING_WEBHOOK_SECRET }}
+          TRACKING_DASHBOARD_TOKEN: ${{ secrets.TRACKING_DASHBOARD_TOKEN }}
+          BOOKING_EMAIL_LOGO_URL: ${{ secrets.BOOKING_EMAIL_LOGO_URL }}
+          BOOKING_EMAIL_AMBASSADOR_MALE_IMAGE_URL: ${{ secrets.BOOKING_EMAIL_AMBASSADOR_MALE_IMAGE_URL }}
+          BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL: ${{ secrets.BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL }}
+          INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
 
       - name: Deploy website (OpenNext -> Workers)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: website
-        run: npm run deploy
+        run: |
+          if [ "${DEPLOY_TARGET}" = "staging" ]; then
+            npm run deploy -- --env staging
+          else
+            npm run deploy
+          fi
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          NEXT_PUBLIC_META_PIXEL_ID: ${{ secrets.NEXT_PUBLIC_META_PIXEL_ID != '' && secrets.NEXT_PUBLIC_META_PIXEL_ID || secrets.META_PIXEL_ID }}
-          NEXT_PUBLIC_BUILD_SHA: ${{ github.sha }}
+          DEPLOY_TARGET: ${{ inputs.target }}
+          DEPLOY_SITE_URL: ${{ inputs.target == 'staging' && 'https://espacofacial-site-staging.skincos.workers.dev' || '' }}
+          NEXT_PUBLIC_SITE_URL: ${{ inputs.target == 'staging' && 'https://espacofacial-site-staging.skincos.workers.dev' || 'https://espacofacial.com' }}
+          NEXT_PUBLIC_META_PIXEL_ID: ${{ inputs.target == 'production' && (secrets.NEXT_PUBLIC_META_PIXEL_ID != '' && secrets.NEXT_PUBLIC_META_PIXEL_ID || secrets.META_PIXEL_ID) || '' }}
+          NEXT_PUBLIC_BUILD_SHA: ${{ needs.promotion.outputs.source_sha }}
           NEXT_PUBLIC_BUILD_TIME: ${{ github.run_id }}
-          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ inputs.target == 'production' && secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '' }}
 
       - name: Deploy SKINCOS legal hub (OpenNext -> Workers)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
         run: npm run deploy:skincos
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NEXT_PUBLIC_META_PIXEL_ID: ${{ secrets.NEXT_PUBLIC_META_PIXEL_ID != '' && secrets.NEXT_PUBLIC_META_PIXEL_ID || secrets.META_PIXEL_ID }}
-          NEXT_PUBLIC_BUILD_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_BUILD_SHA: ${{ needs.promotion.outputs.source_sha }}
           NEXT_PUBLIC_BUILD_TIME: ${{ github.run_id }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
 
       - name: Sync Cloudflare security settings (optional)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
         run: npm run cf:security
         env:
@@ -188,7 +194,7 @@ jobs:
           CF_ZONE_NAME: espacofacial.com
 
       - name: Verify Cloudflare security settings
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
         run: npm run cf:security:check
         env:
@@ -196,7 +202,7 @@ jobs:
           CF_ZONE_NAME: espacofacial.com
 
       - name: Deploy redirects worker (esfa.co)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
         run: npm run deploy:esfa
         env:
@@ -204,25 +210,42 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Sync esfa.co managed redirects (D1)
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
         run: npm run custom-urls:migrate:esfa -- --apply --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Smoke test production
+      - name: Smoke test deployed website
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: website
         run: npm run smoke
         env:
-          SMOKE_AGENDA_TOKEN: ${{ secrets.AGENDA_SYNC_TOKEN }}
-          SMOKE_BASE_URL: https://espacofacial.com
+          SMOKE_AGENDA_TOKEN: ${{ inputs.target == 'production' && secrets.AGENDA_SYNC_TOKEN || '' }}
+          SMOKE_BASE_URL: ${{ inputs.target == 'staging' && 'https://espacofacial-site-staging.skincos.workers.dev' || 'https://espacofacial.com' }}
 
       - name: Smoke test SKINCOS legal pages
-        if: ${{ steps.guard.outputs.skip != 'true' }}
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         run: |
           set -euo pipefail
           curl -fsS https://skincos.com.br/privacidade >/dev/null
           curl -fsS https://skincos.com.br/dados >/dev/null
           curl -fsS https://skincos.com.br/termos >/dev/null
+
+      - name: Write staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        env:
+          PROMOTION_UNIT: public-website-release
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: PROMOTION_SOURCE_TREE="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+
+      - name: Upload staging promotion evidence
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-evidence-public-website-release
+          path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error

--- a/website/scripts/deploy-worker.mjs
+++ b/website/scripts/deploy-worker.mjs
@@ -78,8 +78,27 @@ function readSiteUrlFromConfig(configPath) {
   return match?.[1]?.trim() || fallback;
 }
 
-async function getCurrentVersionId(configPath, env) {
-  const { stdout } = await runAndCapture("npx", ["wrangler", "deployments", "list", "-c", configPath], env);
+function parseOptionalArg(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0) return null;
+
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function getWranglerEnvironmentArgs(environmentName) {
+  if (!environmentName) return [];
+  if (!/^[a-z][a-z0-9_-]*$/i.test(environmentName)) {
+    throw new Error(`Invalid Wrangler environment name: ${environmentName}`);
+  }
+  return ["--env", environmentName];
+}
+
+async function getCurrentVersionId(configPath, env, wranglerEnvironmentArgs) {
+  const { stdout } = await runAndCapture("npx", ["wrangler", "deployments", "list", "-c", configPath, ...wranglerEnvironmentArgs], env);
   const match = stdout.match(/\(100%\)\s+([0-9a-f-]{36})/i);
   return match?.[1] ?? null;
 }
@@ -109,8 +128,9 @@ async function runPostDeploySmoke({ env, siteUrl, retries, delayMs }) {
 }
 
 const args = process.argv.slice(2);
-const configIndex = args.indexOf("--config");
-const configPath = configIndex >= 0 ? args[configIndex + 1] : "wrangler.toml";
+const configPath = parseOptionalArg(args, "--config") ?? "wrangler.toml";
+const wranglerEnvironment = parseOptionalArg(args, "--env");
+const wranglerEnvironmentArgs = getWranglerEnvironmentArgs(wranglerEnvironment);
 const smokeRetries = Number.parseInt(process.env.POST_DEPLOY_SMOKE_RETRIES ?? "6", 10);
 const smokeDelayMs = Number.parseInt(process.env.POST_DEPLOY_SMOKE_DELAY_MS ?? "5000", 10);
 
@@ -120,14 +140,14 @@ const env = {
   NEXT_PUBLIC_BUILD_TIME: getBuildTime(),
 };
 
-const siteUrl = readSiteUrlFromConfig(configPath);
-const previousVersionId = await getCurrentVersionId(configPath, env);
+const siteUrl = process.env.DEPLOY_SITE_URL?.trim() || readSiteUrlFromConfig(configPath);
+const previousVersionId = await getCurrentVersionId(configPath, env, wranglerEnvironmentArgs);
 
 await run("node", ["scripts/assert-production-snapshot.mjs"], env);
 await run("npx", ["opennextjs-cloudflare", "build"], env);
 
 try {
-  await run("npx", ["wrangler", "deploy", "-c", configPath], env);
+  await run("npx", ["wrangler", "deploy", "-c", configPath, ...wranglerEnvironmentArgs], env);
   await runPostDeploySmoke({
     env,
     siteUrl,
@@ -146,6 +166,7 @@ try {
       previousVersionId,
       "-c",
       configPath,
+      ...wranglerEnvironmentArgs,
       "-y",
       "-m",
       `auto-rollback: smoke failure after deploy ${env.NEXT_PUBLIC_BUILD_SHA ?? "unknown"}`,

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -26,3 +26,29 @@ database_id = "9765b1fb-11a4-462c-9657-8a438c755725" # criado via: wrangler d1 c
 binding = "SKINCOS_ESCALA_DB"
 database_name = "skincos-escala"
 database_id = "594fef1b-5597-476e-86f9-59920f284215"
+
+[env.staging]
+name = "espacofacial-site-staging"
+workers_dev = true
+# Never attach the staging Worker to a production hostname.
+routes = []
+
+[env.staging.vars]
+NEXT_PUBLIC_SITE_URL = "https://espacofacial-site-staging.skincos.workers.dev"
+# Staging has no production Turnstile secret and must remain usable for
+# synthetic booking verification without weakening production enforcement.
+BOOKING_REQUIRE_TURNSTILE = "false"
+
+[env.staging.assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
+
+[[env.staging.d1_databases]]
+binding = "BOOKING_DB"
+database_name = "espacofacial-booking-staging"
+database_id = "dea29efb-badd-41f3-962b-d991aa4ac321"
+
+[[env.staging.d1_databases]]
+binding = "SKINCOS_ESCALA_DB"
+database_name = "skincos-escala-staging"
+database_id = "3f59f0a3-2c27-4f15-9f84-a9234f86c2e5"


### PR DESCRIPTION
## Summary
- provisions an isolated `espacofacial-site-staging` Worker configuration with dedicated booking and escala D1 bindings
- keeps staging off production routes and without Meta, notification, or production Turnstile secrets
- makes the website promotion workflow produce staging evidence and prevents staging from running production-only deploys or D1 mutations
- scopes Worker deployment listing, deploy, and rollback to the chosen Wrangler environment

## Validation
- `node --check website/scripts/deploy-worker.mjs`
- workflow YAML parse with `js-yaml`
- `wrangler deployments list -c wrangler.toml --env staging` parsed the staging configuration and reached Cloudflare; expected `Worker does not exist` before its first staged deploy
- `git diff --check`

## Rollback
- Revert this PR; the unused isolated D1 database is `espacofacial-booking-staging` and remains empty until staging deployment.