### PR TITLE
fix(ponto): preserve progressive workflow dispatch

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -591,9 +591,9 @@ jobs:
           }
           const matching = runners.filter((runner) => {
             const labels = (runner.labels || []).map(item => String(item?.name || ""));
-      const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
-      return labels.length === requiredLabels.length
-        && requiredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
+          const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
+          return labels.length === requiredLabels.length
+            && requiredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
           });
           if (
             matching.length !== 1


### PR DESCRIPTION
## Summary\n- restore the YAML block indentation introduced by the one-shot runner attestation\n- keep the progressive release workflow dispatchable and fail-closed\n\n## Validation\n- npm run ponto:governance:test\n- git diff --check\n\nNo deployment or environment mutation.