### PR TITLE
fix(crm): normalize source origin for runtime reuse

### DIFF
--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -500,6 +500,19 @@ function Get-CrmLocalSourceOrigin {
     return "{0}__{1}" -f $sourceRoot, $Module.Trim().ToLowerInvariant()
 }
 
+function Convert-CrmSourceOriginToWsl {
+    param([Parameter(Mandatory = $true)][string]$SourceOrigin)
+
+    # Runtime manifests are written inside Ubuntu, so a source origin that
+    # crosses the typed Windows -> WSL boundary must use the same canonical
+    # path form before it is compared by the Node policy.  The module suffix
+    # (for example ``__crm-shell``) intentionally remains part of the value.
+    if ($SourceOrigin -match '^[A-Za-z]:[\\/]') {
+        return Convert-WindowsPathToWsl -Path $SourceOrigin
+    }
+    return ($SourceOrigin -replace '\\', '/')
+}
+
 function Apply-CrmLocalSourceSnapshot {
     param(
         [Parameter(Mandatory = $true)][object]$Snapshot,
@@ -963,7 +976,7 @@ function Get-CrmPersonaDecision {
         "--build-state", $buildStateWsl,
         "--target", $TargetCommit,
         "--source-fingerprint", $SourceFingerprint,
-        "--source-origin", $SourceOrigin,
+        "--source-origin", (Convert-CrmSourceOriginToWsl -SourceOrigin $SourceOrigin),
         "--persona", $Persona.ToUpperInvariant(),
         "--runtime-id", $RuntimeId,
         "--module", $Module,
@@ -1886,7 +1899,7 @@ function Get-CrmInstanceDecision {
         "--build-state", $buildStateWsl,
         "--target", $TargetCommit,
         "--source-fingerprint", $SourceFingerprint,
-        "--source-origin", $SourceOrigin,
+        "--source-origin", (Convert-CrmSourceOriginToWsl -SourceOrigin $SourceOrigin),
         "--persona", ([string]$Spec.roleKey),
         "--runtime-id", ([string]$Spec.runtimeId),
         "--module", ([string]$Spec.module),

--- a/scripts/tests/crm-local-dual-persona.test.mjs
+++ b/scripts/tests/crm-local-dual-persona.test.mjs
@@ -592,6 +592,8 @@ test('immutable source and build cache are keyed by the exact source fingerprint
   assert.match(launcher, /não corresponde à impressão solicitada; ela não será alterada/)
   assert.match(launcher, /\$crmBuildCacheRoot = Join-Path \$operatorRuntimeRoot "cache\\crm-local\\builds"/)
   assert.match(launcher, /Get-CrmInstanceBuildPaths -SourceFingerprint/)
+  assert.match(launcher, /function Convert-CrmSourceOriginToWsl/)
+  assert.match(launcher, /"--source-origin", \(Convert-CrmSourceOriginToWsl -SourceOrigin \$SourceOrigin\)/)
   assert.match(launcher, /\$sourceOrigin = "\{0\}__\{1\}" -f \$sourceRoot, \(\[string\]\$spec\.runtimeId\)/)
   assert.match(launcher, /Local\\SkincosCrmPersonaSource-\$\(\$Persona\.ToLowerInvariant\(\)\)/)
   assert.match(launcher, /function Assert-CrmLocalLauncherContract/)


### PR DESCRIPTION
## Summary
- normalize Windows source-origin tokens to the canonical WSL form before runtime-policy comparison
- preserve the module/runtime suffix while keeping manifests and policy inputs equivalent
- add a regression assertion to the dual-persona launcher contract test

## Validation
- PowerShell parsers and git diff --check
- crm-local-build-state.test.mjs (15/15)
- crm-local-dual-persona.test.mjs (19/19)
- invoke-skincos-wsl.test.ps1
- test-wsl-runtime-keepalive.ps1