### PR TITLE
fix(runtime): harden native release lineage evidence

### DIFF
--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -21,14 +21,20 @@ through `\\wsl.localhost`; WSL never recursively walks `/mnt/c`.
 
 1. Confirm the reviewed `origin/main` SHA and a clean canonical clone.
 2. On Windows, create `git archive --format=tar <sha>` in the private runtime,
-   compute SHA-256, and copy the tar to native Linux storage through
+   compute SHA-256, produce verified lineage against `origin/main`, and copy
+   the tar and lineage to native Linux storage through
    `\\wsl.localhost\Ubuntu-24.04\home\admin\skincos-native-release\<sha>`.
+
+   ```powershell
+   & scripts/runtime/verify-native-source-release-lineage.ps1 -ReleaseSha <sha> -ParentReleaseSha <current-release-sha>
+   ```
 3. From WSL, validate and promote source:
 
    ```bash
    scripts/runtime/prepare-native-source-release.sh \
      --archive /home/admin/skincos-native-release/<sha>/source.tar \
-     --sha256 <sha256> --release-sha <sha> --apply
+     --sha256 <sha256> --lineage /home/admin/skincos-native-release/<sha>/lineage.json \
+     --lineage-sha256 <lineage-sha256> --apply --stage-only
    ```
 
 4. Build and promote WhatsApp from the same source release:

--- a/scripts/runtime/test-verify-native-source-release-lineage.ps1
+++ b/scripts/runtime/test-verify-native-source-release-lineage.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$scriptPath = Join-Path $PSScriptRoot 'verify-native-source-release-lineage.ps1'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("skincos-lineage-test-" + [guid]::NewGuid().ToString('N'))
+$remoteRoot = "$testRoot-remote.git"
+$output = "$testRoot-lineage.json"
+
+try {
+    New-Item -ItemType Directory -Path $testRoot | Out-Null
+    & git init --initial-branch=main $testRoot | Out-Null
+    & git -C $testRoot config user.email 'lineage-test@invalid.example'
+    & git -C $testRoot config user.name 'SKINCOS lineage test'
+    Set-Content -LiteralPath (Join-Path $testRoot 'fixture.txt') -Value 'parent' -NoNewline
+    & git -C $testRoot add fixture.txt
+    & git -C $testRoot commit -m 'parent' | Out-Null
+    $parent = (& git -C $testRoot rev-parse HEAD).Trim()
+    Set-Content -LiteralPath (Join-Path $testRoot 'fixture.txt') -Value 'release' -NoNewline
+    & git -C $testRoot commit -am 'release' | Out-Null
+    $release = (& git -C $testRoot rev-parse HEAD).Trim()
+    & git init --bare $remoteRoot | Out-Null
+    & git -C $testRoot remote add origin $remoteRoot
+    & git -C $testRoot push -u origin main | Out-Null
+
+    $result = & $scriptPath -ReleaseSha $release -ParentReleaseSha $parent -RepositoryRoot $testRoot -OutputPath $output | ConvertFrom-Json
+    $lineage = Get-Content -Raw -LiteralPath $output | ConvertFrom-Json
+    if ($lineage.releaseId -ne $release -or $lineage.parentReleaseId -ne $parent -or $lineage.verifiedAncestor -ne $true) {
+        throw 'Generated lineage did not preserve verified release ancestry.'
+    }
+    if (-not $result.Sha256 -or $result.OutputPath -ne [IO.Path]::GetFullPath($output)) {
+        throw 'Generated lineage evidence did not include output integrity metadata.'
+    }
+    $bytes = [IO.File]::ReadAllBytes($output)
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        throw 'Generated lineage must be UTF-8 without a BOM for the native JSON verifier.'
+    }
+    Write-Output 'native_release_lineage_tests=pass'
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) { Remove-Item -LiteralPath $testRoot -Recurse -Force }
+    if (Test-Path -LiteralPath $remoteRoot) { Remove-Item -LiteralPath $remoteRoot -Recurse -Force }
+    if (Test-Path -LiteralPath $output) { Remove-Item -LiteralPath $output -Force }
+}

--- a/scripts/runtime/verify-native-source-release-lineage.ps1
+++ b/scripts/runtime/verify-native-source-release-lineage.ps1
@@ -1,35 +1,75 @@
 [CmdletBinding()]
 param(
-  [Parameter(Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{40}$')]
-  [string]$ReleaseId,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{7,64}$')]
+    [string]$ReleaseSha,
 
-  [Parameter(Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{40}$')]
-  [string]$ParentReleaseId,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{7,64}$')]
+    [string]$ParentReleaseSha,
 
-  [Parameter(Mandatory = $true)]
-  [string]$OutputPath
+    [string]$RepositoryRoot = (Join-Path $PSScriptRoot '..\..'),
+
+    [string]$OutputPath
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$release = (git rev-parse "$ReleaseId^{commit}").Trim()
-$parent = (git rev-parse "$ParentReleaseId^{commit}").Trim()
-git merge-base --is-ancestor $parent $release
-if ($LASTEXITCODE -ne 0) {
-  throw "Release $release is not a descendant of effective release $parent. Use the explicit rollback path instead."
+function Invoke-VerifiedGit {
+    param([string[]]$Arguments)
+    $result = & git -C $resolvedRepository @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Git verification failed: git $($Arguments -join ' ')"
+    }
+    return ($result | Out-String).Trim()
 }
 
-$payload = [ordered]@{
-  schemaVersion = 1
-  releaseId = $release
-  parentReleaseId = $parent
-  verifiedAncestor = $true
-  verifiedAt = [DateTime]::UtcNow.ToString('o')
+$resolvedRepository = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$inside = Invoke-VerifiedGit -Arguments @('rev-parse', '--is-inside-work-tree')
+if ($inside -ne 'true') {
+    throw 'RepositoryRoot must be a Git worktree.'
 }
-$parentDir = Split-Path -Parent $OutputPath
-if ($parentDir) { New-Item -ItemType Directory -Force -Path $parentDir | Out-Null }
-$json = $payload | ConvertTo-Json -Depth 3
-[System.IO.File]::WriteAllText($OutputPath, $json + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
-Get-FileHash -Algorithm SHA256 -LiteralPath $OutputPath | Select-Object Path, Hash
+
+$release = (Invoke-VerifiedGit -Arguments @('rev-parse', "$ReleaseSha^{commit}")).ToLowerInvariant()
+$parent = (Invoke-VerifiedGit -Arguments @('rev-parse', "$ParentReleaseSha^{commit}")).ToLowerInvariant()
+$originMain = (Invoke-VerifiedGit -Arguments @('rev-parse', 'origin/main')).ToLowerInvariant()
+
+& git -C $resolvedRepository merge-base --is-ancestor $parent $release
+if ($LASTEXITCODE -ne 0) {
+    throw 'The declared parent release is not an ancestor of the candidate release.'
+}
+& git -C $resolvedRepository merge-base --is-ancestor $release $originMain
+if ($LASTEXITCODE -ne 0) {
+    throw 'The candidate release is not an ancestor of origin/main.'
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $env:SystemDrive "CodexRuntime\operator\admin\skincos\native-releases\$release\lineage.json"
+}
+$resolvedOutput = [IO.Path]::GetFullPath($OutputPath)
+$repositoryPrefix = [IO.Path]::GetFullPath($resolvedRepository).TrimEnd('\') + '\'
+if ($resolvedOutput.StartsWith($repositoryPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Lineage output must be private operator evidence, not a repository file.'
+}
+
+$record = [ordered]@{
+    releaseId        = $release
+    parentReleaseId  = $parent
+    verifiedAncestor = $true
+    verifiedAgainst  = 'origin/main'
+    verifiedAtUtc    = (Get-Date).ToUniversalTime().ToString('o')
+}
+
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $resolvedOutput) | Out-Null
+$json = $record | ConvertTo-Json -Depth 3
+[IO.File]::WriteAllText($resolvedOutput, $json, (New-Object System.Text.UTF8Encoding($false)))
+$hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedOutput).Hash.ToLowerInvariant()
+
+[pscustomobject]@{
+    ReleaseSha       = $release
+    ParentReleaseSha = $parent
+    OriginMain       = $originMain
+    OutputPath       = $resolvedOutput
+    Sha256           = $hash
+} | ConvertTo-Json -Compress


### PR DESCRIPTION
## Scope\n\nHardens the existing native release lineage producer required by prepare-native-source-release.sh.\n\n- Verifies candidate ancestry through origin/main.\n- Refuses repository-local evidence output.\n- Emits UTF-8-without-BOM JSON plus SHA-256.\n- Adds a temporary synthetic Git-repository regression test.\n- Aligns the runtime cutover runbook with the actual stage-only arguments.\n\n## Validation\n\n- powershell -NoProfile -ExecutionPolicy Bypass -File scripts/runtime/test-verify-native-source-release-lineage.ps1\n- ash scripts/runtime/test-prepare-native-source-release.sh\n- git diff --check\n\nNo runtime, release pointer, service, n8n, database, workflow, credential, proxy, tunnel, or Cloudflare change.