### PR TITLE
fix(ponto): validate emergency run workflow path

### DIFF
--- a/.github/workflows/ponto-emergency-latch-reset.yml
+++ b/.github/workflows/ponto-emergency-latch-reset.yml
@@ -85,7 +85,7 @@ jobs:
             || workflow?.path !== ".github/workflows/ponto-emergency-close.yml"
             || String(run?.id || "") !== process.env.EMERGENCY_RUN_ID
             || run?.workflow_id !== workflow.id
-            || run?.path !== `${workflow.path}@refs/heads/main`
+            || run?.path !== workflow.path
             || run?.status !== "completed"
             || run?.conclusion !== "success"
             || run?.event !== "workflow_dispatch"


### PR DESCRIPTION
Use the workflow path returned by GitHub's Actions run API exactly as returned. Keep main branch, active workflow, head SHA ancestry, run name, artifact digest, and sanitized evidence checks strict.