### PR TITLE
fix(ponto): allow monotonic broker reattestation

### DIFF
--- a/docs/ponto-runbook.md
+++ b/docs/ponto-runbook.md
@@ -329,6 +329,10 @@ Somente `.github/workflows/ponto-emergency-latch-reset.yml` pode escrever
 `latched=false`. O reset exige manutenção regular, superfície governada idle e
 evidências imutáveis de latch/reconciliação; depois do reset, o módulo continua
 em manutenção. Fechamento manual e automático escrevem somente `latched=true`.
+Uma nova operação `latch-true` enquanto o broker já está fechado é uma
+reattestação close-only: atualiza apenas o proprietário da evidência e mantém
+`latched=1`; ela não abre, ativa ou limpa o controle. `maintenance` continua
+owner-bound e recusa um proprietário divergente.
 Não delete a chave, não trate ausência como aberta e não escreva `false` em
 script, migration ou publisher alternativo.
 

--- a/docs/ponto-secrets-custody.md
+++ b/docs/ponto-secrets-custody.md
@@ -19,6 +19,9 @@ repository secrets nem ser copiados entre environments. Workflows validam
 presença, escopo, fingerprints e custódia; o valor nunca é impresso nem
 transportado pela evidência pública.
 
+A reattestação do broker permanece close-only e só atualiza a referência de
+execução da evidência enquanto o latch continua fechado.
+
 ## Cloudflare Workers
 
 Os brokers `skincos-ponto-emergency-staging` e

--- a/ops/cloudflare/ponto-emergency-broker/index.js
+++ b/ops/cloudflare/ponto-emergency-broker/index.js
@@ -111,7 +111,15 @@ async function handle(request, env) {
   try {
     const current = await env.DB.prepare("SELECT latched, changed_at, stop_run_id, emergency_run_id FROM broker_state WHERE id = 'timekeeping'").first();
     const now = new Date().toISOString();
-    if (current?.latched === 1 && (current.stop_run_id !== payload.coordinatorRunId || current.emergency_run_id !== payload.emergencyRunId)) return bad("emergency latch already owned", 409);
+    // A close-only re-attestation may transfer the recorded owner while the
+    // latch is already closed. This never opens the module: it only refreshes
+    // the broker-backed evidence so a later protected reset can reference the
+    // current emergency run. Maintenance remains owner-bound below.
+    if (
+      current?.latched === 1
+      && payload.operation !== "latch-true"
+      && (current.stop_run_id !== payload.coordinatorRunId || current.emergency_run_id !== payload.emergencyRunId)
+    ) return bad("emergency latch already owned", 409);
     if (payload.operation === "latch-true") {
       await env.DB.prepare("UPDATE broker_state SET latched = 1, changed_at = ?, stop_run_id = ?, emergency_run_id = ? WHERE id = 'timekeeping'").bind(now, payload.coordinatorRunId, payload.emergencyRunId).run();
     } else {


### PR DESCRIPTION
## Summary\n- let close-only latch-true reattest an already-closed broker state with current run evidence\n- retain owner binding for maintenance and never permit latch-false\n- document monotonic reattestation semantics\n\n## Validation\n- WSL emergency broker tests: 5/5\n- worker JavaScript syntax checked by focused source validation\n- git diff --check