### PR TITLE
fix(ponto): attest live control fallback in rollback

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -72,9 +72,16 @@ export function normalizeRecoveryEvidence({
     || maintenance?.piiIncluded !== false
   ) throw new Error("broker maintenance evidence is invalid");
 
+  // An idempotent broker maintenance call can return the timestamp it saw
+  // before the live control read. For the control fallback, the externally
+  // observed timestamp is the exact value that the rollback attestation must
+  // bind to; the latch path still uses the broker latch timestamp.
   const exactPropagationChangedAt = propagation?.matchedSource === "control"
-    ? maintenance.controlChangedAt
+    ? String(propagation.changedAt || "")
     : maintenance.latchChangedAt;
+  const exactControlChangedAt = propagation?.matchedSource === "control"
+    ? exactPropagationChangedAt
+    : maintenance.controlChangedAt;
   if (
     propagation?.schemaVersion !== 1
     || propagation?.module !== "timekeeping"
@@ -116,7 +123,7 @@ export function normalizeRecoveryEvidence({
       custodyRef: String(maintenance.custodyRef || ""),
       state: "maintenance",
       latched: true,
-      controlChangedAt: maintenance.controlChangedAt,
+      controlChangedAt: exactControlChangedAt,
       latchChangedAt: maintenance.latchChangedAt,
       emergencyLatchRef: {
         stopRunId: coordinatorRunId,

--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -88,6 +88,7 @@ export function normalizeRecoveryEvidence({
     || propagation?.environment !== target
     || propagation?.state !== "maintenance"
     || propagation?.changedAt !== exactPropagationChangedAt
+    || !validDate(exactPropagationChangedAt)
     || propagation?.passed !== true
     || propagation?.exactChangedAtObserved !== true
     || propagation?.exactSourceObserved !== true

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -65,6 +65,35 @@ test("ordinary recovery artifact tree normalizes exact child and broker evidence
   assert.equal(normalized.brokerFailClose.controlChangedAt, maintenance.controlChangedAt);
 });
 
+test("ordinary recovery binds an idempotent control fallback to the live timestamp", () => {
+  const observedControlAt = "2026-07-30T00:03:00.000Z";
+  const normalized = normalizeRecoveryEvidence({
+    reconciliation: {
+      schemaVersion: 1,
+      orchestratorRunId: coordinatorRunId,
+      orchestratorHeadSha: sha,
+      discoveredChildren: 0,
+      unresolved: [],
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    maintenance,
+    propagation: {
+      ...propagation,
+      changedAt: observedControlAt,
+      matchedSource: "control",
+    },
+    sourceMode: "ordinary",
+    coordinatorRunId,
+    emergencyRunId,
+    releaseSha: sha,
+    stage,
+    target,
+  });
+  assert.equal(normalized.brokerFailClose.controlChangedAt, observedControlAt);
+});
+
 test("watchdog evidence normalizes only capability-authorized terminal children", () => {
   const normalized = normalizeRecoveryEvidence({
     reconciliation: {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1772,6 +1772,7 @@ jobs:
       - name: Prove external fail-close through overlay or exact incumbent control
         env:
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
+          PONTO_RECOVERY_PROBE_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
           directory="$RUNNER_TEMP/ponto-ordinary-recovery"
@@ -1782,7 +1783,7 @@ jobs:
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
-          probe.searchParams.set("recovery_close_probe", process.env.PONTO_FAILED_COORDINATOR_RUN_ID);
+          probe.searchParams.set("recovery_close_probe", process.env.PONTO_RECOVERY_PROBE_RUN_ID);
           const response = await fetch(probe, {
             headers: { accept: "application/json", "cache-control": "no-cache" },
           });


### PR DESCRIPTION
Binds ordinary recovery fallback and automatic rollback evidence to the exact live Ponto control timestamp. Uses a per-step recovery probe run ID, keeps the latch path unchanged, and rejects invalid fallback timestamps. All Copilot findings from the superseded PR are addressed. Validation: focused recovery/propagation/watchdog tests; hosted CI, E2E, JS/TS, security and coverage checks on the branch. Single-operator policy applies; no human reviewer required.