### PR TITLE
fix(livia): align QA with accessibility contract

### DIFF
--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -20,6 +20,26 @@ const VERIFIER_ENV_FILES = [
   '/etc/skincos/orb-business.env',
   path.join(runtimePaths.runtimeHome, 'env', 'n8n-business.env'),
 ];
+// These markers assert behavior, rather than a single platform-specific
+// wording. The platform contract deliberately records unsupported alt text
+// explicitly for every unsupported media type, not only for videos.
+const ACCESSIBILITY_BUILD_GRAPH_MARKERS = Object.freeze([
+  'cloudinaryVideoCoverUrl',
+  'normalizeGraphApiVersion',
+  'cover_url',
+  'applyPlatformAccessibilityContract',
+  'accessibilityReason',
+  'alt_text_omitted_for_unsupported_',
+  'body.title = text.title',
+]);
+const ACCESSIBILITY_VERIFIER_MARKERS = Object.freeze([
+  'expectedMediaKind',
+  'facebookStaticPost',
+  'not_applicable_for_static_image',
+  'alt_text_not_submitted_or_mismatched',
+  'alt_text_submitted_to_unsupported_media',
+  'media_alt_text_not_supported_in_current_flow',
+]);
 
 function parseProcessMediaOutput(run) {
   const raw = String(run?.data?.main?.[0]?.[0]?.json?.stdout || '').trim();
@@ -587,7 +607,7 @@ function validateWorkflow() {
   if (command.length > 2500) {
     errors.push(`Process Media Asset command is too large for stable n8n expression parsing (${command.length} chars).`);
   }
-  for (const required of ['cloudinaryVideoCoverUrl', 'normalizeGraphApiVersion', 'cover_url', 'applyPlatformAccessibilityContract', 'alt_text_omitted_for_video', 'body.title = text.title']) {
+  for (const required of ACCESSIBILITY_BUILD_GRAPH_MARKERS) {
     if (!buildGraphScript.includes(required)) {
       errors.push(`build-platform-job-graph.js must enforce the publication delivery contract (${required}).`);
     }
@@ -839,7 +859,7 @@ function validateWorkflow() {
   if (!verifierScript.includes('facebookCompositePost') || !verifierScript.includes('facebookReadObjectId')) {
     errors.push('verify-published-artifacts.js must safely verify Facebook composite post IDs through their numeric attached media.');
   }
-  for (const required of ['expectedMediaKind', 'facebookStaticPost', 'not_applicable_for_static_image', 'video_alt_text_not_supported']) {
+  for (const required of ACCESSIBILITY_VERIFIER_MARKERS) {
     if (!verifierScript.includes(required)) errors.push(`verify-published-artifacts.js must verify images separately from video (${required}).`);
   }
   if (notificationNode === 'Inform Success (1)' && !String(nodeByName.get(notificationNode)?.parameters?.remoteJid || '').includes('N8N_DEFAULT_TEST_PHONE')) {
@@ -1012,6 +1032,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  ACCESSIBILITY_BUILD_GRAPH_MARKERS,
+  ACCESSIBILITY_VERIFIER_MARKERS,
   driveAuditForExecution,
   notificationForExecution,
   readSelectedEnvironmentFile,

--- a/orb/engine/tests/livia-qa-runner.test.js
+++ b/orb/engine/tests/livia-qa-runner.test.js
@@ -6,10 +6,22 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const {
+  ACCESSIBILITY_BUILD_GRAPH_MARKERS,
+  ACCESSIBILITY_VERIFIER_MARKERS,
   driveAuditForExecution,
   notificationForExecution,
   verifierEnvironment,
 } = require('../scripts/livia/qa-runner');
+
+test('QA accessibility markers follow the current cross-media contract', () => {
+  const buildGraph = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'livia', 'build-platform-job-graph.js'), 'utf8');
+  const verifier = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'livia', 'verify-published-artifacts.js'), 'utf8');
+
+  for (const marker of ACCESSIBILITY_BUILD_GRAPH_MARKERS) assert.ok(buildGraph.includes(marker), marker);
+  for (const marker of ACCESSIBILITY_VERIFIER_MARKERS) assert.ok(verifier.includes(marker), marker);
+  assert.ok(!buildGraph.includes('alt_text_omitted_for_video'));
+  assert.ok(!verifier.includes('video_alt_text_not_supported'));
+});
 
 test('qa audit passes only the selected Token Vault values to the independent verifier', () => {
   const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'livia-qa-env-'));


### PR DESCRIPTION
## Summary

- aligns the Livia QA runner with the current media accessibility contract;
- replaces stale video-only marker checks with explicit required/unsupported contract invariants;
- adds a regression test against the real builder and verifier sources.

## Root cause

The post-promotion QA runner still required two removed, video-specific error strings. The active contract correctly records unsupported alt text per platform and media kind, so the stale wording caused a false negative despite a valid fail-closed workflow.

## Validation

- `node --test tests/livia-qa-runner.test.js`
- `npm run livia:qa:test`
- `sudo node .../scripts/livia/qa-runner.js validate` against active workflow version `9ffb27cf-cd41-405e-9e7f-8c0e4f1aee64`