### PR TITLE
docs(livia): record scheduled no-media follow-up

### DIFF
--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1759,3 +1759,28 @@ Checkpoint pós-restore íntegro:
 `ac8f12e006b0b2af1cca3bd3d5f9704e3183193c8d672e7641a7d777263ed2f1`.
 O aceite end-to-end de um carrossel inédito continua pendente até o novo
 arquivo aparecer no Drive canônico; a mídia histórica não deve ser usada.
+
+## Livia — verificação agendada posterior e restauração final — 2026-07-31
+
+Após a janela inicial, a agenda temporária foi executada novamente somente
+para confirmar o caminho produtivo. A execução `351` (`trigger`) terminou em
+`success` de 12:52:55.232 a 12:53:00.311 (-03), no nó `List Files`, com
+`plannedJobs=0`, `httpCalls=0`, zero destinos e nenhuma mutação no Drive.
+O próprio n8n, além do conector de Drive, retornou zero arquivos elegíveis;
+portanto nenhum carrossel histórico foi reutilizado.
+
+A agenda foi restaurada por transação versionada para
+`d3f4bd2a-f11c-4bc6-9b70-33fdf0f6a9d7`, mantendo `field: days` às 13:26, e o
+Orb foi reiniciado somente pelo `orb-safe-restart.sh` após drenagem. A versão
+ativa continua pinada ao release imutável
+`01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`; o manifesto atual tem SHA-256
+`25a4dcb08cdf20158fd2dc93ee4f3709eb4ab6e3370e4e5397218608a8fcecd2` e
+`audit-live` confirmou `mutableRuntimeReferences=0`. Healthchecks local e
+público permaneceram HTTP 200 e não houve warning novo no journal.
+
+Checkpoint pós-restauração:
+`C:\CodexRuntime\operator\admin\skincos\checkpoints\livia-carousel-followup-post-restore-20260731T125600-0300`, índice SHA-256
+`9702EE69E5B398706FDC9A4E515C6F02FC3E5D32FC596E39EF6E72705B05D3ED`.
+O aceite end-to-end de carrossel inédito segue pendente exclusivamente pela
+ausência dos novos IDs no Drive canônico; não há correção de código pendente
+nem impacto no caminho de Reel comprovado anteriormente.

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -1451,6 +1451,20 @@
       "execution": 350,
       "rollback_checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\checkpoints\\livia-carousel-pr939-post-restore-20260731T123400-0300",
       "rollback_checkpoint_sha256": "ac8f12e006b0b2af1cca3bd3d5f9704e3183193c8d672e7641a7d777263ed2f1"
+    },
+    {
+      "observed_at": "2026-07-31T15:57:00Z",
+      "surface": "production-runtime-and-drive-followup",
+      "scope": "livia-scheduled-carousel-followup-351",
+      "state": "scheduled-trigger-success-no-media-schedule-restored",
+      "method": "Canonical Drive re-list/search; active execution preflight; temporary schedule version with expected-version transaction; structural validation; controlled Orb drain/restart; Schedule Trigger execution 351; QA audit; restore version transaction; manifest audit-live; local/public health and journal probes",
+      "result": "Execution 351 ran in trigger mode from 2026-07-31T12:52:55.232-03 to 12:53:00.311-03 and ended at List Files with plannedJobs=0, httpCalls=0 and zero targets. The canonical Drive folder 1Dq_1TeD4RCQAaYFSarXA7c63nDvtUvE9 still contained 57 historical files; no file created or modified after the latest published group was visible, and global media searches were empty. The daily schedule was restored to field days at 13:26 in active version d3f4bd2a-f11c-4bc6-9b70-33fdf0f6a9d7. The immutable release remains 01d2b6d1f79a9017e0a87efa2a1a32f82eed219f, workflow hash cca251e26fc87957f341abb264571025a00a142a4162be8d98b6338ae213afbb, current manifest SHA-256 25a4dcb08cdf20158fd2dc93ee4f3709eb4ab6e3370e4e5397218608a8fcecd2, audit-live mutableRuntimeReferences=0, local/public health 200, and no warning journal entries after the restart.",
+      "limitation": "No unpublished carousel was available to publish; no gateway, Drive mark, notification or social publication was created. The next real acceptance requires the new Drive file IDs to become visible to the same credentials used by List Files.",
+      "sha": "01d2b6d1f79a9017e0a87efa2a1a32f82eed219f",
+      "workflow_version": "d3f4bd2a-f11c-4bc6-9b70-33fdf0f6a9d7",
+      "execution": 351,
+      "rollback_checkpoint": "C:\\CodexRuntime\\operator\\admin\\skincos\\checkpoints\\livia-carousel-followup-post-restore-20260731T125600-0300",
+      "rollback_checkpoint_sha256": "9702EE69E5B398706FDC9A4E515C6F02FC3E5D32FC596E39EF6E72705B05D3ED"
     }
   ]
 }


### PR DESCRIPTION
﻿## Escopo
Registra a execução agendada real 351, a ausência de mídia inédita no Drive e a restauração final da agenda do Livia.

## Evidência
- `351` terminou `success` em modo `trigger`, com `List Files` como último nó, `plannedJobs=0` e `httpCalls=0`.
- O Drive canônico permaneceu com 57 arquivos históricos; nenhuma mídia nova foi reutilizada.
- A agenda ativa foi restaurada para `field: days`, 13:26, no workflow version `d3f4bd2a-f11c-4bc6-9b70-33fdf0f6a9d7`.
- O bundle imutável e o manifesto permaneceram íntegros; `audit-live` retornou zero referências mutáveis.

## Validação
- `ConvertFrom-Json` do ledger
- `git diff --check`
- healthchecks local/público HTTP 200

Nenhum workflow, release, credencial, Reel ou outro módulo foi alterado.
