### PR TITLE
fix(ponto): accept canonical WAF run provenance

### DIFF
--- a/.github/workflows/ponto-waf-security.yml
+++ b/.github/workflows/ponto-waf-security.yml
@@ -273,7 +273,7 @@ jobs:
             workflow?.state !== "active"
             || workflow?.path !== ".github/workflows/ponto-waf-security.yml"
             || run?.workflow_id !== workflow.id
-            || run?.path !== `${workflow.path}@refs/heads/main`
+            || run?.path !== workflow.path
             || run?.status !== "completed"
             || run?.conclusion !== "success"
             || run?.event !== "workflow_dispatch"


### PR DESCRIPTION
## Summary
- accept GitHub's canonical workflow path in exact same-SHA WAF probe provenance
- retain the main branch, workflow identity, run id, head SHA, artifact digest and repository checks

## Validation
- node --test .github/scripts/ponto-waf-security.test.mjs (15/15)
- hosted architecture/action validation will cover workflow syntax