### PR TITLE
fix(ponto): reconcile authorized replacement ownership

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -81,6 +81,24 @@ await attestPontoCloudflareResources({
 });
 
 const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const workerOwnershipReportFile = String(process.env.PONTO_WORKER_OWNERSHIP_REPORT || "");
+const authorizedWorkerOwnership = (() => {
+  if (!workerOwnershipReportFile) return null;
+  if (!fs.existsSync(workerOwnershipReportFile)) throw new Error("authorized Worker ownership evidence is missing");
+  const report = readJson(workerOwnershipReportFile);
+  const expectedCandidateVersionId = String(process.env.PONTO_TIMEKEEPING_CANDIDATE_VERSION_ID || "").toLowerCase();
+  if (
+    report.schemaVersion !== 1
+    || report.target !== (staging ? "staging" : stage)
+    || report.workerName !== (staging ? "skincos-timekeeping-staging" : "skincos-timekeeping")
+    || String(report.candidateVersionId || "").toLowerCase() !== expectedCandidateVersionId
+    || report.passed !== true
+    || report.credentialsIncluded !== false
+    || report.piiIncluded !== false
+    || !/^ponto:auto-abort:[0-9a-f]{40}:orchestrator-[1-9][0-9]*$/.test(String(report.authorizedReplacementMessage || ""))
+  ) throw new Error("authorized Worker ownership evidence is invalid");
+  return report;
+})();
 const brokerFailCloseFile = path.join(
   artifactRoot,
   "automatic-rollback/ponto-broker-fail-close.json",
@@ -391,6 +409,9 @@ for (const [name, spec] of Object.entries(surfaceSpecs)) {
       deploymentId: String(source.deploymentId || ""),
       candidatePercent: expectedWeights[stage][name],
       incumbentPercent: 100 - expectedWeights[stage][name],
+      ...(name === "timekeeping" && authorizedWorkerOwnership
+        ? { authorizedReplacementMessage: authorizedWorkerOwnership.authorizedReplacementMessage }
+        : {}),
     };
   }
 }
@@ -656,6 +677,9 @@ const rollbackWorker = (name, item) => {
       targetVersionId: item.incumbentVersionId,
       candidatePercent: 0,
       incumbentPercent: 100,
+      disposition: ownership === "candidate-owned-reconciled"
+        ? "candidate-owned-reconciled"
+        : "candidate-owned",
     };
   } catch {
     proofs[name] = {

--- a/.github/scripts/ponto-rollback-ownership.mjs
+++ b/.github/scripts/ponto-rollback-ownership.mjs
@@ -52,6 +52,13 @@ export function classifyWorkerRollbackOwnership(payload, item, stage) {
   const candidateOwned = sameVersions(actual, expectedCandidateVersions(item, stage))
     && (!expectedDeploymentId || deploymentId === expectedDeploymentId);
   if (candidateOwned) return "candidate-owned";
+  const authorizedReplacementMessage = String(item?.authorizedReplacementMessage || "");
+  const reconciledCandidateOwned = sameVersions(actual, expectedCandidateVersions(item, stage))
+    && Boolean(expectedDeploymentId)
+    && deploymentId !== expectedDeploymentId
+    && /^ponto:auto-abort:[0-9a-f]{40}:orchestrator-[1-9][0-9]*$/.test(authorizedReplacementMessage)
+    && String(payload?.annotations?.["workers/message"] || "") === authorizedReplacementMessage;
+  if (reconciledCandidateOwned) return "candidate-owned-reconciled";
   const incumbentOnly = [{ id: item.incumbentVersionId.toLowerCase(), percentage: 100 }];
   if (sameVersions(actual, incumbentOnly)) return "already-incumbent";
   return "ownership-conflict";

--- a/.github/scripts/ponto-rollback-ownership.test.mjs
+++ b/.github/scripts/ponto-rollback-ownership.test.mjs
@@ -12,6 +12,7 @@ import {
 const candidate = "11111111-1111-4111-8111-111111111111";
 const incumbent = "22222222-2222-4222-8222-222222222222";
 const deployment = "33333333-3333-4333-8333-333333333333";
+const priorAbortMessage = `ponto:auto-abort:${"a".repeat(40)}:orchestrator-12345`;
 const item = {
   candidateVersionId: candidate,
   incumbentVersionId: incumbent,
@@ -49,6 +50,29 @@ test("distinguishes an untouched incumbent from conflicting live drift", () => {
   );
   assert.equal(
     classifyWorkerRollbackOwnership(worker([{ version_id: candidate, percentage: 100 }], "55555555-5555-4555-8555-555555555555"), item, "production"),
+    "ownership-conflict",
+  );
+});
+
+test("reconciles a replacement deployment only with the exact prior recovery abort message", () => {
+  const current = {
+    ...worker([{ version_id: candidate, percentage: 100 }], "55555555-5555-4555-8555-555555555555"),
+    annotations: { "workers/message": priorAbortMessage },
+  };
+  assert.equal(
+    classifyWorkerRollbackOwnership(
+      current,
+      { ...item, authorizedReplacementMessage: priorAbortMessage },
+      "staging",
+    ),
+    "candidate-owned-reconciled",
+  );
+  assert.equal(
+    classifyWorkerRollbackOwnership(
+      current,
+      { ...item, authorizedReplacementMessage: "ponto:auto-abort:wrong" },
+      "staging",
+    ),
     "ownership-conflict",
   );
 });

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -15,6 +15,9 @@ test("staging recovery rollback is exact, serialized, and environment protected"
     "watchdog_run_id",
     "timekeeping_candidate_version_id",
     "timekeeping_incumbent_version_id",
+    "timekeeping_owner_recovery_run_id",
+    "timekeeping_owner_coordinator_run_id",
+    "timekeeping_owner_release_sha",
     "authorization_ref",
   ]) assert.match(workflow, new RegExp(`\\b${input}:`));
   assert.match(workflow, /fresh-close:/);
@@ -42,6 +45,9 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /git rev-parse origin\/main.*GITHUB_SHA/);
   assert.match(workflow, /actions\/download-artifact@[0-9a-f]{40}/);
   assert.match(workflow, /run-id: \$\{\{ inputs\.watchdog_run_id \}\}/);
+  assert.match(workflow, /ponto-worker-ownership-recovery\.mjs/);
+  assert.match(workflow, /current-worker-ownership\.json/);
+  assert.match(workflow, /name: ponto-staging-recovery-rollback-\$\{\{ inputs\.timekeeping_owner_coordinator_run_id \}\}-\$\{\{ inputs\.timekeeping_owner_recovery_run_id \}\}/);
   assert.doesNotMatch(workflow, /watchdog\.head_sha !== releaseSha/);
   assert.match(workflow, /!\/\^\[0-9a-f\]\{40\}/);
   assert.match(workflow, /ponto-automatic-rollback\.mjs/);

--- a/.github/scripts/ponto-worker-ownership-recovery.mjs
+++ b/.github/scripts/ponto-worker-ownership-recovery.mjs
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA = /^[0-9a-f]{40}$/;
+const RUN_ID = /^[1-9][0-9]*$/;
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+export function buildAuthorizedWorkerOwnership({
+  run,
+  replay,
+  repository,
+  recoveryRunId,
+  coordinatorRunId,
+  releaseSha,
+  candidateVersionId,
+}) {
+  const normalizedReleaseSha = String(releaseSha || "").toLowerCase();
+  const normalizedCandidateVersionId = String(candidateVersionId || "").toLowerCase();
+  if (
+    !RUN_ID.test(String(recoveryRunId || ""))
+    || !RUN_ID.test(String(coordinatorRunId || ""))
+    || !repository?.includes("/")
+    || !SHA.test(normalizedReleaseSha)
+    || !UUID.test(normalizedCandidateVersionId)
+    || String(run?.id || "") !== String(recoveryRunId)
+    || run?.path !== ".github/workflows/ponto-staging-recovery-rollback.yml"
+    || run?.status !== "completed"
+    || run?.conclusion !== "success"
+    || Number(run?.run_attempt) !== 1
+    || run?.head_branch !== "main"
+    || run?.repository?.full_name !== repository
+    || !SHA.test(String(run?.head_sha || "").toLowerCase())
+    || !String(run?.display_title || "").includes(`coordinator=${coordinatorRunId}`)
+    || replay?.schemaVersion !== 1
+    || replay?.automaticInterruption !== true
+    || replay?.sourceSha !== normalizedReleaseSha
+    || replay?.failedStage !== "staging"
+    || replay?.orchestratorRunId !== String(coordinatorRunId)
+    || replay?.moduleMaintenanceRunId !== String(recoveryRunId)
+    || replay?.moduleFailClosed !== true
+    || replay?.passed !== true
+    || replay?.credentialsIncluded !== false
+    || replay?.piiIncluded !== false
+  ) throw new Error("prior Ponto recovery ownership provenance is invalid");
+
+  const proof = replay.proofs?.timekeeping;
+  if (
+    proof?.passed !== true
+    || proof?.workerName !== "skincos-timekeeping-staging"
+    || String(proof?.targetVersionId || "").toLowerCase() !== normalizedCandidateVersionId
+    || Number(proof?.candidatePercent) !== 0
+    || Number(proof?.incumbentPercent) !== 100
+    || !["already-incumbent", "candidate-owned-reconciled"].includes(String(proof?.disposition || ""))
+  ) throw new Error("prior Ponto recovery does not prove the current candidate worker ownership");
+
+  return {
+    schemaVersion: 1,
+    target: "staging",
+    workerName: "skincos-timekeeping-staging",
+    candidateVersionId: normalizedCandidateVersionId,
+    priorRecoveryRunId: String(recoveryRunId),
+    priorCoordinatorRunId: String(coordinatorRunId),
+    priorReleaseSha: normalizedReleaseSha,
+    authorizedReplacementMessage: `ponto:auto-abort:${normalizedReleaseSha}:orchestrator-${coordinatorRunId}`,
+    passed: true,
+    credentialsIncluded: false,
+    piiIncluded: false,
+  };
+}
+
+function main() {
+  const [runFile, artifactRoot, reportFile] = process.argv.slice(2);
+  if (!runFile || !artifactRoot || !reportFile) {
+    throw new Error("usage: ponto-worker-ownership-recovery.mjs <run.json> <artifact-root> <report.json>");
+  }
+  const run = readJson(runFile);
+  const replay = readJson(path.join(artifactRoot, "automatic-rollback/ponto-automatic-rollback-replay.json"));
+  const report = buildAuthorizedWorkerOwnership({
+    run,
+    replay,
+    repository: process.env.GITHUB_REPOSITORY,
+    recoveryRunId: process.env.PONTO_PRIOR_RECOVERY_RUN_ID,
+    coordinatorRunId: process.env.PONTO_PRIOR_RECOVERY_COORDINATOR_RUN_ID,
+    releaseSha: process.env.PONTO_PRIOR_RECOVERY_RELEASE_SHA,
+    candidateVersionId: process.env.PONTO_TIMEKEEPING_CANDIDATE_VERSION_ID,
+  });
+  fs.mkdirSync(path.dirname(reportFile), { recursive: true });
+  fs.writeFileSync(reportFile, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write("Prior Ponto recovery worker ownership is attested.\n");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`Ponto prior recovery ownership failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/ponto-worker-ownership-recovery.test.mjs
+++ b/.github/scripts/ponto-worker-ownership-recovery.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildAuthorizedWorkerOwnership } from "./ponto-worker-ownership-recovery.mjs";
+
+const releaseSha = "a".repeat(40);
+const candidateVersionId = "11111111-1111-4111-8111-111111111111";
+const recoveryRunId = "987654321";
+const coordinatorRunId = "123456789";
+
+const run = {
+  id: Number(recoveryRunId),
+  path: ".github/workflows/ponto-staging-recovery-rollback.yml",
+  status: "completed",
+  conclusion: "success",
+  run_attempt: 1,
+  head_branch: "main",
+  head_sha: "b".repeat(40),
+  display_title: `Ponto staging recovery rollback ${releaseSha} coordinator=${coordinatorRunId}`,
+  repository: { full_name: "jubenitogarcia/skincos" },
+};
+
+const replay = {
+  schemaVersion: 1,
+  automaticInterruption: true,
+  sourceSha: releaseSha,
+  failedStage: "staging",
+  orchestratorRunId: coordinatorRunId,
+  moduleMaintenanceRunId: recoveryRunId,
+  moduleFailClosed: true,
+  passed: true,
+  credentialsIncluded: false,
+  piiIncluded: false,
+  proofs: {
+    timekeeping: {
+      passed: true,
+      workerName: "skincos-timekeeping-staging",
+      targetVersionId: candidateVersionId,
+      candidatePercent: 0,
+      incumbentPercent: 100,
+      disposition: "already-incumbent",
+    },
+  },
+};
+
+test("builds a bounded replacement ownership message from a successful recovery artifact", () => {
+  assert.deepEqual(
+    buildAuthorizedWorkerOwnership({
+      run,
+      replay,
+      repository: "jubenitogarcia/skincos",
+      recoveryRunId,
+      coordinatorRunId,
+      releaseSha,
+      candidateVersionId,
+    }),
+    {
+      schemaVersion: 1,
+      target: "staging",
+      workerName: "skincos-timekeeping-staging",
+      candidateVersionId,
+      priorRecoveryRunId: recoveryRunId,
+      priorCoordinatorRunId: coordinatorRunId,
+      priorReleaseSha: releaseSha,
+      authorizedReplacementMessage: `ponto:auto-abort:${releaseSha}:orchestrator-${coordinatorRunId}`,
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+  );
+});
+
+test("rejects an unsuccessful or differently owned prior recovery", () => {
+  assert.throws(
+    () => buildAuthorizedWorkerOwnership({
+      run: { ...run, conclusion: "failure" },
+      replay,
+      repository: "jubenitogarcia/skincos",
+      recoveryRunId,
+      coordinatorRunId,
+      releaseSha,
+      candidateVersionId,
+    }),
+    /prior Ponto recovery ownership provenance is invalid/,
+  );
+  assert.throws(
+    () => buildAuthorizedWorkerOwnership({
+      run,
+      replay: {
+        ...replay,
+        proofs: { timekeeping: { ...replay.proofs.timekeeping, targetVersionId: "22222222-2222-4222-8222-222222222222" } },
+      },
+      repository: "jubenitogarcia/skincos",
+      recoveryRunId,
+      coordinatorRunId,
+      releaseSha,
+      candidateVersionId,
+    }),
+    /does not prove the current candidate worker ownership/,
+  );
+});

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -24,6 +24,18 @@ on:
         description: "Exact incumbent version to restore"
         required: true
         type: string
+      timekeeping_owner_recovery_run_id:
+        description: "Exact successful Ponto recovery that currently owns the candidate-only Worker deployment"
+        required: true
+        type: string
+      timekeeping_owner_coordinator_run_id:
+        description: "Coordinator run bound to the successful current-owner recovery"
+        required: true
+        type: string
+      timekeeping_owner_release_sha:
+        description: "Release SHA bound to the successful current-owner recovery"
+        required: true
+        type: string
       authorization_ref:
         description: "Opaque approved incident or change reference for the fresh recovery close"
         required: true
@@ -339,6 +351,40 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.watchdog_run_id }}
 
+      - name: Download the exact successful recovery that owns the replacement Worker
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: ponto-staging-recovery-rollback-${{ inputs.timekeeping_owner_coordinator_run_id }}-${{ inputs.timekeeping_owner_recovery_run_id }}
+          path: ${{ runner.temp }}/ponto-staging-recovery-rollback/owner-recovery
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.timekeeping_owner_recovery_run_id }}
+
+      - name: Validate the exact current Worker ownership recovery before mutation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PONTO_PRIOR_RECOVERY_RUN_ID: ${{ inputs.timekeeping_owner_recovery_run_id }}
+          PONTO_PRIOR_RECOVERY_COORDINATOR_RUN_ID: ${{ inputs.timekeeping_owner_coordinator_run_id }}
+          PONTO_PRIOR_RECOVERY_RELEASE_SHA: ${{ inputs.timekeeping_owner_release_sha }}
+          PONTO_TIMEKEEPING_CANDIDATE_VERSION_ID: ${{ inputs.timekeeping_candidate_version_id }}
+          PONTO_PRIOR_RECOVERY_RUN_FILE: ${{ runner.temp }}/ponto-staging-recovery-rollback/owner-recovery-run.json
+          PONTO_PRIOR_RECOVERY_ARTIFACT_ROOT: ${{ runner.temp }}/ponto-staging-recovery-rollback/owner-recovery
+          PONTO_WORKER_OWNERSHIP_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/current-worker-ownership.json
+        run: |
+          set -euo pipefail
+          [[ "$PONTO_PRIOR_RECOVERY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo 'Invalid current-owner recovery run ID'; exit 1; }
+          [[ "$PONTO_PRIOR_RECOVERY_COORDINATOR_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo 'Invalid current-owner coordinator run ID'; exit 1; }
+          [[ "$PONTO_PRIOR_RECOVERY_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid current-owner release SHA'; exit 1; }
+          [[ "$PONTO_PRIOR_RECOVERY_RUN_ID" != "$PONTO_PRIOR_RECOVERY_COORDINATOR_RUN_ID" ]] || { echo 'Current-owner recovery and coordinator runs must differ'; exit 1; }
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PONTO_PRIOR_RECOVERY_RUN_ID" > "$PONTO_PRIOR_RECOVERY_RUN_FILE"
+          owner_head_sha="$(node -e 'const fs=require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).head_sha || "")' "$PONTO_PRIOR_RECOVERY_RUN_FILE")"
+          [[ "$owner_head_sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'Current-owner recovery SHA is invalid'; exit 1; }
+          git merge-base --is-ancestor "$owner_head_sha" origin/main || { echo 'Current-owner recovery source is not reachable from canonical main'; exit 1; }
+          node .github/scripts/ponto-worker-ownership-recovery.mjs \
+            "$PONTO_PRIOR_RECOVERY_RUN_FILE" \
+            "$PONTO_PRIOR_RECOVERY_ARTIFACT_ROOT" \
+            "$PONTO_WORKER_OWNERSHIP_REPORT"
+          rm -f "$PONTO_PRIOR_RECOVERY_RUN_FILE"
+
       - name: Validate exact incumbent custody before mutation
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -563,6 +609,8 @@ jobs:
           PONTO_COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           STAGE: staging
+          PONTO_TIMEKEEPING_CANDIDATE_VERSION_ID: ${{ inputs.timekeeping_candidate_version_id }}
+          PONTO_WORKER_OWNERSHIP_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/current-worker-ownership.json
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PONTO_MODULE_HEALTH_URL: https://api-staging.skincos.com.br/api/ponto/health


### PR DESCRIPTION
## Summary\n- attest the exact successful prior recovery that owns the current candidate-only Worker deployment\n- reconcile a replacement deployment only when its exact version set and Wrangler abort annotation match that sanitized evidence\n- keep unrelated or mismatched ownership fail-closed\n\n## Validation\n- Ponto worker ownership, rollback ownership, automatic rollback safety, recovery workflow, materialization, and orchestrator tests\n- deployment topology validation\n- workflow YAML parse\n- git diff --check\n\nThis closes the historical recovery path after an earlier authorized recovery recreated the same candidate version with a new deployment UUID.