### PR TITLE
fix(ponto): use protected metadata token for custody

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -292,7 +292,10 @@ jobs:
       - name: Verify target-bound asymmetric child capability custody
         if: ${{ inputs.stage != 'preview' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Repository/environment secret metadata needs the protected
+          # read-only administration token; the automatic token is not granted
+          # the repository-secrets scope.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
         run: |


### PR DESCRIPTION
## Summary\n- use the governed read-only metadata token for repository and environment secret-name attestation\n- keep capability values in the target environment and verifier map in repository vars\n- leave the automatic token for ordinary workflow metadata\n\n## Validation\n- git diff --check\n- validate-deploy-topology.mjs\n\nNo deployment or environment mutation in this PR.