### PR TITLE
fix(ponto): propagate protected token through child gates

### DIFF
--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -64,7 +64,11 @@ test("every governed caller grants read-only deployment metadata to the gate", (
     );
     assert.notEqual(gate, -1, name);
     assert.match(source.slice(Math.max(0, gate - 220), gate), /deployments: read/, name);
-    assert.match(source.slice(gate, gate + 180), /secrets: inherit/, name);
+    assert.match(
+      source.slice(gate, gate + 220),
+      /secrets:\n\s+GH_TOKEN: \$\{\{ secrets\.GH_TOKEN \}\}/,
+      name,
+    );
   }
 });
 

--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -36,6 +36,11 @@ test("coordinator and consumer attest live environment protection before authori
   assert.ok(consumerPreflight >= 0);
   assert.ok(consumerPreflight < consume);
   assert.match(gate.slice(consumerPreflight, consume), /deployment-branch-policies/);
+  assert.match(gate, /secrets:\n\s+GH_TOKEN:\n\s+required: false/);
+  assert.match(
+    gate.slice(consumerPreflight, consume),
+    /GH_TOKEN: \$\{\{ secrets\.GH_TOKEN != '' && secrets\.GH_TOKEN \|\| github\.token \}\}/,
+  );
   assert.match(gate, /deployments: read/);
 });
 
@@ -59,6 +64,7 @@ test("every governed caller grants read-only deployment metadata to the gate", (
     );
     assert.notEqual(gate, -1, name);
     assert.match(source.slice(Math.max(0, gate - 220), gate), /deployments: read/, name);
+    assert.match(source.slice(gate, gate + 180), /secrets: inherit/, name);
   }
 });
 

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -55,6 +55,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: pages-secrets

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -55,7 +55,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: pages-secrets

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -51,6 +51,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: workers-secrets

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -51,7 +51,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: workers-secrets

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -61,6 +61,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
       lease_key: core-${{ inputs.unit }}

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -61,7 +61,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
       lease_key: core-${{ inputs.unit }}

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -50,7 +50,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
       lease_key: pages

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -50,6 +50,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
       lease_key: pages

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -79,6 +79,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: ${{ inputs.target != 'preview' }}
       lease_key: timekeeping

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -79,7 +79,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: ${{ inputs.target != 'preview' }}
       lease_key: timekeeping

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -132,6 +132,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: ${{ inputs.module == 'timekeeping' && contains(fromJSON('["canary","active"]'), inputs.state) }}
       lease_key: ${{ inputs.orchestrator_lease_key }}

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -132,7 +132,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: ${{ inputs.module == 'timekeeping' && contains(fromJSON('["canary","active"]'), inputs.state) }}
       lease_key: ${{ inputs.orchestrator_lease_key }}

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -21,6 +21,9 @@ on:
       orchestrator_run_id:
         required: false
         type: string
+    secrets:
+      GH_TOKEN:
+        required: false
 permissions:
   actions: read
   checks: write
@@ -57,7 +60,7 @@ jobs:
       - name: Revalidate protected target environment before consuming authority
         if: ${{ inputs.required }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
           PONTO_ENVIRONMENT_TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -45,7 +45,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: production-baseline

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -45,6 +45,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: production-baseline

--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -61,7 +61,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: production-slo

--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -61,6 +61,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: production-slo

--- a/.github/workflows/ponto-staging-rollback-drill.yml
+++ b/.github/workflows/ponto-staging-rollback-drill.yml
@@ -38,7 +38,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: staging-rollback

--- a/.github/workflows/ponto-staging-rollback-drill.yml
+++ b/.github/workflows/ponto-staging-rollback-drill.yml
@@ -38,6 +38,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: staging-rollback

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -69,6 +69,7 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
+    secrets: inherit
     with:
       required: true
       lease_key: staging-journey

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -69,7 +69,8 @@ jobs:
       contents: read
       deployments: read
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       required: true
       lease_key: staging-journey


### PR DESCRIPTION
Supersedes closed PR #1012, which retained the first-run Semgrep finding and did not re-trigger pull-request checks after the least-privilege fix.

## Objective

Restore the protected-token contract for the reusable Ponto orchestrator gate.

## Root cause

Staging coordinator `30731179399` at `c442dba285175391a16f2f3e325d4b3325f5d728` failed in child `30731216900`: `ponto-orchestrator-gate.yml` used `github.token` while revalidating protected environment metadata, so the single-operator governance attestation was invalid.

## Change

- Declare the optional `GH_TOKEN` secret on the reusable gate.
- Prefer the protected secret for environment-protection reads, with the automatic token as a compatibility fallback.
- Pass only `GH_TOKEN` from every governed Ponto caller.
- Add static contract assertions covering the secret declaration, selection, and all callers.

No data, flags, migrations, or live resources are changed by this PR.

## Validation

- `node --test .github/scripts/ponto-environment-protection-workflow.test.mjs .github/scripts/ponto-orchestrator-lease.test.mjs`
- `node .github/scripts/validate-progressive-release.mjs`
- `git diff --check`

## Rollback

Revert commits `a7f00eb8`, `e7ef3579`, and `fd211cdf` (parent release SHA `c442dba285175391a16f2f3e325d4b3325f5d728`).