### PR TITLE
fix(ponto): validate workflow metadata separately

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -153,6 +153,11 @@ test("Ponto REST run provenance accepts both canonical path representations", ()
       `${name} must accept the live REST path with or without the main-ref suffix`,
     );
   }
+  for (const name of ["cloudflare-pages-sync-ponto.yml", "deploy-timekeeping.yml"]) {
+    const source = workflow(name);
+    assert.match(source, /workflow\.name !== "Attest Ponto Worker secret custody"/);
+    assert.doesNotMatch(source, /run\.name !== "Attest Ponto Worker secret custody"/);
+  }
   assert.match(
     workflow("ponto-progressive-release.yml"),
     /\[workflow\.path, `\$\{workflow\.path\}@refs\/heads\/main`\]\.includes\(run\.path\)/,

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -175,6 +175,7 @@ jobs:
           if (
             workflow.state !== "active"
             || workflow.path !== ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml"
+            || workflow.name !== "Attest Ponto Worker secret custody"
             || run.id !== Number(process.env.ROOT_CUSTODY_RUN_ID)
             || run.workflow_id !== workflow.id
             || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run.path)
@@ -184,7 +185,6 @@ jobs:
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
             || run.head_sha !== process.env.RELEASE_SHA
-            || run.name !== "Attest Ponto Worker secret custody"
             || !expectedTitle
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -524,7 +524,6 @@ jobs:
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
             || run.head_sha !== process.env.RELEASE_SHA
-            || run.name !== "Attest Ponto Worker secret custody"
             || !expectedTitle
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY


### PR DESCRIPTION
## Summary
- validate the static root-custody workflow name from workflow metadata
- stop comparing the dynamic Actions run-name to the static workflow name in Pages and Timekeeping custody consumers
- add regression coverage for the live REST provenance contract

## Evidence
- staging child 30739919026 failed after root custody run 30739845965 returned a dynamic run.name
- focused Ponto tests: 42 passed
- validate-deploy-topology.mjs: passed