### PR TITLE
fix(finance): restore staging smoke grant on rotation

### DIFF
--- a/finance/scripts/staging-smoke-identity-sql.mjs
+++ b/finance/scripts/staging-smoke-identity-sql.mjs
@@ -64,6 +64,7 @@ if (action === 'provision') {
     audit('FINANCE_SMOKE_IDENTITY_ROTATED', { active: true }, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [
+    `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-smoke-operator-nh')},${quote(username)},${quote(scopeId)},'operator',${quote(now)},${quote(technicalActor)}) ON CONFLICT(username,scope_id) DO UPDATE SET permission='operator',created_at=${quote(now)},created_by=${quote(technicalActor)};`,
     financeAudit('FINANCE_SMOKE_GRANT_ROTATION_CONFIRMED', { permission: 'operator' }, { ...baseline, permission: 'operator' }),
   ].join('\n');
 } else {

--- a/finance/test/staging-smoke-identity-scope.test.mjs
+++ b/finance/test/staging-smoke-identity-scope.test.mjs
@@ -37,5 +37,6 @@ test('synthetic Finance identity preserves only the explicit Finance module in t
   assert.match(rotation.core, /role='INJETOR'/);
   assert.match(rotation.core, /allowed_modules_json='\["finance"\]'/);
   assert.match(provision.finance, /ON CONFLICT\(username,scope_id\) DO UPDATE/);
+  assert.match(rotation.finance, /ON CONFLICT\(username,scope_id\) DO UPDATE/);
   assert.match(rotation.finance, /finance_access_grant/);
 });


### PR DESCRIPTION
## Summary\n- keep the dedicated staging actor's identity rotation fail-closed and least-privilege\n- upsert only its single inance-scope-novo-hamburgo operator grant during rotation\n- preserve session invalidation and audit evidence\n- add a focused SQL regression assertion\n\n## Evidence\n- canary 30665186350 stopped at the missing grant baseline before mutation\n- staging identity count is exactly one active synthetic row (diagnostic run 30666627341)\n- prior rotate path only changed identity/audit and left the grant absent\n- targeted WSL test passes; no production or real-user changes\n\nThis is limited to the staging smoke identity required for the Finance canary.