### PR TITLE
fix(ponto): tolerate bootstrap deployment regeneration

### DIFF
--- a/.github/scripts/ponto-core-bootstrap-precondition.mjs
+++ b/.github/scripts/ponto-core-bootstrap-precondition.mjs
@@ -1,0 +1,37 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const requireValue = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+export function validatePontoCoreBootstrapLive({
+  live,
+  expectedDeployment,
+  expectedVersion,
+  target,
+}) {
+  requireValue(live?.exists === true, `live ${target} Ponto Core is absent`);
+  requireValue(UUID_PATTERN.test(String(expectedDeployment || "")), "catalog bootstrap deployment id is invalid");
+  requireValue(UUID_PATTERN.test(String(expectedVersion || "")), "catalog bootstrap version id is invalid");
+
+  const attestation = live.attestation;
+  const activeDeploymentId = String(attestation?.activeDeploymentId || "");
+  const activeVersionId = String(attestation?.activeVersionId || "");
+  requireValue(attestation?.target === target, `live ${target} Ponto Core target differs`);
+  requireValue(UUID_PATTERN.test(activeDeploymentId), `live ${target} Ponto Core deployment id is invalid`);
+  requireValue(activeVersionId === expectedVersion, `live ${target} Ponto Core version differs from the cataloged bootstrap`);
+  requireValue(
+    Array.isArray(attestation?.activeVersions)
+      && attestation.activeVersions.length === 1
+      && attestation.activeVersions[0]?.versionId === expectedVersion
+      && attestation.activeVersions[0]?.percentage === 100,
+    `live ${target} Ponto Core must expose only the cataloged bootstrap version at 100%`,
+  );
+
+  return {
+    deploymentId: activeDeploymentId,
+    catalogDeploymentId: expectedDeployment,
+    deploymentDrifted: activeDeploymentId !== expectedDeployment,
+    versionId: activeVersionId,
+  };
+}

--- a/.github/scripts/ponto-core-bootstrap-precondition.test.mjs
+++ b/.github/scripts/ponto-core-bootstrap-precondition.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validatePontoCoreBootstrapLive } from "./ponto-core-bootstrap-precondition.mjs";
+
+const catalogDeployment = "d88aa85e-a90b-4fd0-b03b-14bf4c6fc248";
+const regeneratedDeployment = "e71a4483-da7a-4fee-9189-1543b03795a9";
+const bootstrapVersion = "0ee7a2fe-deff-4f37-bcda-c35ad54b68f3";
+
+const live = (deploymentId = catalogDeployment, versionId = bootstrapVersion) => ({
+  exists: true,
+  attestation: {
+    target: "staging",
+    activeDeploymentId: deploymentId,
+    activeVersionId: versionId,
+    activeVersions: [{ versionId, percentage: 100 }],
+  },
+});
+
+test("accepts the cataloged bootstrap deployment and version", () => {
+  assert.deepEqual(
+    validatePontoCoreBootstrapLive({
+      live: live(),
+      expectedDeployment: catalogDeployment,
+      expectedVersion: bootstrapVersion,
+      target: "staging",
+    }),
+    {
+      deploymentId: catalogDeployment,
+      catalogDeploymentId: catalogDeployment,
+      deploymentDrifted: false,
+      versionId: bootstrapVersion,
+    },
+  );
+});
+
+test("accepts a recovery-regenerated deployment when the immutable bootstrap version remains exact", () => {
+  const result = validatePontoCoreBootstrapLive({
+    live: live(regeneratedDeployment),
+    expectedDeployment: catalogDeployment,
+    expectedVersion: bootstrapVersion,
+    target: "staging",
+  });
+  assert.equal(result.deploymentId, regeneratedDeployment);
+  assert.equal(result.catalogDeploymentId, catalogDeployment);
+  assert.equal(result.deploymentDrifted, true);
+});
+
+test("rejects a different live bootstrap version even when its deployment is valid", () => {
+  assert.throws(
+    () => validatePontoCoreBootstrapLive({
+      live: live(regeneratedDeployment, "11111111-1111-4111-8111-111111111111"),
+      expectedDeployment: catalogDeployment,
+      expectedVersion: bootstrapVersion,
+      target: "staging",
+    }),
+    /version differs from the cataloged bootstrap/,
+  );
+});
+
+test("rejects a split or partial active version set", () => {
+  const current = live(regeneratedDeployment);
+  current.attestation.activeVersions = [
+    { versionId: bootstrapVersion, percentage: 99 },
+    { versionId: "11111111-1111-4111-8111-111111111111", percentage: 1 },
+  ];
+  assert.throws(
+    () => validatePontoCoreBootstrapLive({
+      live: current,
+      expectedDeployment: catalogDeployment,
+      expectedVersion: bootstrapVersion,
+      target: "staging",
+    }),
+    /only the cataloged bootstrap version at 100%/,
+  );
+});

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -705,28 +705,38 @@ jobs:
           });
           fs.writeFileSync(process.env.PONTO_BOOTSTRAP_LIVE_FILE, `${JSON.stringify(snapshot, null, 2)}\n`, { mode: 0o600 });
           NODE
-          node - "$evidence_dir/live.json" "$deployment_id" "$version_id" "$evidence_dir/precondition.json" "$run_id" "$artifact_id" "$artifact_digest" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$evidence_dir/live.json" "$deployment_id" "$version_id" "$evidence_dir/precondition.json" "$run_id" "$artifact_id" "$artifact_digest" <<'NODE'
+          import fs from "node:fs";
+          import { validatePontoCoreBootstrapLive } from "./.github/scripts/ponto-core-bootstrap-precondition.mjs";
           const [liveFile, expectedDeployment, expectedVersion, outputFile, runId, artifactId, artifactDigest] = process.argv.slice(2);
           const live = JSON.parse(fs.readFileSync(liveFile, "utf8"));
-          if (
-            live?.exists !== true
-            || live?.attestation?.activeDeploymentId !== expectedDeployment
-            || live?.attestation?.activeVersionId !== expectedVersion
-          ) throw new Error("live staging Ponto Core differs from the exact cataloged bootstrap predecessor");
+          const precondition = validatePontoCoreBootstrapLive({
+            live,
+            expectedDeployment,
+            expectedVersion,
+            target: "staging",
+          });
           fs.writeFileSync(outputFile, `${JSON.stringify({
             schemaVersion: 1,
             target: "staging",
             workflowRunId: runId,
             artifactId,
             artifactDigest,
-            deploymentId: expectedDeployment,
-            versionId: expectedVersion,
+            deploymentId: precondition.deploymentId,
+            catalogDeploymentId: precondition.catalogDeploymentId,
+            deploymentDrifted: precondition.deploymentDrifted,
+            versionId: precondition.versionId,
             liveAttestation: live.attestation,
             credentialsIncluded: false,
             piiIncluded: false,
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
+          deployment_id="$(node --input-type=module - "$evidence_dir/precondition.json" <<'NODE'
+          import fs from "node:fs";
+          const precondition = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          process.stdout.write(precondition.deploymentId);
+          NODE
+          )"
           {
             echo "CORE_STAGING_BOOTSTRAP_WORKFLOW_RUN_ID=$run_id"
             echo "CORE_STAGING_BOOTSTRAP_ARTIFACT_ID=$artifact_id"

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -186,15 +186,20 @@ jobs:
           });
           fs.writeFileSync(process.env.PONTO_BOOTSTRAP_LIVE_FILE, `${JSON.stringify(snapshot, null, 2)}\n`, { mode: 0o600 });
           NODE
-          node - "$evidence_dir/live.json" "$deployment_id" "$version_id" <<'NODE'
-          const fs = require("fs");
-          const live = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          if (
-            live?.exists !== true
-            || live?.attestation?.activeDeploymentId !== process.argv[3]
-            || live?.attestation?.activeVersionId !== process.argv[4]
-          ) throw new Error("live production Ponto Core differs from the exact cataloged bootstrap predecessor");
+          deployment_id="$(node --input-type=module - "$evidence_dir/live.json" "$deployment_id" "$version_id" <<'NODE'
+          import fs from "node:fs";
+          import { validatePontoCoreBootstrapLive } from "./.github/scripts/ponto-core-bootstrap-precondition.mjs";
+          const [liveFile, expectedDeployment, expectedVersion] = process.argv.slice(2);
+          const live = JSON.parse(fs.readFileSync(liveFile, "utf8"));
+          const precondition = validatePontoCoreBootstrapLive({
+            live,
+            expectedDeployment,
+            expectedVersion,
+            target: "production",
+          });
+          process.stdout.write(precondition.deploymentId);
           NODE
+          )"
           {
             echo "bootstrap_workflow_run_id=$run_id"
             echo "bootstrap_artifact_id=$artifact_id"

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -742,15 +742,17 @@ jobs:
           });
           fs.writeFileSync(process.env.PONTO_BOOTSTRAP_LIVE_FILE, `${JSON.stringify(snapshot, null, 2)}\n`, { mode: 0o600 });
           NODE
-          node - "$evidence_dir/live.json" "$deployment_id" "$version_id" "$proof_dir/precondition.json" "$run_id" "$artifact_id" "$artifact_digest" "$source_sha" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$evidence_dir/live.json" "$deployment_id" "$version_id" "$proof_dir/precondition.json" "$run_id" "$artifact_id" "$artifact_digest" "$source_sha" <<'NODE'
+          import fs from "node:fs";
+          import { validatePontoCoreBootstrapLive } from "./.github/scripts/ponto-core-bootstrap-precondition.mjs";
           const [liveFile, expectedDeployment, expectedVersion, outputFile, runId, artifactId, artifactDigest, sourceSha] = process.argv.slice(2);
           const live = JSON.parse(fs.readFileSync(liveFile, "utf8"));
-          if (
-            live?.exists !== true
-            || live?.attestation?.activeDeploymentId !== expectedDeployment
-            || live?.attestation?.activeVersionId !== expectedVersion
-          ) throw new Error(`live ${process.env.PONTO_BOOTSTRAP_TARGET} Ponto Core differs from the exact cataloged bootstrap predecessor`);
+          const precondition = validatePontoCoreBootstrapLive({
+            live,
+            expectedDeployment,
+            expectedVersion,
+            target: process.env.PONTO_BOOTSTRAP_TARGET,
+          });
           fs.writeFileSync(outputFile, `${JSON.stringify({
             schemaVersion: 1,
             target: process.env.PONTO_BOOTSTRAP_TARGET,
@@ -758,8 +760,10 @@ jobs:
             artifactId,
             artifactDigest,
             sourceSha,
-            deploymentId: expectedDeployment,
-            versionId: expectedVersion,
+            deploymentId: precondition.deploymentId,
+            catalogDeploymentId: precondition.catalogDeploymentId,
+            deploymentDrifted: precondition.deploymentDrifted,
+            versionId: precondition.versionId,
             liveAttested: true,
             liveAttestation: live.attestation,
             credentialsIncluded: false,


### PR DESCRIPTION
## Root cause

Ponto Core staging remained on the immutable bootstrap version, but the prior recovery recreated its active deployment envelope. The cataloged deployment ID was therefore stale even though the bootstrap Worker version, message, bindings, traffic, and private exposure remained exact.

## Change

- centralize the live bootstrap precondition;
- accept a regenerated deployment only when the cataloged bootstrap version is the sole version at 100% for the expected target;
- preserve both the catalog deployment ID and the live deployment ID in evidence;
- apply the same contract to the progressive coordinator, Core staging publisher, and production baseline capture.

## Validation

- 60 focused Node tests passed in Ubuntu-24.04 WSL;
- deployment topology validation passed;
- `git diff --check` passed;
- no production mutation is included.

Fixes the repeatability failure observed in staging coordinator `30759594674` on `f2703044826be7c4528ada10e76b8b49100fb10f`.