### PR TITLE
fix(crm): detach Gestor local runtime

### DIFF
--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -61,7 +61,8 @@ param(
     )]
     [string]$Action,
     [string]$ProjectRoot,
-    [switch]$CrmAtendimentoDetachedStart
+    [switch]$CrmAtendimentoDetachedStart,
+    [switch]$CrmLocalDetachedStart
 )
 
 $ErrorActionPreference = "Stop"
@@ -1115,7 +1116,8 @@ function Start-CrmGestorBackgroundUpdate {
     $errLog = Join-Path $logRoot "crm-local-gestor-action.err.log"
     $arguments = @(
         '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath,
-        '-Action', 'CrmLocal', '-ProjectRoot', $ProjectRoot
+        '-Action', 'CrmLocal', '-ProjectRoot', $ProjectRoot,
+        '-CrmLocalDetachedStart'
     )
     $previousReviewRef = $env:CRM_LOCAL_REVIEW_REF
     try {
@@ -1125,7 +1127,7 @@ function Start-CrmGestorBackgroundUpdate {
     } finally {
         $env:CRM_LOCAL_REVIEW_REF = $previousReviewRef
     }
-    Write-Host "[crm-consultor] Atualização do Gestor iniciada em segundo plano para $TargetCommit."
+    Write-Host "[crm-local] Inicialização persistente do Gestor iniciada em segundo plano para $TargetCommit."
 }
 
 function Ensure-CrmGestorForConsultor {
@@ -1233,6 +1235,15 @@ function Invoke-ShortcutActionInternal {
         "WebsiteSiteCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:check" }
         "WebsiteReleaseCheck" { Invoke-ShortcutWsl -Command "npm run codex:site:release-check" }
         "CrmLocal" {
+            # run-local-crm keeps the process group alive while it supervises
+            # Pages and its dependencies.  The user-facing shortcut must hand
+            # that group to a hidden PowerShell child; otherwise closing the
+            # invoking terminal tears down a healthy Gestor preview.
+            if (-not $CrmLocalDetachedStart) {
+                $targetCommit = Get-CrmLocalTargetCommit
+                Start-CrmGestorBackgroundUpdate -TargetCommit $targetCommit
+                return
+            }
             Stop-LegacyCrmRuntimeIfNeeded
             $targetCommit = Get-CrmLocalTargetCommit
             Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -255,7 +255,11 @@ test('each CRM module materializes its own exact snapshot and cannot reuse a mis
   assert.match(runtimePolicy, /source_origin_outdated/)
 })
 
-test('Atendimento runtime is detached from the invoking action but keeps the persisted source contract', () => {
+test('Gestor and Atendimento runtimes detach from the invoking action and keep the persisted source contract', () => {
+  assert.match(launcher, /\[switch\]\$CrmLocalDetachedStart/)
+  assert.match(launcher, /function Start-CrmGestorBackgroundUpdate/)
+  assert.match(launcher, /'-CrmLocalDetachedStart'/)
+  assert.match(launcher, /"CrmLocal"\s*\{[\s\S]*if \(-not \$CrmLocalDetachedStart\)[\s\S]*Start-CrmGestorBackgroundUpdate/)
   assert.match(launcher, /function Start-CrmAtendimentoBackgroundUpdate/)
   assert.match(launcher, /-CrmAtendimentoDetachedStart/)
   assert.match(launcher, /-RedirectStandardOutput \$outLog -RedirectStandardError \$errLog/)


### PR DESCRIPTION
## Correção

O atalho CRM Local do Gestor invocava un-local-crm.sh em primeiro plano. Como o supervisor termina com wait no Pages, o processo do invocador nunca devolvia o controle e permanecia dono da sessão WSL.

Ação externa agora cria um PowerShell oculto e persistente; a reentrada interna, identificada por -CrmLocalDetachedStart, executa o launcher apenas uma vez. Isso preserva a origem/fingerprint selecionados e evita recursão quando o Consultor precisa atualizar o Gestor.

## Validação

- parser PowerShell aprovado;
- 
ode --test scripts/tests/crm-local-dual-persona.test.mjs — 28/28;
- chamada de reuso do CrmLocal encerrou em 0,67s com saída 0, mantendo o runtime saudável.