### PR TITLE
fix(ponto): use custody token for staging metadata

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Verify target-bound asymmetric child capability custody
         if: ${{ inputs.stage != 'preview' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
         run: |


### PR DESCRIPTION
## Summary\n- use the approved repository custody token when the Ponto release verifies target-bound secret metadata\n- preserve the default GITHUB token for ordinary release operations\n\n## Validation\n- validate-progressive-release.mjs\n- focused Ponto recovery, rollback ownership and secret custody tests\n- architecture, observability, governance and security checks\n- git diff --check\n\nNo deploy or production change is included.