### PR TITLE
docs(codex): temporary docs-only proof

### DIFF
--- a/docs/codex-docs-only-proof.md
+++ b/docs/codex-docs-only-proof.md
@@ -1,0 +1,3 @@
+# Codex docs-only proof
+
+This temporary note exercises the delivery-first documentation path. It contains no product, runtime, deployment, or business behavior.


### PR DESCRIPTION
Temporary docs-only proof for the delivery-first Codex operator. No product or runtime behavior. Close after hosted classification and workflow suppression evidence is captured.