### PR TITLE
fix(ponto): skip watchdog on successful coordinators

### DIFF
--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -138,6 +138,29 @@ test("watchdog rejects first-attempt success, non-main source, and event/API dri
   })));
 });
 
+test("watchdog workflow skips a successful first-attempt coordinator before provenance validation", () => {
+  const workflowText = fs.readFileSync(
+    new URL("../workflows/ponto-release-watchdog.yml", import.meta.url),
+    "utf8",
+  );
+  const contextJob = workflowText.slice(
+    workflowText.indexOf("  context:"),
+    workflowText.indexOf("  latch:"),
+  );
+  assert.match(contextJob, /github\.run_attempt == 1/);
+  assert.match(contextJob, /github\.event\.workflow_run\.run_attempt > 1/);
+  for (const conclusion of ["failure", "cancelled", "timed_out"]) {
+    assert.match(
+      contextJob,
+      new RegExp(`github\\.event\\.workflow_run\\.conclusion == '${conclusion}'`),
+    );
+  }
+  assert.doesNotMatch(
+    contextJob,
+    /github\.event\.workflow_run\.conclusion == 'success'/,
+  );
+});
+
 test("watchdog never rolls back after failed child reconciliation", () => {
   const workflowText = fs.readFileSync(
     new URL("../workflows/ponto-release-watchdog.yml", import.meta.url),

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -12,7 +12,16 @@ permissions:
 
 jobs:
   context:
-    if: ${{ github.run_attempt == 1 }}
+    if: >-
+      ${{
+        github.run_attempt == 1
+        && (
+          github.event.workflow_run.run_attempt > 1
+          || github.event.workflow_run.conclusion == 'failure'
+          || github.event.workflow_run.conclusion == 'cancelled'
+          || github.event.workflow_run.conclusion == 'timed_out'
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,36 @@
 # DECISIONS
 
+## 2026-07-30 - Accept the complete preview but keep staging closed
+
+- Decision: PR #930's merge
+  `71c54b1d406317c614dc33e48ced170458fbd707` and coordinator run
+  `30566547605` are the first complete four-surface Ponto preview. The
+  Timekeeping, Identity/Inventory, Core API and CRM Pages children all used
+  that exact SHA and completed their non-mutating publishers. Combined evidence
+  artifact `8769249449` and sanitized run ledger `8769249808` are the canonical
+  hosted records; private checkpoint
+  `C:\CodexRuntime\operator\admin\skincos\ponto-release\checkpoints\20260730T144137-20-complete-preview.md`
+  retains every artifact digest.
+- Decision: the preview proves build/test/dry-run lineage only. It does not
+  authorize staging and does not prove a migration, live deployment,
+  module-control transition, authenticated journey, rollback, pilot, canary,
+  external SLO or production use.
+- Decision: the workflow-run watchdog must skip a successful first-attempt
+  coordinator before provenance validation. It continues to admit
+  failure/cancelled/timed-out first attempts and every rerun, including a
+  successful unauthorized rerun. Run `30567091382` proved the missing
+  admission predicate; all emergency jobs skipped and no mutation occurred.
+- Decision: staging remains fail-closed until independent deployment approval,
+  approved target-specific secret custody, the policy-pinned close-only broker,
+  split-custody WAF enforcement and external probes, Ponto resource selectors,
+  clinic JIT runner, Identity/Workforce-authorized cohort and external SLO
+  monitoring are all functional. Existing Cloudflare resources are not release
+  authority, and the four `ENABLE_PONTO_*` flags remain false/absent.
+- Impact: if `main` advances after this evidence, the coordinator contract
+  requires a fresh preview on the new exact `GITHUB_SHA`; the ancestral run
+  cannot become a staging predecessor. Both environments remain
+  `module-control:timekeeping=maintenance`.
+
 ## 2026-07-30 - Use canonical REST workflow paths and static workflow metadata
 
 - Decision: GitHub REST workflow-run provenance compares `run.path` with the

--- a/TASKS.md
+++ b/TASKS.md
@@ -223,7 +223,8 @@ jornada autenticada atual continue válida.
   fixa todos os digests. Foi dry-run: nenhuma superfície live, migration,
   escrita D1/KV ou module-control mudou. Staging continua bloqueado pelos
   predecessores externos abaixo; qualquer avanço de `main` exige novo preview.
-- [ ] Integrar a correção bounded de admissão do watchdog e repetir o preview.
+- [ ] Integrar pela PR #931 a correção bounded de admissão do watchdog e
+  repetir o preview no SHA exato do merge.
   O coordenador bem-sucedido `30566547605` disparou automaticamente o watchdog
   `30567091382`; o context job `90954219518` falhou porque o job admitiu um
   first attempt `success` que o validador corretamente recusa. Todos os jobs de

--- a/TASKS.md
+++ b/TASKS.md
@@ -198,7 +198,7 @@ jornada autenticada atual continue válida.
   encontrou major issue no head exato
   `019a34367f3e2e40387b3f50da74b35149ff5981`, que integrou sem bypass como
   `77f241ec20f8956fc7e9b20dd2b373518dafa7be`.
-- [ ] Integrar a sucessora de ativação Corepack e repetir o `preview` no SHA
+- [x] Integrar a sucessora de ativação Corepack e repetir o `preview` no SHA
   exato resultante. O segundo replacement preview `30564873785` selecionou o
   merge #929 `77f241ec...`; Timekeeping child `30564915304` passou e publicou
   os artefatos `8768441812`
@@ -209,11 +209,29 @@ jornada autenticada atual continue válida.
   testes ou dry-run porque o Corepack incluído no Node 22.12 tentou resolver
   metadata de pnpm com uma signing key desatualizada (`Cannot find matching
   keyid`). Core API e CRM Pages foram pulados e nenhuma superfície live,
-  migration ou controle foi alterado. A sucessora lê o `packageManager` exato
+  migration ou controle foi alterado. A PR #930 lê o `packageManager` exato
   de `inventory/package.json`, executa `corepack prepare` para essa versão e
-  confirma `pnpm --version` antes do primeiro uso nos três jobs Identity.
-  `selected_release_sha` continua nulo até a sucessora integrar e um preview
-  completo das quatro superfícies terminar verde.
+  confirma `pnpm --version` antes do primeiro uso nos três jobs Identity. Seu
+  head `872f1b10c9bd64e1768fa0e8777d992e2658240b` passou 14/14 checks,
+  exact-head Codex review sem major issue e integrou sem bypass como
+  `71c54b1d406317c614dc33e48ced170458fbd707`. O preview completo
+  `30566547605` selecionou exatamente esse SHA; Timekeeping
+  `30566594811`, Identity/Inventory `30566729991`, Core API `30566806246` e
+  CRM Pages `30566905155` passaram. Artifacts `8769249449` e `8769249808`
+  retêm evidência combinada e ledger sanitizado; o checkpoint privado
+  `C:\CodexRuntime\operator\admin\skincos\ponto-release\checkpoints\20260730T144137-20-complete-preview.md`
+  fixa todos os digests. Foi dry-run: nenhuma superfície live, migration,
+  escrita D1/KV ou module-control mudou. Staging continua bloqueado pelos
+  predecessores externos abaixo; qualquer avanço de `main` exige novo preview.
+- [ ] Integrar a correção bounded de admissão do watchdog e repetir o preview.
+  O coordenador bem-sucedido `30566547605` disparou automaticamente o watchdog
+  `30567091382`; o context job `90954219518` falhou porque o job admitiu um
+  first attempt `success` que o validador corretamente recusa. Todos os jobs de
+  emergência foram pulados e nenhuma mutation ocorreu. A correção faz skip
+  somente de first-attempt success e continua admitindo failure, cancelled,
+  timed_out e qualquer rerun; o teste focado passa 9/9. O merge avançará
+  `main`, portanto o novo SHA exato precisa de preview completo antes de
+  staging.
 - [ ] Provisionar e atestar separadamente o broker de fechamento externo nos
   environments `ponto-emergency-staging` e `ponto-emergency-production`:
   secret `PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL` e variables
@@ -250,14 +268,13 @@ jornada autenticada atual continue válida.
   `CLOUDFLARE_ZONE_ID` foram criados como sete variables não secretas do
   repositório e lidos de volta individualmente. Eles estavam ausentes antes e
   foram conferidos contra os recursos Cloudflare live; valores ficam apenas no
-  checkpoint privado. A reconsulta live posterior não encontrou hoje os nomes
-  Ponto-only no repositório; as quatro flags `ENABLE_PONTO_*` também continuam
-  ausentes. O código consumidor está no `main`, mas ausência de qualquer nome
-  necessário falha fechada. Esses IDs não
-  selecionam candidato, não desfazem os fences legados, não implantam nem
-  habilitam o módulo. Pages geral continua usando `CRM_PAGES_PROJECT` /
+  checkpoint privado. A reconsulta live mais recente confirmou presentes por
+  nome os seis selectors Ponto-only e `CLOUDFLARE_ZONE_ID`; as quatro flags
+  `ENABLE_PONTO_*` continuam ausentes. Esses IDs não selecionam candidato, não
+  desfazem os fences legados, não implantam nem habilitam o módulo. Pages geral
+  continua usando `CRM_PAGES_PROJECT` /
   `CRM_PAGES_PROJECT_STAGING` nas definições antigas. A configuração deve ser
-  reprovisionada somente por custódia aprovada para o estágio autorizado.
+  alterada somente por custódia aprovada para o estágio autorizado.
 - [x] Revisar e integrar pela PR #924 o overlay
   `module-control:timekeeping:emergency-latch`: missing/unreadable/malformed ou
   `latched=true` nega; somente schema v1 explícito `latched=false` abre; o
@@ -390,12 +407,11 @@ jornada autenticada atual continue válida.
   `CLOUDFLARE_ZONE_ID` já está presente por nome como variable não secreta do
   repositório e teve readback no checkpoint 14; os três IDs das regras continuam
   ausentes e nenhuma regra foi criada ou alterada.
-  A listagem Cloudflare da zona mostrou somente rulesets managed; o GET do
-  custom entrypoint não foi autorizado. Tanto o browser interno do Codex quanto
-  o perfil Chrome existente chegaram somente ao login Cloudflare, sem sessão
-  autenticada; nenhuma credencial foi inserida e nenhuma mutação ocorreu. O
-  estado das regras continua não comprovado; o workflow com security token após
-  o merge deve atestá-lo, sem bypass no Worker. O secret
+  A listagem autenticada mais recente da zona mostrou somente rulesets managed
+  e nenhum `http_request_firewall_custom`; 12/12 probes externas falharam, logo
+  o enforcement necessário está funcionalmente ausente. O endpoint custom
+  ainda precisa do principal split-custody canônico para aplicar e reatestar as
+  regras sem bypass no Worker. O secret
   `PONTO_WAF_READ_API_TOKEN` deve ser somente do repositório e
   `PONTO_WAF_WRITE_API_TOKEN` somente do environment `production`; ambos estão
   não provisionados e não podem usar `CLOUDFLARE_SECURITY_API_TOKEN` como

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -185,8 +185,8 @@ A trava `timekeeping_period_guards` é adquirida por data antes do cálculo e im
 > `30527767707` é somente evidência fail-close. Mantenha os fences externos e
 > não despache staging antes de reviewer independente, custódia, broker, WAF,
 > runner/coorte e SLO externos. Watchdog `30567091382` expôs que first-attempt
-> success também entrava no job de contexto e gerava false-red; a correção
-> bounded pula somente esse caso e preserva failure/cancelled/timed-out e
+> success também entrava no job de contexto e gerava false-red; a PR #931 pula
+> somente esse caso e preserva failure/cancelled/timed-out e
 > reruns. Como o merge dessa correção avança `main`, execute novo preview no
 > SHA exato antes de usar qualquer predecessor.
 

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -173,17 +173,22 @@ A trava `timekeeping_period_guards` é adquirida por data antes do cálculo e im
 
 ## Deploy e rollback
 
-> Estado em 2026-07-30: os controles de replay, overlay de emergência,
-> mutex/watchdog e os nomes Ponto-only foram integrados pela PR #924 em
-> `91f6e9033fed8a186ef2e93be070db3ed896fdd3`. O primeiro preview
-> `30556924556` falhou no contrato REST de observação depois que o child
-> Timekeeping `30556988335` passou; PR #927 corrige path e nome dinâmico em
-> todas as validações REST, fixa `can_admins_bypass=false` no payload e está
-> com checks finais/re-review/merge e novo preview pendentes. Não há SHA
-> selecionado, provisioning externo nem prova live. Staging e produção continuam
-> `module-control:timekeeping=maintenance`; staging foi fechado pela execução
-> canônica `30527767707`, que é somente evidência fail-close, e os fences
-> externos registrados no checkpoint privado devem permanecer.
+> Estado em 2026-07-30: PRs #924/#927/#929/#930 integraram os controles e as
+> correções observadas sem bypass. O preview completo `30566547605` selecionou
+> exatamente o merge #930
+> `71c54b1d406317c614dc33e48ced170458fbd707`; Timekeeping
+> `30566594811`, Identity/Inventory `30566729991`, Core API `30566806246` e CRM
+> Pages `30566905155` passaram. Artifacts `8769249449` e `8769249808`
+> preservam a evidência combinada e o ledger sanitizado. Isso é dry-run, não
+> prova live nem autorização de staging. Staging e produção continuam
+> `module-control:timekeeping=maintenance`; a execução canônica
+> `30527767707` é somente evidência fail-close. Mantenha os fences externos e
+> não despache staging antes de reviewer independente, custódia, broker, WAF,
+> runner/coorte e SLO externos. Watchdog `30567091382` expôs que first-attempt
+> success também entrava no job de contexto e gerava false-red; a correção
+> bounded pula somente esse caso e preserva failure/cancelled/timed-out e
+> reruns. Como o merge dessa correção avança `main`, execute novo preview no
+> SHA exato antes de usar qualquer predecessor.
 
 Use somente `.github/workflows/ponto-progressive-release.yml` para a composição
 de release. O coordenador não publica por conta própria: ele despacha e atesta

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -58,8 +58,8 @@ runs the preview SHA.
 The successful coordinator triggered watchdog run `30567091382`; context job
 `90954219518` failed because workflow admission included successful
 first-attempt coordinators although the validator correctly rejects them.
-Every emergency job skipped and no live mutation occurred. The bounded
-correction skips only successful first attempts while preserving admission for
+Every emergency job skipped and no live mutation occurred. PR #931 skips only
+successful first attempts while preserving admission for
 failure, cancellation, timeout and every rerun; focused tests pass 9/9.
 
 Both module-control KVs are now maintenance. Timekeeping D1 journals contain
@@ -134,8 +134,8 @@ active external SLO evidence.
 
 The executable blockers, in required order, are:
 
-1. Integrate the bounded watchdog admission correction without bypass and
-   repeat the complete preview on its exact protected-main merge SHA. Preserve
+1. Merge PR #931 without bypass and repeat the complete preview on its exact
+   protected-main merge SHA. Preserve
    run `30566547605` and its retained artifacts as historical evidence, not as
    the predecessor after `main` advances. Historical child definitions cannot
    be rewritten, so the checkpointed fences and disabled legacy smokes remain

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -20,6 +20,11 @@ PR #929 then removed the invalid pnpm cache bootstrap. Its final head
 `019a34367f3e2e40387b3f50da74b35149ff5981` passed all 14 checks, Codex found
 no major issue on that exact head, and protected `main` merged it without
 bypass as `77f241ec20f8956fc7e9b20dd2b373518dafa7be`.
+PR #930 then prepared the exact `inventory/package.json` pnpm pin through
+Corepack before all three Identity jobs. Its final head
+`872f1b10c9bd64e1768fa0e8777d992e2658240b` passed all 14 checks, exact-head
+Codex review found no major issue, and protected `main` merged it without
+bypass as `71c54b1d406317c614dc33e48ced170458fbd707`.
 
 The first post-merge preview (`30556924556`) proved its source and completed
 Timekeeping child `30556988335`, but coordinator job `90919728697` failed
@@ -35,20 +40,37 @@ and Timekeeping child `30564915304` passed, with surface/promotion artifacts
 job `90947405936` before tests or dry-run because Node 22.12's bundled Corepack
 attempted direct pnpm metadata resolution with a stale signing key (`Cannot find
 matching keyid`). Core API and CRM Pages were skipped and no live mutation
-occurred. The bounded successor reads the exact Inventory `packageManager`,
-prepares that version explicitly and verifies the activated pnpm before use in
-all three Identity jobs. `selected_release_sha` remains null until that
-successor and a complete four-surface preview succeed; no live surface runs
-current `main`.
+occurred. PR #930 integrated the bounded exact-pin correction.
+
+Complete replacement preview `30566547605` then admitted exact protected-main
+SHA `71c54b1d406317c614dc33e48ced170458fbd707`. Source job `90952396490`,
+orchestrator job `90952445595`, and canonical children Timekeeping
+`30566594811`, Identity/Inventory `30566729991`, Core API `30566806246` and CRM
+Pages `30566905155` all succeeded. Combined evidence artifact `8769249449`
+and sanitized run ledger `8769249808` retain the exact four-surface evidence;
+private checkpoint
+`C:\CodexRuntime\operator\admin\skincos\ponto-release\checkpoints\20260730T144137-20-complete-preview.md`
+records every child artifact and digest. Preview was dry-run only: it did not
+deploy, migrate, write D1/KV, change module-control, select a pilot, execute an
+authenticated hosted journey or run pilot/canary/production. No live surface
+runs the preview SHA.
+
+The successful coordinator triggered watchdog run `30567091382`; context job
+`90954219518` failed because workflow admission included successful
+first-attempt coordinators although the validator correctly rejects them.
+Every emergency job skipped and no live mutation occurred. The bounded
+correction skips only successful first attempts while preserving admission for
+failure, cancellation, timeout and every rerun; focused tests pass 9/9.
 
 Both module-control KVs are now maintenance. Timekeeping D1 journals contain
 exactly `0001`–`0008` and Identity/Inventory exactly `0001`–`0018` in both
 environments. Timekeeping workers.dev/previews remain publicly enabled,
 readiness returns a false-positive `200/ready=true` during maintenance, staging
 Pages lacks its actor key, and 12/12 required WAF block probes failed across
-the two API hosts. Ruleset reads are unauthorized (403/code 10000), so hidden
-object state remains unproved. Identity/Workforce yields zero authorized
-eligible pilots and the repository has zero self-hosted runners.
+the two API hosts. The latest authenticated account inventory listed only
+managed rulesets and no custom `http_request_firewall_custom` ruleset; required
+edge enforcement is functionally absent. Identity/Workforce yields zero
+authorized eligible pilots and the repository has zero self-hosted runners.
 
 Scheduled production Ponto Smoke run `30521686413` at
 2026-07-30T07:04:44Z failed on all five attempts with the proxy target/actor
@@ -112,13 +134,12 @@ active external SLO evidence.
 
 The executable blockers, in required order, are:
 
-1. Integrate the bounded Corepack signing-key successor without bypass, then
-   repeat preview on its exact protected-main merge SHA. The #924/#927/#929
-   source package is already integrated; only the observed package-manager
-   activation order is changing. Historical child definitions cannot be
-   rewritten, so the
-   checkpointed fences and disabled legacy smokes remain until their exposure
-   expires or the governed release makes them irrelevant.
+1. Integrate the bounded watchdog admission correction without bypass and
+   repeat the complete preview on its exact protected-main merge SHA. Preserve
+   run `30566547605` and its retained artifacts as historical evidence, not as
+   the predecessor after `main` advances. Historical child definitions cannot
+   be rewritten, so the checkpointed fences and disabled legacy smokes remain
+   until their exposure expires or the governed release makes them irrelevant.
 2. An authorized Cloudflare security principal must inspect and attest the exact
    zone-scoped WAF block rules, create/enable them only if that inspection proves
    they are missing or disabled, and use the checkpointed
@@ -127,10 +148,12 @@ The executable blockers, in required order, are:
    `PONTO_WAF_HEADER_RULE_ID` and `PONTO_WAF_CONTRACT_RULE_ID`. The gate
    requires external 403 probes for both public version-selection headers and
    `/insumos/health/workforce-contract`; no Worker-side bypass is accepted.
-   The current connector listed only managed rulesets; GET on the custom
-   ruleset entrypoint was unauthorized, so rule existence and configuration
-   remain unproved. The post-merge security-token workflow still needs to
-   attest them. It requires repository-only `PONTO_WAF_READ_API_TOKEN` and
+   The authenticated Cloudflare account inventory listed only normalization,
+   managed-free and DDoS rulesets for zone
+   `9db33c5e42b507dcd7c5c83e54e6802d`; it found no custom
+   `http_request_firewall_custom` ruleset. The post-merge security-token
+   workflow still must create and attest the required rules through split
+   custody. It requires repository-only `PONTO_WAF_READ_API_TOKEN` and
    production-environment-only `PONTO_WAF_WRITE_API_TOKEN`; both are currently
    unprovisioned, and fallback to `CLOUDFLARE_SECURITY_API_TOKEN` is forbidden.
    The Codex in-app browser and the
@@ -167,13 +190,13 @@ The executable blockers, in required order, are:
 5. Provision the external close-only broker for each target and pin its
    reviewed URL, custody reference, response key ID and Ed25519 public key in
    policy. Each emergency environment needs its own credential and endpoint
-   metadata. Reprovision the Ponto-only D1/KV/Pages identifiers and keep all
-   four `ENABLE_PONTO_*` flags false until their authorized stage. The current
-   name-only inventory finds these inputs absent; a direct Cloudflare/KV
-   credential in an emergency environment is prohibited.
-6. Only after item 1 is merged and the WAF/staging custody inputs are present,
-   select the exact then-current `main` `GITHUB_SHA`, execute `preview` and then
-   `staging` using exactly the coordinator `GITHUB_SHA` on the current `main`.
+   metadata. The six Ponto-only D1/KV/Pages selectors and
+   `CLOUDFLARE_ZONE_ID` are present by name and match existing resources; keep
+   all four `ENABLE_PONTO_*` flags false until their authorized stage. A direct
+   Cloudflare/KV credential in an emergency environment is prohibited.
+6. Only after item 1 and items 2–5 plus the remaining staging inputs are
+   complete, select the exact then-current `main` `GITHUB_SHA` and use its
+   fresh successful `preview` before `staging`.
    The staging predecessor
    must include all four surfaces, checkpoints, additive migrations,
    maintenance/active transitions, authenticated CONSULTOR navigation and

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -44,7 +44,7 @@ provenance is invalid` because the workflow admitted every completed
 first-attempt coordinator while its validator intentionally accepts only
 failure/cancelled/timed-out first attempts or any unauthorized rerun. All
 emergency jobs skipped, so no latch, broker, rollback or live mutation ran.
-The bounded correction moves that contract to job admission: successful
+PR #931 moves that contract to job admission: successful
 first-attempt coordinators are skipped; failure, cancellation, timeout and
 every rerun remain governed. Focused watchdog tests pass 9/9. Because
 integrating this correction advances `main`, its exact merge SHA requires a

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,103 +1,81 @@
 # Current state
 
-## Workforce Timekeeping — pnpm successor #929 integrated; Corepack signing-key successor pending; release fail-closed — 2026-07-30T17:23:36Z
+## Workforce Timekeeping — complete four-surface preview; staging still fail-closed — 2026-07-30T17:41:30Z
 
-This is the authoritative Ponto entry and supersedes the older local-successor
-entries below. PR #924 integrated the post-#921 corrective package as
-`91f6e9033fed8a186ef2e93be070db3ed896fdd3`; its final reviewed head was
-`c35aaf6892fea8ad5ae5745a82be55f24bd5a342`. The merge had all required checks
-green, 20/20 review conversations resolved and the sealed security scans
-reported zero surviving findings. Unrelated PRs #925, #926 and #928 then
-advanced `main` to `46b97519adc056d31553531cf3f90ad5a324fc88`.
+This is the authoritative Ponto entry and supersedes the older release entries
+below. PR #924 integrated the post-#921 corrective package as
+`91f6e9033fed8a186ef2e93be070db3ed896fdd3`; PRs #927 and #929 then corrected
+the GitHub REST run contract and pnpm bootstrap. PR #930 closed the final
+observed Corepack signing-key failure: final head
+`872f1b10c9bd64e1768fa0e8777d992e2658240b` passed all 14 hosted checks,
+independent local security reviews found zero P0/P1/P2, Codex found no major
+issue on that exact head, and protected `main` merged it without bypass as
+`71c54b1d406317c614dc33e48ced170458fbd707`.
 
-The first canonical preview, run `30556924556` on `91f6e903...`, proved source
-admission and completed the Timekeeping child run `30556988335` successfully
-with preview artifacts, but coordinator job `90919728697` failed after a
-20-minute observation timeout. GitHub REST returns workflow-run `path` as the
-canonical file without `@refs/heads/main`; the merged code expected the suffix
-and did not recognize its own successful child. The same live evidence exposed
-a second P1: with `run-name`, REST `run.name` is dynamic, so watchdog run
-`30558653559` rejected the failed coordinator before its latch job.
+Coordinator run `30566547605` selected that exact `main` SHA and completed
+successfully. Source job `90952396490` and orchestrator job `90952445595`
+passed; recovery jobs were correctly skipped. All four canonical dry-run
+children completed on the same immutable SHA:
 
-PR #927 (`codex/admin/ponto-run-path-contract`, first corrective commit
-`4c895a4b`) fixes both contracts while retaining independent workflow ID/path,
-`main` branch, immutable SHA, repository, event, attempt, title/nonce,
-capability and predecessor checks. It also versions the stronger live
-staging/production environment baseline (custom `main`, owner reviewer,
-`prevent_self_review=true`, `can_admins_bypass=false`) so the weaker historical
-payload cannot be reapplied. Its initial published head
-`5b8447a70c30e7011a9a48099d8e1222b72e5992` passed all 14 hosted checks.
-Codex then found two P1s: the versioned environment payload omitted the
-administrator-bypass prohibition, and other REST validators still treated
-dynamic `run.name` as the static workflow name. Corrective commit `c3131eb8`
-sets and validates the non-bypassable environment payload, moves every static
-identity check to canonical workflow metadata and adds a regression guard.
-The full governed suite is now 219/219; actionlint 1.7.12, syntax, architecture,
-topology, progressive policy, module, governance, security exception and diff
-checks are green. Two independent read-only security reviews found no
-remaining P0/P1/P2 after the fixes. Final head
-`7d8945300903847167c0ba55234ab8458cfb240d` passed all 14 hosted checks; both
-review threads were resolved, and Codex re-reviewed that exact head without a
-major issue. PR #927 merged through protected `main`, without bypass, as
-`15ac662e0c3b01317d48270cd211d7910000ca5a`.
+- Timekeeping run `30566594811`, job `90952777570`, surface artifact
+  `8769104630` and promotion artifact `8769104027`;
+- Identity/Inventory run `30566729991`, job `90953095462`, surface artifact
+  `8769138110` and promotion artifact `8769137752`;
+- Core API run `30566806246`, job `90953342171`, surface artifact `8769175430`
+  and promotion artifact `8769175021`;
+- CRM Pages run `30566905155`, job `90953758618`, surface artifact
+  `8769241946` and promotion artifact `8769241662`.
 
-Replacement preview `30562834119` selected that exact merge SHA. Source
-admission succeeded and Timekeeping child `30562866947` completed, publishing
-surface artifact `8767637805`
-(`sha256:700a0e50241bd9272929cdcaf03166e0d800e24ebce1a7c0a81caab94df3c1fa`)
-and promotion artifact `8767637318`
-(`sha256:a42e0bdd3056cc16c06c6662bde2e2a9cbb77fb9d626e12774ffd7e07eb31ea1`).
-Identity/Inventory child `30562970927` then failed in job `90940563185` before
-tests or dry-run because `actions/setup-node` requested pnpm caching before a
-`pnpm` executable existed. PR #929 removed that invalid cache request. Its
-final head `019a34367f3e2e40387b3f50da74b35149ff5981` passed all 14 hosted checks,
-Codex found no major issue on that exact head, and protected `main` merged it
-without bypass as `77f241ec20f8956fc7e9b20dd2b373518dafa7be`.
+The coordinator retained combined preview evidence artifact `8769249449`
+(`sha256:7458fce0e783647c66c1b634515b0099590cfd43d5ed09c306a3bc9516543b62`)
+and sanitized run ledger `8769249808`
+(`sha256:83268fc89fb64bc357ad6ac6a52d97dd8942fa74101cd784ba97466fd1b2baf4`),
+plus consolidated promotion artifacts `8769248202`, `8769248512`,
+`8769248832` and `8769249135`. The private checkpoint
+`C:\CodexRuntime\operator\admin\skincos\ponto-release\checkpoints\20260730T144137-20-complete-preview.md`
+records every child digest. Preview was non-mutating: it did not deploy
+Workers or Pages, apply a migration, write D1/KV, transition module-control,
+select a pilot, run an authenticated hosted journey, or execute
+pilot/canary/production.
 
-Second replacement preview `30564873785` selected that exact #929 merge.
-Source admission and Timekeeping child `30564915304` succeeded, producing
-surface artifact `8768441812`
-(`sha256:541edf288b8cb62ded320c08d3dfb71d28e219164e19bac834966a7b8fd95604`)
-and promotion artifact `8768441200`
-(`sha256:6a7b0a45628672aa57acc8a00a4ba6195407ef4bcb1bc4bc69639f02b702f044`).
-Identity/Inventory child `30565019029` failed in job `90947405936` before tests
-or dry-run: the Corepack bundled with Node 22.12 attempted direct pnpm metadata
-resolution with a stale signing key and returned `Cannot find matching keyid`.
-Core API and CRM Pages were skipped; no Worker/Pages deployment, migration,
-D1/KV write, module transition or other live mutation occurred. The coordinator
-retained sanitized ledger artifact `8768476655`
-(`sha256:90dc7777a40570b7c823344b876415727ae82d77812e7b32baec96b8ffc5eb02`);
-the failed Identity child produced zero artifacts.
-
-The bounded successor reads the exact `packageManager` from
-`inventory/package.json`, requires an exact pnpm version, runs
-`corepack prepare "$pnpm_spec" --activate`, and verifies `pnpm --version`
-before the first package-manager use in all three Identity jobs. A complete
-replacement preview has not yet passed, so `selected_release_sha` remains null.
+The successful coordinator automatically triggered watchdog run
+`30567091382`. Its context job `90954219518` failed with `failed coordinator
+provenance is invalid` because the workflow admitted every completed
+first-attempt coordinator while its validator intentionally accepts only
+failure/cancelled/timed-out first attempts or any unauthorized rerun. All
+emergency jobs skipped, so no latch, broker, rollback or live mutation ran.
+The bounded correction moves that contract to job admission: successful
+first-attempt coordinators are skipped; failure, cancellation, timeout and
+every rerun remain governed. Focused watchdog tests pass 9/9. Because
+integrating this correction advances `main`, its exact merge SHA requires a
+fresh complete preview before staging.
 
 Live Cloudflare remains unchanged and deliberately closed. Both
 `module-control:timekeeping` values are `maintenance`; the emergency-latch key
-is absent in both namespaces, so new source would deny but the old deployments
-do not prove that overlay. Neither Worker/Pages surface identifies #924 or the
-current `main`. Timekeeping D1 journals are exactly `0001`–`0008` and
-Identity/Inventory exactly `0001`–`0018` in staging and production. Required
-WAF behavior is absent (12/12 block probes failed across the two API hosts),
-ruleset reads are unauthorized with Cloudflare 403/code 10000, Timekeeping
-workers.dev/previews remain public, and readiness incorrectly returns
-200/ready=true during maintenance. Staging Pages reports
-`actorKeyConfigured=false`; no authenticated journey was attempted.
+is absent in both namespaces. Timekeeping D1 journals remain exactly
+`0001`–`0008` and Identity/Inventory exactly `0001`–`0018` in staging and
+production. The existing Timekeeping, Core API, Identity and Pages deployments
+remain incumbents rather than the preview SHA. Required WAF behavior is absent
+(12/12 public block probes failed); the authenticated account inventory exposes
+only managed rulesets and no custom `http_request_firewall_custom` ruleset.
+Timekeeping workers.dev/previews remain public, readiness still returns a
+false-positive 200 during maintenance and staging Pages reports
+`actorKeyConfigured=false`.
 
-GitHub remains fail-closed for deployment: staging/production allow only
-custom branch policy `main`, admin bypass is false and the sole reviewer is the
-owner with self-review forbidden. There is no independent collaborator/app
-reviewer and zero self-hosted runners. Name-only inventory confirms the
-required profile/root/capability/Pages-intent custody, WAF tokens/IDs,
-broker URL/credential/custody, pilot credentials/cohort, runner selector/key,
-canary percentage, Ponto resource variables and four enable flags are absent
-at their governed scopes. No secret values were read. Identity/Workforce still
-provides no authorized eligible pilot. Therefore preview may resume only after
-the Corepack successor merges; staging, pilot, canary and production remain
-ineligible.
+GitHub remains fail-closed for deployment: staging/production admit only
+`main`, have `can_admins_bypass=false`, and require the sole owner reviewer
+while forbidding self-review. There is no independent collaborator/app reviewer
+and zero self-hosted runners. The Cloudflare D1, KV, Pages and Worker resources
+exist, and the six Ponto-only D1/KV/Pages repository selectors plus
+`CLOUDFLARE_ZONE_ID` are present by name. The four enable flags remain
+false/absent under the historical rerun fences; selector presence alone neither
+deploys nor authorizes release. Name-only inventory also confirms that approved profile/root/
+capability/Pages-intent custody, WAF split-custody tokens and rule IDs, broker
+URL/credential/custody, pilot credentials/cohort, clinic runner selector/key
+and canary percentage remain absent at governed scopes. No secret values or
+PII were read. Identity/Workforce still provides no authorized eligible pilot.
+The successful preview is therefore valid evidence only; staging, pilot,
+canary and production remain ineligible.
 
 ## Codex Windows native / PowerShell gateway — integrated and validated locally — 2026-07-30T16:21Z
 
@@ -468,9 +446,12 @@ source declaring it disabled. Production `/api/ponto/readiness` still returns
 version-selection header returned 200, while
 `/insumos/health/workforce-contract` returned 401 rather than the required
 edge-generated 403; therefore the required WAF enforcement was not observed.
-This does not establish whether an inaccessible custom rule object exists. The
-zone ruleset listing exposed only managed rulesets, and the custom entrypoint
-GET was not authorized for the available principal.
+At this historical snapshot, that principal did not establish whether an
+inaccessible custom rule object existed: its zone listing exposed only managed
+rulesets and its custom-entrypoint GET was unauthorized. The authoritative
+entry above supersedes this limitation with the later authenticated account
+inventory, which found no custom `http_request_firewall_custom` ruleset and
+confirmed functional absence through the 12/12 failed block probes.
 The Codex in-app browser and the existing Chrome profile both reached only the
 Cloudflare login screen, with no authenticated dashboard session; no credential
 was entered and no mutation was attempted. Rule inspection/attestation remains

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -5,7 +5,7 @@
       "observed_at": "2026-07-30T17:51:13Z",
       "surface": "github-protected-main-github-actions-complete-ponto-preview-and-watchdog-admission",
       "scope": "PR #930 integration, complete exact-main four-surface preview and successful-run watchdog false-red correction",
-      "state": "complete-preview-successful-live-release-still-fail-closed-watchdog-success-admission-fix-prepared",
+      "state": "complete-preview-successful-live-release-still-fail-closed-watchdog-success-admission-successor-pr-931",
       "method": "Verified PR #930 protected merge, all 14 hosted checks and exact-head Codex result; dispatched the Ponto coordinator on the exact merge SHA; inspected all four child jobs and retained artifacts; inspected the automatically triggered watchdog failure; added a job-admission predicate and focused regression test so successful first-attempt coordinators are skipped while failed/cancelled/timed-out first attempts and every rerun remain governed. No secret value, PII, deployment, migration, D1/KV write, module-control transition or identity mutation was performed.",
       "result": "PR #930 final head 872f1b10c9bd64e1768fa0e8777d992e2658240b passed all 14 hosted checks and Codex found no major issue on that exact head, then merged through protected main without bypass as 71c54b1d406317c614dc33e48ced170458fbd707. Coordinator 30566547605, source job 90952396490 and orchestrator job 90952445595 succeeded. Canonical children Timekeeping 30566594811, Identity/Inventory 30566729991, Core API 30566806246 and CRM Pages 30566905155 all completed on that exact SHA. Combined preview evidence 8769249449 has digest sha256:7458fce0e783647c66c1b634515b0099590cfd43d5ed09c306a3bc9516543b62; sanitized run ledger 8769249808 has digest sha256:83268fc89fb64bc357ad6ac6a52d97dd8942fa74101cd784ba97466fd1b2baf4. Automatically triggered watchdog run 30567091382 failed only in context job 90954219518 because the workflow admitted a successful first-attempt coordinator that its validator intentionally rejects; every emergency job skipped and no mutation occurred. The bounded admission fix keeps successful first attempts out of the watchdog while preserving close/recovery handling for failed, cancelled, timed-out or replayed runs; focused tests pass 9/9.",
       "limitation": "Preview is dry-run evidence only and selected_release_sha remains null for live release. No staging deployment, additive migration checkpoint, authenticated CONSULTOR/EMPLOYEE journey, module-control drill, kill switch, rollback, pilot, canary, external SLO or production promotion occurred. Both module-control values remain maintenance. Independent deployment approval, approved secret custody, broker, WAF split custody and block proof, pilot identity/cohort, clinic JIT runner and external SLO remain absent. Any main advancement requires a fresh preview on the new exact coordinator GITHUB_SHA.",
@@ -57,6 +57,7 @@
         "run": 30567091382,
         "job": 90954219518,
         "mutation": false,
+        "successor_pr": 931,
         "fix": "context-job-skips-successful-first-attempt-coordinator-but-keeps-failed-cancelled-timed-out-and-rerun-admission",
         "focused_tests": "9/9"
       },
@@ -78,7 +79,7 @@
         "release_authority": false
       },
       "checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\ponto-release\\checkpoints\\20260730T144137-20-complete-preview.md",
-      "next_action": "Integrate the bounded watchdog admission correction without bypass. Because that merge advances main, execute a fresh four-surface preview on its exact merge SHA. Do not dispatch staging until all independent approval, WAF, custody, broker, runner, pilot and external-SLO predecessors are proved."
+      "next_action": "Merge PR #931 without bypass. Because that merge advances main, execute a fresh four-surface preview on its exact merge SHA. Do not dispatch staging until all independent approval, WAF, custody, broker, runner, pilot and external-SLO predecessors are proved."
     },
     {
       "observed_at": "2026-07-30T17:23:36Z",

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,85 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-30T17:51:13Z",
+      "surface": "github-protected-main-github-actions-complete-ponto-preview-and-watchdog-admission",
+      "scope": "PR #930 integration, complete exact-main four-surface preview and successful-run watchdog false-red correction",
+      "state": "complete-preview-successful-live-release-still-fail-closed-watchdog-success-admission-fix-prepared",
+      "method": "Verified PR #930 protected merge, all 14 hosted checks and exact-head Codex result; dispatched the Ponto coordinator on the exact merge SHA; inspected all four child jobs and retained artifacts; inspected the automatically triggered watchdog failure; added a job-admission predicate and focused regression test so successful first-attempt coordinators are skipped while failed/cancelled/timed-out first attempts and every rerun remain governed. No secret value, PII, deployment, migration, D1/KV write, module-control transition or identity mutation was performed.",
+      "result": "PR #930 final head 872f1b10c9bd64e1768fa0e8777d992e2658240b passed all 14 hosted checks and Codex found no major issue on that exact head, then merged through protected main without bypass as 71c54b1d406317c614dc33e48ced170458fbd707. Coordinator 30566547605, source job 90952396490 and orchestrator job 90952445595 succeeded. Canonical children Timekeeping 30566594811, Identity/Inventory 30566729991, Core API 30566806246 and CRM Pages 30566905155 all completed on that exact SHA. Combined preview evidence 8769249449 has digest sha256:7458fce0e783647c66c1b634515b0099590cfd43d5ed09c306a3bc9516543b62; sanitized run ledger 8769249808 has digest sha256:83268fc89fb64bc357ad6ac6a52d97dd8942fa74101cd784ba97466fd1b2baf4. Automatically triggered watchdog run 30567091382 failed only in context job 90954219518 because the workflow admitted a successful first-attempt coordinator that its validator intentionally rejects; every emergency job skipped and no mutation occurred. The bounded admission fix keeps successful first attempts out of the watchdog while preserving close/recovery handling for failed, cancelled, timed-out or replayed runs; focused tests pass 9/9.",
+      "limitation": "Preview is dry-run evidence only and selected_release_sha remains null for live release. No staging deployment, additive migration checkpoint, authenticated CONSULTOR/EMPLOYEE journey, module-control drill, kill switch, rollback, pilot, canary, external SLO or production promotion occurred. Both module-control values remain maintenance. Independent deployment approval, approved secret custody, broker, WAF split custody and block proof, pilot identity/cohort, clinic JIT runner and external SLO remain absent. Any main advancement requires a fresh preview on the new exact coordinator GITHUB_SHA.",
+      "origin_main": "71c54b1d406317c614dc33e48ced170458fbd707",
+      "corepack_successor_pr": 930,
+      "corepack_successor_final_head": "872f1b10c9bd64e1768fa0e8777d992e2658240b",
+      "corepack_successor_merge_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+      "corepack_successor_hosted_checks": "14/14",
+      "preview_release_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+      "selected_release_sha": null,
+      "preview_run": 30566547605,
+      "preview_source_job": 90952396490,
+      "preview_orchestrator_job": 90952445595,
+      "preview_children": {
+        "timekeeping": {
+          "run": 30566594811,
+          "job": 90952777570,
+          "surface_artifact": 8769104630,
+          "promotion_artifact": 8769104027
+        },
+        "identity_inventory": {
+          "run": 30566729991,
+          "job": 90953095462,
+          "surface_artifact": 8769138110,
+          "promotion_artifact": 8769137752
+        },
+        "core_api": {
+          "run": 30566806246,
+          "job": 90953342171,
+          "surface_artifact": 8769175430,
+          "promotion_artifact": 8769175021
+        },
+        "crm_pages": {
+          "run": 30566905155,
+          "job": 90953758618,
+          "surface_artifact": 8769241946,
+          "promotion_artifact": 8769241662
+        }
+      },
+      "preview_evidence_artifact": {
+        "id": 8769249449,
+        "digest": "sha256:7458fce0e783647c66c1b634515b0099590cfd43d5ed09c306a3bc9516543b62"
+      },
+      "preview_runs_ledger_artifact": {
+        "id": 8769249808,
+        "digest": "sha256:83268fc89fb64bc357ad6ac6a52d97dd8942fa74101cd784ba97466fd1b2baf4"
+      },
+      "watchdog_success_false_red": {
+        "run": 30567091382,
+        "job": 90954219518,
+        "mutation": false,
+        "fix": "context-job-skips-successful-first-attempt-coordinator-but-keeps-failed-cancelled-timed-out-and-rerun-admission",
+        "focused_tests": "9/9"
+      },
+      "module_control": {
+        "staging": "maintenance",
+        "production": "maintenance"
+      },
+      "repository_resource_selectors": {
+        "present_by_name": [
+          "PONTO_MODULE_CONTROL_STAGING_KV_ID",
+          "PONTO_MODULE_CONTROL_PRODUCTION_KV_ID",
+          "PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING",
+          "PONTO_CLOUDFLARE_PAGES_PROJECT",
+          "PONTO_TIMEKEEPING_D1_STAGING_ID",
+          "PONTO_TIMEKEEPING_D1_PRODUCTION_ID",
+          "CLOUDFLARE_ZONE_ID"
+        ],
+        "enable_flags": "all-four-absent",
+        "release_authority": false
+      },
+      "checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\ponto-release\\checkpoints\\20260730T144137-20-complete-preview.md",
+      "next_action": "Integrate the bounded watchdog admission correction without bypass. Because that merge advances main, execute a fresh four-surface preview on its exact merge SHA. Do not dispatch staging until all independent approval, WAF, custody, broker, runner, pilot and external-SLO predecessors are proved."
+    },
+    {
       "observed_at": "2026-07-30T17:23:36Z",
       "surface": "github-protected-main-github-actions-ponto-preview-and-local-corepack-successor",
       "scope": "PR #929 integration, second exact-main replacement preview and bounded Identity Corepack signing-key successor",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -8,7 +8,7 @@
       "id": "p0-workforce-timekeeping-current-main-release",
       "objective": "Complete the governed Workforce Timekeeping release through preview, staging, pilot, canary and production on one immutable source SHA.",
       "priority": 1100,
-      "state": "pr-930-integrated-complete-four-surface-preview-success-watchdog-success-admission-fix-pending-both-environments-maintenance-external-gates-pending",
+      "state": "pr-930-integrated-complete-four-surface-preview-success-watchdog-success-admission-successor-pr-931-fresh-preview-pending-both-environments-maintenance-external-gates-pending",
       "dependencies": [
         "ponto-release-prerequisites"
       ],
@@ -27,7 +27,7 @@
       ],
       "environment": "staging-then-production",
       "permitted_actions": [
-        "integrate the bounded watchdog successful-first-attempt admission correction without bypass, then rerun preview on its exact protected-main merge SHA",
+        "merge PR #931 without bypass, then rerun preview on its exact protected-main merge SHA",
         "preserve the external replay containment checkpoint and fail-closed production and staging environment overrides/fences until the permanent control and governed predecessors are proved",
         "after corrective merge and authorized WAF/secret-custody provisioning, select only the exact then-current main GITHUB_SHA and execute immutable preview then staging",
         "synthetic CONSULTOR-only authenticated journey with teardown and sanitised evidence",
@@ -195,6 +195,8 @@
           "live_mutation": false
         },
         "watchdog_success_admission_successor": {
+          "branch": "codex/admin/ponto-watchdog-success-admission",
+          "pr": 931,
           "failed_watchdog_run": 30567091382,
           "failed_context_job": 90954219518,
           "cause": "successful-first-attempt-coordinator-admitted-to-failure-only-provenance-validator",
@@ -202,7 +204,7 @@
           "live_mutation": false,
           "fix": "skip-successful-first-attempt-and-preserve-failed-cancelled-timed-out-or-rerun-admission",
           "focused_tests": "9/9",
-          "state": "bounded-successor-pending-integration-and-fresh-exact-main-preview"
+          "state": "successor-pr-931-fresh-exact-main-preview-required"
         },
         "post_merge_corrective_overlay": {
           "branch": "codex/admin/ponto-release-evidence",
@@ -688,7 +690,7 @@
       "id": "ponto-release-prerequisites",
       "objective": "Close the technical and authorized-input prerequisites for the single-SHA Ponto staging, pilot and canary sequence.",
       "priority": 1099,
-      "state": "pr-930-integrated-complete-preview-success-watchdog-admission-successor-pending-both-environments-maintenance-broker-policy-null-external-gates-open",
+      "state": "pr-930-integrated-complete-preview-success-watchdog-admission-successor-pr-931-fresh-preview-pending-both-environments-maintenance-broker-policy-null-external-gates-open",
       "dependencies": [],
       "blockers": [
         "PR #930 integrated the exact Corepack activation correction as 71c54b1d406317c614dc33e48ced170458fbd707 after all 14 checks and exact-head Codex review passed; complete preview 30566547605 and all four children succeeded, but watchdog run 30567091382 exposed a false-red admission of successful first attempts and its bounded correction plus a fresh exact-main preview are pending",
@@ -705,7 +707,7 @@
       ],
       "environment": "source-and-staging",
       "permitted_actions": [
-        "integrate the bounded watchdog successful-first-attempt admission correction without bypass and rerun preview on the exact resulting main SHA",
+        "merge PR #931 without bypass and rerun preview on the exact resulting main SHA",
         "preserve the private containment checkpoint and production/staging environment fences until guarded workflows and authorized predecessors are live",
         "obtain a reviewed decision that pins distinct per-target broker URL, custodyRef, responseKeyId and Ed25519 SPKI before provisioning broker endpoints, credentials or keys",
         "provision staging secret names only through an approved source/process without reading or exposing values",
@@ -768,6 +770,8 @@
           "selected_release_sha": null
         },
         "watchdog_success_admission_successor": {
+          "branch": "codex/admin/ponto-watchdog-success-admission",
+          "pr": 931,
           "failed_watchdog_run": 30567091382,
           "failed_context_job": 90954219518,
           "emergency_jobs": "all-skipped",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,23 +1,23 @@
 {
   "schema": 1,
-  "authoritative_at": "2026-07-30T17:23:36Z",
-  "source_main_sha": "77f241ec20f8956fc7e9b20dd2b373518dafa7be",
-  "source_main_state": "verified-current-main-after-pr-929",
+  "authoritative_at": "2026-07-30T17:51:13Z",
+  "source_main_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+  "source_main_state": "verified-current-main-after-pr-930-and-complete-preview",
   "items": [
     {
       "id": "p0-workforce-timekeeping-current-main-release",
       "objective": "Complete the governed Workforce Timekeeping release through preview, staging, pilot, canary and production on one immutable source SHA.",
       "priority": 1100,
-      "state": "pr-929-integrated-replacement-preview-failed-corepack-key-successor-pending-both-environments-maintenance-external-gates-pending",
+      "state": "pr-930-integrated-complete-four-surface-preview-success-watchdog-success-admission-fix-pending-both-environments-maintenance-external-gates-pending",
       "dependencies": [
         "ponto-release-prerequisites"
       ],
       "blockers": [
-        "PR #929 final head 019a34367f3e2e40387b3f50da74b35149ff5981 passed all 14 hosted checks and exact-head Codex review, then merged without bypass as 77f241ec20f8956fc7e9b20dd2b373518dafa7be; replacement preview 30564873785 passed source and Timekeeping child 30564915304 but Identity child 30565019029 failed job 90947405936 before tests because Node 22.12 bundled Corepack had a stale pnpm signing key, and the bounded exact-version Corepack successor is pending",
+        "PR #930 final head 872f1b10c9bd64e1768fa0e8777d992e2658240b passed all 14 hosted checks and exact-head Codex review, then merged without bypass as 71c54b1d406317c614dc33e48ced170458fbd707; complete preview 30566547605 and all four canonical child surfaces succeeded, but automatically triggered watchdog 30567091382 false-reded in context job 90954219518 because successful first attempts were admitted to a validator that intentionally accepts only failures or reruns; the bounded admission correction is pending integration and a fresh exact-main preview",
         "the release-probe and Identity-session contracts are integrated by PR #924 but not live; HMAC-before-login, pilot/canary v2 provenance, atomic UNIQUE D1 nonce acceptance, Core-owned affinity and stale-cookie 401 teardown remain unexercised without authorized staging inputs",
         "the watchdog source is integrated, but run 30558653559 exposed a REST dynamic-name P1 fixed in PR #927; broker policy URL/custodyRef/responseKeyId/Ed25519 SPKI, broker endpoint/credential/keys, clinic runner and independent external recovery proof remain absent",
         "seven historical Timekeeping child runs and CRM Pages attempt-2 run 30491926800 retain their old definitions; live dispatch fences and both disabled legacy Ponto smokes must remain through expiry or reviewed replacement",
-        "required WAF enforcement and the three immutable rule identifiers are unproven: ruleset reads return 403/code 10000 and all 12 required external block probes fail across production and staging",
+        "required WAF enforcement and the three immutable rule identifiers are absent: authenticated account inventory lists only managed rulesets and no custom http_request_firewall_custom ruleset, while all 12 required external block probes fail across production and staging",
         "governed capability custody is unprovisioned: each target environment needs a distinct PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY and the repository needs only PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON verifier metadata",
         "staging and production now require main-only custom branch policies, can_admins_bypass=false and prevent_self_review=true, but the sole repository collaborator is the owner reviewer, GITHUB_TOKEN can_approve_pull_request_reviews=false, no authorized app/bot approver is proved and no independent reviewer is available",
         "scheduled production Ponto Smoke run 30521686413 correctly detects ready=false under maintenance but is not successful external production SLO evidence; UI Smoke run 30518888970 is not an authenticated authorized-user journey",
@@ -27,7 +27,7 @@
       ],
       "environment": "staging-then-production",
       "permitted_actions": [
-        "integrate the bounded Identity Corepack signing-key successor without bypass, then rerun preview on its exact protected-main merge SHA",
+        "integrate the bounded watchdog successful-first-attempt admission correction without bypass, then rerun preview on its exact protected-main merge SHA",
         "preserve the external replay containment checkpoint and fail-closed production and staging environment overrides/fences until the permanent control and governed predecessors are proved",
         "after corrective merge and authorized WAF/secret-custody provisioning, select only the exact then-current main GITHUB_SHA and execute immutable preview then staging",
         "synthetic CONSULTOR-only authenticated journey with teardown and sanitised evidence",
@@ -35,7 +35,7 @@
         "production promotion only after matching staging, pilot and canary evidence and an Identity/Workforce-valid pilot scope"
       ],
       "prohibited_actions": [
-        "dispatch staging before the bounded Corepack successor is integrated and a complete four-surface replacement preview succeeds on one exact coordinator GITHUB_SHA",
+        "dispatch staging before the watchdog admission correction is integrated and a fresh four-surface preview succeeds on its exact coordinator GITHUB_SHA",
         "restore any removed, disabled or fenced production/staging dispatch input before the permanent legacy-run control is merged and release predecessors are authorized",
         "use administrator environment bypass or PR #921 code-governance status as deployment/pilot approval",
         "claim automatic interruption rollback or external freeze readiness before the policy-bound broker, clinic runner and independent external recovery proof exist",
@@ -63,12 +63,12 @@
       ],
       "done_definition": "A single immutable release has complete preview, staging, pilot, canary and production evidence, an authenticated authorized-user journey, proven rollback and post-release observation.",
       "next_item": "finance-current-main-staging-evidence",
-      "last_verified": "2026-07-30T17:23:36Z",
+      "last_verified": "2026-07-30T17:51:13Z",
       "evidence": {
         "base_sha": "f202e29f4178bba8966edf71539c942618254de0",
         "merge_sha": "10b2197731d0210cf8fc8cd961f7a787d73bf650",
         "selected_release_sha": null,
-        "origin_main_last_verified": "77f241ec20f8956fc7e9b20dd2b373518dafa7be",
+        "origin_main_last_verified": "71c54b1d406317c614dc33e48ced170458fbd707",
         "origin_main_last_verified_state": "verified",
         "technical_controls_merge_sha": "aa9bfa6595b9cb12e7228f67f9606527bb375de2",
         "post_pr_886_delta": {
@@ -144,7 +144,10 @@
         "corepack_signing_key_successor": {
           "branch": "codex/admin/ponto-preview-corepack",
           "base_main_sha": "77f241ec20f8956fc7e9b20dd2b373518dafa7be",
-          "state": "local-bounded-pr-merge-and-complete-preview-pending",
+          "pr": 930,
+          "final_head_sha": "872f1b10c9bd64e1768fa0e8777d992e2658240b",
+          "merge_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+          "state": "integrated-all-14-hosted-checks-green-exact-head-codex-review-clean-complete-preview-success",
           "checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\ponto-release\\checkpoints\\20260730T142303-19-corepack-preview-failure.md",
           "failed_preview_run": 30564873785,
           "failed_preview_job": 90946808121,
@@ -170,6 +173,36 @@
           "pre_use_verification": "pnpm-version-must-equal-exact-package-manager-pin",
           "covered_identity_jobs": 3,
           "live_mutation": false
+        },
+        "complete_preview": {
+          "release_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+          "run": 30566547605,
+          "source_job": 90952396490,
+          "orchestrator_job": 90952445595,
+          "timekeeping_run": 30566594811,
+          "identity_inventory_run": 30566729991,
+          "core_api_run": 30566806246,
+          "crm_pages_run": 30566905155,
+          "evidence_artifact": {
+            "id": 8769249449,
+            "digest": "sha256:7458fce0e783647c66c1b634515b0099590cfd43d5ed09c306a3bc9516543b62"
+          },
+          "runs_ledger_artifact": {
+            "id": 8769249808,
+            "digest": "sha256:83268fc89fb64bc357ad6ac6a52d97dd8942fa74101cd784ba97466fd1b2baf4"
+          },
+          "checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\ponto-release\\checkpoints\\20260730T144137-20-complete-preview.md",
+          "live_mutation": false
+        },
+        "watchdog_success_admission_successor": {
+          "failed_watchdog_run": 30567091382,
+          "failed_context_job": 90954219518,
+          "cause": "successful-first-attempt-coordinator-admitted-to-failure-only-provenance-validator",
+          "emergency_jobs": "all-skipped",
+          "live_mutation": false,
+          "fix": "skip-successful-first-attempt-and-preserve-failed-cancelled-timed-out-or-rerun-admission",
+          "focused_tests": "9/9",
+          "state": "bounded-successor-pending-integration-and-fresh-exact-main-preview"
         },
         "post_merge_corrective_overlay": {
           "branch": "codex/admin/ponto-release-evidence",
@@ -655,10 +688,10 @@
       "id": "ponto-release-prerequisites",
       "objective": "Close the technical and authorized-input prerequisites for the single-SHA Ponto staging, pilot and canary sequence.",
       "priority": 1099,
-      "state": "pr-929-integrated-corepack-preview-successor-pending-both-environments-maintenance-broker-policy-null-external-gates-open",
+      "state": "pr-930-integrated-complete-preview-success-watchdog-admission-successor-pending-both-environments-maintenance-broker-policy-null-external-gates-open",
       "dependencies": [],
       "blockers": [
-        "PR #929 integrated the first pnpm bootstrap correction as 77f241ec20f8956fc7e9b20dd2b373518dafa7be after all 14 checks and exact-head Codex review passed; replacement preview 30564873785 passed Timekeeping but Identity child 30565019029 exposed the Node 22.12 bundled Corepack stale signing-key path, and its bounded exact-version activation successor plus a complete replacement preview are pending",
+        "PR #930 integrated the exact Corepack activation correction as 71c54b1d406317c614dc33e48ced170458fbd707 after all 14 checks and exact-head Codex review passed; complete preview 30566547605 and all four children succeeded, but watchdog run 30567091382 exposed a false-red admission of successful first attempts and its bounded correction plus a fresh exact-main preview are pending",
         "the release-probe and Identity-session contracts are integrated but not live; authorized custody and staging predecessors required to exercise them are absent",
         "the watchdog REST correction is integrated by PR #927, but broker policy URL/custodyRef/responseKeyId/Ed25519 SPKI, endpoint/credential/keys, clinic runner and independent external recovery proof remain absent",
         "historical child runs remain rerunnable under their old definitions and therefore externally contained through expiry or reviewed replacement",
@@ -666,22 +699,22 @@
         "staging and production now enforce main-only custom branch policy, no administrator bypass and prevent-self-review, but the sole repository collaborator is the owner reviewer, GITHUB_TOKEN can_approve_pull_request_reviews=false, no authorized app/bot approver is proved and no independent reviewer is available",
         "PONTO_PROFILE_DATA_KEY and its approved custody reference are absent from staging",
         "target-environment root-attestation and Pages-intent keys, repository root key-id metadata and environment idempotency custody references are absent",
-        "required WAF enforcement and the three rule identifiers remain unproven: custom entrypoint access is unauthorized and 12/12 required public block probes fail; production pilot identity, runner and canary inputs remain separately blocked",
+        "required WAF enforcement and the three rule identifiers remain absent: authenticated account inventory finds no custom http_request_firewall_custom ruleset and 12/12 required public block probes fail; production pilot identity, runner and canary inputs remain separately blocked",
         "legacy Ponto UI smoke is disabled and its repository credentials were removed, while legacy backend workflow 230950805 is disabled and run 30536124024 ended completed/cancelled; the historical GESTOR account still requires authorized Identity/Workforce reconciliation",
         "the close-only broker remains fail-closed because reviewed policy identities and provisioned endpoints/credentials/keys are absent: url, custodyRef, responseKeyId and responsePublicKeyPem are null for staging and production"
       ],
       "environment": "source-and-staging",
       "permitted_actions": [
-        "integrate the bounded Corepack signing-key successor without bypass and rerun preview on the exact resulting main SHA",
+        "integrate the bounded watchdog successful-first-attempt admission correction without bypass and rerun preview on the exact resulting main SHA",
         "preserve the private containment checkpoint and production/staging environment fences until guarded workflows and authorized predecessors are live",
         "obtain a reviewed decision that pins distinct per-target broker URL, custodyRef, responseKeyId and Ed25519 SPKI before provisioning broker endpoints, credentials or keys",
         "provision staging secret names only through an approved source/process without reading or exposing values",
         "after complete staging evidence and separate pre-production authorization, provision distinct and separately custodied production secrets",
-        "select the then-current exact main GITHUB_SHA only after the Corepack successor and its evidence update are integrated",
+        "select the then-current exact main GITHUB_SHA only after the watchdog successor and its evidence update are integrated",
         "run preview/staging and synthetic teardown only after all staging guards pass"
       ],
       "prohibited_actions": [
-        "dispatch staging before the Corepack successor is merged and a complete replacement preview succeeds on the exact selected SHA",
+        "dispatch staging before the watchdog successor is merged and a fresh complete preview succeeds on the exact selected SHA",
         "restore removed D1 identifiers, disabled deploy flags or fenced Pages project variables before the permanent legacy-run control is merged and authorized",
         "use can_admins_bypass or PR code review state as deployment/pilot approval",
         "ask the sole owner, GITHUB_TOKEN or an unproved app/bot to manufacture an invalid approval",
@@ -703,9 +736,9 @@
       ],
       "done_definition": "All technical controls and authorized inputs required to begin the governed single-SHA release sequence are present and fail-closed defaults remain intact.",
       "next_item": "p0-workforce-timekeeping-current-main-release",
-      "last_verified": "2026-07-30T17:23:36Z",
+      "last_verified": "2026-07-30T17:51:13Z",
       "evidence": {
-        "origin_main_boundary": "77f241ec20f8956fc7e9b20dd2b373518dafa7be",
+        "origin_main_boundary": "71c54b1d406317c614dc33e48ced170458fbd707",
         "origin_main_boundary_state": "verified",
         "selected_release_sha": null,
         "technical_controls_branch": "codex/admin/ponto-progressive-release",
@@ -727,8 +760,20 @@
           "successful_timekeeping_child_run": 30564915304,
           "failed_identity_child_run": 30565019029,
           "failed_identity_job": 90947405936,
-          "state": "local-bounded-pr-merge-and-complete-preview-pending",
+          "pr": 930,
+          "final_head_sha": "872f1b10c9bd64e1768fa0e8777d992e2658240b",
+          "merge_sha": "71c54b1d406317c614dc33e48ced170458fbd707",
+          "complete_preview_run": 30566547605,
+          "state": "integrated-complete-four-surface-preview-success",
           "selected_release_sha": null
+        },
+        "watchdog_success_admission_successor": {
+          "failed_watchdog_run": 30567091382,
+          "failed_context_job": 90954219518,
+          "emergency_jobs": "all-skipped",
+          "live_mutation": false,
+          "focused_tests": "9/9",
+          "state": "bounded-fix-pending-integration-and-fresh-preview"
         },
         "local_freeze": {
           "observed_at": "2026-07-30T15:29:06Z",
@@ -797,7 +842,7 @@
         },
         "repository_resource_variables": {
           "checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\ponto-release\\checkpoints\\20260730T074500-14-ponto-resource-variables-before.md",
-          "observed_at": "2026-07-30T16:08:11Z",
+          "observed_at": "2026-07-30T17:51:13Z",
           "historical_checkpoint_present_by_name": [
             "PONTO_MODULE_CONTROL_STAGING_KV_ID",
             "PONTO_MODULE_CONTROL_PRODUCTION_KV_ID",
@@ -807,11 +852,18 @@
             "PONTO_TIMEKEEPING_D1_PRODUCTION_ID",
             "CLOUDFLARE_ZONE_ID"
           ],
-          "current_ponto_present_by_name": [],
+          "current_ponto_present_by_name": [
+            "PONTO_MODULE_CONTROL_STAGING_KV_ID",
+            "PONTO_MODULE_CONTROL_PRODUCTION_KV_ID",
+            "PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING",
+            "PONTO_CLOUDFLARE_PAGES_PROJECT",
+            "PONTO_TIMEKEEPING_D1_STAGING_ID",
+            "PONTO_TIMEKEEPING_D1_PRODUCTION_ID"
+          ],
           "current_shared_present_by_name": [
             "CLOUDFLARE_ZONE_ID"
           ],
-          "state": "fresh-name-only-inventory-finds-ponto-resource-variables-absent-fail-closed",
+          "state": "fresh-name-only-inventory-finds-six-ponto-resource-selectors-present-four-enable-flags-absent-fail-closed",
           "values_recorded_in_public_ledger": false
         },
         "external_gates_state": "active-open-authorized-input-required",


### PR DESCRIPTION
# Summary

Closes the false-red exposed after the first complete four-surface Ponto preview. Watchdog run 30567091382 admitted a successful first-attempt coordinator and then failed its intentionally failure-only provenance validator. The context job now skips only successful first attempts while continuing to admit failed, cancelled, timed-out, and every rerun coordinator. Ledgers record PR #930, complete preview 30566547605, the watchdog defect, current Cloudflare/GitHub fail-closed state, and the exact external blockers.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (runbook, decisions, state, blockers, evidence, work queue)
- [x] Security review (two independent bounded reviews; gitleaks diff scan)
- [x] Performance impact measured (job admission skips an unnecessary runner; no runtime path impact)

## Links
- Issue: watchdog run 30567091382 / job 90954219518
- Design/ADR: DECISIONS.md
- Migration steps: none; fresh preview required on the exact merge SHA

## Screenshots / Evidence
- Complete preview: 30566547605, all four canonical children successful
- Focused watchdog: 9/9
- Governed Ponto suite: 213/213
- actionlint 1.7.12: green
- Architecture, GitHub governance, deploy topology, progressive policy, staging manifest, observability: green
- Diff-only gitleaks: zero
- Independent reviews: zero P0/P1/P2
- No Worker/Pages deploy, migration, D1/KV write, module-control transition, secret provisioning, identity change, pilot, canary, or production action