### PR TITLE
fix(website): retry post-deploy smoke propagation

### DIFF
--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -220,7 +220,17 @@ jobs:
       - name: Smoke test deployed website
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: website
-        run: npm run smoke
+        run: |
+          for attempt in $(seq 1 6); do
+            if npm run smoke; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 6 ]; then
+              echo "Smoke not yet reachable after deploy; retrying (${attempt}/6) in 10 seconds."
+              sleep 10
+            fi
+          done
+          exit 1
         env:
           SMOKE_AGENDA_TOKEN: ${{ inputs.target == 'production' && secrets.AGENDA_SYNC_TOKEN || '' }}
           SMOKE_BASE_URL: ${{ inputs.target == 'staging' && 'https://espacofacial-site-staging.skincos.workers.dev' || 'https://espacofacial.com' }}


### PR DESCRIPTION
## Summary
- retries the existing website smoke validation for up to one minute after deployment
- keeps the full smoke suite mandatory; only accommodates Workers global propagation

## Evidence
The isolated staging Worker served the expected build SHA and all checked routes immediately after the failed one-shot smoke, proving a propagation race rather than an application failure.

## Validation
- workflow YAML parse with `js-yaml`
- `git diff --check`