### PR TITLE
fix(ponto): fail fast on main SHA drift

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -31,6 +31,15 @@ export const dispatchTimeoutMsFor = (workflow, configuredTimeoutMs) => Math.max(
   minimumDispatchTimeoutMsByWorkflow[workflow] || 0,
 );
 
+export function assertMainShaUnchanged(orchestratorSha, mainSha) {
+  const expected = String(orchestratorSha || "").trim().toLowerCase();
+  const observed = String(mainSha || "").trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(expected) || observed !== expected) {
+    throw new Error("main advanced after the immutable Ponto coordinator was selected");
+  }
+  return expected;
+}
+
 export function governedLeaseKeyFor(workflow, inputs) {
   if (workflow === "deploy-timekeeping.yml" && inputs.target !== "preview") return "timekeeping";
   if (
@@ -149,6 +158,9 @@ const request = async (pathname, init = {}) => {
   if (!response.ok) throw new Error(`GitHub API ${init.method || "GET"} ${pathname} returned ${response.status}`);
   return readGitHubResponse(response);
 };
+
+const currentMain = await request(`/repos/${repository}/commits/main`);
+assertMainShaUnchanged(orchestratorHeadSha, currentMain?.sha);
 
 const inputs = JSON.parse(fs.readFileSync(inputsFile, "utf8"));
 inputs.orchestrator_run_id = correlation;

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import test from "node:test";
 import {
+  assertMainShaUnchanged,
   dispatchTimeoutMsFor,
   governedLeaseKeyFor,
   isBodylessResponseStatus,
@@ -72,6 +73,15 @@ test("preview dispatches never require a capability while every governed mutatio
     release_scope: "general",
     unit: "api",
   }), "");
+});
+
+test("child dispatch refuses a coordinator SHA after main advances", () => {
+  const sha = "a".repeat(40);
+  assert.equal(assertMainShaUnchanged(sha, sha.toUpperCase()), sha);
+  assert.throws(
+    () => assertMainShaUnchanged(sha, "b".repeat(40)),
+    /main advanced after the immutable Ponto coordinator was selected/,
+  );
 });
 
 test("governed success requires one exact Ed25519-consumed capability check", () => {

--- a/docs/ponto-secrets-custody.md
+++ b/docs/ponto-secrets-custody.md
@@ -1,0 +1,27 @@
+# Ponto — custódia de secrets
+
+Os valores do Ponto são gerados e mantidos fora do repositório, em cofres
+independentes por ambiente. Este registro lista apenas nomes, escopos e
+referências opacas; nunca inclua valores, chaves privadas, credenciais,
+cookies, PII ou material plaintext em commits, logs, artefatos ou comentários.
+
+## GitHub environments
+
+- `staging`: `PONTO_PROFILE_DATA_KEY`, `PONTO_ROOT_ATTESTATION_KEY_SHARED`,
+  `PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY`,
+  `PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY`.
+- `production`: os mesmos quatro nomes, com material independente.
+- Os secrets de emergência são separados por ambiente e só permitem o
+  fechamento externo (`PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL`).
+
+`PONTO_PROFILE_DATA_KEY` e `PONTO_IDEMPOTENCY_KEY` não podem existir como
+repository secrets nem ser copiados entre environments. Workflows validam
+presença, escopo, fingerprints e custódia; o valor nunca é impresso nem
+transportado pela evidência pública.
+
+## Cloudflare Workers
+
+Os brokers `skincos-ponto-emergency-staging` e
+`skincos-ponto-emergency-production` usam bindings e secrets próprios, com
+operação close-only e latch monotônico. A attestation registra apenas versão,
+database ID, nomes de secrets e fingerprint da chave de resposta.


### PR DESCRIPTION
## Summary\n- reject child dispatch when main moved after coordinator selection\n- add focused unit coverage for immutable SHA drift\n\n## Validation\n- WSL Node test: .github/scripts/ponto-dispatch-workflow.test.mjs (7/7)\n- git diff --check