### PR TITLE
fix(ponto): wait for WAF edge propagation

### DIFF
--- a/.github/scripts/ponto-waf-security.mjs
+++ b/.github/scripts/ponto-waf-security.mjs
@@ -382,6 +382,13 @@ export async function runPublicProbes({ fetchImpl = fetch, requireBlocks }) {
   return observations;
 }
 
+export async function waitForEdgePropagation({ delayMs = 30_000 } = {}) {
+  if (!Number.isInteger(delayMs) || delayMs < 0 || delayMs > 60_000) {
+    throw new Error("WAF edge propagation delay is invalid");
+  }
+  if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 function validateProbePredecessor(report, { zoneId, liveSnapshot }) {
   if (
     report?.schemaVersion !== 1
@@ -645,7 +652,11 @@ export async function execute({
       after = applied.after;
       let probes;
       try {
-        probes = await runPublicProbes({ fetchImpl, requireBlocks: true });
+          const propagationDelayMs = env.PONTO_WAF_EDGE_PROPAGATION_DELAY_MS === undefined
+            ? 30_000
+            : Number(env.PONTO_WAF_EDGE_PROPAGATION_DELAY_MS);
+          if (applied.mutated) await waitForEdgePropagation({ delayMs: propagationDelayMs });
+          probes = await runPublicProbes({ fetchImpl, requireBlocks: true });
       } catch (error) {
         if (applied.mutated) {
           // Public probing occurs after the mutation boundary and can race with

--- a/.github/scripts/ponto-waf-security.test.mjs
+++ b/.github/scripts/ponto-waf-security.test.mjs
@@ -10,6 +10,7 @@ import {
   captureSnapshot,
   execute,
   publicSnapshot,
+  waitForEdgePropagation,
   writableRule,
 } from "./ponto-waf-security.mjs";
 
@@ -52,6 +53,14 @@ test("standalone WAF apply proves split custody before write-token hydration", (
   assert.match(
     workflow.slice(custodyIndex, writeIndex),
     /!repository\.has\(read\)[\s\S]*repository\.has\(write\)[\s\S]*owner\.has\(read\)[\s\S]*owner\.has\(write\)[\s\S]*staging\.has\(read\)[\s\S]*staging\.has\(write\)[\s\S]*production\.has\(read\)[\s\S]*!production\.has\(write\)/,
+  );
+});
+
+test("WAF edge propagation wait is bounded and testable", async () => {
+  await waitForEdgePropagation({ delayMs: 0 });
+  await assert.rejects(
+    waitForEdgePropagation({ delayMs: 60_001 }),
+    /propagation delay is invalid/,
   );
 });
 
@@ -224,6 +233,7 @@ const envFor = (mode, artifactDir) => ({
   GITHUB_SHA: releaseSha,
   GITHUB_RUN_ID: mode === "probe" ? "100" : "101",
   PONTO_WAF_ARTIFACT_DIR: artifactDir,
+  PONTO_WAF_EDGE_PROPAGATION_DELAY_MS: "0",
 });
 
 test("contract uses supported fail-closed Cloudflare Rules language primitives", () => {


### PR DESCRIPTION
## Summary\n- wait a bounded 30 seconds after a WAF mutation before external probes\n- keep a single immutable postimage probe and automatic exact rollback on failure\n- permit zero delay only for deterministic local tests\n\nCloudflare edge propagation was proven at 30 seconds with a reversible create/probe/delete exercise; the previous immediate probe rolled back before the edge enforced the rules.\n\n## Validation\n- focused WAF tests: 16/16\n- no secret values or credentials in source or artifacts