### PR TITLE
docs(codex): reload App before supervised proof

### DIFF
--- a/docs/operations/codex-supervised-continuity.md
+++ b/docs/operations/codex-supervised-continuity.md
@@ -70,14 +70,20 @@ the current `trusted_hash` and `enabled = true`. A trusted entry without
 `enabled = true` is not acceptance evidence: the real proof must still show a
 `block_and_continue` event and an automatically generated second turn.
 
-Trust and enablement are read when an App session is initialized. A background
-follow-up sent to an already-existing thread is not a substitute for opening a
-fresh interactive App session in the standalone activation clone after the
-Trust/Enable review. If that session emits a valid `continue` contract but its
-thread has no Stop-hook event and no generated second turn, classify the result
-as `app_hook_not_loaded`; preserve the thread/turn identifiers and sanitized
-evidence, clean the temporary artifact, and do not retry the same session. The
-acceptance check is intentionally strict:
+After a Trust/Enable review or a trusted-hook command update, fully close and
+reopen the Windows Desktop App before opening the fresh interactive App session
+in the standalone activation clone. A new top-level chat in a Desktop process
+that was already running is not evidence that its in-memory project-hook
+registry reloaded the current configuration. A background follow-up sent to an
+already-existing thread is not a substitute for that fresh interactive App
+session.
+
+If that session emits a valid `continue` contract but its thread has no
+project Stop-hook event and no generated second turn, classify the result as
+`app_hook_not_loaded`; preserve the thread/turn identifiers, sanitized
+evidence, and the reversible marker as frozen failure evidence, then do not
+retry the same session. A global Stop-hook event alone does not establish that
+the project hook was loaded. The acceptance check is intentionally strict:
 
 ```powershell
 python .\scripts\validate-codex-app-proof.py <sanitized-evidence.json>


### PR DESCRIPTION
## Objetivo
Atualiza o runbook de continuidade supervisionada após uma prova canônica real ter encerrado no primeiro turno apesar de `Trust` e `Enable` válidos. O procedimento agora exige reinício completo do Codex Desktop antes da nova sessão top-level e preserva a evidência falha congelada.

## Escopo e risco
Somente `docs/operations/codex-supervised-continuity.md`. Não altera hooks, Skill, código de runtime, configuração, produção, dados, credenciais ou o hook global. Rollback: reverter este único commit.

## Evidência que motivou a correção
- thread top-level `019fbea3-fe37-7992-a94b-55c679cac2ce`, turn `019fbea4-3a9c-7c32-969c-c57a957a1c60`;
- contrato `continue` válido, mas sem segundo turno, `block_and_continue`, `supervisor-cycle` ou contrato terminal;
- o Stop global foi observado e permitiu o encerramento; o hook de projeto confiado/habilitado não foi despachado;
- um app-server novo da mesma build descobre o hook como `trusted` e `enabled`, consistente com registro em memória obsoleto no processo Desktop já em execução.

## Validação
- `git diff --check`
- `scripts/tests/test_validate_codex_app_proof.py` via wrapper WSL: 4 testes aprovados
- evidência sanitizada da falha executada contra `scripts/validate-codex-app-proof.py`: rejeição esperada (`valid=false`) para um único turno, sem flexibilizar o validador.