### PR TITLE
fix(ponto): retain successful immutable checks

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -209,7 +209,14 @@ jobs:
           const checkRuns = Array.isArray(checks)
             ? checks.flatMap(page => Array.isArray(page?.check_runs) ? page.check_runs : [])
             : (checks.check_runs || []);
-          const byName = new Map(checkRuns.map(run => [String(run.name || ""), run]));
+          const byName = new Map();
+          for (const run of checkRuns) {
+            const name = String(run.name || "");
+            const current = byName.get(name);
+            if (!current || (current.conclusion !== "success" && run.conclusion === "success")) {
+              byName.set(name, run);
+            }
+          }
           for (const name of policy.governance.requiredChecks || []) {
             const run = byName.get(name);
             if (!run || run.conclusion !== "success") throw new Error(`required check is not successful for immutable release SHA: ${name}`);


### PR DESCRIPTION
## Summary\n- select a successful check when duplicate check-runs share a name\n- keep immutable release gates fail-closed when no successful run exists\n\n## Validation\n- validate-progressive-release.mjs\n- ponto-waf-security.test.mjs\n- ponto-release-evidence.test.mjs\n- ponto:governance:test\n- git diff --check\n\nNo deployment or environment mutation.