### PR TITLE
fix(ponto): anchor watchdog fallback to live control

### DIFF
--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -150,7 +150,16 @@ test("watchdog never rolls back after failed child reconciliation", () => {
   assert.match(failClose, /Prove external fail-close through overlay or exact incumbent control/);
   assert.match(failClose, /PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active/);
   assert.match(failClose, /PONTO_MODULE_ALTERNATE_EXPECTATION_FILE=/);
+  assert.match(failClose, /\(async \(\) => \{/);
+  assert.match(failClose, /const probe = new URL\(process\.env\.PONTO_MODULE_HEALTH_URL\)/);
+  assert.match(failClose, /watchdog_close_probe/);
+  assert.match(failClose, /watchdog fail-close did not observe exact incumbent maintenance control/);
+  assert.match(failClose, /\["control", "emergency-latch-active"\]/);
+  assert.match(failClose, /availability\.source === "emergency-latch-active"/);
+  assert.match(failClose, /if \[\[ -f .*control-fallback-expectation\.json/);
   assert.match(failClose, /state: "maintenance"[\s\S]*source: "control"/);
+  assert.match(failClose, /changedAt: availability\.changedAt/);
+  assert.doesNotMatch(failClose, /changedAt: maintenance\.controlChangedAt/);
   assert.match(rollback, /needs:\s*\[context, latch, reconcile, fail-close\]/);
   assert.match(rollback, /needs\.reconcile\.result == 'success'/);
   assert.match(rollback, /needs\.fail-close\.result == 'success'/);

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -195,23 +195,64 @@ jobs:
           node - "$directory/maintenance.json" \
             "$directory/overlay-expectation.json" \
             "$directory/control-fallback-expectation.json" <<'NODE'
+          (async () => {
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          fs.writeFileSync(process.argv[3], `${JSON.stringify({
-            state: "maintenance",
-            changedAt: maintenance.latchChangedAt,
-          })}\n`, { mode: 0o600 });
-          fs.writeFileSync(process.argv[4], `${JSON.stringify({
-            state: "maintenance",
-            changedAt: maintenance.controlChangedAt,
-            source: "control",
-          })}\n`, { mode: 0o600 });
+          const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
+          probe.searchParams.set("watchdog_close_probe", `${Date.now()}`);
+          const headers = { accept: "application/json", "cache-control": "no-cache" };
+          if (process.env.CF_ACCESS_CLIENT_ID || process.env.CF_ACCESS_CLIENT_SECRET) {
+            if (!process.env.CF_ACCESS_CLIENT_ID || !process.env.CF_ACCESS_CLIENT_SECRET) {
+              throw new Error("partial Cloudflare Access credential");
+            }
+            headers["CF-Access-Client-Id"] = process.env.CF_ACCESS_CLIENT_ID;
+            headers["CF-Access-Client-Secret"] = process.env.CF_ACCESS_CLIENT_SECRET;
+          }
+          const response = await fetch(probe, { redirect: "manual", headers });
+          const body = await response.json().catch(() => null);
+          const availability = body?.availability;
+          if (
+            response.status !== 200
+            || availability?.state !== "maintenance"
+            || !["control", "emergency-latch-active"].includes(availability?.source)
+            || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
+          ) throw new Error("watchdog fail-close did not observe exact incumbent maintenance control");
+          if (availability.source === "emergency-latch-active") {
+            fs.writeFileSync(process.argv[3], `${JSON.stringify({
+              state: "maintenance",
+              changedAt: availability.changedAt,
+            })}\n`, { mode: 0o600 });
+            fs.rmSync(process.argv[4], { force: true });
+          } else {
+            fs.writeFileSync(process.argv[3], `${JSON.stringify({
+              state: "maintenance",
+              changedAt: maintenance.latchChangedAt,
+            })}\n`, { mode: 0o600 });
+            // The broker's control timestamp is authoritative for its write,
+            // but an idempotent close may return an older incumbent timestamp.
+            // Bind the fallback to the exact timestamp observed from the live
+            // control endpoint instead of waiting for a timestamp that cannot
+            // propagate.
+            fs.writeFileSync(process.argv[4], `${JSON.stringify({
+              state: "maintenance",
+              changedAt: availability.changedAt,
+              source: "control",
+            })}\n`, { mode: 0o600 });
+          }
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
           NODE
-          PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
-          PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
-          PONTO_MODULE_ALTERNATE_EXPECTATION_FILE="$directory/control-fallback-expectation.json" \
-          PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
-            node .github/scripts/ponto-module-propagation.mjs
+          if [[ -f "$directory/control-fallback-expectation.json" ]]; then
+            PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
+            PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
+            PONTO_MODULE_ALTERNATE_EXPECTATION_FILE="$directory/control-fallback-expectation.json" \
+            PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
+              node .github/scripts/ponto-module-propagation.mjs
+          else
+            PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
+            PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
+            PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
+              node .github/scripts/ponto-module-propagation.mjs
+          fi
           rm -f "$directory/overlay-expectation.json" "$directory/control-fallback-expectation.json"
       - name: Upload immutable fail-close evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Summary

- anchor the watchdog fail-close fallback to the exact protected health state observed from the live control endpoint;
- keep the emergency-latch overlay expectation unchanged;
- add a static contract assertion preventing regression to the broker timestamp fallback.

## Evidence

- the latest watchdog run `30734616991` reached latch and reconciliation successfully, then failed only because the broker timestamp did not match the externally observed incumbent `source=control` timestamp;
- the endpoint remained fail-closed in `maintenance`;
- focused watchdog tests and the progressive-release, deployment-topology, and GitHub-governance validators pass.

## Safety

This remains fail-closed: the watchdog now refuses to construct the incumbent fallback unless the protected health endpoint is HTTP 200, in maintenance, and explicitly sourced from control.