### PR TITLE
fix(ponto): use bash-compatible actor validation

### DIFF
--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -71,7 +71,7 @@ jobs:
             exit 1
           }
           issuer_actor="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ORCHESTRATOR_RUN_ID" --jq '.actor.login')"
-          [[ "$issuer_actor" =~ ^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$ ]] || {
+          [[ "$issuer_actor" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,38})$ ]] || {
             echo 'Governed Ponto coordinator actor is invalid'
             exit 1
           }


### PR DESCRIPTION
## Summary
- correct the Bash actor-validation expression in the reusable Ponto child gate
- keep the direct coordinator actor lookup introduced by PR #1013

## Root cause
The first staging retry on `fde3d06f5f57f79772c029998a69c246e8f912a1` reached the updated child gate, but the Bash `[[ =~ ]]` expression used JavaScript non-capturing-group syntax and rejected the valid coordinator actor before environment attestation. The run was fail-closed before candidate mutation.

## Validation
- `node --test .github/scripts/ponto-secret-custody.test.mjs .github/scripts/ponto-environment-protection-workflow.test.mjs .github/scripts/ponto-required-checks.test.mjs` via `scripts/invoke-skincos-wsl.ps1` on Ubuntu-24.04
- 12 tests passed
- `git diff --check`

## Risk and rollback
One Bash validation expression changes; no secret values or environment state were changed. Roll back to parent `fde3d06f5f57f79772c029998a69c246e8f912a1` or revert the merge commit.