### PR TITLE
fix(ponto): ignore successful watchdog sources

### DIFF
--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -53,7 +53,7 @@ export async function validateWatchdogContext({
   const unauthorizedReplay = Number.isInteger(runAttempt) && runAttempt > 1;
   const validConclusion = unauthorizedReplay
     ? typeof run?.conclusion === "string" && run.conclusion.length > 0
-    : FAILURE_CONCLUSIONS.has(run?.conclusion);
+    : FAILURE_CONCLUSIONS.has(run?.conclusion) || run?.conclusion === "success";
   if (
     !(
       workflow?.state === "active"
@@ -85,6 +85,8 @@ export async function validateWatchdogContext({
     || eventRun.conclusion !== run.conclusion
   ) throw new Error("failed coordinator provenance is invalid");
   const stage = match[1];
+  const requiresClose = stage !== "preview"
+    && (unauthorizedReplay || FAILURE_CONCLUSIONS.has(run.conclusion));
   return {
     schemaVersion: 1,
     coordinatorRunId: String(run.id),
@@ -95,7 +97,7 @@ export async function validateWatchdogContext({
     conclusion: run.conclusion,
     runAttempt,
     unauthorizedReplay,
-    requiresClose: stage !== "preview",
+    requiresClose,
     passed: true,
   };
 }

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -106,17 +106,30 @@ test("watchdog audits a preview rerun without assigning a live target or closing
   }
 });
 
-test("watchdog rejects first-attempt success, non-main source, and event/API drift", async (t) => {
-  for (const [name, value] of [
-    ["success", { ...run, conclusion: "success" }],
-    ["wrong path", { ...run, path: ".github/workflows/other.yml@refs/heads/main" }],
-  ]) {
-    await t.test(name, async () => {
-      await assert.rejects(validateWatchdogContext(input({
-        request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml") ? workflow : value,
-      })));
-    });
-  }
+test("watchdog treats first-attempt success as a no-op and rejects provenance drift", async (t) => {
+  await t.test("first-attempt success is a no-op", async () => {
+    const context = await validateWatchdogContext(input({
+      event: {
+        workflow_run: {
+          ...event.workflow_run,
+          conclusion: "success",
+        },
+      },
+      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
+        ? workflow
+        : { ...run, conclusion: "success" },
+    }));
+    assert.equal(context.conclusion, "success");
+    assert.equal(context.requiresClose, false);
+    assert.equal(context.passed, true);
+  });
+  await t.test("wrong path", async () => {
+    await assert.rejects(validateWatchdogContext(input({
+      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
+        ? workflow
+        : { ...run, path: ".github/workflows/other.yml@refs/heads/main" },
+    })));
+  });
   await assert.rejects(validateWatchdogContext(input({ gitRef: "refs/heads/feature" })));
   await assert.rejects(validateWatchdogContext(input({ watchdogRunAttempt: "2" })));
   await assert.rejects(validateWatchdogContext(input({


### PR DESCRIPTION
## Summary

- treat an exact first-attempt successful Ponto coordinator as a validated watchdog no-op;
- retain fail-close for failed/cancelled/timed-out coordinators;
- retain fail-close for all unauthorized reruns with a valid terminal conclusion;
- cover the no-op contract in the watchdog context tests.

## Evidence

- preview run `30735551931` completed successfully across all four surfaces;
- watchdog `30735757788` incorrectly failed only because it treated that successful preview completion as invalid failed-coordinator provenance;
- focused watchdog tests and the progressive-release, deployment-topology, and GitHub-governance validators pass.

## Safety

The change only removes the false alarm for an exact successful first attempt. Any failed or unauthorized replay still requires the existing close path.