### PR TITLE
fix(ponto): validate dynamic emergency close run name

### DIFF
--- a/.github/workflows/ponto-emergency-latch-reset.yml
+++ b/.github/workflows/ponto-emergency-latch-reset.yml
@@ -90,7 +90,7 @@ jobs:
             || run?.conclusion !== "success"
             || run?.event !== "workflow_dispatch"
             || run?.head_branch !== "main"
-            || run?.name !== "Ponto emergency close"
+            || run?.name !== `Ponto emergency close ${process.env.TARGET}`
             || run?.display_title !== `Ponto emergency close ${process.env.TARGET}`
             || run?.run_attempt !== 1
             || run?.repository?.full_name !== process.env.GITHUB_REPOSITORY


### PR DESCRIPTION
Align the latch-reset provenance check with GitHub's dynamic workflow run name (Ponto emergency close <target>), while retaining exact workflow, branch, SHA, attempt, artifact, and sanitized evidence checks.