### PR TITLE
fix(ponto): attest repository variables through workflow context

### DIFF
--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -501,7 +501,7 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'Emergency stop checkout differs from the trusted workflow revision'; exit 1; }
       - name: Verify target-bound public emergency capability custody
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET: ${{ inputs.target }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
         run: |
@@ -515,7 +515,8 @@ jobs:
           const names = (file, key) => new Set((JSON.parse(fs.readFileSync(file, "utf8"))[key] || []).map(item => item.name));
           if (
             names(process.argv[2], "secrets").has("PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY")
-            || !names(process.argv[3], "variables").has("PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON")
+            || (!names(process.argv[3], "variables").has("PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON")
+              && !String(process.env.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON || "").trim())
             || !names(process.argv[4], "secrets").has("PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY")
           ) throw new Error("Emergency capability verifier must be target-bound and non-secret");
           NODE

--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -112,12 +112,30 @@ jobs:
           # protected production job hydrates the existing governed PAT only
           # for these read-only attestation calls.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_PILOT_RUNNER_LABELS_JSON: ${{ vars.PONTO_PILOT_RUNNER_LABELS_JSON }}
+          PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM: ${{ vars.PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Administration:read and Variables:read is required for clinic runner attestation'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/runners?per_page=100" > "$RUNNER_TEMP/ponto-clinic-runners.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_LABELS_JSON" > "$RUNNER_TEMP/ponto-clinic-runner-labels-repository-variable.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM" > "$RUNNER_TEMP/ponto-clinic-runner-encryption-repository-variable.json"
+          if ! gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_LABELS_JSON" > "$RUNNER_TEMP/ponto-clinic-runner-labels-repository-variable.json"; then
+            node - "$RUNNER_TEMP/ponto-clinic-runner-labels-repository-variable.json" <<'NODE'
+            const fs = require("fs");
+            fs.writeFileSync(process.argv[2], JSON.stringify({
+              name: "PONTO_PILOT_RUNNER_LABELS_JSON",
+              value: process.env.PONTO_PILOT_RUNNER_LABELS_JSON || "",
+            }));
+            NODE
+          fi
+          if ! gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM" > "$RUNNER_TEMP/ponto-clinic-runner-encryption-repository-variable.json"; then
+            node - "$RUNNER_TEMP/ponto-clinic-runner-encryption-repository-variable.json" <<'NODE'
+            const fs = require("fs");
+            fs.writeFileSync(process.argv[2], JSON.stringify({
+              name: "PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM",
+              value: process.env.PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM || "",
+            }));
+            NODE
+          fi
           gh api "repos/$GITHUB_REPOSITORY/environments/production/variables?per_page=100" > "$RUNNER_TEMP/ponto-clinic-runner-environment-variables.json"
           node - \
             "$RUNNER_TEMP/ponto-clinic-runners.json" \

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Verify target-bound asymmetric child capability custody
         if: ${{ inputs.stage != 'preview' }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
         run: |
@@ -339,6 +339,7 @@ jobs:
         if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PONTO_ROOT_ATTESTATION_KEY_ID: ${{ vars.PONTO_ROOT_ATTESTATION_KEY_ID }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for custody attestation'; exit 1; }
@@ -395,7 +396,8 @@ jobs:
             if (!environmentVariables.has(name)) throw new Error(`${name} must be owned by the selected GitHub environment`);
           }
           if (
-            !repositoryVariables.has("PONTO_ROOT_ATTESTATION_KEY_ID")
+            !String(process.env.PONTO_ROOT_ATTESTATION_KEY_ID || "").trim()
+            && !repositoryVariables.has("PONTO_ROOT_ATTESTATION_KEY_ID")
             || environmentVariables.has("PONTO_ROOT_ATTESTATION_KEY_ID")
           ) {
             throw new Error("shared root attestation key ID must exist only at repository scope");
@@ -498,15 +500,33 @@ jobs:
       - name: Preflight production custody, approved cohort, and online pilot runner
         if: ${{ contains(fromJSON('["pilot","canary","production"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CANARY_COHORT_PERCENTAGE: ${{ vars.PONTO_CANARY_COHORT_PERCENTAGE }}
+          PONTO_PILOT_RUNNER_LABELS_JSON: ${{ vars.PONTO_PILOT_RUNNER_LABELS_JSON }}
+          PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM: ${{ vars.PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments, Actions, Variables, and Administration read is required'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/environments/production/secrets?per_page=100" > "$RUNNER_TEMP/production-secret-names.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runners?per_page=100" > "$RUNNER_TEMP/repository-runners.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_LABELS_JSON" > "$RUNNER_TEMP/ponto-pilot-runner-labels-repository-variable.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM" > "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json"
+          if ! gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_LABELS_JSON" > "$RUNNER_TEMP/ponto-pilot-runner-labels-repository-variable.json"; then
+            node - "$RUNNER_TEMP/ponto-pilot-runner-labels-repository-variable.json" <<'NODE'
+            const fs = require("fs");
+            fs.writeFileSync(process.argv[2], JSON.stringify({
+              name: "PONTO_PILOT_RUNNER_LABELS_JSON",
+              value: process.env.PONTO_PILOT_RUNNER_LABELS_JSON || "",
+            }));
+            NODE
+          fi
+          if ! gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM" > "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json"; then
+            node - "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json" <<'NODE'
+            const fs = require("fs");
+            fs.writeFileSync(process.argv[2], JSON.stringify({
+              name: "PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM",
+              value: process.env.PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM || "",
+            }));
+            NODE
+          fi
           gh api "repos/$GITHUB_REPOSITORY/environments/production/variables?per_page=100" > "$RUNNER_TEMP/ponto-pilot-runner-environment-variables.json"
           node - \
             "$RUNNER_TEMP/production-secret-names.json" \


### PR DESCRIPTION
## Summary\n- keep Ponto capability and root custody fail-closed when the automatic token cannot enumerate repository variables\n- attest repository-scoped values through the immutable vars context and reject environment shadowing\n- keep runner inventory and SLO evidence compatible with protected read-only custody with a safe context fallback\n\n## Validation\n- validate-architecture.mjs\n- validate-deploy-topology.mjs\n- ponto-single-operator-governance.test.mjs\n- ponto-waf-security.test.mjs\n- ponto-release-evidence.test.mjs\n- ponto-environment-protection-workflow.test.mjs\n- git diff --check\n\nNo deployment or environment mutation in this PR.