### PR TITLE
fix(ponto): accept both canonical workflow path forms

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -172,7 +172,7 @@ test("ordered predecessor provenance is exact and replay resistant before artifa
     /workflow\?\.state !== "active"/,
     /workflow\?\.path !== "\.github\/workflows\/ponto-progressive-release\.yml"/,
     /String\(run\?\.id \|\| ""\) !== process\.env\.PREDECESSOR_RUN_ID/,
-    /run\.path !== `\$\{workflow\.path\}@refs\/heads\/main`/,
+    /(?:run\.path !== `\$\{workflow\.path\}@refs\/heads\/main`|!\[workflow\.path, `\$\{workflow\.path\}@refs\/heads\/main`\]\.includes\(run\.path\))/,
     /run\.run_attempt !== 1/,
     /run\.head_sha \|\| ""\)\.toLowerCase\(\) !== process\.env\.RELEASE_SHA/,
     /run\.display_title !== expectedTitle/,

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -165,7 +165,7 @@ jobs:
             || !Number.isInteger(workflow?.id)
             || String(run?.id || "") !== process.env.PREDECESSOR_RUN_ID
             || run.workflow_id !== workflow.id
-            || run.path !== `${workflow.path}@refs/heads/main`
+            || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
             || run.status !== "completed"
             || run.conclusion !== "success"
             || run.run_attempt !== 1


### PR DESCRIPTION
The progressive release coordinator inline predecessor provenance check must accept both GitHub API path representations for the canonical workflow: the bare workflow path and the path suffixed with @refs/heads/main. This fixes the exact-main preview predecessor gate without weakening workflow identity, SHA, branch, event, or repository checks. Focused validator, governance, broker, and reconciliation tests pass.