### PR TITLE
fix(finance): wait for release smoke convergence

### DIFF
--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -68,6 +68,8 @@ for (const required of [
   'Attest production authorization and remote resources before mutation',
   'Provision or attest Finance service secret before D1 checkpoint',
   'FINANCE_PRODUCTION_WORKER_URL',
+  'worker-release-smoke.mjs',
+  '--consecutive-successes 2',
 ]) {
   if (!financeWorkflow.includes(required)) fail(`Finance publisher is missing its production safety gate: ${required}`);
 }

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -226,6 +226,7 @@ jobs:
           npx --yes wrangler@4.112.0 versions deploy "${FINANCE_VERSION_ID}@100%" --yes --config finance/wrangler.toml "${ENV_ARGS[@]}"
       - name: Smoke independently deployed Finance Worker
         id: smoke
+        timeout-minutes: 3
         env:
           TARGET: ${{ inputs.target }}
           STAGING_WORKER_URL: ${{ vars.FINANCE_STAGING_WORKER_URL }}
@@ -233,13 +234,14 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then BASE_URL="${FINANCE_PRODUCTION_WORKER_URL:-}"; else BASE_URL="$STAGING_WORKER_URL"; fi
-          [[ "$BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'Finance Worker URL is missing or invalid'; exit 1; }
-          for endpoint in health readiness; do
-            output="$RUNNER_TEMP/finance-${endpoint}.json"
-            code="$(curl --silent --show-error --output "$output" --write-out '%{http_code}' "$BASE_URL/$endpoint")"
-            [[ "$code" == 200 ]] || { cat "$output"; exit 1; }
-            node -e "const x=require(process.argv[1]);const expected=process.argv[2];if(!x.ok||x.unit!=='finance'||x.version!==expected||(process.argv[3]==='readiness'&&!x.ready))process.exit(1)" "$output" "$RELEASE_SHA" "$endpoint"
-          done
+          node finance/scripts/worker-release-smoke.mjs \
+            --base-url "$BASE_URL" \
+            --release-sha "$RELEASE_SHA" \
+            --environment "$TARGET" \
+            --attempts 12 \
+            --sleep-ms 5000 \
+            --timeout-ms 10000 \
+            --consecutive-successes 2
       - name: Write staging promotion evidence
         if: inputs.target == 'staging'
         env:

--- a/finance/scripts/worker-release-smoke.mjs
+++ b/finance/scripts/worker-release-smoke.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const FINANCE_UNIT = 'finance';
+const HEALTH_ENDPOINTS = ['health', 'readiness'];
+
+export function normalizeBaseUrl(value) {
+  const parsed = new URL(String(value ?? '').trim());
+  if (
+    parsed.protocol !== 'https:' ||
+    !parsed.hostname ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    !['', '/'].includes(parsed.pathname)
+  ) {
+    throw new Error('Finance Worker base URL must be an HTTPS origin without credentials, path, query or fragment');
+  }
+  return parsed.origin;
+}
+
+function sanitizedObservation(endpoint, status, payload) {
+  return {
+    endpoint,
+    status,
+    ok: payload?.ok,
+    unit: payload?.unit,
+    version: payload?.version,
+    environment: payload?.environment,
+    ready: payload?.ready,
+    d1: payload?.dependencies?.d1?.state,
+    moduleControl: payload?.dependencies?.module_control?.state,
+    availability: payload?.availability?.state,
+  };
+}
+
+export function validateEndpointResponse({ endpoint, status, payload, releaseSha, environment }) {
+  const observation = sanitizedObservation(endpoint, status, payload);
+  const failures = [];
+
+  if (status !== 200) failures.push(`HTTP ${status}`);
+  if (payload?.ok !== true) failures.push('ok is not true');
+  if (payload?.unit !== FINANCE_UNIT) failures.push('unit is not finance');
+  if (payload?.version !== releaseSha) failures.push('version does not match release SHA');
+  if (payload?.environment !== environment) failures.push('environment does not match target');
+  if (payload?.dependencies?.d1?.state !== 'healthy') failures.push('D1 is not healthy');
+  if (payload?.dependencies?.module_control?.state !== 'healthy') failures.push('module-control is not healthy');
+  if (payload?.availability?.state !== 'active') failures.push('availability is not active');
+  if (endpoint === 'readiness' && payload?.ready !== true) failures.push('ready is not true');
+
+  if (failures.length) {
+    throw new Error(`${endpoint} rejected: ${failures.join(', ')}; observed=${JSON.stringify(observation)}`);
+  }
+  return observation;
+}
+
+async function fetchEndpoint({ baseUrl, endpoint, timeoutMs, fetchImpl }) {
+  const response = await fetchImpl(`${baseUrl}/${endpoint}`, {
+    cache: 'no-store',
+    headers: {
+      accept: 'application/json',
+      'user-agent': 'SKINCOS-Finance-Release-Smoke/1.0',
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  let payload;
+  try {
+    payload = JSON.parse(await response.text());
+  } catch {
+    throw new Error(`${endpoint} did not return valid JSON (HTTP ${response.status})`);
+  }
+  return { status: response.status, payload };
+}
+
+export async function runFinanceReleaseSmoke(
+  {
+    baseUrl,
+    releaseSha,
+    environment,
+    attempts = 12,
+    sleepMs = 5_000,
+    timeoutMs = 10_000,
+    consecutiveSuccesses = 2,
+  },
+  {
+    fetchImpl = globalThis.fetch,
+    sleep = (duration) => new Promise((resolve) => setTimeout(resolve, duration)),
+    logger = console,
+  } = {},
+) {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  if (!/^[0-9a-f]{40}$/.test(releaseSha)) throw new Error('release SHA must be a full lowercase commit SHA');
+  if (!['staging', 'production'].includes(environment)) throw new Error('environment must be staging or production');
+  if (!Number.isInteger(attempts) || attempts < 1) throw new Error('attempts must be a positive integer');
+  if (!Number.isInteger(consecutiveSuccesses) || consecutiveSuccesses < 1 || consecutiveSuccesses > attempts) {
+    throw new Error('consecutive successes must be a positive integer no greater than attempts');
+  }
+
+  let consecutive = 0;
+  let lastFailure = 'no request completed';
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      let lastObservation;
+      for (const endpoint of HEALTH_ENDPOINTS) {
+        const result = await fetchEndpoint({
+          baseUrl: normalizedBaseUrl,
+          endpoint,
+          timeoutMs,
+          fetchImpl,
+        });
+        lastObservation = validateEndpointResponse({
+          endpoint,
+          status: result.status,
+          payload: result.payload,
+          releaseSha,
+          environment,
+        });
+      }
+      consecutive += 1;
+      logger.log(
+        `Finance release smoke attempt ${attempt}/${attempts} healthy ` +
+          `(${consecutive}/${consecutiveSuccesses} consecutive), version=${lastObservation.version}`,
+      );
+      if (consecutive >= consecutiveSuccesses) {
+        return {
+          ok: true,
+          attemptsUsed: attempt,
+          consecutiveSuccesses: consecutive,
+          releaseSha,
+          environment,
+        };
+      }
+    } catch (error) {
+      consecutive = 0;
+      lastFailure = error instanceof Error ? error.message : String(error);
+      logger.error(`Finance release smoke attempt ${attempt}/${attempts} failed: ${lastFailure}`);
+    }
+
+    if (attempt < attempts) await sleep(sleepMs);
+  }
+
+  throw new Error(`Finance release smoke did not converge after ${attempts} attempts: ${lastFailure}`);
+}
+
+function parsePositiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function parseCliArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) throw new Error(`Invalid argument near ${key ?? '<end>'}`);
+    values[key.slice(2)] = value;
+  }
+  return {
+    baseUrl: values['base-url'],
+    releaseSha: values['release-sha'],
+    environment: values.environment,
+    attempts: parsePositiveInteger(values.attempts ?? '12', 'attempts'),
+    sleepMs: parsePositiveInteger(values['sleep-ms'] ?? '5000', 'sleep-ms'),
+    timeoutMs: parsePositiveInteger(values['timeout-ms'] ?? '10000', 'timeout-ms'),
+    consecutiveSuccesses: parsePositiveInteger(
+      values['consecutive-successes'] ?? '2',
+      'consecutive-successes',
+    ),
+  };
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const result = await runFinanceReleaseSmoke(options);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/finance/test/worker-release-smoke.test.mjs
+++ b/finance/test/worker-release-smoke.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  normalizeBaseUrl,
+  runFinanceReleaseSmoke,
+  validateEndpointResponse,
+} from '../scripts/worker-release-smoke.mjs';
+
+const releaseSha = 'a'.repeat(40);
+
+function payload(overrides = {}) {
+  return {
+    ok: true,
+    unit: 'finance',
+    version: releaseSha,
+    environment: 'staging',
+    ready: true,
+    dependencies: {
+      d1: { state: 'healthy', required: true },
+      module_control: { state: 'healthy', required: false },
+    },
+    availability: { state: 'active' },
+    ...overrides,
+  };
+}
+
+function response(body, status = 200) {
+  return {
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const silentLogger = { log() {}, error() {} };
+
+test('Finance release smoke accepts only a bare HTTPS Worker origin', () => {
+  assert.equal(normalizeBaseUrl('https://skincos-finance-staging.example.workers.dev/'), 'https://skincos-finance-staging.example.workers.dev');
+  assert.throws(() => normalizeBaseUrl('http://example.test'), /HTTPS origin/);
+  assert.throws(() => normalizeBaseUrl('https://example.test/health'), /HTTPS origin/);
+  assert.throws(() => normalizeBaseUrl('https://user:password@example.test'), /HTTPS origin/);
+});
+
+test('Finance release smoke validates the immutable version and required dependencies', () => {
+  assert.equal(
+    validateEndpointResponse({
+      endpoint: 'readiness',
+      status: 200,
+      payload: payload(),
+      releaseSha,
+      environment: 'staging',
+    }).version,
+    releaseSha,
+  );
+  assert.throws(
+    () => validateEndpointResponse({
+      endpoint: 'health',
+      status: 200,
+      payload: payload({ version: 'b'.repeat(40) }),
+      releaseSha,
+      environment: 'staging',
+    }),
+    /version does not match release SHA/,
+  );
+  assert.throws(
+    () => validateEndpointResponse({
+      endpoint: 'readiness',
+      status: 200,
+      payload: payload({ dependencies: { d1: { state: 'failed' }, module_control: { state: 'healthy' } } }),
+      releaseSha,
+      environment: 'staging',
+    }),
+    /D1 is not healthy/,
+  );
+});
+
+test('Finance release smoke tolerates propagation and requires consecutive healthy samples', async () => {
+  const responses = [
+    response(payload({ version: 'b'.repeat(40) })),
+    response(payload()),
+    response(payload()),
+    response(payload()),
+    response(payload()),
+  ];
+  let sleeps = 0;
+
+  const result = await runFinanceReleaseSmoke(
+    {
+      baseUrl: 'https://skincos-finance-staging.example.workers.dev',
+      releaseSha,
+      environment: 'staging',
+      attempts: 4,
+      sleepMs: 1,
+      timeoutMs: 100,
+      consecutiveSuccesses: 2,
+    },
+    {
+      fetchImpl: async () => responses.shift(),
+      sleep: async () => {
+        sleeps += 1;
+      },
+      logger: silentLogger,
+    },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.attemptsUsed, 3);
+  assert.equal(sleeps, 2);
+  assert.equal(responses.length, 0);
+});
+
+test('Finance release smoke fails closed when the release never converges', async () => {
+  await assert.rejects(
+    runFinanceReleaseSmoke(
+      {
+        baseUrl: 'https://skincos-finance-staging.example.workers.dev',
+        releaseSha,
+        environment: 'staging',
+        attempts: 2,
+        sleepMs: 1,
+        timeoutMs: 100,
+        consecutiveSuccesses: 2,
+      },
+      {
+        fetchImpl: async () => response(payload({ availability: { state: 'disabled' } })),
+        sleep: async () => {},
+        logger: silentLogger,
+      },
+    ),
+    /did not converge.*availability is not active/,
+  );
+});


### PR DESCRIPTION
## Context
Finance staging run 30494465682 deployed version `c100c050-5c50-4b8e-8f0f-9f7dc10292c2` for release `4fd3d6de095a090529dc37fdfd4b000d1b2b4840`, then started its one-shot smoke 183 ms after Wrangler reported success. The first request still observed propagation state and failed, while repeated `/health` and `/readiness` reads 30 seconds later were healthy on the exact release SHA.

## Changes
- replace the immediate one-shot curl with a bounded Finance release smoke;
- require exact SHA, target environment, D1, module-control, active availability and readiness;
- require two consecutive healthy samples within 12 attempts;
- emit only sanitized observations on failure;
- cover URL validation, dependency/version rejection, propagation convergence and fail-closed exhaustion;
- require the convergence smoke in the deploy topology validator.

## Validation
- `node --test finance/test/worker-release-smoke.test.mjs` (4/4);
- clean ext4/WSL `npm --prefix finance test` (56/56) after PR #895;
- live two-sample smoke against Finance staging on `4fd3d6de...`;
- `npm run architecture:validate`;
- deployment topology validator;
- JS security exceptions and no-demo guard;
- `git diff --check`.

## Rollout
Merge without bypass, then repeat Finance preview and staging on the new merge SHA. The staging run must create a fresh encrypted checkpoint, converge on the exact version, publish promotion evidence and pass the authenticated canary chain before any production authorization.

## Rollback
The workflow change is reverted by reverting this PR. The failed staging run preserved encrypted D1 checkpoint artifact `8741082464`; its deployed Worker version is immutable and remains directly replaceable by the canonical rollback operation.