### PR TITLE
feat(ponto): add private Core rollback baseline

### DIFF
--- a/api/src/router.js
+++ b/api/src/router.js
@@ -40,6 +40,38 @@ function operationalPayload(env, requestId, ready, dependencies) {
     };
 }
 
+function isPontoRouteOnly(env) {
+    return String(env?.PONTO_ROUTE_ONLY || '').trim() === 'true';
+}
+
+function hasTimekeepingBinding(env) {
+    return typeof env?.TIMEKEEPING?.fetch === 'function';
+}
+
+function pontoOperationalPayload(env, requestId, ready, dependencyState) {
+    const metadata = env?.CF_VERSION_METADATA || {};
+    return {
+        ok: Boolean(ready),
+        service: 'ponto-core',
+        unit: 'ponto-core',
+        version: String(env.APP_VERSION || 'unknown'),
+        version_metadata: {
+            id: String(metadata.id || 'unknown'),
+            tag: String(metadata.tag || ''),
+        },
+        environment: String(env.ENVIRONMENT || 'production'),
+        ready: Boolean(ready),
+        dependencies: {
+            timekeeping: {
+                required: true,
+                state: dependencyState,
+            },
+        },
+        request_id: requestId,
+        requestId,
+    };
+}
+
 function operationalLog(env, requestId, status, route) {
     console.log({
         domain: 'api',
@@ -50,6 +82,48 @@ function operationalLog(env, requestId, status, route) {
         status,
         route,
     });
+}
+
+function pontoOperationalLog(env, requestId, status, route) {
+    console.log({
+        domain: 'ponto-core',
+        version: String(env.APP_VERSION || 'unknown'),
+        environment: String(env.ENVIRONMENT || 'production'),
+        request_id: requestId,
+        duration_ms: 0,
+        status,
+        route,
+    });
+}
+
+async function pontoReadiness(request, env, ctx, timekeepingHandler, requestId) {
+    if (!hasTimekeepingBinding(env) || typeof timekeepingHandler !== 'function') {
+        pontoOperationalLog(env, requestId, 503, '/readiness');
+        return json(503, pontoOperationalPayload(env, requestId, false, 'unavailable'), requestId);
+    }
+
+    const probeUrl = new URL(request.url);
+    probeUrl.pathname = '/api/ponto/readiness';
+    probeUrl.search = '';
+    const probe = new Request(probeUrl.toString(), {
+        method: 'GET',
+        headers: {
+            accept: 'application/json',
+            'x-request-id': requestId,
+        },
+    });
+
+    try {
+        const response = await timekeepingHandler(probe, env, ctx);
+        const ready = response.ok;
+        await response.body?.cancel().catch(() => {});
+        const status = ready ? 200 : 503;
+        pontoOperationalLog(env, requestId, status, '/readiness');
+        return json(status, pontoOperationalPayload(env, requestId, ready, ready ? 'healthy' : 'degraded'), requestId);
+    } catch {
+        pontoOperationalLog(env, requestId, 503, '/readiness');
+        return json(503, pontoOperationalPayload(env, requestId, false, 'unavailable'), requestId);
+    }
 }
 
 /**
@@ -65,6 +139,24 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
     return async function handleGatewayRequest(request, env, ctx) {
         const requestId = requestIdFor(request);
         const url = new URL(request.url);
+        const pontoRouteOnly = isPontoRouteOnly(env);
+        const pontoRoute = url.pathname === '/api/ponto' || url.pathname.startsWith('/api/ponto/');
+
+        if (pontoRouteOnly) {
+            if (request.method === 'GET' && url.pathname === '/health') {
+                const configured = hasTimekeepingBinding(env);
+                pontoOperationalLog(env, requestId, 200, '/health');
+                return json(200, pontoOperationalPayload(env, requestId, configured, configured ? 'configured' : 'unavailable'), requestId);
+            }
+
+            if (request.method === 'GET' && url.pathname === '/readiness') {
+                return pontoReadiness(request, env, ctx, timekeepingHandler, requestId);
+            }
+
+            if (!pontoRoute) {
+                return json(404, { ok: false, error: 'ponto_route_only', request_id: requestId, requestId }, requestId);
+            }
+        }
 
         if (url.pathname === '/health') {
             const dependencies = { d1: { required: true, state: env.DB ? 'configured' : 'unavailable' } };
@@ -86,7 +178,7 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
             }
         }
 
-        if (url.pathname === '/api/ponto' || url.pathname.startsWith('/api/ponto/')) {
+        if (pontoRoute) {
             if (typeof timekeepingHandler !== 'function') {
                 return json(503, { ok: false, error: 'workforce_unavailable', requestId }, requestId);
             }

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import { createGatewayHandler } from '../src/router.js';
 import { createApiGateway, forwardFinanceProbe, forwardFinanceToService, handleGatewayRequest } from '../src/gateway.js';
+import pontoCoreWorker from '../workers/ponto.js';
 import { verifySignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 import { resetBoundServiceResilienceForTest } from '../../shared/service-adapters/cloudflare-service-binding.js';
 
@@ -35,6 +37,107 @@ test('readiness proves D1 is available and fails closed when it is not', async (
     const unavailable = await gateway(new Request('https://api.skincos.com.br/readiness'), {}, {});
     assert.equal(unavailable.status, 503);
     assert.equal((await unavailable.json()).ready, false);
+});
+
+test('Ponto route-only health and readiness use only the Timekeeping binding', async () => {
+    const probePaths = [];
+    const isolated = createGatewayHandler({
+        inventoryHandler: async () => new Response('must-not-run'),
+        timekeepingHandler: async (request) => {
+            probePaths.push(new URL(request.url).pathname);
+            return new Response(JSON.stringify({ ok: true, ready: true }), { headers: { 'content-type': 'application/json' } });
+        },
+    });
+    const env = {
+        PONTO_ROUTE_ONLY: 'true',
+        TIMEKEEPING: { fetch: async () => new Response('unused') },
+        APP_VERSION: 'baseline-sha',
+        ENVIRONMENT: 'staging',
+        CF_VERSION_METADATA: { id: 'version-id', tag: 'baseline-tag' },
+    };
+
+    const health = await isolated(new Request('https://ponto-core.invalid/health', { headers: { 'x-request-id': 'ponto-health-1' } }), env, {});
+    assert.equal(health.status, 200);
+    const healthBody = await health.json();
+    assert.equal(healthBody.unit, 'ponto-core');
+    assert.equal(healthBody.ready, true);
+    assert.equal(healthBody.dependencies.timekeeping.state, 'configured');
+    assert.equal(healthBody.dependencies.d1, undefined);
+    assert.deepEqual(healthBody.version_metadata, { id: 'version-id', tag: 'baseline-tag' });
+
+    const readiness = await isolated(new Request('https://ponto-core.invalid/readiness?ignored=true'), env, {});
+    assert.equal(readiness.status, 200);
+    assert.equal((await readiness.json()).dependencies.timekeeping.state, 'healthy');
+    assert.deepEqual(probePaths, ['/api/ponto/readiness']);
+});
+
+test('Ponto route-only readiness fails closed without a healthy Timekeeping service', async () => {
+    const isolated = createGatewayHandler({
+        inventoryHandler: async () => new Response('must-not-run'),
+        timekeepingHandler: async () => new Response(JSON.stringify({ ok: false }), { status: 503 }),
+    });
+    const baseEnv = { PONTO_ROUTE_ONLY: 'true', TIMEKEEPING: { fetch: async () => new Response('unused') } };
+
+    const degraded = await isolated(new Request('https://ponto-core.invalid/readiness'), baseEnv, {});
+    assert.equal(degraded.status, 503);
+    assert.equal((await degraded.json()).dependencies.timekeeping.state, 'degraded');
+
+    const absent = await isolated(new Request('https://ponto-core.invalid/readiness'), { PONTO_ROUTE_ONLY: 'true' }, {});
+    assert.equal(absent.status, 503);
+    assert.equal((await absent.json()).dependencies.timekeeping.state, 'unavailable');
+});
+
+test('Ponto route-only mode denies every non-Ponto and non-probe route before sibling handlers', async () => {
+    let siblingCalls = 0;
+    const isolated = createGatewayHandler({
+        inventoryHandler: async () => { siblingCalls += 1; return new Response('inventory'); },
+        timekeepingHandler: async () => { siblingCalls += 1; return new Response('timekeeping'); },
+        financeHandler: async () => { siblingCalls += 1; return new Response('finance'); },
+    });
+    const env = { PONTO_ROUTE_ONLY: 'true', TIMEKEEPING: { fetch: async () => new Response('unused') } };
+
+    for (const [path, method] of [['/inventory/insumos', 'GET'], ['/finance/health', 'GET'], ['/internal/orb/dispatch', 'POST'], ['/health', 'POST'], ['/unknown', 'GET']]) {
+        const response = await isolated(new Request(`https://ponto-core.invalid${path}`, { method }), env, {});
+        assert.equal(response.status, 404);
+        assert.equal((await response.json()).error, 'ponto_route_only');
+    }
+    assert.equal(siblingCalls, 0);
+});
+
+test('dedicated Ponto entrypoint requires the route-only guard and never exposes sibling mounts', async () => {
+    resetBoundServiceResilienceForTest();
+    let bindingCalls = 0;
+    const binding = { fetch: async () => { bindingCalls += 1; return new Response(JSON.stringify({ ok: true, service: 'workforce-timekeeping' }), { headers: { 'content-type': 'application/json' } }); } };
+
+    const invalid = await pontoCoreWorker.fetch(new Request('https://ponto-core.invalid/api/ponto/health'), { TIMEKEEPING: binding }, {});
+    assert.equal(invalid.status, 503);
+    assert.equal((await invalid.json()).error, 'PONTO_CORE_CONFIG_INVALID');
+    assert.equal(bindingCalls, 0);
+
+    const denied = await pontoCoreWorker.fetch(new Request('https://ponto-core.invalid/inventory/insumos'), { PONTO_ROUTE_ONLY: 'true', TIMEKEEPING: binding }, {});
+    assert.equal(denied.status, 404);
+    assert.equal((await denied.json()).error, 'ponto_route_only');
+    assert.equal(bindingCalls, 0);
+
+    const forwarded = await pontoCoreWorker.fetch(new Request('https://ponto-core.invalid/api/ponto/health'), { PONTO_ROUTE_ONLY: 'true', TIMEKEEPING: binding }, {});
+    assert.equal(forwarded.status, 200);
+    assert.equal((await forwarded.json()).service, 'workforce-timekeeping');
+    assert.equal(bindingCalls, 1);
+});
+
+test('dedicated Ponto Wrangler config has private, independent staging and production services', async () => {
+    const config = await readFile(new URL('../wrangler.ponto.toml', import.meta.url), 'utf8');
+    assert.match(config, /^name = "skincos-ponto-core"$/m);
+    assert.match(config, /^\[env\.staging\]\r?\nname = "skincos-ponto-core-staging"$/m);
+    assert.match(config, /^main = "workers\/ponto\.js"$/m);
+    assert.equal((config.match(/^workers_dev = false$/gm) || []).length, 2);
+    assert.equal((config.match(/^preview_urls = false$/gm) || []).length, 2);
+    assert.equal((config.match(/^PONTO_ROUTE_ONLY = "true"$/gm) || []).length, 2);
+    assert.doesNotMatch(config, /^\s*(?:route|routes)\s*=/m);
+    assert.doesNotMatch(config, /\b(?:d1_databases|durable_objects|r2_buckets)\b/);
+    assert.doesNotMatch(config, /\bbinding = "(?:DB|FINANCE|INVENTORY|BACKUP_BUCKET|RATE_LIMITER|JOB_QUEUE)"\b/);
+    assert.match(config, /service = "skincos-timekeeping"/);
+    assert.match(config, /service = "skincos-timekeeping-staging"/);
 });
 
 test('inventory is mounted without retaining the legacy public prefix', async () => {

--- a/api/workers/ponto.js
+++ b/api/workers/ponto.js
@@ -1,0 +1,39 @@
+import { createGatewayHandler } from '../src/router.js';
+import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
+
+const invalidConfiguration = () => new Response(
+    JSON.stringify({ ok: false, error: 'PONTO_CORE_CONFIG_INVALID' }),
+    {
+        status: 503,
+        headers: {
+            'content-type': 'application/json; charset=utf-8',
+            'cache-control': 'no-store',
+        },
+    },
+);
+
+const handlePontoCoreRequest = createGatewayHandler({
+    // The route-only guard makes this handler unreachable. Keeping an explicit
+    // fail-closed implementation also prevents a future router refactor from
+    // silently restoring an Inventory surface in this dedicated bundle.
+    inventoryHandler: async () => new Response(
+        JSON.stringify({ ok: false, error: 'ponto_route_only' }),
+        {
+            status: 404,
+            headers: {
+                'content-type': 'application/json; charset=utf-8',
+                'cache-control': 'no-store',
+            },
+        },
+    ),
+    timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', { timeoutMs: 800 }),
+});
+
+export default {
+    fetch(request, env, ctx) {
+        if (String(env?.PONTO_ROUTE_ONLY || '').trim() !== 'true') {
+            return invalidConfiguration();
+        }
+        return handlePontoCoreRequest(request, env, ctx);
+    },
+};

--- a/api/wrangler.ponto.toml
+++ b/api/wrangler.ponto.toml
@@ -1,0 +1,42 @@
+name = "skincos-ponto-core"
+main = "workers/ponto.js"
+compatibility_date = "2024-11-20"
+workers_dev = false
+preview_urls = false
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[version_metadata]
+binding = "CF_VERSION_METADATA"
+
+[vars]
+APP_VERSION = "unreleased"
+ENVIRONMENT = "production"
+PONTO_ROUTE_ONLY = "true"
+
+[[services]]
+binding = "TIMEKEEPING"
+service = "skincos-timekeeping"
+
+[env.staging]
+name = "skincos-ponto-core-staging"
+workers_dev = false
+preview_urls = false
+
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1
+
+[env.staging.version_metadata]
+binding = "CF_VERSION_METADATA"
+
+[env.staging.vars]
+APP_VERSION = "unreleased"
+ENVIRONMENT = "staging"
+PONTO_ROUTE_ONLY = "true"
+
+[[env.staging.services]]
+binding = "TIMEKEEPING"
+service = "skincos-timekeeping-staging"


### PR DESCRIPTION
## Summary
- add a dedicated private Ponto Core Worker entrypoint and independent staging/production configs
- expose only `/api/ponto`, `/health`, and `/readiness`; all sibling API routes fail closed
- bind only to Timekeeping and retain Cloudflare version metadata for immutable release evidence
- establish a no-traffic rollback baseline before the coordinated Ponto candidate release

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (deferred to the coordinated release evidence PR)
- [x] Security boundary reviewed locally
- [x] No route, workers.dev, preview URL, D1, Finance, or Inventory exposure

## Validation
- Ubuntu-24.04: `node --test api/test/gateway.test.mjs` — 22/22 passed
- Wrangler 4.112.0 dry-run — production and staging passed
- `git diff --check` — clean

## Release boundary
This PR does not deploy or enable Ponto. It creates the private, no-traffic baseline needed for an independently attested rollback target. Production remains fail-closed.

## Links
- Predecessor documentation PR: #894
- Candidate source ancestry starts from main `790070968160eb5606225396ec35b65e8aca4651`