### PR TITLE
fix(ponto): record sanitized KV recovery failures

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -88,6 +88,10 @@ const brokerFailCloseFile = path.join(
 const brokerFailClose = fs.existsSync(brokerFailCloseFile)
   ? readJson(brokerFailCloseFile)
   : null;
+const safeReadbackFailureCode = (error) => {
+  const code = String(error?.code || "cloudflare-kv-readback-failed");
+  return /^[a-z0-9-]{1,96}$/.test(code) ? code : "cloudflare-kv-readback-failed";
+};
 const readExternalModuleHealth = async () => {
   if (moduleHealthUrl !== expectedModuleHealthUrl) {
     return { passed: false, status: 0, reason: "module-health-url-not-pinned" };
@@ -155,22 +159,34 @@ const attestNoSurfaceRollback = async () => {
 const readAndAttestBrokerFailClose = async () => {
   let moduleControl = null;
   let emergencyLatch = null;
+  let readbackFailure = "";
   try {
-    moduleControl = await readCloudflareKvJson({
-      accountId,
-      namespaceId: moduleControlNamespaceId,
-      key: "module-control:timekeeping",
-      apiToken,
-    });
-    emergencyLatch = await readCloudflareKvJson({
-      accountId,
-      namespaceId: moduleControlNamespaceId,
-      key: "module-control:timekeeping:emergency-latch",
-      apiToken,
-    });
+    try {
+      moduleControl = await readCloudflareKvJson({
+        accountId,
+        namespaceId: moduleControlNamespaceId,
+        key: "module-control:timekeeping",
+        apiToken,
+      });
+    } catch (error) {
+      readbackFailure = `control-${safeReadbackFailureCode(error)}`;
+      throw error;
+    }
+    try {
+      emergencyLatch = await readCloudflareKvJson({
+        accountId,
+        namespaceId: moduleControlNamespaceId,
+        key: "module-control:timekeeping:emergency-latch",
+        apiToken,
+      });
+    } catch (error) {
+      readbackFailure = `latch-${safeReadbackFailureCode(error)}`;
+      throw error;
+    }
   } catch {
     moduleControl = null;
     emergencyLatch = null;
+    if (!readbackFailure) readbackFailure = "cloudflare-kv-readback-failed";
   }
   const directAttestation = attestBrokerFailCloseEvidence({
     evidence: brokerFailClose,
@@ -185,14 +201,14 @@ const readAndAttestBrokerFailClose = async () => {
     return {
       moduleControl,
       emergencyLatch,
-      attestation: { ...directAttestation, readbackMode: "direct-kv" },
+      attestation: { ...directAttestation, readbackMode: "direct-kv", readbackFailure: "" },
     };
   }
   const noSurfaceAttestation = await attestNoSurfaceRollback();
   return {
     moduleControl,
     emergencyLatch,
-    attestation: noSurfaceAttestation || directAttestation,
+    attestation: noSurfaceAttestation || { ...directAttestation, readbackFailure },
   };
 };
 const surfaceSpecs = {
@@ -992,6 +1008,10 @@ const report = {
     state: "unresolved",
     remoteKvReadbackMatched: false,
     emergencyLatchReadbackMatched: false,
+    readbackFailure: [
+      preMutationFailClose.attestation.readbackFailure,
+      postMutationFailClose.attestation.readbackFailure,
+    ].filter(Boolean),
   },
   childReconciliation: childReconciliationPassed ? {
     passed: true,

--- a/.github/scripts/ponto-kv-readback.mjs
+++ b/.github/scripts/ponto-kv-readback.mjs
@@ -7,6 +7,8 @@ const requireValue = (value, label) => {
   return normalized;
 };
 
+const readbackError = (message, code) => Object.assign(new Error(message), { code });
+
 /**
  * Read a JSON-valued KV record through the account-scoped Cloudflare API.
  * The returned value is kept in memory for custody comparison. Response
@@ -27,27 +29,54 @@ export async function readCloudflareKvJson({
     throw new Error("Cloudflare account or KV namespace ID is malformed");
   }
 
-  const response = await fetchImpl(
-    `${API_BASE}/accounts/${encodeURIComponent(account)}/storage/kv/namespaces/${encodeURIComponent(namespace)}/values/${encodeURIComponent(recordKey)}`,
-    {
-      method: "GET",
-      headers: {
-        authorization: `Bearer ${token}`,
-        accept: "application/json",
+  let response;
+  try {
+    response = await fetchImpl(
+      `${API_BASE}/accounts/${encodeURIComponent(account)}/storage/kv/namespaces/${encodeURIComponent(namespace)}/values/${encodeURIComponent(recordKey)}`,
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: "application/json",
+        },
+        signal: AbortSignal.timeout(30_000),
       },
-      signal: AbortSignal.timeout(30_000),
-    },
-  );
-  const raw = await response.text();
-  if (!response.ok) throw new Error(`Cloudflare KV readback failed (HTTP ${response.status})`);
+    );
+  } catch {
+    throw readbackError(
+      "Cloudflare KV readback request failed",
+      "cloudflare-kv-readback-request-failed",
+    );
+  }
+  let raw;
+  try {
+    raw = await response.text();
+  } catch {
+    throw readbackError(
+      "Cloudflare KV readback body unavailable",
+      "cloudflare-kv-readback-body-unavailable",
+    );
+  }
+  if (!response.ok) {
+    throw readbackError(
+      `Cloudflare KV readback failed (HTTP ${response.status})`,
+      `cloudflare-kv-readback-http-${response.status}`,
+    );
+  }
   let value;
   try {
     value = JSON.parse(raw);
   } catch {
-    throw new Error("Cloudflare KV readback is not valid JSON");
+    throw readbackError(
+      "Cloudflare KV readback is not valid JSON",
+      "cloudflare-kv-readback-invalid-json",
+    );
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Cloudflare KV readback JSON shape is invalid");
+    throw readbackError(
+      "Cloudflare KV readback JSON shape is invalid",
+      "cloudflare-kv-readback-invalid-shape",
+    );
   }
   return value;
 }

--- a/.github/scripts/ponto-kv-readback.test.mjs
+++ b/.github/scripts/ponto-kv-readback.test.mjs
@@ -44,6 +44,7 @@ test("fails closed without including Cloudflare response content", async () => {
       }),
     }),
     (error) => error.message === "Cloudflare KV readback failed (HTTP 403)"
+      && error.code === "cloudflare-kv-readback-http-403"
       && !error.message.includes(secretLikeBody),
   );
 });


### PR DESCRIPTION
## Objetivo\nTornar observável, sem expor segredos, a razão pela qual o rollback fail-closed não conseguiu atestar os dois registros KV do latch staging.\n\n## Alteração\nOs erros de leitura Cloudflare KV agora carregam somente códigos sanitizados (request, HTTP status, corpo indisponível, JSON inválido ou shape inválido) no artefato privado de rollback. Nenhum corpo de resposta, valor KV ou credencial entra no relatório. O rollback continua bloqueado quando a leitura não é atestada.\n\n## Validação\n- testes focados de recovery/KV/evidência;\n- validate-deploy-topology.mjs;\n- git diff --check.\n\n## Operação\nO PR não altera staging/produção. Após merge, o mesmo workflow de recovery será repetido com os IDs já comprovados.