### PR TITLE
fix(finance): alinhar smoke de importação em staging

### DIFF
--- a/crm/console/modules/RemoteFinanceModule.tsx
+++ b/crm/console/modules/RemoteFinanceModule.tsx
@@ -4,10 +4,18 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/car
 
 type FinanceRemote = { mount: (element: HTMLElement) => void | (() => void) }
 
+// Keep a small, non-sensitive failure class in the DOM for the staging smoke.
+// Do not expose error messages, URLs or stack traces to CRM users.
+const remoteFailureKind = (cause: unknown) => {
+  const name = cause instanceof Error ? cause.name : ''
+  return /^[A-Za-z][A-Za-z0-9]{0,63}$/.test(name) ? name : 'RemoteLoadError'
+}
+
 /** Loads an independently published Finance bundle without making it a shell dependency. */
 export function RemoteFinanceModule() {
   const container = React.useRef<HTMLDivElement>(null)
   const [failed, setFailed] = React.useState(false)
+  const [failureKind, setFailureKind] = React.useState('')
   const [retry, setRetry] = React.useState(0)
   const remoteUrl = String(import.meta.env.VITE_FINANCE_MODULE_URL || '').trim()
 
@@ -15,12 +23,13 @@ export function RemoteFinanceModule() {
     if (!remoteUrl || !container.current) return
     let disposed = false; let cleanup: void | (() => void)
     setFailed(false)
+    setFailureKind('')
     import(/* @vite-ignore */ remoteUrl)
       .then((remote: FinanceRemote) => { if (!disposed) cleanup = remote.mount(container.current!) })
-      .catch(() => { if (!disposed) setFailed(true) })
+      .catch((cause) => { if (!disposed) { setFailureKind(remoteFailureKind(cause)); setFailed(true) } })
     return () => { disposed = true; cleanup?.() }
   }, [remoteUrl, retry])
 
-  if (!remoteUrl || failed) return <Card className="border-amber-400/30 bg-slate-950/60 text-white" data-testid="finance-remote-unavailable"><CardHeader><CardTitle>Financeiro indisponível</CardTitle><CardDescription>{remoteUrl ? 'A versão independente do Financeiro não pôde ser carregada. A navegação e os demais módulos continuam disponíveis.' : 'O Financeiro ainda não foi associado a um artefato liberado neste ambiente.'}</CardDescription></CardHeader><CardContent>{remoteUrl && <Button variant="outline" onClick={() => setRetry((value) => value + 1)}>Tentar novamente</Button>}</CardContent></Card>
+  if (!remoteUrl || failed) return <Card className="border-amber-400/30 bg-slate-950/60 text-white" data-testid="finance-remote-unavailable" data-finance-remote-error={failed ? failureKind || 'RemoteLoadError' : undefined}><CardHeader><CardTitle>Financeiro indisponível</CardTitle><CardDescription>{remoteUrl ? 'A versão independente do Financeiro não pôde ser carregada. A navegação e os demais módulos continuam disponíveis.' : 'O Financeiro ainda não foi associado a um artefato liberado neste ambiente.'}</CardDescription></CardHeader><CardContent>{remoteUrl && <Button variant="outline" onClick={() => setRetry((value) => value + 1)}>Tentar novamente</Button>}</CardContent></Card>
   return <div ref={container} data-finance-remote="true" aria-busy="true" />
 }

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -117,8 +117,16 @@ try {
   if (commitRequested) {
     if (stagedBody.alreadyStaged) throw new Error('synthetic import unexpectedly reused a previous batch');
     if (loaded.batch?.status !== 'staged') throw new Error(`batch is not staged (${loaded.batch?.status || 'unknown'}); refusing commit`);
+    // Staging persists the source at the stage boundary. Analyse must mirror
+    // the UI contract and send only the mutable analysis controls; reposting
+    // the original source omits the persisted batch mapping and can turn a
+    // valid staged batch into an empty analysis.
+    const analyzePayload = {
+      mapping: loaded.batch?.mapping || stagedBody.analysis?.mapping || {},
+      encoding: payload.encoding || 'utf-8',
+    };
     const analyzed = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/analyze`)}?scopeId=${encodeURIComponent(scopeId)}`, {
-      method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(payload),
+      method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(analyzePayload),
     });
     const analysisBody = await json(analyzed);
     if (!analysisBody.analysis?.rows?.length) throw new Error('import analyze did not return rows');

--- a/finance/scripts/staging-ui-smoke.mjs
+++ b/finance/scripts/staging-ui-smoke.mjs
@@ -71,6 +71,7 @@ const readRemoteState = () => page.evaluate(() => ({
   container: Boolean(document.querySelector('[data-finance-remote="true"]')),
   module: Boolean(document.querySelector('[data-finance-module="true"]')),
   unavailable: Boolean(document.querySelector('[data-testid="finance-remote-unavailable"]')),
+  failureKind: document.querySelector('[data-testid="finance-remote-unavailable"]')?.getAttribute('data-finance-remote-error') || null,
 }))
 try {
   console.log('[finance-staging-ui] carregando CRM de staging')
@@ -105,7 +106,7 @@ try {
   await page.getByTestId('crm-header-layout').getByRole('heading', { name: 'Financeiro' }).waitFor({ state: 'visible', timeout: 30_000 })
   await page.locator('[data-finance-remote="true"], [data-testid="finance-remote-unavailable"], [data-finance-module="true"]').waitFor({ state: 'visible', timeout: 30_000 })
   remoteState = await readRemoteState()
-  if (remoteState.unavailable) fail('O bundle remoto do Financeiro não pôde ser carregado.')
+  if (remoteState.unavailable) fail(`O bundle remoto do Financeiro não pôde ser carregado (${remoteState.failureKind || 'RemoteLoadError'}).`)
   await page.locator('[data-finance-module="true"]').waitFor({ state: 'visible', timeout: 30_000 })
   remoteState = await readRemoteState()
   console.log('[finance-staging-ui] módulo Financeiro renderizado')

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -5,9 +5,10 @@ import test from 'node:test';
 const read = (file) => readFile(new URL(`../scripts/${file}`, import.meta.url), 'utf8');
 
 test('staging Finance API smokes use the authenticated Pages transport', async () => {
-  const [canary, importer] = await Promise.all([
+  const [canary, importer, remoteFinanceModule] = await Promise.all([
     read('staging-synthetic-canary.mjs'),
     read('staging-import-smoke.mjs'),
+    readFile(new URL('../../crm/console/modules/RemoteFinanceModule.tsx', import.meta.url), 'utf8'),
   ]);
 
   for (const source of [canary, importer]) {
@@ -23,4 +24,8 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(importer, /const password = requiredSecret\('FINANCE_SMOKE_PASSWORD'\)/);
   assert.match(canary, /String\(process\.env\[name\] \?\? ''\)/);
   assert.match(importer, /String\(process\.env\[name\] \?\? ''\)/);
+  assert.match(importer, /const analyzePayload = \{[\s\S]*mapping: loaded\.batch\?\.mapping \|\| stagedBody\.analysis\?\.mapping \|\| \{\}/);
+  assert.match(importer, /body: JSON\.stringify\(analyzePayload\)/);
+  assert.match(remoteFinanceModule, /data-finance-remote-error/);
+  assert.match(remoteFinanceModule, /remoteFailureKind\(cause\)/);
 });


### PR DESCRIPTION
## Contexto
O canário de staging interrompeu corretamente: a jornada de importação reenviava o payload de stage ao endpoint de análise, divergindo do contrato usado pelo frontend. O carregamento remoto do Financeiro também era reportado sem uma classificação sanitizada de falha.

## Alterações
- envia somente mapping e encoding persistidos na etapa de análise;
- mantém o bundle independente e expõe apenas a classe segura do erro ao smoke;
- registra a classe no relatório sanitizado do smoke;
- cobre os dois contratos por teste de regressão.

## Validação local
- 
ode --check dos dois smokes;
- 
ode --test finance/test/staging-smoke-transport.test.mjs;
- 
pm --prefix finance run test -- --runInBand;
- 
pm --prefix crm/console run lint;
- 
pm --prefix crm/console run typecheck;
- 
pm --prefix crm/console run test -- --run;
- git diff --check.

Sem deploy, flags, grants, usuários, secrets ou produção.