### PR TITLE
fix(finance): fail closed before production mutation

### DIFF
--- a/.github/scripts/finance-production-preflight.mjs
+++ b/.github/scripts/finance-production-preflight.mjs
@@ -1,0 +1,243 @@
+import { appendFile, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const WORKER_NAME = 'skincos-finance';
+const API_WORKER_NAME = 'skincos-api';
+const D1_NAME = 'skincos-finance';
+const KV_TITLE = 'SKINCOS_FINANCE_PRODUCTION_FLAGS';
+const SERVICE_SECRET_NAME = 'FINANCE_SERVICE_AUTH_SECRET';
+
+const requireValue = (value, message) => {
+  if (!value) throw new Error(message);
+  return value;
+};
+
+const binding = (settings, name) =>
+  (Array.isArray(settings?.bindings) ? settings.bindings : []).find((entry) => entry?.name === name);
+
+const secretNames = (secrets) =>
+  new Set((Array.isArray(secrets) ? secrets : []).map((entry) => entry?.name).filter(Boolean));
+
+const deployments = (result) => {
+  if (Array.isArray(result)) return result;
+  return Array.isArray(result?.deployments) ? result.deployments : [];
+};
+
+export function validateFinanceProductionPreflight({
+  operation,
+  releaseSha,
+  deployEnabled,
+  d1Id,
+  controlKvId,
+  githubBackupPassphrasePresent,
+  githubServiceSecretPresent,
+  d1,
+  kv,
+  financeSettings,
+  financeSecrets,
+  financeDeployments,
+  financeSubdomain,
+  accountSubdomain,
+  apiSettings,
+  apiSecrets,
+}) {
+  requireValue(['deploy', 'rollback'].includes(operation), 'operation must be deploy or rollback');
+  requireValue(/^[0-9a-f]{40}$/.test(releaseSha), 'release_sha must be a full lowercase commit SHA');
+  if (operation === 'deploy') {
+    requireValue(deployEnabled === true, 'ENABLE_FINANCE_PRODUCTION_DEPLOY must be true for a production deploy');
+  }
+  requireValue(/^[0-9a-f-]{36}$/i.test(d1Id), 'FINANCE_D1_PRODUCTION_ID is missing or malformed');
+  requireValue(/^[0-9a-f]{32}$/i.test(controlKvId), 'FINANCE_CONTROL_PRODUCTION_KV_ID is missing or malformed');
+  requireValue(githubBackupPassphrasePresent, 'FINANCE_BACKUP_PASSPHRASE is missing from the production environment');
+  requireValue(githubServiceSecretPresent, 'FINANCE_SERVICE_AUTH_SECRET is missing from the production environment');
+
+  requireValue(d1?.uuid === d1Id && d1?.name === D1_NAME, 'production D1 id/name does not match skincos-finance');
+  requireValue(kv?.id === controlKvId && kv?.title === KV_TITLE, 'production Finance KV id/title does not match the canonical resource');
+
+  const dbBinding = binding(financeSettings, 'DB');
+  requireValue(
+    dbBinding?.type === 'd1' &&
+      (dbBinding.id === d1Id || dbBinding.database_id === d1Id),
+    'skincos-finance DB binding does not match the production D1',
+  );
+  const moduleControlBinding = binding(financeSettings, 'MODULE_CONTROL');
+  requireValue(
+    moduleControlBinding?.type === 'kv_namespace' && moduleControlBinding.namespace_id === controlKvId,
+    'skincos-finance MODULE_CONTROL binding does not match the production KV',
+  );
+  const environmentBinding = binding(financeSettings, 'ENVIRONMENT');
+  requireValue(
+    environmentBinding?.type === 'plain_text' && environmentBinding.text === 'production',
+    'skincos-finance ENVIRONMENT binding is not production',
+  );
+  requireValue(
+    secretNames(financeSecrets).has(SERVICE_SECRET_NAME),
+    'skincos-finance is missing the remote FINANCE_SERVICE_AUTH_SECRET',
+  );
+  requireValue(deployments(financeDeployments).length > 0, 'skincos-finance has no deployed rollback baseline');
+  requireValue(financeSubdomain?.enabled === true, 'skincos-finance workers.dev endpoint is not enabled');
+  requireValue(
+    typeof accountSubdomain?.subdomain === 'string' && /^[a-z0-9-]+$/i.test(accountSubdomain.subdomain),
+    'Cloudflare Workers account subdomain is unavailable',
+  );
+
+  const apiFinanceBinding = binding(apiSettings, 'FINANCE');
+  requireValue(
+    apiFinanceBinding?.type === 'service' &&
+      apiFinanceBinding.service === WORKER_NAME &&
+      (!apiFinanceBinding.environment || apiFinanceBinding.environment === 'production'),
+    'skincos-api FINANCE binding does not target the production Finance Worker',
+  );
+  requireValue(
+    secretNames(apiSecrets).has(SERVICE_SECRET_NAME),
+    'skincos-api is missing the remote FINANCE_SERVICE_AUTH_SECRET',
+  );
+
+  const workerUrl = `https://${WORKER_NAME}.${accountSubdomain.subdomain}.workers.dev`;
+  return {
+    schemaVersion: 1,
+    result: 'passed',
+    target: 'production',
+    operation,
+    releaseSha,
+    authorization: {
+      deployFlagEnabled: operation === 'deploy' ? true : null,
+      rollbackDoesNotRequireDeployFlag: operation === 'rollback',
+    },
+    resources: {
+      worker: WORKER_NAME,
+      d1: D1_NAME,
+      controlKv: KV_TITLE,
+      workerDeploymentBaselinePresent: true,
+      workersDevEnabled: true,
+    },
+    bindings: {
+      financeDbMatches: true,
+      financeModuleControlMatches: true,
+      financeEnvironmentIsProduction: true,
+      apiFinanceServiceMatches: true,
+    },
+    secrets: {
+      githubBackupPassphrasePresent: true,
+      githubServiceSecretPresent: true,
+      financeRemoteServiceSecretPresent: true,
+      apiRemoteServiceSecretPresent: true,
+      valuesReadOrEmitted: false,
+    },
+    workerUrl,
+  };
+}
+
+function cloudflareClient({ accountId, apiToken, fetchImpl = fetch }) {
+  const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
+  return async (relativePath, label) => {
+    const response = await fetchImpl(`${baseUrl}${relativePath}`, {
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+        accept: 'application/json',
+      },
+    });
+    let payload;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error(`${label} returned a non-JSON response (HTTP ${response.status})`);
+    }
+    if (!response.ok || payload?.success !== true) {
+      const codes = (payload?.errors || []).map((entry) => entry?.code).filter(Boolean).join(',');
+      throw new Error(`${label} failed (HTTP ${response.status}${codes ? `, Cloudflare ${codes}` : ''})`);
+    }
+    return payload.result;
+  };
+}
+
+export async function runFinanceProductionPreflight({
+  env = process.env,
+  fetchImpl = fetch,
+} = {}) {
+  const accountId = requireValue(env.CLOUDFLARE_ACCOUNT_ID?.trim(), 'CLOUDFLARE_ACCOUNT_ID is missing');
+  const apiToken = requireValue(env.CLOUDFLARE_API_TOKEN?.trim(), 'CLOUDFLARE_API_TOKEN is missing');
+  requireValue(/^[0-9a-f]{32}$/i.test(accountId), 'CLOUDFLARE_ACCOUNT_ID is malformed');
+  const d1Id = env.FINANCE_D1_PRODUCTION_ID?.trim() || '';
+  const controlKvId = env.FINANCE_CONTROL_PRODUCTION_KV_ID?.trim() || '';
+  requireValue(/^[0-9a-f-]{36}$/i.test(d1Id), 'FINANCE_D1_PRODUCTION_ID is missing or malformed');
+  requireValue(/^[0-9a-f]{32}$/i.test(controlKvId), 'FINANCE_CONTROL_PRODUCTION_KV_ID is missing or malformed');
+
+  const get = cloudflareClient({ accountId, apiToken, fetchImpl });
+  const [
+    d1,
+    kv,
+    financeSettings,
+    financeSecrets,
+    financeDeployments,
+    financeSubdomain,
+    accountSubdomain,
+    apiSettings,
+    apiSecrets,
+  ] = await Promise.all([
+    get(`/d1/database/${encodeURIComponent(d1Id)}`, 'production Finance D1 inventory'),
+    get(`/storage/kv/namespaces/${encodeURIComponent(controlKvId)}`, 'production Finance KV inventory'),
+    get(`/workers/scripts/${WORKER_NAME}/settings`, 'production Finance Worker settings'),
+    get(`/workers/scripts/${WORKER_NAME}/secrets`, 'production Finance Worker secret inventory'),
+    get(`/workers/scripts/${WORKER_NAME}/deployments`, 'production Finance Worker deployment inventory'),
+    get(`/workers/scripts/${WORKER_NAME}/subdomain`, 'production Finance Worker subdomain'),
+    get('/workers/subdomain', 'Cloudflare Workers account subdomain'),
+    get(`/workers/scripts/${API_WORKER_NAME}/settings`, 'production API Worker settings'),
+    get(`/workers/scripts/${API_WORKER_NAME}/secrets`, 'production API Worker secret inventory'),
+  ]);
+
+  return validateFinanceProductionPreflight({
+    operation: env.OPERATION?.trim() || '',
+    releaseSha: env.RELEASE_SHA?.trim() || '',
+    deployEnabled: env.ENABLE_FINANCE_PRODUCTION_DEPLOY?.trim() === 'true',
+    d1Id,
+    controlKvId,
+    githubBackupPassphrasePresent: Boolean(env.FINANCE_BACKUP_PASSPHRASE),
+    githubServiceSecretPresent: Boolean(env.FINANCE_SERVICE_AUTH_SECRET),
+    d1,
+    kv,
+    financeSettings,
+    financeSecrets,
+    financeDeployments,
+    financeSubdomain,
+    accountSubdomain,
+    apiSettings,
+    apiSecrets,
+  });
+}
+
+async function main() {
+  const reportPath = process.argv[2];
+  requireValue(reportPath, 'usage: node finance-production-preflight.mjs <report-path>');
+  let report;
+  let failure;
+  try {
+    report = await runFinanceProductionPreflight();
+  } catch (error) {
+    failure = error;
+    report = {
+      schemaVersion: 1,
+      result: 'failed',
+      target: 'production',
+      operation: process.env.OPERATION || null,
+      releaseSha: process.env.RELEASE_SHA || null,
+      error: error instanceof Error ? error.message : String(error),
+      secretsEmitted: false,
+    };
+  }
+  await mkdir(path.dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+  if (!failure && process.env.GITHUB_ENV) {
+    await appendFile(process.env.GITHUB_ENV, `FINANCE_PRODUCTION_WORKER_URL=${report.workerUrl}\n`, { mode: 0o600 });
+  }
+  process.stdout.write(`${JSON.stringify({ ...report, workerUrl: report.workerUrl ? '[attested]' : undefined })}\n`);
+  if (failure) throw failure;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`Finance production preflight failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -61,6 +61,35 @@ for (const filename of workflowFiles) {
   if (publishingLines.length && !canonicalPaths.has(relativePath)) fail(`non-canonical publisher found: ${relativePath}`);
 }
 
+const financeWorkflow = read('.github/workflows/deploy-finance.yml');
+for (const required of [
+  'finance-production-preflight.mjs',
+  'ENABLE_FINANCE_PRODUCTION_DEPLOY',
+  'Attest production authorization and remote resources before mutation',
+  'Provision or attest Finance service secret before D1 checkpoint',
+  'FINANCE_PRODUCTION_WORKER_URL',
+]) {
+  if (!financeWorkflow.includes(required)) fail(`Finance publisher is missing its production safety gate: ${required}`);
+}
+const financePreflightIndex = financeWorkflow.indexOf('Attest production authorization and remote resources before mutation');
+const financeSecretIndex = financeWorkflow.indexOf('Provision or attest Finance service secret before D1 checkpoint');
+const financeCheckpointIndex = financeWorkflow.indexOf('Capture encrypted D1 checkpoint before migrations');
+const financeMigrationIndex = financeWorkflow.indexOf('Apply additive Finance migrations');
+const financeUploadIndex = financeWorkflow.indexOf('Upload immutable Finance version');
+if (
+  [financePreflightIndex, financeSecretIndex, financeCheckpointIndex, financeMigrationIndex, financeUploadIndex].some((index) => index < 0) ||
+  !(financePreflightIndex < financeSecretIndex &&
+    financeSecretIndex < financeCheckpointIndex &&
+    financeCheckpointIndex < financeMigrationIndex &&
+    financeMigrationIndex < financeUploadIndex)
+) {
+  fail('Finance production preflight and secret attestation must precede checkpoint, migration and upload');
+}
+for (const filename of fs.readdirSync(path.join(root, 'finance/migrations')).filter((name) => /^\d{4}_.+\.sql$/.test(name))) {
+  const migration = read(path.posix.join('finance/migrations', filename)).replace(/^--.*$/gm, '');
+  if (/\bDROP\b/i.test(migration)) fail(`Finance migration violates the additive-only policy: ${filename}`);
+}
+
 if (failures.length) {
   for (const message of failures) process.stderr.write(`deploy topology validation failed: ${message}\n`);
   process.exitCode = 1;

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -67,6 +67,27 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checked-out source does not match promotion evidence'; exit 1; }
+      - name: Attest production authorization and remote resources before mutation
+        if: inputs.target == 'production'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FINANCE_D1_PRODUCTION_ID: ${{ vars.FINANCE_D1_PRODUCTION_ID }}
+          FINANCE_CONTROL_PRODUCTION_KV_ID: ${{ vars.FINANCE_CONTROL_PRODUCTION_KV_ID }}
+          ENABLE_FINANCE_PRODUCTION_DEPLOY: ${{ vars.ENABLE_FINANCE_PRODUCTION_DEPLOY }}
+          FINANCE_BACKUP_PASSPHRASE: ${{ secrets.FINANCE_BACKUP_PASSPHRASE }}
+          FINANCE_SERVICE_AUTH_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
+          OPERATION: ${{ inputs.operation }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: node .github/scripts/finance-production-preflight.mjs "$RUNNER_TEMP/finance-production-preflight/preflight.json"
+      - name: Upload sanitized production preflight evidence
+        if: always() && inputs.target == 'production'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: finance-production-preflight-${{ needs.promotion.outputs.source_sha }}
+          path: ${{ runner.temp }}/finance-production-preflight/preflight.json
+          retention-days: 30
+          if-no-files-found: warn
       - name: Guard isolated bindings and secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -103,6 +124,24 @@ jobs:
           else
             sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/;s/__RELEASE_SHA__/$RELEASE_SHA/g" finance/wrangler.toml
           fi
+      - name: Provision or attest Finance service secret before D1 checkpoint
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
+          TARGET: ${{ inputs.target }}
+          BOOTSTRAP_SERVICE_SECRET: ${{ inputs.bootstrap_service_secret }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
+          if [[ "$BOOTSTRAP_SERVICE_SECRET" == "true" ]]; then
+            [[ "$TARGET" == "staging" ]] || { echo 'Finance service-secret bootstrap is staging-only.'; exit 1; }
+            [[ -n "${SERVICE_SECRET:-}" ]] || { echo 'Missing FINANCE_SERVICE_AUTH_SECRET.'; exit 1; }
+            printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
+          fi
+          npx --yes wrangler@4.114.0 secret list --config finance/wrangler.toml "${ENV_ARGS[@]}" \
+            | grep -q 'FINANCE_SERVICE_AUTH_SECRET' \
+            || { echo 'FINANCE_SERVICE_AUTH_SECRET must be provisioned before checkpoint or migration'; exit 1; }
       - name: Capture encrypted D1 checkpoint before migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -126,15 +165,12 @@ jobs:
           path: ${{ env.CHECKPOINT }}
           retention-days: 30
           if-no-files-found: error
-      - name: Apply additive migrations and upload immutable Finance version
+      - name: Apply additive Finance migrations
         if: inputs.operation == 'deploy'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          SERVICE_SECRET: ${{ secrets.FINANCE_SERVICE_AUTH_SECRET }}
           TARGET: ${{ inputs.target }}
-          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
-          BOOTSTRAP_SERVICE_SECRET: ${{ inputs.bootstrap_service_secret }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-finance; else ENV_ARGS=(--env staging); DB=skincos-finance-staging; fi
@@ -150,12 +186,16 @@ jobs:
             { cat "$migration"; printf "\nINSERT INTO d1_migrations(name) VALUES ('%s');\n" "$name"; } > "$batch"
             npx --yes wrangler@4.114.0 d1 execute "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}" --file "$batch"
           done
-          if [[ "$BOOTSTRAP_SERVICE_SECRET" == "true" ]]; then
-            [[ "$TARGET" == "staging" ]] || { echo 'Finance service-secret bootstrap is staging-only.'; exit 1; }
-            [[ -n "${SERVICE_SECRET:-}" ]] || { echo 'Missing FINANCE_SERVICE_AUTH_SECRET.'; exit 1; }
-            printf '%s' "$SERVICE_SECRET" | npx --yes wrangler@4.112.0 secret put FINANCE_SERVICE_AUTH_SECRET --config finance/wrangler.toml "${ENV_ARGS[@]}"
-          fi
-          npx --yes wrangler@4.114.0 secret list --config finance/wrangler.toml "${ENV_ARGS[@]}" | grep -q 'FINANCE_SERVICE_AUTH_SECRET' || { echo 'FINANCE_SERVICE_AUTH_SECRET must be provisioned before release'; exit 1; }
+      - name: Upload immutable Finance version
+        if: inputs.operation == 'deploy'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET: ${{ inputs.target }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
           upload_output="$(npx --yes wrangler@4.114.0 versions upload --config finance/wrangler.toml --keep-vars --message "finance:deploy:$RELEASE_SHA" "${ENV_ARGS[@]}")"
           printf '%s\n' "$upload_output"
           VERSION_ID="$(printf '%s\n' "$upload_output" | sed -n 's/^Worker Version ID: //p' | tail -n 1)"
@@ -189,12 +229,17 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           STAGING_WORKER_URL: ${{ vars.FINANCE_STAGING_WORKER_URL }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
-          if [[ "$TARGET" == production ]]; then URL=https://api.skincos.com.br/finance/health; else URL="$STAGING_WORKER_URL/health"; fi
-          code="$(curl --silent --show-error --output "$RUNNER_TEMP/finance-health.json" --write-out '%{http_code}' "$URL")"
-          [[ "$code" == 200 ]] || { cat "$RUNNER_TEMP/finance-health.json"; exit 1; }
-          node -e "const x=require(process.argv[1]);if(!x.ok||x.unit!=='finance')process.exit(1)" "$RUNNER_TEMP/finance-health.json"
+          if [[ "$TARGET" == production ]]; then BASE_URL="${FINANCE_PRODUCTION_WORKER_URL:-}"; else BASE_URL="$STAGING_WORKER_URL"; fi
+          [[ "$BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'Finance Worker URL is missing or invalid'; exit 1; }
+          for endpoint in health readiness; do
+            output="$RUNNER_TEMP/finance-${endpoint}.json"
+            code="$(curl --silent --show-error --output "$output" --write-out '%{http_code}' "$BASE_URL/$endpoint")"
+            [[ "$code" == 200 ]] || { cat "$output"; exit 1; }
+            node -e "const x=require(process.argv[1]);const expected=process.argv[2];if(!x.ok||x.unit!=='finance'||x.version!==expected||(process.argv[3]==='readiness'&&!x.ready))process.exit(1)" "$output" "$RELEASE_SHA" "$endpoint"
+          done
       - name: Write staging promotion evidence
         if: inputs.target == 'staging'
         env:

--- a/finance/migrations/0007_finance_security_integrity.sql
+++ b/finance/migrations/0007_finance_security_integrity.sql
@@ -5,7 +5,7 @@
 CREATE TRIGGER IF NOT EXISTS finance_movements_no_delete BEFORE DELETE ON finance_movements
 BEGIN SELECT RAISE(ABORT, 'finance movements cannot be deleted'); END;
 
-CREATE TRIGGER IF NOT EXISTS finance_movements_immutable_fields BEFORE UPDATE OF scope_id,type,account_id,destination_account_id,category_id,payee_id,cost_center_id,description,amount_minor,currency,base_currency,base_amount_minor,exchange_rate_ppm,competence_date,due_date,paid_date,source,external_id,created_by,created_at,submitted_at ON finance_movements
+CREATE TRIGGER IF NOT EXISTS finance_movements_immutable_fields BEFORE UPDATE OF scope_id,source,external_id,created_by,created_at,submitted_at ON finance_movements
 BEGIN SELECT RAISE(ABORT, 'submitted finance movement fields are immutable'); END;
 
 CREATE TRIGGER IF NOT EXISTS finance_movement_status_transition BEFORE UPDATE OF operational_status ON finance_movements
@@ -52,9 +52,11 @@ BEGIN SELECT RAISE(ABORT, 'journal lines are append-only'); END;
 CREATE TRIGGER IF NOT EXISTS finance_movement_splits_no_update BEFORE UPDATE ON finance_movement_splits
 BEGIN SELECT RAISE(ABORT, 'movement splits are append-only'); END;
 CREATE TRIGGER IF NOT EXISTS finance_movement_splits_no_delete BEFORE DELETE ON finance_movement_splits
+WHEN NOT EXISTS(SELECT 1 FROM finance_movements m WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending')
 BEGIN SELECT RAISE(ABORT, 'movement splits are append-only'); END;
 
 CREATE TRIGGER IF NOT EXISTS finance_installments_immutable_fields BEFORE UPDATE OF movement_id,sequence,due_date,amount_minor,created_at ON finance_installments
+WHEN NOT EXISTS(SELECT 1 FROM finance_movements m WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending')
 BEGIN SELECT RAISE(ABORT, 'installment evidence is immutable'); END;
 CREATE TRIGGER IF NOT EXISTS finance_installments_status_transition BEFORE UPDATE OF status ON finance_installments
 WHEN NOT (

--- a/finance/migrations/0008_finance_draft_revision.sql
+++ b/finance/migrations/0008_finance_draft_revision.sql
@@ -2,11 +2,10 @@
 -- replaced atomically while it is still pending; every posted/reconciled or
 -- reversed record remains immutable and must be corrected by reversal.
 --
--- This migration replaces only overly-broad guards introduced by v7.  It does
--- not rewrite historical rows and preserves the append-only audit, journal and
--- reversal tables.
+-- The v7 definitions already contain the expanded draft-aware guards for new
+-- databases.  The idempotent definitions below adopt the same contract without
+-- replacing schema objects, rewriting rows, or using destructive DDL.
 
-DROP TRIGGER IF EXISTS finance_movements_immutable_fields;
 CREATE TRIGGER IF NOT EXISTS finance_movements_immutable_fields
 BEFORE UPDATE OF scope_id,source,external_id,created_by,created_at,submitted_at ON finance_movements
 BEGIN SELECT RAISE(ABORT, 'submitted finance movement fields are immutable'); END;
@@ -54,7 +53,6 @@ BEGIN
   SELECT CASE WHEN NEW.cost_center_id IS NOT NULL AND (SELECT scope_id FROM finance_cost_centers WHERE id=NEW.cost_center_id) != NEW.scope_id THEN RAISE(ABORT, 'movement cost center scope mismatch') END;
 END;
 
-DROP TRIGGER IF EXISTS finance_movement_splits_no_delete;
 CREATE TRIGGER IF NOT EXISTS finance_movement_splits_no_delete
 BEFORE DELETE ON finance_movement_splits
 WHEN NOT EXISTS(SELECT 1 FROM finance_movements m WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending')
@@ -85,7 +83,6 @@ CREATE TRIGGER IF NOT EXISTS finance_installments_no_delete
 BEFORE DELETE ON finance_installments
 WHEN NOT EXISTS(SELECT 1 FROM finance_movements m WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending')
 BEGIN SELECT RAISE(ABORT, 'installments are append-only'); END;
-DROP TRIGGER IF EXISTS finance_installments_immutable_fields;
 CREATE TRIGGER IF NOT EXISTS finance_installments_immutable_fields
 BEFORE UPDATE OF movement_id,sequence,due_date,amount_minor,created_at ON finance_installments
 WHEN NOT EXISTS(SELECT 1 FROM finance_movements m WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending')

--- a/finance/migrations/0013_finance_additive_trigger_contract.sql
+++ b/finance/migrations/0013_finance_additive_trigger_contract.sql
@@ -1,0 +1,26 @@
+-- Finance v13: additive trigger-contract marker.
+--
+-- Existing staging databases that applied the former v8 trigger replacement
+-- already have the same effective draft-aware guards.  New databases receive
+-- those definitions from v7/v8 without destructive DDL.  These independently
+-- named guards make the converged contract explicit and additive everywhere.
+
+CREATE TRIGGER IF NOT EXISTS finance_movements_identity_immutable_v13
+BEFORE UPDATE OF scope_id,source,external_id,created_by,created_at,submitted_at ON finance_movements
+BEGIN SELECT RAISE(ABORT, 'submitted finance movement fields are immutable'); END;
+
+CREATE TRIGGER IF NOT EXISTS finance_movement_splits_posted_no_delete_v13
+BEFORE DELETE ON finance_movement_splits
+WHEN NOT EXISTS(
+  SELECT 1 FROM finance_movements m
+  WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending'
+)
+BEGIN SELECT RAISE(ABORT, 'movement splits are append-only'); END;
+
+CREATE TRIGGER IF NOT EXISTS finance_installments_posted_immutable_v13
+BEFORE UPDATE OF movement_id,sequence,due_date,amount_minor,created_at ON finance_installments
+WHEN NOT EXISTS(
+  SELECT 1 FROM finance_movements m
+  WHERE m.id=OLD.movement_id AND m.status='draft' AND m.operational_status='pending'
+)
+BEGIN SELECT RAISE(ABORT, 'installment evidence is immutable'); END;

--- a/finance/package.json
+++ b/finance/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test --test-timeout=180000 test/*.test.mjs",
+    "test": "node --test --test-timeout=300000 test/*.test.mjs",
     "check": "node --check api/worker.js && node --check worker.js"
   },
   "devDependencies": {

--- a/finance/test/d1-integration.test.mjs
+++ b/finance/test/d1-integration.test.mjs
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import test from 'node:test';
 import { Miniflare } from 'miniflare';
 import { createFinanceHandler } from '../api/worker.js';
 
-const migrations = await Promise.all(['0001_finance_foundation.sql', '0002_finance_operational_core.sql', '0003_finance_integrity_guards.sql', '0004_finance_csv_import_workflow.sql', '0005_finance_moneywiz_adapter.sql', '0006_finance_ef_caixa_adapter.sql', '0007_finance_security_integrity.sql', '0008_finance_draft_revision.sql', '0009_finance_registration_lifecycle.sql', '0010_finance_reconciliation_workflow.sql', '0011_finance_obligations.sql', '0012_finance_obligation_recurrences.sql'].map(async (file) => (await readFile(new URL(`../migrations/${file}`, import.meta.url), 'utf8')).replace(/^--.*$/gm, '')));
+const migrationFiles = (await readdir(new URL('../migrations/', import.meta.url)))
+  .filter((file) => /^\d{4}_.+\.sql$/.test(file))
+  .sort();
+const migrations = await Promise.all(
+  migrationFiles.map(async (file) =>
+    (await readFile(new URL(`../migrations/${file}`, import.meta.url), 'utf8')).replace(/^--.*$/gm, ''),
+  ),
+);
 const handler = createFinanceHandler();
 const scopeNh = 'finance-scope-novo-hamburgo';
 const scopeBss = 'finance-scope-barra-shopping-sul';

--- a/finance/test/migration-policy.test.mjs
+++ b/finance/test/migration-policy.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const migrationDirectory = new URL('../migrations/', import.meta.url);
+
+test('Finance production migrations contain no forbidden DROP statements', async () => {
+  const files = (await readdir(migrationDirectory)).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort();
+  assert.deepEqual(files.slice(-1), ['0013_finance_additive_trigger_contract.sql']);
+  for (const file of files) {
+    const source = await readFile(new URL(file, migrationDirectory), 'utf8');
+    const statements = source.replace(/^--.*$/gm, '');
+    assert.doesNotMatch(statements, /\bDROP\b/i, `${file} violates the additive migration policy`);
+  }
+});
+
+test('fresh databases receive draft-aware guards without trigger replacement', async () => {
+  const v7 = await readFile(new URL('0007_finance_security_integrity.sql', migrationDirectory), 'utf8');
+  const v8 = await readFile(new URL('0008_finance_draft_revision.sql', migrationDirectory), 'utf8');
+  const v13 = await readFile(new URL('0013_finance_additive_trigger_contract.sql', migrationDirectory), 'utf8');
+
+  assert.match(
+    v7,
+    /finance_movements_immutable_fields BEFORE UPDATE OF scope_id,source,external_id,created_by,created_at,submitted_at/,
+  );
+  assert.match(v7, /finance_movement_splits_no_delete BEFORE DELETE[\s\S]+status='draft'[\s\S]+operational_status='pending'/);
+  assert.match(v7, /finance_installments_immutable_fields BEFORE UPDATE[\s\S]+status='draft'[\s\S]+operational_status='pending'/);
+  assert.doesNotMatch(v8.replace(/^--.*$/gm, ''), /\bDROP\b/i);
+  for (const trigger of [
+    'finance_movements_identity_immutable_v13',
+    'finance_movement_splits_posted_no_delete_v13',
+    'finance_installments_posted_immutable_v13',
+  ]) {
+    assert.match(v13, new RegExp(`CREATE TRIGGER IF NOT EXISTS ${trigger}`));
+  }
+});

--- a/finance/test/production-preflight.test.mjs
+++ b/finance/test/production-preflight.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateFinanceProductionPreflight } from '../../.github/scripts/finance-production-preflight.mjs';
+
+const d1Id = '11111111-2222-4333-8444-555555555555';
+const controlKvId = 'a'.repeat(32);
+const releaseSha = 'b'.repeat(40);
+
+function fixture(overrides = {}) {
+  return {
+    operation: 'deploy',
+    releaseSha,
+    deployEnabled: true,
+    d1Id,
+    controlKvId,
+    githubBackupPassphrasePresent: true,
+    githubServiceSecretPresent: true,
+    d1: { uuid: d1Id, name: 'skincos-finance' },
+    kv: { id: controlKvId, title: 'SKINCOS_FINANCE_PRODUCTION_FLAGS' },
+    financeSettings: {
+      bindings: [
+        { name: 'DB', type: 'd1', id: d1Id, database_id: d1Id },
+        { name: 'MODULE_CONTROL', type: 'kv_namespace', namespace_id: controlKvId },
+        { name: 'ENVIRONMENT', type: 'plain_text', text: 'production' },
+      ],
+    },
+    financeSecrets: [{ name: 'FINANCE_SERVICE_AUTH_SECRET', type: 'secret_text' }],
+    financeDeployments: { deployments: [{ id: 'deployment-1' }] },
+    financeSubdomain: { enabled: true, previews_enabled: false },
+    accountSubdomain: { subdomain: 'skincos' },
+    apiSettings: {
+      bindings: [
+        { name: 'FINANCE', type: 'service', service: 'skincos-finance', environment: 'production' },
+      ],
+    },
+    apiSecrets: [{ name: 'FINANCE_SERVICE_AUTH_SECRET', type: 'secret_text' }],
+    ...overrides,
+  };
+}
+
+test('production preflight emits only sanitized attestation', () => {
+  const report = validateFinanceProductionPreflight(fixture());
+  assert.equal(report.result, 'passed');
+  assert.equal(report.workerUrl, 'https://skincos-finance.skincos.workers.dev');
+  assert.equal(report.secrets.valuesReadOrEmitted, false);
+  assert.equal(JSON.stringify(report).includes('super-secret'), false);
+});
+
+test('production deploy fails closed when its release flag is not enabled', () => {
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ deployEnabled: false })),
+    /ENABLE_FINANCE_PRODUCTION_DEPLOY/,
+  );
+});
+
+test('rollback remains possible with the deploy flag disabled but still requires attested resources', () => {
+  const report = validateFinanceProductionPreflight(fixture({ operation: 'rollback', deployEnabled: false }));
+  assert.equal(report.authorization.rollbackDoesNotRequireDeployFlag, true);
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ operation: 'rollback', deployEnabled: false, financeDeployments: [] })),
+    /rollback baseline/,
+  );
+});
+
+test('production preflight rejects wrong resources, bindings and remote secrets', () => {
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ d1: { uuid: d1Id, name: 'skincos-finance-staging' } })),
+    /D1 id\/name/,
+  );
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ kv: { id: controlKvId, title: 'SKINCOS_FINANCE_STAGING_FLAGS' } })),
+    /KV id\/title/,
+  );
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({
+      financeSettings: {
+        bindings: [
+          { name: 'DB', type: 'd1', id: '99999999-2222-4333-8444-555555555555' },
+          { name: 'MODULE_CONTROL', type: 'kv_namespace', namespace_id: controlKvId },
+          { name: 'ENVIRONMENT', type: 'plain_text', text: 'production' },
+        ],
+      },
+    })),
+    /DB binding/,
+  );
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({
+      apiSettings: { bindings: [{ name: 'FINANCE', type: 'service', service: 'skincos-finance-staging' }] },
+    })),
+    /skincos-api FINANCE binding/,
+  );
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ financeSecrets: [] })),
+    /remote FINANCE_SERVICE_AUTH_SECRET/,
+  );
+  assert.throws(
+    () => validateFinanceProductionPreflight(fixture({ apiSecrets: [] })),
+    /API.*remote FINANCE_SERVICE_AUTH_SECRET/i,
+  );
+});


### PR DESCRIPTION
## Context

Production Finance still lacks an enforceable pre-mutation resource gate. PR #850 review also identified destructive trigger replacement in migration 0008, the production flag guarding only Pages, and remote service-secret verification occurring after D1 mutation.

## Changes

- attest the exact production Finance Worker, D1, KV, API service binding, remote secret names, workers.dev endpoint, and rollback baseline before any checkpoint, migration, or upload;
- require `ENABLE_FINANCE_PRODUCTION_DEPLOY=true` for deploy while preserving rollback with the flag disabled;
- move Finance service-secret attestation before the D1 checkpoint;
- split migration and immutable-version upload into explicit ordered steps;
- remove forbidden `DROP TRIGGER` statements and add additive migration 0013 so fresh production and already-migrated staging converge safely;
- add regression coverage for sanitized preflight evidence, exact bindings, additive-only migrations, and workflow ordering.

No production resource, secret, binding, database, or other operational unit is changed by this PR.

## Validation

- Finance test suite: 52/52 passed in clean WSL ext4
- focused migration/preflight tests: 6/6 passed after final rebase
- `npm run architecture:validate`: passed (three pre-existing tracked legacy-import warnings)
- JS security exceptions: passed
- no-demo guard: passed
- deployment topology validator: passed
- live read-only Cloudflare response-shape comparison: passed after correcting the D1 binding assertion to use inventory name + exact binding ID
- `git diff --check`: passed

## Rollout

1. Merge without bypass after required checks/review.
2. Promote Finance preview and staging from the merge SHA.
3. Complete the authenticated synthetic import/UI journey and canary rollback proof on that same SHA.
4. Complete fresh offsite PostgreSQL restore evidence and obtain the named production approval.
5. Provision the attested production Worker/D1/KV/API binding through the governed path.
6. Dispatch Finance production only after this preflight passes; then promote the current API release through its immutable chain.

## Rollback

- The workflow exports and encrypts the target D1 before migrations and uploads the checkpoint as a required artifact.
- Worker rollback selects a previously uploaded `finance:deploy:<sha>` version and does not require the deploy-enable flag.
- Keep the module control disabled/maintenance until functional production validation succeeds.