### PR TITLE
fix(livia): move job graph payload out of argv

### DIFF
--- a/orb/engine/scripts/patch-livia-job-graph-payload-file.js
+++ b/orb/engine/scripts/patch-livia-job-graph-payload-file.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+'use strict';
+
+// Keep the full publish-context payload out of Execute Command argv.  Large
+// carousels otherwise hit the operating-system argv limit (spawn E2BIG) before
+// the job graph builder can validate anything.  The payload is written
+// atomically by the existing publication-window guard and consumed by the
+// pinned builder through --payload-file.
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'WGXr4vYkv9UoJ8zc';
+const ASSERT_NODE = 'Assert Livia Publication Window';
+const BUILD_NODE = 'BQ - Build Platform Job Graph';
+const PAYLOAD_DIR = '/tmp/livia-job-graph-input';
+const PAYLOAD_FILE_RE = /^\/tmp\/livia-job-graph-input\/[A-Za-z0-9_-]+\.json$/;
+
+const ASSERT_CODE = String.raw`const fs = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+
+const lockPath = '/var/lib/skincos-runtime/orb/state/livia-maintenance/restart.lock';
+if (fs.existsSync(lockPath)) {
+  throw new Error('Assert Livia Publication Window: manutenção controlada do Orb em andamento; publicação interrompida antes do gateway.');
+}
+
+const payloadDir = '${PAYLOAD_DIR}';
+fs.mkdirSync(payloadDir, { recursive: true, mode: 0o700 });
+const executionId = String($execution?.retryOf || $execution?.id || 'noexec')
+  .replace(/[^A-Za-z0-9_-]/g, '_')
+  .slice(0, 80) || 'noexec';
+
+return $input.all().map((item, index) => {
+  const payload = item && item.json && typeof item.json === 'object' ? item.json : {};
+  const serialized = JSON.stringify(payload);
+  if (!serialized || serialized === '{}') {
+    throw new Error('Assert Livia Publication Window: contexto de publicação vazio; payload não foi gravado.');
+  }
+  const sha256 = crypto.createHash('sha256').update(serialized, 'utf8').digest('hex');
+  const filename = executionId + '_' + String(index) + '_' + sha256 + '.json';
+  const target = path.join(payloadDir, filename);
+  // The final name already contains the execution id, item index and payload
+  // digest, so it is unique without depending on Node's process global (which
+  // is intentionally unavailable in the n8n Code sandbox).
+  const temporary = target + '.tmp';
+  fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temporary, target);
+  return {
+    json: {
+      ...payload,
+      _liviaBuildJobGraphPayloadFile: target,
+      _liviaBuildJobGraphPayloadSha256: sha256,
+    },
+    binary: item && item.binary,
+    pairedItem: item && item.pairedItem,
+  };
+});`;
+
+function shellQuote(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+function buildCommand(releaseRoot) {
+  return `={{ (() => {
+  const payload = ($json && typeof $json === "object") ? $json : {};
+  const payloadFile = String(payload._liviaBuildJobGraphPayloadFile || "").trim();
+  const payloadSha256 = String(payload._liviaBuildJobGraphPayloadSha256 || "").trim().toLowerCase();
+  if (!/^\\/tmp\\/livia-job-graph-input\\/[A-Za-z0-9_-]+\\.json$/.test(payloadFile)) {
+    throw new Error("BQ - Build Platform Job Graph: payload file ausente ou fora do diretório privado.");
+  }
+  if (!/^[a-f0-9]{64}$/.test(payloadSha256)) {
+    throw new Error("BQ - Build Platform Job Graph: SHA-256 do payload ausente ou inválido.");
+  }
+  function sh(value) { return "'" + String(value).replace(/'/g, "'\\\\''") + "'"; }
+  const source = sh("${releaseRoot}/compose2-current.js");
+  const builder = sh("${releaseRoot}/scripts/livia/build-platform-job-graph.js");
+  const file = sh(payloadFile);
+  const hash = sh(payloadSha256);
+  return "trap 'rm -f -- " + payloadFile + "' EXIT HUP INT TERM; test -f " + file +
+    " && test \\\"$(sha256sum " + file + " | awk '{print $1}')\\\" = " + hash +
+    " && LIVIA_BUILD_JOB_GRAPH_SOURCE=" + source + " node " + builder + " --payload-file " + file;
+})() }}`;
+}
+
+function patchWorkflow(workflow, releaseRoot) {
+  if (workflow?.id !== WORKFLOW_ID) throw new Error('Expected the active Livia workflow.');
+  if (!/^\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine$/.test(String(releaseRoot || ''))) {
+    throw new Error('release root must be an immutable /opt/skincos/releases/<sha>/source/orb/engine path.');
+  }
+  const nodes = new Map((workflow.nodes || []).map((node) => [node.name, node]));
+  const assertNode = nodes.get(ASSERT_NODE);
+  const buildNode = nodes.get(BUILD_NODE);
+  if (!assertNode || assertNode.type !== 'n8n-nodes-base.code') throw new Error(`${ASSERT_NODE} must be a Code node.`);
+  if (!buildNode || buildNode.type !== 'n8n-nodes-base.executeCommand') throw new Error(`${BUILD_NODE} must be an Execute Command node.`);
+  assertNode.parameters = { ...(assertNode.parameters || {}), jsCode: ASSERT_CODE };
+  buildNode.parameters = { ...(buildNode.parameters || {}), command: buildCommand(releaseRoot) };
+  return workflow;
+}
+
+function validate(workflow) {
+  const nodes = new Map((workflow.nodes || []).map((node) => [node.name, node]));
+  const assertCode = String(nodes.get(ASSERT_NODE)?.parameters?.jsCode || '');
+  const command = String(nodes.get(BUILD_NODE)?.parameters?.command || '');
+  if (!assertCode.includes('_liviaBuildJobGraphPayloadFile') || !assertCode.includes('fs.renameSync')) {
+    throw new Error('Publication-window guard must atomically persist the job-graph payload.');
+  }
+  if (!command.includes('--payload-file') || command.includes('JSON.stringify(payload)')) {
+    throw new Error('Job-graph command must use the private payload file and never serialize payload into argv.');
+  }
+  if (!PAYLOAD_FILE_RE.test('/tmp/livia-job-graph-input/example_0_' + '0'.repeat(64) + '.json')) {
+    throw new Error('Internal payload-file contract is invalid.');
+  }
+  return [ASSERT_NODE, BUILD_NODE];
+}
+
+function main() {
+  const [input, output] = process.argv.slice(2).filter((value) => !value.startsWith('--'));
+  const releaseRoot = process.argv.find((value) => value.startsWith('--release-root='))?.slice('--release-root='.length) || '';
+  if (!input || !output || !releaseRoot) throw new Error('Usage: patch-livia-job-graph-payload-file.js <input.json> <output.json> --release-root=/opt/skincos/releases/<sha>/source/orb/engine');
+  const workflow = patchWorkflow(JSON.parse(fs.readFileSync(path.resolve(input), 'utf8')), releaseRoot);
+  const touched = validate(workflow);
+  fs.writeFileSync(path.resolve(output), `${JSON.stringify(workflow, null, 2)}\n`, { mode: 0o640 });
+  process.stdout.write(`${JSON.stringify({ ok: true, workflowId: WORKFLOW_ID, nodes: touched })}\n`);
+}
+
+if (require.main === module) main();
+
+module.exports = { ASSERT_CODE, BUILD_NODE, PAYLOAD_DIR, PAYLOAD_FILE_RE, buildCommand, patchWorkflow, validate };

--- a/orb/engine/scripts/prepare-livia-production-candidate.js
+++ b/orb/engine/scripts/prepare-livia-production-candidate.js
@@ -12,6 +12,7 @@ const { patchWorkflow: patchDrivePublicationMarks } = require('./patch-livia-dri
 const { patchWorkflow: patchTokenVaultPreflight } = require('./patch-livia-token-vault-preflight');
 const { patchWorkflow: patchAccessibilityContract } = require('./patch-livia-accessibility-contract');
 const { patchWorkflow: patchFacebookCarouselContract } = require('./patch-livia-facebook-carousel-contract');
+const { patchWorkflow: patchJobGraphPayloadFile } = require('./patch-livia-job-graph-payload-file');
 const { patchResumeIdentity, validate: pinRuntimeIsolation } = require('./patch-livia-runtime-isolation');
 
 const RELEASE_ROOT_RE = /^\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine$/;
@@ -37,6 +38,7 @@ function buildCandidate(workflow, releaseRoot) {
   candidate = patchTokenVaultPreflight(candidate, releaseRoot);
   candidate = patchAccessibilityContract(candidate);
   candidate = patchFacebookCarouselContract(candidate);
+  candidate = patchJobGraphPayloadFile(candidate, releaseRoot);
   const semanticResumeNodes = patchResumeIdentity(candidate);
   const runtimeNodes = pinRuntimeIsolation(candidate, releaseRoot);
 
@@ -50,6 +52,7 @@ function buildCandidate(workflow, releaseRoot) {
         'token-vault-preflight',
         'accessibility-contract',
         'facebook-carousel-contract',
+        'job-graph-payload-file',
         'runtime-isolation',
       ],
       runtimeNodes,

--- a/orb/engine/scripts/validate-livia-workflow.js
+++ b/orb/engine/scripts/validate-livia-workflow.js
@@ -274,6 +274,7 @@ function validateContracts() {
   const buildQueue = codeOf('Build Publish Queue');
   const bqBuildPlatformJobGraph = codeOf('BQ - Build Platform Job Graph');
   const bqBuildPlatformJobGraphCommand = commandOf('BQ - Build Platform Job Graph');
+  const publicationWindowGuard = codeOf('Assert Livia Publication Window');
   const bqSeedPublishState = codeOf('BQ - Seed Publish State');
   const bqValidateJobGraph = codeOf('BQ - Validate Job Graph');
   const switchOutput = String(getNode('Switch Publish Route')?.parameters?.output || '');
@@ -347,6 +348,9 @@ function validateContracts() {
     assert(typeOf('BQ - Build Platform Job Graph') === 'n8n-nodes-base.executeCommand', 'BQ - Build Platform Job Graph must be externalized as Execute Command');
     assert(bqBuildPlatformJobGraphCommand.includes('build-platform-job-graph.js'), 'BQ - Build Platform Job Graph must delegate to scripts/livia/build-platform-job-graph.js');
     assert(bqBuildPlatformJobGraphCommand.includes('--payload'), 'BQ - Build Platform Job Graph command must pass the input payload to the external script');
+    assert(bqBuildPlatformJobGraphCommand.includes('--payload-file'), 'BQ - Build Platform Job Graph must transport the payload through the private file contract');
+    assert(!bqBuildPlatformJobGraphCommand.includes('JSON.stringify(payload)'), 'BQ - Build Platform Job Graph must not embed the full payload in argv');
+    assert(publicationWindowGuard.includes('_liviaBuildJobGraphPayloadFile') && publicationWindowGuard.includes('fs.renameSync'), 'Assert Livia Publication Window must atomically persist the job-graph payload before Execute Command');
     assert(!/\/opt\/skincos\/current\/source|\b(?:ORB_ROOT|N8N_ROOT)\b/.test(bqBuildPlatformJobGraphCommand), 'BQ - Build Platform Job Graph must use an immutable workflow runtime root.');
     assert(/\/opt\/skincos\/releases\/[0-9a-f]{40}\/source\/orb\/engine/.test(bqBuildPlatformJobGraphCommand), 'BQ - Build Platform Job Graph must use a pinned immutable release root.');
     assert(bqBuildPlatformJobGraphCommand.length < 2500, `BQ - Build Platform Job Graph command must stay small enough for stable expression parsing (${bqBuildPlatformJobGraphCommand.length} chars)`);

--- a/orb/engine/tests/livia-production-candidate.test.js
+++ b/orb/engine/tests/livia-production-candidate.test.js
@@ -22,6 +22,7 @@ test('production candidate builder applies every Livia fail-closed patch as one 
     'token-vault-preflight',
     'accessibility-contract',
     'facebook-carousel-contract',
+    'job-graph-payload-file',
     'runtime-isolation',
   ]);
   assert.equal(nodes.has('Merge Drive Result and Context'), false);
@@ -32,6 +33,11 @@ test('production candidate builder applies every Livia fail-closed patch as one 
   assert.match(nodes.get('Prepare HTTP Publish Request').parameters.jsCode, /sourceMediaCount/);
   assert.match(nodes.get('Prepare HTTP Publish Request').parameters.jsCode, /perdeu a ordem ou identidade semântica/);
   assert.match(nodes.get('Collect Publish Results').parameters.jsCode, /mediaEvidenceContract/);
+  assert.match(nodes.get('Assert Livia Publication Window').parameters.jsCode, /_liviaBuildJobGraphPayloadFile/);
+  assert.match(nodes.get('Assert Livia Publication Window').parameters.jsCode, /fs\.renameSync/);
+  assert.doesNotMatch(nodes.get('Assert Livia Publication Window').parameters.jsCode, /process\.pid/);
+  assert.match(nodes.get('BQ - Build Platform Job Graph').parameters.command, /--payload-file/);
+  assert.doesNotMatch(nodes.get('BQ - Build Platform Job Graph').parameters.command, /JSON\.stringify\(payload\)/);
 
   for (const node of workflow.nodes.filter((node) => node.type === 'n8n-nodes-base.executeCommand')) {
     const command = String(node.parameters?.command || '');


### PR DESCRIPTION
## Objetivo

Corrigir o transporte do contexto do job graph do workflow Livia para carrosséis grandes, sem alterar a semântica de imagem, carrossel, Reel ou publicação por plataforma.

## Causa

O contexto completo era serializado na linha de comando do Execute Command. Carrosséis grandes ultrapassavam o limite de argv e falhavam com `spawn E2BIG` antes do builder e do gateway.

## Alteração

- `Assert Livia Publication Window` grava o payload em arquivo privado, atomicamente, com SHA-256.
- `BQ - Build Platform Job Graph` valida caminho/hash e usa `--payload-file`; o conteúdo não é colocado em argv.
- O arquivo é removido pelo trap do comando.
- Validações e testes de contrato cobrem o transporte e rejeitam `process.pid` no sandbox.
- Nenhum nó de vídeo, `Analyze Video`, frame editorial ou contrato de Reel foi alterado.

## Validação

- 11 testes Livia de candidato, runtime e QA: verdes.
- Matriz offline: imagem única, vídeo único, carrossel de imagens, carrossel de vídeos e carrossel misto.
- Execução real `349`: 8 imagens, 64 jobs, seis destinos, todos verificados, sem duplicidade.
- Release operacional já usada pelo workflow: `c96caa4fec6fc0c33cc3b3904792905c6f38eda7`.

## Rollback

A versão histórica anterior do workflow e o checkpoint privado permanecem preservados. O rollback é feito por nova versão histórica, usando o manifesto correspondente; não há alteração do ponteiro global.

Checkpoint: `C:\CodexRuntime\operator\admin\skincos\checkpoints\livia-carousel-success-20260731T143500Z\`