### PR TITLE
fix(ponto): parse Wrangler Pages secret output

### DIFF
--- a/.github/scripts/parse-wrangler-json.mjs
+++ b/.github/scripts/parse-wrangler-json.mjs
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const JSON_START = /[\[{]/;
+
+export function parseWranglerJson(rawOutput) {
+  const raw = String(rawOutput || "");
+  const start = raw.search(JSON_START);
+  if (start < 0) throw new Error("Wrangler output did not contain a JSON document");
+
+  const candidate = raw.slice(start).trim();
+  try {
+    return JSON.parse(candidate);
+  } catch (error) {
+    const lastArray = candidate.lastIndexOf("]");
+    const lastObject = candidate.lastIndexOf("}");
+    const end = Math.max(lastArray, lastObject);
+    if (end < 0) throw error;
+    return JSON.parse(candidate.slice(0, end + 1));
+  }
+}
+
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (invokedAsScript) {
+  const [inputFile] = process.argv.slice(2);
+  if (!inputFile) throw new Error("Wrangler output file is required");
+  const parsed = parseWranglerJson(fs.readFileSync(inputFile, "utf8"));
+  process.stdout.write(`${JSON.stringify(parsed)}\n`);
+}

--- a/.github/scripts/parse-wrangler-json.test.mjs
+++ b/.github/scripts/parse-wrangler-json.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseWranglerJson } from "./parse-wrangler-json.mjs";
+
+test("parses Wrangler banner followed by a JSON array", () => {
+  assert.deepEqual(
+    parseWranglerJson("⛅️ wrangler 4.112.0\n[{\"name\":\"PONTO_ACTOR_HMAC_KEY\"}]\n"),
+    [{ name: "PONTO_ACTOR_HMAC_KEY" }],
+  );
+});
+
+test("parses JSON followed by a Wrangler warning", () => {
+  assert.deepEqual(
+    parseWranglerJson("[{\"name\":\"PONTO_NETWORK_CONTEXT_KEY\"}]\nwarning: retrying\n"),
+    [{ name: "PONTO_NETWORK_CONTEXT_KEY" }],
+  );
+});
+
+test("parses a JSON object after leading output", () => {
+  assert.deepEqual(
+    parseWranglerJson("wrangler notice\n{\"result\":true}\n"),
+    { result: true },
+  );
+});
+
+test("rejects output without JSON", () => {
+  assert.throws(
+    () => parseWranglerJson("wrangler failed: no response"),
+    /did not contain a JSON document/,
+  );
+});

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -345,8 +345,10 @@ jobs:
         run: |
           set -euo pipefail
           secret_list="$RUNNER_TEMP/pages-ponto-secret-list.json"
+          normalized_secret_list="$RUNNER_TEMP/pages-ponto-secret-list.normalized.json"
           npx --yes wrangler@4.112.0 pages secret list --project-name "$PAGES_PROJECT" --env production > "$secret_list"
-          node - "$secret_list" <<'NODE'
+          node .github/scripts/parse-wrangler-json.mjs "$secret_list" > "$normalized_secret_list"
+          node - "$normalized_secret_list" <<'NODE'
           const fs = require("fs");
           const listed = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const names = new Set(listed.map(item => item.name));
@@ -356,7 +358,7 @@ jobs:
             if (!names.has(name)) throw new Error(`remote Pages value must be provisioned before release: ${name}`);
           }
           NODE
-          rm -f "$secret_list"
+          rm -f "$secret_list" "$normalized_secret_list"
 
       - name: Capture Ponto staging Pages rollback deployment
         if: ${{ inputs.release_scope == 'ponto' && inputs.target == 'staging' }}
@@ -804,15 +806,17 @@ jobs:
         run: |
           set -euo pipefail
           list="$RUNNER_TEMP/pages-secret-list.json"
+          normalized_list="$RUNNER_TEMP/pages-secret-list.normalized.json"
           npx --yes wrangler@4.112.0 pages secret list --project-name "$PROJECT" --env production > "$list"
-          node - "$list" <<'NODE'
+          node .github/scripts/parse-wrangler-json.mjs "$list" > "$normalized_list"
+          node - "$normalized_list" <<'NODE'
           const fs = require("fs");
           const names = new Set(JSON.parse(fs.readFileSync(process.argv[2], "utf8")).map(item => item.name));
           for (const name of ["PONTO_API_TARGET", "PONTO_ACTOR_HMAC_KEY", "PONTO_NETWORK_CONTEXT_KEY", "PONTO_RELEASE_PROBE_HMAC_KEY"]) {
             if (!names.has(name)) throw new Error(`remote Pages value is absent: ${name}`);
           }
           NODE
-          rm -f "$list"
+          rm -f "$list" "$normalized_list"
       - name: Select Pages rollback deployment
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- normalize Wrangler banner/warning output before parsing Pages secret lists
- cover staging and production Ponto Pages gates
- add focused parser tests

## Validation
- Ubuntu-24.04 Node tests: 4 parser tests passed
- deployment topology validation passed
- Ponto orchestrator lease tests: 14 passed
- git diff --check passed

Fixes the staging failure observed in run 30763825341 (Wrangler banner was parsed as JSON).