### PR TITLE
test(booking): isolate synthetic CAPI verification

### DIFF
--- a/website/src/app/api/booking/request/route.ts
+++ b/website/src/app/api/booking/request/route.ts
@@ -10,6 +10,7 @@ import { issueBookingStatusToken } from "@/lib/bookingSecurity";
 import { META_SCHEDULE_CONTENT_TYPE } from "@/lib/metaEventContracts";
 import { sendMetaServerEvent } from "@/lib/metaConversionsApi";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
+import { isAuthorizedSyntheticBookingTest, SYNTHETIC_BOOKING_TEST_TOKEN_HEADER } from "@/lib/syntheticBookingTest";
 
 export const dynamic = "force-dynamic";
 
@@ -495,8 +496,16 @@ export async function POST(request: Request) {
         }
     }
 
+    const syntheticBookingTest = isAuthorizedSyntheticBookingTest({
+        expectedToken: await getRuntimeSecret("BOOKING_SYNTHETIC_TEST_TOKEN"),
+        providedToken: request.headers.get(SYNTHETIC_BOOKING_TEST_TOKEN_HEADER) ?? "",
+        patientName,
+        email,
+        whatsapp,
+    });
+
     const notifications =
-        status === "confirmed"
+        status === "confirmed" && !syntheticBookingTest
             ? await sendBookingNotifications({
                 id,
                 unitSlug,
@@ -513,9 +522,9 @@ export async function POST(request: Request) {
                 statusToken,
             })
             : {
-                email: { ok: false, status: "skipped", error: "not_confirmed" },
-                whatsapp: { ok: false, status: "skipped", error: "not_confirmed" },
-                unitEmail: { ok: false, status: "skipped", error: "not_confirmed" },
+                email: { ok: false, status: "skipped", error: syntheticBookingTest ? "synthetic_test" : "not_confirmed" },
+                whatsapp: { ok: false, status: "skipped", error: syntheticBookingTest ? "synthetic_test" : "not_confirmed" },
+                unitEmail: { ok: false, status: "skipped", error: syntheticBookingTest ? "synthetic_test" : "not_confirmed" },
             };
 
     if (status === "confirmed") {
@@ -589,35 +598,38 @@ export async function POST(request: Request) {
         );
     }
 
-    // Optional: notify external automation via webhook (WhatsApp integration etc.)
-    await tryPostWebhook({
-        event: "booking.created",
-        booking: {
-            id,
-            status,
-            unitSlug,
-            doctorSlug: effectiveDoctorSlug,
-            doctorName: safeDoctorName,
-            durationMinutes,
-            includes: body.includes ?? null,
-            service: { id: service.id, name: service.name },
-            selectedServices: selectedProcedures.map((item) => ({ id: item.id, name: item.name })),
-            startAtMs,
-            endAtMs,
-            confirmByMs,
-            patientName,
-            patientGender,
-            email,
-            whatsapp,
-            cpf,
-            address,
-            customerId,
-            notes,
-            metaEventId,
-            trackingContext: trackingContextResolved,
-        },
-        decisionLinks,
-    });
+    // Synthetic CAPI verification must never reach downstream email, WhatsApp,
+    // or automation channels. The authorization is intentionally short-lived.
+    if (!syntheticBookingTest) {
+        await tryPostWebhook({
+            event: "booking.created",
+            booking: {
+                id,
+                status,
+                unitSlug,
+                doctorSlug: effectiveDoctorSlug,
+                doctorName: safeDoctorName,
+                durationMinutes,
+                includes: body.includes ?? null,
+                service: { id: service.id, name: service.name },
+                selectedServices: selectedProcedures.map((item) => ({ id: item.id, name: item.name })),
+                startAtMs,
+                endAtMs,
+                confirmByMs,
+                patientName,
+                patientGender,
+                email,
+                whatsapp,
+                cpf,
+                address,
+                customerId,
+                notes,
+                metaEventId,
+                trackingContext: trackingContextResolved,
+            },
+            decisionLinks,
+        });
+    }
 
     return json(
         {

--- a/website/src/lib/syntheticBookingTest.ts
+++ b/website/src/lib/syntheticBookingTest.ts
@@ -1,0 +1,31 @@
+import { constantTimeEqual } from "@/lib/bookingSecurity";
+
+export const SYNTHETIC_BOOKING_TEST_TOKEN_HEADER = "x-booking-synthetic-test-token";
+
+type SyntheticBookingTestInput = {
+    expectedToken: string;
+    providedToken: string;
+    patientName: string;
+    email: string;
+    whatsapp: string;
+};
+
+/**
+ * A production-only, operator-authenticated escape hatch for synthetic CAPI
+ * verification. It is inert without the short-lived Worker secret and accepts
+ * only an unmistakably fake identity, so a normal booking can never suppress
+ * notifications or automation.
+ */
+export function isAuthorizedSyntheticBookingTest(input: SyntheticBookingTestInput): boolean {
+    const expectedToken = input.expectedToken.trim();
+    const providedToken = input.providedToken.trim();
+    if (!expectedToken || !providedToken || !constantTimeEqual(providedToken, expectedToken)) {
+        return false;
+    }
+
+    return (
+        input.patientName.trim().toUpperCase().startsWith("META CAPI TEST") &&
+        input.email.trim().toLowerCase().endsWith("@capi-test.invalid") &&
+        input.whatsapp.trim() === "555199990000"
+    );
+}

--- a/website/tests/syntheticBookingTest.test.ts
+++ b/website/tests/syntheticBookingTest.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isAuthorizedSyntheticBookingTest } from "../src/lib/syntheticBookingTest";
+
+const validInput = {
+    expectedToken: "temporary-test-token",
+    providedToken: "temporary-test-token",
+    patientName: "META CAPI TEST Synthetic",
+    email: "schedule@capi-test.invalid",
+    whatsapp: "555199990000",
+};
+
+test("synthetic booking notification suppression requires the secret and all fake identity markers", () => {
+    assert.equal(isAuthorizedSyntheticBookingTest(validInput), true);
+    assert.equal(isAuthorizedSyntheticBookingTest({ ...validInput, providedToken: "wrong-token" }), false);
+    assert.equal(isAuthorizedSyntheticBookingTest({ ...validInput, patientName: "Maria Silva" }), false);
+    assert.equal(isAuthorizedSyntheticBookingTest({ ...validInput, email: "maria@example.com" }), false);
+    assert.equal(isAuthorizedSyntheticBookingTest({ ...validInput, whatsapp: "555199999999" }), false);
+});


### PR DESCRIPTION
## Summary
- adds a short-lived, authenticated synthetic-booking mode for the production CAPI verification only
- requires a fixed fake identity and a temporary Worker secret before notifications or automation are suppressed
- leaves all normal bookings and their notification path unchanged

## Validation
- `npm test` — 84 passed in an isolated WSL checkout
- `npm run typecheck` — build plus TypeScript passed in that checkout
- `git diff --check`

## Operational use
The temporary `BOOKING_SYNTHETIC_TEST_TOKEN` will be set only for the controlled test and removed immediately afterward. It is never committed or documented with a value.