### PR TITLE
fix(runtime): stage Livia payload patch for promotion

### DIFF
--- a/scripts/runtime/prepare-native-source-release.sh
+++ b/scripts/runtime/prepare-native-source-release.sh
@@ -166,6 +166,7 @@ sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/scripts/patch-livia-token-vault-preflight.js" \
   "$DESTINATION/orb/engine/scripts/patch-livia-accessibility-contract.js" \
   "$DESTINATION/orb/engine/scripts/patch-livia-facebook-carousel-contract.js" \
+  "$DESTINATION/orb/engine/scripts/patch-livia-job-graph-payload-file.js" \
   "$DESTINATION/orb/engine/scripts/patch-livia-runtime-isolation.js"
 # The workflow-version writer runs as postgres.  It hashes the exact Livia
 # sidecar entrypoints before committing a workflow version, so it needs read

--- a/scripts/runtime/test-prepare-native-source-release.sh
+++ b/scripts/runtime/test-prepare-native-source-release.sh
@@ -24,6 +24,7 @@ required=(
   'patch-livia-token-vault-preflight.js'
   'patch-livia-accessibility-contract.js'
   'patch-livia-facebook-carousel-contract.js'
+  'patch-livia-job-graph-payload-file.js'
   'patch-livia-runtime-isolation.js'
   'Missing required command: setfacl'
   'u:postgres:rwx'


### PR DESCRIPTION
## Objetivo

Completar o processo de promoção nativa do Livia após a PR #937.

## Causa

O bundle já incluía `patch-livia-job-graph-payload-file.js`, mas `prepare-native-source-release.sh` não concedia leitura desse módulo ao usuário `postgres`. A promoção falhava ao construir o candidato antes de alterar produção.

## Alteração

- Conceder ACL de leitura ao patch do payload no bundle imutável.
- Adicionar teste de contrato que impede a regressão da ACL.
- Nenhum workflow, credencial, ponteiro global ou lógica de publicação é alterado por esta PR.

## Validação

- `test-prepare-native-source-release.sh` passou.
- Bundle candidato será reconstruído do merge commit e validado antes do repin.
- Rollback permanece no release anterior `f0200ee0aebe8d9f479179237435ed8727ce9458` e no checkpoint privado.

## Risco e rollback

Escopo restrito ao staging de source nativo. Se a validação falhar, nenhum ponteiro ou workflow é alterado. Após promoção, o rollback usa a release imutável anterior pelo procedimento controlado.