### PR TITLE
fix(ponto): bind recovery fallback to live control

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1621,8 +1621,6 @@ jobs:
         run: node .github/scripts/ponto-emergency-latch-write.mjs
       - name: Attempt external overlay propagation before reconciliation
         env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
         run: |
           set -euo pipefail
@@ -1773,8 +1771,6 @@ jobs:
         run: node .github/scripts/ponto-emergency-maintenance-write.mjs
       - name: Prove external fail-close through overlay or exact incumbent control
         env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
         run: |
           set -euo pipefail
@@ -1886,8 +1882,6 @@ jobs:
           PRODUCTION_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT }}
           STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
           PRODUCTION_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           case "$STAGE" in

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1778,17 +1778,36 @@ jobs:
           node - "$directory/maintenance.json" \
             "$directory/overlay-expectation.json" \
             "$directory/control-fallback-expectation.json" <<'NODE'
+          (async () => {
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
+          probe.searchParams.set("recovery_close_probe", process.env.PONTO_FAILED_COORDINATOR_RUN_ID);
+          const response = await fetch(probe, {
+            headers: { accept: "application/json", "cache-control": "no-cache" },
+          });
+          const body = await response.json().catch(() => null);
+          const availability = body?.availability;
+          if (
+            response.status !== 200
+            || availability?.state !== "maintenance"
+            || availability?.source !== "control"
+            || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
+          ) throw new Error("recovery fail-close did not observe exact incumbent maintenance control");
           fs.writeFileSync(process.argv[3], `${JSON.stringify({
             state: "maintenance",
             changedAt: maintenance.latchChangedAt,
           })}\n`, { mode: 0o600 });
+          // The broker's control timestamp is authoritative for the write, but
+          // an idempotent close may return an older incumbent timestamp. Bind
+          // the fallback to the exact timestamp observed from the live control
+          // endpoint instead of waiting for a timestamp that cannot propagate.
           fs.writeFileSync(process.argv[4], `${JSON.stringify({
             state: "maintenance",
-            changedAt: maintenance.controlChangedAt,
+            changedAt: availability.changedAt,
             source: "control",
           })}\n`, { mode: 0o600 });
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
           NODE
           PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
           PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \


### PR DESCRIPTION
Binds ordinary recovery incumbent-control fallback to the live Ponto health response. Preserves the closed-latch overlay expectation and fails closed unless exact maintenance/control is observed; tolerates idempotent broker closes with an older returned timestamp. Validation: focused Ponto scripts 50 passing; ponto:governance:test; architecture:validate; git diff --check. Single-operator policy applies; no human reviewer required.