### PR TITLE
fix(orb): make MCP gateway provisioning reversible

### DIFF
--- a/docs/runbooks/mcp-gateway-release-rollback.md
+++ b/docs/runbooks/mcp-gateway-release-rollback.md
@@ -2,17 +2,26 @@
 
 The read-only gateway uses `/opt/skincos/current/mcp-readonly-source`, an atomic
 service-specific link. It never changes `/opt/skincos/current/source`, Orb, or
-orb-proxy. Before a live reconciliation, capture `status`, run `preflight` for
-both the incumbent and target immutable SHA, then select and restart only the
-gateway. If validation fails, execute `rollback <incumbent-sha>`.
+orb-proxy. The lifecycle script must itself run from a staged immutable source
+release that contains the integrated unit; it refuses a checkout. `provision`
+captures the previous unit, atomically installs the unit, reloads systemd and
+selects the target gateway release without restarting any service. It restores
+the previous unit automatically if provisioning cannot be verified.
+
+Before a live reconciliation, capture `status`, run `preflight` for both the
+incumbent and target immutable SHA, provision the exclusive pointer, then use
+`promote <target> <incumbent>`. A failed post-restart health check automatically
+selects and restarts the incumbent exactly once; do not retry promotion in that
+execution.
 
 ```bash
-MCP_GATEWAY_APPLY=YES scripts/runtime/mcp-gateway-release.sh select <target-sha>
-MCP_GATEWAY_APPLY=YES scripts/runtime/mcp-gateway-release.sh restart
+MCP_GATEWAY_APPLY=YES scripts/runtime/mcp-gateway-release.sh provision <target-sha>
+MCP_GATEWAY_APPLY=YES scripts/runtime/mcp-gateway-release.sh promote <target-sha> <incumbent-sha>
 scripts/runtime/mcp-gateway-release.sh status
 ```
 
 The script refuses paths outside `/opt/skincos/releases`, missing server or
-lineage files, non-SHA input, unverified lineage, development paths and any
-apply operation without explicit confirmation. No n8n, database, workflow,
-credential, proxy, tunnel or global release pointer is changed.
+lineage files, non-SHA input, unverified lineage, development paths, an
+unverified unit, a non-immutable control source, and any apply operation without
+explicit confirmation. No n8n, database, workflow, credential, proxy, tunnel
+or global release pointer is changed.

--- a/scripts/runtime/mcp-gateway-release.sh
+++ b/scripts/runtime/mcp-gateway-release.sh
@@ -7,10 +7,20 @@ RELEASE_BASE=${MCP_GATEWAY_RELEASE_BASE:-/opt/skincos/releases}
 LINK=${MCP_GATEWAY_RELEASE_LINK:-/opt/skincos/current/mcp-readonly-source}
 SERVICE=${MCP_GATEWAY_SERVICE:-skincos-orb-mcp-readonly.service}
 APPLY=${MCP_GATEWAY_APPLY:-}
+TEST_MODE=${MCP_GATEWAY_TEST_MODE:-}
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+UNIT_DEST=${MCP_GATEWAY_UNIT_DEST:-/etc/systemd/system/skincos-orb-mcp-readonly.service}
+CHECKPOINT_ROOT=${MCP_GATEWAY_CHECKPOINT_ROOT:-/var/lib/skincos-runtime/orb-mcp-readonly/release-unit-checkpoints}
+SYSTEMCTL_BIN=${MCP_GATEWAY_SYSTEMCTL_BIN:-/usr/bin/systemctl}
+SYSTEMD_ANALYZE_BIN=${MCP_GATEWAY_SYSTEMD_ANALYZE_BIN:-/usr/bin/systemd-analyze}
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
-need_apply() { [[ "$APPLY" == YES ]] || die 'refused: set MCP_GATEWAY_APPLY=YES'; }
+need_apply() {
+  [[ "$APPLY" == YES ]] || die 'refused: set MCP_GATEWAY_APPLY=YES'
+  [[ "$TEST_MODE" == YES || "$(id -u)" == 0 ]] || die 'refused: run the applied lifecycle as root.'
+}
 release_root() { printf '%s/%s/source/orb/engine/mcp-readonly-gateway\n' "$RELEASE_BASE" "$1"; }
+systemd() { "$SYSTEMCTL_BIN" "$@"; }
 
 validate_release() {
   local sha=$1 root lineage realbase
@@ -51,27 +61,153 @@ select_release() {
   printf 'selected_release=%s\n' "$sha"
 }
 
+control_source_root() {
+  local source_release lineage
+  [[ "$TEST_MODE" == YES ]] && { printf '%s\n' "$SCRIPT_ROOT"; return; }
+  [[ "$SCRIPT_ROOT" =~ ^/opt/skincos/releases/([0-9a-f]{40})/source$ ]] || die 'provision must run from a staged immutable release, never a checkout.'
+  source_release=${BASH_REMATCH[1]}
+  lineage="$SCRIPT_ROOT/.skincos-release-lineage.json"
+  [[ -f "$lineage" ]] || die 'control release lineage is missing.'
+  node --input-type=module - "$lineage" "$source_release" <<'NODE'
+import fs from 'node:fs';
+const [lineage, sha] = process.argv.slice(2);
+const data = JSON.parse(fs.readFileSync(lineage, 'utf8'));
+if (data.releaseId !== sha || data.verifiedAncestor !== true) process.exit(1);
+NODE
+  printf '%s\n' "$SCRIPT_ROOT"
+}
+
+unit_source() {
+  local root
+  root=$(control_source_root)
+  if [[ "$TEST_MODE" == YES && -n "${MCP_GATEWAY_UNIT_SOURCE:-}" ]]; then
+    printf '%s\n' "$MCP_GATEWAY_UNIT_SOURCE"
+  else
+    printf '%s/orb/engine/mcp-readonly-gateway/systemd/skincos-orb-mcp-readonly.service\n' "$root"
+  fi
+}
+
+verify_unit() {
+  local unit=$1
+  [[ -f "$unit" ]] || die 'gateway unit source is missing.'
+  grep -Fqx 'WorkingDirectory=/opt/skincos/current/mcp-readonly-source' "$unit" || die 'gateway unit does not use the exclusive source pointer.'
+  grep -Fqx 'ExecStart=/usr/bin/node /opt/skincos/current/mcp-readonly-source/server.mjs' "$unit" || die 'gateway unit executable is not exclusive.'
+  grep -Fqx 'ReadOnlyPaths=/opt/skincos/current/mcp-readonly-source' "$unit" || die 'gateway unit read-only path is not exclusive.'
+  "$SYSTEMD_ANALYZE_BIN" verify "$unit"
+}
+
+capture_unit_checkpoint() {
+  local checkpoint timestamp
+  timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+  checkpoint="$CHECKPOINT_ROOT/$timestamp-$$"
+  install -d -m 0700 "$checkpoint"
+  if [[ -f "$UNIT_DEST" ]]; then
+    install -m 0600 "$UNIT_DEST" "$checkpoint/unit.previous.service"
+    sha256sum "$checkpoint/unit.previous.service" >"$checkpoint/unit.previous.sha256"
+  else
+    printf 'absent\n' >"$checkpoint/unit.previous.absent"
+  fi
+  printf 'service=%s\nunit_destination=%s\n' "$SERVICE" "$UNIT_DEST" >"$checkpoint/metadata"
+  printf '%s\n' "$checkpoint"
+}
+
+restore_unit_checkpoint() {
+  local checkpoint=$1 tmp
+  [[ "$checkpoint" == "$CHECKPOINT_ROOT"/* && -d "$checkpoint" ]] || die 'checkpoint is outside the gateway checkpoint root.'
+  if [[ -f "$checkpoint/unit.previous.service" ]]; then
+    tmp="${UNIT_DEST}.restore.$$"
+    install -m 0644 "$checkpoint/unit.previous.service" "$tmp"
+    mv -Tf "$tmp" "$UNIT_DEST"
+  elif [[ -f "$checkpoint/unit.previous.absent" ]]; then
+    rm -f -- "$UNIT_DEST"
+  else
+    die 'checkpoint does not contain a prior unit state.'
+  fi
+  systemd daemon-reload
+}
+
+verify_loaded_unit() {
+  local rendered
+  if [[ "$TEST_MODE" == YES ]]; then
+    rendered=$(<"$UNIT_DEST")
+  else
+    rendered=$(systemd show "$SERVICE" -p WorkingDirectory -p ExecStart)
+  fi
+  [[ "$rendered" == *'/opt/skincos/current/mcp-readonly-source'* ]] || return 1
+  [[ "$rendered" == *'server.mjs'* ]] || return 1
+}
+
+provision() {
+  local target=$1 unit checkpoint tmp
+  need_apply
+  validate_release "$target"
+  unit=$(unit_source)
+  verify_unit "$unit"
+  checkpoint=$(capture_unit_checkpoint)
+  install -d -m 0755 "$(dirname "$UNIT_DEST")"
+  tmp="${UNIT_DEST}.next.$$"
+  if ! install -m 0644 "$unit" "$tmp" || ! mv -Tf "$tmp" "$UNIT_DEST" || ! systemd daemon-reload || ! verify_loaded_unit; then
+    rm -f -- "$tmp"
+    restore_unit_checkpoint "$checkpoint" || true
+    die 'gateway unit provisioning failed and the prior unit was restored.'
+  fi
+  if ! select_release "$target"; then
+    restore_unit_checkpoint "$checkpoint" || true
+    die 'gateway pointer selection failed and the prior unit was restored.'
+  fi
+  printf 'control_release=%s\nunit_checkpoint=%s\n' "$(control_source_root)" "$checkpoint"
+}
+
+health_ok() {
+  curl -fsS --max-time 5 "http://127.0.0.1:${MCP_GATEWAY_PORT:-8766}/.well-known/oauth-protected-resource/mcp" >/dev/null
+}
+
+restart_controlled() {
+  local attempt
+  need_apply
+  systemd restart "$SERVICE"
+  for attempt in {1..10}; do
+    if systemd is-active --quiet "$SERVICE" && health_ok; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+promote() {
+  local target=$1 incumbent=$2
+  validate_release "$target"; validate_release "$incumbent"
+  select_release "$target"
+  if restart_controlled; then
+    printf 'promoted_release=%s\n' "$target"
+    return 0
+  fi
+  printf 'promotion_failed=1; applying_gateway_rollback=%s\n' "$incumbent" >&2
+  select_release "$incumbent"
+  restart_controlled || die 'gateway promotion and automatic rollback both failed.'
+  die 'gateway promotion failed; rollback completed.'
+}
+
 status() {
   local configured=unconfigured pid=0 cwd=none health=unproven
   configured=$(configured_release || true); configured=${configured:-unconfigured}
-  if command -v systemctl >/dev/null; then
-    pid=$(systemctl show "$SERVICE" -p MainPID --value 2>/dev/null || echo 0)
+  if command -v "$SYSTEMCTL_BIN" >/dev/null; then
+    pid=$(systemd show "$SERVICE" -p MainPID --value 2>/dev/null || echo 0)
     [[ "$pid" =~ ^[1-9][0-9]*$ ]] && cwd=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || echo inaccessible)
   fi
-  if command -v curl >/dev/null; then health=$(curl -fsS --max-time 5 http://127.0.0.1:${MCP_GATEWAY_PORT:-8766}/.well-known/oauth-protected-resource/mcp >/dev/null && echo ok || echo failed); fi
+  if command -v curl >/dev/null; then health=$(health_ok && echo ok || echo failed); fi
   printf 'configured_release=%s\npid=%s\ncwd=%s\nhealth=%s\n' "$configured" "$pid" "$cwd" "$health"
   printf 'allowed_tools=list_workflows,search_workflows,get_workflow_summary,get_workflow_graph,find_workflow_dependencies,list_recent_executions,get_execution_error,compare_workflow_with_repository,get_orb_status\n'
   printf 'forbidden_tool=execute_workflow\n'
 }
 
-restart_controlled() { need_apply; systemctl restart "$SERVICE"; systemctl is-active --quiet "$SERVICE" || die 'gateway restart failed'; }
-
-usage() { echo 'usage: mcp-gateway-release.sh preflight <sha>|select <sha>|restart|rollback <sha>|status'; }
+usage() { echo 'usage: mcp-gateway-release.sh preflight <sha>|provision <sha>|select <sha>|restart|promote <target-sha> <incumbent-sha>|rollback <sha>|status'; }
 case "${1:-}" in
   preflight) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; validate_release "$2"; echo "preflight_release=$2" ;;
+  provision) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; provision "$2" ;;
   select) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; select_release "$2" ;;
-  restart) [[ $# -eq 1 ]] || { usage >&2; exit 2; }; restart_controlled ;;
-  rollback) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; select_release "$2"; restart_controlled ;;
+  restart) [[ $# -eq 1 ]] || { usage >&2; exit 2; }; restart_controlled || die 'gateway restart or health check failed.' ;;
+  promote) [[ $# -eq 3 ]] || { usage >&2; exit 2; }; promote "$2" "$3" ;;
+  rollback) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; select_release "$2"; restart_controlled || die 'gateway rollback restart or health check failed.' ;;
   status) [[ $# -eq 1 ]] || { usage >&2; exit 2; }; status ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/scripts/runtime/test-mcp-gateway-release.sh
+++ b/scripts/runtime/test-mcp-gateway-release.sh
@@ -3,16 +3,32 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 SCRIPT="$ROOT/scripts/runtime/mcp-gateway-release.sh"
 tmp=$(mktemp -d); trap 'rm -rf -- "$tmp"' EXIT
-for sha in 1111111111111111111111111111111111111111 2222222222222222222222222222222222222222; do
+first=1111111111111111111111111111111111111111
+second=2222222222222222222222222222222222222222
+for sha in "$first" "$second"; do
   mkdir -p "$tmp/releases/$sha/source/orb/engine/mcp-readonly-gateway"
   printf 'console.log("shadow")\n' >"$tmp/releases/$sha/source/orb/engine/mcp-readonly-gateway/server.mjs"
   printf '{"releaseId":"%s","verifiedAncestor":true}\n' "$sha" >"$tmp/releases/$sha/source/.skincos-release-lineage.json"
 done
-env MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" "$SCRIPT" preflight 1111111111111111111111111111111111111111 | grep -q preflight_release
-if env MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" "$SCRIPT" select 1111111111111111111111111111111111111111; then exit 1; fi
-env MCP_GATEWAY_APPLY=YES MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" "$SCRIPT" select 1111111111111111111111111111111111111111 | grep -q selected_release
-[[ "$(readlink -f "$tmp/current/mcp-readonly-source")" == "$tmp/releases/1111111111111111111111111111111111111111/source/orb/engine/mcp-readonly-gateway" ]]
-env MCP_GATEWAY_APPLY=YES MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" "$SCRIPT" select 2222222222222222222222222222222222222222 | grep -q selected_release
-[[ "$(readlink -f "$tmp/current/mcp-readonly-source")" == "$tmp/releases/2222222222222222222222222222222222222222/source/orb/engine/mcp-readonly-gateway" ]]
-if env MCP_GATEWAY_RELEASE_BASE="$tmp/releases" "$SCRIPT" preflight ../etc/passwd; then exit 1; fi
+unit="$tmp/gateway.service"
+printf '%s\n' \
+  '[Service]' \
+  'WorkingDirectory=/opt/skincos/current/mcp-readonly-source' \
+  'ExecStart=/usr/bin/node /opt/skincos/current/mcp-readonly-source/server.mjs' \
+  'ReadOnlyPaths=/opt/skincos/current/mcp-readonly-source' >"$unit"
+fake_systemd="$tmp/fake-systemctl"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_systemd"; chmod +x "$fake_systemd"
+fake_analyze="$tmp/fake-systemd-analyze"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_analyze"; chmod +x "$fake_analyze"
+base=(env MCP_GATEWAY_TEST_MODE=YES MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" MCP_GATEWAY_UNIT_SOURCE="$unit" MCP_GATEWAY_UNIT_DEST="$tmp/systemd/skincos-orb-mcp-readonly.service" MCP_GATEWAY_CHECKPOINT_ROOT="$tmp/checkpoints" MCP_GATEWAY_SYSTEMCTL_BIN="$fake_systemd" MCP_GATEWAY_SYSTEMD_ANALYZE_BIN="$fake_analyze")
+"${base[@]}" "$SCRIPT" preflight "$first" | grep -q preflight_release
+if "${base[@]}" "$SCRIPT" select "$first"; then exit 1; fi
+provision_output=$("${base[@]}" MCP_GATEWAY_APPLY=YES "$SCRIPT" provision "$first")
+[[ "$provision_output" == *"selected_release=$first"* ]]
+[[ "$provision_output" == *'unit_checkpoint='* ]]
+[[ "$(readlink -f "$tmp/current/mcp-readonly-source")" == "$tmp/releases/$first/source/orb/engine/mcp-readonly-gateway" ]]
+cmp -s "$unit" "$tmp/systemd/skincos-orb-mcp-readonly.service"
+"${base[@]}" MCP_GATEWAY_APPLY=YES "$SCRIPT" select "$second" | grep -q selected_release
+[[ "$(readlink -f "$tmp/current/mcp-readonly-source")" == "$tmp/releases/$second/source/orb/engine/mcp-readonly-gateway" ]]
+if "${base[@]}" "$SCRIPT" preflight ../etc/passwd; then exit 1; fi
 echo 'mcp_gateway_release_tests=pass'


### PR DESCRIPTION
## Scope\n\nCompletes the operational gap after #857: the gateway-only lifecycle now provisions the exclusive systemd unit from a staged immutable control release, records a unit checkpoint, reloads systemd without restarting services, and automatically rolls the gateway release back on failed post-restart health.\n\n## Safety\n\n- Never changes /opt/skincos/current/source.\n- Never changes n8n, database, workflows, credentials, proxy, tunnel, or other services.\n- Refuses checkout-sourced provisioning in production.\n- Tests use only temporary synthetic release trees.\n\n## Local validation\n\n- bash -n scripts/runtime/mcp-gateway-release.sh\n- bash scripts/runtime/test-mcp-gateway-release.sh\n- node orb/engine/mcp-readonly-gateway/scripts/validate-architecture.mjs\n- systemd-analyze verify unit template (DrvFS permission warning only; installed mode is 0644).\n- git diff --check