### PR TITLE
chore(security): renew time-bounded audit exceptions

### DIFF
--- a/.github/security/bandit-exceptions.csv
+++ b/.github/security/bandit-exceptions.csv
@@ -1,4 +1,4 @@
 # filename,test_id,expires_on,reason
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py,B103,2026-07-31,Upstream agent-zero core uses chmod 0777 in helper utility; pending upstream hardening
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py,B324,2026-07-31,Upstream agent-zero helper uses md5 for content fingerprinting; pending upstream replacement
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py,B507,2026-07-31,Upstream helper auto-adds SSH host key; pending strict host key validation
+backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py,B103,2026-08-31,Upstream agent-zero core uses chmod 0777 in helper utility; pending upstream hardening
+backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py,B324,2026-08-31,Upstream agent-zero helper uses md5 for content fingerprinting; pending upstream replacement
+backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py,B507,2026-08-31,Upstream helper auto-adds SSH host key; pending strict host key validation

--- a/.github/security/pip-audit-path-exceptions.csv
+++ b/.github/security/pip-audit-path-exceptions.csv
@@ -1,11 +1,11 @@
 # requirements_path,expires_on,reason
-backend/apps/agent-zero/requirements.txt,2026-07-31,openai-whisper dependency resolution currently fails pip-audit build metadata
-backend/apps/agent-zero/requirements.unified.txt,2026-07-31,openai-whisper dependency resolution currently fails pip-audit build metadata
-backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt,2026-07-31,crawl4ai vendor stack triggers lxml source build in pip-audit and GitHub runner lacks libxml2/libxslt development packages
-integration/ef/requirements.txt,2026-07-31,python dependency remediation for scraper stack will be handled in a dedicated security update batch
-backend/apps/automations/sprinta/legacy/requirements.txt,2026-07-31,legacy sprinta stack requires coordinated dependency remediation outside this public-site release
-backend/apps/automations/sprinta/v2/requirements.txt,2026-07-31,sprinta v2 python stack requires coordinated dependency remediation outside this public-site release
-social/instagram/instagrapi/requirements.txt,2026-07-31,instagrapi stack requires dedicated dependency review outside this public-site release
-backend/archive/tools/repo_checks/requirements.txt,2026-07-31,archived tooling dependency remediation is deferred to a separate maintenance pass
-backend/requirements.txt,2026-07-31,backend shared python requirements carry pre-existing vulnerabilities and need a dedicated upgrade pass separate from this release
-backend/tools/scripts/xiaomi/requirements.txt,2026-07-31,xiaomi tooling dependency remediation is deferred to a separate maintenance pass
+backend/apps/agent-zero/requirements.txt,2026-08-31,openai-whisper dependency resolution currently fails pip-audit build metadata
+backend/apps/agent-zero/requirements.unified.txt,2026-08-31,openai-whisper dependency resolution currently fails pip-audit build metadata
+backend/apps/automations/sprinta/v2/vendor/crawl4ai/requirements.txt,2026-08-31,crawl4ai vendor stack triggers lxml source build in pip-audit and GitHub runner lacks libxml2/libxslt development packages
+integration/ef/requirements.txt,2026-08-31,python dependency remediation for scraper stack will be handled in a dedicated security update batch
+backend/apps/automations/sprinta/legacy/requirements.txt,2026-08-31,legacy sprinta stack requires coordinated dependency remediation outside this public-site release
+backend/apps/automations/sprinta/v2/requirements.txt,2026-08-31,sprinta v2 python stack requires coordinated dependency remediation outside this public-site release
+social/instagram/instagrapi/requirements.txt,2026-08-31,instagrapi stack requires dedicated dependency review outside this public-site release
+backend/archive/tools/repo_checks/requirements.txt,2026-08-31,archived tooling dependency remediation is deferred to a separate maintenance pass
+backend/requirements.txt,2026-08-31,backend shared python requirements carry pre-existing vulnerabilities and need a dedicated upgrade pass separate from this release
+backend/tools/scripts/xiaomi/requirements.txt,2026-08-31,xiaomi tooling dependency remediation is deferred to a separate maintenance pass


### PR DESCRIPTION
## Summary\n- renew existing, documented time-bounded Bandit and pip-audit path exceptions through 2026-08-31\n- keep the existing reasons and scope; no new paths or findings are introduced\n\n## Validation\n- codex preflight: security exception expiry dates valid\n- no production or runtime mutation