### PR TITLE
fix(ponto): run emergency propagation probe as async script

### DIFF
--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -51,6 +51,7 @@ jobs:
           umask 077
           node - "$directory/authorization.json" <<'NODE'
           const crypto = require("crypto");
+          (async () => {
           const fs = require("fs");
           fs.writeFileSync(process.argv[2], `${JSON.stringify({
             schemaVersion: 1,
@@ -126,6 +127,7 @@ jobs:
             changedAt: availability.changedAt,
             source: "control",
           })}\n`, { mode: 0o600 });
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
           NODE
           PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
           PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \

--- a/docs/ponto-secrets-custody.md
+++ b/docs/ponto-secrets-custody.md
@@ -24,6 +24,11 @@ execução da evidência enquanto o latch continua fechado. A prova de fail-clos
 também consulta o health endpoint autorizado; nenhum header de Access ou
 secret é incluído no artefato sanitizado.
 
+O probe de propagação executa a consulta autorizada em um escopo assíncrono
+fechado, evitando que o runner interprete `require` e `await` como módulos
+incompatíveis; o resultado continua sanitizado e limitado ao estado de
+disponibilidade.
+
 ## Cloudflare Workers
 
 Os brokers `skincos-ponto-emergency-staging` e


### PR DESCRIPTION
Wrap the fail-close propagation probe in an async scope so Node does not reject require plus await. The sanitized control-fallback evidence contract is unchanged. Includes custody documentation note.