### PR TITLE
fix(ponto): keep authorization evidence writer synchronous

### DIFF
--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -51,7 +51,6 @@ jobs:
           umask 077
           node - "$directory/authorization.json" <<'NODE'
           const crypto = require("crypto");
-          (async () => {
           const fs = require("fs");
           fs.writeFileSync(process.argv[2], `${JSON.stringify({
             schemaVersion: 1,


### PR DESCRIPTION
Remove the accidental async wrapper from the synchronous authorization evidence writer. The live health propagation probe remains wrapped for fetch/await and the sanitized evidence contract is unchanged.