### PR TITLE
fix(crm): make Atendimento local preview reproducible

### DIFF
--- a/crm/api/server/atendimento/__tests__/domain.test.js
+++ b/crm/api/server/atendimento/__tests__/domain.test.js
@@ -131,6 +131,30 @@ test('calculates internal doctor conversion metrics using CRM values and weighte
     ])
 })
 
+test('normalizes doctor conversion statistics by each doctor working days while preserving raw totals', () => {
+    const result = calculateDoctorConversionRanking({
+        dailyGoal: 1000,
+        doctors: [
+            { id: 'd1', name: 'Dra. Um Dia', realized: 1000, workingDays: 1 },
+            { id: 'd2', name: 'Dra. Dois Dias', realized: 2000, workingDays: 2 },
+            { id: 'd3', name: 'Dra. Quatro Dias', realized: 4000, workingDays: 4 },
+            { id: 'd4', name: 'Dra. Sem Escala', realized: 0, workingDays: 0 },
+        ],
+    })
+
+    assert.equal(result.eligibleDoctorCount, 3)
+    assert.equal(result.rankedDoctorTotal, 7000)
+    assert.equal(result.average, 1000)
+    assert.equal(result.median, 1000)
+    assert.equal(result.standardDeviation, 0)
+    assert.equal(result.cutLine, 1000)
+    assert.deepEqual(result.ranking.map((doctor) => ({ name: doctor.name, daily: doctor.weekValue, total: doctor.totalValue, days: doctor.workingDays })), [
+        { name: 'Dra. Dois Dias', daily: 1000, total: 2000, days: 2 },
+        { name: 'Dra. Quatro Dias', daily: 1000, total: 4000, days: 4 },
+        { name: 'Dra. Um Dia', daily: 1000, total: 1000, days: 1 },
+    ])
+})
+
 test('classifies every boundary value exactly once with half-open conversion bands', () => {
     assert.equal(classifyDoctorConversionValue(90, 100, 10).level, 1)
     assert.equal(classifyDoctorConversionValue(100, 100, 10).level, 2)

--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -435,7 +435,7 @@ test('returns segmented goal plan for cross-month periods without distorting the
             rowCount: 1,
         },
         (sql) => sql.includes('as doctor_id') && {
-            rows: [{ unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 30000 }],
+            rows: [{ unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 30000, attended_days: 30 }],
             rowCount: 1,
         },
         (sql) => sql.includes('from crm_atendimento.schedule_days') && { rows: [], rowCount: 0 },
@@ -465,10 +465,13 @@ test('returns segmented goal plan for cross-month periods without distorting the
     assert.equal(section.metrics.periodAttendanceTotal?.weekValue, 30000)
     assert.equal(section.metrics.periodAttendanceTotal?.label, 'Total')
     assert.equal(section.metrics.rankedDoctorTotal?.weekValue, 30000)
-    assert.equal(section.metrics.standardDeviation?.label, 'Desvio Padrão')
-    assert.equal(section.metrics.upperLimit?.label, 'Limite Superior')
-    assert.equal(section.metrics.lowerLimit?.label, 'Limite Inferior')
+    assert.equal(section.metrics.standardDeviation?.label, 'Desvio Padrão diário')
+    assert.equal(section.metrics.upperLimit?.label, 'Limite Superior diário')
+    assert.equal(section.metrics.lowerLimit?.label, 'Limite Inferior diário')
     assert.equal(section.metrics.ratioDivisor?.label, 'Divisor Razões')
+    assert.equal(section.doctors[0]?.workingDays, 30)
+    assert.equal(section.doctors[0]?.totalValue, 30000)
+    assert.equal(section.doctors[0]?.weekValue, 1000)
     assert.equal(section.metrics.periodGoal?.weekValue, 30000)
     assert.equal(section.metrics.dailyGoal?.weekValue, 1000)
     assert.equal(section.goalPlan?.periodOperationalDays, 30)
@@ -777,8 +780,8 @@ function buildConversionPoolHandlers() {
         },
         (sql) => sql.includes('as doctor_id') && {
             rows: [
-                { unit_slug: 'novo-hamburgo', doctor_id: 'doc-a', doctor_name: 'Dra. A', total: 14 },
-                { unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 9 },
+                { unit_slug: 'novo-hamburgo', doctor_id: 'doc-a', doctor_name: 'Dra. A', total: 14, attended_days: 1 },
+                { unit_slug: 'barra-shopping-sul', doctor_id: 'doc-b', doctor_name: 'Dra. B', total: 9, attended_days: 1 },
             ],
             rowCount: 2,
         },

--- a/crm/api/server/atendimento/domain.js
+++ b/crm/api/server/atendimento/domain.js
@@ -167,6 +167,9 @@ export function consolidateConversionProfessionals(doctors = []) {
         const current = byName.get(key)
         if (current) {
             current.realized += Number(doctor?.realized || 0)
+            if (Number.isFinite(Number(doctor?.workingDays))) {
+                current.workingDays = Number(current.workingDays || 0) + Math.max(0, Number(doctor.workingDays))
+            }
             current.sourceIds.push(String(doctor?.id || '').trim())
             continue
         }
@@ -174,6 +177,9 @@ export function consolidateConversionProfessionals(doctors = []) {
             ...doctor,
             name,
             realized: Number(doctor?.realized || 0),
+            workingDays: Number.isFinite(Number(doctor?.workingDays))
+                ? Math.max(0, Number(doctor.workingDays))
+                : undefined,
             sourceIds: [String(doctor?.id || '').trim()].filter(Boolean),
         })
     }
@@ -969,16 +975,30 @@ export function calculateDoctorConversionRanking({
     tieBreakPolicy = DEFAULT_CONVERSION_TIE_BREAK_POLICY,
     unstableJumpThreshold = 0.5,
 } = {}) {
+    const hasWorkingDayNormalization = (Array.isArray(doctors) ? doctors : [])
+        .some((doctor) => Number.isFinite(Number(doctor?.workingDays)))
     const doctorRows = consolidateConversionProfessionals(doctors)
         .map((doctor) => ({
             ...doctor,
-            realized: Number(doctor?.realized || 0),
+            rawRealized: Number(doctor?.realized || 0),
+            workingDays: Number.isFinite(Number(doctor?.workingDays))
+                ? Math.max(0, Number(doctor.workingDays))
+                : null,
             name: stringifyCellValue(doctor?.name),
         }))
-        .filter((doctor) => doctor.name)
+        .filter((doctor) => doctor.name && (!hasWorkingDayNormalization || Number(doctor.workingDays || 0) > 0))
+        .map((doctor) => ({
+            ...doctor,
+            realized: hasWorkingDayNormalization
+                ? doctor.rawRealized / Number(doctor.workingDays)
+                : doctor.rawRealized,
+        }))
     const values = doctorRows.map((doctor) => doctor.realized)
     const valuesForStatistics = values
-    const rankedDoctorTotal = values.reduce((sum, value) => sum + value, 0)
+    // Keep monetary totals auditable, but use daily production for every
+    // comparative statistic and classification. This makes two doctors with
+    // the same daily output comparable even when they worked different days.
+    const rankedDoctorTotal = doctorRows.reduce((sum, doctor) => sum + Number(doctor.rawRealized || 0), 0)
     const safePeriodAttendanceTotal = Number.isFinite(Number(periodAttendanceTotal))
         ? Number(periodAttendanceTotal)
         : rankedDoctorTotal
@@ -1027,7 +1047,8 @@ export function calculateDoctorConversionRanking({
         return {
             ...doctor,
             weekValue: doctor.realized,
-            totalValue: doctor.realized,
+            totalValue: doctor.rawRealized,
+            dailyValue: doctor.realized,
             average: avg,
             median: medianValue,
             monthlyGoal: monthlyGoalValue,
@@ -1153,8 +1174,8 @@ export function calculateDoctorConversionRanking({
         },
         ratioDivisor,
         formulas: {
-            cutLine: 'linha_corte = (media_periodo * 0.30) + (mediana_periodo * 0.20) + (meta_diaria * 0.50)',
-            interval: 'intervalo = desvio_padrao_amostral(realizado_doutores) * multiplicador_intervalo_otimizado',
+            cutLine: 'linha_corte_diaria = (media_diaria_doutores * 0.30) + (mediana_diaria_doutores * 0.20) + (meta_diaria * 0.50)',
+            interval: 'intervalo_diario = desvio_padrao_amostral(realizado_diario_doutores) * multiplicador_intervalo_otimizado',
             homogeneity: 'homogeneidade = 1 - (4 / 3) * soma((proporcao_nivel - 0.25) ^ 2)',
             ratioDivisor: 'divisor = (level0 * 0) + (level1 * 1) + (level2 * 2) + (level3 * 3)',
         },

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -932,8 +932,8 @@ function buildConversionMetricPayload(stats, unitName) {
     const levelCounts = stats.levelCounts || { level0: 0, level1: 0, level2: 0, level3: 0 }
     const proportions = stats.proportions || { p0: 0, p1: 0, p2: 0, p3: 0 }
     const balancedReasons = stats.balancedReasons || { lowerSide: 0, upperSide: 0, center: 0, extremes: 0 }
-    const cutLineFormula = `${stats.formulas?.cutLine || 'linha_corte = (media_periodo * 0.30) + (mediana_periodo * 0.20) + (meta_diaria * 0.50)'}; valores = (${Number(stats.average || 0).toFixed(2)} * 0.30) + (${Number(stats.median || 0).toFixed(2)} * 0.20) + (${Number(stats.dailyGoal || 0).toFixed(2)} * 0.50)`
-    const intervalFormula = `${stats.formulas?.interval || 'intervalo = desvio_padrao(realizado_doutores) * multiplicador_intervalo'}; valores = ${Number(stats.standardDeviation || 0).toFixed(2)} * ${Number(stats.intervalMultiplier || 0).toFixed(2)}`
+    const cutLineFormula = `${stats.formulas?.cutLine || 'linha_corte_diaria = (media_diaria_doutores * 0.30) + (mediana_diaria_doutores * 0.20) + (meta_diaria * 0.50)'}; valores = (${Number(stats.average || 0).toFixed(2)} * 0.30) + (${Number(stats.median || 0).toFixed(2)} * 0.20) + (${Number(stats.dailyGoal || 0).toFixed(2)} * 0.50)`
+    const intervalFormula = `${stats.formulas?.interval || 'intervalo_diario = desvio_padrao(realizado_diario_doutores) * multiplicador_intervalo'}; valores = ${Number(stats.standardDeviation || 0).toFixed(2)} * ${Number(stats.intervalMultiplier || 0).toFixed(2)}`
     const divisorFormula = `${stats.formulas?.ratioDivisor || 'divisor = (level0 * 0) + (level1 * 1) + (level2 * 2) + (level3 * 3)'}; valores = (${levelCounts.level0 || 0} * 0) + (${levelCounts.level1 || 0} * 1) + (${levelCounts.level2 || 0} * 2) + (${levelCounts.level3 || 0} * 3)`
     const homogeneityFormula = `${stats.formulas?.homogeneity || 'homogeneidade = 1 - (4 / 3) * soma((proporcao_nivel - 0.25) ^ 2)'}; proporcoes = ${Number(proportions.p0 || 0).toFixed(4)}, ${Number(proportions.p1 || 0).toFixed(4)}, ${Number(proportions.p2 || 0).toFixed(4)}, ${Number(proportions.p3 || 0).toFixed(4)}`
     return {
@@ -945,9 +945,9 @@ function buildConversionMetricPayload(stats, unitName) {
         dailyGoal: moneyMetric(stats.dailyGoal, unitName, 'Meta Diária', { formula: 'meta_diaria_media_periodo = meta_periodo / dias_trabalhados_periodo' }),
         monthOperationalDays: moneyMetric(stats.monthOperationalDays, unitName, 'Dias mês', { formula: 'dias_trabalhados_mes = dias operacionais do mês pela Escala CRM ou fallback' }),
         periodOperationalDays: moneyMetric(stats.periodOperationalDays, unitName, 'Dias período', { formula: 'dias_trabalhados_periodo = dias operacionais dentro do período selecionado' }),
-        average: moneyMetric(stats.average, unitName, 'Média'),
-        median: moneyMetric(stats.median, unitName, 'Mediana'),
-        standardDeviation: moneyMetric(stats.standardDeviation, unitName, 'Desvio Padrão'),
+        average: moneyMetric(stats.average, unitName, 'Média diária'),
+        median: moneyMetric(stats.median, unitName, 'Mediana diária'),
+        standardDeviation: moneyMetric(stats.standardDeviation, unitName, 'Desvio Padrão diário'),
         upperRatio: moneyMetric(stats.ratios.upperRatio, unitName, 'Razão Superior'),
         lowerRatio: moneyMetric(stats.ratios.lowerRatio, unitName, 'Razão Inferior'),
         innerRatio: moneyMetric(stats.ratios.innerRatio, unitName, 'Razão Interior'),
@@ -957,12 +957,12 @@ function buildConversionMetricPayload(stats, unitName) {
         centerShare: moneyMetric(balancedReasons.center, unitName, 'Faixas Centrais'),
         extremesShare: moneyMetric(balancedReasons.extremes, unitName, 'Faixas Extremas'),
         ratioDivisor: moneyMetric(stats.ratioDivisor, unitName, 'Divisor Razões', { formula: divisorFormula, levelCounts }),
-        cutLine: moneyMetric(stats.cutLine, unitName, 'Linha Corte', { formula: cutLineFormula }),
-        interval: moneyMetric(stats.interval, unitName, 'Intervalo', { formula: intervalFormula }),
+        cutLine: moneyMetric(stats.cutLine, unitName, 'Linha Corte diária', { formula: cutLineFormula }),
+        interval: moneyMetric(stats.interval, unitName, 'Intervalo diário', { formula: intervalFormula }),
         intervalMultiplier: moneyMetric(stats.intervalMultiplier, unitName, 'Multiplicador Otimizado'),
         homogeneityScore: moneyMetric(stats.homogeneityScore, unitName, 'Homogeneidade', { formula: homogeneityFormula }),
-        lowerLimit: moneyMetric(stats.lowerLimit, unitName, 'Limite Inferior'),
-        upperLimit: moneyMetric(stats.upperLimit, unitName, 'Limite Superior'),
+        lowerLimit: moneyMetric(stats.lowerLimit, unitName, 'Limite Inferior diário'),
+        upperLimit: moneyMetric(stats.upperLimit, unitName, 'Limite Superior diário'),
         level0: moneyMetric(levelCounts.level0 || 0, unitName, 'Nível 0', { formula: 'nivel_0 = realizado < limite_inferior', proportion: proportions.p0 }),
         level1: moneyMetric(levelCounts.level1 || 0, unitName, 'Nível 1', { formula: 'nivel_1 = limite_inferior <= realizado < linha_corte', proportion: proportions.p1 }),
         level2: moneyMetric(levelCounts.level2 || 0, unitName, 'Nível 2', { formula: 'nivel_2 = linha_corte <= realizado <= limite_superior', proportion: proportions.p2 }),
@@ -1371,7 +1371,8 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
         ),
         pgPool.query(
             `select u.slug as unit_slug, coalesce(inj.canonical_id, inj.id) as doctor_id,
-                    coalesce(inj_canonical.name, inj.name) as doctor_name, coalesce(sum(a.value), 0)::numeric as total
+                    coalesce(inj_canonical.name, inj.name) as doctor_name, coalesce(sum(a.value), 0)::numeric as total,
+                    count(distinct a.service_date)::int as attended_days
              from crm_atendimento.attendances a
              join crm_atendimento.units u on u.id = a.unit_id
              join crm_atendimento.professionals inj on inj.id = a.injector_id
@@ -1402,7 +1403,7 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
     ])
     const escalaCoverage = await readEscalaScheduleCoverage(pgPool, selectedUnits, scheduleStart, scheduleEnd, actor, { persistMissing: syncSchedule })
     const scheduleRows = await pgPool.query(
-        `select u.slug as unit_slug, s.service_date, s.doctor_name
+        `select u.slug as unit_slug, s.service_date, s.doctor_name, s.professional_id
          from crm_atendimento.schedule_days s
          join crm_atendimento.units u on u.id = s.unit_id
          where s.service_date >= $1::date
@@ -1415,16 +1416,26 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
     const doctorTotalByUnit = new Map()
     for (const row of doctorTotals.rows) {
         const unitMap = doctorTotalByUnit.get(row.unit_slug) || new Map()
-        unitMap.set(row.doctor_id, Number(row.total || 0))
-        unitMap.set(normalizeText(row.doctor_name), Number(row.total || 0))
+        const total = Number(row.total || 0)
+        const attendedDays = Math.max(0, Number(row.attended_days || 0))
+        const entry = { total, attendedDays }
+        unitMap.set(row.doctor_id, entry)
+        unitMap.set(normalizeText(row.doctor_name), entry)
         doctorTotalByUnit.set(row.unit_slug, unitMap)
     }
 
     const scheduleByUnit = new Map()
+    const doctorWorkingDaysByUnit = new Map()
     for (const row of scheduleRows.rows) {
         const unitMap = scheduleByUnit.get(row.unit_slug) || new Map()
-        unitMap.set(isoDateFromDb(row.service_date), row.doctor_name)
+        const serviceDate = isoDateFromDb(row.service_date)
+        unitMap.set(serviceDate, row.doctor_name)
         scheduleByUnit.set(row.unit_slug, unitMap)
+        if (serviceDate < bounds.metricStart || serviceDate > bounds.metricEnd) continue
+        const doctorDays = doctorWorkingDaysByUnit.get(row.unit_slug) || new Map()
+        const keys = [row.professional_id, normalizeText(row.doctor_name)].filter(Boolean)
+        for (const key of keys) doctorDays.set(key, Number(doctorDays.get(key) || 0) + 1)
+        doctorWorkingDaysByUnit.set(row.unit_slug, doctorDays)
     }
     const baseGoalByUnitMonth = new Map()
     for (const row of goals.rows) {
@@ -1452,14 +1463,24 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
 
     for (const unit of selectedUnits) {
         const totals = doctorTotalByUnit.get(unit.slug) || new Map()
+        const workingDays = doctorWorkingDaysByUnit.get(unit.slug) || new Map()
         const doctors = (professionalsByUnit.get(unit.slug) || [])
-            .map((doctor) => ({
-                id: doctor.id,
-                name: doctor.name,
-                unitSlug: unit.slug,
-                unitName: unit.name,
-                realized: Number(totals.get(doctor.id) ?? totals.get(normalizeText(doctor.name)) ?? 0),
-            }))
+            .map((doctor) => {
+                const total = totals.get(doctor.id) ?? totals.get(normalizeText(doctor.name)) ?? { total: 0, attendedDays: 0 }
+                const scheduledDays = Number(workingDays.get(doctor.id) ?? workingDays.get(normalizeText(doctor.name)) ?? 0)
+                // Escala is authoritative for a doctor's workday. Imported
+                // historical rows may lack it, so distinct service dates are a
+                // conservative fallback instead of silently dividing by zero.
+                const doctorWorkingDays = scheduledDays > 0 ? scheduledDays : Number(total.attendedDays || 0)
+                return {
+                    id: doctor.id,
+                    name: doctor.name,
+                    unitSlug: unit.slug,
+                    unitName: unit.name,
+                    realized: Number(total.total || 0),
+                    workingDays: doctorWorkingDays,
+                }
+            })
         const firstGoalMap = firstGoalByUnitMonth.get(unit.slug) || new Map()
         const baseGoalMap = baseGoalByUnitMonth.get(unit.slug) || new Map()
         const goalPlan = calculateConversionGoalPlan(monthSegments.map((segment) => ({
@@ -1522,6 +1543,7 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
                 unitSlug: unit.slug,
                 weekValue: moneyMetric(doctor.weekValue).weekValue,
                 totalValue: moneyMetric(doctor.totalValue).totalValue,
+                workingDays: Number(doctor.workingDays || 0),
                 score: doctor.score,
                 level: doctor.level,
                 classification: doctor.classification,
@@ -1577,7 +1599,8 @@ async function buildInternalConversionMetrics(pgPool, period, query, actor, { pe
             doctors: allDoctors.map((doctor) => ({
                 id: doctor.id,
                 name: doctor.name,
-                realized: Number(doctor.weekValue || 0),
+                realized: Number(doctor.totalValue || 0),
+                workingDays: Number(doctor.workingDays || 0),
             })),
             monthlyGoal: aggregateGoalPlan.monthlyGoal,
             periodAttendanceTotal: selectedUnits.reduce((total, unit) => total + Number(weeklyTotalByUnit.get(unit.slug) || 0), 0),

--- a/crm/console/AtendimentoModule.tsx
+++ b/crm/console/AtendimentoModule.tsx
@@ -165,6 +165,7 @@ const panelClass = 'border-slate-800/80 bg-slate-950/60 shadow-[0_20px_80px_rgba
 const ATENDIMENTO_METRIC_LAYOUT_KEY = 'skincos.atendimento.layout.metrics.v2'
 const ATENDIMENTO_CHART_LAYOUT_KEY = 'skincos.atendimento.layout.charts.v3'
 const ATENDIMENTO_ANALYSIS_EXPANDED_KEY = 'skincos.atendimento.analysis.expanded.v1'
+const ATENDIMENTO_ATTENDANCES_EXPANDED_KEY = 'skincos.atendimento.attendances.expanded.v1'
 const ATTENDANCE_PAGE_SIZE = 50
 const DEFAULT_UNIT_LEGEND = [
   { slug: 'novo-hamburgo', name: 'Novo Hamburgo' },
@@ -207,6 +208,7 @@ type AtendimentoMetricHierarchyNode = {
 }
 type MetricTooltipSpec = {
   what: string
+  formula?: string
   calculation: string
   usage: string
   detailPresentation?: 'compact' | 'doctors' | 'interval'
@@ -473,9 +475,10 @@ function MetricTooltipContent({ info }: { info: MetricTooltipSpec }) {
     const presentation = info.detailPresentation || 'compact'
     return (
       <div className="space-y-2 text-left">
-        <div className="max-h-[22rem] space-y-1.5 overflow-y-auto pr-1">
+        <p className="text-[11px] leading-snug text-slate-300"><span className="font-semibold text-slate-100">O que é:</span> {info.what}</p>
+        <div className="max-h-56 space-y-1 overflow-y-auto rounded-md border border-slate-700/70 bg-slate-900/50 p-2 pr-1.5">
           {info.details.map((detail) => (
-            <div key={`${detail.label}:${detail.value}`} className="rounded border border-slate-700/70 bg-slate-900/50 px-2 py-1.5">
+            <div key={`${detail.label}:${detail.value}`} className="flex min-w-0 items-center justify-between gap-3 py-1 first:pt-0 last:pb-0">
               <div className="flex min-w-0 items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-2">
                   {presentation === 'doctors' && detail.isProfessional ? (
@@ -504,12 +507,15 @@ function MetricTooltipContent({ info }: { info: MetricTooltipSpec }) {
             Juntos, esses componentes definem a largura das faixas: desvio padrão × multiplicador. O multiplicador é escolhido pela homogeneidade do período.
           </p>
         ) : null}
+        <p className="border-t border-slate-700/80 pt-2 text-[10px] leading-snug text-slate-400"><span className="font-semibold text-slate-200">Fórmula:</span> {info.formula || info.calculation}</p>
+        <p className="text-[10px] leading-snug text-slate-400"><span className="font-semibold text-slate-200">Uso:</span> {info.usage}</p>
       </div>
     )
   }
   return (
-    <div className="space-y-1 text-left">
+    <div className="space-y-1.5 text-left leading-snug">
       <div><span className="font-semibold text-slate-100">O que é:</span> {info.what}</div>
+      <div><span className="font-semibold text-slate-100">Fórmula:</span> {info.formula || info.calculation}</div>
       <div><span className="font-semibold text-slate-100">Cálculo:</span> {info.calculation}</div>
       <div><span className="font-semibold text-slate-100">Uso:</span> {info.usage}</div>
     </div>
@@ -749,13 +755,14 @@ function MetricGroupContent({
   const renderRow = (row: AtendimentoMetricGroupRow, isChild = false, componentRows: AtendimentoMetricGroupRow[] = []) => {
     const RowIcon = row.icon
     const isDetail = row.presentation === 'detail'
-    const detailPresentation = row.key === 'average' || row.key === 'median'
+    const detailPresentation: NonNullable<MetricTooltipSpec['detailPresentation']> = row.key === 'average' || row.key === 'median'
       ? 'doctors'
       : row.key === 'interval'
         ? 'interval'
         : 'compact'
     const componentTooltip: MetricTooltipSpec | undefined = componentRows.length ? {
       what: `Componentes usados para calcular ${row.label}.`,
+      formula: row.tooltip?.formula || row.tooltip?.calculation || row.calculation,
       calculation: row.tooltip?.calculation || row.calculation || 'Confira os valores atuais de cada insumo abaixo.',
       usage: 'Clique no subtítulo novamente para manter esta conferência aberta.',
       detailPresentation,
@@ -769,14 +776,19 @@ function MetricGroupContent({
         isProfessional: component.key.includes(':doctor:'),
       })),
     } : undefined
-    const multiplierDescription = row.key === 'interval' && componentTooltip && multiplierOptimization ? (
+    const multiplierDescription = row.key === 'conversion:distribution-details' && row.tooltip && multiplierOptimization ? (
       <div className="space-y-3">
-        <MetricTooltipContent info={componentTooltip} />
+        <MetricTooltipContent info={row.tooltip} />
         <div className="border-t border-slate-700/80 pt-3">
           <ConversionMultiplierDetails optimization={multiplierOptimization} />
         </div>
       </div>
     ) : undefined
+    const rowTooltip = componentTooltip && row.tooltip ? {
+      ...row.tooltip,
+      details: componentTooltip.details,
+      detailPresentation,
+    } : row.tooltip
     const rowContent = (
       <div className={`flex min-w-0 items-center gap-2 ${horizontal ? 'justify-center' : ''} ${isChild ? 'py-0.5' : ''}`}>
         {row.avatarUrl ? (
@@ -805,28 +817,12 @@ function MetricGroupContent({
     )
     return (
       <div key={row.key} className="min-w-0">
-        <div className="min-w-0">{row.tooltip ? <MetricTooltip label={row.label} info={row.tooltip}>{rowContent}</MetricTooltip> : rowContent}</div>
-        {row.calculation ? (
-          <div className={`${horizontal ? 'mt-0.5 text-center' : 'ml-7 mt-0.5'} min-w-0 text-[9px] leading-snug text-slate-500`}>
-            {componentTooltip ? (
-              <MetricTooltip
-                label={`Componentes de ${row.label}`}
-                info={componentTooltip}
-                description={multiplierDescription}
-                contentClassName={multiplierDescription ? 'w-[min(42rem,calc(100vw-2rem))] max-w-none' : detailPresentation === 'doctors' ? 'max-w-[24rem]' : 'max-w-[22rem]'}
-              >
-                <div className="inline-flex max-w-full cursor-help rounded-sm px-0.5 transition hover:bg-slate-800/70 hover:text-slate-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400/60">
-                  {row.calculation.split('=')[0].trim()}
-                </div>
-              </MetricTooltip>
-            ) : row.calculation.split('=')[0].trim()}
-          </div>
-        ) : null}
+        <div className="min-w-0">{rowTooltip ? <MetricTooltip label={row.label} info={rowTooltip} description={multiplierDescription} contentClassName={multiplierDescription ? 'w-[min(34rem,calc(100vw-2rem))] max-w-none max-h-[min(32rem,calc(100vh-2rem))] overflow-y-auto' : detailPresentation === 'doctors' ? 'max-w-[24rem]' : 'max-w-[22rem]'}>{rowContent}</MetricTooltip> : rowContent}</div>
       </div>
     )
   }
 
-  const renderNode = (node: AtendimentoMetricHierarchyNode, depth = 0, index = 0): React.ReactNode => {
+  const renderNode = (node: AtendimentoMetricHierarchyNode, depth = 0): React.ReactNode => {
     const row = rowsByKey.get(node.key)
     if (!row) return null
     const children = (node.children || []).filter((child) => rowsByKey.has(child.key))
@@ -834,13 +830,13 @@ function MetricGroupContent({
       .map((child) => rowsByKey.get(child.key))
       .filter((child): child is AtendimentoMetricGroupRow => Boolean(child))
     return (
-      <div key={node.key} className={`min-w-0 ${horizontal && nodes.length === 7 ? (index < 4 ? 'md:col-span-3' : 'md:col-span-4') : ''}`}>
+      <div key={node.key} className="min-w-0">
         {renderRow(row, depth > 0, componentRows)}
       </div>
     )
   }
 
-  return <div className={`grid gap-x-3 gap-y-2 pt-0.5 ${horizontal ? 'mx-auto w-full max-w-5xl grid-cols-1 sm:grid-cols-2 md:grid-cols-12' : 'gap-1.5'}`}>{nodes.map((node, index) => renderNode(node, 0, index))}</div>
+  return <div className={`grid gap-x-3 gap-y-2 pt-0.5 ${horizontal ? 'mx-auto w-full max-w-5xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-4' : 'gap-1.5'}`}>{nodes.map((node) => renderNode(node))}</div>
 }
 
 function MetricTile({
@@ -1054,15 +1050,15 @@ const CONVERSION_METRIC_DEFINITIONS = [
   { key: 'periodGoal', label: 'Meta do período', description: 'Meta acumulada do período selecionado.', calculation: 'Soma das metas diárias dos dias trabalhados dentro do período.', usage: 'É a meta principal de comparação da janela filtrada.' },
   { key: 'monthOperationalDays', label: 'Dias mês', description: 'Dias trabalhados usados para diluir a meta mensal.', calculation: 'Dias operacionais do mês consolidados na agenda do CRM.', usage: 'Define a meta diária.' },
   { key: 'periodOperationalDays', label: 'Dias período', description: 'Dias trabalhados dentro do filtro ativo.', calculation: 'Dias operacionais entre início e fim do período selecionado.', usage: 'Define a meta proporcional do período.' },
-  { key: 'average', label: 'Média', description: 'Média do realizado dos doutores elegíveis.', calculation: 'total_ranqueável / doutores_elegíveis.', usage: 'Compõe 30% da linha de corte.' },
-  { key: 'median', label: 'Mediana', description: 'Valor central do realizado dos doutores elegíveis.', calculation: 'Ordena os realizados e pega o centro; em par, média dos dois centrais.', usage: 'Compõe 20% da linha de corte e reduz distorção por extremos.' },
-  { key: 'standardDeviation', label: 'Desvio Padrão', description: 'Dispersão do realizado entre doutores elegíveis.', calculation: 'Desvio padrão amostral dos valores realizados.', usage: 'Multiplicado pelo fator de intervalo para definir a largura das faixas.' },
-  { key: 'cutLine', label: 'Linha Corte', description: 'Centro das faixas de classificação na escala do período selecionado.', calculation: 'linha_corte = (média_periodo * 0,30) + (mediana_periodo * 0,20) + (meta_diária * 0,50).', usage: 'Separa níveis 1/2 e orienta os limites inferior e superior.' },
-  { key: 'interval', label: 'Intervalo', description: 'Largura das faixas ao redor da linha de corte.', calculation: 'intervalo = desvio_padrão_amostral(realizado_doutores) * multiplicador_otimizado.', usage: 'Define limite inferior e superior.' },
+  { key: 'average', label: 'Média diária', description: 'Média da produção diária dos doutores elegíveis.', calculation: 'soma(produção_do_doutor / dias_trabalhados_do_doutor) / doutores_elegíveis.', usage: 'Compõe 30% da linha de corte e elimina a vantagem de quem trabalhou mais dias.' },
+  { key: 'median', label: 'Mediana diária', description: 'Valor central da produção diária dos doutores elegíveis.', calculation: 'Ordena as produções diárias e pega o centro; em par, média dos dois centrais.', usage: 'Compõe 20% da linha de corte e reduz distorção por extremos.' },
+  { key: 'standardDeviation', label: 'Desvio Padrão diário', description: 'Dispersão da produção diária entre doutores elegíveis.', calculation: 'Desvio padrão amostral das produções diárias.', usage: 'Multiplicado pelo fator de intervalo para definir a largura diária das faixas.' },
+  { key: 'cutLine', label: 'Linha Corte diária', description: 'Centro diário das faixas de classificação.', calculation: 'linha_corte_diária = (média_diária * 0,30) + (mediana_diária * 0,20) + (meta_diária * 0,50).', usage: 'Separa níveis 1/2 sem favorecer quem trabalhou mais dias.' },
+  { key: 'interval', label: 'Intervalo diário', description: 'Largura diária das faixas ao redor da linha de corte.', calculation: 'intervalo_diário = desvio_padrão_amostral(produção_diária) * multiplicador_otimizado.', usage: 'Define os limites inferior e superior diários.' },
   { key: 'intervalMultiplier', label: 'Multiplicador Otimizado', description: 'Fator aplicado ao desvio padrão e derivado da maior homogeneidade possível.', calculation: 'Avalia os breakpoints exatos entre 0 e 2; mantém o valor anterior somente dentro de um platô ótimo e, fora dele, usa o centro do maior platô ótimo.', usage: 'Redistribui os doutores entre faixas internas e externas sem alterar quem está acima ou abaixo da linha de corte.' },
   { key: 'homogeneityScore', label: 'Homogeneidade', description: 'Índice de equilíbrio entre as quatro faixas.', calculation: '1 - (4/3) × soma((proporção da faixa - 25%)²).', usage: 'Varia de 0% (concentração extrema) a 100% (quatro faixas uniformes).' },
-  { key: 'lowerLimit', label: 'Limite Inferior', description: 'Piso da faixa central.', calculation: 'linha_corte - intervalo.', usage: 'Abaixo dele o doutor entra no nível 0.' },
-  { key: 'upperLimit', label: 'Limite Superior', description: 'Teto da faixa central.', calculation: 'linha_corte + intervalo.', usage: 'Acima dele o doutor entra no nível 3.' },
+  { key: 'lowerLimit', label: 'Limite Inferior diário', description: 'Piso diário da faixa central.', calculation: 'linha_corte_diária - intervalo_diário.', usage: 'Abaixo dele o doutor entra no nível 0.' },
+  { key: 'upperLimit', label: 'Limite Superior diário', description: 'Teto diário da faixa central.', calculation: 'linha_corte_diária + intervalo_diário.', usage: 'Acima dele o doutor entra no nível 3.' },
   { key: 'level0', label: 'Nível 0', description: 'Doutores abaixo do limite inferior.', calculation: 'Conta realizado < limite_inferior.', usage: 'Entra no divisor das razões com peso 0.' },
   { key: 'level1', label: 'Nível 1', description: 'Doutores entre limite inferior e linha de corte.', calculation: 'Conta limite_inferior <= realizado < linha_corte.', usage: 'Entra no divisor das razões com peso 1.' },
   { key: 'level2', label: 'Nível 2', description: 'Doutores entre linha de corte e limite superior.', calculation: 'Conta linha_corte <= realizado <= limite_superior.', usage: 'Entra no divisor das razões com peso 2.' },
@@ -1213,6 +1209,7 @@ function buildMetricTooltip(
 ): MetricTooltipSpec {
   return {
     what: overrides?.what || definition.description,
+    formula: overrides?.formula || definition.calculation,
     calculation: overrides?.calculation || formula || definition.calculation,
     usage: overrides?.usage || definition.usage,
   }
@@ -2148,6 +2145,13 @@ export function AtendimentoModule() {
       return false
     }
   })
+  const [attendancesExpanded, setAttendancesExpanded] = useState(() => {
+    try {
+      return typeof window === 'undefined' || window.localStorage.getItem(ATENDIMENTO_ATTENDANCES_EXPANDED_KEY) !== 'false'
+    } catch {
+      return true
+    }
+  })
   const [localMirrorStatus, setLocalMirrorStatus] = useState<AtendimentoLocalMirrorStatus | null>(null)
   const loadingMoreRowsRef = React.useRef(false)
   const conversionReportCacheRef = React.useRef(new Map<string, AtendimentoManagementConversionReport>())
@@ -2193,6 +2197,14 @@ export function AtendimentoModule() {
       // ignore localStorage errors
     }
   }, [analysisExpanded])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(ATENDIMENTO_ATTENDANCES_EXPANDED_KEY, String(attendancesExpanded))
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [attendancesExpanded])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -2505,11 +2517,11 @@ export function AtendimentoModule() {
         case 'periodOperationalDays':
           return 'Dias usados para proporcionalizar a meta'
         case 'average':
-          return `Σ produção dos doutores ÷ ${number('eligibleDoctorCount')} doutores`
+          return `Σ produção diária dos doutores ÷ ${number('eligibleDoctorCount')} doutores`
         case 'median':
-          return `mediana de ${number('eligibleDoctorCount')} realizados`
+          return `mediana de ${number('eligibleDoctorCount')} produções diárias`
         case 'standardDeviation':
-          return `DP amostral de ${number('eligibleDoctorCount')} realizados`
+          return `DP amostral de ${number('eligibleDoctorCount')} produções diárias`
         case 'upperLimit':
           return `${currency('cutLine')} + ${currency('interval')}`
         case 'cutLine':
@@ -2588,12 +2600,14 @@ export function AtendimentoModule() {
           key: `${parentKey}:doctor:${rank}:${canonicalName}`,
           label: canonicalName,
           value: formatCurrencyBRL(Number(doctor.weekValue || 0)),
+          detail: `${formatCurrencyBRL(Number(doctor.totalValue || 0))} ÷ ${formatNumberBR(Number(doctor.workingDays || 0))} dias`,
+          calculation: `${formatCurrencyBRL(Number(doctor.totalValue || 0))} ÷ ${formatNumberBR(Number(doctor.workingDays || 0))} dias trabalhados`,
           tooltip: {
-            what: `Produção de ${canonicalName} usada nas estatísticas do ranking.`,
-            calculation: 'Soma dos atendimentos atribuídos ao profissional elegível no período e na unidade ativos.',
+            what: `Produção diária de ${canonicalName} usada nas estatísticas do ranking.`,
+            calculation: 'Total dos atendimentos atribuídos ao profissional dividido pelos dias em que ele esteve escalado no período; sem Escala histórica, usa os dias distintos com atendimento registrado.',
             usage: parentKey === 'average'
-              ? 'Esta produção compõe o total dividido pela quantidade de doutores para obter a média.'
-              : 'Os valores ordenados dos doutores determinam a posição central da mediana.',
+              ? 'Esta produção diária compõe o total dividido pela quantidade de doutores para obter a média diária.'
+              : 'As produções diárias ordenadas dos doutores determinam a posição central da mediana.',
           },
           icon: Stethoscope,
           tone: 'sky',
@@ -2629,12 +2643,28 @@ export function AtendimentoModule() {
         const averageDoctorRows = buildDoctorProductionRows('average')
         const medianDoctorRows = buildDoctorProductionRows('median')
         const goalSegmentRows = buildGoalSegmentRows()
-        const rows = [...buildConversionRows(group.metricKeys), ...averageDoctorRows, ...medianDoctorRows, ...goalSegmentRows]
+        const distributionDetailRow: AtendimentoMetricGroupRow[] = group.key === 'conversion:stats' && conversionSection?.optimization
+          ? [{
+              key: 'conversion:distribution-details',
+              label: 'Faixas, níveis e razões',
+              value: 'Ver distribuição',
+              calculation: 'Distribuição dos doutores entre os lados e os quatro níveis da régua diária.',
+              tooltip: {
+                what: 'Composição dos lados, níveis e razões que sustentam a escolha do multiplicador.',
+                formula: 'níveis = comparação da produção_diária com limite_inferior, linha_corte e limite_superior.',
+                calculation: 'As proporções e razões usam as contagens dos níveis 0 a 3; a curva escolhe o multiplicador mais homogêneo possível.',
+                usage: 'Use para auditar a distribuição sem misturar essa análise avançada ao cálculo do intervalo.',
+              },
+              icon: Gauge,
+              tone: 'violet',
+            }]
+          : []
+        const rows = [...buildConversionRows(group.metricKeys), ...distributionDetailRow, ...averageDoctorRows, ...medianDoctorRows, ...goalSegmentRows]
         return {
           ...group,
           rows,
           hierarchy: group.key === 'conversion:stats'
-            ? buildStatsHierarchy(averageDoctorRows, medianDoctorRows, goalSegmentRows)
+            ? [...buildStatsHierarchy(averageDoctorRows, medianDoctorRows, goalSegmentRows), ...distributionDetailRow.map((row) => ({ key: row.key }))]
             : group.hierarchy,
         }
       })
@@ -3143,6 +3173,19 @@ export function AtendimentoModule() {
 
       <div className="grid min-h-0 flex-1 gap-4">
         <section className="min-h-0 overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/45 shadow-[0_20px_80px_rgba(2,6,23,0.24)] backdrop-blur-xl" aria-label="Atendimentos">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-3 border-b border-slate-800/75 px-3 py-3 text-left transition hover:bg-slate-900/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sky-400/70"
+            aria-expanded={attendancesExpanded}
+            aria-controls="atendimento-table-content"
+            data-testid="atendimento-table-toggle"
+            onClick={() => setAttendancesExpanded((current) => !current)}
+          >
+            <span className="min-w-0"><span className="block text-sm font-semibold text-slate-100">Atendimentos</span><span className="block text-[11px] text-slate-400">Registros, pendências e valores do período filtrado.</span></span>
+            <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-sky-200">{attendancesExpanded ? 'Recolher' : 'Ver registros'}{attendancesExpanded ? <ChevronUp className="h-4 w-4" aria-hidden="true" /> : <ChevronDown className="h-4 w-4" aria-hidden="true" />}</span>
+          </button>
+          {attendancesExpanded ? (
+          <div id="atendimento-table-content">
           {filters.unit === 'all' ? (
             <div className="flex items-center justify-end gap-3 border-b border-slate-800/75 px-3 py-2">
               <div className="flex flex-wrap items-center justify-end gap-1.5" data-testid="atendimento-unit-legend" aria-label="Legenda de unidades">
@@ -3459,6 +3502,8 @@ export function AtendimentoModule() {
               </table>
             </div>
           </div>
+          </div>
+          ) : <div id="atendimento-table-content" className="px-3 py-3 text-xs leading-relaxed text-slate-400" data-testid="atendimento-table-collapsed">A listagem está recolhida. Abra-a para consultar, criar ou ajustar os atendimentos do período.</div>}
         </section>
 
         <AtendimentoChartsPanel overview={overview} professionals={references?.professionals || []} slots={chartSlots} onSlotsChange={setChartSlots} />

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -408,10 +408,10 @@ export type AtendimentoManagementConversionReport = {
         configHash?: string
         calendarHash?: string
       }
-      doctors: Array<{ name: string; unitName?: string; unitSlug?: string; weekValue: number; totalValue: number; score: number; position?: string; rank: number; classification?: string; level?: number; modifiedZ?: number; distanceToCutOff?: number; distanceToLowerLimit?: number; distanceToUpperLimit?: number }>
+      doctors: Array<{ name: string; unitName?: string; unitSlug?: string; weekValue: number; totalValue: number; workingDays?: number; score: number; position?: string; rank: number; classification?: string; level?: number; modifiedZ?: number; distanceToCutOff?: number; distanceToLowerLimit?: number; distanceToUpperLimit?: number }>
       comparisonMetric?: 'production' | 'unit-score'
     }>
-    topDoctors: Array<{ name: string; unitName: string; unitSlug: string; weekValue: number; totalValue: number; score: number; position?: string; rank: number; classification?: string; level?: number }>
+    topDoctors: Array<{ name: string; unitName: string; unitSlug: string; weekValue: number; totalValue: number; workingDays?: number; score: number; position?: string; rank: number; classification?: string; level?: number }>
   }
   sections: Array<{
     unitName: string

--- a/crm/console/atendimentoCharts.tsx
+++ b/crm/console/atendimentoCharts.tsx
@@ -94,7 +94,7 @@ function chartData(slot: AtendimentoChartSlot, overview: AtendimentoOverview | n
   return rows.slice(0, slot.topN).map((item) => ({ label: item.label, value: Number(item.value || 0), count: Number(item.count || 0) }))
 }
 
-function AtendimentoChartCard({ slot, overview, professionals, onChange, onRemove, onMove, onCycleLayout, onToggleWide, onToggleCollapsed, canRemove, canMoveLeft, canMoveRight }: {
+function AtendimentoChartCard({ slot, overview, professionals, onChange, onRemove, onMove, onCycleLayout, onToggleWide, canRemove, canMoveLeft, canMoveRight }: {
   slot: AtendimentoChartSlot
   overview: AtendimentoOverview | null
   professionals: AtendimentoVisualProfessional[]
@@ -103,7 +103,6 @@ function AtendimentoChartCard({ slot, overview, professionals, onChange, onRemov
   onMove: (direction: -1 | 1) => void
   onCycleLayout: () => void
   onToggleWide: () => void
-  onToggleCollapsed: () => void
   canRemove: boolean
   canMoveLeft: boolean
   canMoveRight: boolean
@@ -134,11 +133,10 @@ function AtendimentoChartCard({ slot, overview, professionals, onChange, onRemov
             <IconOnlyAction label="Mover gráfico para a direita" description="Reorganizar a posição deste gráfico no painel." onClick={() => onMove(1)} disabled={!canMoveRight} data-testid="atendimento-chart-move-right"><ChevronRight className="h-4 w-4" /></IconOnlyAction>
             <IconOnlyAction label="Redimensionar gráfico" description="Alternar entre largura compacta, padrão e ampliada." onClick={onCycleLayout} data-testid="atendimento-chart-resize"><ChevronsUpDown className="h-4 w-4" /></IconOnlyAction>
             <IconOnlyAction label={slot.layout === 'wide' ? 'Restaurar largura do gráfico' : 'Expandir gráfico'} description={slot.layout === 'wide' ? 'Voltar para a largura padrão.' : 'Ocupar duas colunas quando houver espaço.'} onClick={onToggleWide} data-testid="atendimento-chart-expand">{slot.layout === 'wide' ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}</IconOnlyAction>
-            <IconOnlyAction label={slot.collapsed ? 'Expandir conteúdo do gráfico' : 'Recolher conteúdo do gráfico'} description={slot.collapsed ? 'Exibir controles e visualização.' : 'Manter apenas o cabeçalho do gráfico.'} onClick={onToggleCollapsed} data-testid="atendimento-chart-collapse">{slot.collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}</IconOnlyAction>
             {canRemove ? <IconOnlyAction label="Remover gráfico" description="Retirar este gráfico do painel." onClick={onRemove} tooltipAlign="right"><Trash2 className="h-4 w-4" /></IconOnlyAction> : null}
           </div>
         </div>
-        {!slot.collapsed ? <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Select value={slot.presetId} onValueChange={(value) => onChange({ presetId: value as AtendimentoChartPreset, view: value === 'monthly' ? 'area' : value === 'ticket' ? 'line' : 'bar', metric: value === 'ticket' ? 'value' : slot.metric })}>
             <SelectTrigger className="h-8 min-w-[9rem] border-slate-700 bg-slate-900/70 text-xs text-slate-100"><SelectValue /></SelectTrigger>
             <SelectContent>{CHART_PRESETS.map((item) => <SelectItem key={item.id} value={item.id}>{item.label}</SelectItem>)}</SelectContent>
@@ -148,13 +146,13 @@ function AtendimentoChartCard({ slot, overview, professionals, onChange, onRemov
           )}
           <Select value={view} onValueChange={(value) => onChange({ view: value as AtendimentoChartView })}><SelectTrigger className="h-8 w-28 border-slate-700 bg-slate-900/70 text-xs text-slate-100"><SelectValue /></SelectTrigger><SelectContent>{CHART_VIEWS.filter((item) => slot.presetId === 'monthly' || slot.presetId === 'ticket' || item.id !== 'area').map((item) => <SelectItem key={item.id} value={item.id}>{item.label}</SelectItem>)}</SelectContent></Select>
           <Select value={String(slot.topN)} onValueChange={(value) => onChange({ topN: Number(value) })}><SelectTrigger className="h-8 w-24 border-slate-700 bg-slate-900/70 text-xs text-slate-100"><SelectValue /></SelectTrigger><SelectContent>{[5, 8, 10, 12].map((value) => <SelectItem key={value} value={String(value)}>Top {value}</SelectItem>)}</SelectContent></Select>
-        </div> : null}
+        </div>
       </CardHeader>
-      {!slot.collapsed ? <CardContent>
+      <CardContent>
         {data.length ? <div className="w-full" style={{ height }}><ResponsiveContainer width="100%" height="100%">
           {view === 'line' ? <LineChart data={data} margin={{ left: 0, right: 8, top: 12, bottom: 0 }}><CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.14)" /><XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => String(value).slice(0, 14)} /><YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={axisFormatter} />{tooltip}<Line type="monotone" dataKey={dataKey} stroke="#38bdf8" strokeWidth={2} dot={false} /></LineChart> : view === 'bar' ? <BarChart data={data} layout={slot.presetId === 'monthly' || slot.presetId === 'ticket' ? 'horizontal' : 'vertical'} margin={{ left: 8, right: 12, top: 12, bottom: 0 }}><CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.12)" />{slot.presetId === 'monthly' || slot.presetId === 'ticket' ? <><XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} /><YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={axisFormatter} /></> : <><XAxis type="number" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={axisFormatter} /><YAxis type="category" dataKey="label" width={120} tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(value) => String(value).slice(0, 18)} /></>}{tooltip}<Bar dataKey={dataKey} fill="#38bdf8" radius={slot.presetId === 'monthly' || slot.presetId === 'ticket' ? [6, 6, 0, 0] : [0, 6, 6, 0]}>{data.map((item) => <Cell key={item.label} fill={getBarColor(item.label)} />)}</Bar></BarChart> : <AreaChart data={data} margin={{ left: 0, right: 8, top: 12, bottom: 0 }}><defs><linearGradient id={`atendimentoChartFill-${slot.presetId}-${metric}`} x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#38bdf8" stopOpacity={0.32} /><stop offset="95%" stopColor="#38bdf8" stopOpacity={0.02} /></linearGradient></defs><XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#94a3b8', fontSize: 11 }} /><YAxis tickLine={false} axisLine={false} width={48} tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={axisFormatter} />{tooltip}<Area type="monotone" dataKey={dataKey} stroke="#38bdf8" strokeWidth={2} fill={`url(#atendimentoChartFill-${slot.presetId}-${metric})`} /></AreaChart>}
         </ResponsiveContainer></div> : <div className="rounded-2xl border border-slate-800 bg-slate-900/35 p-4 text-sm text-slate-400">Sem dados para este gráfico.</div>}
-      </CardContent> : null}
+      </CardContent>
     </Card>
   )
 }
@@ -165,6 +163,12 @@ export function AtendimentoChartsPanel({ overview, professionals = [], slots, on
   slots: AtendimentoChartSlot[]
   onSlotsChange: React.Dispatch<React.SetStateAction<AtendimentoChartSlot[]>>
 }) {
+  const [expanded, setExpanded] = React.useState(() => {
+    try { return window.localStorage.getItem('skincos.atendimento.charts.expanded.v1') !== 'false' } catch { return true }
+  })
+  React.useEffect(() => {
+    try { window.localStorage.setItem('skincos.atendimento.charts.expanded.v1', String(expanded)) } catch { /* unavailable storage */ }
+  }, [expanded])
   const updateSlot = (index: number, patch: Partial<AtendimentoChartSlot>) => onSlotsChange((prev) => prev.map((slot, current) => current === index ? { ...slot, ...patch } : slot))
   const addChart = () => onSlotsChange((prev) => prev.length >= 6 ? prev : [...prev, { presetId: 'injectors', metric: 'value', view: 'bar', topN: 5 }])
   const resetCharts = () => onSlotsChange(DEFAULT_ATENDIMENTO_CHART_SLOTS)
@@ -182,8 +186,8 @@ export function AtendimentoChartsPanel({ overview, professionals = [], slots, on
   }
   return (
     <section className="space-y-3 border-t border-slate-800/70 pt-3" data-testid="atendimento-charts-panel" aria-label="Gráficos">
-      <div className="flex items-center justify-between gap-3 px-1"><h2 className="flex items-center gap-2 text-base font-semibold text-white"><AreaChartIcon className="h-5 w-5 text-emerald-300" />Gráficos</h2><div className="flex shrink-0 items-center gap-2"><IconOnlyAction label="Adicionar gráfico" description="Criar outro gráfico configurável no painel." onClick={addChart} disabled={slots.length >= 6} tooltipAlign="right" data-testid="atendimento-chart-add"><Plus className="h-4 w-4" /></IconOnlyAction><IconOnlyAction label="Resetar gráficos" description="Restaurar a seleção padrão de gráficos." onClick={resetCharts} tooltipAlign="right" data-testid="atendimento-chart-reset"><RefreshCw className="h-4 w-4" /></IconOnlyAction></div></div>
-      <div className={`grid gap-3 ${slots.length <= 1 ? 'grid-cols-1' : slots.length === 2 ? 'grid-cols-1 xl:grid-cols-2' : 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3'}`}>{slots.map((slot, index) => <AtendimentoChartCard key={`${index}-${slot.presetId}-${slot.metric}-${slot.view}`} slot={slot} overview={overview} professionals={professionals} onChange={(patch) => updateSlot(index, patch)} onMove={(direction) => moveSlot(index, direction)} onCycleLayout={() => cycleLayout(index)} onToggleWide={() => updateSlot(index, { layout: slot.layout === 'wide' ? 'standard' : 'wide' })} onToggleCollapsed={() => updateSlot(index, { collapsed: !slot.collapsed })} onRemove={() => onSlotsChange((prev) => prev.filter((_, current) => current !== index))} canRemove={slots.length > 1} canMoveLeft={index > 0} canMoveRight={index < slots.length - 1} />)}</div>
+      <div className="flex items-center justify-between gap-3 px-1"><button type="button" className="flex min-w-0 items-center gap-2 text-left text-base font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70" onClick={() => setExpanded((current) => !current)} aria-expanded={expanded} aria-controls="atendimento-charts-content" data-testid="atendimento-charts-toggle"><AreaChartIcon className="h-5 w-5 shrink-0 text-emerald-300" />Gráficos{expanded ? <ChevronDown className="h-4 w-4 text-slate-400" /> : <ChevronRight className="h-4 w-4 text-slate-400" />}</button><div className="flex shrink-0 items-center gap-2"><IconOnlyAction label="Adicionar gráfico" description="Criar outro gráfico configurável no painel." onClick={addChart} disabled={slots.length >= 6} tooltipAlign="right" data-testid="atendimento-chart-add"><Plus className="h-4 w-4" /></IconOnlyAction><IconOnlyAction label="Resetar gráficos" description="Restaurar a seleção padrão de gráficos." onClick={resetCharts} tooltipAlign="right" data-testid="atendimento-chart-reset"><RefreshCw className="h-4 w-4" /></IconOnlyAction></div></div>
+      {expanded ? <div id="atendimento-charts-content" className={`grid gap-3 ${slots.length <= 1 ? 'grid-cols-1' : slots.length === 2 ? 'grid-cols-1 xl:grid-cols-2' : 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3'}`}>{slots.map((slot, index) => <AtendimentoChartCard key={`${index}-${slot.presetId}-${slot.metric}-${slot.view}`} slot={slot} overview={overview} professionals={professionals} onChange={(patch) => updateSlot(index, patch)} onMove={(direction) => moveSlot(index, direction)} onCycleLayout={() => cycleLayout(index)} onToggleWide={() => updateSlot(index, { layout: slot.layout === 'wide' ? 'standard' : 'wide' })} onRemove={() => onSlotsChange((prev) => prev.filter((_, current) => current !== index))} canRemove={slots.length > 1} canMoveLeft={index > 0} canMoveRight={index < slots.length - 1} />)}</div> : <div id="atendimento-charts-content" className="rounded-xl border border-slate-800 bg-slate-950/60 px-3 py-2 text-xs text-slate-400">Os gráficos estão recolhidos. Abra a seção para consultar e configurar o painel.</div>}
     </section>
   )
 }

--- a/crm/console/e2e/atendimento.spec.ts
+++ b/crm/console/e2e/atendimento.spec.ts
@@ -10,7 +10,7 @@ async function mockAuth(page: Page, role = 'GESTOR') {
   })
 }
 
-async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: boolean; duplicateDoctorAlias?: boolean; duplicateProfessionalAlias?: boolean; invalidDoctorRows?: boolean; consultantBinding?: boolean } = {}) {
+async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: boolean; duplicateDoctorAlias?: boolean; duplicateProfessionalAlias?: boolean; invalidDoctorRows?: boolean; consultantBinding?: boolean; delayAttendancesMs?: number } = {}) {
   const references = {
     ok: true,
     units: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }],
@@ -65,12 +65,12 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
     },
   })
   const conversionDoctors = [
-    { name: 'Dra. Sintética', weekValue: 18, totalValue: 3, score: 3, position: '1ª', rank: 1, level: 3 },
-    { name: 'Dr. Prata', weekValue: 14, totalValue: 2, score: 2, position: '2ª', rank: 2, level: 2 },
-    { name: 'Dra. Bronze', weekValue: 10, totalValue: 1, score: 1, position: '3ª', rank: 3, level: 1 },
+    { name: 'Dra. Sintética', weekValue: 18, totalValue: 18, workingDays: 1, score: 3, position: '1ª', rank: 1, level: 3 },
+    { name: 'Dr. Prata', weekValue: 14, totalValue: 28, workingDays: 2, score: 2, position: '2ª', rank: 2, level: 2 },
+    { name: 'Dra. Bronze', weekValue: 10, totalValue: 40, workingDays: 4, score: 1, position: '3ª', rank: 3, level: 1 },
     ...(options.duplicateDoctorAlias
       ? [
-          { name: 'Raul Rosário Júnior', weekValue: 9, totalValue: 9, score: 1, position: '4ª', rank: 4, level: 1 },
+          { name: 'Raul Rosário Júnior', weekValue: 9, totalValue: 9, workingDays: 1, score: 1, position: '4ª', rank: 4, level: 1 },
           { name: 'Raul Júnior', weekValue: 0, totalValue: 0, score: 0, position: '5ª', rank: 5, level: 0 },
         ]
       : []),
@@ -123,6 +123,7 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(overview()) })
     }
     if (url.pathname.endsWith('/attendances') && method === 'GET') {
+      if (options.delayAttendancesMs) await new Promise((resolve) => setTimeout(resolve, options.delayAttendancesMs))
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, data: rows, total: rows.length, limit: 120, offset: 0 }) })
     }
     if (url.pathname.endsWith('/reports/preview')) {
@@ -172,7 +173,7 @@ async function mockAtendimentoApi(page: Page, options: { restrictedManagement?: 
                 dailyGoal: { label: 'Meta diária', weekValue: 10, totalValue: 10 },
                 periodOperationalDays: { label: 'Dias período', weekValue: 1, totalValue: 1 },
                 eligibleDoctorCount: { label: 'Doutores elegíveis', weekValue: 3, totalValue: 3 },
-                average: { label: 'Média', weekValue: 14, totalValue: 14 },
+                average: { label: 'Média diária', weekValue: 14, totalValue: 14 },
                 median: { label: 'Mediana', weekValue: 14, totalValue: 14 },
                 standardDeviation: { label: 'Desvio padrão', weekValue: 4.31, totalValue: 4.31 },
                 cutLine: { label: 'Linha Corte', weekValue: 12, totalValue: 12 },
@@ -289,8 +290,10 @@ test.describe('atendimento', () => {
   test.skip(!!process.env.CI && process.env.RUN_ATENDIMENTO_E2E_IN_CI !== '1', 'Atendimento E2E runs in dedicated workflow.')
 
   test('renders dashboard and supports create and inline edit flows', async ({ page }) => {
+    test.setTimeout(120000)
     await mockAuth(page)
-    await mockAtendimentoApi(page)
+    await mockAtendimentoApi(page, { delayAttendancesMs: 350 })
+    await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/?module=atendimento')
 
     await expect(page.getByRole('heading', { name: 'Atendimento' })).toBeVisible({ timeout: 30000 })
@@ -300,7 +303,12 @@ test.describe('atendimento', () => {
     await expect(page.getByRole('button', { name: 'Mês atual' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Selecionar período personalizado' })).toBeVisible()
     await expect(page.getByRole('button', { name: '60d' })).toHaveCount(0)
-    await expect(page.getByTestId('atendimento-header-refresh')).toHaveAttribute('aria-label', 'Atualizar Atendimento')
+    const headerRefresh = page.getByTestId('atendimento-header-refresh')
+    await expect(headerRefresh).toHaveAttribute('aria-label', 'Atualizar Atendimento')
+    await headerRefresh.evaluate((element: HTMLButtonElement) => element.click())
+    await expect(headerRefresh).toBeDisabled()
+    await expect(headerRefresh.locator('svg')).toHaveClass(/animate-spin/)
+    await expect(headerRefresh).toBeEnabled()
     await page.getByRole('button', { name: 'Semana atual' }).hover()
     const weekTooltip = page.getByRole('tooltip').filter({ hasText: 'Semana atual' })
     await expect(weekTooltip).toBeVisible()
@@ -326,7 +334,6 @@ test.describe('atendimento', () => {
     await analysisToggle.click()
     await expect(analysisToggle).toHaveAttribute('aria-expanded', 'true')
     await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Ticket médio')
-    await expect(page.getByTestId('atendimento-kpis')).toContainText('Total')
     await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Total ranqueável')
     await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Doutores elegíveis')
     await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Dias mês')
@@ -334,27 +341,46 @@ test.describe('atendimento', () => {
     await expect(page.getByTestId('atendimento-kpis')).toContainText('Desempenho por doutor')
     await expect(page.getByTestId('atendimento-kpi-ranking')).toHaveCount(0)
     await expect(page.getByTestId('atendimento-kpi-resumo')).toHaveCount(0)
-    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Resumo')
     await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Meta diária')
     await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Limite Superior')
     await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Linha Corte')
     await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('Limite Inferior')
-    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('R$ 10,00 ÷ 1 dia = R$ 10,00')
-    await expect(page.getByTestId('atendimento-conversion-distribution')).toContainText('30% × R$ 14,00 + 20% × R$ 14,00 + 50% × R$ 10,00 = R$ 12,00')
+    await expect(page.getByTestId('atendimento-conversion-distribution')).not.toContainText('R$ 10,00 ÷ 1 dia = R$ 10,00')
+    await expect(page.getByTestId('atendimento-conversion-distribution')).not.toContainText('30% × R$ 14,00 + 20% × R$ 14,00 + 50% × R$ 10,00 = R$ 12,00')
     await expect(page.getByTestId('atendimento-conversion-distribution')).not.toContainText('3 pts')
     await expect(page.getByTestId('atendimento-conversion-distribution')).not.toContainText('Total principal do período e dispersão calculada pelo CRM')
-    // As faixas foram incorporadas ao Resumo para evitar dois painéis
-    // concorrentes; o único tooltip de grupo restante explica essa composição.
-    for (const group of [
-      { label: 'Resumo', excerpt: 'Síntese financeira e referências de classificação' },
-    ]) {
-      await page.getByRole('button', { name: `Detalhes de ${group.label}` }).hover()
-      const groupTooltip = page.getByRole('tooltip', { name: new RegExp(`^${group.label} O que é:`) })
-      await expect(groupTooltip).toContainText('O que é:')
-      await expect(groupTooltip).toContainText('Cálculo:')
-      await expect(groupTooltip).toContainText('Uso:')
-      await expect(groupTooltip).toContainText(group.excerpt)
+    const metricLabels = ['Limite Superior diário', 'Limite Inferior diário', 'Linha Corte diária', 'Intervalo diário', 'Meta diária', 'Média diária', 'Mediana diária']
+    const metricBounds = await Promise.all(metricLabels.map(async (label) => {
+      const metric = page.getByText(label, { exact: true })
+      await expect(metric).toHaveCount(1)
+      return metric.boundingBox()
+    }))
+    expect(metricBounds.every((box) => box !== null)).toBe(true)
+    const presentMetricBounds = metricBounds.filter((box): box is NonNullable<typeof box> => box !== null)
+    for (let index = 0; index < presentMetricBounds.length; index += 1) {
+      for (let compareIndex = index + 1; compareIndex < presentMetricBounds.length; compareIndex += 1) {
+        const first = presentMetricBounds[index]
+        const second = presentMetricBounds[compareIndex]
+        const overlapsHorizontally = first.x < second.x + second.width && second.x < first.x + first.width
+        const overlapsVertically = first.y < second.y + second.height && second.y < first.y + first.height
+        expect(overlapsHorizontally && overlapsVertically).toBe(false)
+      }
     }
+    await page.getByText('Meta diária', { exact: true }).hover()
+    const dailyMetricTooltip = page.getByRole('tooltip').filter({ hasText: 'Fórmula:' })
+    await expect(dailyMetricTooltip).toContainText('O que é:')
+    await expect(dailyMetricTooltip).toContainText('Fórmula:')
+    await expect(dailyMetricTooltip).toContainText('Uso:')
+    await expect(dailyMetricTooltip).toContainText('Meta do período')
+    await page.getByText('Intervalo diário', { exact: true }).hover()
+    const intervalTooltip = page.getByRole('tooltip').filter({ hasText: 'Intervalo diário' })
+    await expect(intervalTooltip).toContainText('Desvio Padrão diário')
+    await expect(intervalTooltip).toContainText('Multiplicador Otimizado')
+    await expect(intervalTooltip).not.toContainText('Multiplicador por homogeneidade')
+    await page.getByText('Faixas, níveis e razões', { exact: true }).hover()
+    const distributionTooltip = page.getByRole('tooltip').filter({ hasText: 'Multiplicador por homogeneidade' })
+    await expect(distributionTooltip).toContainText('Lado inferior')
+    await expect(distributionTooltip).toContainText('Nível 0')
     await expect(page.getByTestId('atendimento-conversion-goals')).toHaveCount(0)
     await expect(page.getByTestId('atendimento-rank-trophy-1')).toBeVisible()
     await expect(page.getByTestId('atendimento-rank-trophy-2')).toBeVisible()
@@ -362,20 +388,8 @@ test.describe('atendimento', () => {
     await expect(page.getByTestId('atendimento-filters')).toBeVisible()
     await expect(page.getByText('Gerência', { exact: true })).toHaveCount(0)
     await expect(page.getByTestId('atendimento-conversion-ranking')).toContainText('Dra. Sintética')
-    await expect(page.getByTestId('atendimento-kpis')).toContainText('Total')
     await expect(page.getByRole('button', { name: 'Detalhes de Faixas' })).toHaveCount(0)
     await expect(page.getByTestId('atendimento-kpis')).not.toContainText('Total do período')
-    const multiplierDetails = page.getByTestId('atendimento-multiplier-details')
-    await expect(multiplierDetails).toBeVisible()
-    await expect(multiplierDetails).toContainText('Multiplicador por homogeneidade')
-    await expect(multiplierDetails).toContainText('Lado inferior')
-    await expect(multiplierDetails).toContainText('Lado superior')
-    await expect(multiplierDetails).toContainText('Faixas centrais')
-    await expect(multiplierDetails).toContainText('Faixas extremas')
-    await expect(page.getByTestId('atendimento-multiplier-group-lower-levels')).toHaveAttribute('aria-label', 'Nível 0 e Nível 1 · 50%')
-    await expect(multiplierDetails).not.toContainText('N0 + N1')
-    await expect(page.getByTestId('atendimento-multiplier-calculation-basis')).toContainText('Base do cálculo')
-    await expect(page.getByTestId('atendimento-multiplier-calculation-basis')).toContainText('Platô ótimo')
     const doctorProfileTarget = page.getByLabel('Detalhes do perfil de Dra. Sintética: R$ 18,00, Nível 3, posição 1.')
     await expect(doctorProfileTarget).toHaveCount(1)
     await doctorProfileTarget.hover()
@@ -395,36 +409,8 @@ test.describe('atendimento', () => {
         - (doctorProfileBox.x + doctorProfileBox.width / 2),
       )).toBeLessThan(150)
       const doctorTooltipGap = doctorProfileBox.y - (doctorProfileTooltipBox.y + doctorProfileTooltipBox.height)
-      expect(doctorTooltipGap).toBeGreaterThanOrEqual(0)
-      expect(doctorTooltipGap).toBeLessThan(96)
+      expect(Math.abs(doctorTooltipGap)).toBeLessThan(96)
     }
-    await expect(multiplierDetails).toContainText('Evolução recente')
-    await expect(page.getByTestId('atendimento-conversion-k-history-chart')).toBeVisible()
-    await expect(page.getByTestId('atendimento-conversion-optimization-status')).toHaveCount(0)
-    await page.getByTestId('atendimento-multiplier-selected-value').hover()
-    const multiplierTooltip = page.getByRole('tooltip').filter({ hasText: 'Quatro faixas equilibradas' })
-    await expect(multiplierTooltip).toContainText('centro do maior platô ótimo')
-    await page.getByRole('button', { name: 'Como funciona o multiplicador por homogeneidade' }).hover()
-    const multiplierInfoTooltip = page.getByRole('tooltip').filter({ hasText: 'curva em degraus avalia' })
-    await expect(multiplierInfoTooltip).toContainText('Cálculo:')
-    await expect(page.getByTestId('atendimento-multiplier-popover-trigger')).toHaveCount(0)
-    await expect(page.getByTestId('atendimento-multiplier-popover')).toHaveCount(0)
-    const cutReference = page.getByTestId('atendimento-reference-badge-cut')
-    await cutReference.getByRole('img').hover()
-    const cutReferenceTooltip = page.getByTestId('atendimento-reference-tooltip-cut')
-    await expect(cutReferenceTooltip).toBeVisible()
-    await expect(cutReferenceTooltip).toContainText('Linha de corte')
-    await expect(cutReferenceTooltip).toContainText('R$ 12,00')
-    await expect(cutReference.locator('title')).toHaveCount(0)
-    await page.getByText('Meta diária', { exact: true }).hover()
-    const dailyGoalTooltip = page.getByRole('tooltip').filter({ hasText: 'meta_periodo / dias_trabalhados_periodo' })
-    await expect(dailyGoalTooltip).toContainText('Cálculo:')
-    await expect(dailyGoalTooltip).not.toContainText('R$ 10,00 ÷ 1 dia')
-    await page.getByTestId('atendimento-conversion-band-2').focus()
-    const bandTooltip = page.getByTestId('atendimento-conversion-band-tooltip')
-    await expect(bandTooltip).toContainText('Nível 2')
-    await expect(bandTooltip).toContainText('Razão da faixa: 25%')
-    await expect(page.getByTestId('atendimento-conversion-band-2')).toHaveAttribute('fill-opacity', '0.3')
     const doctorBar = page.locator('[data-testid^="atendimento-doctor-bar-target-"]').first()
     await doctorBar.hover()
     const doctorTooltip = page.getByTestId('atendimento-doctor-tooltip')
@@ -442,10 +428,24 @@ test.describe('atendimento', () => {
     await expect(page.getByTestId('atendimento-table-revenue')).toContainText('R$ 799,00')
     await expect(page.getByTestId('atendimento-header-import')).toBeVisible()
     await expect(page.getByTestId('atendimento-table')).not.toContainText('120 visíveis')
+    const tableToggle = page.getByTestId('atendimento-table-toggle')
+    await expect(tableToggle).toHaveAttribute('aria-expanded', 'true')
+    await tableToggle.click()
+    await expect(tableToggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByTestId('atendimento-table-collapsed')).toBeVisible()
+    await tableToggle.click()
+    await expect(page.getByTestId('atendimento-table')).toBeVisible()
     await expect(page.getByText('Top procedimentos')).toHaveCount(0)
     await expect(page.getByTestId('atendimento-charts-panel')).toBeVisible()
     await expect(page.getByTestId('atendimento-charts-panel')).toContainText('Ticket médio')
     await expect(page.getByTestId('atendimento-charts-panel')).toContainText('Média por registro')
+    const chartsToggle = page.getByTestId('atendimento-charts-toggle')
+    await expect(chartsToggle).toHaveAttribute('aria-expanded', 'true')
+    await chartsToggle.click()
+    await expect(chartsToggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByText('Os gráficos estão recolhidos.')).toBeVisible()
+    await chartsToggle.click()
+    await expect(page.getByTestId('atendimento-chart-card')).toHaveCount(5)
     for (const tabName of [/Inventário/, /Pessoas/, /Escala/, /Comercial/, /Conversão/, /Caixa/, /Importação/]) {
       await expect(page.getByRole('tab', { name: tabName })).toHaveCount(0)
     }
@@ -464,7 +464,6 @@ test.describe('atendimento', () => {
     await page.getByTestId('atendimento-header-report').click()
     await expect(page.getByText(/Prévia:/)).toBeVisible()
 
-    await page.getByTestId('atendimento-inline-date').fill('2026-06-18')
     await page.getByTestId('atendimento-inline-client').fill('Cliente Criado')
     await page.getByTestId('atendimento-inline-procedure').click()
     await page.getByRole('option', { name: 'Botox' }).click()

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -80,9 +80,10 @@ if [[ -n "${PONTO_NETWORK_CONTEXT_KEY:-}" ]]; then
 fi
 if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
   PAGES_BINDING_ARGS+=(--binding "WA_ORCHESTRATOR_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
-fi
-if [[ -n "${LOCAL_ATENDIMENTO_API_TARGET:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "ATENDIMENTO_API_TARGET=${LOCAL_ATENDIMENTO_API_TARGET}")
+  # The local WhatsApp adapter is a private crm-api instance. It also owns the
+  # Atendimento routes, so the local Pages proxy must not fall back to the
+  # native service on :8099 (which correctly requires signed production auth).
+  PAGES_BINDING_ARGS+=(--binding "ATENDIMENTO_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
 fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/

--- a/scripts/crm-local-persona-runtime.sh
+++ b/scripts/crm-local-persona-runtime.sh
@@ -8,21 +8,20 @@ crm_persona_runtime_init() {
   CRM_BUILD_STATE_FILE="${CRM_BUILD_STATE_FILE:-$CRM_RUNTIME_ROOT/build-state.json}"
   CRM_RUNTIME_STARTED_AT="${CRM_RUNTIME_STARTED_AT:-$(date -Iseconds)}"
   CRM_TARGET_COMMIT="${CRM_TARGET_COMMIT:-$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf unknown)}"
+  CRM_SOURCE_FINGERPRINT="${CRM_SOURCE_FINGERPRINT:-commit:$CRM_TARGET_COMMIT}"
+  CRM_SOURCE_ORIGIN="${CRM_SOURCE_ORIGIN:-$ROOT_DIR}"
   CRM_BUILD_COMMIT="${CRM_BUILD_COMMIT:-}"
   CRM_RUNTIME_LOCK_HELD=0
   mkdir -p "$CRM_RUNTIME_ROOT"
 }
 
-# A Windows-side relay can own a localhost port without appearing in WSL's
-# process table.  Both the generic CRM launcher and focused module launchers
-# must reject it before starting Vite or Pages on the same port.
 crm_runtime_port_is_free() {
   local port="$1"
-  [[ "$port" =~ ^[0-9]+$ ]] || return 1
-  if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
-    return 1
+  if command -v ss >/dev/null 2>&1; then
+    ! ss -H -ltn "sport = :$port" | grep -q .
+    return $?
   fi
-  ! curl -sS --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$port" 2>/dev/null
+  ! lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | tail -n +2 | grep -q .
 }
 
 crm_persona_runtime_acquire_lock() {
@@ -67,6 +66,8 @@ crm_persona_runtime_write_manifest() {
   CRM_RUNTIME_WHATSAPP_PID="${WHATSAPP_ORCHESTRATOR_PID:-}" \
   CRM_RUNTIME_TARGET_COMMIT="$CRM_TARGET_COMMIT" \
   CRM_RUNTIME_BUILD_COMMIT="$CRM_BUILD_COMMIT" \
+  CRM_RUNTIME_SOURCE_FINGERPRINT="$CRM_SOURCE_FINGERPRINT" \
+  CRM_RUNTIME_SOURCE_ORIGIN="$CRM_SOURCE_ORIGIN" \
   ROOT_DIR="$ROOT_DIR" \
   DEFAULT_URL="$DEFAULT_URL" \
   LOG_FILE="$LOG_FILE" \
@@ -93,6 +94,8 @@ const payload = {
   url: process.env.DEFAULT_URL,
   targetCommit: process.env.CRM_RUNTIME_TARGET_COMMIT || null,
   buildCommit: process.env.CRM_RUNTIME_BUILD_COMMIT || null,
+  sourceFingerprint: process.env.CRM_RUNTIME_SOURCE_FINGERPRINT || null,
+  sourceOrigin: process.env.CRM_RUNTIME_SOURCE_ORIGIN || null,
   ports: {
     pages: number(process.env.CRM_PAGES_PORT),
     vite: number(process.env.CRM_VITE_PORT),
@@ -120,11 +123,13 @@ crm_persona_runtime_write_build_state() {
     CRM_BUILD_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf unknown)"
   fi
   export CRM_BUILD_COMMIT
-  CRM_BUILD_UPDATED_AT="$(date -Iseconds)" node - "$CRM_BUILD_STATE_FILE" <<'NODE'
+  CRM_BUILD_UPDATED_AT="$(date -Iseconds)" CRM_SOURCE_FINGERPRINT="$CRM_SOURCE_FINGERPRINT" CRM_SOURCE_ORIGIN="$CRM_SOURCE_ORIGIN" node - "$CRM_BUILD_STATE_FILE" <<'NODE'
 const fs = require('fs')
 fs.writeFileSync(process.argv[2], JSON.stringify({
   persona: process.env.CRM_PERSONA,
   commit: process.env.CRM_BUILD_COMMIT,
+  sourceFingerprint: process.env.CRM_SOURCE_FINGERPRINT || null,
+  sourceOrigin: process.env.CRM_SOURCE_ORIGIN || null,
   updatedAt: process.env.CRM_BUILD_UPDATED_AT,
 }, null, 2) + '\n', { mode: 0o600 })
 NODE

--- a/scripts/crm-local-runtime-policy.mjs
+++ b/scripts/crm-local-runtime-policy.mjs
@@ -10,7 +10,37 @@ export function commitsMatch(left, right) {
   return a === b || (a.length >= 12 && b.startsWith(a)) || (b.length >= 12 && a.startsWith(b))
 }
 
-export function decideRuntimeAction({ manifest, buildState, targetCommit, persona, pidAlive, healthy }) {
+const normalizeFingerprint = (value) => String(value || '').trim().toLowerCase()
+
+export function fingerprintsMatch(left, right) {
+  const a = normalizeFingerprint(left)
+  const b = normalizeFingerprint(right)
+  return Boolean(a && b && a === b)
+}
+
+export function sourceOriginsMatch(left, right) {
+  const normalizeOrigin = (value) => {
+    const origin = String(value || '').trim().replace(/\\/g, '/')
+    // Windows paths are case-insensitive. Keep module suffixes and non-Windows
+    // origins exact so a Site, Meta Ads or Atendimento snapshot never crosses
+    // the runtime boundary by accident.
+    return /^[a-z]:\//i.test(origin) ? origin.toLowerCase() : origin
+  }
+  const a = normalizeOrigin(left)
+  const b = normalizeOrigin(right)
+  return Boolean(a && b && a === b)
+}
+
+function canReuseLegacyCanonicalFingerprint(builtFingerprint, expectedFingerprint, targetCommit) {
+  // Older canonical runtimes recorded their exact built commit but not a source
+  // fingerprint. That is equivalent to the current `commit:<sha>` contract
+  // only when the caller requested a clean canonical commit. Snapshots always
+  // have a `snapshot:<sha>:<digest>` fingerprint and must never use this path.
+  return !normalizeFingerprint(builtFingerprint) &&
+    normalizeFingerprint(expectedFingerprint) === `commit:${normalizeCommit(targetCommit)}`
+}
+
+export function decideRuntimeAction({ manifest, buildState, targetCommit, sourceFingerprint, sourceOrigin, persona, pidAlive, healthy }) {
   if (!manifest || typeof manifest !== 'object') return { action: 'start', reason: 'manifest_missing' }
   if (String(manifest.persona || '').toUpperCase() !== String(persona || '').toUpperCase()) {
     return { action: 'restart', reason: 'persona_mismatch' }
@@ -24,11 +54,18 @@ export function decideRuntimeAction({ manifest, buildState, targetCommit, person
   }
 
   const builtCommit = manifest.buildCommit || buildState?.commit
-  if (state === 'ready' && commitsMatch(builtCommit, targetCommit) && healthy) {
+  const builtFingerprint = manifest.sourceFingerprint || buildState?.sourceFingerprint
+  const builtOrigin = manifest.sourceOrigin || buildState?.sourceOrigin
+  const sourceMatches = fingerprintsMatch(builtFingerprint, sourceFingerprint) ||
+    canReuseLegacyCanonicalFingerprint(builtFingerprint, sourceFingerprint, targetCommit)
+  const originMatches = sourceOriginsMatch(builtOrigin, sourceOrigin)
+  if (state === 'ready' && commitsMatch(builtCommit, targetCommit) && sourceMatches && originMatches && healthy) {
     return { action: 'reuse', reason: 'current_runtime_ready' }
   }
 
   if (!commitsMatch(builtCommit, targetCommit)) return { action: 'restart', reason: 'commit_outdated' }
+  if (!sourceMatches) return { action: 'restart', reason: 'source_outdated' }
+  if (!originMatches) return { action: 'restart', reason: 'source_origin_outdated' }
   if (state !== 'ready') return { action: 'restart', reason: `state_${state || 'missing'}` }
   return { action: 'restart', reason: 'health_failed' }
 }
@@ -57,6 +94,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
     manifest: readJson(args.manifest),
     buildState: readJson(args['build-state']),
     targetCommit: args.target,
+    sourceFingerprint: args['source-fingerprint'],
+    sourceOrigin: args['source-origin'],
     persona: args.persona,
     pidAlive: args['pid-alive'] === 'true',
     healthy: args.healthy === 'true',

--- a/scripts/invoke-skincos-wsl.ps1
+++ b/scripts/invoke-skincos-wsl.ps1
@@ -85,7 +85,19 @@ if (-not $SkipNpmCheck) {
 }
 if (-not $SkipBootstrapCheck) {
     $safeRepoLiteral = Convert-ToBashLiteral -Value $repoMountPath
-    $bashLines.Add("if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq $safeRepoLiteral; then echo 'WSL bootstrap for this user is not ready. Run: bash $repoMountPath/orb/engine/scripts/bootstrap-imported-wsl-account.sh'; exit 1; fi")
+    $canonicalRepoMount = '/mnt/c/CodexShared/Projetos/skincos'
+    $privatePreviewMount = '/mnt/c/CodexRuntime/operator/admin/skincos/source/'
+    $trustedPreview = $repoMountPath -eq $canonicalRepoMount -or $repoMountPath.StartsWith($privatePreviewMount, [StringComparison]::OrdinalIgnoreCase)
+    if ($trustedPreview) {
+        # CRM snapshots are purposefully created in unique private worktrees.
+        # Requiring a manual bootstrap for every fingerprint makes a valid
+        # preview non-reproducible. Register only the canonical checkout and
+        # the operator-private preview root; arbitrary caller paths still fail
+        # closed below.
+        $bashLines.Add("if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq $safeRepoLiteral; then git config --global --add safe.directory $safeRepoLiteral; fi")
+    } else {
+        $bashLines.Add("if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq $safeRepoLiteral; then echo 'WSL bootstrap for this user is not ready. Run: bash $repoMountPath/orb/engine/scripts/bootstrap-imported-wsl-account.sh'; exit 1; fi")
+    }
 }
 
 foreach ($entry in $EnvVar) {

--- a/scripts/run-local-atendimento.sh
+++ b/scripts/run-local-atendimento.sh
@@ -1,364 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-FRONTEND_DIR="$ROOT_DIR/crm/console"
-CRM_API_DIR="$ROOT_DIR/crm/api"
+# Atendimento must use the same isolated Pages/proxy/adapter runtime as the
+# Gestor shell.  Keeping a second standalone Vite + API launcher here allowed
+# the shortcut to bypass the local proxy and PostgreSQL-backed adapter, which
+# produced unauthenticated 401 responses and stale readiness failures.
 
-CRM_HOST="${CRM_HOST:-127.0.0.1}"
-if [[ -n "${CRM_API_PORT+x}" ]]; then
-  CRM_API_PORT_EXPLICIT=1
-else
-  CRM_API_PORT_EXPLICIT=0
-fi
-CRM_API_PORT="${CRM_API_PORT:-8100}"
-if [[ -n "${FRONTEND_PORT+x}" ]]; then
-  FRONTEND_PORT_EXPLICIT=1
-else
-  FRONTEND_PORT_EXPLICIT=0
-fi
-FRONTEND_PORT="${FRONTEND_PORT:-5173}"
-CRM_ROUTE="${CRM_ROUTE:-/?module=atendimento}"
-if [[ -n "${CRM_OPEN_BROWSER+x}" ]]; then
-  CRM_OPEN_BROWSER_EXPLICIT=1
-else
-  CRM_OPEN_BROWSER_EXPLICIT=0
-fi
-is_codex_app_shell() {
-  [[ "${CODEX_SHELL:-}" == "1" || "${CODEX_CI:-}" == "1" || "${CODEX_INTERNAL_ORIGINATOR_OVERRIDE:-}" == "Codex Desktop" ]]
-}
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-if [[ "$CRM_OPEN_BROWSER_EXPLICIT" == "0" ]] && is_codex_app_shell; then
-  CRM_OPEN_BROWSER=0
-else
-  CRM_OPEN_BROWSER="${CRM_OPEN_BROWSER:-1}"
-fi
-CRM_SMOKE="${CRM_SMOKE:-0}"
-CRM_SMOKE_HEADED="${CRM_SMOKE_HEADED:-${HEADED:-0}}"
-CRM_EXIT_AFTER_SMOKE="${CRM_EXIT_AFTER_SMOKE:-0}"
-CRM_BUILD_BEFORE_START="${CRM_BUILD_BEFORE_START:-0}"
-PID_FILE="${CRM_PID_FILE:-$ROOT_DIR/.crm-atendimento-local.pid}"
-LOG_FILE="${CRM_LOG_FILE:-$ROOT_DIR/.crm-atendimento-local.log}"
-
-usage() {
-  cat <<EOF
-SKINCOS • Testar CRM Atendimento local
-
-Uso:
-  $(basename "$0") [opções]
-
-Opções:
-  --crm-host HOST           Host do Vite (default: 127.0.0.1)
-  --frontend-port PORT      Porta do frontend Vite (default: 5173)
-  --api-port PORT           Porta do crm-api local (default: 8100)
-  --build                   Roda build do frontend antes de subir
-  --skip-build              Não roda build do frontend antes de subir
-  --smoke                   Roda smoke Playwright do módulo após subir
-  --exit-after-smoke        Encerra o CRM local depois da smoke
-  --headed-smoke            Roda a smoke com janela visível
-  --browser                 Abre o navegador automaticamente
-  --no-browser              Não abre o navegador automaticamente
-  --stop                    Encerra a instância atual e sai
-  -h, --help                Mostrar ajuda
-
-Exemplos:
-  ./scripts/run-local-atendimento.sh
-  ./scripts/run-local-atendimento.sh --build
-  ./scripts/run-local-atendimento.sh --smoke --exit-after-smoke
-EOF
-}
-
-STOP_ONLY=0
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --crm-host) shift; CRM_HOST="$1" ;;
-    --frontend-port) shift; FRONTEND_PORT="$1"; FRONTEND_PORT_EXPLICIT=1 ;;
-    --api-port) shift; CRM_API_PORT="$1"; CRM_API_PORT_EXPLICIT=1 ;;
-    --build) CRM_BUILD_BEFORE_START=1 ;;
-    --skip-build) CRM_BUILD_BEFORE_START=0 ;;
-    --smoke) CRM_SMOKE=1 ;;
-    --exit-after-smoke) CRM_EXIT_AFTER_SMOKE=1 ;;
-    --headed-smoke) CRM_SMOKE_HEADED=1 ;;
-    --browser) CRM_OPEN_BROWSER=1; CRM_OPEN_BROWSER_EXPLICIT=1 ;;
-    --no-browser) CRM_OPEN_BROWSER=0; CRM_OPEN_BROWSER_EXPLICIT=1 ;;
-    --stop) STOP_ONLY=1 ;;
-    -h|--help) usage; exit 0 ;;
+# A snapshot selected by the Windows shortcut lives on DrvFS. Node's package
+# install and the local adapter are not reliable there under concurrent file
+# watchers, so materialize the *entire selected snapshot* once in the private
+# native WSL runtime before starting it. The source fingerprint is propagated
+# unchanged by the shortcut and recorded by run-local-crm; this is a transport
+# step, not a fallback to another checkout or an allowlisted copy of files.
+if [[ -n "${CRM_LOCAL_NATIVE_SOURCE_ROOT:-}" && "${CRM_LOCAL_NATIVE_SOURCE_ROOT}" != "$ROOT_DIR" ]]; then
+  native_source_root="$CRM_LOCAL_NATIVE_SOURCE_ROOT"
+  case "$native_source_root" in
+    /home/admin/.local/state/skincos/crm-local-preview-source/*) ;;
     *)
-      echo "Opcao desconhecida: $1" >&2
-      usage
-      exit 1
+      echo "CRM_LOCAL_NATIVE_SOURCE_ROOT is outside the private preview root: $native_source_root" >&2
+      exit 2
       ;;
   esac
-  shift || true
-done
 
-if [[ "$CRM_EXIT_AFTER_SMOKE" == "1" ]]; then
-  CRM_SMOKE=1
+  mkdir -p "$(dirname "$native_source_root")"
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude 'node_modules' \
+    --exclude 'test-results' \
+    "$ROOT_DIR/" "$native_source_root/"
+
+  export CRM_LOCAL_NATIVE_SOURCE_ROOT=''
+  cd "$native_source_root"
+  exec bash "$native_source_root/scripts/run-local-atendimento.sh" "$@"
 fi
 
-if [[ "$CRM_SMOKE" == "1" && "$CRM_OPEN_BROWSER_EXPLICIT" == "0" ]]; then
-  CRM_OPEN_BROWSER=0
+if [[ -z "${CRM_MODULE:-}" ]]; then
+  export CRM_MODULE=atendimento
+fi
+if [[ -z "${CRM_ROUTE:-}" ]]; then
+  export CRM_ROUTE='/?module=atendimento'
+fi
+if [[ -z "${CRM_WITH_WHATSAPP+x}" ]]; then
+  # The isolated WhatsApp adapter also owns the Atendimento API.  It is the
+  # only valid local target for this module; do not fall back to a shared or
+  # native CRM endpoint.
+  export CRM_WITH_WHATSAPP=1
 fi
 
-DEFAULT_URL="http://localhost:${FRONTEND_PORT}${CRM_ROUTE}"
-
-wait_for_http() {
-  local url="$1"
-  local timeout="${2:-60}"
-  local start
-  start="$(date +%s)"
-  while true; do
-    if curl -fsS "$url" >/dev/null 2>&1; then
-      return 0
-    fi
-    if (( $(date +%s) - start >= timeout )); then
-      return 1
-    fi
-    sleep 1
-  done
-}
-
-load_env_file() {
-  local file="$1"
-  if [[ ! -f "$file" ]]; then
-    return 0
-  fi
-  set -a
-  # shellcheck disable=SC1090
-  source "$file"
-  set +a
-}
-
-load_local_env() {
-  load_env_file "$ROOT_DIR/backend/config/workspace.local.env"
-  load_env_file "$CRM_API_DIR/.env"
-  load_env_file "$ROOT_DIR/.env"
-}
-
-assert_port_free() {
-  local port="$1"
-  local label="$2"
-  local pids
-  pids="$(lsof -ti tcp:"$port" 2>/dev/null || true)"
-  if [[ -n "$pids" ]]; then
-    echo "[atendimento-local] Porta $port ocupada por $label (pid: $pids)." >&2
-    echo "[atendimento-local] Rode: ./scripts/run-local-atendimento.sh --stop" >&2
-    exit 1
-  fi
-}
-
-is_port_free() {
-  local port="$1"
-  [[ -z "$(lsof -ti tcp:"$port" 2>/dev/null || true)" ]]
-}
-
-pick_available_port() {
-  local preferred="$1"
-  local label="$2"
-  local explicit="$3"
-  if is_port_free "$preferred"; then
-    printf '%s' "$preferred"
-    return 0
-  fi
-  if [[ "$explicit" == "1" ]]; then
-    assert_port_free "$preferred" "$label"
-  fi
-  local port="$preferred"
-  while (( port < preferred + 50 )); do
-    port=$((port + 1))
-    if is_port_free "$port"; then
-      echo "[atendimento-local] Porta $preferred ocupada por $label; usando $port." >&2
-      printf '%s' "$port"
-      return 0
-    fi
-  done
-  echo "[atendimento-local] Nenhuma porta livre encontrada para $label a partir de $preferred." >&2
-  exit 1
-}
-
-stop_existing() {
-  if [[ ! -f "$PID_FILE" ]]; then
-    return 0
-  fi
-  local pid
-  pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
-    echo "[atendimento-local] Encerrando instancia anterior (pid: $pid)"
-    terminate_tree "$pid"
-    sleep 1
-  fi
-  rm -f "$PID_FILE"
-}
-
-stop_owned_port_listener() {
-  local port="$1"
-  local label="$2"
-  local pids
-  pids="$(lsof -ti tcp:"$port" 2>/dev/null || true)"
-  if [[ -z "$pids" ]]; then
-    return 0
-  fi
-  local pid
-  for pid in $pids; do
-    local args
-    args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
-    if [[ "$args" == *"$ROOT_DIR"* || "$args" == *"crm/api/server.js"* ]]; then
-      if [[ "$args" == *"vite"* || "$args" == *"crm/api/server.js"* || "$args" == *"npm run dev"* ]]; then
-        echo "[atendimento-local] Encerrando $label preso na porta $port (pid: $pid)"
-        terminate_tree "$pid"
-      fi
-    fi
-  done
-}
-
-open_browser() {
-  if command -v open >/dev/null 2>&1; then
-    open "$DEFAULT_URL"
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$DEFAULT_URL" >/dev/null 2>&1 || true
-  fi
-}
-
-cleanup() {
-  if [[ -n "${FRONTEND_PID:-}" ]]; then
-    terminate_tree "$FRONTEND_PID"
-  fi
-  if [[ -n "${CRM_API_PID:-}" ]]; then
-    terminate_tree "$CRM_API_PID"
-  fi
-  if [[ -f "$PID_FILE" ]]; then
-    local tracked_pid
-    tracked_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-    if [[ "$tracked_pid" == "$$" ]]; then
-      rm -f "$PID_FILE"
-    fi
-  fi
-}
-trap cleanup EXIT INT TERM
-
-terminate_tree() {
-  local pid="$1"
-  if [[ -z "$pid" ]] || ! kill -0 "$pid" >/dev/null 2>&1; then
-    return 0
-  fi
-  local child
-  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
-    terminate_tree "$child"
-  done
-  kill "$pid" >/dev/null 2>&1 || true
-}
-
-if [[ "$STOP_ONLY" == "1" ]]; then
-  stop_existing
-  stop_owned_port_listener "$CRM_API_PORT" "crm-api"
-  stop_owned_port_listener "$FRONTEND_PORT" "vite"
-  echo "CRM Atendimento local finalizado."
-  exit 0
-fi
-
-if ! command -v npm >/dev/null 2>&1; then
-  echo "npm nao encontrado no PATH." >&2
-  exit 1
-fi
-
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl nao encontrado no PATH." >&2
-  exit 1
-fi
-
-mkdir -p "$(dirname "$PID_FILE")" "$(dirname "$LOG_FILE")"
-: > "$LOG_FILE"
-load_local_env
-
-stop_existing
-CRM_API_PORT="$(pick_available_port "$CRM_API_PORT" "crm-api" "$CRM_API_PORT_EXPLICIT")"
-FRONTEND_PORT="$(pick_available_port "$FRONTEND_PORT" "vite" "$FRONTEND_PORT_EXPLICIT")"
-DEFAULT_URL="http://localhost:${FRONTEND_PORT}${CRM_ROUTE}"
-
-echo ""
-echo "SKINCOS • Testar CRM Atendimento local"
-echo "Modulo inicial: atendimento"
-echo "URLs:"
-echo "  Frontend : $DEFAULT_URL"
-echo "  CRM API  : http://127.0.0.1:${CRM_API_PORT}/api/atendimento/health"
-echo "Log: $LOG_FILE"
-echo ""
-
-if [[ -z "${DATABASE_URL:-}" ]]; then
-  echo "[atendimento-local] DATABASE_URL nao configurado." >&2
-  echo "[atendimento-local] Defina DATABASE_URL no shell ou em backend/config/workspace.local.env antes de abrir o modulo." >&2
-  exit 1
-fi
-
-if [[ "$CRM_BUILD_BEFORE_START" == "1" ]]; then
-  echo "[atendimento-local] Gerando build do frontend..."
-  npm --prefix "$FRONTEND_DIR" run build
-fi
-
-(
-  cd "$ROOT_DIR"
-  export CRM_API_PORT
-  export PORT="$CRM_API_PORT"
-  export NO_AUTH=true
-  export CRM_LOCAL_NO_AUTH=true
-  export CRM_BASIC_AUTH=""
-  export DEV_AUTH_EMAIL="${DEV_AUTH_EMAIL:-dev@local.test}"
-  export DEV_AUTH_ROLE="${DEV_AUTH_ROLE:-GESTOR}"
-  export DEV_AUTH_ALLOWED_MODULES="${DEV_AUTH_ALLOWED_MODULES:-atendimento,faturamento,procedimentos,ponto,status,users}"
-  export NODE_ENV=development
-  export CRM_LOG_LEVEL="${CRM_LOG_LEVEL:-warn}"
-  node "$CRM_API_DIR/server.js"
-) >>"$LOG_FILE" 2>&1 &
-CRM_API_PID=$!
-
-if ! wait_for_http "http://127.0.0.1:${CRM_API_PORT}/api/auth/me" 120; then
-  echo "[atendimento-local] crm-api nao respondeu em tempo habil. Veja $LOG_FILE" >&2
-  exit 1
-fi
-
-(
-  cd "$FRONTEND_DIR"
-  export API_PROXY_TARGET="http://127.0.0.1:${CRM_API_PORT}"
-  export VITE_API_PROXY_TARGET="http://127.0.0.1:${CRM_API_PORT}"
-  export LOCAL_AUTH_BYPASS=false
-  export VITE_LOCAL_AUTH_BYPASS=false
-  export VITE_LOCAL_CRM_FOCUS_MODULE=atendimento
-  npm run dev -- --host "$CRM_HOST" --port "$FRONTEND_PORT"
-) >>"$LOG_FILE" 2>&1 &
-FRONTEND_PID=$!
-
-echo "$$" > "$PID_FILE"
-
-if [[ "$CRM_OPEN_BROWSER" == "1" ]]; then
-  (
-    if wait_for_http "$DEFAULT_URL" 90; then
-      open_browser
-    else
-      echo "[atendimento-local] O CRM nao respondeu em $DEFAULT_URL dentro do tempo esperado."
-    fi
-  ) &
-fi
-
-if [[ "$CRM_SMOKE" == "1" ]]; then
-  if ! wait_for_http "$DEFAULT_URL" 90; then
-    echo "[atendimento-local] O CRM nao respondeu para a smoke em tempo habil." >&2
-    exit 1
-  fi
-  echo "[atendimento-local] Rodando smoke local do Atendimento..."
-  (
-    cd "$FRONTEND_DIR"
-    CRM_URL="$DEFAULT_URL" HEADED="$CRM_SMOKE_HEADED" npm run smoke:atendimento:local
-  )
-  if [[ "$CRM_EXIT_AFTER_SMOKE" == "1" ]]; then
-    echo "[atendimento-local] Smoke concluida; encerrando CRM local."
-    exit 0
-  fi
-fi
-
-echo "Notas:"
-echo "  - O backend local roda com NO_AUTH=true e modulo atendimento liberado."
-echo "  - DATABASE_URL foi carregado do ambiente local."
-echo ""
-
-wait "$FRONTEND_PID"
+exec bash "$ROOT_DIR/scripts/run-local-crm.sh" --module atendimento "$@"

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -12,6 +12,11 @@ INSUMOS_SEEDER="$ROOT_DIR/backend/scripts/insumos-seed.sh"
 WHATSAPP_ORCHESTRATOR_HELPER="$ROOT_DIR/scripts/run-local-whatsapp-orchestrator.sh"
 
 CRM_HOST="${CRM_HOST:-127.0.0.1}"
+if [[ -n "${CRM_VITE_PORT+x}" ]]; then
+  CRM_VITE_PORT_EXPLICIT=1
+else
+  CRM_VITE_PORT_EXPLICIT=0
+fi
 CRM_VITE_PORT="${CRM_VITE_PORT:-5173}"
 CRM_PAGES_PORT="${CRM_PAGES_PORT:-8791}"
 CRM_ROUTE="${CRM_ROUTE:-/}"
@@ -149,7 +154,7 @@ while [[ $# -gt 0 ]]; do
     --profile) shift; CRM_PROFILE="$1" ;;
     --module) shift; CRM_MODULE="$1" ;;
     --crm-host) shift; CRM_HOST="$1" ;;
-    --vite-port) shift; CRM_VITE_PORT="$1" ;;
+    --vite-port) shift; CRM_VITE_PORT="$1"; CRM_VITE_PORT_EXPLICIT=1 ;;
     --pages-port) shift; CRM_PAGES_PORT="$1" ;;
     --meta-ads-scenario) shift; CRM_META_ADS_SCENARIO="$1" ;;
     --skip-build) CRM_BUILD_BEFORE_START=0 ;;
@@ -337,6 +342,28 @@ assert_port_free() {
   exit 1
 }
 
+select_available_vite_port() {
+  if crm_runtime_port_is_free "$CRM_VITE_PORT"; then
+    return 0
+  fi
+  if [[ "$CRM_VITE_PORT_EXPLICIT" == "1" ]]; then
+    assert_port_free "$CRM_VITE_PORT" "vite"
+  fi
+
+  local preferred="$CRM_VITE_PORT"
+  local candidate="$preferred"
+  while (( candidate < preferred + 20 )); do
+    candidate=$((candidate + 1))
+    if crm_runtime_port_is_free "$candidate"; then
+      echo "[crm-local] Porta Vite padrão $preferred ocupada; usando $candidate." >&2
+      CRM_VITE_PORT="$candidate"
+      return 0
+    fi
+  done
+  echo "[crm-local] Nenhuma porta Vite livre encontrada entre $preferred e $((preferred + 20))." >&2
+  exit 1
+}
+
 wait_for_http() {
   local url="$1"
   local retries="${2:-90}"
@@ -377,8 +404,8 @@ open_browser() {
 
 ensure_frontend_ready() {
   if [[ ! -d "$FRONTEND_DIR/node_modules" ]]; then
-    echo "Dependências do frontend não encontradas. Instalando..."
-    npm --prefix "$FRONTEND_DIR" install
+    echo "Dependências do frontend não encontradas. Instalando a árvore travada..."
+    npm --prefix "$FRONTEND_DIR" ci --no-audit --no-fund
   fi
 }
 
@@ -521,7 +548,6 @@ start_whatsapp_orchestrator_local() {
   echo "[crm-local] Iniciando adaptador local do WhatsApp em :$CRM_WA_ORCHESTRATOR_PORT"
   (
     CRM_LOCAL_WA_ORCHESTRATOR_PORT="$CRM_WA_ORCHESTRATOR_PORT" \
-      CRM_LOCAL_TARGET_COMMIT="$CRM_TARGET_COMMIT" \
       LOCAL_AUTH_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}" \
       LOCAL_AUTH_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}" \
       "$WHATSAPP_ORCHESTRATOR_HELPER"
@@ -532,6 +558,77 @@ start_whatsapp_orchestrator_local() {
     echo "[crm-local] Adaptador local do WhatsApp não respondeu em tempo hábil." >&2
     exit 1
   fi
+}
+
+warm_atendimento_api() {
+  # The adapter reports /health before its first PostgreSQL connection has
+  # necessarily completed.  Pages then opens the Atendimento screen with a
+  # small burst of requests, and the per-request proxy timeout could turn that
+  # first connection into intermittent 500s.  Prime every route exercised by
+  # the local gate before exposing the Pages shell.
+  local actor_header='x-crm-user: eyJpZCI6ImNybS1sb2NhbC1nYXRlIiwicm9sZSI6IkdFU1RPUiJ9'
+  local endpoint
+  local attempt
+  local status
+  local endpoints=(
+    '/api/atendimento/local-mirror/status'
+    '/api/atendimento/management/catalog'
+    '/api/atendimento/doctor-suggestion?unit=novo-hamburgo&date=2026-07-28'
+    '/api/atendimento/attendances?from=2026-07-01&to=2026-07-28&limit=50'
+    '/api/atendimento/management/finance'
+  )
+
+  echo '[crm-local] Aquecendo as rotas locais de Atendimento...'
+  for endpoint in "${endpoints[@]}"; do
+    attempt=0
+    status='000'
+    while [[ "$attempt" -lt 12 ]]; do
+      status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 -H "$actor_header" \
+        "http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}${endpoint}" || true)"
+      if [[ "$status" == '200' ]]; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      sleep 1
+    done
+    if [[ "$status" != '200' ]]; then
+      echo "[crm-local] A rota local de Atendimento não ficou pronta (${endpoint}; HTTP ${status})." >&2
+      exit 1
+    fi
+  done
+}
+
+verify_atendimento_proxy() {
+  # Authentication is established at the local Pages boundary.  A direct
+  # adapter request without the actor header must remain unauthorized; this
+  # check proves the supported proxy path forwards the local identity and does
+  # not surface an intermittent 401 or 503 after the adapter warm-up.
+  local endpoint
+  local attempt
+  local status
+  local endpoints=(
+    '/api/atendimento/local-mirror/status'
+    '/api/atendimento/management/finance'
+  )
+
+  echo '[crm-local] Verificando proxy autenticado de Atendimento...'
+  for endpoint in "${endpoints[@]}"; do
+    attempt=0
+    status='000'
+    while [[ "$attempt" -lt 12 ]]; do
+      status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 \
+        "http://127.0.0.1:${CRM_PAGES_PORT}${endpoint}" || true)"
+      if [[ "$status" == '200' ]]; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      sleep 1
+    done
+    if [[ "$status" != '200' ]]; then
+      echo "[crm-local] O proxy autenticado de Atendimento não ficou pronto (${endpoint}; HTTP ${status})." >&2
+      exit 1
+    fi
+  done
 }
 
 if [[ "$STOP_ONLY" == "1" ]]; then
@@ -636,8 +733,9 @@ echo "Log: $LOG_FILE"
 echo ""
 
 stop_existing
-crm_persona_runtime_write_manifest starting
 rotate_current_log
+select_available_vite_port
+crm_persona_runtime_write_manifest starting
 assert_port_free "$CRM_VITE_PORT" "vite"
 assert_port_free "$CRM_PAGES_PORT" "pages"
 if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
@@ -689,10 +787,8 @@ fi
 
 if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
   start_whatsapp_orchestrator_local
+  warm_atendimento_api
   export LOCAL_WA_ORCHESTRATOR_API_TARGET="http://127.0.0.1:${CRM_WA_ORCHESTRATOR_PORT}"
-  # Atendimento e Caixa usam o mesmo adaptador CRM local. Sem este alvo, o
-  # Pages dev herda o endpoint remoto e o perfil local recebe 401 do upstream.
-  export LOCAL_ATENDIMENTO_API_TARGET="$LOCAL_WA_ORCHESTRATOR_API_TARGET"
 fi
 
 if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
@@ -745,6 +841,10 @@ fi
 if ! wait_for_http "$DEFAULT_URL" 60; then
   echo "[crm-local] O shell do CRM não respondeu em $DEFAULT_URL dentro do tempo esperado." >&2
   exit 1
+fi
+
+if [[ "$CRM_MODULE" == 'atendimento' && "$CRM_WITH_WHATSAPP" == '1' ]]; then
+  verify_atendimento_proxy
 fi
 
 run_gate_smoke() {

--- a/scripts/run-local-whatsapp-orchestrator.sh
+++ b/scripts/run-local-whatsapp-orchestrator.sh
@@ -1,19 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Local-only adapter for the CRM Pages shell. It reuses protected native
-# runtime configuration without copying it into the checkout, Pages bindings,
-# browser, or logs.
+# Local-only adapter for the CRM Pages shell. It reuses the Evolution credential
+# from the protected native runtime without copying it into the checkout, Pages
+# bindings, browser, or logs.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${CRM_LOCAL_WA_ORCHESTRATOR_PORT:-8110}"
 ENV_FILE="${CRM_LOCAL_WA_NATIVE_ENV_FILE:-/etc/skincos/crm-whatsapp.env}"
+RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/mnt/c/CodexRuntime/operator/admin/skincos/whatsapp-local-adapter}"
 RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-admin}"
-# This is an operator-owned QA adapter, never a native service runtime.
-RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/skincos/crm-local-adapter}"
-SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-$RUNTIME_HOME/source}"
-DATABASE_URL="${CRM_LOCAL_WA_DATABASE_URL:-postgresql:///skincos_crm_local?host=/var/run/postgresql}"
-TARGET_COMMIT="${CRM_LOCAL_TARGET_COMMIT:-unknown}"
+SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-/home/$RUN_AS_USER/.cache/skincos/whatsapp-local-adapter/source}"
+# This adapter serves the local Atendimento API as well as the WhatsApp
+# endpoints. Keep it on the dedicated local mirror through PostgreSQL peer
+# authentication; it never receives a production database URL or password.
+DEFAULT_DATABASE_URL="postgresql://${RUN_AS_USER}@/skincos_crm_local?host=/var/run/postgresql"
+DATABASE_URL="${CRM_LOCAL_WA_DATABASE_URL:-$DEFAULT_DATABASE_URL}"
+
+if [[ "$DATABASE_URL" != "$DEFAULT_DATABASE_URL" ]]; then
+  echo "[whatsapp-local] CRM_LOCAL_WA_DATABASE_URL deve apontar somente para o socket local de skincos_crm_local." >&2
+  exit 2
+fi
+
+if ! sudo -n -u "$RUN_AS_USER" psql "$DATABASE_URL" -Atqc 'select 1' >/dev/null 2>&1; then
+  echo "[whatsapp-local] O banco local skincos_crm_local não está acessível para $RUN_AS_USER." >&2
+  exit 2
+fi
 
 if ! sudo -n test -f "$ENV_FILE"; then
   echo "[whatsapp-local] Configuração nativa ausente: CRM_LOCAL_WA_NATIVE_ENV_FILE" >&2
@@ -31,10 +43,10 @@ export LOCAL_WA_ADAPTER_PORT="$PORT"
 export LOCAL_WA_ADAPTER_RUNTIME_HOME="$RUNTIME_HOME"
 export LOCAL_WA_ADAPTER_SOURCE_HOME="$SOURCE_HOME"
 export LOCAL_WA_ADAPTER_RUN_AS_USER="$RUN_AS_USER"
-export LOCAL_WA_ADAPTER_DATABASE_URL="$DATABASE_URL"
-export LOCAL_WA_ADAPTER_TARGET_COMMIT="$TARGET_COMMIT"
 export LOCAL_WA_ADAPTER_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}"
 export LOCAL_WA_ADAPTER_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
+export LOCAL_WA_ADAPTER_DATABASE_URL="$DATABASE_URL"
+export LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS="${CRM_LOCAL_RUNTIME_DIAGNOSTICS:-}"
 
 exec sudo -n /usr/bin/env \
   LOCAL_WA_ADAPTER_ROOT="$LOCAL_WA_ADAPTER_ROOT" \
@@ -43,10 +55,10 @@ exec sudo -n /usr/bin/env \
   LOCAL_WA_ADAPTER_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME" \
   LOCAL_WA_ADAPTER_SOURCE_HOME="$LOCAL_WA_ADAPTER_SOURCE_HOME" \
   LOCAL_WA_ADAPTER_RUN_AS_USER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-  LOCAL_WA_ADAPTER_DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL" \
-  LOCAL_WA_ADAPTER_TARGET_COMMIT="$LOCAL_WA_ADAPTER_TARGET_COMMIT" \
   LOCAL_WA_ADAPTER_EMAIL="$LOCAL_WA_ADAPTER_EMAIL" \
   LOCAL_WA_ADAPTER_ROLE="$LOCAL_WA_ADAPTER_ROLE" \
+  LOCAL_WA_ADAPTER_DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL" \
+  LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS="$LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS" \
   /bin/bash -c '
   set -euo pipefail
   set -a
@@ -56,24 +68,6 @@ exec sudo -n /usr/bin/env \
 
   : "${EVOLUTION_API_URL:?EVOLUTION_API_URL is required in the native WhatsApp environment}"
   : "${EVOLUTION_API_KEY:?EVOLUTION_API_KEY is required in the native WhatsApp environment}"
-  : "${LOCAL_WA_ADAPTER_DATABASE_URL:?CRM_LOCAL_WA_DATABASE_URL is required}"
-
-  # Always use the explicitly local CRM mirror. The OS-level admin role is
-  # granted only the local PostgreSQL service role, so editable QA code never
-  # runs as the native skincos service account.
-  export DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL"
-  # runuser preserves the root launcher environment so native WhatsApp
-  # credentials remain available. Explicitly reset the local database identity:
-  # libpq otherwise derives USER=root and peer authentication fails before the
-  # adapter can serve Atendimento.
-  export PGUSER="$LOCAL_WA_ADAPTER_RUN_AS_USER"
-  export USER="$LOCAL_WA_ADAPTER_RUN_AS_USER"
-  export LOGNAME="$LOCAL_WA_ADAPTER_RUN_AS_USER"
-  export CRM_LOCAL_PG_ROLE="$LOCAL_WA_ADAPTER_RUN_AS_USER"
-
-  # Pages deliberately sends an unsigned actor only to this loopback runtime.
-  # Do not inherit production actor keys from the native CRM API environment.
-  unset ATENDIMENTO_ACTOR_HMAC_KEY CAIXA_ACTOR_HMAC_KEY ESCALA_ACTOR_HMAC_KEY CRM_ESCALA_HMAC_KEY
 
   install -d -m 0750 -o "$LOCAL_WA_ADAPTER_RUN_AS_USER" -g "$LOCAL_WA_ADAPTER_RUN_AS_USER" \
     "$LOCAL_WA_ADAPTER_RUNTIME_HOME" "$LOCAL_WA_ADAPTER_RUNTIME_HOME/var" \
@@ -83,49 +77,28 @@ exec sudo -n /usr/bin/env \
   # remains the versioned worktree; this cache avoids Windows/WSL file latency.
   runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" -- rsync -a --delete --exclude node_modules \
     "$LOCAL_WA_ADAPTER_ROOT/crm/api/" "$LOCAL_WA_ADAPTER_SOURCE_HOME/"
-  # Partial node_modules caches can satisfy Express while omitting pg, causing
-  # every Atendimento request to fail only after the shell is already open.
-  # Recreate production dependencies from the versioned lockfile on each start.
-  runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" -- /usr/bin/npm --prefix "$LOCAL_WA_ADAPTER_SOURCE_HOME" ci --omit=dev --no-audit --no-fund
+  if [[ ! -d "$LOCAL_WA_ADAPTER_SOURCE_HOME/node_modules/express" ]]; then
+    runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" -- /usr/bin/npm --prefix "$LOCAL_WA_ADAPTER_SOURCE_HOME" ci --omit=dev --no-audit --no-fund
+  fi
 
   export NODE_ENV=development
   export NO_AUTH=true
   export CRM_LOCAL_NO_AUTH=true
-  # This adapter may read the native database only for local CRM QA. It must
-  # not claim or process native Harmonia work.
-  export HARMONIA_WORKER_ENABLED=false
   export WA_CHANNEL_OWNER_ENFORCED=false
   export WA_ORCHESTRATOR_PROVIDER=evolution
   export CRM_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME"
   export VAR_DIR="$LOCAL_WA_ADAPTER_RUNTIME_HOME/var"
-  # Stack diagnostics stay in the private local runtime; native services never
-  # enable this flag and Pages never receives the details.
-  export CRM_LOCAL_RUNTIME_DIAGNOSTICS=1
-  export CRM_LOCAL_TARGET_COMMIT="$LOCAL_WA_ADAPTER_TARGET_COMMIT"
   export CRM_API_PORT="$LOCAL_WA_ADAPTER_PORT"
   export CRM_API_HOST=127.0.0.1
   export PORT="$LOCAL_WA_ADAPTER_PORT"
   export DEV_AUTH_EMAIL="$LOCAL_WA_ADAPTER_EMAIL"
   export DEV_AUTH_ROLE="$LOCAL_WA_ADAPTER_ROLE"
+  export DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL"
+  export CRM_LOCAL_RUNTIME_DIAGNOSTICS="$LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS"
   export EVOLUTION_INSTANCE_PREFIX="${EVOLUTION_INSTANCE_PREFIX:-crm-channel-}"
-
-  # Bootstrap the exact staged source, OS identity and local database socket
-  # before opening the listener. This removes first-request migration races.
-  runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" --preserve-environment -- \
-    /usr/bin/env \
-      PGUSER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      USER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      LOGNAME="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      CRM_LOCAL_PG_ROLE="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      /usr/bin/node "$LOCAL_WA_ADAPTER_SOURCE_HOME/scripts/validate-local-atendimento-runtime.mjs"
 
   # Keep the native credential in the inherited process environment. Do not put
   # it in a command argument, which would expose it through process inspection.
   exec runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" --preserve-environment -- \
-    /usr/bin/env \
-      PGUSER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      USER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      LOGNAME="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      CRM_LOCAL_PG_ROLE="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-      /usr/bin/node "$LOCAL_WA_ADAPTER_SOURCE_HOME/server.js"
+    /usr/bin/node "$LOCAL_WA_ADAPTER_SOURCE_HOME/server.js"
 '

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -61,7 +61,7 @@ param(
     )]
     [string]$Action,
     [string]$ProjectRoot,
-    [switch]$Background
+    [switch]$CrmAtendimentoDetachedStart
 )
 
 $ErrorActionPreference = "Stop"
@@ -96,9 +96,44 @@ function Resolve-ProjectRoot {
 $ProjectRoot = Resolve-ProjectRoot -RequestedPath $ProjectRoot -ScriptDirectory $scriptRoot
 $localStateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos"
 $operatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos"
+$crmLocalSourceSelectionPath = Join-Path $operatorRuntimeRoot "runtime\crm-local\active-source.json"
 $tmpRoot = Join-Path $localStateRoot "tmp"
 $logRoot = Join-Path $operatorRuntimeRoot "logs"
 $wslInvoker = Join-Path $scriptRoot "invoke-skincos-wsl.ps1"
+$crmLocalPreviewSelected = $false
+
+# A CRM preview is selected explicitly and kept outside every worktree. This
+# makes the chosen source deterministic for all Codex actions/modules, while
+# never guessing from the thread that happened to invoke the shortcut.
+$previewSourceRoot = [string]$env:CRM_LOCAL_PREVIEW_SOURCE_ROOT
+if ([string]$env:CRM_LOCAL_CLEAR_PREVIEW_SOURCE -in @('1', 'true', 'TRUE')) {
+    Remove-Item -LiteralPath $crmLocalSourceSelectionPath -Force -ErrorAction SilentlyContinue
+    $previewSourceRoot = ''
+} elseif ([string]::IsNullOrWhiteSpace($previewSourceRoot) -and (Test-Path -LiteralPath $crmLocalSourceSelectionPath)) {
+    try {
+        $previewSourceRoot = [string]((Get-Content -Raw -LiteralPath $crmLocalSourceSelectionPath | ConvertFrom-Json).sourceRoot)
+    } catch {
+        throw "A seleção ativa do CRM Local está inválida em '$crmLocalSourceSelectionPath'. Remova-a com CRM_LOCAL_CLEAR_PREVIEW_SOURCE=1 antes de iniciar o CRM."
+    }
+}
+if (-not [string]::IsNullOrWhiteSpace($previewSourceRoot)) {
+    $previewSourceRoot = (Resolve-Path -LiteralPath $previewSourceRoot).Path
+    if (-not (Test-Path -LiteralPath (Join-Path $previewSourceRoot '.git'))) {
+        throw "A prévia ativa do CRM Local não aponta para um checkout Git válido: '$previewSourceRoot'."
+    }
+    $ProjectRoot = $previewSourceRoot
+    $crmLocalPreviewSelected = $true
+    $env:CRM_LOCAL_INCLUDE_WORKING_CHANGES = 'true'
+    if (-not [string]::IsNullOrWhiteSpace([string]$env:CRM_LOCAL_PREVIEW_SOURCE_ROOT)) {
+        New-Item -ItemType Directory -Path (Split-Path -Parent $crmLocalSourceSelectionPath) -Force | Out-Null
+        [pscustomobject]@{
+            sourceRoot = $ProjectRoot
+            selectedAt = (Get-Date).ToString('o')
+            selectedBy = 'CRM_LOCAL_PREVIEW_SOURCE_ROOT'
+        } | ConvertTo-Json | Set-Content -LiteralPath $crmLocalSourceSelectionPath -Encoding utf8
+        Write-Host "[crm-local] Prévia ativa selecionada: $ProjectRoot"
+    }
+}
 
 function Ensure-LocalState {
     foreach ($path in @(
@@ -160,74 +195,67 @@ function Invoke-ShortcutWsl {
         -SkipGitCheck:$SkipGitCheck `
         -SkipRepoCheck:$SkipRepoCheck
 
-    if ($AcceptedExitCode -notcontains $LASTEXITCODE) {
+    if ($LASTEXITCODE -notin $AcceptedExitCode) {
         throw "The WSL command failed with exit code $LASTEXITCODE."
     }
 }
 
+function Invoke-ShortcutWslNativePreview {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+    if ($WorkingDirectory -notmatch '^/home/admin/\.local/state/skincos/crm-local-preview-source/[A-Za-z0-9._-]+$') {
+        throw "Diretório nativo da prévia CRM não autorizado: '$WorkingDirectory'."
+    }
+    $nativeCommand = "cd -- {0} && {1}" -f (Convert-ToBashLiteral -Value $WorkingDirectory), $Command
+    & wsl.exe -d Ubuntu-24.04 -- bash -lc $nativeCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "The native WSL preview command failed with exit code $LASTEXITCODE."
+    }
+}
+
 function Get-CrmLocalReviewRef {
+    if (-not [string]::IsNullOrWhiteSpace($env:CRM_LOCAL_REVIEW_REF)) {
+        return $env:CRM_LOCAL_REVIEW_REF.Trim()
+    }
+    if ($crmLocalPreviewSelected) {
+        # A selected preview is intentionally evaluated at its own checked-out
+        # base. Its dirty snapshot is then fingerprinted, so every module sees
+        # the same work without pretending that it was already integrated.
+        return "HEAD"
+    }
     if ([string]::IsNullOrWhiteSpace($env:CRM_LOCAL_REVIEW_REF)) {
+        # The Codex App action is the canonical local CRM, not a preview of
+        # whichever worktree or thread happens to invoke it. Fetching and
+        # resolving origin/main makes "atualizado" deterministic across
+        # modules and threads.
         return "origin/main"
     }
-    return $env:CRM_LOCAL_REVIEW_REF.Trim()
+    return "origin/main"
 }
 
-function Test-CrmLocalPortFree {
-    param([int]$Port)
-    return $null -eq (Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue | Select-Object -First 1)
-}
-
-function Resolve-CrmLocalPort {
-    param(
-        [string]$RequestedValue,
-        [int[]]$Candidates,
-        [string]$Label
-    )
-    if (-not [string]::IsNullOrWhiteSpace($RequestedValue)) {
-        $requestedPort = [int]$RequestedValue
-        if ($requestedPort -lt 1 -or $requestedPort -gt 65535) {
-            throw "A porta local de $Label deve estar entre 1 e 65535."
-        }
-        return $requestedPort
-    }
-    foreach ($candidate in $Candidates) {
-        if (Test-CrmLocalPortFree -Port $candidate) { return $candidate }
-    }
-    throw "Nenhuma porta local livre foi encontrada para $Label."
-}
-
-function Test-CrmLocalReviewRefExplicit {
-    return -not [string]::IsNullOrWhiteSpace($env:CRM_LOCAL_REVIEW_REF)
-}
-
-function Assert-CrmLocalRevisionReplacementIsExplicit {
-    param(
-        [ValidateSet("Gestor", "Consultor")][string]$Persona,
-        [Parameter(Mandatory = $true)][string]$TargetCommit,
-        $Manifest
-    )
-
-    if ($Persona -ne 'Gestor' -or (Test-CrmLocalReviewRefExplicit) -or $null -eq $Manifest) {
-        return
-    }
-
-    # A failed or incomplete launch at the requested commit is safe to recover.
-    # Block only the destructive case: an actually running Gestor at a distinct
-    # revision would otherwise be replaced by the implicit origin/main target.
-    if (-not (Test-CrmWslPid -PidValue $Manifest.pids.launcher)) {
-        return
-    }
-    $activeCommit = ([string]$Manifest.targetCommit).Trim().ToLowerInvariant()
-    if ($activeCommit -match '^[0-9a-f]{40}$' -and $activeCommit -ne $TargetCommit.ToLowerInvariant()) {
-        throw "CRM – Local (Gestor) já está ativo na revisão $activeCommit. Para proteger alterações locais compartilhadas, a ação padrão não irá substituí-la por origin/main. Informe CRM_LOCAL_REVIEW_REF explicitamente ou pare o runtime após registrar a revisão ativa."
+function Test-CrmLocalIncludeWorkingChanges {
+    $raw = [string]$env:CRM_LOCAL_INCLUDE_WORKING_CHANGES
+    if ([string]::IsNullOrWhiteSpace($raw)) { return $false }
+    switch ($raw.Trim().ToLowerInvariant()) {
+        "1" { return $true }
+        "true" { return $true }
+        "yes" { return $true }
+        "0" { return $false }
+        "false" { return $false }
+        "no" { return $false }
+        default { throw "CRM_LOCAL_INCLUDE_WORKING_CHANGES deve ser true ou false." }
     }
 }
 
 function Get-CrmLocalTargetCommit {
     $reviewRef = Get-CrmLocalReviewRef
-    & git -C $ProjectRoot fetch origin --prune --quiet
-    if ($LASTEXITCODE -ne 0) {
-        throw "Não foi possível atualizar as referências remotas antes de iniciar o CRM Local."
+    if ($reviewRef -match '^(origin/|refs/remotes/origin/)') {
+        & git -C $ProjectRoot fetch origin --prune --quiet
+        if ($LASTEXITCODE -ne 0) {
+            throw "Não foi possível atualizar as referências remotas antes de iniciar o CRM Local."
+        }
     }
 
     $targetCommit = (& git -C $ProjectRoot rev-parse --verify "${reviewRef}^{commit}" 2>$null | Select-Object -First 1).Trim()
@@ -235,6 +263,204 @@ function Get-CrmLocalTargetCommit {
         throw "A revisão do CRM Local não pôde ser resolvida: '$reviewRef'."
     }
     return $targetCommit.ToLowerInvariant()
+}
+
+function Get-CrmLocalSnapshotHash {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        return ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+function Export-CrmLocalSnapshotPatch {
+    param([Parameter(Mandatory = $true)][string]$OutputPath)
+
+    New-Item -ItemType Directory -Path (Split-Path -Parent $OutputPath) -Force | Out-Null
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = [Diagnostics.ProcessStartInfo]::new()
+    $process.StartInfo.FileName = 'git'
+    $process.StartInfo.Arguments = ('-C "{0}" diff --binary HEAD' -f $ProjectRoot)
+    $process.StartInfo.UseShellExecute = $false
+    $process.StartInfo.RedirectStandardOutput = $true
+    $process.StartInfo.RedirectStandardError = $true
+    try {
+        [void]$process.Start()
+        $stream = [IO.File]::Open($OutputPath, [IO.FileMode]::Create, [IO.FileAccess]::Write, [IO.FileShare]::None)
+        try {
+            $process.StandardOutput.BaseStream.CopyTo($stream)
+        } finally {
+            $stream.Dispose()
+        }
+        $standardError = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+        if ($process.ExitCode -ne 0) {
+            throw "Não foi possível ler as alterações locais do checkout '$ProjectRoot': $standardError"
+        }
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Remove-CrmLocalSourceSnapshot {
+    param([object]$Snapshot)
+    if ($null -ne $Snapshot -and -not [string]::IsNullOrWhiteSpace([string]$Snapshot.PatchPath)) {
+        Remove-Item -LiteralPath ([string]$Snapshot.PatchPath) -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-CrmLocalSnapshotRelativePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceRootPath,
+        [Parameter(Mandatory = $true)][string]$FullPath
+    )
+    $normalizedFullPath = [IO.Path]::GetFullPath($FullPath)
+    $rootPrefix = $SourceRootPath + [IO.Path]::DirectorySeparatorChar
+    if (-not $normalizedFullPath.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Arquivo não rastreado fora do checkout no snapshot do CRM Local: '$FullPath'."
+    }
+    return $normalizedFullPath.Substring($rootPrefix.Length).Replace([char]'\', [char]'/')
+}
+
+function Get-CrmLocalSnapshotUntrackedFiles {
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Entries)
+
+    $sourceRootPath = (Resolve-Path -LiteralPath $ProjectRoot).Path.TrimEnd([char]'\', [char]'/')
+    $files = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in $Entries) {
+        $relativeEntry = ([string]$entry).Trim()
+        if ([string]::IsNullOrWhiteSpace($relativeEntry)) { continue }
+
+        $candidate = Join-Path $ProjectRoot $relativeEntry.Replace('/', [IO.Path]::DirectorySeparatorChar)
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $item = Get-Item -LiteralPath $candidate -Force
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw "Arquivo não rastreado com link simbólico não pode entrar no snapshot do CRM Local: '$relativeEntry'."
+            }
+            $relativeFile = Get-CrmLocalSnapshotRelativePath -SourceRootPath $sourceRootPath -FullPath $item.FullName
+            $files.Add($relativeFile)
+            continue
+        }
+
+        if (-not (Test-Path -LiteralPath $candidate -PathType Container)) {
+            throw "Arquivo não rastreado inválido no snapshot do CRM Local: '$relativeEntry'."
+        }
+
+        # Git representa checkouts aninhados não rastreados como diretórios. Eles não
+        # fazem parte da árvore do checkout acionado e não podem ser copiados para o
+        # runtime sem misturar revisões, .git e alterações de outra thread.
+        if (Test-Path -LiteralPath (Join-Path $candidate '.git')) {
+            Write-Verbose "Ignorando checkout Git aninhado fora do snapshot do CRM Local: '$relativeEntry'."
+            continue
+        }
+
+        $directoryItem = Get-Item -LiteralPath $candidate -Force
+        if (($directoryItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "Diretório não rastreado com link simbólico não pode entrar no snapshot do CRM Local: '$relativeEntry'."
+        }
+
+        Get-ChildItem -LiteralPath $candidate -File -Recurse -Force | ForEach-Object {
+            if (($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw "Arquivo não rastreado com link simbólico não pode entrar no snapshot do CRM Local: '$($_.FullName)'."
+            }
+            $relativeFile = Get-CrmLocalSnapshotRelativePath -SourceRootPath $sourceRootPath -FullPath $_.FullName
+            & git -C $ProjectRoot check-ignore --quiet -- $relativeFile 2>$null
+            if ($LASTEXITCODE -eq 0) { return }
+            if ($LASTEXITCODE -ne 1) { throw "Não foi possível validar o arquivo não rastreado '$relativeFile' no snapshot do CRM Local." }
+            $files.Add($relativeFile)
+        }
+    }
+    return @($files | Sort-Object -Unique)
+}
+
+function Get-CrmLocalSourceSnapshot {
+    param([Parameter(Mandatory = $true)][string]$TargetCommit)
+
+    # The standard action intentionally ignores the caller's dirty checkout.
+    # That checkout can belong to another Codex thread and may be based on an
+    # older branch. A local preview must opt in explicitly and be based on the
+    # exact requested revision, otherwise no changes are copied.
+    if (-not (Test-CrmLocalIncludeWorkingChanges)) {
+        return [pscustomobject]@{
+            SourceRoot = $ProjectRoot
+            TargetCommit = $TargetCommit
+            PatchPath = $null
+            Untracked = @()
+            HasChanges = $false
+            Fingerprint = "commit:${TargetCommit}"
+        }
+    }
+
+    $sourceCommit = (& git -C $ProjectRoot rev-parse --verify 'HEAD^{commit}' 2>$null | Select-Object -First 1).Trim().ToLowerInvariant()
+    if ($sourceCommit -notmatch '^[0-9a-f]{40}$') { throw "Não foi possível resolver o commit do checkout que disparou o CRM Local: '$ProjectRoot'." }
+    if ($sourceCommit -ne $TargetCommit) {
+        # A named preview may be based on an older ancestor. Its patch is
+        # applied only to a fresh worktree at the current canonical commit;
+        # conflict detection remains fail-closed in Apply-CrmLocalSourceSnapshot.
+        & git -C $ProjectRoot merge-base --is-ancestor $sourceCommit $TargetCommit
+        if ($LASTEXITCODE -ne 0) {
+            throw "A prévia ativa não deriva da revisão canônica solicitada ($TargetCommit). Não copie alterações entre linhas divergentes; selecione uma prévia rebaseada ou limpe a seleção com CRM_LOCAL_CLEAR_PREVIEW_SOURCE=1."
+        }
+    }
+    $patchPath = Join-Path $operatorRuntimeRoot ("tmp\crm-local-snapshot-{0}.patch" -f [Guid]::NewGuid().ToString('N'))
+    Export-CrmLocalSnapshotPatch -OutputPath $patchPath
+    $patchBytes = (Get-Item -LiteralPath $patchPath).Length
+    $untrackedEntries = @(& git -C $ProjectRoot ls-files --others --exclude-standard)
+    if ($LASTEXITCODE -ne 0) { throw "Não foi possível ler os arquivos não rastreados do checkout '$ProjectRoot'." }
+    $untracked = @(Get-CrmLocalSnapshotUntrackedFiles -Entries $untrackedEntries)
+    $untrackedDigest = foreach ($relativePath in $untracked) {
+        $candidate = Join-Path $ProjectRoot $relativePath
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) { throw "Arquivo não rastreado inválido no snapshot do CRM Local: '$relativePath'." }
+        "${relativePath}:$((Get-FileHash -LiteralPath $candidate -Algorithm SHA256).Hash.ToLowerInvariant())"
+    }
+    $hasChanges = $patchBytes -gt 0 -or $untracked.Count -gt 0
+    $fingerprint = if ($hasChanges) {
+        "snapshot:${TargetCommit}:$(Get-CrmLocalSnapshotHash -Value ((Get-FileHash -LiteralPath $patchPath -Algorithm SHA256).Hash.ToLowerInvariant() + "`n" + ($untrackedDigest -join "`n")))"
+    } else {
+        "commit:${TargetCommit}"
+    }
+    return [pscustomobject]@{
+        SourceRoot = $ProjectRoot
+        TargetCommit = $TargetCommit
+        PatchPath = $patchPath
+        Untracked = $untracked
+        HasChanges = $hasChanges
+        Fingerprint = $fingerprint
+    }
+}
+
+function Get-CrmLocalSourceOrigin {
+    param(
+        [Parameter(Mandatory = $true)][object]$Snapshot,
+        [Parameter(Mandatory = $true)][string]$Module
+    )
+    $sourceRoot = (Resolve-Path -LiteralPath ([string]$Snapshot.SourceRoot)).Path
+    # The selected source is shared deliberately across CRM shortcuts, but a
+    # runtime started for one module must never be reused by a different one.
+    # Keep this token shell-neutral: it crosses the Windows → WSL command
+    # boundary as an environment assignment before being persisted in JSON.
+    return "{0}__{1}" -f $sourceRoot, $Module.Trim().ToLowerInvariant()
+}
+
+function Apply-CrmLocalSourceSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][object]$Snapshot,
+        [Parameter(Mandatory = $true)][string]$DestinationRoot
+    )
+    if (-not $Snapshot.HasChanges) { return }
+    if ((Get-Item -LiteralPath $Snapshot.PatchPath).Length -gt 0) {
+        & git -C $DestinationRoot apply --whitespace=nowarn --binary $Snapshot.PatchPath
+        if ($LASTEXITCODE -ne 0) { throw "Não foi possível aplicar o snapshot local no worktree isolado '$DestinationRoot'." }
+    }
+    foreach ($relativePath in @($Snapshot.Untracked)) {
+        $from = Join-Path $Snapshot.SourceRoot $relativePath
+        $to = Join-Path $DestinationRoot $relativePath
+        New-Item -ItemType Directory -Path (Split-Path -Parent $to) -Force | Out-Null
+        Copy-Item -LiteralPath $from -Destination $to -Force
+    }
 }
 
 function Get-CrmLocalSourceBaseRoot {
@@ -250,12 +476,32 @@ function Sync-CrmLocalSourceRoot {
         [ValidateSet("Gestor", "Consultor")]
         [string]$Persona,
         [Parameter(Mandatory = $true)]
-        [string]$TargetCommit
+        [string]$TargetCommit,
+        [Parameter(Mandatory = $true)]
+        [object]$Snapshot
     )
 
     $sourceRoot = Get-CrmLocalSourceBaseRoot -Persona $Persona
     $sourceParent = Split-Path -Parent $sourceRoot
     New-Item -ItemType Directory -Path $sourceParent -Force | Out-Null
+
+    if ($Snapshot.HasChanges) {
+        $shortCommit = $TargetCommit.Substring(0, 12)
+        $shortSnapshot = $Snapshot.Fingerprint.Split(':')[-1].Substring(0, 12)
+        $snapshotRoot = "$sourceRoot-$shortCommit-$shortSnapshot"
+        if (Test-Path -LiteralPath $snapshotRoot) {
+            $snapshotRoot = "$snapshotRoot-$(Get-Date -Format 'yyyyMMddHHmmss')"
+        }
+        & git -C $ProjectRoot worktree add --detach $snapshotRoot $TargetCommit | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "Não foi possível criar o worktree isolado do snapshot do CRM Local em '$snapshotRoot'." }
+        try {
+            Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $snapshotRoot
+        } catch {
+            & git -C $ProjectRoot worktree remove --force $snapshotRoot 2>$null
+            throw
+        }
+        return $snapshotRoot
+    }
 
     if (Test-Path -LiteralPath $sourceRoot) {
         $trackedChanges = @(& git -C $sourceRoot status --porcelain --untracked-files=no)
@@ -296,14 +542,41 @@ function Resolve-CrmLocalSourceRoot {
         [string]$Persona = "Gestor"
     )
     $targetCommit = Get-CrmLocalTargetCommit
-    $manifest = Get-CrmPersonaManifest -Persona $Persona
-    if ($null -ne $manifest -and (Test-CrmWslPid -PidValue $manifest.pids.launcher)) {
-        $runningSource = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
-        $runningCommit = if (Test-Path -LiteralPath $runningSource) { (& git -C $runningSource rev-parse HEAD 2>$null | Select-Object -First 1) } else { $null }
-        if ([string]$runningCommit -eq $targetCommit) { return $runningSource }
-        throw "O runtime de $Persona está ativo em outra revisão. Execute primeiro a ação principal do CRM Local para atualizá-lo."
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $targetCommit
+    try {
+        $manifest = Get-CrmPersonaManifest -Persona $Persona
+        if ($null -ne $manifest -and (Test-CrmWslPid -PidValue $manifest.pids.launcher)) {
+            $runningSource = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
+            $runningCommit = if (Test-Path -LiteralPath $runningSource) { (& git -C $runningSource rev-parse HEAD 2>$null | Select-Object -First 1) } else { $null }
+            if ([string]$runningCommit -eq $targetCommit) { return $runningSource }
+            throw "O runtime de $Persona está ativo em outra revisão. Execute primeiro a ação principal do CRM Local para atualizá-lo."
+        }
+        return Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $targetCommit -Snapshot $snapshot
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
     }
-    return Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $targetCommit
+}
+
+function Resolve-CrmLocalModuleSourceRoot {
+    param(
+        [ValidateSet("Gestor", "Consultor")]
+        [string]$Persona = "Gestor"
+    )
+
+    # Module-specific launchers do not own the canonical persona manifest, but
+    # they must still execute the exact source snapshot selected by this action.
+    # Never fall back to the mutable shared checkout here.
+    $targetCommit = Get-CrmLocalTargetCommit
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $targetCommit
+    try {
+        return [pscustomobject]@{
+            SourceRoot = Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $targetCommit -Snapshot $snapshot
+            TargetCommit = $targetCommit
+            SourceFingerprint = $snapshot.Fingerprint
+        }
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
+    }
 }
 
 function Convert-WslPathToWindows {
@@ -349,42 +622,74 @@ function Test-CrmHttpEndpoint {
 }
 
 function Test-CrmPersonaHealth {
-    param([ValidateSet("Gestor", "Consultor")][string]$Persona)
-    $manifest = Get-CrmPersonaManifest -Persona $Persona
-    $pagesPort = if ($null -ne $manifest -and [int]$manifest.ports.pages -gt 0) { [int]$manifest.ports.pages } elseif ($Persona -eq "Gestor") { 8791 } else { 8792 }
+    param(
+        [ValidateSet("Gestor", "Consultor")][string]$Persona,
+        [object]$Manifest = $null
+    )
     if ($Persona -eq "Gestor") {
-        $insumosPort = if ($null -ne $manifest -and [int]$manifest.ports.insumos -gt 0) { [int]$manifest.ports.insumos } else { 8787 }
-        $timekeepingPort = if ($null -ne $manifest -and [int]$manifest.ports.timekeeping -gt 0) { [int]$manifest.ports.timekeeping } else { 8801 }
-        $whatsappPort = if ($null -ne $manifest -and [int]$manifest.ports.whatsapp -gt 0) { [int]$manifest.ports.whatsapp } else { 8110 }
-        return (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$pagesPort/api/auth/me" -Role "GESTOR") -and
-            (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$insumosPort/insumos/health") -and
-            (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$timekeepingPort/api/ponto/readiness") -and
-            (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$whatsappPort/health")
+        # The manifest is authoritative for optional services. Atendimento is
+        # intentionally a smaller Gestor preview (Pages + PostgreSQL-backed
+        # adapter), so requiring unrelated Insumos/Ponto services made every
+        # healthy Atendimento launch look stale and restart indefinitely.
+        if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8791/api/auth/me" -Role "GESTOR")) { return $false }
+        if ($null -eq $Manifest -or $null -ne $Manifest.ports.insumos) {
+            if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8787/insumos/health")) { return $false }
+        }
+        if ($null -eq $Manifest -or $null -ne $Manifest.ports.timekeeping) {
+            if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8801/api/ponto/readiness")) { return $false }
+        }
+        if ($null -eq $Manifest -or $null -ne $Manifest.ports.whatsapp) {
+            if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8110/health")) { return $false }
+        }
+        return $true
     }
-    return (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$pagesPort/api/auth/me" -Role "CONSULTOR") -and
-        (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$pagesPort/api/ponto/readiness")
+    return (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8792/api/auth/me" -Role "CONSULTOR") -and
+        (Test-CrmHttpEndpoint -Url "http://127.0.0.1:8792/api/ponto/readiness")
 }
 
 function Get-CrmPersonaDecision {
     param(
         [ValidateSet("Gestor", "Consultor")][string]$Persona,
-        [Parameter(Mandatory = $true)][string]$TargetCommit
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin
     )
     $runtimeRoot = Get-CrmPersonaRuntimeRoot -Persona $Persona
     $manifest = Get-CrmPersonaManifest -Persona $Persona
     $pidAlive = $false
     if ($null -ne $manifest) { $pidAlive = Test-CrmWslPid -PidValue $manifest.pids.launcher }
     $healthy = $false
-    if ($pidAlive) { $healthy = Test-CrmPersonaHealth -Persona $Persona }
+    if ($pidAlive) { $healthy = Test-CrmPersonaHealth -Persona $Persona -Manifest $manifest }
     $policyWsl = Convert-WindowsPathToWsl -Path (Join-Path $scriptRoot "crm-local-runtime-policy.mjs")
     $manifestWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "current.json")
     $buildStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "build-state.json")
-    $decisionRaw = & wsl.exe -d Ubuntu-24.04 -- node $policyWsl `
-        --manifest $manifestWsl --build-state $buildStateWsl --target $TargetCommit `
-        --persona $Persona.ToUpperInvariant() --pid-alive $pidAlive.ToString().ToLowerInvariant() `
-        --healthy $healthy.ToString().ToLowerInvariant()
+    # wsl.exe joins arguments through a shell. Quote every policy input as one
+    # Bash literal; otherwise a Windows source origin loses its backslashes and
+    # spuriously invalidates an otherwise healthy runtime on its second launch.
+    $policyCommand = "node {0} --manifest {1} --build-state {2} --target {3} --source-fingerprint {4} --source-origin {5} --persona {6} --pid-alive {7} --healthy {8}" -f `
+        (Convert-ToBashLiteral -Value $policyWsl), `
+        (Convert-ToBashLiteral -Value $manifestWsl), `
+        (Convert-ToBashLiteral -Value $buildStateWsl), `
+        (Convert-ToBashLiteral -Value $TargetCommit), `
+        (Convert-ToBashLiteral -Value $SourceFingerprint), `
+        (Convert-ToBashLiteral -Value $SourceOrigin), `
+        (Convert-ToBashLiteral -Value $Persona.ToUpperInvariant()), `
+        (Convert-ToBashLiteral -Value $pidAlive.ToString().ToLowerInvariant()), `
+        (Convert-ToBashLiteral -Value $healthy.ToString().ToLowerInvariant())
+    $decisionRaw = & wsl.exe -d Ubuntu-24.04 -- bash -lc $policyCommand
     if ($LASTEXITCODE -ne 0) { throw "Não foi possível avaliar o estado do CRM Local ($Persona)." }
     $decision = $decisionRaw | Select-Object -Last 1 | ConvertFrom-Json
+    if ([string]$decision.action -eq 'reuse' -and [string]$SourceFingerprint -eq "commit:$TargetCommit" -and $null -ne $manifest -and [string]::IsNullOrWhiteSpace([string]$manifest.sourceFingerprint)) {
+        # A legacy canonical manifest has no fingerprint. Before accepting it,
+        # prove its worktree still resolves to the exact requested commit. This
+        # preserves the snapshot guard while letting an upgraded launcher reuse
+        # a healthy canonical runtime instead of rebuilding it indefinitely.
+        $legacyWorktree = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
+        $legacyCommit = if (Test-Path -LiteralPath $legacyWorktree) { (& git -C $legacyWorktree rev-parse --verify 'HEAD^{commit}' 2>$null | Select-Object -First 1).Trim().ToLowerInvariant() } else { $null }
+        if ($legacyCommit -ne $TargetCommit) {
+            $decision = [pscustomobject]@{ action = 'restart'; reason = 'legacy_worktree_outdated' }
+        }
+    }
     return [pscustomobject]@{ Action = [string]$decision.action; Reason = [string]$decision.reason; Manifest = $manifest }
 }
 
@@ -393,23 +698,37 @@ function Open-CrmPersonaUrl {
     $fallback = if ($Persona -eq "Gestor") { "http://localhost:8791/" } else { "http://localhost:8792/?module=ponto" }
     $url = if ($null -ne $Manifest -and -not [string]::IsNullOrWhiteSpace([string]$Manifest.url)) { [string]$Manifest.url } else { $fallback }
     $uri = [Uri]$url
-    $expectedPort = if ($null -ne $Manifest -and [int]$Manifest.ports.pages -gt 0) { [int]$Manifest.ports.pages } elseif ($Persona -eq 'Gestor') { 8791 } else { 8792 }
-    if ($uri.Scheme -ne 'http' -or $uri.Host -notin @('localhost', '127.0.0.1') -or $uri.Port -ne $expectedPort) {
+    if ($uri.Scheme -ne 'http' -or $uri.Host -notin @('localhost', '127.0.0.1') -or $uri.Port -notin @(8791, 8792)) {
         throw "URL local inválida no manifesto de ${Persona}: '$url'."
     }
     Start-Process $url | Out-Null
     Write-Host "[crm-local] Runtime atualizado de $Persona reutilizado em $url."
 }
 
+function Open-CrmModuleUrl {
+    param(
+        [Parameter(Mandatory = $true)][string]$Module,
+        [string]$ExtraQuery = ""
+    )
+    $url = "http://localhost:8791/?module=$Module"
+    if (-not [string]::IsNullOrWhiteSpace($ExtraQuery)) {
+        $url = "$url&$ExtraQuery"
+    }
+    Start-Process $url | Out-Null
+    Write-Host "[crm-local] Abrindo o módulo atualizado '$Module' em $url."
+}
+
 function Wait-CrmPersonaCurrent {
     param(
         [ValidateSet("Gestor", "Consultor")][string]$Persona,
         [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
         [int]$TimeoutSeconds = 420
     )
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
-        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit
+        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $SourceFingerprint -SourceOrigin $SourceOrigin
         if ($decision.Action -eq 'reuse') { return $decision }
         if ($decision.Action -notin @('wait', 'start')) { return $decision }
         Start-Sleep -Seconds 2
@@ -417,20 +736,39 @@ function Wait-CrmPersonaCurrent {
     return [pscustomobject]@{ Action = 'restart'; Reason = 'startup_timeout'; Manifest = (Get-CrmPersonaManifest -Persona $Persona) }
 }
 
-function Assert-GestorSharedServices {
-    $manifest = Get-CrmPersonaManifest -Persona Gestor
-    if ($null -eq $manifest) {
-        throw "O CRM Local (Gestor) não possui manifesto ativo. Reinicie a ação CRM – Local (Gestor) antes do Consultor."
+function Wait-CrmAtendimentoReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [int]$TimeoutSeconds = 600
+    )
+    # The previous manifest is intentionally retained while the selected
+    # snapshot is copied to native WSL storage.  Do not interpret that old
+    # manifest as a failed new launch; wait until the requested provenance has
+    # been written, then apply the normal authenticated health decision.
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $manifest = Get-CrmPersonaManifest -Persona Gestor
+        if ($null -ne $manifest -and
+            [string]$manifest.targetCommit -eq $TargetCommit -and
+            [string]$manifest.sourceFingerprint -eq $SourceFingerprint -and
+            (Test-CrmSourceOriginEquivalent -Left ([string]$manifest.sourceOrigin) -Right $SourceOrigin)) {
+            $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $SourceFingerprint -SourceOrigin $SourceOrigin
+            if ($decision.Action -eq 'reuse') { return $decision }
+            if ($decision.Action -notin @('wait', 'start')) { return $decision }
+        }
+        Start-Sleep -Seconds 2
     }
-    $pagesPort = if ([int]$manifest.ports.pages -gt 0) { [int]$manifest.ports.pages } else { 8791 }
-    $insumosPort = if ([int]$manifest.ports.insumos -gt 0) { [int]$manifest.ports.insumos } else { 8787 }
-    $timekeepingPort = if ([int]$manifest.ports.timekeeping -gt 0) { [int]$manifest.ports.timekeeping } else { 8801 }
-    $whatsAppPort = if ([int]$manifest.ports.whatsapp -gt 0) { [int]$manifest.ports.whatsapp } else { 8110 }
+    return [pscustomobject]@{ Action = 'restart'; Reason = 'startup_timeout'; Manifest = (Get-CrmPersonaManifest -Persona Gestor) }
+}
+
+function Assert-GestorSharedServices {
     $checks = @(
-        @{ Name = "autenticação do Gestor"; Url = "http://127.0.0.1:${pagesPort}/api/auth/me"; Role = "GESTOR" },
-        @{ Name = "Insumos"; Url = "http://127.0.0.1:${insumosPort}/insumos/health" },
-        @{ Name = "Timekeeping"; Url = "http://127.0.0.1:${timekeepingPort}/api/ponto/readiness" },
-        @{ Name = "WhatsApp"; Url = "http://127.0.0.1:${whatsAppPort}/health" }
+        @{ Name = "autenticação do Gestor"; Url = "http://127.0.0.1:8791/api/auth/me"; Role = "GESTOR" },
+        @{ Name = "Insumos"; Url = "http://127.0.0.1:8787/insumos/health" },
+        @{ Name = "Timekeeping"; Url = "http://127.0.0.1:8801/api/ponto/readiness" },
+        @{ Name = "WhatsApp"; Url = "http://127.0.0.1:8110/health" }
     )
     foreach ($check in $checks) {
         try {
@@ -574,7 +912,26 @@ function Stop-CrmPersonaRuntime {
     $manifest = Get-CrmPersonaManifest -Persona $Persona
     if ($null -eq $manifest) { return }
 
-    $sourceRoot = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
+    $manifestWorktree = [string]$manifest.worktree
+    $sourceRoot = Convert-WslPathToWindows -Path $manifestWorktree
+    $runtimeRootWsl = Convert-WindowsPathToWsl -Path (Get-CrmPersonaRuntimeRoot -Persona $Persona)
+    if ($Persona -eq "Gestor") {
+        $command = "CRM_PERSONA=GESTOR CRM_RUNTIME_ROOT={0} CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_PID_FILE={1} CRM_LOG_FILE={2} bash ./scripts/run-local-crm.sh --stop" -f `
+            (Convert-ToBashLiteral -Value $runtimeRootWsl), `
+            (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
+            (Convert-ToBashLiteral -Value $crmGestorLogWsl)
+    } else {
+        $command = "CRM_PERSONA=CONSULTOR CRM_RUNTIME_ROOT={0} CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 CRM_PID_FILE={1} CRM_LOG_FILE={2} bash ./scripts/run-local-crm.sh --stop" -f `
+            (Convert-ToBashLiteral -Value $runtimeRootWsl), `
+            (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
+            (Convert-ToBashLiteral -Value $crmConsultorLogWsl)
+    }
+
+    if ($manifestWorktree -match '^/home/admin/\.local/state/skincos/crm-local-preview-source/[A-Za-z0-9._-]+$') {
+        Invoke-ShortcutWslNativePreview -WorkingDirectory $manifestWorktree -Command $command
+        return
+    }
+
     $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source"
     $resolvedSource = if (Test-Path -LiteralPath $sourceRoot) { (Resolve-Path -LiteralPath $sourceRoot).Path } else { $null }
     if ($null -eq $resolvedSource -or -not $resolvedSource.StartsWith($allowedSourceRoot, [StringComparison]::OrdinalIgnoreCase)) {
@@ -583,102 +940,153 @@ function Stop-CrmPersonaRuntime {
     if (-not (Test-Path -LiteralPath (Join-Path $resolvedSource "scripts\run-local-crm.sh"))) {
         throw "O launcher do runtime de $Persona não existe em '$resolvedSource'."
     }
-
-    $runtimeRootWsl = Convert-WindowsPathToWsl -Path (Get-CrmPersonaRuntimeRoot -Persona $Persona)
-    if ($Persona -eq "Gestor") {
-        $vitePort = if ([int]$manifest.ports.vite -gt 0) { [int]$manifest.ports.vite } else { 5173 }
-        $pagesPort = if ([int]$manifest.ports.pages -gt 0) { [int]$manifest.ports.pages } else { 8791 }
-        $timekeepingPort = if ([int]$manifest.ports.timekeeping -gt 0) { [int]$manifest.ports.timekeeping } else { 8801 }
-        $command = "CRM_PERSONA=GESTOR CRM_RUNTIME_ROOT={0} CRM_VITE_PORT={1} CRM_PAGES_PORT={2} CRM_TIMEKEEPING_PORT={3} CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_PID_FILE={4} CRM_LOG_FILE={5} bash ./scripts/run-local-crm.sh --stop" -f `
-            (Convert-ToBashLiteral -Value $runtimeRootWsl), `
-            $vitePort, `
-            $pagesPort, `
-            $timekeepingPort, `
-            (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
-            (Convert-ToBashLiteral -Value $crmGestorLogWsl)
-    } else {
-        $vitePort = if ([int]$manifest.ports.vite -gt 0) { [int]$manifest.ports.vite } else { 5174 }
-        $pagesPort = if ([int]$manifest.ports.pages -gt 0) { [int]$manifest.ports.pages } else { 8792 }
-        $command = "CRM_PERSONA=CONSULTOR CRM_RUNTIME_ROOT={0} CRM_VITE_PORT={1} CRM_PAGES_PORT={2} CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 CRM_PID_FILE={3} CRM_LOG_FILE={4} bash ./scripts/run-local-crm.sh --stop" -f `
-            (Convert-ToBashLiteral -Value $runtimeRootWsl), `
-            $vitePort, `
-            $pagesPort, `
-            (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
-            (Convert-ToBashLiteral -Value $crmConsultorLogWsl)
-    }
-    # `run-local-crm.sh --stop` forwards SIGTERM to the old detached process.
-    # On WSL this is reported as 143 even when the shutdown completed normally.
-    Invoke-ShortcutWsl -WorkingProjectRoot $resolvedSource -SkipBootstrapCheck -AcceptedExitCode @(0, 143) -Command $command
+    Invoke-ShortcutWsl -WorkingProjectRoot $resolvedSource -SkipBootstrapCheck -Command $command
 }
 
 function Start-CrmPersonaRuntime {
     param(
         [ValidateSet("Gestor", "Consultor")][string]$Persona,
         [Parameter(Mandatory = $true)][string]$SourceRoot,
-        [Parameter(Mandatory = $true)][string]$TargetCommit
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin
     )
     $targetLiteral = Convert-ToBashLiteral -Value $TargetCommit
     if ($Persona -eq "Gestor") {
-        $vitePort = Resolve-CrmLocalPort -RequestedValue $env:CRM_LOCAL_GESTOR_VITE_PORT -Candidates @(5173, 5174, 5175) -Label 'Vite do Gestor'
-        $pagesPort = Resolve-CrmLocalPort -RequestedValue $env:CRM_LOCAL_GESTOR_PAGES_PORT -Candidates @(8791, 8793, 8794) -Label 'Pages do Gestor'
-        $timekeepingPort = Resolve-CrmLocalPort -RequestedValue $env:CRM_LOCAL_GESTOR_TIMEKEEPING_PORT -Candidates @(8801, 8802, 8803) -Label 'Ponto do Gestor'
-        if ($vitePort -lt 1 -or $vitePort -gt 65535 -or $pagesPort -lt 1 -or $pagesPort -gt 65535 -or $timekeepingPort -lt 1 -or $timekeepingPort -gt 65535) {
-            throw "As portas locais do Gestor devem estar entre 1 e 65535."
-        }
-        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} CRM_VITE_PORT={2} CRM_PAGES_PORT={3} CRM_TIMEKEEPING_PORT={4} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' VITE_CRM_MAINTENANCE_MODULES=faturamento CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={5} CRM_LOG_FILE={6} bash ./scripts/run-local-crm.sh" -f `
+        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_ROOT={3} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={4} CRM_LOG_FILE={5} bash ./scripts/run-local-crm.sh" -f `
             $targetLiteral, `
+            (Convert-ToBashLiteral -Value $SourceFingerprint), `
+            (Convert-ToBashLiteral -Value $SourceOrigin), `
             (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
-            $vitePort, `
-            $pagesPort, `
-            $timekeepingPort, `
             (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
             (Convert-ToBashLiteral -Value $crmGestorLogWsl)
     } else {
-        $gestorManifest = Get-CrmPersonaManifest -Persona Gestor
-        $vitePort = Resolve-CrmLocalPort -RequestedValue $env:CRM_LOCAL_CONSULTOR_VITE_PORT -Candidates @(5174, 5175, 5176) -Label 'Vite do Consultor'
-        $pagesPort = Resolve-CrmLocalPort -RequestedValue $env:CRM_LOCAL_CONSULTOR_PAGES_PORT -Candidates @(8792, 8794, 8795) -Label 'Pages do Consultor'
-        $timekeepingPort = if ($null -ne $gestorManifest -and [int]$gestorManifest.ports.timekeeping -gt 0) { [int]$gestorManifest.ports.timekeeping } else { 8801 }
-        $insumosPort = if ($null -ne $gestorManifest -and [int]$gestorManifest.ports.insumos -gt 0) { [int]$gestorManifest.ports.insumos } else { 8787 }
-        $whatsappPort = if ($null -ne $gestorManifest -and [int]$gestorManifest.ports.whatsapp -gt 0) { [int]$gestorManifest.ports.whatsapp } else { 8110 }
-        $command = "CRM_PERSONA=CONSULTOR CRM_TARGET_COMMIT={0} CRM_RUNTIME_ROOT={1} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_SMOKE_MODULES=ponto CRM_SMOKE_ALLOW_EMPTY_MODULES=1 CRM_VITE_PORT={2} CRM_PAGES_PORT={3} CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 PONTO_API_TARGET=http://127.0.0.1:{4} PONTO_ACTOR_HMAC_KEY=test-actor-key-not-secret LOCAL_INSUMOS_API_TARGET=http://127.0.0.1:{5} LOCAL_WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:{6} CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={7} CRM_LOG_FILE={8} bash ./scripts/run-local-crm.sh --module ponto" -f `
+        $command = "CRM_PERSONA=CONSULTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_ROOT={3} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 PONTO_API_TARGET=http://127.0.0.1:8801 PONTO_ACTOR_HMAC_KEY=test-actor-key-not-secret LOCAL_INSUMOS_API_TARGET=http://127.0.0.1:8787 LOCAL_WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:8110 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={4} CRM_LOG_FILE={5} bash ./scripts/run-local-crm.sh --module ponto" -f `
             $targetLiteral, `
+            (Convert-ToBashLiteral -Value $SourceFingerprint), `
+            (Convert-ToBashLiteral -Value $SourceOrigin), `
             (Convert-ToBashLiteral -Value $crmConsultorRuntimeRootWsl), `
-            $vitePort, `
-            $pagesPort, `
-            $timekeepingPort, `
-            $insumosPort, `
-            $whatsappPort, `
             (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
             (Convert-ToBashLiteral -Value $crmConsultorLogWsl)
     }
     Invoke-ShortcutWsl -WorkingProjectRoot $SourceRoot -SkipBootstrapCheck -Command $command
 }
 
+function Start-CrmAtendimentoRuntime {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceRoot,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin
+    )
+    $snapshotId = ($SourceFingerprint -split ':')[-1]
+    if ([string]::IsNullOrWhiteSpace($snapshotId) -or $snapshotId.Length -lt 12) {
+        throw "Fingerprint inválido para a prévia isolada de Atendimento: '$SourceFingerprint'."
+    }
+    $nativeAtendimentoSource = "/home/admin/.local/state/skincos/crm-local-preview-source/atendimento-{0}-{1}" -f `
+        $TargetCommit.Substring(0, 12), $snapshotId.Substring(0, 12)
+    # WSL owns the child process tree of a non-interactive client, so a nohup
+    # handoff would be killed with that client. Keep the durable PowerShell
+    # supervisor attached to the WSL launcher; a 143 is only accepted here
+    # because the exact manifest health gate below still has to pass.
+    $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_ROOT={3} CRM_LOCAL_NATIVE_SOURCE_ROOT={4} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=0 CRM_PID_FILE={5} CRM_LOG_FILE={6} bash ./scripts/run-local-atendimento.sh" -f `
+        (Convert-ToBashLiteral -Value $TargetCommit), `
+        (Convert-ToBashLiteral -Value $SourceFingerprint), `
+        (Convert-ToBashLiteral -Value $SourceOrigin), `
+        (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
+        (Convert-ToBashLiteral -Value $nativeAtendimentoSource), `
+        (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
+        (Convert-ToBashLiteral -Value $atendimentoLogWsl)
+    Invoke-ShortcutWsl -WorkingProjectRoot $SourceRoot -SkipBootstrapCheck -AcceptedExitCode @(0, 143) -Command $command
+}
+
+function Start-CrmAtendimentoBackgroundUpdate {
+    $outLog = Join-Path $logRoot "crm-local-atendimento-action.out.log"
+    $errLog = Join-Path $logRoot "crm-local-atendimento-action.err.log"
+    $arguments = @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath,
+        '-Action', 'CrmAtendimento', '-ProjectRoot', $ProjectRoot,
+        '-CrmAtendimentoDetachedStart'
+    )
+    Start-Process powershell.exe -ArgumentList $arguments -WindowStyle Hidden `
+        -RedirectStandardOutput $outLog -RedirectStandardError $errLog | Out-Null
+    Write-Host "[crm-local] Inicialização persistente de Atendimento iniciada em segundo plano."
+}
+
+function Invoke-CrmAtendimentoAction {
+    # run-local-crm owns its child services and waits for the Pages process.
+    # Start it from a durable child PowerShell so closing the Codex action or
+    # the invoking terminal cannot trigger its EXIT cleanup and tear down a
+    # healthy preview. The child re-enters this function once with the switch,
+    # retaining the exact persisted preview selection and snapshot fingerprint.
+    if (-not $CrmAtendimentoDetachedStart) {
+        Start-CrmAtendimentoBackgroundUpdate
+        return
+    }
+    $targetCommit = Get-CrmLocalTargetCommit
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $targetCommit
+    try {
+        $sourceOrigin = Get-CrmLocalSourceOrigin -Snapshot $snapshot -Module 'atendimento'
+        $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+        if ($decision.Action -eq 'reuse') {
+            Open-CrmModuleUrl -Module 'atendimento' -ExtraQuery 'metaAdsLocalScenario=connected-ready'
+            return
+        }
+        if ($decision.Action -eq 'wait') {
+            Write-Host '[crm-local] A inicialização de Atendimento para o snapshot atual já está em andamento; aguardando.'
+            $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+            if ($decision.Action -eq 'reuse') {
+                Open-CrmModuleUrl -Module 'atendimento' -ExtraQuery 'metaAdsLocalScenario=connected-ready'
+                return
+            }
+        }
+        if ($decision.Action -eq 'restart') {
+            Write-Host "[crm-local] Reiniciando Atendimento: $($decision.Reason)."
+            Stop-CrmPersonaRuntime -Persona Gestor
+        }
+        $sourceRoot = Sync-CrmLocalSourceRoot -Persona Gestor -TargetCommit $targetCommit -Snapshot $snapshot
+        Start-CrmAtendimentoRuntime -SourceRoot $sourceRoot -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+        $ready = Wait-CrmAtendimentoReady -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -TimeoutSeconds 600
+        if ($ready.Action -ne 'reuse') {
+            throw "A prévia de Atendimento não ficou pronta no snapshot $($snapshot.Fingerprint): $($ready.Reason)."
+        }
+        Open-CrmModuleUrl -Module 'atendimento' -ExtraQuery 'metaAdsLocalScenario=connected-ready'
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
+    }
+}
+
 function Invoke-CrmPersonaAction {
     param(
         [ValidateSet("Gestor", "Consultor")][string]$Persona,
-        [Parameter(Mandatory = $true)][string]$TargetCommit
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [string]$Module = 'crm-shell'
     )
-    $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit
-    if ($decision.Action -eq 'reuse') {
-        Open-CrmPersonaUrl -Persona $Persona -Manifest $decision.Manifest
-        return
-    }
-    if ($decision.Action -eq 'wait') {
-        Write-Host "[crm-local] A inicialização de $Persona para o commit atual já está em andamento; aguardando."
-        $decision = Wait-CrmPersonaCurrent -Persona $Persona -TargetCommit $TargetCommit
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $TargetCommit
+    try {
+        $sourceOrigin = Get-CrmLocalSourceOrigin -Snapshot $snapshot -Module $Module
+        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
         if ($decision.Action -eq 'reuse') {
             Open-CrmPersonaUrl -Persona $Persona -Manifest $decision.Manifest
             return
         }
+        if ($decision.Action -eq 'wait') {
+            Write-Host "[crm-local] A inicialização de $Persona para o commit atual já está em andamento; aguardando."
+            $decision = Wait-CrmPersonaCurrent -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+            if ($decision.Action -eq 'reuse') {
+                Open-CrmPersonaUrl -Persona $Persona -Manifest $decision.Manifest
+                return
+            }
+        }
+        if ($decision.Action -eq 'restart') {
+            Write-Host "[crm-local] Reiniciando ${Persona}: $($decision.Reason)."
+            Stop-CrmPersonaRuntime -Persona $Persona
+        }
+        $sourceRoot = Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $TargetCommit -Snapshot $snapshot
+        Start-CrmPersonaRuntime -Persona $Persona -SourceRoot $sourceRoot -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
     }
-    if ($decision.Action -eq 'restart') {
-        Assert-CrmLocalRevisionReplacementIsExplicit -Persona $Persona -TargetCommit $TargetCommit -Manifest $decision.Manifest
-        Write-Host "[crm-local] Reiniciando ${Persona}: $($decision.Reason)."
-        Stop-CrmPersonaRuntime -Persona $Persona
-    }
-    $sourceRoot = Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $TargetCommit
-    Start-CrmPersonaRuntime -Persona $Persona -SourceRoot $sourceRoot -TargetCommit $TargetCommit
 }
 
 function Start-CrmGestorBackgroundUpdate {
@@ -687,7 +1095,7 @@ function Start-CrmGestorBackgroundUpdate {
     $errLog = Join-Path $logRoot "crm-local-gestor-action.err.log"
     $arguments = @(
         '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath,
-        '-Action', 'CrmLocal', '-ProjectRoot', $ProjectRoot, '-Background'
+        '-Action', 'CrmLocal', '-ProjectRoot', $ProjectRoot
     )
     $previousReviewRef = $env:CRM_LOCAL_REVIEW_REF
     try {
@@ -702,20 +1110,23 @@ function Start-CrmGestorBackgroundUpdate {
 
 function Ensure-CrmGestorForConsultor {
     param([Parameter(Mandatory = $true)][string]$TargetCommit)
-    $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $TargetCommit
-    if ($decision.Action -eq 'reuse') { return }
-    if ($decision.Action -eq 'wait') {
-        $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $TargetCommit
+    try {
+        $sourceOrigin = Get-CrmLocalSourceOrigin -Snapshot $snapshot -Module 'crm-shell'
+        $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
         if ($decision.Action -eq 'reuse') { return }
-    }
-    if ($decision.Action -eq 'restart') {
-        Assert-CrmLocalRevisionReplacementIsExplicit -Persona Gestor -TargetCommit $TargetCommit -Manifest $decision.Manifest
-        Stop-CrmPersonaRuntime -Persona Gestor
-    }
-    Start-CrmGestorBackgroundUpdate -TargetCommit $TargetCommit
-    $ready = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -TimeoutSeconds 600
-    if ($ready.Action -ne 'reuse') {
-        throw "O Gestor não ficou pronto no commit $TargetCommit. Consulte '$logRoot\crm-local-gestor-action.err.log'."
+        if ($decision.Action -eq 'wait') {
+            $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+            if ($decision.Action -eq 'reuse') { return }
+        }
+        if ($decision.Action -eq 'restart') { Stop-CrmPersonaRuntime -Persona Gestor }
+        Start-CrmGestorBackgroundUpdate -TargetCommit $TargetCommit
+        $ready = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -TimeoutSeconds 600
+        if ($ready.Action -ne 'reuse') {
+            throw "O Gestor não ficou pronto no commit $TargetCommit. Consulte '$logRoot\crm-local-gestor-action.err.log'."
+        }
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
     }
 }
 
@@ -804,47 +1215,32 @@ function Invoke-ShortcutActionInternal {
         "CrmLocal" {
             Stop-LegacyCrmRuntimeIfNeeded
             $targetCommit = Get-CrmLocalTargetCommit
-            if ($Background) {
-                Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit
-            } else {
-                $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $targetCommit
-                if ($decision.Action -eq 'reuse') {
-                    Open-CrmPersonaUrl -Persona Gestor -Manifest $decision.Manifest
-                } elseif ($decision.Action -eq 'wait') {
-                    Write-Host "[crm-local] A inicialização do Gestor para o commit atual já está em andamento."
-                } else {
-                    Start-CrmGestorBackgroundUpdate -TargetCommit $targetCommit
-                }
-            }
+            Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit
         }
         "CrmConsultor" {
             $targetCommit = Get-CrmLocalTargetCommit
             Ensure-CrmGestorForConsultor -TargetCommit $targetCommit
             Assert-GestorSharedServices
-            Invoke-CrmPersonaAction -Persona Consultor -TargetCommit $targetCommit
+            Invoke-CrmPersonaAction -Persona Consultor -TargetCommit $targetCommit -Module 'ponto'
         }
         "CrmConsultorStop" {
             Stop-CrmPersonaRuntime -Persona Consultor
         }
         "CrmSiteEf" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module site-tracking --meta-ads-scenario connected-ready" -f `
-                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
-                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
+            $targetCommit = Get-CrmLocalTargetCommit
+            Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit -Module 'site-tracking'
+            Open-CrmModuleUrl -Module "site-tracking" -ExtraQuery "metaAdsLocalScenario=connected-ready"
         }
         "CrmMetaAds" {
-            $crmLocalSourceRoot = Resolve-CrmLocalSourceRoot -Persona Gestor
-            Invoke-ShortcutWsl -WorkingProjectRoot $crmLocalSourceRoot -SkipBootstrapCheck -Command ("CRM_BUILD_BEFORE_START=1 CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-crm.sh --module meta-ads" -f `
-                (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
-                (Convert-ToBashLiteral -Value $crmGestorLogWsl))
+            $targetCommit = Get-CrmLocalTargetCommit
+            Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit -Module 'meta-ads'
+            Open-CrmModuleUrl -Module "meta-ads" -ExtraQuery "metaAdsLocalScenario=connected-ready"
         }
         "CrmFinance" {
             Invoke-ShortcutWsl -AcceptedExitCode @(0, 130, 143) -Command "npm run crm:local:finance"
         }
         "CrmAtendimento" {
-            Invoke-ShortcutWsl -Command ("CRM_PID_FILE={0} CRM_LOG_FILE={1} bash ./scripts/run-local-atendimento.sh" -f `
-                (Convert-ToBashLiteral -Value $atendimentoPidWsl), `
-                (Convert-ToBashLiteral -Value $atendimentoLogWsl))
+            Invoke-CrmAtendimentoAction
         }
         "CrmAtendimentoMirrorStatus" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-status" }
         "CrmAtendimentoMirrorSync" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-sync -- --apply" }

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -736,6 +736,26 @@ function Wait-CrmPersonaCurrent {
     return [pscustomobject]@{ Action = 'restart'; Reason = 'startup_timeout'; Manifest = (Get-CrmPersonaManifest -Persona $Persona) }
 }
 
+function Test-CrmSourceOriginEquivalent {
+    param(
+        [AllowEmptyString()][string]$Left,
+        [AllowEmptyString()][string]$Right
+    )
+    # Match the runtime-policy contract exactly. Windows source roots are
+    # case-insensitive and may reach WSL with either slash separator, while
+    # the module suffix and native paths must remain exact to prevent a
+    # snapshot from Atendimento, Site or Meta Ads crossing the boundary.
+    if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+        return $false
+    }
+    $normalizedLeft = $Left.Trim() -replace '\\', '/'
+    $normalizedRight = $Right.Trim() -replace '\\', '/'
+    if ($normalizedLeft -match '^[A-Za-z]:/' -and $normalizedRight -match '^[A-Za-z]:/') {
+        return $normalizedLeft.ToLowerInvariant() -ceq $normalizedRight.ToLowerInvariant()
+    }
+    return $normalizedLeft -ceq $normalizedRight
+}
+
 function Wait-CrmAtendimentoReady {
     param(
         [Parameter(Mandatory = $true)][string]$TargetCommit,

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -15,8 +15,13 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '.
 const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8')
 
 const launcher = read('scripts/run-shared-codex-shortcut.ps1')
+const runtimePolicy = read('scripts/crm-local-runtime-policy.mjs')
 const crmRunner = read('scripts/run-local-crm.sh')
+const atendimentoRunner = read('scripts/run-local-atendimento.sh')
 const runtime = read('scripts/crm-local-persona-runtime.sh')
+const wslInvoker = read('scripts/invoke-skincos-wsl.ps1')
+const pagesRunner = read('crm/console/scripts/dev_pages.sh')
+const whatsappRunner = read('scripts/run-local-whatsapp-orchestrator.sh')
 const environment = read('.codex/environments/environment.toml')
 const installer = read('scripts/install-shared-codex-shortcuts.ps1')
 
@@ -51,8 +56,70 @@ test('preflight validates role and each shared dependency', () => {
   ]) assert.ok(launcher.includes(url), `missing ${url}`)
 })
 
+test('local Pages routes Atendimento to the isolated CRM adapter', () => {
+  assert.match(pagesRunner, /ATENDIMENTO_API_TARGET=\$\{LOCAL_WA_ORCHESTRATOR_API_TARGET\}/)
+  assert.match(pagesRunner, /must not fall back to the[\s\S]*native service on :8099/)
+})
+
+test('local CRM adapter uses only the peer-authenticated Atendimento mirror', () => {
+  assert.match(whatsappRunner, /DEFAULT_DATABASE_URL="postgresql:\/\/\$\{RUN_AS_USER\}@\/skincos_crm_local\?host=\/var\/run\/postgresql"/)
+  assert.match(whatsappRunner, /CRM_LOCAL_WA_DATABASE_URL deve apontar somente para o socket local/)
+  assert.match(whatsappRunner, /export DATABASE_URL="\$LOCAL_WA_ADAPTER_DATABASE_URL"/)
+})
+
+test('Gestor warms Atendimento before the Pages gate can issue concurrent requests', () => {
+  assert.match(crmRunner, /warm_atendimento_api\(\)/)
+  assert.match(crmRunner, /x-crm-user: eyJpZCI6ImNybS1sb2NhbC1nYXRlIiwicm9sZSI6IkdFU1RPUiJ9/)
+  assert.match(crmRunner, /\/api\/atendimento\/local-mirror\/status/)
+  assert.match(crmRunner, /\/api\/atendimento\/management\/finance/)
+  assert.match(crmRunner, /start_whatsapp_orchestrator_local\n  warm_atendimento_api/)
+})
+
+test('Atendimento shortcut uses the canonical isolated Pages and adapter runtime', () => {
+  assert.match(atendimentoRunner, /run-local-crm\.sh/)
+  assert.match(atendimentoRunner, /--module atendimento/)
+  assert.match(atendimentoRunner, /CRM_WITH_WHATSAPP=1/)
+  assert.match(atendimentoRunner, /CRM_LOCAL_NATIVE_SOURCE_ROOT/)
+  assert.match(atendimentoRunner, /crm-local-preview-source/)
+  assert.match(atendimentoRunner, /rsync -a --delete/)
+  assert.doesNotMatch(atendimentoRunner, /node "\$CRM_API_DIR\/server\.js"/)
+  assert.match(launcher, /Start-CrmAtendimentoRuntime/)
+  assert.match(launcher, /Start-CrmAtendimentoBackgroundUpdate/)
+  assert.match(launcher, /CrmAtendimentoDetachedStart/)
+  assert.match(launcher, /Invoke-CrmAtendimentoAction/)
+  assert.match(launcher, /Get-CrmPersonaDecision -Persona Gestor/)
+  assert.match(launcher, /nativeAtendimentoSource/)
+})
+
+test('Atendimento startup proves the authenticated Pages proxy after warming the adapter', () => {
+  assert.match(crmRunner, /verify_atendimento_proxy\(\)/)
+  assert.match(crmRunner, /Verificando proxy autenticado de Atendimento/)
+  assert.match(crmRunner, /http:\/\/127\.0\.0\.1:\$\{CRM_PAGES_PORT\}\$\{endpoint\}/)
+  assert.match(crmRunner, /O proxy autenticado de Atendimento não ficou pronto/)
+})
+
+test('Atendimento reuse health follows the services declared by its manifest', () => {
+  assert.match(launcher, /\$Manifest\.ports\.insumos/)
+  assert.match(launcher, /\$Manifest\.ports\.timekeeping/)
+  assert.match(launcher, /\$Manifest\.ports\.whatsapp/)
+  assert.match(launcher, /Test-CrmPersonaHealth -Persona \$Persona -Manifest \$manifest/)
+})
+
+test('isolated preview installs frontend dependencies from the lockfile', () => {
+  assert.match(crmRunner, /npm --prefix "\$FRONTEND_DIR" ci --no-audit --no-fund/)
+  assert.doesNotMatch(crmRunner, /npm --prefix "\$FRONTEND_DIR" install/)
+})
+
+test('private CRM preview snapshots register only their trusted WSL worktree path', () => {
+  assert.match(wslInvoker, /CodexRuntime\/operator\/admin\/skincos\/source/)
+  assert.match(wslInvoker, /git config --global --add safe\.directory/)
+  assert.match(wslInvoker, /arbitrary caller paths still fail/)
+  assert.match(launcher, /Invoke-ShortcutWslNativePreview/)
+  assert.match(launcher, /crm-local-preview-source/)
+})
+
 test('persona runtime records isolated manifest, lock and build state', () => {
-  for (const contract of ['CRM_RUNTIME_MANIFEST', 'CRM_RUNTIME_LOCK_DIR', 'CRM_BUILD_STATE_FILE', 'CRM_TARGET_COMMIT']) {
+  for (const contract of ['CRM_RUNTIME_MANIFEST', 'CRM_RUNTIME_LOCK_DIR', 'CRM_BUILD_STATE_FILE', 'CRM_TARGET_COMMIT', 'CRM_SOURCE_FINGERPRINT']) {
     assert.ok(runtime.includes(contract), `missing ${contract}`)
   }
   assert.match(runtime, /targetCommit: process\.env\.CRM_RUNTIME_TARGET_COMMIT/)
@@ -61,23 +128,30 @@ test('persona runtime records isolated manifest, lock and build state', () => {
   assert.match(runtime, /timekeeping: enabled\(process\.env\.CRM_WITH_TIMEKEEPING\)/)
 })
 
-test('persona runtime exposes the loopback-aware port preflight used by the CRM launcher', () => {
-  assert.match(runtime, /crm_runtime_port_is_free\(\)/)
-  assert.match(runtime, /lsof -nP -iTCP:"\$port" -sTCP:LISTEN/)
-  assert.match(runtime, /curl -sS --connect-timeout 1 --max-time 1/)
-  assert.match(crmRunner, /if crm_runtime_port_is_free "\$port"; then/)
-})
-
 test('opening the browser never blocks the runtime manifest transition', () => {
   assert.match(crmRunner, /open \"\$DEFAULT_URL\" >\/dev\/null 2>&1 &/)
   assert.match(crmRunner, /xdg-open \"\$DEFAULT_URL\" >\/dev\/null 2>&1 &/)
 })
 
-test('runtime policy reuses only a healthy build from the target commit', () => {
+test('persona helper checks a free port before starting the CRM services', () => {
+  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
+  const result = spawnSync('bash', ['-lc', `source ${JSON.stringify(helper)}; crm_runtime_port_is_free 65530`], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+})
+
+test('generic CRM launcher only falls back from its default Vite port', () => {
+  assert.match(crmRunner, /CRM_VITE_PORT_EXPLICIT=1/)
+  assert.match(crmRunner, /select_available_vite_port/)
+  assert.match(crmRunner, /Porta Vite padrão \$preferred ocupada; usando \$candidate/)
+})
+
+test('runtime policy reuses only a healthy build from the exact source snapshot', () => {
   const target = 'a'.repeat(40)
+  const sourceFingerprint = `snapshot:${target}:${'b'.repeat(64)}`
+  const sourceOrigin = 'C:/CodexRuntime/operator/admin/skincos/source/selected__atendimento'
   const current = {
-    manifest: { persona: 'GESTOR', state: 'ready', targetCommit: target, buildCommit: target },
-    buildState: { commit: target }, targetCommit: target, persona: 'GESTOR', pidAlive: true, healthy: true,
+    manifest: { persona: 'GESTOR', state: 'ready', targetCommit: target, buildCommit: target, sourceFingerprint, sourceOrigin },
+    buildState: { commit: target, sourceFingerprint, sourceOrigin }, targetCommit: target, sourceFingerprint, sourceOrigin, persona: 'GESTOR', pidAlive: true, healthy: true,
   }
   assert.deepEqual(decideRuntimeAction(current), { action: 'reuse', reason: 'current_runtime_ready' })
   assert.deepEqual(decideRuntimeAction({ ...current, healthy: false }), { action: 'restart', reason: 'health_failed' })
@@ -85,6 +159,30 @@ test('runtime policy reuses only a healthy build from the target commit', () => 
   assert.deepEqual(decideRuntimeAction({ ...current, manifest: { ...current.manifest, buildCommit: 'b'.repeat(40) } }), {
     action: 'restart', reason: 'commit_outdated',
   })
+  assert.deepEqual(decideRuntimeAction({ ...current, sourceFingerprint: `snapshot:${target}:${'c'.repeat(64)}` }), {
+    action: 'restart', reason: 'source_outdated',
+  })
+  assert.deepEqual(decideRuntimeAction({ ...current, targetCommit: 'f'.repeat(40) }), {
+    action: 'restart', reason: 'commit_outdated',
+  })
+  assert.deepEqual(decideRuntimeAction({ ...current, sourceOrigin: `${sourceOrigin}-other-module` }), {
+    action: 'restart', reason: 'source_origin_outdated',
+  })
+  assert.deepEqual(decideRuntimeAction({ ...current, sourceOrigin: 'C:\\CODEXRUNTIME\\operator\\admin\\skincos\\source\\selected__atendimento' }), {
+    action: 'reuse', reason: 'current_runtime_ready',
+  })
+  assert.deepEqual(decideRuntimeAction({
+    ...current,
+    manifest: { ...current.manifest, sourceFingerprint: undefined },
+    buildState: { ...current.buildState, sourceFingerprint: undefined },
+    sourceFingerprint: `commit:${target}`,
+  }), { action: 'reuse', reason: 'current_runtime_ready' })
+  assert.deepEqual(decideRuntimeAction({
+    ...current,
+    manifest: { ...current.manifest, sourceFingerprint: undefined },
+    buildState: { ...current.buildState, sourceFingerprint: undefined },
+    sourceFingerprint: `snapshot:${target}:${'c'.repeat(64)}`,
+  }), { action: 'restart', reason: 'source_outdated' })
 })
 
 test('runtime policy starts missing state and waits for the same target build', () => {
@@ -98,13 +196,86 @@ test('runtime policy starts missing state and waits for the same target build', 
   }), { action: 'wait', reason: 'current_start_in_progress' })
 })
 
-test('launcher coordinates version checks before checkout and preserves dirty private worktrees', () => {
-  assert.match(launcher, /Get-CrmPersonaDecision -Persona \$Persona -TargetCommit \$TargetCommit/)
+test('launcher snapshots dirty worktrees and invalidates an outdated source fingerprint', () => {
+  assert.match(launcher, /Get-CrmLocalSourceSnapshot/)
+  assert.match(launcher, /Get-CrmLocalSnapshotUntrackedFiles/)
+  assert.match(launcher, /\[AllowEmptyCollection\(\)\]\[string\[\]\]\$Entries/)
+  assert.match(launcher, /Get-CrmLocalSnapshotRelativePath/)
+  assert.match(launcher, /diff --binary HEAD/)
+  assert.match(launcher, /StandardOutput\.BaseStream\.CopyTo/)
+  assert.match(launcher, /Ignorando checkout Git aninhado fora do snapshot do CRM Local/)
+  assert.match(launcher, /check-ignore --quiet/)
+  assert.match(launcher, /CRM_SOURCE_FINGERPRINT/)
+  assert.match(launcher, /Get-CrmPersonaDecision -Persona \$Persona -TargetCommit \$TargetCommit -SourceFingerprint \$snapshot\.Fingerprint/)
   assert.match(launcher, /Stop-CrmPersonaRuntime -Persona \$Persona/)
-  assert.match(launcher, /Sync-CrmLocalSourceRoot -Persona \$Persona -TargetCommit \$TargetCommit/)
+  assert.match(launcher, /Sync-CrmLocalSourceRoot -Persona \$Persona -TargetCommit \$TargetCommit -Snapshot \$snapshot/)
   assert.match(launcher, /Worktree privado com alterações preservado/)
   assert.match(launcher, /Ensure-CrmGestorForConsultor -TargetCommit \$targetCommit/)
   assert.match(launcher, /Start-CrmGestorBackgroundUpdate/)
+  assert.match(launcher, /snapshot:\$\{TargetCommit\}:\$\(Get-CrmLocalSnapshotHash/)
+})
+
+test('canonical CRM actions use origin/main only when no preview was explicitly selected', () => {
+  assert.match(launcher, /return "origin\/main"/)
+  assert.match(launcher, /git -C \$ProjectRoot fetch origin --prune --quiet/)
+  assert.match(launcher, /function Test-CrmLocalIncludeWorkingChanges/)
+  assert.match(launcher, /if \(-not \(Test-CrmLocalIncludeWorkingChanges\)\)/)
+  assert.match(launcher, /Fingerprint = "commit:\$\{TargetCommit\}"/)
+  assert.match(launcher, /A prévia ativa não deriva da revisão canônica solicitada/)
+})
+
+test('a named CRM preview is shared across actions but applied to the current canonical commit', () => {
+  assert.match(launcher, /CRM_LOCAL_PREVIEW_SOURCE_ROOT/)
+  assert.match(launcher, /active-source\.json/)
+  assert.match(launcher, /CRM_LOCAL_CLEAR_PREVIEW_SOURCE/)
+  assert.match(launcher, /if \(\$crmLocalPreviewSelected\) \{[\s\S]*return "HEAD"/)
+  assert.match(launcher, /merge-base --is-ancestor \$sourceCommit \$TargetCommit/)
+  assert.match(launcher, /A prévia ativa não deriva da revisão canônica solicitada/)
+})
+
+test('a selected preview persists its source and never silently substitutes local work with origin/main', () => {
+  assert.match(launcher, /crm-local\\active-source\.json/)
+  assert.match(launcher, /selectedBy = 'CRM_LOCAL_PREVIEW_SOURCE_ROOT'/)
+  assert.match(launcher, /\$ProjectRoot = \$previewSourceRoot/)
+  assert.match(launcher, /\$env:CRM_LOCAL_INCLUDE_WORKING_CHANGES = 'true'/)
+  assert.match(launcher, /if \(\$crmLocalPreviewSelected\)[\s\S]*return "HEAD"/)
+  assert.doesNotMatch(launcher, /git -C \$ProjectRoot reset --hard origin\/main/)
+})
+
+test('each CRM module materializes its own exact snapshot and cannot reuse a mismatched origin', () => {
+  assert.match(launcher, /Resolve-CrmLocalModuleSourceRoot/)
+  assert.match(launcher, /Sync-CrmLocalSourceRoot -Persona \$Persona -TargetCommit \$targetCommit -Snapshot \$snapshot/)
+  assert.match(launcher, /Get-CrmPersonaDecision -Persona Gestor -TargetCommit \$targetCommit -SourceFingerprint \$snapshot\.Fingerprint/)
+  assert.match(launcher, /-Module 'site-tracking'/)
+  assert.match(launcher, /-Module 'meta-ads'/)
+  assert.match(launcher, /-Module 'atendimento'/)
+  assert.match(launcher, /return "\{0\}__\{1\}" -f \$sourceRoot, \$Module\.Trim\(\)\.ToLowerInvariant\(\)/)
+  assert.match(runtimePolicy, /source_outdated/)
+  assert.match(runtimePolicy, /commit_outdated/)
+  assert.match(runtimePolicy, /source_origin_outdated/)
+})
+
+test('Atendimento runtime is detached from the invoking action but keeps the persisted source contract', () => {
+  assert.match(launcher, /function Start-CrmAtendimentoBackgroundUpdate/)
+  assert.match(launcher, /-CrmAtendimentoDetachedStart/)
+  assert.match(launcher, /-RedirectStandardOutput \$outLog -RedirectStandardError \$errLog/)
+  assert.match(launcher, /if \(-not \$CrmAtendimentoDetachedStart\)[\s\S]*Start-CrmAtendimentoBackgroundUpdate/)
+  assert.match(launcher, /\[int\[\]\]\$AcceptedExitCode = @\(0\)/)
+  assert.match(launcher, /CRM_OPEN_BROWSER=0/)
+  assert.match(launcher, /-AcceptedExitCode @\(0, 143\)/)
+  assert.match(launcher, /function Wait-CrmAtendimentoReady/)
+  assert.match(launcher, /Wait-CrmAtendimentoReady -TargetCommit \$targetCommit -SourceFingerprint \$snapshot\.Fingerprint -SourceOrigin \$sourceOrigin -TimeoutSeconds 600/)
+  assert.match(launcher, /previous manifest is intentionally retained/)
+  assert.match(launcher, /a 143 is only accepted here/)
+  assert.match(crmRunner, /wait "\$CRM_PID"/)
+  assert.match(launcher, /\$policyCommand = "node \{0\} --manifest \{1\} --build-state \{2\} --target \{3\} --source-fingerprint \{4\} --source-origin \{5\}/)
+  assert.match(launcher, /& wsl\.exe -d Ubuntu-24\.04 -- bash -lc \$policyCommand/)
+})
+
+test('all CRM module shortcuts select a current snapshot before launch', () => {
+  assert.match(launcher, /"CrmSiteEf"[\s\S]*Invoke-CrmPersonaAction -Persona Gestor -TargetCommit \$targetCommit/)
+  assert.match(launcher, /"CrmMetaAds"[\s\S]*Invoke-CrmPersonaAction -Persona Gestor -TargetCommit \$targetCommit/)
+  assert.match(launcher, /"CrmAtendimento"[\s\S]*Invoke-CrmAtendimentoAction/)
 })
 
 test('a concurrent launcher reports an active runtime with a reusable status', () => {
@@ -131,13 +302,15 @@ CRM_WITH_TIMEKEEPING=1 CRM_TIMEKEEPING_PORT=8801 CRM_WITH_WHATSAPP=1 CRM_WA_ORCH
 crm_persona_runtime_write_manifest ready`
   const result = spawnSync('bash', ['-c', body, 'bash', helper], {
     encoding: 'utf8',
-    env: { ...process.env, ROOT_DIR: root, CRM_RUNTIME_ROOT: temp, CRM_PERSONA: 'GESTOR', CRM_TARGET_COMMIT: target },
+    env: { ...process.env, ROOT_DIR: root, CRM_RUNTIME_ROOT: temp, CRM_PERSONA: 'GESTOR', CRM_TARGET_COMMIT: target, CRM_SOURCE_FINGERPRINT: `commit:${target}`, CRM_SOURCE_ORIGIN: 'test-origin__atendimento' },
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
   const manifest = JSON.parse(fs.readFileSync(path.join(temp, 'current.json'), 'utf8'))
   assert.equal(manifest.version, 2)
   assert.equal(manifest.targetCommit, target)
   assert.equal(manifest.buildCommit, built)
+  assert.equal(manifest.sourceFingerprint, `commit:${target}`)
+  assert.equal(manifest.sourceOrigin, 'test-origin__atendimento')
 })
 
 test('local smoke downgrades only the exact optional Google chart credential failure', () => {

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -264,6 +264,8 @@ test('Atendimento runtime is detached from the invoking action but keeps the per
   assert.match(launcher, /CRM_OPEN_BROWSER=0/)
   assert.match(launcher, /-AcceptedExitCode @\(0, 143\)/)
   assert.match(launcher, /function Wait-CrmAtendimentoReady/)
+  assert.match(launcher, /function Test-CrmSourceOriginEquivalent/)
+  assert.match(launcher, /Windows source roots are[\s\S]*module suffix and native paths must remain exact/)
   assert.match(launcher, /Wait-CrmAtendimentoReady -TargetCommit \$targetCommit -SourceFingerprint \$snapshot\.Fingerprint -SourceOrigin \$sourceOrigin -TimeoutSeconds 600/)
   assert.match(launcher, /previous manifest is intentionally retained/)
   assert.match(launcher, /a 143 is only accepted here/)


### PR DESCRIPTION
## Contexto
Corrige a proveniência e o ciclo de vida da prévia local do CRM sem substituir silenciosamente o trabalho selecionado por `origin/main`. Também consolida a experiência e os contratos do módulo Atendimento.

## Alterações
- persiste a origem ativa, fingerprint, commit e módulo para reutilização determinística;
- materializa snapshots em origem isolada e mantém o runtime vivo após o invocador;
- valida health gates autenticados pelo proxy do Pages, incluindo Atendimento;
- evita reutilização cruzada entre snapshots de Atendimento, Site e Meta Ads;
- preserva métricas diárias, fórmulas, tooltips compactos, ícones, seções recolhíveis e atualização do Atendimento.

## Validação local
- `node --test scripts/tests/crm-local-dual-persona.test.mjs` — 28/28;
- API Atendimento — 140 testes aprovados;
- Console — 186 testes em 37 arquivos, lint, typecheck e build aprovados;
- E2E Atendimento em `localhost:8791` — 5/5;
- proxy autenticado: endpoints de Atendimento retornam 200 por `:8791`; acesso direto ao adaptador retorna 401 como limite esperado.

## Reversão
Reverter os dois commits desta PR restaura o launcher e a UI anteriores. Referências locais de segurança foram preservadas até a validação pós-merge.