### PR TITLE
fix(ponto): restore runner workflow YAML indentation

### DIFF
--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -202,9 +202,9 @@ jobs:
           }
           const matching = (payload.runners || []).filter((runner) => {
             const labels = (runner.labels || []).map(label => String(label?.name || ""));
-          const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
-          return labels.length === configuredLabels.length
-            && configuredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
+            const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
+            return labels.length === configuredLabels.length
+              && configuredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
           });
           if (
             matching.length !== 1


### PR DESCRIPTION
Restores the embedded runner-label JavaScript indentation under YAML run blocks. The prior merge left those lines outside the block, so GitHub stopped recognizing workflow_dispatch and push validation runs failed without jobs. No behavior changes beyond restoring valid workflow structure.