### PR TITLE
fix(finance): retry transient import analysis

### DIFF
--- a/finance/scripts/staging-import-smoke.mjs
+++ b/finance/scripts/staging-import-smoke.mjs
@@ -49,6 +49,14 @@ async function request(path, init = {}) {
   try { return await fetch(`${baseUrl}${path}`, { ...init, signal: timer.signal }); }
   finally { timer.done(); }
 }
+async function retryTransientRequest(path, init, attempts = 3) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await request(path, init);
+    if (response.status < 500 || attempt === attempts) return response;
+    await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+  }
+  throw new Error('unreachable retry state');
+}
 const financePath = (path) => `/api/finance${path}`;
 const json = async (response) => {
   const body = await response.json().catch(() => null);
@@ -125,7 +133,7 @@ try {
       mapping: loaded.batch?.mapping || stagedBody.analysis?.mapping || {},
       encoding: payload.encoding || 'utf-8',
     };
-    const analyzed = await request(`${financePath(`/imports/${encodeURIComponent(batchId)}/analyze`)}?scopeId=${encodeURIComponent(scopeId)}`, {
+    const analyzed = await retryTransientRequest(`${financePath(`/imports/${encodeURIComponent(batchId)}/analyze`)}?scopeId=${encodeURIComponent(scopeId)}`, {
       method: 'POST', headers: authHeaders(`${key}:analyze`), body: JSON.stringify(analyzePayload),
     });
     const analysisBody = await json(analyzed);

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -26,6 +26,8 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(canary, /String\(process\.env\[name\] \?\? ''\)/);
   assert.match(importer, /String\(process\.env\[name\] \?\? ''\)/);
   assert.match(importer, /const analyzePayload = \{[\s\S]*mapping: loaded\.batch\?\.mapping \|\| stagedBody\.analysis\?\.mapping \|\| \{\}/);
+  assert.match(importer, /retryTransientRequest\(`\$\{financePath\(`\/imports\/\$\{encodeURIComponent\(batchId\)\}\/analyze`\)\}/);
+  assert.match(importer, /response\.status < 500 \|\| attempt === attempts/);
   assert.match(importer, /body: JSON\.stringify\(analyzePayload\)/);
   assert.match(importer, /analysisBody\?\.ok !== true/);
   assert.doesNotMatch(importer, /analysisBody\.analysis\?\.rows/);


### PR DESCRIPTION
## Context
The staging synthetic canary for `64b0fbc4d25982df1f5566b6f4241bcaef54eb8b` passed health, authenticated journey, import stage, shell smoke and baseline restoration, but `/imports/{batch}/analyze` received one transient `503 domain_service_degraded`.

## Change
Retry only transient 5xx responses for the idempotent analyze request, reusing its stable idempotency key. Persistent 5xx responses still fail the smoke and the canary remains fail-closed.

## Validation
- `node --check finance/scripts/staging-import-smoke.mjs`
- `node --test finance/test/staging-smoke-transport.test.mjs`
- `git diff --check`

No production resources, flags, grants, users, secrets or data are changed.