### PR TITLE
fix(ponto): accept live workflow path provenance

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -134,3 +134,27 @@ test("Pages derivation and Timekeeping upload independently attest environment c
     );
   }
 });
+
+test("Ponto REST run provenance accepts both canonical path representations", () => {
+  const pages = workflow("cloudflare-pages-sync-ponto.yml");
+  assert.match(
+    pages,
+    /\[expectedPath, `\$\{expectedPath\}@refs\/heads\/main`\]\.includes\(run\.path\)/,
+  );
+  for (const name of [
+    "cloudflare-pages-sync-ponto.yml",
+    "deploy-timekeeping.yml",
+    "ponto-production-baseline.yml",
+  ]) {
+    const source = workflow(name);
+    assert.match(
+      source,
+      /\[workflow\.path, `\$\{workflow\.path\}@refs\/heads\/main`\]\.includes\(run\.path\)/,
+      `${name} must accept the live REST path with or without the main-ref suffix`,
+    );
+  }
+  assert.match(
+    workflow("ponto-progressive-release.yml"),
+    /\[workflow\.path, `\$\{workflow\.path\}@refs\/heads\/main`\]\.includes\(run\.path\)/,
+  );
+});

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -111,7 +111,7 @@ jobs:
           const expectedPath = workflow.path;
           if (
             run.workflow_id !== workflow.id
-            || run.path !== expectedPath
+            || ![expectedPath, `${expectedPath}@refs/heads/main`].includes(run.path)
             || run.status !== "completed"
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
@@ -142,7 +142,7 @@ jobs:
             || workflow.path !== ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml"
             || run.id !== Number(process.env.ROOT_CUSTODY_RUN_ID)
             || run.workflow_id !== workflow.id
-            || run.path !== `${workflow.path}@refs/heads/main`
+            || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
             || run.run_attempt !== 1
             || run.status !== "completed"
             || run.conclusion !== "success"

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -517,7 +517,7 @@ jobs:
             || workflow.name !== "Attest Ponto Worker secret custody"
             || run.id !== Number(process.env.ROOT_CUSTODY_RUN_ID)
             || run.workflow_id !== workflow.id
-            || run.path !== `${workflow.path}@refs/heads/main`
+            || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
             || run.run_attempt !== 1
             || run.status !== "completed"
             || run.conclusion !== "success"

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -98,7 +98,7 @@ jobs:
             workflow.state !== "active"
             || workflow.path !== ".github/workflows/ponto-progressive-release.yml"
             || run.workflow_id !== workflow.id
-            || run.path !== `${workflow.path}@refs/heads/main`
+            || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
             || run.status !== "completed"
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -825,7 +825,7 @@ jobs:
           );
           const reusableRuns = runs
             .filter(run => run.workflow_id === workflow.id
-              && run.path === workflow.path
+              && [workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
               && run.status === "completed"
               && run.conclusion === "success"
               && run.event === "workflow_dispatch"


### PR DESCRIPTION
## Summary
- accept both GitHub REST workflow run path forms in Ponto Pages and Timekeeping custody checks
- apply the same contract to the production baseline and reusable baseline lookup
- add regression coverage for the live path representations

## Validation
- node --test focused Ponto custody, dispatch, reconciliation, and lease suites: 40 passed
- validate-deploy-topology.mjs: passed
- observed staging failure: root custody run returned the canonical workflow path without the refs/heads/main suffix