### PR TITLE
fix(ponto): align Pages evidence journal path

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -215,6 +215,7 @@ test("Pages custody uses structured Cloudflare project env_vars for inventory ch
   assert.match(source, /pages\/projects\/\$PROJECT/);
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /Object\.keys\(envVars\)/);
+  assert.match(source, /node - "\$before_project_file" "\$evidence_file"[\s\S]+process\.argv\[3\]/);
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /normalize_wrangler_array/);
 });

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -215,7 +215,14 @@ test("Pages custody uses structured Cloudflare project env_vars for inventory ch
   assert.match(source, /pages\/projects\/\$PROJECT/);
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /Object\.keys\(envVars\)/);
-  assert.match(source, /node - "\$before_project_file" "\$evidence_file"[\s\S]+process\.argv\[3\]/);
+  const journalWriterStart = source.indexOf('node - "$before_project_file" "$evidence_file" <<\'NODE\'');
+  const journalWriterEnd = source.indexOf("\n          NODE", journalWriterStart);
+  assert.ok(journalWriterStart >= 0, "Pages custody must have a before-inventory journal writer");
+  assert.ok(journalWriterEnd > journalWriterStart, "Pages journal writer heredoc must terminate");
+  assert.match(
+    source.slice(journalWriterStart, journalWriterEnd),
+    /fs\.writeFileSync\(process\.argv\[3\]/,
+  );
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /normalize_wrangler_array/);
 });

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -400,7 +400,7 @@ jobs:
           if (process.env.TARGET === "production" && !names.has("PONTO_API_TARGET")) {
             throw new Error("production PONTO_API_TARGET secret is absent");
           }
-          fs.writeFileSync(process.argv[4], `${JSON.stringify({
+          fs.writeFileSync(process.argv[3], `${JSON.stringify({
             schemaVersion: 1,
             surface: "pagesEnvironmentSecrets",
             target: process.env.TARGET,


### PR DESCRIPTION
## Summary\n- write the pre-mutation Pages journal to the explicit evidence argument\n- retain the explicit private path contract from the latest Pages custody fix\n- add a regression assertion for the two-argument journal writer\n\n## Validation\n- 21 Ponto custody/orchestrator tests\n- deployment topology validation\n- git diff --check\n\nThe failed staging attempt proved the old undefined path before any Pages mutation; automatic latch/reconcile/close/rollback completed successfully.