### PR TITLE
fix(ponto): accept live child workflow provenance

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -155,6 +155,12 @@ const KEY_ID = /^[a-z][a-z0-9._-]{2,63}$/;
 const TARGETS = ["staging", "production"];
 const ED25519_SIGNATURE = /^[A-Za-z0-9_-]{86}$/;
 
+export function acceptsWorkflowRunPath(workflowPath, observedPath) {
+  const canonicalPath = String(workflowPath || "").trim();
+  const livePath = String(observedPath || "").trim();
+  return [canonicalPath, `${canonicalPath}@refs/heads/main`].includes(livePath);
+}
+
 const canonicalClaims = claims => CLAIM_FIELDS.map((field) => {
   const name = Buffer.from(field, "utf8");
   const value = Buffer.from(String(claims?.[field] ?? ""), "utf8");
@@ -565,7 +571,7 @@ const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage, cur
     || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
     || String(run?.id || "") !== orchestratorRunId
     || run?.workflow_id !== workflow.id
-    || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run?.path)
+    || !acceptsWorkflowRunPath(workflow.path, run?.path)
     || run?.run_attempt !== 1
     || run?.status !== "in_progress"
     || run?.conclusion != null
@@ -623,7 +629,7 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
   if (
     String(child?.id || "") !== childRunId
     || child?.run_attempt !== 1
-    || child?.path !== `${childWorkflowPath}@refs/heads/main`
+    || !acceptsWorkflowRunPath(childWorkflowPath, child?.path)
     || child?.status !== "in_progress"
     || child?.conclusion != null
     || child?.event !== "workflow_dispatch"
@@ -657,7 +663,7 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || issuer?.workflow_id !== issuerWorkflow?.id
     || issuerWorkflow?.state !== "active"
     || issuerWorkflow?.path !== issuerWorkflowPath
-    || issuer?.path !== `${issuerWorkflowPath}@refs/heads/main`
+    || !acceptsWorkflowRunPath(issuerWorkflowPath, issuer?.path)
     || issuer?.run_attempt !== 1
     || issuer?.status !== "in_progress"
     || issuer?.conclusion != null

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   canonicalizeGovernedIntent,
+  acceptsWorkflowRunPath,
   createCapabilityCheck,
   expectedGovernedRunName,
   transitionCapabilityDocument,
@@ -133,6 +134,14 @@ test("assert-active accepts only the exact live first-attempt coordinator", asyn
     assert.equal(result.code, 0, result.stderr);
     assert.match(result.stdout, /active first-attempt Ponto coordinator/);
   });
+});
+
+test("workflow run provenance accepts both live GitHub REST path forms", () => {
+  const workflowPath = ".github/workflows/deploy-timekeeping.yml";
+  assert.equal(acceptsWorkflowRunPath(workflowPath, workflowPath), true);
+  assert.equal(acceptsWorkflowRunPath(workflowPath, `${workflowPath}@refs/heads/main`), true);
+  assert.equal(acceptsWorkflowRunPath(workflowPath, ".github/workflows/other.yml"), false);
+  assert.equal(acceptsWorkflowRunPath(workflowPath, `${workflowPath}@refs/heads/feature`), false);
 });
 
 test("assert-active rejects a rerun of the privileged child before any API access", async () => {


### PR DESCRIPTION
# Summary

Fix the Ponto capability consumer's workflow-run provenance check to accept both live GitHub REST path forms: the canonical workflow path and the path annotated with `@refs/heads/main`. The coordinator path check already accepted both forms, but child and delegated issuer checks still rejected the current REST form and fail-closed before Worker secret publication.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (focused provenance review)
- [ ] Performance impact measured

## Links
- Issue: Ponto progressive release recovery
- Design/ADR: Existing Ponto orchestrator capability contract
- Migration steps: None

## Screenshots / Evidence
- Ubuntu-24.04 focal tests: 15/15 passed.
- `git diff --check` passed.
- The change preserves the exact SHA, branch, event, attempt, repository, issuer, and active-run checks.