### PR TITLE
fix(codex): reject incomplete App continuity evidence

### DIFF
--- a/docs/operations/codex-supervised-continuity.md
+++ b/docs/operations/codex-supervised-continuity.md
@@ -70,6 +70,24 @@ the current `trusted_hash` and `enabled = true`. A trusted entry without
 `enabled = true` is not acceptance evidence: the real proof must still show a
 `block_and_continue` event and an automatically generated second turn.
 
+Trust and enablement are read when an App session is initialized. A background
+follow-up sent to an already-existing thread is not a substitute for opening a
+fresh interactive App session in the standalone activation clone after the
+Trust/Enable review. If that session emits a valid `continue` contract but its
+thread has no Stop-hook event and no generated second turn, classify the result
+as `app_hook_not_loaded`; preserve the thread/turn identifiers and sanitized
+evidence, clean the temporary artifact, and do not retry the same session. The
+acceptance check is intentionally strict:
+
+```powershell
+python .\scripts\validate-codex-app-proof.py <sanitized-evidence.json>
+```
+
+It accepts only two `turn.started`/`turn.completed` pairs, an observed
+`block_and_continue` event, no manually submitted second prompt, the real
+`supervisor-cycle`, and verified artifact cleanup. A one-turn result must stay
+an explicit integration defect until a fresh session proves the complete loop.
+
 The registered host commands resolve the runner only from the physical parent
 of `git rev-parse --path-format=absolute --git-common-dir`. They require the
 common directory to be a real `.git` directory, use the exact

--- a/scripts/tests/test_validate_codex_app_proof.py
+++ b/scripts/tests/test_validate_codex_app_proof.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "validate-codex-app-proof.py"
+SPEC = importlib.util.spec_from_file_location("validate_codex_app_proof", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def valid_evidence() -> dict[str, object]:
+    return {
+        "turns_observed": {
+            "turn_started": 2,
+            "turn_completed": 2,
+            "automatic_second_turn": True,
+            "manual_second_prompt": False,
+        },
+        "hook_observation": {
+            "new_block_and_continue_event": True,
+            "app_thread_hook_items": 1,
+        },
+        "contract": {"first_status": "continue"},
+        "supervisor_cycle": {"executed": True},
+        "terminal_contract": {"status": "complete"},
+        "artifact": {"removed": True},
+    }
+
+
+class ValidateCodexAppProofTest(unittest.TestCase):
+    def test_accepts_two_turn_hook_proof(self) -> None:
+        self.assertEqual(module.validate_proof(valid_evidence()), [])
+
+    def test_rejects_single_turn_even_with_continue_contract(self) -> None:
+        evidence = valid_evidence()
+        evidence["turns_observed"] = {
+            "turn_started": 1,
+            "turn_completed": 1,
+            "automatic_second_turn": False,
+            "manual_second_prompt": False,
+        }
+        errors = module.validate_proof(evidence)
+        self.assertIn("exactly two turn.started events are required", errors)
+        self.assertIn("automatic_second_turn must be true", errors)
+
+    def test_rejects_missing_hook_event(self) -> None:
+        evidence = valid_evidence()
+        evidence["hook_observation"] = {
+            "new_block_and_continue_event": False,
+            "app_thread_hook_items": 0,
+        }
+        errors = module.validate_proof(evidence)
+        self.assertIn("a block_and_continue event is required", errors)
+        self.assertIn("the App thread must contain a Stop-hook observation", errors)
+
+    def test_rejects_missing_cycle_or_terminal_contract(self) -> None:
+        evidence = valid_evidence()
+        evidence.pop("supervisor_cycle")
+        evidence.pop("terminal_contract")
+        errors = module.validate_proof(evidence)
+        self.assertIn("the real supervisor-cycle execution is required", errors)
+        self.assertIn("a terminal complete contract is required", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-codex-app-proof.py
+++ b/scripts/validate-codex-app-proof.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate the evidence package for a real Codex App continuity proof.
+
+This is deliberately a strict acceptance check.  A single completed turn, even
+with a valid ``continue`` contract, is not proof that the Stop hook ran.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def validate_proof(evidence: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    turns = evidence.get("turns_observed")
+    if not isinstance(turns, dict):
+        return ["turns_observed is missing"]
+    if turns.get("turn_started") != 2:
+        errors.append("exactly two turn.started events are required")
+    if turns.get("turn_completed") != 2:
+        errors.append("exactly two turn.completed events are required")
+    if turns.get("automatic_second_turn") is not True:
+        errors.append("automatic_second_turn must be true")
+    if turns.get("manual_second_prompt") is not False:
+        errors.append("manual_second_prompt must be false")
+
+    hook = evidence.get("hook_observation")
+    if not isinstance(hook, dict):
+        errors.append("hook_observation is missing")
+    else:
+        if hook.get("new_block_and_continue_event") is not True:
+            errors.append("a block_and_continue event is required")
+        if not isinstance(hook.get("app_thread_hook_items"), int) or hook["app_thread_hook_items"] < 1:
+            errors.append("the App thread must contain a Stop-hook observation")
+
+    first_contract = evidence.get("contract")
+    if not isinstance(first_contract, dict) or first_contract.get("first_status") != "continue":
+        errors.append("the first turn must emit a continue contract")
+
+    cycle = evidence.get("supervisor_cycle")
+    if not isinstance(cycle, dict) or cycle.get("executed") is not True:
+        errors.append("the real supervisor-cycle execution is required")
+
+    terminal = evidence.get("terminal_contract")
+    if not isinstance(terminal, dict) or terminal.get("status") != "complete":
+        errors.append("a terminal complete contract is required")
+
+    artifact = evidence.get("artifact")
+    if not isinstance(artifact, dict) or artifact.get("removed") is not True:
+        errors.append("the synthetic artifact must be removed")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("evidence", type=Path, help="sanitized JSON evidence package")
+    args = parser.parse_args()
+    try:
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"valid": False, "errors": [f"cannot read evidence: {exc}"]}))
+        return 2
+    if not isinstance(evidence, dict):
+        print(json.dumps({"valid": False, "errors": ["evidence must be a JSON object"]}))
+        return 2
+    errors = validate_proof(evidence)
+    result = {"valid": not errors, "errors": errors}
+    print(json.dumps(result, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Summary

- add a strict validator for sanitized Codex App continuity evidence;
- reject a one-turn result even when the first `continue` contract is valid;
- require the observed Stop-hook event, automatic second turn, real `supervisor-cycle`, terminal contract, and cleanup;
- document that a background follow-up to an existing thread is not a fresh interactive App session and classify the reproducible failure as `app_hook_not_loaded`.

This is a focused integration-evidence correction. It does not change the project Stop hook, global hook, production, or authorization behavior.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: Reproducible Codex App/Stop-hook integration defect from the canonical one-turn proof after Trust/Enable validation.
- Design/ADR: `docs/operations/codex-supervised-continuity.md`
- Migration steps: None.

## Screenshots / Evidence
- WSL focused validator tests: 4/4 passed.
- Existing WSL supervisor gate, Skill behavior, and shell wrapper suite: 33 Python tests plus behavior/wrapper checks passed.
- The captured App proof is intentionally rejected: 1 `turn.started`/`turn.completed`, no new `block_and_continue`, no generated second turn, no `supervisor-cycle`, and no terminal contract.
- The temporary synthetic artifact was removed; no second manual prompt was sent.