### PR TITLE
fix(finance): usar transporte Pages no smoke de staging

### DIFF
--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -97,7 +97,7 @@ jobs:
         continue-on-error: true
         env:
           FINANCE_STAGING_CANARY_ACK: "1"
-          FINANCE_CANARY_BASE_URL: https://api-staging.skincos.com.br
+          FINANCE_CANARY_BASE_URL: https://skincos-staging.pages.dev
           FINANCE_CANARY_USERNAME: finance-staging-smoke
           FINANCE_CANARY_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
           FINANCE_CANARY_SCOPE_ID: finance-scope-novo-hamburgo
@@ -109,7 +109,7 @@ jobs:
         continue-on-error: true
         env:
           FINANCE_SMOKE_ACK: "1"
-          FINANCE_SMOKE_BASE_URL: https://api-staging.skincos.com.br
+          FINANCE_SMOKE_BASE_URL: https://skincos-staging.pages.dev
           FINANCE_SMOKE_USERNAME: finance-staging-smoke
           FINANCE_SMOKE_PASSWORD: ${{ secrets.FINANCE_SMOKE_PASSWORD }}
           FINANCE_SMOKE_SCOPE_ID: finance-scope-novo-hamburgo

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -18,7 +18,7 @@ if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > 60000) t
 if (process.env.FINANCE_SMOKE_ACK !== '1') throw new Error('FINANCE_SMOKE_ACK=1 is required');
 
 const baseUrl = required('FINANCE_SMOKE_BASE_URL').replace(/\/$/, '');
-if (!/^https:\/\/api-staging\.skincos\.com\.br$/i.test(baseUrl)) throw new Error('FINANCE_SMOKE_BASE_URL must be the staging gateway');
+if (baseUrl !== 'https://skincos-staging.pages.dev') throw new Error('FINANCE_SMOKE_BASE_URL must be the staging CRM shell');
 const username = required('FINANCE_SMOKE_USERNAME');
 const password = required('FINANCE_SMOKE_PASSWORD');
 const scopeId = required('FINANCE_SMOKE_SCOPE_ID');
@@ -42,25 +42,26 @@ async function request(path, init = {}) {
   try { return await fetch(`${baseUrl}${path}`, { ...init, signal: timer.signal }); }
   finally { timer.done(); }
 }
+const financePath = (path) => `/api/finance${path}`;
 const json = async (response) => {
   const body = await response.json().catch(() => null);
   if (!response.ok) throw new Error(`HTTP ${response.status}: ${body?.error || 'unexpected response'}`);
   return body;
 };
 
-const login = await request('/insumos/auth/login', {
-  method: 'POST', headers: { 'content-type': 'application/json', origin: 'https://crm-staging.skincos.com.br' },
+const login = await request('/api/auth/login', {
+  method: 'POST', headers: { 'content-type': 'application/json', origin: baseUrl },
   body: JSON.stringify({ username, password }),
 });
 const loginBody = await json(login);
 const setCookies = typeof login.headers.getSetCookie === 'function' ? login.headers.getSetCookie() : [login.headers.get('set-cookie') || ''];
 const cookie = setCookies.map((value) => value.split(';', 1)[0]).filter(Boolean).join('; ');
 if (!cookie || !loginBody.csrfToken) throw new Error('staging auth did not issue session and CSRF cookies');
-const authHeaders = (idempotencyKey) => ({ 'content-type': 'application/json', cookie, origin: 'https://crm-staging.skincos.com.br', 'x-csrf-token': loginBody.csrfToken, ...(idempotencyKey ? { 'idempotency-key': idempotencyKey } : {}) });
+const authHeaders = (idempotencyKey) => ({ 'content-type': 'application/json', cookie, origin: baseUrl, 'x-csrf-token': loginBody.csrfToken, ...(idempotencyKey ? { 'idempotency-key': idempotencyKey } : {}) });
 const key = `staging-import-smoke:${sourceType}:${scopeId}:${nonce}`;
 const created = [];
 const createRegistration = async (collection, value, idempotencyKey) => {
-  const response = await request(`/finance/${collection}?scopeId=${encodeURIComponent(scopeId)}`, {
+  const response = await request(`${financePath(`/${collection}`)}?scopeId=${encodeURIComponent(scopeId)}`, {
     method: 'POST', headers: authHeaders(idempotencyKey), body: JSON.stringify(value),
   });
   const createdBody = await json(response);
@@ -72,7 +73,7 @@ const createRegistration = async (collection, value, idempotencyKey) => {
 const cleanup = async () => {
   const results = [];
   for (const entity of [...created].reverse()) {
-    const response = await request(`/finance/${entity.collection}/${encodeURIComponent(entity.id)}/archive?scopeId=${encodeURIComponent(scopeId)}`, {
+    const response = await request(`${financePath(`/${entity.collection}/${encodeURIComponent(entity.id)}/archive`)}?scopeId=${encodeURIComponent(scopeId)}`, {
       method: 'POST', headers: authHeaders(`${key}:cleanup:${entity.collection}:${entity.id}`), body: JSON.stringify({ reason: 'Controlled staging smoke cleanup' }),
     });
     const archived = await json(response);
@@ -93,20 +94,20 @@ try {
   const payload = sourceType === 'ef-caixa'
     ? { filename: 'staging-ef-smoke.json', sourceType, efCaixa: JSON.parse(raw) }
     : { filename: `staging-${sourceType}-smoke.csv`, sourceType, csv: raw, encoding: 'utf-8' };
-  const staged = await request(`/finance/imports?scopeId=${encodeURIComponent(scopeId)}`, {
+  const staged = await request(`${financePath('/imports')}?scopeId=${encodeURIComponent(scopeId)}`, {
     method: 'POST', headers: authHeaders(key), body: JSON.stringify(payload),
   });
   const stagedBody = await json(staged);
   const batchId = String(stagedBody.batchId || '').trim();
   if (!batchId) throw new Error('staging did not return batchId');
-  const loadBatch = async () => json(await request(`/finance/imports/${encodeURIComponent(batchId)}?scopeId=${encodeURIComponent(scopeId)}`, { headers: authHeaders() }));
+  const loadBatch = async () => json(await request(`${financePath(`/imports/${encodeURIComponent(batchId)}`)}?scopeId=${encodeURIComponent(scopeId)}`, { headers: authHeaders() }));
   result.stage = { status: staged.status, alreadyStaged: Boolean(stagedBody.alreadyStaged), rows: Number(stagedBody.analysis?.rows?.length || 0) };
   let loaded = await loadBatch();
   result.before = stateSummary(loaded);
   if (commitRequested) {
     if (stagedBody.alreadyStaged) throw new Error('synthetic import unexpectedly reused a previous batch');
     if (loaded.batch?.status !== 'staged') throw new Error(`batch is not staged (${loaded.batch?.status || 'unknown'}); refusing commit`);
-    const analyzed = await request(`/finance/imports/${encodeURIComponent(batchId)}/analyze?scopeId=${encodeURIComponent(scopeId)}`, {
+    const analyzed = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/analyze`)}?scopeId=${encodeURIComponent(scopeId)}`, {
       method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(payload),
     });
     const analysisBody = await json(analyzed);
@@ -118,29 +119,29 @@ try {
     const account = await createRegistration('accounts', { name: `Conta sintética ${nonce}`, type: 'bank', currency: 'BRL', openingBalanceMinor: 0 }, `${key}:account`);
     const income = await createRegistration('categories', { name: `Receita sintética ${nonce}`, direction: 'income' }, `${key}:income`);
     const expense = await createRegistration('categories', { name: `Despesa sintética ${nonce}`, direction: 'expense' }, `${key}:expense`);
-    const decision = await request(`/finance/imports/${encodeURIComponent(batchId)}/decisions?scopeId=${encodeURIComponent(scopeId)}`, {
+    const decision = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/decisions`)}?scopeId=${encodeURIComponent(scopeId)}`, {
       method: 'POST', headers: authHeaders(`${key}:decision`), body: JSON.stringify({ rowId: candidate.id, decision: 'import' }),
     });
     await json(decision);
     loaded = await loadBatch();
     const persisted = (loaded.rows || []).find((row) => row.id === candidate.id);
     if (!persisted || persisted.status !== 'valid' || persisted.decision !== 'import') throw new Error(`import decision did not persist: ${JSON.stringify(stateSummary(loaded))}`);
-    const preview = await request(`/finance/imports/${encodeURIComponent(batchId)}/preview?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:preview`), body: '{}' });
+    const preview = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/preview`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:preview`), body: '{}' });
     const previewBody = await json(preview);
     if (Number(previewBody.ready || 0) < 1) throw new Error('no approved rows after explicit decision');
     const commitPayload = { defaultAccountId: account.id, incomeCategoryId: income.id, expenseCategoryId: expense.id };
-    const commit = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
+    const commit = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/commit`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
     const commitBody = await json(commit);
     loaded = await loadBatch();
     const committedRows = (loaded.rows || []).filter((row) => row.status === 'committed' && row.movement_id);
     if (loaded.batch?.status !== 'committed' || !committedRows.length) throw new Error(`commit did not produce committed rows: ${JSON.stringify(stateSummary(loaded))}`);
-    const replay = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
+    const replay = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/commit`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify(commitPayload) });
     const replayBody = await json(replay);
     if (!replayBody.replayed) throw new Error('repeat commit did not replay the original operation');
-    const conflict = await request(`/finance/imports/${encodeURIComponent(batchId)}/commit?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify({ ...commitPayload, expenseCategoryId: income.id }) });
+    const conflict = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/commit`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:commit`), body: JSON.stringify({ ...commitPayload, expenseCategoryId: income.id }) });
     const conflictBody = await conflict.json().catch(() => null);
     if (conflict.status !== 409 || conflictBody?.error !== 'IDEMPOTENCY_CONFLICT') throw new Error(`incompatible second confirmation did not conflict: ${conflict.status}`);
-    const audit = await request(`/finance/audit?scopeId=${encodeURIComponent(scopeId)}&entityType=import_batch&entityId=${encodeURIComponent(batchId)}`, { headers: authHeaders() });
+    const audit = await request(`${financePath('/audit')}?scopeId=${encodeURIComponent(scopeId)}&entityType=import_batch&entityId=${encodeURIComponent(batchId)}`, { headers: authHeaders() });
     const auditBody = await json(audit);
     if (Number(auditBody.total || 0) < 2) throw new Error('import audit trail is incomplete');
     result.decision = { status: decision.status, persisted: true };
@@ -149,7 +150,7 @@ try {
     result.audit = { status: audit.status, events: Number(auditBody.total || 0) };
     result.afterCommit = stateSummary(loaded);
     if (undoRequested) {
-      const undo = await request(`/finance/imports/${encodeURIComponent(batchId)}/undo?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
+      const undo = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/undo`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
       const undoBody = await json(undo);
       loaded = await loadBatch();
       if (loaded.batch?.status !== 'undone') throw new Error('import undo did not reach the compensated state');

--- a/finance/scripts/staging-synthetic-canary.mjs
+++ b/finance/scripts/staging-synthetic-canary.mjs
@@ -16,12 +16,13 @@ const finish = async (ok, cause) => {
 try {
   if (process.env.FINANCE_STAGING_CANARY_ACK !== '1') throw new Error('FINANCE_STAGING_CANARY_ACK=1 is required');
   const baseUrl = required('FINANCE_CANARY_BASE_URL').replace(/\/$/, '');
-  if (baseUrl !== 'https://api-staging.skincos.com.br') throw new Error('canary base URL must be staging gateway');
+  if (baseUrl !== 'https://skincos-staging.pages.dev') throw new Error('canary base URL must be the staging CRM shell');
   const username = required('FINANCE_CANARY_USERNAME');
   if (username !== 'finance-staging-smoke') throw new Error('only dedicated synthetic smoke actor may run canary');
   const password = required('FINANCE_CANARY_PASSWORD');
   const scopeId = required('FINANCE_CANARY_SCOPE_ID');
   if (scopeId !== 'finance-scope-novo-hamburgo') throw new Error('only synthetic Novo Hamburgo scope is allowed');
+  const financePath = (path) => `/api/finance${path}`;
   const request = async (name, path, init = {}) => {
     const started = Date.now();
     try {
@@ -39,35 +40,38 @@ try {
     if (response.status !== status) { report.errors += 1; if (status === 200 && response.status === 401) report.authenticationFailures += 1; throw new Error(`${name} returned ${response.status}`); }
     return body;
   };
-  const loginResponse = await request('login', '/insumos/auth/login', { method: 'POST', headers: { 'content-type': 'application/json', origin: 'https://crm-staging.skincos.com.br' }, body: JSON.stringify({ username, password }) });
+  // Authenticate through the same Pages proxy used by the browser shell. The
+  // session cookie is host-scoped to the staging shell and is not portable to
+  // a direct api-staging request.
+  const loginResponse = await request('login', '/api/auth/login', { method: 'POST', headers: { 'content-type': 'application/json', origin: baseUrl }, body: JSON.stringify({ username, password }) });
   const login = await loginResponse.json().catch(() => null);
   if (loginResponse.status !== 200) { report.authenticationFailures += 1; throw new Error(`login returned ${loginResponse.status}`); }
   const cookie = (typeof loginResponse.headers.getSetCookie === 'function' ? loginResponse.headers.getSetCookie() : [loginResponse.headers.get('set-cookie') || '']).map((item) => item.split(';', 1)[0]).filter(Boolean).join('; ');
   if (!cookie || !login?.csrfToken) { report.authenticationFailures += 1; throw new Error('synthetic staging login did not issue session'); }
-  const headers = { cookie, origin: 'https://crm-staging.skincos.com.br', 'x-csrf-token': login.csrfToken };
+  const headers = { cookie, origin: baseUrl, 'x-csrf-token': login.csrfToken };
   const expectedSha = required('FINANCE_CANARY_RELEASE_SHA');
   if (!/^[0-9a-f]{40}$/.test(expectedSha)) throw new Error('FINANCE_CANARY_RELEASE_SHA must be a full SHA');
-  const health = await expect('health', '/finance/health', { headers: { origin: 'https://crm-staging.skincos.com.br' } });
+  const health = await expect('health', financePath('/health'), { headers: { origin: baseUrl } });
   if (health.version !== expectedSha) { report.dependencyFailures += 1; throw new Error('Finance Worker version does not match canary SHA'); }
-  const bootstrap = await expect('bootstrap', `/finance/bootstrap?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  const bootstrap = await expect('bootstrap', `${financePath('/bootstrap')}?scopeId=${encodeURIComponent(scopeId)}`, { headers });
   if (bootstrap.moduleEnabled !== true || bootstrap.canAccess !== true || !Array.isArray(bootstrap.grants) || bootstrap.grants.length !== 1 || bootstrap.grants[0]?.scope_id !== scopeId || bootstrap.grants[0]?.unit_slug !== 'novo-hamburgo' || bootstrap.grants[0]?.permission !== 'operator') throw new Error('synthetic canary scope or grant mismatch');
-  const readiness = await expect('readiness', '/finance/readiness', { headers: { origin: 'https://crm-staging.skincos.com.br' } });
+  const readiness = await expect('readiness', financePath('/readiness'), { headers: { origin: baseUrl } });
   if (!readiness.ready || readiness.dependencies?.d1?.state !== 'healthy') { report.dependencyFailures += 1; throw new Error('Finance dependency is not ready'); }
-  await expect('accounts', `/finance/accounts?scopeId=${encodeURIComponent(scopeId)}`, { headers });
-  await expect('categories', `/finance/categories?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  await expect('accounts', `${financePath('/accounts')}?scopeId=${encodeURIComponent(scopeId)}`, { headers });
+  await expect('categories', `${financePath('/categories')}?scopeId=${encodeURIComponent(scopeId)}`, { headers });
   const nonce = `canary-${Date.now()}`;
-  const tag = await expect('synthetic-audit-create', `/finance/tags?scopeId=${encodeURIComponent(scopeId)}`, {
+  const tag = await expect('synthetic-audit-create', `${financePath('/tags')}?scopeId=${encodeURIComponent(scopeId)}`, {
     method: 'POST', headers: { ...headers, 'content-type': 'application/json', 'idempotency-key': `${nonce}:create` }, body: JSON.stringify({ name: nonce }),
   }, 201);
   const tagId = String(tag.tag?.id || '').trim();
   if (!tagId) { report.auditFailures += 1; throw new Error('synthetic audit probe did not return an identifier'); }
-  const archived = await expect('synthetic-audit-compensate', `/finance/tags/${encodeURIComponent(tagId)}/archive?scopeId=${encodeURIComponent(scopeId)}`, {
+  const archived = await expect('synthetic-audit-compensate', `${financePath(`/tags/${encodeURIComponent(tagId)}/archive`)}?scopeId=${encodeURIComponent(scopeId)}`, {
     method: 'POST', headers: { ...headers, 'content-type': 'application/json', 'idempotency-key': `${nonce}:archive` }, body: JSON.stringify({ reason: 'Synthetic canary compensation' }),
   }, 201);
   if (archived.active !== false) { report.dataDivergences += 1; throw new Error('synthetic canary compensation did not archive its record'); }
-  const audit = await expect('audit', `/finance/audit?scopeId=${encodeURIComponent(scopeId)}&entityType=tag&entityId=${encodeURIComponent(tagId)}`, { headers });
+  const audit = await expect('audit', `${financePath('/audit')}?scopeId=${encodeURIComponent(scopeId)}&entityType=tag&entityId=${encodeURIComponent(tagId)}`, { headers });
   if (Number(audit.total || 0) < 2) { report.auditFailures += 1; throw new Error('synthetic canary audit trail is incomplete'); }
-  const denied = await request('cross-unit-denied', '/finance/accounts?scopeId=finance-scope-barra-shopping-sul', { headers });
+  const denied = await request('cross-unit-denied', `${financePath('/accounts')}?scopeId=finance-scope-barra-shopping-sul`, { headers });
   if (denied.status !== 403) { report.journeyFailures += 1; throw new Error('cross-unit access was not denied'); }
   // The only write is a synthetic tag and its compensating archive; no real
   // actor, unit, financial movement, import or personal scope is touched.

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const read = (file) => readFile(new URL(`../scripts/${file}`, import.meta.url), 'utf8');
+
+test('staging Finance API smokes use the authenticated Pages transport', async () => {
+  const [canary, importer] = await Promise.all([
+    read('staging-synthetic-canary.mjs'),
+    read('staging-import-smoke.mjs'),
+  ]);
+
+  for (const source of [canary, importer]) {
+    assert.match(source, /https:\/\/skincos-staging\.pages\.dev/);
+    assert.match(source, /\/api\/auth\/login/);
+    assert.match(source, /\/api\/finance/);
+    assert.doesNotMatch(source, /api-staging\.skincos\.com\.br/);
+  }
+});


### PR DESCRIPTION
## Contexto\nO canary sintético falhou antes da jornada porque autenticava diretamente em pi-staging, enquanto a sessão real é emitida e encaminhada pelo CRM Pages staging.\n\n## Mudança\n- autentica canary e import smoke por https://skincos-staging.pages.dev/api/auth;\n- encaminha Finance pelo mesmo proxy /api/finance;\n- adiciona regressão que bloqueia retorno ao transporte direto.\n\n## Segurança\nSomente código/workflow; sem segredo, produção, flag, grant ou dado. O canary continua restaurando o baseline desativado.\n\n## Validação local\n- 21 testes Finance direcionados (D1/Miniflare integral fica para CI Linux);\n- 
pm --prefix finance run check;\n- git diff --check.