### PR TITLE
fix(ponto): accept Wrangler deploy output without env field

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -215,6 +215,7 @@ test("Pages custody uses structured Cloudflare project env_vars for inventory ch
   assert.match(source, /pages\/projects\/\$PROJECT/);
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /Object\.keys\(envVars\)/);
+  assert.match(source, /node - "\$before_project_file" "\$evidence_file"[\s\S]+process\.argv\[3\]/);
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /normalize_wrangler_array/);
 });

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -215,7 +215,14 @@ test("Pages custody uses structured Cloudflare project env_vars for inventory ch
   assert.match(source, /pages\/projects\/\$PROJECT/);
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /Object\.keys\(envVars\)/);
-  assert.match(source, /node - "\$before_project_file" "\$evidence_file"[\s\S]+process\.argv\[3\]/);
+  const journalWriterStart = source.indexOf('node - "$before_project_file" "$evidence_file" <<\'NODE\'');
+  const journalWriterEnd = source.indexOf("\n          NODE", journalWriterStart);
+  assert.ok(journalWriterStart >= 0, "Pages custody must have a before-inventory journal writer");
+  assert.ok(journalWriterEnd > journalWriterStart, "Pages journal writer heredoc must terminate");
+  assert.match(
+    source.slice(journalWriterStart, journalWriterEnd),
+    /fs\.writeFileSync\(process\.argv\[3\]/,
+  );
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /normalize_wrangler_array/);
 });

--- a/.github/scripts/ponto-wrangler-output.mjs
+++ b/.github/scripts/ponto-wrangler-output.mjs
@@ -16,7 +16,12 @@ const actualName = String(record.worker_name || record.project_name || record.na
 if (actualName !== expectedName) throw new Error(`Wrangler output target differs: ${actualName || "missing"}`);
 const expectedEnvironment = String(process.env.PONTO_EXPECTED_WRANGLER_ENV || "").trim();
 const actualEnvironment = String(record.wrangler_environment || record.environment || "");
-if (expectedEnvironment && actualEnvironment !== expectedEnvironment) {
+// Wrangler's version-deploy NDJSON record identifies the exact Worker and
+// deployment, but does not currently repeat the --env value. Keep strict
+// environment validation for records that expose it and for version-upload;
+// the exact Worker name remains mandatory for version-deploy.
+const missingEnvironmentAllowed = expectedType === "version-deploy" && !actualEnvironment;
+if (expectedEnvironment && actualEnvironment !== expectedEnvironment && !missingEnvironmentAllowed) {
   throw new Error(`Wrangler output environment differs: ${actualEnvironment || "missing"}`);
 }
 const versionId = String(record.version_id || "");

--- a/.github/scripts/ponto-wrangler-output.test.mjs
+++ b/.github/scripts/ponto-wrangler-output.test.mjs
@@ -20,6 +20,45 @@ test("extracts only a structured version upload for the exact Worker", () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("accepts version deploy output without a repeated Wrangler environment", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
+  const file = path.join(dir, "output.ndjson");
+  fs.writeFileSync(file, [
+    JSON.stringify({
+      type: "version-deploy",
+      version: 1,
+      worker_name: "skincos-timekeeping-staging",
+      deployment_id: "22222222-2222-4222-8222-222222222222",
+    }),
+    "",
+  ].join("\n"));
+  const result = spawnSync(process.execPath, [script, file, "version-deploy", "skincos-timekeeping-staging"], {
+    encoding: "utf8",
+    env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "staging" },
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects an explicit version deploy environment mismatch", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
+  const file = path.join(dir, "output.ndjson");
+  fs.writeFileSync(file, [
+    JSON.stringify({
+      type: "version-deploy",
+      version: 1,
+      worker_name: "skincos-timekeeping-staging",
+      deployment_id: "22222222-2222-4222-8222-222222222222",
+      environment: "production",
+    }),
+    "",
+  ].join("\n"));
+  const result = spawnSync(process.execPath, [script, file, "version-deploy", "skincos-timekeeping-staging"], {
+    encoding: "utf8",
+    env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "staging" },
+  });
+  assert.notEqual(result.status, 0);
+});
+
 test("rejects a different target or command-failed record", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
   const file = path.join(dir, "output.ndjson");

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -400,7 +400,7 @@ jobs:
           if (process.env.TARGET === "production" && !names.has("PONTO_API_TARGET")) {
             throw new Error("production PONTO_API_TARGET secret is absent");
           }
-          fs.writeFileSync(process.argv[4], `${JSON.stringify({
+          fs.writeFileSync(process.argv[3], `${JSON.stringify({
             schemaVersion: 1,
             surface: "pagesEnvironmentSecrets",
             target: process.env.TARGET,


### PR DESCRIPTION
## Context\n\nThe governed staging run published the exact candidate but Wrangler's version-deploy NDJSON omitted the environment field. The validator rejected the record after mutation, leaving deployment_id unattested and correctly refusing automatic compensation.\n\n## Change\n\n- allow a missing environment only for version-deploy records;\n- keep version-upload strict and reject explicit environment mismatches;\n- add regression coverage for both cases.\n\n## Validation\n\n- focused Wrangler output tests pass in Ubuntu-24.04 WSL;\n- no production activation or Finance change.\n\nStaging remains fail-closed in maintenance until the next governed run.