### PR TITLE
fix(ponto): settle required release checks

### DIFF
--- a/.github/scripts/ponto-required-checks.mjs
+++ b/.github/scripts/ponto-required-checks.mjs
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+const flattenCheckRuns = (checks) => {
+  if (Array.isArray(checks)) {
+    return checks.flatMap((page) => Array.isArray(page?.check_runs) ? page.check_runs : []);
+  }
+  return Array.isArray(checks?.check_runs) ? checks.check_runs : [];
+};
+
+export function assessRequiredChecks({ pulls, checks, policy, releaseSha, repository }) {
+  const sha = String(releaseSha || "").toLowerCase();
+  const merged = (Array.isArray(pulls) ? pulls : []).filter((pr) =>
+    pr?.base?.ref === "main"
+    && pr?.state === "closed"
+    && pr?.merged_at
+    && String(pr?.merge_commit_sha || "").toLowerCase() === sha
+    && String(pr?.head?.repo?.full_name || "") === repository,
+  );
+
+  if (merged.length !== 1) {
+    return {
+      state: "failed",
+      reason: "immutable release SHA lacks exactly one canonical merged PR into main",
+      mergedCount: merged.length,
+    };
+  }
+
+  const byName = new Map();
+  for (const run of flattenCheckRuns(checks)) {
+    const name = String(run?.name || "");
+    const current = byName.get(name);
+    if (!current || (current.conclusion !== "success" && run.conclusion === "success")) {
+      byName.set(name, run);
+    }
+  }
+
+  const pending = [];
+  const failed = [];
+  for (const name of policy?.governance?.requiredChecks || []) {
+    const run = byName.get(name);
+    if (!run || run.status !== "completed") {
+      pending.push(name);
+    } else if (run.conclusion !== "success") {
+      failed.push(`${name} (${run.conclusion || "no conclusion"})`);
+    }
+  }
+
+  if (failed.length > 0) {
+    return {
+      state: "failed",
+      reason: `required checks failed for immutable release SHA: ${failed.join(", ")}`,
+      failed,
+      pending,
+    };
+  }
+  if (pending.length > 0) {
+    return {
+      state: "pending",
+      reason: `required checks are not yet terminal for immutable release SHA: ${pending.join(", ")}`,
+      pending,
+    };
+  }
+  return { state: "passed", reason: "all required checks are successful for the immutable release SHA" };
+}
+
+function main() {
+  const [pullsFile, checksFile] = process.argv.slice(2);
+  if (!pullsFile || !checksFile) {
+    throw new Error("usage: node ponto-required-checks.mjs <merged-pulls.json> <check-runs.json>");
+  }
+
+  const result = assessRequiredChecks({
+    pulls: readJson(pullsFile),
+    checks: readJson(checksFile),
+    policy: readJson(path.join(root, ".github/governance/progressive-release-policy.json")),
+    releaseSha: process.env.RELEASE_SHA,
+    repository: process.env.GITHUB_REPOSITORY,
+  });
+
+  if (result.state === "passed") {
+    console.log(result.reason);
+    return;
+  }
+  console.error(result.reason);
+  process.exitCode = result.state === "pending" ? 2 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/.github/scripts/ponto-required-checks.test.mjs
+++ b/.github/scripts/ponto-required-checks.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assessRequiredChecks } from "./ponto-required-checks.mjs";
+
+const policy = { governance: { requiredChecks: ["CI Smoke (Assert)", "Central E2E Smoke"] } };
+const pulls = [{
+  base: { ref: "main" },
+  state: "closed",
+  merged_at: "2026-08-02T03:00:30Z",
+  merge_commit_sha: "a".repeat(40),
+  head: { repo: { full_name: "jubenitogarcia/skincos" } },
+}];
+
+const check = (name, conclusion = "success", status = "completed") => ({ name, conclusion, status });
+
+test("passes when the canonical merge and every required check are successful", () => {
+  const result = assessRequiredChecks({
+    pulls,
+    checks: { check_runs: [check("CI Smoke (Assert)"), check("Central E2E Smoke")] },
+    policy,
+    releaseSha: "A".repeat(40),
+    repository: "jubenitogarcia/skincos",
+  });
+  assert.equal(result.state, "passed");
+});
+
+test("keeps the release gate pending while a required check is absent or running", () => {
+  const result = assessRequiredChecks({
+    pulls,
+    checks: { check_runs: [check("CI Smoke (Assert)", "", "in_progress")] },
+    policy,
+    releaseSha: "a".repeat(40),
+    repository: "jubenitogarcia/skincos",
+  });
+  assert.equal(result.state, "pending");
+  assert.deepEqual(result.pending, ["CI Smoke (Assert)", "Central E2E Smoke"]);
+});
+
+test("fails closed when a required check is terminally unsuccessful", () => {
+  const result = assessRequiredChecks({
+    pulls,
+    checks: { check_runs: [check("CI Smoke (Assert)", "failure"), check("Central E2E Smoke")] },
+    policy,
+    releaseSha: "a".repeat(40),
+    repository: "jubenitogarcia/skincos",
+  });
+  assert.equal(result.state, "failed");
+  assert.match(result.reason, /CI Smoke \(Assert\)/);
+});

--- a/.github/workflows/central-e2e-smoke.yml
+++ b/.github/workflows/central-e2e-smoke.yml
@@ -17,7 +17,6 @@ on:
       - "scripts/*codex*.ps1"
       - ".github/governance/**"
       - ".github/workflows/codex-autonomy-gate.yml"
-      - ".github/workflows/**"
   pull_request:
     paths-ignore:
       - "docs/**"

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -17,7 +17,6 @@ on:
       - "scripts/*codex*.ps1"
       - ".github/governance/**"
       - ".github/workflows/codex-autonomy-gate.yml"
-      - ".github/workflows/**"
   pull_request:
     paths-ignore:
       - "docs/**"

--- a/.github/workflows/lint-format-static.yml
+++ b/.github/workflows/lint-format-static.yml
@@ -17,7 +17,6 @@ on:
       - "scripts/*codex*.ps1"
       - ".github/governance/**"
       - ".github/workflows/codex-autonomy-gate.yml"
-      - ".github/workflows/**"
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -117,6 +117,8 @@ jobs:
       # journey/drill budgets, leaves at least 50 minutes for fail-close,
       # reconciliation, rollback, and evidence before the 330-minute job cap.
       PONTO_DISPATCH_TIMEOUT_MS: "1200000"
+      PONTO_REQUIRED_CHECK_SETTLE_TIMEOUT_SECONDS: "900"
+      PONTO_REQUIRED_CHECK_SETTLE_POLL_SECONDS: "10"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
@@ -191,37 +193,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/pulls" > "$RUNNER_TEMP/ponto-release-pulls.json"
-          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/check-runs?per_page=100" > "$RUNNER_TEMP/ponto-release-checks.json"
-          node - "$RUNNER_TEMP/ponto-release-pulls.json" "$RUNNER_TEMP/ponto-release-checks.json" <<'NODE'
-          const fs = require("fs");
-          const read = file => JSON.parse(fs.readFileSync(file, "utf8"));
-          const pulls = read(process.argv[2]);
-          const checks = read(process.argv[3]);
-          const sha = process.env.RELEASE_SHA.toLowerCase();
-          const policy = read(".github/governance/progressive-release-policy.json");
-          const merged = (Array.isArray(pulls) ? pulls : []).filter(pr =>
-            pr?.base?.ref === "main" && pr?.state === "closed" && pr?.merged_at
-            && String(pr?.merge_commit_sha || "").toLowerCase() === sha
-            && String(pr?.head?.repo?.full_name || "") === process.env.GITHUB_REPOSITORY
-          );
-          if (merged.length !== 1) throw new Error("immutable release SHA lacks exactly one canonical merged PR into main");
-          const checkRuns = Array.isArray(checks)
-            ? checks.flatMap(page => Array.isArray(page?.check_runs) ? page.check_runs : [])
-            : (checks.check_runs || []);
-          const byName = new Map();
-          for (const run of checkRuns) {
-            const name = String(run.name || "");
-            const current = byName.get(name);
-            if (!current || (current.conclusion !== "success" && run.conclusion === "success")) {
-              byName.set(name, run);
-            }
-          }
-          for (const name of policy.governance.requiredChecks || []) {
-            const run = byName.get(name);
-            if (!run || run.conclusion !== "success") throw new Error(`required check is not successful for immutable release SHA: ${name}`);
-          }
-          NODE
+          deadline=$(( $(date +%s) + PONTO_REQUIRED_CHECK_SETTLE_TIMEOUT_SECONDS ))
+          while true; do
+            gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/pulls" > "$RUNNER_TEMP/ponto-release-pulls.json"
+            gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/check-runs?per_page=100" > "$RUNNER_TEMP/ponto-release-checks.json"
+            set +e
+            node .github/scripts/ponto-required-checks.mjs \
+              "$RUNNER_TEMP/ponto-release-pulls.json" \
+              "$RUNNER_TEMP/ponto-release-checks.json"
+            check_status=$?
+            set -e
+            case "$check_status" in
+              0) break ;;
+              2)
+                if (( $(date +%s) >= deadline )); then
+                  echo 'required checks did not become terminal before the bounded settle timeout' >&2
+                  exit 1
+                fi
+                sleep "$PONTO_REQUIRED_CHECK_SETTLE_POLL_SECONDS"
+                ;;
+              *) exit "$check_status" ;;
+            esac
+          done
           rm -f "$RUNNER_TEMP/ponto-release-pulls.json" "$RUNNER_TEMP/ponto-release-checks.json"
       - name: Attest single-operator Codex governance and protected environment before issuing any capability
         if: ${{ inputs.stage != 'preview' }}


### PR DESCRIPTION
# Summary

Fix the Ponto progressive-release gate that failed on run 30730088733 for immutable SHA 9c37f179bc3832ffa0a0e36f1a06e140fa88a0cc.

The gate now:
- runs the three required workflows when workflow files change;
- polls the required check-runs until they are terminal, with a bounded 15-minute timeout;
- fails closed on a terminal failure or an unreconciled timeout;
- covers the check-attestation contract with focused tests.

## Type of change
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (workflow remains fail-closed; no secrets added)
- [ ] Performance impact measured

## Operational scope and rollback

- Surfaces: .github/workflows/ci-smoke.yml, central-e2e-smoke.yml, lint-format-static.yml, ponto-progressive-release.yml, and the required-check attestation helper.
- Risk: release-gate behavior only; no application data, migration, grant, flag, or credential change.
- Pre-production validation: focused helper tests, progressive-release policy validation, syntax check, and diff check passed locally.
- Rollback: revert commit c38d2621; the prior gate remains fail-closed and no deployed surface is changed by this PR.
- Evidence: coordinator run 30730088733 failed before capability issuance because CI Smoke (Assert) was absent for the immutable SHA; recovery children completed successfully.
