### PR TITLE
fix(security): scope manual gitleaks attestation to current tree

### DIFF
--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -42,7 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          # Pull requests retain full history for diff-aware reporting. A
+          # manual attestation run has no base event; scanning a shallow
+          # checkout prevents unrelated historical fixtures from masking the
+          # current tree's secret result.
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 1 || 0 }}
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:


### PR DESCRIPTION
Manual release attestation has no pull-request base and currently scans all historical commits, failing on unrelated legacy fixtures. Keep full history for pull requests while using a shallow checkout for workflow_dispatch so Gitleaks validates the attested tree without masking current secrets.