### PR TITLE
fix(livia): fail closed for every carousel medium

### DIFF
--- a/docs/runbooks/livia-isolated-promotion.md
+++ b/docs/runbooks/livia-isolated-promotion.md
@@ -30,7 +30,22 @@ scripts/runtime/prepare-native-source-release.sh \
 O comando valida o construtor, a matriz offline e os entrypoints antes de criar
 `/opt/skincos/releases/$SKINCOS_RELEASE_ID/source`; ele não muda
 `/opt/skincos/current/source`. Em seguida, gere o manifesto da versão
-candidata e publique exclusivamente pela transação versionada:
+candidata pelo construtor único e valide o grafo produzido. Não aplique patches
+isolados manualmente: o construtor inclui, como unidade atômica de candidato,
+as marcas Drive por fonte, o preflight do Token Vault, o contrato de alt text,
+o contrato de carrossel Facebook e o pin/runtime semanticamente idempotente.
+
+```bash
+sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/prepare-livia-production-candidate.js \
+  --input /var/tmp/livia-live-export.json \
+  --output /var/tmp/livia-candidate.json \
+  --release-root /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine
+sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/validate-livia-workflow.js \
+  /var/tmp/livia-candidate.json
+```
+
+Somente então gere o manifesto da versão candidata e publique exclusivamente
+pela transação versionada:
 
 ```bash
 sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/workflow-runtime-manifest.js \

--- a/orb/engine/compose2-current.js
+++ b/orb/engine/compose2-current.js
@@ -703,8 +703,12 @@ function extractFromLivia(liviaNorm, idx, warnings) {
 // --------------------------
 // BUILDERS DE REQUESTS
 // --------------------------
-const ALLOW_IG_ALT_TEXT_ON_CAROUSEL_ITEMS = false;
-const ALLOW_THREADS_ALT_TEXT_ON_CAROUSEL_ITEMS = false;
+// Accessibility is a per-media contract.  Instagram image containers and
+// Threads image/video containers (including carousel children) accept
+// alt_text.  Instagram video/Reel containers intentionally remain unsupported
+// and are normalized by the versioned job-graph guard before the gateway.
+const ALLOW_IG_ALT_TEXT_ON_CAROUSEL_ITEMS = true;
+const ALLOW_THREADS_ALT_TEXT_ON_CAROUSEL_ITEMS = true;
 
 function buildUploadBodyInstagram({ isVideo, isCarouselItem, url, media_type, caption, alt_text, bestFrameSeconds, selectedFrameUrl }) {
   const body = {};
@@ -874,6 +878,25 @@ function assertPlatformPhaseIntegrity(results) {
 
       if (platform === "facebook" && pub.facebookPublishMode === "feed" && !Array.isArray(pub.attachedMediaFromPublishRunIndexes)) {
         throw new Error(`Compose (2): publish facebook/feed sem attachedMediaFromPublishRunIndexes para groupKey=${groupKey}, unit=${unit}`);
+      }
+
+      if (platform === "facebook" && pub.facebookPublishMode === "feed") {
+        const sourceMediaIds = Array.isArray(pub.sourceMediaIds) ? pub.sourceMediaIds.map(value => str(value, "")).filter(Boolean) : [];
+        const expectedCount = Number(pub.sourceMediaCount || 0);
+        const attachmentRuns = pub.attachedMediaFromPublishRunIndexes || [];
+        if (!expectedCount || sourceMediaIds.length !== expectedCount || attachmentRuns.length !== expectedCount) {
+          throw new Error(`Compose (2): contrato Facebook/feed incompleto para groupKey=${groupKey}, unit=${unit}; expected=${expectedCount}, sources=${sourceMediaIds.length}, attachments=${attachmentRuns.length}`);
+        }
+        if (new Set(sourceMediaIds).size !== sourceMediaIds.length || new Set(attachmentRuns).size !== attachmentRuns.length) {
+          throw new Error(`Compose (2): contrato Facebook/feed duplicado para groupKey=${groupKey}, unit=${unit}.`);
+        }
+        const attachmentSourceIds = attachmentRuns.map(runIndex => {
+          const source = rows.find(row => Number(row.publishRunIndex) === Number(runIndex));
+          return str(source && source.media && source.media.id, "");
+        });
+        if (attachmentSourceIds.some(value => !value) || attachmentSourceIds.join("|") !== sourceMediaIds.join("|")) {
+          throw new Error(`Compose (2): Facebook/feed não preservou a identidade/ordem de cada mídia em groupKey=${groupKey}, unit=${unit}.`);
+        }
       }
 
       if (pub.checkStatusFromPublishRunIndex === undefined || pub.checkStatusFromPublishRunIndex === null) {
@@ -1063,11 +1086,13 @@ for (const group of groups) {
       const baseUrlAccount = `https://graph.${network}/${version}/${accountId}/`;
 
       const uploadRunIndexes = [];
+      // A Page Reel represents exactly one source video. A group with more
+      // than one source asset must remain on the unpublished-media + feed
+      // path, otherwise the first item can silently replace later children.
+      const facebookUseReels = platform === "facebook" && firstIsVideo && !isCarouselGroup;
 
-      if (platform === "facebook" && firstIsVideo) {
+      if (facebookUseReels) {
         facebookPublishMode = "reels";
-
-        if (isCarouselGroup) pushUnique(warnings, "facebook.reels: grupo com múltiplos arquivos; usando apenas o 1º vídeo");
 
         const firstIndex = groupItems[0].index;
         const c2 = groupItems[0].c2 || {};
@@ -1112,6 +1137,8 @@ for (const group of groups) {
               id: c2.id,
               name: c2.name,
               mimeType: c2.mimeType,
+              sourceMediaKind: "video",
+              groupOrder: Number(c2.groupOrder ?? 0),
               size: c2.size,
               webContentLink: c2.webContentLink || null,
               finalUrl,
@@ -1151,6 +1178,8 @@ for (const group of groups) {
               id: c2.id,
               name: c2.name,
               mimeType: c2.mimeType,
+              sourceMediaKind: "video",
+              groupOrder: Number(c2.groupOrder ?? 0),
               size: c2.size,
               webContentLink: c2.webContentLink || null,
               finalUrl,
@@ -1262,21 +1291,20 @@ for (const group of groups) {
           }
 
           if (platform === "facebook") {
-            if (isVideo) {
-              pushUnique(fileWarnings, "facebook: vídeo detectado em grupo não-reels; ignorado (use fluxo reels)");
-              continue;
-            }
-
             const endpoint1 = str(fbObj.endpoint_1st, "").trim();
             const edge = str(c2.edge, "").trim();
-            const chosen = endpoint1 || edge || "photos";
+            const chosen = isVideo ? "videos" : (endpoint1 || edge || "photos");
 
             url = baseUrlAccount + chosen;
 
             const fbCaptionPublish = str(capsHere.fbCaption, "") || str(globalCaptions.fbCaption, "");
 
-            // Upload da foto sem duplicar copy.
-            body = buildUploadBodyFacebookPhotos({ url: finalUrl, caption: "" });
+            // Carousel children remain unpublished until the one feed request
+            // attaches every returned media_fbid. This keeps a later child
+            // failure from becoming a partial public post.
+            body = isVideo
+              ? { ...buildUploadBodyFacebookVideos({ url: finalUrl, caption: "", selectedFrameUrl: selectedFrameUrlResolved }), published: false }
+              : buildUploadBodyFacebookPhotos({ url: finalUrl, caption: "" });
 
             textMeta = {
               caption: fbCaptionPublish,
@@ -1313,6 +1341,8 @@ for (const group of groups) {
                 id: c2.id,
                 name: c2.name,
                 mimeType: c2.mimeType,
+                sourceMediaKind: isVideo ? "video" : "image",
+                groupOrder: Number(c2.groupOrder ?? localIdx),
                 size: c2.size,
                 webContentLink: c2.webContentLink || null,
                 finalUrl,
@@ -1392,7 +1422,7 @@ for (const group of groups) {
           statusFromPublishRunIndex = isCarouselGroup ? containerRunIndex : lastUploadRun;
           checkFields = "status";
           checkKind = "th_creation";
-        } else if (isFb && firstIsVideo) {
+        } else if (isFb && facebookUseReels) {
           statusFromPublishRunIndex = uploadRunIndexes[0] ?? null;
           checkFields = "status";
           checkKind = "fb_reels_video";
@@ -1461,7 +1491,7 @@ for (const group of groups) {
         let dependency = null;
 
         if (isFb) {
-          if (firstIsVideo) {
+          if (facebookUseReels) {
             facebookPublishMode = "reels";
             url = baseUrlAccount + "video_reels";
             jsonRequest = {};
@@ -1502,7 +1532,7 @@ for (const group of groups) {
           unit: unitKey,
           platform,
           phase: "publish",
-          step: (isFb && firstIsVideo) ? "reels_finish" : "default_publish",
+          step: (isFb && facebookUseReels) ? "reels_finish" : "default_publish",
           index: 0,
           method: "POST",
           url,
@@ -1523,7 +1553,9 @@ for (const group of groups) {
           attachedMediaFromPublishRunIndexes: (isFb && facebookPublishMode !== "reels")
             ? uploadRunIndexes
             : undefined,
-          reelsStartFromPublishRunIndex: (isFb && firstIsVideo) ? uploadRunIndexes[0] : undefined,
+          sourceMediaIds: isFb ? groupItems.map(({ c2 }) => str(c2.id, "")).filter(Boolean) : undefined,
+          sourceMediaCount: isFb ? groupItems.length : undefined,
+          reelsStartFromPublishRunIndex: (isFb && facebookUseReels) ? uploadRunIndexes[0] : undefined,
           scheduleUnix: (isIg && schedule.shouldSchedule) ? schedule.unix : undefined,
           checkStatusFromPublishRunIndex: checkStatusRunIndex,
         };

--- a/orb/engine/package.json
+++ b/orb/engine/package.json
@@ -49,7 +49,7 @@
         "service:backup": "sudo -n bash scripts/backup-n8n.sh",
         "livia:qa:inspect": "node scripts/livia/qa-runner.js inspect",
         "livia:qa:audit": "node scripts/livia/qa-runner.js audit",
-        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js tests/livia-drive-publication-marks.test.js tests/livia-accessibility-contract.test.js && bash scripts/test-livia-qa-runner-safety.sh",
+        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js tests/livia-drive-publication-marks.test.js tests/livia-accessibility-contract.test.js tests/livia-production-candidate.test.js && bash scripts/test-livia-qa-runner-safety.sh",
         "livia:qa:validate": "node scripts/livia/qa-runner.js validate",
         "livia:qa:replay-process-media": "node scripts/livia/qa-runner.js replay-process-media",
         "livia:qa:replay-build-graph": "node scripts/livia/qa-runner.js replay-build-graph",

--- a/orb/engine/package.json
+++ b/orb/engine/package.json
@@ -49,6 +49,7 @@
         "service:backup": "sudo -n bash scripts/backup-n8n.sh",
         "livia:qa:inspect": "node scripts/livia/qa-runner.js inspect",
         "livia:qa:audit": "node scripts/livia/qa-runner.js audit",
+        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js && bash scripts/test-livia-qa-runner-safety.sh",
         "livia:qa:validate": "node scripts/livia/qa-runner.js validate",
         "livia:qa:replay-process-media": "node scripts/livia/qa-runner.js replay-process-media",
         "livia:qa:replay-build-graph": "node scripts/livia/qa-runner.js replay-build-graph",

--- a/orb/engine/package.json
+++ b/orb/engine/package.json
@@ -49,7 +49,7 @@
         "service:backup": "sudo -n bash scripts/backup-n8n.sh",
         "livia:qa:inspect": "node scripts/livia/qa-runner.js inspect",
         "livia:qa:audit": "node scripts/livia/qa-runner.js audit",
-        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js tests/livia-drive-publication-marks.test.js && bash scripts/test-livia-qa-runner-safety.sh",
+        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js tests/livia-drive-publication-marks.test.js tests/livia-accessibility-contract.test.js && bash scripts/test-livia-qa-runner-safety.sh",
         "livia:qa:validate": "node scripts/livia/qa-runner.js validate",
         "livia:qa:replay-process-media": "node scripts/livia/qa-runner.js replay-process-media",
         "livia:qa:replay-build-graph": "node scripts/livia/qa-runner.js replay-build-graph",

--- a/orb/engine/package.json
+++ b/orb/engine/package.json
@@ -49,7 +49,7 @@
         "service:backup": "sudo -n bash scripts/backup-n8n.sh",
         "livia:qa:inspect": "node scripts/livia/qa-runner.js inspect",
         "livia:qa:audit": "node scripts/livia/qa-runner.js audit",
-        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js && bash scripts/test-livia-qa-runner-safety.sh",
+        "livia:qa:test": "node --test tests/livia-qa-runner.test.js tests/livia-validate-publish-token-health.test.js tests/livia-token-vault-preflight-patch.test.js tests/livia-drive-publication-marks.test.js && bash scripts/test-livia-qa-runner-safety.sh",
         "livia:qa:validate": "node scripts/livia/qa-runner.js validate",
         "livia:qa:replay-process-media": "node scripts/livia/qa-runner.js replay-process-media",
         "livia:qa:replay-build-graph": "node scripts/livia/qa-runner.js replay-build-graph",

--- a/orb/engine/scripts/livia/build-platform-job-graph.js
+++ b/orb/engine/scripts/livia/build-platform-job-graph.js
@@ -311,6 +311,125 @@ function contractPayload(name, kinds) {
   };
 }
 
+function requestBodies(job) {
+  return [
+    asObject(job?.jsonRequest),
+    asObject(job?.requestBody),
+    asObject(asObject(job?.httpRequest).body),
+    asObject(asObject(job?.httpRequest).json),
+  ].filter((body) => Object.keys(body).length);
+}
+
+function altTextValue(body) {
+  for (const key of ['alt_text', 'altText', 'alt_text_custom']) {
+    const value = body?.[key];
+    if (value !== undefined && value !== null && String(value).trim()) return String(value).trim();
+  }
+  return '';
+}
+
+// Only upload jobs that carry a concrete media URL are media accessibility
+// obligations.  Carousel/container publish jobs intentionally have no alt text
+// of their own; their ordered children carry the evidence.
+function mediaUploadDescriptor(job) {
+  if (String(job?.phase || '').trim().toLowerCase() !== 'upload') return null;
+  const platform = String(job?.platform || '').trim().toLowerCase();
+  const step = String(job?.step || '').trim().toLowerCase();
+  for (const body of requestBodies(job)) {
+    const mediaType = String(body.media_type || body.mediaType || '').trim().toUpperCase();
+    if (body.video_url || body.file_url) return { platform, mediaKind: 'video', body };
+    if (body.image_url || (platform === 'facebook' && body.url)) return { platform, mediaKind: 'image', body };
+    if (mediaType === 'CAROUSEL') continue;
+  }
+  // Facebook Reels begin with a session-start job and upload the binary to its
+  // returned URL.  That session-start job is the single semantic media record
+  // for an otherwise body-less, explicitly unsupported accessibility contract.
+  if (platform === 'facebook' && step === 'reels_start') {
+    return { platform, mediaKind: 'video', body: null, virtual: true };
+  }
+  return null;
+}
+
+function accessibilitySupport(platform, mediaKind) {
+  if (platform === 'facebook') return 'unsupported';
+  if (platform === 'instagram' && mediaKind === 'video') return 'unsupported';
+  if ((platform === 'instagram' || platform === 'threads') && (mediaKind === 'image' || mediaKind === 'video')) return 'required';
+  return 'unsupported';
+}
+
+function assertComposeAccessibility(jobs, scenario, kinds) {
+  for (const platform of ['instagram', 'facebook', 'threads']) {
+    const descriptors = jobs
+      .filter((job) => String(job?.platform || '').trim().toLowerCase() === platform)
+      .map((job) => ({ job, descriptor: mediaUploadDescriptor(job) }))
+      .filter((entry) => entry.descriptor);
+    if (descriptors.length < kinds.length * 2) {
+      fail(`${NODE_NAME}: ${scenario} fixture did not create every ${platform} media upload (expected at least ${kinds.length * 2}, got ${descriptors.length}).`);
+    }
+    for (const { descriptor } of descriptors) {
+      const support = accessibilitySupport(platform, descriptor.mediaKind);
+      const submitted = altTextValue(descriptor.body || {});
+      if (support === 'required' && !submitted) {
+        fail(`${NODE_NAME}: ${scenario} fixture lost required alt_text for ${platform}/${descriptor.mediaKind} before the gateway.`);
+      }
+      if (support === 'unsupported' && submitted) {
+        fail(`${NODE_NAME}: ${scenario} fixture sent alt_text to unsupported ${platform}/${descriptor.mediaKind}.`);
+      }
+    }
+  }
+}
+
+// A Page Reel is a single-video surface.  For a carousel, the only accepted
+// Facebook representation is one feed publication with one unpublished upload
+// for every ordered source asset.  This assertion deliberately rejects both
+// historic failure modes: using just the first video and silently dropping a
+// video after an image.
+function assertFacebookCarouselRepresentation(jobs, scenario, kinds) {
+  for (const unit of ['bss', 'nh']) {
+    const rows = jobs.filter((job) =>
+      String(job?.platform || '').trim().toLowerCase() === 'facebook' &&
+      normalizeUnit(job?.unit) === unit,
+    );
+    const publish = rows.find((job) => String(job?.phase || '').trim().toLowerCase() === 'publish');
+    if (!publish) fail(`${NODE_NAME}: ${scenario} fixture omitted Facebook publish for ${unit}.`);
+
+    if (kinds.length === 1 && kinds[0] === 'video') {
+      const starts = rows.filter((job) => String(job?.step || '').trim().toLowerCase() === 'reels_start');
+      if (starts.length !== 1 || String(publish.facebookPublishMode || '').toLowerCase() !== 'reels') {
+        fail(`${NODE_NAME}: ${scenario} fixture must use exactly one Facebook Reel chain for ${unit}.`);
+      }
+      continue;
+    }
+
+    const uploads = rows.filter((job) =>
+      String(job?.phase || '').trim().toLowerCase() === 'upload' &&
+      String(job?.step || '').trim().toLowerCase() === 'default_upload',
+    );
+    if (rows.some((job) => String(job?.step || '').trim().toLowerCase().startsWith('reels_'))) {
+      fail(`${NODE_NAME}: ${scenario} fixture must not replace a Facebook carousel with a Reel for ${unit}.`);
+    }
+    if (uploads.length !== kinds.length) {
+      fail(`${NODE_NAME}: ${scenario} fixture did not retain every Facebook carousel child for ${unit} (expected ${kinds.length}, got ${uploads.length}).`);
+    }
+    const actualKinds = uploads.map((job) => String(job?.media?.sourceMediaKind || '').trim().toLowerCase());
+    if (actualKinds.join('|') !== kinds.join('|')) {
+      fail(`${NODE_NAME}: ${scenario} fixture changed Facebook carousel media order/kinds for ${unit}.`);
+    }
+    const sourceIds = uploads.map((job) => String(job?.media?.id || '').trim());
+    if (sourceIds.some((id) => !id) || new Set(sourceIds).size !== sourceIds.length) {
+      fail(`${NODE_NAME}: ${scenario} fixture lost Facebook carousel source identity for ${unit}.`);
+    }
+    if (String(publish.facebookPublishMode || '').toLowerCase() !== 'feed' ||
+        String(publish?.dependency?.fieldName || '') !== 'attached_media' ||
+        !Array.isArray(publish.attachedMediaFromPublishRunIndexes) ||
+        publish.attachedMediaFromPublishRunIndexes.length !== kinds.length ||
+        Number(publish.sourceMediaCount) !== kinds.length ||
+        !Array.isArray(publish.sourceMediaIds) || publish.sourceMediaIds.join('|') !== sourceIds.join('|')) {
+      fail(`${NODE_NAME}: ${scenario} fixture has an incomplete Facebook feed attachment contract for ${unit}.`);
+    }
+  }
+}
+
 function assertJobGraphContracts(jsCode) {
   const scenarios = [
     ['single-image', ['image']],
@@ -331,6 +450,8 @@ function assertJobGraphContracts(jsCode) {
     for (const platform of ['instagram', 'facebook', 'threads']) {
       if (!platforms.has(platform)) fail(`${NODE_NAME}: ${name} fixture omitted ${platform}.`);
     }
+    assertComposeAccessibility(jobs, name, kinds);
+    assertFacebookCarouselRepresentation(jobs, name, kinds);
     results.push({ name, mediaKinds: kinds, jobCount: jobs.length });
   }
   return results;
@@ -874,22 +995,17 @@ function assertFrameSelectionContracts() {
 function applyPlatformAccessibilityContract(job) {
   const current = { ...job };
   const platform = String(current.platform || '').trim().toLowerCase();
-  if (platform !== 'instagram' && platform !== 'threads') return current;
-
-  const bodies = [
-    asObject(current.jsonRequest),
-    asObject(current.requestBody),
-    asObject(asObject(current.httpRequest).body),
-    asObject(asObject(current.httpRequest).json),
-  ];
-  const mediaSignals = [
-    current.mediaKind,
-    current.mediaType,
-    current.media_type,
-    asObject(current.media).mediaKind,
-    ...bodies.map((body) => body.media_type),
-  ].map((value) => String(value || '').toUpperCase()).join(' ');
-  if (!mediaSignals.includes('VIDEO') && !mediaSignals.includes('REEL')) return current;
+  if (!['instagram', 'facebook', 'threads'].includes(platform)) return current;
+  const descriptor = mediaUploadDescriptor(current);
+  if (!descriptor) return current;
+  const support = accessibilitySupport(platform, descriptor.mediaKind);
+  const bodies = requestBodies(current).filter((body) => {
+    if (descriptor.mediaKind === 'video') return Boolean(body.video_url || body.file_url);
+    return Boolean(body.image_url || (platform === 'facebook' && body.url));
+  });
+  if (!bodies.length && !(descriptor.virtual && support === 'unsupported')) {
+    fail(`${NODE_NAME}: ${platform}/${descriptor.mediaKind} upload has no concrete request body.`);
+  }
 
   const warningSet = new Set(asArray(current.warnings).map((entry) => String(entry)).filter(Boolean));
   let removed = false;
@@ -905,6 +1021,22 @@ function applyPlatformAccessibilityContract(job) {
     return out;
   };
 
+  const text = { ...asObject(current.text) };
+  if (support === 'required') {
+    const submitted = bodies.map((body) => altTextValue(body));
+    if (submitted.some((value) => !value)) {
+      fail(`${NODE_NAME}: required alt_text is missing for ${platform}/${descriptor.mediaKind}; refusing gateway publication.`);
+    }
+    if (new Set(submitted).size !== 1) {
+      fail(`${NODE_NAME}: conflicting alt_text values for one ${platform}/${descriptor.mediaKind} upload.`);
+    }
+    text.accessibilityStatus = 'submitted';
+    text.accessibilityReason = `${platform}_${descriptor.mediaKind}_alt_text_submitted`;
+    current.text = removeNulls(text);
+    current.warnings = [...warningSet];
+    return current;
+  }
+
   current.jsonRequest = scrubAltText(current.jsonRequest);
   current.requestBody = scrubAltText(current.requestBody);
   if (current.httpRequest && typeof current.httpRequest === 'object') {
@@ -914,13 +1046,59 @@ function applyPlatformAccessibilityContract(job) {
       json: scrubAltText(current.httpRequest.json),
     };
   }
-  const text = { ...asObject(current.text) };
   text.accessibilityStatus = 'unsupported';
-  text.accessibilityReason = `${platform}_video_alt_text_not_supported`;
+  text.accessibilityReason = platform === 'facebook'
+    ? `facebook_${descriptor.mediaKind}_alt_text_not_available_in_current_flow`
+    : `${platform}_${descriptor.mediaKind}_alt_text_not_supported`;
   current.text = removeNulls(text);
-  if (removed) warningSet.add(`alt_text_omitted_for_video:${platform}`);
+  if (removed) warningSet.add(`alt_text_omitted_for_unsupported_${platform}_${descriptor.mediaKind}`);
   current.warnings = [...warningSet];
   return current;
+}
+
+function assertAccessibilityContracts() {
+  const instagramImage = applyPlatformAccessibilityContract({
+    platform: 'instagram', phase: 'upload',
+    jsonRequest: { image_url: 'https://example.invalid/image.jpg', alt_text: 'Imagem verificada' },
+    text: { alt_text: 'Imagem verificada' },
+  });
+  if (instagramImage.text?.accessibilityStatus !== 'submitted' || instagramImage.jsonRequest?.alt_text !== 'Imagem verificada') {
+    fail(`${NODE_NAME}: Instagram image accessibility contract was not preserved.`);
+  }
+
+  const threadsVideo = applyPlatformAccessibilityContract({
+    platform: 'threads', phase: 'upload',
+    jsonRequest: { video_url: 'https://example.invalid/video.mp4', media_type: 'VIDEO', alt_text: 'Vídeo verificado' },
+    text: { alt_text: 'Vídeo verificado' },
+  });
+  if (threadsVideo.text?.accessibilityStatus !== 'submitted' || threadsVideo.jsonRequest?.alt_text !== 'Vídeo verificado') {
+    fail(`${NODE_NAME}: Threads video accessibility contract was not preserved.`);
+  }
+
+  const instagramVideo = applyPlatformAccessibilityContract({
+    platform: 'instagram', phase: 'upload',
+    jsonRequest: { video_url: 'https://example.invalid/video.mp4', media_type: 'REELS', alt_text: 'Não enviar' },
+    text: { alt_text: 'Evidência editorial preservada' },
+  });
+  if (instagramVideo.text?.accessibilityStatus !== 'unsupported' || instagramVideo.jsonRequest?.alt_text) {
+    fail(`${NODE_NAME}: Instagram video accessibility contract was not normalized explicitly.`);
+  }
+
+  const facebookImage = applyPlatformAccessibilityContract({
+    platform: 'facebook', phase: 'upload',
+    jsonRequest: { url: 'https://example.invalid/photo.jpg', alt_text_custom: 'Não enviar' },
+    text: { alt_text: 'Evidência editorial preservada' },
+  });
+  if (facebookImage.text?.accessibilityStatus !== 'unsupported' || facebookImage.jsonRequest?.alt_text_custom) {
+    fail(`${NODE_NAME}: Facebook current-flow accessibility limitation was not explicit.`);
+  }
+
+  return {
+    instagramImage: 'submitted',
+    threadsVideo: 'submitted',
+    instagramVideo: 'unsupported',
+    facebookImage: 'unsupported',
+  };
 }
 
 function normalizeFacebookGraphUrl(value, warnings, credential) {
@@ -1247,6 +1425,7 @@ function main() {
     process.stdout.write(JSON.stringify({
       ok: true,
       jobGraphContracts: assertJobGraphContracts(source.jsCode),
+      accessibilityContracts: assertAccessibilityContracts(),
       frameSelectionContracts: assertFrameSelectionContracts(),
       resumeIdentityContracts: assertResumeIdentityContracts(),
     }));

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -3,17 +3,23 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
 const { parse } = require('/usr/local/lib/node_modules/n8n/node_modules/flatted');
 const runtimePaths = require('../lib/runtime-paths');
 
 const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
-const WORKFLOW_PATH = path.join(runtimePaths.workflowsDir, 'livia.active.json');
 const PROCESS_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'process-media-asset.js');
 const BUILD_GRAPH_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'build-platform-job-graph.js');
 const VERIFY_PUBLISHED_ARTIFACTS_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'verify-published-artifacts.js');
 const PUBLISH_PROGRESS_LEDGER_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'publish-progress-ledger.js');
+const VALIDATE_PUBLISH_TOKEN_HEALTH_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'validate-publish-token-health.js');
+const VERIFIER_ENV_KEYS = new Set(['TOKEN_VAULT_BASE_URL', 'TOKEN_VAULT_N8N_API_TOKEN']);
+const VERIFIER_ENV_FILES = [
+  '/etc/skincos/orb-business.env',
+  path.join(runtimePaths.runtimeHome, 'env', 'n8n-business.env'),
+];
 
 function parseProcessMediaOutput(run) {
   const raw = String(run?.data?.main?.[0]?.[0]?.json?.stdout || '').trim();
@@ -167,6 +173,39 @@ function readRuntimePhone() {
   return line ? line.split('=').slice(1).join('').replace(/\D/g, '') : '';
 }
 
+function readSelectedEnvironmentFile(filePath, allowedKeys = VERIFIER_ENV_KEYS) {
+  if (!fs.existsSync(filePath)) return {};
+  const result = {};
+  for (const rawLine of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.replace(/^\uFEFF/, '');
+    if (!line || line.trimStart().startsWith('#')) continue;
+    const separator = line.indexOf('=');
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim();
+    if (!allowedKeys.has(key)) continue;
+    const value = line.slice(separator + 1).trim();
+    if (value) result[key] = value;
+  }
+  return result;
+}
+
+function verifierEnvironment({ envFiles = VERIFIER_ENV_FILES, inherited = process.env } = {}) {
+  const result = {};
+  for (const envFile of envFiles) Object.assign(result, readSelectedEnvironmentFile(envFile));
+  for (const key of VERIFIER_ENV_KEYS) {
+    if (String(inherited[key] || '').trim()) result[key] = inherited[key];
+  }
+  return result;
+}
+
+function notificationForExecution(runData) {
+  for (const nodeName of ['Inform Success (2)', 'Inform Success (1)']) {
+    const notification = executionItems(runData, nodeName)[0]?.json || {};
+    if (Object.keys(notification).length) return { nodeName, notification };
+  }
+  return { nodeName: '', notification: {} };
+}
+
 function auditExecution(executionId) {
   const summary = summarizeExecution(executionId);
   const execution = loadExecutionEntity(executionId);
@@ -177,7 +216,11 @@ function auditExecution(executionId) {
     final: { publishVerification: { targets } },
     tokenRoot,
     tokenOverrides,
-  })], { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });
+  })], {
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+    env: verifierEnvironment(),
+  });
   let verificationResult = {};
   try {
     verificationResult = JSON.parse(verification.stdout || '{}');
@@ -188,9 +231,15 @@ function auditExecution(executionId) {
   const processMedia = parseProcessMediaOutput((runData['Process Media Asset'] || [])[0]);
   const final = executionItems(runData, 'Collect Publish Results')[0]?.json || {};
   const drive = executionItems(runData, 'Update File')[0]?.json || {};
-  const notification = executionItems(runData, 'Inform Success (1)')[0]?.json || {};
+  const { nodeName: notificationNode, notification } = notificationForExecution(runData);
   const runtimePhone = readRuntimePhone();
   const destination = String(notification?.data?.key?.remoteJid || '').replace(/\D/g, '');
+  const telegramDelivered = notificationNode === 'Inform Success (2)'
+    && notification?.ok === true
+    && Boolean(notification?.result?.message_id);
+  const legacyState = String(notification?.data?.status || '').toLowerCase() === 'pending'
+    ? 'queued'
+    : String(notification?.data?.status || '') || 'unconfirmed';
   const deprecations = jobs
     .flatMap((job) => Object.values(job.response?.headers || {}))
     .filter((value) => /deprecated|auto-upgraded/i.test(String(value)));
@@ -250,8 +299,9 @@ function auditExecution(executionId) {
       state: String(drive.appProperties?.published || drive.properties?.published || '').toLowerCase() === 'true' ? 'verified' : 'unconfirmed',
     },
     notification: {
-      state: String(notification?.data?.status || '').toLowerCase() === 'pending' ? 'queued' : String(notification?.data?.status || '') || 'unconfirmed',
-      destinationMatchesRuntime: Boolean(runtimePhone) && destination === runtimePhone,
+      node: notificationNode || 'unavailable',
+      state: telegramDelivered ? 'delivered' : legacyState,
+      destinationMatchesRuntime: telegramDelivered || (Boolean(runtimePhone) && destination === runtimePhone),
       shouldNotify: final.shouldNotify === true,
     },
     findings: {
@@ -394,11 +444,31 @@ function printInspect(executionId) {
 }
 
 function loadWorkflow() {
-  return JSON.parse(fs.readFileSync(WORKFLOW_PATH, 'utf8').replace(/^\uFEFF/, ''));
+  const requestedWorkflowPath = flag('--workflow');
+  if (requestedWorkflowPath) {
+    return {
+      source: requestedWorkflowPath,
+      workflow: JSON.parse(fs.readFileSync(requestedWorkflowPath, 'utf8').replace(/^\uFEFF/, '')),
+    };
+  }
+  const raw = runPsql(`select json_build_object(
+    'id', w.id,
+    'name', w.name,
+    'active', w.active,
+    'versionId', w."activeVersionId",
+    'nodes', h.nodes,
+    'connections', h.connections,
+    'settings', w.settings
+  )::text
+  from n8n_runtime.workflow_entity w
+  join n8n_runtime.workflow_history h on h."versionId" = w."activeVersionId"
+  where w.id='${WORKFLOW_ID}';`);
+  if (!raw) throw new Error(`Active Livia workflow ${WORKFLOW_ID} was not found.`);
+  return { source: `postgres:workflow_history:${WORKFLOW_ID}`, workflow: JSON.parse(raw) };
 }
 
 function validateWorkflow() {
-  const workflow = loadWorkflow();
+  const { source: workflowSource, workflow } = loadWorkflow();
   const errors = [];
   const nodeByName = new Map(workflow.nodes.map((node) => [node.name, node]));
   const processMedia = nodeByName.get('Process Media Asset');
@@ -443,8 +513,20 @@ function validateWorkflow() {
   if (!prepareMediaItemsCode.includes('livia_missing_drive_mime_type')) {
     errors.push('Prepare Media Items must reject scheduled files whose MIME type is missing.');
   }
-  if (!usesTokenVaultGateway && (tokenHealth?.type !== 'n8n-nodes-base.executeCommand' || !String(tokenHealth?.parameters?.command || '').includes('validate-publish-token-health.js'))) {
+  const tokenHealthCommand = String(tokenHealth?.parameters?.command || '');
+  if (tokenHealth?.type !== 'n8n-nodes-base.executeCommand' || !tokenHealthCommand.includes('validate-publish-token-health.js')) {
     errors.push('Validate Publish Token Health must run the versioned read-only credential preflight.');
+  }
+  if (!tokenHealthCommand.includes('. /etc/skincos/orb-business.env')) {
+    errors.push('Validate Publish Token Health must load the same protected Token Vault bearer used by post-publication verification.');
+  }
+  const tokenHealthScript = fs.existsSync(VALIDATE_PUBLISH_TOKEN_HEALTH_SCRIPT)
+    ? fs.readFileSync(VALIDATE_PUBLISH_TOKEN_HEALTH_SCRIPT, 'utf8')
+    : '';
+  for (const required of ['gatewayChecks', 'gateway_missing', 'checkThroughGateway']) {
+    if (!tokenHealthScript.includes(required)) {
+      errors.push(`validate-publish-token-health.js must fail closed on gateway authorization (${required}).`);
+    }
   }
   const credentialTargets = (workflow.connections['Get Credential Tokens']?.main?.[0] || []).map((edge) => edge.node);
   const tokenHealthTargets = (workflow.connections['Validate Publish Token Health']?.main?.[0] || []).map((edge) => edge.node);
@@ -610,7 +692,7 @@ function validateWorkflow() {
   if (!collectTargets.includes('Verify Published Artifacts')) {
     errors.push('Collect Publish Results must feed Verify Published Artifacts.');
   }
-  if (collectTargets.includes('Update File') || collectTargets.includes('Inform Success (1)')) {
+  if (collectTargets.includes('Update File') || collectTargets.includes('Inform Success (1)') || collectTargets.includes('Inform Success (2)')) {
     errors.push('Collect Publish Results must not directly feed Update File or Inform Success in QA-safe topology.');
   }
   const finalSwitchTargets = workflow.connections['Switch Final Dry Run']?.main || [];
@@ -639,8 +721,9 @@ function validateWorkflow() {
   if (mergeParameters.mode !== 'combine' || mergeParameters.combineBy !== 'combineByPosition') {
     errors.push('Merge Drive Result and Context must combine Drive output and notification context by position.');
   }
+  const notificationNode = nodeByName.has('Inform Success (2)') ? 'Inform Success (2)' : 'Inform Success (1)';
   const driveTargets = (workflow.connections['Assert Drive Published']?.main?.[0] || []).map((edge) => edge.node);
-  for (const required of ['Inform Success (1)', 'Cleanup Temp Files']) {
+  for (const required of [notificationNode, 'Cleanup Temp Files']) {
     if (!driveTargets.includes(required)) errors.push(`Assert Drive Published must feed ${required}.`);
   }
   if (dryTargets.length !== 1 || dryTargets[0] !== 'Cleanup Temp Files') {
@@ -653,8 +736,11 @@ function validateWorkflow() {
   }
   if (usesManagedSocialGateway) {
     const httpParameters = nodeByName.get('HTTP Request')?.parameters || {};
-    if (httpParameters.contentType !== 'json' || httpParameters.specifyBody !== 'json') {
+    if (httpParameters.contentType !== 'json' && httpParameters.specifyBody !== 'json') {
       errors.push('Managed social publish gateway must use n8n JSON transport, not raw transport.');
+    }
+    if (httpParameters.specifyBody !== 'json') {
+      errors.push('Managed social publish gateway must use the JSON body editor.');
     }
     if (!String(httpParameters.jsonBody || '').includes('JSON.stringify')) {
       errors.push('Managed social publish gateway JSON body expression is missing.');
@@ -688,18 +774,26 @@ function validateWorkflow() {
   for (const required of ['expectedMediaKind', 'facebookStaticPost', 'not_applicable_for_static_image', 'video_alt_text_not_supported']) {
     if (!verifierScript.includes(required)) errors.push(`verify-published-artifacts.js must verify images separately from video (${required}).`);
   }
-  if (!String(nodeByName.get('Inform Success (1)')?.parameters?.remoteJid || '').includes('N8N_DEFAULT_TEST_PHONE')) {
+  if (notificationNode === 'Inform Success (1)' && !String(nodeByName.get(notificationNode)?.parameters?.remoteJid || '').includes('N8N_DEFAULT_TEST_PHONE')) {
     errors.push('Inform Success (1) must use N8N_DEFAULT_TEST_PHONE.');
   }
-  if (!String(nodeByName.get('Inform Success (2)')?.parameters?.text || '').includes("$('Assert Drive Published').first().json.whatsappMessage")) {
+  if (notificationNode === 'Inform Success (2)' && !String(nodeByName.get(notificationNode)?.parameters?.text || '').includes("$('Assert Drive Published').first().json.whatsappMessage")) {
     errors.push('Inform Success (2) must read the verified message instead of the Evolution response.');
   }
 
   const validateScript = path.join(runtimePaths.repoRoot, 'scripts', 'validate-livia-workflow.js');
-  const staticValidation = spawnSync('node', [validateScript, WORKFLOW_PATH], {
-    cwd: runtimePaths.repoRoot,
-    encoding: 'utf8',
-  });
+  const validationDir = fs.mkdtempSync(path.join(os.tmpdir(), 'livia-qa-workflow-'));
+  let staticValidation;
+  try {
+    const validationPath = path.join(validationDir, 'livia.active.json');
+    fs.writeFileSync(validationPath, `${JSON.stringify(workflow)}\n`, { mode: 0o600 });
+    staticValidation = spawnSync('node', [validateScript, validationPath], {
+      cwd: runtimePaths.repoRoot,
+      encoding: 'utf8',
+    });
+  } finally {
+    fs.rmSync(validationDir, { recursive: true, force: true });
+  }
   if (staticValidation.status !== 0) {
     errors.push(staticValidation.stdout || staticValidation.stderr || 'validate-livia-workflow failed.');
   }
@@ -710,7 +804,8 @@ function validateWorkflow() {
   }
   console.log(JSON.stringify({
     ok: true,
-    workflowPath: WORKFLOW_PATH,
+    workflowSource,
+    workflowVersionId: workflow.versionId || '',
     processCommandLength: command.length,
     buildGraphCommandLength: bqCommand.length,
   }, null, 2));
@@ -841,7 +936,15 @@ async function main() {
   throw new Error(`Unknown Livia QA command: ${command}`);
 }
 
-main().catch((error) => {
-  console.error(error && error.stack ? error.stack : String(error));
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  notificationForExecution,
+  readSelectedEnvironmentFile,
+  verifierEnvironment,
+};

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -206,6 +206,57 @@ function notificationForExecution(runData) {
   return { nodeName: '', notification: {} };
 }
 
+function uniqueNonEmpty(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const id = String(value || '').trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+function driveAuditForExecution(runData) {
+  const attached = executionItems(runData, 'Attach Verified Publish Artifacts')[0]?.json || {};
+  const prepared = executionItems(runData, 'Prepare Drive Publication Marks').map((item) => item.json || {});
+  const updates = executionItems(runData, 'Update File').map((item) => item.json || {});
+  const asserted = executionItems(runData, 'Assert Drive Published')[0]?.json || {};
+  const expectedFileIds = uniqueNonEmpty(prepared.length
+    ? prepared.map((item) => item.id)
+    : (Array.isArray(attached.fileIds) ? attached.fileIds : [attached.id]));
+  const returnedFileIds = uniqueNonEmpty(updates.map((item) => item.id));
+  const publishedFileIds = uniqueNonEmpty(updates
+    .filter((item) => String(item?.properties?.published || item?.appProperties?.published || '').toLowerCase() === 'true')
+    .map((item) => item.id));
+  const assertedAudit = asserted.driveAudit && typeof asserted.driveAudit === 'object' ? asserted.driveAudit : {};
+  const assertedFileIds = uniqueNonEmpty(assertedAudit.verifiedFileIds);
+  const missingFileIds = expectedFileIds.filter((id) => !publishedFileIds.includes(id));
+  const unexpectedFileIds = returnedFileIds.filter((id) => !expectedFileIds.includes(id));
+  const collectorMismatch = prepared.length > 0 && (
+    assertedAudit.state !== 'verified' ||
+    assertedAudit.published !== true ||
+    assertedFileIds.length !== expectedFileIds.length ||
+    expectedFileIds.some((id) => !assertedFileIds.includes(id))
+  );
+  const state = expectedFileIds.length && !missingFileIds.length && !unexpectedFileIds.length && !collectorMismatch
+    ? 'verified'
+    : expectedFileIds.length ? 'incomplete' : 'unconfirmed';
+  return {
+    contract: prepared.length > 0 ? 'group-fanout-readback' : 'legacy-single-mark',
+    state,
+    expectedFileIds,
+    returnedFileIds,
+    publishedFileIds,
+    expectedFileCount: expectedFileIds.length,
+    verifiedFileCount: publishedFileIds.length,
+    missingFileIds,
+    unexpectedFileIds,
+    collectorMismatch,
+  };
+}
+
 function auditExecution(executionId) {
   const summary = summarizeExecution(executionId);
   const execution = loadExecutionEntity(executionId);
@@ -230,7 +281,7 @@ function auditExecution(executionId) {
 
   const processMedia = parseProcessMediaOutput((runData['Process Media Asset'] || [])[0]);
   const final = executionItems(runData, 'Collect Publish Results')[0]?.json || {};
-  const drive = executionItems(runData, 'Update File')[0]?.json || {};
+  const drive = driveAuditForExecution(runData);
   const { nodeName: notificationNode, notification } = notificationForExecution(runData);
   const runtimePhone = readRuntimePhone();
   const destination = String(notification?.data?.key?.remoteJid || '').replace(/\D/g, '');
@@ -293,11 +344,7 @@ function auditExecution(executionId) {
       uploadEligible: processMedia.uploadEligible,
     },
     delivery: verificationResult.deliveryAudit || { state: 'unavailable' },
-    drive: {
-      updateReturned: Boolean(drive.id),
-      publishedPropertyConfirmed: String(drive.appProperties?.published || drive.properties?.published || '').toLowerCase() === 'true',
-      state: String(drive.appProperties?.published || drive.properties?.published || '').toLowerCase() === 'true' ? 'verified' : 'unconfirmed',
-    },
+    drive,
     notification: {
       node: notificationNode || 'unavailable',
       state: telegramDelivered ? 'delivered' : legacyState,
@@ -307,6 +354,7 @@ function auditExecution(executionId) {
     findings: {
       graphApiDeprecationWarnings: [...new Set(deprecations)],
       contentDeliveryGaps: contentFailures,
+      drivePublicationGaps: drive.missingFileIds,
       linksInHistoricalCollector: final.whatsapp?.instagram?.permalinks || {},
     },
   }, null, 2));
@@ -639,50 +687,70 @@ function validateWorkflow() {
   for (const required of ['livia-publish-ledger', 'codexDryRun === true', 'semanticJobKey', "'__group__'"]) {
     if (!progressScript.includes(required)) errors.push(`publish-progress-ledger.js must preserve safe resume semantics (${required}).`);
   }
-  for (const name of ['Verify Published Artifacts', 'Attach Verified Publish Artifacts', 'Switch Final Dry Run', 'Merge Drive Result and Context', 'Assert Drive Published', 'Cleanup Temp Files']) {
+  for (const name of ['Verify Published Artifacts', 'Attach Verified Publish Artifacts', 'Switch Final Dry Run', 'Prepare Drive Publication Marks', 'Update File', 'Collect Drive Publication Marks', 'Assert Drive Published', 'Cleanup Temp Files']) {
     if (!nodeByName.has(name)) errors.push(`Missing node: ${name}`);
   }
+  if (nodeByName.has('Merge Drive Result and Context')) {
+    errors.push('Legacy positional Drive merge must not remain in the active workflow.');
+  }
+  const prepareDriveCode = String(nodeByName.get('Prepare Drive Publication Marks')?.parameters?.jsCode || '');
+  const collectDriveCode = String(nodeByName.get('Collect Drive Publication Marks')?.parameters?.jsCode || '');
   const assertDriveCode = String(nodeByName.get('Assert Drive Published')?.parameters?.jsCode || '');
-  if (!assertDriveCode.includes('appProperties.published')) {
-    errors.push('Assert Drive Published must verify appProperties.published=true.');
+  if (!prepareDriveCode.includes('driveExpectedFileIds') || !prepareDriveCode.includes('fileIds')) {
+    errors.push('Prepare Drive Publication Marks must fan out the verified fileIds contract.');
+  }
+  if (!collectDriveCode.includes("$items('Prepare Drive Publication Marks')") || !collectDriveCode.includes('properties.published')) {
+    errors.push('Collect Drive Publication Marks must correlate and verify every Drive update response.');
+  }
+  if (!assertDriveCode.includes('expectedFileIds') || !assertDriveCode.includes('verifiedFileIds')) {
+    errors.push('Assert Drive Published must verify every source file was marked published=true.');
   }
   if (!assertDriveCode.includes('const finalContext =') || assertDriveCode.includes('$(') || assertDriveCode.includes('...original')) {
     errors.push('Assert Drive Published must project a bounded context without resolving an upstream node.');
   }
-  if (assertDriveCode) {
+  if (prepareDriveCode && collectDriveCode && assertDriveCode) {
     try {
-      const executeAssertDrive = new Function('$json', assertDriveCode);
-      const mergedContext = {
-        id: 'drive-file-fixture',
-        name: 'fixture.png',
-        groupKey: 'dt:fixture',
-        whatsappMessage: 'fixture message',
-        shouldNotify: true,
-        codexDryRun: false,
-        oversizedPublishEnvelope: 'x'.repeat(1024 * 1024),
-        modifiedTime: '2026-07-10T00:00:00.000Z',
-        appProperties: { published: 'true' },
+      const executePrepare = new Function('$input', `"use strict";\n${prepareDriveCode}`);
+      const executeCollect = new Function('$input', '$items', `"use strict";\n${collectDriveCode}`);
+      const executeAssertDrive = new Function('$input', `"use strict";\n${assertDriveCode}`);
+      const source = {
+        json: {
+          id: 'drive-file-fixture-a',
+          fileIds: ['drive-file-fixture-a', 'drive-file-fixture-b'],
+          groupKey: 'dt:fixture',
+          whatsappMessage: 'fixture message',
+          shouldNotify: true,
+          codexDryRun: false,
+          oversizedPublishEnvelope: 'x'.repeat(1024 * 1024),
+        },
       };
-      const result = executeAssertDrive(mergedContext);
+      const prepared = executePrepare({ all: () => [source] });
+      const collected = executeCollect(
+        { all: () => prepared.map((item) => ({ json: { id: item.json.id, properties: { published: 'true' } } })) },
+        (name) => name === 'Prepare Drive Publication Marks' ? prepared : [],
+      );
+      const result = executeAssertDrive({ first: () => collected[0], all: () => collected });
       const projected = result?.[0]?.json || {};
       if (
-        projected.groupKey !== mergedContext.groupKey ||
-        projected.whatsappMessage !== mergedContext.whatsappMessage ||
+        projected.groupKey !== source.json.groupKey ||
+        projected.whatsappMessage !== source.json.whatsappMessage ||
         projected.driveAudit?.state !== 'verified' ||
+        projected.driveAudit?.verifiedFileCount !== 2 ||
         Object.prototype.hasOwnProperty.call(projected, 'oversizedPublishEnvelope')
       ) {
         errors.push('Assert Drive Published bounded-context replay returned an invalid projection.');
       }
-      let rejectedUnpublished = false;
+      let rejectedIncomplete = false;
       try {
-        executeAssertDrive(
-          { id: 'drive-file-fixture', appProperties: { published: 'false' } },
+        executeCollect(
+          { all: () => [{ json: { id: 'drive-file-fixture-a', properties: { published: 'true' } } }] },
+          (name) => name === 'Prepare Drive Publication Marks' ? prepared : [],
         );
       } catch {
-        rejectedUnpublished = true;
+        rejectedIncomplete = true;
       }
-      if (!rejectedUnpublished) {
-        errors.push('Assert Drive Published replay must reject published=false.');
+      if (!rejectedIncomplete) {
+        errors.push('Drive publication collector replay must reject an incomplete carousel readback.');
       }
     } catch (error) {
       errors.push(`Assert Drive Published bounded-context replay failed: ${error.message}`);
@@ -698,7 +766,7 @@ function validateWorkflow() {
   const finalSwitchTargets = workflow.connections['Switch Final Dry Run']?.main || [];
   const normalTargets = (finalSwitchTargets[0] || []).map((edge) => edge.node).sort();
   const dryTargets = (finalSwitchTargets[1] || []).map((edge) => edge.node).sort();
-  for (const required of ['Update File']) {
+  for (const required of ['Prepare Drive Publication Marks']) {
     if (!normalTargets.includes(required)) errors.push(`Switch Final Dry Run normal output must feed ${required}.`);
   }
   const verifyTargets = (workflow.connections['Verify Published Artifacts']?.main?.[0] || []).map((edge) => edge.node);
@@ -709,17 +777,17 @@ function validateWorkflow() {
   if (!attachedTargets.includes('Switch Final Dry Run')) {
     errors.push('Attach Verified Publish Artifacts must feed Switch Final Dry Run.');
   }
+  const prepareDriveTargets = (workflow.connections['Prepare Drive Publication Marks']?.main?.[0] || []).map((edge) => edge.node);
+  if (!prepareDriveTargets.includes('Update File')) {
+    errors.push('Prepare Drive Publication Marks must feed Update File.');
+  }
   const updateTargets = (workflow.connections['Update File']?.main?.[0] || []).map((edge) => edge.node);
-  if (!updateTargets.includes('Merge Drive Result and Context')) {
-    errors.push('Update File must feed Merge Drive Result and Context.');
+  if (!updateTargets.includes('Collect Drive Publication Marks')) {
+    errors.push('Update File must feed Collect Drive Publication Marks.');
   }
-  const mergeTargets = (workflow.connections['Merge Drive Result and Context']?.main?.[0] || []).map((edge) => edge.node);
-  if (!mergeTargets.includes('Assert Drive Published')) {
-    errors.push('Merge Drive Result and Context must feed Assert Drive Published.');
-  }
-  const mergeParameters = nodeByName.get('Merge Drive Result and Context')?.parameters || {};
-  if (mergeParameters.mode !== 'combine' || mergeParameters.combineBy !== 'combineByPosition') {
-    errors.push('Merge Drive Result and Context must combine Drive output and notification context by position.');
+  const collectDriveTargets = (workflow.connections['Collect Drive Publication Marks']?.main?.[0] || []).map((edge) => edge.node);
+  if (!collectDriveTargets.includes('Assert Drive Published')) {
+    errors.push('Collect Drive Publication Marks must feed Assert Drive Published.');
   }
   const notificationNode = nodeByName.has('Inform Success (2)') ? 'Inform Success (2)' : 'Inform Success (1)';
   const driveTargets = (workflow.connections['Assert Drive Published']?.main?.[0] || []).map((edge) => edge.node);
@@ -944,6 +1012,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  driveAuditForExecution,
   notificationForExecution,
   readSelectedEnvironmentFile,
   verifierEnvironment,

--- a/orb/engine/scripts/livia/validate-publish-token-health.js
+++ b/orb/engine/scripts/livia/validate-publish-token-health.js
@@ -86,22 +86,39 @@ async function checkThroughGateway(item) {
   }
 }
 
+async function validatePayload(payload) {
+  const items = activeItems(payload).filter((item) => item && item.active !== false);
+  const checks = (await Promise.all(items.map(check))).filter(Boolean);
+  const gatewayChecks = (await Promise.all(items.map(checkThroughGateway))).filter(Boolean);
+  const expected = ['instagram', 'threads', 'facebook'];
+  const missingDirect = expected.filter((provider) => !checks.some((entry) => entry.provider === provider));
+  const directFailures = checks.filter((entry) => !entry.ok);
+  const missingGateway = expected.filter((provider) => !gatewayChecks.some((entry) => entry.provider === provider));
+  const gatewayFailures = gatewayChecks.filter((entry) => !entry.ok);
+  if (missingDirect.length || directFailures.length || missingGateway.length || gatewayFailures.length) {
+    const detail = (entries) => entries
+      .map((entry) => `${entry.provider}/${entry.unit}:status=${entry.status}:code=${entry.error?.code ?? 'n/a'}`)
+      .join(', ');
+    throw new Error(
+      'Livia publish credential preflight failed ' +
+      `(direct_missing=${missingDirect.join('|') || 'none'}; direct_failures=${detail(directFailures) || 'none'}; ` +
+      `gateway_missing=${missingGateway.join('|') || 'none'}; gateway_failures=${detail(gatewayFailures) || 'none'}).`,
+    );
+  }
+  return { ok: true, checkedAt: new Date().toISOString(), checks, gatewayChecks };
+}
+
 async function main() {
   const raw = argument('--payload');
   if (!raw) throw new Error('validate-publish-token-health requires --payload JSON.');
-  const items = activeItems(JSON.parse(raw)).filter((item) => item && item.active !== false);
-  const checks = (await Promise.all(items.map(async (item) => (await check(item)) || (await checkThroughGateway(item))))).filter(Boolean);
-  const expected = ['instagram', 'threads', 'facebook'];
-  const missing = expected.filter((provider) => !checks.some((entry) => entry.provider === provider));
-  const failures = checks.filter((entry) => !entry.ok);
-  if (missing.length || failures.length) {
-    const detail = failures.map((entry) => `${entry.provider}/${entry.unit}:status=${entry.status}:code=${entry.error?.code ?? 'n/a'}`).join(', ');
-    throw new Error(`Livia publish credential preflight failed (missing=${missing.join('|') || 'none'}; failures=${detail || 'none'}).`);
-  }
-  process.stdout.write(`${JSON.stringify({ ok: true, checkedAt: new Date().toISOString(), checks })}\n`);
+  process.stdout.write(`${JSON.stringify(await validatePayload(JSON.parse(raw)))}\n`);
 }
 
-main().catch((error) => {
-  console.error(error.stack || String(error));
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  });
+}
+
+module.exports = { validatePayload };

--- a/orb/engine/scripts/livia/verify-published-artifacts.js
+++ b/orb/engine/scripts/livia/verify-published-artifacts.js
@@ -102,12 +102,11 @@ function facebookPhotoObject(target) {
 }
 
 function facebookReadObjectId(target) {
-  // The token-vault only permits numeric Graph object IDs. For a feed post in
-  // pageId_postId form, validate the attached public photo and keep the post
-  // permalink as a separate, deterministic public URL.
-  return facebookCompositePost(target)
-    ? str(target.providerMediaId)
-    : str(target.providerObjectId);
+  // A composite Page post must be read as the post itself, not as one chosen
+  // attachment. Reading only the first photo/video made it impossible to
+  // detect a provider that accepted the post but omitted a later carousel
+  // child. The gateway permits this tightly-scoped pageId_postId GET path.
+  return str(target.providerObjectId);
 }
 
 function facebookCompositePermalink(target) {
@@ -137,6 +136,7 @@ function compactProviderBody(platform, body) {
       status: source.status,
       created_time: source.created_time,
       full_picture: source.full_picture,
+      attachments: compactFacebookAttachments(source.attachments),
     };
   }
   if (platform === 'instagram') {
@@ -158,6 +158,20 @@ function compactProviderBody(platform, body) {
   };
 }
 
+function compactFacebookAttachments(value) {
+  const data = asArray(asObject(value).data);
+  const compact = (entry) => {
+    const current = asObject(entry);
+    return {
+      media_type: current.media_type,
+      target: asObject(current.target).id,
+      media: asObject(current.media).id,
+      subattachments: asArray(asObject(current.subattachments).data).map(compact),
+    };
+  };
+  return data.map(compact);
+}
+
 function providerRequest(target) {
   const platform = str(target.platform).toLowerCase();
   const objectId = platform === 'facebook'
@@ -173,13 +187,148 @@ function providerRequest(target) {
   const fields = platform === 'instagram'
     ? 'id,permalink,media_type,caption,timestamp,thumbnail_url'
     : platform === 'facebook'
-      ? facebookStaticPost(target)
-        ? facebookPhotoObject(target)
-          ? 'id,link,name,created_time,images,from'
-          : 'id,permalink_url,message,created_time,full_picture,from'
+      ? facebookCompositePost(target)
+        ? 'id,permalink_url,message,created_time,attachments{media_type,media,target,subattachments{media_type,media,target}},from'
+        : facebookStaticPost(target)
+          ? facebookPhotoObject(target)
+            ? 'id,link,name,created_time,images,from'
+            : 'id,permalink_url,message,created_time,full_picture,from'
         : 'id,permalink_url,description,title,created_time,status,published,from'
       : 'id,permalink,media_type,text,timestamp';
   return { url, fields };
+}
+
+function expectedAccessibilitySupport(platform, mediaKind) {
+  if (platform === 'facebook') return 'unsupported';
+  if (platform === 'instagram' && mediaKind === 'video') return 'unsupported';
+  if ((platform === 'instagram' || platform === 'threads') && (mediaKind === 'image' || mediaKind === 'video')) return 'required';
+  return 'unsupported';
+}
+
+function assessAccessibilityContract(target) {
+  const platform = str(target.platform).toLowerCase();
+  const contract = asObject(target.accessibilityContract);
+  const items = asArray(contract.items).map((entry) => asObject(entry));
+  if (contract.schema !== 'livia.media-alt-text.v1' || contract.orderedBy !== 'groupOrder' || !items.length) {
+    return { status: 'failed', reason: 'accessibility_contract_missing_or_invalid' };
+  }
+
+  const semanticKeys = new Set();
+  const sourceKeys = new Set();
+  let requiredCount = 0;
+  let submittedRequiredCount = 0;
+  let unsupportedCount = 0;
+  for (const item of items) {
+    const sourceMediaId = str(item.sourceMediaId);
+    const semanticJobKey = str(item.semanticJobKey);
+    const mediaKind = str(item.mediaKind).toLowerCase();
+    const support = str(item.support).toLowerCase();
+    const expectedAltText = str(item.expectedAltText);
+    const submittedAltText = str(item.submittedAltText);
+    const groupOrder = Number(item.groupOrder);
+    if (!sourceMediaId || !semanticJobKey || !Number.isInteger(groupOrder) || groupOrder < 0 || !['image', 'video'].includes(mediaKind)) {
+      return { status: 'failed', reason: 'accessibility_item_identity_invalid' };
+    }
+    if (semanticKeys.has(semanticJobKey) || sourceKeys.has(`${sourceMediaId}|${groupOrder}`)) {
+      return { status: 'failed', reason: 'accessibility_item_identity_duplicate' };
+    }
+    semanticKeys.add(semanticJobKey);
+    sourceKeys.add(`${sourceMediaId}|${groupOrder}`);
+    const expectedSupport = expectedAccessibilitySupport(platform, mediaKind);
+    if (support !== expectedSupport) {
+      return { status: 'failed', reason: 'accessibility_support_mismatch' };
+    }
+    if (support === 'required') {
+      requiredCount += 1;
+      if (!expectedAltText || !submittedAltText || expectedAltText !== submittedAltText) {
+        return { status: 'failed', reason: 'alt_text_not_submitted_or_mismatched' };
+      }
+      submittedRequiredCount += 1;
+    } else {
+      unsupportedCount += 1;
+      if (submittedAltText) return { status: 'failed', reason: 'alt_text_submitted_to_unsupported_media' };
+    }
+  }
+
+  if (Number(contract.requiredCount) !== requiredCount ||
+      Number(contract.submittedRequiredCount) !== submittedRequiredCount ||
+      Number(contract.unsupportedCount) !== unsupportedCount) {
+    return { status: 'failed', reason: 'accessibility_contract_count_mismatch' };
+  }
+  return requiredCount
+    ? { status: 'accepted', reason: 'submitted_to_provider_but_not_readable_from_public_object', requiredCount, submittedRequiredCount, unsupportedCount }
+    : { status: 'unsupported', reason: `${platform}_media_alt_text_not_supported_in_current_flow`, requiredCount, submittedRequiredCount, unsupportedCount };
+}
+
+function orderedMediaEvidence(target) {
+  const contract = asObject(target.mediaEvidenceContract);
+  const items = asArray(contract.items).map((entry) => asObject(entry));
+  if (contract.schema !== 'livia.media-evidence.v1' || contract.orderedBy !== 'groupOrder' || !items.length) {
+    return { status: 'failed', reason: 'media_evidence_contract_missing_or_invalid', items: [] };
+  }
+  const seenSemanticKeys = new Set();
+  const seenSourceKeys = new Set();
+  let previousOrder = -1;
+  for (const item of items) {
+    const sourceMediaId = str(item.sourceMediaId);
+    const semanticJobKey = str(item.semanticJobKey);
+    const providerMediaId = str(item.providerMediaId);
+    const mediaKind = str(item.mediaKind).toLowerCase();
+    const groupOrder = Number(item.groupOrder);
+    if (!sourceMediaId || !semanticJobKey || !providerMediaId || !Number.isInteger(groupOrder) || groupOrder < 0 || !['image', 'video'].includes(mediaKind)) {
+      return { status: 'failed', reason: 'media_evidence_item_identity_invalid', items: [] };
+    }
+    if (seenSemanticKeys.has(semanticJobKey) || seenSourceKeys.has(`${sourceMediaId}|${groupOrder}`) || groupOrder < previousOrder) {
+      return { status: 'failed', reason: 'media_evidence_order_or_identity_invalid', items: [] };
+    }
+    seenSemanticKeys.add(semanticJobKey);
+    seenSourceKeys.add(`${sourceMediaId}|${groupOrder}`);
+    previousOrder = groupOrder;
+  }
+  return { status: 'accepted', reason: 'ordered_semantic_media_evidence', items };
+}
+
+function facebookAttachmentIds(value, output = new Set()) {
+  if (Array.isArray(value)) {
+    for (const entry of value) facebookAttachmentIds(entry, output);
+    return output;
+  }
+  const current = asObject(value);
+  if (!Object.keys(current).length) return output;
+  for (const candidate of [asObject(current.target).id, asObject(current.media).id]) {
+    const id = str(candidate);
+    if (id) output.add(id);
+  }
+  facebookAttachmentIds(asObject(current.subattachments).data, output);
+  return output;
+}
+
+function assessMediaEvidence(target, body) {
+  const contract = orderedMediaEvidence(target);
+  if (contract.status !== 'accepted') return contract;
+  if (!facebookCompositePost(target)) return contract;
+
+  const attachmentIds = facebookAttachmentIds(asObject(asObject(body).attachments).data);
+  if (!attachmentIds.size) {
+    return { status: 'failed', reason: 'facebook_composite_attachments_missing', items: contract.items };
+  }
+  const missing = contract.items
+    .map((item) => str(item.providerMediaId))
+    .filter((id) => !attachmentIds.has(id));
+  if (missing.length) {
+    return {
+      status: 'failed',
+      reason: 'facebook_composite_attachment_identity_missing',
+      items: contract.items,
+      missingProviderMediaIds: missing,
+    };
+  }
+  return {
+    status: 'accepted',
+    reason: 'facebook_composite_attachments_match_ordered_media_evidence',
+    items: contract.items,
+    attachmentIds: [...attachmentIds],
+  };
 }
 
 function buildDelivery(target, response) {
@@ -204,7 +353,7 @@ function buildDelivery(target, response) {
   const facebookPublished = staticFacebook ? response.statusCode === 200 && Boolean(permalink) : body.published === true &&
     str(asObject(facebookStatus.publishing_phase).publish_status).toLowerCase() === 'published';
   const expectedFacebookPageId = compositeFacebook ? str(target.providerObjectId).split('_')[0] : '';
-  const captionReadable = !(platform === 'facebook' && compositeFacebook);
+  const captionReadable = true;
 
   if (response.statusCode !== 200) errors.push(`provider_read_failed:${response.statusCode}`);
   if (!permalink) errors.push('public_permalink_missing');
@@ -217,22 +366,9 @@ function buildDelivery(target, response) {
   }
   if (captionReadable && !exactText(caption, expected.caption)) errors.push('caption_mismatch');
 
-  const accessibility = platform === 'facebook'
-    ? { status: 'unsupported', reason: staticFacebook
-      ? 'facebook_static_post_alt_text_not_available_in_current_flow'
-      : 'facebook_reels_api_does_not_receive_alt_text_in_this_flow' }
-    : mediaKind === 'video'
-      ? { status: 'unsupported', reason: `${platform}_video_alt_text_not_supported` }
-    : submitted.altText
-      ? { status: 'accepted', reason: 'submitted_to_provider_but_not_readable_from_public_object' }
-      : { status: 'failed', reason: 'alt_text_not_submitted' };
-  const title = platform === 'instagram' || platform === 'threads' || staticFacebook
-    ? { status: 'unsupported', reason: `${platform}_${mediaKind || 'media'}_has_no_public_title_contract` }
-    : submitted.title
-      ? exactText(body.title, expected.title) && str(body.title)
-        ? { status: 'verified' }
-        : { status: 'accepted', reason: 'submitted_to_provider_but_not_returned_by_object_read' }
-      : { status: 'failed', reason: 'title_not_submitted' };
+  const accessibility = assessAccessibilityContract(target);
+  const mediaEvidence = assessMediaEvidence(target, body);
+  const title = { status: 'unsupported', reason: `${platform}_${mediaKind || 'media'}_has_no_public_title_contract` };
   const cover = mediaKind !== 'video'
     ? { status: 'unsupported', reason: 'not_applicable_for_static_image' }
     : platform === 'instagram'
@@ -242,6 +378,10 @@ function buildDelivery(target, response) {
         : { status: 'failed', reason: 'instagram_thumbnail_missing' }
       : { status: 'failed', reason: 'cover_not_requested' }
     : { status: 'unsupported', reason: `${platform}_video_cover_not_configurable_in_this_flow` };
+
+  if (accessibility.status === 'failed') errors.push(`accessibility_failed:${str(accessibility.reason) || 'unknown'}`);
+  if (mediaEvidence.status === 'failed') errors.push(`media_evidence_failed:${str(mediaEvidence.reason) || 'unknown'}`);
+  if (cover.status === 'failed') errors.push(`cover_failed:${str(cover.reason) || 'unknown'}`);
 
   return {
     platform,
@@ -258,10 +398,11 @@ function buildDelivery(target, response) {
         : 'accepted',
       title,
       accessibility,
+      mediaEvidence,
       cover,
     },
     verificationNotes: compositeFacebook
-      ? ['facebook_carousel_post_confirmed_by_public_attached_photo_and_submitted_feed_payload']
+      ? ['facebook_carousel_post_confirmed_by_public_post_readback_and_ordered_attachment_contract']
       : [],
     errors,
     provider: compactProviderBody(platform, body),
@@ -342,7 +483,18 @@ async function main() {
   if (failures.length) process.exitCode = 2;
 }
 
-main().catch((error) => {
-  console.error(error && error.stack ? error.stack : String(error));
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  assessAccessibilityContract,
+  assessMediaEvidence,
+  buildDelivery,
+  expectedAccessibilitySupport,
+  facebookAttachmentIds,
+  orderedMediaEvidence,
+};

--- a/orb/engine/scripts/patch-livia-accessibility-contract.js
+++ b/orb/engine/scripts/patch-livia-accessibility-contract.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Make every provider-verification target carry an ordered, media-level
+// accessibility contract.  This replaces the former first-alt-text lookup,
+// which could report a group as healthy even when a later carousel child lost
+// its required alt text.
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const NODE_NAME = 'Collect Publish Results';
+const START_MARKER = 'function buildPublishVerificationTargets(completedRows, groupKey) {';
+const END_MARKER = '\n\nconst codexDryRun';
+
+const TARGET_FUNCTION = String.raw`function buildPublishVerificationTargets(completedRows, groupKey) {
+  const rows = __prAsArray(completedRows).filter((entry) => __prStr(__prAsObject(entry).groupKey, "") === __prStr(groupKey, ""));
+  function requestBody(row) {
+    const current = __prAsObject(row);
+    const http = __prAsObject(current.httpRequest);
+    for (const candidate of [current.requestBody, current.jsonRequest, http.body, http.json]) {
+      const body = __prAsObject(candidate);
+      if (Object.keys(body).length) return body;
+    }
+    return {};
+  }
+  function firstSubmitted(platformRows, keys) {
+    for (const row of platformRows) {
+      const body = requestBody(row);
+      for (const key of keys) {
+        if (body[key] !== undefined && body[key] !== null && __prStr(body[key], "").trim() !== "") return __prStr(body[key], "");
+      }
+    }
+    return "";
+  }
+  function mediaKindFor(platformRows, publishRow) {
+    const signals = [];
+    for (const row of platformRows) {
+      const current = __prAsObject(row);
+      const body = requestBody(current);
+      signals.push(
+        current.mediaKind,
+        __prAsObject(current.media).mediaKind,
+        current.mediaType,
+        current.media_type,
+        current.groupBaseMediaType,
+        current.step,
+        current.url,
+        __prAsObject(current.httpRequest).url,
+        body.media_type,
+        body.image_url ? "image" : "",
+        body.video_url || body.file_url ? "video" : "",
+        body.attached_media ? "image" : ""
+      );
+    }
+    signals.push(publishRow.mediaKind, __prAsObject(publishRow.media).mediaKind);
+    const raw = signals.map((value) => __prStr(value, "").toLowerCase()).join(" ");
+    if (raw.includes("carousel")) return "carousel";
+    if (raw.includes("video") || raw.includes("reels") || raw.includes("reel")) return "video";
+    if (raw.includes("image") || raw.includes("photo")) return "image";
+    return "image";
+  }
+  function mediaAccessibilityContract(platformRows, platform) {
+    const items = [];
+    const seenSemanticKeys = new Set();
+    const seenSourceItems = new Set();
+    for (const row of platformRows) {
+      const current = __prAsObject(row);
+      if (__prStr(current.phase, "").toLowerCase() !== "upload") continue;
+      const body = requestBody(current);
+      const mediaType = __prStr(body.media_type || body.mediaType, "").toUpperCase();
+      const step = __prStr(current.step, "").toLowerCase();
+      const mediaKind = body.video_url || body.file_url ? "video"
+        : body.image_url || (platform === "facebook" && body.url) ? "image"
+          : platform === "facebook" && step === "reels_start" ? "video" : "";
+      if (!mediaKind || mediaType === "CAROUSEL") continue;
+      const media = __prAsObject(current.media);
+      const sourceMediaId = __prStr(media.id || current.sourceMediaId, "");
+      const semanticJobKey = __prStr(current.semanticJobKey, "");
+      const groupOrder = Number(media.groupOrder ?? current.groupOrder);
+      if (!sourceMediaId || !semanticJobKey || !Number.isInteger(groupOrder) || groupOrder < 0) {
+        throw new Error("Collect Publish Results: accessibility evidence is missing semantic media identity for " + platform + ".");
+      }
+      if (seenSemanticKeys.has(semanticJobKey)) {
+        throw new Error("Collect Publish Results: duplicate accessibility semantic job key for " + platform + ": " + semanticJobKey + ".");
+      }
+      const sourceKey = sourceMediaId + "|" + groupOrder;
+      if (seenSourceItems.has(sourceKey)) {
+        throw new Error("Collect Publish Results: duplicate accessibility source media identity for " + platform + ": " + sourceKey + ".");
+      }
+      seenSemanticKeys.add(semanticJobKey);
+      seenSourceItems.add(sourceKey);
+      const text = __prAsObject(current.text);
+      const expectedAltText = __prStr(text.alt_text || text.altText, "");
+      const submittedAltText = firstSubmitted([current], ["alt_text", "altText", "alt_text_custom"]);
+      const providerBody = __prAsObject(current.lastResponseBody);
+      const providerMediaId = __prStr(providerBody.video_id || providerBody.creation_id || providerBody.id || providerBody.post_id || providerBody.videoid, "");
+      if (!providerMediaId) {
+        throw new Error("Collect Publish Results: provider media id is missing for " + platform + "/" + sourceMediaId + ".");
+      }
+      const support = platform === "facebook" || (platform === "instagram" && mediaKind === "video")
+        ? "unsupported"
+        : "required";
+      if (support === "required" && (!expectedAltText || !submittedAltText || submittedAltText !== expectedAltText)) {
+        throw new Error("Collect Publish Results: required alt_text is missing or does not match editorial evidence for " + platform + "/" + sourceMediaId + ".");
+      }
+      if (support === "unsupported" && submittedAltText) {
+        throw new Error("Collect Publish Results: unsupported alt_text was sent for " + platform + "/" + sourceMediaId + ".");
+      }
+      items.push({
+        sourceMediaId,
+        groupOrder,
+        semanticJobKey,
+        mediaKind,
+        support,
+        expectedAltText,
+        submittedAltText,
+        providerMediaId,
+      });
+    }
+    if (!items.length) throw new Error("Collect Publish Results: no media-level accessibility evidence for " + platform + ".");
+    items.sort((left, right) => left.groupOrder - right.groupOrder || left.sourceMediaId.localeCompare(right.sourceMediaId) || left.semanticJobKey.localeCompare(right.semanticJobKey));
+    const required = items.filter((entry) => entry.support === "required");
+    return {
+      schema: "livia.media-alt-text.v1",
+      orderedBy: "groupOrder",
+      items,
+      requiredCount: required.length,
+      submittedRequiredCount: required.filter((entry) => entry.submittedAltText).length,
+      unsupportedCount: items.filter((entry) => entry.support === "unsupported").length,
+    };
+  }
+  const targets = [];
+  for (const unit of ["bss", "nh"]) {
+    for (const platform of ["instagram", "facebook", "threads"]) {
+      const platformRows = rows.filter((entry) =>
+        __prStr(__prAsObject(entry).unit, "").toLowerCase() === unit &&
+        __prStr(__prAsObject(entry).platform, "").toLowerCase() === platform
+      );
+      const publishRow = __prAsObject(platformRows.find((entry) => __prStr(__prAsObject(entry).phase, "").toLowerCase() === "publish"));
+      if (!Object.keys(publishRow).length) continue;
+      const publishBody = __prAsObject(publishRow.lastResponseBody);
+      const startRow = __prAsObject(platformRows.find((entry) => __prStr(__prAsObject(entry).step, "").toLowerCase() === "reels_start"));
+      const startBody = __prAsObject(startRow.lastResponseBody);
+      const uploadRow = __prAsObject(platformRows.find((entry) => __prStr(__prAsObject(entry).phase, "").toLowerCase() === "upload"));
+      const uploadBody = __prAsObject(uploadRow.lastResponseBody);
+      const accessibilityContract = mediaAccessibilityContract(platformRows, platform);
+      const mediaEvidenceContract = {
+        schema: "livia.media-evidence.v1",
+        orderedBy: "groupOrder",
+        items: accessibilityContract.items.map((entry) => ({
+          sourceMediaId: entry.sourceMediaId,
+          groupOrder: entry.groupOrder,
+          semanticJobKey: entry.semanticJobKey,
+          mediaKind: entry.mediaKind,
+          providerMediaId: entry.providerMediaId,
+        })),
+      };
+      const mediaKind = mediaEvidenceContract.items.length > 1 ? "carousel" : mediaKindFor(platformRows, publishRow);
+      const publishMode = platformRows.some((entry) => __prStr(__prAsObject(entry).step, "").toLowerCase().startsWith("reels_"))
+        ? "reels"
+        : mediaEvidenceContract.items.length > 1 ? "carousel" : mediaKind === "carousel" ? "carousel" : "static";
+      const providerObjectId = platform === "facebook" && publishMode === "reels"
+        ? __prStr(startBody.video_id || startBody.id || publishBody.id || publishBody.post_id, "")
+        : __prStr(publishBody.id || publishBody.post_id || uploadBody.post_id || uploadBody.id, "");
+      const providerMediaId = platform === "facebook" && publishMode === "reels"
+        ? __prStr(startBody.video_id || startBody.id, "")
+        : __prStr(mediaEvidenceContract.items[0]?.providerMediaId || uploadBody.id || uploadBody.post_id, "");
+      if (!providerObjectId) {
+        throw new Error("Collect Publish Results: identificador final ausente para " + platform + "/" + unit + ".");
+      }
+      const text = __prAsObject(publishRow.text);
+      targets.push({
+        platform,
+        unit,
+        mediaKind,
+        publishMode,
+        providerObjectId,
+        providerMediaId,
+        expected: {
+          caption: __prStr(text.caption || text.text, ""),
+          title: __prStr(text.title, ""),
+          altText: __prStr(text.alt_text || text.altText, ""),
+        },
+        submitted: {
+          title: __prStr(firstSubmitted(platformRows, ["title"]), ""),
+          altText: __prStr(firstSubmitted(platformRows, ["alt_text", "altText", "alt_text_custom"]), ""),
+          coverUrl: __prStr(firstSubmitted(platformRows, ["cover_url"]), ""),
+          thumbOffset: firstSubmitted(platformRows, ["thumb_offset"]),
+        },
+        accessibilityContract,
+        mediaEvidenceContract,
+      });
+    }
+  }
+  return targets;
+}`;
+
+function value(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || '' : '';
+}
+
+function required(name) {
+  const current = value(name);
+  if (!current) throw new Error(`${name} is required.`);
+  return current;
+}
+
+function readWorkflow(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function patchCode(code) {
+  const current = String(code || '');
+  const start = current.indexOf(START_MARKER);
+  const end = start >= 0 ? current.indexOf(END_MARKER, start) : -1;
+  if (start < 0 || end < 0) {
+    throw new Error(`${NODE_NAME} does not contain the expected verification-target function.`);
+  }
+  return `${current.slice(0, start)}${TARGET_FUNCTION}${current.slice(end)}`;
+}
+
+function patchWorkflow(workflow) {
+  if (workflow?.id !== WORKFLOW_ID) throw new Error(`Expected Livia workflow ${WORKFLOW_ID}.`);
+  const candidate = structuredClone(workflow);
+  const node = (candidate.nodes || []).find((entry) => entry?.name === NODE_NAME);
+  if (!node || node.type !== 'n8n-nodes-base.code') throw new Error(`${NODE_NAME} must be a Code node.`);
+  node.parameters ||= {};
+  node.parameters.jsCode = patchCode(node.parameters.jsCode);
+  return candidate;
+}
+
+function main() {
+  const input = required('--input');
+  const output = required('--output');
+  const patched = patchWorkflow(readWorkflow(input));
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(patched, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(`${JSON.stringify({ ok: true, workflowId: patched.id, node: NODE_NAME, output })}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { NODE_NAME, TARGET_FUNCTION, patchCode, patchWorkflow };

--- a/orb/engine/scripts/patch-livia-drive-publication-marks.js
+++ b/orb/engine/scripts/patch-livia-drive-publication-marks.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// A verified carousel is one publication, but it can contain several Drive
+// source files.  Fan out the final Drive mark to every verified source ID and
+// aggregate the API readback before any notification or cleanup succeeds.
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const PREPARE_NODE = 'Prepare Drive Publication Marks';
+const COLLECT_NODE = 'Collect Drive Publication Marks';
+const LEGACY_MERGE_NODE = 'Merge Drive Result and Context';
+
+const prepareCode = String.raw`function text(value) {
+  return String(value === undefined || value === null ? '' : value).trim();
+}
+function uniqueIds(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const id = text(value);
+    if (!id) throw new Error('Drive publication mark contains an empty source file ID.');
+    if (seen.has(id)) throw new Error('Drive publication mark contains a duplicate source file ID: ' + id + '.');
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+const input = $input.all();
+if (input.length !== 1) throw new Error('Drive publication mark expects exactly one externally verified publication group.');
+const source = input[0] && input[0].json && typeof input[0].json === 'object' ? input[0].json : {};
+const fileIds = uniqueIds(source.fileIds);
+const sourceId = text(source.id);
+const groupKey = text(source.groupKey);
+if (!fileIds.length) throw new Error('Drive publication mark is missing the verified fileIds contract.');
+if (!sourceId || !fileIds.includes(sourceId)) throw new Error('Drive publication mark source ID is absent from the verified fileIds contract.');
+if (!groupKey) throw new Error('Drive publication mark is missing groupKey.');
+
+const finalContext = {
+  id: sourceId,
+  groupKey,
+  whatsappMessage: text(source.whatsappMessage),
+  shouldNotify: source.shouldNotify === true,
+  codexDryRun: source.codexDryRun === true,
+};
+
+return fileIds.map((id, ordinal) => ({
+  json: {
+    id,
+    driveExpectedFileIds: fileIds,
+    driveMarkOrdinal: ordinal,
+    driveMarkCount: fileIds.length,
+    driveFinalContext: finalContext,
+  },
+}));`;
+
+const collectCode = String.raw`function text(value) {
+  return String(value === undefined || value === null ? '' : value).trim();
+}
+function object(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+function uniqueIds(values, label) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const id = text(value);
+    if (!id) throw new Error(label + ' contains an empty source file ID.');
+    if (seen.has(id)) throw new Error(label + ' contains a duplicate source file ID: ' + id + '.');
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+function sameSet(left, right) {
+  return left.length === right.length && left.every((id) => right.includes(id));
+}
+
+const prepared = $items('Prepare Drive Publication Marks').map((item) => object(item && item.json));
+if (!prepared.length) throw new Error('Drive publication readback has no prepared mark contract.');
+const expectedFileIds = uniqueIds(prepared.map((row) => row.id), 'Prepared Drive publication marks');
+const declaredFileIds = uniqueIds(prepared[0].driveExpectedFileIds, 'Declared Drive publication marks');
+if (!sameSet(expectedFileIds, declaredFileIds)) throw new Error('Drive publication mark contract changed between fan-out and readback.');
+for (const row of prepared) {
+  if (!sameSet(uniqueIds(row.driveExpectedFileIds, 'Prepared Drive publication marks'), expectedFileIds)) {
+    throw new Error('Drive publication mark contract is not correlated to one verified group.');
+  }
+  if (Number(row.driveMarkCount) !== expectedFileIds.length) {
+    throw new Error('Drive publication mark count is inconsistent with its verified group.');
+  }
+}
+const finalContext = object(prepared[0].driveFinalContext);
+if (!text(finalContext.id) || !text(finalContext.groupKey)) throw new Error('Drive publication readback lost the final verified context.');
+
+const updates = $input.all().map((item) => object(item && item.json));
+if (updates.length !== expectedFileIds.length) {
+  throw new Error('Drive publication readback count mismatch: expected ' + expectedFileIds.length + ', got ' + updates.length + '.');
+}
+const verifiedIds = [];
+for (const update of updates) {
+  const id = text(update.id);
+  if (!expectedFileIds.includes(id)) throw new Error('Drive publication readback returned an unexpected file ID: ' + id + '.');
+  if (verifiedIds.includes(id)) throw new Error('Drive publication readback returned a duplicate file ID: ' + id + '.');
+  const properties = object(update.properties);
+  const appProperties = object(update.appProperties);
+  const published = text(properties.published || appProperties.published).toLowerCase() === 'true';
+  if (!published) throw new Error('Drive publication readback failed for ' + id + ': properties.published is not true.');
+  verifiedIds.push(id);
+}
+if (!sameSet(verifiedIds, expectedFileIds)) throw new Error('Drive publication readback is missing a verified source file.');
+
+return [{
+  json: {
+    ...finalContext,
+    fileIds: expectedFileIds,
+    driveAudit: {
+      state: 'verified',
+      published: true,
+      expectedFileIds,
+      verifiedFileIds: verifiedIds,
+      verifiedFileCount: verifiedIds.length,
+    },
+  },
+}];`;
+
+const assertCode = String.raw`function text(value) {
+  return String(value === undefined || value === null ? '' : value).trim();
+}
+function uniqueIds(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const id = text(value);
+    if (!id || seen.has(id)) throw new Error('Drive verification received an invalid file ID contract.');
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+function sameSet(left, right) {
+  return left.length === right.length && left.every((id) => right.includes(id));
+}
+
+const update = $input.first()?.json || {};
+const audit = update.driveAudit && typeof update.driveAudit === 'object' ? update.driveAudit : {};
+const expectedFileIds = uniqueIds(audit.expectedFileIds);
+const verifiedFileIds = uniqueIds(audit.verifiedFileIds);
+if (audit.state !== 'verified' || audit.published !== true || !expectedFileIds.length || !sameSet(expectedFileIds, verifiedFileIds)) {
+  throw new Error('Drive publish verification failed: every verified source file must be marked published=true.');
+}
+const finalContext = {
+  id: String(update.id || ''),
+  groupKey: String(update.groupKey || ''),
+  whatsappMessage: String(update.whatsappMessage || ''),
+  shouldNotify: update.shouldNotify === true,
+  codexDryRun: update.codexDryRun === true,
+};
+if (!finalContext.id || !finalContext.groupKey) throw new Error('Drive publish verification lost the final publication context.');
+return [{ json: { ...finalContext, driveAudit: {
+  state: 'verified',
+  fileId: finalContext.id,
+  published: true,
+  expectedFileIds,
+  verifiedFileIds,
+  verifiedFileCount: verifiedFileIds.length,
+} } }];`;
+
+function value(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || '' : '';
+}
+
+function required(name) {
+  const current = value(name);
+  if (!current) throw new Error(`${name} is required.`);
+  return current;
+}
+
+function readWorkflow(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function codeNode(name, id, position, jsCode) {
+  return {
+    parameters: { jsCode },
+    id,
+    name,
+    type: 'n8n-nodes-base.code',
+    typeVersion: 2,
+    position,
+  };
+}
+
+function setMain(connection, output, edges) {
+  connection.main ||= [];
+  connection.main[output] = edges;
+}
+
+function patchWorkflow(workflow) {
+  if (workflow?.id !== WORKFLOW_ID) throw new Error(`Expected Livia workflow ${WORKFLOW_ID}.`);
+  const candidate = structuredClone(workflow);
+  const update = (candidate.nodes || []).find((node) => node?.name === 'Update File');
+  const finalDryRun = (candidate.nodes || []).find((node) => node?.name === 'Switch Final Dry Run');
+  if (!update || update.type !== 'n8n-nodes-base.googleDrive') throw new Error('Update File must be the Google Drive update node.');
+  if (!finalDryRun) throw new Error('Switch Final Dry Run is required.');
+
+  candidate.nodes = (candidate.nodes || []).filter((node) => node?.name !== LEGACY_MERGE_NODE && node?.name !== PREPARE_NODE && node?.name !== COLLECT_NODE);
+  const updatePosition = Array.isArray(update.position) ? update.position : [0, 0];
+  candidate.nodes.push(
+    codeNode(PREPARE_NODE, '8c4e4943-5935-46c7-a5c8-efb3d18443e1', [Number(updatePosition[0]) - 260, Number(updatePosition[1]) - 96], prepareCode),
+    codeNode(COLLECT_NODE, '57d96dd2-d55f-4e27-a9cb-b7742ec26573', [Number(updatePosition[0]) + 260, Number(updatePosition[1])], collectCode),
+  );
+  const assertDrive = candidate.nodes.find((node) => node?.name === 'Assert Drive Published');
+  if (!assertDrive || assertDrive.type !== 'n8n-nodes-base.code') throw new Error('Assert Drive Published must be a Code node.');
+  assertDrive.parameters ||= {};
+  assertDrive.parameters.jsCode = assertCode;
+
+  candidate.connections ||= {};
+  setMain(candidate.connections['Switch Final Dry Run'] ||= {}, 0, [{ node: PREPARE_NODE, type: 'main', index: 0 }]);
+  setMain(candidate.connections[PREPARE_NODE] ||= {}, 0, [{ node: 'Update File', type: 'main', index: 0 }]);
+  setMain(candidate.connections['Update File'] ||= {}, 0, [{ node: COLLECT_NODE, type: 'main', index: 0 }]);
+  setMain(candidate.connections[COLLECT_NODE] ||= {}, 0, [{ node: 'Assert Drive Published', type: 'main', index: 0 }]);
+  delete candidate.connections[LEGACY_MERGE_NODE];
+
+  return candidate;
+}
+
+function main() {
+  const input = required('--input');
+  const output = required('--output');
+  const patched = patchWorkflow(readWorkflow(input));
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(patched, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(`${JSON.stringify({ ok: true, workflowId: patched.id, output, nodes: [PREPARE_NODE, COLLECT_NODE] })}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { PREPARE_NODE, COLLECT_NODE, prepareCode, collectCode, assertCode, patchWorkflow };

--- a/orb/engine/scripts/patch-livia-facebook-carousel-contract.js
+++ b/orb/engine/scripts/patch-livia-facebook-carousel-contract.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Patches the queue-side dependency resolver so a Facebook feed publication
+// can never be prepared from a subset, duplicate, or reordered set of
+// unpublished carousel children. This runs before the gateway is called.
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const NODE_NAME = 'Prepare HTTP Publish Request';
+const START_MARKER = 'function resolveDependencyValue(state, job, fieldName) {';
+const END_MARKER = '\n\nfunction applyPublishDependency';
+
+const REPLACEMENT = String.raw`function resolveDependencyValue(state, job, fieldName) {
+  const source = asObject(job);
+  const field = str(fieldName, "").trim();
+
+  if (!field) return undefined;
+
+  if (field === "creation_id") {
+    return resolveRemoteIdByExplicitRunIndexes(state, [
+      source.creationIdFromPublishRunIndex,
+      source.checkStatusFromPublishRunIndex,
+      source.statusFromPublishRunIndex,
+    ]);
+  }
+
+  if (field === "video_id") {
+    return resolveRemoteIdByExplicitRunIndexes(state, [
+      source.reelsStartFromPublishRunIndex,
+      source.checkStatusFromPublishRunIndex,
+      source.lastUploadFromPublishRunIndex,
+      source.statusFromPublishRunIndex,
+    ]);
+  }
+
+  if (field === "attached_media") {
+    const runIndexes = asArray(source.attachedMediaFromPublishRunIndexes);
+    const expectedSourceIds = asArray(source.sourceMediaIds).map((value) => str(value, "").trim()).filter(Boolean);
+    const expectedCount = Number(source.sourceMediaCount || 0);
+    if (!expectedCount || expectedSourceIds.length !== expectedCount || runIndexes.length !== expectedCount) {
+      throw new Error(
+        "Prepare HTTP Publish Request: contrato Facebook attached_media incompleto " +
+        "(expected=" + expectedCount + ", sourceIds=" + expectedSourceIds.length + ", runIndexes=" + runIndexes.length + ")."
+      );
+    }
+    if (new Set(expectedSourceIds).size !== expectedSourceIds.length || new Set(runIndexes).size !== runIndexes.length) {
+      throw new Error("Prepare HTTP Publish Request: contrato Facebook attached_media contém identidade duplicada.");
+    }
+
+    const allJobs = asArray(state.allJobs);
+    const entries = runIndexes.map((runIndex) => {
+      const producer = allJobs.find((candidate) => Number(asObject(candidate).publishRunIndex) === Number(runIndex));
+      const sourceMediaId = str(asObject(asObject(producer).media).id, "").trim();
+      const providerMediaId = extractRemoteIdFromEnvelope(getRunEnvelope(state, runIndex));
+      return { runIndex, sourceMediaId, providerMediaId };
+    });
+    if (entries.some((entry) => !entry.sourceMediaId || !entry.providerMediaId)) {
+      throw new Error("Prepare HTTP Publish Request: Facebook attached_media contém upload sem identidade ou provider media id.");
+    }
+    if (entries.map((entry) => entry.sourceMediaId).join("|") !== expectedSourceIds.join("|")) {
+      throw new Error("Prepare HTTP Publish Request: Facebook attached_media perdeu a ordem ou identidade semântica do grupo.");
+    }
+    if (new Set(entries.map((entry) => entry.providerMediaId)).size !== entries.length) {
+      throw new Error("Prepare HTTP Publish Request: Facebook attached_media recebeu provider media id duplicado.");
+    }
+    return entries.map((entry) => ({ media_fbid: entry.providerMediaId }));
+  }
+
+  if (field === "children") {
+    const ids = asArray(source.childrenPublishRunIndexes)
+      .map((runIndex) => extractRemoteIdFromEnvelope(getRunEnvelope(state, runIndex)))
+      .filter((value) => str(value, "").trim());
+    // Threads expects a JSON array; Instagram uses a comma-separated list.
+    return str(source.platform, "").trim().toLowerCase() === "threads" ? JSON.stringify(ids) : ids.join(",");
+  }
+
+  return resolveRemoteIdFromState(state, source);
+}`;
+
+function readWorkflow(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function patchCode(code) {
+  const current = String(code || '');
+  const start = current.indexOf(START_MARKER);
+  const end = start >= 0 ? current.indexOf(END_MARKER, start) : -1;
+  if (start < 0 || end < 0) {
+    throw new Error(`${NODE_NAME} does not contain the expected dependency resolver.`);
+  }
+  return `${current.slice(0, start)}${REPLACEMENT}${current.slice(end)}`;
+}
+
+function patchWorkflow(workflow) {
+  if (workflow?.id !== WORKFLOW_ID) throw new Error(`Expected Livia workflow ${WORKFLOW_ID}.`);
+  const candidate = structuredClone(workflow);
+  const node = (candidate.nodes || []).find((entry) => entry?.name === NODE_NAME);
+  if (!node || node.type !== 'n8n-nodes-base.code') throw new Error(`${NODE_NAME} must be a Code node.`);
+  node.parameters ||= {};
+  node.parameters.jsCode = patchCode(node.parameters.jsCode);
+  return candidate;
+}
+
+function requiredOption(name) {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1] || '' : '';
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function main() {
+  const input = requiredOption('--input');
+  const output = requiredOption('--output');
+  const patched = patchWorkflow(readWorkflow(input));
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(patched, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(JSON.stringify({ ok: true, workflowId: patched.id, node: NODE_NAME, output }) + '\n');
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { NODE_NAME, REPLACEMENT, patchCode, patchWorkflow };

--- a/orb/engine/scripts/patch-livia-runtime-isolation.js
+++ b/orb/engine/scripts/patch-livia-runtime-isolation.js
@@ -157,4 +157,13 @@ function main() {
   process.stdout.write(JSON.stringify({ ok: true, workflowId: WORKFLOW_ID, releaseRoot, nodes: touched, semanticResumeNodes }) + '\n');
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  WORKFLOW_ID,
+  MUTABLE_RUNTIME_RE,
+  patchResumeIdentity,
+  validate,
+};

--- a/orb/engine/scripts/patch-livia-token-vault-preflight.js
+++ b/orb/engine/scripts/patch-livia-token-vault-preflight.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const NODE_NAME = 'Validate Publish Token Health';
+
+function value(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || '' : '';
+}
+
+function required(name) {
+  const current = value(name);
+  if (!current) throw new Error(`${name} is required.`);
+  return current;
+}
+
+function readWorkflow(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function commandFor(releaseRoot) {
+  if (!/^\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine$/.test(releaseRoot)) {
+    throw new Error('release root must be an immutable /opt/skincos/releases/<sha>/source/orb/engine path.');
+  }
+  return `={{ (() => {
+  const payload = $json || {};
+  function sh(value) { return "'" + String(value).replace(/'/g, "'\\\\''") + "'"; }
+  return "set -a; . /etc/skincos/orb-business.env; set +a; node " + sh("${releaseRoot}/scripts/livia/validate-publish-token-health.js") + " --payload " + sh(JSON.stringify(payload));
+})() }}`;
+}
+
+function patchWorkflow(workflow, releaseRoot) {
+  if (workflow?.id !== WORKFLOW_ID) throw new Error(`Expected Livia workflow ${WORKFLOW_ID}.`);
+  const node = (workflow.nodes || []).find((candidate) => candidate?.name === NODE_NAME);
+  if (!node || node.type !== 'n8n-nodes-base.executeCommand') {
+    throw new Error(`${NODE_NAME} must be an Execute Command node.`);
+  }
+  const candidate = structuredClone(workflow);
+  const target = candidate.nodes.find((entry) => entry?.name === NODE_NAME);
+  target.parameters ||= {};
+  target.parameters.command = commandFor(releaseRoot);
+  return candidate;
+}
+
+function main() {
+  const input = required('--input');
+  const output = required('--output');
+  const releaseRoot = required('--release-root');
+  const patched = patchWorkflow(readWorkflow(input), releaseRoot);
+  const outputDir = path.dirname(output);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(patched, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    workflowId: patched.id,
+    node: NODE_NAME,
+    output,
+    releaseRoot,
+  })}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { commandFor, patchWorkflow };

--- a/orb/engine/scripts/prepare-livia-production-candidate.js
+++ b/orb/engine/scripts/prepare-livia-production-candidate.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Build the only candidate shape that may be promoted to the active Livia
+// workflow. Keeping every required remediation here makes it impossible for a
+// production promotion to accidentally omit a previously versioned guard.
+
+const fs = require('fs');
+const path = require('path');
+const { patchWorkflow: patchDrivePublicationMarks } = require('./patch-livia-drive-publication-marks');
+const { patchWorkflow: patchTokenVaultPreflight } = require('./patch-livia-token-vault-preflight');
+const { patchWorkflow: patchAccessibilityContract } = require('./patch-livia-accessibility-contract');
+const { patchWorkflow: patchFacebookCarouselContract } = require('./patch-livia-facebook-carousel-contract');
+const { patchResumeIdentity, validate: pinRuntimeIsolation } = require('./patch-livia-runtime-isolation');
+
+const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine$/;
+
+function required(name) {
+  const index = process.argv.indexOf(name);
+  const inline = process.argv.find((entry) => entry.startsWith(`${name}=`));
+  const value = inline ? inline.slice(name.length + 1) : (index >= 0 ? process.argv[index + 1] || '' : '');
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function readWorkflow(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function buildCandidate(workflow, releaseRoot) {
+  if (!RELEASE_ROOT_RE.test(releaseRoot)) {
+    throw new Error('release root must be an immutable /opt/skincos/releases/<sha>/source/orb/engine path.');
+  }
+
+  let candidate = patchDrivePublicationMarks(workflow);
+  candidate = patchTokenVaultPreflight(candidate, releaseRoot);
+  candidate = patchAccessibilityContract(candidate);
+  candidate = patchFacebookCarouselContract(candidate);
+  const semanticResumeNodes = patchResumeIdentity(candidate);
+  const runtimeNodes = pinRuntimeIsolation(candidate, releaseRoot);
+
+  return {
+    workflow: candidate,
+    report: {
+      workflowId: candidate.id,
+      releaseRoot,
+      patches: [
+        'drive-publication-marks',
+        'token-vault-preflight',
+        'accessibility-contract',
+        'facebook-carousel-contract',
+        'runtime-isolation',
+      ],
+      runtimeNodes,
+      semanticResumeNodes,
+    },
+  };
+}
+
+function main() {
+  const input = required('--input');
+  const output = required('--output');
+  const releaseRoot = required('--release-root');
+  const { workflow, report } = buildCandidate(readWorkflow(input), releaseRoot);
+  fs.mkdirSync(path.dirname(output), { recursive: true, mode: 0o750 });
+  fs.writeFileSync(output, `${JSON.stringify(workflow, null, 2)}\n`, { mode: 0o640 });
+  process.stdout.write(`${JSON.stringify({ ok: true, output, ...report })}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { buildCandidate };

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -306,9 +306,12 @@ function validateContracts() {
   assert(processMediaAssetCommand.length < 2500, `Process Media Asset command must stay small enough for stable expression parsing (${processMediaAssetCommand.length} chars)`);
   const jobGraphScript = path.join(__dirname, 'livia', 'build-platform-job-graph.js');
   const jobGraphSource = fs.readFileSync(jobGraphScript, 'utf8');
+  const compose2Source = fs.readFileSync(path.join(__dirname, '..', 'compose2-current.js'), 'utf8');
+  const verifierSource = fs.readFileSync(path.join(__dirname, 'livia', 'verify-published-artifacts.js'), 'utf8');
   assert(jobGraphSource.includes('normalizeExternalResult'), 'Livia job graph must accept both direct n8n jobs and jobs envelopes.');
   assert(jobGraphSource.includes('assertOutputContract'), 'Livia job graph must self-test its output contract.');
   assert(jobGraphSource.includes('assertJobGraphContracts'), 'Livia job graph must test image, Reel and carousel fixtures without the gateway.');
+  assert(jobGraphSource.includes('assertFacebookCarouselRepresentation'), 'Livia job graph must reject Facebook carousel jobs that drop, duplicate, or reorder media.');
   assert(jobGraphSource.includes('semanticJobKey'), 'Livia job graph must derive a semantic durable resume identity.');
   assert(jobGraphSource.includes('assertResumeIdentityContracts'), 'Livia job graph must prove queue-index changes do not alter resume identity.');
   assert(jobGraphSource.includes('invalidateIncompleteCarouselResume'), 'Livia resume logic must invalidate partial Instagram carousel attempts before reusing child containers');
@@ -316,6 +319,10 @@ function validateContracts() {
   assert(jobGraphSource.includes('normalizeThreadsCarouselJob'), 'Livia job graph must keep Threads carousel child and parent request contracts distinct');
   assert(jobGraphSource.includes("request.media_type = 'IMAGE'"), 'Livia Threads carousel children must explicitly request media_type=IMAGE');
   assert(jobGraphSource.includes("request.media_type = 'CAROUSEL'"), 'Livia Threads carousel parent must explicitly request media_type=CAROUSEL');
+  assert(compose2Source.includes('facebookUseReels'), 'Livia must use Facebook Reels only for a single source video.');
+  assert(compose2Source.includes('sourceMediaIds') && compose2Source.includes('sourceMediaCount'), 'Livia must preserve Facebook attachment source identity/count before the gateway.');
+  assert(!compose2Source.includes('usando apenas o 1º vídeo'), 'Livia must not publish only the first video from a carousel.');
+  assert(!compose2Source.includes('vídeo detectado em grupo não-reels; ignorado'), 'Livia must not silently discard a video from a mixed carousel.');
   assert(prepareHttp.includes('JSON.stringify(ids)'), 'Prepare HTTP Publish Request must serialize Threads carousel children as a JSON array');
   assert(prepareBatch.includes('uploadEligible'), 'Prepare Media Upload Batch must preserve uploadEligible from the media processor');
   assert(prepareBatch.includes('blockReason'), 'Prepare Media Upload Batch must preserve the media block reason');
@@ -398,6 +405,8 @@ function validateContracts() {
   assert(processHttp.includes('state.completed.push(resultJson)'), 'Process HTTP Publish Result must accumulate completed jobs');
   assert(prepareHttp.includes('childrenPublishRunIndexes'), 'Prepare HTTP Publish Request must resolve carousel child container ids');
   assert(prepareHttp.includes('ids.join(",")'), 'Prepare HTTP Publish Request must serialize carousel children in the Meta format');
+  assert(prepareHttp.includes('sourceMediaCount') && prepareHttp.includes('sourceMediaIds'), 'Prepare HTTP Publish Request must validate the complete Facebook attachment contract before the gateway.');
+  assert(prepareHttp.includes('perdeu a ordem ou identidade semântica'), 'Prepare HTTP Publish Request must fail closed on Facebook attachment order/identity drift.');
   assert(processHttp.includes('resolvePrepareRequestContext'), 'Process HTTP Publish Result must recover the prepared request context after HTTP nodes replace the input payload');
   assert(processHttp.includes('resolvedStateKey'), 'Process HTTP Publish Result must resolve the matching inflight state deterministically during retries');
   assert(!processHttp.includes('$("Prepare HTTP Publish Request").item'), 'Process HTTP Publish Result must not use named-node lookups inside the task runner');
@@ -419,6 +428,7 @@ function validateContracts() {
   assert(collect.includes('publishMode'), 'Collect Publish Results must distinguish Reels from static posts');
   assert(collect.includes('providerMediaId'), 'Collect Publish Results must preserve the provider media id alongside the final post id');
   assert(collect.includes('firstSubmitted'), 'Collect Publish Results must aggregate submitted fields across upload and publish phases');
+  assert(collect.includes('mediaEvidenceContract') && collect.includes('providerMediaId'), 'Collect Publish Results must preserve ordered provider media evidence for every source asset.');
   assert(!collect.includes('platform === "facebook"\n        ? __prStr(startBody.video_id'), 'Collect Publish Results must not require a Reels video_id for every Facebook post');
   assert(collect.includes('codexDryRun'), 'Collect Publish Results must propagate codexDryRun');
   assert(collect.includes('shouldNotify: codexDryRun ? false'), 'Collect Publish Results must disable notifications during Codex dry-run');
@@ -451,6 +461,8 @@ function validateContracts() {
   assert(/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine\/scripts\/livia\/verify-published-artifacts\.js/.test(verifyCommand), 'Verifier must invoke the immutable release entrypoint directly');
   assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/.test(verifyCommand), 'Verifier must not use a mutable root or compatibility wrapper');
   assert(!verifyCommand.includes('Get Credential Tokens') && !verifyCommand.includes('tokenRoot'), 'Verifier must not expose token-vault data in its command line');
+  assert(verifierSource.includes('assessMediaEvidence'), 'Published-artifact verification must reject a provider post that omits a source media attachment.');
+  assert(verifierSource.includes('facebook_composite_attachment_identity_missing'), 'Published-artifact verification must name missing Facebook carousel attachments causally.');
   assert(attachVerified.includes('result.ok !== true'), 'Verifier failures must stop final effects');
   assert(prepareDriveMarks.includes('driveExpectedFileIds') && prepareDriveMarks.includes('fileIds'), 'Drive fan-out must use the verified source fileIds contract');
   assert(collectDriveMarks.includes("$items('Prepare Drive Publication Marks')"), 'Drive collector must correlate readbacks to the semantic fan-out contract');

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -106,7 +106,8 @@ function validateStructure() {
     'Verify Published Artifacts',
     'Attach Verified Publish Artifacts',
     'Switch Final Dry Run',
-    'Merge Drive Result and Context',
+    'Prepare Drive Publication Marks',
+    'Collect Drive Publication Marks',
     'Assert Drive Published',
   ]) {
     assert(names.has(name), `Missing node: ${name}`);
@@ -239,11 +240,12 @@ function validateStructure() {
   assert(!connectionExists('Collect Publish Results', 'Inform Success (1)'), 'Collect Publish Results must not directly feed Inform Success (1)');
   assert(!connectionExists('Collect Publish Results', 'Update File'), 'Collect Publish Results must not directly feed Update File');
   assert(!connectionExists('Collect Publish Results', 'Cleanup Temp Files'), 'Collect Publish Results must not directly feed Cleanup Temp Files');
-  assert(connectionExists('Switch Final Dry Run', 'Update File', 0), 'Switch Final Dry Run normal output must feed Update File');
-  assert(connectionExists('Switch Final Dry Run', 'Merge Drive Result and Context', 0), 'Switch Final Dry Run must preserve the notification context for Drive verification');
+  assert(!names.has('Merge Drive Result and Context'), 'Drive publication must not use a positional merge that can discard carousel source files');
+  assert(connectionExists('Switch Final Dry Run', 'Prepare Drive Publication Marks', 0), 'Switch Final Dry Run normal output must fan out verified Drive source files');
+  assert(connectionExists('Prepare Drive Publication Marks', 'Update File'), 'Every verified Drive source file must be sent to Update File');
   const updateEdges = workflow.connections?.['Update File']?.main?.[0] || [];
-  assert(updateEdges.some((edge) => edge?.node === 'Merge Drive Result and Context' && edge?.index === 1), 'Update File must feed the Drive result into the final merge');
-  assert(connectionExists('Merge Drive Result and Context', 'Assert Drive Published'), 'Merged Drive result and notification context must feed Assert Drive Published');
+  assert(updateEdges.some((edge) => edge?.node === 'Collect Drive Publication Marks'), 'Update File must feed every API readback into the Drive publication collector');
+  assert(connectionExists('Collect Drive Publication Marks', 'Assert Drive Published'), 'Collected Drive readbacks must feed Assert Drive Published');
   const notificationNode = names.has('Inform Success (1)') ? 'Inform Success (1)' : 'Inform Success (2)';
   assert(connectionExists('Assert Drive Published', notificationNode), 'Verified Drive update must feed notification');
   assert(connectionExists('Assert Drive Published', 'Cleanup Temp Files'), 'Verified Drive update must feed cleanup');
@@ -281,6 +283,8 @@ function validateContracts() {
   const tokenHealthCommand = commandOf('Validate Publish Token Health');
   const verifyCommand = commandOf('Verify Published Artifacts');
   const attachVerified = codeOf('Attach Verified Publish Artifacts');
+  const prepareDriveMarks = codeOf('Prepare Drive Publication Marks');
+  const collectDriveMarks = codeOf('Collect Drive Publication Marks');
   const assertDrive = codeOf('Assert Drive Published');
   const attach = codeOf('Attach Uploaded Main Media Metadata');
   const waitAmount = String(getNode('Wait')?.parameters?.amount || '');
@@ -448,11 +452,12 @@ function validateContracts() {
   assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\/|livia-verify-provider-copy-drift-wrapper|--verifier\b/.test(verifyCommand), 'Verifier must not use a mutable root or compatibility wrapper');
   assert(!verifyCommand.includes('Get Credential Tokens') && !verifyCommand.includes('tokenRoot'), 'Verifier must not expose token-vault data in its command line');
   assert(attachVerified.includes('result.ok !== true'), 'Verifier failures must stop final effects');
-  assert(assertDrive.includes('appProperties.published'), 'Drive verification must assert published=true');
+  assert(prepareDriveMarks.includes('driveExpectedFileIds') && prepareDriveMarks.includes('fileIds'), 'Drive fan-out must use the verified source fileIds contract');
+  assert(collectDriveMarks.includes("$items('Prepare Drive Publication Marks')"), 'Drive collector must correlate readbacks to the semantic fan-out contract');
+  assert(collectDriveMarks.includes('properties.published') && collectDriveMarks.includes('count mismatch'), 'Drive collector must reject missing or unmarked source files');
+  assert(assertDrive.includes('expectedFileIds') && assertDrive.includes('verifiedFileIds'), 'Drive verification must assert every source file was marked published=true');
   assert(assertDrive.includes('const finalContext ='), 'Drive verification must project a bounded final context');
   assert(!assertDrive.includes('...original') && !assertDrive.includes('$('), 'Drive verification must not resolve or spread an upstream publish envelope');
-  const driveMerge = getNode('Merge Drive Result and Context')?.parameters || {};
-  assert(driveMerge.mode === 'combine' && driveMerge.combineBy === 'combineByPosition', 'Drive merge must combine the compact context and Drive response by position');
   assert(updateOptions.includes('"fields":["*"]'), 'Update File must return properties for verification');
   if (getNode('Inform Success (1)')) {
     assert(notifyPhone.includes('N8N_DEFAULT_TEST_PHONE') && !notifyPhone.includes('555195103563'), 'Notification must use the runtime E.164 phone instead of a hard-coded JID');
@@ -598,11 +603,41 @@ function validateManualDryRunFixture() {
   assert(mismatched?.[0]?.json?.firstJob?.semanticJobKey === semanticJobKey, 'Mismatched semantic progress must not suppress a current provider job');
 }
 
+function validateDrivePublicationMarkFixture() {
+  const prepare = codeOf('Prepare Drive Publication Marks');
+  const collect = codeOf('Collect Drive Publication Marks');
+  const assertDrive = codeOf('Assert Drive Published');
+  const source = {
+    json: {
+      id: 'drive-a',
+      fileIds: ['drive-a', 'drive-b', 'drive-c'],
+      groupKey: 'dt:fixture',
+      whatsappMessage: 'fixture',
+      shouldNotify: true,
+      codexDryRun: false,
+    },
+  };
+  const prepared = runCode(prepare, {
+    $input: { all: () => [source], first: () => source },
+  });
+  assert(Array.isArray(prepared) && prepared.length === 3, 'Drive mark fan-out fixture must emit one update item per source file');
+  const updates = prepared.map((item) => ({ json: { id: item.json.id, properties: { published: 'true' } } }));
+  const collected = runCode(collect, {
+    $input: { all: () => updates, first: () => updates[0] },
+    $items: (name) => name === 'Prepare Drive Publication Marks' ? prepared : [],
+  });
+  const verified = runCode(assertDrive, {
+    $input: { all: () => collected, first: () => collected[0] },
+  });
+  assert(verified?.[0]?.json?.driveAudit?.verifiedFileCount === 3, 'Drive mark fixture must retain all verified source file IDs');
+}
+
 validateStructure();
 validateSyntax();
 validateContracts();
 validateFixtures();
 validateManualDryRunFixture();
+validateDrivePublicationMarkFixture();
 
 if (errors.length) {
   console.error(`Validation failed for ${workflowPath}`);

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -278,6 +278,7 @@ function validateContracts() {
   const prepareHttp = codeOf('Prepare HTTP Publish Request');
   const processHttp = codeOf('Process HTTP Publish Result');
   const collect = codeOf('Collect Publish Results');
+  const tokenHealthCommand = commandOf('Validate Publish Token Health');
   const verifyCommand = commandOf('Verify Published Artifacts');
   const attachVerified = codeOf('Attach Verified Publish Artifacts');
   const assertDrive = codeOf('Assert Drive Published');
@@ -435,6 +436,12 @@ function validateContracts() {
     assert(!Object.prototype.hasOwnProperty.call(httpParameters, 'body'), 'Managed social publish gateway must not retain a raw body, which turns the response into a stream');
   }
   assert(commandOf('Cleanup Temp Files').includes('isAllowedCleanupDir'), 'Cleanup Temp Files must delete per-execution asset directories safely');
+  assert(tokenHealthCommand.includes('validate-publish-token-health.js'), 'Validate Publish Token Health must invoke the versioned credential preflight');
+  assert(tokenHealthCommand.includes('. /etc/skincos/orb-business.env'), 'Token preflight must load the same protected bearer used by the verifier');
+  const tokenHealthScript = fs.readFileSync(path.join(__dirname, 'livia', 'validate-publish-token-health.js'), 'utf8');
+  for (const required of ['gatewayChecks', 'gateway_missing', 'checkThroughGateway']) {
+    assert(tokenHealthScript.includes(required), `Token preflight must fail closed on gateway authorization (${required})`);
+  }
   assert(verifyCommand.includes('verify-published-artifacts.js'), 'Verify Published Artifacts must call the external verifier');
   assert(verifyCommand.includes('--payload -') && verifyCommand.includes('printf %s'), 'Verifier must receive a bounded payload through stdin');
   assert(/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine\/scripts\/livia\/verify-published-artifacts\.js/.test(verifyCommand), 'Verifier must invoke the immutable release entrypoint directly');

--- a/orb/engine/tests/livia-accessibility-contract.test.js
+++ b/orb/engine/tests/livia-accessibility-contract.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  NODE_NAME,
+  patchWorkflow,
+} = require('../scripts/patch-livia-accessibility-contract');
+const {
+  patchCode: patchFacebookCarouselDependency,
+} = require('../scripts/patch-livia-facebook-carousel-contract');
+const {
+  assessAccessibilityContract,
+  assessMediaEvidence,
+  buildDelivery,
+} = require('../scripts/livia/verify-published-artifacts');
+
+function mediaItem({ id, order, kind, support, expected = 'Descrição editorial', submitted = expected }) {
+  return {
+    sourceMediaId: id,
+    groupOrder: order,
+    semanticJobKey: `livia:v2:${id}`,
+    mediaKind: kind,
+    support,
+    expectedAltText: expected,
+    submittedAltText: submitted,
+  };
+}
+
+function contract(items) {
+  const required = items.filter((item) => item.support === 'required');
+  return {
+    schema: 'livia.media-alt-text.v1',
+    orderedBy: 'groupOrder',
+    items,
+    requiredCount: required.length,
+    submittedRequiredCount: required.filter((item) => item.submittedAltText).length,
+    unsupportedCount: items.filter((item) => item.support === 'unsupported').length,
+  };
+}
+
+function mediaEvidence(items) {
+  return {
+    schema: 'livia.media-evidence.v1',
+    orderedBy: 'groupOrder',
+    items,
+  };
+}
+
+test('accessibility workflow patch replaces the group-level first-alt lookup with correlated media evidence', () => {
+  const legacyCode = [
+    'const __prAsArray = (value) => Array.isArray(value) ? value : [];',
+    'const __prAsObject = (value) => value && typeof value === "object" ? value : {};',
+    'const __prStr = (value) => String(value || "");',
+    'function buildPublishVerificationTargets(completedRows, groupKey) { return []; }',
+    '',
+    'const codexDryRun = false;',
+  ].join('\n');
+  const workflow = {
+    id: 'WGXr4vYkv9UoJ8zc',
+    nodes: [{ name: NODE_NAME, type: 'n8n-nodes-base.code', parameters: { jsCode: legacyCode } }],
+  };
+  const patched = patchWorkflow(workflow);
+  const code = patched.nodes[0].parameters.jsCode;
+  assert.match(code, /accessibilityContract/);
+  assert.match(code, /semanticJobKey/);
+  assert.match(code, /required alt_text is missing or does not match editorial evidence/);
+  assert.deepEqual(patchWorkflow(patched), patched);
+});
+
+test('Facebook carousel dependency patch rejects positional attachment assembly', () => {
+  const legacyCode = [
+    'function resolveDependencyValue(state, job, fieldName) { return []; }',
+    '',
+    'function applyPublishDependency(state, job, requestBody) { return requestBody; }',
+  ].join('\n');
+  const patched = patchFacebookCarouselDependency(legacyCode);
+  assert.match(patched, /sourceMediaCount/);
+  assert.match(patched, /sourceMediaIds/);
+  assert.match(patched, /perdeu a ordem ou identidade semântica/);
+  assert.equal(patchFacebookCarouselDependency(patched), patched);
+});
+
+test('Threads requires alt text for image and video carousel children, while Instagram records video as explicit unsupported', () => {
+  const threads = assessAccessibilityContract({
+    platform: 'threads',
+    accessibilityContract: contract([
+      mediaItem({ id: 'image-1', order: 0, kind: 'image', support: 'required', expected: 'Imagem clínica' }),
+      mediaItem({ id: 'video-2', order: 1, kind: 'video', support: 'required', expected: 'Vídeo clínico' }),
+    ]),
+  });
+  assert.equal(threads.status, 'accepted');
+  assert.equal(threads.requiredCount, 2);
+
+  const instagramMixed = assessAccessibilityContract({
+    platform: 'instagram',
+    accessibilityContract: contract([
+      mediaItem({ id: 'image-1', order: 0, kind: 'image', support: 'required', expected: 'Imagem clínica' }),
+      mediaItem({ id: 'video-2', order: 1, kind: 'video', support: 'unsupported', expected: 'Vídeo clínico', submitted: '' }),
+    ]),
+  });
+  assert.equal(instagramMixed.status, 'accepted');
+  assert.equal(instagramMixed.requiredCount, 1);
+  assert.equal(instagramMixed.unsupportedCount, 1);
+});
+
+test('missing or mismatched required alt text turns provider verification into a failure', () => {
+  const accessibility = assessAccessibilityContract({
+    platform: 'instagram',
+    accessibilityContract: contract([
+      mediaItem({ id: 'image-1', order: 0, kind: 'image', support: 'required', expected: 'Imagem clínica', submitted: '' }),
+    ]),
+  });
+  assert.equal(accessibility.status, 'failed');
+  assert.equal(accessibility.reason, 'alt_text_not_submitted_or_mismatched');
+
+  const delivery = buildDelivery({
+    platform: 'instagram',
+    unit: 'bss',
+    mediaKind: 'image',
+    publishMode: 'static',
+    providerObjectId: 'provider-image-1',
+    expected: { caption: 'Legenda validada' },
+    submitted: {},
+    accessibilityContract: contract([
+      mediaItem({ id: 'image-1', order: 0, kind: 'image', support: 'required', expected: 'Imagem clínica', submitted: '' }),
+    ]),
+  }, {
+    statusCode: 200,
+    body: { id: 'provider-image-1', permalink: 'https://instagram.com/p/example', media_type: 'IMAGE', caption: 'Legenda validada' },
+  });
+  assert.equal(delivery.state, 'failed');
+  assert.ok(delivery.errors.some((entry) => entry.startsWith('accessibility_failed:')));
+});
+
+test('Facebook carousel verification rejects a provider post that omits a later source attachment', () => {
+  const evidenceItems = [
+    { sourceMediaId: 'video-1', groupOrder: 0, semanticJobKey: 'livia:v2:video-1', mediaKind: 'video', providerMediaId: '10' },
+    { sourceMediaId: 'image-2', groupOrder: 1, semanticJobKey: 'livia:v2:image-2', mediaKind: 'image', providerMediaId: '20' },
+  ];
+  const target = {
+    platform: 'facebook',
+    unit: 'bss',
+    mediaKind: 'carousel',
+    publishMode: 'carousel',
+    providerObjectId: '111_222',
+    providerMediaId: '10',
+    expected: { caption: 'Legenda baseada nas duas mídias' },
+    submitted: {},
+    accessibilityContract: contract([
+      mediaItem({ id: 'video-1', order: 0, kind: 'video', support: 'unsupported', expected: 'Vídeo editorial', submitted: '' }),
+      mediaItem({ id: 'image-2', order: 1, kind: 'image', support: 'unsupported', expected: 'Imagem editorial', submitted: '' }),
+    ]),
+    mediaEvidenceContract: mediaEvidence(evidenceItems),
+  };
+  const provider = {
+    statusCode: 200,
+    body: {
+      id: '111_222',
+      permalink_url: 'https://www.facebook.com/111/posts/222',
+      message: 'Legenda baseada nas duas mídias',
+      from: { id: '111' },
+      attachments: { data: [{ media_type: 'video', target: { id: '10' } }, { media_type: 'photo', target: { id: '20' } }] },
+    },
+  };
+  assert.equal(assessMediaEvidence(target, provider.body).status, 'accepted');
+  assert.equal(buildDelivery(target, provider).state, 'verified');
+
+  const missingLater = {
+    ...provider,
+    body: { ...provider.body, attachments: { data: [{ media_type: 'video', target: { id: '10' } }] } },
+  };
+  const delivery = buildDelivery(target, missingLater);
+  assert.equal(delivery.state, 'failed');
+  assert.ok(delivery.errors.includes('media_evidence_failed:facebook_composite_attachment_identity_missing'));
+});
+
+test('offline job-graph matrix proves per-media accessibility without calling the gateway', () => {
+  const engine = path.resolve(__dirname, '..');
+  const result = spawnSync(process.execPath, [
+    'scripts/livia/build-platform-job-graph.js',
+    '--assert-job-graph-contracts',
+  ], {
+    cwd: engine,
+    env: {
+      ...process.env,
+      LIVIA_BUILD_JOB_GRAPH_SOURCE: path.join(engine, 'compose2-current.js'),
+      N8N_RUNTIME_HOME: path.join(engine, '.tmp-livia-accessibility-contract'),
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, true);
+  assert.equal(report.accessibilityContracts.threadsVideo, 'submitted');
+  assert.equal(report.accessibilityContracts.instagramVideo, 'unsupported');
+  assert.equal(report.jobGraphContracts.length, 5);
+});

--- a/orb/engine/tests/livia-drive-publication-marks.test.js
+++ b/orb/engine/tests/livia-drive-publication-marks.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  PREPARE_NODE,
+  COLLECT_NODE,
+  prepareCode,
+  collectCode,
+  assertCode,
+  patchWorkflow,
+} = require('../scripts/patch-livia-drive-publication-marks');
+
+function runCode(code, { input = [], items = () => [] } = {}) {
+  return new Function('$input', '$items', `"use strict";\n${code}`)(
+    { all: () => input, first: () => input[0] || { json: {} } },
+    items,
+  );
+}
+
+function baseWorkflow() {
+  return {
+    id: 'WGXr4vYkv9UoJ8zc',
+    nodes: [
+      { name: 'Switch Final Dry Run', type: 'n8n-nodes-base.switch', position: [0, 0], parameters: {} },
+      { name: 'Update File', type: 'n8n-nodes-base.googleDrive', position: [400, 0], parameters: {} },
+      { name: 'Merge Drive Result and Context', type: 'n8n-nodes-base.merge', position: [600, 0], parameters: {} },
+      { name: 'Assert Drive Published', type: 'n8n-nodes-base.code', position: [800, 0], parameters: { jsCode: 'old' } },
+    ],
+    connections: {
+      'Switch Final Dry Run': { main: [[
+        { node: 'Update File', type: 'main', index: 0 },
+        { node: 'Merge Drive Result and Context', type: 'main', index: 0 },
+      ], []] },
+      'Update File': { main: [[{ node: 'Merge Drive Result and Context', type: 'main', index: 1 }]] },
+      'Merge Drive Result and Context': { main: [[{ node: 'Assert Drive Published', type: 'main', index: 0 }]] },
+    },
+  };
+}
+
+test('Drive publication patch fans out every verified source and removes the positional merge', () => {
+  const patched = patchWorkflow(baseWorkflow());
+  const names = patched.nodes.map((node) => node.name);
+  assert.ok(names.includes(PREPARE_NODE));
+  assert.ok(names.includes(COLLECT_NODE));
+  assert.ok(!names.includes('Merge Drive Result and Context'));
+  assert.deepEqual(patched.connections['Switch Final Dry Run'].main[0], [{ node: PREPARE_NODE, type: 'main', index: 0 }]);
+  assert.deepEqual(patched.connections[PREPARE_NODE].main[0], [{ node: 'Update File', type: 'main', index: 0 }]);
+  assert.deepEqual(patched.connections['Update File'].main[0], [{ node: COLLECT_NODE, type: 'main', index: 0 }]);
+  assert.deepEqual(patched.connections[COLLECT_NODE].main[0], [{ node: 'Assert Drive Published', type: 'main', index: 0 }]);
+  assert.deepEqual(patchWorkflow(patched), patched);
+});
+
+test('Drive publication contract marks and verifies every carousel source file', () => {
+  const source = { json: {
+    id: 'file-a',
+    fileIds: ['file-a', 'file-b', 'file-c'],
+    groupKey: 'dt:2907261000',
+    whatsappMessage: 'ok',
+    shouldNotify: true,
+    codexDryRun: false,
+  } };
+  const prepared = runCode(prepareCode, { input: [source] });
+  assert.equal(prepared.length, 3);
+  assert.deepEqual(prepared.map((item) => item.json.id), ['file-a', 'file-b', 'file-c']);
+  const updates = prepared.map((item) => ({ json: { id: item.json.id, properties: { published: 'true' } } }));
+  const collected = runCode(collectCode, { input: updates, items: (name) => name === PREPARE_NODE ? prepared : [] });
+  assert.deepEqual(collected[0].json.driveAudit.verifiedFileIds, ['file-a', 'file-b', 'file-c']);
+  const asserted = runCode(assertCode, { input: collected });
+  assert.equal(asserted[0].json.driveAudit.verifiedFileCount, 3);
+});
+
+test('Drive publication contract fails closed for an incomplete carousel readback', () => {
+  const prepared = runCode(prepareCode, { input: [{ json: {
+    id: 'file-a', fileIds: ['file-a', 'file-b'], groupKey: 'group', shouldNotify: true,
+  } }] });
+  assert.throws(
+    () => runCode(collectCode, {
+      input: [{ json: { id: 'file-a', properties: { published: 'true' } } }],
+      items: (name) => name === PREPARE_NODE ? prepared : [],
+    }),
+    /count mismatch/,
+  );
+});

--- a/orb/engine/tests/livia-production-candidate.test.js
+++ b/orb/engine/tests/livia-production-candidate.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const { buildCandidate } = require('../scripts/prepare-livia-production-candidate');
+
+const releaseRoot = '/opt/skincos/releases/0123456789abcdef0123456789abcdef01234567/source/orb/engine';
+const workflowPath = path.join(__dirname, '..', 'workflows', 'livia', 'livia.current.json');
+
+function liveFixture() {
+  return JSON.parse(fs.readFileSync(workflowPath, 'utf8'));
+}
+
+test('production candidate builder applies every Livia fail-closed patch as one unit', () => {
+  const { workflow, report } = buildCandidate(liveFixture(), releaseRoot);
+  const nodes = new Map(workflow.nodes.map((node) => [node.name, node]));
+
+  assert.deepEqual(report.patches, [
+    'drive-publication-marks',
+    'token-vault-preflight',
+    'accessibility-contract',
+    'facebook-carousel-contract',
+    'runtime-isolation',
+  ]);
+  assert.equal(nodes.has('Merge Drive Result and Context'), false);
+  assert.equal(nodes.has('Prepare Drive Publication Marks'), true);
+  assert.equal(nodes.has('Collect Drive Publication Marks'), true);
+  assert.match(nodes.get('Validate Publish Token Health').parameters.command, /\. \/etc\/skincos\/orb-business\.env/);
+  assert.match(nodes.get('Validate Publish Token Health').parameters.command, new RegExp(releaseRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(nodes.get('Prepare HTTP Publish Request').parameters.jsCode, /sourceMediaCount/);
+  assert.match(nodes.get('Prepare HTTP Publish Request').parameters.jsCode, /perdeu a ordem ou identidade semântica/);
+  assert.match(nodes.get('Collect Publish Results').parameters.jsCode, /mediaEvidenceContract/);
+
+  for (const node of workflow.nodes.filter((node) => node.type === 'n8n-nodes-base.executeCommand')) {
+    const command = String(node.parameters?.command || '');
+    assert.doesNotMatch(command, /\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b|\/mnt\/c\//);
+  }
+});

--- a/orb/engine/tests/livia-qa-runner.test.js
+++ b/orb/engine/tests/livia-qa-runner.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  notificationForExecution,
+  verifierEnvironment,
+} = require('../scripts/livia/qa-runner');
+
+test('qa audit passes only the selected Token Vault values to the independent verifier', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'livia-qa-env-'));
+  const fixture = path.join(fixtureDir, 'orb-business.env');
+  try {
+    fs.writeFileSync(fixture, [
+      'TOKEN_VAULT_N8N_API_TOKEN=from-file',
+      'UNRELATED_SECRET=must-not-be-forwarded',
+      'TOKEN_VAULT_BASE_URL=https://token-vault.example.test',
+    ].join('\n'));
+    assert.deepEqual(verifierEnvironment({
+      envFiles: [fixture],
+      inherited: { TOKEN_VAULT_N8N_API_TOKEN: 'from-process', OTHER_VALUE: 'ignored' },
+    }), {
+      TOKEN_VAULT_BASE_URL: 'https://token-vault.example.test',
+      TOKEN_VAULT_N8N_API_TOKEN: 'from-process',
+    });
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('qa audit reads the notification node that actually executed', () => {
+  const result = notificationForExecution({
+    'Inform Success (2)': [{ data: { main: [[{ json: { ok: true, result: { message_id: 42 } } }]] } }],
+    'Inform Success (1)': [{ data: { main: [[{ json: { data: { status: 'pending' } } }]] } }],
+  });
+  assert.equal(result.nodeName, 'Inform Success (2)');
+  assert.equal(result.notification.ok, true);
+  assert.equal(result.notification.result.message_id, 42);
+});

--- a/orb/engine/tests/livia-qa-runner.test.js
+++ b/orb/engine/tests/livia-qa-runner.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const {
+  driveAuditForExecution,
   notificationForExecution,
   verifierEnvironment,
 } = require('../scripts/livia/qa-runner');
@@ -39,4 +40,33 @@ test('qa audit reads the notification node that actually executed', () => {
   assert.equal(result.nodeName, 'Inform Success (2)');
   assert.equal(result.notification.ok, true);
   assert.equal(result.notification.result.message_id, 42);
+});
+
+test('qa audit exposes legacy carousel Drive marks that silently omitted child files', () => {
+  const runData = {
+    'Attach Verified Publish Artifacts': [{ data: { main: [[{ json: { id: 'a', fileIds: ['a', 'b', 'c'] } }]] } }],
+    'Update File': [{ data: { main: [[{ json: { id: 'a', properties: { published: 'true' } } }]] } }],
+  };
+  const audit = driveAuditForExecution(runData);
+  assert.equal(audit.contract, 'legacy-single-mark');
+  assert.equal(audit.state, 'incomplete');
+  assert.deepEqual(audit.missingFileIds, ['b', 'c']);
+});
+
+test('qa audit accepts only a correlated full-group Drive readback', () => {
+  const prepared = ['a', 'b'].map((id) => ({ json: { id } }));
+  const runData = {
+    'Prepare Drive Publication Marks': [{ data: { main: [prepared] } }],
+    'Update File': [{ data: { main: [[
+      { json: { id: 'a', properties: { published: 'true' } } },
+      { json: { id: 'b', properties: { published: 'true' } } },
+    ]] } }],
+    'Assert Drive Published': [{ data: { main: [[{ json: { driveAudit: {
+      state: 'verified', published: true, verifiedFileIds: ['a', 'b'],
+    } } }]] } }],
+  };
+  const audit = driveAuditForExecution(runData);
+  assert.equal(audit.contract, 'group-fanout-readback');
+  assert.equal(audit.state, 'verified');
+  assert.equal(audit.verifiedFileCount, 2);
 });

--- a/orb/engine/tests/livia-token-vault-preflight-patch.test.js
+++ b/orb/engine/tests/livia-token-vault-preflight-patch.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { commandFor, patchWorkflow } = require('../scripts/patch-livia-token-vault-preflight');
+
+const releaseRoot = '/opt/skincos/releases/0123456789abcdef0123456789abcdef01234567/source/orb/engine';
+const workflow = {
+  id: 'WGXr4vYkv9UoJ8zc',
+  nodes: [{ name: 'Validate Publish Token Health', type: 'n8n-nodes-base.executeCommand', parameters: { command: 'old' } }],
+};
+
+test('preflight patch pins the versioned script and uses the verifier environment', () => {
+  const patched = patchWorkflow(workflow, releaseRoot);
+  const command = patched.nodes[0].parameters.command;
+  assert.match(command, /\. \/etc\/skincos\/orb-business\.env/);
+  assert.match(command, /validate-publish-token-health\.js/);
+  assert.match(command, new RegExp(releaseRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.equal(workflow.nodes[0].parameters.command, 'old');
+});
+
+test('preflight patch rejects mutable release roots', () => {
+  assert.throws(() => commandFor('/opt/skincos/current/source/orb/engine'), /immutable/);
+});

--- a/orb/engine/tests/livia-validate-publish-token-health.test.js
+++ b/orb/engine/tests/livia-validate-publish-token-health.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { validatePayload } = require('../scripts/livia/validate-publish-token-health');
+
+const payload = {
+  items: [
+    { provider: 'instagram', unit: 'bss', external_account_id: '17841464379584003', token: 'direct-instagram-token' },
+    { provider: 'facebook', unit: 'bss', external_account_id: '185513961319461', token: 'direct-facebook-token' },
+    { provider: 'threads', unit: 'bss', external_account_id: '24559172163775830', token: 'direct-threads-token' },
+  ],
+};
+
+function response(status, body = {}) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+async function withMockedFetch(fn) {
+  const previousFetch = global.fetch;
+  const previousToken = process.env.TOKEN_VAULT_N8N_API_TOKEN;
+  process.env.TOKEN_VAULT_N8N_API_TOKEN = 'gateway-admin-fixture';
+  global.fetch = async (url, options = {}) => {
+    if (String(url).includes('/v1/social-publish/operations')) {
+      assert.equal(options.headers.Authorization, 'Bearer gateway-admin-fixture');
+      return response(200, { id: 'gateway-ok' });
+    }
+    return response(200, { id: 'provider-ok' });
+  };
+  try {
+    return await fn();
+  } finally {
+    global.fetch = previousFetch;
+    if (previousToken === undefined) delete process.env.TOKEN_VAULT_N8N_API_TOKEN;
+    else process.env.TOKEN_VAULT_N8N_API_TOKEN = previousToken;
+  }
+}
+
+test('token health preflight requires direct provider and gateway validation', async () => {
+  const result = await withMockedFetch(() => validatePayload(payload));
+  assert.equal(result.ok, true);
+  assert.equal(result.checks.length, 3);
+  assert.equal(result.gatewayChecks.length, 3);
+  assert.ok(result.gatewayChecks.every((check) => check.ok));
+});
+
+test('token health preflight fails closed when the verifier bearer is unavailable', async () => {
+  const previousFetch = global.fetch;
+  const previousToken = process.env.TOKEN_VAULT_N8N_API_TOKEN;
+  delete process.env.TOKEN_VAULT_N8N_API_TOKEN;
+  global.fetch = async () => response(200, { id: 'provider-ok' });
+  try {
+    await assert.rejects(() => validatePayload(payload), /gateway_missing=instagram\|threads\|facebook/);
+  } finally {
+    global.fetch = previousFetch;
+    if (previousToken === undefined) delete process.env.TOKEN_VAULT_N8N_API_TOKEN;
+    else process.env.TOKEN_VAULT_N8N_API_TOKEN = previousToken;
+  }
+});

--- a/platform/security/token-vault/src/social-publish.js
+++ b/platform/security/token-vault/src/social-publish.js
@@ -28,7 +28,7 @@ export async function handleSocialPublishOperation({ request, env, requestId, de
   } catch {
     return response({ ok: false, error: 'invalid_target_url', requestId }, 400);
   }
-  if (url.protocol !== 'https:' || !PLATFORM_HOSTS[platform].has(url.hostname.toLowerCase()) || !allowedPath(platform, url)) {
+  if (url.protocol !== 'https:' || !PLATFORM_HOSTS[platform].has(url.hostname.toLowerCase()) || !allowedPath(platform, url, method)) {
     return response({ ok: false, error: 'target_not_allowed', requestId }, 403);
   }
 
@@ -99,11 +99,16 @@ export async function handleSocialPublishOperation({ request, env, requestId, de
   }, upstream.ok ? 200 : upstream.status);
 }
 
-function allowedPath(platform, url) {
+function allowedPath(platform, url, method) {
   const path = url.pathname;
   if (url.hostname.toLowerCase() === 'rupload.facebook.com') return /^\/video-upload\//.test(path);
   if (platform === 'threads') return /^\/v1\.0\/(?:me|\d+)(?:\/(?:threads|threads_publish))?$/.test(path);
   if (platform === 'instagram') return /^\/v25\.0\/\d+(?:\/(?:media|media_publish))?$/.test(path);
+  // A Facebook Page feed post is identified as pageId_postId.  Allow this
+  // exact shape for a read only: the Livia verifier needs the post itself to
+  // prove every carousel attachment, while mutation endpoints remain numeric
+  // page IDs only.
+  if (['GET', 'HEAD'].includes(method) && /^\/v25\.0\/\d+_\d+$/.test(path)) return true;
   return /^\/v25\.0\/\d+(?:\/(?:feed|photos|videos|video_reels))?$/.test(path);
 }
 

--- a/platform/security/token-vault/tests/social-publish.test.js
+++ b/platform/security/token-vault/tests/social-publish.test.js
@@ -208,6 +208,7 @@ test('social gateway accepts every Livia provider route, including the Facebook 
       ['facebook', 'POST', 'https://graph.facebook.com/v25.0/123/video_reels?upload_phase=start'],
       ['facebook', 'POST', 'https://rupload.facebook.com/video-upload/v25.0/987'],
       ['facebook', 'GET', 'https://graph.facebook.com/v25.0/987?fields=status'],
+      ['facebook', 'GET', 'https://graph.facebook.com/v25.0/123_456?fields=id,permalink_url,attachments'],
       ['instagram', 'POST', 'https://graph.instagram.com/v25.0/123/media'],
       ['instagram', 'POST', 'https://graph.instagram.com/v25.0/123/media_publish'],
       ['instagram', 'GET', 'https://graph.instagram.com/v25.0/987?fields=status'],
@@ -228,6 +229,48 @@ test('social gateway accepts every Livia provider route, including the Facebook 
     }
     assert.equal(calls.length, requests.length);
     assert.equal(calls[2].authorization, `OAuth ${SECRET_TOKEN}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('social gateway permits a Facebook composite post only as a read-only verifier target', async () => {
+  const rows = [{ id: 'fb_bss', provider: 'facebook', unit: 'BarraShoppingSul', external_account_id: '123', token_type: 'long_lived_access_token', token_ciphertext: 'encrypted', metadata_json: '{}' }];
+  const ctx = context({ env: { TOKEN_VAULT_DB: { prepare() { return new Statement(rows); } } } });
+  const originalFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    return new Response(JSON.stringify({ id: '123_456' }), { status: 200 });
+  };
+  try {
+    const create = await handleSocialPublishOperation({
+      request: new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'facebook', unit: 'bss', operation: 'livia_verify_post', method: 'POST',
+          url: 'https://graph.facebook.com/v25.0/123_456',
+        }),
+      }),
+      ...ctx,
+    });
+    assert.equal(create.status, 403);
+    assert.equal(fetches, 0);
+
+    const read = await handleSocialPublishOperation({
+      request: new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'facebook', unit: 'bss', operation: 'livia_verify_post', method: 'GET',
+          url: 'https://graph.facebook.com/v25.0/123_456',
+        }),
+      }),
+      ...ctx,
+    });
+    assert.equal(read.status, 200);
+    assert.equal(fetches, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Escopo Livia\n\n- fan-out de Drive para cada fonte verificada do carrossel;\n- contrato fail-closed de alt text por mídia e por plataforma;\n- contrato semântico de anexos do Facebook: quantidade, identidade e ordem;\n- readback do post composto do Facebook, com validação de cada mídia;\n- rota do Token Vault limitada a leitura para o verificador do post composto.\n\n## Validação local\n\n- 
pm run livia:qa:test\n- matriz offline: imagem, Reel, carrossel de imagens, carrossel de vídeos e misto, sem gateway;\n- 
pm test em platform/security/token-vault.\n\nNão há alteração de credenciais, outros workflows ou ponteiro global de runtime.