### PR TITLE
fix(ponto): align Pages custody evidence arguments

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -215,6 +215,7 @@ test("Pages custody uses structured Cloudflare project env_vars for inventory ch
   assert.match(source, /pages\/projects\/\$PROJECT/);
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /Object\.keys\(envVars\)/);
+  assert.match(source, /node - "\$before_project_file" "\$evidence_file"[\s\S]+process\.argv\[3\]/);
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /normalize_wrangler_array/);
 });

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -347,7 +347,7 @@ jobs:
             .update(domain)
             .digest("base64url");
           fs.writeFileSync(
-            process.argv[4],
+            process.argv[3],
             `${JSON.stringify({
               PONTO_ACTOR_HMAC_KEY: derive("skincos/ponto/actor/v1"),
               PONTO_NETWORK_CONTEXT_KEY: derive("skincos/ponto/network-context/v1"),


### PR DESCRIPTION
## Summary\n- align the initial Pages custody evidence writer with its two explicit Node arguments\n- add a structural regression assertion\n\n## Validation\n- focused Ponto lease tests\n- deployment topology validation\n- git diff --check\n\nThe previous staging attempt proved the mismatch before any Pages mutation; its automatic latch/reconcile/close/rollback completed successfully.