### PR TITLE
fix(finance): estabilizar canário de staging

### DIFF
--- a/crm/console/vite.finance.config.ts
+++ b/crm/console/vite.finance.config.ts
@@ -5,6 +5,10 @@ import { defineConfig } from 'vite'
 /** Dedicated deployable Finance artifact. The CRM shell loads it by a stable URL. */
 export default defineConfig({
   plugins: [react()],
+  // Library builds do not receive Vite's application HTML replacement. Pin
+  // React's browser bundle to production so it never evaluates Node's
+  // `process.env.NODE_ENV` in the independently served artifact.
+  define: { 'process.env.NODE_ENV': '"production"' },
   resolve: { alias: { '@': resolve(import.meta.dirname, '.') }, dedupe: ['react', 'react-dom'] },
   build: {
     outDir: 'dist-finance',

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -129,9 +129,13 @@ try {
       method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(analyzePayload),
     });
     const analysisBody = await json(analyzed);
-    if (!analysisBody.analysis?.rows?.length) throw new Error('import analyze did not return rows');
-    result.analyze = { status: analyzed.status, rows: Number(analysisBody.analysis.rows.length) };
+    if (analysisBody?.ok !== true || String(analysisBody.batchId || '') !== batchId) throw new Error('import analyze did not confirm the staged batch');
+    // The API writes analysed rows to the batch journal and returns its summary
+    // contract, not a duplicate row collection. Confirm the persisted result
+    // through the same read endpoint used by the UI.
     loaded = await loadBatch();
+    if (!(loaded.rows || []).some((row) => row.status === 'valid')) throw new Error(`import analyze did not persist valid rows: ${JSON.stringify(stateSummary(loaded))}`);
+    result.analyze = { status: analyzed.status, rows: Number((loaded.rows || []).length) };
     const candidate = (loaded.rows || []).find((row) => row.status === 'valid');
     if (!candidate) throw new Error(`no valid import row after staging: ${JSON.stringify(stateSummary(loaded))}`);
     const account = await createRegistration('accounts', { name: `Conta sintética ${nonce}`, type: 'bank', currency: 'BRL', openingBalanceMinor: 0 }, `${key}:account`);

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -5,10 +5,11 @@ import test from 'node:test';
 const read = (file) => readFile(new URL(`../scripts/${file}`, import.meta.url), 'utf8');
 
 test('staging Finance API smokes use the authenticated Pages transport', async () => {
-  const [canary, importer, remoteFinanceModule] = await Promise.all([
+  const [canary, importer, remoteFinanceModule, financeViteConfig] = await Promise.all([
     read('staging-synthetic-canary.mjs'),
     read('staging-import-smoke.mjs'),
     readFile(new URL('../../crm/console/modules/RemoteFinanceModule.tsx', import.meta.url), 'utf8'),
+    readFile(new URL('../../crm/console/vite.finance.config.ts', import.meta.url), 'utf8'),
   ]);
 
   for (const source of [canary, importer]) {
@@ -26,6 +27,9 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(importer, /String\(process\.env\[name\] \?\? ''\)/);
   assert.match(importer, /const analyzePayload = \{[\s\S]*mapping: loaded\.batch\?\.mapping \|\| stagedBody\.analysis\?\.mapping \|\| \{\}/);
   assert.match(importer, /body: JSON\.stringify\(analyzePayload\)/);
+  assert.match(importer, /analysisBody\?\.ok !== true/);
+  assert.doesNotMatch(importer, /analysisBody\.analysis\?\.rows/);
   assert.match(remoteFinanceModule, /data-finance-remote-error/);
   assert.match(remoteFinanceModule, /remoteFailureKind\(cause\)/);
+  assert.match(financeViteConfig, /'process\.env\.NODE_ENV': '\"production\"'/);
 });


### PR DESCRIPTION
## Evidência que motivou a correção
O canário de staging 30494052020 executou com o SHA c64bc546f4034cfc9d0652f7e7ebeb0c556bf8b0. API e importação chegaram a executar, mas o smoke interpretava incorretamente a resposta de análise; o bundle remoto falhou em navegador com ReferenceError por conter caminhos React que acessavam process.env.NODE_ENV.

## Alterações
- valida a análise pela releitura persistida do lote, igual ao frontend;
- fixa a build de biblioteca Financeiro em produção para remover a dependência de process.env do navegador;
- adiciona guardas de regressão para os dois contratos.

## Validação local
- checks de sintaxe dos smokes;
- testes Finance e smoke transport;
- lint, typecheck e testes CRM;
- build dedicado ite.finance.config.ts e verificação de ausência de process.env.NODE_ENV no bundle;
- git diff --check.

Sem deploy, flags, grants, usuários, secrets ou produção.