### PR TITLE
fix(ponto): close nested module-control heredoc

### DIFF
--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -259,7 +259,7 @@ jobs:
               if (!Array.isArray(keys) || keys.some((entry) => entry?.name === process.env.EXPECTED_KEY)) {
                 throw new Error("module-control prior value exists but could not be read");
               }
-              NODE
+          NODE
               printf '{}\n' > "$prior"
             fi
           fi


### PR DESCRIPTION
The staging coordinator reached module-control maintenance and exposed a malformed nested heredoc in module-availability.yml. The indented NODE terminator was not recognized by bash, causing a fail-closed syntax error before state mutation. This one-line correction keeps the module-control transition and its evidence path intact. Focused workflow/reconciliation validators pass.