### PR TITLE
fix(finance): recover staging canary journeys

### DIFF
--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -116,6 +116,7 @@ jobs:
         run: node finance/scripts/staging-import-smoke.mjs --fixture finance/test/fixtures/staging-smoke-import.csv --commit --undo --report "$RUNNER_TEMP/import-report.json"
       - name: Install browser dependencies for isolated shell smoke
         if: steps.canary_open.outcome == 'success'
+        timeout-minutes: 20
         run: |
           npm --prefix crm/console ci
           npm --prefix crm/console exec -- playwright install --with-deps chromium

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -54,6 +54,8 @@ const INSUMOS_OVERVIEW_PERIOD_KEY = 'skincos.insumos.overview.period.v1'
 const INSUMOS_OVERVIEW_FROM_KEY = 'skincos.insumos.overview.from.v1'
 const INSUMOS_OVERVIEW_TO_KEY = 'skincos.insumos.overview.to.v1'
 const INSUMOS_ESTOQUE_THRESHOLDS_KEY = 'skincos.insumos.estoque.thresholds.v1'
+const FINANCE_BOOTSTRAP_MAX_ATTEMPTS = 3
+const FINANCE_BOOTSTRAP_RETRY_DELAY_MS = 750
 // Demo banners are not allowed. Keep the UI strictly real-data oriented.
 
 function fmtMoneyBRLCompact(value: number) {
@@ -325,10 +327,35 @@ export default function AppFunctionalNeatlab() {
 	    const [sidebarHover, setSidebarHover] = useState(false)
 	    React.useEffect(() => {
 	        if (!Array.isArray(user?.allowedModules) || !user.allowedModules.map(String).includes('finance')) { setFinanceEnabled(false); return }
-	        fetch(`${String(import.meta.env.VITE_FINANCE_API_ORIGIN || '/api').replace(/\/$/, '')}/finance/bootstrap`, { credentials: 'include' })
-	            .then((res) => res.ok ? res.json() : null)
-	            .then((payload) => setFinanceEnabled(Boolean(payload?.moduleEnabled && payload?.canAccess)))
-	            .catch(() => setFinanceEnabled(false))
+	        let cancelled = false
+	        let retryTimer: ReturnType<typeof window.setTimeout> | undefined
+	        const bootstrap = async (attempt: number): Promise<void> => {
+	            try {
+	                const response = await fetch(`${String(import.meta.env.VITE_FINANCE_API_ORIGIN || '/api').replace(/\/$/, '')}/finance/bootstrap`, { credentials: 'include' })
+	                if (!response.ok) {
+	                    if (response.status >= 500 && attempt + 1 < FINANCE_BOOTSTRAP_MAX_ATTEMPTS) {
+	                        retryTimer = window.setTimeout(() => { void bootstrap(attempt + 1) }, FINANCE_BOOTSTRAP_RETRY_DELAY_MS)
+	                        return
+	                    }
+	                    if (!cancelled) setFinanceEnabled(false)
+	                    return
+	                }
+	                const payload = await response.json()
+	                if (!cancelled) setFinanceEnabled(Boolean(payload?.moduleEnabled && payload?.canAccess))
+	            } catch {
+	                if (attempt + 1 < FINANCE_BOOTSTRAP_MAX_ATTEMPTS) {
+	                    retryTimer = window.setTimeout(() => { void bootstrap(attempt + 1) }, FINANCE_BOOTSTRAP_RETRY_DELAY_MS)
+	                    return
+	                }
+	                if (!cancelled) setFinanceEnabled(false)
+	            }
+	        }
+	        setFinanceEnabled(false)
+	        void bootstrap(0)
+	        return () => {
+	            cancelled = true
+	            if (retryTimer) window.clearTimeout(retryTimer)
+	        }
 	    }, [allowedModulesKey, user?.allowedModules])
 	    const [sidebarCanHover, setSidebarCanHover] = useState(() => {
 	        try {

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -328,7 +328,7 @@ export default function AppFunctionalNeatlab() {
 	    React.useEffect(() => {
 	        if (!Array.isArray(user?.allowedModules) || !user.allowedModules.map(String).includes('finance')) { setFinanceEnabled(false); return }
 	        let cancelled = false
-	        let retryTimer: ReturnType<typeof window.setTimeout> | undefined
+	        let retryTimer: number | undefined
 	        const bootstrap = async (attempt: number): Promise<void> => {
 	            try {
 	                const response = await fetch(`${String(import.meta.env.VITE_FINANCE_API_ORIGIN || '/api').replace(/\/$/, '')}/finance/bootstrap`, { credentials: 'include' })

--- a/crm/console/e2e/module-shell-isolation.spec.ts
+++ b/crm/console/e2e/module-shell-isolation.spec.ts
@@ -70,3 +70,20 @@ test('a Finance chunk failure does not take down the shell or another module', a
   await expect(page).toHaveURL(/module=insumos/)
   await expect(page.getByRole('heading', { name: 'Insumos' })).toBeVisible({ timeout: 30_000 })
 })
+
+test('a transient Finance bootstrap failure retries without exposing Finance before authorization', async ({ page }) => {
+  await mockAuthenticatedShell(page)
+  let attempts = 0
+  await page.route('**/api/finance/bootstrap**', async (route) => {
+    attempts += 1
+    if (attempts === 1) {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ ok: false, error: 'DEPENDENCY_UNAVAILABLE' }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, moduleEnabled: true, canAccess: true }) })
+  })
+  await page.goto('/?module=finance')
+
+  await expect(page.getByRole('button', { name: 'Financeiro' })).toBeVisible({ timeout: 30_000 })
+  await expect.poll(() => attempts).toBeGreaterThanOrEqual(2)
+})

--- a/crm/console/tests/financeApi.test.ts
+++ b/crm/console/tests/financeApi.test.ts
@@ -134,6 +134,9 @@ describe('Finance transport helpers', () => {
     const app = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8')
     expect(app).toContain("unlockedModuleKeys(financeEnabled ? 'finance' : DEFAULT_MODULE_KEY")
     expect(app).toContain('}, [financeEnabled, initializing])')
+    expect(app).toContain('const FINANCE_BOOTSTRAP_MAX_ATTEMPTS = 3')
+    expect(app).toContain('response.status >= 500')
+    expect(app).toContain('FINANCE_BOOTSTRAP_RETRY_DELAY_MS')
   })
 
   it('keeps the local authorization smoke synchronized with the asynchronous Finance bootstrap gate', () => {

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -175,9 +175,14 @@ try {
       const undo = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/undo`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
       const undoBody = await json(undo);
       loaded = await loadBatch();
-      const movementsCompensated = (loaded.rows || []).filter((row) => row.movement_id).length;
-      if (!loaded.batch?.undone_at || Number(undoBody.undone || 0) < movementsCompensated) throw new Error('import undo did not reach the compensated state');
-      result.undo = { status: undo.status, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch.status, compensatedAt: loaded.batch.undone_at, movementsCompensated };
+      const movementIds = (loaded.rows || []).map((row) => String(row.movement_id || '')).filter(Boolean);
+      const reversed = await Promise.all(movementIds.map(async (movementId) => {
+        const response = await request(`${financePath(`/movements/${encodeURIComponent(movementId)}`)}?scopeId=${encodeURIComponent(scopeId)}`, { headers: authHeaders() });
+        const body = await json(response);
+        return { status: response.status, operationalStatus: body.movement?.operational_status, reversedAt: body.movement?.reversed_at };
+      }));
+      if (!loaded.batch?.undone_at || Number(undoBody.undone || 0) !== movementIds.length || reversed.some((movement) => movement.status !== 200 || movement.operationalStatus !== 'cancelled' || !movement.reversedAt)) throw new Error('import undo did not reach the compensated state');
+      result.undo = { status: undo.status, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch.status, compensatedAt: loaded.batch.undone_at, movementsCompensated: reversed.length };
     }
   }
   result.ok = true;

--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -175,8 +175,9 @@ try {
       const undo = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/undo`)}?scopeId=${encodeURIComponent(scopeId)}`, { method: 'POST', headers: authHeaders(`${key}:undo`), body: JSON.stringify({ reason: 'Controlled staging smoke reversal' }) });
       const undoBody = await json(undo);
       loaded = await loadBatch();
-      if (loaded.batch?.status !== 'undone') throw new Error('import undo did not reach the compensated state');
-      result.undo = { status: undo.status, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch.status, movementsCompensated: (loaded.rows || []).filter((row) => row.movement_id).length };
+      const movementsCompensated = (loaded.rows || []).filter((row) => row.movement_id).length;
+      if (!loaded.batch?.undone_at || Number(undoBody.undone || 0) < movementsCompensated) throw new Error('import undo did not reach the compensated state');
+      result.undo = { status: undo.status, undone: Number(undoBody.undone || 0), replayed: Boolean(undoBody.replayed), batchStatus: loaded.batch.status, compensatedAt: loaded.batch.undone_at, movementsCompensated };
     }
   }
   result.ok = true;

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -29,6 +29,9 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(importer, /body: JSON\.stringify\(analyzePayload\)/);
   assert.match(importer, /analysisBody\?\.ok !== true/);
   assert.doesNotMatch(importer, /analysisBody\.analysis\?\.rows/);
+  assert.match(importer, /loaded\.batch\?\.undone_at/);
+  assert.match(importer, /Number\(undoBody\.undone \|\| 0\) < movementsCompensated/);
+  assert.doesNotMatch(importer, /loaded\.batch\?\.status !== 'undone'/);
   assert.match(remoteFinanceModule, /data-finance-remote-error/);
   assert.match(remoteFinanceModule, /remoteFailureKind\(cause\)/);
   assert.match(financeViteConfig, /'process\.env\.NODE_ENV': '\"production\"'/);

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -30,7 +30,9 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(importer, /analysisBody\?\.ok !== true/);
   assert.doesNotMatch(importer, /analysisBody\.analysis\?\.rows/);
   assert.match(importer, /loaded\.batch\?\.undone_at/);
-  assert.match(importer, /Number\(undoBody\.undone \|\| 0\) < movementsCompensated/);
+  assert.match(importer, /financePath\(`\/movements\/\$\{encodeURIComponent\(movementId\)\}`\)/);
+  assert.match(importer, /movement\.operationalStatus !== 'cancelled'/);
+  assert.match(importer, /Number\(undoBody\.undone \|\| 0\) !== movementIds\.length/);
   assert.doesNotMatch(importer, /loaded\.batch\?\.status !== 'undone'/);
   assert.match(remoteFinanceModule, /data-finance-remote-error/);
   assert.match(remoteFinanceModule, /remoteFailureKind\(cause\)/);


### PR DESCRIPTION
## Context
The staging-only synthetic Finance canary for `291d9359ec1ba669d1775eff35b53d244437b1a1` correctly failed closed, restored its baseline, and exposed two journey defects:

- the import smoke expected a batch `status=undone`, while the audited Worker contract records compensation in `undone_at`;
- a single transient `503` from `/api/finance/bootstrap` permanently hid Finance in the CRM shell even after a subsequent authorized `200`.

## Change
- validate compensation through `undone_at` and the Worker-reported compensated movement count;
- retry only transient bootstrap failures (bounded: 3 attempts / 750ms); keep 401/403 and all final failures fail-closed;
- add the isolated shell regression scenario;
- bound browser-dependency installation to preserve the canary restoration path.

## Validation
- `node --check finance/scripts/staging-import-smoke.mjs`
- `node --test finance/test/staging-smoke-transport.test.mjs`
- `npm --prefix finance run test`
- `npm --prefix crm/console run typecheck`
- `npm --prefix crm/console run lint`
- `npm --prefix crm/console run test`
- `npm --prefix crm/console run build`
- `git diff --check`

No production deploy, flags, grants, users, credentials, or data are changed.