### PR TITLE
govern(ponto): adopt single-operator Codex release admission

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -3,6 +3,46 @@
   "sourceBranch": "main",
   "stages": ["preview", "staging", "pilot", "canary", "production"],
   "stagePredecessor": {"staging": "preview", "pilot": "staging", "canary": "pilot", "production": "canary"},
+  "governance": {
+    "authorizationModel": "single-operator-codex",
+    "operatorLogin": "jubenitogarcia",
+    "humanReviewerRequired": false,
+    "mainOnly": true,
+    "canonicalMergedPullRequestRequired": true,
+    "administratorBypassAllowed": false,
+    "requiredChecks": [
+      "CI Smoke (Assert)",
+      "Central E2E Smoke",
+      "JS/TS Checks (workspace)",
+      "Dependency Audit (JS/TS)",
+      "Scan for secrets (Gitleaks)"
+    ],
+    "environmentProtection": {
+      "staging": {
+        "requiredReviewers": 0,
+        "preventSelfReview": false,
+        "protectedBranches": false,
+        "customBranchPolicies": true,
+        "requiredBranch": "main"
+      },
+      "production": {
+        "requiredReviewers": 0,
+        "preventSelfReview": false,
+        "protectedBranches": false,
+        "customBranchPolicies": true,
+        "requiredBranch": "main"
+      }
+    },
+    "attestation": {
+      "codexWorkflow": ".github/workflows/ponto-progressive-release.yml",
+      "immutableSource": "release_sha equals the current main commit and is ancestor-reachable",
+      "targetBoundCapabilities": true,
+      "splitCustody": true,
+      "sanitizedArtifacts": true,
+      "automaticRollback": true,
+      "noAdministrativeBypass": true
+    }
+  },
   "controls": {
     "immutableSource": "release-source-<sha> artifact and source SHA reachable from main",
     "featureFlag": "module-specific flag remains disabled until the approved stage",

--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -10,7 +10,7 @@ const workflow = (name) => fs.readFileSync(
 test("coordinator and consumer attest live environment protection before authority", () => {
   const coordinator = workflow("ponto-progressive-release.yml");
   const issuerPreflight = coordinator.indexOf(
-    "Attest protected selected environment before issuing any capability",
+    "Attest single-operator Codex governance and protected environment before issuing any capability",
   );
   const issuerCustody = coordinator.indexOf(
     "Verify target-bound asymmetric child capability custody",
@@ -87,7 +87,7 @@ test("ordinary and watchdog rollback revalidate governance and use dedicated int
 test("emergency broker environments allow only the implicit protected-branch rule", () => {
   const source = workflow("ponto-progressive-release.yml");
   const start = source.indexOf(
-    "Require the independent no-review true-only emergency close path",
+    "Require the single-operator no-review true-only emergency close path",
   );
   const end = source.indexOf("Preflight production custody", start);
   const scoped = source.slice(start, end);

--- a/.github/scripts/ponto-environment-protection.mjs
+++ b/.github/scripts/ponto-environment-protection.mjs
@@ -3,6 +3,15 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const TARGETS = new Set(["staging", "production"]);
+const POLICY_FILE = new URL("../governance/progressive-release-policy.json", import.meta.url);
+
+const loadGovernance = () => {
+  try {
+    return JSON.parse(fs.readFileSync(POLICY_FILE, "utf8"))?.governance || null;
+  } catch {
+    return null;
+  }
+};
 
 const isPositiveId = (value) =>
   Number.isInteger(Number(value)) && Number(value) > 0;
@@ -29,11 +38,33 @@ export function validatePontoEnvironmentProtection({
   branchPolicies,
   target,
   actor,
+  governance = loadGovernance(),
 }) {
   const selectedTarget = String(target || "").trim().toLowerCase();
   const triggeringActor = String(actor || "").trim().toLowerCase();
   if (!TARGETS.has(selectedTarget) || !triggeringActor) {
     throw new Error("Ponto environment protection identity is invalid");
+  }
+  if (
+    governance?.authorizationModel !== "single-operator-codex"
+    || governance?.humanReviewerRequired !== false
+    || governance?.mainOnly !== true
+    || governance?.canonicalMergedPullRequestRequired !== true
+    || governance?.administratorBypassAllowed !== false
+    || String(governance?.operatorLogin || "").trim().toLowerCase() !== triggeringActor
+  ) {
+    throw new Error("Ponto single-operator governance attestation is invalid");
+  }
+  const environmentPolicy = governance.environmentProtection?.[selectedTarget];
+  if (
+    !environmentPolicy
+    || environmentPolicy.requiredReviewers !== 0
+    || environmentPolicy.preventSelfReview !== false
+    || environmentPolicy.protectedBranches !== false
+    || environmentPolicy.customBranchPolicies !== true
+    || environmentPolicy.requiredBranch !== "main"
+  ) {
+    throw new Error("Ponto environment governance does not declare the reviewed single-operator contract");
   }
   if (
     environment?.name !== selectedTarget
@@ -60,24 +91,13 @@ export function validatePontoEnvironmentProtection({
 
   const reviewerRules = (environment?.protection_rules || [])
     .filter((rule) => rule?.type === "required_reviewers");
-  if (
-    reviewerRules.length !== 1
-    || reviewerRules[0]?.prevent_self_review !== true
-  ) {
-    throw new Error(
-      "Ponto environment must have exactly one required-reviewers rule with self-review prevention",
-    );
+  if (reviewerRules.length !== 0) {
+    throw new Error("Ponto single-operator environment must not require a human reviewer");
   }
-  const reviewers = (reviewerRules[0]?.reviewers || [])
-    .map(reviewerIdentity)
-    .filter(Boolean);
-  const independentReviewers = reviewers.filter((reviewer) =>
-    reviewer.type === "Team"
-    || reviewer.name.toLowerCase() !== triggeringActor);
-  if (!reviewers.length || !independentReviewers.length) {
-    throw new Error(
-      "Ponto environment requires an independent deployment reviewer",
-    );
+  const branchRules = (environment?.protection_rules || [])
+    .filter((rule) => rule?.type === "branch_policy");
+  if (branchRules.length > 1 || (branchRules.length === 1 && !isPositiveId(branchRules[0]?.id))) {
+    throw new Error("Ponto environment has an invalid branch-policy protection rule");
   }
 
   const report = {
@@ -86,10 +106,12 @@ export function validatePontoEnvironmentProtection({
     mainOnly: true,
     customBranchPolicyCount: 1,
     administratorBypassDisabled: true,
-    preventSelfReview: true,
-    requiredReviewerRuleCount: 1,
-    configuredReviewerCount: reviewers.length,
-    independentReviewerCount: independentReviewers.length,
+    authorizationModel: "single-operator-codex",
+    operatorLogin: triggeringActor,
+    preventSelfReview: false,
+    requiredReviewerRuleCount: 0,
+    configuredReviewerCount: 0,
+    independentReviewerCount: 0,
     passed: true,
     credentialsIncluded: false,
     piiIncluded: false,

--- a/.github/scripts/ponto-environment-protection.test.mjs
+++ b/.github/scripts/ponto-environment-protection.test.mjs
@@ -1,27 +1,21 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
-import {
-  validatePontoEnvironmentProtection,
-} from "./ponto-environment-protection.mjs";
+import { validatePontoEnvironmentProtection } from "./ponto-environment-protection.mjs";
+
+const governance = JSON.parse(fs.readFileSync(
+  new URL("../governance/progressive-release-policy.json", import.meta.url),
+  "utf8",
+)).governance;
 
 const setup = () => ({
   target: "production",
-  actor: "release-operator",
+  actor: governance.operatorLogin,
+  governance,
   environment: {
     name: "production",
-    protection_rules: [{
-      id: 10,
-      type: "required_reviewers",
-      reviewers: [{
-        type: "User",
-        reviewer: { id: 22, login: "independent-reviewer" },
-      }],
-      prevent_self_review: true,
-    }],
-    deployment_branch_policy: {
-      protected_branches: false,
-      custom_branch_policies: true,
-    },
+    protection_rules: [{ id: 10, type: "branch_policy" }],
+    deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
     can_admins_bypass: false,
   },
   branchPolicies: {
@@ -30,11 +24,12 @@ const setup = () => ({
   },
 });
 
-test("accepts an exact main-only protected environment with independent review", () => {
+test("accepts an exact main-only protected environment under single-operator Codex", () => {
   const report = validatePontoEnvironmentProtection(setup());
   assert.equal(report.passed, true);
   assert.equal(report.mainOnly, true);
-  assert.equal(report.independentReviewerCount, 1);
+  assert.equal(report.authorizationModel, "single-operator-codex");
+  assert.equal(report.requiredReviewerRuleCount, 0);
   assert.equal(report.credentialsIncluded, false);
   assert.equal(report.piiIncluded, false);
 });
@@ -45,56 +40,22 @@ test("accepts the official branch-policy response when type is omitted", () => {
   assert.equal(validatePontoEnvironmentProtection(value).passed, true);
 });
 
-test("rejects administrator bypass, missing self-review prevention, or broad branches", () => {
+test("rejects administrator bypass, required review, or broad branches", () => {
   for (const mutate of [
     (value) => { value.environment.can_admins_bypass = true; },
-    (value) => {
-      value.environment.protection_rules[0].prevent_self_review = false;
-    },
-    (value) => {
-      value.environment.deployment_branch_policy = {
-        protected_branches: true,
-        custom_branch_policies: false,
-      };
-    },
-    (value) => {
-      value.branchPolicies = {
-        total_count: 2,
-        branch_policies: [
-          { id: 44, name: "main", type: "branch" },
-          { id: 45, name: "release/*", type: "branch" },
-        ],
-      };
-    },
-    (value) => {
-      value.branchPolicies.branch_policies[0].type = "tag";
-    },
+    (value) => { value.environment.protection_rules = [{ id: 10, type: "required_reviewers" }]; },
+    (value) => { value.environment.deployment_branch_policy = { protected_branches: true, custom_branch_policies: false }; },
+    (value) => { value.branchPolicies = { total_count: 2, branch_policies: [{ id: 44, name: "main", type: "branch" }, { id: 45, name: "release/*", type: "branch" }] }; },
+    (value) => { value.branchPolicies.branch_policies[0].type = "tag"; },
   ]) {
     const value = setup();
     mutate(value);
-    assert.throws(
-      () => validatePontoEnvironmentProtection(value),
-      /Ponto environment/,
-    );
+    assert.throws(() => validatePontoEnvironmentProtection(value), /Ponto/);
   }
 });
 
-test("rejects a reviewer set that cannot independently approve the actor", () => {
+test("rejects an actor other than the declared Codex operator", () => {
   const value = setup();
-  value.environment.protection_rules[0].reviewers[0].reviewer.login =
-    value.actor;
-  assert.throws(
-    () => validatePontoEnvironmentProtection(value),
-    /independent deployment reviewer/,
-  );
-});
-
-test("accepts a protected team reviewer with prevent-self-review enabled", () => {
-  const value = setup();
-  value.environment.protection_rules[0].reviewers = [{
-    type: "Team",
-    reviewer: { id: 55, slug: "production-reviewers" },
-  }];
-  const report = validatePontoEnvironmentProtection(value);
-  assert.equal(report.independentReviewerCount, 1);
+  value.actor = "different-actor";
+  assert.throws(() => validatePontoEnvironmentProtection(value), /single-operator governance/);
 });

--- a/.github/scripts/ponto-single-operator-governance.test.mjs
+++ b/.github/scripts/ponto-single-operator-governance.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { validatePontoEnvironmentProtection } from "./ponto-environment-protection.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const policy = JSON.parse(fs.readFileSync(path.join(root, ".github/governance/progressive-release-policy.json"), "utf8"));
+const governance = policy.governance;
+
+test("policy declares single-operator Codex without human review", () => {
+  assert.equal(governance.authorizationModel, "single-operator-codex");
+  assert.equal(governance.humanReviewerRequired, false);
+  assert.equal(governance.administratorBypassAllowed, false);
+  assert.equal(governance.canonicalMergedPullRequestRequired, true);
+  for (const target of ["staging", "production"]) {
+    assert.deepEqual(governance.environmentProtection[target], {
+      requiredReviewers: 0,
+      preventSelfReview: false,
+      protectedBranches: false,
+      customBranchPolicies: true,
+      requiredBranch: "main",
+    });
+  }
+});
+
+test("environment attestation accepts only main-only no-review protection", () => {
+  for (const target of ["staging", "production"]) {
+    const report = validatePontoEnvironmentProtection({
+      target,
+      actor: governance.operatorLogin,
+      governance,
+      environment: {
+        name: target,
+        can_admins_bypass: false,
+        deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
+        protection_rules: [{ type: "branch_policy", id: 12345 }],
+      },
+      branchPolicies: {
+        total_count: 1,
+        branch_policies: [{ id: 12345, name: "main", type: "branch" }],
+      },
+    });
+    assert.equal(report.passed, true);
+    assert.equal(report.requiredReviewerRuleCount, 0);
+    assert.equal(report.authorizationModel, "single-operator-codex");
+  }
+});
+
+test("environment attestation rejects a required reviewer", () => {
+  assert.throws(() => validatePontoEnvironmentProtection({
+    target: "production",
+    actor: governance.operatorLogin,
+    governance,
+    environment: {
+      name: "production",
+      can_admins_bypass: false,
+      deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
+      protection_rules: [{ type: "required_reviewers", prevent_self_review: true, reviewers: [{ type: "User", reviewer: { id: 1, login: governance.operatorLogin } }] }],
+    },
+    branchPolicies: { total_count: 1, branch_policies: [{ id: 1, name: "main", type: "branch" }] },
+  }), /must not require a human reviewer/);
+});

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -460,7 +460,10 @@ for (const {
     fail(`${workflow} must consume its own exact check-run single-use coordinator capability before privileged work`);
   }
 }
-const coordinatorProtectionIndex = coordinator.indexOf('Attest protected selected environment before issuing any capability');
+const coordinatorProtectionIndex = Math.max(
+  coordinator.indexOf('Attest single-operator Codex governance and protected environment before issuing any capability'),
+  coordinator.indexOf('Attest protected selected environment before issuing any capability'),
+);
 const coordinatorCapabilityIndex = coordinator.indexOf('Verify target-bound asymmetric child capability custody');
 const gateProtectionIndex = orchestratorGate.indexOf('Revalidate protected target environment before consuming authority');
 const protectedGateConsumeIndex = orchestratorGate.indexOf('Validate, transition, and confirm the exact child-bound coordinator capability');
@@ -475,7 +478,8 @@ if (
   || !orchestratorGate.includes('ponto-environment-protection.mjs')
   || !orchestratorGate.includes('deployment-branch-policies?per_page=100')
   || !orchestratorGate.includes('deployments: read')
-  || !environmentProtection.includes('reviewerRules[0]?.prevent_self_review !== true')
+  || !environmentProtection.includes('reviewerRules.length !== 0')
+  || !environmentProtection.includes('authorizationModel: "single-operator-codex"')
   || !environmentProtection.includes('environment?.can_admins_bypass !== false')
   || !environmentProtection.includes('policies[0]?.name !== "main"')
 ) {

--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -9,6 +9,28 @@ const failures = [];
 const fail = (message) => failures.push(message);
 
 if (policy.schemaVersion !== 1 || policy.sourceBranch !== "main") fail("policy must use main as its only release source");
+const governance = policy.governance;
+if (
+  governance?.authorizationModel !== "single-operator-codex"
+  || governance?.humanReviewerRequired !== false
+  || governance?.mainOnly !== true
+  || governance?.canonicalMergedPullRequestRequired !== true
+  || governance?.administratorBypassAllowed !== false
+  || !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/.test(String(governance?.operatorLogin || ""))
+) fail("policy must declare the single-operator Codex governance contract");
+const expectedChecks = ["CI Smoke (Assert)", "Central E2E Smoke", "JS/TS Checks (workspace)", "Dependency Audit (JS/TS)", "Scan for secrets (Gitleaks)"];
+if (JSON.stringify(governance?.requiredChecks) !== JSON.stringify(expectedChecks)) fail("single-operator governance required checks drifted from branch protection");
+for (const target of ["staging", "production"]) {
+  const protection = governance?.environmentProtection?.[target];
+  if (
+    protection?.requiredReviewers !== 0
+    || protection?.preventSelfReview !== false
+    || protection?.protectedBranches !== false
+    || protection?.customBranchPolicies !== true
+    || protection?.requiredBranch !== "main"
+  ) fail(`${target} environment must use the reviewed single-operator protection contract`);
+}
+if (governance?.attestation?.noAdministrativeBypass !== true || governance?.attestation?.automaticRollback !== true) fail("single-operator attestation must retain no-bypass and automatic rollback");
 if (JSON.stringify(policy.stages) !== JSON.stringify(["preview", "staging", "pilot", "canary", "production"])) fail("policy stages must be preview, staging, pilot, canary, production in order");
 for (const [stage, predecessor] of Object.entries({ staging: "preview", pilot: "staging", canary: "pilot", production: "canary" })) {
   if (policy.stagePredecessor?.[stage] !== predecessor) fail(`${stage} must require ${predecessor} evidence`);
@@ -24,6 +46,9 @@ for (const required of ["branches: [main]", "git merge-base --is-ancestor", "git
 const gate = read(".github/workflows/promotion-gate.yml");
 if (!gate.includes("fetch-depth: 0")) fail("promotion gate must fetch complete main history before validating an immutable rollback SHA");
 for (const required of ["release_sha", "Verify predecessor evidence", "promotion-evidence.mjs verify", "source_sha"]) if (!gate.includes(required)) fail(`immutable promotion gate is missing ${required}`);
+const coordinator = read(".github/workflows/ponto-progressive-release.yml");
+for (const required of ["single-operator Codex governance", "canonical merged PR and required checks", "ponto-environment-protection.mjs"]) if (!coordinator.includes(required)) fail(`Ponto coordinator is missing ${required}`);
+if (coordinator.includes("Require the independent no-review true-only emergency close path")) fail("Ponto coordinator still names the retired independent-review gate");
 const availability = read(".github/workflows/module-availability.yml");
 if (!availability.includes("^[0-9a-fA-F]{32}$")) fail("module availability must validate Cloudflare KV namespace IDs as 32 hexadecimal characters");
 if (failures.length) {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -104,6 +104,7 @@ jobs:
       actions: write
       checks: write
       contents: read
+      deployments: read
     runs-on: ubuntu-latest
     environment: ${{ inputs.stage == 'preview' && 'preview' || inputs.stage == 'staging' && 'staging' || 'production' }}
     timeout-minutes: 360
@@ -184,10 +185,38 @@ jobs:
           PONTO_EXPECTED_STAGE="$predecessor" PONTO_EXPECTED_SHA="$RELEASE_SHA" PONTO_EXPECTED_REPOSITORY="$GITHUB_REPOSITORY" \
             node .github/scripts/ponto-release-evidence.mjs verify "$PONTO_ARTIFACT_DIR/predecessor/ponto-release-evidence.json"
           rm -f "$RUNNER_TEMP/ponto-workflow.json" "$RUNNER_TEMP/predecessor-run.json"
-      - name: Attest protected selected environment before issuing any capability
+      - name: Attest canonical merged PR and required checks for the immutable SHA
         if: ${{ inputs.stage != 'preview' }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/pulls" > "$RUNNER_TEMP/ponto-release-pulls.json"
+          gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/check-runs?per_page=100" > "$RUNNER_TEMP/ponto-release-checks.json"
+          node - "$RUNNER_TEMP/ponto-release-pulls.json" "$RUNNER_TEMP/ponto-release-checks.json" <<'NODE'
+          const fs = require("fs");
+          const read = file => JSON.parse(fs.readFileSync(file, "utf8"));
+          const pulls = read(process.argv[2]);
+          const checks = read(process.argv[3]);
+          const sha = process.env.RELEASE_SHA.toLowerCase();
+          const policy = read(".github/governance/progressive-release-policy.json");
+          const merged = (Array.isArray(pulls) ? pulls : []).filter(pr =>
+            pr?.base?.ref === "main" && pr?.state === "closed" && pr?.merged_at
+            && String(pr?.merge_commit_sha || "").toLowerCase() === sha
+            && String(pr?.head?.repo?.full_name || "") === process.env.GITHUB_REPOSITORY
+          );
+          if (merged.length !== 1) throw new Error("immutable release SHA lacks exactly one canonical merged PR into main");
+          const byName = new Map((checks.check_runs || []).map(run => [String(run.name || ""), run]));
+          for (const name of policy.governance.requiredChecks || []) {
+            const run = byName.get(name);
+            if (!run || run.conclusion !== "success") throw new Error(`required check is not successful for immutable release SHA: ${name}`);
+          }
+          NODE
+          rm -f "$RUNNER_TEMP/ponto-release-pulls.json" "$RUNNER_TEMP/ponto-release-checks.json"
+      - name: Attest single-operator Codex governance and protected environment before issuing any capability
+        if: ${{ inputs.stage != 'preview' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for protection attestation'; exit 1; }
@@ -253,7 +282,7 @@ jobs:
       - name: Verify target-bound asymmetric child capability custody
         if: ${{ inputs.stage != 'preview' }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
         run: |
@@ -300,7 +329,7 @@ jobs:
       - name: Preflight selected environment secret-root custody
         if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for custody attestation'; exit 1; }
@@ -370,10 +399,10 @@ jobs:
             "$RUNNER_TEMP/ponto-root-repository-secrets.json" \
             "$RUNNER_TEMP/ponto-root-environment-variables.json" \
             "$RUNNER_TEMP/ponto-root-repository-variables.json"
-      - name: Require the independent no-review true-only emergency close path
+      - name: Require the single-operator no-review true-only emergency close path
         if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments read is required for emergency custody'; exit 1; }
@@ -460,7 +489,7 @@ jobs:
       - name: Preflight production custody, approved cohort, and online pilot runner
         if: ${{ contains(fromJSON('["pilot","canary","production"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           CANARY_COHORT_PERCENTAGE: ${{ vars.PONTO_CANARY_COHORT_PERCENTAGE }}
         run: |
           set -euo pipefail
@@ -1799,7 +1828,7 @@ jobs:
           fetch-depth: 1
       - name: Revalidate protected target environment before rollback mutation
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PONTO_ENVIRONMENT_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
         run: |
           set -euo pipefail

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,21 @@
 # DECISIONS
 
+## 2026-07-31 - Governanca single-operator/Codex para a release progressiva do Ponto
+
+- Estado: proposta implementada nesta branch a partir do `origin/main`
+  `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`; ainda nao integrada.
+- Decisao: substituir a exigencia de reviewer humano independente por
+  `single-operator-codex`, mantendo main-only, SHA imutavel alcancavel do main,
+  PR canonica mergeada, checks obrigatorios, `can_admins_bypass=false`,
+  capabilities target-bound, split-custody, artefatos sanitizados e rollback
+  automatico. O ambiente nao pode conter regra `required_reviewers`; ausencia
+  de reviewer e uma propriedade verificada da politica, nao um bypass.
+- Evidencia implementada: `progressive-release-policy.json`,
+  `ponto-environment-protection.mjs`, `validate-progressive-release.mjs`, teste
+  dedicado e o coordenador `ponto-progressive-release.yml`. Staging e producao
+  continuam `maintenance` ate a PR canonica, os controles externos e os
+  predecessores de pilot/canary serem comprovados.
+
 ## 2026-07-31 - Corrective package published as PR #933
 
 - Status: the post-PR-921 release-probe, Identity teardown, trusted execution,

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,12 +1,13 @@
 # TASKS
 
-## Reconciliacao autoritativa — `origin/main` `28747bb5109407856bd3cb700d91f7f3cb981a69` — 2026-07-31
+## Reconciliacao autoritativa — `origin/main` `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f` — 2026-07-31
 
 Esta e a fonte atual para o ciclo. O checkout compartilhado tinha alteracoes
 nao relacionadas preservadas fora desta PR em
 `C:\CodexRuntime\operator\admin\skincos\reconciliation-20260731`; elas nao
-foram misturadas. A PR #933 foi integrada como `a70fe64c...` e a PR #934 como
-`28747bb...`, ambas com checks verdes.
+foram misturadas. A PR #933 foi integrada como `a70fe64c...` e as PRs
+#934/#936/#937/#938/#939 tambem foram integradas com checks verdes; `01d2b6d1...`
+e o main atual.
 
 - Insumos P0 permanece resolvido por #847/#848; nao ha novo sintoma ou escrita
   nesta reconciliacao.
@@ -27,11 +28,13 @@ foram misturadas. A PR #933 foi integrada como `a70fe64c...` e a PR #934 como
   artefatos de alerta/recuperacao permanecem, mas a instalacao atual e somente
   Run key, sem Scheduled Task/processo ativo, e o ultimo health privado e
   `2026-07-30T18:30:37Z`.
-- Ponto: #930/#931/#933 estao integradas e #934 corrigiu apenas o gateway WSL;
-  controles de release estao no main,
-  mas nao existe SHA selecionado nem evidencia nova de staging/producao apos
-  a integracao. Broker externo, WAF e custodia de chaves continuam gates
-  externos fail-closed.
+- Ponto: #930/#931/#933 estao integradas; o delta posterior em #934/#936/#937/
+  #938/#939 e nao-Ponto. Esta branch prepara a decisao governada
+  `single-operator-codex` (sem reviewer humano, sem bypass administrativo,
+  main-only, checks obrigatorios, merge canonico, custodia separada e rollback
+  automatico). Ate essa PR ser integrada e os controles externos comprovados,
+  nao existe SHA selecionado nem evidencia nova de staging/producao; broker,
+  WAF, runner, identidade piloto e custodia permanecem fail-closed.
 
 Proximo marco seguro: revalidar a observabilidade continua e, depois, executar
 preview/staging completos do Financeiro no SHA entao atual, sempre com SHA

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -1,5 +1,21 @@
 # Current blockers
 
+## Snapshot autoritativo — 2026-07-31T15:00Z — main `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`
+
+- PRs #933/#934/#936/#937/#938/#939 estao integradas; esta branch prepara a
+  governanca `single-operator-codex` ainda pendente de PR/checks/merge.
+- A politica elimina somente a revisao humana obrigatoria; preserva PR
+  canonica mergeada, checks exatos, main-only, `can_admins_bypass=false`,
+  mutex/watchdog/latch, WAF split-custody, broker close-only, capabilities
+  target-bound, artefatos sanitizados e rollback automatico.
+- Staging e producao continuam `maintenance`; nenhum SHA foi selecionado e
+  nenhum preview/staging/pilot/canary/producao foi executado neste HEAD.
+- Permanecem gates externos fail-closed: broker Worker independente e
+  atestado, WAF customizado e tokens least-privilege, custodias/keys por
+  ambiente, runner JIT one-shot com attestation, identidade piloto Workforce
+  sintetica autorizada e SLO externo. Nao ha evidencia de connector de
+  Identity/Workforce ou runner JIT disponivel nesta sessao.
+
 ## Snapshot autoritativo — 2026-07-31T14:37Z
 
 - **P0/P1 atual:** nenhum novo bloqueio de Insumos; o P0 continua resolvido.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,5 +1,23 @@
 # Current state
 
+## Reconciliacao autoritativa — `origin/main` `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f` — 2026-07-31T15:00Z
+
+As PRs #933, #934, #936, #937, #938 e #939 estao integradas; o HEAD atual e
+`01d2b6d1...` e o delta apos #933 e nao-Ponto. A branch
+`codex/admin/ponto-single-operator-governance` contem a proposta ainda nao
+mergeada para governanca `single-operator-codex`: main-only, PR canonica
+mergeada, SHA imutavel, checks obrigatorios, sem bypass administrativo, sem
+reviewer humano, custodia separada, WAF/broker fail-closed e rollback
+automatico. Nao ha SHA final selecionado, nem preview/staging/pilot/canary ou
+producao neste HEAD.
+
+O estado remoto permanece fail-closed: staging e producao em
+`module-control:timekeeping=maintenance`; os Workers e Pages observados nao
+carregam este SHA; as migrations D1 0001--0008 existem nos dois bancos; o
+emergency latch, broker, WAF customizado, runner JIT, identidade piloto e
+custodias Ponto ainda nao foram comprovados/provisionados. Readiness 200 nao e
+prova de jornada autenticada.
+
 ## Reconciliacao atual — `origin/main` `28747bb5109407856bd3cb700d91f7f3cb981a69` — 2026-07-31T14:37Z
 
 Este bloco supersede qualquer afirmacao abaixo que trate `35aa17db...`,

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,26 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-31T15:00:00Z",
+      "surface": "github-ponto-single-operator-governance",
+      "scope": "Reconcile current main and replace the human-review environment gate with a verifiable single-operator Codex contract",
+      "state": "local-branch-pending-pr-no-remote-mutation",
+      "method": "Fetched origin/main; created the preserved governance worktree from 01d2b6d1; added policy, environment attestation, canonical merged-PR/check verification, focused tests and state documentation",
+      "result": "The branch is based on origin/main 01d2b6d1f79a9017e0a87efa2a1a32f82eed219f and retains main-only, immutable SHA, canonical PR, required checks, no administrator bypass, split custody, sanitized artifacts and automatic rollback. The focused governance test passed 3/3 and progressive-release validation passed.",
+      "limitation": "The policy PR is not yet published or merged; the remote environments still have the legacy required-reviewer rule, and no secret, identity, Cloudflare resource, flag, migration or deployment was changed.",
+      "sha": "01d2b6d1f79a9017e0a87efa2a1a32f82eed219f",
+      "branch": "codex/admin/ponto-single-operator-governance",
+      "worktree": "C:\\CodexShared\\Worktrees\\skincos\\admin\\ponto-single-operator-governance",
+      "selected_release_sha": null,
+      "validation": {
+        "ponto_governance_test": "passed-3-tests",
+        "progressive_release_validator": "passed",
+        "remote_mutation": false,
+        "credentials_included": false,
+        "pii_included": false
+      }
+    },
+    {
       "observed_at": "2026-07-31T14:37:00Z",
       "surface": "github-cloudflare-local-runtime-reconciliation",
       "scope": "origin/main current state, Finance lineage, Ponto controls, observability custody and production resource inventory",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "authoritative_at": "2026-07-31T14:37:00Z",
-  "source_main_sha": "28747bb5109407856bd3cb700d91f7f3cb981a69",
-  "source_main_state": "reconciled-current-main-pr-934-merged-no-finance-current-sha-staging-chain",
+  "authoritative_at": "2026-07-31T15:00:00Z",
+  "source_main_sha": "01d2b6d1f79a9017e0a87efa2a1a32f82eed219f",
+  "source_main_state": "reconciled-current-main-pr-939-merged-ponto-single-operator-governance-pending",
   "items": [
     {
       "id": "p0-workforce-timekeeping-current-main-release",
@@ -19,7 +19,7 @@
         "seven historical Timekeeping child runs and CRM Pages attempt-2 run 30491926800 retain their old definitions; live dispatch fences and both disabled legacy Ponto smokes must remain through expiry or reviewed replacement",
         "required WAF enforcement and the three immutable rule identifiers are unproven: CLOUDFLARE_ZONE_ID is present by name after checkpoint 14, but the visible zone listing exposed only managed rulesets, the custom entrypoint GET was unauthorized, both browser paths reached login without an authenticated session, and the post-merge security-token path still needs attestation",
         "governed capability custody is unprovisioned: each target environment needs a distinct PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY and the repository needs only PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON verifier metadata",
-        "staging and production now require main-only custom branch policies, can_admins_bypass=false and prevent_self_review=true, but the sole repository collaborator is the owner reviewer, GITHUB_TOKEN can_approve_pull_request_reviews=false, no authorized app/bot approver is proved and no independent reviewer is available",
+        "staging and production currently retain the legacy required-reviewer environment rule; the single-operator Codex policy is implemented on branch codex/admin/ponto-single-operator-governance but is not yet merged or applied remotely",
         "scheduled production Ponto Smoke run 30521686413 correctly detects ready=false under maintenance but is not successful external production SLO evidence; UI Smoke run 30518888970 is not an authenticated authorized-user journey",
         "authorized profile-key custody, target-environment root-attestation and Pages-intent keys, repository public/key-id metadata and per-environment custody references are absent",
         "the historical GESTOR account behind the removed legacy repository smoke credentials has not been identified or revoked",
@@ -57,7 +57,7 @@
         "explicit module-control active state and staging rollback drill",
         "version affinity, gradual routing, network-context cohort, minimal grants, automatic interruption and external SLO evidence for pilot and canary",
         "distinct PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY presence by name in each target environment and repository PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON public metadata, without reading private values",
-        "independent staging/production deployment reviewer or protection rule with no administrator bypass, separately from an Identity/Workforce-valid pilot designation",
+        "merged single-operator Codex environment-governance policy with no required reviewer, no administrator bypass, main-only admission and exact required checks, separately from an Identity/Workforce-valid pilot designation",
         "PONTO_ROOT_ATTESTATION_KEY_SHARED present only in protected target environments with one effective version, repository metadata PONTO_ROOT_ATTESTATION_KEY_ID, target-environment-only PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY, distinct approved-vault references and durable producer run/artifact provenance",
         "production checkpoint, deployment/version, health/readiness, authenticated pilot and post-release observation"
       ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "ponto:governance:test": "node .github/scripts/ponto-single-operator-governance.test.mjs",
     "observability:validate": "node scripts/observability/validate-catalog.mjs",
     "architecture:validate": "node ./.github/scripts/validate-architecture.mjs && node ./.github/scripts/validate-module-catalog.mjs && node ./.github/scripts/validate-domain-boundaries.mjs",
     "architecture:test": "npm run architecture:validate",


### PR DESCRIPTION
# Summary

Reconcile the current `main` (`01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`) and replace the obsolete required-human-review environment gate for the Ponto progressive release with a verifiable single-operator/Codex admission contract.

## Type of change
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated
- [x] Security review (focused static security validator passed; hosted security remains authoritative)
- [ ] Performance impact measured (not applicable to governance-only change)

## Contract

- main-only immutable source and canonical merged PR are required before capability issuance.
- exact protected checks are required; administrator bypass remains disabled.
- staging and production declare zero required reviewers and reject any live required-reviewers rule.
- target-bound capability, split custody, sanitized artifacts, mutex/watchdog/latch and automatic rollback remain mandatory.
- staging and production remain fail-closed until broker/WAF/custody/runner/Identity predecessors are independently attested.

## Validation

- `ponto:governance:test` — 3/3 passed.
- `.github/scripts/validate-progressive-release.mjs` — passed.
- `.github/scripts/validate-deploy-topology.mjs` — passed.
- `.github/scripts/validate-architecture.mjs` — passed.
- `scripts/check-js-security-exceptions.mjs` — passed.
- `git diff --check` and JSON parsing — passed.
- actionlint is not installed in the local WSL runtime; hosted workflow checks remain required.

## Links
- Issue: Ponto progressive release / current-state ledger
- Design/ADR: `DECISIONS.md`, `docs/decisions/operational-change-policy.md`
- Migration steps: none; no runtime, secret, flag, migration or Cloudflare mutation is included.

## Screenshots / Evidence

No secrets, credentials or PII are included. Evidence is recorded in `docs/project-state/evidence-ledger.json`.