### PR TITLE
fix(finance): reactivate stale staging smoke identity

### DIFF
--- a/.github/workflows/finance-staging-smoke-identity.yml
+++ b/.github/workflows/finance-staging-smoke-identity.yml
@@ -62,7 +62,7 @@ jobs:
           IFS=: read -r active_count total_count <<< "$counts"
           [[ "$active_count" =~ ^[0-9]+$ && "$total_count" =~ ^[0-9]+$ ]] || { echo 'Could not verify the synthetic-identity count.'; exit 1; }
           if [[ "$ACTION" == provision ]]; then
-            [[ "$total_count" == 0 ]] || { echo 'Synthetic identity already exists; use rotate or revoke before provisioning.'; exit 1; }
+            [[ "$total_count" == 0 || ( "$total_count" == 1 && "$active_count" == 0 ) ]] || { echo 'Synthetic identity must be absent or a single inactive row before provisioning.'; exit 1; }
           else
             [[ "$active_count" == 1 && "$total_count" == 1 ]] || { echo 'Expected exactly one active synthetic identity.'; exit 1; }
           fi

--- a/finance/scripts/staging-smoke-identity-sql.mjs
+++ b/finance/scripts/staging-smoke-identity-sql.mjs
@@ -47,13 +47,16 @@ if (action === 'provision') {
   coreSql = [
     // Cloudflare D1's remote SQL API rejects explicit transaction control.
     // Each generated file is submitted as a single D1 request by the canonical
-    // workflow, so leave transaction ownership to the D1 service.
-    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'INJETOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1);`,
-    audit('FINANCE_SMOKE_IDENTITY_PROVISIONED', null, { ...baseline, active: true }),
+    // workflow, so leave transaction ownership to the D1 service. Provision is
+    // safe for the one known synthetic username even when a previous revoke
+    // left its inactive row behind: reactivate that row, otherwise insert it.
+    `UPDATE crm_users SET email=${quote('finance-staging-smoke@staging.invalid')},display_name=${quote('Finance staging smoke (synthetic)')},password_hash=${quote(passwordHash())},role='INJETOR',photo_url='',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},ativo=1,updated_at=${quote(now)},session_version=COALESCE(session_version,0)+1 WHERE username=${quote(username)} AND ativo=0;`,
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) SELECT ${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'INJETOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1 WHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE username=${quote(username)});`,
+    audit('FINANCE_SMOKE_IDENTITY_PROVISIONED_OR_REACTIVATED', null, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [
-    `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-smoke-operator-nh')},${quote(username)},${quote(scopeId)},'operator',${quote(now)},${quote(technicalActor)});`,
-    financeAudit('FINANCE_SMOKE_GRANT_PROVISIONED', null, { ...baseline, permission: 'operator' }),
+    `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-smoke-operator-nh')},${quote(username)},${quote(scopeId)},'operator',${quote(now)},${quote(technicalActor)}) ON CONFLICT(username,scope_id) DO UPDATE SET permission='operator',created_at=${quote(now)},created_by=${quote(technicalActor)};`,
+    financeAudit('FINANCE_SMOKE_GRANT_PROVISIONED_OR_REACTIVATED', null, { ...baseline, permission: 'operator' }),
   ].join('\n');
 } else if (action === 'rotate') {
   coreSql = [

--- a/finance/test/staging-smoke-identity-scope.test.mjs
+++ b/finance/test/staging-smoke-identity-scope.test.mjs
@@ -30,8 +30,12 @@ test('synthetic Finance identity preserves only the explicit Finance module in t
 
   assert.match(provision.core, /'INJETOR'/);
   assert.match(provision.core, /'\["finance"\]'/);
+  assert.match(provision.core, /UPDATE crm_users SET/);
+  assert.match(provision.core, /WHERE username='finance-staging-smoke' AND ativo=0/);
+  assert.match(provision.core, /WHERE NOT EXISTS \(SELECT 1 FROM crm_users/);
   assert.doesNotMatch(provision.core, /'CONSULTOR'/);
   assert.match(rotation.core, /role='INJETOR'/);
   assert.match(rotation.core, /allowed_modules_json='\["finance"\]'/);
+  assert.match(provision.finance, /ON CONFLICT\(username,scope_id\) DO UPDATE/);
   assert.match(rotation.finance, /finance_access_grant/);
 });


### PR DESCRIPTION
## Summary\n- keep the staging-only synthetic identity lifecycle fail-closed to one known username\n- allow provision to safely reactivate the single inactive row left by a prior revoke\n- upsert only the corresponding Finance grant and audit the operation\n- add focused regression coverage\n\n## Evidence\n- canary 30665186350 stopped before mutation because the existing synthetic row had no active Finance grant\n- provision 30665225404 and rotate 30665278455 failed safely at the stale-row guard\n- targeted test passes through the WSL wrapper\n- no production, flags, real grants, users, or data changes\n\nThis is limited to the staging smoke identity lifecycle required by the Finance canary.