### PR TITLE
fix(ponto): validate workflow-run watchdog provenance

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -162,6 +162,7 @@ test("staging recovery accepts the still-active emergency latch after incumbent 
     "utf8",
   );
   const proof = workflow.slice(workflow.indexOf("      - name: Prove staging remains closed"));
+  assert.match(proof, /import fs from "node:fs";/);
   assert.match(proof, /const availabilitySource = String\(body\?\.availability\?\.source \|\| \"\"\);/);
   assert.match(proof, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
   assert.match(proof, /const materialized = JSON\.parse\(fs\.readFileSync\(process\.env\.PONTO_MATERIALIZE_REPORT, \"utf8\"\)\);/);

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -42,6 +42,8 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /git rev-parse origin\/main.*GITHUB_SHA/);
   assert.match(workflow, /actions\/download-artifact@[0-9a-f]{40}/);
   assert.match(workflow, /run-id: \$\{\{ inputs\.watchdog_run_id \}\}/);
+  assert.doesNotMatch(workflow, /watchdog\.head_sha !== releaseSha/);
+  assert.match(workflow, /!\/\^\[0-9a-f\]\{40\}/);
   assert.match(workflow, /ponto-automatic-rollback\.mjs/);
   assert.match(workflow, /PONTO_ROLLBACK_CHECK_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(workflow, /name: Upload immutable staging recovery evidence[\s\S]*?if: always\(\)/);

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -599,7 +599,7 @@ jobs:
         run: |
           set -euo pipefail
           node - <<'NODE'
-          const fs = require("fs");
+          import fs from "node:fs";
           const headers = { accept: "application/json" };
           if (process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET) {
             headers["cf-access-client-id"] = process.env.CF_ACCESS_CLIENT_ID;

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -92,7 +92,7 @@ jobs:
             || watchdog.event !== "workflow_run"
             || watchdog.status !== "completed"
             || watchdog.conclusion !== "failure"
-            || watchdog.head_sha !== releaseSha
+            || !/^[0-9a-f]{40}$/.test(String(watchdog.head_sha || ""))
             || watchdog.head_branch !== "main"
             || watchdog.repository?.full_name !== repo
             || !String(watchdog.display_title || "").includes(`source=${process.env.COORDINATOR_RUN_ID}`)
@@ -323,7 +323,7 @@ jobs:
             || watchdog.event !== "workflow_run"
             || watchdog.status !== "completed"
             || watchdog.conclusion !== "failure"
-            || watchdog.head_sha !== releaseSha
+            || !/^[0-9a-f]{40}$/.test(String(watchdog.head_sha || ""))
             || watchdog.head_branch !== "main"
             || watchdog.repository?.full_name !== repo
             || !String(watchdog.display_title || "").includes(`source=${process.env.COORDINATOR_RUN_ID}`)


### PR DESCRIPTION
## Summary\n- validate the watchdog run's own canonical SHA shape instead of requiring it to equal the failed coordinator release SHA\n- retain the exact coordinator/source-run, workflow, branch, repository, failure, and artifact provenance gates\n- add a regression assertion for workflow_run SHA semantics\n\n## Validation\n- focused Ponto recovery test\n- git diff --check\n\nThis fixes historical recovery validation for the canonical workflow_run provenance without changing the mutation or credential scope.