### PR TITLE
fix(ponto): reattest existing closed latch before reset

### DIFF
--- a/.github/workflows/ponto-emergency-latch-reset.yml
+++ b/.github/workflows/ponto-emergency-latch-reset.yml
@@ -247,7 +247,6 @@ jobs:
             || priorLatch?.schemaVersion !== 1
             || priorLatch?.module !== "timekeeping"
             || priorLatch?.latched !== true
-            || priorLatch?.stopRunId !== process.env.EMERGENCY_RUN_ID
           ) throw new Error("live emergency latch differs from the exact attested stop");
           fs.writeFileSync(process.argv[4], `${JSON.stringify({
             schemaVersion: 2,
@@ -261,6 +260,7 @@ jobs:
               emergencyArtifactDigest: process.env.EMERGENCY_ARTIFACT_DIGEST,
               authorizationRef: process.env.AUTHORIZATION_REF,
               priorLatchSource: process.env.PONTO_PRIOR_LATCH_SOURCE,
+              priorEmergencyRunId: priorLatch.stopRunId || null,
             },
           })}\n`, { mode: 0o600 });
           fs.writeFileSync(process.argv[5], `${JSON.stringify({
@@ -276,6 +276,7 @@ jobs:
               emergencyArtifactDigest: process.env.EMERGENCY_ARTIFACT_DIGEST,
               authorizationRef: process.env.AUTHORIZATION_REF,
               priorLatchSource: process.env.PONTO_PRIOR_LATCH_SOURCE,
+              priorEmergencyRunId: priorLatch.stopRunId || null,
             },
           })}\n`, { mode: 0o600 });
           NODE


### PR DESCRIPTION
Permit reset after a fresh broker-backed close attestation when an existing KV latch was closed by a prior recovery run. Require the existing latch to be schema-valid and latched=true, preserve its prior run ID in sanitized reset evidence, and continue failing closed otherwise.