### PR TITLE
fix(ponto): use protected token for emergency custody

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -418,7 +418,10 @@ jobs:
       - name: Require the single-operator no-review true-only emergency close path
         if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Emergency environment secret/variable metadata requires the protected
+          # read-only administration token; the automatic token is not granted
+          # the repository-environment metadata scope.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments read is required for emergency custody'; exit 1; }


### PR DESCRIPTION
## Summary
- use the protected read-only `GH_TOKEN` for the Ponto emergency custody metadata gate
- preserve the existing required-check settle fix already present on `main`

## Root cause
The staging coordinator reached `Require the single-operator no-review true-only emergency close path`, but the step used `github.token`; GitHub returned HTTP 403 for environment secret/variable metadata. The capability custody gate had already proved that the protected repository secret is the correct custody path.

## Validation
- `node --test .github/scripts/ponto-secret-custody.test.mjs .github/scripts/ponto-environment-protection-workflow.test.mjs .github/scripts/ponto-required-checks.test.mjs` via `scripts/invoke-skincos-wsl.ps1` on Ubuntu-24.04
- 12 tests passed
- `git diff --check`

## Risk and rollback
One workflow-token binding changes; no secret values were read or changed. Rollback is the parent commit `32def59f8eb27f9c2192b50e5aa16aab790e92eb` or reverting the merge commit.