### PR TITLE
fix(ponto): verify account-scoped WAF tokens

### DIFF
--- a/.github/scripts/ponto-waf-security.mjs
+++ b/.github/scripts/ponto-waf-security.mjs
@@ -310,9 +310,11 @@ async function readEntrypoint(client, zoneId) {
 }
 
 async function verifyCustody(client, zoneId) {
-  const token = await client.request("/user/tokens/verify");
-  if (token.result?.status !== "active") throw new Error("Cloudflare security token is not active");
   const zone = await client.request(`/zones/${zoneId}`);
+  const accountId = String(zone.result?.account?.id || "").toLowerCase();
+  if (!HEX32.test(accountId)) throw new Error("Cloudflare security token did not resolve an account-scoped zone");
+  const token = await client.request(`/accounts/${accountId}/tokens/verify`);
+  if (token.result?.status !== "active") throw new Error("Cloudflare security token is not active");
   if (
     String(zone.result?.id || "").toLowerCase() !== zoneId
     || String(zone.result?.name || "").toLowerCase() !== ZONE_NAME
@@ -329,9 +331,7 @@ async function verifyCustody(client, zoneId) {
     expressionDialectValidated: true,
     expressionDigests,
     zoneName: ZONE_NAME,
-    accountId: HEX32.test(String(zone.result?.account?.id || "").toLowerCase())
-      ? String(zone.result.account.id).toLowerCase()
-      : null,
+    accountId,
   };
 }
 

--- a/.github/scripts/ponto-waf-security.mjs
+++ b/.github/scripts/ponto-waf-security.mjs
@@ -312,7 +312,7 @@ async function readEntrypoint(client, zoneId) {
 async function verifyCustody(client, zoneId) {
   const zone = await client.request(`/zones/${zoneId}`);
   const accountId = String(zone.result?.account?.id || "").toLowerCase();
-  if (!HEX32.test(accountId)) throw new Error("Cloudflare security token did not resolve an account-scoped zone");
+  if (!HEX32.test(accountId)) throw new Error("Cloudflare zone response did not include a usable account id for token verification");
   const token = await client.request(`/accounts/${accountId}/tokens/verify`);
   if (token.result?.status !== "active") throw new Error("Cloudflare security token is not active");
   if (

--- a/.github/scripts/ponto-waf-security.test.mjs
+++ b/.github/scripts/ponto-waf-security.test.mjs
@@ -135,7 +135,7 @@ function cloudflareHarness(initialEntrypoint = null) {
     if (parsed.origin === "https://api.cloudflare.com") {
       assert.equal(new Headers(init.headers).get("authorization"), "Bearer security-token");
       state.methods.push({ method, pathname: parsed.pathname });
-      if (parsed.pathname === "/client/v4/user/tokens/verify") {
+      if (parsed.pathname === "/client/v4/accounts/" + "6".repeat(32) + "/tokens/verify") {
         return envelope({ status: "active" });
       }
       if (parsed.pathname === `/client/v4/zones/${zoneId}`) {


### PR DESCRIPTION
## Summary
- verify Cloudflare account API tokens using the account-scoped endpoint returned by the exact zone
- retain exact zone, active token, expression and fail-closed checks
- update focused WAF harness coverage

## Validation
- node --test .github/scripts/ponto-waf-security.test.mjs (15/15)

This is a minimal fix required because Cloudflare's Account WAF tokens reject /user/tokens/verify with 401/1000.