### PR TITLE
fix(ponto): preserve coordinator actor in child gate

### DIFF
--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -35,7 +35,10 @@ test("coordinator and consumer attest live environment protection before authori
   );
   assert.ok(consumerPreflight >= 0);
   assert.ok(consumerPreflight < consume);
-  assert.match(gate.slice(consumerPreflight, consume), /deployment-branch-policies/);
+  const consumerScoped = gate.slice(consumerPreflight, consume);
+  assert.match(consumerScoped, /deployment-branch-policies/);
+  assert.match(consumerScoped, /actions\/runs\/\$ORCHESTRATOR_RUN_ID/);
+  assert.match(consumerScoped, /GITHUB_ACTOR="\$issuer_actor" node/);
   assert.match(gate, /deployments: read/);
 });
 

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -59,17 +59,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PONTO_ENVIRONMENT_TARGET: ${{ inputs.target }}
+          ORCHESTRATOR_RUN_ID: ${{ inputs.orchestrator_run_id }}
         run: |
           set -euo pipefail
           [[ "$PONTO_ENVIRONMENT_TARGET" == staging || "$PONTO_ENVIRONMENT_TARGET" == production ]] || {
             echo 'Governed Ponto capability target must be staging or production'
             exit 1
           }
+          [[ "$ORCHESTRATOR_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo 'Governed Ponto capability consumption requires the direct coordinator run'
+            exit 1
+          }
+          issuer_actor="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ORCHESTRATOR_RUN_ID" --jq '.actor.login')"
+          [[ "$issuer_actor" =~ ^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$ ]] || {
+            echo 'Governed Ponto coordinator actor is invalid'
+            exit 1
+          }
           gh api "repos/$GITHUB_REPOSITORY/environments/$PONTO_ENVIRONMENT_TARGET" \
             > "$RUNNER_TEMP/ponto-environment.json"
           gh api "repos/$GITHUB_REPOSITORY/environments/$PONTO_ENVIRONMENT_TARGET/deployment-branch-policies?per_page=100" \
             > "$RUNNER_TEMP/ponto-environment-branch-policies.json"
-          node .github/scripts/ponto-environment-protection.mjs \
+          # A workflow-dispatch child runs as github-actions[bot]; preserve the
+          # direct coordinator actor for the single-operator attestation.
+          GITHUB_ACTOR="$issuer_actor" node .github/scripts/ponto-environment-protection.mjs \
             "$RUNNER_TEMP/ponto-environment.json" \
             "$RUNNER_TEMP/ponto-environment-branch-policies.json" \
             "$RUNNER_TEMP/ponto-environment-protection.json"


### PR DESCRIPTION
## Summary
- preserve the direct coordinator actor when a governed Ponto child is dispatched as `github-actions[bot]`
- fail closed when a required child lacks its direct coordinator run id
- keep the existing protected-token custody correction from PR #1011 as the base

## Root cause
Staging run `30731179399` reached the worker custody child `30731216900`, where the reusable environment gate rejected the child actor `github-actions[bot]` against the single-operator policy. The parent coordinator had already attested the direct operator `jubenitogarcia`; the child gate was incorrectly reusing its own workflow-dispatch actor.

## Validation
- `node --test .github/scripts/ponto-secret-custody.test.mjs .github/scripts/ponto-environment-protection-workflow.test.mjs .github/scripts/ponto-required-checks.test.mjs` via `scripts/invoke-skincos-wsl.ps1` on Ubuntu-24.04
- 12 tests passed
- `git diff --check`

## Risk and rollback
The reusable gate performs one read-only Actions run lookup and uses only the returned actor for the existing governance attestation. No secret values or environment state were changed. Roll back to parent `c442dba285175391a16f2f3e325d4b3325f5d728` or revert the merge commit.