### PR TITLE
fix(meta): make Contact redirect single-flight

### DIFF
--- a/website/src/components/TrackedWhatsappLink.tsx
+++ b/website/src/components/TrackedWhatsappLink.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import Link, { type LinkProps } from "next/link";
-import { type MouseEventHandler, type ReactNode, useMemo } from "react";
+import {
+    type AnchorHTMLAttributes,
+    type MouseEventHandler,
+    type ReactNode,
+    useMemo,
+} from "react";
 import { buildTrackingContextFromBrowser } from "@/lib/attribution";
 import { trackContactConversion } from "@/lib/conversions";
 import { createMetaEventId } from "@/lib/metaBrowser";
 import { trackEvent } from "@/lib/analytics";
 import { buildWhatsappRedirectHref } from "@/lib/whatsappTracking";
 
-type TrackedWhatsappLinkProps = Omit<LinkProps, "href"> & {
+type TrackedWhatsappLinkProps = Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    "href" | "onClick"
+> & {
     children: ReactNode;
     className?: string;
     rawUrl?: string | null;
@@ -58,7 +65,7 @@ export default function TrackedWhatsappLink({
     );
 
     return (
-        <Link
+        <a
             {...rest}
             href={fallbackHref}
             className={className}
@@ -113,6 +120,6 @@ export default function TrackedWhatsappLink({
             }}
         >
             {children}
-        </Link>
+        </a>
     );
 }

--- a/website/tests/trackedWhatsappLink.test.ts
+++ b/website/tests/trackedWhatsappLink.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("tracked WhatsApp contact uses a native anchor for exactly one redirect request", async () => {
+    const source = await readFile(
+        new URL("../src/components/TrackedWhatsappLink.tsx", import.meta.url),
+        "utf8",
+    );
+
+    assert.equal(source.includes('from "next/link"'), false);
+    assert.equal(source.includes("<a"), true);
+    assert.equal(source.includes("window.location.assign(href)"), true);
+});


### PR DESCRIPTION
## Objetivo

Evita duas navegações concorrentes no clique de WhatsApp. A rota interna de tracking agora usa ancora nativa e mantém a navegação explicita após gerar o event_id e o contexto consentido.

## Evidencia

- reproduzido em produção: dois registros D1 por um clique quando next/link disputava com window.location.assign
- regressão impede reintrodução de next/link no componente
- a suíte completa no branch de fechamento passou 92/92, ESLint e typecheck/build em Node 22.23.1

## Validação pós-deploy

Um único Contact sintético consentido será confrontado entre Pixel Browser e CAPI/D1 pelo mesmo event_id; os registros diagnósticos anteriores já foram removidos.