### PR TITLE
fix(ponto): reattest closed KV latch before reset

### DIFF
--- a/.github/workflows/ponto-emergency-latch-reset.yml
+++ b/.github/workflows/ponto-emergency-latch-reset.yml
@@ -246,7 +246,9 @@ jobs:
             !["maintenance", "disabled"].includes(prior?.state)
             || priorLatch?.schemaVersion !== 1
             || priorLatch?.module !== "timekeeping"
-            || priorLatch?.latched !== true
+            || (priorLatch?.latched !== true
+              && !(process.env.PONTO_PRIOR_LATCH_SOURCE === "kv"
+                && priorLatch?.latched === false))
             || (priorLatch?.stopRunId !== process.env.EMERGENCY_RUN_ID
               && process.env.PONTO_PRIOR_LATCH_SOURCE !== "kv")
           ) throw new Error("live emergency latch differs from the exact attested stop");


### PR DESCRIPTION
## Summary\n- preserve fail-closed reset while accepting an already-closed KV latch after the exact broker-backed emergency-close attestation\n- retain exact stop-run provenance for non-KV fallback states\n\n## Validation\n- deployment topology validator\n- focused Ponto emergency latch, maintenance, and child reconciliation tests\n\nThis is a single-operator Codex governance change; no human reviewer is required by the current main rules.