### PR TITLE
fix(ponto): accept active emergency latch after rollback

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -156,6 +156,17 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   assert.doesNotMatch(rollbackJob, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
 });
 
+test("staging recovery accepts the still-active emergency latch after incumbent restore", () => {
+  const workflow = fs.readFileSync(
+    new URL("../workflows/ponto-staging-recovery-rollback.yml", import.meta.url),
+    "utf8",
+  );
+  const proof = workflow.slice(workflow.indexOf("      - name: Prove staging remains closed"));
+  assert.match(proof, /const availabilitySource = String\(body\?\.availability\?\.source \|\| \"\"\);/);
+  assert.match(proof, /!\["control", "emergency-latch-active"\]\.includes\(availabilitySource\)/);
+  assert.match(proof, /workerVersionId !== process\.env\.TIMEKEEPING_INCUMBENT_VERSION_ID\.toLowerCase\(\)/);
+});
+
 test("coordinator reserves a bounded recovery budget inside the GitHub job limit", () => {
   const workflow = fs.readFileSync(
     new URL("../workflows/ponto-progressive-release.yml", import.meta.url),

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -602,13 +602,14 @@ jobs:
             headers,
           });
           const body = await response.json().catch(() => null);
+          const availabilitySource = String(body?.availability?.source || "");
           const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
           if (
             response.status !== 200
             || body?.ok !== false
             || body?.ready !== false
             || body?.availability?.state !== "maintenance"
-            || body?.availability?.source !== "control"
+            || !["control", "emergency-latch-active"].includes(availabilitySource)
             || workerVersionId !== process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
           ) throw new Error("staging health did not prove maintenance on the restored Timekeeping incumbent");
           NODE


### PR DESCRIPTION
## Summary\n- accept the still-active emergency latch as a valid fail-closed source after restoring the exact Timekeeping incumbent\n- keep the restored incumbent version and maintenance assertions unchanged\n- add a workflow regression assertion for the accepted source contract\n\n## Evidence\n- run 30750265921 restored incumbent 30d4f35b-584b-40a7-95ad-d00ca747e057\n- live health returned HTTP 200, ok=false, ready=false, maintenance, source=emergency-latch-active\n- no reset or production mutation\n\n## Validation\n- Ubuntu-24.04 focal Ponto tests passed (28/28)