### PR TITLE
fix(ponto): paginate custody metadata

### DIFF
--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -75,6 +75,23 @@ test("every governed caller grants read-only deployment metadata to the gate", (
   }
 });
 
+test("custody metadata consumers read every GitHub API page", () => {
+  for (const name of [
+    "cloudflare-pages-sync-ponto.yml",
+    "cloudflare-workers-sync-ponto-secrets.yml",
+    "deploy-timekeeping.yml",
+  ]) {
+    const source = workflow(name);
+    assert.equal(
+      (source.match(/gh api --paginate --slurp [^\n]+\/variables\?per_page=100/g) || []).length,
+      2,
+      name,
+    );
+    assert.match(source, /const entries = Array\.isArray\(payload\)/, name);
+    assert.match(source, /payload\.flatMap\(page =>/, name);
+  }
+});
+
 test("ordinary and watchdog rollback revalidate governance and use dedicated intent custody", () => {
   for (const name of [
     "ponto-progressive-release.yml",

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -184,17 +184,23 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for custody attestation'; exit 1; }
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET/secrets?per_page=100" > "$RUNNER_TEMP/environment-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/repository-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET/variables?per_page=100" > "$RUNNER_TEMP/environment-variables.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/repository-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET/secrets?per_page=100" > "$RUNNER_TEMP/environment-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/repository-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET/variables?per_page=100" > "$RUNNER_TEMP/environment-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/repository-variables.json"
           node - \
             "$RUNNER_TEMP/environment-secrets.json" \
             "$RUNNER_TEMP/repository-secrets.json" \
             "$RUNNER_TEMP/environment-variables.json" \
             "$RUNNER_TEMP/repository-variables.json" <<'NODE'
           const fs = require("fs");
-          const names = (file, key) => new Set((JSON.parse(fs.readFileSync(file, "utf8"))[key] || []).map(item => item.name));
+          const names = (file, key) => {
+            const payload = JSON.parse(fs.readFileSync(file, "utf8"));
+            const entries = Array.isArray(payload)
+              ? payload.flatMap(page => Array.isArray(page?.[key]) ? page[key] : [])
+              : (Array.isArray(payload?.[key]) ? payload[key] : []);
+            return new Set(entries.map(item => item.name));
+          };
           const environmentSecrets = names(process.argv[2], "secrets");
           const repositorySecrets = names(process.argv[3], "secrets");
           const environmentVariables = names(process.argv[4], "variables");

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -140,17 +140,23 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for custody attestation'; exit 1; }
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET/secrets?per_page=100" > "$RUNNER_TEMP/environment-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/repository-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET/variables?per_page=100" > "$RUNNER_TEMP/environment-variables.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/repository-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET/secrets?per_page=100" > "$RUNNER_TEMP/environment-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/repository-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET/variables?per_page=100" > "$RUNNER_TEMP/environment-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/repository-variables.json"
           node - \
             "$RUNNER_TEMP/environment-secrets.json" \
             "$RUNNER_TEMP/repository-secrets.json" \
             "$RUNNER_TEMP/environment-variables.json" \
             "$RUNNER_TEMP/repository-variables.json" <<'NODE'
           const fs = require("fs");
-          const names = (file, key) => new Set((JSON.parse(fs.readFileSync(file, "utf8"))[key] || []).map(item => item.name));
+          const names = (file, key) => {
+            const payload = JSON.parse(fs.readFileSync(file, "utf8"));
+            const entries = Array.isArray(payload)
+              ? payload.flatMap(page => Array.isArray(page?.[key]) ? page[key] : [])
+              : (Array.isArray(payload?.[key]) ? payload[key] : []);
+            return new Set(entries.map(item => item.name));
+          };
           const environmentSecrets = names(process.argv[2], "secrets");
           const repositorySecrets = names(process.argv[3], "secrets");
           const environmentVariables = names(process.argv[4], "variables");

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -355,17 +355,23 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || { echo 'GH_TOKEN with Environments:read is required for candidate secret custody attestation'; exit 1; }
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET_ENVIRONMENT/secrets?per_page=100" > "$RUNNER_TEMP/timekeeping-environment-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/timekeeping-repository-secrets.json"
-          gh api "repos/$GITHUB_REPOSITORY/environments/$TARGET_ENVIRONMENT/variables?per_page=100" > "$RUNNER_TEMP/timekeeping-environment-variables.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/timekeeping-repository-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET_ENVIRONMENT/secrets?per_page=100" > "$RUNNER_TEMP/timekeeping-environment-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/secrets?per_page=100" > "$RUNNER_TEMP/timekeeping-repository-secrets.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/$TARGET_ENVIRONMENT/variables?per_page=100" > "$RUNNER_TEMP/timekeeping-environment-variables.json"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/actions/variables?per_page=100" > "$RUNNER_TEMP/timekeeping-repository-variables.json"
           node - \
             "$RUNNER_TEMP/timekeeping-environment-secrets.json" \
             "$RUNNER_TEMP/timekeeping-repository-secrets.json" \
             "$RUNNER_TEMP/timekeeping-environment-variables.json" \
             "$RUNNER_TEMP/timekeeping-repository-variables.json" <<'NODE'
           const fs = require("fs");
-          const names = (file, key) => new Set((JSON.parse(fs.readFileSync(file, "utf8"))[key] || []).map(item => item.name));
+          const names = (file, key) => {
+            const payload = JSON.parse(fs.readFileSync(file, "utf8"));
+            const entries = Array.isArray(payload)
+              ? payload.flatMap(page => Array.isArray(page?.[key]) ? page[key] : [])
+              : (Array.isArray(payload?.[key]) ? payload[key] : []);
+            return new Set(entries.map(item => item.name));
+          };
           const environmentSecrets = names(process.argv[2], "secrets");
           const repositorySecrets = names(process.argv[3], "secrets");
           const environmentVariables = names(process.argv[4], "variables");


### PR DESCRIPTION
# Summary

Fix the governed Ponto secret-custody consumers to read all pages returned by the GitHub Actions secrets/variables APIs. The first staging mutation reached the corrected capability consumer successfully, then failed because the repository metadata variable `PONTO_ROOT_ATTESTATION_KEY_ID` was beyond the first metadata page.

The three affected consumers now use `gh api --paginate --slurp` and flatten the paged payload before enforcing the existing fail-closed scope rules.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (focused custody-scope review)
- [ ] Performance impact measured

## Links
- Issue: Ponto progressive release recovery
- Design/ADR: Existing Ponto custody-scope contract
- Migration steps: None

## Screenshots / Evidence
- Ubuntu-24.04 focal tests: 16/16 passed.
- Progressive release policy validation passed.
- GitHub governance validation passed.
- `git diff --check` passed.
- The staging run `30733634136` proved the prior child capability-consume failure is fixed; it then failed closed only at the paginated custody metadata check.