### PR TITLE
fix(ponto): attest live control fallback in rollback

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -72,9 +72,16 @@ export function normalizeRecoveryEvidence({
     || maintenance?.piiIncluded !== false
   ) throw new Error("broker maintenance evidence is invalid");
 
+  // An idempotent broker maintenance call can return the timestamp it saw
+  // before the live control read. For the control fallback, the externally
+  // observed timestamp is the exact value that the rollback attestation must
+  // bind to; the latch path still uses the broker latch timestamp.
   const exactPropagationChangedAt = propagation?.matchedSource === "control"
-    ? maintenance.controlChangedAt
+    ? String(propagation.changedAt || "")
     : maintenance.latchChangedAt;
+  const exactControlChangedAt = propagation?.matchedSource === "control"
+    ? exactPropagationChangedAt
+    : maintenance.controlChangedAt;
   if (
     propagation?.schemaVersion !== 1
     || propagation?.module !== "timekeeping"
@@ -116,7 +123,7 @@ export function normalizeRecoveryEvidence({
       custodyRef: String(maintenance.custodyRef || ""),
       state: "maintenance",
       latched: true,
-      controlChangedAt: maintenance.controlChangedAt,
+      controlChangedAt: exactControlChangedAt,
       latchChangedAt: maintenance.latchChangedAt,
       emergencyLatchRef: {
         stopRunId: coordinatorRunId,

--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -88,6 +88,7 @@ export function normalizeRecoveryEvidence({
     || propagation?.environment !== target
     || propagation?.state !== "maintenance"
     || propagation?.changedAt !== exactPropagationChangedAt
+    || !validDate(exactPropagationChangedAt)
     || propagation?.passed !== true
     || propagation?.exactChangedAtObserved !== true
     || propagation?.exactSourceObserved !== true

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -65,6 +65,35 @@ test("ordinary recovery artifact tree normalizes exact child and broker evidence
   assert.equal(normalized.brokerFailClose.controlChangedAt, maintenance.controlChangedAt);
 });
 
+test("ordinary recovery binds an idempotent control fallback to the live timestamp", () => {
+  const observedControlAt = "2026-07-30T00:03:00.000Z";
+  const normalized = normalizeRecoveryEvidence({
+    reconciliation: {
+      schemaVersion: 1,
+      orchestratorRunId: coordinatorRunId,
+      orchestratorHeadSha: sha,
+      discoveredChildren: 0,
+      unresolved: [],
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    maintenance,
+    propagation: {
+      ...propagation,
+      changedAt: observedControlAt,
+      matchedSource: "control",
+    },
+    sourceMode: "ordinary",
+    coordinatorRunId,
+    emergencyRunId,
+    releaseSha: sha,
+    stage,
+    target,
+  });
+  assert.equal(normalized.brokerFailClose.controlChangedAt, observedControlAt);
+});
+
 test("watchdog evidence normalizes only capability-authorized terminal children", () => {
   const normalized = normalizeRecoveryEvidence({
     reconciliation: {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1621,8 +1621,6 @@ jobs:
         run: node .github/scripts/ponto-emergency-latch-write.mjs
       - name: Attempt external overlay propagation before reconciliation
         env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
         run: |
           set -euo pipefail
@@ -1773,8 +1771,6 @@ jobs:
         run: node .github/scripts/ponto-emergency-maintenance-write.mjs
       - name: Prove external fail-close through overlay or exact incumbent control
         env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
         run: |
           set -euo pipefail
@@ -1886,8 +1882,6 @@ jobs:
           PRODUCTION_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT }}
           STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
           PRODUCTION_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           case "$STAGE" in

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1772,6 +1772,7 @@ jobs:
       - name: Prove external fail-close through overlay or exact incumbent control
         env:
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
+          PONTO_RECOVERY_PROBE_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
           directory="$RUNNER_TEMP/ponto-ordinary-recovery"
@@ -1782,7 +1783,7 @@ jobs:
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
-          probe.searchParams.set("recovery_close_probe", process.env.PONTO_FAILED_COORDINATOR_RUN_ID);
+          probe.searchParams.set("recovery_close_probe", process.env.PONTO_RECOVERY_PROBE_RUN_ID);
           const response = await fetch(probe, {
             headers: { accept: "application/json", "cache-control": "no-cache" },
           });

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1778,17 +1778,36 @@ jobs:
           node - "$directory/maintenance.json" \
             "$directory/overlay-expectation.json" \
             "$directory/control-fallback-expectation.json" <<'NODE'
+          (async () => {
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
+          probe.searchParams.set("recovery_close_probe", process.env.PONTO_FAILED_COORDINATOR_RUN_ID);
+          const response = await fetch(probe, {
+            headers: { accept: "application/json", "cache-control": "no-cache" },
+          });
+          const body = await response.json().catch(() => null);
+          const availability = body?.availability;
+          if (
+            response.status !== 200
+            || availability?.state !== "maintenance"
+            || availability?.source !== "control"
+            || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
+          ) throw new Error("recovery fail-close did not observe exact incumbent maintenance control");
           fs.writeFileSync(process.argv[3], `${JSON.stringify({
             state: "maintenance",
             changedAt: maintenance.latchChangedAt,
           })}\n`, { mode: 0o600 });
+          // The broker's control timestamp is authoritative for the write, but
+          // an idempotent close may return an older incumbent timestamp. Bind
+          // the fallback to the exact timestamp observed from the live control
+          // endpoint instead of waiting for a timestamp that cannot propagate.
           fs.writeFileSync(process.argv[4], `${JSON.stringify({
             state: "maintenance",
-            changedAt: maintenance.controlChangedAt,
+            changedAt: availability.changedAt,
             source: "control",
           })}\n`, { mode: 0o600 });
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
           NODE
           PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
           PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \


### PR DESCRIPTION
Makes automatic rollback evidence bind an idempotent emergency-close fallback to the exact live control timestamp observed by recovery-close. The normal latch path remains bound to the broker latch/control timestamps. Adds a focused regression test. Validation: focused recovery, propagation and watchdog tests pass; git diff --check. Single-operator policy applies; no human reviewer required.