### PR TITLE
fix(token-vault): redact provider pagination tokens

### DIFF
--- a/platform/security/token-vault/src/social-publish.js
+++ b/platform/security/token-vault/src/social-publish.js
@@ -128,6 +128,7 @@ function sanitizeObject(value) {
 }
 
 function sanitizeValue(value) {
+  if (typeof value === 'string') return sanitizeUrlString(value);
   if (Array.isArray(value)) return value.map(sanitizeValue);
   if (!isObject(value)) return value;
   const out = {};
@@ -136,6 +137,22 @@ function sanitizeValue(value) {
     out[key] = sanitizeValue(entry);
   }
   return out;
+}
+
+function sanitizeUrlString(value) {
+  try {
+    const url = new URL(value);
+    let removed = false;
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (FORBIDDEN_KEYS.test(key)) {
+        url.searchParams.delete(key);
+        removed = true;
+      }
+    }
+    return removed ? url.toString() : value;
+  } catch {
+    return value;
+  }
 }
 
 function normalizeUnit(value) {

--- a/platform/security/token-vault/tests/social-publish.test.js
+++ b/platform/security/token-vault/tests/social-publish.test.js
@@ -86,6 +86,45 @@ test('social gateway injects token upstream and never returns it', async () => {
   }
 });
 
+test('social gateway strips credential query parameters from provider pagination URLs', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    data: [{ id: 'media-1' }],
+    paging: {
+      next: `https://graph.instagram.com/v25.0/123/media?after=cursor-1&access_token=${SECRET_TOKEN}&fields=id`,
+    },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+  try {
+    const ctx = context();
+    const response = await handleSocialPublishOperation({
+      request: new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'instagram',
+          unit: 'nh',
+          operation: 'media_list',
+          method: 'GET',
+          url: 'https://graph.instagram.com/v25.0/123/media',
+        }),
+      }),
+      ...ctx,
+    });
+    const body = await response.json();
+    const next = new URL(body.paging.next);
+    assert.equal(response.status, 200);
+    assert.equal(JSON.stringify(body).includes(SECRET_TOKEN), false);
+    assert.equal(next.searchParams.has('access_token'), false);
+    assert.equal(next.searchParams.get('after'), 'cursor-1');
+    assert.equal(next.searchParams.get('fields'), 'id');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('social gateway rejects arbitrary hosts before credential lookup', async () => {
   const ctx = context();
   const request = new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {


### PR DESCRIPTION
## Escopo
- remove parâmetros de credencial de URLs de paginação retornadas por provedores;
- preserva parâmetros não sensíveis para diagnóstico;
- adiciona regressão com URL de paginação contendo token de fixture.

## Validação
- `npm test` — 41/41;
- `node --check src/social-publish.js`;
- `wrangler versions upload --keep-vars --dry-run`.

Não altera workflow, credenciais, bindings ou outros módulos.