### PR TITLE
fix(deploy): pass immutable release inputs to smoke

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -737,6 +737,7 @@ jobs:
           BOOTSTRAP_FINANCE_CONTEXT: ${{ inputs.bootstrap_finance_context }}
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+          TIMEKEEPING_VERSION_ID: ${{ inputs.timekeeping_version_id }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "staging" ]]; then

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -230,6 +230,7 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           STAGING_WORKER_URL: ${{ vars.FINANCE_STAGING_WORKER_URL }}
+          FINANCE_PRODUCTION_WORKER_URL: ${{ vars.FINANCE_PRODUCTION_WORKER_URL }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Pass the explicit Timekeeping version into the Core API deploy step and the production Finance Worker URL into its smoke. This closes two directly observed canonical-pipeline defects; no production flags, grants, users, or data are changed by the PR.