### PR TITLE
fix(livia): reconcile publish history identity

### DIFF
--- a/orb/engine/scripts/apply-livia-runtime-isolation.js
+++ b/orb/engine/scripts/apply-livia-runtime-isolation.js
@@ -115,6 +115,18 @@ async function main() {
         WHERE id=$9`,
       [JSON.stringify(candidate.nodes), JSON.stringify(candidate.connections), JSON.stringify(candidate.settings || parseJson(row.settings, {})), JSON.stringify(candidate.meta || parseJson(row.meta, {})), nextVersion, nextVersion, Number(row.versionCounter) + 1, now, WORKFLOW_ID],
     );
+    // n8n's publish-history identity can be stale after a restore.  Reconcile
+    // it inside the same transaction and lock writers so this isolated
+    // promotion cannot either collide with a historical record or advance a
+    // different workflow's history concurrently.
+    await client.query('LOCK TABLE n8n_runtime.workflow_publish_history IN SHARE ROW EXCLUSIVE MODE');
+    await client.query(
+      `SELECT setval(
+        pg_get_serial_sequence('n8n_runtime.workflow_publish_history', 'id')::regclass,
+        (SELECT COALESCE(MAX(id), 0) FROM n8n_runtime.workflow_publish_history),
+        true
+      )`,
+    );
     await client.query(
       `INSERT INTO n8n_runtime.workflow_published_version ("workflowId","publishedVersionId","createdAt","updatedAt")
        VALUES ($1,$2,$3,$3)

--- a/orb/engine/tests/livia-runtime-isolation.test.js
+++ b/orb/engine/tests/livia-runtime-isolation.test.js
@@ -12,6 +12,7 @@ const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
 const RELEASE = 'c525f5e1d68829fe4c93197f65d85429a2e0385c';
 const RELEASE_ROOT = `/opt/skincos/releases/${RELEASE}/source/orb/engine`;
 const PATCHER = path.resolve(__dirname, '..', 'scripts', 'patch-livia-runtime-isolation.js');
+const APPLIER = path.resolve(__dirname, '..', 'scripts', 'apply-livia-runtime-isolation.js');
 
 function commandNode(name, command) {
   return { name, type: 'n8n-nodes-base.executeCommand', parameters: { command } };
@@ -50,4 +51,11 @@ test('runtime isolation replaces a mutable verifier wrapper with the pinned entr
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
   }
+});
+
+test('runtime isolation reconciles a stale publish-history identity under a writer lock', () => {
+  const source = fs.readFileSync(APPLIER, 'utf8');
+  assert.match(source, /LOCK TABLE n8n_runtime\.workflow_publish_history IN SHARE ROW EXCLUSIVE MODE/);
+  assert.match(source, /pg_get_serial_sequence\('n8n_runtime\.workflow_publish_history', 'id'\)::regclass/);
+  assert.match(source, /COALESCE\(MAX\(id\), 0\)/);
 });


### PR DESCRIPTION
## What changed
- Reconcile the n8n publish-history identity under a writer lock before an isolated Livia version promotion.
- Prevent restored or stale sequence state from colliding with historical workflow publish records.
- Add a regression test for the transaction guard.

## Root cause
A production promotion correctly aborted because the identity counter was behind the persisted history. The workflow version did not change.

## Validation
- node --check scripts/apply-livia-runtime-isolation.js
- node --test tests/livia-runtime-isolation.test.js
- npm run livia:qa:test (22 passing)