### PR TITLE
fix(api): tolerate idempotent Finance cold writes

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -6,14 +6,15 @@ import { createSignedDomainContext } from '../../shared/service-adapters/signed-
 const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
-const FINANCE_OPERATION_TIMEOUT_MS = 3_000;
+const FINANCE_READ_TIMEOUT_MS = 3_000;
+const FINANCE_WRITE_TIMEOUT_MS = 5_000;
 
-function financeServiceTimeout() {
-    // Finance mutations carry mandatory idempotency keys. Give reads and
-    // writes a bounded cold-start window so a completed operation is not
-    // converted into a fabricated gateway 503. The dependency still fails
-    // closed after three seconds or on a real upstream 5xx.
-    return FINANCE_OPERATION_TIMEOUT_MS;
+function financeServiceTimeout(request) {
+    // State-changing Finance routes carry mandatory idempotency keys. Give
+    // write methods a wider, still-bounded D1 cold-start window so a committed
+    // operation is not converted into a fabricated gateway 503. Reads retain
+    // the tighter deadline and every real upstream 5xx still fails closed.
+    return ['GET', 'HEAD'].includes(request.method) ? FINANCE_READ_TIMEOUT_MS : FINANCE_WRITE_TIMEOUT_MS;
 }
 
 export async function forwardFinanceProbe(request, env) {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -191,11 +191,29 @@ test('Finance operations preserve slow successful binding responses but stay bou
   assert.equal(write.status, 200);
 
   resetBoundServiceResilienceForTest();
+  const timedOutRead = await forwardFinanceToService(new Request('https://api.skincos.com.br/audit?scopeId=finance-scope-novo-hamburgo', {
+    headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-read-bounded-timeout' },
+  }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
+    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 3_100)); return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }); } },
+  }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
+  assert.equal(timedOutRead.status, 503);
+
+  resetBoundServiceResilienceForTest();
+  const coldWrite = await forwardFinanceToService(new Request('https://api.skincos.com.br/tags?scopeId=finance-scope-novo-hamburgo', {
+    method: 'POST', headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-write-cold-start' },
+  }), {
+    FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
+    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 3_100)); return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }); } },
+  }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
+  assert.equal(coldWrite.status, 200);
+
+  resetBoundServiceResilienceForTest();
   const timedOut = await forwardFinanceToService(new Request('https://api.skincos.com.br/tags?scopeId=finance-scope-novo-hamburgo', {
     method: 'POST', headers: { cookie: 'session=private', 'x-csrf-token': 'csrf-ok', 'x-request-id': 'finance-write-bounded-timeout' },
   }), {
     FINANCE_SERVICE_AUTH_SECRET: 'finance-secret',
-    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 3_100)); return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }); } },
+    FINANCE: { fetch: async () => { await new Promise((resolve) => setTimeout(resolve, 5_100)); return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }); } },
   }, {}, { actor: { username: 'pilot', allowedModules: ['finance'] }, csrf: 'csrf-ok' });
   assert.equal(timedOut.status, 503);
 });


### PR DESCRIPTION
## Diagnóstico

A verificação pós-abort do Finance staging (`30502801857`) reproduziu um 503 artificial em `synthetic-audit-create`: a escrita idempotente ultrapassou por pouco o deadline uniforme de 3 s do gateway (`3253 ms`). O Worker Finance, o import/undo e a UI permaneceram saudáveis; o kill switch e a restauração do baseline funcionaram.

## Alteração

- mantém leituras Finance limitadas a 3 s;
- amplia somente métodos de escrita para uma janela ainda limitada de 5 s;
- preserva fail-closed para upstream 5xx e para operações acima do novo limite;
- adiciona regressões que distinguem leitura lenta, cold write idempotente e timeout real de escrita.

## Validação

- `node --test api/test/gateway.test.mjs`: 17/17 pass;
- `git diff --check`: pass;
- evidência operacional: canário inicial `30502567022` verde; abort-drill `30502693151` acionou/restaurou corretamente; verify `30502801857` isolou o cold write de 3253 ms.

## Rollout

Após merge, promover o SHA integrado somente em `Deploy Core Worker` com `unit=api` por preview → staging. Reutilizar Finance Worker/UI e CRM staging apenas se a política de linhagem exigir um único SHA; depois repetir verify, abort-drill e verify final antes de qualquer avaliação de produção.

## Rollback

Executar o workflow canônico `Deploy Core Worker` com `unit=api` para o release anterior `3868c79ac3bfb9fd98f8bf90be16648e35728c59` e seu predecessor válido. Nenhum D1, KV, binding, secret ou outra unidade é alterado por este PR.