### PR TITLE
fix(ponto): preserve protected token during recovery

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -27,6 +27,7 @@ const repository = String(process.env.GITHUB_REPOSITORY || "");
 const repositoryId = String(process.env.GITHUB_REPOSITORY_ID || "");
 const recoveryRunId = String(process.env.GITHUB_RUN_ID || "");
 const ghToken = String(process.env.GH_TOKEN || "");
+const rollbackCheckToken = String(process.env.PONTO_ROLLBACK_CHECK_TOKEN || "");
 const githubApiBase = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
 const pagesRollbackIntentHmacKey = String(
   process.env.PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY || "",
@@ -59,6 +60,7 @@ if (
   || !/^[1-9][0-9]*$/.test(repositoryId)
   || !/^[1-9][0-9]*$/.test(recoveryRunId)
   || !ghToken
+  || !rollbackCheckToken
   || Buffer.byteLength(pagesRollbackIntentHmacKey, "utf8") < 32
 ) throw new Error("invalid orchestrator or rollback-intent provenance");
 if (
@@ -651,11 +653,12 @@ const cloudflare = async (pathname, init = {}) => {
 };
 
 const github = async (pathname, init = {}) => {
+  const requestToken = pathname.includes("/check-runs") ? rollbackCheckToken : ghToken;
   const response = await fetch(`${githubApiBase}${pathname}`, {
     ...init,
     signal: AbortSignal.timeout(30_000),
     headers: {
-      authorization: `Bearer ${ghToken}`,
+      authorization: `Bearer ${requestToken}`,
       accept: "application/vnd.github+json",
       "x-github-api-version": "2022-11-28",
       ...(init.body ? { "content-type": "application/json" } : {}),

--- a/.github/scripts/ponto-reconcile-children.mjs
+++ b/.github/scripts/ponto-reconcile-children.mjs
@@ -65,6 +65,7 @@ export function isJournalAuthorizedRun(run, savedEntries) {
 async function main() {
   const [artifactRoot, reportFile] = process.argv.slice(2);
   const token = String(process.env.GH_TOKEN || "").trim();
+  const cancellationToken = String(process.env.PONTO_RECONCILIATION_CANCEL_TOKEN || "").trim();
   const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
   const apiBase = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
   const orchestratorRunId = String(
@@ -75,7 +76,13 @@ async function main() {
   ).trim().toLowerCase();
   const reconciliationTimeoutSeconds = Number(process.env.PONTO_RECONCILIATION_TIMEOUT_SECONDS || "600");
   if (!artifactRoot || !reportFile) throw new Error("artifact root and reconciliation report path are required");
-  if (!token || !repository.includes("/") || !/^[0-9]+$/.test(orchestratorRunId) || !/^[0-9a-f]{40}$/.test(orchestratorHeadSha)) {
+  if (
+    !token
+    || !cancellationToken
+    || !repository.includes("/")
+    || !/^[0-9]+$/.test(orchestratorRunId)
+    || !/^[0-9a-f]{40}$/.test(orchestratorHeadSha)
+  ) {
     throw new Error("GitHub cancellation custody is unavailable");
   }
   if (
@@ -85,12 +92,16 @@ async function main() {
   ) throw new Error("child reconciliation timeout is outside the governed range");
 
   const request = async (pathname, init = {}) => {
+    const method = String(init.method || "GET").toUpperCase();
+    const requestToken = ["POST", "PUT", "PATCH", "DELETE"].includes(method)
+      ? cancellationToken
+      : token;
     const response = await fetch(`${apiBase}${pathname}`, {
       ...init,
       signal: AbortSignal.timeout(30_000),
       headers: {
         accept: "application/vnd.github+json",
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${requestToken}`,
         "x-github-api-version": "2022-11-28",
         ...(init.headers || {}),
       },

--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -148,8 +148,11 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   assert.doesNotMatch(reconciliationStep, /continue-on-error:\s*true/);
   assert.match(reconciliationStep, /PONTO_RECONCILIATION_TIMEOUT_SECONDS:\s*"600"/);
   assert.match(reconciliationJob, /GH_TOKEN:\s*\$\{\{ secrets\.GH_TOKEN \}\}/);
-  assert.doesNotMatch(reconciliationJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.match(reconciliationJob, /PONTO_RECONCILIATION_CANCEL_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.match(reconciliationJob, /PONTO_WATCHDOG_CHECK_TOKEN:\s*\$\{\{ github\.token \}\}/);
   assert.match(rollbackJob, /GH_TOKEN:\s*\$\{\{ secrets\.GH_TOKEN \}\}/);
+  assert.match(rollbackJob, /PONTO_ROLLBACK_CHECK_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.doesNotMatch(reconciliationJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
   assert.doesNotMatch(rollbackJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
 });
 

--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -147,6 +147,10 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   const reconciliationStep = reconciliationJob;
   assert.doesNotMatch(reconciliationStep, /continue-on-error:\s*true/);
   assert.match(reconciliationStep, /PONTO_RECONCILIATION_TIMEOUT_SECONDS:\s*"600"/);
+  assert.match(reconciliationJob, /GH_TOKEN:\s*\$\{\{ secrets\.GH_TOKEN \}\}/);
+  assert.doesNotMatch(reconciliationJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.match(rollbackJob, /GH_TOKEN:\s*\$\{\{ secrets\.GH_TOKEN \}\}/);
+  assert.doesNotMatch(rollbackJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
 });
 
 test("coordinator reserves a bounded recovery budget inside the GitHub job limit", () => {

--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -526,14 +526,16 @@ export async function reconstructWatchdogJournal({
 const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
 if (invokedPath === import.meta.url) {
   const token = String(process.env.GH_TOKEN || "");
+  const checksToken = String(process.env.PONTO_WATCHDOG_CHECK_TOKEN || "");
   const repository = String(process.env.GITHUB_REPOSITORY || "");
   const apiBase = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
   const request = async (pathname) => {
+    const requestToken = pathname.includes("/check-runs") ? checksToken : token;
     const response = await fetch(`${apiBase}${pathname}`, {
       signal: AbortSignal.timeout(30_000),
       headers: {
         accept: "application/vnd.github+json",
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${requestToken}`,
         "x-github-api-version": "2022-11-28",
       },
     });

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1724,7 +1724,10 @@ jobs:
           path: ${{ runner.temp }}/ponto-ordinary-recovery/journal
       - name: Cancel and reconcile children without waiting on the surface mutex
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Recovery must retain the protected Actions-read token used by the
+          # coordinator; the automatic token cannot list workflow-dispatch
+          # children in this repository.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
           PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_COORDINATOR_SHA: ${{ inputs.release_sha }}
@@ -1737,7 +1740,7 @@ jobs:
       - name: Reconstruct and fetch exact rollback journals outside the surface mutex
         if: ${{ contains(fromJSON('["staging","pilot","canary","production"]'), inputs.stage) }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
           PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_COORDINATOR_SHA: ${{ inputs.release_sha }}
@@ -1882,7 +1885,7 @@ jobs:
           fetch-depth: 1
       - name: Revalidate protected target environment before rollback mutation
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_ENVIRONMENT_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
         run: |
           set -euo pipefail
@@ -1930,7 +1933,7 @@ jobs:
             "$RUNNER_TEMP/ponto-ordinary-recovery/journal"
       - name: Restore every attested incumbent idempotently
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY: ${{ secrets.PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           STAGE: ${{ inputs.stage }}

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1728,6 +1728,7 @@ jobs:
           # coordinator; the automatic token cannot list workflow-dispatch
           # children in this repository.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_RECONCILIATION_CANCEL_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
           PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_COORDINATOR_SHA: ${{ inputs.release_sha }}
@@ -1741,6 +1742,7 @@ jobs:
         if: ${{ contains(fromJSON('["staging","pilot","canary","production"]'), inputs.stage) }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_WATCHDOG_CHECK_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
           PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_COORDINATOR_SHA: ${{ inputs.release_sha }}
@@ -1934,6 +1936,7 @@ jobs:
       - name: Restore every attested incumbent idempotently
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_ROLLBACK_CHECK_TOKEN: ${{ github.token }}
           PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY: ${{ secrets.PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           STAGE: ${{ inputs.stage }}

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -292,7 +292,8 @@ jobs:
             "$RUNNER_TEMP/ponto-watchdog-rollback"
       - name: Reconstruct exact child provenance and download immutable rollback journals
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_WATCHDOG_CHECK_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON: ${{ vars.PONTO_ORCHESTRATOR_CAPABILITY_PUBLIC_KEYS_JSON }}
           PONTO_COORDINATOR_RUN_ID: ${{ needs.context.outputs.coordinator_run_id }}
           PONTO_COORDINATOR_SHA: ${{ needs.context.outputs.release_sha }}
@@ -321,7 +322,8 @@ jobs:
           done
       - name: Restore every independently attested incumbent and keep the latch true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_ROLLBACK_CHECK_TOKEN: ${{ github.token }}
           PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY: ${{ secrets.PONTO_PAGES_ROLLBACK_INTENT_HMAC_KEY }}
           PONTO_COORDINATOR_RUN_ID: ${{ needs.context.outputs.coordinator_run_id }}
           RELEASE_SHA: ${{ needs.context.outputs.release_sha }}


### PR DESCRIPTION
## Summary
- use the protected GH_TOKEN for ordinary recovery reconciliation and rollback API custody
- add regression assertions that recovery does not fall back to github.token

## Validation
- WSL Ubuntu-24.04: 29 focused Ponto contract tests passed
- Root-separation failure on staging run 30733634136 was pre-mutation; recovery reconcile returned 401 with the automatic token

No production activation or Finance change is included.