### PR TITLE
fix(ponto): classify broker readback mismatch

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -49,6 +49,12 @@ test("broker custody readback uses the account-scoped Cloudflare API", () => {
   assert.doesNotMatch(source, /const readRemoteModuleKey = \(key\) => spawnSync\("npx"/);
 });
 
+test("broker readback diagnostics expose only a bounded mismatch category", () => {
+  assert.match(source, /classifyBrokerReadback/);
+  assert.match(source, /readbackFailure: readbackFailure \|\| classifyBrokerReadback/);
+  assert.doesNotMatch(source, /readbackFailure:\s*moduleControl/);
+});
+
 test("zero-surface recovery uses a fresh external maintenance probe instead of faking rollback", () => {
   assert.match(source, /PONTO_MODULE_HEALTH_URL/);
   assert.match(source, /Object\.keys\(plan\)\.length !== 0/);

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -92,6 +92,26 @@ const safeReadbackFailureCode = (error) => {
   const code = String(error?.code || "cloudflare-kv-readback-failed");
   return /^[a-z0-9-]{1,96}$/.test(code) ? code : "cloudflare-kv-readback-failed";
 };
+const classifyBrokerReadback = ({ moduleControl, emergencyLatch }) => {
+  const target = staging ? "staging" : "production";
+  if (!brokerFailClose) return "broker-evidence-missing";
+  if (!moduleControl) return "module-control-unavailable";
+  if (moduleControl.schemaVersion !== 2) return "module-control-schema-mismatch";
+  if (moduleControl.state !== "maintenance") return "module-control-state-mismatch";
+  if (moduleControl.changedAt !== brokerFailClose.controlChangedAt) return "module-control-timestamp-mismatch";
+  if (moduleControl.emergencyLatchRef?.stopRunId !== orchestratorRunId) return "module-control-stop-run-mismatch";
+  if (moduleControl.emergencyLatchRef?.emergencyRunId !== brokerFailClose.emergencyRunId) return "module-control-emergency-run-mismatch";
+  if (moduleControl.emergencyLatchRef?.latchChangedAt !== brokerFailClose.latchChangedAt) return "module-control-latch-timestamp-mismatch";
+  if (!emergencyLatch) return "emergency-latch-unavailable";
+  if (emergencyLatch.schemaVersion !== 1) return "emergency-latch-schema-mismatch";
+  if (emergencyLatch.module !== "timekeeping") return "emergency-latch-module-mismatch";
+  if (emergencyLatch.target !== target) return "emergency-latch-target-mismatch";
+  if (emergencyLatch.latched !== true) return "emergency-latch-state-mismatch";
+  if (emergencyLatch.changedAt !== brokerFailClose.latchChangedAt) return "emergency-latch-timestamp-mismatch";
+  if (emergencyLatch.stopRunId !== orchestratorRunId) return "emergency-latch-stop-run-mismatch";
+  if (emergencyLatch.emergencyRunId !== brokerFailClose.emergencyRunId) return "emergency-latch-emergency-run-mismatch";
+  return "broker-evidence-attestation-mismatch";
+};
 const readExternalModuleHealth = async () => {
   if (moduleHealthUrl !== expectedModuleHealthUrl) {
     return { passed: false, status: 0, reason: "module-health-url-not-pinned" };
@@ -208,7 +228,10 @@ const readAndAttestBrokerFailClose = async () => {
   return {
     moduleControl,
     emergencyLatch,
-    attestation: noSurfaceAttestation || { ...directAttestation, readbackFailure },
+    attestation: noSurfaceAttestation || {
+      ...directAttestation,
+      readbackFailure: readbackFailure || classifyBrokerReadback({ moduleControl, emergencyLatch }),
+    },
   };
 };
 const surfaceSpecs = {


### PR DESCRIPTION
## Objetivo\nIdentificar, sem expor valores, por que os registros KV lidos durante o rollback não satisfazem o contrato do fail-close.\n\n## Alteração\nO artefato privado agora registra uma categoria limitada para divergência de schema, estado, timestamp ou referência do módulo/latch. Nenhum valor KV, timestamp real, corpo HTTP ou credencial é emitido; a mutação continua proibida enquanto o atestado não passar.\n\n## Validação\n- testes focados de rollback/KV/workflow;\n- validate-deploy-topology.mjs;\n- git diff --check.\n\n## Contexto operacional\nAs duas tentativas de recovery terminaram antes de qualquer mutação porque o atestado KV falhou. Staging permanece em maintenance/control no candidato e600...; o incumbent comprovado continua d6e60024-bb67-48da-91b1-4d7e16ee31ba.