### PR TITLE
fix(ponto): use protected token for custody metadata

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -341,7 +341,10 @@ jobs:
       - name: Preflight selected environment secret-root custody
         if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Environment secret/variable metadata requires the protected
+          # read-only administration token; the automatic token is not granted
+          # the repository-environment metadata scope.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ROOT_ATTESTATION_KEY_ID: ${{ vars.PONTO_ROOT_ATTESTATION_KEY_ID }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
# Summary

Use the protected repository secret `GH_TOKEN` for the Ponto progressive-release secret-root custody preflight.

## Root cause

The staging coordinator reached the secret-root custody step with `github.token`. That automatic token returned HTTP 403 for the repository/environment secrets and variables metadata API, while the existing protected read-only administration token was already used successfully by the preceding capability-custody step.

## Scope and risk

- One workflow environment binding change in `.github/workflows/ponto-progressive-release.yml`.
- No secret values, application code, Cloudflare resources, flags, grants, or production data changed.
- The staging coordinator remains fail-closed if the protected token is absent or metadata custody is invalid.
- Rollback: revert this commit; no data migration or runtime rollback is required.

## Validation

- Ubuntu-24.04 WSL: `node --test .github/scripts/ponto-secret-custody.test.mjs .github/scripts/ponto-environment-protection-workflow.test.mjs`
- 9 tests passed.
- `git diff --check` passed.

## Release follow-up

After merge, rerun only the Ponto staging coordinator for the immutable `e65ab162ea36613f13493c77d5a708d35046ba43` using the already-green preview predecessor `30725778261`.