### PR TITLE
fix(site): protect WhatsApp redirect query envelope

### DIFF
--- a/website/src/app/api/whatsapp/redirect/route.ts
+++ b/website/src/app/api/whatsapp/redirect/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getBookingDb, coerceTrackingContext, insertMetaCapiDeliveryLog, insertWhatsappClickEvent, nowMs, parseCookieHeader, sanitizeOneLine } from "@/lib/bookingDb";
 import { sendMetaServerEvent } from "@/lib/metaConversionsApi";
-import { buildWhatsappClickToken, expandWhatsappTrackingContext, injectWhatsappToken, parseWhatsappDestination } from "@/lib/whatsappTracking";
+import { buildWhatsappClickToken, decodeWhatsappRedirectQueryValue, expandWhatsappTrackingContext, injectWhatsappToken, parseWhatsappDestination } from "@/lib/whatsappTracking";
 
 export const dynamic = "force-dynamic";
 
@@ -22,13 +22,18 @@ function clientIp(request: Request): string | null {
 
 export async function GET(request: Request) {
     const url = new URL(request.url);
-    const rawDestination = (url.searchParams.get("dest") ?? "").trim();
+    const rawDestination = decodeWhatsappRedirectQueryValue(
+        (url.searchParams.get("dest") ?? "").trim(),
+    );
     const parsedDestination = parseWhatsappDestination(rawDestination);
     if (!parsedDestination) {
         return NextResponse.json({ ok: false, error: "invalid_destination" }, { status: 400 });
     }
 
-    const rawContext = url.searchParams.get("ctx");
+    const rawContextParam = url.searchParams.get("ctx");
+    const rawContext = rawContextParam
+        ? decodeWhatsappRedirectQueryValue(rawContextParam)
+        : null;
     let trackingContext = null;
     if (rawContext) {
         try {
@@ -57,8 +62,14 @@ export async function GET(request: Request) {
     const unitSlug = sanitizeOneLine(url.searchParams.get("unit_slug") ?? "") || null;
     const doctorName = sanitizeOneLine(url.searchParams.get("doctor_name") ?? "") || null;
     const bookingId = sanitizeOneLine(url.searchParams.get("booking_id") ?? "") || null;
-    const pageUrl = sanitizeOneLine(url.searchParams.get("page_url") ?? "") || trackingContextResolved?.pageUrl || null;
-    const pagePath = sanitizeOneLine(url.searchParams.get("page_path") ?? "") || trackingContextResolved?.pagePath || null;
+    const rawPageUrl = url.searchParams.get("page_url");
+    const rawPagePath = url.searchParams.get("page_path");
+    const pageUrl = sanitizeOneLine(
+        rawPageUrl ? decodeWhatsappRedirectQueryValue(rawPageUrl) : "",
+    ) || trackingContextResolved?.pageUrl || null;
+    const pagePath = sanitizeOneLine(
+        rawPagePath ? decodeWhatsappRedirectQueryValue(rawPagePath) : "",
+    ) || trackingContextResolved?.pagePath || null;
     const clientUserAgent = sanitizeOneLine(request.headers.get("user-agent") ?? "") || null;
 
     const destinationUrl = new URL(parsedDestination.destinationUrl);

--- a/website/src/lib/whatsappTracking.ts
+++ b/website/src/lib/whatsappTracking.ts
@@ -16,6 +16,27 @@ export type WhatsappTrackingPayload = {
 
 const WHATSAPP_HOSTS = new Set(["wa.me", "api.whatsapp.com", "chat.whatsapp.com"]);
 const MAX_WHATSAPP_REDIRECT_HREF_LENGTH = 2_000;
+const OPAQUE_QUERY_VALUE_PREFIX = "u1.";
+
+export function encodeWhatsappRedirectQueryValue(value: string): string {
+    return `${OPAQUE_QUERY_VALUE_PREFIX}${encodeURIComponent(value)}`;
+}
+
+export function decodeWhatsappRedirectQueryValue(value: string): string {
+    if (!value.startsWith(OPAQUE_QUERY_VALUE_PREFIX)) return value;
+
+    const payload = value.slice(OPAQUE_QUERY_VALUE_PREFIX.length);
+    // Cloudflare/OpenNext may normalize the outer query once before the route
+    // constructs request.url. In that case the protected value is already
+    // decoded, while direct/local requests still carry the encoded payload.
+    if (/^(?:https?:\/\/|\/|\{|\[)/i.test(payload)) return payload;
+
+    try {
+        return decodeURIComponent(payload);
+    } catch {
+        return payload;
+    }
+}
 
 function normalizeUrl(value: string | null | undefined): string | null {
     const trimmed = (value ?? "").trim();
@@ -221,7 +242,7 @@ export function buildWhatsappRedirectHref(params: {
     if (!isSupportedWhatsappUrl(destinationUrl)) return null;
 
     const url = new URL("/api/whatsapp/redirect", "https://espacofacial.com");
-    url.searchParams.set("dest", destinationUrl);
+    url.searchParams.set("dest", encodeWhatsappRedirectQueryValue(destinationUrl));
 
     const tracking = params.tracking;
     if (tracking?.eventId) url.searchParams.set("event_id", tracking.eventId);
@@ -229,11 +250,20 @@ export function buildWhatsappRedirectHref(params: {
     if (tracking?.unitSlug) url.searchParams.set("unit_slug", tracking.unitSlug);
     if (tracking?.doctorName) url.searchParams.set("doctor_name", tracking.doctorName);
     if (tracking?.source) url.searchParams.set("source", tracking.source);
-    if (tracking?.pageUrl && !tracking.trackingContext) url.searchParams.set("page_url", tracking.pageUrl);
-    if (tracking?.pagePath && !tracking.trackingContext) url.searchParams.set("page_path", tracking.pagePath);
+    if (tracking?.pageUrl && !tracking.trackingContext) {
+        url.searchParams.set("page_url", encodeWhatsappRedirectQueryValue(tracking.pageUrl));
+    }
+    if (tracking?.pagePath && !tracking.trackingContext) {
+        url.searchParams.set("page_path", encodeWhatsappRedirectQueryValue(tracking.pagePath));
+    }
     if (tracking?.bookingId) url.searchParams.set("booking_id", tracking.bookingId);
     if (tracking?.trackingContext) {
-        url.searchParams.set("ctx", JSON.stringify(compactTrackingContext(tracking.trackingContext)));
+        url.searchParams.set(
+            "ctx",
+            encodeWhatsappRedirectQueryValue(
+                JSON.stringify(compactTrackingContext(tracking.trackingContext)),
+            ),
+        );
     }
 
     const redirectHref = `${url.pathname}${url.search}`;
@@ -245,8 +275,12 @@ export function buildWhatsappRedirectHref(params: {
     // attribution envelope is too large to transport reliably. Without ctx,
     // server-side CAPI remains fail-closed.
     url.searchParams.delete("ctx");
-    if (tracking?.pageUrl) url.searchParams.set("page_url", tracking.pageUrl);
-    if (tracking?.pagePath) url.searchParams.set("page_path", tracking.pagePath);
+    if (tracking?.pageUrl) {
+        url.searchParams.set("page_url", encodeWhatsappRedirectQueryValue(tracking.pageUrl));
+    }
+    if (tracking?.pagePath) {
+        url.searchParams.set("page_path", encodeWhatsappRedirectQueryValue(tracking.pagePath));
+    }
     const correlatedFallbackHref = `${url.pathname}${url.search}`;
     if (correlatedFallbackHref.length <= MAX_WHATSAPP_REDIRECT_HREF_LENGTH) {
         return correlatedFallbackHref;

--- a/website/tests/whatsappTracking.test.ts
+++ b/website/tests/whatsappTracking.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import type { TrackingContext } from "../src/lib/attribution";
 import { CADASTRO_WHEEL_PRIZES } from "../src/lib/cadastroWheelPrizes";
 import { buildWhatsAppUrl } from "../src/lib/whatsapp";
-import { buildWhatsappRedirectHref, buildWhatsappRedirectHrefFromRequest, buildWhatsappClickToken, expandWhatsappTrackingContext, injectWhatsappToken, parseWhatsappDestination } from "../src/lib/whatsappTracking";
+import { buildWhatsappRedirectHref, buildWhatsappRedirectHrefFromRequest, buildWhatsappClickToken, decodeWhatsappRedirectQueryValue, expandWhatsappTrackingContext, injectWhatsappToken, parseWhatsappDestination } from "../src/lib/whatsappTracking";
 
 test("buildWhatsappRedirectHref wraps supported whatsapp destination with tracking params", () => {
     const href = buildWhatsappRedirectHref({
@@ -17,10 +17,14 @@ test("buildWhatsappRedirectHref wraps supported whatsapp destination with tracki
         },
     });
 
+    assert.ok(href);
+    const redirectUrl = new URL(href, "https://espacofacial.com");
     assert.equal(
-        href,
-        "/api/whatsapp/redirect?dest=https%3A%2F%2Fwa.me%2F5551999999999%3Ftext%3DOi&event_id=contact_evt_1&placement=booking_confirmation&unit_slug=novo-hamburgo&source=booking_confirmation&booking_id=req_123",
+        decodeWhatsappRedirectQueryValue(redirectUrl.searchParams.get("dest") ?? ""),
+        "https://wa.me/5551999999999?text=Oi",
     );
+    assert.equal(redirectUrl.searchParams.get("event_id"), "contact_evt_1");
+    assert.equal(redirectUrl.searchParams.get("booking_id"), "req_123");
 });
 
 test("parseWhatsappDestination extracts phone and text from api.whatsapp.com", () => {
@@ -43,9 +47,11 @@ test("buildWhatsappRedirectHrefFromRequest preserves attribution params on the d
         },
     });
 
+    assert.ok(href);
+    const redirectUrl = new URL(href, "https://espacofacial.com");
     assert.equal(
-        href,
-        "/api/whatsapp/redirect?dest=https%3A%2F%2Fapi.whatsapp.com%2Fsend%3Fphone%3D5551999999999%26text%3DOi%26utm_source%3Dmeta%26utm_campaign%3Dabril%26fbclid%3Dfbclid_123&placement=legacy_redirect&unit_slug=novo-hamburgo&source=legacy_redirect%3A%2Fnovohamburgo%2Ffaleconosco",
+        decodeWhatsappRedirectQueryValue(redirectUrl.searchParams.get("dest") ?? ""),
+        "https://api.whatsapp.com/send?phone=5551999999999&text=Oi&utm_source=meta&utm_campaign=abril&fbclid=fbclid_123",
     );
 });
 
@@ -120,7 +126,9 @@ test("campaign-rich Contact redirect keeps consent and matching context within a
     assert.equal(redirectUrl.searchParams.has("page_url"), false);
     assert.equal(redirectUrl.searchParams.has("page_path"), false);
 
-    const compactContext = JSON.parse(redirectUrl.searchParams.get("ctx") ?? "null") as TrackingContext;
+    const compactContext = JSON.parse(
+        decodeWhatsappRedirectQueryValue(redirectUrl.searchParams.get("ctx") ?? "null"),
+    ) as TrackingContext;
     assert.equal(Object.hasOwn(compactContext, "l"), false);
     assert.equal(Object.hasOwn(compactContext, "h"), false);
     const transportedContext = expandWhatsappTrackingContext(compactContext) as TrackingContext;
@@ -132,6 +140,25 @@ test("campaign-rich Contact redirect keeps consent and matching context within a
     assert.equal(transportedContext.landingUrl, trackingContext.landingUrl);
     assert.deepEqual(transportedContext.firstTouch, trackingContext.firstTouch);
     assert.deepEqual(transportedContext.lastTouch, trackingContext.lastTouch);
+
+    const onceNormalizedUrl = new URL(
+        decodeURIComponent(href),
+        "https://espacofacial.com",
+    );
+    assert.equal(
+        decodeWhatsappRedirectQueryValue(onceNormalizedUrl.searchParams.get("dest") ?? ""),
+        "https://api.whatsapp.com/send?phone=5551980882293",
+    );
+    assert.deepEqual(
+        expandWhatsappTrackingContext(
+            JSON.parse(
+                decodeWhatsappRedirectQueryValue(
+                    onceNormalizedUrl.searchParams.get("ctx") ?? "null",
+                ),
+            ),
+        ),
+        trackingContext,
+    );
 
     for (const prize of CADASTRO_WHEEL_PRIZES) {
         const prizeHref = buildWhatsappRedirectHref({
@@ -190,10 +217,19 @@ test("buildWhatsappRedirectHref keeps internal correlation without ctx when the 
     assert.ok(href);
     assert.ok(href.startsWith("/api/whatsapp/redirect?"));
     const fallbackUrl = new URL(href, "https://espacofacial.com");
-    assert.equal(fallbackUrl.searchParams.get("dest"), destination);
+    assert.equal(
+        decodeWhatsappRedirectQueryValue(fallbackUrl.searchParams.get("dest") ?? ""),
+        destination,
+    );
     assert.equal(fallbackUrl.searchParams.get("event_id"), "contact_transport_fallback");
-    assert.equal(fallbackUrl.searchParams.get("page_url"), pageUrl);
-    assert.equal(fallbackUrl.searchParams.get("page_path"), pagePath);
+    assert.equal(
+        decodeWhatsappRedirectQueryValue(fallbackUrl.searchParams.get("page_url") ?? ""),
+        pageUrl,
+    );
+    assert.equal(
+        decodeWhatsappRedirectQueryValue(fallbackUrl.searchParams.get("page_path") ?? ""),
+        pagePath,
+    );
     assert.equal(fallbackUrl.searchParams.has("ctx"), false);
     assert.ok(href.length <= 2_000);
 });


### PR DESCRIPTION
## Contexto

A normalização de query no runtime Cloudflare/OpenNext consumia uma camada de percent-encoding antes da rota. Valores internos de \dest\ e \ctx\ com \&\ eram então reinterpretados como parâmetros externos: a mensagem do WhatsApp era truncada e o contexto de consentimento/atribuição chegava nulo, mantendo a CAPI fail-closed.

## Alteração

- protege somente valores opacos do redirect com envelope versionado e uma camada URI adicional;
- decodifica tanto o request direto/local quanto o request já normalizado pelo edge;
- mantém compatibilidade com URLs legadas sem envelope;
- cobre destino, contexto e fallback de página;
- adiciona regressão que simula uma normalização prévia completa da query.

## Validação local limpa

- \
pm test\: 87/87
- \
pm run lint\: OK
- \
pm run typecheck\: OK (inclui build de produção)

Não altera Pixel, tokens, secrets nem a política fail-closed de consentimento.