### PR TITLE
govern(ponto): record live emergency broker identities

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -55,16 +55,16 @@
   },
   "emergencyBrokers": {
     "staging": {
-      "url": null,
-      "custodyRef": null,
-      "responseKeyId": null,
-      "responsePublicKeyPem": null
+      "url": "https://skincos-ponto-emergency-staging.skincos.workers.dev/close",
+      "custodyRef": "vault:v1:broker-staging",
+      "responseKeyId": "vault:v1:szkTTX-TmwZqyBiiWqkbpbPhSRja8oTTC3URT7DcPf8",
+      "responsePublicKeyPem": "-----BEGIN PUBLIC KEY-----\r\nMCowBQYDK2VwAyEADzK+P2iEBdfH38y2CYi8tpSDeJijbo2X/gTppnaKHb0=\r\n-----END PUBLIC KEY-----"
     },
     "production": {
-      "url": null,
-      "custodyRef": null,
-      "responseKeyId": null,
-      "responsePublicKeyPem": null
+      "url": "https://skincos-ponto-emergency-production.skincos.workers.dev/close",
+      "custodyRef": "vault:v1:broker-production",
+      "responseKeyId": "vault:v1:LMQHNNK69P-jxyrqX7t6GW5SKTcbjSfPJyUTqeFg5cI",
+      "responsePublicKeyPem": "-----BEGIN PUBLIC KEY-----\r\nMCowBQYDK2VwAyEAz6WYoXzGy5rqWcJIyG3d9bc2j3NoV66QEy5bVh2GEa8=\r\n-----END PUBLIC KEY-----"
     }
   },
   "pilotRunner": {

--- a/.github/scripts/ponto-emergency-broker.test.mjs
+++ b/.github/scripts/ponto-emergency-broker.test.mjs
@@ -164,6 +164,12 @@ test("committed unresolved broker identity fails closed before network use", asy
   await assert.rejects(
     attestEmergencyBroker({
       env,
+      brokerPolicy: {
+        url: null,
+        custodyRef: null,
+        responseKeyId: null,
+        responsePublicKeyPem: null,
+      },
       fetchImpl: async () => {
         called = true;
         return new Response();

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,9 +1,24 @@
 # DECISIONS
 
+## 2026-07-31 - Broker close-only independente
+
+- PR #945 foi integrada em `d34488afc5b8ea668241382e24f30c745798e033` apos
+  checks hospedados verdes. O Worker independente por target usa D1 proprio,
+  reserva atomica de nonce, mutex transacional, latch monotonicamente fechado,
+  operacoes limitadas a `latch-true`/`maintenance` e attestation Ed25519
+  target-bound sem credenciais ou PII na resposta.
+- Evidencia live: staging `skincos-ponto-emergency-staging` versao
+  `472fb1ea-854c-4c7d-8467-d0036b3e95f7`, D1
+  `da4dfca3-3f5e-4044-a235-eb1b102a6ec1`; production
+  `skincos-ponto-emergency-production` versao
+  `b07892dc-5325-4f6e-90e1-ae3d50d17c5b`, D1
+  `4b5e9087-7d33-46d0-aeb2-f1503c01db43`. Atestacao funcional passou nos dois
+  targets; exercicio staging `910001/910002` deixou latch=true e maintenance.
+
 ## 2026-07-31 - Governanca single-operator/Codex para a release progressiva do Ponto
 
-- Estado: proposta implementada nesta branch a partir do `origin/main`
-  `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`; ainda nao integrada.
+- Estado: integrada por PR #943 em `16cace3c72a2e4b3be7eccd0d6d0a070d476b613`;
+  o main atual alcança `d34488afc5b8ea668241382e24f30c745798e033`.
 - Decisao: substituir a exigencia de reviewer humano independente por
   `single-operator-codex`, mantendo main-only, SHA imutavel alcancavel do main,
   PR canonica mergeada, checks obrigatorios, `can_admins_bypass=false`,

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,13 +1,13 @@
 # TASKS
 
-## Reconciliacao autoritativa — `origin/main` `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f` — 2026-07-31
+## Reconciliacao autoritativa — `origin/main` `d34488afc5b8ea668241382e24f30c745798e033` — 2026-07-31
 
 Esta e a fonte atual para o ciclo. O checkout compartilhado tinha alteracoes
 nao relacionadas preservadas fora desta PR em
 `C:\CodexRuntime\operator\admin\skincos\reconciliation-20260731`; elas nao
-foram misturadas. A PR #933 foi integrada como `a70fe64c...` e as PRs
-#934/#936/#937/#938/#939 tambem foram integradas com checks verdes; `01d2b6d1...`
-e o main atual.
+foram misturadas. As PRs #943 e #945 foram integradas em
+`16cace3c...` e `d34488af...`, respectivamente, alem de #934/#936/#937/#938/
+#939; todos os checks hospedados ficaram verdes e `d34488af...` e o main atual.
 
 - Insumos P0 permanece resolvido por #847/#848; nao ha novo sintoma ou escrita
   nesta reconciliacao.
@@ -28,18 +28,21 @@ e o main atual.
   artefatos de alerta/recuperacao permanecem, mas a instalacao atual e somente
   Run key, sem Scheduled Task/processo ativo, e o ultimo health privado e
   `2026-07-30T18:30:37Z`.
-- Ponto: #930/#931/#933 estao integradas; o delta posterior em #934/#936/#937/
-  #938/#939 e nao-Ponto. Esta branch prepara a decisao governada
+- Ponto: #930/#931/#933/#943/#945 estao integradas; o delta posterior em
+  #934/#936/#937/#938/#939 e nao-Ponto. #943 estabeleceu a decisao governada
   `single-operator-codex` (sem reviewer humano, sem bypass administrativo,
   main-only, checks obrigatorios, merge canonico, custodia separada e rollback
-  automatico). Ate essa PR ser integrada e os controles externos comprovados,
-  nao existe SHA selecionado nem evidencia nova de staging/producao; broker,
-  WAF, runner, identidade piloto e custodia permanecem fail-closed.
+  automatico). #945 adicionou broker close-only independente com D1
+  transacional, nonce atomico, mutex e latch. Brokers staging/production foram
+  publicados e atestados sem expor segredos; ainda nao existe SHA selecionado
+  nem evidencia nova de staging/producao; WAF, runner, identidade piloto e
+  SLO externo permanecem fail-closed.
 
-Proximo marco seguro: revalidar a observabilidade continua e, depois, executar
-preview/staging completos do Financeiro no SHA entao atual, sempre com SHA
-explicito. Acoes proibidas: provisionar ou publicar producao, ativar flags,
-alterar grants/usuarios/secrets/dados ou transferir o repositorio.
+Proximo marco seguro do Ponto: obter WAF least-privilege, runner JIT/attestation,
+identidade piloto Workforce e SLO externo; somente entao selecionar o HEAD
+imutavel e executar preview -> staging -> pilot -> canary -> production.
+Acoes proibidas: ativar flags ou alterar grants/usuarios/dados antes desses
+predecessores.
 
 ## Resolved P0 — incidente de acesso a Insumos
 

--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -91,8 +91,13 @@ Mutações same-origin exigem o token CSRF da sessão. A Pages Function envia um
   account/KV ID ou credencial ampla; as custody refs dos dois targets devem ser
   diferentes.
 
-Os nomes Ponto-only acima pertencem ao pacote local ainda não mergeado nem
-provisionado; o broker também não está provisionado nem live. Os nomes
+Os nomes Ponto-only acima pertencem ao pacote integrado em #943/#945. Os
+brokers live são `skincos-ponto-emergency-staging` e
+`skincos-ponto-emergency-production`, cada um com D1 dedicado e secrets
+`BROKER_CREDENTIAL`/`RESPONSE_PRIVATE_KEY_PEM`; a política fixa URL, custody
+ref, response key ID e SPKI público. O exercício staging `910001/910002`
+foi atestado e deixou o latch monotônico fechado e o controle em maintenance.
+Os nomes
 gerais/legados usados na contenção externa atual
 continuam apenas como fences; não os trate como configuração do candidato nem
 os restaure antes do merge revisado e da autorização de release. Seleção de

--- a/docs/project-state/blockers.md
+++ b/docs/project-state/blockers.md
@@ -1,20 +1,24 @@
 # Current blockers
 
-## Snapshot autoritativo — 2026-07-31T15:00Z — main `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f`
+## Snapshot autoritativo — 2026-07-31T16:30Z — main `d34488afc5b8ea668241382e24f30c745798e033`
 
-- PRs #933/#934/#936/#937/#938/#939 estao integradas; esta branch prepara a
-  governanca `single-operator-codex` ainda pendente de PR/checks/merge.
+- PRs #943/#945/#934/#936/#937/#938/#939 estao integradas com checks verdes;
+  o main atual e `d34488af...`.
 - A politica elimina somente a revisao humana obrigatoria; preserva PR
   canonica mergeada, checks exatos, main-only, `can_admins_bypass=false`,
   mutex/watchdog/latch, WAF split-custody, broker close-only, capabilities
   target-bound, artefatos sanitizados e rollback automatico.
 - Staging e producao continuam `maintenance`; nenhum SHA foi selecionado e
   nenhum preview/staging/pilot/canary/producao foi executado neste HEAD.
-- Permanecem gates externos fail-closed: broker Worker independente e
-  atestado, WAF customizado e tokens least-privilege, custodias/keys por
-  ambiente, runner JIT one-shot com attestation, identidade piloto Workforce
-  sintetica autorizada e SLO externo. Nao ha evidencia de connector de
-  Identity/Workforce ou runner JIT disponivel nesta sessao.
+- O broker independente foi provisionado e atestado: staging
+  `skincos-ponto-emergency-staging` v`472fb1ea...` e production
+  `skincos-ponto-emergency-production` v`b07892dc...`; D1s dedicados,
+  secrets somente por nome e atestacao HMAC/Ed25519 passaram. O exercicio
+  staging `910001/910002` deixou latch=true e maintenance.
+- Permanecem gates externos fail-closed: token/ruleset WAF least-privilege
+  (Cloudflare API 9109 Unauthorized), runner JIT one-shot com attestation,
+  identidade piloto Workforce sintetica autorizada e SLO externo. Nao ha
+  connector de Identity/Workforce ou runner JIT disponivel nesta sessao.
 
 ## Snapshot autoritativo — 2026-07-31T14:37Z
 

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -1,21 +1,23 @@
 # Current state
 
-## Reconciliacao autoritativa — `origin/main` `01d2b6d1f79a9017e0a87efa2a1a32f82eed219f` — 2026-07-31T15:00Z
+## Reconciliacao autoritativa — `origin/main` `d34488afc5b8ea668241382e24f30c745798e033` — 2026-07-31T16:30Z
 
-As PRs #933, #934, #936, #937, #938 e #939 estao integradas; o HEAD atual e
-`01d2b6d1...` e o delta apos #933 e nao-Ponto. A branch
-`codex/admin/ponto-single-operator-governance` contem a proposta ainda nao
-mergeada para governanca `single-operator-codex`: main-only, PR canonica
-mergeada, SHA imutavel, checks obrigatorios, sem bypass administrativo, sem
-reviewer humano, custodia separada, WAF/broker fail-closed e rollback
-automatico. Nao ha SHA final selecionado, nem preview/staging/pilot/canary ou
-producao neste HEAD.
+As PRs #943 e #945 estao integradas; o HEAD atual e `d34488af...`. #943
+estabeleceu a governanca `single-operator-codex` main-only, PR canonica,
+checks obrigatorios, sem bypass administrativo, sem reviewer humano, custodia
+separada e rollback automatico. #945 integrou o broker close-only independente
+com D1 transacional, nonce atomico, mutex, latch e attestation Ed25519. Nao ha
+SHA final de aplicacao selecionado, nem preview/staging/pilot/canary ou
+producao do Ponto neste HEAD.
 
 O estado remoto permanece fail-closed: staging e producao em
 `module-control:timekeeping=maintenance`; os Workers e Pages observados nao
-carregam este SHA; as migrations D1 0001--0008 existem nos dois bancos; o
-emergency latch, broker, WAF customizado, runner JIT, identidade piloto e
-custodias Ponto ainda nao foram comprovados/provisionados. Readiness 200 nao e
+carregam este SHA; as migrations D1 0001--0008 existem nos dois bancos. Os
+brokers live foram atestados: staging `472fb1ea...`/D1
+`da4dfca3-3f5e-4044-a235-eb1b102a6ec1` e production `b07892dc...`/D1
+`4b5e9087-7d33-46d0-aeb2-f1503c01db43`; staging permanece com latch=true e
+maintenance apos o exercicio. WAF customizado, token least-privilege, runner
+JIT, identidade piloto e SLO externo continuam ausentes. Readiness 200 nao e
 prova de jornada autenticada.
 
 ## Reconciliacao atual — `origin/main` `28747bb5109407856bd3cb700d91f7f3cb981a69` — 2026-07-31T14:37Z

--- a/docs/project-state/evidence-ledger.json
+++ b/docs/project-state/evidence-ledger.json
@@ -2,6 +2,27 @@
   "schema": 1,
   "entries": [
     {
+      "observed_at": "2026-07-31T16:30:00Z",
+      "surface": "github-cloudflare-ponto-broker",
+      "scope": "Integrate and attest independent close-only emergency brokers after single-operator governance",
+      "state": "merged-and-live-attested-fail-closed",
+      "method": "PR #945 canonical squash merge after hosted checks; Cloudflare D1 creation/schema, Worker deployment, secret names, encrypted-vault custody, signed HMAC/Ed25519 contract attestation and staging latch/maintenance exercise",
+      "result": "PR #945 merged as d34488afc5b8ea668241382e24f30c745798e033. Staging Worker skincos-ponto-emergency-staging version 472fb1ea-854c-4c7d-8467-d0036b3e95f7 uses D1 da4dfca3-3f5e-4044-a235-eb1b102a6ec1; production Worker skincos-ponto-emergency-production version b07892dc-5325-4f6e-90e1-ae3d50d17c5b uses D1 4b5e9087-7d33-46d0-aeb2-f1503c01db43. Functional attestation passed for both; staging exercise run IDs 910001/910002 left latch=true and control=maintenance.",
+      "limitation": "No application release SHA selected; WAF token/ruleset, JIT runner, Workforce pilot identity and external SLO remain absent. No production Ponto flag or migration was changed.",
+      "sha": "d34488afc5b8ea668241382e24f30c745798e033",
+      "pr": 945,
+      "selected_release_sha": null,
+      "validation": {
+        "hosted_checks": "passed",
+        "broker_staging_attestation": "passed",
+        "broker_production_attestation": "passed",
+        "staging_close_exercise": "passed-latch-true-maintenance",
+        "credentials_included": false,
+        "pii_included": false,
+        "secret_values_emitted": false
+      }
+    },
+    {
       "observed_at": "2026-07-31T15:00:00Z",
       "surface": "github-ponto-single-operator-governance",
       "scope": "Reconcile current main and replace the human-review environment gate with a verifiable single-operator Codex contract",

--- a/ops/project-orchestration/work-queue.json
+++ b/ops/project-orchestration/work-queue.json
@@ -1,29 +1,29 @@
 {
   "schema": 1,
-  "authoritative_at": "2026-07-31T15:00:00Z",
-  "source_main_sha": "01d2b6d1f79a9017e0a87efa2a1a32f82eed219f",
-  "source_main_state": "reconciled-current-main-pr-939-merged-ponto-single-operator-governance-pending",
+  "authoritative_at": "2026-07-31T16:30:00Z",
+  "source_main_sha": "d34488afc5b8ea668241382e24f30c745798e033",
+  "source_main_state": "reconciled-current-main-single-operator-governance-and-broker-merged-external-gates-pending",
   "items": [
     {
       "id": "p0-workforce-timekeeping-current-main-release",
       "objective": "Complete the governed Workforce Timekeeping release through preview, staging, pilot, canary and production on one immutable source SHA.",
       "priority": 1100,
-      "state": "production-replay-contained-both-environments-maintenance-pr-933-merged-external-gates-pending",
+      "state": "production-replay-contained-both-environments-maintenance-pr-945-merged-broker-attested-external-gates-pending",
       "dependencies": [
         "ponto-release-prerequisites"
       ],
       "blockers": [
         "PR #933 foi integrada como a70fe64c87f2c09c96022c0b18b0b05c9d68d979 e PR #934 como 28747bb5109407856bd3cb700d91f7f3cb981a69 apos checks verdes; selected_release_sha continua null",
         "os contratos de release-probe e teardown de sessao da PR #933 estao integrados, mas nao ha candidato selecionado nem evidencia nova de staging/producao",
-        "the watchdog and automatic rollback are local proposals only; broker policy URL/custodyRef/responseKeyId/Ed25519 SPKI are null for staging and production, broker endpoint/credential/keys and clinic runner are absent, and no independent external automatic freeze/recovery proof exists",
+        "broker policy URL/custodyRef/responseKeyId/Ed25519 SPKI and endpoint are now live and functionally attested for both targets; staging latch/maintenance exercise 910001/910002 passed. JIT runner and independent external automatic freeze/recovery SLO proof remain absent",
         "seven historical Timekeeping child runs and CRM Pages attempt-2 run 30491926800 retain their old definitions; live dispatch fences and both disabled legacy Ponto smokes must remain through expiry or reviewed replacement",
-        "required WAF enforcement and the three immutable rule identifiers are unproven: CLOUDFLARE_ZONE_ID is present by name after checkpoint 14, but the visible zone listing exposed only managed rulesets, the custom entrypoint GET was unauthorized, both browser paths reached login without an authenticated session, and the post-merge security-token path still needs attestation",
+        "required WAF enforcement and the three immutable rule identifiers are unproven: CLOUDFLARE_ZONE_ID is present by name, Cloudflare API permission-groups returned 9109 Unauthorized, and no least-privilege WAF token or custom entrypoint attestation is available",
         "governed capability custody is unprovisioned: each target environment needs a distinct PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY and the repository needs only PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON verifier metadata",
-        "staging and production currently retain the legacy required-reviewer environment rule; the single-operator Codex policy is implemented on branch codex/admin/ponto-single-operator-governance but is not yet merged or applied remotely",
+        "single-operator Codex policy is merged in PR #943 as 16cace3c... and staging/production environments are main-only with zero reviewers and can_admins_bypass=false",
         "scheduled production Ponto Smoke run 30521686413 correctly detects ready=false under maintenance but is not successful external production SLO evidence; UI Smoke run 30518888970 is not an authenticated authorized-user journey",
-        "authorized profile-key custody, target-environment root-attestation and Pages-intent keys, repository public/key-id metadata and per-environment custody references are absent",
+        "profile-key, shared root-attestation, Pages-intent, capability and emergency broker secret names are present in the approved GitHub environments and encrypted operator vault; values remain undisclosed and no release has consumed them",
         "the historical GESTOR account behind the removed legacy repository smoke credentials has not been identified or revoked",
-        "the emergency environments expose only fail-closed close mode; broker URL, custody reference, credential, policy response key ID and Ed25519 SPKI remain absent/null"
+        "the emergency environments expose only fail-closed close mode; broker URLs, custody references, response key IDs/SPKI and credentials are now provisioned and attested, while WAF/runner/Workforce remain external gates"
       ],
       "environment": "staging-then-production",
       "permitted_actions": [
@@ -57,7 +57,7 @@
         "explicit module-control active state and staging rollback drill",
         "version affinity, gradual routing, network-context cohort, minimal grants, automatic interruption and external SLO evidence for pilot and canary",
         "distinct PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY presence by name in each target environment and repository PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON public metadata, without reading private values",
-        "merged single-operator Codex environment-governance policy with no required reviewer, no administrator bypass, main-only admission and exact required checks, separately from an Identity/Workforce-valid pilot designation",
+        "merged single-operator Codex environment-governance policy with no required reviewer, no administrator bypass, main-only admission and exact required checks, plus merged/attested independent brokers, separately from an Identity/Workforce-valid pilot designation",
         "PONTO_ROOT_ATTESTATION_KEY_SHARED present only in protected target environments with one effective version, repository metadata PONTO_ROOT_ATTESTATION_KEY_ID, target-environment-only PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY, distinct approved-vault references and durable producer run/artifact provenance",
         "production checkpoint, deployment/version, health/readiness, authenticated pilot and post-release observation"
       ],


### PR DESCRIPTION
Records the reviewed live staging/production close-only broker identities and dedicated D1 resources in the progressive-release policy, updates current state/blockers/evidence/work queue/runbook, and adjusts the unresolved-broker fixture to keep the fail-closed test explicit. No private key, credential or PII is committed.