### PR TITLE
fix(ponto): keep staging recovery proof valid in node

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -162,6 +162,7 @@ test("staging recovery accepts the still-active emergency latch after incumbent 
     "utf8",
   );
   const proof = workflow.slice(workflow.indexOf("      - name: Prove staging remains closed"));
+  assert.match(proof, /import fs from "node:fs";/);
   assert.match(proof, /const availabilitySource = String\(body\?\.availability\?\.source \|\| \"\"\);/);
   assert.match(proof, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
   assert.match(proof, /const materialized = JSON\.parse\(fs\.readFileSync\(process\.env\.PONTO_MATERIALIZE_REPORT, \"utf8\"\)\);/);

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -599,7 +599,7 @@ jobs:
         run: |
           set -euo pipefail
           node - <<'NODE'
-          const fs = require("fs");
+          import fs from "node:fs";
           const headers = { accept: "application/json" };
           if (process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET) {
             headers["cf-access-client-id"] = process.env.CF_ACCESS_CLIENT_ID;


### PR DESCRIPTION
## Summary\n- use an explicit ESM fs import in the staging recovery health proof\n- add a regression assertion so top-level await cannot regress to CommonJS require\n\n## Validation\n- focused staging recovery workflow tests\n- YAML parse\n- diff check\n\nThis fixes the terminal proof failure observed in recovery run 30751951061 after materialization and incumbent restoration had already succeeded.