### PR TITLE
fix(finance): deploy Pages from isolated directory

### DIFF
--- a/.github/workflows/deploy-finance-ui.yml
+++ b/.github/workflows/deploy-finance-ui.yml
@@ -75,19 +75,18 @@ jobs:
         run: |
           set -euo pipefail
           # crm/console/wrangler.toml belongs to the shell Pages deployment and
-          # contains Worker-only secret declarations. Finance is a separate
-          # Pages project; use an explicit, secret-free config so Wrangler
-          # cannot discover the shell config and reject the deployment.
-          FINANCE_PAGES_CONFIG="$RUNNER_TEMP/finance-pages.toml"
-          cat > "$FINANCE_PAGES_CONFIG" <<'EOF'
-          name = "skincos-finance-ui"
-          compatibility_date = "2026-07-23"
-          EOF
-          npx --yes wrangler@4.114.0 pages deploy dist-finance \
-            --config "$FINANCE_PAGES_CONFIG" \
+          # contains Worker-only secret declarations. Pages does not allow a
+          # custom config path, so deploy from a temporary directory without
+          # inheriting the shell config.
+          FINANCE_PAGES_DIR="$RUNNER_TEMP/finance-pages"
+          mkdir -p "$FINANCE_PAGES_DIR"
+          cp -R dist-finance/. "$FINANCE_PAGES_DIR/"
+          pushd "$FINANCE_PAGES_DIR" >/dev/null
+          npx --yes wrangler@4.114.0 pages deploy . \
             --project-name "$PROJECT" \
             --branch "$BRANCH" \
             --commit-hash "$RELEASE_SHA"
+          popd >/dev/null
         working-directory: crm/console
       - name: Write staging promotion evidence
         if: inputs.target == 'staging'


### PR DESCRIPTION
## Summary\n- deploy the Finance Pages artifact from a temporary directory\n- avoid the shell's Worker-only wrangler.toml, which Pages auto-discovers and rejects\n- keep the explicit immutable SHA and isolated project/branch\n\n## Validation\n- git diff --check\n- prior b848 staging UI failure: 30664146208\n- current 4a0598 staging UI failure: 30664640887 (custom config path unsupported)\n- no production, flags, grants, users, or data changes\n\nThis is the smallest follow-up to the merged #954 workflow fix.