### PR TITLE
fix(finance): preservar contrato de senha no smoke

### DIFF
--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -9,6 +9,13 @@ const required = (name) => {
   if (!value) throw new Error(`${name} is required`);
   return value;
 };
+// Keep credentials byte-for-byte compatible with the CRM browser login.
+// Identifiers and URLs can be normalized; passwords cannot.
+const requiredSecret = (name) => {
+  const value = String(process.env[name] ?? '');
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
 const arg = (name, fallback = '') => {
   const index = process.argv.indexOf(name);
   return index >= 0 ? String(process.argv[index + 1] || '').trim() : fallback;
@@ -20,7 +27,7 @@ if (process.env.FINANCE_SMOKE_ACK !== '1') throw new Error('FINANCE_SMOKE_ACK=1 
 const baseUrl = required('FINANCE_SMOKE_BASE_URL').replace(/\/$/, '');
 if (baseUrl !== 'https://skincos-staging.pages.dev') throw new Error('FINANCE_SMOKE_BASE_URL must be the staging CRM shell');
 const username = required('FINANCE_SMOKE_USERNAME');
-const password = required('FINANCE_SMOKE_PASSWORD');
+const password = requiredSecret('FINANCE_SMOKE_PASSWORD');
 const scopeId = required('FINANCE_SMOKE_SCOPE_ID');
 const sourceType = arg('--source', 'generic');
 if (!['generic', 'moneywiz', 'ef-caixa'].includes(sourceType)) throw new Error('--source must be generic, moneywiz, or ef-caixa');

--- a/finance/scripts/staging-synthetic-canary.mjs
+++ b/finance/scripts/staging-synthetic-canary.mjs
@@ -7,6 +7,9 @@ const reportFile = process.argv.includes('--report') ? process.argv[process.argv
 if (!reportFile) throw new Error('--report is required');
 const report = { ok: false, generatedAt: new Date().toISOString(), samples: [], errors: 0, authenticationFailures: 0, journeyFailures: 0, dataDivergences: 0, auditFailures: 0, dependencyFailures: 0 };
 const required = (name) => { const item = String(process.env[name] || '').trim(); if (!item) throw new Error(`${name} is required`); return item; };
+// Credentials are opaque values: trimming would silently change a valid
+// password while the browser uses it verbatim.
+const requiredSecret = (name) => { const item = String(process.env[name] ?? ''); if (!item) throw new Error(`${name} is required`); return item; };
 const finish = async (ok, cause) => {
   report.ok = ok;
   if (cause) report.failure = String(cause.message || cause).replace(/[\r\n]/g, ' ').slice(0, 180);
@@ -19,7 +22,7 @@ try {
   if (baseUrl !== 'https://skincos-staging.pages.dev') throw new Error('canary base URL must be the staging CRM shell');
   const username = required('FINANCE_CANARY_USERNAME');
   if (username !== 'finance-staging-smoke') throw new Error('only dedicated synthetic smoke actor may run canary');
-  const password = required('FINANCE_CANARY_PASSWORD');
+  const password = requiredSecret('FINANCE_CANARY_PASSWORD');
   const scopeId = required('FINANCE_CANARY_SCOPE_ID');
   if (scopeId !== 'finance-scope-novo-hamburgo') throw new Error('only synthetic Novo Hamburgo scope is allowed');
   const financePath = (path) => `/api/finance${path}`;

--- a/finance/scripts/staging-ui-smoke.mjs
+++ b/finance/scripts/staging-ui-smoke.mjs
@@ -45,6 +45,8 @@ const page = await context.newPage()
 const consoleErrors = []
 const financeResponses = []
 const serverErrors = []
+const remoteResponses = []
+const remoteRequestFailures = []
 
 page.on('console', (message) => {
   if (message.type() === 'error') consoleErrors.push(message.text())
@@ -54,9 +56,22 @@ page.on('response', (response) => {
   const evidence = `${response.status()} ${target.pathname}`
   if (target.pathname.includes('/api/finance/')) financeResponses.push(evidence)
   if (response.status() >= 500) serverErrors.push(evidence)
+  if (target.hostname === 'skincos-finance-ui-staging.pages.dev' && target.pathname === '/finance-module.js') remoteResponses.push(evidence)
+})
+page.on('requestfailed', (request) => {
+  const target = new URL(request.url())
+  if (target.hostname === 'skincos-finance-ui-staging.pages.dev' && target.pathname === '/finance-module.js') {
+    remoteRequestFailures.push(String(request.failure()?.errorText || 'request failed').slice(0, 160))
+  }
 })
 
 let bootstrap = null
+let remoteState = null
+const readRemoteState = () => page.evaluate(() => ({
+  container: Boolean(document.querySelector('[data-finance-remote="true"]')),
+  module: Boolean(document.querySelector('[data-finance-module="true"]')),
+  unavailable: Boolean(document.querySelector('[data-testid="finance-remote-unavailable"]')),
+}))
 try {
   console.log('[finance-staging-ui] carregando CRM de staging')
   await page.goto(baseUrl.toString(), { waitUntil: 'domcontentloaded', timeout: 90_000 })
@@ -88,6 +103,11 @@ try {
   await financeNav.waitFor({ state: 'visible', timeout: 30_000 })
   await financeNav.click()
   await page.getByTestId('crm-header-layout').getByRole('heading', { name: 'Financeiro' }).waitFor({ state: 'visible', timeout: 30_000 })
+  await page.locator('[data-finance-remote="true"], [data-testid="finance-remote-unavailable"], [data-finance-module="true"]').waitFor({ state: 'visible', timeout: 30_000 })
+  remoteState = await readRemoteState()
+  if (remoteState.unavailable) fail('O bundle remoto do Financeiro não pôde ser carregado.')
+  await page.locator('[data-finance-module="true"]').waitFor({ state: 'visible', timeout: 30_000 })
+  remoteState = await readRemoteState()
   console.log('[finance-staging-ui] módulo Financeiro renderizado')
   await page.getByRole('tab', { name: 'Visão geral' }).waitFor({ state: 'visible', timeout: 30_000 })
   await page.getByRole('tab', { name: 'Visão geral' }).click()
@@ -115,11 +135,12 @@ try {
   await page.getByText('Contas financeiras').first().waitFor({ state: 'visible', timeout: 30_000 })
   await page.screenshot({ path: screenshot, fullPage: false })
   if (financeResponses.some((response) => /^5\d\d\b/.test(response))) fail(`Erro de serviço Financeiro: ${JSON.stringify(financeResponses)}`)
-  fs.writeFileSync(report, `${JSON.stringify({ ok: true, url: baseUrl.toString(), bootstrap, financeResponses, serverErrors, consoleErrors, screenshot }, null, 2)}\n`)
+  fs.writeFileSync(report, `${JSON.stringify({ ok: true, url: baseUrl.toString(), bootstrap, remoteState, financeResponses, remoteResponses, remoteRequestFailures, serverErrors, consoleErrors, screenshot }, null, 2)}\n`)
   console.log(JSON.stringify({ ok: true, url: baseUrl.toString(), grants: labels, financeResponses, serverErrors, screenshot }))
 } catch (error) {
+  remoteState = await readRemoteState().catch(() => remoteState)
   await page.screenshot({ path: screenshot, fullPage: false }).catch(() => {})
-  fs.writeFileSync(report, `${JSON.stringify({ ok: false, url: baseUrl.toString(), error: String(error?.message || error), bootstrap, consoleErrors, financeResponses, serverErrors, screenshot }, null, 2)}\n`)
+  fs.writeFileSync(report, `${JSON.stringify({ ok: false, url: baseUrl.toString(), error: String(error?.message || error), bootstrap, remoteState, consoleErrors, financeResponses, remoteResponses, remoteRequestFailures, serverErrors, screenshot }, null, 2)}\n`)
   throw error
 } finally {
   await context.close().catch(() => {})

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -18,4 +18,9 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
     assert.doesNotMatch(source, /JSON\.stringify\(\{ username, password \}\)/);
     assert.doesNotMatch(source, /api-staging\.skincos\.com\.br/);
   }
+
+  assert.match(canary, /const password = requiredSecret\('FINANCE_CANARY_PASSWORD'\)/);
+  assert.match(importer, /const password = requiredSecret\('FINANCE_SMOKE_PASSWORD'\)/);
+  assert.match(canary, /String\(process\.env\[name\] \?\? ''\)/);
+  assert.match(importer, /String\(process\.env\[name\] \?\? ''\)/);
 });


### PR DESCRIPTION
## Escopo\n- preserva FINANCE_SMOKE_PASSWORD e FINANCE_CANARY_PASSWORD byte a byte, em paridade com o login do shell;\n- registra de forma sanitizada se o bundle remoto do Financeiro carregou, montou ou entrou em fallback;\n- não altera runtime, flags, grants, dados nem qualquer ambiente.\n\n## Validação local\n- 
ode --check dos três smokes;\n- 
ode --test finance/test/staging-smoke-transport.test.mjs finance/test/staging-smoke-identity-scope.test.mjs;\n- git diff --check.\n\nA PR existe para fechar o canário de staging com uma causa verificável; nenhuma promoção de produção é acionada.