### PR TITLE
feat(crm): modularize and isolate local CRM runtimes

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,34 +8,29 @@ script = ""
 [[actions]]
 name = "Workspace"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action WorkspaceMenu"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action WorkspaceMenu"
 
 [[actions]]
 name = "Contexto"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action ContextMenu"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action ContextMenu"
 
 [[actions]]
-name = "Local"
+name = "CRM – Local"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action LocalMenu"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action CrmLocal"
 
 [[actions]]
-name = "CRM – Local (Gestor)"
+name = "CRM – Módulos"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmLocal"
-
-[[actions]]
-name = "CRM – Consultor (Ponto)"
-icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action CrmConsultor"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action CrmModules"
 
 [[actions]]
 name = "EF App"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action EfAppMenu"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action EfAppMenu"
 
 [[actions]]
 name = "Orb"
 icon = "run"
-command = "powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run-shared-codex-shortcut.ps1 -Action OrbMenu"
+command = "powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action OrbMenu"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Plataforma interna (local) para automações e operações da clínica.
   - `REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET=true`
 
 ### Testar CRM local
+- No Codex App/Windows, use `CRM – Local` para o CRM completo ou `CRM – Módulos` para escolher diretamente papel e módulo.
+- O catálogo modular, a matriz de papéis, o isolamento e os comandos explícitos estão em `docs/runbooks/crm-local-modular.md`.
 - Launcher recomendado: `npm run crm:local`
 - Atalho direto para o módulo Meta Ads: `npm run crm:local:meta-ads`
 - Atalho direto para o módulo Site EF: `npm run crm:local:site-tracking`
@@ -94,7 +96,9 @@ Plataforma interna (local) para automações e operações da clínica.
   - sobe o CRM via `Pages Functions` local (`crm/console/scripts/dev_pages.sh`)
   - ativa bypass local de auth apenas em `localhost`
   - preserva os módulos que já suportam leitura real com segurança, como `Escala`
-  - os atalhos `CRM Local`, `Site EF` e `Meta Ads` usam um worktree privado, destacado em `origin/main`. Alterações não integradas no checkout aberto não são carregadas no runtime local.
+  - cada ação materializa uma fonte privada identificada pelo snapshot exato; uma prévia explicitamente selecionada inclui suas alterações locais sem modificar o checkout compartilhado.
+  - cada combinação módulo × papel possui portas, manifesto/PIDs, logs, estado, registry Wrangler e perfil de navegador próprios em `C:\CodexRuntime\operator\admin\skincos`.
+  - o build é alinhado automaticamente ao lockfile e às impressões determinísticas de código, configuração e assets; uma segunda execução idêntica reutiliza somente a instância comprovadamente saudável.
   - o primeiro uso do gate local instala o Chromium do Playwright; o CRM não inicia se a smoke obrigatória não puder ser executada.
   - no perfil genérico, o launcher inicia o `workforce/timekeeping` local, aplica suas migrations e faz o proxy do Ponto assinar requests com uma chave local de teste; nenhum secret de produção é copiado para o ambiente local.
 - Para testar a sessão real sem bypass: `CRM_PROFILE=session npm run crm:local`

--- a/backend/scripts/insumos.sh
+++ b/backend/scripts/insumos.sh
@@ -39,13 +39,131 @@ ensure_insumos_exists() {
 }
 
 ensure_insumos_deps() {
-  if [[ ! -d "$INSUMOS_DIR/node_modules" ]]; then
-    echo "[insumos] Installing inventory Worker dependencies from the locked graph (pnpm)..."
-    if ! install_node_deps "$INSUMOS_DIR" ci; then
-      echo "[insumos] Inventory Worker dependency installation failed; refusing to continue with an incomplete workspace." >&2
-      exit 1
-    fi
+  local lockfile="$INSUMOS_DIR/pnpm-lock.yaml"
+  local state_file="${CRM_INSUMOS_DEPENDENCY_STATE_FILE:-$INSUMOS_DIR/node_modules/.skincos-pnpm-lock.sha256}"
+  local install_lock="${CRM_INSUMOS_DEPENDENCY_LOCK_FILE:-$INSUMOS_DIR/.skincos-dependencies.lock}"
+  local cache_root="${CRM_INSUMOS_DEPENDENCY_CACHE_ROOT:-}"
+  local lock_hash
+  local manifest_hash
+  local dependency_key
+  if [[ ! -f "$lockfile" ]]; then
+    echo "[insumos] pnpm-lock.yaml not found at $lockfile" >&2
+    exit 1
   fi
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "[insumos] flock is required to publish the locked dependency graph safely." >&2
+    exit 1
+  fi
+  lock_hash="$(sha256sum "$lockfile" | awk '{print $1}')"
+  manifest_hash="$(sha256sum "$INSUMOS_DIR/package.json" | awk '{print $1}')"
+  if [[ ! "$lock_hash" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "[insumos] Could not fingerprint the locked dependency graph." >&2
+    exit 1
+  fi
+  if [[ ! "$manifest_hash" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "[insumos] Could not fingerprint the dependency manifest." >&2
+    exit 1
+  fi
+  dependency_key="$(
+    printf 'package.json:%s\npnpm-lock.yaml:%s\n' "$manifest_hash" "$lock_hash" |
+      sha256sum |
+      awk '{print $1}'
+  )"
+  if [[ ! "$dependency_key" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "[insumos] Could not fingerprint the complete dependency contract." >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$state_file")" "$(dirname "$install_lock")"
+  (
+    exec 9>"$install_lock"
+    flock 9
+
+    local recorded_key=""
+    [[ -f "$state_file" ]] && recorded_key="$(tr -d '\r\n' < "$state_file")"
+
+    if [[ -z "$cache_root" ]]; then
+      if [[ ! -x "$INSUMOS_DIR/node_modules/.bin/wrangler" || "$recorded_key" != "$dependency_key" ]]; then
+        echo "[insumos] Aligning inventory Worker dependencies with the locked graph (pnpm)..."
+        if ! install_node_deps "$INSUMOS_DIR" ci ||
+           [[ ! -x "$INSUMOS_DIR/node_modules/.bin/wrangler" ]]; then
+          echo "[insumos] Inventory Worker dependency installation failed; refusing to continue with an incomplete workspace." >&2
+          exit 1
+        fi
+      fi
+    else
+      mkdir -p "$cache_root"
+      local cache_dir="$cache_root/$dependency_key"
+      local ready_file="$cache_dir/.skincos-dependency-key.sha256"
+      local expected_modules="$cache_dir/node_modules"
+      local quarantine_root="$cache_root/quarantine"
+      local source_modules="$INSUMOS_DIR/node_modules"
+      local source_modules_target=""
+      local temporary=""
+      local stale_candidate
+
+      mkdir -p "$quarantine_root"
+      shopt -s nullglob
+      for stale_candidate in "$cache_root"/."$dependency_key".tmp.*; do
+        local quarantine_candidate="$quarantine_root/$(basename "$stale_candidate").$(date +%Y%m%d-%H%M%S).$$"
+        mv -- "$stale_candidate" "$quarantine_candidate"
+        echo "[insumos] Preserved an interrupted dependency candidate at $quarantine_candidate." >&2
+      done
+      shopt -u nullglob
+
+      if [[ ( -e "$cache_dir" || -L "$cache_dir" ) &&
+            ( ! -x "$expected_modules/.bin/wrangler" ||
+              ! -f "$ready_file" ||
+              "$(tr -d '\r\n' < "$ready_file" 2>/dev/null || true)" != "$dependency_key" ) ]]; then
+        if [[ -L "$source_modules" ]]; then
+          source_modules_target="$(readlink -f "$source_modules" 2>/dev/null || true)"
+        fi
+        if [[ "$source_modules_target" == "$expected_modules" ]]; then
+          echo "[insumos] Published dependency cache is incomplete but may still be in use; refusing to move it." >&2
+          exit 1
+        fi
+        local quarantine_cache="$quarantine_root/${dependency_key}.$(date +%Y%m%d-%H%M%S).$$"
+        mv -- "$cache_dir" "$quarantine_cache"
+        echo "[insumos] Preserved an incomplete unpublished dependency cache at $quarantine_cache." >&2
+      fi
+
+      if [[ ! -d "$cache_dir" ]]; then
+        temporary="$(mktemp -d "$cache_root/.${dependency_key}.tmp.XXXXXX")"
+        if ! cp -- "$INSUMOS_DIR/package.json" "$lockfile" "$temporary/" ||
+           ! install_node_deps "$temporary" ci ||
+           [[ ! -x "$temporary/node_modules/.bin/wrangler" ]]; then
+          echo "[insumos] Inventory Worker dependency installation failed; the unpublished candidate will be quarantined on retry." >&2
+          exit 1
+        fi
+        printf '%s\n' "$dependency_key" > "$temporary/.skincos-dependency-key.sha256"
+        mv -- "$temporary" "$cache_dir"
+        temporary=""
+      fi
+
+      if [[ -e "$source_modules" || -L "$source_modules" ]]; then
+        if [[ ! -L "$source_modules" ||
+              "$(readlink -f "$source_modules" 2>/dev/null || true)" != "$expected_modules" ]]; then
+          echo "[insumos] inventory/node_modules is not the expected private cache link; refusing to replace a tree that may be in use." >&2
+          exit 1
+        fi
+      else
+        local source_link="${source_modules}.crm-local.$$"
+        ln -s "$expected_modules" "$source_link"
+        if ! mv -T -- "$source_link" "$source_modules" 2>/dev/null; then
+          rm -f -- "$source_link"
+          if [[ ! -L "$source_modules" ||
+                "$(readlink -f "$source_modules" 2>/dev/null || true)" != "$expected_modules" ]]; then
+            echo "[insumos] Another launcher published an incompatible dependency link." >&2
+            exit 1
+          fi
+        fi
+      fi
+    fi
+
+    local state_tmp="${state_file}.tmp.$$"
+    printf '%s\n' "$dependency_key" > "$state_tmp"
+    mv -f "$state_tmp" "$state_file"
+  )
 }
 
 cmd=${1:-help}

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -34,6 +34,7 @@ import { createTrackingDashboardRouter } from './server/trackingDashboardRoutes.
 import { createAtendimentoRouter } from './server/atendimento/routes.js'
 import { createCaixaRouter } from './server/caixa/routes.js'
 import { configuredCorsOrigins, isAllowedCrmCorsOrigin } from './server/corsPolicy.js'
+import { effectiveAllowedModules, normalizeCrmRole as normalizeRole } from './server/crmRolePolicy.js'
 import { resolveEvolutionMediaUrl } from './server/whatsappMediaUrl.js'
 
 // Axios for facade requests to Unified System
@@ -610,25 +611,6 @@ if (DEV_AUTH_ENABLED) {
 const VISUAL_THEME_FILE = process.env.CRM_VISUAL_THEME_FILE || path.join(CORE_STATE_DIR, 'visual_theme.v1.json')
 let visualThemeState = { themes: {} }
 let saveVisualThemeTimer = null
-
-const ROLE_ALIASES = new Map([
-    ['ADMIN', 'GESTOR'],
-    ['OPERADOR', 'INJETOR'],
-    ['RH', 'SUPERVISOR'],
-    ['AUDITOR', 'SUPERVISOR'],
-    ['EMPLOYEE', 'CONSULTOR'],
-])
-
-const normalizeRole = (value) => {
-    const raw = String(value || '').trim().toUpperCase()
-    if (!raw) return ''
-    return ROLE_ALIASES.get(raw) || raw
-}
-
-const effectiveAllowedModules = (role, allowedModules) => {
-    if (normalizeRole(role) === 'CONSULTOR') return ['atendimento']
-    return Array.isArray(allowedModules) ? allowedModules.map((x) => String(x)).filter(Boolean) : []
-}
 
 const normalizeCrmUser = (user) => {
     if (!user || typeof user !== 'object') return user

--- a/crm/api/server/__tests__/crmRolePolicy.test.js
+++ b/crm/api/server/__tests__/crmRolePolicy.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  crmRolePolicy,
+  effectiveAllowedModules,
+  normalizeCrmRole,
+  validateCrmRolePolicy,
+} from '../crmRolePolicy.js'
+
+test('uses the canonical aliases and fixed Consultant grants', () => {
+  for (const [alias, role] of Object.entries(crmRolePolicy.roleAliases)) {
+    assert.equal(normalizeCrmRole(alias), role)
+  }
+  assert.deepEqual(
+    effectiveAllowedModules('CONSULTOR', ['insumos', 'atendimento', 'status']),
+    crmRolePolicy.fixedModuleGrants.CONSULTOR,
+  )
+  assert.deepEqual(
+    effectiveAllowedModules('EMPLOYEE', []),
+    crmRolePolicy.fixedModuleGrants.CONSULTOR,
+  )
+})
+
+test('preserves normalized explicit grants for roles without a fixed policy', () => {
+  assert.deepEqual(
+    effectiveAllowedModules('GESTOR', ['insumos', ' insumos ', '', 'ponto']),
+    ['insumos', 'ponto'],
+  )
+})
+
+test('fails closed when fixed grants exceed the restricted role policy', () => {
+  const policy = structuredClone(crmRolePolicy)
+  policy.fixedModuleGrants.CONSULTOR.push('insumos')
+  assert.throws(
+    () => validateCrmRolePolicy(policy),
+    /CRM_ROLE_POLICY_FIXED_GRANTS_OUTSIDE_POLICY:CONSULTOR/,
+  )
+})

--- a/crm/api/server/crmRolePolicy.js
+++ b/crm/api/server/crmRolePolicy.js
@@ -1,0 +1,70 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_POLICY_FILE = fileURLToPath(
+  new URL('../../console/modules/localRolePolicy.json', import.meta.url),
+)
+
+function stringArray(value, code) {
+  if (!Array.isArray(value)) throw new Error(code)
+  const normalized = value.map((entry) => String(entry || '').trim())
+  if (normalized.some((entry) => !entry) || new Set(normalized).size !== normalized.length) {
+    throw new Error(code)
+  }
+  return normalized
+}
+
+export function validateCrmRolePolicy(value) {
+  if (!value || value.schemaVersion !== 1 || !Number.isSafeInteger(value.policyVersion) ||
+      !value.roleAliases || typeof value.roleAliases !== 'object' ||
+      !value.restrictedRoleModules || typeof value.restrictedRoleModules !== 'object' ||
+      !value.fixedModuleGrants || typeof value.fixedModuleGrants !== 'object') {
+    throw new Error('CRM_ROLE_POLICY_INVALID')
+  }
+
+  for (const [alias, target] of Object.entries(value.roleAliases)) {
+    if (!alias || alias !== alias.toUpperCase() ||
+        !target || String(target) !== String(target).toUpperCase()) {
+      throw new Error('CRM_ROLE_POLICY_ALIASES_INVALID')
+    }
+  }
+
+  for (const [role, modules] of Object.entries(value.fixedModuleGrants)) {
+    const fixed = stringArray(modules, `CRM_ROLE_POLICY_FIXED_GRANTS_INVALID:${role}`)
+    const restricted = stringArray(
+      value.restrictedRoleModules[role],
+      `CRM_ROLE_POLICY_RESTRICTED_MODULES_INVALID:${role}`,
+    )
+    if (fixed.some((moduleKey) => !restricted.includes(moduleKey))) {
+      throw new Error(`CRM_ROLE_POLICY_FIXED_GRANTS_OUTSIDE_POLICY:${role}`)
+    }
+  }
+  return value
+}
+
+export function loadCrmRolePolicy(file = process.env.CRM_ROLE_POLICY_FILE || DEFAULT_POLICY_FILE) {
+  const resolved = path.resolve(file)
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(resolved, 'utf8'))
+  } catch (error) {
+    throw new Error(`CRM_ROLE_POLICY_LOAD_FAILED:${resolved}`, { cause: error })
+  }
+  return validateCrmRolePolicy(parsed)
+}
+
+export const crmRolePolicy = loadCrmRolePolicy()
+
+export function normalizeCrmRole(value, policy = crmRolePolicy) {
+  const raw = String(value || '').trim().toUpperCase()
+  return policy.roleAliases[raw] || raw
+}
+
+export function effectiveAllowedModules(role, allowedModules, policy = crmRolePolicy) {
+  const normalizedRole = normalizeCrmRole(role, policy)
+  const fixed = policy.fixedModuleGrants[normalizedRole]
+  if (fixed) return [...fixed]
+  if (!Array.isArray(allowedModules)) return []
+  return Array.from(new Set(allowedModules.map(String).map((item) => item.trim()).filter(Boolean)))
+}

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -180,7 +180,7 @@ type ApiError = {
 
 type InsumosMeResponse = {
     success?: boolean
-    user?: { username?: string; displayName?: string; email?: string; role?: string; allowedUnits?: string[]; allowedModules?: string[] }
+    user?: { username?: string; displayName?: string; email?: string; role?: string; allowedUnits?: string[]; allowedModules?: string[]; localFocusModule?: string }
     csrfToken?: string
 }
 
@@ -321,8 +321,12 @@ export default function AppFunctionalNeatlab() {
 	    // confirmed flag, explicit module grant and scope grant. Keep the
 	    // generic unlocked-module policy intact for every other module.
 	    const UNLOCKED_MODULE_KEYS = useMemo(
-	        () => unlockedModuleKeys(financeEnabled ? 'finance' : DEFAULT_MODULE_KEY, isOnlineCrmRuntime(window.location.hostname)),
-	        [DEFAULT_MODULE_KEY, financeEnabled]
+	        () => unlockedModuleKeys(
+                financeEnabled ? 'finance' : DEFAULT_MODULE_KEY,
+                isOnlineCrmRuntime(window.location.hostname),
+                user?.localFocusModule || '',
+            ),
+	        [DEFAULT_MODULE_KEY, financeEnabled, user?.localFocusModule]
 	    )
 	    const [sidebarHover, setSidebarHover] = useState(false)
 	    React.useEffect(() => {

--- a/crm/console/authPolicy.ts
+++ b/crm/console/authPolicy.ts
@@ -1,15 +1,17 @@
+import rolePolicy from './modules/localRolePolicy.json'
+
+const ROLE_ALIASES = rolePolicy.roleAliases as Record<string, string>
+const FIXED_MODULE_GRANTS = rolePolicy.fixedModuleGrants as Record<string, readonly string[]>
+
 /** Shared client/Pages policy for role aliases and effective module grants. */
 export function normalizeCrmRole(value: unknown): string {
   const raw = String(value || '').trim().toUpperCase()
-  if (raw === 'ADMIN') return 'GESTOR'
-  if (raw === 'OPERADOR') return 'INJETOR'
-  if (raw === 'RH' || raw === 'AUDITOR') return 'SUPERVISOR'
-  if (raw === 'EMPLOYEE') return 'CONSULTOR'
-  return raw
+  return ROLE_ALIASES[raw] || raw
 }
 
 export function effectiveAllowedModules(role: unknown, allowedModules: unknown): string[] {
-  if (normalizeCrmRole(role) === 'CONSULTOR') return ['atendimento']
+  const fixed = FIXED_MODULE_GRANTS[normalizeCrmRole(role)]
+  if (fixed) return [...fixed]
   if (!Array.isArray(allowedModules)) return []
   return Array.from(new Set(allowedModules.map(String).map((item) => item.trim()).filter(Boolean)))
 }

--- a/crm/console/contexts.tsx
+++ b/crm/console/contexts.tsx
@@ -9,9 +9,6 @@ import { useKV } from '@/spark-mock'
 import { csrfHeader } from '@/csrf'
 import { effectiveAllowedModules, normalizeCrmRole } from '@/authPolicy'
 
-const LOCAL_CRM_FOCUS_MODULE = (import.meta as any).env?.VITE_LOCAL_CRM_FOCUS_MODULE || ''
-const SKIP_INSTAGRAM_PREFLIGHT = LOCAL_CRM_FOCUS_MODULE === 'meta-ads'
-
 // =========================
 // Auth
 // =========================
@@ -25,6 +22,7 @@ export interface AuthUser {
   role?: string
   allowedUnits?: string[]
   allowedModules?: string[]
+  localFocusModule?: string
   createdAt: string
   avatarUrl?: string
 }
@@ -110,6 +108,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       role: insumosUser.role ? normalizeCrmRole(insumosUser.role) : undefined,
       allowedUnits: Array.isArray(insumosUser.allowedUnits) ? insumosUser.allowedUnits : undefined,
       allowedModules: effectiveAllowedModules(insumosUser.role, insumosUser.allowedModules),
+      localFocusModule: insumosUser.localFocusModule ? String(insumosUser.localFocusModule) : undefined,
       createdAt: String(insumosUser.createdAt || new Date().toISOString()),
       avatarUrl: insumosUser.photoUrl ? String(insumosUser.photoUrl) : undefined,
     }
@@ -466,7 +465,8 @@ export function IntegrationsProvider({ children }: { children: ReactNode }) {
     ; (window as any).__INTEGRATIONS_PROVIDER_MOUNTED__ = true
   }
 
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, user } = useAuth()
+  const skipInstagramPreflight = user?.localFocusModule === 'meta-ads'
   const [instagram, setInstagram] = useState<InstagramIntegrationState>({ connected: false })
   const [whatsapp, setWhatsApp] = useState<WhatsAppIntegrationState>({ connected: false })
 
@@ -510,12 +510,12 @@ export function IntegrationsProvider({ children }: { children: ReactNode }) {
       setInstagram({ connected: false })
       return
     }
-    if (SKIP_INSTAGRAM_PREFLIGHT) {
+    if (skipInstagramPreflight) {
       setInstagram({ connected: false })
       return
     }
     void refreshInstagram()
-  }, [isAuthenticated, refreshInstagram])
+  }, [isAuthenticated, refreshInstagram, skipInstagramPreflight])
 
   const connectInstagram = async (token: string, businessAccountId: string) => {
     const res = await fetch('/api/instagram/connect', {

--- a/crm/console/crmRoleAccess.ts
+++ b/crm/console/crmRoleAccess.ts
@@ -1,6 +1,15 @@
+import rolePolicy from './modules/localRolePolicy.json'
+import { normalizeCrmRole } from './authPolicy'
+
 // This is a navigation allowlist, not an authorization bypass.  The CRM
 // Function and Workforce Worker independently authorize every Ponto request.
-export const CONSULTOR_MODULE_KEYS = new Set(['atendimento', 'ponto'])
+export const CONSULTOR_MODULE_KEYS = new Set(rolePolicy.restrictedRoleModules.CONSULTOR)
+
+const RESTRICTED_ROLE_MODULES = rolePolicy.restrictedRoleModules as Record<string, readonly string[]>
+const EXCLUSIVE_MODULE_ROLES = rolePolicy.exclusiveModuleRoles as Record<string, readonly string[]>
+const IMPLIED_MODULE_GRANTS = rolePolicy.impliedModuleGrants as Record<string, readonly string[]>
+const UNRESTRICTED_ROLES = new Set<string>(rolePolicy.unrestrictedRoles)
+const ALWAYS_AVAILABLE_MODULES = new Set<string>(rolePolicy.alwaysAvailableModules)
 
 function normalizedModules(value: unknown): string[] {
   return Array.isArray(value)
@@ -11,28 +20,28 @@ function normalizedModules(value: unknown): string[] {
 /** Navigation policy only; every API remains authorized on the server. */
 export function hasCrmModuleAccess(role: unknown, allowedModules: unknown, moduleKey: unknown): boolean {
   const key = String(moduleKey || '').trim()
-  const roleKey = String(role || '').trim().toUpperCase()
+  const roleKey = normalizeCrmRole(role)
   if (!key) return false
   // Consultants and the legacy EMPLOYEE spelling can operate only Atendimento
   // and their self-service Ponto area. This must be evaluated before the
   // generic self-service Ponto allowance below so assigned module lists never
   // broaden their navigation.
-  if (roleKey === 'CONSULTOR' || roleKey === 'EMPLOYEE') return CONSULTOR_MODULE_KEYS.has(key)
+  const restrictedModules = RESTRICTED_ROLE_MODULES[roleKey]
+  if (restrictedModules) return restrictedModules.includes(key)
   // Every authenticated CRM user can access the self-service timekeeping area.
   // Data and administrative operations remain authorized by the Ponto proxy and
   // Workforce service; this function only governs sidebar navigation.
-  if (key === 'ponto') return true
-  // Customer intelligence includes detailed commercial and clinical history.
-  if (key === 'clientes') return roleKey === 'GESTOR' || roleKey === 'ADMIN'
-  if (roleKey === 'GESTOR' || roleKey === 'ADMIN') return true
-  if (key === 'escala-profissionais') return roleKey === 'GERENTE'
+  if (ALWAYS_AVAILABLE_MODULES.has(key)) return true
+  // Some modules contain privileged commercial or workforce information and
+  // therefore remain exclusive even when a legacy grant list is broad.
+  const exclusiveRoles = EXCLUSIVE_MODULE_ROLES[key]
+  if (exclusiveRoles) return exclusiveRoles.includes(roleKey)
+  if (UNRESTRICTED_ROLES.has(roleKey)) return true
 
   const allowed = normalizedModules(allowedModules)
-  if (!allowed.length) return true // compatibility for existing non-Consultor users
+  if (!allowed.length) return rolePolicy.allowEmptyGrantListForAuthenticatedLegacyRoles
   if (allowed.includes(key)) return true
-  if (key === 'procedimentos') return allowed.some((module) => ['procedimentos', 'atendimento'].includes(module))
-  if (key === 'faturamento') return allowed.some((module) => ['faturamento', 'atendimento'].includes(module))
-  if (key === 'conversa') return allowed.some((module) => ['whatsapp-business', 'harmonia', 'omnichannel'].includes(module))
-  if (key === 'ai-automation') return allowed.some((module) => ['ai-automation', 'automation', 'whatsapp-n8n'].includes(module))
+  const impliedGrants = IMPLIED_MODULE_GRANTS[key]
+  if (impliedGrants) return allowed.some((module) => impliedGrants.includes(module))
   return false
 }

--- a/crm/console/functions/_lib/crmAuth.ts
+++ b/crm/console/functions/_lib/crmAuth.ts
@@ -9,6 +9,7 @@ export type CrmAuthUser = {
   role?: string
   allowedUnits?: string[]
   allowedModules?: string[]
+  localFocusModule?: string
 }
 
 const json = (status: number, body: any) =>
@@ -100,6 +101,7 @@ export function getLocalDevAuthUser(context: any): CrmAuthUser {
   const allowedModules =
     parseList(env.LOCAL_AUTH_ALLOWED_MODULES) ||
     parseList(env.DEV_AUTH_ALLOWED_MODULES)
+  const localFocusModule = String(env.LOCAL_CRM_FOCUS_MODULE || '').trim()
 
   return {
     id: username,
@@ -110,6 +112,9 @@ export function getLocalDevAuthUser(context: any): CrmAuthUser {
     role,
     allowedUnits,
     allowedModules: effectiveAllowedModules(role, allowedModules),
+    localFocusModule: /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(localFocusModule)
+      ? localFocusModule
+      : undefined,
   }
 }
 

--- a/crm/console/moduleAvailability.ts
+++ b/crm/console/moduleAvailability.ts
@@ -1,36 +1,39 @@
-const ONLINE_DISABLED_MODULE_KEYS = new Set([
-  'caixa',
-  'faturamento',
-  'meta-ads',
-  'meta-pages-review',
-  'procedimentos',
-  'instagram-studio',
-  'site-tracking',
-  'unit-monitor',
-])
+import localLaunchCatalog from './modules/localLaunchCatalog.json'
 
-export const DEFAULT_UNLOCKED_MODULE_KEYS = [
-  'insumos',
-  'conversa',
-  'atendimento',
-  // Ponto is self-service for authenticated Workforce identities. Role and
-  // server authorization still constrain what each identity can do inside it.
-  'ponto',
-  'clientes',
-  'caixa',
-  'faturamento',
-  'procedimentos',
-  'unit-monitor',
-  'instagram-studio',
-  'meta-pages-review',
-  'meta-ads',
-  'site-tracking',
-  'escala-profissionais',
-] as const
+const ONLINE_ENABLED_MODULE_KEYS = new Set(
+  localLaunchCatalog.modules
+    .filter((entry) => entry.onlineEnabled === true)
+    .map((entry) => entry.key),
+)
+// Finance has a separate release/grant gate in App.tsx and intentionally is
+// not part of the local launch catalog.
+const ONLINE_SEPARATELY_GATED_MODULE_KEYS = new Set(['finance'])
 
-export function unlockedModuleKeys(defaultModuleKey: string, isOnline: boolean): Set<string> {
+// Ponto remains self-service for authenticated Workforce identities. Role and
+// server authorization still constrain what each identity can do inside it.
+// The neutral catalog is shared with the Windows/WSL launcher discovery CLI.
+export const DEFAULT_UNLOCKED_MODULE_KEYS: readonly string[] = Object.freeze(
+  localLaunchCatalog.modules.map((entry) => entry.key),
+)
+
+export function unlockedModuleKeys(
+  defaultModuleKey: string,
+  isOnline: boolean,
+  localFocusModule = '',
+): Set<string> {
+  const focused = String(localFocusModule || '').trim()
+  // This value comes from the authenticated local runtime binding, not from
+  // the hostname or a build-time Vite variable. When present it is authoritative
+  // even if the loopback service is reached through a local alias/proxy.
+  if (focused) {
+    return new Set(DEFAULT_UNLOCKED_MODULE_KEYS.includes(focused) ? [focused] : [])
+  }
   const candidates = [defaultModuleKey, ...DEFAULT_UNLOCKED_MODULE_KEYS]
-  return new Set(candidates.filter((key) => !isOnline || !ONLINE_DISABLED_MODULE_KEYS.has(key)))
+  return new Set(candidates.filter((key) => (
+    !isOnline ||
+    ONLINE_ENABLED_MODULE_KEYS.has(key) ||
+    ONLINE_SEPARATELY_GATED_MODULE_KEYS.has(key)
+  )))
 }
 
 export function isOnlineCrmRuntime(hostname: string): boolean {

--- a/crm/console/modules/localLaunchCatalog.json
+++ b/crm/console/modules/localLaunchCatalog.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": 1,
+  "catalogVersion": 1,
+  "launcherContractVersion": 1,
+  "baseDependencyIds": [
+    "crm-console",
+    "pages-functions"
+  ],
+  "modules": [
+    {
+      "key": "insumos",
+      "label": "Insumos",
+      "route": "/?module=insumos",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "insumos-worker"
+      ]
+    },
+    {
+      "key": "conversa",
+      "label": "Conversa",
+      "route": "/?module=conversa",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "atendimento",
+      "label": "Atendimento",
+      "route": "/?module=atendimento",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "ponto",
+      "label": "Ponto",
+      "route": "/?module=ponto",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "timekeeping-worker"
+      ]
+    },
+    {
+      "key": "clientes",
+      "label": "Clientes",
+      "route": "/?module=clientes",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "caixa",
+      "label": "Caixa",
+      "route": "/?module=caixa",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "faturamento",
+      "label": "Faturamento",
+      "route": "/?module=faturamento",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "procedimentos",
+      "label": "Procedimentos",
+      "route": "/?module=procedimentos",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "unit-monitor",
+      "label": "Unit Monitor",
+      "route": "/?module=unit-monitor",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "crm-local-adapter"
+      ]
+    },
+    {
+      "key": "instagram-studio",
+      "label": "Redes Sociais",
+      "route": "/?module=instagram-studio",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "social-local-pages"
+      ]
+    },
+    {
+      "key": "meta-pages-review",
+      "label": "Meta Review",
+      "route": "/?module=meta-pages-review",
+      "onlineEnabled": false,
+      "dependencyIds": [
+        "meta-review-local-pages"
+      ]
+    },
+    {
+      "key": "meta-ads",
+      "label": "Meta Ads",
+      "route": "/?module=meta-ads",
+      "onlineEnabled": false,
+      "localScenario": "connected-ready",
+      "dependencyIds": [
+        "meta-ads-local-scenario"
+      ]
+    },
+    {
+      "key": "site-tracking",
+      "label": "Site EF",
+      "route": "/?module=site-tracking",
+      "onlineEnabled": false,
+      "localScenario": "connected-ready",
+      "dependencyIds": [
+        "tracking-local-scenario"
+      ]
+    },
+    {
+      "key": "escala-profissionais",
+      "label": "Escala",
+      "route": "/?module=escala-profissionais",
+      "onlineEnabled": true,
+      "dependencyIds": [
+        "escala-local-mock"
+      ]
+    }
+  ]
+}

--- a/crm/console/modules/localRolePolicy.json
+++ b/crm/console/modules/localRolePolicy.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": 1,
+  "roleAliases": {
+    "ADMIN": "GESTOR",
+    "OPERADOR": "INJETOR",
+    "RH": "SUPERVISOR",
+    "AUDITOR": "SUPERVISOR",
+    "EMPLOYEE": "CONSULTOR"
+  },
+  "launchRoles": [
+    {
+      "key": "GESTOR",
+      "label": "Gestor",
+      "access": "all"
+    },
+    {
+      "key": "CONSULTOR",
+      "label": "Consultor",
+      "access": "allowlist"
+    }
+  ],
+  "unrestrictedRoles": [
+    "GESTOR"
+  ],
+  "restrictedRoleModules": {
+    "CONSULTOR": [
+      "atendimento",
+      "ponto"
+    ]
+  },
+  "fixedModuleGrants": {
+    "CONSULTOR": [
+      "atendimento"
+    ]
+  },
+  "alwaysAvailableModules": [
+    "ponto"
+  ],
+  "exclusiveModuleRoles": {
+    "clientes": [
+      "GESTOR"
+    ],
+    "escala-profissionais": [
+      "GESTOR",
+      "GERENTE"
+    ]
+  },
+  "impliedModuleGrants": {
+    "procedimentos": [
+      "procedimentos",
+      "atendimento"
+    ],
+    "faturamento": [
+      "faturamento",
+      "atendimento"
+    ],
+    "conversa": [
+      "whatsapp-business",
+      "harmonia",
+      "omnichannel"
+    ],
+    "ai-automation": [
+      "ai-automation",
+      "automation",
+      "whatsapp-n8n"
+    ]
+  },
+  "allowEmptyGrantListForAuthenticatedLegacyRoles": true
+}

--- a/crm/console/scripts/crm-local-smoke.cjs
+++ b/crm/console/scripts/crm-local-smoke.cjs
@@ -42,7 +42,13 @@ function moduleRoute(key) {
 }
 
 function moduleUrl(key) {
-  return new globalThis.URL(moduleRoute(key), APP_URL).toString()
+  const target = new globalThis.URL(moduleRoute(key), APP_URL)
+  if (key === 'meta-ads' || key === 'site-tracking') {
+    const bootstrap = new globalThis.URL(APP_URL)
+    const scenario = bootstrap.searchParams.get('metaAdsLocalScenario')
+    if (scenario) target.searchParams.set('metaAdsLocalScenario', scenario)
+  }
+  return target.toString()
 }
 
 function stripAnsi(value) {

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -10,15 +10,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 VITE_PORT="${VITE_PORT:-5173}"
 PAGES_PORT="${PAGES_PORT:-8788}"
+R2_PERSIST_DIR_EXPLICIT="${R2_PERSIST_DIR+x}"
 R2_PERSIST_DIR="${R2_PERSIST_DIR:-.wrangler}"
+CRM_DIST_DIR="${CRM_DIST_DIR:-$ROOT_DIR/dist}"
 CRM_LOCAL_LOG_LEVEL="${CRM_LOCAL_LOG_LEVEL:-warn}"
+CRM_LOCAL_ISOLATED="${CRM_LOCAL_ISOLATED:-0}"
 COMPAT_DATE="${COMPAT_DATE:-2026-01-13}"
 
 cd "$ROOT_DIR"
-
-if [[ ! -f "$ROOT_DIR/.dev.vars" && -f "$ROOT_DIR/.dev.vars.example" ]]; then
-  cp "$ROOT_DIR/.dev.vars.example" "$ROOT_DIR/.dev.vars"
-  echo "[dev_pages] .dev.vars não existia; criado a partir de .dev.vars.example"
+if [[ "$CRM_DIST_DIR" != /* ]]; then
+  CRM_DIST_DIR="$ROOT_DIR/$CRM_DIST_DIR"
 fi
 
 ensure_dev_var() {
@@ -46,54 +47,152 @@ upsert_non_secret_dev_var() {
   fi
 }
 
-upsert_non_secret_dev_var "LOCAL_AUTH_BYPASS" "${LOCAL_AUTH_BYPASS:-false}"
-upsert_non_secret_dev_var "LOCAL_AUTH_ROLE" "${LOCAL_AUTH_ROLE:-GESTOR}"
-upsert_non_secret_dev_var "LOCAL_AUTH_TEST_USER_ADMIN" "${LOCAL_AUTH_TEST_USER_ADMIN:-true}"
-upsert_non_secret_dev_var "LOCAL_AUTH_USERNAME" "${LOCAL_AUTH_USERNAME:-dev}"
-upsert_non_secret_dev_var "LOCAL_AUTH_EMAIL" "${LOCAL_AUTH_EMAIL:-dev@local.test}"
-upsert_non_secret_dev_var "LOCAL_AUTH_NAME" "${LOCAL_AUTH_NAME:-Dev Local}"
-upsert_non_secret_dev_var "LOCAL_AUTH_ALLOWED_MODULES" "${LOCAL_AUTH_ALLOWED_MODULES:-}"
-upsert_non_secret_dev_var "LOCAL_AUTH_ALLOWED_UNITS" "${LOCAL_AUTH_ALLOWED_UNITS:-}"
-finance_api_target="${LOCAL_FINANCE_API_TARGET:-${FINANCE_API_TARGET:-}}"
-[[ -n "$finance_api_target" ]] && upsert_non_secret_dev_var "FINANCE_API_TARGET" "$finance_api_target"
-for finance_key in LOCAL_FINANCE_ACTOR LOCAL_FINANCE_CSRF_TOKEN; do
-  finance_value="${!finance_key:-}"
-  [[ -n "$finance_value" ]] && upsert_non_secret_dev_var "$finance_key" "$finance_value"
-done
-ensure_dev_var "ESCALA_API_TARGET" "https://escala-api.skincos.com.br"
-ensure_dev_var "LOCAL_ESCALA_MOCK" "false"
-ensure_dev_var "LOCAL_ESCALA_SHADOW_WRITES" "true"
-ensure_dev_var "ESCALA_ACTOR_HMAC_KEY" "__CONFIGURE_REAL_ESCALA_HMAC_KEY__"
-
 PAGES_BINDING_ARGS=()
+PAGES_ENV_ARGS=()
+PAGES_RESOURCE_ARGS=()
+
+add_binding() {
+  local key="$1"
+  local value="$2"
+  PAGES_BINDING_ARGS+=(--binding "${key}=${value}")
+}
+
+add_optional_binding() {
+  local key="$1"
+  local value="${2:-}"
+  if [[ -n "$value" ]]; then
+    add_binding "$key" "$value"
+  fi
+}
+
+local_auth_bypass="${LOCAL_AUTH_BYPASS:-false}"
+local_auth_role="${LOCAL_AUTH_ROLE:-GESTOR}"
+local_auth_test_user_admin="${LOCAL_AUTH_TEST_USER_ADMIN:-true}"
+local_auth_username="${LOCAL_AUTH_USERNAME:-dev}"
+local_auth_email="${LOCAL_AUTH_EMAIL:-dev@local.test}"
+local_auth_name="${LOCAL_AUTH_NAME:-Dev Local}"
+local_auth_allowed_modules="${LOCAL_AUTH_ALLOWED_MODULES:-}"
+local_auth_allowed_units="${LOCAL_AUTH_ALLOWED_UNITS:-}"
+finance_api_target="${LOCAL_FINANCE_API_TARGET:-${FINANCE_API_TARGET:-}}"
+auth_path_prefix="${AUTH_PATH_PREFIX:-/insumos/auth}"
+escala_api_target="${ESCALA_API_TARGET:-https://escala-api.skincos.com.br}"
+local_escala_mock="${LOCAL_ESCALA_MOCK:-false}"
+local_escala_shadow_writes="${LOCAL_ESCALA_SHADOW_WRITES:-true}"
+
+if [[ "$CRM_LOCAL_ISOLATED" == "1" ]]; then
+  if [[ -z "$R2_PERSIST_DIR_EXPLICIT" || "$R2_PERSIST_DIR" != /* ]]; then
+    echo "[dev_pages] CRM_LOCAL_ISOLATED=1 exige R2_PERSIST_DIR absoluto e explícito." >&2
+    exit 2
+  fi
+  mkdir -p "$R2_PERSIST_DIR"
+  root_real="$(realpath -m "$ROOT_DIR")"
+  persist_real="$(realpath -m "$R2_PERSIST_DIR")"
+  if [[ "$persist_real" == "$root_real" || "$persist_real" == "$root_real/"* ]]; then
+    echo "[dev_pages] O estado isolado do Pages deve ficar fora da árvore fonte: $persist_real" >&2
+    exit 2
+  fi
+  if [[ ! -f "$CRM_DIST_DIR/index.html" ]]; then
+    echo "[dev_pages] O modo isolado exige um dist já construído; nenhum artefato será criado na árvore fonte." >&2
+    exit 2
+  fi
+
+  # An explicit empty env file prevents Wrangler from loading the mutable
+  # .dev.vars shared by another local instance. Every local identity value is
+  # supplied to this process only.
+  PAGES_ENV_ARGS+=(--env-file /dev/null)
+  # Every isolated runtime gets its own local R2 namespace under
+  # R2_PERSIST_DIR. This keeps Meta/Instagram integration state useful without
+  # touching the production bucket.
+  PAGES_RESOURCE_ARGS+=(--r2 SHARE_BUCKET)
+  add_binding "LOCAL_AUTH_BYPASS" "$local_auth_bypass"
+  add_binding "LOCAL_AUTH_ROLE" "$local_auth_role"
+  add_binding "LOCAL_AUTH_TEST_USER_ADMIN" "$local_auth_test_user_admin"
+  add_binding "LOCAL_AUTH_USERNAME" "$local_auth_username"
+  add_binding "LOCAL_AUTH_EMAIL" "$local_auth_email"
+  add_binding "LOCAL_AUTH_NAME" "$local_auth_name"
+  add_binding "LOCAL_AUTH_ALLOWED_MODULES" "$local_auth_allowed_modules"
+  add_binding "LOCAL_AUTH_ALLOWED_UNITS" "$local_auth_allowed_units"
+
+  add_optional_binding "AUTH_API_TARGET" "${AUTH_API_TARGET:-}"
+  add_binding "AUTH_PATH_PREFIX" "$auth_path_prefix"
+  add_optional_binding "CRM_API_TARGET" "${CRM_API_TARGET:-}"
+  add_optional_binding "CAIXA_API_TARGET" "${CAIXA_API_TARGET:-}"
+  add_optional_binding "TRACKING_API_TARGET" "${TRACKING_API_TARGET:-}"
+  add_optional_binding "UNIT_MONITOR_API_TARGET" "${UNIT_MONITOR_API_TARGET:-}"
+  add_optional_binding "FINANCE_API_TARGET" "$finance_api_target"
+  add_optional_binding "LOCAL_FINANCE_ACTOR" "${LOCAL_FINANCE_ACTOR:-}"
+  add_optional_binding "LOCAL_FINANCE_CSRF_TOKEN" "${LOCAL_FINANCE_CSRF_TOKEN:-}"
+  add_binding "ESCALA_API_TARGET" "$escala_api_target"
+  add_binding "LOCAL_ESCALA_MOCK" "$local_escala_mock"
+  add_binding "LOCAL_ESCALA_SHADOW_WRITES" "$local_escala_shadow_writes"
+  add_optional_binding "ESCALA_ACTOR_HMAC_KEY" "${ESCALA_ACTOR_HMAC_KEY:-}"
+  add_optional_binding "INSTAGRAM_MODULE_TARGET" "${INSTAGRAM_MODULE_TARGET:-}"
+  add_optional_binding "INTEGRATIONS_ENCRYPTION_SECRET" "${INTEGRATIONS_ENCRYPTION_SECRET:-}"
+  add_binding "REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET" "${REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET:-true}"
+else
+  if [[ ! -f "$ROOT_DIR/.dev.vars" && -f "$ROOT_DIR/.dev.vars.example" ]]; then
+    cp "$ROOT_DIR/.dev.vars.example" "$ROOT_DIR/.dev.vars"
+    echo "[dev_pages] .dev.vars não existia; criado a partir de .dev.vars.example"
+  fi
+
+  upsert_non_secret_dev_var "LOCAL_AUTH_BYPASS" "$local_auth_bypass"
+  upsert_non_secret_dev_var "LOCAL_AUTH_ROLE" "$local_auth_role"
+  upsert_non_secret_dev_var "LOCAL_AUTH_TEST_USER_ADMIN" "$local_auth_test_user_admin"
+  upsert_non_secret_dev_var "LOCAL_AUTH_USERNAME" "$local_auth_username"
+  upsert_non_secret_dev_var "LOCAL_AUTH_EMAIL" "$local_auth_email"
+  upsert_non_secret_dev_var "LOCAL_AUTH_NAME" "$local_auth_name"
+  upsert_non_secret_dev_var "LOCAL_AUTH_ALLOWED_MODULES" "$local_auth_allowed_modules"
+  upsert_non_secret_dev_var "LOCAL_AUTH_ALLOWED_UNITS" "$local_auth_allowed_units"
+  if [[ -n "$finance_api_target" ]]; then
+    upsert_non_secret_dev_var "FINANCE_API_TARGET" "$finance_api_target"
+  fi
+  for finance_key in LOCAL_FINANCE_ACTOR LOCAL_FINANCE_CSRF_TOKEN; do
+    finance_value="${!finance_key:-}"
+    if [[ -n "$finance_value" ]]; then
+      upsert_non_secret_dev_var "$finance_key" "$finance_value"
+    fi
+  done
+  ensure_dev_var "ESCALA_API_TARGET" "https://escala-api.skincos.com.br"
+  ensure_dev_var "LOCAL_ESCALA_MOCK" "false"
+  ensure_dev_var "LOCAL_ESCALA_SHADOW_WRITES" "true"
+  ensure_dev_var "ESCALA_ACTOR_HMAC_KEY" "__CONFIGURE_REAL_ESCALA_HMAC_KEY__"
+fi
+
+add_optional_binding "LOCAL_CRM_FOCUS_MODULE" "${LOCAL_CRM_FOCUS_MODULE:-}"
+
 if [[ -n "${LOCAL_INSUMOS_API_TARGET:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "INSUMOS_API_TARGET=${LOCAL_INSUMOS_API_TARGET}")
+  add_binding "INSUMOS_API_TARGET" "$LOCAL_INSUMOS_API_TARGET"
+elif [[ "$CRM_LOCAL_ISOLATED" == "1" ]]; then
+  add_optional_binding "INSUMOS_API_TARGET" "${INSUMOS_API_TARGET:-}"
 fi
 if [[ -n "${PONTO_API_TARGET:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "PONTO_API_TARGET=${PONTO_API_TARGET}")
+  add_binding "PONTO_API_TARGET" "$PONTO_API_TARGET"
 fi
 if [[ -n "${PONTO_ACTOR_HMAC_KEY:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "PONTO_ACTOR_HMAC_KEY=${PONTO_ACTOR_HMAC_KEY}")
+  add_binding "PONTO_ACTOR_HMAC_KEY" "$PONTO_ACTOR_HMAC_KEY"
 fi
 if [[ -n "${PONTO_NETWORK_CONTEXT_KEY:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "PONTO_NETWORK_CONTEXT_KEY=${PONTO_NETWORK_CONTEXT_KEY}")
+  add_binding "PONTO_NETWORK_CONTEXT_KEY" "$PONTO_NETWORK_CONTEXT_KEY"
 fi
 if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
-  PAGES_BINDING_ARGS+=(--binding "WA_ORCHESTRATOR_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
+  add_binding "WA_ORCHESTRATOR_API_TARGET" "$LOCAL_WA_ORCHESTRATOR_API_TARGET"
   # The local WhatsApp adapter is a private crm-api instance. It also owns the
   # Atendimento routes, so the local Pages proxy must not fall back to the
   # native service on :8099 (which correctly requires signed production auth).
-  PAGES_BINDING_ARGS+=(--binding "ATENDIMENTO_API_TARGET=${LOCAL_WA_ORCHESTRATOR_API_TARGET}")
+  add_binding "ATENDIMENTO_API_TARGET" "$LOCAL_WA_ORCHESTRATOR_API_TARGET"
+elif [[ "$CRM_LOCAL_ISOLATED" == "1" ]]; then
+  add_optional_binding "WA_ORCHESTRATOR_API_TARGET" "${WA_ORCHESTRATOR_API_TARGET:-}"
+  add_optional_binding "ATENDIMENTO_API_TARGET" "${ATENDIMENTO_API_TARGET:-}"
 fi
 
 # Evita rota API quebrada por _routes.json desatualizado em dist/
-if [[ -f "$ROOT_DIR/public/_routes.json" ]]; then
-  mkdir -p "$ROOT_DIR/dist"
-  cp "$ROOT_DIR/public/_routes.json" "$ROOT_DIR/dist/_routes.json"
+if [[ "$CRM_LOCAL_ISOLATED" != "1" && -f "$ROOT_DIR/public/_routes.json" ]]; then
+  mkdir -p "$CRM_DIST_DIR"
+  cp "$ROOT_DIR/public/_routes.json" "$CRM_DIST_DIR/_routes.json"
 fi
 
 echo "[dev_pages] Iniciando Vite em :$VITE_PORT"
-npm run dev -- --host 127.0.0.1 --port "$VITE_PORT" &
+npm run dev -- --host 127.0.0.1 --port "$VITE_PORT" --strictPort &
 VITE_PID=$!
 
 cleanup() {
@@ -104,4 +203,4 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[dev_pages] Iniciando Pages Functions (proxy :$VITE_PORT) em :$PAGES_PORT"
-npx --no-install wrangler pages dev "$ROOT_DIR/dist" --proxy "$VITE_PORT" --port "$PAGES_PORT" --compatibility-date "$COMPAT_DATE" --persist-to "$R2_PERSIST_DIR" --log-level "$CRM_LOCAL_LOG_LEVEL" --show-interactive-dev-session false "${PAGES_BINDING_ARGS[@]}"
+npx --no-install wrangler pages dev "$CRM_DIST_DIR" "${PAGES_ENV_ARGS[@]}" "${PAGES_RESOURCE_ARGS[@]}" --proxy "$VITE_PORT" --port "$PAGES_PORT" --compatibility-date "$COMPAT_DATE" --persist-to "$R2_PERSIST_DIR" --log-level "$CRM_LOCAL_LOG_LEVEL" --show-interactive-dev-session false "${PAGES_BINDING_ARGS[@]}"

--- a/crm/console/tests/authPolicy.test.ts
+++ b/crm/console/tests/authPolicy.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
 import { effectiveAllowedModules, isAtendimentoManager, normalizeCrmRole } from '../authPolicy'
+import rolePolicy from '../modules/localRolePolicy.json'
 
 describe('CRM effective role policy', () => {
   it('narrows consultants to Atendimento even for legacy blank or broad grants', () => {
-    expect(effectiveAllowedModules('CONSULTOR', [])).toEqual(['atendimento'])
-    expect(effectiveAllowedModules('CONSULTOR', ['insumos', 'atendimento', 'status'])).toEqual(['atendimento'])
+    expect(rolePolicy.fixedModuleGrants.CONSULTOR).toEqual(['atendimento'])
+    expect(effectiveAllowedModules('CONSULTOR', [])).toEqual(rolePolicy.fixedModuleGrants.CONSULTOR)
+    expect(effectiveAllowedModules('CONSULTOR', ['insumos', 'atendimento', 'status'])).toEqual(rolePolicy.fixedModuleGrants.CONSULTOR)
   })
 
   it('keeps role aliases and management permissions explicit', () => {
-    expect(normalizeCrmRole('ADMIN')).toBe('GESTOR')
-    expect(normalizeCrmRole('EMPLOYEE')).toBe('CONSULTOR')
+    for (const [alias, role] of Object.entries(rolePolicy.roleAliases)) {
+      expect(normalizeCrmRole(alias)).toBe(role)
+    }
     expect(isAtendimentoManager('GERENTE')).toBe(true)
     expect(isAtendimentoManager('CONSULTOR')).toBe(false)
   })

--- a/crm/console/tests/crmLocalTestUserAccess.test.ts
+++ b/crm/console/tests/crmLocalTestUserAccess.test.ts
@@ -46,4 +46,15 @@ describe('local CRM test user', () => {
       allowedModules: ['atendimento'],
     })
   })
+
+  it('publishes only a valid server-bound modular focus', () => {
+    expect(getLocalDevAuthUser(context({
+      LOCAL_AUTH_ROLE: 'GESTOR',
+      LOCAL_CRM_FOCUS_MODULE: 'meta-pages-review',
+    })).localFocusModule).toBe('meta-pages-review')
+    expect(getLocalDevAuthUser(context({
+      LOCAL_AUTH_ROLE: 'GESTOR',
+      LOCAL_CRM_FOCUS_MODULE: '../meta-pages-review',
+    })).localFocusModule).toBeUndefined()
+  })
 })

--- a/crm/console/tests/financeApi.test.ts
+++ b/crm/console/tests/financeApi.test.ts
@@ -132,7 +132,8 @@ describe('Finance transport helpers', () => {
 
   it('unlocks Finance navigation only after the server bootstrap authorizes it', () => {
     const app = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8')
-    expect(app).toContain("unlockedModuleKeys(financeEnabled ? 'finance' : DEFAULT_MODULE_KEY")
+    expect(app).toContain("financeEnabled ? 'finance' : DEFAULT_MODULE_KEY,")
+    expect(app).toContain("user?.localFocusModule || ''")
     expect(app).toContain('}, [financeEnabled, initializing])')
     expect(app).toContain('resolveFinanceBootstrapEnabled')
   })

--- a/crm/console/tests/localLaunchCatalog.test.ts
+++ b/crm/console/tests/localLaunchCatalog.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+import { hasCrmModuleAccess } from '../crmRoleAccess'
+import { DEFAULT_UNLOCKED_MODULE_KEYS } from '../moduleAvailability'
+import localLaunchCatalog from '../modules/localLaunchCatalog.json'
+import rolePolicy from '../modules/localRolePolicy.json'
+
+const registrySource = readFileSync(new URL('../modules/registry.tsx', import.meta.url), 'utf8')
+
+function registryLabels(): Map<string, string> {
+  return new Map(
+    [...registrySource.matchAll(/manifest\(\{\s*key:\s*'([^']+)',\s*label:\s*'([^']+)'/g)]
+      .map((match) => [match[1], match[2]]),
+  )
+}
+
+describe('CRM local launch catalog', () => {
+  it('is the exact local release list and stays in registry parity', () => {
+    expect(localLaunchCatalog.modules.length).toBeGreaterThan(0)
+    expect(DEFAULT_UNLOCKED_MODULE_KEYS).toEqual(localLaunchCatalog.modules.map((entry) => entry.key))
+    expect(new Set(DEFAULT_UNLOCKED_MODULE_KEYS).size).toBe(DEFAULT_UNLOCKED_MODULE_KEYS.length)
+
+    const labelsByKey = registryLabels()
+    for (const entry of localLaunchCatalog.modules) {
+      expect(entry.route).toBe(`/?module=${encodeURIComponent(entry.key)}`)
+      expect(entry.dependencyIds.length).toBeGreaterThan(0)
+      expect(typeof entry.onlineEnabled).toBe('boolean')
+      expect(labelsByKey.get(entry.key)).toBe(entry.label)
+    }
+  })
+
+  it('uses the same role truth for every catalog and policy combination', () => {
+    const gestor = rolePolicy.launchRoles.find((role) => role.key === 'GESTOR')
+    const consultor = rolePolicy.launchRoles.find((role) => role.key === 'CONSULTOR')
+    expect(gestor).toEqual({ key: 'GESTOR', label: 'Gestor', access: 'all' })
+    expect(consultor).toEqual({ key: 'CONSULTOR', label: 'Consultor', access: 'allowlist' })
+
+    const gestorModules = localLaunchCatalog.modules.filter((entry) => hasCrmModuleAccess('GESTOR', [], entry.key))
+    const consultorModules = localLaunchCatalog.modules.filter((entry) => hasCrmModuleAccess('CONSULTOR', [], entry.key))
+    expect(gestorModules).toHaveLength(localLaunchCatalog.modules.length)
+    expect(consultorModules.map((entry) => entry.key)).toEqual(rolePolicy.restrictedRoleModules.CONSULTOR)
+  })
+
+  it('keeps aliases and privileged module rules compatible with the existing policy', () => {
+    expect(hasCrmModuleAccess('ADMIN', [], 'clientes')).toBe(true)
+    expect(hasCrmModuleAccess('EMPLOYEE', ['insumos'], 'ponto')).toBe(true)
+    expect(hasCrmModuleAccess('GERENTE', ['clientes'], 'clientes')).toBe(false)
+    expect(hasCrmModuleAccess('GERENTE', [], 'escala-profissionais')).toBe(true)
+    expect(hasCrmModuleAccess('SUPERVISOR', ['atendimento'], 'procedimentos')).toBe(true)
+  })
+})

--- a/crm/console/tests/moduleAvailability.test.ts
+++ b/crm/console/tests/moduleAvailability.test.ts
@@ -19,6 +19,18 @@ describe('module availability', () => {
     expect(unlocked.has('meta-ads')).toBe(true)
   })
 
+  it('limits a modular local runtime to its canonical focus module', () => {
+    expect([...unlockedModuleKeys('insumos', false, 'atendimento')]).toEqual(['atendimento'])
+    expect([...unlockedModuleKeys('insumos', false, 'unknown-module')]).toEqual([])
+    expect([...unlockedModuleKeys('insumos', true, 'meta-ads')]).toEqual(['meta-ads'])
+    expect([...unlockedModuleKeys('insumos', true, 'atendimento')]).toEqual(['atendimento'])
+  })
+
+  it('keeps online release opt-in and preserves the separate Finance gate', () => {
+    expect(unlockedModuleKeys('future-local-module', true).has('future-local-module')).toBe(false)
+    expect(unlockedModuleKeys('finance', true).has('finance')).toBe(true)
+  })
+
   it('distinguishes local loopback from online hosts', () => {
     expect(isOnlineCrmRuntime('localhost')).toBe(false)
     expect(isOnlineCrmRuntime('127.0.0.1')).toBe(false)

--- a/crm/console/tsconfig.json
+++ b/crm/console/tsconfig.json
@@ -13,6 +13,7 @@
     "strictNullChecks": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/crm/console/useReplitAuth.ts
+++ b/crm/console/useReplitAuth.ts
@@ -36,6 +36,7 @@ export function useReplitAuth() {
     role: localRole,
     allowedUnits: [],
     allowedModules: [],
+    localFocusModule: undefined,
     createdAt: new Date().toISOString(),
     avatarUrl: undefined,
   }
@@ -69,6 +70,7 @@ export function useReplitAuth() {
       const displayName = String(insumosUser.displayName || insumosUser.name || insumosUser.username || insumosUser.email || '')
       const allowedUnits = Array.isArray(insumosUser.allowedUnits) ? insumosUser.allowedUnits : undefined
       const allowedModules = Array.isArray(insumosUser.allowedModules) ? insumosUser.allowedModules : undefined
+      const localFocusModule = insumosUser.localFocusModule ? String(insumosUser.localFocusModule) : undefined
 
       return {
         id: username,
@@ -79,6 +81,7 @@ export function useReplitAuth() {
         role: insumosUser.role ? String(insumosUser.role) : undefined,
         allowedUnits,
         allowedModules,
+        localFocusModule,
         createdAt: String(insumosUser.createdAt || new Date().toISOString()),
         avatarUrl: insumosUser.photoUrl ? String(insumosUser.photoUrl) : undefined,
       };

--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -80,15 +80,17 @@ Os atalhos ficam no Menu Iniciar compartilhado:
 
 - `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Skincos Codex`
 
-O layout principal agora foi reduzido para cinco atalhos de topo:
+O layout principal expõe seis atalhos de topo:
 
 - `Workspace`
 - `Contexto`
-- `Local`
+- `CRM – Local`
+- `CRM – Módulos`
 - `EF App`
 - `Orb`
 
-Todos eles abrem menus interativos por dominio.
+`CRM – Local` é uma ação direta e não pede variáveis técnicas. Os demais
+atalhos de agrupamento abrem menus curtos por domínio.
 
 ### Workspace
 
@@ -108,11 +110,18 @@ Todos eles abrem menus interativos por dominio.
 - `Thread Bootstrap`
 - `New Worktree`
 
-### Local
+### CRM – Local
 
-- `Website -> Start | Stop | Site Check | Release Check`
-- `CRM -> Local | Site EF | Meta Ads | Atendimento | Stop | Memory | Site Smoke | Meta Ads Smoke | Atendimento Smoke`
-- `Platform Local -> Start`
+Inicia o CRM completo como Gestor, com build automático por impressão,
+Insumos, Timekeeping, adaptador do WhatsApp, Pages Functions, gate dos 14
+módulos e navegador somente depois da aprovação.
+
+### CRM – Módulos
+
+Permite escolher somente papel e módulo. O instalador também cria 16 atalhos
+diretos na subpasta `CRM – Módulos`: 14 módulos para Gestor e Atendimento/Ponto
+para Consultor. Portas, PIDs, logs, estado, autenticação e perfil de navegador
+são privados por combinação.
 
 ### EF App
 
@@ -169,8 +178,8 @@ Limites importantes:
   Windows pode aparecer deslogado ou com `hosts.yml` vazio sem bloquear o fluxo;
 - os atalhos do Menu Iniciar e os botões do topo são complementares: o primeiro
   é compartilhamento no Windows, o segundo é compartilhamento por projeto;
-- a barra principal do Codex App agora foi condensada para os mesmos cinco
-  atalhos de topo do Menu Iniciar.
+- a barra principal do Codex App usa as mesmas seis ações de topo do Menu
+  Iniciar.
 
 ## Local vs runtime live
 
@@ -180,7 +189,8 @@ Os atalhos seguem dois modelos operacionais diferentes.
 
 Usado para edição, QA e iteração dos projetos locais como website e CRM.
 
-- roda a partir do código em `C:\CodexShared\Projetos\skincos`;
+- seleciona o código no clone compartilhado ou worktree atual; o CRM materializa
+  uma cópia imutável no runtime privado antes de executar;
 - guarda PID e estado temporário em `%LOCALAPPDATA%\Codex\skincos\`, e logs
   persistentes em `C:\CodexRuntime\operator\admin\skincos\logs\`;
 - não deve gravar artefatos operacionais novos no clone compartilhado nem no

--- a/docs/runbooks/crm-local-modular.md
+++ b/docs/runbooks/crm-local-modular.md
@@ -1,0 +1,90 @@
+# CRM local modular
+
+## Superfícies suportadas
+
+- `CRM – Local` inicia o CRM completo como Gestor e mantém o gate rígido de todo o shell.
+- `CRM – Módulos` mostra apenas papel e módulo; variáveis técnicas continuam internas.
+- O Menu Iniciar também recebe os 16 atalhos diretos em
+  `Skincos Codex\CRM – Módulos\<papel> – <módulo>.lnk`, por exemplo
+  `Gestor – Insumos.lnk` e `Consultor – Ponto.lnk`.
+- Uma invocação explícita, útil para diagnóstico, é:
+
+```powershell
+.\scripts\run-shared-codex-shortcut.ps1 -Action CrmModule -CrmRole Gestor -CrmModule insumos
+```
+
+Para encerrar somente essa combinação:
+
+```powershell
+.\scripts\run-shared-codex-shortcut.ps1 -Action CrmModuleStop -CrmRole Gestor -CrmModule insumos
+```
+
+Use WSL/Ubuntu-24.04 como runtime do agente e terminal integrado. PowerShell permanece como a ponte para atalhos, navegador e estado nativo do Windows.
+
+No Codex App, a preferência de terminal vale para novas tarefas/sessões. A ação
+do topo deve escrever no terminal integrado da própria tarefa; ela não contém
+deep link nem identificador de tarefa. Se uma versão do cliente Windows ainda
+abrir outra tarefa, execute na tarefa atual:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action CrmLocal
+```
+
+Esse fallback conserva exatamente o mesmo launcher e evita depender do
+roteamento visual do cliente.
+
+## Matriz canônica
+
+O catálogo está em `crm/console/modules/localLaunchCatalog.json`; a política de papéis está em `crm/console/modules/localRolePolicy.json`.
+
+| Papel | Módulos locais |
+| --- | --- |
+| Gestor | Insumos, Conversa, Atendimento, Ponto, Clientes, Caixa, Faturamento, Procedimentos, Unit Monitor, Redes Sociais, Meta Review, Meta Ads, Site EF e Escala |
+| Consultor | Atendimento e Ponto |
+
+Gestor usa a identidade local administrativa e pode acessar os 14 módulos. Consultor usa `role=CONSULTOR`, sem privilégio administrativo, e conserva somente Atendimento e o Ponto de autosserviço. O foco local não libera navegação para módulos cuja dependência não foi iniciada.
+
+Para adicionar uma combinação, altere o catálogo/policy, preserve a chave registrada em `crm/console/modules/registry.tsx` e rode:
+
+```powershell
+wsl.exe -d Ubuntu-24.04 -- bash -lc "node --test scripts/crm-local-module-catalog.test.mjs scripts/tests/crm-local-dual-persona.test.mjs"
+```
+
+## Isolamento e atualização
+
+Cada combinação usa um `runtimeId` determinístico e uma faixa exclusiva de portas. O estado privado fica em:
+
+```text
+C:\CodexRuntime\operator\admin\skincos\runtime\crm-local\instances\<papel>\<módulo>\
+  current.json
+  launch.lock\owner.json
+  logs\
+  state\pages\
+  state\insumos\
+  state\timekeeping\
+  state\whatsapp\
+  state\wrangler-registry\
+  browser\profile\
+```
+
+A fonte exata é materializada em `source\crm-local\immutable\<fingerprint>`. O catálogo publica uma impressão do contrato inteiro do launcher (PowerShell, Bash, policy, build, gate e browser); a ação falha fechada se o chamador e a fonte materializada divergirem. O cache de dependências do frontend fica no filesystem Linux e é identificado pelo lockfile; uma árvore `node_modules` legada do CRM completo é preservada no runtime privado antes da migração para esse cache. As dependências do Insumos ficam no cache de build privado e compartilhado somente pelas instâncias do mesmo snapshot: um lock serializa a instalação, a árvore é publicada por renomeação atômica e candidatos interrompidos são preservados em quarentena. O marcador do contrato `package.json` + `pnpm-lock.yaml` só é gravado depois que o Wrangler é validado. Artefatos, logs, Playwright e decisões de build continuam no runtime privado do operador.
+
+Na repetição de uma ação:
+
+1. o manifesto precisa ser v3, ter o mesmo módulo, papel, configuração, fonte e build;
+2. PID e `startTicks` precisam representar o mesmo processo Linux;
+3. auth, shell e dependências declaradas precisam responder saudáveis;
+4. somente então o navegador é reaberto no perfil daquela combinação;
+5. qualquer divergência encerra graciosamente apenas a combinação e reconstrói o necessário.
+
+Locks publicam um owner atômico com token. Um owner vivo nunca é removido; locks incompletos recentes são tratados como contenção e owners mortos são movidos para quarentena antes da recuperação. A parada usa as identidades registradas e não varre processos ou portas por aproximação.
+
+## Gate e segurança local
+
+O navegador só abre depois que o gate do módulo retorna `ok=true`. Insumos e
+Ponto usam Workers e persistência locais quando declarados; o adapter do CRM
+deriva de `runtimeId` um banco PostgreSQL local próprio e recusa URLs de banco
+arbitrárias. Pages e Insumos compartilham apenas o registry Wrangler privado
+daquela instância.
+
+Os valores de autenticação, chaves de teste, mocks de Escala e cenários de tracking são exclusivamente locais. Não copie `.dev.vars`, sessões, perfis ou valores deste runtime para produção.

--- a/scripts/crm-local-build-state.mjs
+++ b/scripts/crm-local-build-state.mjs
@@ -1,0 +1,772 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const BUILD_STATE_VERSION = 1
+export const BUILD_LOCK_VERSION = 1
+export const DEFAULT_STALE_LOCK_MS = 15 * 60 * 1000
+
+const HASH_ALGORITHM = 'sha256'
+const HASH_PREFIX = `${HASH_ALGORITHM}:`
+const DEFAULT_CONSOLE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'crm', 'console')
+const EXTERNAL_BUILD_INPUT_DIRECTORIES = Object.freeze([
+  'shared/identity-contract',
+])
+
+const BUILD_SOURCE_DIRECTORIES = new Set(['functions', 'modules', 'public', 'scripts'])
+const EXCLUDED_DIRECTORIES = new Set([
+  '.cache',
+  '.git',
+  '.playwright-cli',
+  '.playwright-mcp',
+  '.playwright-output',
+  '.turbo',
+  '.vite',
+  '.wrangler',
+  '.wrangler-staging',
+  'coverage',
+  'dist',
+  'downloads',
+  'e2e',
+  'finance-remote',
+  'node_modules',
+  'output',
+  'pids',
+  'playwright-report',
+  'logs',
+  'test-results',
+  'tests',
+])
+const ROOT_BUILD_EXTENSIONS = new Set([
+  '.cjs',
+  '.css',
+  '.cts',
+  '.html',
+  '.js',
+  '.json',
+  '.jsx',
+  '.less',
+  '.mjs',
+  '.mts',
+  '.sass',
+  '.scss',
+  '.ts',
+  '.tsx',
+  '.toml',
+])
+const ROOT_BUILD_FILES = new Set([
+  'index.html',
+  'npm-shrinkwrap.json',
+  'package-lock.json',
+  'package.json',
+  'pnpm-lock.yaml',
+  'wrangler.toml',
+  'yarn.lock',
+])
+
+export class BuildStateError extends Error {
+  constructor(code, message, details = undefined) {
+    super(message)
+    this.name = 'BuildStateError'
+    this.code = code
+    this.details = details
+  }
+}
+
+function compareNames(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function normalizeRelativePath(value) {
+  return value.split(path.sep).join('/')
+}
+
+function isExcludedFile(name) {
+  const lower = name.toLowerCase()
+  return lower === '.ds_store' ||
+    lower === 'thumbs.db' ||
+    lower === '.eslintcache' ||
+    lower === '.dev.vars' ||
+    lower.startsWith('.dev.vars.') ||
+    lower.endsWith('.log') ||
+    lower.includes('.log.') ||
+    lower.endsWith('.pid') ||
+    lower.endsWith('.pid.lock') ||
+    lower.endsWith('.seed') ||
+    lower.endsWith('.swp') ||
+    lower.endsWith('.swo') ||
+    lower.endsWith('.tmp') ||
+    lower.endsWith('~')
+}
+
+function isBuildInput(relativePath) {
+  const normalized = normalizeRelativePath(relativePath)
+  const parts = normalized.split('/')
+  if (parts.length > 1) return BUILD_SOURCE_DIRECTORIES.has(parts[0])
+
+  const name = parts[0]
+  const lower = name.toLowerCase()
+  return ROOT_BUILD_FILES.has(lower) ||
+    lower.startsWith('tsconfig') && lower.endsWith('.json') ||
+    lower.startsWith('vite.') ||
+    lower.startsWith('vitest.') ||
+    lower.startsWith('postcss.') ||
+    lower.startsWith('tailwind.') ||
+    ROOT_BUILD_EXTENSIONS.has(path.extname(lower))
+}
+
+async function hashFile(filePath) {
+  const hash = createHash(HASH_ALGORITHM)
+  let size = 0
+  await new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath)
+    stream.on('data', (chunk) => {
+      size += chunk.length
+      hash.update(chunk)
+    })
+    stream.on('error', reject)
+    stream.on('end', resolve)
+  })
+  return { digest: hash.digest('hex'), size }
+}
+
+async function collectTreeEntries(rootDir, {
+  include = () => true,
+  excludeTopLevelDirectories = true,
+} = {}) {
+  const root = path.resolve(rootDir)
+  const entries = []
+
+  async function visit(currentDir, relativeDir = '') {
+    const children = await fs.readdir(currentDir, { withFileTypes: true })
+    children.sort((left, right) => compareNames(left.name, right.name))
+
+    for (const child of children) {
+      const relativePath = relativeDir ? path.join(relativeDir, child.name) : child.name
+      const normalizedPath = normalizeRelativePath(relativePath)
+      if (child.isDirectory()) {
+        const isExcludedTopLevel = excludeTopLevelDirectories &&
+          relativeDir === '' &&
+          EXCLUDED_DIRECTORIES.has(child.name.toLowerCase())
+        if (!isExcludedTopLevel) {
+          await visit(path.join(currentDir, child.name), relativePath)
+        }
+        continue
+      }
+      if (isExcludedFile(child.name) || !include(normalizedPath)) continue
+
+      const absolutePath = path.join(currentDir, child.name)
+      if (child.isSymbolicLink()) {
+        const target = await fs.readlink(absolutePath)
+        const content = Buffer.from(`symlink:${normalizeRelativePath(target)}`, 'utf8')
+        entries.push({
+          path: normalizedPath,
+          digest: createHash(HASH_ALGORITHM).update(content).digest('hex'),
+          size: content.length,
+          type: 'symlink',
+        })
+        continue
+      }
+      if (!child.isFile()) continue
+      const hashed = await hashFile(absolutePath)
+      entries.push({ path: normalizedPath, ...hashed, type: 'file' })
+    }
+  }
+
+  await visit(root)
+  entries.sort((left, right) => compareNames(left.path, right.path))
+  return entries
+}
+
+function fingerprintEntries(entries, namespace) {
+  const hash = createHash(HASH_ALGORITHM)
+  hash.update(`skincos:${namespace}:v1\0`)
+  for (const entry of entries) {
+    const encodedPath = Buffer.from(entry.path, 'utf8')
+    hash.update(`${encodedPath.length}:`)
+    hash.update(encodedPath)
+    hash.update(`\0${entry.type}\0${entry.size}\0${entry.digest}\n`)
+  }
+  return `${HASH_PREFIX}${hash.digest('hex')}`
+}
+
+async function directoryExists(directory) {
+  try {
+    return (await fs.stat(directory)).isDirectory()
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+function inferSourceRoot(consoleDir) {
+  const resolvedConsole = path.resolve(consoleDir)
+  const sourceRoot = path.resolve(resolvedConsole, '..', '..')
+  return normalizeRelativePath(path.relative(sourceRoot, resolvedConsole)) === 'crm/console'
+    ? sourceRoot
+    : null
+}
+
+export async function fingerprintBuildInputs(consoleDir = DEFAULT_CONSOLE_DIR, {
+  includeEntries = false,
+  sourceRoot = inferSourceRoot(consoleDir),
+} = {}) {
+  const root = path.resolve(consoleDir)
+  if (!await directoryExists(root)) {
+    throw new BuildStateError('CONSOLE_DIR_MISSING', `CRM console directory does not exist: ${root}`)
+  }
+  const entries = await collectTreeEntries(root, { include: isBuildInput })
+  if (sourceRoot) {
+    const resolvedSourceRoot = path.resolve(sourceRoot)
+    for (const relativeDirectory of EXTERNAL_BUILD_INPUT_DIRECTORIES) {
+      const externalRoot = path.join(resolvedSourceRoot, relativeDirectory)
+      if (!await directoryExists(externalRoot)) {
+        throw new BuildStateError(
+          'EXTERNAL_BUILD_INPUT_MISSING',
+          `Required CRM build input directory does not exist: ${externalRoot}`,
+        )
+      }
+      const externalEntries = await collectTreeEntries(externalRoot)
+      entries.push(...externalEntries.map((entry) => ({
+        ...entry,
+        path: `repo/${normalizeRelativePath(relativeDirectory)}/${entry.path}`,
+      })))
+    }
+    entries.sort((left, right) => compareNames(left.path, right.path))
+  }
+  const result = {
+    fingerprint: fingerprintEntries(entries, 'crm-console-inputs'),
+    fileCount: entries.length,
+    totalBytes: entries.reduce((total, entry) => total + entry.size, 0),
+  }
+  if (includeEntries) result.entries = entries
+  return result
+}
+
+export async function fingerprintLockfile(consoleDir = DEFAULT_CONSOLE_DIR) {
+  const lockfilePath = path.join(path.resolve(consoleDir), 'package-lock.json')
+  try {
+    const hashed = await hashFile(lockfilePath)
+    return {
+      fingerprint: `${HASH_PREFIX}${hashed.digest}`,
+      fileCount: 1,
+      totalBytes: hashed.size,
+      path: 'package-lock.json',
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return { fingerprint: null, fileCount: 0, totalBytes: 0, path: 'package-lock.json' }
+    }
+    throw error
+  }
+}
+
+export async function fingerprintDist(consoleDir = DEFAULT_CONSOLE_DIR, { includeEntries = false } = {}) {
+  const distDir = path.join(path.resolve(consoleDir), 'dist')
+  if (!await directoryExists(distDir)) {
+    return { fingerprint: null, fileCount: 0, totalBytes: 0, exists: false }
+  }
+  const entries = await collectTreeEntries(distDir, { excludeTopLevelDirectories: false })
+  const result = {
+    fingerprint: fingerprintEntries(entries, 'crm-console-dist'),
+    fileCount: entries.length,
+    totalBytes: entries.reduce((total, entry) => total + entry.size, 0),
+    exists: true,
+  }
+  if (includeEntries) result.entries = entries
+  return result
+}
+
+export async function calculateBuildFingerprints(consoleDir = DEFAULT_CONSOLE_DIR, { includeEntries = false } = {}) {
+  const resolvedConsoleDir = path.resolve(consoleDir)
+  const [inputs, lockfile, dist] = await Promise.all([
+    fingerprintBuildInputs(resolvedConsoleDir, { includeEntries }),
+    fingerprintLockfile(resolvedConsoleDir),
+    fingerprintDist(resolvedConsoleDir, { includeEntries }),
+  ])
+  return {
+    version: BUILD_STATE_VERSION,
+    algorithm: HASH_ALGORITHM,
+    consoleDir: resolvedConsoleDir,
+    inputs,
+    lockfile,
+    dist,
+  }
+}
+
+async function distArtifactIsValid(consoleDir, dist) {
+  if (!dist?.exists || !dist.fingerprint || dist.fileCount < 1) return false
+  try {
+    const index = await fs.stat(path.join(path.resolve(consoleDir), 'dist', 'index.html'))
+    return index.isFile() && index.size > 0
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+export async function inspectBuildState(sourceRoot, stateFile) {
+  const resolvedRoot = path.resolve(sourceRoot)
+  const consoleDir = path.join(resolvedRoot, 'crm', 'console')
+  const fingerprints = await calculateBuildFingerprints(consoleDir)
+  const artifactFingerprint = await distArtifactIsValid(consoleDir, fingerprints.dist)
+    ? fingerprints.dist.fingerprint
+    : null
+  const comparable = {
+    ...fingerprints,
+    dist: { ...fingerprints.dist, fingerprint: artifactFingerprint },
+  }
+
+  let state = null
+  try {
+    state = await readBuildState(stateFile)
+  } catch (error) {
+    if (error?.code !== 'INVALID_BUILD_STATE') throw error
+  }
+  return {
+    inputFingerprint: fingerprints.inputs.fingerprint,
+    lockfileFingerprint: fingerprints.lockfile.fingerprint,
+    artifactFingerprint,
+    stateValid: artifactFingerprint !== null && state !== null && buildStateMatches(state, comparable),
+  }
+}
+
+function validFingerprint(value, { nullable = false } = {}) {
+  if (nullable && value === null) return true
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value)
+}
+
+function validCount(value) {
+  return Number.isSafeInteger(value) && value >= 0
+}
+
+export function validateBuildState(state) {
+  const errors = []
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    return { valid: false, errors: ['state must be a JSON object'] }
+  }
+  if (state.version !== BUILD_STATE_VERSION) errors.push(`version must equal ${BUILD_STATE_VERSION}`)
+  if (!validFingerprint(state.inputFingerprint)) errors.push('inputFingerprint must be a sha256 fingerprint')
+  if (!validFingerprint(state.lockfileFingerprint, { nullable: true })) errors.push('lockfileFingerprint must be null or a sha256 fingerprint')
+  if (!validFingerprint(state.distFingerprint)) errors.push('distFingerprint must be a sha256 fingerprint')
+  if (!validCount(state.inputFileCount)) errors.push('inputFileCount must be a non-negative integer')
+  if (!validCount(state.distFileCount)) errors.push('distFileCount must be a non-negative integer')
+  if (!validCount(state.inputBytes)) errors.push('inputBytes must be a non-negative integer')
+  if (!validCount(state.distBytes)) errors.push('distBytes must be a non-negative integer')
+  if (typeof state.builtAt !== 'string' || !Number.isFinite(Date.parse(state.builtAt))) {
+    errors.push('builtAt must be an ISO date')
+  }
+  return { valid: errors.length === 0, errors }
+}
+
+export function createBuildState(fingerprints, { builtAt = new Date().toISOString() } = {}) {
+  if (!fingerprints?.dist?.fingerprint) {
+    throw new BuildStateError('DIST_MISSING', 'Cannot record a successful build without a dist fingerprint')
+  }
+  const state = {
+    version: BUILD_STATE_VERSION,
+    inputFingerprint: fingerprints.inputs?.fingerprint ?? null,
+    lockfileFingerprint: fingerprints.lockfile?.fingerprint ?? null,
+    distFingerprint: fingerprints.dist.fingerprint,
+    inputFileCount: fingerprints.inputs?.fileCount ?? -1,
+    distFileCount: fingerprints.dist.fileCount,
+    inputBytes: fingerprints.inputs?.totalBytes ?? -1,
+    distBytes: fingerprints.dist.totalBytes,
+    builtAt,
+  }
+  const validation = validateBuildState(state)
+  if (!validation.valid) {
+    throw new BuildStateError('INVALID_BUILD_STATE', 'Generated build state is invalid', validation.errors)
+  }
+  return state
+}
+
+async function syncDirectory(directory) {
+  let handle
+  try {
+    handle = await fs.open(directory, 'r')
+    await handle.sync()
+  } catch (error) {
+    if (!['EINVAL', 'ENOTSUP', 'EISDIR', 'EPERM'].includes(error?.code)) throw error
+  } finally {
+    await handle?.close()
+  }
+}
+
+async function writeJsonAtomic(filePath, value, { mode = 0o600 } = {}) {
+  const target = path.resolve(filePath)
+  const parent = path.dirname(target)
+  const temporary = path.join(parent, `.${path.basename(target)}.${process.pid}.${randomUUID()}.tmp`)
+  await fs.mkdir(parent, { recursive: true, mode: 0o700 })
+  let handle
+  try {
+    handle = await fs.open(temporary, 'wx', mode)
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, 'utf8')
+    await handle.sync()
+    await handle.close()
+    handle = null
+    await fs.rename(temporary, target)
+    await fs.chmod(target, mode).catch((error) => {
+      if (error?.code !== 'ENOSYS') throw error
+    })
+    await syncDirectory(parent)
+  } finally {
+    await handle?.close()
+    await fs.rm(temporary, { force: true }).catch(() => {})
+  }
+}
+
+export async function writeBuildStateAtomic(stateFile, state) {
+  const validation = validateBuildState(state)
+  if (!validation.valid) {
+    throw new BuildStateError('INVALID_BUILD_STATE', 'Refusing to write invalid build state', validation.errors)
+  }
+  await writeJsonAtomic(stateFile, state)
+  return state
+}
+
+export async function readBuildState(stateFile) {
+  let parsed
+  try {
+    parsed = JSON.parse(await fs.readFile(path.resolve(stateFile), 'utf8'))
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    if (error instanceof SyntaxError) {
+      throw new BuildStateError('INVALID_BUILD_STATE', `Build state is not valid JSON: ${stateFile}`)
+    }
+    throw error
+  }
+  const validation = validateBuildState(parsed)
+  if (!validation.valid) {
+    throw new BuildStateError('INVALID_BUILD_STATE', `Build state failed validation: ${stateFile}`, validation.errors)
+  }
+  return parsed
+}
+
+export function buildStateMatches(state, fingerprints) {
+  return validateBuildState(state).valid &&
+    state.inputFingerprint === fingerprints?.inputs?.fingerprint &&
+    state.lockfileFingerprint === fingerprints?.lockfile?.fingerprint &&
+    state.distFingerprint === fingerprints?.dist?.fingerprint
+}
+
+async function processStartMarker(pid) {
+  if (process.platform !== 'linux') return null
+  try {
+    const stat = await fs.readFile(`/proc/${pid}/stat`, 'utf8')
+    const commandEnd = stat.lastIndexOf(')')
+    if (commandEnd < 0) return null
+    const fields = stat.slice(commandEnd + 2).trim().split(/\s+/)
+    return fields[19] || null
+  } catch {
+    return null
+  }
+}
+
+function processIsAlive(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code === 'EPERM'
+  }
+}
+
+async function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(await fs.readFile(path.join(lockDir, 'owner.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function lockAgeMs(lockDir, owner, now) {
+  const acquired = Date.parse(owner?.acquiredAt)
+  if (Number.isFinite(acquired)) return Math.max(0, now - acquired)
+  try {
+    return Math.max(0, now - (await fs.stat(lockDir)).mtimeMs)
+  } catch {
+    return 0
+  }
+}
+
+async function evaluateLockOwner(lockDir, owner, { staleAfterMs, hostname, now }) {
+  const ageMs = await lockAgeMs(lockDir, owner, now)
+  if (!owner || owner.version !== BUILD_LOCK_VERSION || typeof owner.token !== 'string') {
+    return { stale: ageMs >= staleAfterMs, reason: 'owner_missing_or_invalid', ageMs }
+  }
+
+  const sameHost = String(owner.hostname || '').toLowerCase() === hostname.toLowerCase()
+  if (!sameHost) return { stale: ageMs >= staleAfterMs, reason: 'foreign_owner_expired', ageMs }
+  if (!processIsAlive(owner.pid)) return { stale: true, reason: 'owner_dead', ageMs }
+
+  if (owner.processStartMarker) {
+    const currentMarker = await processStartMarker(owner.pid)
+    if (currentMarker && currentMarker !== owner.processStartMarker) {
+      return { stale: true, reason: 'pid_reused', ageMs }
+    }
+  }
+  return { stale: false, reason: 'owner_alive', ageMs }
+}
+
+export async function inspectBuildLock(lockDir, {
+  staleAfterMs = DEFAULT_STALE_LOCK_MS,
+  hostname = os.hostname(),
+  now = Date.now(),
+} = {}) {
+  const resolved = path.resolve(lockDir)
+  try {
+    const stat = await fs.stat(resolved)
+    if (!stat.isDirectory()) {
+      throw new BuildStateError('INVALID_BUILD_LOCK', `Build lock path is not a directory: ${resolved}`)
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { exists: false, stale: false, owner: null, lockDir: resolved }
+    throw error
+  }
+  const owner = await readLockOwner(resolved)
+  const evaluation = await evaluateLockOwner(resolved, owner, { staleAfterMs, hostname, now })
+  return { exists: true, owner, lockDir: resolved, ...evaluation }
+}
+
+export async function acquireBuildLock(lockDir, {
+  ownerPid = process.ppid,
+  staleAfterMs = DEFAULT_STALE_LOCK_MS,
+  hostname = os.hostname(),
+  token = randomUUID(),
+  now = Date.now(),
+} = {}) {
+  if (!Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
+    throw new BuildStateError('INVALID_LOCK_OWNER', `Invalid lock owner PID: ${ownerPid}`)
+  }
+  if (!Number.isSafeInteger(staleAfterMs) || staleAfterMs < 1) {
+    throw new BuildStateError('INVALID_STALE_TIMEOUT', `Invalid stale timeout: ${staleAfterMs}`)
+  }
+
+  const resolved = path.resolve(lockDir)
+  await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 })
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      await fs.mkdir(resolved, { mode: 0o700 })
+      const owner = {
+        version: BUILD_LOCK_VERSION,
+        token,
+        pid: ownerPid,
+        hostname,
+        acquiredAt: new Date(now).toISOString(),
+        processStartMarker: await processStartMarker(ownerPid),
+      }
+      try {
+        await writeJsonAtomic(path.join(resolved, 'owner.json'), owner)
+      } catch (error) {
+        await fs.rm(resolved, { recursive: true, force: true }).catch(() => {})
+        throw error
+      }
+      return { acquired: true, reason: 'acquired', owner, lockDir: resolved }
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error
+    }
+
+    const inspection = await inspectBuildLock(resolved, { staleAfterMs, hostname, now })
+    if (!inspection.exists) continue
+    if (!inspection.stale) {
+      return { acquired: false, reason: inspection.reason, owner: inspection.owner, lockDir: resolved }
+    }
+
+    const quarantine = `${resolved}.stale-${process.pid}-${randomUUID()}`
+    try {
+      await fs.rename(resolved, quarantine)
+    } catch (error) {
+      if (['ENOENT', 'EEXIST'].includes(error?.code)) continue
+      throw error
+    }
+    await fs.rm(quarantine, { recursive: true, force: true })
+  }
+  throw new BuildStateError('LOCK_RACE', `Could not acquire build lock after repeated races: ${resolved}`)
+}
+
+export async function releaseBuildLock(lockDir, token) {
+  if (!token) throw new BuildStateError('LOCK_TOKEN_REQUIRED', 'A lock token is required for release')
+  const resolved = path.resolve(lockDir)
+  const inspection = await inspectBuildLock(resolved)
+  if (!inspection.exists) return { released: false, reason: 'missing', lockDir: resolved }
+  if (inspection.owner?.token !== token) {
+    throw new BuildStateError('LOCK_NOT_OWNER', `Build lock is owned by another token: ${resolved}`)
+  }
+
+  const quarantine = `${resolved}.release-${process.pid}-${randomUUID()}`
+  try {
+    await fs.rename(resolved, quarantine)
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { released: false, reason: 'missing', lockDir: resolved }
+    throw error
+  }
+
+  const movedOwner = await readLockOwner(quarantine)
+  if (movedOwner?.token !== token) {
+    await fs.rename(quarantine, resolved).catch(() => {})
+    throw new BuildStateError('LOCK_NOT_OWNER', `Build lock ownership changed during release: ${resolved}`)
+  }
+  await fs.rm(quarantine, { recursive: true, force: true })
+  return { released: true, reason: 'released', lockDir: resolved }
+}
+
+function parseArgs(argv) {
+  const options = { json: false }
+  const positional = []
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--json') {
+      options.json = true
+    } else if (value === '--entries') {
+      options.entries = true
+    } else if (value.startsWith('--')) {
+      const key = value.slice(2)
+      const next = argv[index + 1]
+      if (next === undefined || next.startsWith('--')) {
+        throw new BuildStateError('USAGE', `Missing value for ${value}`)
+      }
+      options[key] = next
+      index += 1
+    } else {
+      positional.push(value)
+    }
+  }
+  return { command: positional[0], options }
+}
+
+function requiredOption(options, name) {
+  if (!options[name]) throw new BuildStateError('USAGE', `Missing required option --${name}`)
+  return options[name]
+}
+
+function printResult(result, { json = false, scalar = undefined } = {}) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`)
+  } else if (scalar !== undefined) {
+    process.stdout.write(`${scalar ?? 'missing'}\n`)
+  } else {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+  }
+}
+
+function printUsage() {
+  process.stdout.write(`Usage:
+  crm-local-build-state.mjs inspect --root SOURCE_ROOT --state STATE_PATH
+  crm-local-build-state.mjs fingerprint [--console-dir PATH] [--entries] [--json]
+  crm-local-build-state.mjs fingerprint-input [--console-dir PATH] [--json]
+  crm-local-build-state.mjs fingerprint-lockfile [--console-dir PATH] [--json]
+  crm-local-build-state.mjs fingerprint-dist [--console-dir PATH] [--json]
+  crm-local-build-state.mjs state-read --state-file PATH [--json]
+  crm-local-build-state.mjs state-validate --state-file PATH [--json]
+  crm-local-build-state.mjs state-write --state-file PATH [--console-dir PATH] [--json]
+  crm-local-build-state.mjs lock-acquire --lock-dir PATH [--owner-pid PID] [--stale-ms MS] [--json]
+  crm-local-build-state.mjs lock-inspect --lock-dir PATH [--stale-ms MS] [--json]
+  crm-local-build-state.mjs lock-release --lock-dir PATH --token TOKEN [--json]
+
+For Bash, acquire with --owner-pid "$$" and persist the returned owner.token.
+`)
+}
+
+async function runCli(argv) {
+  const { command, options } = parseArgs(argv)
+  const consoleDir = options['console-dir'] || DEFAULT_CONSOLE_DIR
+  if (!command || command === 'help') {
+    printUsage()
+    return
+  }
+
+  if (command === 'inspect') {
+    const result = await inspectBuildState(
+      requiredOption(options, 'root'),
+      requiredOption(options, 'state'),
+    )
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+  if (command === 'fingerprint') {
+    const result = await calculateBuildFingerprints(consoleDir, { includeEntries: options.entries })
+    printResult(result, options)
+    return
+  }
+  if (command === 'fingerprint-input') {
+    const result = await fingerprintBuildInputs(consoleDir, { includeEntries: options.entries })
+    printResult(result, { ...options, scalar: result.fingerprint })
+    return
+  }
+  if (command === 'fingerprint-lockfile') {
+    const result = await fingerprintLockfile(consoleDir)
+    printResult(result, { ...options, scalar: result.fingerprint })
+    return
+  }
+  if (command === 'fingerprint-dist') {
+    const result = await fingerprintDist(consoleDir, { includeEntries: options.entries })
+    printResult(result, { ...options, scalar: result.fingerprint })
+    return
+  }
+  if (command === 'state-read' || command === 'state-validate') {
+    const stateFile = requiredOption(options, 'state-file')
+    const state = await readBuildState(stateFile)
+    const result = { stateFile: path.resolve(stateFile), exists: state !== null, valid: state !== null, state }
+    printResult(result, options)
+    return
+  }
+  if (command === 'state-write') {
+    const stateFile = requiredOption(options, 'state-file')
+    const fingerprints = await calculateBuildFingerprints(consoleDir)
+    const state = createBuildState(fingerprints)
+    await writeBuildStateAtomic(stateFile, state)
+    printResult({ stateFile: path.resolve(stateFile), state }, options)
+    return
+  }
+  if (command === 'lock-acquire') {
+    const lockDir = requiredOption(options, 'lock-dir')
+    const result = await acquireBuildLock(lockDir, {
+      ownerPid: options['owner-pid'] ? Number(options['owner-pid']) : process.ppid,
+      staleAfterMs: options['stale-ms'] ? Number(options['stale-ms']) : DEFAULT_STALE_LOCK_MS,
+    })
+    printResult(result, options)
+    if (!result.acquired) process.exitCode = 73
+    return
+  }
+  if (command === 'lock-inspect') {
+    const result = await inspectBuildLock(requiredOption(options, 'lock-dir'), {
+      staleAfterMs: options['stale-ms'] ? Number(options['stale-ms']) : DEFAULT_STALE_LOCK_MS,
+    })
+    printResult(result, options)
+    return
+  }
+  if (command === 'lock-release') {
+    const result = await releaseBuildLock(
+      requiredOption(options, 'lock-dir'),
+      requiredOption(options, 'token'),
+    )
+    printResult(result, options)
+    return
+  }
+  throw new BuildStateError('USAGE', `Unknown command: ${command}`)
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (invokedPath === import.meta.url) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    const payload = {
+      ok: false,
+      error: {
+        code: error?.code || 'UNEXPECTED',
+        message: error?.message || String(error),
+        details: error?.details,
+      },
+    }
+    if (process.argv.includes('--json')) process.stderr.write(`${JSON.stringify(payload)}\n`)
+    else process.stderr.write(`[crm-local-build-state] ${payload.error.code}: ${payload.error.message}\n`)
+    process.exitCode = error?.code === 'USAGE' ? 2 : 1
+  })
+}

--- a/scripts/crm-local-module-catalog.mjs
+++ b/scripts/crm-local-module-catalog.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(SCRIPT_DIR, '..')
+const CATALOG_FILE = resolve(REPO_ROOT, 'crm/console/modules/localLaunchCatalog.json')
+const ROLE_POLICY_FILE = resolve(REPO_ROOT, 'crm/console/modules/localRolePolicy.json')
+const LAUNCHER_CONTRACT_FILES = Object.freeze([
+  'scripts/run-shared-codex-shortcut.ps1',
+  'scripts/run-local-crm.sh',
+  'scripts/crm-local-persona-runtime.sh',
+  'scripts/crm-local-runtime-policy.mjs',
+  'scripts/crm-local-build-state.mjs',
+  'scripts/crm-local-module-catalog.mjs',
+  'scripts/open-crm-local-browser.ps1',
+  'scripts/run-local-whatsapp-orchestrator.sh',
+  'crm/console/scripts/dev_pages.sh',
+  'crm/console/scripts/crm-local-smoke.cjs',
+  'crm/console/modules/localLaunchCatalog.json',
+  'crm/console/modules/localRolePolicy.json',
+])
+
+export const LOCAL_LAUNCH_SCHEMA_VERSION = 1
+export const LOCAL_LAUNCH_PORT_PLAN = Object.freeze({
+  base: 24000,
+  stride: 10,
+  offsets: Object.freeze({
+    pages: 0,
+    vite: 1,
+    insumos: 2,
+    timekeeping: 3,
+    whatsapp: 4,
+  }),
+})
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function fingerprint(value) {
+  return `sha256:${createHash('sha256').update(stableJson(value)).digest('hex')}`
+}
+
+function launcherContractFingerprint() {
+  const hash = createHash('sha256')
+  for (const relativePath of LAUNCHER_CONTRACT_FILES) {
+    hash.update(relativePath)
+    hash.update('\0')
+    hash.update(readFileSync(resolve(REPO_ROOT, relativePath)))
+    hash.update('\0')
+  }
+  return `sha256:${hash.digest('hex')}`
+}
+
+function dependencyFlags(dependencyIds) {
+  const values = new Set(dependencyIds)
+  return {
+    insumos: values.has('insumos-worker'),
+    timekeeping: values.has('timekeeping-worker'),
+    whatsapp: values.has('crm-local-adapter'),
+  }
+}
+
+function portBundle(index, dependencies, portPlan) {
+  const start = portPlan.base + (index * portPlan.stride)
+  return {
+    pages: start + portPlan.offsets.pages,
+    vite: start + portPlan.offsets.vite,
+    insumos: dependencies.insumos ? start + portPlan.offsets.insumos : null,
+    timekeeping: dependencies.timekeeping ? start + portPlan.offsets.timekeeping : null,
+    whatsapp: dependencies.whatsapp ? start + portPlan.offsets.whatsapp : null,
+  }
+}
+
+function validateSources(catalog, rolePolicy) {
+  if (catalog?.schemaVersion !== 1 || catalog?.launcherContractVersion !== 1 ||
+      !Number.isSafeInteger(catalog?.catalogVersion) ||
+      !Array.isArray(catalog?.baseDependencyIds) ||
+      !Array.isArray(catalog?.modules) || catalog.modules.length < 1) {
+    throw new Error('CRM_LOCAL_MODULE_CATALOG_INVALID')
+  }
+  if (rolePolicy?.schemaVersion !== 1 ||
+      !Number.isSafeInteger(rolePolicy?.policyVersion) ||
+      !Array.isArray(rolePolicy?.launchRoles) || rolePolicy.launchRoles.length < 1) {
+    throw new Error('CRM_LOCAL_ROLE_POLICY_INVALID')
+  }
+  const baseDependencies = catalog.baseDependencyIds.map((value) => String(value || ''))
+  if (baseDependencies.some((value) => !value) ||
+      new Set(baseDependencies).size !== baseDependencies.length) {
+    throw new Error('CRM_LOCAL_BASE_DEPENDENCIES_INVALID')
+  }
+  const keys = catalog.modules.map((entry) => String(entry?.key || ''))
+  if (keys.some((key) => !key) || new Set(keys).size !== keys.length) {
+    throw new Error('CRM_LOCAL_MODULE_KEYS_INVALID')
+  }
+  for (const moduleEntry of catalog.modules) {
+    if (moduleEntry.route !== `/?module=${encodeURIComponent(moduleEntry.key)}`) {
+      throw new Error(`CRM_LOCAL_MODULE_ROUTE_INVALID:${moduleEntry.key}`)
+    }
+    if (!moduleEntry.label || !Array.isArray(moduleEntry.dependencyIds) ||
+        (moduleEntry.onlineEnabled !== undefined && typeof moduleEntry.onlineEnabled !== 'boolean')) {
+      throw new Error(`CRM_LOCAL_MODULE_ENTRY_INVALID:${moduleEntry.key}`)
+    }
+    const dependencyIds = moduleEntry.dependencyIds.map((value) => String(value || ''))
+    if (dependencyIds.some((value) => !value) ||
+        new Set(dependencyIds).size !== dependencyIds.length) {
+      throw new Error(`CRM_LOCAL_MODULE_DEPENDENCIES_INVALID:${moduleEntry.key}`)
+    }
+  }
+  const roleKeys = rolePolicy.launchRoles.map((role) => String(role?.key || ''))
+  if (roleKeys.some((key) => !key) || new Set(roleKeys).size !== roleKeys.length) {
+    throw new Error('CRM_LOCAL_ROLE_KEYS_INVALID')
+  }
+  for (const role of rolePolicy.launchRoles) {
+    if (!role.label || !['all', 'allowlist'].includes(role.access)) {
+      throw new Error(`CRM_LOCAL_ROLE_ENTRY_INVALID:${role.key}`)
+    }
+  }
+}
+
+function roleModuleKeys(role, catalog, rolePolicy) {
+  if (role.access === 'all') return catalog.modules.map((entry) => entry.key)
+  if (role.access !== 'allowlist') throw new Error(`CRM_LOCAL_ROLE_ACCESS_INVALID:${role.key}`)
+  const modules = rolePolicy?.restrictedRoleModules?.[role.key]
+  if (!Array.isArray(modules)) throw new Error(`CRM_LOCAL_ROLE_MODULES_INVALID:${role.key}`)
+  const normalized = modules.map((value) => String(value || ''))
+  if (normalized.some((value) => !value) || new Set(normalized).size !== normalized.length) {
+    throw new Error(`CRM_LOCAL_ROLE_MODULES_INVALID:${role.key}`)
+  }
+  return normalized
+}
+
+function roleFixedModuleGrants(role, rolePolicy) {
+  const modules = rolePolicy?.fixedModuleGrants?.[role.key]
+  if (modules === undefined) return []
+  if (!Array.isArray(modules)) {
+    throw new Error(`CRM_LOCAL_ROLE_FIXED_GRANTS_INVALID:${role.key}`)
+  }
+  const normalized = modules.map((value) => String(value || ''))
+  if (normalized.some((value) => !value) || new Set(normalized).size !== normalized.length) {
+    throw new Error(`CRM_LOCAL_ROLE_FIXED_GRANTS_INVALID:${role.key}`)
+  }
+  const restricted = rolePolicy?.restrictedRoleModules?.[role.key]
+  if (Array.isArray(restricted) && normalized.some((value) => !restricted.includes(value))) {
+    throw new Error(`CRM_LOCAL_ROLE_FIXED_GRANTS_OUTSIDE_POLICY:${role.key}`)
+  }
+  return normalized
+}
+
+export function discoverLocalLaunchCatalog(options = {}) {
+  const catalog = options.catalog || readJson(CATALOG_FILE)
+  const rolePolicy = options.rolePolicy || readJson(ROLE_POLICY_FILE)
+  const portPlan = options.portPlan || LOCAL_LAUNCH_PORT_PLAN
+  validateSources(catalog, rolePolicy)
+
+  const moduleByKey = new Map(catalog.modules.map((entry) => [entry.key, entry]))
+  const contractFingerprint = options.launcherContractFingerprint || launcherContractFingerprint()
+  if (!/^sha256:[a-f0-9]{64}$/.test(contractFingerprint)) {
+    throw new Error('CRM_LOCAL_LAUNCHER_CONTRACT_FINGERPRINT_INVALID')
+  }
+  const roles = rolePolicy.launchRoles.map((role) => ({
+    role: role.label,
+    roleKey: role.key,
+  }))
+  const combinations = []
+
+  for (const role of rolePolicy.launchRoles) {
+    const fixedModuleGrants = roleFixedModuleGrants(role, rolePolicy)
+    for (const moduleKey of roleModuleKeys(role, catalog, rolePolicy)) {
+      const moduleEntry = moduleByKey.get(moduleKey)
+      if (!moduleEntry) throw new Error(`CRM_LOCAL_ROLE_REFERENCES_UNKNOWN_MODULE:${role.key}:${moduleKey}`)
+      const dependencyIds = [...catalog.baseDependencyIds, ...moduleEntry.dependencyIds]
+      const dependencies = dependencyFlags(dependencyIds)
+      const ports = portBundle(combinations.length, dependencies, portPlan)
+      const runtimeId = `crm-local--${moduleEntry.key}--${String(role.key).toLowerCase()}`
+      const combination = {
+        role: role.label,
+        roleKey: role.key,
+        module: moduleEntry.key,
+        label: moduleEntry.label,
+        route: moduleEntry.route,
+        localScenario: moduleEntry.localScenario || null,
+        runtimeId,
+        dependencyIds,
+        dependencies,
+        ports,
+        auth: {
+          testUserAdmin: role.access === 'all',
+          allowedModules: fixedModuleGrants,
+        },
+        launcherContractVersion: catalog.launcherContractVersion,
+        launcherContractFingerprint: contractFingerprint,
+      }
+      combinations.push({
+        ...combination,
+        configFingerprint: fingerprint({
+          schemaVersion: LOCAL_LAUNCH_SCHEMA_VERSION,
+          catalogVersion: catalog.catalogVersion,
+          rolePolicyVersion: rolePolicy.policyVersion,
+          ...combination,
+        }),
+      })
+    }
+  }
+  const runtimeIds = combinations.map((entry) => entry.runtimeId)
+  const ports = combinations.flatMap((entry) => Object.values(entry.ports).filter(Number.isInteger))
+  if (new Set(runtimeIds).size !== runtimeIds.length) {
+    throw new Error('CRM_LOCAL_RUNTIME_IDS_COLLIDE')
+  }
+  if (ports.some((port) => port < 1 || port > 65535) || new Set(ports).size !== ports.length) {
+    throw new Error('CRM_LOCAL_PORT_PLAN_INVALID')
+  }
+
+  const fullRuntimeContract = {
+    runtimeId: 'gestor--full',
+    module: 'full',
+    role: 'Gestor',
+    roleKey: 'GESTOR',
+    route: '/',
+    dependencyIds: [
+      'pages-functions',
+      'insumos-worker',
+      'timekeeping-worker',
+      'crm-local-adapter',
+    ],
+    dependencies: {
+      insumos: true,
+      timekeeping: true,
+      whatsapp: true,
+    },
+    ports: {
+      pages: 8791,
+      vite: 5173,
+      insumos: 8787,
+      timekeeping: 8801,
+      whatsapp: 8110,
+    },
+    gateModules: catalog.modules.map((entry) => entry.key),
+    launcherContractVersion: catalog.launcherContractVersion,
+    launcherContractFingerprint: contractFingerprint,
+  }
+  const fullRuntime = {
+    ...fullRuntimeContract,
+    configFingerprint: fingerprint({
+      schemaVersion: LOCAL_LAUNCH_SCHEMA_VERSION,
+      catalogVersion: catalog.catalogVersion,
+      rolePolicyVersion: rolePolicy.policyVersion,
+      ...fullRuntimeContract,
+    }),
+  }
+
+  return {
+    schemaVersion: LOCAL_LAUNCH_SCHEMA_VERSION,
+    catalogVersion: catalog.catalogVersion,
+    launcherContractVersion: catalog.launcherContractVersion,
+    launcherContractFingerprint: contractFingerprint,
+    rolePolicyVersion: rolePolicy.policyVersion,
+    portPlan,
+    roles,
+    fullRuntime,
+    combinations,
+  }
+}
+
+function parseArgs(argv) {
+  const filters = {}
+  let compact = false
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--json') continue
+    if (value === '--compact') {
+      compact = true
+      continue
+    }
+    if (value === '--role' || value === '--module') {
+      const next = argv[index + 1]
+      if (!next) throw new Error(`CRM_LOCAL_CATALOG_ARGUMENT_REQUIRED:${value}`)
+      filters[value.slice(2)] = next
+      index += 1
+      continue
+    }
+    throw new Error(`CRM_LOCAL_CATALOG_ARGUMENT_UNKNOWN:${value}`)
+  }
+  return { compact, filters }
+}
+
+function filteredOutput(output, filters) {
+  const roleFilter = String(filters.role || '').trim().toUpperCase()
+  const moduleFilter = String(filters.module || '').trim()
+  const combinations = output.combinations.filter((entry) => (
+    (!roleFilter || entry.roleKey === roleFilter) &&
+    (!moduleFilter || entry.module === moduleFilter)
+  ))
+  if ((roleFilter || moduleFilter) && combinations.length === 0) {
+    throw new Error('CRM_LOCAL_COMBINATION_NOT_AVAILABLE')
+  }
+  return { ...output, combinations }
+}
+
+async function main() {
+  const { compact, filters } = parseArgs(process.argv.slice(2))
+  const output = filteredOutput(discoverLocalLaunchCatalog(), filters)
+  process.stdout.write(`${JSON.stringify(output, null, compact ? 0 : 2)}\n`)
+}
+
+const invokedAsScript = process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+
+if (invokedAsScript) {
+  main().catch((error) => {
+    process.stderr.write(`${String(error?.message || error)}\n`)
+    process.exitCode = 2
+  })
+}

--- a/scripts/crm-local-module-catalog.test.mjs
+++ b/scripts/crm-local-module-catalog.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  LOCAL_LAUNCH_PORT_PLAN,
+  discoverLocalLaunchCatalog,
+} from './crm-local-module-catalog.mjs'
+
+const sourceCatalog = JSON.parse(readFileSync(
+  new URL('../crm/console/modules/localLaunchCatalog.json', import.meta.url),
+  'utf8',
+))
+const sourceRolePolicy = JSON.parse(readFileSync(
+  new URL('../crm/console/modules/localRolePolicy.json', import.meta.url),
+  'utf8',
+))
+
+test('discovers every catalog-defined Gestor and policy-defined Consultor combination', () => {
+  const output = discoverLocalLaunchCatalog()
+  assert.equal(output.schemaVersion, 1)
+  assert.equal(output.launcherContractVersion, 1)
+  assert.match(output.launcherContractFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.deepEqual(
+    output.roles,
+    sourceRolePolicy.launchRoles.map((role) => ({ role: role.label, roleKey: role.key })),
+  )
+  assert.equal(
+    output.combinations.filter((entry) => entry.roleKey === 'GESTOR').length,
+    sourceCatalog.modules.length,
+  )
+  assert.deepEqual(
+    output.combinations.filter((entry) => entry.roleKey === 'CONSULTOR').map((entry) => entry.module),
+    sourceRolePolicy.restrictedRoleModules.CONSULTOR,
+  )
+  assert.deepEqual(
+    output.combinations
+      .filter((entry) => entry.roleKey === 'CONSULTOR')
+      .map((entry) => entry.auth),
+    sourceRolePolicy.restrictedRoleModules.CONSULTOR.map(() => ({
+      testUserAdmin: false,
+      allowedModules: sourceRolePolicy.fixedModuleGrants.CONSULTOR,
+    })),
+  )
+  assert.equal(
+    output.combinations.length,
+    sourceCatalog.modules.length + sourceRolePolicy.restrictedRoleModules.CONSULTOR.length,
+  )
+})
+
+test('accepts a new local module without changing validator or port-plan code', () => {
+  const catalog = structuredClone(sourceCatalog)
+  catalog.catalogVersion += 1
+  catalog.modules.push({
+    key: 'future-module',
+    label: 'Future Module',
+    route: '/?module=future-module',
+    dependencyIds: ['crm-local-adapter'],
+  })
+
+  const output = discoverLocalLaunchCatalog({ catalog, rolePolicy: sourceRolePolicy })
+  const future = output.combinations.filter((entry) => entry.module === 'future-module')
+  assert.equal(future.length, 1)
+  assert.equal(future[0].roleKey, 'GESTOR')
+  assert.equal(
+    output.combinations.length,
+    catalog.modules.length + sourceRolePolicy.restrictedRoleModules.CONSULTOR.length,
+  )
+  assert.equal(
+    new Set(output.combinations.flatMap((entry) => Object.values(entry.ports).filter(Number.isInteger))).size,
+    output.combinations.flatMap((entry) => Object.values(entry.ports).filter(Number.isInteger)).length,
+  )
+})
+
+test('assigns deterministic collision-free port bundles and fingerprints', () => {
+  const first = discoverLocalLaunchCatalog()
+  const second = discoverLocalLaunchCatalog()
+  assert.deepEqual(second, first)
+
+  const runtimeIds = new Set()
+  const ports = new Set()
+  const fingerprints = new Set()
+  for (const entry of first.combinations) {
+    assert.match(entry.runtimeId, /^crm-local--[a-z0-9-]+--(?:gestor|consultor)$/)
+    assert.match(entry.configFingerprint, /^sha256:[a-f0-9]{64}$/)
+    assert.equal(entry.launcherContractVersion, first.launcherContractVersion)
+    assert.equal(entry.launcherContractFingerprint, first.launcherContractFingerprint)
+    assert.equal(runtimeIds.has(entry.runtimeId), false)
+    assert.equal(fingerprints.has(entry.configFingerprint), false)
+    runtimeIds.add(entry.runtimeId)
+    fingerprints.add(entry.configFingerprint)
+    for (const port of Object.values(entry.ports).filter(Number.isInteger)) {
+      assert.equal(ports.has(port), false, `port ${port} collided`)
+      ports.add(port)
+    }
+  }
+
+  const shifted = discoverLocalLaunchCatalog({
+    portPlan: {
+      ...LOCAL_LAUNCH_PORT_PLAN,
+      base: LOCAL_LAUNCH_PORT_PLAN.base + 1000,
+    },
+  })
+  assert.notEqual(shifted.combinations[0].configFingerprint, first.combinations[0].configFingerprint)
+})
+
+test('exposes dependency flags and nullable service ports consistently', () => {
+  const { combinations } = discoverLocalLaunchCatalog()
+  for (const entry of combinations) {
+    assert.deepEqual(Object.keys(entry.dependencies), ['insumos', 'timekeeping', 'whatsapp'])
+    for (const service of ['insumos', 'timekeeping', 'whatsapp']) {
+      assert.equal(entry.ports[service] === null, !entry.dependencies[service])
+    }
+  }
+  assert.equal(combinations.find((entry) => entry.module === 'insumos')?.dependencies.insumos, true)
+  assert.equal(combinations.find((entry) => entry.module === 'ponto')?.dependencies.timekeeping, true)
+  assert.equal(combinations.find((entry) => entry.module === 'atendimento')?.dependencies.whatsapp, true)
+  assert.equal(combinations.find((entry) => entry.module === 'unit-monitor')?.dependencies.whatsapp, true)
+  assert.equal(combinations.find((entry) => entry.module === 'meta-ads')?.localScenario, 'connected-ready')
+  assert.equal(combinations.find((entry) => entry.module === 'site-tracking')?.localScenario, 'connected-ready')
+})
+
+test('CLI emits one JSON object and refuses forbidden combinations', () => {
+  const script = fileURLToPath(new URL('./crm-local-module-catalog.mjs', import.meta.url))
+  const success = spawnSync(process.execPath, [script, '--json', '--role', 'CONSULTOR'], { encoding: 'utf8' })
+  assert.equal(success.status, 0, success.stderr)
+  const parsed = JSON.parse(success.stdout)
+  assert.equal(
+    parsed.combinations.length,
+    sourceRolePolicy.restrictedRoleModules.CONSULTOR.length,
+  )
+
+  const denied = spawnSync(process.execPath, [script, '--json', '--role', 'CONSULTOR', '--module', 'insumos'], { encoding: 'utf8' })
+  assert.equal(denied.status, 2)
+  assert.match(denied.stderr, /CRM_LOCAL_COMBINATION_NOT_AVAILABLE/)
+})
+
+test('rejects fixed auth grants outside the role navigation policy', () => {
+  const rolePolicy = structuredClone(sourceRolePolicy)
+  rolePolicy.fixedModuleGrants.CONSULTOR.push('insumos')
+  assert.throws(
+    () => discoverLocalLaunchCatalog({ catalog: sourceCatalog, rolePolicy }),
+    /CRM_LOCAL_ROLE_FIXED_GRANTS_OUTSIDE_POLICY:CONSULTOR/,
+  )
+})

--- a/scripts/crm-local-persona-runtime.sh
+++ b/scripts/crm-local-persona-runtime.sh
@@ -2,7 +2,9 @@
 
 crm_persona_runtime_init() {
   CRM_PERSONA="${CRM_PERSONA:-GESTOR}"
-  CRM_RUNTIME_ROOT="${CRM_RUNTIME_ROOT:-/mnt/c/CodexRuntime/operator/admin/skincos/runtime/crm-local/${CRM_PERSONA,,}}"
+  CRM_RUNTIME_MODULE="${CRM_RUNTIME_MODULE:-${CRM_MODULE:-full}}"
+  CRM_RUNTIME_ID="${CRM_RUNTIME_ID:-${CRM_PERSONA,,}--${CRM_RUNTIME_MODULE}}"
+  CRM_RUNTIME_ROOT="${CRM_RUNTIME_ROOT:-/mnt/c/CodexRuntime/operator/admin/skincos/runtime/crm-local/instances/${CRM_PERSONA,,}/${CRM_RUNTIME_MODULE}}"
   CRM_RUNTIME_MANIFEST="${CRM_RUNTIME_MANIFEST:-$CRM_RUNTIME_ROOT/current.json}"
   CRM_RUNTIME_LOCK_DIR="${CRM_RUNTIME_LOCK_DIR:-$CRM_RUNTIME_ROOT/launch.lock}"
   CRM_BUILD_STATE_FILE="${CRM_BUILD_STATE_FILE:-$CRM_RUNTIME_ROOT/build-state.json}"
@@ -10,46 +12,303 @@ crm_persona_runtime_init() {
   CRM_TARGET_COMMIT="${CRM_TARGET_COMMIT:-$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf unknown)}"
   CRM_SOURCE_FINGERPRINT="${CRM_SOURCE_FINGERPRINT:-commit:$CRM_TARGET_COMMIT}"
   CRM_SOURCE_ORIGIN="${CRM_SOURCE_ORIGIN:-$ROOT_DIR}"
+  CRM_RUNTIME_CONFIG_FINGERPRINT="${CRM_RUNTIME_CONFIG_FINGERPRINT:-}"
+  CRM_BUILD_INPUT_FINGERPRINT="${CRM_BUILD_INPUT_FINGERPRINT:-}"
+  CRM_BUILD_LOCKFILE_FINGERPRINT="${CRM_BUILD_LOCKFILE_FINGERPRINT:-}"
+  CRM_BUILD_ARTIFACT_FINGERPRINT="${CRM_BUILD_ARTIFACT_FINGERPRINT:-}"
   CRM_BUILD_COMMIT="${CRM_BUILD_COMMIT:-}"
   CRM_RUNTIME_LOCK_HELD=0
+  CRM_RUNTIME_LOCK_TOKEN=""
+  CRM_RUNTIME_OBSERVED_LOCK_TOKEN=""
+  CRM_RUNTIME_OBSERVED_LOCK_PID=""
+  CRM_RUNTIME_OBSERVED_LOCK_START_TICKS=""
+  CRM_RUNTIME_LOCK_PARTIAL_TTL="${CRM_RUNTIME_LOCK_PARTIAL_TTL:-30}"
+  CRM_RUNTIME_LOCK_WAIT_ATTEMPTS="${CRM_RUNTIME_LOCK_WAIT_ATTEMPTS:-320}"
+  export CRM_PERSONA CRM_RUNTIME_MODULE CRM_RUNTIME_ID CRM_RUNTIME_STARTED_AT
+  export CRM_TARGET_COMMIT CRM_SOURCE_FINGERPRINT CRM_SOURCE_ORIGIN
+  export CRM_RUNTIME_CONFIG_FINGERPRINT
   mkdir -p "$CRM_RUNTIME_ROOT"
 }
 
 crm_runtime_port_is_free() {
   local port="$1"
   if command -v ss >/dev/null 2>&1; then
-    ! ss -H -ltn "sport = :$port" | grep -q .
-    return $?
+    if ss -H -ltn "sport = :$port" | grep -q .; then
+      return 1
+    fi
+  elif lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | tail -n +2 | grep -q .; then
+    return 1
   fi
-  ! lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | tail -n +2 | grep -q .
+  # A Windows-owned wslrelay listener is not always visible to ss/lsof inside
+  # the distro. Probe raw TCP as a second, protocol-neutral boundary.
+  if command -v timeout >/dev/null 2>&1 &&
+     timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+
+crm_runtime_pid_start_ticks() {
+  local pid="${1:-}"
+  if [[ ! "$pid" =~ ^[0-9]+$ || ! -r "/proc/$pid/stat" ]]; then
+    return 1
+  fi
+  # Field 2 (comm) is parenthesized and may contain spaces or closing
+  # parentheses. Strip through its final ") " delimiter; starttime is then
+  # field 20 of the remaining sequence (original /proc field 22).
+  tr '\n' ' ' < "/proc/$pid/stat" 2>/dev/null | sed 's/^.*) //' | awk '{print $20}'
+}
+
+crm_runtime_pid_identity_matches() {
+  local pid="${1:-}"
+  local expected_ticks="${2:-}"
+  [[ "$pid" =~ ^[0-9]+$ && "$expected_ticks" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  [[ "$(crm_runtime_pid_start_ticks "$pid" 2>/dev/null || true)" == "$expected_ticks" ]]
+}
+
+crm_persona_runtime_manifest_is_ready() {
+  [[ -f "$CRM_RUNTIME_MANIFEST" ]] || return 1
+  local owner_identity
+  local owner_pid
+  local owner_ticks
+  owner_identity="$(
+    CRM_EXPECTED_RUNTIME_ID="$CRM_RUNTIME_ID" \
+    CRM_EXPECTED_MODULE="$CRM_RUNTIME_MODULE" \
+    CRM_EXPECTED_PERSONA="$CRM_PERSONA" \
+    CRM_EXPECTED_TARGET_COMMIT="$CRM_TARGET_COMMIT" \
+    CRM_EXPECTED_SOURCE_FINGERPRINT="$CRM_SOURCE_FINGERPRINT" \
+    CRM_EXPECTED_SOURCE_ORIGIN="$CRM_SOURCE_ORIGIN" \
+    CRM_EXPECTED_CONFIG_FINGERPRINT="$CRM_RUNTIME_CONFIG_FINGERPRINT" \
+    node - "$CRM_RUNTIME_MANIFEST" <<'NODE'
+const fs = require('fs')
+try {
+  const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+  const exact = (actual, expected) => String(actual || '') === String(expected || '')
+  const ready = value?.version === 3 &&
+    value.state === 'ready' &&
+    exact(value.runtimeId, process.env.CRM_EXPECTED_RUNTIME_ID) &&
+    exact(value.module, process.env.CRM_EXPECTED_MODULE) &&
+    String(value.persona || '').toUpperCase() === String(process.env.CRM_EXPECTED_PERSONA || '').toUpperCase() &&
+    exact(value.targetCommit, process.env.CRM_EXPECTED_TARGET_COMMIT) &&
+    exact(value.sourceFingerprint, process.env.CRM_EXPECTED_SOURCE_FINGERPRINT) &&
+    exact(value.sourceOrigin, process.env.CRM_EXPECTED_SOURCE_ORIGIN) &&
+    exact(value.configFingerprint, process.env.CRM_EXPECTED_CONFIG_FINGERPRINT) &&
+    Number.isInteger(value?.pids?.launcher) &&
+    Number.isInteger(value?.pidStartTicks?.launcher)
+  if (!ready) process.exit(2)
+  process.stdout.write(`${value.pids.launcher}:${value.pidStartTicks.launcher}`)
+} catch {
+  process.exit(2)
+}
+NODE
+  )" || return 1
+  IFS=: read -r owner_pid owner_ticks <<< "$owner_identity"
+  if [[ -n "${CRM_RUNTIME_OBSERVED_LOCK_TOKEN:-}" ]]; then
+    local lock_owner=""
+    local lock_token lock_pid lock_ticks lock_runtime_id lock_source lock_config lock_created
+    lock_owner="$(crm_runtime_read_lock_owner "$CRM_RUNTIME_LOCK_DIR/owner.json" 2>/dev/null || true)"
+    [[ -n "$lock_owner" ]] || return 1
+    IFS='|' read -r lock_token lock_pid lock_ticks lock_runtime_id lock_source lock_config lock_created <<< "$lock_owner"
+    [[ "$lock_token" == "$CRM_RUNTIME_OBSERVED_LOCK_TOKEN" &&
+       "$lock_pid" == "$CRM_RUNTIME_OBSERVED_LOCK_PID" &&
+       "$lock_ticks" == "$CRM_RUNTIME_OBSERVED_LOCK_START_TICKS" &&
+       "$owner_pid" == "$lock_pid" &&
+       "$owner_ticks" == "$lock_ticks" ]] || return 1
+  fi
+  crm_runtime_pid_identity_matches "$owner_pid" "$owner_ticks"
+}
+
+crm_persona_runtime_wait_ready() {
+  local timeout_seconds="${1:-360}"
+  [[ -n "${CRM_RUNTIME_OBSERVED_LOCK_TOKEN:-}" &&
+     -n "${CRM_RUNTIME_OBSERVED_LOCK_PID:-}" &&
+     -n "${CRM_RUNTIME_OBSERVED_LOCK_START_TICKS:-}" ]] || return 1
+  local deadline=$(( $(date +%s) + timeout_seconds ))
+  while (( $(date +%s) < deadline )); do
+    if crm_persona_runtime_manifest_is_ready; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+crm_runtime_new_lock_token() {
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    tr -d '\r\n' < /proc/sys/kernel/random/uuid
+    return
+  fi
+  printf '%s-%s-%s\n' "$$" "$(date +%s%N)" "$RANDOM"
+}
+
+crm_runtime_write_lock_owner() {
+  local token="$1"
+  local owner_file="$CRM_RUNTIME_LOCK_DIR/owner.json"
+  local temporary="$CRM_RUNTIME_LOCK_DIR/.owner.${token}.tmp"
+  local start_ticks
+  start_ticks="$(crm_runtime_pid_start_ticks "$$")" || return 1
+
+  CRM_LOCK_TOKEN="$token" \
+  CRM_LOCK_PID="$$" \
+  CRM_LOCK_START_TICKS="$start_ticks" \
+  CRM_LOCK_RUNTIME_ID="$CRM_RUNTIME_ID" \
+  CRM_LOCK_SOURCE_FINGERPRINT="$CRM_SOURCE_FINGERPRINT" \
+  CRM_LOCK_CONFIG_FINGERPRINT="$CRM_RUNTIME_CONFIG_FINGERPRINT" \
+  CRM_LOCK_CREATED_AT="$(date +%s)" \
+  node - "$temporary" <<'NODE'
+const fs = require('fs')
+fs.writeFileSync(process.argv[2], `${JSON.stringify({
+  version: 1,
+  token: process.env.CRM_LOCK_TOKEN,
+  pid: Number(process.env.CRM_LOCK_PID),
+  startTicks: Number(process.env.CRM_LOCK_START_TICKS),
+  runtimeId: process.env.CRM_LOCK_RUNTIME_ID,
+  sourceFingerprint: process.env.CRM_LOCK_SOURCE_FINGERPRINT,
+  configFingerprint: process.env.CRM_LOCK_CONFIG_FINGERPRINT,
+  createdAtEpoch: Number(process.env.CRM_LOCK_CREATED_AT),
+})}\n`, { mode: 0o600 })
+NODE
+  mv -f "$temporary" "$owner_file"
+}
+
+crm_runtime_read_lock_owner() {
+  local owner_file="$1"
+  [[ -f "$owner_file" ]] || return 1
+  node - "$owner_file" <<'NODE'
+const fs = require('fs')
+try {
+  const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+  const valid = value?.version === 1 &&
+    typeof value.token === 'string' && value.token.length > 0 &&
+    Number.isInteger(value.pid) && value.pid > 0 &&
+    Number.isInteger(value.startTicks) && value.startTicks > 0 &&
+    typeof value.runtimeId === 'string' && value.runtimeId.length > 0 &&
+    typeof value.sourceFingerprint === 'string' &&
+    typeof value.configFingerprint === 'string' &&
+    Number.isInteger(value.createdAtEpoch)
+  if (!valid) process.exit(2)
+  const fields = [
+    value.token,
+    value.pid,
+    value.startTicks,
+    value.runtimeId,
+    value.sourceFingerprint,
+    value.configFingerprint,
+    value.createdAtEpoch,
+  ]
+  if (fields.some((field) => String(field).includes('|') || String(field).includes('\n'))) process.exit(2)
+  process.stdout.write(fields.join('|'))
+} catch {
+  process.exit(2)
+}
+NODE
+}
+
+crm_runtime_dispose_quarantined_lock() {
+  local quarantine="$1"
+  rm -f -- "$quarantine/owner.json" "$quarantine"/.owner.*.tmp 2>/dev/null || true
+  if ! rmdir "$quarantine" 2>/dev/null; then
+    echo "[crm-local] Lock em quarentena contém estado desconhecido e não será removido: $quarantine" >&2
+    return 1
+  fi
+}
+
+crm_runtime_quarantine_stale_lock() {
+  local reason="$1"
+  local token
+  local quarantine
+  token="$(crm_runtime_new_lock_token)"
+  quarantine="${CRM_RUNTIME_LOCK_DIR}.stale.${token}"
+  if ! mv "$CRM_RUNTIME_LOCK_DIR" "$quarantine" 2>/dev/null; then
+    return 1
+  fi
+  echo "[crm-local] Recuperando lock órfão de $CRM_RUNTIME_ID ($reason)."
+  crm_runtime_dispose_quarantined_lock "$quarantine"
 }
 
 crm_persona_runtime_acquire_lock() {
-  if mkdir "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null; then
-    printf '%s\n' "$$" > "$CRM_RUNTIME_LOCK_DIR/pid"
-    CRM_RUNTIME_LOCK_HELD=1
-    return 0
-  fi
+  local attempt=0
+  local token
+  local owner_line
+  local owner_token owner_pid owner_ticks owner_runtime_id owner_source owner_config owner_created
+  local lock_mtime lock_age now
+  CRM_RUNTIME_OBSERVED_LOCK_TOKEN=""
+  CRM_RUNTIME_OBSERVED_LOCK_PID=""
+  CRM_RUNTIME_OBSERVED_LOCK_START_TICKS=""
 
-  local owner_pid=""
-  owner_pid="$(cat "$CRM_RUNTIME_LOCK_DIR/pid" 2>/dev/null || true)"
-  if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
-    echo "[crm-local] Runtime de $CRM_PERSONA já está ativo (PID $owner_pid)."
-    return 2
-  fi
+  while (( attempt < CRM_RUNTIME_LOCK_WAIT_ATTEMPTS )); do
+    token="$(crm_runtime_new_lock_token)"
+    if mkdir "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null; then
+      if ! crm_runtime_write_lock_owner "$token"; then
+        rm -f -- "$CRM_RUNTIME_LOCK_DIR"/.owner.*.tmp "$CRM_RUNTIME_LOCK_DIR/owner.json" 2>/dev/null || true
+        rmdir "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null || true
+        echo "[crm-local] Não foi possível publicar o owner atômico do lock de $CRM_RUNTIME_ID." >&2
+        return 1
+      fi
+      CRM_RUNTIME_LOCK_TOKEN="$token"
+      CRM_RUNTIME_LOCK_HELD=1
+      return 0
+    fi
 
-  rm -f "$CRM_RUNTIME_LOCK_DIR/pid" 2>/dev/null || true
-  rmdir "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null || true
-  mkdir "$CRM_RUNTIME_LOCK_DIR"
-  printf '%s\n' "$$" > "$CRM_RUNTIME_LOCK_DIR/pid"
-  CRM_RUNTIME_LOCK_HELD=1
+    owner_line="$(crm_runtime_read_lock_owner "$CRM_RUNTIME_LOCK_DIR/owner.json" 2>/dev/null || true)"
+    if [[ -n "$owner_line" ]]; then
+      IFS='|' read -r owner_token owner_pid owner_ticks owner_runtime_id owner_source owner_config owner_created <<< "$owner_line"
+      if crm_runtime_pid_identity_matches "$owner_pid" "$owner_ticks"; then
+        if [[ "$owner_runtime_id" != "$CRM_RUNTIME_ID" ]]; then
+          echo "[crm-local] O diretório de lock pertence ao runtime vivo '$owner_runtime_id'; '$CRM_RUNTIME_ID' não irá removê-lo." >&2
+          return 4
+        fi
+        if [[ "$owner_source" != "$CRM_SOURCE_FINGERPRINT" || "$owner_config" != "$CRM_RUNTIME_CONFIG_FINGERPRINT" ]]; then
+          echo "[crm-local] $CRM_RUNTIME_ID está em transição por outra revisão/configuração (PID $owner_pid)." >&2
+          return 3
+        fi
+        CRM_RUNTIME_OBSERVED_LOCK_TOKEN="$owner_token"
+        CRM_RUNTIME_OBSERVED_LOCK_PID="$owner_pid"
+        CRM_RUNTIME_OBSERVED_LOCK_START_TICKS="$owner_ticks"
+        echo "[crm-local] Runtime $CRM_RUNTIME_ID já está ativo (PID $owner_pid)."
+        return 2
+      fi
+      crm_runtime_quarantine_stale_lock "owner morto ou PID reutilizado" || true
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    now="$(date +%s)"
+    lock_mtime="$(stat -c %Y "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null || printf '%s' "$now")"
+    lock_age=$((now - lock_mtime))
+    if (( lock_age >= CRM_RUNTIME_LOCK_PARTIAL_TTL )); then
+      crm_runtime_quarantine_stale_lock "owner ausente/inválido há ${lock_age}s" || true
+      attempt=$((attempt + 1))
+      continue
+    fi
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+
+  echo "[crm-local] Tempo limite ao aguardar a publicação atômica do lock de $CRM_RUNTIME_ID." >&2
+  return 1
 }
 
 crm_persona_runtime_release_lock() {
   if [[ "${CRM_RUNTIME_LOCK_HELD:-0}" == "1" ]]; then
-    rm -f "$CRM_RUNTIME_LOCK_DIR/pid" 2>/dev/null || true
-    rmdir "$CRM_RUNTIME_LOCK_DIR" 2>/dev/null || true
+    local owner_line=""
+    local owner_token owner_pid owner_ticks owner_runtime_id owner_source owner_config owner_created
+    local quarantine
+    owner_line="$(crm_runtime_read_lock_owner "$CRM_RUNTIME_LOCK_DIR/owner.json" 2>/dev/null || true)"
+    if [[ -n "$owner_line" ]]; then
+      IFS='|' read -r owner_token owner_pid owner_ticks owner_runtime_id owner_source owner_config owner_created <<< "$owner_line"
+    fi
+    if [[ "$owner_token" == "$CRM_RUNTIME_LOCK_TOKEN" && "$owner_pid" == "$$" && "$owner_runtime_id" == "$CRM_RUNTIME_ID" ]]; then
+      quarantine="${CRM_RUNTIME_LOCK_DIR}.release.${CRM_RUNTIME_LOCK_TOKEN}"
+      if mv "$CRM_RUNTIME_LOCK_DIR" "$quarantine" 2>/dev/null; then
+        crm_runtime_dispose_quarantined_lock "$quarantine" || true
+      fi
+    else
+      echo "[crm-local] O lock de $CRM_RUNTIME_ID mudou de owner; o token antigo não irá removê-lo." >&2
+    fi
     CRM_RUNTIME_LOCK_HELD=0
+    CRM_RUNTIME_LOCK_TOKEN=""
   fi
 }
 
@@ -60,14 +319,28 @@ crm_persona_runtime_write_manifest() {
   CRM_RUNTIME_STATE="$state" \
   CRM_RUNTIME_UPDATED_AT="$(date -Iseconds)" \
   CRM_RUNTIME_LAUNCHER_PID="$$" \
+  CRM_RUNTIME_LAUNCHER_START_TICKS="$(crm_runtime_pid_start_ticks "$$" 2>/dev/null || true)" \
   CRM_RUNTIME_CRM_PID="${CRM_PID:-}" \
+  CRM_RUNTIME_CRM_START_TICKS="$(crm_runtime_pid_start_ticks "${CRM_PID:-}" 2>/dev/null || true)" \
   CRM_RUNTIME_INSUMOS_PID="${INSUMOS_PID:-}" \
+  CRM_RUNTIME_INSUMOS_START_TICKS="$(crm_runtime_pid_start_ticks "${INSUMOS_PID:-}" 2>/dev/null || true)" \
   CRM_RUNTIME_TIMEKEEPING_PID="${TIMEKEEPING_PID:-}" \
+  CRM_RUNTIME_TIMEKEEPING_START_TICKS="$(crm_runtime_pid_start_ticks "${TIMEKEEPING_PID:-}" 2>/dev/null || true)" \
   CRM_RUNTIME_WHATSAPP_PID="${WHATSAPP_ORCHESTRATOR_PID:-}" \
+  CRM_RUNTIME_WHATSAPP_START_TICKS="$(crm_runtime_pid_start_ticks "${WHATSAPP_ORCHESTRATOR_PID:-}" 2>/dev/null || true)" \
   CRM_RUNTIME_TARGET_COMMIT="$CRM_TARGET_COMMIT" \
   CRM_RUNTIME_BUILD_COMMIT="$CRM_BUILD_COMMIT" \
   CRM_RUNTIME_SOURCE_FINGERPRINT="$CRM_SOURCE_FINGERPRINT" \
   CRM_RUNTIME_SOURCE_ORIGIN="$CRM_SOURCE_ORIGIN" \
+  CRM_RUNTIME_CONFIG_FINGERPRINT="$CRM_RUNTIME_CONFIG_FINGERPRINT" \
+  CRM_RUNTIME_BUILD_INPUT_FINGERPRINT="$CRM_BUILD_INPUT_FINGERPRINT" \
+  CRM_RUNTIME_BUILD_LOCKFILE_FINGERPRINT="$CRM_BUILD_LOCKFILE_FINGERPRINT" \
+  CRM_RUNTIME_BUILD_ARTIFACT_FINGERPRINT="$CRM_BUILD_ARTIFACT_FINGERPRINT" \
+  CRM_RUNTIME_BROWSER_PROFILE="${CRM_BROWSER_PROFILE_DIR:-}" \
+  CRM_RUNTIME_PAGES_STATE="${R2_PERSIST_DIR:-}" \
+  CRM_RUNTIME_INSUMOS_STATE="${CRM_INSUMOS_PERSIST_DIR:-}" \
+  CRM_RUNTIME_TIMEKEEPING_STATE="${CRM_TIMEKEEPING_PERSIST_DIR:-}" \
+  CRM_RUNTIME_WHATSAPP_STATE="${CRM_LOCAL_WA_RUNTIME_HOME:-}" \
   ROOT_DIR="$ROOT_DIR" \
   DEFAULT_URL="$DEFAULT_URL" \
   LOG_FILE="$LOG_FILE" \
@@ -85,8 +358,10 @@ const output = process.argv[2]
 const number = (value) => /^\d+$/.test(value || '') ? Number(value) : null
 const enabled = (value) => value === '1'
 const payload = {
-  version: 2,
+  version: 3,
   state: process.env.CRM_RUNTIME_STATE,
+  runtimeId: process.env.CRM_RUNTIME_ID,
+  module: process.env.CRM_RUNTIME_MODULE,
   persona: process.env.CRM_PERSONA,
   startedAt: process.env.CRM_RUNTIME_STARTED_AT,
   updatedAt: process.env.CRM_RUNTIME_UPDATED_AT,
@@ -96,6 +371,12 @@ const payload = {
   buildCommit: process.env.CRM_RUNTIME_BUILD_COMMIT || null,
   sourceFingerprint: process.env.CRM_RUNTIME_SOURCE_FINGERPRINT || null,
   sourceOrigin: process.env.CRM_RUNTIME_SOURCE_ORIGIN || null,
+  configFingerprint: process.env.CRM_RUNTIME_CONFIG_FINGERPRINT || null,
+  build: {
+    inputFingerprint: process.env.CRM_RUNTIME_BUILD_INPUT_FINGERPRINT || null,
+    lockfileFingerprint: process.env.CRM_RUNTIME_BUILD_LOCKFILE_FINGERPRINT || null,
+    artifactFingerprint: process.env.CRM_RUNTIME_BUILD_ARTIFACT_FINGERPRINT || null,
+  },
   ports: {
     pages: number(process.env.CRM_PAGES_PORT),
     vite: number(process.env.CRM_VITE_PORT),
@@ -110,6 +391,20 @@ const payload = {
     timekeeping: number(process.env.CRM_RUNTIME_TIMEKEEPING_PID),
     whatsapp: number(process.env.CRM_RUNTIME_WHATSAPP_PID),
   },
+  pidStartTicks: {
+    launcher: number(process.env.CRM_RUNTIME_LAUNCHER_START_TICKS),
+    pages: number(process.env.CRM_RUNTIME_CRM_START_TICKS),
+    insumos: number(process.env.CRM_RUNTIME_INSUMOS_START_TICKS),
+    timekeeping: number(process.env.CRM_RUNTIME_TIMEKEEPING_START_TICKS),
+    whatsapp: number(process.env.CRM_RUNTIME_WHATSAPP_START_TICKS),
+  },
+  statePaths: {
+    pages: process.env.CRM_RUNTIME_PAGES_STATE || null,
+    insumos: process.env.CRM_RUNTIME_INSUMOS_STATE || null,
+    timekeeping: process.env.CRM_RUNTIME_TIMEKEEPING_STATE || null,
+    whatsapp: process.env.CRM_RUNTIME_WHATSAPP_STATE || null,
+  },
+  browserProfile: process.env.CRM_RUNTIME_BROWSER_PROFILE || null,
   log: process.env.LOG_FILE,
 }
 fs.writeFileSync(output, JSON.stringify(payload, null, 2) + '\n', { mode: 0o600 })
@@ -136,20 +431,50 @@ NODE
 }
 
 crm_persona_runtime_stop_manifest_owner() {
+  CRM_STOP_OWNER_LAUNCHER_PID=""
+  CRM_STOP_OWNER_LAUNCHER_TICKS=""
   [[ -f "$CRM_RUNTIME_MANIFEST" ]] || return 0
-  local owner_pid=""
-  owner_pid="$(ROOT_DIR="$ROOT_DIR" node - "$CRM_RUNTIME_MANIFEST" <<'NODE'
+  local owner_identities=""
+  owner_identities="$(ROOT_DIR="$ROOT_DIR" CRM_RUNTIME_ID="$CRM_RUNTIME_ID" node - "$CRM_RUNTIME_MANIFEST" <<'NODE'
 const fs = require('fs')
 try {
   const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
-  if (value.worktree === process.env.ROOT_DIR && Number.isInteger(value?.pids?.launcher)) {
-    process.stdout.write(String(value.pids.launcher))
+  if (value.worktree === process.env.ROOT_DIR && value.runtimeId === process.env.CRM_RUNTIME_ID) {
+    const names = ['launcher', 'pages', 'insumos', 'timekeeping', 'whatsapp']
+    const identities = names.flatMap((name) => (
+      Number.isInteger(value?.pids?.[name]) && Number.isInteger(value?.pidStartTicks?.[name])
+        ? [`${name}:${value.pids[name]}:${value.pidStartTicks[name]}`]
+        : []
+    ))
+    process.stdout.write(identities.join('\n'))
   }
 } catch {}
 NODE
 )"
-  if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
-    echo "[crm-local] Encerrando runtime identificado de $CRM_PERSONA (PID $owner_pid)."
-    terminate_pid "$owner_pid"
+  local owner_name
+  local owner_pid
+  local owner_ticks
+  while IFS=: read -r owner_name owner_pid owner_ticks; do
+    [[ -n "$owner_name" ]] || continue
+    if [[ "$owner_name" == "launcher" ]]; then
+      CRM_STOP_OWNER_LAUNCHER_PID="$owner_pid"
+      CRM_STOP_OWNER_LAUNCHER_TICKS="$owner_ticks"
+    fi
+    if [[ "$owner_pid" != "$$" ]] && crm_runtime_pid_identity_matches "$owner_pid" "$owner_ticks"; then
+      echo "[crm-local] Encerrando processo identificado de $CRM_RUNTIME_ID ($owner_name, PID $owner_pid)."
+      terminate_pid "$owner_pid"
+    fi
+  done <<< "$owner_identities"
+
+  if [[ -n "$CRM_STOP_OWNER_LAUNCHER_PID" && -n "$CRM_STOP_OWNER_LAUNCHER_TICKS" && -f "$PID_FILE" ]]; then
+    local tracked_pid tracked_ticks tracked_runtime_id
+    tracked_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    tracked_ticks="$(cat "${PID_FILE}.start-ticks" 2>/dev/null || true)"
+    tracked_runtime_id="$(cat "${PID_FILE}.runtime-id" 2>/dev/null || true)"
+    if [[ "$tracked_pid" == "$CRM_STOP_OWNER_LAUNCHER_PID" &&
+          "$tracked_ticks" == "$CRM_STOP_OWNER_LAUNCHER_TICKS" &&
+          "$tracked_runtime_id" == "$CRM_RUNTIME_ID" ]]; then
+      rm -f "$PID_FILE" "${PID_FILE}.start-ticks" "${PID_FILE}.runtime-id"
+    fi
   fi
 }

--- a/scripts/crm-local-runtime-policy.mjs
+++ b/scripts/crm-local-runtime-policy.mjs
@@ -31,6 +31,12 @@ export function sourceOriginsMatch(left, right) {
   return Boolean(a && b && a === b)
 }
 
+function exactOptionalMatch(actual, expected) {
+  const wanted = String(expected || '').trim()
+  if (!wanted) return true
+  return String(actual || '').trim() === wanted
+}
+
 function canReuseLegacyCanonicalFingerprint(builtFingerprint, expectedFingerprint, targetCommit) {
   // Older canonical runtimes recorded their exact built commit but not a source
   // fingerprint. That is equivalent to the current `commit:<sha>` contract
@@ -40,16 +46,41 @@ function canReuseLegacyCanonicalFingerprint(builtFingerprint, expectedFingerprin
     normalizeFingerprint(expectedFingerprint) === `commit:${normalizeCommit(targetCommit)}`
 }
 
-export function decideRuntimeAction({ manifest, buildState, targetCommit, sourceFingerprint, sourceOrigin, persona, pidAlive, healthy }) {
+export function decideRuntimeAction({
+  manifest,
+  buildState,
+  targetCommit,
+  sourceFingerprint,
+  sourceOrigin,
+  persona,
+  runtimeId,
+  module,
+  configFingerprint,
+  buildInputFingerprint,
+  lockfileFingerprint,
+  artifactFingerprint,
+  pidAlive,
+  healthy,
+}) {
   if (!manifest || typeof manifest !== 'object') return { action: 'start', reason: 'manifest_missing' }
   if (String(manifest.persona || '').toUpperCase() !== String(persona || '').toUpperCase()) {
     return { action: 'restart', reason: 'persona_mismatch' }
+  }
+  if (!exactOptionalMatch(manifest.runtimeId, runtimeId)) return { action: 'restart', reason: 'runtime_id_mismatch' }
+  if (!exactOptionalMatch(manifest.module, module)) return { action: 'restart', reason: 'module_mismatch' }
+  if (!exactOptionalMatch(manifest.configFingerprint, configFingerprint)) {
+    return { action: 'restart', reason: 'runtime_config_outdated' }
   }
   if (!pidAlive) return { action: 'restart', reason: 'launcher_dead' }
 
   const state = String(manifest.state || '').toLowerCase()
   const intendedCommit = manifest.targetCommit || manifest.buildCommit || buildState?.commit
-  if (state === 'starting' && commitsMatch(intendedCommit, targetCommit)) {
+  const intendedFingerprint = manifest.sourceFingerprint || buildState?.sourceFingerprint
+  const intendedOrigin = manifest.sourceOrigin || buildState?.sourceOrigin
+  if (state === 'starting' &&
+      commitsMatch(intendedCommit, targetCommit) &&
+      (!sourceFingerprint || fingerprintsMatch(intendedFingerprint, sourceFingerprint)) &&
+      (!sourceOrigin || sourceOriginsMatch(intendedOrigin, sourceOrigin))) {
     return { action: 'wait', reason: 'current_start_in_progress' }
   }
 
@@ -59,13 +90,29 @@ export function decideRuntimeAction({ manifest, buildState, targetCommit, source
   const sourceMatches = fingerprintsMatch(builtFingerprint, sourceFingerprint) ||
     canReuseLegacyCanonicalFingerprint(builtFingerprint, sourceFingerprint, targetCommit)
   const originMatches = sourceOriginsMatch(builtOrigin, sourceOrigin)
-  if (state === 'ready' && commitsMatch(builtCommit, targetCommit) && sourceMatches && originMatches && healthy) {
+  const buildInputMatches = exactOptionalMatch(
+    manifest?.build?.inputFingerprint || buildState?.inputFingerprint,
+    buildInputFingerprint,
+  )
+  const lockfileMatches = exactOptionalMatch(
+    manifest?.build?.lockfileFingerprint || buildState?.lockfileFingerprint,
+    lockfileFingerprint,
+  )
+  const artifactMatches = exactOptionalMatch(
+    manifest?.build?.artifactFingerprint || buildState?.artifactFingerprint,
+    artifactFingerprint,
+  )
+  if (state === 'ready' && commitsMatch(builtCommit, targetCommit) && sourceMatches && originMatches &&
+      buildInputMatches && lockfileMatches && artifactMatches && healthy) {
     return { action: 'reuse', reason: 'current_runtime_ready' }
   }
 
   if (!commitsMatch(builtCommit, targetCommit)) return { action: 'restart', reason: 'commit_outdated' }
   if (!sourceMatches) return { action: 'restart', reason: 'source_outdated' }
   if (!originMatches) return { action: 'restart', reason: 'source_origin_outdated' }
+  if (!buildInputMatches) return { action: 'restart', reason: 'build_inputs_outdated' }
+  if (!lockfileMatches) return { action: 'restart', reason: 'dependencies_outdated' }
+  if (!artifactMatches) return { action: 'restart', reason: 'artifact_outdated' }
   if (state !== 'ready') return { action: 'restart', reason: `state_${state || 'missing'}` }
   return { action: 'restart', reason: 'health_failed' }
 }
@@ -97,6 +144,12 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
     sourceFingerprint: args['source-fingerprint'],
     sourceOrigin: args['source-origin'],
     persona: args.persona,
+    runtimeId: args['runtime-id'],
+    module: args.module,
+    configFingerprint: args['config-fingerprint'],
+    buildInputFingerprint: args['build-input-fingerprint'],
+    lockfileFingerprint: args['lockfile-fingerprint'],
+    artifactFingerprint: args['artifact-fingerprint'],
     pidAlive: args['pid-alive'] === 'true',
     healthy: args.healthy === 'true',
   })

--- a/scripts/install-shared-codex-shortcuts.ps1
+++ b/scripts/install-shared-codex-shortcuts.ps1
@@ -28,6 +28,17 @@ function Remove-DirectoryIfExists {
     }
 }
 
+function Test-SamePath {
+    param(
+        [string]$Left,
+        [string]$Right
+    )
+
+    $leftFull = [System.IO.Path]::GetFullPath($Left).TrimEnd('\')
+    $rightFull = [System.IO.Path]::GetFullPath($Right).TrimEnd('\')
+    return [string]::Equals($leftFull, $rightFull, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Clear-DirectoryContents {
     param([string]$Path)
 
@@ -77,6 +88,27 @@ function New-ShortcutFile {
     }
 }
 
+function Convert-WindowsPathToWsl {
+    param([string]$Path)
+    if ($Path -match '^(?<drive>[A-Za-z]):\\(?<rest>.*)$') {
+        return "/mnt/$($Matches.drive.ToLowerInvariant())/$($Matches.rest -replace '\\', '/')"
+    }
+    return $Path
+}
+
+function Get-CrmLocalModuleCatalog {
+    $catalogScript = Join-Path $ProjectRoot "scripts\crm-local-module-catalog.mjs"
+    if (-not (Test-Path -LiteralPath $catalogScript)) {
+        throw "CRM module catalog is missing: '$catalogScript'."
+    }
+    $catalogScriptWsl = Convert-WindowsPathToWsl -Path $catalogScript
+    $raw = & wsl.exe -d Ubuntu-24.04 -- node $catalogScriptWsl --json
+    if ($LASTEXITCODE -ne 0) {
+        throw "The CRM module catalog could not be read through Ubuntu-24.04."
+    }
+    return ($raw -join "`n") | ConvertFrom-Json
+}
+
 if ($Uninstall) {
     Remove-DirectoryIfExists -Path $StartMenuRoot
     Remove-DirectoryIfExists -Path $UserStartMenuRoot
@@ -95,9 +127,8 @@ $powershellExe = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powe
 $shortcuts = @(
     @{ Name = "Workspace"; Action = "WorkspaceMenu"; Description = "Menu de bootstrap, validacao, WSL e GitHub do workspace Skincos." },
     @{ Name = "Contexto"; Action = "ContextMenu"; Description = "Menu de status, contexto e bootstrap de thread do Skincos." },
-    @{ Name = "Local"; Action = "LocalMenu"; Description = "Menu de website, CRM e stack local principal do Skincos." },
-    @{ Name = "CRM – Local (Gestor)"; Action = "CrmLocal"; Description = "Inicia o CRM Gestor local e os serviços compartilhados." },
-    @{ Name = "CRM – Consultor (Ponto)"; Action = "CrmConsultor"; Description = "Abre o CRM local com a persona sintética de Consultor no módulo Ponto." },
+    @{ Name = "CRM – Local"; Action = "CrmLocal"; Description = "Inicia o CRM completo local com gate de todos os módulos." },
+    @{ Name = "CRM – Módulos"; Action = "CrmModules"; Description = "Escolhe um módulo e um papel real em runtime local isolado." },
     @{ Name = "EF App"; Action = "EfAppMenu"; Description = "Menu das automacoes do app.espacofacial.com.br." },
     @{ Name = "Orb"; Action = "OrbMenu"; Description = "Menu do runtime live do orb/n8n e utilitarios de suporte." }
 )
@@ -121,6 +152,25 @@ function Install-ShortcutSet {
         }
     }
 
+    $moduleRoot = Join-Path $TargetRoot "CRM – Módulos"
+    Ensure-Directory -Path $moduleRoot
+    $catalog = Get-CrmLocalModuleCatalog
+    foreach ($spec in @($catalog.combinations)) {
+        $shortcutName = "{0} – {1}" -f ([string]$spec.role), ([string]$spec.label)
+        $shortcutPath = Join-Path $moduleRoot ($shortcutName + ".lnk")
+        $arguments = '-NoExit -ExecutionPolicy Bypass -File "{0}" -Action CrmModule -CrmRole "{1}" -CrmModule "{2}" -ProjectRoot "{3}"' -f `
+            $runner, ([string]$spec.role), ([string]$spec.module), $ProjectRoot
+        $description = "Inicia $([string]$spec.label) como $([string]$spec.role) em runtime local isolado."
+        New-ShortcutFile -ShortcutPath $shortcutPath -TargetPath $powershellExe -Arguments $arguments -WorkingDirectory $ProjectRoot -Description $description
+        $installed += [pscustomobject]@{
+            name = $shortcutName
+            action = "CrmModule"
+            role = [string]$spec.role
+            module = [string]$spec.module
+            path = $shortcutPath
+        }
+    }
+
     return $installed
 }
 
@@ -130,6 +180,14 @@ $warning = $null
 
 try {
     $installed = Install-ShortcutSet -TargetRoot $StartMenuRoot
+    if (-not (Test-SamePath -Left $StartMenuRoot -Right $UserStartMenuRoot)) {
+        try {
+            Remove-DirectoryIfExists -Path $UserStartMenuRoot
+        }
+        catch {
+            $warning = "Shared shortcuts were installed, but the stale current-user shortcut root could not be removed: $($_.Exception.Message)"
+        }
+    }
 }
 catch {
     if ($_.Exception.Message -notmatch "Access denied") {
@@ -140,6 +198,17 @@ catch {
     $mode = "user-fallback"
     $warning = "Shared Start Menu write was denied in this Windows session. Shortcuts were installed for the current user only."
     $installed = Install-ShortcutSet -TargetRoot $UserStartMenuRoot
+    if (-not (Test-SamePath -Left $StartMenuRoot -Right $UserStartMenuRoot)) {
+        try {
+            Remove-DirectoryIfExists -Path $StartMenuRoot
+        }
+        catch {
+            $warning += " The shared shortcut root could not be cleaned; remove stale shared shortcuts from an elevated PowerShell session."
+        }
+        if (Test-Path -LiteralPath $StartMenuRoot) {
+            $warning += " A shared shortcut root is still present and may expose stale entries."
+        }
+    }
 }
 
 [pscustomobject]@{

--- a/scripts/open-crm-local-browser.ps1
+++ b/scripts/open-crm-local-browser.ps1
@@ -1,0 +1,101 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Url,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ProfilePath,
+
+    [string]$BrowserPath,
+
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$uri = $null
+if (-not [Uri]::TryCreate($Url, [UriKind]::Absolute, [ref]$uri)) {
+    throw 'A URL do CRM deve ser uma URI absoluta.'
+}
+
+$loopbackHost = $uri.DnsSafeHost.Trim('[', ']').ToLowerInvariant()
+if (
+    $uri.Scheme -ne 'http' -or
+    $loopbackHost -notin @('localhost', '127.0.0.1', '::1') -or
+    -not [string]::IsNullOrEmpty($uri.UserInfo) -or
+    $uri.Port -lt 1 -or
+    $uri.Port -gt 65535
+) {
+    throw 'A URL do CRM deve usar HTTP, um host loopback explícito e uma porta válida, sem credenciais.'
+}
+
+$privateRuntimeRoot = [IO.Path]::GetFullPath('C:\CodexRuntime\operator\admin\skincos')
+if (-not [IO.Path]::IsPathRooted($ProfilePath)) {
+    throw 'O perfil do navegador deve usar um caminho Windows absoluto.'
+}
+
+$profileFullPath = [IO.Path]::GetFullPath($ProfilePath)
+$privateRuntimePrefix = $privateRuntimeRoot.TrimEnd(
+    [IO.Path]::DirectorySeparatorChar,
+    [IO.Path]::AltDirectorySeparatorChar
+) + [IO.Path]::DirectorySeparatorChar
+if (-not $profileFullPath.StartsWith($privateRuntimePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "O perfil do navegador deve ficar no runtime privado: $privateRuntimeRoot"
+}
+
+function Resolve-CrmLocalBrowser {
+    param([string]$RequestedPath)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        $resolvedRequestedPath = [IO.Path]::GetFullPath($RequestedPath)
+        if (-not (Test-Path -LiteralPath $resolvedRequestedPath -PathType Leaf)) {
+            throw "Navegador não encontrado: $resolvedRequestedPath"
+        }
+        if ([IO.Path]::GetFileName($resolvedRequestedPath).ToLowerInvariant() -notin @('msedge.exe', 'chrome.exe')) {
+            throw 'BrowserPath deve apontar para msedge.exe ou chrome.exe.'
+        }
+        return $resolvedRequestedPath
+    }
+
+    $programFiles = [Environment]::GetEnvironmentVariable('ProgramFiles')
+    $programFilesX86 = [Environment]::GetEnvironmentVariable('ProgramFiles(x86)')
+    $localAppData = [Environment]::GetEnvironmentVariable('LOCALAPPDATA')
+    $candidates = @(
+        $(if ($programFiles) { Join-Path $programFiles 'Microsoft\Edge\Application\msedge.exe' }),
+        $(if ($programFilesX86) { Join-Path $programFilesX86 'Microsoft\Edge\Application\msedge.exe' }),
+        $(if ($localAppData) { Join-Path $localAppData 'Microsoft\Edge\Application\msedge.exe' }),
+        $(if ($programFiles) { Join-Path $programFiles 'Google\Chrome\Application\chrome.exe' }),
+        $(if ($programFilesX86) { Join-Path $programFilesX86 'Google\Chrome\Application\chrome.exe' }),
+        $(if ($localAppData) { Join-Path $localAppData 'Google\Chrome\Application\chrome.exe' })
+    ) | Where-Object { $_ }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return [IO.Path]::GetFullPath($candidate)
+        }
+    }
+
+    throw 'Microsoft Edge ou Google Chrome não foi encontrado neste host.'
+}
+
+$resolvedBrowserPath = Resolve-CrmLocalBrowser -RequestedPath $BrowserPath
+$browserArguments = @(
+    "--user-data-dir=`"$profileFullPath`""
+    '--new-window'
+    '--no-first-run'
+    $uri.AbsoluteUri
+)
+
+if ($DryRun) {
+    [pscustomobject]@{
+        BrowserPath = $resolvedBrowserPath
+        ProfilePath = $profileFullPath
+        Url = $uri.AbsoluteUri
+        Arguments = $browserArguments
+    }
+    return
+}
+
+New-Item -ItemType Directory -Path $profileFullPath -Force | Out-Null
+Start-Process -FilePath $resolvedBrowserPath -ArgumentList $browserArguments | Out-Null

--- a/scripts/run-local-crm.sh
+++ b/scripts/run-local-crm.sh
@@ -10,6 +10,7 @@ INSUMOS_HELPER="$ROOT_DIR/backend/scripts/insumos.sh"
 INSUMOS_EXPORTER="$ROOT_DIR/backend/scripts/insumos-d1-export.cjs"
 INSUMOS_SEEDER="$ROOT_DIR/backend/scripts/insumos-seed.sh"
 WHATSAPP_ORCHESTRATOR_HELPER="$ROOT_DIR/scripts/run-local-whatsapp-orchestrator.sh"
+BUILD_STATE_HELPER="$ROOT_DIR/scripts/crm-local-build-state.mjs"
 
 CRM_HOST="${CRM_HOST:-127.0.0.1}"
 if [[ -n "${CRM_VITE_PORT+x}" ]]; then
@@ -87,6 +88,23 @@ PID_FILE="${CRM_PID_FILE:-$ROOT_DIR/.crm-local-dev.pid}"
 LOG_FILE="${CRM_LOG_FILE:-$ROOT_DIR/.crm-local-dev.log}"
 SNAPSHOT_DEFAULT_PATH="${CRM_INSUMOS_SNAPSHOT_DEFAULT:-$ROOT_DIR/backend/var/local/insumos-snapshot.latest.json}"
 crm_persona_runtime_init
+CRM_BUILD_LOCK_DIR="${CRM_BUILD_LOCK_DIR:-$CRM_RUNTIME_ROOT/build.lock}"
+CRM_DEPENDENCY_STATE_ROOT="${CRM_DEPENDENCY_STATE_ROOT:-$(dirname "$CRM_BUILD_LOCK_DIR")/dependencies}"
+CRM_FRONTEND_DEPENDENCY_CACHE_ROOT="${CRM_FRONTEND_DEPENDENCY_CACHE_ROOT:-/home/$(id -un)/.cache/skincos/crm-local/frontend-dependencies}"
+CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION="${CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION:-0}"
+CRM_WRANGLER_REGISTRY_PATH="${CRM_WRANGLER_REGISTRY_PATH:-$CRM_RUNTIME_ROOT/state/wrangler-registry}"
+CRM_INSUMOS_PERSIST_DIR="${CRM_INSUMOS_PERSIST_DIR:-$CRM_RUNTIME_ROOT/state/insumos}"
+CRM_INSUMOS_DEPENDENCY_ROOT="${CRM_INSUMOS_DEPENDENCY_ROOT:-$CRM_DEPENDENCY_STATE_ROOT/insumos}"
+CRM_INSUMOS_DEPENDENCY_STATE_FILE="${CRM_INSUMOS_DEPENDENCY_STATE_FILE:-$CRM_INSUMOS_DEPENDENCY_ROOT/dependency-key.sha256}"
+CRM_INSUMOS_DEPENDENCY_LOCK_FILE="${CRM_INSUMOS_DEPENDENCY_LOCK_FILE:-$CRM_INSUMOS_DEPENDENCY_ROOT/install.lock}"
+CRM_INSUMOS_DEPENDENCY_CACHE_ROOT="${CRM_INSUMOS_DEPENDENCY_CACHE_ROOT:-$CRM_INSUMOS_DEPENDENCY_ROOT/cache}"
+CRM_TIMEKEEPING_PERSIST_DIR="${CRM_TIMEKEEPING_PERSIST_DIR:-$CRM_RUNTIME_ROOT/state/timekeeping}"
+R2_PERSIST_DIR="${R2_PERSIST_DIR:-$CRM_RUNTIME_ROOT/state/pages}"
+PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-0}"
+export WRANGLER_REGISTRY_PATH="$CRM_WRANGLER_REGISTRY_PATH"
+export CRM_INSUMOS_DEPENDENCY_STATE_FILE
+export CRM_INSUMOS_DEPENDENCY_LOCK_FILE
+export CRM_INSUMOS_DEPENDENCY_CACHE_ROOT
 
 report_timestamp() {
   date +%Y%m%d-%H%M%S
@@ -239,32 +257,80 @@ collect_descendants() {
 
 terminate_pid() {
   local target_pid="$1"
-  local descendant_pids
+  local target_ticks
+  local descendant_pid
+  local descendant_ticks
+  local descendant_identities=""
   if ! kill -0 "$target_pid" >/dev/null 2>&1; then
     return 0
   fi
-  descendant_pids="$(collect_descendants "$target_pid" | tr '\n' ' ')"
-  if [[ -n "$descendant_pids" ]]; then
-    kill -TERM $descendant_pids >/dev/null 2>&1 || true
+  target_ticks="$(crm_runtime_pid_start_ticks "$target_pid" 2>/dev/null || true)"
+  [[ "$target_ticks" =~ ^[0-9]+$ ]] || return 0
+
+  while IFS= read -r descendant_pid; do
+    [[ -n "$descendant_pid" ]] || continue
+    descendant_ticks="$(crm_runtime_pid_start_ticks "$descendant_pid" 2>/dev/null || true)"
+    if [[ "$descendant_ticks" =~ ^[0-9]+$ ]]; then
+      descendant_identities+="${descendant_pid}:${descendant_ticks}"$'\n'
+    fi
+  done < <(collect_descendants "$target_pid")
+
+  while IFS=: read -r descendant_pid descendant_ticks; do
+    [[ -n "$descendant_pid" ]] || continue
+    if crm_runtime_pid_identity_matches "$descendant_pid" "$descendant_ticks"; then
+      kill -TERM "$descendant_pid" >/dev/null 2>&1 || true
+    fi
+  done <<< "$descendant_identities"
+  if crm_runtime_pid_identity_matches "$target_pid" "$target_ticks"; then
+    kill -TERM "$target_pid" >/dev/null 2>&1 || true
   fi
-  kill -TERM "$target_pid" >/dev/null 2>&1 || true
-  sleep 2
-  if [[ -n "$descendant_pids" ]]; then
-    kill -KILL $descendant_pids >/dev/null 2>&1 || true
+
+  local attempt
+  local any_alive
+  for attempt in {1..40}; do
+    any_alive=0
+    if crm_runtime_pid_identity_matches "$target_pid" "$target_ticks"; then
+      any_alive=1
+    fi
+    while IFS=: read -r descendant_pid descendant_ticks; do
+      [[ -n "$descendant_pid" ]] || continue
+      if crm_runtime_pid_identity_matches "$descendant_pid" "$descendant_ticks"; then
+        any_alive=1
+      fi
+    done <<< "$descendant_identities"
+    if [[ "$any_alive" == "0" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  while IFS=: read -r descendant_pid descendant_ticks; do
+    [[ -n "$descendant_pid" ]] || continue
+    if crm_runtime_pid_identity_matches "$descendant_pid" "$descendant_ticks"; then
+      kill -KILL "$descendant_pid" >/dev/null 2>&1 || true
+    fi
+  done <<< "$descendant_identities"
+  if crm_runtime_pid_identity_matches "$target_pid" "$target_ticks"; then
+    kill -KILL "$target_pid" >/dev/null 2>&1 || true
   fi
-  kill -KILL "$target_pid" >/dev/null 2>&1 || true
 }
 
 stop_existing() {
   local existing_pid
+  local existing_ticks
+  local existing_runtime_id
 
   if [[ -f "$PID_FILE" ]]; then
     existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
-      echo "Instância anterior do CRM local detectada (PID $existing_pid). Finalizando..."
+    existing_ticks="$(cat "${PID_FILE}.start-ticks" 2>/dev/null || true)"
+    existing_runtime_id="$(cat "${PID_FILE}.runtime-id" 2>/dev/null || true)"
+    if crm_runtime_pid_identity_matches "$existing_pid" "$existing_ticks" && [[ "$existing_runtime_id" == "$CRM_RUNTIME_ID" ]]; then
+      echo "Instância anterior $CRM_RUNTIME_ID detectada (PID $existing_pid). Finalizando..."
       terminate_pid "$existing_pid"
+    elif [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+      echo "[crm-local] PID $existing_pid não possui a identidade esperada de $CRM_RUNTIME_ID; ele não será encerrado." >&2
     fi
-    rm -f "$PID_FILE"
+    rm -f "$PID_FILE" "${PID_FILE}.start-ticks" "${PID_FILE}.runtime-id"
   fi
 }
 
@@ -393,12 +459,31 @@ wait_for_crm_api() {
 }
 
 open_browser() {
-  if command -v open >/dev/null 2>&1; then
-    open "$DEFAULT_URL" >/dev/null 2>&1 &
-    disown "$!" >/dev/null 2>&1 || true
+  local browser_log="${CRM_BROWSER_OPEN_LOG:-${LOG_FILE}.browser.log}"
+  mkdir -p "$(dirname "$browser_log")"
+  if [[ -n "${CRM_BROWSER_SCRIPT:-}" && -n "${CRM_BROWSER_PROFILE_DIR:-}" ]] && command -v powershell.exe >/dev/null 2>&1; then
+    local browser_script_windows
+    local browser_profile_windows
+    browser_script_windows="$(wslpath -w "$CRM_BROWSER_SCRIPT")"
+    browser_profile_windows="$(wslpath -w "$CRM_BROWSER_PROFILE_DIR")"
+    if ! powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$browser_script_windows" \
+      -Url "$DEFAULT_URL" -ProfilePath "$browser_profile_windows" >>"$browser_log" 2>&1; then
+      echo "[crm-local] Não foi possível abrir o navegador isolado. Consulte $browser_log." >&2
+      return 1
+    fi
+  elif command -v open >/dev/null 2>&1; then
+    if ! open "$DEFAULT_URL" >>"$browser_log" 2>&1; then
+      echo "[crm-local] Não foi possível abrir o navegador. Consulte $browser_log." >&2
+      return 1
+    fi
   elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$DEFAULT_URL" >/dev/null 2>&1 &
-    disown "$!" >/dev/null 2>&1 || true
+    if ! xdg-open "$DEFAULT_URL" >>"$browser_log" 2>&1; then
+      echo "[crm-local] Não foi possível abrir o navegador. Consulte $browser_log." >&2
+      return 1
+    fi
+  else
+    echo "[crm-local] Nenhum abridor de navegador compatível foi encontrado." >&2
+    return 1
   fi
 }
 
@@ -409,6 +494,260 @@ ensure_frontend_ready() {
   fi
 }
 
+ensure_frontend_dependencies() {
+  local lockfile_fingerprint="$1"
+  if [[ "${CRM_ISOLATED_RUNTIME:-0}" != "1" ]]; then
+    npm --prefix "$FRONTEND_DIR" ci --no-audit --no-fund
+    return
+  fi
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "[crm-local] flock não está disponível para preparar o cache de dependências do frontend." >&2
+    return 1
+  fi
+
+  local dependency_key="${lockfile_fingerprint#sha256:}"
+  if [[ ! "$dependency_key" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "[crm-local] Impressão inválida do lockfile do frontend." >&2
+    return 1
+  fi
+  local cache_root="$CRM_FRONTEND_DEPENDENCY_CACHE_ROOT"
+  local cache_dir="$cache_root/$dependency_key"
+  local ready_file="$cache_dir/.skincos-lockfile.sha256"
+  local lock_file="$cache_root/$dependency_key.lock"
+  mkdir -p "$cache_root"
+
+  if [[ -e "$FRONTEND_DIR/node_modules" || -L "$FRONTEND_DIR/node_modules" ]]; then
+    if [[ -L "$FRONTEND_DIR/node_modules" &&
+          "$(readlink -f "$FRONTEND_DIR/node_modules" 2>/dev/null || true)" == "$cache_dir/node_modules" &&
+          -d "$cache_dir/node_modules" &&
+          -f "$ready_file" &&
+          "$(tr -d '\r\n' < "$ready_file")" == "$dependency_key" ]]; then
+      return 0
+    fi
+    if [[ "$CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION" == "1" &&
+          -L "$FRONTEND_DIR/node_modules" ]]; then
+      local resolved_source
+      local resolved_cache_root
+      local existing_dependency_target
+      local existing_dependency_relative
+      resolved_source="$(readlink -f "$ROOT_DIR")"
+      case "$resolved_source" in
+        /mnt/c/CodexRuntime/operator/admin/skincos/source/crm-local-gestor-main|\
+        /mnt/c/CodexRuntime/operator/admin/skincos/source/crm-local-gestor-main-*) ;;
+        *)
+          echo "[crm-local] Realinhamento de dependências legadas recusado fora da fonte privada do CRM completo: $resolved_source" >&2
+          return 1
+          ;;
+      esac
+      resolved_cache_root="$(readlink -f "$cache_root")"
+      existing_dependency_target="$(readlink -f "$FRONTEND_DIR/node_modules" 2>/dev/null || true)"
+      existing_dependency_relative="${existing_dependency_target#"$resolved_cache_root"/}"
+      if [[ "$existing_dependency_target" != "$resolved_cache_root/"* ||
+            ! "$existing_dependency_relative" =~ ^[a-f0-9]{64}/node_modules$ ]]; then
+        echo "[crm-local] O symlink legado de node_modules não pertence ao cache privado autorizado; ele não será removido." >&2
+        return 1
+      fi
+      rm -- "$FRONTEND_DIR/node_modules"
+      echo "[crm-local] Symlink legado de node_modules removido para alinhar o novo lockfile."
+    fi
+    if [[ "$CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION" == "1" &&
+          -d "$FRONTEND_DIR/node_modules" &&
+          ! -L "$FRONTEND_DIR/node_modules" ]]; then
+      local resolved_source
+      local migration_root
+      local migration_target
+      resolved_source="$(readlink -f "$ROOT_DIR")"
+      case "$resolved_source" in
+        /mnt/c/CodexRuntime/operator/admin/skincos/source/crm-local-gestor-main|\
+        /mnt/c/CodexRuntime/operator/admin/skincos/source/crm-local-gestor-main-*) ;;
+        *)
+          echo "[crm-local] Migração de dependências legadas recusada fora da fonte privada do CRM completo: $resolved_source" >&2
+          return 1
+          ;;
+      esac
+      migration_root="$CRM_RUNTIME_ROOT/state/legacy-dependencies"
+      migration_target="$migration_root/node_modules.$(date +%Y%m%d-%H%M%S).$$"
+      mkdir -p "$migration_root"
+      if ! mv -- "$FRONTEND_DIR/node_modules" "$migration_target"; then
+        echo "[crm-local] Não foi possível preservar node_modules legado em $migration_target." >&2
+        return 1
+      fi
+      echo "[crm-local] node_modules legado preservado em $migration_target antes de vincular o cache isolado."
+    fi
+  fi
+
+  if [[ -e "$FRONTEND_DIR/node_modules" || -L "$FRONTEND_DIR/node_modules" ]]; then
+    echo "[crm-local] node_modules da fonte imutável não aponta para o cache esperado; ele não será substituído." >&2
+    return 1
+  fi
+
+  exec 7>"$lock_file"
+  flock 7
+  local recorded=""
+  if [[ -f "$ready_file" ]]; then
+    recorded="$(tr -d '\r\n' < "$ready_file")"
+  fi
+  if [[ -e "$cache_dir" && ( ! -d "$cache_dir/node_modules" || "$recorded" != "$dependency_key" ) ]]; then
+    echo "[crm-local] Cache de dependências incompleto em $cache_dir; ele não será substituído enquanto outro runtime pode utilizá-lo." >&2
+    flock -u 7
+    exec 7>&-
+    return 1
+  fi
+  if [[ ! -d "$cache_dir/node_modules" ]]; then
+    local temporary
+    temporary="$(mktemp -d "$cache_root/.${dependency_key}.XXXXXX")"
+    if ! cp "$FRONTEND_DIR/package.json" "$FRONTEND_DIR/package-lock.json" "$temporary/" ||
+       ! npm --prefix "$temporary" ci --no-audit --no-fund; then
+      rm -rf -- "$temporary"
+      flock -u 7
+      exec 7>&-
+      return 1
+    fi
+    printf '%s\n' "$dependency_key" > "$temporary/.skincos-lockfile.sha256"
+    mv "$temporary" "$cache_dir"
+  fi
+  if ! ln -s "$cache_dir/node_modules" "$FRONTEND_DIR/node_modules" 2>/dev/null; then
+    if [[ ! -L "$FRONTEND_DIR/node_modules" ||
+          "$(readlink -f "$FRONTEND_DIR/node_modules" 2>/dev/null || true)" != "$cache_dir/node_modules" ]]; then
+      echo "[crm-local] Outra execução publicou um node_modules incompatível na fonte imutável." >&2
+      flock -u 7
+      exec 7>&-
+      return 1
+    fi
+  fi
+  flock -u 7
+  exec 7>&-
+}
+
+inspect_frontend_build() {
+  node "$BUILD_STATE_HELPER" inspect --root "$ROOT_DIR" --state "$CRM_BUILD_STATE_FILE"
+}
+
+build_descriptor_field() {
+  local descriptor="$1"
+  local field="$2"
+  printf '%s' "$descriptor" | node -e '
+const fs = require("fs")
+const value = JSON.parse(fs.readFileSync(0, "utf8"))[process.argv[1]]
+if (value !== null && value !== undefined) process.stdout.write(String(value))
+' "$field"
+}
+
+recorded_build_lockfile_fingerprint() {
+  node - "$CRM_BUILD_STATE_FILE" <<'NODE'
+const fs = require('fs')
+try {
+  const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+  if (typeof value.lockfileFingerprint === 'string') process.stdout.write(value.lockfileFingerprint)
+} catch {}
+NODE
+}
+
+acquire_frontend_build_lock() {
+  local attempt=0
+  local result=""
+  local status=0
+  while (( attempt < 600 )); do
+    status=0
+    result="$(node "$BUILD_STATE_HELPER" lock-acquire --lock-dir "$CRM_BUILD_LOCK_DIR" --owner-pid "$$" --json 2>/dev/null)" || status=$?
+    if [[ "$status" == "0" ]]; then
+      CRM_BUILD_LOCK_TOKEN="$(printf '%s' "$result" | node -e 'const fs=require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(0,"utf8")).owner.token)')"
+      export CRM_BUILD_LOCK_TOKEN
+      return 0
+    fi
+    if [[ "$status" != "73" ]]; then
+      echo "[crm-local] Falha ao adquirir o lock global de build." >&2
+      return "$status"
+    fi
+    if (( attempt == 0 )); then
+      echo "[crm-local] Outro runtime está preparando o mesmo build; aguardando sem iniciar um build concorrente..."
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  echo "[crm-local] Tempo limite ao aguardar o lock global de build." >&2
+  return 1
+}
+
+release_frontend_build_lock() {
+  if [[ -z "${CRM_BUILD_LOCK_TOKEN:-}" ]]; then
+    return 0
+  fi
+  node "$BUILD_STATE_HELPER" lock-release --lock-dir "$CRM_BUILD_LOCK_DIR" --token "$CRM_BUILD_LOCK_TOKEN" --json >/dev/null
+  CRM_BUILD_LOCK_TOKEN=""
+}
+
+refresh_frontend_build_fingerprints() {
+  local descriptor
+  descriptor="$(inspect_frontend_build)"
+  CRM_BUILD_INPUT_FINGERPRINT="$(build_descriptor_field "$descriptor" inputFingerprint)"
+  CRM_BUILD_LOCKFILE_FINGERPRINT="$(build_descriptor_field "$descriptor" lockfileFingerprint)"
+  CRM_BUILD_ARTIFACT_FINGERPRINT="$(build_descriptor_field "$descriptor" artifactFingerprint)"
+  CRM_BUILD_COMMIT="$CRM_TARGET_COMMIT"
+  export CRM_BUILD_INPUT_FINGERPRINT CRM_BUILD_LOCKFILE_FINGERPRINT
+  export CRM_BUILD_ARTIFACT_FINGERPRINT CRM_BUILD_COMMIT
+}
+
+prepare_frontend_artifact_locked() {
+  local descriptor
+  local state_valid
+  local current_lockfile
+  local recorded_lockfile
+  descriptor="$(inspect_frontend_build)"
+  state_valid="$(build_descriptor_field "$descriptor" stateValid)"
+  current_lockfile="$(build_descriptor_field "$descriptor" lockfileFingerprint)"
+  recorded_lockfile="$(recorded_build_lockfile_fingerprint)"
+
+  if [[ ! -d "$FRONTEND_DIR/node_modules" || "$recorded_lockfile" != "$current_lockfile" ]]; then
+    echo "[crm-local] Alinhando dependências do frontend ao lockfile atual..."
+    if ! ensure_frontend_dependencies "$current_lockfile"; then
+      return 1
+    fi
+  fi
+
+  if [[ "$CRM_BUILD_BEFORE_START" == "auto" && "$state_valid" == "true" ]]; then
+    echo "[crm-local] Build reutilizado: insumos e artefato permanecem idênticos."
+    refresh_frontend_build_fingerprints
+    return 0
+  fi
+
+  if [[ "$CRM_BUILD_BEFORE_START" == "0" ]]; then
+    ensure_frontend_dist_ready
+    refresh_frontend_build_fingerprints
+    return 0
+  fi
+
+  echo "[crm-local] Gerando build do frontend para os insumos atuais..."
+  if ! npm --prefix "$FRONTEND_DIR" run build; then
+    return 1
+  fi
+  if ! node "$BUILD_STATE_HELPER" state-write \
+    --state-file "$CRM_BUILD_STATE_FILE" \
+    --console-dir "$FRONTEND_DIR" \
+    --json >/dev/null; then
+    return 1
+  fi
+  refresh_frontend_build_fingerprints || return 1
+}
+
+prepare_frontend_artifact() {
+  if [[ ! -x "$BUILD_STATE_HELPER" && ! -f "$BUILD_STATE_HELPER" ]]; then
+    echo "[crm-local] Helper determinístico de build ausente: $BUILD_STATE_HELPER" >&2
+    return 1
+  fi
+  acquire_frontend_build_lock
+  local status=0
+  set +e
+  prepare_frontend_artifact_locked
+  status=$?
+  set -e
+  release_frontend_build_lock || {
+    echo "[crm-local] Não foi possível liberar o lock global de build com segurança." >&2
+    return 1
+  }
+  return "$status"
+}
+
 ensure_playwright_chromium() {
   if [[ "$CRM_GATE_STRICT" != "1" && "$CRM_SMOKE" != "1" ]]; then
     return 0
@@ -417,7 +756,7 @@ ensure_playwright_chromium() {
   echo "[crm-local] Garantindo o Chromium do Playwright para o gate local..."
   (
     cd "$FRONTEND_DIR"
-    PLAYWRIGHT_BROWSERS_PATH=0 npm exec playwright install chromium
+    PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" npm exec playwright install chromium
   )
 }
 
@@ -426,24 +765,52 @@ ensure_timekeeping_ready() {
     echo "[crm-local] O domínio Workforce/Timekeeping não foi encontrado em $TIMEKEEPING_DIR." >&2
     exit 1
   fi
-  if [[ ! -d "$TIMEKEEPING_DIR/node_modules" ]]; then
-    echo "[crm-local] Instalando dependências locais do Timekeeping..."
-    npm --prefix "$TIMEKEEPING_DIR" install
+  if [[ ! -f "$TIMEKEEPING_DIR/package-lock.json" ]]; then
+    echo "[crm-local] O lockfile do Timekeeping não foi encontrado." >&2
+    exit 1
   fi
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "[crm-local] flock não está disponível para serializar as dependências do Timekeeping." >&2
+    exit 1
+  fi
+
+  mkdir -p "$CRM_DEPENDENCY_STATE_ROOT"
+  local lock_file="$CRM_DEPENDENCY_STATE_ROOT/timekeeping.lock"
+  local state_file="$CRM_DEPENDENCY_STATE_ROOT/timekeeping-package-lock.sha256"
+  local current_hash
+  local recorded_hash=""
+  current_hash="$(sha256sum "$TIMEKEEPING_DIR/package-lock.json" | awk '{print $1}')"
+  exec 8>"$lock_file"
+  flock 8
+  if [[ -f "$state_file" ]]; then
+    recorded_hash="$(tr -d '\r\n' < "$state_file")"
+  fi
+  if [[ ! -d "$TIMEKEEPING_DIR/node_modules/wrangler" || "$current_hash" != "$recorded_hash" ]]; then
+    echo "[crm-local] Alinhando dependências locais do Timekeeping ao lockfile..."
+    npm --prefix "$TIMEKEEPING_DIR" ci --no-audit --no-fund
+    local state_tmp="${state_file}.tmp.$$"
+    printf '%s\n' "$current_hash" > "$state_tmp"
+    mv -f "$state_tmp" "$state_file"
+  fi
+  flock -u 8
+  exec 8>&-
 }
 
 start_timekeeping_local() {
   ensure_timekeeping_ready
+  mkdir -p "$CRM_TIMEKEEPING_PERSIST_DIR"
   echo "[crm-local] Aplicando migrations locais do Timekeeping..."
   (
     cd "$TIMEKEEPING_DIR"
-    ./node_modules/.bin/wrangler d1 migrations apply skincos-timekeeping --local --config=wrangler.toml
+    ./node_modules/.bin/wrangler d1 migrations apply skincos-timekeeping --local --config=wrangler.toml \
+      --persist-to "$CRM_TIMEKEEPING_PERSIST_DIR"
   ) >>"$LOG_FILE" 2>&1
 
   echo "[crm-local] Iniciando Workforce/Timekeeping local em :$CRM_TIMEKEEPING_PORT"
   (
     cd "$TIMEKEEPING_DIR"
     ./node_modules/.bin/wrangler dev --local --port "$CRM_TIMEKEEPING_PORT" --config=wrangler.toml \
+      --persist-to "$CRM_TIMEKEEPING_PERSIST_DIR" \
       --var "PONTO_ACTOR_HMAC_KEY:$CRM_TIMEKEEPING_ACTOR_KEY" \
       --var "PONTO_IDEMPOTENCY_KEY:$CRM_TIMEKEEPING_IDEMPOTENCY_KEY" \
       --var "PONTO_TEMPLATES_KEY:$CRM_TIMEKEEPING_TEMPLATES_KEY"
@@ -465,6 +832,11 @@ ensure_frontend_dist_ready() {
 }
 
 ensure_insumos_seed_config() {
+  if [[ "${CRM_ISOLATED_RUNTIME:-0}" == "1" ]]; then
+    # Isolated runtimes pass local-only values directly to their Wrangler
+    # process. Never rewrite the immutable source tree or a shared .dev.vars.
+    return 0
+  fi
   local insumos_dev_vars="$ROOT_DIR/inventory/.dev.vars"
   if [[ ! -f "$insumos_dev_vars" && -f "$ROOT_DIR/inventory/.dev.vars.example" ]]; then
     cp "$ROOT_DIR/inventory/.dev.vars.example" "$insumos_dev_vars"
@@ -496,10 +868,11 @@ refresh_insumos_snapshot_if_needed() {
 }
 
 ensure_insumos_local_schema() {
+  mkdir -p "$CRM_INSUMOS_PERSIST_DIR"
   echo "[crm-local] Aplicando migrations locais do Insumos..."
   (
     cd "$ROOT_DIR"
-    ./backend/scripts/insumos.sh migrate --local
+    ./backend/scripts/insumos.sh migrate --local --persist-to "$CRM_INSUMOS_PERSIST_DIR"
   ) >>"$LOG_FILE" 2>&1
 }
 
@@ -516,7 +889,16 @@ start_insumos_local() {
   fi
   (
     cd "$ROOT_DIR"
-    ALLOW_DEV_AUTH_BYPASS="$auth_bypass" PORT="$CRM_INSUMOS_PORT" ./backend/scripts/insumos.sh dev \
+    ALLOW_DEV_AUTH_BYPASS="$auth_bypass" ./backend/scripts/insumos.sh dev \
+      --ip 127.0.0.1 \
+      --port "$CRM_INSUMOS_PORT" \
+      --persist-to "$CRM_INSUMOS_PERSIST_DIR" \
+      --var "APP_ORIGIN:http://localhost:${CRM_PAGES_PORT}" \
+      --var "APP_ORIGINS:http://localhost:${CRM_PAGES_PORT}" \
+      --var "SESSION_SECRET:skincos-${CRM_RUNTIME_ID}-local-session" \
+      --var "ALLOW_DEV_SEED:true" \
+      --var "INSUMOS_SEED_TOKEN:${CRM_INSUMOS_SEED_TOKEN}" \
+      --var "ALLOW_DEV_AUTH_BYPASS:${auth_bypass}" \
       --log-level "$CRM_LOCAL_LOG_LEVEL" \
       --show-interactive-dev-session false \
       --test-scheduled
@@ -633,19 +1015,18 @@ verify_atendimento_proxy() {
 
 if [[ "$STOP_ONLY" == "1" ]]; then
   crm_persona_runtime_stop_manifest_owner
-  stop_existing
-  stop_owned_port_listener "$CRM_VITE_PORT" "vite"
-  stop_owned_port_listener "$CRM_PAGES_PORT" "pages"
-  if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
-    stop_owned_port_listener "$CRM_WA_ORCHESTRATOR_PORT" "whatsapp"
+  stop_lock_status=0
+  crm_persona_runtime_acquire_lock || stop_lock_status=$?
+  if [[ "$stop_lock_status" == "2" || "$stop_lock_status" == "3" || "$stop_lock_status" == "4" ]]; then
+    echo "[crm-local] Outro launcher tornou-se owner de $CRM_RUNTIME_ID durante a parada; seu manifesto não será sobrescrito."
+    exit 0
   fi
-  if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
-    stop_owned_port_listener "$CRM_INSUMOS_PORT" "insumos"
-  fi
-  if [[ "$CRM_WITH_TIMEKEEPING" == "1" ]]; then
-    stop_owned_port_listener "$CRM_TIMEKEEPING_PORT" "workforce-timekeeping"
+  if [[ "$stop_lock_status" != "0" ]]; then
+    echo "[crm-local] Não foi possível serializar a parada de $CRM_RUNTIME_ID." >&2
+    exit "$stop_lock_status"
   fi
   crm_persona_runtime_write_manifest stopped
+  crm_persona_runtime_release_lock
   echo "CRM local finalizado."
   exit 0
 fi
@@ -665,6 +1046,22 @@ case "$CRM_LOCAL_LOG_LEVEL" in
     ;;
 esac
 
+case "$CRM_BUILD_BEFORE_START" in
+  0|1|auto) ;;
+  *)
+    echo "CRM_BUILD_BEFORE_START inválido: $CRM_BUILD_BEFORE_START (use 0, 1 ou auto)." >&2
+    exit 1
+    ;;
+esac
+
+case "$CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION" in
+  0|1) ;;
+  *)
+    echo "CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION inválido: $CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION (use 0 ou 1)." >&2
+    exit 1
+    ;;
+esac
+
 if ! command -v npm >/dev/null 2>&1; then
   echo "npm não encontrado no PATH." >&2
   exit 1
@@ -679,15 +1076,17 @@ mkdir -p "$(dirname "$PID_FILE")" "$(dirname "$LOG_FILE")"
 runtime_lock_status=0
 crm_persona_runtime_acquire_lock || runtime_lock_status=$?
 if [[ "$runtime_lock_status" == "2" ]]; then
-  echo "[crm-local] Aguardando o runtime existente de $CRM_PERSONA ficar pronto..."
-  if wait_for_crm_api "http://127.0.0.1:${CRM_PAGES_PORT}/api/auth/me" 360 && wait_for_http "$DEFAULT_URL" 30; then
+  echo "[crm-local] Aguardando o gate completo do runtime existente de $CRM_PERSONA..."
+  if crm_persona_runtime_wait_ready 360 &&
+     wait_for_crm_api "http://127.0.0.1:${CRM_PAGES_PORT}/api/auth/me" 10 &&
+     wait_for_http "$DEFAULT_URL" 10; then
     if [[ "$CRM_OPEN_BROWSER" == "1" ]]; then
       open_browser
     fi
-    echo "[crm-local] Runtime existente de $CRM_PERSONA reutilizado em $DEFAULT_URL."
+    echo "[crm-local] Runtime existente de $CRM_PERSONA reutilizado após manifesto ready e gate verde em $DEFAULT_URL."
     exit 0
   fi
-  echo "[crm-local] O runtime existente de $CRM_PERSONA não ficou pronto dentro do tempo esperado." >&2
+  echo "[crm-local] O runtime existente de $CRM_PERSONA não publicou manifesto ready exato dentro do tempo esperado." >&2
   exit 1
 fi
 if [[ "$runtime_lock_status" != "0" ]]; then
@@ -695,6 +1094,19 @@ if [[ "$runtime_lock_status" != "0" ]]; then
   exit "$runtime_lock_status"
 fi
 bootstrap_cleanup() {
+  # Dependencies start before the long-lived Pages supervisor is registered.
+  # If any readiness check fails in that window, terminate every child already
+  # acquired by this launcher so a retry cannot inherit an orphaned listener.
+  local child_pid
+  for child_pid in \
+    "${CRM_PID:-}" \
+    "${INSUMOS_PID:-}" \
+    "${TIMEKEEPING_PID:-}" \
+    "${WHATSAPP_ORCHESTRATOR_PID:-}"; do
+    if [[ -n "$child_pid" ]]; then
+      terminate_pid "$child_pid"
+    fi
+  done
   crm_persona_runtime_write_manifest failed 2>/dev/null || true
   crm_persona_runtime_release_lock
 }
@@ -741,16 +1153,8 @@ assert_port_free "$CRM_PAGES_PORT" "pages"
 if [[ "$CRM_WITH_WHATSAPP" == "1" ]]; then
   assert_port_free "$CRM_WA_ORCHESTRATOR_PORT" "whatsapp"
 fi
-ensure_frontend_ready
+prepare_frontend_artifact
 ensure_playwright_chromium
-
-if [[ "$CRM_BUILD_BEFORE_START" == "1" ]]; then
-  echo "[crm-local] Gerando build do frontend para alinhar o shell local ao online..."
-  npm --prefix "$FRONTEND_DIR" run build
-  crm_persona_runtime_write_build_state
-else
-  ensure_frontend_dist_ready
-fi
 
 INSUMOS_PID=""
 WHATSAPP_ORCHESTRATOR_PID=""
@@ -796,7 +1200,7 @@ if [[ "$CRM_WITH_INSUMOS" == "1" ]]; then
 fi
 
 if [[ -n "$CRM_MODULE" ]]; then
-  export VITE_LOCAL_CRM_FOCUS_MODULE="$CRM_MODULE"
+  export LOCAL_CRM_FOCUS_MODULE="$CRM_MODULE"
 fi
 
 (
@@ -806,25 +1210,29 @@ fi
 CRM_PID=$!
 
 echo "$$" > "$PID_FILE"
+crm_runtime_pid_start_ticks "$$" > "${PID_FILE}.start-ticks"
+printf '%s\n' "$CRM_RUNTIME_ID" > "${PID_FILE}.runtime-id"
+crm_persona_runtime_write_manifest starting
 
 cleanup() {
   if [[ -n "${CRM_PID:-}" ]]; then
-    kill "$CRM_PID" >/dev/null 2>&1 || true
+    terminate_pid "$CRM_PID"
   fi
   if [[ -n "${INSUMOS_PID:-}" ]]; then
-    kill "$INSUMOS_PID" >/dev/null 2>&1 || true
+    terminate_pid "$INSUMOS_PID"
   fi
   if [[ -n "${TIMEKEEPING_PID:-}" ]]; then
-    kill "$TIMEKEEPING_PID" >/dev/null 2>&1 || true
+    terminate_pid "$TIMEKEEPING_PID"
   fi
   if [[ -n "${WHATSAPP_ORCHESTRATOR_PID:-}" ]]; then
-    kill "$WHATSAPP_ORCHESTRATOR_PID" >/dev/null 2>&1 || true
+    terminate_pid "$WHATSAPP_ORCHESTRATOR_PID"
   fi
   if [[ -f "$PID_FILE" ]]; then
     local tracked_pid
     tracked_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
     if [[ "$tracked_pid" == "$$" ]]; then
       rm -f "$PID_FILE"
+      rm -f "${PID_FILE}.start-ticks" "${PID_FILE}.runtime-id"
     fi
   fi
   crm_persona_runtime_write_manifest stopped 2>/dev/null || true
@@ -850,8 +1258,9 @@ fi
 run_gate_smoke() {
   echo "[crm-local] Rodando gate obrigatório do shell local..."
   run_browser_smoke env \
-    PLAYWRIGHT_BROWSERS_PATH=0 \
+    PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" \
     CRM_URL="$DEFAULT_URL" \
+    CRM_SMOKE_MODULES="${CRM_GATE_MODULES:-}" \
     HEADED=0 \
     TIMEOUT_MS="${CRM_GATE_TIMEOUT_MS:-120000}" \
     CRM_SMOKE_REPORT_FILE="$GATE_REPORT_FILE" \
@@ -957,13 +1366,13 @@ fi
 if [[ "$CRM_SMOKE" == "1" ]]; then
   if [[ "$CRM_MODULE" == "meta-ads" ]]; then
     echo "[crm-local] Rodando smoke local do Meta Ads..."
-    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH=0 CRM_URL="$DEFAULT_URL" META_ADS_LOCAL_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}" HEADED="$CRM_SMOKE_HEADED" npm run smoke:meta-ads:local
+    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" CRM_URL="$DEFAULT_URL" META_ADS_LOCAL_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}" HEADED="$CRM_SMOKE_HEADED" npm run smoke:meta-ads:local
   elif [[ "$CRM_MODULE" == "site-tracking" ]]; then
     echo "[crm-local] Rodando smoke local do Site EF..."
-    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH=0 CRM_URL="$DEFAULT_URL" META_ADS_LOCAL_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}" HEADED="$CRM_SMOKE_HEADED" npm run smoke:site-tracking:local
+    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" CRM_URL="$DEFAULT_URL" META_ADS_LOCAL_SCENARIO="${CRM_META_ADS_SCENARIO:-connected-ready}" HEADED="$CRM_SMOKE_HEADED" npm run smoke:site-tracking:local
   else
     echo "[crm-local] Rodando smoke local padrão..."
-    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH=0 CRM_URL="$DEFAULT_URL" HEADED="$CRM_SMOKE_HEADED" node ./scripts/crm-local-smoke.cjs
+    run_browser_smoke env PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" CRM_URL="$DEFAULT_URL" HEADED="$CRM_SMOKE_HEADED" node ./scripts/crm-local-smoke.cjs
   fi
 
   if [[ "$CRM_EXIT_AFTER_SMOKE" == "1" ]]; then

--- a/scripts/run-local-whatsapp-orchestrator.sh
+++ b/scripts/run-local-whatsapp-orchestrator.sh
@@ -6,61 +6,347 @@ set -euo pipefail
 # bindings, browser, or logs.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 PORT="${CRM_LOCAL_WA_ORCHESTRATOR_PORT:-8110}"
 ENV_FILE="${CRM_LOCAL_WA_NATIVE_ENV_FILE:-/etc/skincos/crm-whatsapp.env}"
 RUNTIME_HOME="${CRM_LOCAL_WA_RUNTIME_HOME:-/mnt/c/CodexRuntime/operator/admin/skincos/whatsapp-local-adapter}"
 RUN_AS_USER="${CRM_LOCAL_WA_RUN_AS_USER:-admin}"
 SOURCE_HOME="${CRM_LOCAL_WA_SOURCE_HOME:-/home/$RUN_AS_USER/.cache/skincos/whatsapp-local-adapter/source}"
-# This adapter serves the local Atendimento API as well as the WhatsApp
-# endpoints. Keep it on the dedicated local mirror through PostgreSQL peer
-# authentication; it never receives a production database URL or password.
-DEFAULT_DATABASE_URL="postgresql://${RUN_AS_USER}@/skincos_crm_local?host=/var/run/postgresql"
-DATABASE_URL="${CRM_LOCAL_WA_DATABASE_URL:-$DEFAULT_DATABASE_URL}"
+RUNTIME_ID="${CRM_RUNTIME_ID:-}"
+ROLE_POLICY_FILE="${CRM_ROLE_POLICY_FILE:-$ROOT_DIR/crm/console/modules/localRolePolicy.json}"
+BASE_DATABASE_NAME="skincos_crm_local"
+POSTGRES_SOCKET_DIR="/var/run/postgresql"
 
-if [[ "$DATABASE_URL" != "$DEFAULT_DATABASE_URL" ]]; then
-  echo "[whatsapp-local] CRM_LOCAL_WA_DATABASE_URL deve apontar somente para o socket local de skincos_crm_local." >&2
-  exit 2
-fi
+CRM_LOCAL_WA_PSQL_BIN="${CRM_LOCAL_WA_PSQL_BIN:-/usr/bin/psql}"
+CRM_LOCAL_WA_CREATEDB_BIN="${CRM_LOCAL_WA_CREATEDB_BIN:-/usr/bin/createdb}"
+CRM_LOCAL_WA_DROPDB_BIN="${CRM_LOCAL_WA_DROPDB_BIN:-/usr/bin/dropdb}"
+CRM_LOCAL_WA_PG_DUMP_BIN="${CRM_LOCAL_WA_PG_DUMP_BIN:-/usr/bin/pg_dump}"
+CRM_LOCAL_WA_RUNUSER_BIN="${CRM_LOCAL_WA_RUNUSER_BIN:-/usr/sbin/runuser}"
+CRM_LOCAL_WA_FLOCK_BIN="${CRM_LOCAL_WA_FLOCK_BIN:-/usr/bin/flock}"
+CRM_LOCAL_WA_SHA256SUM_BIN="${CRM_LOCAL_WA_SHA256SUM_BIN:-/usr/bin/sha256sum}"
 
-if ! sudo -n -u "$RUN_AS_USER" psql "$DATABASE_URL" -Atqc 'select 1' >/dev/null 2>&1; then
-  echo "[whatsapp-local] O banco local skincos_crm_local não está acessível para $RUN_AS_USER." >&2
-  exit 2
-fi
+crm_local_wa_runtime_database_name() {
+  local runtime_id="${1:-}"
+  local digest
+  if [[ ! "$runtime_id" =~ ^[a-z0-9][a-z0-9._-]{0,127}$ ]]; then
+    echo "[whatsapp-local] CRM_RUNTIME_ID deve conter somente letras minúsculas, números, ponto, hífen ou sublinhado." >&2
+    return 2
+  fi
+  digest="$(printf '%s' "$runtime_id" | "$CRM_LOCAL_WA_SHA256SUM_BIN" | awk '{print $1}')"
+  if [[ ! "$digest" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "[whatsapp-local] Não foi possível derivar a identidade PostgreSQL de $runtime_id." >&2
+    return 2
+  fi
+  printf 'skincos_crm_local_%s\n' "${digest:0:20}"
+}
 
-if ! sudo -n test -f "$ENV_FILE"; then
-  echo "[whatsapp-local] Configuração nativa ausente: CRM_LOCAL_WA_NATIVE_ENV_FILE" >&2
-  exit 2
-fi
+crm_local_wa_database_url() {
+  local database_user="${1:-}"
+  local database_name="${2:-}"
+  if [[ ! "$database_user" =~ ^[a-z_][a-z0-9_-]{0,62}$ ||
+        ! "$database_name" =~ ^[a-z_][a-z0-9_]{0,62}$ ]]; then
+    echo "[whatsapp-local] Identidade PostgreSQL local inválida." >&2
+    return 2
+  fi
+  printf 'postgresql://%s@/%s?host=%s\n' "$database_user" "$database_name" "$POSTGRES_SOCKET_DIR"
+}
 
-if ! sudo -n test -r "$ENV_FILE"; then
-  echo "[whatsapp-local] Não foi possível ler a configuração nativa protegida. Configure CRM_LOCAL_WA_NATIVE_ENV_FILE ou a permissão local necessária." >&2
-  exit 2
-fi
+crm_local_wa_run_as() {
+  local account="$1"
+  shift
+  "$CRM_LOCAL_WA_RUNUSER_BIN" -u "$account" -- "$@"
+}
 
-export LOCAL_WA_ADAPTER_ROOT="$ROOT_DIR"
-export LOCAL_WA_ADAPTER_ENV_FILE="$ENV_FILE"
-export LOCAL_WA_ADAPTER_PORT="$PORT"
-export LOCAL_WA_ADAPTER_RUNTIME_HOME="$RUNTIME_HOME"
-export LOCAL_WA_ADAPTER_SOURCE_HOME="$SOURCE_HOME"
-export LOCAL_WA_ADAPTER_RUN_AS_USER="$RUN_AS_USER"
-export LOCAL_WA_ADAPTER_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}"
-export LOCAL_WA_ADAPTER_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}"
-export LOCAL_WA_ADAPTER_DATABASE_URL="$DATABASE_URL"
-export LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS="${CRM_LOCAL_RUNTIME_DIAGNOSTICS:-}"
+crm_local_wa_database_exists() {
+  local database_name="$1"
+  local result
+  result="$(
+    crm_local_wa_run_as postgres "$CRM_LOCAL_WA_PSQL_BIN" \
+      --dbname "postgresql:///postgres?host=$POSTGRES_SOCKET_DIR" \
+      --no-align --tuples-only --quiet \
+      --command "select 1 from pg_database where datname = '$database_name'"
+  )"
+  [[ "$(printf '%s' "$result" | tr -d '[:space:]')" == "1" ]]
+}
 
-exec sudo -n /usr/bin/env \
-  LOCAL_WA_ADAPTER_ROOT="$LOCAL_WA_ADAPTER_ROOT" \
-  LOCAL_WA_ADAPTER_ENV_FILE="$LOCAL_WA_ADAPTER_ENV_FILE" \
-  LOCAL_WA_ADAPTER_PORT="$LOCAL_WA_ADAPTER_PORT" \
-  LOCAL_WA_ADAPTER_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME" \
-  LOCAL_WA_ADAPTER_SOURCE_HOME="$LOCAL_WA_ADAPTER_SOURCE_HOME" \
-  LOCAL_WA_ADAPTER_RUN_AS_USER="$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-  LOCAL_WA_ADAPTER_EMAIL="$LOCAL_WA_ADAPTER_EMAIL" \
-  LOCAL_WA_ADAPTER_ROLE="$LOCAL_WA_ADAPTER_ROLE" \
-  LOCAL_WA_ADAPTER_DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL" \
-  LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS="$LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS" \
-  /bin/bash -c '
-  set -euo pipefail
+crm_local_wa_runtime_marker() {
+  local database_name="$1"
+  local database_url
+  database_url="$(crm_local_wa_database_url "$RUN_AS_USER" "$database_name")"
+  crm_local_wa_run_as "$RUN_AS_USER" "$CRM_LOCAL_WA_PSQL_BIN" \
+    --dbname "$database_url" \
+    --no-align --tuples-only --quiet \
+    --command "select runtime_id from public.skincos_crm_local_runtime where singleton is true limit 1" \
+    2>/dev/null || true
+}
+
+crm_local_wa_drop_temporary_database() {
+  local database_name="$1"
+  crm_local_wa_run_as postgres "$CRM_LOCAL_WA_DROPDB_BIN" \
+    --host "$POSTGRES_SOCKET_DIR" \
+    --if-exists \
+    "$database_name" >/dev/null 2>&1 || true
+}
+
+crm_local_wa_verify_database() {
+  local database_name="$1"
+  local expected_runtime_id="$2"
+  local database_url
+  local identity
+  database_url="$(crm_local_wa_database_url "$RUN_AS_USER" "$database_name")"
+  identity="$(
+    crm_local_wa_run_as "$RUN_AS_USER" "$CRM_LOCAL_WA_PSQL_BIN" \
+      --dbname "$database_url" \
+      --no-align --tuples-only --quiet \
+      --command "select current_database() || '|' || current_setting('transaction_read_only')"
+  )"
+  if [[ "$identity" != "$database_name|off" ]]; then
+    echo "[whatsapp-local] O banco isolado de $expected_runtime_id não está acessível e gravável." >&2
+    return 2
+  fi
+  if [[ "$(crm_local_wa_runtime_marker "$database_name")" != "$expected_runtime_id" ]]; then
+    echo "[whatsapp-local] O banco $database_name pertence a outro runtime ou está incompleto; ele não será reutilizado." >&2
+    return 2
+  fi
+}
+
+crm_local_wa_prepare_runtime_database() {
+  local target_database="$1"
+  local expected_runtime_id="$2"
+  local base_database_url="postgresql://postgres@/$BASE_DATABASE_NAME?host=$POSTGRES_SOCKET_DIR"
+  local temporary_database
+  local temporary_database_url
+  local base_identity
+  local publish_status=0
+  local marker_sql
+
+  if [[ ! "$target_database" =~ ^[a-z_][a-z0-9_]{0,62}$ ||
+        ! "$expected_runtime_id" =~ ^[a-z0-9][a-z0-9._-]{0,127}$ ]]; then
+    echo "[whatsapp-local] Identidade do banco isolado inválida." >&2
+    return 2
+  fi
+
+  mkdir -p "$RUNTIME_HOME"
+  exec {database_lock_fd}>"$RUNTIME_HOME/postgres-create.lock"
+  "$CRM_LOCAL_WA_FLOCK_BIN" "$database_lock_fd"
+
+  if crm_local_wa_database_exists "$target_database"; then
+    crm_local_wa_verify_database "$target_database" "$expected_runtime_id"
+    "$CRM_LOCAL_WA_FLOCK_BIN" -u "$database_lock_fd"
+    exec {database_lock_fd}>&-
+    return 0
+  fi
+
+  base_identity="$(
+    crm_local_wa_run_as postgres "$CRM_LOCAL_WA_PSQL_BIN" \
+      --dbname "$base_database_url" \
+      --no-align --tuples-only --quiet \
+      --command "select current_database() || '|' || current_setting('transaction_read_only')"
+  )"
+  if [[ "$base_identity" != "$BASE_DATABASE_NAME|off" ]]; then
+    echo "[whatsapp-local] O espelho PostgreSQL local $BASE_DATABASE_NAME não está acessível e gravável." >&2
+    return 2
+  fi
+
+  temporary_database="${target_database}_tmp_$$_${RANDOM}"
+  if [[ ${#temporary_database} -gt 63 || ! "$temporary_database" =~ ^[a-z_][a-z0-9_]{0,62}$ ]]; then
+    echo "[whatsapp-local] Nome temporário PostgreSQL inválido para $expected_runtime_id." >&2
+    return 2
+  fi
+  if crm_local_wa_database_exists "$temporary_database"; then
+    echo "[whatsapp-local] O banco temporário $temporary_database já existe; nenhuma base será sobrescrita." >&2
+    return 2
+  fi
+
+  crm_local_wa_run_as postgres "$CRM_LOCAL_WA_CREATEDB_BIN" \
+    --host "$POSTGRES_SOCKET_DIR" \
+    --owner "$RUN_AS_USER" \
+    --template template0 \
+    "$temporary_database"
+  temporary_database_url="$(crm_local_wa_database_url "$RUN_AS_USER" "$temporary_database")"
+
+  if ! crm_local_wa_run_as postgres "$CRM_LOCAL_WA_PG_DUMP_BIN" \
+      --dbname "$base_database_url" \
+      --format plain \
+      --no-owner \
+      --no-privileges |
+    crm_local_wa_run_as "$RUN_AS_USER" "$CRM_LOCAL_WA_PSQL_BIN" \
+      --dbname "$temporary_database_url" \
+      --set ON_ERROR_STOP=1 \
+      --quiet; then
+    echo "[whatsapp-local] Falha ao clonar o espelho local para $expected_runtime_id." >&2
+    crm_local_wa_drop_temporary_database "$temporary_database"
+    return 2
+  fi
+
+  marker_sql="$(cat <<'SQL'
+create table if not exists public.skincos_crm_local_runtime (
+  singleton boolean primary key default true check (singleton),
+  runtime_id text not null unique,
+  source_database text not null,
+  created_at timestamptz not null default now()
+);
+insert into public.skincos_crm_local_runtime(singleton, runtime_id, source_database)
+values (true, :'runtime_id', :'source_database')
+on conflict (singleton) do nothing;
+SQL
+)"
+  if ! printf '%s\n' "$marker_sql" |
+    crm_local_wa_run_as "$RUN_AS_USER" "$CRM_LOCAL_WA_PSQL_BIN" \
+      --dbname "$temporary_database_url" \
+      --set ON_ERROR_STOP=1 \
+      --set "runtime_id=$expected_runtime_id" \
+      --set "source_database=$BASE_DATABASE_NAME" \
+      --quiet \
+      --file -; then
+    echo "[whatsapp-local] Falha ao identificar o banco isolado de $expected_runtime_id." >&2
+    crm_local_wa_drop_temporary_database "$temporary_database"
+    return 2
+  fi
+
+  crm_local_wa_run_as postgres "$CRM_LOCAL_WA_PSQL_BIN" \
+    --dbname "postgresql:///postgres?host=$POSTGRES_SOCKET_DIR" \
+    --set ON_ERROR_STOP=1 \
+    --quiet \
+    --command "alter database $temporary_database rename to $target_database" ||
+    publish_status=$?
+
+  if [[ "$publish_status" != "0" ]]; then
+    # A publisher outside this filesystem lock may have won the database-name
+    # race. Accept only the exact same runtime marker, then discard our private
+    # temporary clone. Never replace an existing database by name alone.
+    if crm_local_wa_database_exists "$target_database" &&
+      [[ "$(crm_local_wa_runtime_marker "$target_database")" == "$expected_runtime_id" ]]; then
+      crm_local_wa_drop_temporary_database "$temporary_database"
+    else
+      crm_local_wa_drop_temporary_database "$temporary_database"
+      echo "[whatsapp-local] O banco isolado de $expected_runtime_id não pôde ser publicado com segurança." >&2
+      return 2
+    fi
+  fi
+
+  crm_local_wa_verify_database "$target_database" "$expected_runtime_id"
+  printf '[whatsapp-local] PostgreSQL isolado pronto: %s (%s).\n' "$target_database" "$expected_runtime_id"
+  "$CRM_LOCAL_WA_FLOCK_BIN" -u "$database_lock_fd"
+  exec {database_lock_fd}>&-
+}
+
+crm_local_wa_validate_privileged_inputs() {
+  local canonical_root
+  local canonical_runtime_home
+  local canonical_source_home
+  local expected_runtime_home
+  local expected_source_base
+  local expected_role
+  local source_suffix
+  local source_leaf
+
+  if [[ "$LOCAL_WA_ADAPTER_RUN_AS_USER" != "admin" ]]; then
+    echo "[whatsapp-local] O estágio privilegiado aceita somente o operador local admin." >&2
+    return 2
+  fi
+  if [[ "$LOCAL_WA_ADAPTER_ENV_FILE" != "/etc/skincos/crm-whatsapp.env" ]]; then
+    echo "[whatsapp-local] O arquivo de credenciais protegido não pertence à allowlist local." >&2
+    return 2
+  fi
+  if [[ ! "$LOCAL_WA_ADAPTER_PORT" =~ ^[0-9]{4,5}$ ||
+        "$LOCAL_WA_ADAPTER_PORT" -lt 1024 ||
+        "$LOCAL_WA_ADAPTER_PORT" -gt 65535 ]]; then
+    echo "[whatsapp-local] Porta inválida para o adapter local." >&2
+    return 2
+  fi
+
+  canonical_root="$(readlink -f -- "$LOCAL_WA_ADAPTER_ROOT" 2>/dev/null || true)"
+  canonical_runtime_home="$(readlink -m -- "$LOCAL_WA_ADAPTER_RUNTIME_HOME" 2>/dev/null || true)"
+  canonical_source_home="$(readlink -m -- "$LOCAL_WA_ADAPTER_SOURCE_HOME" 2>/dev/null || true)"
+  if [[ -z "$canonical_root" ||
+        "$LOCAL_WA_ADAPTER_ROOT" != "$canonical_root" ||
+        "$LOCAL_WA_ADAPTER_RUNTIME_HOME" != "$canonical_runtime_home" ||
+        "$LOCAL_WA_ADAPTER_SOURCE_HOME" != "$canonical_source_home" ]]; then
+    echo "[whatsapp-local] Os caminhos do estágio privilegiado devem ser absolutos, canônicos e livres de symlinks." >&2
+    return 2
+  fi
+
+  if [[ "$LOCAL_WA_ADAPTER_RUNTIME_ID" == "gestor--full" ]]; then
+    expected_role="GESTOR"
+    expected_runtime_home="/mnt/c/CodexRuntime/operator/admin/skincos/runtime/crm-local/instances/gestor/full/state/whatsapp"
+    source_leaf="${canonical_root##*/}"
+    if [[ ! "$source_leaf" =~ ^crm-local-gestor-main(-[A-Za-z0-9._-]+)?$ ||
+          "${canonical_root%/*}" != "/mnt/c/CodexRuntime/operator/admin/skincos/source" ]]; then
+      echo "[whatsapp-local] A fonte do CRM completo não pertence à raiz privada autorizada." >&2
+      return 2
+    fi
+  elif [[ "$LOCAL_WA_ADAPTER_RUNTIME_ID" =~ ^crm-local--([a-z0-9][a-z0-9._-]{0,127})--(gestor|consultor)$ ]]; then
+    expected_role="${BASH_REMATCH[2]^^}"
+    expected_runtime_home="/mnt/c/CodexRuntime/operator/admin/skincos/runtime/crm-local/instances/${BASH_REMATCH[2]}/${BASH_REMATCH[1]}/state/whatsapp"
+    source_leaf="${canonical_root##*/}"
+    if [[ ! "$source_leaf" =~ ^[a-f0-9]{24}$ ||
+          "${canonical_root%/*}" != "/mnt/c/CodexRuntime/operator/admin/skincos/source/crm-local/immutable" ]]; then
+      echo "[whatsapp-local] A fonte modular não pertence à raiz imutável autorizada." >&2
+      return 2
+    fi
+  else
+    echo "[whatsapp-local] A identidade do runtime não pertence ao contrato local autorizado." >&2
+    return 2
+  fi
+
+  if [[ "$LOCAL_WA_ADAPTER_ROLE" != "$expected_role" ||
+        "$canonical_runtime_home" != "$expected_runtime_home" ]]; then
+    echo "[whatsapp-local] Papel ou diretório de estado não corresponde à identidade do runtime." >&2
+    return 2
+  fi
+
+  expected_source_base="/home/admin/.cache/skincos/crm-local/$LOCAL_WA_ADAPTER_RUNTIME_ID/whatsapp"
+  if [[ "$canonical_source_home" != "$expected_source_base" ]]; then
+    source_suffix="${canonical_source_home#"$expected_source_base"-}"
+    if [[ "$canonical_source_home" != "$expected_source_base-"* ||
+          ! "$source_suffix" =~ ^[a-f0-9]{16}$ ]]; then
+      echo "[whatsapp-local] O cache do adapter está fora da raiz privada derivada do runtime." >&2
+      return 2
+    fi
+  fi
+
+  if [[ ! -d "$canonical_root/crm/api" ||
+        "$(readlink -f -- "$LOCAL_WA_ADAPTER_ROLE_POLICY_FILE" 2>/dev/null || true)" != "$canonical_root/crm/console/modules/localRolePolicy.json" ||
+        ! -f "$canonical_root/crm/console/modules/localRolePolicy.json" ]]; then
+    echo "[whatsapp-local] Fonte da API ou política de papéis não corresponde à revisão privada autorizada." >&2
+    return 2
+  fi
+  if [[ ! "$LOCAL_WA_ADAPTER_EMAIL" =~ ^[a-z0-9._+-]+@local\.test$ ]]; then
+    echo "[whatsapp-local] A identidade do adapter deve permanecer no domínio sintético local.test." >&2
+    return 2
+  fi
+}
+
+crm_local_wa_root_main() {
+  if [[ "$(id -u)" != "0" ]]; then
+    echo "[whatsapp-local] O estágio privilegiado do adapter exige root." >&2
+    return 2
+  fi
+
+  : "${LOCAL_WA_ADAPTER_ROOT:?}"
+  : "${LOCAL_WA_ADAPTER_ENV_FILE:?}"
+  : "${LOCAL_WA_ADAPTER_PORT:?}"
+  : "${LOCAL_WA_ADAPTER_RUNTIME_HOME:?}"
+  : "${LOCAL_WA_ADAPTER_SOURCE_HOME:?}"
+  : "${LOCAL_WA_ADAPTER_RUN_AS_USER:?}"
+  : "${LOCAL_WA_ADAPTER_RUNTIME_ID:?}"
+  : "${LOCAL_WA_ADAPTER_DATABASE_NAME:?}"
+  : "${LOCAL_WA_ADAPTER_DATABASE_URL:?}"
+  : "${LOCAL_WA_ADAPTER_ROLE_POLICY_FILE:?}"
+  : "${LOCAL_WA_ADAPTER_EMAIL:?}"
+  : "${LOCAL_WA_ADAPTER_ROLE:?}"
+  : "${LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS+x}"
+  readonly LOCAL_WA_ADAPTER_ROOT LOCAL_WA_ADAPTER_ENV_FILE LOCAL_WA_ADAPTER_PORT
+  readonly LOCAL_WA_ADAPTER_RUNTIME_HOME LOCAL_WA_ADAPTER_SOURCE_HOME
+  readonly LOCAL_WA_ADAPTER_RUN_AS_USER LOCAL_WA_ADAPTER_RUNTIME_ID
+  readonly LOCAL_WA_ADAPTER_DATABASE_NAME LOCAL_WA_ADAPTER_DATABASE_URL
+  readonly LOCAL_WA_ADAPTER_ROLE_POLICY_FILE
+  readonly LOCAL_WA_ADAPTER_EMAIL LOCAL_WA_ADAPTER_ROLE
+  readonly LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS
+
+  crm_local_wa_validate_privileged_inputs
+
   set -a
   # The file belongs to the native runtime. Never print or persist its values.
   source "$LOCAL_WA_ADAPTER_ENV_FILE"
@@ -69,36 +355,146 @@ exec sudo -n /usr/bin/env \
   : "${EVOLUTION_API_URL:?EVOLUTION_API_URL is required in the native WhatsApp environment}"
   : "${EVOLUTION_API_KEY:?EVOLUTION_API_KEY is required in the native WhatsApp environment}"
 
-  install -d -m 0750 -o "$LOCAL_WA_ADAPTER_RUN_AS_USER" -g "$LOCAL_WA_ADAPTER_RUN_AS_USER" \
-    "$LOCAL_WA_ADAPTER_RUNTIME_HOME" "$LOCAL_WA_ADAPTER_RUNTIME_HOME/var" \
-    "$(dirname "$LOCAL_WA_ADAPTER_SOURCE_HOME")" "$LOCAL_WA_ADAPTER_SOURCE_HOME"
+  # The protected native environment supplies credentials only. Reassert every
+  # launcher path and identity after sourcing it so generic names in that file
+  # cannot redirect this privileged stage.
+  ROOT_DIR="$LOCAL_WA_ADAPTER_ROOT"
+  ENV_FILE="$LOCAL_WA_ADAPTER_ENV_FILE"
+  PORT="$LOCAL_WA_ADAPTER_PORT"
+  RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME"
+  SOURCE_HOME="$LOCAL_WA_ADAPTER_SOURCE_HOME"
+  RUN_AS_USER="$LOCAL_WA_ADAPTER_RUN_AS_USER"
+  RUNTIME_ID="$LOCAL_WA_ADAPTER_RUNTIME_ID"
+  ROLE_POLICY_FILE="$LOCAL_WA_ADAPTER_ROLE_POLICY_FILE"
+  PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+  export PATH
+  BASE_DATABASE_NAME="skincos_crm_local"
+  POSTGRES_SOCKET_DIR="/var/run/postgresql"
+  CRM_LOCAL_WA_PSQL_BIN="/usr/bin/psql"
+  CRM_LOCAL_WA_CREATEDB_BIN="/usr/bin/createdb"
+  CRM_LOCAL_WA_DROPDB_BIN="/usr/bin/dropdb"
+  CRM_LOCAL_WA_PG_DUMP_BIN="/usr/bin/pg_dump"
+  CRM_LOCAL_WA_RUNUSER_BIN="/usr/sbin/runuser"
+  CRM_LOCAL_WA_FLOCK_BIN="/usr/bin/flock"
+  CRM_LOCAL_WA_SHA256SUM_BIN="/usr/bin/sha256sum"
+
+  local expected_database_name
+  local expected_database_url
+  expected_database_name="$(crm_local_wa_runtime_database_name "$RUNTIME_ID")"
+  expected_database_url="$(crm_local_wa_database_url "$RUN_AS_USER" "$expected_database_name")"
+  if [[ "$LOCAL_WA_ADAPTER_DATABASE_NAME" != "$expected_database_name" ||
+        "$LOCAL_WA_ADAPTER_DATABASE_URL" != "$expected_database_url" ]]; then
+    echo "[whatsapp-local] A identidade do banco isolado mudou entre os estágios do launcher." >&2
+    return 2
+  fi
+  if [[ "$ROLE_POLICY_FILE" != /* || ! -f "$ROLE_POLICY_FILE" || ! -r "$ROLE_POLICY_FILE" ]]; then
+    echo "[whatsapp-local] A política local de papéis não está acessível em caminho absoluto." >&2
+    return 2
+  fi
+
+  # A local adapter must never start the background Harmonia worker inherited
+  # from the native environment.
+  export HARMONIA_WORKER_ENABLED=false
+
+  install -d -m 0750 -o "$RUN_AS_USER" -g "$RUN_AS_USER" \
+    "$RUNTIME_HOME" "$RUNTIME_HOME/var" \
+    "$(dirname "$SOURCE_HOME")" "$SOURCE_HOME"
+
+  crm_local_wa_prepare_runtime_database "$expected_database_name" "$RUNTIME_ID"
 
   # Run a private staged copy from the WSL filesystem. The editable source
   # remains the versioned worktree; this cache avoids Windows/WSL file latency.
-  runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" -- rsync -a --delete --exclude node_modules \
-    "$LOCAL_WA_ADAPTER_ROOT/crm/api/" "$LOCAL_WA_ADAPTER_SOURCE_HOME/"
-  if [[ ! -d "$LOCAL_WA_ADAPTER_SOURCE_HOME/node_modules/express" ]]; then
-    runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" -- /usr/bin/npm --prefix "$LOCAL_WA_ADAPTER_SOURCE_HOME" ci --omit=dev --no-audit --no-fund
+  exec 9>"$RUNTIME_HOME/npm-ci.lock"
+  flock 9
+  runuser -u "$RUN_AS_USER" -- rsync -a --delete --exclude node_modules \
+    "$ROOT_DIR/crm/api/" "$SOURCE_HOME/"
+  local package_lock_state="$RUNTIME_HOME/package-lock.sha256"
+  if [[ ! -f "$SOURCE_HOME/package-lock.json" ]]; then
+    echo "[whatsapp-local] package-lock.json ausente no espelho local." >&2
+    return 2
   fi
+  local package_lock_hash
+  local recorded_package_lock_hash=""
+  package_lock_hash="$(sha256sum "$SOURCE_HOME/package-lock.json" | awk '{print $1}')"
+  [[ -f "$package_lock_state" ]] && recorded_package_lock_hash="$(tr -d '\r\n' < "$package_lock_state")"
+  if [[ ! -d "$SOURCE_HOME/node_modules/express" || "$package_lock_hash" != "$recorded_package_lock_hash" ]]; then
+    runuser -u "$RUN_AS_USER" -- /usr/bin/npm --prefix "$SOURCE_HOME" ci --omit=dev --no-audit --no-fund
+    local package_lock_state_tmp="${package_lock_state}.tmp.$$"
+    printf '%s\n' "$package_lock_hash" > "$package_lock_state_tmp"
+    chown "$RUN_AS_USER:$RUN_AS_USER" "$package_lock_state_tmp"
+    chmod 0640 "$package_lock_state_tmp"
+    mv -f "$package_lock_state_tmp" "$package_lock_state"
+  fi
+  flock -u 9
 
   export NODE_ENV=development
   export NO_AUTH=true
   export CRM_LOCAL_NO_AUTH=true
   export WA_CHANNEL_OWNER_ENFORCED=false
   export WA_ORCHESTRATOR_PROVIDER=evolution
-  export CRM_RUNTIME_HOME="$LOCAL_WA_ADAPTER_RUNTIME_HOME"
-  export VAR_DIR="$LOCAL_WA_ADAPTER_RUNTIME_HOME/var"
-  export CRM_API_PORT="$LOCAL_WA_ADAPTER_PORT"
+  export CRM_RUNTIME_HOME="$RUNTIME_HOME"
+  export VAR_DIR="$RUNTIME_HOME/var"
+  export CRM_API_PORT="$PORT"
   export CRM_API_HOST=127.0.0.1
-  export PORT="$LOCAL_WA_ADAPTER_PORT"
+  export PORT
   export DEV_AUTH_EMAIL="$LOCAL_WA_ADAPTER_EMAIL"
   export DEV_AUTH_ROLE="$LOCAL_WA_ADAPTER_ROLE"
-  export DATABASE_URL="$LOCAL_WA_ADAPTER_DATABASE_URL"
+  export DATABASE_URL="$expected_database_url"
+  export CRM_ROLE_POLICY_FILE="$ROLE_POLICY_FILE"
   export CRM_LOCAL_RUNTIME_DIAGNOSTICS="$LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS"
   export EVOLUTION_INSTANCE_PREFIX="${EVOLUTION_INSTANCE_PREFIX:-crm-channel-}"
 
   # Keep the native credential in the inherited process environment. Do not put
   # it in a command argument, which would expose it through process inspection.
-  exec runuser -u "$LOCAL_WA_ADAPTER_RUN_AS_USER" --preserve-environment -- \
-    /usr/bin/node "$LOCAL_WA_ADAPTER_SOURCE_HOME/server.js"
-'
+  exec runuser -u "$RUN_AS_USER" --preserve-environment -- \
+    /usr/bin/node "$SOURCE_HOME/server.js"
+}
+
+crm_local_wa_main() {
+  if [[ "${1:-}" == "--root-stage" ]]; then
+    crm_local_wa_root_main
+    return
+  fi
+  if [[ $# -ne 0 ]]; then
+    echo "[whatsapp-local] Opção desconhecida: $1" >&2
+    return 2
+  fi
+
+  local target_database_name
+  local target_database_url
+  target_database_name="$(crm_local_wa_runtime_database_name "$RUNTIME_ID")"
+  target_database_url="$(crm_local_wa_database_url "$RUN_AS_USER" "$target_database_name")"
+  if [[ -n "${CRM_LOCAL_WA_DATABASE_URL:-}" && "$CRM_LOCAL_WA_DATABASE_URL" != "$target_database_url" ]]; then
+    echo "[whatsapp-local] CRM_LOCAL_WA_DATABASE_URL não corresponde ao banco derivado de CRM_RUNTIME_ID." >&2
+    return 2
+  fi
+
+  if ! sudo -n test -f "$ENV_FILE"; then
+    echo "[whatsapp-local] Configuração nativa ausente: CRM_LOCAL_WA_NATIVE_ENV_FILE" >&2
+    return 2
+  fi
+  if ! sudo -n test -r "$ENV_FILE"; then
+    echo "[whatsapp-local] Não foi possível ler a configuração nativa protegida. Configure CRM_LOCAL_WA_NATIVE_ENV_FILE ou a permissão local necessária." >&2
+    return 2
+  fi
+
+  exec sudo -n /usr/bin/env \
+    LOCAL_WA_ADAPTER_ROOT="$ROOT_DIR" \
+    LOCAL_WA_ADAPTER_ENV_FILE="$ENV_FILE" \
+    LOCAL_WA_ADAPTER_PORT="$PORT" \
+    LOCAL_WA_ADAPTER_RUNTIME_HOME="$RUNTIME_HOME" \
+    LOCAL_WA_ADAPTER_SOURCE_HOME="$SOURCE_HOME" \
+    LOCAL_WA_ADAPTER_RUN_AS_USER="$RUN_AS_USER" \
+    LOCAL_WA_ADAPTER_RUNTIME_ID="$RUNTIME_ID" \
+    LOCAL_WA_ADAPTER_DATABASE_NAME="$target_database_name" \
+    LOCAL_WA_ADAPTER_DATABASE_URL="$target_database_url" \
+    LOCAL_WA_ADAPTER_ROLE_POLICY_FILE="$ROLE_POLICY_FILE" \
+    LOCAL_WA_ADAPTER_EMAIL="${LOCAL_AUTH_EMAIL:-dev@local.test}" \
+    LOCAL_WA_ADAPTER_ROLE="${LOCAL_AUTH_ROLE:-GESTOR}" \
+    LOCAL_WA_ADAPTER_RUNTIME_DIAGNOSTICS="${CRM_LOCAL_RUNTIME_DIAGNOSTICS:-}" \
+    /bin/bash "$SCRIPT_PATH" --root-stage
+}
+
+if [[ "${CRM_LOCAL_WA_LIBRARY_ONLY:-0}" != "1" ]]; then
+  crm_local_wa_main "$@"
+fi

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -23,6 +23,9 @@ param(
         "WebsiteSiteCheck",
         "WebsiteReleaseCheck",
         "CrmLocal",
+        "CrmModules",
+        "CrmModule",
+        "CrmModuleStop",
         "CrmConsultor",
         "CrmConsultorStop",
         "CrmSiteEf",
@@ -61,8 +64,14 @@ param(
     )]
     [string]$Action,
     [string]$ProjectRoot,
+    [ValidateSet("Gestor", "Consultor")]
+    [string]$CrmRole,
+    [ValidatePattern('^[a-z0-9]+(?:-[a-z0-9]+)*$')]
+    [string]$CrmModule,
     [switch]$CrmAtendimentoDetachedStart,
-    [switch]$CrmLocalDetachedStart
+    [switch]$CrmLocalDetachedStart,
+    [switch]$CrmRuntimeDetachedStart,
+    [switch]$CrmRuntimeSuppressBrowser
 )
 
 $ErrorActionPreference = "Stop"
@@ -171,6 +180,21 @@ function Convert-ToBashLiteral {
     param([string]$Value)
 
     return "'" + $Value.Replace("'", "'""'""'") + "'"
+}
+
+function Test-WindowsPathWithinRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Root
+    )
+
+    $candidate = [IO.Path]::GetFullPath($Path).TrimEnd([char]'\', [char]'/')
+    $boundaryRoot = [IO.Path]::GetFullPath($Root).TrimEnd([char]'\', [char]'/')
+    if ($candidate.Equals($boundaryRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+    $prefix = $boundaryRoot + [IO.Path]::DirectorySeparatorChar
+    return $candidate.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)
 }
 
 function Invoke-ShortcutWsl {
@@ -479,62 +503,172 @@ function Sync-CrmLocalSourceRoot {
         [Parameter(Mandatory = $true)]
         [string]$TargetCommit,
         [Parameter(Mandatory = $true)]
-        [object]$Snapshot
+        [object]$Snapshot,
+        [switch]$Versioned
     )
 
     $sourceRoot = Get-CrmLocalSourceBaseRoot -Persona $Persona
     $sourceParent = Split-Path -Parent $sourceRoot
     New-Item -ItemType Directory -Path $sourceParent -Force | Out-Null
-
-    if ($Snapshot.HasChanges) {
-        $shortCommit = $TargetCommit.Substring(0, 12)
-        $shortSnapshot = $Snapshot.Fingerprint.Split(':')[-1].Substring(0, 12)
-        $snapshotRoot = "$sourceRoot-$shortCommit-$shortSnapshot"
-        if (Test-Path -LiteralPath $snapshotRoot) {
-            $snapshotRoot = "$snapshotRoot-$(Get-Date -Format 'yyyyMMddHHmmss')"
-        }
-        & git -C $ProjectRoot worktree add --detach $snapshotRoot $TargetCommit | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw "Não foi possível criar o worktree isolado do snapshot do CRM Local em '$snapshotRoot'." }
+    $mutexName = "Local\SkincosCrmPersonaSource-$($Persona.ToLowerInvariant())"
+    $mutex = [Threading.Mutex]::new($false, $mutexName)
+    $lockHeld = $false
+    try {
         try {
-            Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $snapshotRoot
-        } catch {
-            & git -C $ProjectRoot worktree remove --force $snapshotRoot 2>$null
-            throw
+            $lockHeld = $mutex.WaitOne([TimeSpan]::FromMinutes(10))
+        } catch [Threading.AbandonedMutexException] {
+            $lockHeld = $true
+            Write-Host "[crm-local] Recuperando mutex abandonado da fonte privada de $Persona."
         }
-        return $snapshotRoot
-    }
+        if (-not $lockHeld) {
+            throw "Tempo limite ao aguardar a fonte privada do CRM Local ($Persona)."
+        }
 
-    if (Test-Path -LiteralPath $sourceRoot) {
-        $trackedChanges = @(& git -C $sourceRoot status --porcelain --untracked-files=no)
-        if ($LASTEXITCODE -ne 0) {
-            throw "O worktree privado do CRM Local não está íntegro: '$sourceRoot'."
-        }
-        if ($trackedChanges.Count -gt 0) {
+        if ($Snapshot.HasChanges -or $Versioned) {
             $shortCommit = $TargetCommit.Substring(0, 12)
-            $replacement = "$sourceRoot-$shortCommit"
-            if (Test-Path -LiteralPath $replacement) {
-                $replacement = "$replacement-$(Get-Date -Format 'yyyyMMddHHmmss')"
+            $snapshotRoot = "$sourceRoot-$shortCommit"
+            if ($Snapshot.HasChanges) {
+                $shortSnapshot = $Snapshot.Fingerprint.Split(':')[-1].Substring(0, 12)
+                $snapshotRoot = "$snapshotRoot-$shortSnapshot"
             }
-            Write-Host "[crm-local] Worktree privado com alterações preservado em '$sourceRoot'; usando '$replacement'."
-            $sourceRoot = $replacement
+            if (Test-Path -LiteralPath $snapshotRoot) {
+                $snapshotRoot = "$snapshotRoot-$(Get-Date -Format 'yyyyMMddHHmmss')"
+            }
+            & git -C $ProjectRoot worktree add --detach $snapshotRoot $TargetCommit | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "Não foi possível criar o worktree isolado do snapshot do CRM Local em '$snapshotRoot'." }
+            try {
+                Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $snapshotRoot
+            } catch {
+                & git -C $ProjectRoot worktree remove --force $snapshotRoot 2>$null
+                throw
+            }
+            return $snapshotRoot
         }
-    }
 
-    if (-not (Test-Path -LiteralPath $sourceRoot)) {
+        if (Test-Path -LiteralPath $sourceRoot) {
+            $trackedChanges = @(& git -C $sourceRoot status --porcelain --untracked-files=no)
+            if ($LASTEXITCODE -ne 0) {
+                throw "O worktree privado do CRM Local não está íntegro: '$sourceRoot'."
+            }
+            if ($trackedChanges.Count -gt 0) {
+                $shortCommit = $TargetCommit.Substring(0, 12)
+                $replacement = "$sourceRoot-$shortCommit"
+                if (Test-Path -LiteralPath $replacement) {
+                    $replacement = "$replacement-$(Get-Date -Format 'yyyyMMddHHmmss')"
+                }
+                Write-Host "[crm-local] Worktree privado com alterações preservado em '$sourceRoot'; usando '$replacement'."
+                $sourceRoot = $replacement
+            }
+        }
+
+        if (-not (Test-Path -LiteralPath $sourceRoot)) {
+            & git -C $ProjectRoot worktree prune | Out-Null
+            & git -C $ProjectRoot worktree add --detach $sourceRoot $TargetCommit | Out-Host
+            if ($LASTEXITCODE -ne 0) {
+                throw "Não foi possível criar o worktree limpo do CRM Local em '$sourceRoot'."
+            }
+            return $sourceRoot
+        }
+
+        & git -C $sourceRoot checkout --detach $TargetCommit | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Não foi possível alinhar o worktree privado do CRM Local ao commit $TargetCommit."
+        }
+
+        return $sourceRoot
+    } finally {
+        if ($lockHeld) { $mutex.ReleaseMutex() }
+        $mutex.Dispose()
+    }
+}
+
+function Sync-CrmLocalImmutableSourceRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetCommit,
+        [Parameter(Mandatory = $true)]
+        [object]$Snapshot
+    )
+
+    $sourceKey = (Get-CrmLocalSnapshotHash -Value ([string]$Snapshot.Fingerprint)).Substring(0, 24)
+    $sourceRoot = Join-Path $operatorRuntimeRoot ("source\crm-local\immutable\{0}" -f $sourceKey)
+    $metadataPath = Join-Path $operatorRuntimeRoot ("source\crm-local\metadata\{0}.json" -f $sourceKey)
+    New-Item -ItemType Directory -Path (Split-Path -Parent $sourceRoot) -Force | Out-Null
+    New-Item -ItemType Directory -Path (Split-Path -Parent $metadataPath) -Force | Out-Null
+
+    # Every runtime for the same exact source snapshot may share this immutable
+    # tree and its build artifact. Creation itself is serialized so two Codex
+    # actions cannot materialize or patch the same worktree concurrently.
+    $mutexName = "Local\SkincosCrmSource-$sourceKey"
+    $mutex = [Threading.Mutex]::new($false, $mutexName)
+    $lockHeld = $false
+    try {
+        try {
+            $lockHeld = $mutex.WaitOne([TimeSpan]::FromMinutes(10))
+        } catch [Threading.AbandonedMutexException] {
+            # The previous materializer died while owning the mutex. Windows
+            # transfers ownership to this process; retain it and recover only
+            # after proving the private source is not used by a WSL process.
+            $lockHeld = $true
+            Write-Host "[crm-local] Recuperando mutex abandonado da fonte privada $sourceKey."
+        }
+        if (-not $lockHeld) {
+            throw "Tempo limite ao aguardar a fonte imutável do CRM Local ($sourceKey)."
+        }
+
+        if (Test-Path -LiteralPath $sourceRoot) {
+            if (-not (Test-Path -LiteralPath $metadataPath)) {
+                $sourceRootWsl = Convert-WindowsPathToWsl -Path $sourceRoot
+                if (Test-CrmWslSourceInUse -SourceRootWsl $sourceRootWsl) {
+                    throw "A fonte privada '$sourceRoot' existe sem metadados e ainda está em uso; ela não será movida."
+                }
+                $immutableRoot = Join-Path $operatorRuntimeRoot "source\crm-local\immutable"
+                if (-not (Test-WindowsPathWithinRoot -Path $sourceRoot -Root $immutableRoot)) {
+                    throw "A fonte privada incompleta está fora da raiz autorizada: '$sourceRoot'."
+                }
+                $quarantineRoot = Join-Path $operatorRuntimeRoot "source\crm-local\quarantine"
+                New-Item -ItemType Directory -Path $quarantineRoot -Force | Out-Null
+                $quarantinePath = Join-Path $quarantineRoot ("{0}-{1}" -f $sourceKey, (Get-Date -Format 'yyyyMMddHHmmssfff'))
+                Move-Item -LiteralPath $sourceRoot -Destination $quarantinePath
+                & git -C $ProjectRoot worktree prune | Out-Null
+                Write-Host "[crm-local] Fonte incompleta preservada em quarentena: '$quarantinePath'."
+            } else {
+                $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+                $actualCommit = (& git -C $sourceRoot rev-parse --verify 'HEAD^{commit}' 2>$null | Select-Object -First 1).Trim().ToLowerInvariant()
+                if ($actualCommit -ne $TargetCommit -or [string]$metadata.fingerprint -ne [string]$Snapshot.Fingerprint) {
+                    throw "A fonte privada '$sourceRoot' não corresponde à impressão solicitada; ela não será alterada enquanto outros runtimes podem usá-la."
+                }
+                return $sourceRoot
+            }
+        }
+
         & git -C $ProjectRoot worktree prune | Out-Null
         & git -C $ProjectRoot worktree add --detach $sourceRoot $TargetCommit | Out-Host
         if ($LASTEXITCODE -ne 0) {
-            throw "Não foi possível criar o worktree limpo do CRM Local em '$sourceRoot'."
+            throw "Não foi possível criar a fonte imutável do CRM Local em '$sourceRoot'."
+        }
+        try {
+            Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $sourceRoot
+            $metadata = [ordered]@{
+                version = 1
+                sourceKey = $sourceKey
+                targetCommit = $TargetCommit
+                fingerprint = [string]$Snapshot.Fingerprint
+                sourceCheckout = [string]$Snapshot.SourceRoot
+                createdAt = (Get-Date).ToString('o')
+            }
+            $temporaryMetadata = "$metadataPath.$([Guid]::NewGuid().ToString('N')).tmp"
+            $metadata | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $temporaryMetadata -Encoding utf8
+            Move-Item -LiteralPath $temporaryMetadata -Destination $metadataPath -Force
+        } catch {
+            & git -C $ProjectRoot worktree remove --force $sourceRoot 2>$null
+            throw
         }
         return $sourceRoot
+    } finally {
+        if ($lockHeld) { $mutex.ReleaseMutex() }
+        $mutex.Dispose()
     }
-
-    & git -C $sourceRoot checkout --detach $TargetCommit | Out-Host
-    if ($LASTEXITCODE -ne 0) {
-        throw "Não foi possível alinhar o worktree privado do CRM Local ao commit $TargetCommit."
-    }
-
-    return $sourceRoot
 }
 
 function Resolve-CrmLocalSourceRoot {
@@ -546,7 +680,7 @@ function Resolve-CrmLocalSourceRoot {
     $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $targetCommit
     try {
         $manifest = Get-CrmPersonaManifest -Persona $Persona
-        if ($null -ne $manifest -and (Test-CrmWslPid -PidValue $manifest.pids.launcher)) {
+        if ($null -ne $manifest -and (Test-CrmManifestLauncherIdentity -Manifest $manifest)) {
             $runningSource = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
             $runningCommit = if (Test-Path -LiteralPath $runningSource) { (& git -C $runningSource rev-parse HEAD 2>$null | Select-Object -First 1) } else { $null }
             if ([string]$runningCommit -eq $targetCommit) { return $runningSource }
@@ -609,6 +743,60 @@ function Test-CrmWslPid {
     return $LASTEXITCODE -eq 0
 }
 
+function Get-CrmWslPidStartTicks {
+    param([object]$PidValue)
+    $pidText = [string]$PidValue
+    if ($pidText -notmatch '^[0-9]+$') { return $null }
+    # Keep awk's "$20" inside the sourced Bash file. Passing it in a
+    # `wsl.exe ... bash -lc` argument lets an intermediate shell expand it to
+    # "$2" + "0", which makes every live PID look stale.
+    $runtimeHelper = Join-Path $scriptRoot "crm-local-persona-runtime.sh"
+    if (-not (Test-Path -LiteralPath $runtimeHelper)) { return $null }
+    $runtimeHelperWsl = Convert-WindowsPathToWsl -Path $runtimeHelper
+    $command = "source {0}; crm_runtime_pid_start_ticks {1}" -f `
+        (Convert-ToBashLiteral -Value $runtimeHelperWsl), `
+        (Convert-ToBashLiteral -Value $pidText)
+    $raw = & wsl.exe -d Ubuntu-24.04 -- bash -lc $command 2>$null
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $ticks = [string]($raw | Select-Object -Last 1)
+    if ($ticks -notmatch '^[0-9]+$') { return $null }
+    return $ticks
+}
+
+function Test-CrmManifestLauncherIdentity {
+    param([object]$Manifest)
+    if ($null -eq $Manifest) { return $false }
+    if ([int]$Manifest.version -ge 3) {
+        return Test-CrmWslPidIdentity `
+            -PidValue $Manifest.pids.launcher `
+            -StartTicks $Manifest.pidStartTicks.launcher
+    }
+    return Test-CrmWslPid -PidValue $Manifest.pids.launcher
+}
+
+function Test-CrmWslLauncherProcess {
+    param(
+        [object]$PidValue,
+        [Parameter(Mandatory = $true)][string]$ExpectedWorkingDirectory
+    )
+    $pidText = [string]$PidValue
+    if ($pidText -notmatch '^[0-9]+$') { return $false }
+    $command = @'
+pid={0}; expected={1}; test -r "/proc/$pid/cmdline" || exit 1; actual="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"; test "$actual" = "$expected" || exit 1; cmd="$(tr '\0' ' ' < "/proc/$pid/cmdline")"; case "$cmd" in *scripts/run-local-crm.sh*) exit 0 ;; *) exit 1 ;; esac
+'@ -f $pidText, (Convert-ToBashLiteral -Value $ExpectedWorkingDirectory)
+    & wsl.exe -d Ubuntu-24.04 -- bash -lc $command 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-CrmWslSourceInUse {
+    param([Parameter(Mandatory = $true)][string]$SourceRootWsl)
+    $command = @'
+expected={0}; for link in /proc/[0-9]*/cwd; do actual="$(readlink -f "$link" 2>/dev/null || true)"; case "$actual" in "$expected"|"$expected"/*) exit 0 ;; esac; done; exit 1
+'@ -f (Convert-ToBashLiteral -Value $SourceRootWsl)
+    & wsl.exe -d Ubuntu-24.04 -- bash -lc $command 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
 function Test-CrmHttpEndpoint {
     param([string]$Url, [string]$Role)
     try {
@@ -628,6 +816,22 @@ function Test-CrmPersonaHealth {
         [object]$Manifest = $null
     )
     if ($Persona -eq "Gestor") {
+        if ($null -ne $Manifest -and [int]$Manifest.version -ge 3) {
+            $buildSource = Convert-WslPathToWindows -Path ([string]$Manifest.worktree)
+            $buildStatePath = Join-Path (Get-CrmPersonaRuntimeRoot -Persona $Persona) "build-state.json"
+            if (-not (Test-Path -LiteralPath $buildSource)) { return $false }
+            try {
+                $buildDescriptor = Get-CrmInstanceBuildDescriptor -SourceRoot $buildSource -StatePath $buildStatePath
+            } catch {
+                return $false
+            }
+            if (-not [bool]$buildDescriptor.stateValid -or
+                [string]$Manifest.build.inputFingerprint -ne [string]$buildDescriptor.inputFingerprint -or
+                [string]$Manifest.build.lockfileFingerprint -ne [string]$buildDescriptor.lockfileFingerprint -or
+                [string]$Manifest.build.artifactFingerprint -ne [string]$buildDescriptor.artifactFingerprint) {
+                return $false
+            }
+        }
         # The manifest is authoritative for optional services. Atendimento is
         # intentionally a smaller Gestor preview (Pages + PostgreSQL-backed
         # adapter), so requiring unrelated Insumos/Ponto services made every
@@ -653,21 +857,44 @@ function Get-CrmPersonaDecision {
         [ValidateSet("Gestor", "Consultor")][string]$Persona,
         [Parameter(Mandatory = $true)][string]$TargetCommit,
         [Parameter(Mandatory = $true)][string]$SourceFingerprint,
-        [Parameter(Mandatory = $true)][string]$SourceOrigin
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [string]$RuntimeId = "",
+        [string]$Module = "",
+        [string]$ConfigFingerprint = "",
+        [string]$PolicySourceRoot = ""
     )
     $runtimeRoot = Get-CrmPersonaRuntimeRoot -Persona $Persona
     $manifest = Get-CrmPersonaManifest -Persona $Persona
     $pidAlive = $false
-    if ($null -ne $manifest) { $pidAlive = Test-CrmWslPid -PidValue $manifest.pids.launcher }
+    if ($null -ne $manifest) { $pidAlive = Test-CrmManifestLauncherIdentity -Manifest $manifest }
     $healthy = $false
     if ($pidAlive) { $healthy = Test-CrmPersonaHealth -Persona $Persona -Manifest $manifest }
-    $policyWsl = Convert-WindowsPathToWsl -Path (Join-Path $scriptRoot "crm-local-runtime-policy.mjs")
+    if ([string]::IsNullOrWhiteSpace($PolicySourceRoot) -and
+        [string]::IsNullOrWhiteSpace($ConfigFingerprint) -and
+        $null -ne $manifest) {
+        $manifestSource = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
+        $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source"
+        if ((Test-Path -LiteralPath $manifestSource) -and
+            (Test-WindowsPathWithinRoot -Path $manifestSource -Root $allowedSourceRoot) -and
+            (Test-Path -LiteralPath (Join-Path $manifestSource "scripts\crm-local-runtime-policy.mjs"))) {
+            $PolicySourceRoot = $manifestSource
+        }
+    }
+    $policyPath = if ([string]::IsNullOrWhiteSpace($PolicySourceRoot)) {
+        Join-Path $scriptRoot "crm-local-runtime-policy.mjs"
+    } else {
+        Join-Path $PolicySourceRoot "scripts\crm-local-runtime-policy.mjs"
+    }
+    if (-not (Test-Path -LiteralPath $policyPath)) {
+        throw "Política do CRM Local não encontrada na fonte avaliada: '$policyPath'."
+    }
+    $policyWsl = Convert-WindowsPathToWsl -Path $policyPath
     $manifestWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "current.json")
     $buildStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "build-state.json")
     # wsl.exe joins arguments through a shell. Quote every policy input as one
     # Bash literal; otherwise a Windows source origin loses its backslashes and
     # spuriously invalidates an otherwise healthy runtime on its second launch.
-    $policyCommand = "node {0} --manifest {1} --build-state {2} --target {3} --source-fingerprint {4} --source-origin {5} --persona {6} --pid-alive {7} --healthy {8}" -f `
+    $policyCommand = "node {0} --manifest {1} --build-state {2} --target {3} --source-fingerprint {4} --source-origin {5} --persona {6} --runtime-id {7} --module {8} --config-fingerprint {9} --pid-alive {10} --healthy {11}" -f `
         (Convert-ToBashLiteral -Value $policyWsl), `
         (Convert-ToBashLiteral -Value $manifestWsl), `
         (Convert-ToBashLiteral -Value $buildStateWsl), `
@@ -675,6 +902,9 @@ function Get-CrmPersonaDecision {
         (Convert-ToBashLiteral -Value $SourceFingerprint), `
         (Convert-ToBashLiteral -Value $SourceOrigin), `
         (Convert-ToBashLiteral -Value $Persona.ToUpperInvariant()), `
+        (Convert-ToBashLiteral -Value $RuntimeId), `
+        (Convert-ToBashLiteral -Value $Module), `
+        (Convert-ToBashLiteral -Value $ConfigFingerprint), `
         (Convert-ToBashLiteral -Value $pidAlive.ToString().ToLowerInvariant()), `
         (Convert-ToBashLiteral -Value $healthy.ToString().ToLowerInvariant())
     $decisionRaw = & wsl.exe -d Ubuntu-24.04 -- bash -lc $policyCommand
@@ -702,7 +932,27 @@ function Open-CrmPersonaUrl {
     if ($uri.Scheme -ne 'http' -or $uri.Host -notin @('localhost', '127.0.0.1') -or $uri.Port -notin @(8791, 8792)) {
         throw "URL local inválida no manifesto de ${Persona}: '$url'."
     }
-    Start-Process $url | Out-Null
+    if ($Persona -eq "Gestor") {
+        $sourceRoot = if ($null -ne $Manifest) { Convert-WslPathToWindows -Path ([string]$Manifest.worktree) } else { $null }
+        $browserLauncher = if (-not [string]::IsNullOrWhiteSpace($sourceRoot)) {
+            $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source"
+            if (-not (Test-Path -LiteralPath $sourceRoot) -or
+                -not (Test-WindowsPathWithinRoot -Path $sourceRoot -Root $allowedSourceRoot)) {
+                throw "A fonte do runtime de ${Persona} não está na raiz privada autorizada: '$sourceRoot'."
+            }
+            Join-Path $sourceRoot "scripts\open-crm-local-browser.ps1"
+        } else {
+            Join-Path $scriptRoot "open-crm-local-browser.ps1"
+        }
+        if (-not (Test-Path -LiteralPath $browserLauncher)) {
+            throw "Launcher do navegador não encontrado na fonte do runtime de ${Persona}: '$browserLauncher'."
+        }
+        & $browserLauncher `
+            -Url $url `
+            -ProfilePath (Join-Path $crmGestorRuntimeRoot "browser\profile")
+    } else {
+        Start-Process $url | Out-Null
+    }
     Write-Host "[crm-local] Runtime atualizado de $Persona reutilizado em $url."
 }
 
@@ -725,11 +975,14 @@ function Wait-CrmPersonaCurrent {
         [Parameter(Mandatory = $true)][string]$TargetCommit,
         [Parameter(Mandatory = $true)][string]$SourceFingerprint,
         [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [string]$RuntimeId = "",
+        [string]$Module = "",
+        [string]$ConfigFingerprint = "",
         [int]$TimeoutSeconds = 420
     )
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
-        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $SourceFingerprint -SourceOrigin $SourceOrigin
+        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $SourceFingerprint -SourceOrigin $SourceOrigin -RuntimeId $RuntimeId -Module $Module -ConfigFingerprint $ConfigFingerprint
         if ($decision.Action -eq 'reuse') { return $decision }
         if ($decision.Action -notin @('wait', 'start')) { return $decision }
         Start-Sleep -Seconds 2
@@ -807,6 +1060,32 @@ function Assert-GestorSharedServices {
     }
 }
 
+function Stop-CrmVerifiedLegacyWslLauncher {
+    param(
+        [Parameter(Mandatory = $true)][object]$PidValue,
+        [Parameter(Mandatory = $true)][string]$ExpectedWorkingDirectory,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+    $launcherPid = [string]$PidValue
+    if (-not (Test-CrmWslLauncherProcess -PidValue $launcherPid -ExpectedWorkingDirectory $ExpectedWorkingDirectory)) {
+        throw "O PID legado $launcherPid de $Label não possui cwd/cmdline compatíveis; ele não será encerrado."
+    }
+    $startTicks = Get-CrmWslPidStartTicks -PidValue $launcherPid
+    if ($null -eq $startTicks -or -not (Test-CrmWslPidIdentity -PidValue $launcherPid -StartTicks $startTicks)) {
+        throw "A identidade do PID legado $launcherPid de $Label mudou durante a validação; ele não será encerrado."
+    }
+
+    Write-Host "[crm-local] Encerrando somente o launcher legado verificado de $Label (PID $launcherPid)."
+    & wsl.exe -d Ubuntu-24.04 -- bash -lc "kill -TERM $launcherPid 2>/dev/null || true"
+    for ($attempt = 0; $attempt -lt 20; $attempt++) {
+        if (-not (Test-CrmWslPidIdentity -PidValue $launcherPid -StartTicks $startTicks)) { return }
+        Start-Sleep -Milliseconds 500
+    }
+    if (Test-CrmWslPidIdentity -PidValue $launcherPid -StartTicks $startTicks) {
+        & wsl.exe -d Ubuntu-24.04 -- bash -lc "kill -KILL $launcherPid 2>/dev/null || true"
+    }
+}
+
 function Stop-LegacyCrmRuntimeIfNeeded {
     $manifestPath = Join-Path $operatorRuntimeRoot "runtime\crm-local\current.json"
     if (-not (Test-Path -LiteralPath $manifestPath)) { return }
@@ -820,12 +1099,32 @@ function Stop-LegacyCrmRuntimeIfNeeded {
     $legacyProjectWsl = Convert-WindowsPathToWsl -Path $legacyProjectRoot
     if ($manifestWorktree -ne $legacyProjectWsl) { return }
 
-    Write-Host "[crm-local] Encerrando somente o runtime legado identificado antes de iniciar o Gestor canônico."
-    $legacyRuntimeRootWsl = Convert-WindowsPathToWsl -Path (Join-Path $operatorRuntimeRoot "runtime\crm-local")
-    Invoke-ShortcutWsl -WorkingProjectRoot $legacyProjectRoot -SkipBootstrapCheck -Command ("CRM_PERSONA=LEGACY CRM_RUNTIME_ROOT={0} CRM_PID_FILE={1} CRM_LOG_FILE={2} bash ./scripts/run-local-crm.sh --stop" -f `
-        (Convert-ToBashLiteral -Value $legacyRuntimeRootWsl), `
-        (Convert-ToBashLiteral -Value $crmLegacyPidWsl), `
-        (Convert-ToBashLiteral -Value $crmLegacyLogWsl))
+    Stop-CrmVerifiedLegacyWslLauncher `
+        -PidValue $manifest.pids.launcher `
+        -ExpectedWorkingDirectory $legacyProjectWsl `
+        -Label "CRM Local"
+}
+
+function Stop-LegacyCrmPersonaRuntimeIfNeeded {
+    $legacyRoot = Join-Path $operatorRuntimeRoot "runtime\crm-local\gestor"
+    $manifestPath = Join-Path $legacyRoot "current.json"
+    if (-not (Test-Path -LiteralPath $manifestPath)) { return }
+    try { $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json } catch { return }
+    if ([string]$manifest.runtimeId) { return }
+    if ([int]$manifest.ports.pages -ne 8791) { return }
+    $launcherPid = [string]$manifest.pids.launcher
+    if (-not (Test-CrmWslPid -PidValue $launcherPid)) { return }
+    $worktreeWindows = Convert-WslPathToWindows -Path ([string]$manifest.worktree)
+    $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source"
+    if (-not (Test-Path -LiteralPath $worktreeWindows)) { return }
+    $resolvedSource = (Resolve-Path -LiteralPath $worktreeWindows).Path
+    if (-not (Test-WindowsPathWithinRoot -Path $resolvedSource -Root $allowedSourceRoot)) {
+        throw "O runtime legado do Gestor aponta para uma fonte não autorizada: '$resolvedSource'."
+    }
+    Stop-CrmVerifiedLegacyWslLauncher `
+        -PidValue $launcherPid `
+        -ExpectedWorkingDirectory ([string]$manifest.worktree) `
+        -Label "CRM Local Gestor"
 }
 
 function Invoke-RepoPowerShellScript {
@@ -892,14 +1191,17 @@ $websiteLog = Join-Path $logRoot "website-local-dev.log"
 $websitePort = Join-Path $tmpRoot "website-local-dev.port"
 $sharedRoot = Split-Path (Split-Path $ProjectRoot -Parent) -Parent
 $websiteSourceRoot = Join-Path $sharedRoot "Worktrees\skincos\shared\website-local-main"
-$crmGestorPid = Join-Path $tmpRoot "crm-local-gestor.pid"
-$crmGestorLog = Join-Path $logRoot "crm-local-gestor.log"
-$crmConsultorPid = Join-Path $tmpRoot "crm-local-consultor.pid"
-$crmConsultorLog = Join-Path $logRoot "crm-local-consultor.log"
+$crmInstanceRoot = Join-Path $operatorRuntimeRoot "runtime\crm-local\instances"
+$crmGestorRuntimeRoot = Join-Path $crmInstanceRoot "gestor\full"
+$crmConsultorRuntimeRoot = Join-Path $crmInstanceRoot "consultor\legacy-ponto"
+$crmBuildCacheRoot = Join-Path $operatorRuntimeRoot "cache\crm-local\builds"
+$crmPlaywrightCacheRoot = Join-Path $operatorRuntimeRoot "cache\playwright"
+$crmGestorPid = Join-Path $crmGestorRuntimeRoot "supervisor.pid"
+$crmGestorLog = Join-Path $crmGestorRuntimeRoot "logs\runtime.log"
+$crmConsultorPid = Join-Path $crmConsultorRuntimeRoot "supervisor.pid"
+$crmConsultorLog = Join-Path $crmConsultorRuntimeRoot "logs\runtime.log"
 $crmLegacyPid = Join-Path $tmpRoot "crm-local-dev.pid"
 $crmLegacyLog = Join-Path $logRoot "crm-local-dev.log"
-$crmGestorRuntimeRoot = Join-Path $operatorRuntimeRoot "runtime\crm-local\gestor"
-$crmConsultorRuntimeRoot = Join-Path $operatorRuntimeRoot "runtime\crm-local\consultor"
 $atendimentoPid = Join-Path $tmpRoot "crm-atendimento-local.pid"
 $atendimentoLog = Join-Path $logRoot "crm-atendimento-local.log"
 $efAppStateRoot = Join-Path $localStateRoot "espacofacial-app"
@@ -955,7 +1257,7 @@ function Stop-CrmPersonaRuntime {
 
     $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source"
     $resolvedSource = if (Test-Path -LiteralPath $sourceRoot) { (Resolve-Path -LiteralPath $sourceRoot).Path } else { $null }
-    if ($null -eq $resolvedSource -or -not $resolvedSource.StartsWith($allowedSourceRoot, [StringComparison]::OrdinalIgnoreCase)) {
+    if ($null -eq $resolvedSource -or -not (Test-WindowsPathWithinRoot -Path $resolvedSource -Root $allowedSourceRoot)) {
         throw "O runtime de $Persona aponta para um worktree não autorizado: '$sourceRoot'."
     }
     if (-not (Test-Path -LiteralPath (Join-Path $resolvedSource "scripts\run-local-crm.sh"))) {
@@ -970,25 +1272,49 @@ function Start-CrmPersonaRuntime {
         [Parameter(Mandatory = $true)][string]$SourceRoot,
         [Parameter(Mandatory = $true)][string]$TargetCommit,
         [Parameter(Mandatory = $true)][string]$SourceFingerprint,
-        [Parameter(Mandatory = $true)][string]$SourceOrigin
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [Parameter(Mandatory = $true)][string]$ConfigFingerprint
     )
     $targetLiteral = Convert-ToBashLiteral -Value $TargetCommit
     if ($Persona -eq "Gestor") {
-        $command = "CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_ROOT={3} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_EMAIL=dev@local.test LOCAL_AUTH_NAME='Gestor Local' CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={4} CRM_LOG_FILE={5} bash ./scripts/run-local-crm.sh" -f `
+        $browserProfileWsl = Convert-WindowsPathToWsl -Path (Join-Path $crmGestorRuntimeRoot "browser\profile")
+        $browserScriptWsl = Convert-WindowsPathToWsl -Path (Join-Path $SourceRoot "scripts\open-crm-local-browser.ps1")
+        $playwrightCacheWsl = Convert-WindowsPathToWsl -Path $crmPlaywrightCacheRoot
+        $pagesStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $crmGestorRuntimeRoot "state\pages")
+        $insumosStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $crmGestorRuntimeRoot "state\insumos")
+        $timekeepingStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $crmGestorRuntimeRoot "state\timekeeping")
+        $whatsappStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $crmGestorRuntimeRoot "state\whatsapp")
+        $command = "CRM_RUNTIME_ID=gestor--full CRM_RUNTIME_MODULE=full CRM_PERSONA=GESTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_CONFIG_FINGERPRINT={3} CRM_RUNTIME_ROOT={4} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=true LOCAL_AUTH_ROLE=GESTOR LOCAL_AUTH_USERNAME=gestor-full-local LOCAL_AUTH_EMAIL=gestor.full@local.test LOCAL_AUTH_NAME='Gestor Local' LOCAL_ESCALA_MOCK=true LOCAL_ESCALA_SHADOW_WRITES=false CRM_META_ADS_SCENARIO=connected-ready INTEGRATIONS_ENCRYPTION_SECRET=skincos-gestor--full-local-integrations REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET=true UNIT_MONITOR_API_TARGET=http://127.0.0.1:8110 CRM_WITH_INSUMOS=1 CRM_INSUMOS_PERSIST_DIR={5} CRM_WITH_TIMEKEEPING=1 CRM_TIMEKEEPING_PERSIST_DIR={6} CRM_WITH_WHATSAPP=1 CRM_LOCAL_WA_RUNTIME_HOME={7} CRM_LOCAL_WA_SOURCE_HOME=/home/admin/.cache/skincos/crm-local/gestor--full/whatsapp R2_PERSIST_DIR={8} CRM_LOCAL_ISOLATED=1 CRM_ISOLATED_RUNTIME=1 CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION=1 PLAYWRIGHT_BROWSERS_PATH={9} CRM_BROWSER_PROFILE_DIR={10} CRM_BROWSER_SCRIPT={11} CRM_BUILD_BEFORE_START=auto CRM_OPEN_BROWSER=1 CRM_PID_FILE={12} CRM_LOG_FILE={13} bash ./scripts/run-local-crm.sh" -f `
             $targetLiteral, `
             (Convert-ToBashLiteral -Value $SourceFingerprint), `
             (Convert-ToBashLiteral -Value $SourceOrigin), `
+            (Convert-ToBashLiteral -Value $ConfigFingerprint), `
             (Convert-ToBashLiteral -Value $crmGestorRuntimeRootWsl), `
+            (Convert-ToBashLiteral -Value $insumosStateWsl), `
+            (Convert-ToBashLiteral -Value $timekeepingStateWsl), `
+            (Convert-ToBashLiteral -Value $whatsappStateWsl), `
+            (Convert-ToBashLiteral -Value $pagesStateWsl), `
+            (Convert-ToBashLiteral -Value $playwrightCacheWsl), `
+            (Convert-ToBashLiteral -Value $browserProfileWsl), `
+            (Convert-ToBashLiteral -Value $browserScriptWsl), `
             (Convert-ToBashLiteral -Value $crmGestorPidWsl), `
             (Convert-ToBashLiteral -Value $crmGestorLogWsl)
     } else {
-        $command = "CRM_PERSONA=CONSULTOR CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_ROOT={3} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_ROLE=CONSULTOR LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 PONTO_API_TARGET=http://127.0.0.1:8801 PONTO_ACTOR_HMAC_KEY=test-actor-key-not-secret LOCAL_INSUMOS_API_TARGET=http://127.0.0.1:8787 LOCAL_WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:8110 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={4} CRM_LOG_FILE={5} bash ./scripts/run-local-crm.sh --module ponto" -f `
+        $consultorSpec = Resolve-CrmLocalModuleSpec -Role Consultor -Module "ponto" -SourceRoot $SourceRoot
+        $consultorRoleKey = [string]$consultorSpec.roleKey
+        $consultorAuthAdmin = if ([bool]$consultorSpec.auth.testUserAdmin) { "true" } else { "false" }
+        $consultorAllowedModules = @($consultorSpec.auth.allowedModules) -join ","
+        $command = "CRM_RUNTIME_ID=consultor--ponto CRM_RUNTIME_MODULE=ponto CRM_PERSONA={7} CRM_TARGET_COMMIT={0} CRM_SOURCE_FINGERPRINT={1} CRM_SOURCE_ORIGIN={2} CRM_RUNTIME_CONFIG_FINGERPRINT={3} CRM_RUNTIME_ROOT={4} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN={8} LOCAL_AUTH_ROLE={7} LOCAL_AUTH_EMAIL=consultor.local@local.test LOCAL_AUTH_USERNAME=consultor-local LOCAL_AUTH_NAME='Consultor Local' LOCAL_AUTH_ALLOWED_MODULES={9} CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 PONTO_API_TARGET=http://127.0.0.1:8801 PONTO_ACTOR_HMAC_KEY=test-actor-key-not-secret LOCAL_INSUMOS_API_TARGET=http://127.0.0.1:8787 LOCAL_WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:8110 CRM_BUILD_BEFORE_START=1 CRM_OPEN_BROWSER=1 CRM_PID_FILE={5} CRM_LOG_FILE={6} bash ./scripts/run-local-crm.sh --module ponto" -f `
             $targetLiteral, `
             (Convert-ToBashLiteral -Value $SourceFingerprint), `
             (Convert-ToBashLiteral -Value $SourceOrigin), `
+            (Convert-ToBashLiteral -Value $ConfigFingerprint), `
             (Convert-ToBashLiteral -Value $crmConsultorRuntimeRootWsl), `
             (Convert-ToBashLiteral -Value $crmConsultorPidWsl), `
-            (Convert-ToBashLiteral -Value $crmConsultorLogWsl)
+            (Convert-ToBashLiteral -Value $crmConsultorLogWsl), `
+            (Convert-ToBashLiteral -Value $consultorRoleKey), `
+            $consultorAuthAdmin, `
+            (Convert-ToBashLiteral -Value $consultorAllowedModules)
     }
     Invoke-ShortcutWsl -WorkingProjectRoot $SourceRoot -SkipBootstrapCheck -Command $command
 }
@@ -1066,6 +1392,7 @@ function Invoke-CrmAtendimentoAction {
             Stop-CrmPersonaRuntime -Persona Gestor
         }
         $sourceRoot = Sync-CrmLocalSourceRoot -Persona Gestor -TargetCommit $targetCommit -Snapshot $snapshot
+        Assert-CrmLocalLauncherContract -SourceRoot $sourceRoot
         Start-CrmAtendimentoRuntime -SourceRoot $sourceRoot -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
         $ready = Wait-CrmAtendimentoReady -TargetCommit $targetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -TimeoutSeconds 600
         if ($ready.Action -ne 'reuse') {
@@ -1083,28 +1410,35 @@ function Invoke-CrmPersonaAction {
         [Parameter(Mandatory = $true)][string]$TargetCommit,
         [string]$Module = 'crm-shell'
     )
+    $runtimeId = if ($Persona -eq "Gestor") { "gestor--full" } else { "consultor--ponto" }
+    $runtimeModule = if ($Persona -eq "Gestor") { "full" } else { "ponto" }
+    $configFingerprint = Get-CrmPersonaRuntimeConfigFingerprint -Persona $Persona
     $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $TargetCommit
     try {
         $sourceOrigin = Get-CrmLocalSourceOrigin -Snapshot $snapshot -Module $Module
-        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+        $decision = Get-CrmPersonaDecision -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -RuntimeId $runtimeId -Module $runtimeModule -ConfigFingerprint $configFingerprint
         if ($decision.Action -eq 'reuse') {
             Open-CrmPersonaUrl -Persona $Persona -Manifest $decision.Manifest
             return
         }
         if ($decision.Action -eq 'wait') {
             Write-Host "[crm-local] A inicialização de $Persona para o commit atual já está em andamento; aguardando."
-            $decision = Wait-CrmPersonaCurrent -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+            $decision = Wait-CrmPersonaCurrent -Persona $Persona -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -RuntimeId $runtimeId -Module $runtimeModule -ConfigFingerprint $configFingerprint
             if ($decision.Action -eq 'reuse') {
                 Open-CrmPersonaUrl -Persona $Persona -Manifest $decision.Manifest
                 return
             }
         }
+        # Materialize and verify the candidate before touching the currently
+        # healthy runtime. A versioned source avoids changing files underneath
+        # the process that is still serving the previous revision.
+        $sourceRoot = Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $TargetCommit -Snapshot $snapshot -Versioned
+        Assert-CrmLocalLauncherContract -SourceRoot $sourceRoot
         if ($decision.Action -eq 'restart') {
             Write-Host "[crm-local] Reiniciando ${Persona}: $($decision.Reason)."
             Stop-CrmPersonaRuntime -Persona $Persona
         }
-        $sourceRoot = Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $TargetCommit -Snapshot $snapshot
-        Start-CrmPersonaRuntime -Persona $Persona -SourceRoot $sourceRoot -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+        Start-CrmPersonaRuntime -Persona $Persona -SourceRoot $sourceRoot -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -ConfigFingerprint $configFingerprint
     } finally {
         Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
     }
@@ -1132,23 +1466,545 @@ function Start-CrmGestorBackgroundUpdate {
 
 function Ensure-CrmGestorForConsultor {
     param([Parameter(Mandatory = $true)][string]$TargetCommit)
+    $configFingerprint = Get-CrmPersonaRuntimeConfigFingerprint -Persona Gestor
     $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $TargetCommit
     try {
         $sourceOrigin = Get-CrmLocalSourceOrigin -Snapshot $snapshot -Module 'crm-shell'
-        $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+        $decision = Get-CrmPersonaDecision -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -RuntimeId "gestor--full" -Module "full" -ConfigFingerprint $configFingerprint
         if ($decision.Action -eq 'reuse') { return }
         if ($decision.Action -eq 'wait') {
-            $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin
+            $decision = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -RuntimeId "gestor--full" -Module "full" -ConfigFingerprint $configFingerprint
             if ($decision.Action -eq 'reuse') { return }
         }
         if ($decision.Action -eq 'restart') { Stop-CrmPersonaRuntime -Persona Gestor }
         Start-CrmGestorBackgroundUpdate -TargetCommit $TargetCommit
-        $ready = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -TimeoutSeconds 600
+        $ready = Wait-CrmPersonaCurrent -Persona Gestor -TargetCommit $TargetCommit -SourceFingerprint $snapshot.Fingerprint -SourceOrigin $sourceOrigin -RuntimeId "gestor--full" -Module "full" -ConfigFingerprint $configFingerprint -TimeoutSeconds 600
         if ($ready.Action -ne 'reuse') {
             throw "O Gestor não ficou pronto no commit $TargetCommit. Consulte '$logRoot\crm-local-gestor-action.err.log'."
         }
     } finally {
         Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
+    }
+}
+
+function Get-CrmLocalModuleCatalog {
+    param([string]$SourceRoot = "")
+    $catalogScript = if ([string]::IsNullOrWhiteSpace($SourceRoot)) {
+        Join-Path $scriptRoot "crm-local-module-catalog.mjs"
+    } else {
+        Join-Path $SourceRoot "scripts\crm-local-module-catalog.mjs"
+    }
+    if (-not (Test-Path -LiteralPath $catalogScript)) {
+        throw "Catálogo modular do CRM Local não encontrado: '$catalogScript'."
+    }
+    $catalogScriptWsl = Convert-WindowsPathToWsl -Path $catalogScript
+    $raw = & wsl.exe -d Ubuntu-24.04 -- node $catalogScriptWsl --json
+    if ($LASTEXITCODE -ne 0) {
+        throw "Não foi possível descobrir os módulos locais pela fonte canônica."
+    }
+    try {
+        return ($raw -join "`n") | ConvertFrom-Json
+    } catch {
+        throw "O catálogo modular do CRM Local retornou JSON inválido: $($_.Exception.Message)"
+    }
+}
+
+function Get-CrmPersonaRuntimeConfigFingerprint {
+    param([ValidateSet("Gestor", "Consultor")][string]$Persona)
+    $catalog = Get-CrmLocalModuleCatalog
+    if ($Persona -eq "Gestor") {
+        if ([string]::IsNullOrWhiteSpace([string]$catalog.fullRuntime.configFingerprint)) {
+            throw "O catálogo modular não publicou a configuração determinística do CRM completo."
+        }
+        return [string]$catalog.fullRuntime.configFingerprint
+    }
+    return "legacy-consultor-v3:$([string]$catalog.launcherContractFingerprint)"
+}
+
+function Assert-CrmLocalLauncherContract {
+    param([Parameter(Mandatory = $true)][string]$SourceRoot)
+    $callerCatalog = Get-CrmLocalModuleCatalog
+    $sourceCatalog = Get-CrmLocalModuleCatalog -SourceRoot $SourceRoot
+    if ([int]$callerCatalog.launcherContractVersion -ne [int]$sourceCatalog.launcherContractVersion -or
+        [string]$callerCatalog.launcherContractFingerprint -ne [string]$sourceCatalog.launcherContractFingerprint) {
+        throw "O contrato do launcher que recebeu a ação diverge da fonte materializada em '$SourceRoot'. Atualize/reinstale os atalhos antes de iniciar o CRM; revisões diferentes não serão misturadas."
+    }
+}
+
+function Resolve-CrmLocalModuleSpec {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Gestor", "Consultor")]
+        [string]$Role,
+        [Parameter(Mandatory = $true)]
+        [string]$Module,
+        [string]$SourceRoot = ""
+    )
+    $catalog = Get-CrmLocalModuleCatalog -SourceRoot $SourceRoot
+    $matches = @($catalog.combinations | Where-Object {
+        [string]$_.role -ieq $Role -and [string]$_.module -ceq $Module
+    })
+    if ($matches.Count -ne 1) {
+        throw "A combinação CRM '$Role / $Module' não é liberada pela fonte canônica. Use a ação CRM – Módulos para ver somente combinações permitidas."
+    }
+    return $matches[0]
+}
+
+function Get-CrmInstanceRuntimeRoot {
+    param([Parameter(Mandatory = $true)][object]$Spec)
+    $roleSegment = ([string]$Spec.role).Trim().ToLowerInvariant()
+    $moduleSegment = ([string]$Spec.module).Trim().ToLowerInvariant()
+    return Join-Path $crmInstanceRoot (Join-Path $roleSegment $moduleSegment)
+}
+
+function Get-CrmInstanceManifest {
+    param([Parameter(Mandatory = $true)][object]$Spec)
+    $path = Join-Path (Get-CrmInstanceRuntimeRoot -Spec $Spec) "current.json"
+    if (-not (Test-Path -LiteralPath $path)) { return $null }
+    try { return Get-Content -LiteralPath $path -Raw | ConvertFrom-Json } catch { return $null }
+}
+
+function Get-CrmInstanceBuildPaths {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceRoot
+    )
+    $sourceKey = (Get-CrmLocalSnapshotHash -Value $SourceFingerprint).Substring(0, 24)
+    $cacheRoot = Join-Path $crmBuildCacheRoot $sourceKey
+    return [pscustomobject]@{
+        Root = $cacheRoot
+        State = Join-Path $cacheRoot "build-state.json"
+        Lock = Join-Path $cacheRoot "build.lock"
+        SourceRoot = $SourceRoot
+    }
+}
+
+function Get-CrmInstanceBuildDescriptor {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceRoot,
+        [Parameter(Mandatory = $true)][string]$StatePath
+    )
+    $helper = Join-Path $SourceRoot "scripts\crm-local-build-state.mjs"
+    if (-not (Test-Path -LiteralPath $helper)) {
+        throw "Controle determinístico de build não encontrado: '$helper'."
+    }
+    $helperWsl = Convert-WindowsPathToWsl -Path $helper
+    $sourceWsl = Convert-WindowsPathToWsl -Path $SourceRoot
+    $stateWsl = Convert-WindowsPathToWsl -Path $StatePath
+    $command = "node {0} inspect --root {1} --state {2}" -f `
+        (Convert-ToBashLiteral -Value $helperWsl), `
+        (Convert-ToBashLiteral -Value $sourceWsl), `
+        (Convert-ToBashLiteral -Value $stateWsl)
+    # Several module actions can reach this calculation at once. The helper
+    # streams files, but a process per module can still exhaust the WSL VM while
+    # all of them traverse the same source and dist trees. Serialize only the
+    # descriptor calculation; the actual build remains protected by its
+    # cross-shell build lock.
+    $descriptorKey = (Get-CrmLocalSnapshotHash -Value $StatePath).Substring(0, 24)
+    $mutex = [Threading.Mutex]::new($false, "Local\SkincosCrmBuildDescriptor-$descriptorKey")
+    $lockHeld = $false
+    try {
+        try {
+            $lockHeld = $mutex.WaitOne([TimeSpan]::FromMinutes(10))
+        } catch [Threading.AbandonedMutexException] {
+            $lockHeld = $true
+            Write-Host "[crm-local] Recuperando mutex abandonado da impressão de build $descriptorKey."
+        }
+        if (-not $lockHeld) {
+            throw "Tempo limite ao calcular a impressão compartilhada do build em '$SourceRoot'."
+        }
+        $raw = & wsl.exe -d Ubuntu-24.04 -- bash -lc $command
+        if ($LASTEXITCODE -ne 0) {
+            throw "Não foi possível calcular a impressão do build em '$SourceRoot'."
+        }
+        try {
+            return ($raw | Select-Object -Last 1) | ConvertFrom-Json
+        } catch {
+            throw "O controle de build retornou JSON inválido: $($_.Exception.Message)"
+        }
+    } finally {
+        if ($lockHeld) { $mutex.ReleaseMutex() }
+        $mutex.Dispose()
+    }
+}
+
+function Test-CrmWslPidIdentity {
+    param(
+        [object]$PidValue,
+        [object]$StartTicks
+    )
+    $pidText = [string]$PidValue
+    $ticksText = [string]$StartTicks
+    if ($pidText -notmatch '^[0-9]+$' -or $ticksText -notmatch '^[0-9]+$') { return $false }
+    $actualTicks = Get-CrmWslPidStartTicks -PidValue $pidText
+    return $null -ne $actualTicks -and [string]$actualTicks -eq $ticksText
+}
+
+function Test-CrmInstanceHealth {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][object]$Manifest,
+        [Parameter(Mandatory = $true)][object]$BuildDescriptor
+    )
+    if (-not [bool]$BuildDescriptor.stateValid) { return $false }
+    if ([string]$Manifest.build.inputFingerprint -ne [string]$BuildDescriptor.inputFingerprint) { return $false }
+    if ([string]$Manifest.build.lockfileFingerprint -ne [string]$BuildDescriptor.lockfileFingerprint) { return $false }
+    if ([string]$Manifest.build.artifactFingerprint -ne [string]$BuildDescriptor.artifactFingerprint) { return $false }
+
+    $pagesPort = [int]$Spec.ports.pages
+    if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$pagesPort/api/auth/me" -Role ([string]$Spec.roleKey))) {
+        return $false
+    }
+    if (-not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$pagesPort/?module=$([string]$Spec.module)")) {
+        return $false
+    }
+    if ([bool]$Spec.dependencies.insumos -and
+        -not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$([int]$Spec.ports.insumos)/insumos/health")) {
+        return $false
+    }
+    if ([bool]$Spec.dependencies.timekeeping -and
+        -not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$([int]$Spec.ports.timekeeping)/api/ponto/readiness")) {
+        return $false
+    }
+    if ([bool]$Spec.dependencies.whatsapp -and
+        -not (Test-CrmHttpEndpoint -Url "http://127.0.0.1:$([int]$Spec.ports.whatsapp)/health")) {
+        return $false
+    }
+    return $true
+}
+
+function Get-CrmInstanceDecision {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [Parameter(Mandatory = $true)][object]$BuildDescriptor,
+        [Parameter(Mandatory = $true)][string]$BuildStatePath,
+        [Parameter(Mandatory = $true)][string]$SourceRoot
+    )
+    $manifest = Get-CrmInstanceManifest -Spec $Spec
+    $pidAlive = $false
+    if ($null -ne $manifest) {
+        $pidAlive = Test-CrmWslPidIdentity -PidValue $manifest.pids.launcher -StartTicks $manifest.pidStartTicks.launcher
+    }
+    $healthy = $false
+    if ($pidAlive) {
+        $healthy = Test-CrmInstanceHealth -Spec $Spec -Manifest $manifest -BuildDescriptor $BuildDescriptor
+    }
+
+    $runtimeRoot = Get-CrmInstanceRuntimeRoot -Spec $Spec
+    $policyPath = Join-Path $SourceRoot "scripts\crm-local-runtime-policy.mjs"
+    if (-not (Test-Path -LiteralPath $policyPath)) {
+        throw "Política do runtime modular não encontrada na fonte executada: '$policyPath'."
+    }
+    $policyWsl = Convert-WindowsPathToWsl -Path $policyPath
+    $manifestWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "current.json")
+    $buildStateWsl = Convert-WindowsPathToWsl -Path $BuildStatePath
+    $artifactFingerprint = [string]$BuildDescriptor.artifactFingerprint
+    $policyCommand = "node {0} --manifest {1} --build-state {2} --target {3} --source-fingerprint {4} --source-origin {5} --persona {6} --runtime-id {7} --module {8} --config-fingerprint {9} --build-input-fingerprint {10} --lockfile-fingerprint {11} --artifact-fingerprint {12} --pid-alive {13} --healthy {14}" -f `
+        (Convert-ToBashLiteral -Value $policyWsl), `
+        (Convert-ToBashLiteral -Value $manifestWsl), `
+        (Convert-ToBashLiteral -Value $buildStateWsl), `
+        (Convert-ToBashLiteral -Value $TargetCommit), `
+        (Convert-ToBashLiteral -Value $SourceFingerprint), `
+        (Convert-ToBashLiteral -Value $SourceOrigin), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.roleKey)), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.runtimeId)), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.module)), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.configFingerprint)), `
+        (Convert-ToBashLiteral -Value ([string]$BuildDescriptor.inputFingerprint)), `
+        (Convert-ToBashLiteral -Value ([string]$BuildDescriptor.lockfileFingerprint)), `
+        (Convert-ToBashLiteral -Value $artifactFingerprint), `
+        (Convert-ToBashLiteral -Value $pidAlive.ToString().ToLowerInvariant()), `
+        (Convert-ToBashLiteral -Value $healthy.ToString().ToLowerInvariant())
+    $decisionRaw = & wsl.exe -d Ubuntu-24.04 -- bash -lc $policyCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "Não foi possível avaliar o runtime '$([string]$Spec.runtimeId)'."
+    }
+    $decision = $decisionRaw | Select-Object -Last 1 | ConvertFrom-Json
+    return [pscustomobject]@{
+        Action = [string]$decision.action
+        Reason = [string]$decision.reason
+        Manifest = $manifest
+    }
+}
+
+function Open-CrmInstanceUrl {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][object]$Manifest
+    )
+    $runtimeRoot = Get-CrmInstanceRuntimeRoot -Spec $Spec
+    $expectedProfile = Join-Path $runtimeRoot "browser\profile"
+    $fallbackUrl = "http://localhost:$([int]$Spec.ports.pages)/?module=$([string]$Spec.module)"
+    $url = if (-not [string]::IsNullOrWhiteSpace([string]$Manifest.url)) { [string]$Manifest.url } else { $fallbackUrl }
+    $uri = [Uri]$url
+    if ($uri.Scheme -ne "http" -or $uri.Host -notin @("localhost", "127.0.0.1") -or $uri.Port -ne [int]$Spec.ports.pages) {
+        throw "URL inválida no manifesto '$([string]$Spec.runtimeId)': '$url'."
+    }
+    $sourceRoot = Convert-WslPathToWindows -Path ([string]$Manifest.worktree)
+    $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source\crm-local\immutable"
+    $resolvedSource = if (Test-Path -LiteralPath $sourceRoot) { (Resolve-Path -LiteralPath $sourceRoot).Path } else { $null }
+    if ($null -eq $resolvedSource -or -not (Test-WindowsPathWithinRoot -Path $resolvedSource -Root $allowedSourceRoot)) {
+        throw "O runtime '$([string]$Spec.runtimeId)' aponta para uma fonte não autorizada: '$sourceRoot'."
+    }
+    & (Join-Path $resolvedSource "scripts\open-crm-local-browser.ps1") -Url $url -ProfilePath $expectedProfile
+    Write-Host "[crm-local] $([string]$Spec.role) / $([string]$Spec.label) reutilizado sem rebuild em $url."
+}
+
+function Stop-CrmInstanceRuntime {
+    param([Parameter(Mandatory = $true)][object]$Spec)
+    $runtimeRoot = Get-CrmInstanceRuntimeRoot -Spec $Spec
+    $manifest = Get-CrmInstanceManifest -Spec $Spec
+    if ($null -eq $manifest) {
+        Write-Host "[crm-local] Não há manifesto para $([string]$Spec.role) / $([string]$Spec.label); nenhum processo será encerrado por aproximação."
+        return
+    }
+    $sourceRoot = Convert-WslPathToWindows -Path ([string]$manifest.worktree
+    )
+    $allowedSourceRoot = Join-Path $operatorRuntimeRoot "source\crm-local\immutable"
+    $resolvedSource = if (Test-Path -LiteralPath $sourceRoot) { (Resolve-Path -LiteralPath $sourceRoot).Path } else { $null }
+    if ($null -eq $resolvedSource -or -not (Test-WindowsPathWithinRoot -Path $resolvedSource -Root $allowedSourceRoot)) {
+        throw "O runtime '$([string]$Spec.runtimeId)' aponta para uma fonte não autorizada: '$sourceRoot'."
+    }
+
+    $runtimeRootWsl = Convert-WindowsPathToWsl -Path $runtimeRoot
+    $pidWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "supervisor.pid")
+    $logWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "logs\runtime.log")
+    $command = "CRM_RUNTIME_ID={0} CRM_RUNTIME_MODULE={1} CRM_PERSONA={2} CRM_RUNTIME_ROOT={3} CRM_VITE_PORT={4} CRM_PAGES_PORT={5} CRM_WITH_INSUMOS={6} CRM_INSUMOS_PORT={7} CRM_WITH_TIMEKEEPING={8} CRM_TIMEKEEPING_PORT={9} CRM_WITH_WHATSAPP={10} CRM_WA_ORCHESTRATOR_PORT={11} CRM_PID_FILE={12} CRM_LOG_FILE={13} bash ./scripts/run-local-crm.sh --stop" -f `
+        (Convert-ToBashLiteral -Value ([string]$Spec.runtimeId)), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.module)), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.roleKey)), `
+        (Convert-ToBashLiteral -Value $runtimeRootWsl), `
+        [int]$Spec.ports.vite, [int]$Spec.ports.pages, `
+        $(if ([bool]$Spec.dependencies.insumos) { 1 } else { 0 }), [int]$Spec.ports.insumos, `
+        $(if ([bool]$Spec.dependencies.timekeeping) { 1 } else { 0 }), [int]$Spec.ports.timekeeping, `
+        $(if ([bool]$Spec.dependencies.whatsapp) { 1 } else { 0 }), [int]$Spec.ports.whatsapp, `
+        (Convert-ToBashLiteral -Value $pidWsl), `
+        (Convert-ToBashLiteral -Value $logWsl)
+    Invoke-ShortcutWsl -WorkingProjectRoot $resolvedSource -SkipBootstrapCheck -Command $command
+}
+
+function Start-CrmInstanceRuntime {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][string]$SourceRoot,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [Parameter(Mandatory = $true)][object]$BuildPaths
+    )
+    $runtimeRoot = Get-CrmInstanceRuntimeRoot -Spec $Spec
+    $runtimeRootWsl = Convert-WindowsPathToWsl -Path $runtimeRoot
+    $buildStateWsl = Convert-WindowsPathToWsl -Path $BuildPaths.State
+    $buildLockWsl = Convert-WindowsPathToWsl -Path $BuildPaths.Lock
+    $playwrightCacheWsl = Convert-WindowsPathToWsl -Path $crmPlaywrightCacheRoot
+    $browserProfileWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "browser\profile")
+    $browserScriptWsl = Convert-WindowsPathToWsl -Path (Join-Path $SourceRoot "scripts\open-crm-local-browser.ps1")
+    $pidWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "supervisor.pid")
+    $logWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "logs\runtime.log")
+    $pagesStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "state\pages")
+    $insumosStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "state\insumos")
+    $timekeepingStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "state\timekeeping")
+    $whatsappStateWsl = Convert-WindowsPathToWsl -Path (Join-Path $runtimeRoot "state\whatsapp")
+    $gateModules = [string]$Spec.module
+    $roleKey = [string]$Spec.roleKey
+    $roleLower = $roleKey.ToLowerInvariant()
+    $module = [string]$Spec.module
+    $localAuthAdmin = if ([bool]$Spec.auth.testUserAdmin) { "true" } else { "false" }
+    $allowedModules = @($Spec.auth.allowedModules) -join ","
+    $withInsumos = if ([bool]$Spec.dependencies.insumos) { 1 } else { 0 }
+    $withTimekeeping = if ([bool]$Spec.dependencies.timekeeping) { 1 } else { 0 }
+    $withWhatsapp = if ([bool]$Spec.dependencies.whatsapp) { 1 } else { 0 }
+    $openBrowser = if ($CrmRuntimeSuppressBrowser) { 0 } else { 1 }
+    $username = "$roleLower-$module-local"
+    $email = "$roleLower.$module@local.test"
+    $displayName = "$([string]$Spec.role) Local - $([string]$Spec.label)"
+    $localScenario = [string]$Spec.localScenario
+    $nativeSourceKey = (Get-CrmLocalSnapshotHash -Value $SourceFingerprint).Substring(0, 16)
+    $whatsappSourceWsl = "/home/admin/.cache/skincos/crm-local/$([string]$Spec.runtimeId)/whatsapp-$nativeSourceKey"
+
+    New-Item -ItemType Directory -Path (Join-Path $runtimeRoot "logs") -Force | Out-Null
+    New-Item -ItemType Directory -Path $BuildPaths.Root -Force | Out-Null
+    New-Item -ItemType Directory -Path $crmPlaywrightCacheRoot -Force | Out-Null
+
+    $command = "CRM_RUNTIME_ID={0} CRM_RUNTIME_MODULE={1} CRM_PERSONA={2} CRM_TARGET_COMMIT={3} CRM_SOURCE_FINGERPRINT={4} CRM_SOURCE_ORIGIN={5} CRM_RUNTIME_CONFIG_FINGERPRINT={6} CRM_RUNTIME_ROOT={7} CRM_BUILD_STATE_FILE={8} CRM_BUILD_LOCK_DIR={9} PLAYWRIGHT_BROWSERS_PATH={10} CRM_BROWSER_PROFILE_DIR={11} CRM_BROWSER_SCRIPT={12} LOCAL_AUTH_BYPASS=true LOCAL_AUTH_TEST_USER_ADMIN={13} LOCAL_AUTH_ROLE={14} LOCAL_AUTH_USERNAME={15} LOCAL_AUTH_EMAIL={16} LOCAL_AUTH_NAME={17} LOCAL_AUTH_ALLOWED_MODULES={18} CRM_VITE_PORT={19} CRM_PAGES_PORT={20} CRM_WITH_INSUMOS={21} CRM_INSUMOS_PORT={22} CRM_INSUMOS_PERSIST_DIR={23} CRM_WITH_TIMEKEEPING={24} CRM_TIMEKEEPING_PORT={25} CRM_TIMEKEEPING_PERSIST_DIR={26} CRM_WITH_WHATSAPP={27} CRM_WA_ORCHESTRATOR_PORT={28} CRM_LOCAL_WA_RUNTIME_HOME={29} CRM_LOCAL_WA_SOURCE_HOME={30} R2_PERSIST_DIR={31} CRM_ISOLATED_RUNTIME=1 CRM_LOCAL_ISOLATED=1 CRM_BUILD_BEFORE_START=auto CRM_GATE_STRICT=1 CRM_GATE_MODULES={32} CRM_OPEN_BROWSER=$openBrowser CRM_PID_FILE={33} CRM_LOG_FILE={34} bash ./scripts/run-local-crm.sh --module {35}" -f `
+        (Convert-ToBashLiteral -Value ([string]$Spec.runtimeId)), `
+        (Convert-ToBashLiteral -Value $module), `
+        (Convert-ToBashLiteral -Value $roleKey), `
+        (Convert-ToBashLiteral -Value $TargetCommit), `
+        (Convert-ToBashLiteral -Value $SourceFingerprint), `
+        (Convert-ToBashLiteral -Value $SourceOrigin), `
+        (Convert-ToBashLiteral -Value ([string]$Spec.configFingerprint)), `
+        (Convert-ToBashLiteral -Value $runtimeRootWsl), `
+        (Convert-ToBashLiteral -Value $buildStateWsl), `
+        (Convert-ToBashLiteral -Value $buildLockWsl), `
+        (Convert-ToBashLiteral -Value $playwrightCacheWsl), `
+        (Convert-ToBashLiteral -Value $browserProfileWsl), `
+        (Convert-ToBashLiteral -Value $browserScriptWsl), `
+        $localAuthAdmin, `
+        (Convert-ToBashLiteral -Value $roleKey), `
+        (Convert-ToBashLiteral -Value $username), `
+        (Convert-ToBashLiteral -Value $email), `
+        (Convert-ToBashLiteral -Value $displayName), `
+        (Convert-ToBashLiteral -Value $allowedModules), `
+        [int]$Spec.ports.vite, [int]$Spec.ports.pages, `
+        $withInsumos, [int]$Spec.ports.insumos, (Convert-ToBashLiteral -Value $insumosStateWsl), `
+        $withTimekeeping, [int]$Spec.ports.timekeeping, (Convert-ToBashLiteral -Value $timekeepingStateWsl), `
+        $withWhatsapp, [int]$Spec.ports.whatsapp, (Convert-ToBashLiteral -Value $whatsappStateWsl), `
+        (Convert-ToBashLiteral -Value $whatsappSourceWsl), `
+        (Convert-ToBashLiteral -Value $pagesStateWsl), `
+        (Convert-ToBashLiteral -Value $gateModules), `
+        (Convert-ToBashLiteral -Value $pidWsl), `
+        (Convert-ToBashLiteral -Value $logWsl), `
+        (Convert-ToBashLiteral -Value $module)
+    $isolatedBindings = @(
+        "LOCAL_ESCALA_MOCK=true",
+        "LOCAL_ESCALA_SHADOW_WRITES=false",
+        "INTEGRATIONS_ENCRYPTION_SECRET=$(Convert-ToBashLiteral -Value "skincos-$([string]$Spec.runtimeId)-local-integrations")",
+        "REQUIRE_INTEGRATIONS_ENCRYPTION_SECRET=true"
+    )
+    if (-not [string]::IsNullOrWhiteSpace($localScenario)) {
+        $isolatedBindings += "CRM_META_ADS_SCENARIO=$(Convert-ToBashLiteral -Value $localScenario)"
+    }
+    if ($withWhatsapp -eq 1) {
+        $isolatedBindings += "UNIT_MONITOR_API_TARGET=http://127.0.0.1:$([int]$Spec.ports.whatsapp)"
+    }
+    $command = "$($isolatedBindings -join ' ') $command"
+    Invoke-ShortcutWsl -WorkingProjectRoot $SourceRoot -SkipBootstrapCheck -AcceptedExitCode @(0, 130, 143) -Command $command
+}
+
+function Wait-CrmInstanceCurrent {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [Parameter(Mandatory = $true)][string]$SourceFingerprint,
+        [Parameter(Mandatory = $true)][string]$SourceOrigin,
+        [Parameter(Mandatory = $true)][object]$BuildPaths,
+        [int]$TimeoutSeconds = 900
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $descriptor = Get-CrmInstanceBuildDescriptor -SourceRoot $BuildPaths.SourceRoot -StatePath $BuildPaths.State
+        $decision = Get-CrmInstanceDecision -Spec $Spec -TargetCommit $TargetCommit -SourceFingerprint $SourceFingerprint -SourceOrigin $SourceOrigin -BuildDescriptor $descriptor -BuildStatePath $BuildPaths.State -SourceRoot $BuildPaths.SourceRoot
+        if ($decision.Action -eq "reuse") { return $decision }
+        if ($decision.Action -ne "wait") { return $decision }
+        Start-Sleep -Seconds 2
+    }
+    return [pscustomobject]@{ Action = "restart"; Reason = "startup_timeout"; Manifest = (Get-CrmInstanceManifest -Spec $Spec) }
+}
+
+function Start-CrmInstanceBackgroundUpdate {
+    param(
+        [Parameter(Mandatory = $true)][object]$Spec,
+        [Parameter(Mandatory = $true)][string]$TargetCommit
+    )
+    $runtimeRoot = Get-CrmInstanceRuntimeRoot -Spec $Spec
+    New-Item -ItemType Directory -Path (Join-Path $runtimeRoot "logs") -Force | Out-Null
+    $outLog = Join-Path $runtimeRoot "logs\action.out.log"
+    $errLog = Join-Path $runtimeRoot "logs\action.err.log"
+    $arguments = @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $PSCommandPath,
+        "-Action", "CrmModule", "-ProjectRoot", $ProjectRoot,
+        "-CrmRole", [string]$Spec.role, "-CrmModule", [string]$Spec.module,
+        "-CrmRuntimeDetachedStart"
+    )
+    if ($CrmRuntimeSuppressBrowser) {
+        $arguments += "-CrmRuntimeSuppressBrowser"
+    }
+    $previousReviewRef = $env:CRM_LOCAL_REVIEW_REF
+    try {
+        $env:CRM_LOCAL_REVIEW_REF = $TargetCommit
+        Start-Process powershell.exe -ArgumentList $arguments -WindowStyle Hidden `
+            -RedirectStandardOutput $outLog -RedirectStandardError $errLog | Out-Null
+    } finally {
+        $env:CRM_LOCAL_REVIEW_REF = $previousReviewRef
+    }
+    if ($CrmRuntimeSuppressBrowser) {
+        Write-Host "[crm-local] $([string]$Spec.role) / $([string]$Spec.label) iniciou em segundo plano; navegador suprimido pela validação interna."
+    } else {
+        Write-Host "[crm-local] $([string]$Spec.role) / $([string]$Spec.label) iniciou em segundo plano; o navegador abrirá após o gate."
+    }
+}
+
+function Invoke-CrmModuleAction {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Gestor", "Consultor")]
+        [string]$Role,
+        [Parameter(Mandatory = $true)]
+        [string]$Module
+    )
+    $spec = Resolve-CrmLocalModuleSpec -Role $Role -Module $Module
+    $targetCommit = Get-CrmLocalTargetCommit
+    if (-not $CrmRuntimeDetachedStart) {
+        Start-CrmInstanceBackgroundUpdate -Spec $spec -TargetCommit $targetCommit
+        return
+    }
+
+    $snapshot = Get-CrmLocalSourceSnapshot -TargetCommit $targetCommit
+    $sourceFingerprint = [string]$snapshot.Fingerprint
+    try {
+        $sourceRoot = Sync-CrmLocalImmutableSourceRoot -TargetCommit $targetCommit -Snapshot $snapshot
+        $sourceSpec = Resolve-CrmLocalModuleSpec -Role $Role -Module $Module -SourceRoot $sourceRoot
+        if ([string]$sourceSpec.runtimeId -ne [string]$spec.runtimeId -or
+            [string]$sourceSpec.configFingerprint -ne [string]$spec.configFingerprint) {
+            throw "O catálogo do launcher diverge da fonte materializada para '$Role / $Module'; a instância não será iniciada com contratos misturados."
+        }
+        $spec = $sourceSpec
+        $sourceOrigin = "{0}__{1}" -f $sourceRoot, ([string]$spec.runtimeId)
+        $buildPaths = Get-CrmInstanceBuildPaths -SourceFingerprint ([string]$snapshot.Fingerprint) -SourceRoot $sourceRoot
+        New-Item -ItemType Directory -Path $buildPaths.Root -Force | Out-Null
+        $descriptor = Get-CrmInstanceBuildDescriptor -SourceRoot $sourceRoot -StatePath $buildPaths.State
+        $decision = Get-CrmInstanceDecision -Spec $spec -TargetCommit $targetCommit -SourceFingerprint ([string]$snapshot.Fingerprint) -SourceOrigin $sourceOrigin -BuildDescriptor $descriptor -BuildStatePath $buildPaths.State -SourceRoot $sourceRoot
+        if ($decision.Action -eq "reuse") {
+            if ($CrmRuntimeSuppressBrowser) {
+                Write-Host "[crm-local] $([string]$spec.role) / $([string]$spec.label) reutilizado sem rebuild; navegador suprimido pela validação interna."
+            } else {
+                Open-CrmInstanceUrl -Spec $spec -Manifest $decision.Manifest
+            }
+            return
+        }
+        if ($decision.Action -eq "wait") {
+            $ready = Wait-CrmInstanceCurrent -Spec $spec -TargetCommit $targetCommit -SourceFingerprint ([string]$snapshot.Fingerprint) -SourceOrigin $sourceOrigin -BuildPaths $buildPaths
+            if ($ready.Action -eq "reuse") {
+                if ($CrmRuntimeSuppressBrowser) {
+                    Write-Host "[crm-local] $([string]$spec.role) / $([string]$spec.label) ficou pronto; navegador suprimido pela validação interna."
+                } else {
+                    Open-CrmInstanceUrl -Spec $spec -Manifest $ready.Manifest
+                }
+                return
+            }
+            $decision = $ready
+        }
+        if ($decision.Action -eq "restart") {
+            Write-Host "[crm-local] Atualizando somente $([string]$spec.runtimeId): $($decision.Reason)."
+            Stop-CrmInstanceRuntime -Spec $spec
+        }
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
+        $snapshot = $null
+        Start-CrmInstanceRuntime -Spec $spec -SourceRoot $sourceRoot -TargetCommit $targetCommit -SourceFingerprint $sourceFingerprint -SourceOrigin $sourceOrigin -BuildPaths $buildPaths
+    } finally {
+        Remove-CrmLocalSourceSnapshot -Snapshot $snapshot
+    }
+}
+
+function Show-CrmModulesMenu {
+    $catalog = Get-CrmLocalModuleCatalog
+    while ($true) {
+        $roleOptions = @($catalog.roles | ForEach-Object {
+            New-MenuOption -Label ([string]$_.role) -Action ([string]$_.role)
+        })
+        $roleSelection = Read-MenuSelection -Title "CRM – Módulos" -Options $roleOptions -CancelLabel "Sair"
+        if ($null -eq $roleSelection) { return }
+        $selectedRole = [string]$roleSelection.Action
+        $moduleOptions = @($catalog.combinations | Where-Object { [string]$_.role -eq $selectedRole } | ForEach-Object {
+            New-MenuOption -Label ([string]$_.label) -Action ([string]$_.module)
+        })
+        $moduleSelection = Read-MenuSelection -Title "CRM – $selectedRole" -Options $moduleOptions
+        if ($null -eq $moduleSelection) { continue }
+        Invoke-CrmModuleAction -Role $selectedRole -Module ([string]$moduleSelection.Action)
     }
 }
 
@@ -1245,33 +2101,44 @@ function Invoke-ShortcutActionInternal {
                 return
             }
             Stop-LegacyCrmRuntimeIfNeeded
+            Stop-LegacyCrmPersonaRuntimeIfNeeded
             $targetCommit = Get-CrmLocalTargetCommit
             Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit
         }
+        "CrmModules" {
+            Show-CrmModulesMenu
+        }
+        "CrmModule" {
+            if ([string]::IsNullOrWhiteSpace($CrmRole) -or [string]::IsNullOrWhiteSpace($CrmModule)) {
+                throw "CrmModule exige -CrmRole Gestor|Consultor e -CrmModule <módulo>."
+            }
+            Invoke-CrmModuleAction -Role $CrmRole -Module $CrmModule
+        }
+        "CrmModuleStop" {
+            if ([string]::IsNullOrWhiteSpace($CrmRole) -or [string]::IsNullOrWhiteSpace($CrmModule)) {
+                throw "CrmModuleStop exige -CrmRole Gestor|Consultor e -CrmModule <módulo>."
+            }
+            $spec = Resolve-CrmLocalModuleSpec -Role $CrmRole -Module $CrmModule
+            Stop-CrmInstanceRuntime -Spec $spec
+        }
         "CrmConsultor" {
-            $targetCommit = Get-CrmLocalTargetCommit
-            Ensure-CrmGestorForConsultor -TargetCommit $targetCommit
-            Assert-GestorSharedServices
-            Invoke-CrmPersonaAction -Persona Consultor -TargetCommit $targetCommit -Module 'ponto'
+            Invoke-CrmModuleAction -Role Consultor -Module "ponto"
         }
         "CrmConsultorStop" {
-            Stop-CrmPersonaRuntime -Persona Consultor
+            $spec = Resolve-CrmLocalModuleSpec -Role Consultor -Module "ponto"
+            Stop-CrmInstanceRuntime -Spec $spec
         }
         "CrmSiteEf" {
-            $targetCommit = Get-CrmLocalTargetCommit
-            Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit -Module 'site-tracking'
-            Open-CrmModuleUrl -Module "site-tracking" -ExtraQuery "metaAdsLocalScenario=connected-ready"
+            Invoke-CrmModuleAction -Role Gestor -Module "site-tracking"
         }
         "CrmMetaAds" {
-            $targetCommit = Get-CrmLocalTargetCommit
-            Invoke-CrmPersonaAction -Persona Gestor -TargetCommit $targetCommit -Module 'meta-ads'
-            Open-CrmModuleUrl -Module "meta-ads" -ExtraQuery "metaAdsLocalScenario=connected-ready"
+            Invoke-CrmModuleAction -Role Gestor -Module "meta-ads"
         }
         "CrmFinance" {
             Invoke-ShortcutWsl -AcceptedExitCode @(0, 130, 143) -Command "npm run crm:local:finance"
         }
         "CrmAtendimento" {
-            Invoke-CrmAtendimentoAction
+            Invoke-CrmModuleAction -Role Gestor -Module "atendimento"
         }
         "CrmAtendimentoMirrorStatus" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-status" }
         "CrmAtendimentoMirrorSync" { Invoke-ShortcutWsl -Command "npm run codex:crm:atendimento-mirror-sync -- --apply" }
@@ -1457,21 +2324,9 @@ function Show-CrmMenu {
         $selection = Read-MenuSelection `
             -Title "Local > CRM" `
             -Options @(
-                (New-MenuOption -Label "CRM – Local (Gestor)" -Action "CrmLocal"),
-                (New-MenuOption -Label "CRM – Consultor (Ponto)" -Action "CrmConsultor"),
-                (New-MenuOption -Label "CRM – Consultor Stop" -Action "CrmConsultorStop"),
-                (New-MenuOption -Label "CRM Site EF" -Action "CrmSiteEf"),
-                (New-MenuOption -Label "CRM Meta Ads" -Action "CrmMetaAds"),
-                (New-MenuOption -Label "CRM Financeiro" -Action "CrmFinance"),
-                (New-MenuOption -Label "CRM Atendimento" -Action "CrmAtendimento"),
-                (New-MenuOption -Label "CRM Atendimento - Status do Clone" -Action "CrmAtendimentoMirrorStatus"),
-                (New-MenuOption -Label "CRM Atendimento - Atualizar Clone" -Action "CrmAtendimentoMirrorSync"),
-                (New-MenuOption -Label "CRM Local (Gestor) Stop" -Action "CrmLocalStop"),
-                (New-MenuOption -Label "CRM Memory" -Action "CrmMemory"),
-                (New-MenuOption -Label "CRM Site Smoke" -Action "CrmSiteSmoke"),
-                (New-MenuOption -Label "CRM Meta Ads Smoke" -Action "CrmMetaAdsSmoke"),
-                (New-MenuOption -Label "CRM Financeiro Smoke" -Action "CrmFinanceSmoke"),
-                (New-MenuOption -Label "CRM Atendimento Smoke" -Action "CrmAtendimentoSmoke")
+                (New-MenuOption -Label "CRM – Local" -Action "CrmLocal"),
+                (New-MenuOption -Label "CRM – Módulos" -Action "CrmModules"),
+                (New-MenuOption -Label "Encerrar CRM – Local" -Action "CrmLocalStop")
             )
         if ($null -eq $selection) {
             return

--- a/scripts/tests/crm-local-build-state.test.mjs
+++ b/scripts/tests/crm-local-build-state.test.mjs
@@ -1,0 +1,382 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  acquireBuildLock,
+  buildStateMatches,
+  calculateBuildFingerprints,
+  createBuildState,
+  fingerprintBuildInputs,
+  fingerprintDist,
+  fingerprintLockfile,
+  inspectBuildState,
+  inspectBuildLock,
+  readBuildState,
+  releaseBuildLock,
+  validateBuildState,
+  writeBuildStateAtomic,
+} from '../crm-local-build-state.mjs'
+
+const helperPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'crm-local-build-state.mjs')
+const fixtureFiles = {
+  'App.tsx': 'export const App = () => null\n',
+  'index.html': '<div id="root"></div>\n',
+  'vite.config.ts': 'export default {}\n',
+  'package.json': '{"name":"fixture","scripts":{"build":"vite build"}}\n',
+  'package-lock.json': '{"lockfileVersion":3,"packages":{}}\n',
+  'functions/api/status.ts': 'export const onRequest = () => new Response("ok")\n',
+  'modules/example.ts': 'export const module = "example"\n',
+  'public/logo.bin': Buffer.from([0, 1, 2, 255]),
+  'scripts/check-bundle-budget.mjs': 'export const budget = 1\n',
+}
+
+async function writeFixture(root, entries = Object.entries(fixtureFiles)) {
+  for (const [relativePath, content] of entries) {
+    const target = path.join(root, relativePath)
+    await fsp.mkdir(path.dirname(target), { recursive: true })
+    await fsp.writeFile(target, content)
+  }
+}
+
+async function tempDirectory(prefix) {
+  return fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+}
+
+test('build input fingerprint is deterministic across creation order and metadata changes', async (t) => {
+  const first = await tempDirectory('crm-build-input-a-')
+  const second = await tempDirectory('crm-build-input-b-')
+  t.after(() => Promise.all([
+    fsp.rm(first, { recursive: true, force: true }),
+    fsp.rm(second, { recursive: true, force: true }),
+  ]))
+  await writeFixture(first)
+  await writeFixture(second, Object.entries(fixtureFiles).reverse())
+
+  const oldTime = new Date('2001-01-01T00:00:00.000Z')
+  await fsp.utimes(path.join(second, 'App.tsx'), oldTime, oldTime)
+  const left = await fingerprintBuildInputs(first, { includeEntries: true })
+  const right = await fingerprintBuildInputs(second, { includeEntries: true })
+
+  assert.equal(left.fingerprint, right.fingerprint)
+  assert.equal(left.fileCount, Object.keys(fixtureFiles).length)
+  assert.deepEqual(left.entries.map((entry) => entry.path), right.entries.map((entry) => entry.path))
+})
+
+test('build input fingerprint includes code, config, functions and public assets', async (t) => {
+  const root = await tempDirectory('crm-build-includes-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  let previous = await fingerprintBuildInputs(root)
+
+  for (const relativePath of ['App.tsx', 'vite.config.ts', 'functions/api/status.ts', 'public/logo.bin', 'package.json']) {
+    await fsp.appendFile(path.join(root, relativePath), Buffer.from([3]))
+    const current = await fingerprintBuildInputs(root)
+    assert.notEqual(current.fingerprint, previous.fingerprint, `${relativePath} did not invalidate the build`)
+    previous = current
+  }
+})
+
+test('build input fingerprint includes shared identity contract imported outside crm/console', async (t) => {
+  const sourceRoot = await tempDirectory('crm-build-shared-input-')
+  t.after(() => fsp.rm(sourceRoot, { recursive: true, force: true }))
+  const consoleDir = path.join(sourceRoot, 'crm', 'console')
+  const identityContract = path.join(sourceRoot, 'shared', 'identity-contract', 'index.js')
+  await writeFixture(consoleDir)
+  await writeFixture(consoleDir, [['dist/index.html', '<h1>built</h1>\n']])
+  await fsp.mkdir(path.dirname(identityContract), { recursive: true })
+  await fsp.writeFile(identityContract, 'export const normalizeUnit = (value) => value\n')
+
+  const before = await calculateBuildFingerprints(consoleDir, { includeEntries: true })
+  const state = createBuildState(before, { builtAt: '2026-07-29T12:00:00.000Z' })
+  assert.ok(before.inputs.entries.some((entry) => entry.path === 'repo/shared/identity-contract/index.js'))
+
+  await fsp.appendFile(identityContract, '// changed\n')
+  const after = await calculateBuildFingerprints(consoleDir)
+
+  assert.notEqual(after.inputs.fingerprint, before.inputs.fingerprint)
+  assert.equal(after.lockfile.fingerprint, before.lockfile.fingerprint)
+  assert.equal(after.dist.fingerprint, before.dist.fingerprint)
+  assert.equal(buildStateMatches(state, after), false)
+})
+
+test('changing public/downloads invalidates the build input fingerprint and recorded state', async (t) => {
+  const root = await tempDirectory('crm-build-public-downloads-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  await writeFixture(root, [
+    ['public/downloads/catalog.pdf', Buffer.from([0x25, 0x50, 0x44, 0x46, 0x31])],
+    ['dist/index.html', '<h1>built</h1>\n'],
+  ])
+
+  const before = await calculateBuildFingerprints(root, { includeEntries: true })
+  const state = createBuildState(before, { builtAt: '2026-07-29T12:00:00.000Z' })
+  assert.ok(before.inputs.entries.some((entry) => entry.path === 'public/downloads/catalog.pdf'))
+
+  await fsp.appendFile(path.join(root, 'public', 'downloads', 'catalog.pdf'), Buffer.from([0x32]))
+  const after = await calculateBuildFingerprints(root)
+
+  assert.notEqual(after.inputs.fingerprint, before.inputs.fingerprint)
+  assert.equal(after.lockfile.fingerprint, before.lockfile.fingerprint)
+  assert.equal(after.dist.fingerprint, before.dist.fingerprint)
+  assert.equal(buildStateMatches(state, after), false)
+})
+
+test('build input fingerprint excludes local state and generated artifacts', async (t) => {
+  const root = await tempDirectory('crm-build-excludes-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  const baseline = await fingerprintBuildInputs(root)
+
+  const excluded = {
+    '.dev.vars': 'SECRET=value\n',
+    '.dev.vars.local': 'SECRET=other\n',
+    'node_modules/pkg/index.js': 'generated\n',
+    'dist/index.html': 'generated\n',
+    '.wrangler/state.json': '{}\n',
+    '.wrangler-staging/state.json': '{}\n',
+    'test-results/result.json': '{}\n',
+    'playwright-report/index.html': 'report\n',
+    '.playwright-output/trace.zip': 'trace\n',
+    'logs/runtime.txt': 'local output\n',
+    'pids/runtime.pid.lock': '123\n',
+    'downloads/export.json': '{}\n',
+    'tests/unit.test.ts': 'throw new Error("test only")\n',
+    'e2e/example.spec.ts': 'test("only")\n',
+    'runtime.log': 'local log\n',
+  }
+  await writeFixture(root, Object.entries(excluded))
+  const current = await fingerprintBuildInputs(root, { includeEntries: true })
+
+  assert.equal(current.fingerprint, baseline.fingerprint)
+  for (const relativePath of Object.keys(excluded)) {
+    assert.ok(!current.entries.some((entry) => entry.path === relativePath), `${relativePath} was included`)
+  }
+})
+
+test('lockfile fingerprint is independent and detects dependency changes', async (t) => {
+  const root = await tempDirectory('crm-lockfile-fingerprint-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+
+  const first = await fingerprintLockfile(root)
+  await fsp.appendFile(path.join(root, 'App.tsx'), '// code only\n')
+  assert.equal((await fingerprintLockfile(root)).fingerprint, first.fingerprint)
+  await fsp.appendFile(path.join(root, 'package-lock.json'), '\n')
+  assert.notEqual((await fingerprintLockfile(root)).fingerprint, first.fingerprint)
+})
+
+test('dist fingerprint distinguishes missing, empty and changed artifacts', async (t) => {
+  const root = await tempDirectory('crm-dist-fingerprint-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  assert.deepEqual(await fingerprintDist(root), {
+    fingerprint: null,
+    fileCount: 0,
+    totalBytes: 0,
+    exists: false,
+  })
+
+  await fsp.mkdir(path.join(root, 'dist'))
+  const empty = await fingerprintDist(root)
+  assert.equal(empty.exists, true)
+  assert.match(empty.fingerprint, /^sha256:[a-f0-9]{64}$/)
+
+  await writeFixture(root, [['dist/index.html', '<h1>one</h1>\n']])
+  const first = await fingerprintDist(root)
+  await fsp.writeFile(path.join(root, 'dist', 'index.html'), '<h1>two</h1>\n')
+  const second = await fingerprintDist(root)
+  assert.notEqual(second.fingerprint, first.fingerprint)
+})
+
+test('changing dist/downloads invalidates the artifact fingerprint and recorded state', async (t) => {
+  const root = await tempDirectory('crm-build-dist-downloads-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  await writeFixture(root, [
+    ['dist/index.html', '<h1>built</h1>\n'],
+    ['dist/downloads/catalog.pdf', Buffer.from([0x25, 0x50, 0x44, 0x46, 0x31])],
+  ])
+
+  const before = await calculateBuildFingerprints(root, { includeEntries: true })
+  const state = createBuildState(before, { builtAt: '2026-07-29T12:00:00.000Z' })
+  assert.ok(before.dist.entries.some((entry) => entry.path === 'downloads/catalog.pdf'))
+
+  await fsp.appendFile(path.join(root, 'dist', 'downloads', 'catalog.pdf'), Buffer.from([0x32]))
+  const after = await calculateBuildFingerprints(root)
+
+  assert.equal(after.inputs.fingerprint, before.inputs.fingerprint)
+  assert.equal(after.lockfile.fingerprint, before.lockfile.fingerprint)
+  assert.notEqual(after.dist.fingerprint, before.dist.fingerprint)
+  assert.equal(buildStateMatches(state, after), false)
+})
+
+test('valid build state is written atomically and read back', async (t) => {
+  const root = await tempDirectory('crm-build-state-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  await writeFixture(root, [['dist/index.html', '<h1>built</h1>\n']])
+  const fingerprints = await calculateBuildFingerprints(root)
+  const state = createBuildState(fingerprints, { builtAt: '2026-07-29T12:00:00.000Z' })
+  const stateFile = path.join(root, 'private-state', 'build-state.json')
+
+  await writeBuildStateAtomic(stateFile, state)
+  assert.deepEqual(await readBuildState(stateFile), state)
+  assert.equal(buildStateMatches(state, fingerprints), true)
+  assert.deepEqual(await fsp.readdir(path.dirname(stateFile)), ['build-state.json'])
+
+  await fsp.writeFile(path.join(root, 'dist', 'index.html'), '<h1>changed</h1>\n')
+  assert.equal(buildStateMatches(state, await calculateBuildFingerprints(root)), false)
+})
+
+test('invalid build state is rejected for validation, read and write', async (t) => {
+  const root = await tempDirectory('crm-invalid-build-state-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  const invalid = { version: 99, inputFingerprint: 'bad' }
+  assert.equal(validateBuildState(invalid).valid, false)
+
+  const stateFile = path.join(root, 'invalid.json')
+  await fsp.writeFile(stateFile, JSON.stringify(invalid))
+  await assert.rejects(readBuildState(stateFile), (error) => error.code === 'INVALID_BUILD_STATE')
+  await assert.rejects(writeBuildStateAtomic(stateFile, invalid), (error) => error.code === 'INVALID_BUILD_STATE')
+})
+
+test('live lock cannot be stolen and only its token can release it', async (t) => {
+  const root = await tempDirectory('crm-build-lock-live-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  const lockDir = path.join(root, 'build.lock')
+
+  const first = await acquireBuildLock(lockDir, { ownerPid: process.pid })
+  assert.equal(first.acquired, true)
+  const second = await acquireBuildLock(lockDir, { ownerPid: process.pid, token: 'second-token' })
+  assert.equal(second.acquired, false)
+  assert.equal(second.reason, 'owner_alive')
+  await assert.rejects(releaseBuildLock(lockDir, 'wrong-token'), (error) => error.code === 'LOCK_NOT_OWNER')
+  assert.equal((await inspectBuildLock(lockDir)).exists, true)
+  assert.equal((await releaseBuildLock(lockDir, first.owner.token)).released, true)
+  assert.equal((await inspectBuildLock(lockDir)).exists, false)
+})
+
+test('dead lock owner is recovered without deleting a live replacement', async (t) => {
+  const root = await tempDirectory('crm-build-lock-stale-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  const lockDir = path.join(root, 'build.lock')
+  await fsp.mkdir(lockDir)
+  await fsp.writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+    version: 1,
+    token: 'dead-owner',
+    pid: 2_000_000_000,
+    hostname: os.hostname(),
+    acquiredAt: new Date().toISOString(),
+    processStartMarker: null,
+  }))
+
+  const acquired = await acquireBuildLock(lockDir, { ownerPid: process.pid, token: 'replacement' })
+  assert.equal(acquired.acquired, true)
+  assert.equal(acquired.owner.token, 'replacement')
+  assert.equal((await inspectBuildLock(lockDir)).owner.token, 'replacement')
+  await releaseBuildLock(lockDir, 'replacement')
+})
+
+test('CLI emits machine-readable JSON for Bash integration', async (t) => {
+  const root = await tempDirectory('crm-build-cli-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  await writeFixture(root, [['dist/index.html', '<h1>built</h1>\n']])
+
+  const result = spawnSync(process.execPath, [
+    helperPath,
+    'fingerprint',
+    '--console-dir',
+    root,
+    '--json',
+  ], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.ok, true)
+  assert.match(output.inputs.fingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.match(output.lockfile.fingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.match(output.dist.fingerprint, /^sha256:[a-f0-9]{64}$/)
+})
+
+test('inspect CLI resolves a source root and validates the recorded artifact state', async (t) => {
+  const sourceRoot = await tempDirectory('crm-build-inspect-')
+  t.after(() => fsp.rm(sourceRoot, { recursive: true, force: true }))
+  const consoleDir = path.join(sourceRoot, 'crm', 'console')
+  const stateFile = path.join(sourceRoot, 'private', 'build-state.json')
+  await writeFixture(consoleDir)
+  await fsp.mkdir(path.join(sourceRoot, 'shared', 'identity-contract'), { recursive: true })
+  await fsp.writeFile(
+    path.join(sourceRoot, 'shared', 'identity-contract', 'index.js'),
+    'export const normalizeUnit = (value) => value\n',
+  )
+
+  let inspection = await inspectBuildState(sourceRoot, stateFile)
+  assert.equal(inspection.artifactFingerprint, null)
+  assert.equal(inspection.stateValid, false)
+
+  await writeFixture(consoleDir, [['dist/index.html', '<h1>built</h1>\n']])
+  const fingerprints = await calculateBuildFingerprints(consoleDir)
+  await writeBuildStateAtomic(stateFile, createBuildState(fingerprints))
+  inspection = await inspectBuildState(sourceRoot, stateFile)
+  assert.match(inspection.artifactFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(inspection.stateValid, true)
+
+  const result = spawnSync(process.execPath, [
+    helperPath,
+    'inspect',
+    '--root',
+    sourceRoot,
+    '--state',
+    stateFile,
+  ], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim().split('\n').length, 1)
+  assert.deepEqual(Object.keys(JSON.parse(result.stdout)).sort(), [
+    'artifactFingerprint',
+    'inputFingerprint',
+    'lockfileFingerprint',
+    'stateValid',
+  ])
+  assert.equal(JSON.parse(result.stdout).stateValid, true)
+
+  await fsp.writeFile(path.join(consoleDir, 'dist', 'index.html'), '')
+  inspection = await inspectBuildState(sourceRoot, stateFile)
+  assert.equal(inspection.artifactFingerprint, null)
+  assert.equal(inspection.stateValid, false)
+})
+
+test('CLI lock acquisition uses the supplied Bash owner PID and reports contention', async (t) => {
+  const root = await tempDirectory('crm-build-cli-lock-')
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  const lockDir = path.join(root, 'build.lock')
+  const acquired = spawnSync(process.execPath, [
+    helperPath,
+    'lock-acquire',
+    '--lock-dir',
+    lockDir,
+    '--owner-pid',
+    String(process.pid),
+    '--json',
+  ], { encoding: 'utf8' })
+  assert.equal(acquired.status, 0, acquired.stderr)
+  const owner = JSON.parse(acquired.stdout).owner
+  assert.equal(owner.pid, process.pid)
+
+  const busy = spawnSync(process.execPath, [
+    helperPath,
+    'lock-acquire',
+    '--lock-dir',
+    lockDir,
+    '--owner-pid',
+    String(process.pid),
+    '--json',
+  ], { encoding: 'utf8' })
+  assert.equal(busy.status, 73, busy.stderr)
+  assert.equal(JSON.parse(busy.stdout).reason, 'owner_alive')
+  await releaseBuildLock(lockDir, owner.token)
+})

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -32,6 +32,21 @@ function tomlActions(source) {
   }))
 }
 
+function runBashHarness(body, options = {}) {
+  const harnessRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-local-bash-harness-'))
+  const harnessPath = path.join(harnessRoot, 'run.sh')
+  try {
+    fs.writeFileSync(harnessPath, `${body}\n`, { mode: 0o700 })
+    return spawnSync('bash', [harnessPath], {
+      ...options,
+      cwd: root,
+      encoding: 'utf8',
+    })
+  } finally {
+    fs.rmSync(harnessRoot, { recursive: true, force: true })
+  }
+}
+
 test('Codex App and Windows expose CRM – Local and CRM – Módulos without the generic Local surface', () => {
   const crmActions = tomlActions(environment).filter(({ name }) => name?.startsWith('CRM'))
   assert.deepEqual(crmActions, [
@@ -281,10 +296,9 @@ test('auto build is fingerprinted, serialized and recorded only through the dete
 test('runtime v3 manifest records role/module, build, PID identities, private state and browser profile', (t) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-v3-'))
   t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
   const target = '5'.repeat(40)
   const body = `set -e
-source "$1"
+source scripts/crm-local-persona-runtime.sh
 crm_persona_runtime_init
 CRM_BUILD_COMMIT=${target}
 CRM_BUILD_INPUT_FINGERPRINT=sha256:${'6'.repeat(64)}
@@ -350,8 +364,7 @@ value.token = process.env.CRM_LOCK_ORIGINAL_TOKEN
 fs.writeFileSync(file, JSON.stringify(value) + '\\n')
 NODE
 crm_persona_runtime_release_lock`
-  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
-    encoding: 'utf8',
+  const result = runBashHarness(body, {
     env: {
       ...process.env,
       ROOT_DIR: root,
@@ -422,9 +435,8 @@ test('a concurrent launch waits for the exact ready manifest before health check
 test('runtime lock publishes one atomic owner and self-heals only a proven stale identity', (t) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-v3-'))
   t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
   const body = `set -e
-source "$1"
+source scripts/crm-local-persona-runtime.sh
 crm_persona_runtime_init
 mkdir -p "$CRM_RUNTIME_LOCK_DIR"
 current_ticks="$(crm_runtime_pid_start_ticks "$$")"
@@ -453,8 +465,7 @@ if (value.version !== 1 || !value.token || value.pid !== Number(process.argv[3])
 NODE
 crm_persona_runtime_release_lock
 test ! -e "$CRM_RUNTIME_LOCK_DIR"`
-  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
-    encoding: 'utf8',
+  const result = runBashHarness(body, {
     env: {
       ...process.env,
       ROOT_DIR: root,
@@ -472,9 +483,8 @@ test ! -e "$CRM_RUNTIME_LOCK_DIR"`
 test('runtime lock never steals a live owner with another source and release is token-CAS', (t) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-cas-'))
   t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
   const body = `set -e
-source "$1"
+source scripts/crm-local-persona-runtime.sh
 crm_persona_runtime_init
 mkdir -p "$CRM_RUNTIME_LOCK_DIR"
 ticks="$(crm_runtime_pid_start_ticks "$$")"
@@ -510,8 +520,7 @@ NODE
 crm_persona_runtime_release_lock
 test -d "$CRM_RUNTIME_LOCK_DIR"
 test "$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1])).token" "$CRM_RUNTIME_LOCK_DIR/owner.json")" = successor-token`
-  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
-    encoding: 'utf8',
+  const result = runBashHarness(body, {
     env: {
       ...process.env,
       ROOT_DIR: root,
@@ -529,9 +538,8 @@ test "$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1])).token" 
 test('runtime lock treats a fresh partial owner as contention instead of deleting it', (t) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-partial-'))
   t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
   const body = `set -e
-source "$1"
+source scripts/crm-local-persona-runtime.sh
 crm_persona_runtime_init
 mkdir -p "$CRM_RUNTIME_LOCK_DIR"
 set +e
@@ -541,8 +549,7 @@ set -e
 test "$status" = 1
 test -d "$CRM_RUNTIME_LOCK_DIR"
 test ! -e "$CRM_RUNTIME_LOCK_DIR/owner.json"`
-  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
-    encoding: 'utf8',
+  const result = runBashHarness(body, {
     env: {
       ...process.env,
       ROOT_DIR: root,
@@ -558,15 +565,14 @@ test ! -e "$CRM_RUNTIME_LOCK_DIR/owner.json"`
 })
 
 test('PID identity reads start ticks correctly when Linux comm contains spaces and a parenthesis', () => {
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
   const body = `set -e
-source "$1"
+source scripts/crm-local-persona-runtime.sh
 printf 'crm ) worker' > "/proc/$$/comm"
 actual="$(crm_runtime_pid_start_ticks "$$")"
   expected="$(node -e 'const fs=require("fs");const s=fs.readFileSync("/proc/"+process.ppid+"/stat","utf8");const i=s.lastIndexOf(")");process.stdout.write(s.slice(i+2).trim().split(/\\s+/)[19])')"
 test "$actual" = "$expected"
 crm_runtime_pid_identity_matches "$$" "$expected"`
-  const result = spawnSync('bash', ['-c', body, 'bash', helper], { encoding: 'utf8' })
+  const result = runBashHarness(body)
   assert.equal(result.status, 0, result.stderr || result.stdout)
   assert.match(launcher, /source \{0\}; crm_runtime_pid_start_ticks \{1\}/)
   assert.doesNotMatch(launcher, /awk '\{print `\$20\}'/)

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -1,343 +1,620 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
-import { createRequire } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { discoverLocalLaunchCatalog } from '../crm-local-module-catalog.mjs'
 import { decideRuntimeAction } from '../crm-local-runtime-policy.mjs'
-
-const require = createRequire(import.meta.url)
-const { partitionModuleErrors } = require('../../crm/console/scripts/crm-local-smoke-policy.cjs')
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
 const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8')
 
 const launcher = read('scripts/run-shared-codex-shortcut.ps1')
-const runtimePolicy = read('scripts/crm-local-runtime-policy.mjs')
 const crmRunner = read('scripts/run-local-crm.sh')
-const atendimentoRunner = read('scripts/run-local-atendimento.sh')
 const runtime = read('scripts/crm-local-persona-runtime.sh')
-const wslInvoker = read('scripts/invoke-skincos-wsl.ps1')
+const buildStateHelper = read('scripts/crm-local-build-state.mjs')
+const browserLauncher = read('scripts/open-crm-local-browser.ps1')
 const pagesRunner = read('crm/console/scripts/dev_pages.sh')
-const whatsappRunner = read('scripts/run-local-whatsapp-orchestrator.sh')
 const environment = read('.codex/environments/environment.toml')
 const installer = read('scripts/install-shared-codex-shortcuts.ps1')
+const moduleCatalog = JSON.parse(read('crm/console/modules/localLaunchCatalog.json'))
+const rolePolicy = JSON.parse(read('crm/console/modules/localRolePolicy.json'))
+const catalog = discoverLocalLaunchCatalog()
 
-test('Codex and Windows actions expose both personas', () => {
-  for (const label of ['CRM – Local (Gestor)', 'CRM – Consultor (Ponto)']) {
-    assert.match(environment, new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
-    assert.match(installer, new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+const expectedGestorModules = moduleCatalog.modules.map(({ key }) => key)
+
+function tomlActions(source) {
+  return source.split('[[actions]]').slice(1).map((block) => ({
+    name: block.match(/^name = "([^"]+)"/m)?.[1],
+    command: block.match(/^command = "([^"]+)"/m)?.[1],
+  }))
+}
+
+test('Codex App and Windows expose CRM – Local and CRM – Módulos without the generic Local surface', () => {
+  const crmActions = tomlActions(environment).filter(({ name }) => name?.startsWith('CRM'))
+  assert.deepEqual(crmActions, [
+    {
+      name: 'CRM – Local',
+      command: 'powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action CrmLocal',
+    },
+    {
+      name: 'CRM – Módulos',
+      command: 'powershell.exe -ExecutionPolicy Bypass -File ./scripts/run-shared-codex-shortcut.ps1 -Action CrmModules',
+    },
+  ])
+  assert.ok(!tomlActions(environment).some(({ name }) => name === 'Local'))
+  assert.doesNotMatch(environment, /CRM – Local \(Gestor\)|CRM – Consultor \(Ponto\)/)
+
+  const shortcutBlock = installer.match(/\$shortcuts = @\(([\s\S]*?)\r?\n\)/)?.[1]
+  assert.ok(shortcutBlock, 'top-level Windows shortcut list was not found')
+  const crmShortcuts = [...shortcutBlock.matchAll(/@\{ Name = "(CRM[^"]+)"; Action = "([^"]+)"/g)]
+    .map((match) => ({ name: match[1], action: match[2] }))
+  assert.deepEqual(crmShortcuts, [
+    { name: 'CRM – Local', action: 'CrmLocal' },
+    { name: 'CRM – Módulos', action: 'CrmModules' },
+  ])
+  assert.doesNotMatch(shortcutBlock, /Name = "Local"|CRM – Local \(Gestor\)|CRM – Consultor \(Ponto\)/)
+  assert.match(installer, /\$moduleRoot = Join-Path \$TargetRoot "CRM – Módulos"/)
+  assert.match(installer, /foreach \(\$spec in @\(\$catalog\.combinations\)\)/)
+  assert.match(installer, /-Action CrmModule -CrmRole "\{1\}" -CrmModule "\{2\}"/)
+})
+
+test('canonical catalog exposes every catalog and role-policy combination', () => {
+  assert.deepEqual(moduleCatalog.modules.map(({ key }) => key), expectedGestorModules)
+  assert.deepEqual(rolePolicy.restrictedRoleModules.CONSULTOR, ['atendimento', 'ponto'])
+  assert.deepEqual(catalog.roles, [
+    { role: 'Gestor', roleKey: 'GESTOR' },
+    { role: 'Consultor', roleKey: 'CONSULTOR' },
+  ])
+
+  const gestor = catalog.combinations.filter(({ roleKey }) => roleKey === 'GESTOR')
+  const consultor = catalog.combinations.filter(({ roleKey }) => roleKey === 'CONSULTOR')
+  assert.deepEqual(gestor.map(({ module }) => module), expectedGestorModules)
+  assert.deepEqual(consultor.map(({ module }) => module), ['atendimento', 'ponto'])
+  const expectedCombinationCount = expectedGestorModules.length +
+    rolePolicy.restrictedRoleModules.CONSULTOR.length
+  assert.equal(catalog.combinations.length, expectedCombinationCount)
+  assert.ok(!catalog.combinations.some(({ module }) => module === 'finance'))
+
+  for (const spec of catalog.combinations) {
+    assert.equal(spec.route, `/?module=${encodeURIComponent(spec.module)}`)
+    assert.equal(spec.runtimeId, `crm-local--${spec.module}--${spec.roleKey.toLowerCase()}`)
+    assert.match(spec.configFingerprint, /^sha256:[a-f0-9]{64}$/)
   }
+  assert.equal(new Set(catalog.combinations.map(({ runtimeId }) => runtimeId)).size, expectedCombinationCount)
+  assert.equal(new Set(catalog.combinations.map(({ configFingerprint }) => configFingerprint)).size, expectedCombinationCount)
+  assert.equal(catalog.fullRuntime.runtimeId, 'gestor--full')
+  assert.equal(catalog.fullRuntime.module, 'full')
+  assert.equal(catalog.fullRuntime.roleKey, 'GESTOR')
+  assert.deepEqual(catalog.fullRuntime.gateModules, expectedGestorModules)
+  assert.match(catalog.fullRuntime.configFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(catalog.fullRuntime.launcherContractFingerprint, catalog.launcherContractFingerprint)
+
+  const changedContract = discoverLocalLaunchCatalog({
+    launcherContractFingerprint: `sha256:${'0'.repeat(64)}`,
+  })
+  assert.notEqual(changedContract.fullRuntime.configFingerprint, catalog.fullRuntime.configFingerprint)
 })
 
-test('Gestor owns every shared service on the canonical ports', () => {
-  assert.match(launcher, /CRM_PERSONA=GESTOR/)
-  assert.match(launcher, /CRM_WITH_INSUMOS=1 CRM_WITH_TIMEKEEPING=1 CRM_WITH_WHATSAPP=1/)
-  assert.match(crmRunner, /run-local-whatsapp-orchestrator\.sh/)
-  for (const port of ['8791', '8787', '8801', '8110']) assert.match(launcher, new RegExp(port))
+test('catalog CLI filters valid combinations and rejects role/module combinations outside policy', () => {
+  const cli = path.join(root, 'scripts', 'crm-local-module-catalog.mjs')
+  const valid = spawnSync(process.execPath, [cli, '--role', 'CONSULTOR', '--module', 'ponto', '--compact'], {
+    encoding: 'utf8',
+  })
+  assert.equal(valid.status, 0, valid.stderr || valid.stdout)
+  const result = JSON.parse(valid.stdout)
+  assert.equal(result.combinations.length, 1)
+  assert.equal(result.combinations[0].runtimeId, 'crm-local--ponto--consultor')
+
+  const invalid = spawnSync(process.execPath, [cli, '--role', 'CONSULTOR', '--module', 'insumos', '--compact'], {
+    encoding: 'utf8',
+  })
+  assert.equal(invalid.status, 2)
+  assert.match(invalid.stderr, /CRM_LOCAL_COMBINATION_NOT_AVAILABLE/)
 })
 
-test('Consultor owns only its Pages and Vite runtime', () => {
-  assert.match(launcher, /CRM_PERSONA=CONSULTOR/)
-  assert.match(launcher, /CRM_VITE_PORT=5174 CRM_PAGES_PORT=8792/)
-  assert.match(launcher, /CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0/)
-  assert.doesNotMatch(launcher, /CRM_ROUTE='\/\?localAuthReset=1'/)
-})
-
-test('preflight validates role and each shared dependency', () => {
-  assert.match(launcher, /Role = "GESTOR"/)
-  for (const url of [
-    'http://127.0.0.1:8791/api/auth/me',
-    'http://127.0.0.1:8787/insumos/health',
-    'http://127.0.0.1:8801/api/ponto/readiness',
-    'http://127.0.0.1:8110/health',
-  ]) assert.ok(launcher.includes(url), `missing ${url}`)
-})
-
-test('local Pages routes Atendimento to the isolated CRM adapter', () => {
-  assert.match(pagesRunner, /ATENDIMENTO_API_TARGET=\$\{LOCAL_WA_ORCHESTRATOR_API_TARGET\}/)
-  assert.match(pagesRunner, /must not fall back to the[\s\S]*native service on :8099/)
-})
-
-test('local CRM adapter uses only the peer-authenticated Atendimento mirror', () => {
-  assert.match(whatsappRunner, /DEFAULT_DATABASE_URL="postgresql:\/\/\$\{RUN_AS_USER\}@\/skincos_crm_local\?host=\/var\/run\/postgresql"/)
-  assert.match(whatsappRunner, /CRM_LOCAL_WA_DATABASE_URL deve apontar somente para o socket local/)
-  assert.match(whatsappRunner, /export DATABASE_URL="\$LOCAL_WA_ADAPTER_DATABASE_URL"/)
-})
-
-test('Gestor warms Atendimento before the Pages gate can issue concurrent requests', () => {
-  assert.match(crmRunner, /warm_atendimento_api\(\)/)
-  assert.match(crmRunner, /x-crm-user: eyJpZCI6ImNybS1sb2NhbC1nYXRlIiwicm9sZSI6IkdFU1RPUiJ9/)
-  assert.match(crmRunner, /\/api\/atendimento\/local-mirror\/status/)
-  assert.match(crmRunner, /\/api\/atendimento\/management\/finance/)
-  assert.match(crmRunner, /start_whatsapp_orchestrator_local\n  warm_atendimento_api/)
-})
-
-test('Atendimento shortcut uses the canonical isolated Pages and adapter runtime', () => {
-  assert.match(atendimentoRunner, /run-local-crm\.sh/)
-  assert.match(atendimentoRunner, /--module atendimento/)
-  assert.match(atendimentoRunner, /CRM_WITH_WHATSAPP=1/)
-  assert.match(atendimentoRunner, /CRM_LOCAL_NATIVE_SOURCE_ROOT/)
-  assert.match(atendimentoRunner, /crm-local-preview-source/)
-  assert.match(atendimentoRunner, /rsync -a --delete/)
-  assert.doesNotMatch(atendimentoRunner, /node "\$CRM_API_DIR\/server\.js"/)
-  assert.match(launcher, /Start-CrmAtendimentoRuntime/)
-  assert.match(launcher, /Start-CrmAtendimentoBackgroundUpdate/)
-  assert.match(launcher, /CrmAtendimentoDetachedStart/)
-  assert.match(launcher, /Invoke-CrmAtendimentoAction/)
-  assert.match(launcher, /Get-CrmPersonaDecision -Persona Gestor/)
-  assert.match(launcher, /nativeAtendimentoSource/)
-})
-
-test('Atendimento startup proves the authenticated Pages proxy after warming the adapter', () => {
-  assert.match(crmRunner, /verify_atendimento_proxy\(\)/)
-  assert.match(crmRunner, /Verificando proxy autenticado de Atendimento/)
-  assert.match(crmRunner, /http:\/\/127\.0\.0\.1:\$\{CRM_PAGES_PORT\}\$\{endpoint\}/)
-  assert.match(crmRunner, /O proxy autenticado de Atendimento não ficou pronto/)
-})
-
-test('Atendimento reuse health follows the services declared by its manifest', () => {
-  assert.match(launcher, /\$Manifest\.ports\.insumos/)
-  assert.match(launcher, /\$Manifest\.ports\.timekeeping/)
-  assert.match(launcher, /\$Manifest\.ports\.whatsapp/)
-  assert.match(launcher, /Test-CrmPersonaHealth -Persona \$Persona -Manifest \$manifest/)
-})
-
-test('isolated preview installs frontend dependencies from the lockfile', () => {
-  assert.match(crmRunner, /npm --prefix "\$FRONTEND_DIR" ci --no-audit --no-fund/)
-  assert.doesNotMatch(crmRunner, /npm --prefix "\$FRONTEND_DIR" install/)
-})
-
-test('private CRM preview snapshots register only their trusted WSL worktree path', () => {
-  assert.match(wslInvoker, /CodexRuntime\/operator\/admin\/skincos\/source/)
-  assert.match(wslInvoker, /git config --global --add safe\.directory/)
-  assert.match(wslInvoker, /arbitrary caller paths still fail/)
-  assert.match(launcher, /Invoke-ShortcutWslNativePreview/)
-  assert.match(launcher, /crm-local-preview-source/)
-})
-
-test('persona runtime records isolated manifest, lock and build state', () => {
-  for (const contract of ['CRM_RUNTIME_MANIFEST', 'CRM_RUNTIME_LOCK_DIR', 'CRM_BUILD_STATE_FILE', 'CRM_TARGET_COMMIT', 'CRM_SOURCE_FINGERPRINT']) {
-    assert.ok(runtime.includes(contract), `missing ${contract}`)
+test('all module/role instances have non-overlapping deterministic ports', () => {
+  const allocated = []
+  for (const [index, spec] of catalog.combinations.entries()) {
+    const start = catalog.portPlan.base + (index * catalog.portPlan.stride)
+    assert.equal(spec.ports.pages, start + catalog.portPlan.offsets.pages)
+    assert.equal(spec.ports.vite, start + catalog.portPlan.offsets.vite)
+    for (const dependency of ['insumos', 'timekeeping', 'whatsapp']) {
+      const expected = spec.dependencies[dependency]
+        ? start + catalog.portPlan.offsets[dependency]
+        : null
+      assert.equal(spec.ports[dependency], expected, `${spec.runtimeId}:${dependency}`)
+    }
+    allocated.push(...Object.values(spec.ports).filter(Number.isInteger))
   }
-  assert.match(runtime, /targetCommit: process\.env\.CRM_RUNTIME_TARGET_COMMIT/)
-  assert.match(runtime, /buildCommit: process\.env\.CRM_RUNTIME_BUILD_COMMIT/)
-  assert.match(runtime, /CRM_BUILD_COMMIT="\$CRM_TARGET_COMMIT"/)
-  assert.match(runtime, /timekeeping: enabled\(process\.env\.CRM_WITH_TIMEKEEPING\)/)
+  assert.equal(new Set(allocated).size, allocated.length)
 })
 
-test('opening the browser never blocks the runtime manifest transition', () => {
-  assert.match(crmRunner, /open \"\$DEFAULT_URL\" >\/dev\/null 2>&1 &/)
-  assert.match(crmRunner, /xdg-open \"\$DEFAULT_URL\" >\/dev\/null 2>&1 &/)
+test('CRM – Módulos consumes the canonical role field and launches only a resolved specification', () => {
+  assert.match(launcher, /function Get-CrmLocalModuleCatalog/)
+  assert.match(launcher, /crm-local-module-catalog\.mjs/)
+  assert.match(launcher, /function Resolve-CrmLocalModuleSpec/)
+  assert.match(launcher, /A combinação CRM '\$Role \/ \$Module' não é liberada pela fonte canônica/)
+  assert.match(launcher, /New-MenuOption -Label \(\[string\]\$_\.role\) -Action \(\[string\]\$_\.role\)/)
+  assert.match(launcher, /Invoke-CrmModuleAction -Role \$selectedRole -Module \(\[string\]\$moduleSelection\.Action\)/)
 })
 
-test('persona helper checks a free port before starting the CRM services', () => {
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
-  const result = spawnSync('bash', ['-lc', `source ${JSON.stringify(helper)}; crm_runtime_port_is_free 65530`], { encoding: 'utf8' })
-  assert.equal(result.status, 0, result.stderr || result.stdout)
+test('launcher derives local auth grants from the canonical role policy', () => {
+  assert.match(launcher, /\$localAuthAdmin = if \(\[bool\]\$Spec\.auth\.testUserAdmin\)/)
+  assert.match(launcher, /\$allowedModules = @\(\$Spec\.auth\.allowedModules\) -join ","/)
+  assert.match(
+    launcher,
+    /\$consultorSpec = Resolve-CrmLocalModuleSpec -Role Consultor -Module "ponto" -SourceRoot \$SourceRoot/,
+  )
+  assert.match(launcher, /\$consultorAllowedModules = @\(\$consultorSpec\.auth\.allowedModules\) -join ","/)
+  assert.doesNotMatch(launcher, /LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto/)
 })
 
-test('generic CRM launcher only falls back from its default Vite port', () => {
-  assert.match(crmRunner, /CRM_VITE_PORT_EXPLICIT=1/)
-  assert.match(crmRunner, /select_available_vite_port/)
-  assert.match(crmRunner, /Porta Vite padrão \$preferred ocupada; usando \$candidate/)
+test('launcher assigns each role/module its own runtime, state, gate and browser paths', () => {
+  assert.match(launcher, /\$crmInstanceRoot = Join-Path \$operatorRuntimeRoot "runtime\\crm-local\\instances"/)
+  assert.match(launcher, /return Join-Path \$crmInstanceRoot \(Join-Path \$roleSegment \$moduleSegment\)/)
+  assert.match(launcher, /Join-Path \$runtimeRoot "state\\pages"/)
+  assert.match(launcher, /Join-Path \$runtimeRoot "state\\insumos"/)
+  assert.match(launcher, /Join-Path \$runtimeRoot "state\\timekeeping"/)
+  assert.match(launcher, /Join-Path \$runtimeRoot "state\\whatsapp"/)
+  for (const contract of [
+    'CRM_RUNTIME_ID={0}',
+    'CRM_RUNTIME_MODULE={1}',
+    'CRM_RUNTIME_CONFIG_FINGERPRINT={6}',
+    'CRM_BUILD_STATE_FILE={8}',
+    'CRM_BUILD_LOCK_DIR={9}',
+    'CRM_BROWSER_PROFILE_DIR={11}',
+    'CRM_LOCAL_ISOLATED=1',
+    'CRM_GATE_STRICT=1',
+    'CRM_GATE_MODULES={32}',
+  ]) {
+    assert.ok(launcher.includes(contract), `missing modular launch contract ${contract}`)
+  }
+  assert.match(launcher, /Start-CrmInstanceBackgroundUpdate -Spec \$spec -TargetCommit \$targetCommit/)
+  assert.match(launcher, /Atualizando somente \$\(\[string\]\$spec\.runtimeId\)/)
+  assert.match(launcher, /Local\\SkincosCrmBuildDescriptor-\$descriptorKey/)
+  assert.match(launcher, /\$mutex\.WaitOne\(\[TimeSpan\]::FromMinutes\(10\)\)/)
 })
 
-test('runtime policy reuses only a healthy build from the exact source snapshot', () => {
+test('runtime policy reuses only the exact v3 module, configuration and build', () => {
   const target = 'a'.repeat(40)
-  const sourceFingerprint = `snapshot:${target}:${'b'.repeat(64)}`
-  const sourceOrigin = 'C:/CodexRuntime/operator/admin/skincos/source/selected__atendimento'
-  const current = {
-    manifest: { persona: 'GESTOR', state: 'ready', targetCommit: target, buildCommit: target, sourceFingerprint, sourceOrigin },
-    buildState: { commit: target, sourceFingerprint, sourceOrigin }, targetCommit: target, sourceFingerprint, sourceOrigin, persona: 'GESTOR', pidAlive: true, healthy: true,
+  const expected = {
+    targetCommit: target,
+    sourceFingerprint: `snapshot:${target}:${'b'.repeat(64)}`,
+    sourceOrigin: 'C:/CodexRuntime/operator/admin/skincos/source/crm-local/immutable/a1',
+    persona: 'GESTOR',
+    runtimeId: 'crm-local--atendimento--gestor',
+    module: 'atendimento',
+    configFingerprint: `sha256:${'c'.repeat(64)}`,
+    buildInputFingerprint: `sha256:${'d'.repeat(64)}`,
+    lockfileFingerprint: `sha256:${'e'.repeat(64)}`,
+    artifactFingerprint: `sha256:${'f'.repeat(64)}`,
+    pidAlive: true,
+    healthy: true,
   }
+  const manifest = {
+    version: 3,
+    state: 'ready',
+    persona: expected.persona,
+    runtimeId: expected.runtimeId,
+    module: expected.module,
+    targetCommit: target,
+    buildCommit: target,
+    sourceFingerprint: expected.sourceFingerprint,
+    sourceOrigin: expected.sourceOrigin,
+    configFingerprint: expected.configFingerprint,
+    build: {
+      inputFingerprint: expected.buildInputFingerprint,
+      lockfileFingerprint: expected.lockfileFingerprint,
+      artifactFingerprint: expected.artifactFingerprint,
+    },
+  }
+  const current = { ...expected, manifest }
+
   assert.deepEqual(decideRuntimeAction(current), { action: 'reuse', reason: 'current_runtime_ready' })
-  assert.deepEqual(decideRuntimeAction({ ...current, healthy: false }), { action: 'restart', reason: 'health_failed' })
-  assert.deepEqual(decideRuntimeAction({ ...current, pidAlive: false }), { action: 'restart', reason: 'launcher_dead' })
-  assert.deepEqual(decideRuntimeAction({ ...current, manifest: { ...current.manifest, buildCommit: 'b'.repeat(40) } }), {
-    action: 'restart', reason: 'commit_outdated',
+  for (const [field, value, reason] of [
+    ['runtimeId', 'crm-local--ponto--gestor', 'runtime_id_mismatch'],
+    ['module', 'ponto', 'module_mismatch'],
+    ['configFingerprint', `sha256:${'1'.repeat(64)}`, 'runtime_config_outdated'],
+    ['buildInputFingerprint', `sha256:${'2'.repeat(64)}`, 'build_inputs_outdated'],
+    ['lockfileFingerprint', `sha256:${'3'.repeat(64)}`, 'dependencies_outdated'],
+    ['artifactFingerprint', `sha256:${'4'.repeat(64)}`, 'artifact_outdated'],
+  ]) {
+    assert.deepEqual(decideRuntimeAction({ ...current, [field]: value }), { action: 'restart', reason })
+  }
+  assert.deepEqual(decideRuntimeAction({ ...current, pidAlive: false }), {
+    action: 'restart',
+    reason: 'launcher_dead',
   })
-  assert.deepEqual(decideRuntimeAction({ ...current, sourceFingerprint: `snapshot:${target}:${'c'.repeat(64)}` }), {
-    action: 'restart', reason: 'source_outdated',
+  assert.deepEqual(decideRuntimeAction({ ...current, healthy: false }), {
+    action: 'restart',
+    reason: 'health_failed',
   })
-  assert.deepEqual(decideRuntimeAction({ ...current, targetCommit: 'f'.repeat(40) }), {
-    action: 'restart', reason: 'commit_outdated',
-  })
-  assert.deepEqual(decideRuntimeAction({ ...current, sourceOrigin: `${sourceOrigin}-other-module` }), {
-    action: 'restart', reason: 'source_origin_outdated',
-  })
-  assert.deepEqual(decideRuntimeAction({ ...current, sourceOrigin: 'C:\\CODEXRUNTIME\\operator\\admin\\skincos\\source\\selected__atendimento' }), {
-    action: 'reuse', reason: 'current_runtime_ready',
-  })
-  assert.deepEqual(decideRuntimeAction({
-    ...current,
-    manifest: { ...current.manifest, sourceFingerprint: undefined },
-    buildState: { ...current.buildState, sourceFingerprint: undefined },
-    sourceFingerprint: `commit:${target}`,
-  }), { action: 'reuse', reason: 'current_runtime_ready' })
-  assert.deepEqual(decideRuntimeAction({
-    ...current,
-    manifest: { ...current.manifest, sourceFingerprint: undefined },
-    buildState: { ...current.buildState, sourceFingerprint: undefined },
-    sourceFingerprint: `snapshot:${target}:${'c'.repeat(64)}`,
-  }), { action: 'restart', reason: 'source_outdated' })
 })
 
-test('runtime policy starts missing state and waits for the same target build', () => {
-  const target = 'c'.repeat(40)
-  assert.deepEqual(decideRuntimeAction({ manifest: null, targetCommit: target, persona: 'CONSULTOR' }), {
-    action: 'start', reason: 'manifest_missing',
-  })
-  assert.deepEqual(decideRuntimeAction({
-    manifest: { persona: 'CONSULTOR', state: 'starting', targetCommit: target },
-    targetCommit: target, persona: 'CONSULTOR', pidAlive: true, healthy: false,
-  }), { action: 'wait', reason: 'current_start_in_progress' })
+test('full CRM propagates its catalog-derived runtime contract through policy and launch', () => {
+  assert.doesNotMatch(launcher, /CRM_RUNTIME_CONFIG_FINGERPRINT=full-v2/)
+  assert.match(launcher, /return \[string\]\$catalog\.fullRuntime\.configFingerprint/)
+  assert.match(launcher, /--runtime-id \{7\} --module \{8\} --config-fingerprint \{9\}/)
+  assert.match(
+    launcher,
+    /Get-CrmPersonaDecision[^\r\n]+-RuntimeId \$runtimeId -Module \$runtimeModule -ConfigFingerprint \$configFingerprint/,
+  )
+  assert.match(
+    launcher,
+    /CRM_RUNTIME_ID=gestor--full CRM_RUNTIME_MODULE=full[\s\S]*?CRM_RUNTIME_CONFIG_FINGERPRINT=\{3\}/,
+  )
+  assert.match(
+    launcher,
+    /Start-CrmPersonaRuntime[^\r\n]+-ConfigFingerprint \$configFingerprint/,
+  )
+  const personaAction = launcher.slice(
+    launcher.indexOf('function Invoke-CrmPersonaAction'),
+    launcher.indexOf('function Start-CrmGestorBackgroundUpdate'),
+  )
+  const candidateIndex = personaAction.indexOf(
+    'Sync-CrmLocalSourceRoot -Persona $Persona -TargetCommit $TargetCommit -Snapshot $snapshot -Versioned',
+  )
+  const contractIndex = personaAction.indexOf('Assert-CrmLocalLauncherContract -SourceRoot $sourceRoot')
+  const stopIndex = personaAction.indexOf('Stop-CrmPersonaRuntime -Persona $Persona')
+  assert.ok(candidateIndex >= 0 && contractIndex > candidateIndex)
+  assert.ok(stopIndex > contractIndex, 'the current full CRM must remain alive until the candidate contract passes')
 })
 
-test('launcher snapshots dirty worktrees and invalidates an outdated source fingerprint', () => {
-  assert.match(launcher, /Get-CrmLocalSourceSnapshot/)
-  assert.match(launcher, /Get-CrmLocalSnapshotUntrackedFiles/)
-  assert.match(launcher, /\[AllowEmptyCollection\(\)\]\[string\[\]\]\$Entries/)
-  assert.match(launcher, /Get-CrmLocalSnapshotRelativePath/)
-  assert.match(launcher, /diff --binary HEAD/)
-  assert.match(launcher, /StandardOutput\.BaseStream\.CopyTo/)
-  assert.match(launcher, /Ignorando checkout Git aninhado fora do snapshot do CRM Local/)
-  assert.match(launcher, /check-ignore --quiet/)
-  assert.match(launcher, /CRM_SOURCE_FINGERPRINT/)
-  assert.match(launcher, /Get-CrmPersonaDecision -Persona \$Persona -TargetCommit \$TargetCommit -SourceFingerprint \$snapshot\.Fingerprint/)
-  assert.match(launcher, /Stop-CrmPersonaRuntime -Persona \$Persona/)
-  assert.match(launcher, /Sync-CrmLocalSourceRoot -Persona \$Persona -TargetCommit \$TargetCommit -Snapshot \$snapshot/)
-  assert.match(launcher, /Worktree privado com alterações preservado/)
-  assert.match(launcher, /Ensure-CrmGestorForConsultor -TargetCommit \$targetCommit/)
-  assert.match(launcher, /Start-CrmGestorBackgroundUpdate/)
-  assert.match(launcher, /snapshot:\$\{TargetCommit\}:\$\(Get-CrmLocalSnapshotHash/)
+test('auto build is fingerprinted, serialized and recorded only through the deterministic helper', () => {
+  assert.match(crmRunner, /CRM_BUILD_BEFORE_START.*auto/s)
+  assert.match(crmRunner, /node "\$BUILD_STATE_HELPER" inspect --root "\$ROOT_DIR" --state "\$CRM_BUILD_STATE_FILE"/)
+  assert.match(crmRunner, /lock-acquire --lock-dir "\$CRM_BUILD_LOCK_DIR" --owner-pid "\$\$"/)
+  assert.match(crmRunner, /lock-release --lock-dir "\$CRM_BUILD_LOCK_DIR" --token "\$CRM_BUILD_LOCK_TOKEN"/)
+  assert.match(crmRunner, /if \[\[ "\$CRM_BUILD_BEFORE_START" == "auto" && "\$state_valid" == "true" \]\]/)
+  assert.match(crmRunner, /npm --prefix "\$FRONTEND_DIR" ci --no-audit --no-fund/)
+  assert.match(crmRunner, /node "\$BUILD_STATE_HELPER" state-write/)
+  assert.doesNotMatch(crmRunner, /npm --prefix "\$FRONTEND_DIR" install/)
+  for (const fingerprint of ['inputFingerprint', 'lockfileFingerprint', 'artifactFingerprint']) {
+    assert.ok(buildStateHelper.includes(fingerprint), `missing ${fingerprint}`)
+    assert.ok(runtime.includes(fingerprint), `manifest does not record ${fingerprint}`)
+  }
 })
 
-test('canonical CRM actions use origin/main only when no preview was explicitly selected', () => {
-  assert.match(launcher, /return "origin\/main"/)
-  assert.match(launcher, /git -C \$ProjectRoot fetch origin --prune --quiet/)
-  assert.match(launcher, /function Test-CrmLocalIncludeWorkingChanges/)
-  assert.match(launcher, /if \(-not \(Test-CrmLocalIncludeWorkingChanges\)\)/)
-  assert.match(launcher, /Fingerprint = "commit:\$\{TargetCommit\}"/)
-  assert.match(launcher, /A prévia ativa não deriva da revisão canônica solicitada/)
-})
-
-test('a named CRM preview is shared across actions but applied to the current canonical commit', () => {
-  assert.match(launcher, /CRM_LOCAL_PREVIEW_SOURCE_ROOT/)
-  assert.match(launcher, /active-source\.json/)
-  assert.match(launcher, /CRM_LOCAL_CLEAR_PREVIEW_SOURCE/)
-  assert.match(launcher, /if \(\$crmLocalPreviewSelected\) \{[\s\S]*return "HEAD"/)
-  assert.match(launcher, /merge-base --is-ancestor \$sourceCommit \$TargetCommit/)
-  assert.match(launcher, /A prévia ativa não deriva da revisão canônica solicitada/)
-})
-
-test('a selected preview persists its source and never silently substitutes local work with origin/main', () => {
-  assert.match(launcher, /crm-local\\active-source\.json/)
-  assert.match(launcher, /selectedBy = 'CRM_LOCAL_PREVIEW_SOURCE_ROOT'/)
-  assert.match(launcher, /\$ProjectRoot = \$previewSourceRoot/)
-  assert.match(launcher, /\$env:CRM_LOCAL_INCLUDE_WORKING_CHANGES = 'true'/)
-  assert.match(launcher, /if \(\$crmLocalPreviewSelected\)[\s\S]*return "HEAD"/)
-  assert.doesNotMatch(launcher, /git -C \$ProjectRoot reset --hard origin\/main/)
-})
-
-test('each CRM module materializes its own exact snapshot and cannot reuse a mismatched origin', () => {
-  assert.match(launcher, /Resolve-CrmLocalModuleSourceRoot/)
-  assert.match(launcher, /Sync-CrmLocalSourceRoot -Persona \$Persona -TargetCommit \$targetCommit -Snapshot \$snapshot/)
-  assert.match(launcher, /Get-CrmPersonaDecision -Persona Gestor -TargetCommit \$targetCommit -SourceFingerprint \$snapshot\.Fingerprint/)
-  assert.match(launcher, /-Module 'site-tracking'/)
-  assert.match(launcher, /-Module 'meta-ads'/)
-  assert.match(launcher, /-Module 'atendimento'/)
-  assert.match(launcher, /return "\{0\}__\{1\}" -f \$sourceRoot, \$Module\.Trim\(\)\.ToLowerInvariant\(\)/)
-  assert.match(runtimePolicy, /source_outdated/)
-  assert.match(runtimePolicy, /commit_outdated/)
-  assert.match(runtimePolicy, /source_origin_outdated/)
-})
-
-test('Gestor and Atendimento runtimes detach from the invoking action and keep the persisted source contract', () => {
-  assert.match(launcher, /\[switch\]\$CrmLocalDetachedStart/)
-  assert.match(launcher, /function Start-CrmGestorBackgroundUpdate/)
-  assert.match(launcher, /'-CrmLocalDetachedStart'/)
-  assert.match(launcher, /"CrmLocal"\s*\{[\s\S]*if \(-not \$CrmLocalDetachedStart\)[\s\S]*Start-CrmGestorBackgroundUpdate/)
-  assert.match(launcher, /function Start-CrmAtendimentoBackgroundUpdate/)
-  assert.match(launcher, /-CrmAtendimentoDetachedStart/)
-  assert.match(launcher, /-RedirectStandardOutput \$outLog -RedirectStandardError \$errLog/)
-  assert.match(launcher, /if \(-not \$CrmAtendimentoDetachedStart\)[\s\S]*Start-CrmAtendimentoBackgroundUpdate/)
-  assert.match(launcher, /\[int\[\]\]\$AcceptedExitCode = @\(0\)/)
-  assert.match(launcher, /CRM_OPEN_BROWSER=0/)
-  assert.match(launcher, /-AcceptedExitCode @\(0, 143\)/)
-  assert.match(launcher, /function Wait-CrmAtendimentoReady/)
-  assert.match(launcher, /function Test-CrmSourceOriginEquivalent/)
-  assert.match(launcher, /Windows source roots are[\s\S]*module suffix and native paths must remain exact/)
-  assert.match(launcher, /Wait-CrmAtendimentoReady -TargetCommit \$targetCommit -SourceFingerprint \$snapshot\.Fingerprint -SourceOrigin \$sourceOrigin -TimeoutSeconds 600/)
-  assert.match(launcher, /previous manifest is intentionally retained/)
-  assert.match(launcher, /a 143 is only accepted here/)
-  assert.match(crmRunner, /wait "\$CRM_PID"/)
-  assert.match(launcher, /\$policyCommand = "node \{0\} --manifest \{1\} --build-state \{2\} --target \{3\} --source-fingerprint \{4\} --source-origin \{5\}/)
-  assert.match(launcher, /& wsl\.exe -d Ubuntu-24\.04 -- bash -lc \$policyCommand/)
-})
-
-test('all CRM module shortcuts select a current snapshot before launch', () => {
-  assert.match(launcher, /"CrmSiteEf"[\s\S]*Invoke-CrmPersonaAction -Persona Gestor -TargetCommit \$targetCommit/)
-  assert.match(launcher, /"CrmMetaAds"[\s\S]*Invoke-CrmPersonaAction -Persona Gestor -TargetCommit \$targetCommit/)
-  assert.match(launcher, /"CrmAtendimento"[\s\S]*Invoke-CrmAtendimentoAction/)
-})
-
-test('a concurrent launcher reports an active runtime with a reusable status', () => {
-  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-'))
+test('runtime v3 manifest records role/module, build, PID identities, private state and browser profile', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-v3-'))
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
   const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
-  const command = `ROOT_DIR=${JSON.stringify(root)} CRM_RUNTIME_ROOT=${JSON.stringify(temp)} CRM_PERSONA=GESTOR bash -c 'source ${JSON.stringify(helper)}; crm_persona_runtime_init; mkdir -p "$CRM_RUNTIME_LOCK_DIR"; printf "%s\\n" "$$" > "$CRM_RUNTIME_LOCK_DIR/pid"; crm_persona_runtime_acquire_lock; test "$?" = 2'`
-  const result = spawnSync('bash', ['-lc', command], { encoding: 'utf8' })
-  assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(result.stdout, /Runtime de GESTOR já está ativo/)
-})
-
-test('runtime manifest records the exact target and built commits', () => {
-  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-manifest-'))
-  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
-  const target = 'd'.repeat(40)
-  const built = 'e'.repeat(40)
-  const body = `source "$1"
+  const target = '5'.repeat(40)
+  const body = `set -e
+source "$1"
 crm_persona_runtime_init
-CRM_BUILD_COMMIT=${built}
-DEFAULT_URL=http://localhost:8791/
-LOG_FILE="$CRM_RUNTIME_ROOT/runtime.log"
-CRM_PAGES_PORT=8791 CRM_VITE_PORT=5173 CRM_WITH_INSUMOS=1 CRM_INSUMOS_PORT=8787
-CRM_WITH_TIMEKEEPING=1 CRM_TIMEKEEPING_PORT=8801 CRM_WITH_WHATSAPP=1 CRM_WA_ORCHESTRATOR_PORT=8110
-crm_persona_runtime_write_manifest ready`
+CRM_BUILD_COMMIT=${target}
+CRM_BUILD_INPUT_FINGERPRINT=sha256:${'6'.repeat(64)}
+CRM_BUILD_LOCKFILE_FINGERPRINT=sha256:${'7'.repeat(64)}
+CRM_BUILD_ARTIFACT_FINGERPRINT=sha256:${'8'.repeat(64)}
+DEFAULT_URL=http://localhost:24020/?module=atendimento
+LOG_FILE="$CRM_RUNTIME_ROOT/logs/runtime.log"
+CRM_PAGES_PORT=24020 CRM_VITE_PORT=24021 CRM_WITH_INSUMOS=0 CRM_INSUMOS_PORT=24022
+CRM_WITH_TIMEKEEPING=0 CRM_TIMEKEEPING_PORT=24023 CRM_WITH_WHATSAPP=1 CRM_WA_ORCHESTRATOR_PORT=24024
+CRM_PID=$$
+CRM_BROWSER_PROFILE_DIR="$CRM_RUNTIME_ROOT/browser/profile"
+R2_PERSIST_DIR="$CRM_RUNTIME_ROOT/state/pages"
+CRM_LOCAL_WA_RUNTIME_HOME="$CRM_RUNTIME_ROOT/state/whatsapp"
+crm_persona_runtime_write_manifest ready
+crm_persona_runtime_manifest_is_ready
+CRM_RUNTIME_CONFIG_FINGERPRINT=sha256:${'a'.repeat(64)}
+if crm_persona_runtime_manifest_is_ready; then
+  echo "mismatched runtime configuration was accepted as ready" >&2
+  exit 1
+fi
+CRM_RUNTIME_CONFIG_FINGERPRINT=sha256:${'9'.repeat(64)}
+crm_persona_runtime_acquire_lock
+set +e
+crm_persona_runtime_acquire_lock
+contention_status="$?"
+set -e
+test "$contention_status" = 2
+crm_persona_runtime_wait_ready 1
+sleep 10 &
+stale_pid="$!"
+stale_ticks="$(crm_runtime_pid_start_ticks "$stale_pid")"
+node - "$CRM_RUNTIME_MANIFEST" "$stale_pid" "$stale_ticks" <<'NODE'
+const fs = require('fs')
+const file = process.argv[2]
+const value = JSON.parse(fs.readFileSync(file, 'utf8'))
+value.pids.launcher = Number(process.argv[3])
+value.pidStartTicks.launcher = Number(process.argv[4])
+fs.writeFileSync(file, JSON.stringify(value) + '\\n')
+NODE
+if crm_persona_runtime_manifest_is_ready; then
+  echo "ready manifest from another live launcher was accepted" >&2
+  exit 1
+fi
+kill "$stale_pid"
+wait "$stale_pid" 2>/dev/null || true
+crm_persona_runtime_write_manifest ready
+node - "$CRM_RUNTIME_LOCK_DIR/owner.json" <<'NODE'
+const fs = require('fs')
+const file = process.argv[2]
+const value = JSON.parse(fs.readFileSync(file, 'utf8'))
+value.token = 'successor-token'
+fs.writeFileSync(file, JSON.stringify(value) + '\\n')
+NODE
+if crm_persona_runtime_manifest_is_ready; then
+  echo "ready manifest from a replaced lock token was accepted" >&2
+  exit 1
+fi
+CRM_LOCK_ORIGINAL_TOKEN="$CRM_RUNTIME_LOCK_TOKEN" node - "$CRM_RUNTIME_LOCK_DIR/owner.json" <<'NODE'
+const fs = require('fs')
+const file = process.argv[2]
+const value = JSON.parse(fs.readFileSync(file, 'utf8'))
+value.token = process.env.CRM_LOCK_ORIGINAL_TOKEN
+fs.writeFileSync(file, JSON.stringify(value) + '\\n')
+NODE
+crm_persona_runtime_release_lock`
   const result = spawnSync('bash', ['-c', body, 'bash', helper], {
     encoding: 'utf8',
-    env: { ...process.env, ROOT_DIR: root, CRM_RUNTIME_ROOT: temp, CRM_PERSONA: 'GESTOR', CRM_TARGET_COMMIT: target, CRM_SOURCE_FINGERPRINT: `commit:${target}`, CRM_SOURCE_ORIGIN: 'test-origin__atendimento' },
+    env: {
+      ...process.env,
+      ROOT_DIR: root,
+      CRM_RUNTIME_ROOT: temp,
+      CRM_RUNTIME_ID: 'crm-local--atendimento--gestor',
+      CRM_RUNTIME_MODULE: 'atendimento',
+      CRM_PERSONA: 'GESTOR',
+      CRM_TARGET_COMMIT: target,
+      CRM_SOURCE_FINGERPRINT: `commit:${target}`,
+      CRM_SOURCE_ORIGIN: `${root}__crm-local--atendimento--gestor`,
+      CRM_RUNTIME_CONFIG_FINGERPRINT: `sha256:${'9'.repeat(64)}`,
+    },
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
+
   const manifest = JSON.parse(fs.readFileSync(path.join(temp, 'current.json'), 'utf8'))
-  assert.equal(manifest.version, 2)
+  assert.equal(manifest.version, 3)
+  assert.equal(manifest.runtimeId, 'crm-local--atendimento--gestor')
+  assert.equal(manifest.module, 'atendimento')
+  assert.equal(manifest.persona, 'GESTOR')
   assert.equal(manifest.targetCommit, target)
-  assert.equal(manifest.buildCommit, built)
-  assert.equal(manifest.sourceFingerprint, `commit:${target}`)
-  assert.equal(manifest.sourceOrigin, 'test-origin__atendimento')
+  assert.equal(manifest.buildCommit, target)
+  assert.deepEqual(manifest.build, {
+    inputFingerprint: `sha256:${'6'.repeat(64)}`,
+    lockfileFingerprint: `sha256:${'7'.repeat(64)}`,
+    artifactFingerprint: `sha256:${'8'.repeat(64)}`,
+  })
+  assert.ok(Number.isInteger(manifest.pids.launcher))
+  assert.ok(Number.isInteger(manifest.pidStartTicks.launcher))
+  assert.ok(Number.isInteger(manifest.pidStartTicks.pages))
+  assert.equal(manifest.ports.pages, 24020)
+  assert.equal(manifest.ports.whatsapp, 24024)
+  assert.equal(manifest.ports.insumos, null)
+  assert.equal(manifest.browserProfile, path.join(temp, 'browser/profile'))
+  assert.equal(manifest.statePaths.pages, path.join(temp, 'state/pages'))
+  assert.equal(manifest.statePaths.whatsapp, path.join(temp, 'state/whatsapp'))
 })
 
-test('local smoke downgrades only the exact optional Google chart credential failure', () => {
-  const optional = {
-    status: 500,
-    url: 'http://localhost:8791/api/atendimento/management/charts?tab=Comercial',
-    body: '{"ok":false,"error":"No key or keyFile set."}',
-  }
-  const genericConsole = 'Failed to load resource: the server responded with a status of 500 (Internal Server Error)'
-  const accepted = partitionModuleErrors('faturamento', [optional], [genericConsole])
-  assert.equal(accepted.apiErrors.length, 0)
-  assert.equal(accepted.apiWarnings.length, 1)
-  assert.equal(accepted.consoleErrors.length, 0)
-  assert.equal(accepted.consoleWarnings.length, 1)
-
-  for (const changed of [
-    { ...optional, status: 502 },
-    { ...optional, url: 'http://localhost:8791/api/atendimento/management/finance' },
-    { ...optional, body: '{"ok":false,"error":"DATABASE_URL missing"}' },
+test('a concurrent launch waits for the exact ready manifest before health checks or browser opening', () => {
+  const lockBranch = crmRunner.match(
+    /if \[\[ "\$runtime_lock_status" == "2" \]\]; then([\s\S]*?)\nfi\nif \[\[ "\$runtime_lock_status" != "0" \]\]/,
+  )?.[1]
+  assert.ok(lockBranch, 'runtime contention branch not found')
+  const readyIndex = lockBranch.indexOf('crm_persona_runtime_wait_ready 360')
+  const apiIndex = lockBranch.indexOf('wait_for_crm_api')
+  const browserIndex = lockBranch.indexOf('open_browser')
+  assert.ok(readyIndex >= 0)
+  assert.ok(apiIndex > readyIndex)
+  assert.ok(browserIndex > apiIndex)
+  assert.match(runtime, /value\.state === 'ready'/)
+  for (const expectedField of [
+    'CRM_EXPECTED_RUNTIME_ID',
+    'CRM_EXPECTED_MODULE',
+    'CRM_EXPECTED_PERSONA',
+    'CRM_EXPECTED_TARGET_COMMIT',
+    'CRM_EXPECTED_SOURCE_FINGERPRINT',
+    'CRM_EXPECTED_SOURCE_ORIGIN',
+    'CRM_EXPECTED_CONFIG_FINGERPRINT',
   ]) {
-    assert.equal(partitionModuleErrors('faturamento', [changed], []).apiErrors.length, 1)
+    assert.ok(runtime.includes(expectedField), `ready identity does not bind ${expectedField}`)
   }
-  assert.equal(partitionModuleErrors('atendimento', [optional], []).apiErrors.length, 1)
+  assert.match(runtime, /CRM_RUNTIME_OBSERVED_LOCK_TOKEN/)
+  assert.match(runtime, /"\$lock_token" == "\$CRM_RUNTIME_OBSERVED_LOCK_TOKEN"/)
+  assert.match(runtime, /"\$owner_pid" == "\$lock_pid"/)
+  assert.match(runtime, /crm_runtime_pid_identity_matches "\$owner_pid" "\$owner_ticks"/)
+})
+
+test('runtime lock publishes one atomic owner and self-heals only a proven stale identity', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-v3-'))
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
+  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
+  const body = `set -e
+source "$1"
+crm_persona_runtime_init
+mkdir -p "$CRM_RUNTIME_LOCK_DIR"
+current_ticks="$(crm_runtime_pid_start_ticks "$$")"
+node - "$CRM_RUNTIME_LOCK_DIR/owner.json" "$$" "$((current_ticks + 1))" "$CRM_RUNTIME_ID" <<'NODE'
+const fs = require('fs')
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  version: 1,
+  token: 'stale-owner',
+  pid: Number(process.argv[3]),
+  startTicks: Number(process.argv[4]),
+  runtimeId: process.argv[5],
+  sourceFingerprint: process.env.CRM_SOURCE_FINGERPRINT,
+  configFingerprint: process.env.CRM_RUNTIME_CONFIG_FINGERPRINT,
+  createdAtEpoch: Math.floor(Date.now() / 1000),
+}) + '\\n')
+NODE
+crm_persona_runtime_acquire_lock
+test "$CRM_RUNTIME_LOCK_HELD" = 1
+node - "$CRM_RUNTIME_LOCK_DIR/owner.json" "$$" "$current_ticks" "$CRM_RUNTIME_ID" <<'NODE'
+const fs = require('fs')
+const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+if (value.version !== 1 || !value.token || value.pid !== Number(process.argv[3]) ||
+    value.startTicks !== Number(process.argv[4]) || value.runtimeId !== process.argv[5] ||
+    value.sourceFingerprint !== process.env.CRM_SOURCE_FINGERPRINT ||
+    value.configFingerprint !== process.env.CRM_RUNTIME_CONFIG_FINGERPRINT) process.exit(1)
+NODE
+crm_persona_runtime_release_lock
+test ! -e "$CRM_RUNTIME_LOCK_DIR"`
+  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ROOT_DIR: root,
+      CRM_RUNTIME_ROOT: temp,
+      CRM_RUNTIME_ID: 'crm-local--ponto--consultor',
+      CRM_RUNTIME_MODULE: 'ponto',
+      CRM_PERSONA: 'CONSULTOR',
+      CRM_SOURCE_FINGERPRINT: `sha256:${'a'.repeat(64)}`,
+      CRM_RUNTIME_CONFIG_FINGERPRINT: `sha256:${'b'.repeat(64)}`,
+    },
+  })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+})
+
+test('runtime lock never steals a live owner with another source and release is token-CAS', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-cas-'))
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
+  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
+  const body = `set -e
+source "$1"
+crm_persona_runtime_init
+mkdir -p "$CRM_RUNTIME_LOCK_DIR"
+ticks="$(crm_runtime_pid_start_ticks "$$")"
+node - "$CRM_RUNTIME_LOCK_DIR/owner.json" "$$" "$ticks" "$CRM_RUNTIME_ID" <<'NODE'
+const fs = require('fs')
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  version: 1,
+  token: 'live-other-source',
+  pid: Number(process.argv[3]),
+  startTicks: Number(process.argv[4]),
+  runtimeId: process.argv[5],
+  sourceFingerprint: 'sha256:old',
+  configFingerprint: process.env.CRM_RUNTIME_CONFIG_FINGERPRINT,
+  createdAtEpoch: Math.floor(Date.now() / 1000),
+}) + '\\n')
+NODE
+set +e
+crm_persona_runtime_acquire_lock
+status="$?"
+set -e
+test "$status" = 3
+test "$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1])).token" "$CRM_RUNTIME_LOCK_DIR/owner.json")" = live-other-source
+rm -f "$CRM_RUNTIME_LOCK_DIR/owner.json"
+rmdir "$CRM_RUNTIME_LOCK_DIR"
+crm_persona_runtime_acquire_lock
+node - "$CRM_RUNTIME_LOCK_DIR/owner.json" <<'NODE'
+const fs = require('fs')
+const file = process.argv[2]
+const value = JSON.parse(fs.readFileSync(file, 'utf8'))
+value.token = 'successor-token'
+fs.writeFileSync(file, JSON.stringify(value) + '\\n')
+NODE
+crm_persona_runtime_release_lock
+test -d "$CRM_RUNTIME_LOCK_DIR"
+test "$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1])).token" "$CRM_RUNTIME_LOCK_DIR/owner.json")" = successor-token`
+  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ROOT_DIR: root,
+      CRM_RUNTIME_ROOT: temp,
+      CRM_RUNTIME_ID: 'crm-local--atendimento--gestor',
+      CRM_RUNTIME_MODULE: 'atendimento',
+      CRM_PERSONA: 'GESTOR',
+      CRM_SOURCE_FINGERPRINT: `sha256:${'c'.repeat(64)}`,
+      CRM_RUNTIME_CONFIG_FINGERPRINT: `sha256:${'d'.repeat(64)}`,
+    },
+  })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+})
+
+test('runtime lock treats a fresh partial owner as contention instead of deleting it', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-runtime-lock-partial-'))
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }))
+  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
+  const body = `set -e
+source "$1"
+crm_persona_runtime_init
+mkdir -p "$CRM_RUNTIME_LOCK_DIR"
+set +e
+crm_persona_runtime_acquire_lock
+status="$?"
+set -e
+test "$status" = 1
+test -d "$CRM_RUNTIME_LOCK_DIR"
+test ! -e "$CRM_RUNTIME_LOCK_DIR/owner.json"`
+  const result = spawnSync('bash', ['-c', body, 'bash', helper], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ROOT_DIR: root,
+      CRM_RUNTIME_ROOT: temp,
+      CRM_RUNTIME_ID: 'crm-local--insumos--gestor',
+      CRM_RUNTIME_MODULE: 'insumos',
+      CRM_PERSONA: 'GESTOR',
+      CRM_RUNTIME_LOCK_PARTIAL_TTL: '5',
+      CRM_RUNTIME_LOCK_WAIT_ATTEMPTS: '3',
+    },
+  })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+})
+
+test('PID identity reads start ticks correctly when Linux comm contains spaces and a parenthesis', () => {
+  const helper = path.join(root, 'scripts', 'crm-local-persona-runtime.sh')
+  const body = `set -e
+source "$1"
+printf 'crm ) worker' > "/proc/$$/comm"
+actual="$(crm_runtime_pid_start_ticks "$$")"
+  expected="$(node -e 'const fs=require("fs");const s=fs.readFileSync("/proc/"+process.ppid+"/stat","utf8");const i=s.lastIndexOf(")");process.stdout.write(s.slice(i+2).trim().split(/\\s+/)[19])')"
+test "$actual" = "$expected"
+crm_runtime_pid_identity_matches "$$" "$expected"`
+  const result = spawnSync('bash', ['-c', body, 'bash', helper], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  assert.match(launcher, /source \{0\}; crm_runtime_pid_start_ticks \{1\}/)
+  assert.doesNotMatch(launcher, /awk '\{print `\$20\}'/)
+})
+
+test('immutable source and build cache are keyed by the exact source fingerprint', () => {
+  assert.match(launcher, /function Sync-CrmLocalImmutableSourceRoot/)
+  assert.match(launcher, /source\\crm-local\\immutable\\\{0\}/)
+  assert.match(launcher, /Get-CrmLocalSnapshotHash -Value \(\[string\]\$Snapshot\.Fingerprint\)/)
+  assert.match(launcher, /Local\\SkincosCrmSource-\$sourceKey/)
+  assert.match(launcher, /não corresponde à impressão solicitada; ela não será alterada/)
+  assert.match(launcher, /\$crmBuildCacheRoot = Join-Path \$operatorRuntimeRoot "cache\\crm-local\\builds"/)
+  assert.match(launcher, /Get-CrmInstanceBuildPaths -SourceFingerprint/)
+  assert.match(launcher, /\$sourceOrigin = "\{0\}__\{1\}" -f \$sourceRoot, \(\[string\]\$spec\.runtimeId\)/)
+  assert.match(launcher, /Local\\SkincosCrmPersonaSource-\$\(\$Persona\.ToLowerInvariant\(\)\)/)
+  assert.match(launcher, /function Assert-CrmLocalLauncherContract/)
+  assert.match(launcher, /launcherContractFingerprint/)
+  assert.match(launcher, /Assert-CrmLocalLauncherContract -SourceRoot \$sourceRoot/)
+})
+
+test('browser and Pages state remain inside the private role/module runtime', () => {
+  assert.match(launcher, /\$expectedProfile = Join-Path \$runtimeRoot "browser\\profile"/)
+  assert.match(launcher, /open-crm-local-browser\.ps1"\) -Url \$url -ProfilePath \$expectedProfile/)
+  assert.match(browserLauncher, /\$privateRuntimeRoot = \[IO\.Path\]::GetFullPath\('C:\\CodexRuntime\\operator\\admin\\skincos'\)/)
+  assert.match(browserLauncher, /--user-data-dir=/)
+  assert.match(browserLauncher, /\$loopbackHost -notin @\('localhost', '127\.0\.0\.1', '::1'\)/)
+  assert.match(crmRunner, /CRM_BROWSER_SCRIPT.*-ProfilePath "\$browser_profile_windows"/s)
+  assert.match(launcher, /\$browserScriptWsl = Convert-WindowsPathToWsl -Path \(Join-Path \$SourceRoot "scripts\\open-crm-local-browser\.ps1"\)/)
+  assert.match(launcher, /\[switch\]\$CrmRuntimeSuppressBrowser/)
+  assert.match(launcher, /CRM_OPEN_BROWSER=\$openBrowser/)
+  assert.match(launcher, /\$arguments \+= "-CrmRuntimeSuppressBrowser"/)
+  assert.match(pagesRunner, /R2_PERSIST_DIR/)
+  assert.match(pagesRunner, /--persist-to "\$R2_PERSIST_DIR"/)
+})
+
+test('legacy explicit actions remain compatible by delegating to the modular runtime', () => {
+  const mappings = [
+    ['CrmConsultor', 'Consultor', 'ponto'],
+    ['CrmSiteEf', 'Gestor', 'site-tracking'],
+    ['CrmMetaAds', 'Gestor', 'meta-ads'],
+    ['CrmAtendimento', 'Gestor', 'atendimento'],
+  ]
+  for (const [action, role, module] of mappings) {
+    const pattern = new RegExp(
+      `"${action}"\\s*\\{\\s*Invoke-CrmModuleAction -Role ${role} -Module "${module}"`,
+    )
+    assert.match(launcher, pattern)
+  }
+  assert.match(launcher, /"CrmConsultorStop"\s*\{[\s\S]*Resolve-CrmLocalModuleSpec -Role Consultor -Module "ponto"/)
+  assert.match(launcher, /"CrmModuleStop"\s*\{[\s\S]*Resolve-CrmLocalModuleSpec -Role \$CrmRole -Module \$CrmModule/)
 })

--- a/scripts/tests/crm-local-isolation-hooks.test.mjs
+++ b/scripts/tests/crm-local-isolation-hooks.test.mjs
@@ -1,0 +1,598 @@
+import assert from 'node:assert/strict';
+import {
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, '..', '..');
+const devPagesPath = path.join(repositoryRoot, 'crm', 'console', 'scripts', 'dev_pages.sh');
+const browserLauncherPath = path.join(repositoryRoot, 'scripts', 'open-crm-local-browser.ps1');
+const whatsappAdapterPath = path.join(repositoryRoot, 'scripts', 'run-local-whatsapp-orchestrator.sh');
+const crmRunnerPath = path.join(repositoryRoot, 'scripts', 'run-local-crm.sh');
+const insumosHelperPath = path.join(repositoryRoot, 'backend', 'scripts', 'insumos.sh');
+
+async function makeIsolatedFixture() {
+  const fixtureParent = await mkdtemp(path.join(os.tmpdir(), 'crm-local-isolation-'));
+  const consoleRoot = path.join(fixtureParent, 'console');
+  const persistRoot = path.join(fixtureParent, 'private-runtime');
+  const artifactRoot = path.join(fixtureParent, 'immutable-dist');
+  const fakeBin = path.join(fixtureParent, 'bin');
+  const capturePath = path.join(fixtureParent, 'wrangler-args.txt');
+
+  await mkdir(path.join(consoleRoot, 'scripts'), { recursive: true });
+  await mkdir(path.join(consoleRoot, 'dist'), { recursive: true });
+  await mkdir(artifactRoot, { recursive: true });
+  await mkdir(path.join(consoleRoot, 'public'), { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await cp(devPagesPath, path.join(consoleRoot, 'scripts', 'dev_pages.sh'));
+  await writeFile(path.join(consoleRoot, 'dist', 'index.html'), 'built\n');
+  await writeFile(path.join(consoleRoot, 'dist', '_routes.json'), 'dist-sentinel\n');
+  await writeFile(path.join(artifactRoot, 'index.html'), 'immutable-build\n');
+  await writeFile(path.join(artifactRoot, '_routes.json'), 'immutable-routes\n');
+  await writeFile(path.join(consoleRoot, 'public', '_routes.json'), 'public-sentinel\n');
+  await writeFile(path.join(consoleRoot, '.dev.vars'), 'dev-vars-sentinel\n');
+  await writeFile(path.join(fakeBin, 'npm'), '#!/usr/bin/env bash\nexit 0\n');
+  await writeFile(
+    path.join(fakeBin, 'npx'),
+    '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$CAPTURE_FILE"\n',
+  );
+  await chmod(path.join(fakeBin, 'npm'), 0o755);
+  await chmod(path.join(fakeBin, 'npx'), 0o755);
+
+  return { fixtureParent, consoleRoot, persistRoot, artifactRoot, fakeBin, capturePath };
+}
+
+test('isolated Pages mode keeps shared files immutable and binds the full local identity', async (t) => {
+  const fixture = await makeIsolatedFixture();
+  t.after(() => rm(fixture.fixtureParent, { recursive: true, force: true }));
+
+  const result = spawnSync('bash', [path.join(fixture.consoleRoot, 'scripts', 'dev_pages.sh')], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fixture.fakeBin}:${process.env.PATH}`,
+      CAPTURE_FILE: fixture.capturePath,
+      CRM_LOCAL_ISOLATED: '1',
+      R2_PERSIST_DIR: fixture.persistRoot,
+      CRM_DIST_DIR: fixture.artifactRoot,
+      LOCAL_AUTH_BYPASS: 'true',
+      LOCAL_AUTH_ROLE: 'CONSULTOR',
+      LOCAL_AUTH_TEST_USER_ADMIN: 'false',
+      LOCAL_AUTH_USERNAME: 'isolated-user',
+      LOCAL_AUTH_EMAIL: 'isolated@example.test',
+      LOCAL_AUTH_NAME: 'Isolated User',
+      LOCAL_AUTH_ALLOWED_MODULES: 'atendimento,ponto',
+      LOCAL_AUTH_ALLOWED_UNITS: 'unit-a',
+      AUTH_API_TARGET: 'http://127.0.0.1:8110',
+      CRM_API_TARGET: 'http://127.0.0.1:8112',
+      TRACKING_API_TARGET: 'http://127.0.0.1:8113',
+      UNIT_MONITOR_API_TARGET: 'http://127.0.0.1:8114',
+      LOCAL_INSUMOS_API_TARGET: 'http://127.0.0.1:8101',
+      LOCAL_WA_ORCHESTRATOR_API_TARGET: 'http://127.0.0.1:8111',
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.equal(await readFile(path.join(fixture.consoleRoot, '.dev.vars'), 'utf8'), 'dev-vars-sentinel\n');
+  assert.equal(
+    await readFile(path.join(fixture.consoleRoot, 'dist', '_routes.json'), 'utf8'),
+    'dist-sentinel\n',
+  );
+  assert.equal(
+    await readFile(path.join(fixture.artifactRoot, '_routes.json'), 'utf8'),
+    'immutable-routes\n',
+  );
+
+  const wranglerArguments = (await readFile(fixture.capturePath, 'utf8')).trim().split('\n');
+  assert.ok(wranglerArguments.includes('/dev/null'));
+  assert.ok(wranglerArguments.includes(fixture.persistRoot));
+  assert.ok(wranglerArguments.includes(fixture.artifactRoot));
+  for (const binding of [
+    'LOCAL_AUTH_BYPASS=true',
+    'LOCAL_AUTH_ROLE=CONSULTOR',
+    'LOCAL_AUTH_TEST_USER_ADMIN=false',
+    'LOCAL_AUTH_USERNAME=isolated-user',
+    'LOCAL_AUTH_EMAIL=isolated@example.test',
+    'LOCAL_AUTH_NAME=Isolated User',
+    'LOCAL_AUTH_ALLOWED_MODULES=atendimento,ponto',
+    'LOCAL_AUTH_ALLOWED_UNITS=unit-a',
+    'AUTH_API_TARGET=http://127.0.0.1:8110',
+    'AUTH_PATH_PREFIX=/insumos/auth',
+    'CRM_API_TARGET=http://127.0.0.1:8112',
+    'TRACKING_API_TARGET=http://127.0.0.1:8113',
+    'UNIT_MONITOR_API_TARGET=http://127.0.0.1:8114',
+    'ESCALA_API_TARGET=https://escala-api.skincos.com.br',
+    'LOCAL_ESCALA_MOCK=false',
+    'LOCAL_ESCALA_SHADOW_WRITES=true',
+    'INSUMOS_API_TARGET=http://127.0.0.1:8101',
+    'WA_ORCHESTRATOR_API_TARGET=http://127.0.0.1:8111',
+    'ATENDIMENTO_API_TARGET=http://127.0.0.1:8111',
+  ]) {
+    assert.ok(wranglerArguments.includes(binding), `missing binding: ${binding}`);
+  }
+});
+
+test('isolated Pages mode refuses implicit or source-tree persistence', async (t) => {
+  const fixture = await makeIsolatedFixture();
+  t.after(() => rm(fixture.fixtureParent, { recursive: true, force: true }));
+  const baseEnvironment = {
+    ...process.env,
+    PATH: `${fixture.fakeBin}:${process.env.PATH}`,
+    CAPTURE_FILE: fixture.capturePath,
+    CRM_LOCAL_ISOLATED: '1',
+  };
+
+  const implicitResult = spawnSync(
+    'bash',
+    [path.join(fixture.consoleRoot, 'scripts', 'dev_pages.sh')],
+    { encoding: 'utf8', env: baseEnvironment },
+  );
+  assert.equal(implicitResult.status, 2);
+  assert.match(implicitResult.stderr, /R2_PERSIST_DIR absoluto e explícito/);
+
+  const sourceTreeResult = spawnSync(
+    'bash',
+    [path.join(fixture.consoleRoot, 'scripts', 'dev_pages.sh')],
+    {
+      encoding: 'utf8',
+      env: { ...baseEnvironment, R2_PERSIST_DIR: path.join(fixture.consoleRoot, 'runtime') },
+    },
+  );
+  assert.equal(sourceTreeResult.status, 2);
+  assert.match(sourceTreeResult.stderr, /fora da árvore fonte/);
+});
+
+test('Vite uses strictPort and the local adapter refreshes dependencies by lockfile hash', async () => {
+  const devPages = await readFile(devPagesPath, 'utf8');
+  const whatsappAdapter = await readFile(whatsappAdapterPath, 'utf8');
+  const crmRunner = await readFile(crmRunnerPath, 'utf8');
+  const insumosHelper = await readFile(insumosHelperPath, 'utf8');
+
+  assert.match(devPages, /--strictPort/);
+  assert.match(whatsappAdapter, /export HARMONIA_WORKER_ENABLED=false/);
+  assert.match(whatsappAdapter, /sha256sum .*package-lock\.json/);
+  assert.match(whatsappAdapter, /package_lock_hash.*recorded_package_lock_hash/);
+  assert.match(whatsappAdapter, /package_lock_state_tmp=.*\$\$/);
+  assert.match(whatsappAdapter, /mv -f "\$package_lock_state_tmp" "\$package_lock_state"/);
+  assert.match(whatsappAdapter, /ROLE_POLICY_FILE="\$\{CRM_ROLE_POLICY_FILE:-\$ROOT_DIR\/crm\/console\/modules\/localRolePolicy\.json\}"/);
+  assert.match(whatsappAdapter, /CRM_ROLE_POLICY_FILE="\$ROLE_POLICY_FILE"/);
+  assert.match(whatsappAdapter, /crm_local_wa_runtime_database_name/);
+  assert.match(whatsappAdapter, /postgres-create\.lock/);
+  assert.match(whatsappAdapter, /--template template0/);
+  assert.match(whatsappAdapter, /CRM_LOCAL_WA_PG_DUMP_BIN/);
+  assert.match(whatsappAdapter, /skincos_crm_local_runtime/);
+  assert.match(whatsappAdapter, /alter database \$temporary_database rename to \$target_database/);
+  assert.doesNotMatch(
+    whatsappAdapter,
+    /DEFAULT_DATABASE_URL="postgresql:\/\/\$\{RUN_AS_USER\}@\/skincos_crm_local/,
+  );
+  assert.match(crmRunner, /export WRANGLER_REGISTRY_PATH="\$CRM_WRANGLER_REGISTRY_PATH"/);
+  assert.match(crmRunner, /--ip 127\.0\.0\.1\s+\\\s+--port "\$CRM_INSUMOS_PORT"/);
+  assert.match(crmRunner, /readlink -f "\$FRONTEND_DIR\/node_modules"/);
+  assert.match(
+    crmRunner,
+    /\/mnt\/c\/CodexRuntime\/operator\/admin\/skincos\/source\/crm-local-gestor-main/,
+  );
+  assert.match(crmRunner, /migration_root="\$CRM_RUNTIME_ROOT\/state\/legacy-dependencies"/);
+  assert.match(crmRunner, /mv -- "\$FRONTEND_DIR\/node_modules" "\$migration_target"/);
+  assert.match(crmRunner, /existing_dependency_relative.*\^\[a-f0-9\]\{64\}\/node_modules\$/);
+  assert.match(crmRunner, /rm -- "\$FRONTEND_DIR\/node_modules"/);
+  assert.match(crmRunner, /CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION.*0/);
+  assert.match(crmRunner, /CRM_INSUMOS_DEPENDENCY_ROOT=.*CRM_DEPENDENCY_STATE_ROOT\/insumos/);
+  assert.match(crmRunner, /CRM_INSUMOS_DEPENDENCY_STATE_FILE=.*dependency-key\.sha256/);
+  assert.match(crmRunner, /CRM_INSUMOS_DEPENDENCY_LOCK_FILE=.*install\.lock/);
+  assert.match(crmRunner, /CRM_INSUMOS_DEPENDENCY_CACHE_ROOT=.*cache/);
+  assert.match(insumosHelper, /node_modules\/\.bin\/wrangler/);
+  assert.match(insumosHelper, /CRM_INSUMOS_DEPENDENCY_STATE_FILE/);
+  assert.match(insumosHelper, /CRM_INSUMOS_DEPENDENCY_LOCK_FILE/);
+  assert.match(insumosHelper, /CRM_INSUMOS_DEPENDENCY_CACHE_ROOT/);
+  assert.match(insumosHelper, /command -v flock/);
+  assert.match(insumosHelper, /flock 9/);
+  assert.match(insumosHelper, /mktemp -d .*dependency_key/);
+  assert.match(insumosHelper, /Preserved an interrupted dependency candidate/);
+  assert.match(insumosHelper, /inventory\/node_modules is not the expected private cache link/);
+  assert.match(insumosHelper, /state_tmp=.*\$\$/);
+  assert.match(insumosHelper, /mv -f "\$state_tmp" "\$state_file"/);
+  assert.match(
+    await readFile(path.join(repositoryRoot, 'scripts', 'run-shared-codex-shortcut.ps1'), 'utf8'),
+    /CRM_ALLOW_LEGACY_DEPENDENCY_MIGRATION=1/,
+  );
+  assert.doesNotMatch(crmRunner, /PORT="\$CRM_INSUMOS_PORT".*insumos\.sh dev/);
+  assert.match(crmRunner, /powershell\.exe .*>>"\$browser_log" 2>&1; then/s);
+  assert.doesNotMatch(
+    crmRunner,
+    /-ProfilePath "\$browser_profile_windows" >\/dev\/null 2>&1 &/,
+  );
+  assert.match(whatsappAdapter, /crm_local_wa_validate_privileged_inputs/);
+  assert.match(whatsappAdapter, /LOCAL_WA_ADAPTER_RUN_AS_USER" != "admin"/);
+  assert.match(
+    whatsappAdapter,
+    /runtime\/crm-local\/instances\/\$\{BASH_REMATCH\[2\]\}\/\$\{BASH_REMATCH\[1\]\}\/state\/whatsapp/,
+  );
+  assert.match(
+    whatsappAdapter,
+    /source\/crm-local\/immutable/,
+  );
+  assert.match(
+    whatsappAdapter,
+    /home\/admin\/\.cache\/skincos\/crm-local\/\$LOCAL_WA_ADAPTER_RUNTIME_ID\/whatsapp/,
+  );
+});
+
+test('privileged WhatsApp stage rejects caller-controlled paths before any mutation', () => {
+  const adapter = whatsappAdapterPath.replaceAll('\\', '/');
+  const result = spawnSync('bash', ['-lc', `
+set -euo pipefail
+export CRM_LOCAL_WA_LIBRARY_ONLY=1
+source '${adapter}'
+LOCAL_WA_ADAPTER_ROOT=/tmp/untrusted-source
+LOCAL_WA_ADAPTER_ENV_FILE=/etc/skincos/crm-whatsapp.env
+LOCAL_WA_ADAPTER_PORT=24024
+LOCAL_WA_ADAPTER_RUNTIME_HOME=/etc
+LOCAL_WA_ADAPTER_SOURCE_HOME=/etc/skincos-adapter
+LOCAL_WA_ADAPTER_RUN_AS_USER=admin
+LOCAL_WA_ADAPTER_RUNTIME_ID=crm-local--atendimento--gestor
+LOCAL_WA_ADAPTER_ROLE_POLICY_FILE=/tmp/untrusted-source/crm/console/modules/localRolePolicy.json
+LOCAL_WA_ADAPTER_EMAIL=gestor.atendimento@local.test
+LOCAL_WA_ADAPTER_ROLE=GESTOR
+crm_local_wa_validate_privileged_inputs
+`], { encoding: 'utf8' });
+
+  assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stderr, /caminhos.*absolutos|fonte.*autorizada/i);
+});
+
+function spawnBash(scriptPath, env) {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [scriptPath], { encoding: 'utf8', env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status, signal) => resolve({ status, signal, stdout, stderr }));
+  });
+}
+
+async function makeInsumosDependencyFixture() {
+  const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), 'crm-local-insumos-deps-'));
+  const backendScripts = path.join(fixtureRoot, 'backend', 'scripts');
+  const inventoryRoot = path.join(fixtureRoot, 'inventory');
+  const dependencyRoot = path.join(fixtureRoot, 'private-dependencies');
+  const helperPath = path.join(backendScripts, 'insumos.sh');
+  const installCounter = path.join(fixtureRoot, 'install-count.txt');
+  const failureSentinel = path.join(fixtureRoot, 'fail-once.done');
+
+  await mkdir(backendScripts, { recursive: true });
+  await mkdir(inventoryRoot, { recursive: true });
+  await cp(insumosHelperPath, helperPath);
+  await chmod(helperPath, 0o755);
+  await writeFile(path.join(backendScripts, 'env.sh'), '#!/usr/bin/env bash\n');
+  await writeFile(path.join(backendScripts, 'node_pkg.sh'), `#!/usr/bin/env bash
+install_node_deps() {
+  local target="$1"
+  local count=0
+  [[ -f "$INSUMOS_TEST_INSTALL_COUNTER" ]] && count="$(cat "$INSUMOS_TEST_INSTALL_COUNTER")"
+  printf '%s\\n' "$((count + 1))" > "$INSUMOS_TEST_INSTALL_COUNTER"
+  sleep "\${INSUMOS_TEST_INSTALL_DELAY:-0}"
+  if [[ "\${INSUMOS_TEST_FAIL_ONCE:-0}" == "1" && ! -f "$INSUMOS_TEST_FAILURE_SENTINEL" ]]; then
+    : > "$INSUMOS_TEST_FAILURE_SENTINEL"
+    return 1
+  fi
+  mkdir -p "$target/node_modules/.bin"
+  printf '#!/usr/bin/env bash\\nexit 0\\n' > "$target/node_modules/.bin/wrangler"
+  chmod +x "$target/node_modules/.bin/wrangler"
+}
+run_pnpm() { return 0; }
+`);
+  await writeFile(
+    path.join(inventoryRoot, 'package.json'),
+    '{"name":"fixture-insumos","private":true,"packageManager":"pnpm@9.15.4"}\n',
+  );
+  await writeFile(path.join(inventoryRoot, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n");
+  await writeFile(path.join(inventoryRoot, 'wrangler.toml'), 'name = "fixture-insumos"\n');
+
+  return {
+    fixtureRoot,
+    helperPath,
+    installCounter,
+    failureSentinel,
+    dependencyRoot,
+    env: {
+      ...process.env,
+      CRM_INSUMOS_DEPENDENCY_STATE_FILE: path.join(dependencyRoot, 'dependency-key.sha256'),
+      CRM_INSUMOS_DEPENDENCY_LOCK_FILE: path.join(dependencyRoot, 'install.lock'),
+      CRM_INSUMOS_DEPENDENCY_CACHE_ROOT: path.join(dependencyRoot, 'cache'),
+      INSUMOS_TEST_INSTALL_COUNTER: installCounter,
+      INSUMOS_TEST_FAILURE_SENTINEL: failureSentinel,
+    },
+  };
+}
+
+test('Insumos dependencies publish once behind a shared lock for concurrent runtimes', async (t) => {
+  const fixture = await makeInsumosDependencyFixture();
+  t.after(() => rm(fixture.fixtureRoot, { recursive: true, force: true }));
+  const env = { ...fixture.env, INSUMOS_TEST_INSTALL_DELAY: '0.2' };
+
+  const [first, second] = await Promise.all([
+    spawnBash(fixture.helperPath, env),
+    spawnBash(fixture.helperPath, env),
+  ]);
+
+  assert.equal(first.status, 0, `${first.stdout}\n${first.stderr}`);
+  assert.equal(second.status, 0, `${second.stdout}\n${second.stderr}`);
+  assert.equal(await readFile(fixture.installCounter, 'utf8'), '1\n');
+  const dependencyKey = (await readFile(env.CRM_INSUMOS_DEPENDENCY_STATE_FILE, 'utf8')).trim();
+  assert.match(dependencyKey, /^[a-f0-9]{64}$/);
+  const expectedModules = path.join(env.CRM_INSUMOS_DEPENDENCY_CACHE_ROOT, dependencyKey, 'node_modules');
+  assert.equal(
+    path.resolve(path.dirname(path.join(fixture.fixtureRoot, 'inventory', 'node_modules')), await readlink(path.join(fixture.fixtureRoot, 'inventory', 'node_modules'))),
+    expectedModules,
+  );
+  assert.equal(
+    await readFile(
+      path.join(env.CRM_INSUMOS_DEPENDENCY_CACHE_ROOT, dependencyKey, '.skincos-dependency-key.sha256'),
+      'utf8',
+    ),
+    `${dependencyKey}\n`,
+  );
+});
+
+test('Insumos dependencies quarantine an interrupted unpublished candidate before retry', async (t) => {
+  const fixture = await makeInsumosDependencyFixture();
+  t.after(() => rm(fixture.fixtureRoot, { recursive: true, force: true }));
+  const env = { ...fixture.env, INSUMOS_TEST_FAIL_ONCE: '1' };
+
+  const interrupted = await spawnBash(fixture.helperPath, env);
+  assert.notEqual(interrupted.status, 0);
+  assert.match(interrupted.stderr, /unpublished candidate will be quarantined/i);
+
+  const recovered = await spawnBash(fixture.helperPath, env);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  assert.match(recovered.stderr, /Preserved an interrupted dependency candidate/);
+  assert.equal(await readFile(fixture.installCounter, 'utf8'), '2\n');
+  const quarantined = await readdir(path.join(env.CRM_INSUMOS_DEPENDENCY_CACHE_ROOT, 'quarantine'));
+  assert.equal(quarantined.length, 1);
+});
+
+test('PostgreSQL runtime identity is deterministic and distinct by CRM_RUNTIME_ID', () => {
+  const adapter = whatsappAdapterPath.replaceAll('\\', '/');
+  const result = spawnSync('bash', ['-lc', `
+set -euo pipefail
+CRM_LOCAL_WA_LIBRARY_ONLY=1 source '${adapter}'
+first="$(crm_local_wa_runtime_database_name crm-local--atendimento--gestor)"
+repeat="$(crm_local_wa_runtime_database_name crm-local--atendimento--gestor)"
+second="$(crm_local_wa_runtime_database_name crm-local--atendimento--consultor)"
+printf '%s\\n%s\\n%s\\n' "$first" "$repeat" "$second"
+`], { encoding: 'utf8' });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const [first, repeat, second] = result.stdout.trim().split('\n');
+  assert.match(first, /^skincos_crm_local_[a-f0-9]{20}$/);
+  assert.equal(repeat, first);
+  assert.notEqual(second, first);
+});
+
+test('PostgreSQL runtime database creation is serialized and atomically reused', async (t) => {
+  const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), 'crm-local-postgres-isolation-'));
+  const fakeBin = path.join(fixtureRoot, 'bin');
+  const fakeDatabaseState = path.join(fixtureRoot, 'databases');
+  const runtimeHome = path.join(fixtureRoot, 'runtime');
+  const harnessPath = path.join(fixtureRoot, 'prepare.sh');
+  const createdbLog = path.join(fixtureRoot, 'createdb.log');
+  t.after(() => rm(fixtureRoot, { recursive: true, force: true }));
+
+  await mkdir(fakeBin, { recursive: true });
+  await mkdir(fakeDatabaseState, { recursive: true });
+  await mkdir(runtimeHome, { recursive: true });
+
+  const fakePsql = `#!/usr/bin/env bash
+set -euo pipefail
+database_url=""
+command_text=""
+runtime_id=""
+file_input=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dbname) shift; database_url="$1" ;;
+    --dbname=*) database_url="\${1#--dbname=}" ;;
+    --command) shift; command_text="$1" ;;
+    --command=*) command_text="\${1#--command=}" ;;
+    --set) shift; [[ "$1" == runtime_id=* ]] && runtime_id="\${1#runtime_id=}" ;;
+    --set=runtime_id=*) runtime_id="\${1#--set=runtime_id=}" ;;
+    --file) shift; file_input="$1" ;;
+  esac
+  shift || true
+done
+database_name="$(printf '%s' "$database_url" | sed -E 's#^postgresql://[^@/]*@?/([^?]+).*$#\\1#')"
+if [[ "$command_text" == *"select 1 from pg_database"* ]]; then
+  requested="$(printf '%s' "$command_text" | sed -E "s/.*datname = '([^']+)'.*/\\1/")"
+  [[ -d "$FAKE_DB_STATE/$requested" ]] && printf '1\\n'
+elif [[ "$command_text" == *"current_database()"* ]]; then
+  printf '%s|off\\n' "$database_name"
+elif [[ "$command_text" == *"select runtime_id from public.skincos_crm_local_runtime"* ]]; then
+  [[ -f "$FAKE_DB_STATE/$database_name/runtime-id" ]] && cat "$FAKE_DB_STATE/$database_name/runtime-id"
+elif [[ "$command_text" == alter\\ database*rename\\ to* ]]; then
+  source_name="$(printf '%s' "$command_text" | awk '{print $3}')"
+  target_name="$(printf '%s' "$command_text" | awk '{print $6}')"
+  [[ ! -e "$FAKE_DB_STATE/$target_name" ]]
+  mv "$FAKE_DB_STATE/$source_name" "$FAKE_DB_STATE/$target_name"
+elif [[ "$file_input" == "-" ]]; then
+  cat >/dev/null
+  printf '%s\\n' "$runtime_id" > "$FAKE_DB_STATE/$database_name/runtime-id"
+else
+  cat > "$FAKE_DB_STATE/$database_name/dump.sql"
+fi
+`;
+  const fakeCreatedb = `#!/usr/bin/env bash
+set -euo pipefail
+database_name="\${!#}"
+mkdir "$FAKE_DB_STATE/$database_name"
+printf '%s\\n' "$database_name" >> "$FAKE_CREATEDB_LOG"
+sleep 0.2
+`;
+  const fakeDropdb = `#!/usr/bin/env bash
+set -euo pipefail
+database_name="\${!#}"
+rm -rf "$FAKE_DB_STATE/$database_name"
+`;
+  const fakePgDump = `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' 'fixture dump'
+`;
+
+  for (const [name, content] of [
+    ['psql', fakePsql],
+    ['createdb', fakeCreatedb],
+    ['dropdb', fakeDropdb],
+    ['pg_dump', fakePgDump],
+  ]) {
+    const target = path.join(fakeBin, name);
+    await writeFile(target, content);
+    await chmod(target, 0o755);
+  }
+
+  const adapter = whatsappAdapterPath.replaceAll('\\', '/');
+  await writeFile(harnessPath, `#!/usr/bin/env bash
+set -euo pipefail
+export CRM_LOCAL_WA_LIBRARY_ONLY=1
+export CRM_LOCAL_WA_PSQL_BIN="$FAKE_BIN/psql"
+export CRM_LOCAL_WA_CREATEDB_BIN="$FAKE_BIN/createdb"
+export CRM_LOCAL_WA_DROPDB_BIN="$FAKE_BIN/dropdb"
+export CRM_LOCAL_WA_PG_DUMP_BIN="$FAKE_BIN/pg_dump"
+source '${adapter}'
+crm_local_wa_run_as() {
+  shift
+  "$@"
+}
+RUNTIME_HOME="$FAKE_RUNTIME_HOME"
+RUN_AS_USER=admin
+database_name="$(crm_local_wa_runtime_database_name "$TEST_RUNTIME_ID")"
+crm_local_wa_prepare_runtime_database "$database_name" "$TEST_RUNTIME_ID"
+`);
+  await chmod(harnessPath, 0o755);
+
+  const runtimeId = 'crm-local--atendimento--gestor';
+  const testEnv = {
+    ...process.env,
+    FAKE_BIN: fakeBin,
+    FAKE_DB_STATE: fakeDatabaseState,
+    FAKE_CREATEDB_LOG: createdbLog,
+    FAKE_RUNTIME_HOME: runtimeHome,
+    TEST_RUNTIME_ID: runtimeId,
+  };
+  const [first, second] = await Promise.all([
+    spawnBash(harnessPath, testEnv),
+    spawnBash(harnessPath, testEnv),
+  ]);
+  assert.equal(first.status, 0, `${first.stdout}\n${first.stderr}`);
+  assert.equal(second.status, 0, `${second.stdout}\n${second.stderr}`);
+
+  const databaseNameResult = spawnSync('bash', ['-lc', `
+CRM_LOCAL_WA_LIBRARY_ONLY=1 source '${adapter}'
+crm_local_wa_runtime_database_name '${runtimeId}'
+`], { encoding: 'utf8' });
+  assert.equal(databaseNameResult.status, 0, databaseNameResult.stderr);
+  const databaseName = databaseNameResult.stdout.trim();
+  assert.equal(
+    (await readFile(createdbLog, 'utf8')).trim().split('\n').length,
+    1,
+    'the shared runtime lock must publish the database only once',
+  );
+  assert.equal(
+    await readFile(path.join(fakeDatabaseState, databaseName, 'runtime-id'), 'utf8'),
+    `${runtimeId}\n`,
+  );
+  assert.equal(
+    (await readFile(path.join(fakeDatabaseState, databaseName, 'dump.sql'), 'utf8')).trim(),
+    'fixture dump',
+  );
+  const entries = await readFile(createdbLog, 'utf8');
+  assert.doesNotMatch(entries, /_tmp_.*\n.*_tmp_/);
+});
+
+function toWindowsPath(sourcePath) {
+  if (process.platform === 'win32') {
+    return sourcePath;
+  }
+  const result = spawnSync('wslpath', ['-w', sourcePath], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test('browser launcher accepts only loopback URLs and profiles inside the private runtime', () => {
+  const scriptPath = toWindowsPath(browserLauncherPath);
+  const validProfile =
+    'C:\\CodexRuntime\\operator\\admin\\skincos\\runtime\\crm-local\\instances\\test\\browser-profile';
+  const validResult = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-Url',
+      'http://127.0.0.1:8791/?module=atendimento',
+      '-ProfilePath',
+      validProfile,
+      '-DryRun',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(validResult.status, 0, `${validResult.stdout}\n${validResult.stderr}`);
+  assert.match(validResult.stdout, /msedge\.exe|chrome\.exe/i);
+
+  const remoteResult = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-Url',
+      'https://crm.skincos.com.br/',
+      '-ProfilePath',
+      validProfile,
+      '-DryRun',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(remoteResult.status, 0);
+  assert.match(remoteResult.stderr, /host loopback/);
+
+  const outsideProfileResult = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-Url',
+      'http://localhost:8791/',
+      '-ProfilePath',
+      'C:\\Temp\\crm-browser-profile',
+      '-DryRun',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(outsideProfileResult.status, 0);
+  assert.match(outsideProfileResult.stderr, /runtime privado/);
+});


### PR DESCRIPTION
## Resumo
- expõe `CRM – Local` como ação direta e `CRM – Módulos` como seletor explícito, sem a superfície genérica `Local`
- adiciona catálogo extensível com 14 módulos Gestor e Atendimento/Ponto Consultor
- isola portas, PID, logs, estado, auth, browser e banco por papel/módulo
- implementa build automático determinístico, reutilização exata, locks/CAS, recuperação de órfãos e colisão fail-closed
- publica dependências do Insumos atomicamente em cache privado compartilhado por snapshot
- preserva o gate rígido do CRM completo e só abre o navegador após aprovação

## Validação
- launcher/isolation: 49/49
- frontend Vitest: 196/196
- frontend typecheck: verde
- frontend build/budget: verde (560,5 KiB inicial)
- CRM API: 143/143
- catálogo/atalhos: 6 ações superiores + 16 atalhos modulares, nomes e portas únicos
- PowerShell, Bash, TOML e `git diff --check`: verdes
- runtime: 16/16 combinações aprovadas; Gestor/Consultor simultâneos; reuse, rebuild seletivo, colisão e órfão validados
- CRM completo: gate dos 14 módulos verde e reuso sem rebuild

## Operação
- nenhum deploy de produção; mudança é de launcher/runtime local
- atalhos do Windows serão reinstalados a partir do commit mesclado