### PR TITLE
fix(ponto): pass Pages custody paths explicitly

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -135,6 +135,27 @@ test("Pages derivation and Timekeeping upload independently attest environment c
   }
 });
 
+test("Pages root derivation passes private paths through explicit environment variables", () => {
+  const source = workflow("cloudflare-pages-sync-ponto.yml");
+  const start = source.indexOf("- name: Derive and provision environment-scoped Ponto Pages keys");
+  const end = source.indexOf("- name: Upload sanitised Pages secret attestation", start);
+  const step = source.slice(start, end);
+  const rootStart = source.indexOf("node --input-type=module - <<'NODE'", start);
+  const rootEnd = source.indexOf("NODE\n          unset PONTO_ROOT_CUSTODY_FILE", rootStart);
+  const rootStep = source.slice(rootStart, rootEnd);
+  assert.ok(start >= 0 && end > start);
+  assert.ok(rootStart >= start && rootEnd > rootStart);
+  assert.match(step, /export PONTO_ROOT_CUSTODY_FILE=/);
+  assert.match(step, /export PONTO_STAGING_EVIDENCE_FILE=/);
+  assert.match(step, /export PONTO_DERIVED_SECRET_FILE=/);
+  assert.match(rootStep, /fs\.readFileSync\(process\.env\.PONTO_ROOT_CUSTODY_FILE/);
+  assert.match(rootStep, /fs\.readFileSync\(process\.env\.PONTO_STAGING_EVIDENCE_FILE/);
+  assert.match(rootStep, /fs\.writeFileSync\(\s*process\.env\.PONTO_DERIVED_SECRET_FILE/);
+  assert.doesNotMatch(rootStep, /process\.argv\[(?:2|3|4)\]/);
+  assert.match(step, /unset PONTO_ROOT_CUSTODY_FILE PONTO_STAGING_EVIDENCE_FILE PONTO_DERIVED_SECRET_FILE/);
+  assert.match(step, /unset PONTO_ROOT_ATTESTATION_KEY_SHARED PONTO_IDEMPOTENCY_KEY/);
+});
+
 test("Ponto REST run provenance accepts both canonical path representations", () => {
   const pages = workflow("cloudflare-pages-sync-ponto.yml");
   assert.match(

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -293,6 +293,9 @@ jobs:
           after_project_file="$RUNNER_TEMP/pages-project-after.json"
           secret_file="$RUNNER_TEMP/pages-release-probe-secret.json"
           evidence_file="$RUNNER_TEMP/pages-release-probe-evidence.json"
+          export PONTO_ROOT_CUSTODY_FILE="$RUNNER_TEMP/current-root-custody/root-custody.json"
+          export PONTO_STAGING_EVIDENCE_FILE="$RUNNER_TEMP/staging-evidence/ponto-release-evidence.json"
+          export PONTO_DERIVED_SECRET_FILE="$secret_file"
           trap 'rm -f "$before_project_file" "$after_project_file" "$secret_file"' EXIT
           node <<'NODE'
           const value = String(process.env.PONTO_IDEMPOTENCY_KEY || "");
@@ -302,10 +305,7 @@ jobs:
             || /[\r\n\0]/.test(value)
           ) throw new Error("PONTO_IDEMPOTENCY_KEY must contain at least 32 UTF-8 bytes and no surrounding/control whitespace");
           NODE
-          node --input-type=module - \
-            "$RUNNER_TEMP/current-root-custody/root-custody.json" \
-            "$RUNNER_TEMP/staging-evidence/ponto-release-evidence.json" \
-            "$secret_file" <<'NODE'
+          node --input-type=module - <<'NODE'
           import crypto from "node:crypto";
           import fs from "node:fs";
           import {
@@ -314,7 +314,7 @@ jobs:
             validateRootCustody,
           } from "./.github/scripts/ponto-root-custody.mjs";
           const attested = validateRootCustody(
-            JSON.parse(fs.readFileSync(process.argv[2], "utf8")),
+            JSON.parse(fs.readFileSync(process.env.PONTO_ROOT_CUSTODY_FILE, "utf8")),
             { target: process.env.TARGET, releaseSha: process.env.RELEASE_SHA },
           );
           const current = rootFingerprint(
@@ -333,7 +333,7 @@ jobs:
             throw new Error("Pages derivation root differs from the pre-mutation root custody commitment");
           }
           if (process.env.TARGET === "production") {
-            const evidence = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+            const evidence = JSON.parse(fs.readFileSync(process.env.PONTO_STAGING_EVIDENCE_FILE, "utf8"));
             const staging = validateRootCustody(evidence?.surfaces?.timekeeping?.rootCustody, {
               target: "staging",
               releaseSha: process.env.RELEASE_SHA,
@@ -347,7 +347,7 @@ jobs:
             .update(domain)
             .digest("base64url");
           fs.writeFileSync(
-            process.argv[4],
+            process.env.PONTO_DERIVED_SECRET_FILE,
             `${JSON.stringify({
               PONTO_ACTOR_HMAC_KEY: derive("skincos/ponto/actor/v1"),
               PONTO_NETWORK_CONTEXT_KEY: derive("skincos/ponto/network-context/v1"),
@@ -356,6 +356,7 @@ jobs:
             { mode: 0o600 },
           );
           NODE
+          unset PONTO_ROOT_CUSTODY_FILE PONTO_STAGING_EVIDENCE_FILE PONTO_DERIVED_SECRET_FILE
           unset PONTO_ROOT_ATTESTATION_KEY_SHARED PONTO_IDEMPOTENCY_KEY
           if [[ "$TARGET" == production ]]; then
             [[ "$PROJECT" != "skincos-staging" ]] || exit 1


### PR DESCRIPTION
## Summary\n- pass root custody, staging evidence, and derived-secret paths through explicit environment variables\n- avoid ambiguous stdin argv handling in the privileged Pages derivation step\n- add regression coverage for the path contract and preserve fail-closed cleanup\n\n## Validation\n- Ponto custody/orchestrator tests: 21 passed\n- deployment topology validation: passed\n- git diff --check: passed\n\nThis is the next fix for the latest staging Pages pre-mutation failure: Node received an undefined path while deriving environment-scoped keys.