### PR TITLE
fix(ponto): avoid recovery workflow self-deadlock

### DIFF
--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -29,6 +29,8 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);
   assert.match(workflow, /group: ponto-surface-mutation/);
   assert.match(workflow, /cancel-in-progress: false/);
+  const freshClose = workflow.match(/jobs:\n  fresh-close:([\s\S]*?)\n\n  rollback:/)?.[1] || "";
+  assert.doesNotMatch(freshClose, /concurrency:/);
   assert.match(workflow, /environment: staging/);
   assert.match(workflow, /\[\[ "\$GITHUB_REF" == refs\/heads\/main \]\]/);
   assert.match(workflow, /git rev-parse origin\/main.*GITHUB_SHA/);

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -46,9 +46,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    concurrency:
-      group: ponto-surface-mutation
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:


### PR DESCRIPTION
## Summary
- remove the duplicate `ponto-surface-mutation` job mutex from `fresh-close`
- retain workflow-level serialization for the complete close and rollback transaction
- add a regression assertion that `fresh-close` cannot reacquire the workflow mutex

## Evidence
- focal Ponto tests: 12 passed
- deployment topology validation: passed
- YAML parse: passed
- codex:preflight: passed

This fixes the no-runner fail-fast observed in recovery runs 30747595696 and 30748510846.