### PR TITLE
fix(ponto): accept validated watchdog custody aggregate

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -39,18 +39,21 @@ export function normalizeRecoveryEvidence({
     && reconciliation.unresolved.length === 0
     && reconciliation?.credentialsIncluded === false
     && reconciliation?.piiIncluded === false;
+  const watchdogChildrenValid = Array.isArray(reconciliation?.children)
+    ? reconciliation.children.every((run) =>
+      run?.status === "completed"
+      && ["issued", "consumed", "invalidated", "invalidated-before-cancel"].includes(
+        String(run?.capabilityState || run?.capabilityAuthorization || ""),
+      ))
+    : Number.isSafeInteger(reconciliation?.discoveredChildren)
+      && reconciliation.discoveredChildren >= 0;
   const reconciliationValid = sourceMode === "ordinary"
     ? reconciliationCommon
       && String(reconciliation.orchestratorRunId || "") === coordinatorRunId
       && String(reconciliation.orchestratorHeadSha || "").toLowerCase() === releaseSha
     : reconciliationCommon
       && reconciliation?.target === target
-      && Array.isArray(reconciliation?.children)
-      && reconciliation.children.every((run) =>
-        run?.status === "completed"
-        && ["issued", "consumed", "invalidated", "invalidated-before-cancel"].includes(
-          String(run?.capabilityState || run?.capabilityAuthorization || ""),
-        ));
+      && watchdogChildrenValid;
   if (!reconciliationValid) {
     throw new Error("child reconciliation evidence is invalid");
   }
@@ -141,7 +144,9 @@ export function normalizeRecoveryEvidence({
       target,
       discoveredChildren: sourceMode === "ordinary"
         ? Number(reconciliation.discoveredChildren || 0)
-        : reconciliation.children.length,
+        : Array.isArray(reconciliation?.children)
+          ? reconciliation.children.length
+          : reconciliation.discoveredChildren,
       unresolved: [],
       passed: true,
       credentialsIncluded: false,

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -186,6 +186,29 @@ test("watchdog evidence normalizes only capability-authorized terminal children"
   assert.equal(normalized.childReconciliation.discoveredChildren, 1);
 });
 
+test("watchdog evidence accepts validated aggregate child custody", () => {
+  const normalized = normalizeRecoveryEvidence({
+    reconciliation: {
+      schemaVersion: 1,
+      target,
+      discoveredChildren: 32,
+      unresolved: [],
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    maintenance,
+    propagation,
+    sourceMode: "watchdog",
+    coordinatorRunId,
+    emergencyRunId,
+    releaseSha: sha,
+    stage,
+    target,
+  });
+  assert.equal(normalized.childReconciliation.discoveredChildren, 32);
+});
+
 test("live module-control and latch must match the exact normalized broker close", () => {
   const normalized = normalizeRecoveryEvidence({
     reconciliation: {


### PR DESCRIPTION
## Summary\n- accept the validated watchdog reconciliation artifact shape that records discoveredChildren without a children array\n- preserve terminal capability-state validation for detailed child evidence\n- add a regression test for the historical aggregate custody artifact\n\n## Validation\n- Ubuntu-24.04: focused Ponto broker and recovery contract tests passed (12/12)\n- no production mutation; staging remains fail-closed