### PR TITLE
fix(ponto): poll restored health before proof

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -167,9 +167,9 @@ test("staging recovery accepts the still-active emergency latch after incumbent 
   assert.match(proof, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
   assert.match(proof, /const materialized = JSON\.parse\(fs\.readFileSync\(process\.env\.PONTO_MATERIALIZE_REPORT, \"utf8\"\)\);/);
   assert.match(proof, /const expectedAvailabilityChangedAt = availabilitySource === \"emergency-latch-active\"/);
-  assert.match(proof, /!\["control", "emergency-latch-active"\]\.includes\(availabilitySource\)/);
-  assert.match(proof, /body\?\.availability\?\.changedAt !== expectedAvailabilityChangedAt/);
-  assert.match(proof, /workerVersionId !== process\.env\.TIMEKEEPING_INCUMBENT_VERSION_ID\.toLowerCase\(\)/);
+  assert.match(proof, /\["control", "emergency-latch-active"\]\.includes\(availabilitySource\)/);
+  assert.match(proof, /body\?\.availability\?\.changedAt === expectedAvailabilityChangedAt/);
+  assert.match(proof, /workerVersionId === process\.env\.TIMEKEEPING_INCUMBENT_VERSION_ID\.toLowerCase\(\)/);
 });
 
 test("coordinator reserves a bounded recovery budget inside the GitHub job limit", () => {

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -32,9 +32,11 @@ test("staging recovery rollback is exact, serialized, and environment protected"
     /\["control", "emergency-latch-active"\]\.includes\((?:body\?\.availability\?\.source|availabilitySource)\)/,
   );
   assert.match(workflow, /PONTO_MATERIALIZE_REPORT: \$\{\{ runner\.temp \}\}\/ponto-staging-recovery-rollback\/fresh-close\/materialized-readback\.json/);
-  assert.match(workflow, /body\?\.availability\?\.changedAt !== expectedAvailabilityChangedAt/);
+  assert.match(workflow, /body\?\.availability\?\.changedAt === expectedAvailabilityChangedAt/);
   assert.match(workflow, /readCloudflareKvJson/);
   assert.match(workflow, /fresh-close\/direct-readback\.json/);
+  assert.match(workflow, /for \(let attempt = 0; attempt < 12; attempt \+= 1\)/);
+  assert.match(workflow, /setTimeout\(resolve, 5_000\)/);
   assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);
   assert.match(workflow, /group: ponto-surface-mutation/);
   assert.match(workflow, /cancel-in-progress: false/);

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -35,10 +35,14 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /body\?\.availability\?\.changedAt === expectedAvailabilityChangedAt/);
   assert.match(workflow, /readCloudflareKvJson/);
   assert.match(workflow, /fresh-close\/direct-readback\.json/);
-  assert.match(workflow, /for \(let attempt = 0; attempt < 12; attempt \+= 1\)/);
+  assert.match(workflow, /const propagationDeadline = Date\.now\(\) \+ 75_000/);
+  assert.match(workflow, /while \(Date\.now\(\) <= propagationDeadline\)/);
   assert.match(workflow, /try \{[\s\S]*?const response = await fetch\(process\.env\.PONTO_MODULE_HEALTH_URL/);
   assert.match(workflow, /\} catch \{[\s\S]*?transient health-probe failure consumes this attempt/);
-  assert.match(workflow, /setTimeout\(resolve, 5_000\)/);
+  assert.match(workflow, /let consecutiveValidSamples = 0/);
+  assert.match(workflow, /if \(consecutiveValidSamples >= 2\)/);
+  assert.match(workflow, /lastValidSampleKey = ""/);
+  assert.match(workflow, /Math\.min\(5_000, remainingMs\)/);
   assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);
   assert.match(workflow, /group: ponto-surface-mutation/);
   assert.match(workflow, /cancel-in-progress: false/);

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -36,6 +36,8 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /readCloudflareKvJson/);
   assert.match(workflow, /fresh-close\/direct-readback\.json/);
   assert.match(workflow, /for \(let attempt = 0; attempt < 12; attempt \+= 1\)/);
+  assert.match(workflow, /try \{[\s\S]*?const response = await fetch\(process\.env\.PONTO_MODULE_HEALTH_URL/);
+  assert.match(workflow, /\} catch \{[\s\S]*?transient health-probe failure consumes this attempt/);
   assert.match(workflow, /setTimeout\(resolve, 5_000\)/);
   assert.match(workflow, /mutation\.compensationDisposition === "not-required"/);
   assert.match(workflow, /group: ponto-surface-mutation/);

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -646,34 +646,42 @@ jobs:
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
-          node - <<'NODE'
+          node --input-type=module - <<'NODE'
           import fs from "node:fs";
           const headers = { accept: "application/json" };
           if (process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET) {
             headers["cf-access-client-id"] = process.env.CF_ACCESS_CLIENT_ID;
             headers["cf-access-client-secret"] = process.env.CF_ACCESS_CLIENT_SECRET;
           }
-          const response = await fetch(process.env.PONTO_MODULE_HEALTH_URL, {
-            redirect: "manual",
-            signal: AbortSignal.timeout(15_000),
-            headers,
-          });
-          const body = await response.json().catch(() => null);
-          const availabilitySource = String(body?.availability?.source || "");
           const materialized = JSON.parse(fs.readFileSync(process.env.PONTO_MATERIALIZE_REPORT, "utf8"));
-          const expectedAvailabilityChangedAt = availabilitySource === "emergency-latch-active"
-            ? materialized?.emergencyLatch?.changedAt
-            : materialized?.moduleControl?.changedAt;
-          const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
-          if (
-            response.status !== 200
-            || body?.ok !== false
-            || body?.ready !== false
-            || body?.availability?.state !== "maintenance"
-            || !["control", "emergency-latch-active"].includes(availabilitySource)
-            || body?.availability?.changedAt !== expectedAvailabilityChangedAt
-            || workerVersionId !== process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
-          ) throw new Error("staging health did not prove maintenance on the restored Timekeeping incumbent");
+          let passed = false;
+          for (let attempt = 0; attempt < 12; attempt += 1) {
+            const response = await fetch(process.env.PONTO_MODULE_HEALTH_URL, {
+              redirect: "manual",
+              signal: AbortSignal.timeout(15_000),
+              headers,
+            });
+            const body = await response.json().catch(() => null);
+            const availabilitySource = String(body?.availability?.source || "");
+            const expectedAvailabilityChangedAt = availabilitySource === "emergency-latch-active"
+              ? materialized?.emergencyLatch?.changedAt
+              : materialized?.moduleControl?.changedAt;
+            const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
+            if (
+              response.status === 200
+              && body?.ok === false
+              && body?.ready === false
+              && body?.availability?.state === "maintenance"
+              && ["control", "emergency-latch-active"].includes(availabilitySource)
+              && body?.availability?.changedAt === expectedAvailabilityChangedAt
+              && workerVersionId === process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
+            ) {
+              passed = true;
+              break;
+            }
+            if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
+          }
+          if (!passed) throw new Error("staging health did not prove maintenance on the restored Timekeeping incumbent");
           NODE
 
       - name: Upload immutable staging recovery evidence

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -654,8 +654,13 @@ jobs:
             headers["cf-access-client-secret"] = process.env.CF_ACCESS_CLIENT_SECRET;
           }
           const materialized = JSON.parse(fs.readFileSync(process.env.PONTO_MATERIALIZE_REPORT, "utf8"));
+          const propagationDeadline = Date.now() + 75_000;
+          let consecutiveValidSamples = 0;
+          let lastValidSampleKey = "";
           let passed = false;
-          for (let attempt = 0; attempt < 12; attempt += 1) {
+          let attempt = 0;
+          while (Date.now() <= propagationDeadline) {
+            attempt += 1;
             try {
               const response = await fetch(process.env.PONTO_MODULE_HEALTH_URL, {
                 redirect: "manual",
@@ -668,7 +673,7 @@ jobs:
                 ? materialized?.emergencyLatch?.changedAt
                 : materialized?.moduleControl?.changedAt;
               const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
-              if (
+              const validSample = (
                 response.status === 200
                 && body?.ok === false
                 && body?.ready === false
@@ -676,16 +681,30 @@ jobs:
                 && ["control", "emergency-latch-active"].includes(availabilitySource)
                 && body?.availability?.changedAt === expectedAvailabilityChangedAt
                 && workerVersionId === process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
-              ) {
+              );
+              const sampleKey = `${availabilitySource}:${body?.availability?.changedAt || ""}:${workerVersionId}`;
+              if (validSample && sampleKey === lastValidSampleKey) {
+                consecutiveValidSamples += 1;
+              } else if (validSample) {
+                lastValidSampleKey = sampleKey;
+                consecutiveValidSamples = 1;
+              } else {
+                lastValidSampleKey = "";
+                consecutiveValidSamples = 0;
+              }
+              if (consecutiveValidSamples >= 2) {
                 passed = true;
                 break;
               }
             } catch {
               // A transient health-probe failure consumes this attempt but must not abort the bounded propagation window.
+              lastValidSampleKey = "";
+              consecutiveValidSamples = 0;
             }
-            if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
+            const remainingMs = propagationDeadline - Date.now();
+            if (remainingMs > 0) await new Promise((resolve) => setTimeout(resolve, Math.min(5_000, remainingMs)));
           }
-          if (!passed) throw new Error("staging health did not prove maintenance on the restored Timekeeping incumbent");
+          if (!passed) throw new Error("staging health did not prove two consecutive maintenance samples on the restored Timekeeping incumbent within the propagation window");
           NODE
 
       - name: Upload immutable staging recovery evidence

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -656,28 +656,32 @@ jobs:
           const materialized = JSON.parse(fs.readFileSync(process.env.PONTO_MATERIALIZE_REPORT, "utf8"));
           let passed = false;
           for (let attempt = 0; attempt < 12; attempt += 1) {
-            const response = await fetch(process.env.PONTO_MODULE_HEALTH_URL, {
-              redirect: "manual",
-              signal: AbortSignal.timeout(15_000),
-              headers,
-            });
-            const body = await response.json().catch(() => null);
-            const availabilitySource = String(body?.availability?.source || "");
-            const expectedAvailabilityChangedAt = availabilitySource === "emergency-latch-active"
-              ? materialized?.emergencyLatch?.changedAt
-              : materialized?.moduleControl?.changedAt;
-            const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
-            if (
-              response.status === 200
-              && body?.ok === false
-              && body?.ready === false
-              && body?.availability?.state === "maintenance"
-              && ["control", "emergency-latch-active"].includes(availabilitySource)
-              && body?.availability?.changedAt === expectedAvailabilityChangedAt
-              && workerVersionId === process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
-            ) {
-              passed = true;
-              break;
+            try {
+              const response = await fetch(process.env.PONTO_MODULE_HEALTH_URL, {
+                redirect: "manual",
+                signal: AbortSignal.timeout(15_000),
+                headers,
+              });
+              const body = await response.json().catch(() => null);
+              const availabilitySource = String(body?.availability?.source || "");
+              const expectedAvailabilityChangedAt = availabilitySource === "emergency-latch-active"
+                ? materialized?.emergencyLatch?.changedAt
+                : materialized?.moduleControl?.changedAt;
+              const workerVersionId = String(body?.versionMetadata?.workerVersionId || "").toLowerCase();
+              if (
+                response.status === 200
+                && body?.ok === false
+                && body?.ready === false
+                && body?.availability?.state === "maintenance"
+                && ["control", "emergency-latch-active"].includes(availabilitySource)
+                && body?.availability?.changedAt === expectedAvailabilityChangedAt
+                && workerVersionId === process.env.TIMEKEEPING_INCUMBENT_VERSION_ID.toLowerCase()
+              ) {
+                passed = true;
+                break;
+              }
+            } catch {
+              // A transient health-probe failure consumes this attempt but must not abort the bounded propagation window.
             }
             if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
           }


### PR DESCRIPTION
## Summary\n- poll staging health for bounded propagation after restoring the exact incumbent\n- require maintenance source/timestamp and incumbent Worker version on the same successful sample\n- add regression assertions for the bounded proof\n\n## Validation\n- focused staging recovery and automatic rollback safety tests\n- workflow YAML parse\n- git diff --check\n\nThe preceding recovery run already restored the incumbent; this closes the final proof race without another ownership change.