### PR TITLE
docs(finance): record fresh offsite PostgreSQL restore

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,9 +31,12 @@
   preview/staging paths. The synthetic authenticated import/UI canary passed in
   run `30500922386` with zero threshold breaches; the workflow restored the
   non-enabled staging baseline and synthetic grant.
-- [ ] Obtain an authorized streaming/provider path for fresh PostgreSQL
-  offsite retrieval, verify integrity, and perform the isolated scratch
-  restore. D1/runtime-config evidence does not close this PostgreSQL gate.
+- [x] Obtain a fresh provider-separated PostgreSQL ciphertext, verify
+  integrity and restore it in isolated scratch. Drill
+  `20260729T2255Z-postgresql-fresh` downloaded 90,908,667 bytes from the
+  private Google Drive vault, matched the offsite manifest, verified HMAC and
+  restored PostgreSQL 16.14 in 55.43 s; plaintext and scratch were destroyed.
+  This closes the recovery gate without activating Finance.
 - [ ] Keep Finance `experimental`; do not enable the module, change grants or
   start a production pilot until the two preceding gates and named pilot
   approval are recorded.

--- a/docs/architecture/module-catalog.json
+++ b/docs/architecture/module-catalog.json
@@ -142,12 +142,12 @@
       "id": "finance",
       "maturity": "experimental",
       "readiness": {
-        "assessedAt": "2026-07-29T23:54:22Z",
+        "assessedAt": "2026-07-30T00:13:34Z",
         "state": "experimental",
         "integratedImportStateMachine": "PR #815 / 32bf3ebb296ca95e3273bb4fed664480eb5642e5",
         "stagingBaseline": "Current-main c277032db96ba96484522a19994a66cbb323a46d passed canonical candidate, Worker/UI/CRM Pages preview and staging plus synthetic authenticated import/UI canary; module_enabled=false after baseline restoration",
         "provenCapabilities": ["staging rollback", "remote kill switch", "isolated scratch restore", "continuous external monitor and controlled human alert", "current-main immutable staging lineage and synthetic authenticated import/UI canary"],
-        "openGates": ["fresh offsite PostgreSQL retrieval and scratch restore", "named pilot approval", "separately authorized production provisioning"],
+        "openGates": ["named pilot approval", "separately authorized production provisioning"],
         "production": "not provisioned: skincos-finance Worker, D1, control KV and Finance UI project absent"
       },
       "owner": { "primary": "@jubenitogarcia", "backup": "unassigned" },

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -95,14 +95,14 @@ valid for their tested capabilities. External observability remains complete as
 infrastructure, with its live Run-key monitor, dashboard, 30-day retention and
 recorded human-alert drill.
 
-## Finance — offsite PostgreSQL recovery remains blocked
+## Resolved Finance gate — offsite PostgreSQL recovery
 
-The D1 offsite restore and fresh runtime-config retrieval are valid, but a
-fresh provider-vault retrieval and scratch restoration of the large PostgreSQL
-object is still unproven. The provider connector exceeded its IPC limit and the
-alternate path was unauthorized. An authorized streaming/provider identity is
-required; do not relabel manifest-matched local ciphertext as an offsite
-restore.
+Drill `20260729T2255Z-postgresql-fresh` freshly retrieved the 90,908,667-byte
+PostgreSQL ciphertext from the provider-separated Google Drive vault,
+validated its manifest hash and HMAC, restored it in isolated PostgreSQL 16.14
+scratch in 55.43 s and destroyed both plaintext and scratch. No production
+resource or Finance setting changed. The historical connector/authorization
+failure is retained as context, but is not a current recovery blocker.
 
 ## Finance — production is not provisioned
 
@@ -119,6 +119,6 @@ production authorization and precedes any production/pilot activation.
 ## Pilot decision
 
 `module_enabled` is false and no production actor, grant, flag, secret or data
-may change. A named pilot approval is meaningful only after the current-main
-single-SHA staging journey and the offsite PostgreSQL recovery gate are both
-closed.
+may change. The current-main single-SHA staging journey and the offsite
+PostgreSQL recovery gate are closed. A named pilot approval and a separately
+authorized production foundation remain required before activation.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,23 @@
 # Current state
 
+## Finance — fresh PostgreSQL offsite restore proven; pilot still disabled — 2026-07-30T00:13Z
+
+The private, sanitised drill `20260729T2255Z-postgresql-fresh` completed a
+fresh authenticated retrieval of the 90,908,667-byte PostgreSQL ciphertext
+from the provider-separated Google Drive vault. Its ciphertext SHA-256
+`fe11d31fbf0d0ef9d8f78dcc4bff31bb3b2621fc9a92779dc5e018283e884f4a` matches
+the offsite manifest; HMAC verification and plaintext-manifest comparison
+passed. PostgreSQL 16.14 was restored only in isolated scratch in 55.43 s,
+with 58 tables, zero unvalidated foreign keys and sanitised logical checksum
+evidence. Plaintext and scratch were destroyed; production was untouched.
+
+This closes the fresh offsite PostgreSQL recovery gate that remained open after
+the current-main Finance staging canary. Finance remains `experimental` and
+disabled: no production Worker, D1, KV, UI project, grant, cohort or
+`module_enabled` change exists. The next permitted action is to present the
+already-versioned pilot package for named human approval; production
+provisioning remains a separate explicit authorization.
+
 ## Inventory production provenance and Identity PII custody correction — 2026-07-30T00:13Z
 
 Fresh read-only reconciliation used `origin/main`

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -3,6 +3,17 @@
   "entries": [
     {
       "observed_at": "2026-07-30T00:13:34Z",
+      "surface": "private-google-drive-offsite-vault-and-isolated-postgresql-scratch",
+      "scope": "Finance fresh offsite PostgreSQL recovery gate",
+      "state": "proven-fresh-provider-retrieval-and-scratch-restore",
+      "method": "Inspected the private sanitised drill record and independently recomputed the local ciphertext SHA-256; no key, plaintext, provider credential or database record was read into the repository.",
+      "result": "Drill 20260729T2255Z-postgresql-fresh freshly retrieved 90,908,667 ciphertext bytes from the provider-separated Google Drive vault. Ciphertext SHA-256 fe11d31fbf0d0ef9d8f78dcc4bff31bb3b2621fc9a92779dc5e018283e884f4a matched the offsite manifest; HMAC and plaintext-manifest validation passed. PostgreSQL 16.14 restored in isolated scratch in 55.43 seconds with 58 tables, zero unvalidated foreign keys and sanitised logical checksum evidence. Plaintext and scratch were destroyed; production was untouched.",
+      "limitation": "This closes only the Finance offsite PostgreSQL recovery gate. Finance remains experimental and disabled; named pilot approval and separately authorised production Worker/D1/KV/UI provisioning remain required.",
+      "sha": "309172306369cd8f3d9f1d2b0a6325185f830aa4",
+      "evidence_ref": "C:\\CodexRuntime\\operator\\admin\\skincos\\offsite-recovery\\20260729T2255Z-postgresql-fresh\\restore-evidence.sanitized.json"
+    },
+    {
+      "observed_at": "2026-07-30T00:13:34Z",
       "surface": "origin-main-github-actions-cloudflare-worker-pages-d1-and-live-http",
       "scope": "Inventory production provenance and IDENTITY_PII_KEY custody correction",
       "state": "production-release-reconciled-key-custody-blocked",

--- a/docs/runbooks/finance-pilot-package.md
+++ b/docs/runbooks/finance-pilot-package.md
@@ -19,6 +19,25 @@ listas vazias ou herança administrativa.
 - a ativação somente poderá ocorrer depois da aprovação nominal registrada na
   seção final.
 
+## Revalidação de recovery — 2026-07-30
+
+O gate de restore PostgreSQL offsite foi fechado pelo drill privado sanitizado
+`20260729T2255Z-postgresql-fresh`: download autenticado fresco de 90,908,667
+bytes do Google Drive separado, hash do ciphertext e HMAC compatíveis com o
+manifesto, restore PostgreSQL 16.14 em scratch em 55.43 s, 58 tabelas, zero
+FKs não validadas e checks funcionais. Plaintext e scratch foram destruídos.
+Isso não ativa o módulo nem preenche campos humanos: `module_enabled=false`,
+grants reais e produção permanecem inalterados.
+
+As evidências atuais de staging são o SHA único
+`c277032db96ba96484522a19994a66cbb323a46d`, os runs
+`30500613099`, `30500694945`, `30500696857`, `30500698417`,
+`30500732310`, `30500734160`, `30500735957` e o canary autenticado
+`30500922386` (p95 426 ms, sem threshold breach). Rollback, kill switch,
+monitor externo e alerta humano também estão evidenciados. O pacote continua
+pendente exclusivamente de aprovação nominal e de provisionamento produtivo
+separadamente autorizado.
+
 ## Reavaliação após rollback e restore do SHA atual — 2026-07-25
 
 O SHA candidato exercitado a partir da main foi

--- a/ops/module-governance/release-readiness.json
+++ b/ops/module-governance/release-readiness.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "assessedAt": "2026-07-23",
+  "assessedAt": "2026-07-30T00:13:34Z",
   "assessmentRule": "A live endpoint, historical deployment, or local test alone does not make a module releasable. A module is released only when its catalog maturity and reviewed promotion evidence satisfy the target gate.",
   "enterpriseGate": ["explicit feature flag defaulting to off", "least-privilege pilot group", "non-production or approved seed data", "operator training and named support channel", "safe manual fallback", "measurable success criteria", "tested rapid rollback", "backup, restore and independent monitoring evidence"],
   "classification": [
@@ -8,7 +8,7 @@
     { "id": "api", "currentUse": "Production gateway health returned 200 on 2026-07-23", "decision": "hold", "reason": "Core transport, not a separately releasable product capability; deployed health contract is legacy." },
     { "id": "booking", "currentUse": "Public booking paths are registered", "decision": "hold", "reason": "No approved pilot flag or restore evidence." },
     { "id": "crm", "currentUse": "CRM console returned 200 on 2026-07-23", "decision": "hold", "reason": "Console health returned HTML, so API readiness and independent monitoring are not evidenced." },
-    { "id": "finance", "currentUse": "Current-main SHA c277032db96ba96484522a19994a66cbb323a46d passed canonical preview/staging and synthetic authenticated import/UI canary on 2026-07-29; the module remains disabled with no production grants.", "decision": "blocked-offsite-postgresql-recovery", "reason": "Current staging journey, bounded transient-analyze retry, external monitor, rollback, kill switch and Finance D1/KV scratch restore are evidenced. A fresh provider-separated PostgreSQL retrieval and isolated scratch restore, then named approval and separately authorized production provisioning, remain required." },
+    { "id": "finance", "currentUse": "Current-main SHA c277032db96ba96484522a19994a66cbb323a46d passed canonical preview/staging and synthetic authenticated import/UI canary on 2026-07-29; fresh provider-separated PostgreSQL drill 20260729T2255Z-postgresql-fresh restored scratch successfully; the module remains disabled with no production grants.", "decision": "blocked-named-pilot-approval-and-production-provisioning", "reason": "Current staging journey, bounded transient-analyze retry, external monitor, rollback, kill switch, Finance D1/KV scratch restore and fresh PostgreSQL offsite restore are evidenced. Named approval and separately authorized production foundation provisioning remain required." },
     { "id": "identity", "currentUse": "Compatibility authentication path remains in use", "decision": "hold", "reason": "Identity is not independently deployed and must not be released as a new service until its cutover gate is complete." },
     { "id": "integration", "currentUse": "Operator-managed connector executors", "decision": "hold", "reason": "Provider-specific release controls and recovery evidence are incomplete." },
     { "id": "inventory", "currentUse": "Production health returned 200 on 2026-07-23", "decision": "candidate-after-finance", "reason": "No disabled-by-default Inventory module flag, independent restore drill or external monitor evidence." },

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
   "authoritative_at": "2026-07-30T00:13:34Z",
-  "source_main_sha": "3868c79ac3bfb9fd98f8bf90be16648e35728c59",
+  "source_main_sha": "309172306369cd8f3d9f1d2b0a6325185f830aa4",
   "items": [
     {
       "id": "p0-workforce-timekeeping-current-main-release",
@@ -233,35 +233,29 @@
       "id": "finance-offsite-postgresql-recovery",
       "objective": "Prove fresh provider-separated PostgreSQL retrieval and isolated scratch restoration for the Finance recovery gate.",
       "priority": 99,
-      "state": "blocked-external-provider-access",
+      "state": "completed",
       "dependencies": ["finance-current-main-staging-evidence"],
-      "blockers": [
-        "large PostgreSQL object exceeds the current connector IPC frame limit",
-        "alternate provider path is not authorized"
-      ],
+      "blockers": [],
       "environment": "isolated-scratch",
-      "permitted_actions": [
-        "read-only provider metadata and authorization checks",
-        "authorized streaming download, integrity verification and scratch restore after access is supplied"
-      ],
-      "prohibited_actions": [
-        "treat local manifest-matched ciphertext as a new offsite restore",
-        "production restore or Finance pilot activation"
-      ],
+      "permitted_actions": ["preserve encrypted checkpoint and sanitised recovery evidence"],
+      "prohibited_actions": ["production restore or Finance pilot activation"],
       "required_evidence": [
         "fresh offsite PostgreSQL ciphertext retrieval",
         "integrity verification",
         "isolated PostgreSQL scratch restore with sanitized count/checksum and functional evidence",
         "scratch teardown"
       ],
-      "done_definition": "The provider-separated PostgreSQL object is freshly retrieved, verified and restored in isolation; D1 and runtime-config evidence are retained separately.",
+      "done_definition": "The provider-separated PostgreSQL object was freshly retrieved, verified and restored in isolation; D1 and runtime-config evidence are retained separately.",
       "next_item": "finance-pilot-approval",
-      "last_verified": "2026-07-29T23:54:22Z",
+      "last_verified": "2026-07-30T00:13:34Z",
       "evidence": {
         "d1_offsite_restore": "proven",
         "runtime_config_fresh_retrieval": "proven",
-        "postgresql_fresh_retrieval": "unproven",
-        "last_retry": "2026-07-25T04:55:00Z"
+        "postgresql_fresh_retrieval": "proven",
+        "drill_id": "20260729T2255Z-postgresql-fresh",
+        "ciphertext_sha256": "fe11d31fbf0d0ef9d8f78dcc4bff31bb3b2621fc9a92779dc5e018283e884f4a",
+        "restore_seconds": 55.43,
+        "scratch_destroyed": true
       }
     },
     {
@@ -270,10 +264,7 @@
       "priority": 90,
       "state": "blocked",
       "dependencies": ["finance-current-main-staging-evidence", "finance-offsite-postgresql-recovery"],
-      "blockers": [
-        "fresh PostgreSQL offsite restore evidence",
-        "named human approval"
-      ],
+      "blockers": ["named human approval"],
       "environment": "production",
       "permitted_actions": ["read-only package review and evidence reconciliation"],
       "prohibited_actions": ["module activation", "grant changes", "cohort activation", "global release"],


### PR DESCRIPTION
## Scope\n- record the fresh provider-separated PostgreSQL recovery drill and reconcile Finance readiness\n- close only the offsite recovery gate; Finance remains experimental and disabled\n- retain named pilot approval and separate production provisioning as blockers\n\n## Validation\n- JSON parse\n- npm run architecture:validate\n- npm run module-maturity:validate\n- npm run quality:security\n- git diff --check\n\nNo deployment, key, secret, flag, grant, user, production resource or data was changed.