### PR TITLE
fix(ponto): bind recovery rollback to direct KV custody

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -21,6 +21,7 @@ export function normalizeRecoveryEvidence({
   releaseSha,
   stage,
   target,
+  moduleControlReadback = null,
 }) {
   if (
     !["ordinary", "watchdog"].includes(sourceMode)
@@ -82,6 +83,31 @@ export function normalizeRecoveryEvidence({
   const exactControlChangedAt = propagation?.matchedSource === "control"
     ? exactPropagationChangedAt
     : maintenance.controlChangedAt;
+  const directReadbackPresent = moduleControlReadback !== null
+    && moduleControlReadback !== undefined;
+  const directModuleControl = moduleControlReadback?.moduleControl;
+  const directEmergencyLatch = moduleControlReadback?.emergencyLatch;
+  const directReadbackValid = !directReadbackPresent || (
+    moduleControlReadback?.schemaVersion === 1
+    && moduleControlReadback?.source === "cloudflare-kv-direct"
+    && moduleControlReadback?.target === target
+    && moduleControlReadback?.credentialsIncluded === false
+    && moduleControlReadback?.piiIncluded === false
+    && directModuleControl?.schemaVersion === 2
+    && directModuleControl?.state === "maintenance"
+    && validDate(directModuleControl?.changedAt)
+    && directModuleControl?.emergencyLatchRef?.stopRunId === coordinatorRunId
+    && directModuleControl?.emergencyLatchRef?.emergencyRunId === emergencyRunId
+    && directModuleControl?.emergencyLatchRef?.latchChangedAt === maintenance.latchChangedAt
+    && directEmergencyLatch?.schemaVersion === 1
+    && directEmergencyLatch?.module === "timekeeping"
+    && directEmergencyLatch?.target === target
+    && directEmergencyLatch?.latched === true
+    && validDate(directEmergencyLatch?.changedAt)
+    && directEmergencyLatch?.changedAt === maintenance.latchChangedAt
+    && directEmergencyLatch?.stopRunId === coordinatorRunId
+    && directEmergencyLatch?.emergencyRunId === emergencyRunId
+  );
   if (
     propagation?.schemaVersion !== 1
     || propagation?.module !== "timekeeping"
@@ -99,7 +125,12 @@ export function normalizeRecoveryEvidence({
     || !["control", "emergency-latch-active"].includes(propagation?.matchedSource)
     || propagation?.credentialsIncluded !== false
     || propagation?.piiIncluded !== false
+    || !directReadbackValid
   ) throw new Error("broker fail-close propagation evidence is invalid");
+
+  const normalizedControlChangedAt = directReadbackPresent
+    ? directModuleControl.changedAt
+    : exactControlChangedAt;
 
   return {
     childReconciliation: {
@@ -128,7 +159,7 @@ export function normalizeRecoveryEvidence({
       custodyRef: String(maintenance.custodyRef || ""),
       state: "maintenance",
       latched: true,
-      controlChangedAt: exactControlChangedAt,
+      controlChangedAt: normalizedControlChangedAt,
       latchChangedAt: maintenance.latchChangedAt,
       emergencyLatchRef: {
         stopRunId: coordinatorRunId,
@@ -200,7 +231,7 @@ export function attestBrokerFailCloseEvidence({
 
 const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
 if (invokedPath === import.meta.url) {
-  const [reconciliationFile, maintenanceFile, propagationFile, outputRoot] =
+  const [reconciliationFile, maintenanceFile, propagationFile, outputRoot, directReadbackFile] =
     process.argv.slice(2);
   if (!reconciliationFile || !maintenanceFile || !propagationFile || !outputRoot) {
     throw new Error(
@@ -217,6 +248,7 @@ if (invokedPath === import.meta.url) {
     releaseSha: String(process.env.RELEASE_SHA || "").toLowerCase(),
     stage: String(process.env.STAGE || ""),
     target: String(process.env.PONTO_RECOVERY_TARGET || ""),
+    moduleControlReadback: directReadbackFile ? readJson(directReadbackFile) : null,
   });
   const directory = path.join(outputRoot, "automatic-rollback");
   fs.mkdirSync(directory, { recursive: true });

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -99,6 +99,66 @@ test("ordinary recovery binds an idempotent control fallback to the live timesta
   assert.equal(normalized.brokerFailClose.controlChangedAt, observedControlAt);
 });
 
+test("direct KV custody overrides a stale control fallback timestamp", () => {
+  const observedControlAt = "2026-07-30T00:03:00.000Z";
+  const directControlAt = "2026-07-30T00:04:00.000Z";
+  const normalized = normalizeRecoveryEvidence({
+    reconciliation: {
+      schemaVersion: 1,
+      orchestratorRunId: coordinatorRunId,
+      orchestratorHeadSha: sha,
+      discoveredChildren: 0,
+      unresolved: [],
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    maintenance,
+    propagation: {
+      ...propagation,
+      lastObserved: {
+        state: "maintenance",
+        changedAt: observedControlAt,
+        source: "control",
+      },
+      matchedSource: "control",
+    },
+    moduleControlReadback: {
+      schemaVersion: 1,
+      source: "cloudflare-kv-direct",
+      target,
+      moduleControl: {
+        schemaVersion: 2,
+        state: "maintenance",
+        changedAt: directControlAt,
+        emergencyLatchRef: {
+          stopRunId: coordinatorRunId,
+          emergencyRunId,
+          latchChangedAt: maintenance.latchChangedAt,
+        },
+      },
+      emergencyLatch: {
+        schemaVersion: 1,
+        module: "timekeeping",
+        target,
+        latched: true,
+        changedAt: maintenance.latchChangedAt,
+        stopRunId: coordinatorRunId,
+        emergencyRunId,
+      },
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    sourceMode: "ordinary",
+    coordinatorRunId,
+    emergencyRunId,
+    releaseSha: sha,
+    stage,
+    target,
+  });
+  assert.equal(normalized.brokerFailClose.controlChangedAt, directControlAt);
+});
+
 test("watchdog evidence normalizes only capability-authorized terminal children", () => {
   const normalized = normalizeRecoveryEvidence({
     reconciliation: {

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -23,6 +23,10 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /PONTO_EMERGENCY_TRIGGER_RUN_ID: \$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /name: ponto-fresh-recovery-close-staging-\$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /name: Normalize the fresh close with historical child reconciliation/);
+  assert.match(workflow, /name: Read back the exact staging module control from Cloudflare KV/);
+  assert.match(workflow, /readCloudflareKvJson/);
+  assert.match(workflow, /fresh-close\/direct-readback\.json/);
+  assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);
   assert.match(workflow, /group: ponto-surface-mutation/);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /environment: staging/);

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -155,9 +155,11 @@ jobs:
             || !uuid(mutation.candidateVersionId)
             || !uuid(mutation.incumbentVersionId)
             || mutation.mutationStarted !== true
-            || mutation.mutationCompleted !== false
             || mutation.rollbackCompleted !== false
-            || mutation.compensationDisposition !== "ownership-conflict"
+            || !(
+              (mutation.mutationCompleted === false && mutation.compensationDisposition === "ownership-conflict")
+              || (mutation.mutationCompleted === true && mutation.compensationDisposition === "not-required")
+            )
             || mutation.credentialsIncluded !== false
             || mutation.piiIncluded !== false
           ) throw new Error("historical watchdog custody does not prove the exact failed Timekeeping mutation");
@@ -397,9 +399,11 @@ jobs:
             || !uuid(mutation.candidateVersionId)
             || !uuid(mutation.incumbentVersionId)
             || mutation.mutationStarted !== true
-            || mutation.mutationCompleted !== false
             || mutation.rollbackCompleted !== false
-            || mutation.compensationDisposition !== "ownership-conflict"
+            || !(
+              (mutation.mutationCompleted === false && mutation.compensationDisposition === "ownership-conflict")
+              || (mutation.mutationCompleted === true && mutation.compensationDisposition === "not-required")
+            )
             || mutation.credentialsIncluded !== false
             || mutation.piiIncluded !== false
           ) throw new Error("watchdog recovery evidence does not prove the exact failed Timekeeping mutation");
@@ -428,6 +432,97 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.run_id }}
 
+      - name: Read back the exact staging module control from Cloudflare KV
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PONTO_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
+          PONTO_COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
+          PONTO_EMERGENCY_RUN_ID: ${{ github.run_id }}
+          PONTO_MAINTENANCE_FILE: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/maintenance.json
+          PONTO_DIRECT_READBACK_FILE: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/direct-readback.json
+        run: |
+          set -euo pipefail
+          node --input-type=module - <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { readCloudflareKvJson } from "./.github/scripts/ponto-kv-readback.mjs";
+
+          const validDate = (value) => Number.isFinite(Date.parse(String(value || "")));
+          const maintenance = JSON.parse(fs.readFileSync(process.env.PONTO_MAINTENANCE_FILE, "utf8"));
+          const moduleControl = await readCloudflareKvJson({
+            accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+            namespaceId: process.env.PONTO_MODULE_CONTROL_KV_ID,
+            key: "module-control:timekeeping",
+            apiToken: process.env.CLOUDFLARE_API_TOKEN,
+          });
+          const emergencyLatch = await readCloudflareKvJson({
+            accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+            namespaceId: process.env.PONTO_MODULE_CONTROL_KV_ID,
+            key: "module-control:timekeeping:emergency-latch",
+            apiToken: process.env.CLOUDFLARE_API_TOKEN,
+          });
+          const coordinatorRunId = process.env.PONTO_COORDINATOR_RUN_ID;
+          const emergencyRunId = process.env.PONTO_EMERGENCY_RUN_ID;
+          if (
+            maintenance?.schemaVersion !== 1
+            || maintenance?.target !== "staging"
+            || maintenance?.coordinatorRunId !== coordinatorRunId
+            || maintenance?.emergencyRunId !== emergencyRunId
+            || maintenance?.state !== "maintenance"
+            || maintenance?.latched !== true
+            || maintenance?.passed !== true
+            || !validDate(maintenance?.latchChangedAt)
+            || moduleControl?.schemaVersion !== 2
+            || moduleControl?.state !== "maintenance"
+            || !validDate(moduleControl?.changedAt)
+            || moduleControl?.emergencyLatchRef?.stopRunId !== coordinatorRunId
+            || moduleControl?.emergencyLatchRef?.emergencyRunId !== emergencyRunId
+            || moduleControl?.emergencyLatchRef?.latchChangedAt !== maintenance.latchChangedAt
+            || emergencyLatch?.schemaVersion !== 1
+            || emergencyLatch?.module !== "timekeeping"
+            || emergencyLatch?.target !== "staging"
+            || emergencyLatch?.latched !== true
+            || !validDate(emergencyLatch?.changedAt)
+            || emergencyLatch?.changedAt !== maintenance.latchChangedAt
+            || emergencyLatch?.stopRunId !== coordinatorRunId
+            || emergencyLatch?.emergencyRunId !== emergencyRunId
+          ) throw new Error("direct staging KV readback is not correlated to the fresh emergency close");
+          const sanitized = {
+            schemaVersion: 1,
+            source: "cloudflare-kv-direct",
+            target: "staging",
+            moduleControl: {
+              schemaVersion: moduleControl.schemaVersion,
+              state: moduleControl.state,
+              changedAt: moduleControl.changedAt,
+              emergencyLatchRef: {
+                stopRunId: moduleControl.emergencyLatchRef.stopRunId,
+                emergencyRunId: moduleControl.emergencyLatchRef.emergencyRunId,
+                latchChangedAt: moduleControl.emergencyLatchRef.latchChangedAt,
+              },
+            },
+            emergencyLatch: {
+              schemaVersion: emergencyLatch.schemaVersion,
+              module: emergencyLatch.module,
+              target: emergencyLatch.target,
+              latched: emergencyLatch.latched,
+              changedAt: emergencyLatch.changedAt,
+              stopRunId: emergencyLatch.stopRunId,
+              emergencyRunId: emergencyLatch.emergencyRunId,
+            },
+            credentialsIncluded: false,
+            piiIncluded: false,
+          };
+          fs.mkdirSync(path.dirname(process.env.PONTO_DIRECT_READBACK_FILE), { recursive: true });
+          fs.writeFileSync(
+            process.env.PONTO_DIRECT_READBACK_FILE,
+            `${JSON.stringify(sanitized, null, 2)}\n`,
+            { mode: 0o600 },
+          );
+          process.stdout.write("Direct staging KV custody readback recorded without values.\n");
+          NODE
+
       - name: Normalize the fresh close with historical child reconciliation
         env:
           PONTO_RECOVERY_SOURCE_MODE: watchdog
@@ -441,7 +536,8 @@ jobs:
             "$RUNNER_TEMP/ponto-staging-recovery-rollback/automatic-rollback/ponto-child-reconciliation.json" \
             "$RUNNER_TEMP/ponto-staging-recovery-rollback/fresh-close/maintenance.json" \
             "$RUNNER_TEMP/ponto-staging-recovery-rollback/fresh-close/final-propagation.json" \
-            "$RUNNER_TEMP/ponto-staging-recovery-rollback"
+            "$RUNNER_TEMP/ponto-staging-recovery-rollback" \
+            "$RUNNER_TEMP/ponto-staging-recovery-rollback/fresh-close/direct-readback.json"
 
       - name: Attest exact staging Ponto resource identities
         env:


### PR DESCRIPTION
## Summary
- bind recovery rollback evidence to a sanitized direct Cloudflare KV readback
- prevent stale external health timestamps from authorizing a rollback
- accept the observed completed-publish / not-required historical mutation state

## Validation
- focal Ponto tests: 12 passed
- deployment topology validation: passed
- YAML parse: passed
- codex:preflight: passed

The workflow reads the two staging KV records in memory and uploads only correlated, sanitized fields.