### PR TITLE
fix(ponto): isolate recovery artifact downloads

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -484,3 +484,25 @@ test("latch reset accepts only a fresh manual close reattestation title", () => 
   assert.match(reset, /run\?\.run_attempt !== 1/);
   assert.match(reset, /Automatic watchdog\/ordinary latches are intentionally not reset/);
 });
+
+test("recovery artifact downloads isolate extraction before merging attested evidence", () => {
+  for (const file of ["ponto-release-watchdog.yml", "ponto-progressive-release.yml"]) {
+    const source = workflow(file);
+    assert.match(
+      source,
+      /download_dir="\$\(mktemp -d "\$PONTO_RECOVERY_ARTIFACT_ROOT\/\.artifact-download\.XXXXXX"\)"/,
+      `${file} must isolate each artifact extraction`,
+    );
+    assert.match(source, /--dir "\$download_dir"/, `${file} must download into the isolated directory`);
+    assert.match(
+      source,
+      /cp -a "\$download_dir"\/\. "\$PONTO_RECOVERY_ARTIFACT_ROOT\/\$destination\/"/,
+      `${file} must merge the isolated artifact after extraction`,
+    );
+    assert.doesNotMatch(
+      source,
+      /--dir "\$PONTO_RECOVERY_ARTIFACT_ROOT\/\$destination"/,
+      `${file} must not extract directly into a pre-populated evidence directory`,
+    );
+  }
+});

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1769,8 +1769,12 @@ jobs:
           NODE
           while IFS=$'\t' read -r run_id artifact destination; do
             mkdir -p "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination"
-            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
-              --name "$artifact" --dir "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination" || true
+            download_dir="$(mktemp -d "$PONTO_RECOVERY_ARTIFACT_ROOT/.artifact-download.XXXXXX")"
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --name "$artifact" --dir "$download_dir"; then
+              cp -a "$download_dir"/. "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination/"
+            fi
+            rm -rf "$download_dir"
           done
       - name: Upload immutable ordinary-recovery reconciliation
         if: always()

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -396,8 +396,12 @@ jobs:
           NODE
           while IFS=$'\t' read -r run_id artifact destination; do
             mkdir -p "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination"
-            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
-              --name "$artifact" --dir "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination" || true
+            download_dir="$(mktemp -d "$PONTO_RECOVERY_ARTIFACT_ROOT/.artifact-download.XXXXXX")"
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --name "$artifact" --dir "$download_dir"; then
+              cp -a "$download_dir"/. "$PONTO_RECOVERY_ARTIFACT_ROOT/$destination/"
+            fi
+            rm -rf "$download_dir"
           done
       - name: Restore every independently attested incumbent and keep the latch true
         env:


### PR DESCRIPTION
## Summary
- isolate each watchdog and ordinary-recovery artifact extraction in a private temporary directory
- merge the downloaded evidence only after extraction, avoiding collisions with coordinator evidence
- add static regression coverage for both recovery paths

## Root cause
The coordinator pre-populates the recovery root with surface and mutation evidence. Child rollback artifacts were downloaded directly into those same directories, so `gh run download` failed on existing files and the watchdog recovery job exited unsuccessfully despite the incumbent evidence remaining intact.

## Validation
- `ponto-orchestrator-lease.test.mjs` (16 passing)
- `validate-deploy-topology.mjs`
- `git diff --check`