### PR TITLE
chore(orb): watch stable n8n releases safely

### DIFF
--- a/docs/operations/orb-n8n-release-qualification.md
+++ b/docs/operations/orb-n8n-release-qualification.md
@@ -10,7 +10,7 @@ Execute o auditor somente em um staging marcado explicitamente e em um diretóri
 N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging \
 N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES \
 N8N_AUDIT_ROOT=/tmp/n8n-release-audit \
-ops/runtime/n8n-security/audit-release-baseline.sh 2.32.5
+bash ops/runtime/n8n-security/audit-release-baseline.sh 2.32.5
 ```
 
 Compare versões por meio de seus `summary.json`. A comparação de advisories não comprova alcançabilidade; cada item crítico requer uma matriz separada de origem, pré-condição, superfície externa, workflow e evidência de teste negativo.
@@ -21,15 +21,18 @@ Compare versões por meio de seus `summary.json`. A comparação de advisories n
 oficial, recusa uma tag pré-release e registra `next`/beta somente como
 informação ignorada. Ele compara a versão com
 `ops/runtime/n8n-security/release-watch-policy.json`; se houver uma release
-estável mais nova, gera lockfiles, executa o auditor isolado e produz um
-relatório sanitizado no diretório privado. O resultado `REJECTED_CRITICAL_DEPENDENCY_GATE`
-encerra a sequência antes de startup, migration ou qualquer alteração live.
+estável mais nova, gera lockfiles exclusivamente a partir de
+`https://registry.npmjs.org/`, executa o auditor isolado e produz um relatório
+sanitizado no diretório privado. `REJECTED_CRITICAL_DEPENDENCY_GATE` e
+`REJECTED_AUDIT_ERROR` encerram a sequência antes de startup, migration ou
+qualquer alteração live. Um relatório íntegro já existente é reutilizado de
+forma idempotente.
 
 ```bash
 N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging \
 N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES \
 N8N_AUDIT_ROOT=/var/tmp/skincos-n8n-release-watch \
-ops/runtime/n8n-security/watch-stable-release.sh
+bash ops/runtime/n8n-security/watch-stable-release.sh
 ```
 
 O observador não atualiza a política, não executa a qualificação funcional

--- a/docs/operations/orb-n8n-release-qualification.md
+++ b/docs/operations/orb-n8n-release-qualification.md
@@ -15,6 +15,28 @@ ops/runtime/n8n-security/audit-release-baseline.sh 2.32.5
 
 Compare versões por meio de seus `summary.json`. A comparação de advisories não comprova alcançabilidade; cada item crítico requer uma matriz separada de origem, pré-condição, superfície externa, workflow e evidência de teste negativo.
 
+## Observador de releases estáveis
+
+`watch-stable-release.sh` consulta exclusivamente a tag `stable` do registry
+oficial, recusa uma tag pré-release e registra `next`/beta somente como
+informação ignorada. Ele compara a versão com
+`ops/runtime/n8n-security/release-watch-policy.json`; se houver uma release
+estável mais nova, gera lockfiles, executa o auditor isolado e produz um
+relatório sanitizado no diretório privado. O resultado `REJECTED_CRITICAL_DEPENDENCY_GATE`
+encerra a sequência antes de startup, migration ou qualquer alteração live.
+
+```bash
+N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging \
+N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES \
+N8N_AUDIT_ROOT=/var/tmp/skincos-n8n-release-watch \
+ops/runtime/n8n-security/watch-stable-release.sh
+```
+
+O observador não atualiza a política, não executa a qualificação funcional
+completa, e nunca faz merge, deploy, restart, migration ou acesso a caminhos de
+produção. Um candidato sem críticos apenas fica marcado para a qualificação
+isolada completa já controlada pelo PR de upgrade draft.
+
 ## Gate de promoção
 
 Uma promoção futura requer, além deste inventário: release estável oficial, checksum fixado, staging completo, backup/restauração comprovados, migrations reversíveis por restauração, regressão OAuth, MCP somente leitura, quatro serviços e bloqueio público de MCP. Qualquer vulnerabilidade crítica com caminho alcançável ou não descartado bloqueia a promoção.

--- a/ops/runtime/n8n-security/audit-release-baseline.sh
+++ b/ops/runtime/n8n-security/audit-release-baseline.sh
@@ -5,6 +5,20 @@ ROOT=$(cd "$(dirname "$0")" && pwd)
 INVENTORY="$ROOT/community-packages.json"
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 info() { printf 'INFO: %s\n' "$*"; }
+canonical_audit_root() {
+  local candidate=$1 parent name canonical_parent resolved
+  [[ -n "$candidate" && "$candidate" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
+  parent=$(dirname -- "$candidate")
+  name=$(basename -- "$candidate")
+  [[ "$name" != . && "$name" != .. ]] || die 'N8N_AUDIT_ROOT must name a private child directory.'
+  canonical_parent=$(realpath -e -- "$parent") || die 'audit root parent must already exist.'
+  resolved="$canonical_parent/$name"
+  [[ ! -e "$resolved" ]] || resolved=$(realpath -e -- "$resolved")
+  case "$resolved" in
+    /opt|/opt/*|/var/lib|/var/lib/*|/etc|/etc/*) die 'audit root must not be a runtime or production configuration path.' ;;
+  esac
+  printf '%s\n' "$resolved"
+}
 
 [[ $# -eq 1 ]] || die 'usage: audit-release-baseline.sh <n8n-version>'
 version=$1
@@ -12,15 +26,15 @@ version=$1
 [[ "${N8N_UPGRADE_ENV:-}" == staging && "${N8N_EXPECTED_ENV:-}" == staging ]] || die 'audit is staging-only.'
 [[ "${N8N_STAGING_MARKER:-}" == orb-n8n-staging ]] || die 'staging marker is absent or invalid.'
 [[ "${N8N_AUDIT_APPLY:-}" == YES ]] || die 'refused: set N8N_AUDIT_APPLY=YES for an isolated fixture.'
-audit_root=${N8N_AUDIT_ROOT:-}
-[[ -n "$audit_root" && "$audit_root" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
-[[ "$audit_root" != /opt/* && "$audit_root" != /var/lib/* && "$audit_root" != /etc/* ]] || die 'audit root must not be a runtime or production configuration path.'
+audit_root=$(canonical_audit_root "${N8N_AUDIT_ROOT:-}")
 [[ "$(node -p process.platform)" == linux && "$(node -p process.arch)" == x64 ]] || die 'expected linux/x64.'
 expected_node=${N8N_AUDIT_NODE_VERSION:-v22.23.1}
 expected_npm=${N8N_AUDIT_NPM_VERSION:-10.9.8}
 [[ "$(node --version)" == "$expected_node" ]] || die "Node mismatch: expected $expected_node."
 [[ "$(npm --version)" == "$expected_npm" ]] || die "npm mismatch: expected $expected_npm."
 [[ -f "$INVENTORY" ]] || die 'community inventory is missing.'
+registry=${N8N_AUDIT_REGISTRY:-https://registry.npmjs.org/}
+[[ "$registry" == https://registry.npmjs.org/ ]] || die 'audit must use the official npm registry.'
 
 workdir="$audit_root/n8n-$version"
 in_progress="$workdir.in-progress.$$"
@@ -46,26 +60,29 @@ while IFS=$'\t' read -r key name component_version; do
   component="$in_progress/components/$key"
   (
     cd "$component"
-    npm install --package-lock-only --ignore-scripts --omit=optional
+    npm --registry "$registry" install --package-lock-only --ignore-scripts --omit=optional
     ci_log=$(mktemp)
-    if ! npm ci --ignore-scripts --omit=optional >"$ci_log" 2>&1; then
+    if ! npm --registry "$registry" ci --ignore-scripts --omit=optional >"$ci_log" 2>&1; then
       if ! grep -q 'ENOTEMPTY' "$ci_log"; then cat "$ci_log" >&2; rm -f "$ci_log"; exit 1; fi
       rm -rf -- "$component/node_modules"
-      npm ci --ignore-scripts --omit=optional
+      npm --registry "$registry" ci --ignore-scripts --omit=optional
     fi
     rm -f "$ci_log"
-    npm audit --omit=optional --json > audit.json || audit_exit=$?
+    npm --registry "$registry" audit --omit=optional --json > audit.json || audit_exit=$?
     : "${audit_exit:=0}"
     node --input-type=module - "$key" "$name" "$component_version" "$audit_exit" <<'NODE'
 import fs from 'node:fs';
 const [component, directPackage, directVersion, auditExit] = process.argv.slice(2);
 const audit = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+const auditError = audit.error && !audit.metadata?.vulnerabilities
+  ? { code: audit.error.code ?? 'UNKNOWN', summary: audit.error.summary ?? 'npm audit returned an error response.' }
+  : null;
 const highCritical = Object.values(audit.vulnerabilities ?? {}).filter((item) => ['high', 'critical'].includes(item.severity)).map((item) => ({
   component, direct_package: directPackage, direct_version: directVersion, package: item.name, severity: item.severity,
   direct: Boolean(item.isDirect), range: item.range, effects: item.effects ?? [], fix_available: item.fixAvailable ?? false,
   via: (item.via ?? []).map((via) => typeof via === 'string' ? { package: via } : ({ source: via.source, title: via.title, url: via.url, severity: via.severity, range: via.range }))
 }));
-fs.writeFileSync('summary.json', `${JSON.stringify({ component, direct_package: directPackage, direct_version: directVersion, audit_exit: Number(auditExit), counts: audit.metadata?.vulnerabilities ?? {}, high_critical: highCritical }, null, 2)}\n`, { mode: 0o600 });
+fs.writeFileSync('summary.json', `${JSON.stringify({ component, direct_package: directPackage, direct_version: directVersion, audit_exit: Number(auditExit), audit_error: auditError, counts: audit.metadata?.vulnerabilities ?? {}, high_critical: highCritical }, null, 2)}\n`, { mode: 0o600 });
 NODE
   )
 done < <(node --input-type=module - "$in_progress/components.json" <<'NODE'
@@ -79,7 +96,8 @@ import fs from 'node:fs'; import path from 'node:path';
 const root = process.argv[2];
 const components = JSON.parse(fs.readFileSync(path.join(root, 'components.json'), 'utf8')).map(({ key }) => JSON.parse(fs.readFileSync(path.join(root, 'components', key, 'summary.json'), 'utf8')));
 const high_critical = components.flatMap((component) => component.high_critical);
-const report = { schema_version: 1, fixture_scope: 'Synthetic dependency-only audit. It never reads runtime configuration, data, credentials, database, workflows, or production paths.', node: process.version, npm: process.env.npm_config_user_agent ?? 'npm/unknown', platform: `${process.platform}/${process.arch}`, install_flags: ['--ignore-scripts', '--omit=optional'], n8n_version: components.find((item) => item.component === 'runtime-n8n').direct_version, components: components.map(({ component, direct_package, direct_version, counts }) => ({ component, direct_package, direct_version, counts })), high_critical };
+const audit_errors = components.filter((component) => component.audit_error).map(({ component, audit_error }) => ({ component, ...audit_error }));
+const report = { schema_version: 1, fixture_scope: 'Synthetic dependency-only audit. It never reads runtime configuration, data, credentials, database, workflows, or production paths.', registry: 'https://registry.npmjs.org/', node: process.version, npm: process.env.npm_config_user_agent ?? 'npm/unknown', platform: `${process.platform}/${process.arch}`, install_flags: ['--ignore-scripts', '--omit=optional'], n8n_version: components.find((item) => item.component === 'runtime-n8n').direct_version, components: components.map(({ component, direct_package, direct_version, counts }) => ({ component, direct_package, direct_version, counts })), audit_errors, high_critical };
 fs.writeFileSync(path.join(root, 'summary.json'), `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
 NODE
 mv "$in_progress" "$workdir"

--- a/ops/runtime/n8n-security/release-watch-policy.json
+++ b/ops/runtime/n8n-security/release-watch-policy.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "last_evaluated_stable": "2.32.6",
+  "purpose": "Persistent comparison point for the isolated n8n release watcher. This is not an approval or production manifest.",
+  "production_policy": "Never select prerelease tags, merge, deploy, restart a service, apply a migration, or access production paths."
+}

--- a/ops/runtime/n8n-security/tests/test-release-baseline.sh
+++ b/ops/runtime/n8n-security/tests/test-release-baseline.sh
@@ -13,6 +13,12 @@ fi
 if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/lib/skincos "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected production path refusal' >&2; exit 1
 fi
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/opt "$ROOT/audit-release-baseline.sh" 2.32.5; then
+  echo 'expected exact runtime root refusal' >&2; exit 1
+fi
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/../opt "$ROOT/audit-release-baseline.sh" 2.32.5; then
+  echo 'expected traversal runtime root refusal' >&2; exit 1
+fi
 node --input-type=module - "$ROOT/community-packages.json" <<'NODE'
 import fs from 'node:fs';
 const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));

--- a/ops/runtime/n8n-security/tests/test-release-baseline.sh
+++ b/ops/runtime/n8n-security/tests/test-release-baseline.sh
@@ -4,19 +4,19 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 tmp=$(mktemp -d)
 trap 'rm -rf -- "$tmp"' EXIT
 
-if N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" "$ROOT/audit-release-baseline.sh" 2.32.5; then
+if N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" bash "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected production environment refusal' >&2; exit 1
 fi
-if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=wrong N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" "$ROOT/audit-release-baseline.sh" 2.32.5; then
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=wrong N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT="$tmp" bash "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected marker refusal' >&2; exit 1
 fi
-if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/lib/skincos "$ROOT/audit-release-baseline.sh" 2.32.5; then
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/lib/skincos bash "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected production path refusal' >&2; exit 1
 fi
-if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/opt "$ROOT/audit-release-baseline.sh" 2.32.5; then
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/opt bash "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected exact runtime root refusal' >&2; exit 1
 fi
-if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/../opt "$ROOT/audit-release-baseline.sh" 2.32.5; then
+if N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_AUDIT_APPLY=YES N8N_AUDIT_ROOT=/var/../opt bash "$ROOT/audit-release-baseline.sh" 2.32.5; then
   echo 'expected traversal runtime root refusal' >&2; exit 1
 fi
 node --input-type=module - "$ROOT/community-packages.json" <<'NODE'

--- a/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
+++ b/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+fake_npm="$tmp/npm"
+fake_auditor="$tmp/auditor"
+policy="$tmp/policy.json"
+
+printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' '[[ "$1" == view && "$2" == n8n && "$3" == dist-tags && "$4" == --json ]]' 'printf "%s\n" "${N8N_RELEASE_WATCH_TEST_TAGS:?}"' > "$fake_npm"
+printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'mkdir -p "$N8N_AUDIT_ROOT/n8n-$1"' 'printf "%s\n" "${N8N_RELEASE_WATCH_TEST_SUMMARY:?}" > "$N8N_AUDIT_ROOT/n8n-$1/summary.json"' > "$fake_auditor"
+chmod +x "$fake_npm" "$fake_auditor"
+printf '%s\n' '{"schema_version":1,"last_evaluated_stable":"2.32.6"}' > "$policy"
+
+base=(env N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_TEST_MODE=YES N8N_RELEASE_WATCH_NPM_BIN="$fake_npm" N8N_RELEASE_WATCH_AUDITOR="$fake_auditor" N8N_RELEASE_WATCH_POLICY="$policy")
+summary_critical='{"n8n_version":"2.32.7","components":[{"component":"runtime-n8n"}],"high_critical":[{"severity":"critical"},{"severity":"high"}]}'
+
+if env N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_TEST_MODE=YES N8N_RELEASE_WATCH_NPM_BIN="$fake_npm" N8N_RELEASE_WATCH_AUDITOR="$fake_auditor" N8N_RELEASE_WATCH_POLICY="$policy" N8N_AUDIT_ROOT="$tmp/production" "$ROOT/watch-stable-release.sh"; then
+  echo 'expected production refusal' >&2; exit 1
+fi
+
+same_output=$("${base[@]}" N8N_AUDIT_ROOT="$tmp/same" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.6","next":"2.33.0-beta.1"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh")
+printf '%s\n' "$same_output" | grep -q 'NO_NEW_STABLE_RELEASE'
+[[ ! -e "$tmp/same/n8n-2.32.6/summary.json" ]]
+
+if "${base[@]}" N8N_AUDIT_ROOT="$tmp/prerelease" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.33.0-beta.1"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh"; then
+  echo 'expected prerelease stable tag refusal' >&2; exit 1
+fi
+
+new_output=$("${base[@]}" N8N_AUDIT_ROOT="$tmp/new" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.7","next":"2.33.0-beta.1"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh")
+printf '%s\n' "$new_output" | grep -q 'REJECTED_CRITICAL_DEPENDENCY_GATE'
+node --input-type=module - "$tmp/new/release-watch-2.32.7.json" <<'NODE'
+import fs from 'node:fs';
+const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (report.candidate_version !== '2.32.7') throw new Error('candidate mismatch');
+if (report.selected_tag !== 'stable') throw new Error('stable tag missing');
+if (report.critical_findings !== 1 || report.high_findings !== 1) throw new Error('finding counts mismatch');
+if (report.result !== 'REJECTED_CRITICAL_DEPENDENCY_GATE') throw new Error('critical gate bypassed');
+if (report.ignored_prerelease_tags.next !== '2.33.0-beta.1') throw new Error('beta tag was not recorded as ignored');
+NODE
+
+echo 'release_watch_tests=pass'

--- a/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
+++ b/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
@@ -8,16 +8,23 @@ fake_npm="$tmp/npm"
 fake_auditor="$tmp/auditor"
 policy="$tmp/policy.json"
 
-printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' '[[ "$1" == view && "$2" == n8n && "$3" == dist-tags && "$4" == --json ]]' 'printf "%s\n" "${N8N_RELEASE_WATCH_TEST_TAGS:?}"' > "$fake_npm"
+printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' '[[ "$1" == --registry && "$2" == https://registry.npmjs.org/ && "$3" == view && "$4" == n8n && "$5" == dist-tags && "$6" == --json ]]' 'printf "%s\n" "${N8N_RELEASE_WATCH_TEST_TAGS:?}"' > "$fake_npm"
 printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'mkdir -p "$N8N_AUDIT_ROOT/n8n-$1"' 'printf "%s\n" "${N8N_RELEASE_WATCH_TEST_SUMMARY:?}" > "$N8N_AUDIT_ROOT/n8n-$1/summary.json"' > "$fake_auditor"
 chmod +x "$fake_npm" "$fake_auditor"
 printf '%s\n' '{"schema_version":1,"last_evaluated_stable":"2.32.6"}' > "$policy"
 
 base=(env N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_TEST_MODE=YES N8N_RELEASE_WATCH_NPM_BIN="$fake_npm" N8N_RELEASE_WATCH_AUDITOR="$fake_auditor" N8N_RELEASE_WATCH_POLICY="$policy")
 summary_critical='{"n8n_version":"2.32.7","components":[{"component":"runtime-n8n"}],"high_critical":[{"severity":"critical"},{"severity":"high"}]}'
+summary_audit_error='{"n8n_version":"2.32.8","components":[{"component":"runtime-n8n"}],"audit_errors":[{"component":"runtime-n8n","code":"EAUDIT"}],"high_critical":[]}'
 
 if env N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_TEST_MODE=YES N8N_RELEASE_WATCH_NPM_BIN="$fake_npm" N8N_RELEASE_WATCH_AUDITOR="$fake_auditor" N8N_RELEASE_WATCH_POLICY="$policy" N8N_AUDIT_ROOT="$tmp/production" "$ROOT/watch-stable-release.sh"; then
   echo 'expected production refusal' >&2; exit 1
+fi
+if "${base[@]}" N8N_AUDIT_ROOT=/opt N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.7"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh"; then
+  echo 'expected exact runtime root refusal' >&2; exit 1
+fi
+if "${base[@]}" N8N_AUDIT_ROOT=/var/../opt N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.7"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh"; then
+  echo 'expected traversal runtime root refusal' >&2; exit 1
 fi
 
 same_output=$("${base[@]}" N8N_AUDIT_ROOT="$tmp/same" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.6","next":"2.33.0-beta.1"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh")
@@ -38,6 +45,17 @@ if (report.selected_tag !== 'stable') throw new Error('stable tag missing');
 if (report.critical_findings !== 1 || report.high_findings !== 1) throw new Error('finding counts mismatch');
 if (report.result !== 'REJECTED_CRITICAL_DEPENDENCY_GATE') throw new Error('critical gate bypassed');
 if (report.ignored_prerelease_tags.next !== '2.33.0-beta.1') throw new Error('beta tag was not recorded as ignored');
+NODE
+
+repeat_output=$("${base[@]}" N8N_AUDIT_ROOT="$tmp/new" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.7","next":"2.33.0-beta.1"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh")
+printf '%s\n' "$repeat_output" | grep -q 'ALREADY_EVALUATED'
+
+audit_error_output=$("${base[@]}" N8N_AUDIT_ROOT="$tmp/audit-error" N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.8"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_audit_error" "$ROOT/watch-stable-release.sh")
+printf '%s\n' "$audit_error_output" | grep -q 'REJECTED_AUDIT_ERROR'
+node --input-type=module - "$tmp/audit-error/release-watch-2.32.8.json" <<'NODE'
+import fs from 'node:fs';
+const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (report.result !== 'REJECTED_AUDIT_ERROR' || report.audit_errors.length !== 1) throw new Error('audit error was not fail-closed');
 NODE
 
 echo 'release_watch_tests=pass'

--- a/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
+++ b/ops/runtime/n8n-security/tests/test-watch-stable-release.sh
@@ -20,6 +20,9 @@ summary_audit_error='{"n8n_version":"2.32.8","components":[{"component":"runtime
 if env N8N_UPGRADE_ENV=production N8N_EXPECTED_ENV=production N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_TEST_MODE=YES N8N_RELEASE_WATCH_NPM_BIN="$fake_npm" N8N_RELEASE_WATCH_AUDITOR="$fake_auditor" N8N_RELEASE_WATCH_POLICY="$policy" N8N_AUDIT_ROOT="$tmp/production" "$ROOT/watch-stable-release.sh"; then
   echo 'expected production refusal' >&2; exit 1
 fi
+if env N8N_UPGRADE_ENV=staging N8N_EXPECTED_ENV=staging N8N_STAGING_MARKER=orb-n8n-staging N8N_RELEASE_WATCH_APPLY=YES N8N_RELEASE_WATCH_POLICY="$policy" N8N_AUDIT_ROOT="$tmp/policy-override" "$ROOT/watch-stable-release.sh"; then
+  echo 'expected non-test policy override refusal' >&2; exit 1
+fi
 if "${base[@]}" N8N_AUDIT_ROOT=/opt N8N_RELEASE_WATCH_TEST_TAGS='{"stable":"2.32.7"}' N8N_RELEASE_WATCH_TEST_SUMMARY="$summary_critical" "$ROOT/watch-stable-release.sh"; then
   echo 'expected exact runtime root refusal' >&2; exit 1
 fi

--- a/ops/runtime/n8n-security/watch-stable-release.sh
+++ b/ops/runtime/n8n-security/watch-stable-release.sh
@@ -5,19 +5,32 @@ ROOT=$(cd "$(dirname "$0")" && pwd)
 POLICY=${N8N_RELEASE_WATCH_POLICY:-"$ROOT/release-watch-policy.json"}
 AUDITOR=${N8N_RELEASE_WATCH_AUDITOR:-"$ROOT/audit-release-baseline.sh"}
 NPM_BIN=${N8N_RELEASE_WATCH_NPM_BIN:-npm}
+OFFICIAL_REGISTRY=https://registry.npmjs.org/
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 info() { printf 'INFO: %s\n' "$*"; }
 is_release_version() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
+canonical_audit_root() {
+  local candidate=$1 parent name canonical_parent resolved
+  [[ -n "$candidate" && "$candidate" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
+  parent=$(dirname -- "$candidate")
+  name=$(basename -- "$candidate")
+  [[ "$name" != . && "$name" != .. ]] || die 'N8N_AUDIT_ROOT must name a private child directory.'
+  canonical_parent=$(realpath -e -- "$parent") || die 'audit root parent must already exist.'
+  resolved="$canonical_parent/$name"
+  [[ ! -e "$resolved" ]] || resolved=$(realpath -e -- "$resolved")
+  case "$resolved" in
+    /opt|/opt/*|/var/lib|/var/lib/*|/etc|/etc/*) die 'audit root must not be a runtime or production configuration path.' ;;
+  esac
+  printf '%s\n' "$resolved"
+}
 
 [[ "${N8N_UPGRADE_ENV:-}" == staging && "${N8N_EXPECTED_ENV:-}" == staging ]] || die 'release watch is staging-only.'
 [[ "${N8N_STAGING_MARKER:-}" == orb-n8n-staging ]] || die 'staging marker is absent or invalid.'
 [[ "${N8N_RELEASE_WATCH_APPLY:-}" == YES ]] || die 'refused: set N8N_RELEASE_WATCH_APPLY=YES for an isolated fixture.'
-audit_root=${N8N_AUDIT_ROOT:-}
-[[ -n "$audit_root" && "$audit_root" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
-[[ "$audit_root" != /opt/* && "$audit_root" != /var/lib/* && "$audit_root" != /etc/* ]] || die 'audit root must not be a runtime or production configuration path.'
+audit_root=$(canonical_audit_root "${N8N_AUDIT_ROOT:-}")
 [[ -f "$POLICY" ]] || die 'release watch policy is missing.'
-[[ -x "$AUDITOR" ]] || die 'release auditor is missing or not executable.'
+[[ -f "$AUDITOR" ]] || die 'release auditor is missing.'
 
 if [[ "${N8N_RELEASE_WATCH_TEST_MODE:-NO}" != YES ]]; then
   [[ "$NPM_BIN" == npm ]] || die 'npm binary override is test-only.'
@@ -36,7 +49,7 @@ is_release_version "$last_evaluated" || die 'last evaluated stable version is in
 mkdir -p "$audit_root"
 tags_file=$(mktemp "$audit_root/.release-watch-tags.XXXXXX")
 trap 'rm -f -- "$tags_file"' EXIT
-"$NPM_BIN" view n8n dist-tags --json > "$tags_file"
+"$NPM_BIN" --registry "$OFFICIAL_REGISTRY" view n8n dist-tags --json > "$tags_file"
 
 stable=$(node --input-type=module - "$tags_file" <<'NODE'
 import fs from 'node:fs';
@@ -67,17 +80,35 @@ if [[ "$comparison_status" == 0 || "$comparison_status" == 11 ]]; then
 fi
 [[ "$comparison_status" == 10 ]] || die 'could not compare stable release versions.'
 
+summary="$audit_root/n8n-$stable/summary.json"
+report="$audit_root/release-watch-$stable.json"
+if [[ -e "$report" ]]; then
+  [[ -f "$report" && -f "$summary" ]] || die 'existing release-watch evidence is incomplete.'
+  prior_result=$(node --input-type=module - "$report" "$summary" "$stable" <<'NODE'
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+const [reportPath, summaryPath, stable] = process.argv.slice(2);
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+const sha = crypto.createHash('sha256').update(fs.readFileSync(summaryPath)).digest('hex');
+if (report.selected_tag !== 'stable' || report.candidate_version !== stable || summary.n8n_version !== stable || report.dependency_summary_sha256 !== sha || typeof report.result !== 'string') process.exit(2);
+process.stdout.write(report.result);
+NODE
+  ) || die 'existing release-watch evidence failed integrity validation.'
+  info "result=ALREADY_EVALUATED candidate=$stable prior_result=$prior_result report=$report"
+  exit 0
+fi
+[[ ! -e "$summary" ]] || die 'existing audit evidence has no release-watch report.'
+
 N8N_UPGRADE_ENV=staging \
 N8N_EXPECTED_ENV=staging \
 N8N_STAGING_MARKER=orb-n8n-staging \
 N8N_AUDIT_APPLY=YES \
 N8N_AUDIT_ROOT="$audit_root" \
-"$AUDITOR" "$stable"
+N8N_AUDIT_REGISTRY="$OFFICIAL_REGISTRY" \
+bash "$AUDITOR" "$stable"
 
-summary="$audit_root/n8n-$stable/summary.json"
 [[ -f "$summary" ]] || die 'auditor did not produce a summary.'
-report="$audit_root/release-watch-$stable.json"
-[[ ! -e "$report" ]] || die 'refusing to overwrite an existing release-watch report.'
 node --input-type=module - "$tags_file" "$summary" "$report" "$last_evaluated" <<'NODE'
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -86,9 +117,10 @@ const tags = JSON.parse(fs.readFileSync(tagsPath, 'utf8'));
 const summaryBytes = fs.readFileSync(summaryPath);
 const summary = JSON.parse(summaryBytes.toString('utf8'));
 const highCritical = summary.high_critical ?? [];
+const auditErrors = summary.audit_errors ?? [];
 const critical = highCritical.filter(({ severity }) => severity === 'critical').length;
 const high = highCritical.filter(({ severity }) => severity === 'high').length;
-const result = critical > 0 ? 'REJECTED_CRITICAL_DEPENDENCY_GATE' : 'READY_FOR_FULL_ISOLATED_QUALIFICATION';
+const result = auditErrors.length > 0 ? 'REJECTED_AUDIT_ERROR' : critical > 0 ? 'REJECTED_CRITICAL_DEPENDENCY_GATE' : 'READY_FOR_FULL_ISOLATED_QUALIFICATION';
 const report = {
   schema_version: 1,
   scope: 'Registry discovery and synthetic dependency-only staging audit. No live service, migration, workflow, credential, database, merge or deployment action is performed.',
@@ -99,9 +131,12 @@ const report = {
   component_count: summary.components?.length ?? 0,
   critical_findings: critical,
   high_findings: high,
+  audit_errors: auditErrors,
   dependency_summary_sha256: crypto.createHash('sha256').update(summaryBytes).digest('hex'),
   result,
-  next_action: result === 'REJECTED_CRITICAL_DEPENDENCY_GATE'
+  next_action: result === 'REJECTED_AUDIT_ERROR'
+    ? 'Do not promote. Resolve the isolated audit transport or registry error, then rerun the watcher with a new clean fixture.'
+    : result === 'REJECTED_CRITICAL_DEPENDENCY_GATE'
     ? 'Do not promote. Wait for a newer official stable release, then rerun the isolated watcher.'
     : 'Run the separately approved full isolated qualification; this watcher never promotes or changes production.'
 };

--- a/ops/runtime/n8n-security/watch-stable-release.sh
+++ b/ops/runtime/n8n-security/watch-stable-release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")" && pwd)
+POLICY=${N8N_RELEASE_WATCH_POLICY:-"$ROOT/release-watch-policy.json"}
+AUDITOR=${N8N_RELEASE_WATCH_AUDITOR:-"$ROOT/audit-release-baseline.sh"}
+NPM_BIN=${N8N_RELEASE_WATCH_NPM_BIN:-npm}
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+info() { printf 'INFO: %s\n' "$*"; }
+is_release_version() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
+
+[[ "${N8N_UPGRADE_ENV:-}" == staging && "${N8N_EXPECTED_ENV:-}" == staging ]] || die 'release watch is staging-only.'
+[[ "${N8N_STAGING_MARKER:-}" == orb-n8n-staging ]] || die 'staging marker is absent or invalid.'
+[[ "${N8N_RELEASE_WATCH_APPLY:-}" == YES ]] || die 'refused: set N8N_RELEASE_WATCH_APPLY=YES for an isolated fixture.'
+audit_root=${N8N_AUDIT_ROOT:-}
+[[ -n "$audit_root" && "$audit_root" = /* ]] || die 'N8N_AUDIT_ROOT must be an absolute private Linux path.'
+[[ "$audit_root" != /opt/* && "$audit_root" != /var/lib/* && "$audit_root" != /etc/* ]] || die 'audit root must not be a runtime or production configuration path.'
+[[ -f "$POLICY" ]] || die 'release watch policy is missing.'
+[[ -x "$AUDITOR" ]] || die 'release auditor is missing or not executable.'
+
+if [[ "${N8N_RELEASE_WATCH_TEST_MODE:-NO}" != YES ]]; then
+  [[ "$NPM_BIN" == npm ]] || die 'npm binary override is test-only.'
+  [[ "$AUDITOR" == "$ROOT/audit-release-baseline.sh" ]] || die 'auditor override is test-only.'
+fi
+
+last_evaluated=${N8N_RELEASE_WATCH_LAST_EVALUATED:-$(node --input-type=module - "$POLICY" <<'NODE'
+import fs from 'node:fs';
+const policy = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (typeof policy.last_evaluated_stable !== 'string') process.exit(2);
+process.stdout.write(policy.last_evaluated_stable);
+NODE
+)}
+is_release_version "$last_evaluated" || die 'last evaluated stable version is invalid.'
+
+mkdir -p "$audit_root"
+tags_file=$(mktemp "$audit_root/.release-watch-tags.XXXXXX")
+trap 'rm -f -- "$tags_file"' EXIT
+"$NPM_BIN" view n8n dist-tags --json > "$tags_file"
+
+stable=$(node --input-type=module - "$tags_file" <<'NODE'
+import fs from 'node:fs';
+const tags = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (typeof tags.stable !== 'string') process.exit(2);
+process.stdout.write(tags.stable);
+NODE
+) || die 'official registry did not provide a stable tag.'
+is_release_version "$stable" || die 'stable tag is not a final x.y.z release.'
+
+if node --input-type=module - "$stable" "$last_evaluated" <<'NODE'
+const parse = (value) => value.split('.').map(Number);
+const [candidate, baseline] = process.argv.slice(2).map(parse);
+for (let index = 0; index < 3; index += 1) {
+  if (candidate[index] > baseline[index]) process.exit(10);
+  if (candidate[index] < baseline[index]) process.exit(11);
+}
+process.exit(0);
+NODE
+then
+  comparison_status=0
+else
+  comparison_status=$?
+fi
+if [[ "$comparison_status" == 0 || "$comparison_status" == 11 ]]; then
+  info "result=NO_NEW_STABLE_RELEASE stable=$stable last_evaluated=$last_evaluated"
+  exit 0
+fi
+[[ "$comparison_status" == 10 ]] || die 'could not compare stable release versions.'
+
+N8N_UPGRADE_ENV=staging \
+N8N_EXPECTED_ENV=staging \
+N8N_STAGING_MARKER=orb-n8n-staging \
+N8N_AUDIT_APPLY=YES \
+N8N_AUDIT_ROOT="$audit_root" \
+"$AUDITOR" "$stable"
+
+summary="$audit_root/n8n-$stable/summary.json"
+[[ -f "$summary" ]] || die 'auditor did not produce a summary.'
+report="$audit_root/release-watch-$stable.json"
+[[ ! -e "$report" ]] || die 'refusing to overwrite an existing release-watch report.'
+node --input-type=module - "$tags_file" "$summary" "$report" "$last_evaluated" <<'NODE'
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+const [tagsPath, summaryPath, reportPath, lastEvaluated] = process.argv.slice(2);
+const tags = JSON.parse(fs.readFileSync(tagsPath, 'utf8'));
+const summaryBytes = fs.readFileSync(summaryPath);
+const summary = JSON.parse(summaryBytes.toString('utf8'));
+const highCritical = summary.high_critical ?? [];
+const critical = highCritical.filter(({ severity }) => severity === 'critical').length;
+const high = highCritical.filter(({ severity }) => severity === 'high').length;
+const result = critical > 0 ? 'REJECTED_CRITICAL_DEPENDENCY_GATE' : 'READY_FOR_FULL_ISOLATED_QUALIFICATION';
+const report = {
+  schema_version: 1,
+  scope: 'Registry discovery and synthetic dependency-only staging audit. No live service, migration, workflow, credential, database, merge or deployment action is performed.',
+  selected_tag: 'stable',
+  candidate_version: summary.n8n_version,
+  last_evaluated_stable: lastEvaluated,
+  ignored_prerelease_tags: Object.fromEntries(Object.entries(tags).filter(([tag, version]) => tag !== 'stable' && typeof version === 'string' && version.includes('-'))),
+  component_count: summary.components?.length ?? 0,
+  critical_findings: critical,
+  high_findings: high,
+  dependency_summary_sha256: crypto.createHash('sha256').update(summaryBytes).digest('hex'),
+  result,
+  next_action: result === 'REJECTED_CRITICAL_DEPENDENCY_GATE'
+    ? 'Do not promote. Wait for a newer official stable release, then rerun the isolated watcher.'
+    : 'Run the separately approved full isolated qualification; this watcher never promotes or changes production.'
+};
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+NODE
+result=$(node --input-type=module - "$report" <<'NODE'
+import fs from 'node:fs';
+process.stdout.write(JSON.parse(fs.readFileSync(process.argv[2], 'utf8')).result);
+NODE
+)
+info "result=$result candidate=$stable report=$report"

--- a/ops/runtime/n8n-security/watch-stable-release.sh
+++ b/ops/runtime/n8n-security/watch-stable-release.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")" && pwd)
-POLICY=${N8N_RELEASE_WATCH_POLICY:-"$ROOT/release-watch-policy.json"}
+DEFAULT_POLICY="$ROOT/release-watch-policy.json"
+POLICY=${N8N_RELEASE_WATCH_POLICY:-"$DEFAULT_POLICY"}
 AUDITOR=${N8N_RELEASE_WATCH_AUDITOR:-"$ROOT/audit-release-baseline.sh"}
 NPM_BIN=${N8N_RELEASE_WATCH_NPM_BIN:-npm}
 OFFICIAL_REGISTRY=https://registry.npmjs.org/
@@ -33,6 +34,7 @@ audit_root=$(canonical_audit_root "${N8N_AUDIT_ROOT:-}")
 [[ -f "$AUDITOR" ]] || die 'release auditor is missing.'
 
 if [[ "${N8N_RELEASE_WATCH_TEST_MODE:-NO}" != YES ]]; then
+  [[ "$POLICY" == "$DEFAULT_POLICY" ]] || die 'release watch policy override is test-only.'
   [[ "$NPM_BIN" == npm ]] || die 'npm binary override is test-only.'
   [[ "$AUDITOR" == "$ROOT/audit-release-baseline.sh" ]] || die 'auditor override is test-only.'
 fi


### PR DESCRIPTION
## Summary
- adds a staging-only watcher for official `stable` n8n releases
- rejects prerelease tags and production paths, then runs the existing isolated lockfile/audit baseline only for a newer stable release
- emits a sanitized private report and never merges, deploys, restarts, migrates, or reads production state

## Validation
- `bash ops/runtime/n8n-security/tests/test-watch-stable-release.sh`
- `bash ops/runtime/n8n-security/tests/test-release-baseline.sh`
- `npm run architecture:test`
- `npm run quality:security` (canonical shared checkout; WSL worktree Git metadata path prevents that script from resolving this linked worktree)

The current official stable remains `2.32.6`; its canonical audit remains blocked by critical dependencies. This PR does not change #828 or production.