### PR TITLE
fix(livia): pin offline graph replay source

### DIFF
--- a/docs/runbooks/livia-isolated-promotion.md
+++ b/docs/runbooks/livia-isolated-promotion.md
@@ -78,6 +78,23 @@ divergência de legenda é falha causal e deve bloquear Drive, notificações e
 cleanup de sucesso até a evidência do provedor ser reconciliada no verificador
 versionado.
 
+### Replay offline do grafo de publicação
+
+Para conferir uma execução histórica sem chamar o gateway, use o `qa-runner`
+da própria release imutável:
+
+```bash
+sudo node /opt/skincos/releases/<release-40-hex>/source/orb/engine/scripts/livia/qa-runner.js \
+  replay-build-graph --execution '<execution-id>'
+```
+
+O runner fixa `LIVIA_BUILD_JOB_GRAPH_SOURCE` em
+`/opt/skincos/releases/<release-40-hex>/source/orb/engine/compose2-current.js`.
+Ele não pode herdar `/opt/skincos/current`, `ORB_ROOT`, `N8N_ROOT` nem procurar
+o antigo Code node. Confirme no resultado a quantidade/fases dos jobs, a
+`coverUrl` de Instagram e o contrato de acessibilidade de Threads; uma falha
+ou qualquer tentativa de gateway invalida o replay.
+
 ## Rollback de workflow
 
 O rollback é uma nova versão histórica, nunca uma edição do banco nem a

--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -15,6 +15,7 @@ const BUILD_GRAPH_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 
 const VERIFY_PUBLISHED_ARTIFACTS_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'verify-published-artifacts.js');
 const PUBLISH_PROGRESS_LEDGER_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'publish-progress-ledger.js');
 const VALIDATE_PUBLISH_TOKEN_HEALTH_SCRIPT = path.join(runtimePaths.repoRoot, 'scripts', 'livia', 'validate-publish-token-health.js');
+const BUILD_GRAPH_REPLAY_SOURCE = path.join(runtimePaths.repoRoot, 'compose2-current.js');
 const VERIFIER_ENV_KEYS = new Set(['TOKEN_VAULT_BASE_URL', 'TOKEN_VAULT_N8N_API_TOKEN']);
 const VERIFIER_ENV_FILES = [
   '/etc/skincos/orb-business.env',
@@ -216,6 +217,16 @@ function verifierEnvironment({ envFiles = VERIFIER_ENV_FILES, inherited = proces
     if (String(inherited[key] || '').trim()) result[key] = inherited[key];
   }
   return result;
+}
+
+function buildGraphReplayEnvironment(inherited = process.env) {
+  // The production Execute Command node supplies this same immutable source
+  // explicitly. A replay must never fall back to a mutable runtime pointer or
+  // the retired in-workflow Code-node discovery path.
+  return {
+    ...inherited,
+    LIVIA_BUILD_JOB_GRAPH_SOURCE: BUILD_GRAPH_REPLAY_SOURCE,
+  };
 }
 
 function notificationForExecution(runData) {
@@ -948,6 +959,7 @@ function replayBuildGraph(executionId) {
   const result = spawnSync('node', [BUILD_GRAPH_SCRIPT, '--payload', JSON.stringify(payload)], {
     encoding: 'utf8',
     maxBuffer: 50 * 1024 * 1024,
+    env: buildGraphReplayEnvironment(),
   });
   if (result.status !== 0) {
     console.error(result.stdout);
@@ -1038,4 +1050,5 @@ module.exports = {
   notificationForExecution,
   readSelectedEnvironmentFile,
   verifierEnvironment,
+  buildGraphReplayEnvironment,
 };

--- a/orb/engine/tests/livia-qa-runner.test.js
+++ b/orb/engine/tests/livia-qa-runner.test.js
@@ -11,6 +11,7 @@ const {
   driveAuditForExecution,
   notificationForExecution,
   verifierEnvironment,
+  buildGraphReplayEnvironment,
 } = require('../scripts/livia/qa-runner');
 
 test('QA accessibility markers follow the current cross-media contract', () => {
@@ -42,6 +43,17 @@ test('qa audit passes only the selected Token Vault values to the independent ve
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
   }
+});
+
+test('qa replay pins the active bundle compose source instead of inheriting a mutable override', () => {
+  const env = buildGraphReplayEnvironment({
+    LIVIA_BUILD_JOB_GRAPH_SOURCE: '/opt/skincos/current/source/orb/engine/compose2-current.js',
+    OTHER_VALUE: 'preserved',
+  });
+
+  assert.equal(env.LIVIA_BUILD_JOB_GRAPH_SOURCE, path.join(__dirname, '..', 'compose2-current.js'));
+  assert.equal(env.OTHER_VALUE, 'preserved');
+  assert.ok(!env.LIVIA_BUILD_JOB_GRAPH_SOURCE.includes('/opt/skincos/current'));
 });
 
 test('qa audit reads the notification node that actually executed', () => {


### PR DESCRIPTION
## Objetivo
Corrige o replay offline do grafo de publicação do Livia após a externalização do construtor.

## Alteração
- fixa `LIVIA_BUILD_JOB_GRAPH_SOURCE` no `compose2-current.js` da própria release;
- impede herança de ponteiro mutável ou descoberta do Code node aposentado;
- adiciona teste de regressão e instrução operacional para o replay sem gateway.

## Validação
- `node --check scripts/livia/qa-runner.js`
- `npm run livia:qa:test` — 20 testes verdes
- replay offline real da execução 343 — 22 jobs, seis destinos, `cover_url` correlacionada; sem chamada ao gateway.

## Risco e rollback
Mudança somente no runner de QA/replay e documentação; não modifica workflow, credenciais, schedule, ledger ou serviço. Reversível pelo commit anterior; promoção só após checks e revisão.