### PR TITLE
fix(ponto): keep Pages rollback fail-closed without candidate

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -62,3 +62,10 @@ test("zero-surface recovery uses a fresh external maintenance probe instead of f
   assert.match(source, /rollbackDisposition/);
   assert.match(source, /no-dispatched-surface-noop/);
 });
+
+test("Pages recovery skips rollback intent custody when no owned candidate exists", () => {
+  assert.match(
+    source,
+    /const pagesIntentInput = plan\.crmPages && UUID\.test\(plan\.crmPages\.candidateDeploymentId \|\| ""\) \?/,
+  );
+});

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -729,7 +729,7 @@ let pagesCreatedDeploymentId = "";
 let pagesMutationAttempted = false;
 let pagesMutationObserved = false;
 let pagesIntent = null;
-const pagesIntentInput = plan.crmPages ? {
+const pagesIntentInput = plan.crmPages && UUID.test(plan.crmPages.candidateDeploymentId || "") ? {
   request: github,
   secret: pagesRollbackIntentHmacKey,
   repositoryId,

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -527,3 +527,23 @@ test("staging Pages incumbent capture retries and requires exact terminal proven
   assert.match(block, /if \[\[ "\$attempt" != 12 \]\]; then sleep 5; fi/);
   assert.doesNotMatch(block, /Unable to resolve staging Pages rollback deployment/);
 });
+
+test("Pages configs keep remote secrets out of Wrangler Pages configuration", () => {
+  for (const relativePath of ["crm/console/wrangler.toml", "crm/console/.wrangler-staging/wrangler.toml"]) {
+    const source = fs.readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+    assert.doesNotMatch(source, /^\[secrets\]/m, `${relativePath} must not declare unsupported Pages secrets`);
+    assert.doesNotMatch(source, /^\[env\.(?:production|preview)\.secrets\]/m, `${relativePath} must not declare unsupported environment secrets`);
+  }
+});
+
+test("staging Pages compensation preserves the incumbent when deployment produced no owned candidate", () => {
+  const source = workflow("deploy-crm-pages.yml");
+  const start = source.indexOf("- name: Restore Ponto staging Pages incumbent after failure or cancellation");
+  const end = source.indexOf("- name: Write Ponto staging Pages mutation journal", start);
+  assert.ok(start >= 0 && end > start, "staging Pages compensation block is absent");
+  const block = source.slice(start, end);
+  assert.match(block, /candidate_id="\$\{PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID:-\}"/);
+  assert.match(block, /No exact owned staging Pages candidate was attested/);
+  assert.match(block, /exit 0/);
+  assert.doesNotMatch(block, /PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID"\]\]/);
+});

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -629,7 +629,12 @@ jobs:
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
-          [[ "$PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$ ]] || {
+          candidate_id="${PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID:-}"
+          if [[ -z "$candidate_id" ]]; then
+            echo 'No exact owned staging Pages candidate was attested; preserving the incumbent without a rollback mutation'
+            exit 0
+          fi
+          [[ "$candidate_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$ ]] || {
             echo 'Staging Pages compensation has no exact owned candidate; refusing to overwrite current state'
             exit 1
           }
@@ -637,7 +642,7 @@ jobs:
             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments?env=production&per_page=25" \
             > "$RUNNER_TEMP/pages-staging-current.json"
-          node - "$RUNNER_TEMP/pages-staging-current.json" "$PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID" <<'NODE'
+          node - "$RUNNER_TEMP/pages-staging-current.json" "$candidate_id" <<'NODE'
           const fs = require("fs");
           const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const latest = (payload?.result || [])

--- a/crm/console/.wrangler-staging/wrangler.toml
+++ b/crm/console/.wrangler-staging/wrangler.toml
@@ -21,13 +21,6 @@ service = "skincos-insumos-staging"
 binding = "MODULE_CONTROL"
 id = "e69fe06b6abc46eca4f4c00198d078f2"
 
-[env.production.secrets]
-required = [
-  "PONTO_ACTOR_HMAC_KEY",
-  "PONTO_NETWORK_CONTEXT_KEY",
-  "PONTO_RELEASE_PROBE_HMAC_KEY",
-]
-
 [env.production.vars]
 INSUMOS_API_TARGET = "https://api-staging.skincos.com.br"
 FINANCE_API_TARGET = "https://api-staging.skincos.com.br"
@@ -54,13 +47,6 @@ service = "skincos-insumos-staging"
 [[env.preview.kv_namespaces]]
 binding = "MODULE_CONTROL"
 id = "e69fe06b6abc46eca4f4c00198d078f2"
-
-[env.preview.secrets]
-required = [
-  "PONTO_ACTOR_HMAC_KEY",
-  "PONTO_NETWORK_CONTEXT_KEY",
-  "PONTO_RELEASE_PROBE_HMAC_KEY",
-]
 
 [env.preview.vars]
 INSUMOS_API_TARGET = "https://api-staging.skincos.com.br"

--- a/crm/console/wrangler.toml
+++ b/crm/console/wrangler.toml
@@ -3,13 +3,6 @@ name = "skincos"
 pages_build_output_dir = "dist"
 compatibility_date = "2026-01-13"
 
-[secrets]
-required = [
-  "PONTO_ACTOR_HMAC_KEY",
-  "PONTO_NETWORK_CONTEXT_KEY",
-  "PONTO_RELEASE_PROBE_HMAC_KEY",
-]
-
 [[env.production.r2_buckets]]
 binding = "SHARE_BUCKET"
 bucket_name = "skincos-share"
@@ -25,13 +18,6 @@ service = "skincos-insumos"
 [[env.production.kv_namespaces]]
 binding = "MODULE_CONTROL"
 id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
-
-[env.production.secrets]
-required = [
-  "PONTO_ACTOR_HMAC_KEY",
-  "PONTO_NETWORK_CONTEXT_KEY",
-  "PONTO_RELEASE_PROBE_HMAC_KEY",
-]
 
 [env.production.vars]
 ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"
@@ -64,13 +50,6 @@ service = "skincos-insumos-staging"
 [[env.preview.kv_namespaces]]
 binding = "MODULE_CONTROL"
 id = "e69fe06b6abc46eca4f4c00198d078f2"
-
-[env.preview.secrets]
-required = [
-  "PONTO_ACTOR_HMAC_KEY",
-  "PONTO_NETWORK_CONTEXT_KEY",
-  "PONTO_RELEASE_PROBE_HMAC_KEY",
-]
 
 [env.preview.vars]
 INSUMOS_API_TARGET = "https://api.skincos.com.br"


### PR DESCRIPTION
## Summary\n- remove unsupported Wrangler Pages secrets tables; remote Pages secrets remain provisioned and attested by the controlled workflow\n- preserve the incumbent without a rollback mutation when a failed Pages deployment produced no owned candidate\n- skip Pages rollback intent custody when no candidate identity exists\n\n## Validation\n- ponto automatic rollback safety tests\n- ponto orchestrator lease tests\n- deployment topology validation\n- git diff --check\n\nOperational evidence: staging run 30771002957 failed before a Pages deployment was created; the exact incumbent remained attested.