### PR TITLE
docs(ponto): record release blockers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -49,8 +49,27 @@ jornada autenticada atual continue válida.
 - [x] Publicar e validar staging com D1/secrets próprios (workflow histórico `29700256254`).
 - [x] Promover por workflow oficial e executar smoke produtivo somente leitura (evidência histórica `29700295125`; API `29700339758`; UI `29753110570`).
 
-### P0 — candidato atual (não promovido)
+### P0 — release atual (candidato final ainda não selecionado)
 
+- [x] Integrar o candidato por PR #886 em `main` como
+  `10b2197731d0210cf8fc8cd961f7a787d73bf650`, com todos os checks obrigatórios
+  verdes. Esta integração não é uma promoção de Worker, gateway ou Pages.
+- [x] Inventariar integralmente o delta posterior à PR #886. Entre
+  `10b21977…` e `66424871…`, o `main` recebeu: contrato/finalização/convergência
+  do canário Finance (PRs #891/#895/#898), guardas produtivas e migration
+  aditiva Finance (PR #890), observação e agendamento seguro de releases
+  estáveis do Orb/n8n (#888/#896), ACL do
+  preparador de release nativo da Livia (#892) e contrato de acessibilidade do
+  QA da Livia (#897). O delta total contém 29 arquivos: 17 de Finance, 8 de
+  Orb/n8n, 2 do QA da Livia e 2 do preparador nativo, com
+  `.github/scripts/validate-deploy-topology.mjs` compartilhado na guarda
+  Finance. Nenhum deles altera diretamente o runtime, migration ou workflow
+  de Ponto, mas a classificação anterior de “somente um arquivo Finance” era
+  incorreta.
+- [ ] Selecionar um único SHA imutável somente depois de integrar os controles
+  obrigatórios de pilot/canary. O gate canônico aceita SHA ancestral
+  alcançável a partir de `main`; portanto `10b21977…` é tecnicamente
+  promovível, mas não é mais automaticamente o candidato correto.
 - [x] Restaurar a navegação de CONSULTOR/EMPLOYEE para exatamente Atendimento e
   Ponto, preservando a autorização no servidor.
 - [x] Cobrir a regressão de navegação e incluir seus arquivos no path filter de
@@ -59,14 +78,47 @@ jornada autenticada atual continue válida.
   específico por execução e evidência sanitizada.
 - [x] Tornar `PONTO_PROFILE_DATA_KEY` obrigatório nos sync/deploys e registrar
   release SHA/environment no health do Worker.
-- [ ] Criar `PONTO_PROFILE_DATA_KEY` por processo de segredo aprovado nos
-  environments `staging` e `production`; não gerar/copyar valor pelo código.
+- [x] Manter `ENABLE_CORE_WORKERS_DEPLOY=true` somente em `staging`.
+  `production` voltou a `false` em `2026-07-29T22:17:37Z`, antes de qualquer
+  dispatch, e permanece fail-closed até existirem staging, pilot e canary
+  válidos.
+- [ ] Implementar e validar, antes de produção, afinidade entre versões do Core
+  API e Timekeeping, roteamento gradual, coorte piloto baseada em contexto de
+  rede, grants mínimos, interrupção automática e evidência externa de SLO. A
+  política progressiva atual marca Core Workers, CRM Pages e Timekeeping como
+  bloqueados enquanto esses controles não existirem. Corrigir também o default
+  fail-open `${ENABLE:-true}` do Core deploy, o checkpoint Timekeeping rotulado
+  com o SHA do dispatch em vez do release SHA e a ausência de inputs/gates
+  executáveis para pilot/canary.
+- [ ] Criar primeiro `PONTO_PROFILE_DATA_KEY` em `staging` por processo de
+  segredo aprovado; não gerar/copyar valor pelo código. Somente após staging
+  completo e autorização pré-produção separada, provisionar um valor
+  independente em `production`.
+- [ ] Desacoplar o deploy produtivo do Core API para Ponto do binding Finance
+  ausente. O `api/wrangler.toml` atual referencia `skincos-finance`, que não
+  existe e já causou Cloudflare `10143`; a correção não pode provisionar nem
+  ativar Finance sob este objetivo.
 - [ ] Fazer preview e staging do mesmo SHA para Timekeeping, Core API e CRM
   Pages; executar a jornada sintética pelo URL imutável do Pages e confirmar
   que o teardown preservou auditoria.
 - [ ] Exercitar `module-control:timekeeping` em staging (`maintenance` →
   `active`) e registrar o rollback; só então tornar `active` explícito em
   produção após promoção imutável, piloto e observação.
+- [x] Fechar explicitamente o Ponto produtivo em `maintenance` pelo workflow
+  canônico `30496220685`. A contenção/rollback operacional mantém essa chave
+  explicitamente em `maintenance`; ela não deve ser removida, pois o estado
+  ausente é fail-open. O conjunto incumbente preservado para rollback de
+  artefato é Timekeeping deployment
+  `0da32d7c-6d6f-4b54-a538-6b7c642e57de`, Core API version
+  `a1d6ddb0-905d-4784-9e77-d1231cd75e90` e CRM Pages deployment
+  `a77cf500-f272-4d37-87c2-c02f78352c4e`, sempre com a manutenção retida até
+  nova atestação. `/api/ponto/me` passou a responder
+  `503/MODULE_MAINTENANCE`; a readiness ainda responde 200 e precisa ser
+  corrigida para refletir o controle operacional.
+- [ ] Corrigir a reconciliação operacional: o inventário agregado encontrou um
+  CONSULTOR ativo no Core de staging sem Workforce ativo correspondente; em
+  produção não há CONSULTOR ativo elegível para o piloto. Não criar ou ativar
+  identidades sem a decisão de Identity/Workforce apropriada.
 - [ ] Não considerar produção, piloto, conclusão ou arquivamento provados até
   existirem artefatos, health/version/gateway e jornada autenticada para o
   mesmo SHA.

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -1,5 +1,54 @@
 # Current blockers
 
+## P0 — Workforce Timekeeping production release is fail-closed
+
+PR #886 is integrated at
+`10b2197731d0210cf8fc8cd961f7a787d73bf650`, but no immutable release has
+completed the current preview/staging/pilot/canary/production chain. The
+production Core deploy flag was restored to
+`ENABLE_CORE_WORKERS_DEPLOY=false` at `2026-07-29T22:17:37Z`; staging remains
+enabled for a later governed operation. Production Ponto itself is explicitly
+in `maintenance` through canonical run `30496220685`.
+
+The executable blockers, in required order, are:
+
+1. integrate and validate version affinity between Core API and Timekeeping,
+   gradual Worker routing, a network-context pilot cohort, minimal grants,
+   automatic interruption and external SLO evidence; make the Core gate
+   fail-closed when unset, label Timekeeping checkpoints with the promoted
+   release SHA, and add executable pilot/canary predecessors plus a
+   Ponto-specific Pages gate;
+2. provision `PONTO_PROFILE_DATA_KEY` in staging only from an approved secret
+   source/process, and move the other staging Ponto runtime secrets out of
+   shared repository scope; provision an independent production set only
+   after complete staging evidence and separate pre-production authorization;
+3. choose one immutable SHA reachable from `main` after those controls are
+   integrated, then prove the same SHA in Timekeeping, Core API and CRM Pages
+   preview/staging; first repair staging Pages, which currently routes its
+   canonical default to the production API and has no actor key;
+4. add a Ponto gateway-only Core API promotion path that does not require the
+   nonexistent `skincos-finance` Worker or mutate/provision Finance; the
+   current production binding already caused Cloudflare `10143`;
+5. exercise `module-control:timekeeping` through maintenance, active and
+   rollback in staging and complete the synthetic authenticated journey with
+   audit-preserving teardown;
+6. reconcile or designate an eligible pilot through Identity/Workforce. The
+   aggregate inventory currently has no active production CONSULTOR with an
+   active Workforce counterpart, and staging has one Core CONSULTOR without
+   that counterpart;
+7. complete separately evidenced pilot and canary predecessors before any
+   production deployment, migration, grant or activation.
+
+`PONTO_PROFILE_DATA_KEY` is absent by name from accessible GitHub
+staging/production metadata and both incumbent Timekeeping Workers.
+`module-control:timekeeping` is absent in staging and explicitly
+`maintenance` in production. Production `/api/ponto/me` returns
+`503/MODULE_MAINTENANCE`, while readiness incorrectly remains 200 and is a
+release-control defect. Incumbent health/version responses do not attest a
+candidate release.
+No production Ponto dispatch, migration, D1/KV write, pilot or canary is
+authorized by the current evidence.
+
 ## Resolved — Insumos unit access P0
 
 Insumos is not an executable blocker. The production closure is recorded on
@@ -11,9 +60,14 @@ do not reopen this item without a new production symptom.
 ## Finance — staging release evidence is incomplete
 
 The current Finance staging Worker and independent UI are healthy at
-`32bf3ebb…` (runs `30168445270` and `30168445288`), but current `origin/main`
-is `6963ba04…`; the API and general CRM Pages staging versions differ as well.
-The next technical milestone is therefore a single immutable current-main
+`32bf3ebb…` (runs `30168445270` and `30168445288`). The last full Finance
+reconciliation compared them with `origin/main` `6963ba04…`; the repository
+has since advanced to the authoritative snapshot `66424871…`. The latest
+Finance-changing ancestor is `291d9359…`, including Finance PRs
+#891/#890/#895/#898; the later main commits do not change Finance, but the
+staging evidence is still not current-main. The API and general CRM Pages
+staging versions differ as well.
+The next Finance technical milestone remains a single immutable current-main
 candidate through canonical Finance Worker/UI preview and staging, followed by
 the synthetic authenticated import/UI journey. Until that happens, no staging
 release is eligible for a pilot decision.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,33 +1,101 @@
 # Current state
 
-## Workforce Timekeeping current-main release — source remediation, not yet staged — 2026-07-29T20:45Z
+## Workforce Timekeeping release — source integrated; production fail-closed — 2026-07-29T22:29Z
 
-The isolated candidate branch `codex/admin/workforce-timekeeping-production`
-starts from `origin/main` `f202e29f4178bba8966edf71539c942618254de0`. Source
-review identified a later navigation regression: commit
-`4bfc56af0ac5b2bf0387a71dfa1825cb84ecdca0` removed `ponto` from the
-CONSULTOR/EMPLOYEE allowlist after the original Workforce release. The candidate
-restores exactly `atendimento` and `ponto` for those roles; server-side Pages
-and Worker authorization remains the enforcement boundary.
+PR #886 integrated the Ponto source remediation into `main` as
+`10b2197731d0210cf8fc8cd961f7a787d73bf650`, with required checks green. It
+restored exactly `atendimento` and `ponto` for CONSULTOR/EMPLOYEE while keeping
+server-side authorization, added the synthetic authenticated staging journey,
+made `PONTO_PROFILE_DATA_KEY` mandatory, and stamped Worker health with release
+SHA/environment. This proves integrated source only; it is not a deployment.
 
-The candidate also makes face punches explicitly false in both Worker configs,
-adds the missing Ponto/profile secret to deploy and periodic-sync guards,
-attests SHA/environment in Worker health, and adds a private-fixture
-authenticated staging journey across CRM Pages, Core API and Timekeeping. The
-D1/KV identifiers configured for staging and production were read-only checked
-for presence and expected formats; direct health/readiness probes returned 200
-but the current Worker reports unproven release provenance (`environment`
-previously `unknown`). The remote module-control key was absent, so its current
-implicit-active behavior is not an explicit activation record.
+The complete delta from that merge to the freshly fetched `origin/main`
+`6642487142e4de30cf27ae337da60d9f7f64449c` contains 29 files and is
+classified as follows:
 
-`PONTO_PROFILE_DATA_KEY` is absent from the repository and environment secret
-metadata. The new fail-closed guard therefore intentionally prevents either
-staging or production deployment until the key is provisioned through an
-approved secret-management path. No secret value was read, generated, copied or
-changed. No PR, CI run, D1 write, KV change, deployment, promotion, pilot or
-production modification has occurred for this candidate. Historical Ponto
-release records below remain historical only; they do not establish current-SHA
-staging or production readiness.
+- Finance, 17 files (PRs #891, #890, #895 and #898):
+  `.github/scripts/finance-production-preflight.mjs`,
+  `.github/scripts/validate-deploy-topology.mjs`,
+  `.github/workflows/deploy-finance.yml`,
+  `crm/console/modules/RemoteFinanceModule.tsx`,
+  `crm/console/vite.finance.config.ts`, migrations `0007`, `0008` and `0013`,
+  `finance/package.json`, both staging smoke scripts, the Worker release smoke
+  and five Finance tests.
+  The shared topology validator change enforces the Finance preflight; it does
+  not alter the Ponto publishers.
+- Orb/n8n release watch, 8 files (#888/#896): the qualification document,
+  scheduled workflow, `audit-release-baseline.sh`,
+  `release-watch-policy.json`, three tests and `watch-stable-release.sh`.
+- Livia QA accessibility, 2 files (PR #897): `qa-runner.js` and its test.
+- Native Livia release preparation, 2 files (PR #892):
+  `prepare-native-source-release.sh` and its test.
+
+No file in that delta directly changes the Timekeeping runtime/migrations,
+Ponto gateway routes or the three canonical Ponto publisher workflows. The
+prior assertion that the delta was only one Finance file was false and is
+superseded. The immutable promotion gate accepts any full SHA reachable from
+`main`, so ancestral `10b21977…` remains technically eligible; it is not the
+final candidate because the governed pilot/canary controls still need a
+reviewed source change. No final release SHA is selected yet.
+
+The progressive policy requires `preview → staging → pilot → canary →
+production` and currently marks Core Workers, CRM Pages and Timekeeping
+pilot/canary blocked by absent version affinity, gradual routing, pilot cohort
+configuration and external SLO interruption evidence. The executable publishers
+offer only preview/staging/production, so the policy predecessors are not
+enforced; Core deploy also defaults a missing gate to enabled
+(`${ENABLE:-true}`), and the Timekeeping checkpoint is named with the dispatch
+SHA instead of the selected ancestral release SHA. CRM Pages has no
+Ponto-specific production gate. These are release-control defects, not
+documentation-only blockers. The production Core API config also binds
+`FINANCE` to nonexistent Worker `skincos-finance`; a prior API promotion failed
+with Cloudflare `10143` before upload. Ponto therefore needs a governed
+gateway-only release path that does not require or advance Finance. The production
+`ENABLE_CORE_WORKERS_DEPLOY` value was therefore restored from `true` to
+`false` at `2026-07-29T22:17:37Z`; staging remains `true`. No workflow was
+dispatched by either variable change.
+
+`PONTO_PROFILE_DATA_KEY` remains absent by name from accessible GitHub
+staging/production secret metadata and both deployed Timekeeping Workers.
+The Cloudflare account's only Secrets Store is empty, so it is not an approved
+source for this key.
+`module-control:timekeeping` remains absent in staging. Production was moved
+from the same implicit default to an explicit `maintenance` state by canonical
+workflow run `30496220685` at `2026-07-29T22:28:04Z`; the prior absent-key
+state is the recorded rollback checkpoint. Production health now reports
+`ok=false`, `ready=false`, `availability=maintenance`, and `/api/ponto/me`
+returns `503/MODULE_MAINTENANCE`. The separate readiness endpoint still returns
+200/ready and must be fixed before release because it ignores module
+availability. Existing version fields still attest only the incumbent
+`1.0.0/unknown`, not #886 or a later candidate. Aggregate Identity/Workforce
+inventory found one active, unit-scoped staging Core CONSULTOR but zero active
+staging Workforce CONSULTORs (the only staging employee is a terminated
+SUPERVISOR). Production has zero active Core CONSULTOR/EMPLOYEE; its one linked
+CONSULTOR onboarding/hierarchy pair is INVITED and the employee is on LEAVE,
+so eligible active pilot count is also zero. The dedicated Ponto smoke account
+is a GESTOR automation identity, not an authorized consultant pilot. No PII was
+read or recorded.
+
+Current deployed lineage is split. Production Timekeeping is 100% on Worker
+version `0da32d7c-6d6f-4b54-a538-6b7c642e57de`, Core API is on
+`a1d6ddb0-905d-4784-9e77-d1231cd75e90`, and CRM Pages deployment
+`a77cf500-f272-4d37-87c2-c02f78352c4e` still identifies source `f30f66e…`.
+Staging Timekeeping is on `d6e60024-bb67-48da-91b1-4d7e16ee31ba`, Core API on
+`bc80ab45-c8c8-4742-9109-7e336303dd4d`, and Pages deployment
+`2bd3d04d-30df-4d2b-9832-8e0da69151b1` identifies `c64bc546…`. More critically,
+the staging Pages proxy resolves its canonical default to the production API
+and reports `actorKeyConfigured=false`; it is not a safe staging journey
+surface until the isolated proxy configuration is corrected and verified.
+
+The secret layout is also not independently isolated yet. Besides the missing
+profile key, several Ponto runtime secrets resolve from repository scope rather
+than environment overrides; production and staging can therefore inherit the
+same value. A release must migrate all Ponto secret names to independent
+environment custody without exposing or copying their values.
+
+No candidate preview/staging deployment, D1 write, migration, KV transition,
+authenticated candidate journey, pilot, canary or production promotion has
+occurred. Historical Ponto records below remain historical only.
 
 ## Authoritative Finance reconciliation — 2026-07-29T14:02Z
 

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,33 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-29T22:29:04Z",
+      "surface": "github-main-pr-894-review-governance-github-environment-metadata",
+      "scope": "Workforce Timekeeping blocker-ledger correction and production fail-closed restoration",
+      "state": "source-integrated-candidate-unselected-production-fail-closed",
+      "method": "Fetched origin/main, enumerated every path and merge after PR #886, inspected the immutable promotion gate and progressive-release policy, read all PR #894 review threads, and restored the production Core deploy variable to false. Secret names and aggregate Identity/Workforce evidence only were used; no secret value or PII was read.",
+      "result": "origin/main is 6642487142e4de30cf27ae337da60d9f7f64449c. PR #886 remains merged as 10b2197731d0210cf8fc8cd961f7a787d73bf650. The full post-merge delta is 29 files: 17 Finance files from PRs #891/#890/#895/#898, 8 Orb/n8n release-watch files from #888/#896, 2 Livia QA files from #897 and 2 native release-preparer files from #892; none directly changes the Ponto runtime, migrations, gateway routes or canonical Ponto publisher workflows. The promotion gate permits a full SHA that is any ancestor of origin/main, but the final Ponto candidate is deliberately unselected until the missing pilot/canary controls are integrated. ENABLE_CORE_WORKERS_DEPLOY remains true in staging and was restored to false in production at 2026-07-29T22:17:37Z before any dispatch. Canonical module-control run 30496220685 then set production Timekeeping to maintenance; health reports not ready and a protected route returns 503/MODULE_MAINTENANCE.",
+      "limitation": "PONTO_PROFILE_DATA_KEY remains absent from accessible staging/production metadata, the empty Cloudflare Secrets Store and both incumbent Timekeeping Workers. Other Ponto secrets still inherit repository scope rather than independent environment custody. The progressive policy blocks Core Workers, CRM Pages and Timekeeping pilot/canary because version affinity, gradual routing, network-context cohort configuration and external SLO interruption evidence are absent. Executable publishers do not enforce pilot/canary predecessors; Core deploy defaults an unset gate to enabled, Timekeeping names checkpoints with the dispatch SHA instead of the selected release SHA, and CRM Pages has no Ponto-specific production gate. Staging Pages currently routes to the production API without an actor key. Production Core API also binds FINANCE to nonexistent skincos-finance, so Ponto needs a gateway-only release path that neither requires nor advances Finance. Staging module-control remains absent, production readiness incorrectly ignores maintenance, there is no eligible active production CONSULTOR pilot, and no candidate preview, staging, journey, pilot, canary or production deployment occurred.",
+      "sha": "6642487142e4de30cf27ae337da60d9f7f64449c",
+      "origin_main": "6642487142e4de30cf27ae337da60d9f7f64449c",
+      "pr": 894,
+      "supersedes": ["2026-07-29T21:57:36Z release candidate scope claim"],
+      "next_action": "Integrate the governed pilot/canary, staging-isolation and Ponto gateway-only controls; provision only the independent staging secrets through an approved source; complete preview/staging; then separately authorize production secrets and an Identity/Workforce-valid pilot before selecting the production predecessors."
+    },
+    {
+      "observed_at": "2026-07-29T21:49:16Z",
+      "surface": "github-main-github-actions-github-environment-metadata-cloudflare-worker-secrets-d1-kv-live-http",
+      "scope": "Workforce Timekeeping current-main release recheck",
+      "state": "main-integrated-staging-and-production-blocked-before-dispatch",
+      "method": "Verified PR #886 merge and required checks; inspected current GitHub secret-name and variable metadata; read Timekeeping Worker secret names, module-control KV keys, D1 aggregate counts and public health endpoints; queried workflow history without reading secret values or personal data.",
+      "result": "PR #886 is merged in main as 10b2197731d0210cf8fc8cd961f7a787d73bf650 with required checks successful. ENABLE_CORE_WORKERS_DEPLOY=true was configured in staging and production so an explicit Core API Ponto promotion will no longer be skipped. Current staging/production Timekeeping health endpoints remain 200 but report the incumbent version/environment, not the candidate SHA. Both module-control:timekeeping keys are absent; the existing health response is default-active rather than an explicit release control. Aggregate reconciliation found one active CONSULTOR in the staging Core without an active Workforce counterpart; production has no active CRM CONSULTOR or active Workforce employee eligible for the required pilot.",
+      "limitation": "PONTO_PROFILE_DATA_KEY is absent from the accessible GitHub staging/production secret metadata and both deployed Timekeeping Workers. The canonical sync/deploy workflow therefore fails closed before checkpoint, migration or deployment. No candidate staging dispatch, synthetic journey, module-control mutation, production checkpoint, production promotion, pilot, data mutation or identity change was performed. Health 200 and the post-merge Ponto UI smoke do not establish current-SHA multi-surface lineage or an authenticated production journey.",
+      "sha": "10b2197731d0210cf8fc8cd961f7a787d73bf650",
+      "pr": 886,
+      "runs": [30492794200, 30492794295, 30492794379, 30492794431, 30492794912, 30492794935, 30492797961, 30493207905],
+      "next_action": "Provision PONTO_PROFILE_DATA_KEY through the approved secret path in both environments, reconcile or designate a valid production pilot identity through Identity/Workforce, then promote this exact SHA through Timekeeping, Core API and CRM Pages staging before the synthetic journey and module-control rollback drill."
+    },
+    {
       "observed_at": "2026-07-29T20:45:00Z",
       "surface": "isolated-worktree-origin-main-github-metadata-cloudflare-d1-kv-live-http",
       "scope": "Workforce Timekeeping current-main release preparation",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,29 +1,40 @@
 {
   "schema": 1,
-  "authoritative_at": "2026-07-29T14:02:00Z",
-  "source_main_sha": "6963ba0495870e8f9b15a0b1e81477dd5f7f3f8b",
+  "authoritative_at": "2026-07-29T22:29:04Z",
+  "source_main_sha": "6642487142e4de30cf27ae337da60d9f7f64449c",
   "items": [
     {
       "id": "p0-workforce-timekeeping-current-main-release",
-      "objective": "Restore CONSULTOR/EMPLOYEE Ponto navigation and prove one immutable Workforce Timekeeping release through staging before any production pilot.",
+      "objective": "Complete the governed Workforce Timekeeping release through preview, staging, pilot, canary and production on one immutable source SHA.",
       "priority": 1100,
-      "state": "source-remediated-staging-blocked-by-secret",
-      "dependencies": [],
+      "state": "source-integrated-production-fail-closed-controls-secret-and-pilot-blocked",
+      "dependencies": [
+        "ponto-release-prerequisites"
+      ],
       "blockers": [
-        "PONTO_PROFILE_DATA_KEY is absent from accessible staging and production secret-name metadata",
-        "no current-main same-SHA Timekeeping, Core API and CRM Pages staging lineage",
-        "module-control:timekeeping has no explicit active state or rollback drill evidence"
+        "PONTO_PROFILE_DATA_KEY is absent from accessible GitHub staging/production secret metadata and both deployed Timekeeping Workers",
+        "remaining Ponto runtime secrets resolve from shared repository scope instead of independent environment custody",
+        "no final candidate SHA is selected after the full post-PR-886 delta and required control changes",
+        "Core Workers, CRM Pages and Timekeeping lack the governed pilot/canary routing, version-affinity, cohort and external-SLO controls",
+        "Core deploy defaults a missing gate to enabled, Timekeeping labels checkpoints with dispatch SHA, and executable publishers do not enforce pilot/canary predecessors",
+        "CRM Pages staging routes its canonical default to the production API and reports no Ponto actor key",
+        "production Core API FINANCE binding targets nonexistent skincos-finance and needs a Ponto gateway-only release path",
+        "no same-SHA Timekeeping, Core API and CRM Pages preview/staging lineage",
+        "staging module-control:timekeeping has no explicit state or rollback drill evidence; production is intentionally maintenance",
+        "aggregate reconciliation found no active CONSULTOR eligible for a production pilot and one active staging CONSULTOR without an active Workforce counterpart"
       ],
       "environment": "staging-then-production",
       "permitted_actions": [
-        "green PR/CI and immutable staging promotion after approved secret provisioning",
+        "green scoped PR/CI for Ponto pilot/canary controls",
+        "immutable preview and staging promotion after approved secret provisioning",
         "synthetic CONSULTOR-only authenticated journey with teardown and sanitised evidence",
         "staging module-control maintenance to active rollback drill",
-        "production promotion only after matching staging evidence and named pilot scope"
+        "production promotion only after matching staging, pilot and canary evidence and an Identity/Workforce-valid pilot scope"
       ],
       "prohibited_actions": [
         "invent, generate, copy or disclose PONTO_PROFILE_DATA_KEY",
         "treat health 200 or historical workflow runs as authenticated release proof",
+        "enable ENABLE_CORE_WORKERS_DEPLOY in production before valid staging, pilot and canary predecessors",
         "advance Finance or unrelated release work under this objective",
         "archive the workstream before production evidence and post-release observation"
       ],
@@ -32,16 +43,77 @@
         "synthetic authenticated CONSULTOR journey including Ponto visibility, PIN, idempotency, unit denial, correction and administrative denial",
         "sanitised teardown evidence preserving audit rows",
         "explicit module-control active state and staging rollback drill",
+        "version affinity, gradual routing, network-context cohort, minimal grants, automatic interruption and external SLO evidence for pilot and canary",
         "production checkpoint, deployment/version, health/readiness, authenticated pilot and post-release observation"
       ],
-      "done_definition": "A single immutable release has complete staging evidence and then separately approved production/pilot evidence; no historical or health-only claim substitutes for that lineage.",
-      "next_item": "finance-current-main-staging-evidence",
-      "last_verified": "2026-07-29T20:45:00Z",
+      "done_definition": "A single immutable release has complete preview, staging, pilot, canary and production evidence, an authenticated authorized-user journey, proven rollback and post-release observation.",
+      "next_item": null,
+      "last_verified": "2026-07-29T22:29:04Z",
       "evidence": {
         "base_sha": "f202e29f4178bba8966edf71539c942618254de0",
+        "merge_sha": "10b2197731d0210cf8fc8cd961f7a787d73bf650",
+        "selected_release_sha": null,
+        "origin_main_last_verified": "6642487142e4de30cf27ae337da60d9f7f64449c",
+        "post_pr_886_delta": {
+          "total_files": 29,
+          "finance_files": 17,
+          "orb_n8n_release_watch_files": 8,
+          "livia_qa_files": 2,
+          "native_release_preparer_files": 2,
+          "direct_ponto_runtime_or_publisher_files": 0
+        },
+        "promotion_source_rule": "full commit SHA reachable from origin/main; HEAD is not required",
+        "pr": 886,
         "regression_commit": "4bfc56af0ac5b2bf0387a71dfa1825cb84ecdca0",
-        "secret_gate": "PONTO_PROFILE_DATA_KEY"
+        "secret_gate": "PONTO_PROFILE_DATA_KEY",
+        "core_deploy_gate": {
+          "staging": true,
+          "production": false,
+          "production_disabled_at": "2026-07-29T22:17:37Z"
+        },
+        "module_control": {
+          "staging": "absent",
+          "production": "maintenance",
+          "production_run": 30496220685,
+          "production_changed_at": "2026-07-29T22:28:04Z"
+        }
       }
+    },
+    {
+      "id": "ponto-release-prerequisites",
+      "objective": "Close the technical and authorized-input prerequisites for the single-SHA Ponto staging, pilot and canary sequence.",
+      "priority": 1099,
+      "state": "in-progress-controls-blocked-by-approved-secret-source-and-pilot-decision",
+      "dependencies": [],
+      "blockers": [
+        "approved PONTO_PROFILE_DATA_KEY and remaining Ponto secret provisioning for staging before any production secret",
+        "reviewed fail-closed pilot/canary controls and release-SHA checkpoint labeling for Core API, CRM Pages and Timekeeping",
+        "isolated CRM Pages staging proxy and actor-key configuration",
+        "Ponto gateway-only Core API release path independent of the absent Finance Worker",
+        "Identity/Workforce-valid production pilot designation"
+      ],
+      "environment": "source-and-staging",
+      "permitted_actions": [
+        "implement and review version affinity, gradual routing, network-context cohort, minimal grants, automatic interruption and SLO evidence",
+        "provision staging secret names only through an approved source/process without reading or exposing values",
+        "provision independent production secrets only after complete staging evidence and separate pre-production authorization",
+        "select one immutable main-reachable SHA after the controls merge",
+        "run preview/staging and synthetic teardown only after all staging guards pass"
+      ],
+      "prohibited_actions": [
+        "generate, copy, disclose or reuse a secret outside the approved custody process",
+        "invent, activate or grant a pilot identity",
+        "production deployment, migration, grant or module activation before pilot and canary evidence"
+      ],
+      "required_evidence": [
+        "green reviewed PR for the controls",
+        "staging secret presence by name before staging and later production presence after separate authorization",
+        "eligible pilot decision through Identity/Workforce",
+        "selected immutable SHA and complete predecessor evidence"
+      ],
+      "done_definition": "All technical controls and authorized inputs required to begin the governed single-SHA release sequence are present and fail-closed defaults remain intact.",
+      "next_item": "p0-workforce-timekeeping-current-main-release",
+      "last_verified": "2026-07-29T22:29:04Z"
     },
     {
       "id": "p0-insumos-unit-access",


### PR DESCRIPTION
## Summary
- supersedes the stale Ponto status and inventories every post-#886 change through `6642487142e4de30cf27ae337da60d9f7f64449c`
- records the actual GitHub/Cloudflare/Identity/Workforce blockers, including missing pilot/canary enforcement, broken staging isolation and absent approved secret custody
- restores `ENABLE_CORE_WORKERS_DEPLOY=false` in production and records canonical maintenance run `30496220685`; no Ponto candidate was deployed
- aligns `TASKS.md`, `current-state.md`, `blockers.md`, the evidence ledger and work queue

## Validation
- `git diff --check`
- parsed both JSON ledgers and verified every `next_item` and dependency resolves
- mechanically reconciled the 29-file delta from `10b21977…` to current `main`
- verified the production Core gate is `false`
- verified production Ponto health reports maintenance and `/api/ponto/me` returns `503/MODULE_MAINTENANCE`

## Rollback and boundaries
- the prior absent module-control key is historical evidence only and must not be restored because it is fail-open
- rollback containment retains explicit `maintenance`; artifact rollback preserves the incumbent Timekeeping, Core API and CRM Pages deployment IDs recorded in `TASKS.md`
- no secret value, PII, identity, grant, migration, deployment or business data was changed
- production remains fail-closed; this documentation PR does not authorize staging, pilot, canary or production promotion