### PR TITLE
fix(ponto): keep release security checks triggerable

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -41,6 +41,14 @@
       "sanitizedArtifacts": true,
       "automaticRollback": true,
       "noAdministrativeBypass": true
+    },
+    "securityAudit": {
+      "workflow": ".github/workflows/security-secrets-audit.yml",
+      "triggerPaths": [
+        ".github/governance/progressive-release-policy.json",
+        ".github/workflows/ponto-",
+        ".github/scripts/ponto-"
+      ]
     }
   },
   "controls": {

--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -31,6 +31,14 @@ for (const target of ["staging", "production"]) {
   ) fail(`${target} environment must use the reviewed single-operator protection contract`);
 }
 if (governance?.attestation?.noAdministrativeBypass !== true || governance?.attestation?.automaticRollback !== true) fail("single-operator attestation must retain no-bypass and automatic rollback");
+const securityAudit = governance?.securityAudit;
+if (securityAudit?.workflow !== ".github/workflows/security-secrets-audit.yml" || !Array.isArray(securityAudit?.triggerPaths) || securityAudit.triggerPaths.length < 3) {
+  fail("Ponto governance must declare security audit coverage for its release surfaces");
+}
+const securityWorkflow = read(".github/workflows/security-secrets-audit.yml");
+for (const triggerPath of securityAudit?.triggerPaths ?? []) {
+  if (!securityWorkflow.includes(triggerPath)) fail(`security audit workflow is missing Ponto trigger path: ${triggerPath}`);
+}
 if (JSON.stringify(policy.stages) !== JSON.stringify(["preview", "staging", "pilot", "canary", "production"])) fail("policy stages must be preview, staging, pilot, canary, production in order");
 for (const [stage, predecessor] of Object.entries({ staging: "preview", pilot: "staging", canary: "pilot", production: "canary" })) {
   if (policy.stagePredecessor?.[stage] !== predecessor) fail(`${stage} must require ${predecessor} evidence`);

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -14,6 +14,9 @@ on:
       - "package-lock.json"
       - "**/package-lock.json"
       - ".github/scripts/npm-audit-gate.mjs"
+      - ".github/governance/progressive-release-policy.json"
+      - ".github/workflows/ponto-*.yml"
+      - ".github/scripts/ponto-*.mjs"
       - "!.github/workflows/security-secrets-audit.yml"
   pull_request:
     branches: [main]
@@ -28,6 +31,9 @@ on:
       - "package-lock.json"
       - "**/package-lock.json"
       - ".github/scripts/npm-audit-gate.mjs"
+      - ".github/governance/progressive-release-policy.json"
+      - ".github/workflows/ponto-*.yml"
+      - ".github/scripts/ponto-*.mjs"
       - "!.github/workflows/security-secrets-audit.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
- Corrige a cobertura de disparo do Security & Secrets Audit para a governança do release progressivo do Ponto.
- Mantém os checks canônicos (Gitleaks e Dependency Audit) disponíveis no SHA imutável, inclusive em mudanças de política/workflow Ponto.
- Adiciona validação para impedir nova deriva entre paths declarados e workflow.

Validação focal local: progressive-release policy, Ponto governance, architecture, git diff --check.
Sem deploy, flags, grants, usuários, secrets ou dados alterados.