### PR TITLE
fix(ponto): attest zero-surface recovery no-op

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -9,7 +9,7 @@ const source = fs.readFileSync(
 
 test("live broker fail-close is attested before any rollback mutation and re-read after", () => {
   const preAttestation = source.indexOf(
-    "const preMutationFailClose = readAndAttestBrokerFailClose();",
+    "const preMutationFailClose = await readAndAttestBrokerFailClose();",
   );
   const permission = source.indexOf("const rollbackPermitted =");
   const workerMutation = source.indexOf('const rollback = spawnSync("npx"');
@@ -17,7 +17,7 @@ test("live broker fail-close is attested before any rollback mutation and re-rea
     "const rolledBack = await rollbackPagesWithReconciliation",
   );
   const postAttestation = source.indexOf(
-    "const postMutationFailClose = readAndAttestBrokerFailClose();",
+    "const postMutationFailClose = await readAndAttestBrokerFailClose();",
   );
   for (const position of [
     preAttestation,
@@ -42,4 +42,12 @@ test("live broker fail-close is attested before any rollback mutation and re-rea
 test("Pages rollback intent has dedicated environment-only custody", () => {
   assert.match(source, /PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY/);
   assert.doesNotMatch(source, /PONTO_ORCHESTRATOR_LEASE_HMAC_KEY/);
+});
+
+test("zero-surface recovery uses a fresh external maintenance probe instead of faking rollback", () => {
+  assert.match(source, /PONTO_MODULE_HEALTH_URL/);
+  assert.match(source, /Object\.keys\(plan\)\.length !== 0/);
+  assert.match(source, /readbackMode: "external-health-noop"/);
+  assert.match(source, /rollbackDisposition/);
+  assert.match(source, /no-dispatched-surface-noop/);
 });

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -35,11 +35,15 @@ const accountId = String(process.env.CLOUDFLARE_ACCOUNT_ID || "");
 const apiToken = String(process.env.CLOUDFLARE_API_TOKEN || "");
 const pagesProject = String(process.env.CLOUDFLARE_PAGES_PROJECT || "");
 const moduleControlNamespaceId = String(process.env.MODULE_CONTROL_KV_ID || "");
+const moduleHealthUrl = String(process.env.PONTO_MODULE_HEALTH_URL || "").trim();
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const staging = stage === "staging";
 const expectedPagesProject = staging ? "skincos-staging" : "skincos";
 const expectedPagesBranch = staging ? "staging" : "main";
 const expectedPagesAlias = staging ? "crm-staging.skincos.com.br" : "crm.skincos.com.br";
+const expectedModuleHealthUrl = staging
+  ? "https://api-staging.skincos.com.br/api/ponto/health"
+  : "https://api.skincos.com.br/api/ponto/health";
 
 if (!artifactRoot || !reportFile) throw new Error("automatic rollback artifact root and report path are required");
 if (!/^[0-9a-f]{40}$/.test(releaseSha) || !["staging", "pilot", "canary", "production"].includes(stage)) throw new Error("invalid automatic rollback identity");
@@ -86,7 +90,71 @@ const readRemoteModuleKey = (key) => spawnSync("npx", [
   moduleControlNamespaceId,
   "--remote",
 ], { encoding: "utf8", env: process.env, maxBuffer: 2 * 1024 * 1024 });
-const readAndAttestBrokerFailClose = () => {
+const readExternalModuleHealth = async () => {
+  if (moduleHealthUrl !== expectedModuleHealthUrl) {
+    return { passed: false, status: 0, reason: "module-health-url-not-pinned" };
+  }
+  try {
+    const response = await fetch(moduleHealthUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(15_000),
+      headers: { accept: "application/json" },
+    });
+    const payload = await response.json().catch(() => null);
+    const availability = payload?.availability;
+    return {
+      passed: response.status === 200
+        && payload?.ok === false
+        && payload?.ready === false
+        && availability?.state === "maintenance"
+        && availability?.source === "control"
+        && Number.isFinite(Date.parse(String(availability?.changedAt || "")))
+        && availability?.changedAt === brokerFailClose?.controlChangedAt,
+      status: response.status,
+      state: String(availability?.state || ""),
+      source: String(availability?.source || ""),
+      changedAt: String(availability?.changedAt || ""),
+    };
+  } catch {
+    return { passed: false, status: 0, reason: "module-health-probe-failed" };
+  }
+};
+const attestNoSurfaceRollback = async () => {
+  // A failed coordinator can legitimately discover zero child mutations. In
+  // that case there is no incumbent deployment to restore; require the
+  // immutable close artifact and a fresh external maintenance probe instead
+  // of pretending that a direct KV readback or deployment rollback occurred.
+  if (Object.keys(plan).length !== 0 || !brokerFailClose) return null;
+  const evidenceValid = brokerFailClose.schemaVersion === 1
+    && brokerFailClose.contractId === "skincos/ponto/emergency-close/v1"
+    && brokerFailClose.coordinatorRunId === orchestratorRunId
+    && brokerFailClose.releaseSha === releaseSha
+    && brokerFailClose.stage === stage
+    && brokerFailClose.target === (staging ? "staging" : "production")
+    && brokerFailClose.state === "maintenance"
+    && brokerFailClose.latched === true
+    && Number.isFinite(Date.parse(String(brokerFailClose.controlChangedAt || "")))
+    && Number.isFinite(Date.parse(String(brokerFailClose.latchChangedAt || "")))
+    && brokerFailClose.emergencyLatchRef?.stopRunId === orchestratorRunId
+    && brokerFailClose.emergencyLatchRef?.emergencyRunId === brokerFailClose.emergencyRunId
+    && brokerFailClose.emergencyLatchRef?.latchChangedAt === brokerFailClose.latchChangedAt
+    && brokerFailClose.propagation?.passed === true
+    && brokerFailClose.passed === true
+    && brokerFailClose.credentialsIncluded === false
+    && brokerFailClose.piiIncluded === false;
+  const health = await readExternalModuleHealth();
+  if (!evidenceValid || !health.passed) return null;
+  return {
+    passed: true,
+    emergencyRunId: brokerFailClose.emergencyRunId,
+    state: "maintenance",
+    controlChangedAt: brokerFailClose.controlChangedAt,
+    latchChangedAt: brokerFailClose.latchChangedAt,
+    readbackMode: "external-health-noop",
+    externalHealth: health,
+  };
+};
+const readAndAttestBrokerFailClose = async () => {
   let moduleControl = null;
   let emergencyLatch = null;
   try {
@@ -104,18 +172,27 @@ const readAndAttestBrokerFailClose = () => {
     moduleControl = null;
     emergencyLatch = null;
   }
+  const directAttestation = attestBrokerFailCloseEvidence({
+    evidence: brokerFailClose,
+    moduleControl,
+    emergencyLatch,
+    coordinatorRunId: orchestratorRunId,
+    releaseSha,
+    stage,
+    target: staging ? "staging" : "production",
+  });
+  if (directAttestation.passed) {
+    return {
+      moduleControl,
+      emergencyLatch,
+      attestation: { ...directAttestation, readbackMode: "direct-kv" },
+    };
+  }
+  const noSurfaceAttestation = await attestNoSurfaceRollback();
   return {
     moduleControl,
     emergencyLatch,
-    attestation: attestBrokerFailCloseEvidence({
-      evidence: brokerFailClose,
-      moduleControl,
-      emergencyLatch,
-      coordinatorRunId: orchestratorRunId,
-      releaseSha,
-      stage,
-      target: staging ? "staging" : "production",
-    }),
+    attestation: noSurfaceAttestation || directAttestation,
   };
 };
 const surfaceSpecs = {
@@ -447,7 +524,7 @@ if (staging && fs.existsSync(drillRunFile)) {
 // KV records and bind the regular control to the exact still-true emergency
 // latch before any Worker or Pages rollback. The workflow-level surface mutex
 // excludes the protected latch reset until the final readback below.
-const preMutationFailClose = readAndAttestBrokerFailClose();
+const preMutationFailClose = await readAndAttestBrokerFailClose();
 if (!preMutationFailClose.attestation.passed) {
   unresolved.push({
     surface: "moduleControl",
@@ -878,7 +955,7 @@ if (plan.coreApi && plan.timekeeping && proofs.coreApi?.passed && proofs.timekee
 // Re-read after every mutation while still holding the surface mutex. A reset,
 // drift, or broker/control mismatch makes the recovery unresolved even when all
 // deployment commands themselves succeeded.
-const postMutationFailClose = readAndAttestBrokerFailClose();
+const postMutationFailClose = await readAndAttestBrokerFailClose();
 if (!postMutationFailClose.attestation.passed) {
   unresolved.push({
     surface: "moduleControl",
@@ -907,8 +984,15 @@ const report = {
     changedAt: moduleFailCloseAttestation.controlChangedAt,
     emergencyLatchChangedAt: moduleFailCloseAttestation.latchChangedAt,
     preMutationReadbackMatched: true,
-    remoteKvReadbackMatched: true,
-    emergencyLatchReadbackMatched: true,
+    remoteKvReadbackMatched: preMutationFailClose.attestation.readbackMode === "direct-kv"
+      && postMutationFailClose.attestation.readbackMode === "direct-kv",
+    emergencyLatchReadbackMatched: preMutationFailClose.attestation.readbackMode === "direct-kv"
+      && postMutationFailClose.attestation.readbackMode === "direct-kv",
+    externalHealthReadbackMatched: preMutationFailClose.attestation.readbackMode === "external-health-noop"
+      && postMutationFailClose.attestation.readbackMode === "external-health-noop",
+    rollbackDisposition: plannedNames.length === 0
+      ? "no-dispatched-surface-noop"
+      : "restored-dispatched-surfaces",
   } : {
     state: "unresolved",
     remoteKvReadbackMatched: false,

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -44,6 +44,12 @@ const expectedPagesAlias = staging ? "crm-staging.skincos.com.br" : "crm.skincos
 const expectedModuleHealthUrl = staging
   ? "https://api-staging.skincos.com.br/api/ponto/health"
   : "https://api.skincos.com.br/api/ponto/health";
+const accessHeaders = {};
+if (process.env.CF_ACCESS_CLIENT_ID || process.env.CF_ACCESS_CLIENT_SECRET) {
+  if (!process.env.CF_ACCESS_CLIENT_ID || !process.env.CF_ACCESS_CLIENT_SECRET) throw new Error("partial Cloudflare Access credential");
+  accessHeaders["CF-Access-Client-Id"] = process.env.CF_ACCESS_CLIENT_ID;
+  accessHeaders["CF-Access-Client-Secret"] = process.env.CF_ACCESS_CLIENT_SECRET;
+}
 
 if (!artifactRoot || !reportFile) throw new Error("automatic rollback artifact root and report path are required");
 if (!/^[0-9a-f]{40}$/.test(releaseSha) || !["staging", "pilot", "canary", "production"].includes(stage)) throw new Error("invalid automatic rollback identity");
@@ -98,7 +104,7 @@ const readExternalModuleHealth = async () => {
     const response = await fetch(moduleHealthUrl, {
       redirect: "manual",
       signal: AbortSignal.timeout(15_000),
-      headers: { accept: "application/json" },
+      headers: { accept: "application/json", ...accessHeaders },
     });
     const payload = await response.json().catch(() => null);
     const availability = payload?.availability;
@@ -893,12 +899,6 @@ for (const name of ["coreApi", "identityWorkforce", "timekeeping"]) {
   if (plan[name]) rollbackWorker(name, plan[name]);
 }
 
-const accessHeaders = {};
-if (process.env.CF_ACCESS_CLIENT_ID || process.env.CF_ACCESS_CLIENT_SECRET) {
-  if (!process.env.CF_ACCESS_CLIENT_ID || !process.env.CF_ACCESS_CLIENT_SECRET) throw new Error("partial Cloudflare Access credential");
-  accessHeaders["CF-Access-Client-Id"] = process.env.CF_ACCESS_CLIENT_ID;
-  accessHeaders["CF-Access-Client-Secret"] = process.env.CF_ACCESS_CLIENT_SECRET;
-}
 const external = {};
 if (plan.identityWorkforce && proofs.identityWorkforce?.passed) {
   try {

--- a/.github/scripts/ponto-rollback-ownership.test.mjs
+++ b/.github/scripts/ponto-rollback-ownership.test.mjs
@@ -208,7 +208,7 @@ test("automatic rollback refuses every mutation until custody reconciliation and
   );
   assert.match(
     source,
-    /const preMutationFailClose = readAndAttestBrokerFailClose\(\);[\s\S]*const rollbackPermitted = childReconciliationPassed\s*&& drillOwnershipResolved\s*&& preMutationFailClose\.attestation\.passed;[\s\S]*if \(!rollbackPermitted\) \{[\s\S]*rollback-blocked-by-custody-reconciliation/,
+    /const preMutationFailClose = (?:await )?readAndAttestBrokerFailClose\(\);[\s\S]*const rollbackPermitted = childReconciliationPassed\s*&& drillOwnershipResolved\s*&& preMutationFailClose\.attestation\.passed;[\s\S]*if \(!rollbackPermitted\) \{[\s\S]*rollback-blocked-by-custody-reconciliation/,
   );
   assert.match(
     source,

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -960,11 +960,17 @@ for (const required of [
     fail(`Watchdog automatic rollback is missing normalized recovery custody: ${required}`);
   }
 }
-const rollbackPreconditionIndex = automaticRollback.indexOf('const preMutationFailClose = readAndAttestBrokerFailClose();');
+const rollbackPreconditionIndex = Math.max(
+  automaticRollback.indexOf('const preMutationFailClose = readAndAttestBrokerFailClose();'),
+  automaticRollback.indexOf('const preMutationFailClose = await readAndAttestBrokerFailClose();'),
+);
 const rollbackPermissionIndex = automaticRollback.indexOf('const rollbackPermitted =');
 const rollbackWorkerMutationIndex = automaticRollback.indexOf('const rollback = spawnSync("npx"');
 const rollbackPagesMutationIndex = automaticRollback.indexOf('const rolledBack = await rollbackPagesWithReconciliation');
-const rollbackPostconditionIndex = automaticRollback.indexOf('const postMutationFailClose = readAndAttestBrokerFailClose();');
+const rollbackPostconditionIndex = Math.max(
+  automaticRollback.indexOf('const postMutationFailClose = readAndAttestBrokerFailClose();'),
+  automaticRollback.indexOf('const postMutationFailClose = await readAndAttestBrokerFailClose();'),
+);
 if (
   rollbackPreconditionIndex < 0
   || rollbackPermissionIndex < 0

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1898,6 +1898,7 @@ jobs:
           STAGE: ${{ inputs.stage }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
           STAGING_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING }}
           PRODUCTION_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT }}
           STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -328,6 +328,7 @@ jobs:
           STAGE: ${{ needs.context.outputs.stage }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PONTO_MODULE_HEALTH_URL: ${{ needs.context.outputs.target == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
           STAGING_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING }}
           PRODUCTION_PAGES_PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT }}
           STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}


### PR DESCRIPTION
## Objective
Make ordinary/watchdog recovery pass safely when the coordinator dispatches no governed child surface. Preserve direct KV attestation for real rollback mutations; for a zero-surface failure, require the immutable emergency-close evidence plus a fresh pinned maintenance health probe and record an explicit no-op disposition.

## Scope and risk
- High-risk recovery workflow/script only; no production activation or migration.
- Staging/production remain fail-closed in maintenance.
- No secrets or PII are added; the health probe is pinned to the target API origin.

## Validation
- Focused Ponto rollback/recovery/ownership tests: green.
- Deployment topology validator: green.
- `npm run ponto:governance:test`: green.
- `npm run architecture:validate`: green (three pre-existing tracked legacy-import warnings).
- `git diff --check`: green.

## Rollback
Revert this PR. Existing direct-KV rollback path is unchanged for any dispatched surface. The new no-op path cannot mutate Worker, Pages, or module-control state.