### PR TITLE
chore(security): allow documented deployment identity

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -29,4 +29,7 @@ regexes = [
   # Ponto replay-containment ledgers. The Cloudflare default rule otherwise
   # mistakes these public resource names for API keys.
   '''^skincos-ponto-fenced-(production|staging)-20260730$''',
+  # Exact public deployment identity recorded in the reconciled evidence
+  # ledger. It is not a credential and is intentionally kept auditable.
+  '''^8498b072-cf07-491c-bba2-4ee2c33ecc54$''',
 ]


### PR DESCRIPTION
## Summary\n- allowlist the exact public rollback deployment UUID that the reconciled evidence ledger records\n- keep the evidence ID auditable while preventing a generic-api-key false positive\n\n## Validation\n- git diff --check\n- hosted Gitleaks run will verify the exact narrow exception\n\nNo runtime, secret, data, or deployment change.