### PR TITLE
fix(livia): reconcile persisted audit contracts

### DIFF
--- a/orb/engine/scripts/livia/qa-runner.js
+++ b/orb/engine/scripts/livia/qa-runner.js
@@ -126,6 +126,51 @@ function firstSubmitted(rows, keys) {
   return '';
 }
 
+function auditTargetKey(target) {
+  return `${String(target?.platform || '').trim().toLowerCase()}/${String(target?.unit || '').trim().toLowerCase()}`;
+}
+
+function reconcileAuditTargets(runData, derivedTargets) {
+  const collected = executionItems(runData, 'Collect Publish Results')[0]?.json || {};
+  const persistedTargets = collected?.publishVerification?.targets;
+  if (!Array.isArray(persistedTargets) || !persistedTargets.length) return derivedTargets;
+
+  const persistedByKey = new Map();
+  for (const target of persistedTargets) {
+    const key = auditTargetKey(target);
+    if (key === '/' || persistedByKey.has(key)) {
+      throw new Error(`Collect Publish Results has an ambiguous persisted verification target: ${key}.`);
+    }
+    persistedByKey.set(key, target);
+  }
+
+  if (persistedByKey.size !== derivedTargets.length) {
+    throw new Error(`Collect Publish Results verification target count (${persistedByKey.size}) does not match reconstructed HTTP targets (${derivedTargets.length}).`);
+  }
+
+  return derivedTargets.map((derived) => {
+    const key = auditTargetKey(derived);
+    const persisted = persistedByKey.get(key);
+    if (!persisted) throw new Error(`Collect Publish Results is missing persisted verification target: ${key}.`);
+
+    for (const field of ['providerObjectId', 'providerMediaId']) {
+      const derivedValue = String(derived[field] || '').trim();
+      const persistedValue = String(persisted[field] || '').trim();
+      if (derivedValue && persistedValue && derivedValue !== persistedValue) {
+        throw new Error(`Persisted verification target ${key} has a conflicting ${field}.`);
+      }
+    }
+
+    return {
+      ...derived,
+      expected: persisted.expected && typeof persisted.expected === 'object' ? persisted.expected : derived.expected,
+      submitted: persisted.submitted && typeof persisted.submitted === 'object' ? persisted.submitted : derived.submitted,
+      accessibilityContract: persisted.accessibilityContract,
+      mediaEvidenceContract: persisted.mediaEvidenceContract,
+    };
+  });
+}
+
 function buildAuditTargets(runData) {
   const prepared = executionItems(runData, 'Prepare HTTP Publish Request').map((item) => item.json || {});
   const responses = executionItems(runData, 'HTTP Request').map((item) => item.json || {});
@@ -178,7 +223,7 @@ function buildAuditTargets(runData) {
     tokenOverrides[platform] ||= {};
     tokenOverrides[platform][unit] ||= token;
   }
-  return { jobs, targets, tokenOverrides };
+  return { jobs, targets: reconcileAuditTargets(runData, targets), tokenOverrides };
 }
 
 function extractNodeParameters(runData, nodeName) {
@@ -1048,6 +1093,7 @@ module.exports = {
   ACCESSIBILITY_VERIFIER_MARKERS,
   driveAuditForExecution,
   notificationForExecution,
+  reconcileAuditTargets,
   readSelectedEnvironmentFile,
   verifierEnvironment,
   buildGraphReplayEnvironment,

--- a/orb/engine/tests/livia-qa-runner.test.js
+++ b/orb/engine/tests/livia-qa-runner.test.js
@@ -10,6 +10,7 @@ const {
   ACCESSIBILITY_VERIFIER_MARKERS,
   driveAuditForExecution,
   notificationForExecution,
+  reconcileAuditTargets,
   verifierEnvironment,
   buildGraphReplayEnvironment,
 } = require('../scripts/livia/qa-runner');
@@ -64,6 +65,54 @@ test('qa audit reads the notification node that actually executed', () => {
   assert.equal(result.nodeName, 'Inform Success (2)');
   assert.equal(result.notification.ok, true);
   assert.equal(result.notification.result.message_id, 42);
+});
+
+test('qa audit reconciles persisted media and accessibility contracts by platform and unit', () => {
+  const accessibilityContract = {
+    schema: 'livia.media-alt-text.v1',
+    orderedBy: 'groupOrder',
+    items: [{ sourceMediaId: 'media-1', semanticJobKey: 'livia:v2:one', mediaKind: 'video', support: 'unsupported' }],
+  };
+  const mediaEvidenceContract = {
+    schema: 'livia.media-evidence.v1',
+    orderedBy: 'groupOrder',
+    items: [{ sourceMediaId: 'media-1', semanticJobKey: 'livia:v2:one', providerMediaId: 'remote-1', mediaKind: 'video', groupOrder: 0 }],
+  };
+  const runData = {
+    'Collect Publish Results': [{ data: { main: [[{ json: { publishVerification: { targets: [{
+      platform: 'instagram',
+      unit: 'bss',
+      providerObjectId: 'object-1',
+      providerMediaId: 'remote-1',
+      expected: { caption: 'persisted caption' },
+      submitted: { coverUrl: 'https://media.example.test/cover.jpg' },
+      accessibilityContract,
+      mediaEvidenceContract,
+    }] } } }]] } }],
+  };
+  const [target] = reconcileAuditTargets(runData, [{
+    platform: 'instagram',
+    unit: 'bss',
+    providerObjectId: 'object-1',
+    providerMediaId: 'remote-1',
+    expected: { caption: 'derived caption' },
+    submitted: {},
+  }]);
+  assert.deepEqual(target.accessibilityContract, accessibilityContract);
+  assert.deepEqual(target.mediaEvidenceContract, mediaEvidenceContract);
+  assert.equal(target.expected.caption, 'persisted caption');
+  assert.equal(target.submitted.coverUrl, 'https://media.example.test/cover.jpg');
+});
+
+test('qa audit fails closed when the persisted target conflicts with the HTTP reconstruction', () => {
+  const runData = {
+    'Collect Publish Results': [{ data: { main: [[{ json: { publishVerification: { targets: [{
+      platform: 'instagram', unit: 'bss', providerObjectId: 'different-object', providerMediaId: 'remote-1',
+    }] } } }]] } }],
+  };
+  assert.throws(() => reconcileAuditTargets(runData, [{
+    platform: 'instagram', unit: 'bss', providerObjectId: 'object-1', providerMediaId: 'remote-1',
+  }]), /conflicting providerObjectId/);
 });
 
 test('qa audit exposes legacy carousel Drive marks that silently omitted child files', () => {


### PR DESCRIPTION
## What changed
- Reconcile the immutable Collect Publish Results target records with the independently reconstructed HTTP targets.
- Preserve the persisted accessibility and media-evidence contracts for the external verifier.
- Fail closed on missing, ambiguous, or conflicting persisted targets.

## Root cause
The independent Livia QA audit rebuilt targets only from HTTP nodes and silently discarded persisted contracts. It therefore produced false ailed delivery states after an otherwise verified production run.

## Validation
- node --check scripts/livia/qa-runner.js
- node --test tests/livia-qa-runner.test.js (8 passing)
- npm run livia:qa:test (22 passing)