### PR TITLE
fix(ponto): align trusted Pages heredocs

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -237,6 +237,14 @@ test("Pages deploy gates use trusted inline API attestation instead of promoted 
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /node - "\$pages_project" "\$DEPLOY_TARGET" <<'NODE'/);
   assert.match(source, /node - "\$pages_project" "\$TARGET" <<'NODE'/);
+  assert.match(
+    source,
+    /node - "\$pages_project" "\$DEPLOY_TARGET" <<'NODE'\n          const fs = require\("fs"\);[\s\S]*?\n          NODE\n/,
+  );
+  assert.match(
+    source,
+    /node - "\$pages_project" "\$TARGET" <<'NODE'\n          const fs = require\("fs"\);[\s\S]*?\n          NODE\n/,
+  );
   assert.match(source, /binding\.type !== "secret_text"/);
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /ponto-pages-environment-attestation\.mjs/);

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -237,14 +237,16 @@ test("Pages deploy gates use trusted inline API attestation instead of promoted 
   assert.match(source, /deployment_configs\?\.production\?\.env_vars/);
   assert.match(source, /node - "\$pages_project" "\$DEPLOY_TARGET" <<'NODE'/);
   assert.match(source, /node - "\$pages_project" "\$TARGET" <<'NODE'/);
-  assert.match(
-    source,
-    /node - "\$pages_project" "\$DEPLOY_TARGET" <<'NODE'\n          const fs = require\("fs"\);[\s\S]*?\n          NODE\n/,
-  );
-  assert.match(
-    source,
-    /node - "\$pages_project" "\$TARGET" <<'NODE'\n          const fs = require\("fs"\);[\s\S]*?\n          NODE\n/,
-  );
+  for (const command of [
+    'node - "$pages_project" "$DEPLOY_TARGET" <<\'NODE\'',
+    'node - "$pages_project" "$TARGET" <<\'NODE\'',
+  ]) {
+    const start = source.indexOf(command);
+    assert.ok(start >= 0, `missing Pages attestation command: ${command}`);
+    const delimiter = source.slice(start).match(/\n([ \t]+)NODE\n/);
+    assert.ok(delimiter, `missing heredoc delimiter after: ${command}`);
+    assert.equal(delimiter[1].length, 10, `heredoc delimiter indentation drifted after: ${command}`);
+  }
   assert.match(source, /binding\.type !== "secret_text"/);
   assert.doesNotMatch(source, /pages secret list/);
   assert.doesNotMatch(source, /ponto-pages-environment-attestation\.mjs/);

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -344,34 +344,34 @@ jobs:
           DEPLOY_TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
-           pages_project="$RUNNER_TEMP/pages-ponto-project.json"
-           trap 'rm -f "$pages_project"' EXIT
-           curl --fail --silent --show-error \
-             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PAGES_PROJECT" \
-             > "$pages_project"
-           node - "$pages_project" "$DEPLOY_TARGET" <<'NODE'
-           const fs = require("fs");
-           const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-           const envVars = payload?.result?.deployment_configs?.production?.env_vars;
-           if (
-             payload?.success !== true
-             || !envVars
-             || typeof envVars !== "object"
-             || Array.isArray(envVars)
-           ) throw new Error("Cloudflare Pages project response did not contain structured production env_vars");
-           const required = [
-             "PONTO_ACTOR_HMAC_KEY",
-             "PONTO_NETWORK_CONTEXT_KEY",
-             "PONTO_RELEASE_PROBE_HMAC_KEY",
-           ];
-           if (process.argv[3] !== "staging") required.push("PONTO_API_TARGET");
-           for (const name of required) {
-             const binding = envVars[name];
-             if (!binding) throw new Error(`remote Pages value is absent: ${name}`);
-             if (binding.type !== "secret_text") throw new Error(`remote Pages value must be secret_text: ${name}`);
-           }
-           NODE
+          pages_project="$RUNNER_TEMP/pages-ponto-project.json"
+          trap 'rm -f "$pages_project"' EXIT
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PAGES_PROJECT" \
+            > "$pages_project"
+          node - "$pages_project" "$DEPLOY_TARGET" <<'NODE'
+          const fs = require("fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const envVars = payload?.result?.deployment_configs?.production?.env_vars;
+          if (
+            payload?.success !== true
+            || !envVars
+            || typeof envVars !== "object"
+            || Array.isArray(envVars)
+          ) throw new Error("Cloudflare Pages project response did not contain structured production env_vars");
+          const required = [
+            "PONTO_ACTOR_HMAC_KEY",
+            "PONTO_NETWORK_CONTEXT_KEY",
+            "PONTO_RELEASE_PROBE_HMAC_KEY",
+          ];
+          if (process.argv[3] !== "staging") required.push("PONTO_API_TARGET");
+          for (const name of required) {
+            const binding = envVars[name];
+            if (!binding) throw new Error(`remote Pages value is absent: ${name}`);
+            if (binding.type !== "secret_text") throw new Error(`remote Pages value must be secret_text: ${name}`);
+          }
+          NODE
 
       - name: Capture Ponto staging Pages rollback deployment
         if: ${{ inputs.release_scope == 'ponto' && inputs.target == 'staging' }}
@@ -818,34 +818,34 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-           pages_project="$RUNNER_TEMP/pages-ponto-project.json"
-           trap 'rm -f "$pages_project"' EXIT
-           curl --fail --silent --show-error \
-             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT" \
-             > "$pages_project"
-           node - "$pages_project" "$TARGET" <<'NODE'
-           const fs = require("fs");
-           const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-           const envVars = payload?.result?.deployment_configs?.production?.env_vars;
-           if (
-             payload?.success !== true
-             || !envVars
-             || typeof envVars !== "object"
-             || Array.isArray(envVars)
-           ) throw new Error("Cloudflare Pages project response did not contain structured production env_vars");
-           const required = [
-             "PONTO_ACTOR_HMAC_KEY",
-             "PONTO_NETWORK_CONTEXT_KEY",
-             "PONTO_RELEASE_PROBE_HMAC_KEY",
-           ];
-           if (process.argv[3] !== "staging") required.push("PONTO_API_TARGET");
-           for (const name of required) {
-             const binding = envVars[name];
-             if (!binding) throw new Error(`remote Pages value is absent: ${name}`);
-             if (binding.type !== "secret_text") throw new Error(`remote Pages value must be secret_text: ${name}`);
-           }
-           NODE
+          pages_project="$RUNNER_TEMP/pages-ponto-project.json"
+          trap 'rm -f "$pages_project"' EXIT
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT" \
+            > "$pages_project"
+          node - "$pages_project" "$TARGET" <<'NODE'
+          const fs = require("fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const envVars = payload?.result?.deployment_configs?.production?.env_vars;
+          if (
+            payload?.success !== true
+            || !envVars
+            || typeof envVars !== "object"
+            || Array.isArray(envVars)
+          ) throw new Error("Cloudflare Pages project response did not contain structured production env_vars");
+          const required = [
+            "PONTO_ACTOR_HMAC_KEY",
+            "PONTO_NETWORK_CONTEXT_KEY",
+            "PONTO_RELEASE_PROBE_HMAC_KEY",
+          ];
+          if (process.argv[3] !== "staging") required.push("PONTO_API_TARGET");
+          for (const name of required) {
+            const binding = envVars[name];
+            if (!binding) throw new Error(`remote Pages value is absent: ${name}`);
+            if (binding.type !== "secret_text") throw new Error(`remote Pages value must be secret_text: ${name}`);
+          }
+          NODE
       - name: Select Pages rollback deployment
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Fix the trusted inline Pages attestation heredoc delimiter so staging and production gates execute the JavaScript from the workflow revision correctly. Add a regression assertion for exact delimiter indentation. The preceding staging run reached the intended gate and failed only on this shell formatting issue; no Pages mutation occurred.