### PR TITLE
ci(orb): schedule safe n8n release watch

### DIFF
--- a/.github/workflows/orb-n8n-stable-release-watch.yml
+++ b/.github/workflows/orb-n8n-stable-release-watch.yml
@@ -1,0 +1,81 @@
+name: Orb n8n stable release watch
+
+on:
+  schedule:
+    - cron: '23 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: orb-n8n-stable-release-watch
+  cancel-in-progress: false
+
+jobs:
+  audit-stable-release:
+    name: Audit new stable n8n release
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      N8N_UPGRADE_ENV: staging
+      N8N_EXPECTED_ENV: staging
+      N8N_STAGING_MARKER: orb-n8n-staging
+      N8N_RELEASE_WATCH_APPLY: 'YES'
+      N8N_AUDIT_ROOT: /tmp/skincos-n8n-release-watch
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.23.1'
+
+      - name: Set up pinned npm from the official registry
+        run: |
+          set -euo pipefail
+          npm --registry https://registry.npmjs.org/ install --global npm@10.9.8 --ignore-scripts
+          test "$(node --version)" = 'v22.23.1'
+          test "$(npm --version)" = '10.9.8'
+
+      - name: Discover and audit only a new official stable release
+        run: |
+          set -euo pipefail
+          bash ops/runtime/n8n-security/watch-stable-release.sh | tee "$RUNNER_TEMP/n8n-release-watch.log"
+
+      - name: Publish sanitized result summary
+        if: always()
+        run: |
+          set -euo pipefail
+          report="$(find "$N8N_AUDIT_ROOT" -maxdepth 1 -type f -name 'release-watch-*.json' -print -quit 2>/dev/null || true)"
+          if [[ -z "$report" ]]; then
+            printf '%s\n' 'No new official stable n8n release was audited in this run.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node --input-type=module - "$report" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          import fs from 'node:fs';
+          const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log('## n8n stable-release watch');
+          console.log(`- candidate: ${report.candidate_version}`);
+          console.log(`- result: ${report.result}`);
+          console.log(`- critical findings: ${report.critical_findings}`);
+          console.log(`- high findings: ${report.high_findings}`);
+          console.log(`- audit errors: ${(report.audit_errors ?? []).length}`);
+          console.log('- scope: isolated dependency audit only; no production action was attempted.');
+          NODE
+
+      - name: Upload sanitized release-watch evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: orb-n8n-release-watch-${{ github.run_id }}
+          retention-days: 30
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/n8n-release-watch.log
+            ${{ env.N8N_AUDIT_ROOT }}/release-watch-*.json
+            ${{ env.N8N_AUDIT_ROOT }}/n8n-*/summary.json
+            ${{ env.N8N_AUDIT_ROOT }}/n8n-*/components/*/summary.json
+            ${{ env.N8N_AUDIT_ROOT }}/n8n-*/components/*/package-lock.json

--- a/docs/operations/orb-n8n-release-qualification.md
+++ b/docs/operations/orb-n8n-release-qualification.md
@@ -40,6 +40,14 @@ completa, e nunca faz merge, deploy, restart, migration ou acesso a caminhos de
 produção. Um candidato sem críticos apenas fica marcado para a qualificação
 isolada completa já controlada pelo PR de upgrade draft.
 
+O workflow agendado `.github/workflows/orb-n8n-stable-release-watch.yml` roda
+diariamente em runner efêmero, sem secrets e com permissão `contents: read`.
+Ele usa o mesmo marcador de staging sintético, Node.js `22.23.1`, npm `10.9.8`
+e o registry npm oficial. Seu diretório de auditoria é `/tmp` do runner, não um
+caminho de runtime da SKINCOS. Ele publica somente o relatório sanitizado e lockfiles
+de auditoria como artefato temporário; não altera a política, não abre ou faz
+merge de PR, não promove nem acessa o runtime de produção.
+
 ## Gate de promoção
 
 Uma promoção futura requer, além deste inventário: release estável oficial, checksum fixado, staging completo, backup/restauração comprovados, migrations reversíveis por restauração, regressão OAuth, MCP somente leitura, quatro serviços e bloqueio público de MCP. Qualquer vulnerabilidade crítica com caminho alcançável ou não descartado bloqueia a promoção.

--- a/ops/runtime/n8n-security/tests/test-release-watch-workflow.sh
+++ b/ops/runtime/n8n-security/tests/test-release-watch-workflow.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../../.." && pwd)
+workflow="$ROOT/.github/workflows/orb-n8n-stable-release-watch.yml"
+
+[[ -f "$workflow" ]] || { echo 'release-watch workflow is missing' >&2; exit 1; }
+
+require_line() { grep -Fqx -- "$1" "$workflow" || { echo "missing required workflow line: $1" >&2; exit 1; }; }
+require_text() { grep -Fq -- "$1" "$workflow" || { echo "missing required workflow text: $1" >&2; exit 1; }; }
+
+require_line 'on:'
+require_line '  schedule:'
+require_line '  workflow_dispatch:'
+require_line '  contents: read'
+require_line '  group: orb-n8n-stable-release-watch'
+require_line '  cancel-in-progress: false'
+require_line '    runs-on: ubuntu-latest'
+require_line '    timeout-minutes: 45'
+require_line '      N8N_UPGRADE_ENV: staging'
+require_line '      N8N_EXPECTED_ENV: staging'
+require_line '      N8N_STAGING_MARKER: orb-n8n-staging'
+require_line "      N8N_RELEASE_WATCH_APPLY: 'YES'"
+require_line '      N8N_AUDIT_ROOT: /tmp/skincos-n8n-release-watch'
+require_text 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6'
+require_text 'persist-credentials: false'
+require_text 'actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6'
+require_text "node-version: '22.23.1'"
+require_text 'npm@10.9.8'
+require_text 'https://registry.npmjs.org/'
+require_text 'bash ops/runtime/n8n-security/watch-stable-release.sh'
+require_text 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4'
+
+if grep -Eq '(pull-requests|contents|deployments):[[:space:]]*write|(upgrade|migrate|rollback)\.sh' "$workflow"; then
+  echo 'workflow contains a forbidden production write capability or command' >&2
+  exit 1
+fi
+
+echo 'release watch workflow tests passed'


### PR DESCRIPTION
## What changed
- adds a daily, manual-dispatchable isolated n8n stable-release watcher
- pins Node 22.23.1, npm 10.9.8 and the official npm registry
- uploads only sanitized audit reports and lockfiles; no credentials or runtime state
- adds a static workflow guard test and operational documentation

## Safety
The workflow has contents: read, no secrets, no write permissions, an ephemeral runner, and never deploys, migrates, merges or accesses production.

## Validation
- release baseline guard tests
- watcher guard tests
- workflow guard test
- no-new-stable official-registry run (2.32.6)
- architecture/module validation
- git diff --check