### PR TITLE
fix(ponto): materialize broker close in module control

### DIFF
--- a/.github/scripts/ponto-module-control-materialize.mjs
+++ b/.github/scripts/ponto-module-control-materialize.mjs
@@ -1,0 +1,271 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { readCloudflareKvJson } from "./ponto-kv-readback.mjs";
+
+const API_BASE = "https://api.cloudflare.com/client/v4";
+const HEX32 = /^[0-9a-f]{32}$/i;
+const RUN_ID = /^[1-9][0-9]*$/;
+const TARGETS = new Set(["staging", "production"]);
+const CONTROL_KEY = "module-control:timekeeping";
+const LATCH_KEY = "module-control:timekeeping:emergency-latch";
+const READBACK_ATTEMPTS = 12;
+const READBACK_DELAY_MS = 5_000;
+const BROKER_CHANGED_BY = "skincos-ponto-emergency-broker";
+
+const required = (value, label) => {
+  const normalized = String(value || "").trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+};
+
+const validDate = (value) => Number.isFinite(Date.parse(String(value || "")));
+
+export const writeCloudflareKvJson = async ({
+  accountId,
+  namespaceId,
+  key,
+  value,
+  apiToken,
+  fetchImpl = fetch,
+}) => {
+  const account = required(accountId, "Cloudflare account ID").toLowerCase();
+  const namespace = required(namespaceId, "Cloudflare KV namespace ID").toLowerCase();
+  const recordKey = required(key, "Cloudflare KV key");
+  const token = required(apiToken, "Cloudflare API token");
+  if (!HEX32.test(account) || !HEX32.test(namespace)) {
+    throw new Error("Cloudflare account or KV namespace ID is malformed");
+  }
+  if (![CONTROL_KEY, LATCH_KEY].includes(recordKey)) {
+    throw new Error("Ponto materialization key is not allowlisted");
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(
+      `${API_BASE}/accounts/${encodeURIComponent(account)}/storage/kv/namespaces/${encodeURIComponent(namespace)}/values/${encodeURIComponent(recordKey)}`,
+      {
+        method: "PUT",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(value),
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch {
+    throw new Error("Cloudflare KV materialization request failed");
+  }
+  if (!response.ok) {
+    throw new Error(`Cloudflare KV materialization failed (HTTP ${response.status})`);
+  }
+};
+
+const readMaintenance = (file) => {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    throw new Error("broker maintenance evidence is unavailable or invalid JSON");
+  }
+};
+
+const exactPayloads = ({ maintenance, priorControl, target, coordinatorRunId, emergencyRunId }) => {
+  if (
+    maintenance?.schemaVersion !== 1
+    || maintenance?.target !== target
+    || maintenance?.contractId !== "skincos/ponto/emergency-close/v1"
+    || maintenance?.coordinatorRunId !== coordinatorRunId
+    || maintenance?.emergencyRunId !== emergencyRunId
+    || maintenance?.state !== "maintenance"
+    || maintenance?.latched !== true
+    || maintenance?.passed !== true
+    || maintenance?.credentialsIncluded !== false
+    || maintenance?.piiIncluded !== false
+    || !validDate(maintenance?.controlChangedAt)
+    || !validDate(maintenance?.latchChangedAt)
+  ) throw new Error("broker maintenance evidence is not exact and target-bound");
+  if (!priorControl || typeof priorControl !== "object" || Array.isArray(priorControl) || priorControl.schemaVersion !== 2) {
+    throw new Error("regular module control is unavailable");
+  }
+
+  return {
+    control: {
+      ...priorControl,
+      schemaVersion: 2,
+      state: "maintenance",
+      message: "Ponto interrompido por parada de emergência.",
+      changedAt: maintenance.controlChangedAt,
+      changedBy: BROKER_CHANGED_BY,
+      emergencyLatchRef: {
+        stopRunId: coordinatorRunId,
+        emergencyRunId,
+        latchChangedAt: maintenance.latchChangedAt,
+      },
+    },
+    latch: {
+      schemaVersion: 1,
+      module: "timekeeping",
+      target,
+      latched: true,
+      changedAt: maintenance.latchChangedAt,
+      changedBy: BROKER_CHANGED_BY,
+      stopRunId: coordinatorRunId,
+      emergencyRunId,
+    },
+  };
+};
+
+const isSameOwner = (value, coordinatorRunId, emergencyRunId) =>
+  value?.latched === true
+  && value?.stopRunId === coordinatorRunId
+  && value?.emergencyRunId === emergencyRunId;
+
+const assertLatchOwnership = ({ priorLatch, expectedLatch }) => {
+  if (priorLatch?.latched !== true || isSameOwner(priorLatch, expectedLatch.stopRunId, expectedLatch.emergencyRunId)) return;
+  if (
+    priorLatch?.target !== expectedLatch.target
+    || !validDate(priorLatch?.changedAt)
+    || Date.parse(priorLatch.changedAt) >= Date.parse(expectedLatch.changedAt)
+  ) throw new Error("Ponto module-control latch is owned by a newer emergency close");
+};
+
+const assertReadback = ({ control, latch, expectedControl, expectedLatch, target }) => {
+  if (
+    control?.schemaVersion !== 2
+    || control?.state !== "maintenance"
+    || control?.changedAt !== expectedControl.changedAt
+    || control?.emergencyLatchRef?.stopRunId !== expectedControl.emergencyLatchRef.stopRunId
+    || control?.emergencyLatchRef?.emergencyRunId !== expectedControl.emergencyLatchRef.emergencyRunId
+    || control?.emergencyLatchRef?.latchChangedAt !== expectedControl.emergencyLatchRef.latchChangedAt
+    || latch?.schemaVersion !== 1
+    || latch?.module !== "timekeeping"
+    || latch?.target !== target
+    || latch?.latched !== true
+    || latch?.changedAt !== expectedLatch.changedAt
+    || latch?.stopRunId !== expectedLatch.stopRunId
+    || latch?.emergencyRunId !== expectedLatch.emergencyRunId
+  ) throw new Error("materialized Ponto module-control readback differs from the exact broker close");
+};
+
+const readOrMissing = async (params, readImpl) => {
+  try {
+    return await readImpl(params);
+  } catch (error) {
+    if (error?.code === "cloudflare-kv-readback-http-404") return null;
+    throw error;
+  }
+};
+
+const readMaterializedWithRetry = async ({
+  readControl,
+  readLatch,
+  expectedControl,
+  expectedLatch,
+  target,
+}) => {
+  let lastError;
+  for (let attempt = 0; attempt < READBACK_ATTEMPTS; attempt += 1) {
+    try {
+      const [readbackLatch, readbackControl] = await Promise.all([
+        readLatch(),
+        readControl(),
+      ]);
+      assertReadback({
+        control: readbackControl,
+        latch: readbackLatch,
+        expectedControl,
+        expectedLatch,
+        target,
+      });
+      return { readbackControl, readbackLatch };
+    } catch (error) {
+      lastError = error;
+      if (attempt === READBACK_ATTEMPTS - 1) throw lastError;
+      await new Promise((resolve) => setTimeout(resolve, READBACK_DELAY_MS));
+    }
+  }
+  throw lastError;
+};
+
+export async function materializeBrokerClose({
+  env = process.env,
+  fetchImpl = fetch,
+  readImpl = readCloudflareKvJson,
+  writeImpl = writeCloudflareKvJson,
+} = {}) {
+  const accountId = required(env.CLOUDFLARE_ACCOUNT_ID, "Cloudflare account ID");
+  const namespaceId = required(env.PONTO_MODULE_CONTROL_KV_ID, "Ponto module-control KV ID");
+  const apiToken = required(env.CLOUDFLARE_API_TOKEN, "Cloudflare API token");
+  const target = required(env.PONTO_MATERIALIZE_TARGET, "Ponto materialization target").toLowerCase();
+  const coordinatorRunId = required(env.PONTO_COORDINATOR_RUN_ID, "Ponto coordinator run ID");
+  const emergencyRunId = required(env.PONTO_EMERGENCY_RUN_ID, "Ponto emergency run ID");
+  const maintenanceFile = required(env.PONTO_MAINTENANCE_FILE, "Ponto maintenance evidence file");
+  if (!TARGETS.has(target) || !RUN_ID.test(coordinatorRunId) || !RUN_ID.test(emergencyRunId)) {
+    throw new Error("Ponto materialization identity is invalid");
+  }
+  if (!HEX32.test(namespaceId)) throw new Error("Ponto module-control KV ID is malformed");
+
+  const readParams = (key) => ({ accountId, namespaceId, key, apiToken, fetchImpl });
+  const writeParams = (key, value) => ({ accountId, namespaceId, key, value, apiToken, fetchImpl });
+  const maintenance = readMaintenance(maintenanceFile);
+  const priorControl = await readOrMissing(readParams(CONTROL_KEY), readImpl);
+  const priorLatch = await readOrMissing(readParams(LATCH_KEY), readImpl);
+  const { control, latch } = exactPayloads({
+    maintenance,
+    priorControl,
+    target,
+    coordinatorRunId,
+    emergencyRunId,
+  });
+  assertLatchOwnership({ priorLatch, expectedLatch: latch });
+
+  await writeImpl(writeParams(LATCH_KEY, latch));
+  await writeImpl(writeParams(CONTROL_KEY, control));
+  const { readbackControl, readbackLatch } = await readMaterializedWithRetry({
+    readControl: () => readImpl(readParams(CONTROL_KEY)),
+    readLatch: () => readImpl(readParams(LATCH_KEY)),
+    expectedControl: control,
+    expectedLatch: latch,
+    target,
+  });
+
+  const report = {
+    schemaVersion: 1,
+    source: "cloudflare-kv-direct",
+    target,
+    moduleControl: {
+      schemaVersion: readbackControl.schemaVersion,
+      state: readbackControl.state,
+      changedAt: readbackControl.changedAt,
+      emergencyLatchRef: {
+        stopRunId: readbackControl.emergencyLatchRef.stopRunId,
+        emergencyRunId: readbackControl.emergencyLatchRef.emergencyRunId,
+        latchChangedAt: readbackControl.emergencyLatchRef.latchChangedAt,
+      },
+    },
+    emergencyLatch: {
+      schemaVersion: readbackLatch.schemaVersion,
+      module: readbackLatch.module,
+      target: readbackLatch.target,
+      latched: readbackLatch.latched,
+      changedAt: readbackLatch.changedAt,
+      stopRunId: readbackLatch.stopRunId,
+      emergencyRunId: readbackLatch.emergencyRunId,
+    },
+    credentialsIncluded: false,
+    piiIncluded: false,
+  };
+  const reportFile = String(env.PONTO_MATERIALIZE_REPORT || "").trim();
+  if (reportFile) {
+    fs.mkdirSync(path.dirname(reportFile), { recursive: true });
+    fs.writeFileSync(reportFile, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+  }
+  return report;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+  await materializeBrokerClose();
+  process.stdout.write("Exact Ponto broker close materialized in module-control KV.\n");
+}

--- a/.github/scripts/ponto-module-control-materialize.test.mjs
+++ b/.github/scripts/ponto-module-control-materialize.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  materializeBrokerClose,
+  writeCloudflareKvJson,
+} from "./ponto-module-control-materialize.mjs";
+
+const maintenance = {
+  schemaVersion: 1,
+  target: "staging",
+  contractId: "skincos/ponto/emergency-close/v1",
+  coordinatorRunId: "30747573120",
+  emergencyRunId: "30750000001",
+  controlChangedAt: "2026-08-02T13:10:00.000Z",
+  latchChangedAt: "2026-08-02T13:09:59.000Z",
+  state: "maintenance",
+  latched: true,
+  passed: true,
+  observations: [{ passed: true }, { passed: true }, { passed: true }],
+  credentialsIncluded: false,
+  piiIncluded: false,
+};
+
+const priorControl = {
+  schemaVersion: 2,
+  state: "maintenance",
+  message: "old state",
+  changedAt: "2026-08-02T12:20:00.000Z",
+  changedBy: "github-actions[bot]",
+  releaseSha: "a".repeat(40),
+  versions: { timekeeping: { candidate: "candidate", incumbent: "incumbent" } },
+};
+
+const baseEnv = (file) => ({
+  CLOUDFLARE_ACCOUNT_ID: "c5dfffe5652dfc8c85b3f29463452ac6",
+  PONTO_MODULE_CONTROL_KV_ID: "e69fe06b6abc46eca4f4c00198d078f2",
+  CLOUDFLARE_API_TOKEN: "synthetic-token",
+  PONTO_MATERIALIZE_TARGET: "staging",
+  PONTO_COORDINATOR_RUN_ID: maintenance.coordinatorRunId,
+  PONTO_EMERGENCY_RUN_ID: maintenance.emergencyRunId,
+  PONTO_MAINTENANCE_FILE: file,
+});
+
+const writeMaintenanceFile = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-materialize-"));
+  const file = path.join(root, "maintenance.json");
+  fs.writeFileSync(file, JSON.stringify(maintenance));
+  return { root, file };
+};
+
+test("materializes only the exact broker close and emits sanitized direct readback", async () => {
+  const { root, file } = writeMaintenanceFile();
+  const values = new Map([["module-control:timekeeping", priorControl]]);
+  const writes = [];
+  const readImpl = async ({ key }) => values.get(key) || null;
+  const writeImpl = async ({ key, value }) => {
+    writes.push(key);
+    values.set(key, value);
+  };
+  const report = await materializeBrokerClose({
+    env: { ...baseEnv(file), PONTO_MATERIALIZE_REPORT: path.join(root, "readback.json") },
+    readImpl,
+    writeImpl,
+  });
+  assert.deepEqual(writes, [
+    "module-control:timekeeping:emergency-latch",
+    "module-control:timekeeping",
+  ]);
+  assert.equal(report.source, "cloudflare-kv-direct");
+  assert.equal(report.moduleControl.changedAt, maintenance.controlChangedAt);
+  assert.equal(report.emergencyLatch.changedAt, maintenance.latchChangedAt);
+  assert.equal(report.credentialsIncluded, false);
+  assert.equal(report.piiIncluded, false);
+  assert.equal(values.get("module-control:timekeeping").releaseSha, priorControl.releaseSha);
+  assert.deepEqual(values.get("module-control:timekeeping").versions, priorControl.versions);
+  assert.equal(fs.existsSync(path.join(root, "readback.json")), true);
+  assert.equal(JSON.stringify(report).includes("synthetic-token"), false);
+});
+
+test("refuses to overwrite a different active emergency owner with a newer timestamp", async () => {
+  const { file } = writeMaintenanceFile();
+  await assert.rejects(
+    materializeBrokerClose({
+      env: baseEnv(file),
+      readImpl: async ({ key }) => key === "module-control:timekeeping"
+        ? priorControl
+        : {
+          schemaVersion: 1,
+          module: "timekeeping",
+          target: "staging",
+          latched: true,
+          changedAt: "2026-08-02T13:11:00.000Z",
+          stopRunId: "30747573120",
+          emergencyRunId: "30750000000",
+        },
+      writeImpl: async () => { throw new Error("write should not be reached"); },
+    }),
+    /owned by a newer emergency close/,
+  );
+});
+
+test("allows a fresh broker close to supersede an older active latch owner", async () => {
+  const { root, file } = writeMaintenanceFile();
+  const values = new Map([
+    ["module-control:timekeeping", priorControl],
+    ["module-control:timekeeping:emergency-latch", {
+      schemaVersion: 1,
+      module: "timekeeping",
+      target: "staging",
+      latched: true,
+      changedAt: "2026-08-02T13:00:00.000Z",
+      stopRunId: "30747573120",
+      emergencyRunId: "30750000000",
+    }],
+  ]);
+  const writes = [];
+  const report = await materializeBrokerClose({
+    env: { ...baseEnv(file), PONTO_MATERIALIZE_REPORT: path.join(root, "readback.json") },
+    readImpl: async ({ key }) => values.get(key) || null,
+    writeImpl: async ({ key, value }) => {
+      writes.push(key);
+      values.set(key, value);
+    },
+  });
+  assert.equal(report.emergencyLatch.emergencyRunId, maintenance.emergencyRunId);
+  assert.deepEqual(writes, [
+    "module-control:timekeeping:emergency-latch",
+    "module-control:timekeeping",
+  ]);
+});
+
+test("rejects broker evidence for a different run or target", async () => {
+  const { file } = writeMaintenanceFile();
+  const invalid = { ...maintenance, target: "production" };
+  fs.writeFileSync(file, JSON.stringify(invalid));
+  await assert.rejects(
+    materializeBrokerClose({
+      env: baseEnv(file),
+      readImpl: async () => null,
+      writeImpl: async () => {},
+    }),
+    /not exact and target-bound/,
+  );
+});
+
+test("refuses to materialize when the regular module control is unavailable", async () => {
+  const { file } = writeMaintenanceFile();
+  await assert.rejects(
+    materializeBrokerClose({
+      env: baseEnv(file),
+      readImpl: async () => null,
+      writeImpl: async () => { throw new Error("write should not be reached"); },
+    }),
+    /regular module control is unavailable/,
+  );
+});
+
+test("rejects arbitrary materialization keys in the write helper", async () => {
+  const source = fs.readFileSync(new URL("./ponto-module-control-materialize.mjs", import.meta.url), "utf8");
+  assert.match(source, /module-control:timekeeping:emergency-latch/);
+  assert.match(source, /module-control:timekeeping/);
+  assert.doesNotMatch(source, /DELETE/);
+});
+
+test("writes the two allowlisted keys through the account-scoped KV API", async () => {
+  let call;
+  await writeCloudflareKvJson({
+    accountId: "c5dfffe5652dfc8c85b3f29463452ac6",
+    namespaceId: "e69fe06b6abc46eca4f4c00198d078f2",
+    key: "module-control:timekeeping",
+    value: { schemaVersion: 2, state: "maintenance" },
+    apiToken: "synthetic-token",
+    fetchImpl: async (url, init) => {
+      call = { url, init };
+      return new Response("", { status: 200 });
+    },
+  });
+  assert.match(call.url, /storage\/kv\/namespaces\/e69fe06b6abc46eca4f4c00198d078f2\/values\/module-control%3Atimekeeping$/);
+  assert.equal(call.init.method, "PUT");
+  assert.equal(call.init.headers.authorization, "Bearer synthetic-token");
+  assert.deepEqual(JSON.parse(call.init.body), { schemaVersion: 2, state: "maintenance" });
+  await assert.rejects(
+    writeCloudflareKvJson({
+      accountId: "c5dfffe5652dfc8c85b3f29463452ac6",
+      namespaceId: "e69fe06b6abc46eca4f4c00198d078f2",
+      key: "module-control:other",
+      value: {},
+      apiToken: "synthetic-token",
+      fetchImpl: async () => new Response("", { status: 200 }),
+    }),
+    /not allowlisted/,
+  );
+});

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -422,6 +422,7 @@ test("every privileged Ponto mutation job refuses workflow reruns without blocki
     ["module-availability.yml", "emergency-reconciliation"],
     ["ponto-emergency-latch-reset.yml", "reset-mutate"],
     ["ponto-emergency-close.yml", "close"],
+    ["ponto-emergency-close.yml", "materialize"],
     ["ponto-production-baseline.yml", "capture"],
     ["ponto-production-slo.yml", "consultor-journey"],
     ["ponto-production-slo.yml", "rollback-observation"],

--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -140,7 +140,7 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   assert.match(closeJob, /Prove external fail-close through overlay or exact incumbent control/);
   assert.match(closeJob, /PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active/);
   assert.match(closeJob, /PONTO_MODULE_ALTERNATE_EXPECTATION_FILE=/);
-  assert.match(closeJob, /state: "maintenance"[\s\S]*source: "control"/);
+  assert.match(closeJob, /\["control", "emergency-latch-active"\]\.includes\(availability\?\.source\)/);
   assert.match(rollbackJob, /needs:\s*\[orchestrate, recovery-reconcile, recovery-close\]/);
   assert.match(rollbackJob, /needs\.recovery-reconcile\.result == 'success'/);
   assert.match(rollbackJob, /concurrency:\s*\n\s*group:\s*ponto-surface-mutation[\s\S]*ponto-automatic-rollback\.mjs/);
@@ -163,7 +163,11 @@ test("staging recovery accepts the still-active emergency latch after incumbent 
   );
   const proof = workflow.slice(workflow.indexOf("      - name: Prove staging remains closed"));
   assert.match(proof, /const availabilitySource = String\(body\?\.availability\?\.source \|\| \"\"\);/);
+  assert.match(proof, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
+  assert.match(proof, /const materialized = JSON\.parse\(fs\.readFileSync\(process\.env\.PONTO_MATERIALIZE_REPORT, \"utf8\"\)\);/);
+  assert.match(proof, /const expectedAvailabilityChangedAt = availabilitySource === \"emergency-latch-active\"/);
   assert.match(proof, /!\["control", "emergency-latch-active"\]\.includes\(availabilitySource\)/);
+  assert.match(proof, /body\?\.availability\?\.changedAt !== expectedAvailabilityChangedAt/);
   assert.match(proof, /workerVersionId !== process\.env\.TIMEKEEPING_INCUMBENT_VERSION_ID\.toLowerCase\(\)/);
 });
 

--- a/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
+++ b/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const read = (relative) => fs.readFileSync(new URL(relative, import.meta.url), "utf8");
+const recovery = read("../workflows/ponto-staging-recovery-rollback.yml");
+const coordinator = read("../workflows/ponto-progressive-release.yml");
+const watchdog = read("../workflows/ponto-release-watchdog.yml");
+const emergencyClose = read("../workflows/ponto-emergency-close.yml");
+
+test("staging recovery materializes the broker close before direct custody readback", () => {
+  const resourceIdentity = recovery.indexOf("ponto-cloudflare-resource-identity.mjs");
+  const materialize = recovery.indexOf("ponto-module-control-materialize.mjs");
+  const directReadback = recovery.indexOf("Read back the exact staging module control from Cloudflare KV");
+  assert.ok(resourceIdentity >= 0);
+  assert.ok(materialize >= 0);
+  assert.ok(materialize > resourceIdentity);
+  assert.ok(directReadback > materialize);
+  assert.match(recovery, /PONTO_MODULE_CONTROL_KV_ID: \$\{\{ vars\.PONTO_MODULE_CONTROL_STAGING_KV_ID \}\}/);
+  assert.match(recovery, /PONTO_MATERIALIZE_TARGET: staging/);
+});
+
+test("ordinary coordinator and watchdog recovery normalize the direct KV custody", () => {
+  for (const workflow of [coordinator, watchdog]) {
+    const resourceIdentity = workflow.indexOf("ponto-cloudflare-resource-identity.mjs");
+    assert.match(workflow, /ponto-module-control-materialize\.mjs/);
+    assert.ok(resourceIdentity >= 0);
+    assert.ok(workflow.indexOf("ponto-module-control-materialize.mjs") > resourceIdentity);
+    assert.match(workflow, /ponto-module-control-direct-readback\.json/);
+    assert.match(workflow, /ponto-recovery-evidence\.mjs[\s\S]*ponto-module-control-direct-readback\.json/);
+  }
+  assert.match(coordinator, /\["control", "emergency-latch-active"\]\.includes\(availability\?\.source\)/);
+});
+
+test("all materialization jobs remain behind the non-cancelling surface mutex", () => {
+  assert.match(recovery, /concurrency:\s+group: ponto-surface-mutation[\s\S]*?cancel-in-progress: false/);
+  assert.match(coordinator, /recovery-rollback:[\s\S]*?group: ponto-surface-mutation[\s\S]*?cancel-in-progress: false/);
+  assert.match(watchdog, /rollback:[\s\S]*?group: ponto-surface-mutation[\s\S]*?cancel-in-progress: false/);
+});
+
+test("manual emergency close materializes under the surface mutex and proves live control", () => {
+  assert.match(emergencyClose, /materialize:\n[\s\S]*?group: ponto-surface-mutation/);
+  assert.match(emergencyClose, /materialize:\n[\s\S]*?ponto-module-control-materialize\.mjs/);
+  assert.match(emergencyClose, /materialize:\n[\s\S]*?ponto-cloudflare-resource-identity\.mjs[\s\S]*?ponto-module-control-materialize\.mjs/);
+  assert.match(emergencyClose, /materialize:\n[\s\S]*?environment: \$\{\{ inputs\.target \}\}/);
+  assert.match(emergencyClose, /materialize:\n[\s\S]*?live control reflects the materialized close/);
+  assert.match(emergencyClose, /\["control", "emergency-latch-active"\]\.includes\(availability\?\.source\)/);
+  assert.match(emergencyClose, /for \(let attempt = 0; attempt < 12; attempt \+= 1\)/);
+  assert.match(emergencyClose, /close:\n[\s\S]*?group: ponto-emergency-latch-\$\{\{ inputs\.target \}\}/);
+});

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -24,6 +24,12 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /name: ponto-fresh-recovery-close-staging-\$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /name: Normalize the fresh close with historical child reconciliation/);
   assert.match(workflow, /name: Read back the exact staging module control from Cloudflare KV/);
+  assert.match(
+    workflow,
+    /\["control", "emergency-latch-active"\]\.includes\((?:body\?\.availability\?\.source|availabilitySource)\)/,
+  );
+  assert.match(workflow, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
+  assert.match(workflow, /body\?\.availability\?\.changedAt !== expectedAvailabilityChangedAt/);
   assert.match(workflow, /readCloudflareKvJson/);
   assert.match(workflow, /fresh-close\/direct-readback\.json/);
   assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -3,6 +3,14 @@ import path from "node:path";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+const jobSource = (source, name) => {
+  const marker = `  ${name}:\n`;
+  const start = source.indexOf(marker);
+  if (start < 0) return "";
+  const remaining = source.slice(start + marker.length);
+  const next = /\n  [a-zA-Z0-9_-]+:\n/.exec(remaining);
+  return source.slice(start, next ? start + marker.length + next.index : source.length);
+};
 const catalog = JSON.parse(read("platform/deploy/operational-units.json"));
 const failures = [];
 const fail = (message) => failures.push(message);
@@ -171,6 +179,8 @@ const coordinator = read('.github/workflows/ponto-progressive-release.yml');
 const orchestratorGate = read('.github/workflows/ponto-orchestrator-gate.yml');
 const emergencyLatchReset = read('.github/workflows/ponto-emergency-latch-reset.yml');
 const emergencyClose = read('.github/workflows/ponto-emergency-close.yml');
+const emergencyCloseOnly = jobSource(emergencyClose, 'close');
+const emergencyCloseMaterialize = jobSource(emergencyClose, 'materialize');
 const emergencyBroker = read('.github/scripts/ponto-emergency-broker.mjs');
 const progressivePolicy = JSON.parse(read('.github/governance/progressive-release-policy.json'));
 const emergencyIdleAssertion = read('.github/scripts/ponto-assert-idle.mjs');
@@ -762,16 +772,22 @@ if (
   fail('Only brief automatic close and governed reset jobs may hold the target latch queue; long module transitions must never delay fail-close');
 }
 if (
-  emergencyClose.includes('group: ponto-surface-mutation')
-  || !/  close:[\s\S]*?group: ponto-emergency-latch-\$\{\{ inputs\.target \}\}[\s\S]*?cancel-in-progress: false/.test(emergencyClose)
-  || !emergencyClose.includes("github.ref == 'refs/heads/main' && github.run_attempt == 1")
-  || !emergencyClose.includes("format('ponto-emergency-{0}', inputs.target)")
-  || !emergencyClose.includes('ponto-emergency-latch-write.mjs')
-  || !emergencyClose.includes('ponto-emergency-maintenance-write.mjs')
-  || !emergencyClose.includes('ponto-module-propagation.mjs')
-  || emergencyClose.includes('CLOUDFLARE_API_TOKEN')
-  || emergencyClose.includes('CF_ACCESS_CLIENT_ID')
-  || emergencyClose.includes('CF_ACCESS_CLIENT_SECRET')
+  emergencyCloseOnly.includes('group: ponto-surface-mutation')
+  || !/  close:[\s\S]*?group: ponto-emergency-latch-\$\{\{ inputs\.target \}\}[\s\S]*?cancel-in-progress: false/.test(emergencyCloseOnly)
+  || !emergencyCloseOnly.includes("github.ref == 'refs/heads/main' && github.run_attempt == 1")
+  || !emergencyCloseOnly.includes("format('ponto-emergency-{0}', inputs.target)")
+  || !emergencyCloseOnly.includes('ponto-emergency-latch-write.mjs')
+  || !emergencyCloseOnly.includes('ponto-emergency-maintenance-write.mjs')
+  || !emergencyCloseOnly.includes('ponto-module-propagation.mjs')
+  || emergencyCloseOnly.includes('CLOUDFLARE_API_TOKEN')
+  || emergencyCloseOnly.includes('CF_ACCESS_CLIENT_ID')
+  || emergencyCloseOnly.includes('CF_ACCESS_CLIENT_SECRET')
+  || !emergencyCloseMaterialize.includes('group: ponto-surface-mutation')
+  || !emergencyCloseMaterialize.includes('ponto-module-control-materialize.mjs')
+  || !emergencyCloseMaterialize.includes('CLOUDFLARE_API_TOKEN')
+  || !emergencyCloseMaterialize.includes('environment: ${{ inputs.target }}')
+  || !emergencyCloseMaterialize.includes('github.run_attempt == 1')
+  || !emergencyCloseMaterialize.includes('cancel-in-progress: false')
 ) {
   fail('Manual Ponto emergency close must serialize on the target latch queue through the close-only broker without waiting on the surface mutex or hydrating broad credentials');
 }

--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -15,6 +15,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -22,6 +23,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && github.run_attempt == 1 }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     environment: ${{ format('ponto-emergency-{0}', inputs.target) }}
     concurrency:
       # This close-only path intentionally does not wait on
@@ -106,7 +109,7 @@ jobs:
           if (
             response.status !== 200
             || availability?.state !== "maintenance"
-            || availability?.source !== "control"
+            || !["control", "emergency-latch-active"].includes(availability?.source)
             || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
           ) throw new Error("live Ponto health did not prove maintenance under the closed latch");
           fs.writeFileSync(process.argv[3], `${JSON.stringify({
@@ -131,6 +134,105 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ponto-emergency-close-${{ inputs.target }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/ponto-manual-emergency-close
+          retention-days: 90
+          if-no-files-found: error
+
+  materialize:
+    if: ${{ needs.close.result == 'success' && github.ref == 'refs/heads/main' && github.run_attempt == 1 }}
+    needs: close
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    environment: ${{ inputs.target }}
+    concurrency:
+      group: ponto-surface-mutation
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - name: Download the close-only broker evidence
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: ponto-emergency-close-${{ inputs.target }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/ponto-manual-emergency-close
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
+      - name: Materialize the exact broker close under the surface mutex
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+          PRODUCTION_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
+          STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
+          PRODUCTION_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
+          PONTO_MATERIALIZE_TARGET: ${{ inputs.target }}
+          PONTO_RESOURCE_TARGET: ${{ inputs.target }}
+          PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
+          PONTO_EMERGENCY_RUN_ID: ${{ github.run_id }}
+          PONTO_MAINTENANCE_FILE: ${{ runner.temp }}/ponto-manual-emergency-close/maintenance.json
+          PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-manual-emergency-close/materialized-readback.json
+          PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-manual-emergency-close/resource-identity.json
+        run: |
+          set -euo pipefail
+          case "$PONTO_MATERIALIZE_TARGET" in
+            staging)
+              PONTO_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            production)
+              PONTO_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            *) echo 'Unsupported manual-close module-control target'; exit 1 ;;
+          esac
+          export PONTO_MODULE_CONTROL_KV_ID PONTO_TIMEKEEPING_D1_ID PONTO_OPPOSITE_TIMEKEEPING_D1_ID PONTO_OPPOSITE_MODULE_CONTROL_KV_ID
+          node .github/scripts/ponto-cloudflare-resource-identity.mjs
+          node .github/scripts/ponto-module-control-materialize.mjs
+      - name: Prove the live control reflects the materialized close
+        env:
+          PONTO_MODULE_HEALTH_URL: ${{ inputs.target == 'production' && 'https://api.skincos.com.br/api/ponto/health' || 'https://api-staging.skincos.com.br/api/ponto/health' }}
+        run: |
+          set -euo pipefail
+          node - "$RUNNER_TEMP/ponto-manual-emergency-close/materialized-readback.json" <<'NODE'
+          (async () => {
+          const fs = require("fs");
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
+          probe.searchParams.set("emergency_close_materialized_probe", process.env.GITHUB_RUN_ID);
+          let lastObservation = "no response";
+          for (let attempt = 0; attempt < 12; attempt += 1) {
+            const response = await fetch(probe, { headers: { accept: "application/json", "cache-control": "no-cache" } });
+            const body = await response.json().catch(() => null);
+            const availability = body?.availability;
+            const expectedChangedAt = availability?.source === "emergency-latch-active"
+              ? report.emergencyLatch.changedAt
+              : report.moduleControl.changedAt;
+            if (
+              response.status === 200
+              && availability?.state === "maintenance"
+              && ["control", "emergency-latch-active"].includes(availability?.source)
+              && availability?.changedAt === expectedChangedAt
+            ) return;
+            lastObservation = `HTTP ${response.status}, source=${String(availability?.source || "")}, changedAt=${String(availability?.changedAt || "")}`;
+            if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
+          }
+          throw new Error(`live Ponto health did not reflect the materialized module control after bounded propagation: ${lastObservation}`);
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
+          NODE
+      - name: Upload sanitized materialized emergency-close evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ponto-emergency-close-materialized-${{ inputs.target }}-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-manual-emergency-close
           retention-days: 90
           if-no-files-found: error

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1835,7 +1835,7 @@ jobs:
           if (
             response.status !== 200
             || availability?.state !== "maintenance"
-            || availability?.source !== "control"
+            || !["control", "emergency-latch-active"].includes(availability?.source)
             || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
           ) throw new Error("recovery fail-close did not observe exact incumbent maintenance control");
           fs.writeFileSync(process.argv[3], `${JSON.stringify({
@@ -1919,6 +1919,43 @@ jobs:
         with:
           name: ponto-ordinary-recovery-maintenance-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-ordinary-recovery/evidence/fail-close
+
+      - name: Materialize the exact broker close under the recovery surface mutex
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+          PRODUCTION_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
+          STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
+          PRODUCTION_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
+          PONTO_MATERIALIZE_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
+          PONTO_RESOURCE_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
+          PONTO_COORDINATOR_RUN_ID: ${{ github.run_id }}
+          PONTO_EMERGENCY_RUN_ID: ${{ github.run_id }}
+          PONTO_MAINTENANCE_FILE: ${{ runner.temp }}/ponto-ordinary-recovery/evidence/fail-close/maintenance.json
+          PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/journal/automatic-rollback/ponto-module-control-direct-readback.json
+          PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/journal/automatic-rollback/ponto-resource-identity.json
+        run: |
+          set -euo pipefail
+          case "$PONTO_RESOURCE_TARGET" in
+            staging)
+              PONTO_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            production)
+              PONTO_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            *) echo 'Unsupported recovery module-control target'; exit 1 ;;
+          esac
+          export PONTO_MODULE_CONTROL_KV_ID PONTO_TIMEKEEPING_D1_ID PONTO_OPPOSITE_TIMEKEEPING_D1_ID PONTO_OPPOSITE_MODULE_CONTROL_KV_ID
+          node .github/scripts/ponto-cloudflare-resource-identity.mjs
+          node .github/scripts/ponto-module-control-materialize.mjs
+
       - name: Normalize exact ordinary recovery custody for automatic rollback
         env:
           PONTO_RECOVERY_SOURCE_MODE: ordinary
@@ -1932,7 +1969,8 @@ jobs:
             "$RUNNER_TEMP/ponto-ordinary-recovery/evidence/reconciliation/children.json" \
             "$RUNNER_TEMP/ponto-ordinary-recovery/evidence/fail-close/maintenance.json" \
             "$RUNNER_TEMP/ponto-ordinary-recovery/evidence/fail-close/final-propagation.json" \
-            "$RUNNER_TEMP/ponto-ordinary-recovery/journal"
+            "$RUNNER_TEMP/ponto-ordinary-recovery/journal" \
+            "$RUNNER_TEMP/ponto-ordinary-recovery/journal/automatic-rollback/ponto-module-control-direct-readback.json"
       - name: Restore every attested incumbent idempotently
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -317,6 +317,43 @@ jobs:
         with:
           name: ponto-watchdog-close-${{ needs.context.outputs.coordinator_run_id }}-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-watchdog-evidence/fail-close
+
+      - name: Materialize the exact broker close under the watchdog surface mutex
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+          PRODUCTION_D1_ID_RAW: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
+          STAGING_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
+          PRODUCTION_MODULE_CONTROL_KV_ID_RAW: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
+          PONTO_MATERIALIZE_TARGET: ${{ needs.context.outputs.target }}
+          PONTO_RESOURCE_TARGET: ${{ needs.context.outputs.target }}
+          PONTO_COORDINATOR_RUN_ID: ${{ needs.context.outputs.coordinator_run_id }}
+          PONTO_EMERGENCY_RUN_ID: ${{ github.run_id }}
+          PONTO_MAINTENANCE_FILE: ${{ runner.temp }}/ponto-watchdog-evidence/fail-close/maintenance.json
+          PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-watchdog-rollback/automatic-rollback/ponto-module-control-direct-readback.json
+          PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-watchdog-rollback/automatic-rollback/ponto-resource-identity.json
+        run: |
+          set -euo pipefail
+          case "$PONTO_MATERIALIZE_TARGET" in
+            staging)
+              PONTO_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            production)
+              PONTO_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
+              PONTO_TIMEKEEPING_D1_ID="$PRODUCTION_D1_ID_RAW"
+              PONTO_OPPOSITE_TIMEKEEPING_D1_ID="$STAGING_D1_ID_RAW"
+              PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
+              ;;
+            *) echo 'Unsupported watchdog module-control target'; exit 1 ;;
+          esac
+          export PONTO_MODULE_CONTROL_KV_ID PONTO_TIMEKEEPING_D1_ID PONTO_OPPOSITE_TIMEKEEPING_D1_ID PONTO_OPPOSITE_MODULE_CONTROL_KV_ID
+          node .github/scripts/ponto-cloudflare-resource-identity.mjs
+          node .github/scripts/ponto-module-control-materialize.mjs
+
       - name: Normalize exact watchdog recovery custody for automatic rollback
         env:
           PONTO_RECOVERY_SOURCE_MODE: watchdog
@@ -330,7 +367,8 @@ jobs:
             "$RUNNER_TEMP/ponto-watchdog-evidence/reconciliation/reconciliation.json" \
             "$RUNNER_TEMP/ponto-watchdog-evidence/fail-close/maintenance.json" \
             "$RUNNER_TEMP/ponto-watchdog-evidence/fail-close/final-propagation.json" \
-            "$RUNNER_TEMP/ponto-watchdog-rollback"
+            "$RUNNER_TEMP/ponto-watchdog-rollback" \
+            "$RUNNER_TEMP/ponto-watchdog-rollback/automatic-rollback/ponto-module-control-direct-readback.json"
       - name: Reconstruct exact child provenance and download immutable rollback journals
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -429,6 +429,25 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.run_id }}
 
+      - name: Materialize the exact fresh broker close under the staging surface mutex
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PONTO_RESOURCE_TARGET: staging
+          PONTO_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+          PONTO_OPPOSITE_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
+          PONTO_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
+          PONTO_OPPOSITE_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
+          PONTO_MATERIALIZE_TARGET: staging
+          PONTO_COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
+          PONTO_EMERGENCY_RUN_ID: ${{ github.run_id }}
+          PONTO_MAINTENANCE_FILE: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/maintenance.json
+          PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/materialized-readback.json
+          PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/resource-identity.json
+        run: |
+          node .github/scripts/ponto-cloudflare-resource-identity.mjs
+          node .github/scripts/ponto-module-control-materialize.mjs
+
       - name: Read back the exact staging module control from Cloudflare KV
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -536,18 +555,6 @@ jobs:
             "$RUNNER_TEMP/ponto-staging-recovery-rollback" \
             "$RUNNER_TEMP/ponto-staging-recovery-rollback/fresh-close/direct-readback.json"
 
-      - name: Attest exact staging Ponto resource identities
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PONTO_RESOURCE_TARGET: staging
-          PONTO_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
-          PONTO_OPPOSITE_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
-          PONTO_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
-          PONTO_OPPOSITE_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
-          PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/resource-identity.json
-        run: node .github/scripts/ponto-cloudflare-resource-identity.mjs
-
       - name: Restore the exact Timekeeping incumbent under the existing latch
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -586,11 +593,13 @@ jobs:
         env:
           PONTO_MODULE_HEALTH_URL: https://api-staging.skincos.com.br/api/ponto/health
           TIMEKEEPING_INCUMBENT_VERSION_ID: ${{ inputs.timekeeping_incumbent_version_id }}
+          PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/materialized-readback.json
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           node - <<'NODE'
+          const fs = require("fs");
           const headers = { accept: "application/json" };
           if (process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET) {
             headers["cf-access-client-id"] = process.env.CF_ACCESS_CLIENT_ID;
@@ -603,6 +612,10 @@ jobs:
           });
           const body = await response.json().catch(() => null);
           const availabilitySource = String(body?.availability?.source || "");
+          const materialized = JSON.parse(fs.readFileSync(process.env.PONTO_MATERIALIZE_REPORT, "utf8"));
+          const expectedAvailabilityChangedAt = availabilitySource === "emergency-latch-active"
+            ? materialized?.emergencyLatch?.changedAt
+            : materialized?.moduleControl?.changedAt;
           const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
           if (
             response.status !== 200
@@ -610,6 +623,7 @@ jobs:
             || body?.ready !== false
             || body?.availability?.state !== "maintenance"
             || !["control", "emergency-latch-active"].includes(availabilitySource)
+            || body?.availability?.changedAt !== expectedAvailabilityChangedAt
             || workerVersionId !== process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
           ) throw new Error("staging health did not prove maintenance on the restored Timekeeping incumbent");
           NODE


### PR DESCRIPTION
## Summary\n- materialize the exact broker maintenance close into the two allowlisted Timekeeping module-control KV records\n- protect writes with the existing non-cancelling surface mutex and correlate direct KV readback to coordinator/emergency evidence\n- apply the same custody step to staging recovery rollback, ordinary recovery, watchdog rollback, and manual emergency close\n\n## Validation\n- 30 focused Node tests passed\n- deployment topology validation passed\n- YAML parse passed for all four affected workflows\n- git diff --check passed\n- codex:preflight: failures=0, warnings=1 (dirty worktree warning before commit)\n\n## Incident context\nThe previous recovery run reached fresh-close but stopped because the broker D1 close was not materialized in the application KV. This change keeps the broker close-only contract and adds a bounded, allowlisted Cloudflare KV materialization/readback step.