### PR TITLE
fix(crm): isolate Finance local runtime manifest

### DIFF
--- a/finance/test/local-fixture.test.mjs
+++ b/finance/test/local-fixture.test.mjs
@@ -65,3 +65,10 @@ test('local Finance launcher preserves the module grant when exercising only the
   assert.doesNotMatch(source, /disabled\|no-module\) LOCAL_MODULES='' ;;/);
   assert.match(source, /curl -sS --connect-timeout 1 --max-time 1/);
 });
+
+test('local Finance launcher isolates its CRM manifest from the full Gestor runtime', async () => {
+  const source = await readFile(launcher, 'utf8');
+  assert.equal((source.match(/CRM_RUNTIME_ROOT="\$RUNTIME_ROOT\/crm"/g) || []).length, 2);
+  assert.equal((source.match(/CRM_RUNTIME_MODULE=finance/g) || []).length, 2);
+  assert.equal((source.match(/CRM_RUNTIME_ID=finance-local--crm/g) || []).length, 2);
+});

--- a/scripts/run-local-finance.sh
+++ b/scripts/run-local-finance.sh
@@ -143,7 +143,9 @@ if [[ "$STOP_ONLY" == 1 ]]; then
   gateway_pid="$(state_value gateway_pid)"
   if [[ "$gateway_pid" =~ ^[0-9]+$ ]] && belongs_to_finance_gateway "$gateway_pid"; then terminate_tree "$gateway_pid"; fi
   rm -f "$STATE_FILE"
-  CRM_VITE_PORT="${CRM_VITE_PORT}" CRM_PAGES_PORT="${CRM_PAGES_PORT}" CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 CRM_PID_FILE="$CRM_PID_FILE" CRM_LOG_FILE="$CRM_LOG_FILE" "$ROOT_DIR/scripts/run-local-crm.sh" --stop || true
+  CRM_PERSONA=GESTOR CRM_RUNTIME_MODULE=finance CRM_RUNTIME_ID=finance-local--crm CRM_RUNTIME_ROOT="$RUNTIME_ROOT/crm" \
+    CRM_VITE_PORT="${CRM_VITE_PORT}" CRM_PAGES_PORT="${CRM_PAGES_PORT}" CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_WITH_WHATSAPP=0 \
+    CRM_PID_FILE="$CRM_PID_FILE" CRM_LOG_FILE="$CRM_LOG_FILE" "$ROOT_DIR/scripts/run-local-crm.sh" --stop || true
   echo 'Financeiro local finalizado.'
   exit 0
 fi
@@ -293,6 +295,7 @@ echo "[finance-local] Iniciando CRM Pages local para cenário $SCENARIO"
   CRM_WITH_WHATSAPP=0 CRM_WITH_INSUMOS=0 CRM_WITH_TIMEKEEPING=0 CRM_GATE_STRICT=0 CRM_BUILD_BEFORE_START="${FINANCE_CRM_BUILD_BEFORE_START:-1}" \
   LOCAL_AUTH_TEST_USER_ADMIN=false LOCAL_AUTH_USERNAME="$LOCAL_FINANCE_ACTOR" LOCAL_AUTH_EMAIL="${LOCAL_FINANCE_ACTOR}@localhost" LOCAL_AUTH_NAME='Finance Local' \
   LOCAL_AUTH_ALLOWED_MODULES="$LOCAL_MODULES" LOCAL_AUTH_ALLOWED_UNITS="$LOCAL_UNITS" \
+  CRM_PERSONA=GESTOR CRM_RUNTIME_MODULE=finance CRM_RUNTIME_ID=finance-local--crm CRM_RUNTIME_ROOT="$RUNTIME_ROOT/crm" \
   LOCAL_FINANCE_API_TARGET="http://127.0.0.1:${GATEWAY_PORT}" LOCAL_FINANCE_ACTOR="$LOCAL_FINANCE_ACTOR" LOCAL_FINANCE_CSRF_TOKEN=finance-local-csrf \
   setsid "$ROOT_DIR/scripts/run-local-crm.sh" --module finance --without-whatsapp --no-browser
 ) >>"$CRM_LOG_FILE" 2>&1 &


### PR DESCRIPTION
# Summary

Isola o subruntime CRM do Financeiro em seu proprio FINANCE_LOCAL_RUNTIME_ROOT. O stop do Financeiro nao sobrescreve mais o manifesto gestor/full antes de CrmLocalStop encerrar o CRM canonico.

Regressao encontrada na validacao pos-merge da PR #925: o launcher financeiro herdava o default modular do CRM e gravava no manifesto do shell completo.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [x] Performance impact measured

## Links
- Issue:
- Design/ADR:
- Migration steps: none; local runtime only

## Screenshots / Evidence
- Bash syntax: pass
- Finance local fixture suite: 4/4 pass
- Real stop harness: full Gestor manifest hash unchanged; isolated finance-local--crm manifest written under the private Finance runtime
- Deploy: not applicable; this changes only a local launcher