### PR TITLE
fix(ponto): restore Workforce self-service release gates

### DIFF
--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -28,14 +28,17 @@ jobs:
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
           PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
+          PONTO_PROFILE_DATA_KEY: ${{ secrets.PONTO_PROFILE_DATA_KEY }}
+          PONTO_NETWORK_CONTEXT_KEY: ${{ secrets.PONTO_NETWORK_CONTEXT_KEY }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
+          IDENTITY_WORKFORCE_HMAC_KEY: ${{ secrets.IDENTITY_WORKFORCE_HMAC_KEY }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_PROFILE_DATA_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY; do
             if [[ -z "${!name:-}" ]]; then echo "Missing required value: $name"; exit 1; fi
           done
           sed -i "s/__CONFIGURE_TIMEKEEPING_D1_ID__/$D1_ID/" workforce/timekeeping/wrangler.toml
-          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY ESCALA_ACTOR_HMAC_KEY; do
+          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_PROFILE_DATA_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY; do
             printf '%s' "${!name}" | npx --yes wrangler@4.112.0 secret put "$name" --config workforce/timekeeping/wrangler.toml >/dev/null
             echo "Synced $name to skincos-timekeeping"
           done

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -55,13 +55,14 @@ jobs:
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
           PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
+          PONTO_PROFILE_DATA_KEY: ${{ secrets.PONTO_PROFILE_DATA_KEY }}
           PONTO_NETWORK_CONTEXT_KEY: ${{ secrets.PONTO_NETWORK_CONTEXT_KEY }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
           IDENTITY_WORKFORCE_HMAC_KEY: ${{ secrets.IDENTITY_WORKFORCE_HMAC_KEY }}
           TIMEKEEPING_BACKUP_PASSPHRASE: ${{ secrets.TIMEKEEPING_BACKUP_PASSPHRASE }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID MODULE_CONTROL_KV_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY TIMEKEEPING_BACKUP_PASSPHRASE; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID D1_ID MODULE_CONTROL_KV_ID PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_PROFILE_DATA_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY TIMEKEEPING_BACKUP_PASSPHRASE; do
             [[ -n "${!name:-}" ]] || { echo "Missing required value: $name"; exit 1; }
           done
           [[ "$D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo "Invalid Timekeeping D1 id"; exit 1; }
@@ -157,13 +158,14 @@ jobs:
           PONTO_ACTOR_HMAC_KEY: ${{ secrets.PONTO_ACTOR_HMAC_KEY }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
           PONTO_TEMPLATES_KEY: ${{ secrets.PONTO_TEMPLATES_KEY }}
+          PONTO_PROFILE_DATA_KEY: ${{ secrets.PONTO_PROFILE_DATA_KEY }}
           PONTO_NETWORK_CONTEXT_KEY: ${{ secrets.PONTO_NETWORK_CONTEXT_KEY }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
           IDENTITY_WORKFORCE_HMAC_KEY: ${{ secrets.IDENTITY_WORKFORCE_HMAC_KEY }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); else ENV_ARGS=(--env staging); fi
-          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY; do
+          for name in PONTO_ACTOR_HMAC_KEY PONTO_IDEMPOTENCY_KEY PONTO_TEMPLATES_KEY PONTO_PROFILE_DATA_KEY PONTO_NETWORK_CONTEXT_KEY ESCALA_ACTOR_HMAC_KEY IDENTITY_WORKFORCE_HMAC_KEY; do
             printf '%s' "${!name}" | workforce/timekeeping/node_modules/.bin/wrangler secret put "$name" --config workforce/timekeeping/wrangler.toml "${ENV_ARGS[@]}" >/dev/null
           done
 
@@ -187,15 +189,17 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TARGET: ${{ inputs.target }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "production" ]]; then ENV_ARGS=(--env ""); else ENV_ARGS=(--env staging); fi
-          workforce/timekeeping/node_modules/.bin/wrangler deploy --config workforce/timekeeping/wrangler.toml --keep-vars "${ENV_ARGS[@]}"
+          workforce/timekeeping/node_modules/.bin/wrangler deploy --config workforce/timekeeping/wrangler.toml --keep-vars "${ENV_ARGS[@]}" --var "APP_VERSION:$RELEASE_SHA" --var "ENVIRONMENT:$TARGET"
 
       - name: Read-only endpoint smoke
         id: smoke
         env:
           TARGET: ${{ inputs.target }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "production" ]]; then BASE=https://api.skincos.com.br; else BASE=https://api-staging.skincos.com.br; fi
@@ -204,7 +208,7 @@ jobs:
             code="$(curl --silent --show-error --retry 5 --retry-delay 4 --dump-header "$headers" --output "$body" --write-out '%{http_code}' "$BASE/api/ponto/$path")"
             [[ "$code" == "200" ]] || { echo "$path returned HTTP $code"; cat "$body"; exit 1; }
             grep -Eiq '^content-type: application/json' "$headers" || { echo "$path returned invalid content-type"; exit 1; }
-            node -e "const p=JSON.parse(require('fs').readFileSync(process.argv[1])); if(!p.ok) process.exit(1)" "$body"
+            node -e "const p=JSON.parse(require('fs').readFileSync(process.argv[1])); if(!p.ok) process.exit(1); if(process.argv[2]==='health' && (p.version!==process.env.RELEASE_SHA || p.environment!==process.env.TARGET || p.availability?.state!=='active')) process.exit(1)" "$body" "$path"
           done
 
       - name: Write staging promotion evidence

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -7,9 +7,16 @@ on:
       - 'api/**'
       - 'crm/console/functions/api/ponto/**'
       - 'crm/console/PontoModule.tsx'
+      - 'crm/console/crmRoleAccess.ts'
+      - 'crm/console/moduleAvailability.ts'
       - 'crm/console/pontoApi.ts'
       - 'crm/console/pontoTypes.ts'
       - 'crm/console/tests/ponto*.test.ts'
+      - 'crm/console/tests/crmRoleAccess.test.ts'
+      - 'crm/console/tests/moduleRegistry.test.ts'
+      - 'crm/console/scripts/ponto-staging-journey.cjs'
+      - 'workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs'
+      - '.github/workflows/timekeeping-staging-journey.yml'
       - '.github/workflows/timekeeping-ci.yml'
   push:
     branches: [main]
@@ -17,6 +24,17 @@ on:
       - 'workforce/timekeeping/**'
       - 'api/**'
       - 'crm/console/functions/api/ponto/**'
+      - 'crm/console/PontoModule.tsx'
+      - 'crm/console/crmRoleAccess.ts'
+      - 'crm/console/moduleAvailability.ts'
+      - 'crm/console/pontoApi.ts'
+      - 'crm/console/pontoTypes.ts'
+      - 'crm/console/tests/ponto*.test.ts'
+      - 'crm/console/tests/crmRoleAccess.test.ts'
+      - 'crm/console/tests/moduleRegistry.test.ts'
+      - 'crm/console/scripts/ponto-staging-journey.cjs'
+      - 'workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs'
+      - '.github/workflows/timekeeping-staging-journey.yml'
 
 permissions:
   contents: read
@@ -47,6 +65,19 @@ jobs:
         run: |
           node workforce/timekeeping/scripts/import-ponto-json.mjs --source workforce/timekeeping/fixtures/ponto_store.synthetic.json --dry-run
           node workforce/timekeeping/scripts/migration-local.test.mjs
+      - name: Validate synthetic staging fixture contract
+        run: |
+          set -euo pipefail
+          fixtures="$RUNNER_TEMP/ponto-staging-fixtures.json"
+          core_sql="$RUNNER_TEMP/ponto-staging-core.sql"
+          timekeeping_sql="$RUNNER_TEMP/ponto-staging-timekeeping.sql"
+          teardown_core="$RUNNER_TEMP/ponto-staging-core-teardown.sql"
+          teardown_timekeeping="$RUNNER_TEMP/ponto-staging-timekeeping-teardown.sql"
+          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision --run-id 123456 --fixtures "$fixtures" --core-sql "$core_sql" --timekeeping-sql "$timekeeping_sql"
+          node -e "const fs=require('fs');const f=JSON.parse(fs.readFileSync(process.argv[1]));const core=fs.readFileSync(process.argv[2],'utf8');const timekeeping=fs.readFileSync(process.argv[3],'utf8');if(f.environment!=='staging'||f.role!=='CONSULTOR'||f.allowedModules.join(',')!=='atendimento,ponto'||!f.pin||!f.password||!core.includes('STAGING_SYNTHETIC')||core.includes(f.password)||core.includes(f.pin)||timekeeping.includes(f.password)||timekeeping.includes(f.pin))process.exit(1)" "$fixtures" "$core_sql" "$timekeeping_sql"
+          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id 123456 --fixtures "$fixtures" --core-sql "$teardown_core" --timekeeping-sql "$teardown_timekeeping"
+          node -e "const fs=require('fs');const core=fs.readFileSync(process.argv[1],'utf8');const timekeeping=fs.readFileSync(process.argv[2],'utf8');if(!core.includes('STAGING_SYNTHETIC')||timekeeping.includes('DELETE FROM timekeeping_audit_events'))process.exit(1)" "$teardown_core" "$teardown_timekeeping"
+          rm -f "$fixtures" "$core_sql" "$timekeeping_sql" "$teardown_core" "$teardown_timekeeping"
       - name: Test gateway routing
         run: |
           set -euo pipefail
@@ -55,4 +86,14 @@ jobs:
           npm --prefix api test
           api/node_modules/.bin/wrangler deploy --dry-run --config api/wrangler.toml --env="" --outdir "$RUNNER_TEMP/api-dry-run"
       - name: Typecheck and test CRM proxy
-        run: npm --prefix crm/console ci && npm --prefix crm/console run typecheck && npm --prefix crm/console run lint && npm --prefix crm/console test && npm --prefix crm/console run build
+        run: |
+          set -euo pipefail
+          npm --prefix crm/console ci
+          npm --prefix crm/console run typecheck
+          npm --prefix crm/console run lint
+          npm --prefix crm/console test
+          npm --prefix crm/console run build
+          if PONTO_STAGING_CRM_URL='https://user@candidate.skincos-staging.pages.dev/' node crm/console/scripts/ponto-staging-journey.cjs 2>/dev/null; then
+            echo 'Ponto staging journey accepted an origin with userinfo.' >&2
+            exit 1
+          fi

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -1,0 +1,141 @@
+name: Timekeeping authenticated staging journey
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Immutable main SHA promoted to staging on all Ponto surfaces
+        required: true
+        type: string
+      timekeeping_staging_run_id:
+        description: Canonical Timekeeping staging run containing promotion evidence
+        required: true
+        type: string
+      core_api_staging_run_id:
+        description: Canonical Core API staging run containing promotion evidence
+        required: true
+        type: string
+      crm_pages_staging_run_id:
+        description: Canonical CRM Pages staging run containing promotion evidence
+        required: true
+        type: string
+      pages_url:
+        description: Immutable skincos-staging Pages deployment URL
+        required: true
+        type: string
+
+concurrency:
+  group: timekeeping-staging-journey-${{ inputs.release_sha }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  journey:
+    name: synthetic authenticated CONSULTOR journey
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 30
+    env:
+      STAGING_CORE_D1_DATABASE: skincos-db-staging
+      STAGING_TIMEKEEPING_D1_DATABASE: skincos-timekeeping-staging
+    steps:
+      - name: Validate immutable source and matching staging evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          TIMEKEEPING_RUN: ${{ inputs.timekeeping_staging_run_id }}
+          CORE_API_RUN: ${{ inputs.core_api_staging_run_id }}
+          CRM_PAGES_RUN: ${{ inputs.crm_pages_staging_run_id }}
+          PAGES_URL: ${{ inputs.pages_url }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full SHA'; exit 1; }
+          [[ "$TIMEKEEPING_RUN" =~ ^[0-9]+$ && "$CORE_API_RUN" =~ ^[0-9]+$ && "$CRM_PAGES_RUN" =~ ^[0-9]+$ ]] || { echo 'canonical run IDs must be numeric'; exit 1; }
+          [[ "$PAGES_URL" =~ ^https://[a-z0-9-]+\.skincos-staging\.pages\.dev/?$ ]] || { echo 'pages_url must be an immutable skincos-staging.pages.dev URL'; exit 1; }
+          mkdir -p "$RUNNER_TEMP/promotion-evidence/timekeeping" "$RUNNER_TEMP/promotion-evidence/core-api" "$RUNNER_TEMP/promotion-evidence/crm-pages"
+          gh run download "$TIMEKEEPING_RUN" --repo "$GITHUB_REPOSITORY" --name promotion-evidence-timekeeping --dir "$RUNNER_TEMP/promotion-evidence/timekeeping"
+          gh run download "$CORE_API_RUN" --repo "$GITHUB_REPOSITORY" --name promotion-evidence-core-api --dir "$RUNNER_TEMP/promotion-evidence/core-api"
+          gh run download "$CRM_PAGES_RUN" --repo "$GITHUB_REPOSITORY" --name promotion-evidence-crm-pages --dir "$RUNNER_TEMP/promotion-evidence/crm-pages"
+          for evidence in "$RUNNER_TEMP/promotion-evidence/timekeeping/promotion-evidence.json" "$RUNNER_TEMP/promotion-evidence/core-api/promotion-evidence.json" "$RUNNER_TEMP/promotion-evidence/crm-pages/promotion-evidence.json"; do
+            node -e "const e=require(process.argv[1]); if(e.sourceSha!==process.env.RELEASE_SHA||e.target!=='staging') process.exit(1)" "$evidence"
+          done
+
+      - name: Checkout smoke harness
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: crm/console/package-lock.json
+
+      - name: Install browser harness
+        run: npm ci
+        working-directory: crm/console
+
+      - name: Install Playwright Chromium
+        run: npx --yes playwright install --with-deps chromium
+        working-directory: crm/console
+
+      - name: Generate runner-private synthetic fixture
+        env:
+          FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
+          CORE_SQL: ${{ runner.temp }}/ponto-staging-core-provision.sql
+          TIMEKEEPING_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-provision.sql
+        run: |
+          set -euo pipefail
+          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL"
+
+      - name: Provision only run-scoped synthetic staging records
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CORE_SQL: ${{ runner.temp }}/ponto-staging-core-provision.sql
+          TIMEKEEPING_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-provision.sql
+        run: |
+          set -euo pipefail
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || { echo 'staging Cloudflare credentials are required'; exit 1; }
+          [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" >/dev/null
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config workforce/timekeeping/wrangler.toml --env staging --remote --file "$TIMEKEEPING_SQL" >/dev/null
+
+      - name: Execute authenticated Ponto journey
+        env:
+          PONTO_STAGING_CRM_URL: ${{ inputs.pages_url }}
+          PONTO_STAGING_FIXTURES_FILE: ${{ runner.temp }}/ponto-staging-fixtures.json
+          PONTO_STAGING_REPORT_FILE: ${{ runner.temp }}/ponto-staging-report.json
+          NODE_PATH: crm/console/node_modules
+        run: node crm/console/scripts/ponto-staging-journey.cjs
+
+      - name: Tear down only this run's synthetic staging records
+        if: ${{ always() }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
+          CORE_SQL: ${{ runner.temp }}/ponto-staging-core-teardown.sql
+          TIMEKEEPING_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-teardown.sql
+        run: |
+          set -euo pipefail
+          [[ -f "$FIXTURES" ]] || exit 0
+          [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
+          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config workforce/timekeeping/wrangler.toml --env staging --remote --file "$TIMEKEEPING_SQL" >/dev/null
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" >/dev/null
+          rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL"
+
+      - name: Upload sanitised journey evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: timekeeping-staging-journey-${{ inputs.release_sha }}
+          path: ${{ runner.temp }}/ponto-staging-report.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,11 @@
   attest only the isolated Worker, D1, KV, Pages project and environment
   configuration through the canonical path; do not copy staging identifiers.
 
-## Controle de Ponto — `codex/admin/workforce-timekeeping-complete`
+## Controle de Ponto — liberação atual de Workforce Timekeeping
+
+As marcações abaixo registram a entrega histórica. Elas não comprovam que o
+`main` atual tenha a mesma versão no CRM Pages, gateway e Worker, nem que a
+jornada autenticada atual continue válida.
 
 - [x] Domínio definitivo criado em `workforce/timekeeping` e montado no gateway.
 - [x] D1 modelado com migrations reproduzíveis, constraints, índices, snapshots e auditoria imutável.
@@ -42,8 +46,30 @@
 - [x] Perfil canônico preparado a partir do modelo de Pessoas, com campos privados cifrados, CNPJ por unidade e tela de perfil no Ponto.
 - [x] Testes locais do domínio, gateway, proxy, cliente, D1 e integração HTTP.
 - [x] Executar todos os gates finais (lint completo, testes completos e build de produção).
-- [x] Publicar e validar staging com D1/secrets próprios (workflow `29700256254`).
-- [x] Promover por workflow oficial e executar smoke produtivo somente leitura (produção `29700295125`; API `29700339758`; UI `29753110570`).
+- [x] Publicar e validar staging com D1/secrets próprios (workflow histórico `29700256254`).
+- [x] Promover por workflow oficial e executar smoke produtivo somente leitura (evidência histórica `29700295125`; API `29700339758`; UI `29753110570`).
+
+### P0 — candidato atual (não promovido)
+
+- [x] Restaurar a navegação de CONSULTOR/EMPLOYEE para exatamente Atendimento e
+  Ponto, preservando a autorização no servidor.
+- [x] Cobrir a regressão de navegação e incluir seus arquivos no path filter de
+  Timekeeping CI.
+- [x] Criar jornada autenticada sintética, com fixture efêmera, teardown
+  específico por execução e evidência sanitizada.
+- [x] Tornar `PONTO_PROFILE_DATA_KEY` obrigatório nos sync/deploys e registrar
+  release SHA/environment no health do Worker.
+- [ ] Criar `PONTO_PROFILE_DATA_KEY` por processo de segredo aprovado nos
+  environments `staging` e `production`; não gerar/copyar valor pelo código.
+- [ ] Fazer preview e staging do mesmo SHA para Timekeeping, Core API e CRM
+  Pages; executar a jornada sintética pelo URL imutável do Pages e confirmar
+  que o teardown preservou auditoria.
+- [ ] Exercitar `module-control:timekeeping` em staging (`maintenance` →
+  `active`) e registrar o rollback; só então tornar `active` explícito em
+  produção após promoção imutável, piloto e observação.
+- [ ] Não considerar produção, piloto, conclusão ou arquivamento provados até
+  existirem artefatos, health/version/gateway e jornada autenticada para o
+  mesmo SHA.
 
 ## External/product follow-up
 

--- a/crm/console/crmRoleAccess.ts
+++ b/crm/console/crmRoleAccess.ts
@@ -1,4 +1,6 @@
-export const CONSULTOR_MODULE_KEYS = new Set(['atendimento'])
+// This is a navigation allowlist, not an authorization bypass.  The CRM
+// Function and Workforce Worker independently authorize every Ponto request.
+export const CONSULTOR_MODULE_KEYS = new Set(['atendimento', 'ponto'])
 
 function normalizedModules(value: unknown): string[] {
   return Array.isArray(value)
@@ -11,8 +13,10 @@ export function hasCrmModuleAccess(role: unknown, allowedModules: unknown, modul
   const key = String(moduleKey || '').trim()
   const roleKey = String(role || '').trim().toUpperCase()
   if (!key) return false
-  // Consultants only operate Atendimento. This must be evaluated before the
-  // generic self-service Ponto allowance below.
+  // Consultants and the legacy EMPLOYEE spelling can operate only Atendimento
+  // and their self-service Ponto area. This must be evaluated before the
+  // generic self-service Ponto allowance below so assigned module lists never
+  // broaden their navigation.
   if (roleKey === 'CONSULTOR' || roleKey === 'EMPLOYEE') return CONSULTOR_MODULE_KEYS.has(key)
   // Every authenticated CRM user can access the self-service timekeeping area.
   // Data and administrative operations remain authorized by the Ponto proxy and

--- a/crm/console/moduleAvailability.ts
+++ b/crm/console/moduleAvailability.ts
@@ -13,6 +13,9 @@ export const DEFAULT_UNLOCKED_MODULE_KEYS = [
   'insumos',
   'conversa',
   'atendimento',
+  // Ponto is self-service for authenticated Workforce identities. Role and
+  // server authorization still constrain what each identity can do inside it.
+  'ponto',
   'clientes',
   'caixa',
   'faturamento',

--- a/crm/console/scripts/ponto-staging-journey.cjs
+++ b/crm/console/scripts/ponto-staging-journey.cjs
@@ -1,0 +1,175 @@
+/*
+ * Synthetic authenticated Ponto staging journey. Credentials and the PIN stay
+ * in a runner-private fixture; the emitted report contains only booleans,
+ * status codes and request-id presence.
+ */
+const fs = require('fs')
+const path = require('path')
+
+const validatedStagingOrigin = (value) => {
+  let candidate
+  try { candidate = new URL(String(value || '')) } catch { throw new Error('PONTO_STAGING_CRM_URL must be a valid immutable staging URL.') }
+  if (candidate.protocol !== 'https:' || !candidate.hostname.endsWith('.skincos-staging.pages.dev') || candidate.port || candidate.username || candidate.password || candidate.pathname !== '/' || candidate.search || candidate.hash) {
+    throw new Error('PONTO_STAGING_CRM_URL must be an immutable skincos-staging.pages.dev HTTPS origin.')
+  }
+  return candidate
+}
+const base = validatedStagingOrigin(process.env.PONTO_STAGING_CRM_URL)
+const validatedApiPath = (value) => {
+  const localOrigin = 'https://ponto-journey.invalid'
+  const candidate = new URL(String(value), localOrigin)
+  if (candidate.origin !== localOrigin || !candidate.pathname.startsWith('/api/')) throw new Error('Ponto journey accepts only relative API paths.')
+  return `${candidate.pathname}${candidate.search}`
+}
+const fixturePath = String(process.env.PONTO_STAGING_FIXTURES_FILE || '')
+const reportPath = String(process.env.PONTO_STAGING_REPORT_FILE || '')
+if (!fixturePath || !reportPath) throw new Error('private fixture and sanitised report paths are required')
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'))
+if (fixture?.environment !== 'staging' || fixture?.role !== 'CONSULTOR' || JSON.stringify(fixture?.allowedModules) !== JSON.stringify(['atendimento', 'ponto'])) {
+  throw new Error('Ponto staging fixture is invalid')
+}
+
+const assert = (condition, message) => { if (!condition) throw new Error(message) }
+const safeRequestMeta = (response) => ({ status: response.status, requestIdPresent: Boolean(response.requestId), cfRayPresent: Boolean(response.cfRay) })
+// The browser stays on the validated staging origin and calls only literal,
+// same-origin routes below.
+const api = async (page, pathname, init = {}) => {
+  const safePathname = validatedApiPath(pathname)
+  // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection -- safePathname is a validated relative API route.
+  return page.evaluate(async ({ safePathname, init }) => {
+    const response = await fetch(safePathname, { credentials: 'include', ...init })
+    const text = await response.text()
+    let json = null
+    try { json = text ? JSON.parse(text) : null } catch {}
+    return {
+      status: response.status,
+      ok: response.ok,
+      json,
+      requestId: String(response.headers.get('x-request-id') || ''),
+      cfRay: String(response.headers.get('cf-ray') || ''),
+    }
+  }, { safePathname, init })
+}
+
+const csrfToken = async (page) => page.evaluate(() => {
+  const value = document.cookie.split(';').map((part) => part.trim()).find((part) => part.startsWith('csrfToken='))
+  return value ? decodeURIComponent(value.slice('csrfToken='.length)) : ''
+})
+
+async function post(page, pathname, body, idempotencyKey) {
+  const csrf = await csrfToken(page)
+  assert(csrf, 'CSRF cookie was not issued after authenticated login')
+  return api(page, pathname, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      'x-csrf-token': csrf,
+      ...(idempotencyKey ? { 'idempotency-key': idempotencyKey } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function main() {
+  const { chromium } = require('playwright')
+  const browser = await chromium.launch({ headless: true, args: ['--disable-dev-shm-usage', '--disable-gpu'] })
+  const context = await browser.newContext({ baseURL: base.origin, viewport: { width: 1365, height: 860 } })
+  const page = await context.newPage()
+  const requests = []
+  page.on('response', (response) => {
+    const url = new URL(response.url())
+    if (url.origin === base.origin && url.pathname.startsWith('/api/ponto/')) {
+      requests.push({ path: url.pathname, status: response.status(), requestIdPresent: Boolean(response.headers()['x-request-id']), cfRayPresent: Boolean(response.headers()['cf-ray']) })
+    }
+  })
+  try {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    const login = await api(page, '/api/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ email: fixture.email, password: fixture.password }),
+    })
+    assert(login.status === 200 && login.json?.success !== false && login.json?.ok !== false, `login failed (${login.status})`)
+    const authMe = await api(page, '/api/auth/me')
+    assert(authMe.status === 200 && authMe.json?.user, `/auth/me failed (${authMe.status})`)
+    assert(String(authMe.json.user.role || '').toUpperCase() === 'CONSULTOR', 'authenticated role is not CONSULTOR')
+    assert(JSON.stringify(authMe.json.user.allowedModules || []) === JSON.stringify(['atendimento', 'ponto']), 'CRM module scope drifted')
+
+    // Reload only after the session is issued so the real application computes
+    // its navigation from the authenticated identity.
+    await page.goto('/?module=ponto', { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    const pontoButton = page.getByRole('button', { name: 'Ponto', exact: true }).first()
+    await pontoButton.click({ timeout: 20_000 })
+    await page.getByText('Meu ponto', { exact: true }).waitFor({ state: 'visible', timeout: 20_000 })
+    for (const label of ['Usuários', 'Insumos', 'Financeiro', 'Clientes', 'Escala']) {
+      assert(await page.getByRole('button', { name: label, exact: true }).count() === 0, `unexpected administrative navigation: ${label}`)
+    }
+
+    const me = await api(page, '/api/ponto/me')
+    assert(me.status === 200 && me.json?.linked === true, `/api/ponto/me did not link the synthetic identity (${me.status})`)
+    assert(JSON.stringify(me.json.allowedUnits || []) === JSON.stringify([fixture.unitId]), 'Ponto unit scope drifted')
+    assert(me.json?.suggestedNextMethod === 'PIN' && me.json?.hasFace === false, 'face/PIN release policy drifted')
+    const profile = await api(page, '/api/ponto/me/profile')
+    assert(profile.status === 200 && profile.json?.ok === true, `/api/ponto/me/profile failed (${profile.status})`)
+    const presence = await api(page, `/api/ponto/me/presence?unit=${encodeURIComponent(fixture.unitId)}`)
+    assert(presence.status === 200 && presence.json?.data?.presenceMode === 'FLEXIBLE', `synthetic presence policy unavailable (${presence.status})`)
+    const before = await api(page, `/api/ponto/me/records?unit=${encodeURIComponent(fixture.unitId)}&limit=20`)
+    assert(before.status === 200 && Array.isArray(before.json?.data) && before.json.data.length === 0, 'synthetic employee was not clean before punch')
+
+    const invalidPin = await post(page, '/api/ponto/me/punch', { pin: '000000', unit: fixture.unitId }, `invalid-${fixture.runId}`)
+    assert(invalidPin.status === 401 && invalidPin.json?.error === 'PIN_INVALID', `invalid PIN did not fail closed (${invalidPin.status}/${invalidPin.json?.error || ''})`)
+    const idempotencyKey = `synthetic-punch-${fixture.runId}`
+    const occurredAt = new Date().toISOString()
+    const punchBody = { pin: fixture.pin, unit: fixture.unitId, occurredAt, requestId: idempotencyKey }
+    const punch = await post(page, '/api/ponto/me/punch', punchBody, idempotencyKey)
+    assert(punch.status === 201 && punch.json?.ok === true && punch.json?.data?.id, `PIN punch failed (${punch.status}/${punch.json?.error || ''})`)
+    const retry = await post(page, '/api/ponto/me/punch', punchBody, idempotencyKey)
+    assert(retry.status === 200 && retry.json?.idempotent === true && retry.json?.data?.id === punch.json.data.id, 'punch retry was not idempotent')
+    const forbiddenUnit = await post(page, '/api/ponto/me/punch', { pin: fixture.pin, unit: fixture.forbiddenUnitId }, `forbidden-unit-${fixture.runId}`)
+    assert(forbiddenUnit.status === 403 && forbiddenUnit.json?.error === 'UNIT_FORBIDDEN', `cross-unit punch did not fail closed (${forbiddenUnit.status}/${forbiddenUnit.json?.error || ''})`)
+    const after = await api(page, `/api/ponto/me/records?unit=${encodeURIComponent(fixture.unitId)}&limit=20`)
+    assert(after.status === 200 && after.json?.data?.length === 1 && after.json.data[0]?.id === punch.json.data.id, 'idempotent punch created an unexpected ledger count')
+    const correction = await post(page, '/api/ponto/corrections', { eventId: punch.json.data.id, proposedAtUtc: new Date(Date.now() + 60_000).toISOString(), reason: 'Synthetic staging correction' }, `correction-${fixture.runId}`)
+    assert(correction.status === 201 && correction.json?.data?.status === 'PENDING', `correction request failed (${correction.status}/${correction.json?.error || ''})`)
+    const corrections = await api(page, '/api/ponto/corrections?status=PENDING')
+    assert(corrections.status === 200 && corrections.json?.data?.some((entry) => entry.id === correction.json.data.id && entry.eventId === punch.json.data.id), 'self correction was not visible to CONSULTOR')
+    const admin = await api(page, '/api/ponto/admin/employees')
+    assert(admin.status === 403 && admin.json?.error === 'FORBIDDEN', `admin Ponto route did not remain server-forbidden (${admin.status}/${admin.json?.error || ''})`)
+
+    const report = {
+      schemaVersion: 1,
+      environment: 'staging',
+      origin: base.origin,
+      at: new Date().toISOString(),
+      role: 'CONSULTOR',
+      navigation: { atendimentoVisible: await page.getByRole('button', { name: 'Atendimento', exact: true }).count() === 1, pontoVisible: true, administrativeNavigationHidden: true },
+      journey: {
+        auth: safeRequestMeta(authMe),
+        me: safeRequestMeta(me),
+        profile: safeRequestMeta(profile),
+        presence: safeRequestMeta(presence),
+        invalidPin: safeRequestMeta(invalidPin),
+        punch: safeRequestMeta(punch),
+        idempotentRetry: safeRequestMeta(retry),
+        crossUnitDenied: safeRequestMeta(forbiddenUnit),
+        correction: safeRequestMeta(correction),
+        adminDenied: safeRequestMeta(admin),
+      },
+      pontoRequests: requests,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    }
+    fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2))
+    console.log(JSON.stringify({ environment: report.environment, role: report.role, navigation: report.navigation, requestCount: requests.length, credentialsIncluded: false, piiIncluded: false }))
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(`[ponto-staging-journey] FAILED: ${String(error?.stack || error)}`)
+  process.exitCode = 1
+})

--- a/crm/console/tests/crmRoleAccess.test.ts
+++ b/crm/console/tests/crmRoleAccess.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { hasCrmModuleAccess } from '../crmRoleAccess'
 
 describe('CRM role module navigation', () => {
-  it('keeps Consultor limited to Atendimento even without an allowedModules list', () => {
+  it('keeps Consultor limited to Atendimento and self-service Ponto even without an allowedModules list', () => {
     expect(hasCrmModuleAccess('CONSULTOR', [], 'atendimento')).toBe(true)
-    expect(hasCrmModuleAccess('CONSULTOR', [], 'ponto')).toBe(false)
+    expect(hasCrmModuleAccess('CONSULTOR', [], 'ponto')).toBe(true)
     expect(hasCrmModuleAccess('CONSULTOR', [], 'faturamento')).toBe(false)
     expect(hasCrmModuleAccess('CONSULTOR', ['insumos'], 'insumos')).toBe(false)
   })
 
   it('keeps the legacy Employee spelling constrained during the transition', () => {
     expect(hasCrmModuleAccess('EMPLOYEE', [], 'atendimento')).toBe(true)
-    expect(hasCrmModuleAccess('EMPLOYEE', [], 'ponto')).toBe(false)
+    expect(hasCrmModuleAccess('EMPLOYEE', [], 'ponto')).toBe(true)
     expect(hasCrmModuleAccess('EMPLOYEE', [], 'users')).toBe(false)
   })
 

--- a/crm/console/tests/moduleRegistry.test.ts
+++ b/crm/console/tests/moduleRegistry.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { crmModuleRegistry, moduleAvailability } from '../modules/registry'
 import { ModuleErrorBoundary } from '../modules/ModuleHost'
+import { unlockedModuleKeys } from '../moduleAvailability'
 
 describe('CRM module registry', () => {
+  it('keeps Ponto released for authenticated self-service navigation', () => {
+    expect(unlockedModuleKeys('insumos', false).has('ponto')).toBe(true)
+    expect(unlockedModuleKeys('insumos', true).has('ponto')).toBe(true)
+  })
+
   it('gives every module a manifest, lazy entrypoint, permission and isolated states', () => {
     const keys = crmModuleRegistry.map((entry) => entry.key)
     expect(new Set(keys).size).toBe(keys.length)

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -48,6 +48,12 @@ Mutações same-origin exigem o token CSRF da sessão. A Pages Function envia um
 - `PONTO_FACE_THRESHOLD`, `PONTO_PIN_ITERATIONS`, `PONTO_COOLDOWN_SECONDS`: ajustes operacionais no servidor;
 - `TIMEKEEPING_D1_STAGING_ID` e `TIMEKEEPING_D1_PRODUCTION_ID`: variables do GitHub, não secrets.
 
+O deploy e o sincronizador periódico falham fechados quando qualquer segredo
+obrigatório falta. Em particular, `PONTO_PROFILE_DATA_KEY` deve existir nos
+environments GitHub `staging` e `production` antes da promoção: não use um
+fallback para `PONTO_ACTOR_HMAC_KEY`, não copie o valor de staging e não gere
+uma chave ad hoc em CI.
+
 Nunca registrar PIN, token de dispositivo, cookie, template, vetor, foto, score ou chave. A UI nunca recebe template/score.
 
 ## Fechamento mensal
@@ -64,11 +70,20 @@ A trava `timekeeping_period_guards` é adquirida por data antes do cálculo e im
 
 ## Deploy e rollback
 
-Executar `.github/workflows/deploy-timekeeping.yml` primeiro em `staging`. O workflow exporta e cifra um checkpoint D1, aplica migrations, configura secrets, publica somente o Worker de Ponto e faz smoke read-only. O gateway/API é publicado exclusivamente pelo publisher canônico `.github/workflows/deploy-core-workers.yml`. Produção exige o `staging_run_id` numérico de uma execução verde para o mesmo SHA e o environment protegido `production`.
+Executar `.github/workflows/deploy-timekeeping.yml` primeiro em `staging`. O workflow exporta e cifra um checkpoint D1, aplica migrations, configura secrets, publica somente o Worker de Ponto e faz smoke read-only. O smoke exige `version` igual ao SHA promovido, `environment` igual ao target e `availability.state=active`. O gateway/API é publicado exclusivamente pelo publisher canônico `.github/workflows/deploy-core-workers.yml`. Produção exige o `staging_run_id` numérico de uma execução verde para o mesmo SHA e o environment protegido `production`.
+
+Para uma liberação de Workforce, promover **o mesmo SHA** por três superfícies
+de staging: Timekeeping, Core API (`unit=api`) e CRM Pages. Em seguida executar
+`.github/workflows/timekeeping-staging-journey.yml` com os três artefatos de
+promoção e o URL imutável `*.skincos-staging.pages.dev`. A jornada cria apenas
+um CONSULTOR sintético efêmero com os módulos `atendimento` e `ponto`, verifica
+navegação, vínculo, PIN inválido, batida/idempotência, escopo de unidade,
+correção própria e negação administrativa; ela remove apenas os registros
+sintéticos daquele run e nunca apaga a auditoria.
 
 Configure secrets e variables separadamente nos environments GitHub `staging` e `production`. O Pages environment `preview` usa `https://api-staging.skincos.com.br`; nunca compartilhe o upstream ou a chave HMAC de produção com preview. O smoke produtivo permanece somente leitura e não aceita opção para criar marcações.
 
-Rollback de aplicação: publicar a versão anterior do Worker de Ponto; se o gateway/API também exigir rollback, usar seu publisher canônico em execução separada. Migrations são expansivas; não remover colunas/tabelas em incidente. Rollback de importação segue `docs/ponto-migration.md`. Backups e evidências ficam em `C:\CodexRuntime\operator\admin\skincos\timekeeping`, nunca no repositório.
+Rollback de aplicação: publicar a versão anterior do Worker de Ponto; se o gateway/API também exigir rollback, usar seu publisher canônico em execução separada. Migrations são expansivas; não remover colunas/tabelas em incidente. Para interromper tráfego antes de rollback de artefato, executar `.github/workflows/module-availability.yml` com `module=timekeeping`, target correto e `state=maintenance` (ou `disabled`); validar health, corrigir/rollback e restaurar `active` pelo mesmo workflow. Registrar os dois run IDs e a versão anterior. Rollback de importação segue `docs/ponto-migration.md`. Backups e evidências ficam em `C:\CodexRuntime\operator\admin\skincos\timekeeping`, nunca no repositório.
 
 ## Incidentes
 

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,34 @@
 # Current state
 
+## Workforce Timekeeping current-main release — source remediation, not yet staged — 2026-07-29T20:45Z
+
+The isolated candidate branch `codex/admin/workforce-timekeeping-production`
+starts from `origin/main` `f202e29f4178bba8966edf71539c942618254de0`. Source
+review identified a later navigation regression: commit
+`4bfc56af0ac5b2bf0387a71dfa1825cb84ecdca0` removed `ponto` from the
+CONSULTOR/EMPLOYEE allowlist after the original Workforce release. The candidate
+restores exactly `atendimento` and `ponto` for those roles; server-side Pages
+and Worker authorization remains the enforcement boundary.
+
+The candidate also makes face punches explicitly false in both Worker configs,
+adds the missing Ponto/profile secret to deploy and periodic-sync guards,
+attests SHA/environment in Worker health, and adds a private-fixture
+authenticated staging journey across CRM Pages, Core API and Timekeeping. The
+D1/KV identifiers configured for staging and production were read-only checked
+for presence and expected formats; direct health/readiness probes returned 200
+but the current Worker reports unproven release provenance (`environment`
+previously `unknown`). The remote module-control key was absent, so its current
+implicit-active behavior is not an explicit activation record.
+
+`PONTO_PROFILE_DATA_KEY` is absent from the repository and environment secret
+metadata. The new fail-closed guard therefore intentionally prevents either
+staging or production deployment until the key is provisioned through an
+approved secret-management path. No secret value was read, generated, copied or
+changed. No PR, CI run, D1 write, KV change, deployment, promotion, pilot or
+production modification has occurred for this candidate. Historical Ponto
+release records below remain historical only; they do not establish current-SHA
+staging or production readiness.
+
 ## Authoritative Finance reconciliation — 2026-07-29T14:02Z
 
 This entry is the authoritative Finance status for `origin/main`

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,17 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-29T20:45:00Z",
+      "surface": "isolated-worktree-origin-main-github-metadata-cloudflare-d1-kv-live-http",
+      "scope": "Workforce Timekeeping current-main release preparation",
+      "state": "source-remediated-local-validation-staging-blocked-by-missing-secret",
+      "method": "Created an isolated worktree from origin/main f202e29f4178bba8966edf71539c942618254de0; reviewed role/navigation history, canonical deploy and sync workflows, D1/KV metadata and live health/readiness; queried GitHub secret names only; generated and inspected private synthetic fixture SQL locally without disclosing credentials; ran Timekeeping domain tests and CRM role/type checks in WSL.",
+      "result": "The candidate restores Ponto navigation for CONSULTOR/EMPLOYEE while retaining server-side authorization, extends Timekeeping CI path coverage, explicitly keeps face punching false, makes Worker health attest the deployed SHA/environment, aligns Worker secret sync with the runtime contract, and adds an immutable multi-surface staging journey with run-scoped synthetic identity/employee data and audit-preserving teardown. Timekeeping D1 migration journals are present in staging and production; both current health/readiness paths returned HTTP 200. Staging/production D1 and module-control IDs were present in GitHub environment metadata; module-control:timekeeping was not yet written explicitly.",
+      "limitation": "PONTO_PROFILE_DATA_KEY is absent from accessible repository/environment secret-name metadata. The candidate deploy/sync guard therefore fails closed before checkpoint, migration or upload; no value was generated, copied or changed. The candidate has not been pushed, reviewed, merged, deployed, run in staging, or promoted. Existing HTTP 200 responses and historical Ponto workflows are not proof of an authenticated current-SHA journey, module activation, pilot or production closure.",
+      "sha": "f202e29f4178bba8966edf71539c942618254de0",
+      "next_action": "Provision PONTO_PROFILE_DATA_KEY through the approved secret path, merge a green candidate, then promote the same immutable SHA through Timekeeping, Core API and CRM Pages staging before the synthetic journey and controlled module-control rollback drill."
+    },
+    {
       "observed_at": "2026-07-29T14:02:00Z",
       "surface": "origin-main-github-actions-cloudflare-d1-pages-live-http-and-operator-monitor",
       "scope": "Authoritative Finance reconciliation",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -4,6 +4,46 @@
   "source_main_sha": "6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b",
   "items": [
     {
+      "id": "p0-workforce-timekeeping-current-main-release",
+      "objective": "Restore CONSULTOR/EMPLOYEE Ponto navigation and prove one immutable Workforce Timekeeping release through staging before any production pilot.",
+      "priority": 1100,
+      "state": "source-remediated-staging-blocked-by-secret",
+      "dependencies": [],
+      "blockers": [
+        "PONTO_PROFILE_DATA_KEY is absent from accessible staging and production secret-name metadata",
+        "no current-main same-SHA Timekeeping, Core API and CRM Pages staging lineage",
+        "module-control:timekeeping has no explicit active state or rollback drill evidence"
+      ],
+      "environment": "staging-then-production",
+      "permitted_actions": [
+        "green PR/CI and immutable staging promotion after approved secret provisioning",
+        "synthetic CONSULTOR-only authenticated journey with teardown and sanitised evidence",
+        "staging module-control maintenance to active rollback drill",
+        "production promotion only after matching staging evidence and named pilot scope"
+      ],
+      "prohibited_actions": [
+        "invent, generate, copy or disclose PONTO_PROFILE_DATA_KEY",
+        "treat health 200 or historical workflow runs as authenticated release proof",
+        "advance Finance or unrelated release work under this objective",
+        "archive the workstream before production evidence and post-release observation"
+      ],
+      "required_evidence": [
+        "same full SHA in Timekeeping, Core API and CRM Pages staging promotion artifacts",
+        "synthetic authenticated CONSULTOR journey including Ponto visibility, PIN, idempotency, unit denial, correction and administrative denial",
+        "sanitised teardown evidence preserving audit rows",
+        "explicit module-control active state and staging rollback drill",
+        "production checkpoint, deployment/version, health/readiness, authenticated pilot and post-release observation"
+      ],
+      "done_definition": "A single immutable release has complete staging evidence and then separately approved production/pilot evidence; no historical or health-only claim substitutes for that lineage.",
+      "next_item": "finance-current-main-staging-evidence",
+      "last_verified": "2026-07-29T20:45:00Z",
+      "evidence": {
+        "base_sha": "f202e29f4178bba8966edf71539c942618254de0",
+        "regression_commit": "4bfc56af0ac5b2bf0387a71dfa1825cb84ecdca0",
+        "secret_gate": "PONTO_PROFILE_DATA_KEY"
+      }
+    },
+    {
       "id": "p0-insumos-unit-access",
       "objective": "P0 — restaurar e estabilizar o acesso por unidade do módulo de Insumos",
       "priority": 1000,

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -1,0 +1,138 @@
+/*
+ * Generates one runner-private, synthetic CONSULTOR for the Ponto staging
+ * journey. The output intentionally contains credentials only in the private
+ * fixture JSON; SQL contains salted hashes, never the raw password or PIN.
+ */
+import { pbkdf2Sync, randomBytes, randomInt } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const usage = 'usage: node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision|teardown --run-id <github-run-id> --fixtures <private-json> --core-sql <sql-file> --timekeeping-sql <sql-file>';
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) args.set(process.argv[index], process.argv[index + 1]);
+const action = String(args.get('--action') || '');
+const runId = String(args.get('--run-id') || '');
+const fixturesPath = args.get('--fixtures');
+const coreSqlPath = args.get('--core-sql');
+const timekeepingSqlPath = args.get('--timekeeping-sql');
+
+if (!['provision', 'teardown'].includes(action) || !/^\d{1,20}$/.test(runId) || !fixturesPath || !coreSqlPath || !timekeepingSqlPath) {
+  throw new Error(usage);
+}
+
+const sql = (value) => `'${String(value).replaceAll("'", "''")}'`;
+const prefix = `stg-ponto-${runId}`;
+const now = new Date().toISOString();
+const password = () => `StgPonto-${randomBytes(18).toString('base64url')}`;
+const pin = () => String(randomInt(100000, 1_000_000));
+const passwordHash = (value) => {
+  const salt = randomBytes(16);
+  const digest = pbkdf2Sync(value, salt, 100_000, 32, 'sha256');
+  return `pbkdf2_sha256$100000$${salt.toString('base64url')}$${digest.toString('base64url')}`;
+};
+const pinCredential = (value) => {
+  const salt = randomBytes(16);
+  const iterations = 150_000;
+  const digest = pbkdf2Sync(value, salt, iterations, 32, 'sha256');
+  return { algorithm: 'PBKDF2-SHA256', iterations, saltB64: salt.toString('base64url'), hashB64: digest.toString('base64url') };
+};
+
+function audit(actionName, actor, detail) {
+  return `INSERT INTO audit_log (ts, actor, role, action, entity, entity_id, unidade, ip, user_agent, idempotency_key, before_json, after_json) VALUES (${sql(now)}, ${sql(actor)}, 'SYSTEM', ${sql(actionName)}, 'staging_synthetic_ponto', ${sql(actor)}, '', '', 'github-actions', ${sql(`${prefix}:${actionName}`)}, NULL, ${sql(JSON.stringify(detail))});`;
+}
+
+function privateFixture() {
+  const userName = `${prefix}-consultor`;
+  const userPassword = password();
+  const userPin = pin();
+  return {
+    schemaVersion: 1,
+    environment: 'staging',
+    runId,
+    prefix,
+    createdAt: now,
+    username: userName,
+    email: `${userName}@staging.invalid`,
+    password: userPassword,
+    pin: userPin,
+    role: 'CONSULTOR',
+    allowedModules: ['atendimento', 'ponto'],
+    allowedUnits: [`${prefix}-unit`],
+    unitId: `${prefix}-unit`,
+    forbiddenUnitId: `${prefix}-other-unit`,
+    employeeId: `${prefix}-employee`,
+  };
+}
+
+function controlledFixture() {
+  const fixture = JSON.parse(readFileSync(fixturesPath, 'utf8'));
+  if (fixture?.environment !== 'staging' || fixture?.prefix !== prefix || fixture?.role !== 'CONSULTOR') {
+    throw new Error('fixture file is not a matching Ponto staging fixture');
+  }
+  for (const field of ['username', 'email', 'password', 'pin', 'employeeId', 'unitId']) {
+    if (!String(fixture[field] || '').startsWith(prefix) && !['password', 'pin'].includes(field)) throw new Error(`fixture ${field} escaped controlled prefix`);
+  }
+  if (!/^\d{6}$/.test(String(fixture.pin || ''))) throw new Error('fixture PIN is invalid');
+  if (JSON.stringify(fixture.allowedModules) !== JSON.stringify(['atendimento', 'ponto'])) throw new Error('fixture modules drifted');
+  return fixture;
+}
+
+if (action === 'provision') {
+  const fixture = privateFixture();
+  const credential = pinCredential(fixture.pin);
+  mkdirSync(dirname(resolve(fixturesPath)), { recursive: true });
+  writeFileSync(fixturesPath, JSON.stringify(fixture), { mode: 0o600 });
+
+  const coreStatements = [
+    `DELETE FROM crm_users WHERE username = ${sql(fixture.username)};`,
+    `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(fixture.username)}, ${sql(fixture.email)}, ${sql('Synthetic Ponto CONSULTOR')}, ${sql(passwordHash(fixture.password))}, 'CONSULTOR', '', ${sql(JSON.stringify(fixture.allowedUnits))}, ${sql(JSON.stringify(fixture.allowedModules))}, 1, ${sql(now)}, ${sql(now)}, 0);`,
+    audit('STAGING_SYNTHETIC_PONTO_PROVISIONED', fixture.username, { runId, role: fixture.role, modules: fixture.allowedModules, unitCount: 1 }),
+  ];
+  const timekeepingStatements = [
+    `DELETE FROM timekeeping_punch_evidence WHERE event_id IN (SELECT id FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)});`,
+    `DELETE FROM timekeeping_corrections WHERE event_id IN (SELECT id FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)});`,
+    `DELETE FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_pin_failures WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_pin_credentials WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_employee_units WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employee_profiles WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employee_unit_hierarchy WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employees WHERE id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_unit_presence_policies WHERE unit_id = ${sql(fixture.unitId)};`,
+    `DELETE FROM workforce_units WHERE id = ${sql(fixture.unitId)};`,
+    `INSERT INTO workforce_units (id, canonical_unit_id, display_name, timezone, active, created_at, updated_at) VALUES (${sql(fixture.unitId)}, ${sql(fixture.unitId)}, 'Synthetic Ponto staging unit', 'America/Sao_Paulo', 1, ${sql(now)}, ${sql(now)});`,
+    `INSERT INTO workforce_employees (id, canonical_employee_id, login_email, display_name, status, access_state, metadata_json, created_at, updated_at) VALUES (${sql(fixture.employeeId)}, ${sql(fixture.employeeId)}, ${sql(fixture.email)}, 'Synthetic Ponto CONSULTOR', 'ACTIVE', 'ACTIVE', '{}', ${sql(now)}, ${sql(now)});`,
+    `INSERT INTO timekeeping_employee_units (id, employee_id, unit_id, effective_from, effective_to, created_at) VALUES (${sql(`${fixture.employeeId}-unit`)}, ${sql(fixture.employeeId)}, ${sql(fixture.unitId)}, '2020-01-01', NULL, ${sql(now)});`,
+    `INSERT INTO timekeeping_unit_presence_policies (unit_id, presence_mode, geofence_latitude, geofence_longitude, geofence_radius_meters, created_at, updated_at, updated_by) VALUES (${sql(fixture.unitId)}, 'FLEXIBLE', NULL, NULL, 150, ${sql(now)}, ${sql(now)}, 'github-actions-synthetic');`,
+    `INSERT INTO timekeeping_pin_credentials (employee_id, algorithm, salt_b64, hash_b64, iterations, updated_by, updated_at) VALUES (${sql(fixture.employeeId)}, ${sql(credential.algorithm)}, ${sql(credential.saltB64)}, ${sql(credential.hashB64)}, ${credential.iterations}, 'github-actions-synthetic', ${sql(now)});`,
+  ];
+  writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
+  writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });
+  console.log(JSON.stringify({ action, environment: 'staging', role: fixture.role, modules: fixture.allowedModules, credentialsWrittenToPrivateFile: true }));
+} else {
+  const fixture = controlledFixture();
+  const coreStatements = [
+    audit('STAGING_SYNTHETIC_PONTO_TORN_DOWN', fixture.username, { runId, result: 'deleted' }),
+    `DELETE FROM auth_attempts WHERE username = ${sql(fixture.username)};`,
+    `DELETE FROM crm_user_prefs WHERE username = ${sql(fixture.username)};`,
+    `DELETE FROM crm_users WHERE username = ${sql(fixture.username)};`,
+  ];
+  // Preserve the immutable timekeeping audit ledger. Only synthetic operational
+  // records with this exact run-scoped employee/unit may be removed.
+  const timekeepingStatements = [
+    `DELETE FROM timekeeping_punch_evidence WHERE event_id IN (SELECT id FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)});`,
+    `DELETE FROM timekeeping_corrections WHERE event_id IN (SELECT id FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)});`,
+    `DELETE FROM timekeeping_events WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_pin_failures WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_pin_credentials WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_employee_units WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employee_profiles WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employee_unit_hierarchy WHERE employee_id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM workforce_employees WHERE id = ${sql(fixture.employeeId)};`,
+    `DELETE FROM timekeeping_unit_presence_policies WHERE unit_id = ${sql(fixture.unitId)};`,
+    `DELETE FROM workforce_units WHERE id = ${sql(fixture.unitId)};`,
+  ];
+  writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
+  writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });
+  console.log(JSON.stringify({ action, environment: 'staging', syntheticOperationalRecordsRemoved: true, timekeepingAuditPreserved: true }));
+}

--- a/workforce/timekeeping/wrangler.toml
+++ b/workforce/timekeeping/wrangler.toml
@@ -19,6 +19,9 @@ id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
 [vars]
 APP_VERSION = "1.0.0"
 APP_ORIGIN = "https://crm.skincos.com.br"
+# Face capture/identification remains deliberately disabled until a separately
+# governed operational release. PIN is the only self-service credential.
+PONTO_FACE_PUNCH_ENABLED = "false"
 
 [env.staging]
 name = "skincos-timekeeping-staging"
@@ -40,3 +43,4 @@ id = "e69fe06b6abc46eca4f4c00198d078f2"
 [env.staging.vars]
 APP_VERSION = "1.0.0"
 APP_ORIGIN = "https://crm-staging.skincos.com.br"
+PONTO_FACE_PUNCH_ENABLED = "false"


### PR DESCRIPTION
## Scope
- restores Ponto navigation for CONSULTOR/EMPLOYEE while retaining server-side authorization;
- fixes the client availability gate that still disabled Ponto;
- adds a staging-only, authenticated synthetic CONSULTOR journey with scoped provision/teardown and audit preservation;
- makes Timekeeping secret reconciliation complete, keeps face punch disabled, and verifies deployed SHA/environment in health smoke.

## Validation
- Worker Ponto tests: 28/28 passing.
- CRM role/module tests, typecheck, build, and local synthetic browser journey passed before publication.
- Fixture contract confirms private 0600 credentials, no raw credentials in SQL, and no deletion of timekeeping audit events.

## Promotion boundary
`PONTO_PROFILE_DATA_KEY` is deliberately required but currently absent from GitHub repository/environment secrets. No value is generated, copied, or exposed here. Staging and production deployments remain fail-closed until the approved secret is provisioned.