### PR TITLE
fix(finance): alinhar identidade sintética ao shell

### DIFF
--- a/docs/runbooks/finance-staging-test-identity.md
+++ b/docs/runbooks/finance-staging-test-identity.md
@@ -2,17 +2,17 @@
 
 ## Identidade e owner
 
-`finance-staging-smoke` é a identidade sintética exclusiva de staging para o smoke e canary Financeiro. Ela é propriedade de `@skincos/finance`; `admin` é o operador responsável pela execução, rotação e teardown. `finance-staging-monitor` permanece somente como identidade `viewer` do monitor e nunca é reutilizada pelo smoke. A identidade usa o login real `POST /insumos/auth/login` e a sessão assinada consumida pelo gateway em `/finance/*`.
+`finance-staging-smoke` é a identidade sintética exclusiva de staging para o smoke e canary Financeiro. Ela é propriedade de `@skincos/finance`; `admin` é o operador responsável pela execução, rotação e teardown. `finance-staging-monitor` permanece somente como identidade `viewer` do monitor e nunca é reutilizada pelo smoke. A identidade usa o login real do shell `POST /api/auth/login` e a sessão assinada consumida pelo gateway em `/api/finance/*`.
 
 - bancos: conta somente em `skincos-db-staging` e grant somente em `skincos-finance-staging`; nunca consultar ou escrever os equivalentes produtivos;
 - e-mail sintético: `finance-staging-smoke@staging.invalid`;
-- papel: `CONSULTOR`;
+- papel: `INJETOR`, o menor papel que preserva o grant explícito de `finance`; `CONSULTOR` é deliberadamente limitado ao Atendimento pelo shell;
 - módulos: somente `finance`;
 - unidade e grant: somente `finance-scope-novo-hamburgo`, permissão `operator`, o mínimo necessário para importar e desfazer;
 - pessoal, BarraShoppingSul, administrador e qualquer mutação fora da importação/compensação sintética controlada: negados;
 - a flag `finance_settings.module_enabled` permanece `false` fora de uma janela de smoke aprovada.
 
-A senha não fica no Git, em secret de produção, cookie ou sessão compartilhada. A credencial atual fica cifrada por DPAPI no runtime privado do operador. Cookies emitidos pelo login são host-only para `api-staging.skincos.com.br` e não devem ser enviados a nenhuma origem de produção.
+A senha não fica no Git, em secret de produção, cookie ou sessão compartilhada. A credencial atual fica cifrada por DPAPI no runtime privado do operador. Cookies emitidos pelo login permanecem no shell de staging e não devem ser enviados a nenhuma origem de produção.
 
 O segredo fica somente no environment GitHub `staging` como
 `FINANCE_SMOKE_PASSWORD`; os nomes não secretos necessários pela jornada usam

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -51,7 +51,10 @@ const json = async (response) => {
 
 const login = await request('/api/auth/login', {
   method: 'POST', headers: { 'content-type': 'application/json', origin: baseUrl },
-  body: JSON.stringify({ username, password }),
+  // `/api/auth/login` uses `email` for either the e-mail address or the
+  // canonical username. Keep the environment variable name to make the
+  // synthetic-only actor policy explicit.
+  body: JSON.stringify({ email: username, password }),
 });
 const loginBody = await json(login);
 const setCookies = typeof login.headers.getSetCookie === 'function' ? login.headers.getSetCookie() : [login.headers.get('set-cookie') || ''];

--- a/finance/scripts/staging-smoke-identity-sql.mjs
+++ b/finance/scripts/staging-smoke-identity-sql.mjs
@@ -39,13 +39,16 @@ const financeAudit = (actionName, before, after) => `INSERT INTO finance_audit_e
 
 let coreSql;
 let financeSql;
-const baseline = { username, environment: 'staging', expiresAt, allowedUnits: ['novo-hamburgo'], allowedModules: ['finance'] };
+// CONSULTOR is intentionally constrained by the CRM shell to Atendimento,
+// regardless of its configured modules. INJETOR is the least-privileged role
+// that preserves the explicit, single-module Finance grant below.
+const baseline = { username, environment: 'staging', role: 'INJETOR', allowedUnits: ['novo-hamburgo'], allowedModules: ['finance'] };
 if (action === 'provision') {
   coreSql = [
     // Cloudflare D1's remote SQL API rejects explicit transaction control.
     // Each generated file is submitted as a single D1 request by the canonical
     // workflow, so leave transaction ownership to the D1 service.
-    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'CONSULTOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1);`,
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'INJETOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1);`,
     audit('FINANCE_SMOKE_IDENTITY_PROVISIONED', null, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [
@@ -54,7 +57,7 @@ if (action === 'provision') {
   ].join('\n');
 } else if (action === 'rotate') {
   coreSql = [
-    `UPDATE crm_users SET password_hash=${quote(passwordHash())},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`,
+    `UPDATE crm_users SET password_hash=${quote(passwordHash())},role='INJETOR',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`,
     audit('FINANCE_SMOKE_IDENTITY_ROTATED', { active: true }, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [

--- a/finance/scripts/staging-synthetic-canary.mjs
+++ b/finance/scripts/staging-synthetic-canary.mjs
@@ -43,7 +43,9 @@ try {
   // Authenticate through the same Pages proxy used by the browser shell. The
   // session cookie is host-scoped to the staging shell and is not portable to
   // a direct api-staging request.
-  const loginResponse = await request('login', '/api/auth/login', { method: 'POST', headers: { 'content-type': 'application/json', origin: baseUrl }, body: JSON.stringify({ username, password }) });
+  // The CRM authentication contract calls the credential identifier `email`
+  // even when the synthetic actor signs in with its canonical username.
+  const loginResponse = await request('login', '/api/auth/login', { method: 'POST', headers: { 'content-type': 'application/json', origin: baseUrl }, body: JSON.stringify({ email: username, password }) });
   const login = await loginResponse.json().catch(() => null);
   if (loginResponse.status !== 200) { report.authenticationFailures += 1; throw new Error(`login returned ${loginResponse.status}`); }
   const cookie = (typeof loginResponse.headers.getSetCookie === 'function' ? loginResponse.headers.getSetCookie() : [loginResponse.headers.get('set-cookie') || '']).map((item) => item.split(';', 1)[0]).filter(Boolean).join('; ');

--- a/finance/test/staging-smoke-identity-scope.test.mjs
+++ b/finance/test/staging-smoke-identity-scope.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const script = new URL('../scripts/staging-smoke-identity-sql.mjs', import.meta.url);
+const password = 'synthetic-test-password-with-at-least-24-characters';
+
+function generate(action) {
+  const directory = mkdtempSync(join(tmpdir(), 'skincos-finance-smoke-'));
+  const core = join(directory, 'core.sql');
+  const finance = join(directory, 'finance.sql');
+  try {
+    const result = spawnSync(process.execPath, [script.pathname, action, '--expires-at', '2026-08-01T00:00:00.000Z', '--core-output', core, '--finance-output', finance], {
+      env: { ...process.env, FINANCE_SMOKE_IDENTITY_ACK: '1', FINANCE_SMOKE_PASSWORD: password },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return { core: readFileSync(core, 'utf8'), finance: readFileSync(finance, 'utf8') };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test('synthetic Finance identity preserves only the explicit Finance module in the shell', () => {
+  const provision = generate('provision');
+  const rotation = generate('rotate');
+
+  assert.match(provision.core, /'INJETOR'/);
+  assert.match(provision.core, /'\["finance"\]'/);
+  assert.doesNotMatch(provision.core, /'CONSULTOR'/);
+  assert.match(rotation.core, /role='INJETOR'/);
+  assert.match(rotation.core, /allowed_modules_json='\["finance"\]'/);
+  assert.match(rotation.finance, /finance_access_grant/);
+});

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -14,6 +14,8 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
     assert.match(source, /https:\/\/skincos-staging\.pages\.dev/);
     assert.match(source, /\/api\/auth\/login/);
     assert.match(source, /\/api\/finance/);
+    assert.match(source, /JSON\.stringify\(\{ email: username, password \}\)/);
+    assert.doesNotMatch(source, /JSON\.stringify\(\{ username, password \}\)/);
     assert.doesNotMatch(source, /api-staging\.skincos\.com\.br/);
   }
 });


### PR DESCRIPTION
## Escopo\n\n- corrige o payload do login sintético para o contrato Pages;\n- usa somente o papel mínimo INJETOR e o módulo explícito inance;\n- reconcilia o registro sintético existente durante a rotação;\n- adiciona testes de regressão e atualiza o runbook.\n\n## Validação\n\n- 
ode --check dos scripts;\n- testes focados do transporte e da identidade;\n- Finance check e suíte sem a integração D1 local;\n- git diff --check.\n\nSem produção, usuários reais, flags reais ou dados reais.