### PR TITLE
fix(ponto): normalize observed control timestamp

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -77,7 +77,7 @@ export function normalizeRecoveryEvidence({
   // observed timestamp is the exact value that the rollback attestation must
   // bind to; the latch path still uses the broker latch timestamp.
   const exactPropagationChangedAt = propagation?.matchedSource === "control"
-    ? String(propagation.changedAt || "")
+    ? String(propagation.lastObserved?.changedAt || "")
     : maintenance.latchChangedAt;
   const exactControlChangedAt = propagation?.matchedSource === "control"
     ? exactPropagationChangedAt

--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -87,8 +87,12 @@ export function normalizeRecoveryEvidence({
     || propagation?.module !== "timekeeping"
     || propagation?.environment !== target
     || propagation?.state !== "maintenance"
-    || propagation?.changedAt !== exactPropagationChangedAt
+    || !validDate(propagation?.changedAt)
+    || propagation?.changedAt !== maintenance.latchChangedAt
     || !validDate(exactPropagationChangedAt)
+    || (propagation?.matchedSource === "control"
+      && (propagation?.lastObserved?.source !== "control"
+        || propagation?.lastObserved?.changedAt !== exactPropagationChangedAt))
     || propagation?.passed !== true
     || propagation?.exactChangedAtObserved !== true
     || propagation?.exactSourceObserved !== true

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -82,6 +82,11 @@ test("ordinary recovery binds an idempotent control fallback to the live timesta
     propagation: {
       ...propagation,
       changedAt: observedControlAt,
+      lastObserved: {
+        state: "maintenance",
+        changedAt: observedControlAt,
+        source: "control",
+      },
       matchedSource: "control",
     },
     sourceMode: "ordinary",

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -81,7 +81,7 @@ test("ordinary recovery binds an idempotent control fallback to the live timesta
     maintenance,
     propagation: {
       ...propagation,
-      changedAt: observedControlAt,
+      changedAt: maintenance.latchChangedAt,
       lastObserved: {
         state: "maintenance",
         changedAt: observedControlAt,


### PR DESCRIPTION
Corrects ordinary recovery evidence to use the live control timestamp in lastObserved when the fallback matched the incumbent control. This keeps broker and live KV attestation aligned after an idempotent close, while preserving the latch path. Adds regression coverage. Validation: focused recovery and propagation tests pass; branch is based on current main e4918c49203d6835f3669c43648b8dc00411be3c. Single-operator policy applies; no human reviewer required.