### PR TITLE
fix(ponto): resolve Pages candidates from API inventory

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -385,6 +385,7 @@ for (const [name, spec] of Object.entries(surfaceSpecs)) {
       candidateDeploymentId,
       incumbentDeploymentId,
       restoredDeploymentId,
+      alias: expectedPagesAlias,
     };
   } else {
     const candidateVersionId = String(source.candidateVersionId || "");

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -547,3 +547,16 @@ test("staging Pages compensation preserves the incumbent when deployment produce
   assert.match(block, /exit 0/);
   assert.doesNotMatch(block, /PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID"\]\]/);
 });
+
+test("Ponto staging Pages resolves and compensates candidates from the API inventory", () => {
+  const source = workflow("deploy-crm-pages.yml");
+  const deployStart = source.indexOf("- name: Deploy to Cloudflare Pages (wrangler)");
+  const restoreEnd = source.indexOf("- name: Write Ponto staging Pages mutation journal", deployStart);
+  assert.ok(deployStart >= 0 && restoreEnd > deployStart, "Ponto Pages deployment block is absent");
+  const block = source.slice(deployStart, restoreEnd);
+  assert.match(block, /ponto-pages-candidate\.mjs/);
+  assert.match(block, /PAGES_STAGING_DEPLOYMENT_STARTED_AT/);
+  assert.match(block, /env=production&page=\$page&per_page=25/);
+  assert.doesNotMatch(block, /ponto-wrangler-output\.mjs/);
+  assert.match(block, /PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=\$candidate_id/);
+});

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -536,16 +536,18 @@ test("Pages configs keep remote secrets out of Wrangler Pages configuration", ()
   }
 });
 
-test("staging Pages compensation preserves the incumbent when deployment produced no owned candidate", () => {
+test("staging Pages compensation fails closed when an owned candidate cannot be attested", () => {
   const source = workflow("deploy-crm-pages.yml");
   const start = source.indexOf("- name: Restore Ponto staging Pages incumbent after failure or cancellation");
   const end = source.indexOf("- name: Write Ponto staging Pages mutation journal", start);
   assert.ok(start >= 0 && end > start, "staging Pages compensation block is absent");
   const block = source.slice(start, end);
   assert.match(block, /candidate_id="\$\{PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID:-\}"/);
-  assert.match(block, /No exact owned staging Pages candidate was attested/);
-  assert.match(block, /exit 0/);
-  assert.doesNotMatch(block, /PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID"\]\]/);
+  assert.match(block, /resolved=false/);
+  assert.match(block, /--pending/);
+  assert.match(block, /Unable to attest the exact staging Pages candidate/);
+  assert.match(block, /exit 1/);
+  assert.doesNotMatch(block, /preserving the incumbent without a rollback mutation/);
 });
 
 test("Ponto staging Pages resolves and compensates candidates from the API inventory", () => {
@@ -555,6 +557,8 @@ test("Ponto staging Pages resolves and compensates candidates from the API inven
   assert.ok(deployStart >= 0 && restoreEnd > deployStart, "Ponto Pages deployment block is absent");
   const block = source.slice(deployStart, restoreEnd);
   assert.match(block, /ponto-pages-candidate\.mjs/);
+  assert.match(source, /Preserve trusted Ponto Pages candidate resolver before release checkout/);
+  assert.match(source, /node "\$RUNNER_TEMP\/ponto-pages-candidate\.mjs"/);
   assert.match(block, /PAGES_STAGING_DEPLOYMENT_STARTED_AT/);
   assert.match(block, /env=production&page=\$page&per_page=25/);
   assert.doesNotMatch(block, /ponto-wrangler-output\.mjs/);

--- a/.github/scripts/ponto-pages-candidate.mjs
+++ b/.github/scripts/ponto-pages-candidate.mjs
@@ -35,40 +35,69 @@ const candidateUrl = (value) => {
   }
 };
 
-export function selectPagesCandidate(deployments, {
+const normalizeExpectations = ({
   project,
   branch = "staging",
   releaseSha,
   startedAt,
   alias = "crm-staging.skincos.com.br",
-}) {
+  candidateId = "",
+}) => {
   const expectedProject = String(project || "");
   const expectedBranch = String(branch || "");
   const expectedSha = String(releaseSha || "").toLowerCase();
   const startedAtMs = Date.parse(String(startedAt || ""));
   const expectedAlias = aliasHost(alias);
+  const expectedCandidateId = String(candidateId || "").toLowerCase();
   if (
     !expectedProject
     || !expectedBranch
     || !SHA.test(expectedSha)
     || !Number.isFinite(startedAtMs)
     || !expectedAlias
-    || !Array.isArray(deployments)
+    || (expectedCandidateId && !UUID.test(expectedCandidateId))
   ) throw new Error("Pages candidate selection identity is invalid");
+  return {
+    expectedProject,
+    expectedBranch,
+    expectedSha,
+    startedAtMs,
+    expectedAlias,
+    expectedCandidateId,
+  };
+};
 
+const matchesIdentity = (deployment, expectations) => {
+  const createdAtMs = Date.parse(String(deployment?.created_on || ""));
+  return UUID.test(String(deployment?.id || ""))
+    && deployment?.project_name === expectations.expectedProject
+    && deployment?.environment === "production"
+    && deployment?.deployment_trigger?.metadata?.branch === expectations.expectedBranch
+    && commitSha(deployment) === expectations.expectedSha
+    && Number.isFinite(createdAtMs)
+    && createdAtMs >= expectations.startedAtMs
+    && deployment?.is_skipped === false
+    && (!expectations.expectedCandidateId
+      || String(deployment.id).toLowerCase() === expectations.expectedCandidateId);
+};
+
+const summarizeCandidate = (deployment, expectedAlias) => ({
+  id: String(deployment.id),
+  url: String(deployment.url || ""),
+  createdOn: String(deployment.created_on),
+  terminal: terminalDeployment(deployment),
+  aliased: new Set((deployment?.aliases || []).map(aliasHost)).has(expectedAlias),
+});
+
+export function selectPagesCandidate(deployments, expectationsInput) {
+  if (!Array.isArray(deployments)) throw new Error("Pages deployment inventory is invalid");
+  const expectations = normalizeExpectations(expectationsInput);
   return deployments
     .filter((deployment) => {
-      const createdAtMs = Date.parse(String(deployment?.created_on || ""));
       const aliases = new Set((deployment?.aliases || []).map(aliasHost));
-      return UUID.test(String(deployment?.id || ""))
-        && deployment?.project_name === expectedProject
-        && deployment?.environment === "production"
-        && deployment?.deployment_trigger?.metadata?.branch === expectedBranch
-        && commitSha(deployment) === expectedSha
-        && Number.isFinite(createdAtMs)
-        && createdAtMs >= startedAtMs
+      return matchesIdentity(deployment, expectations)
         && terminalDeployment(deployment)
-        && aliases.has(expectedAlias)
+        && aliases.has(expectations.expectedAlias)
         && candidateUrl(deployment?.url);
     })
     .sort((a, b) => Date.parse(String(b.created_on)) - Date.parse(String(a.created_on)))
@@ -78,6 +107,28 @@ export function selectPagesCandidate(deployments, {
       createdOn: String(deployment.created_on),
     }))[0] || null;
 }
+
+// During compensation, an exact deployment can exist before it reaches a
+// terminal stage or receives the public alias. Capture that identity first,
+// then keep polling that same deployment until the terminal owned candidate
+// is attested. Never infer that the incumbent is safe from a missing match.
+export function selectPagesPendingCandidate(deployments, expectationsInput) {
+  if (!Array.isArray(deployments)) throw new Error("Pages deployment inventory is invalid");
+  const expectations = normalizeExpectations(expectationsInput);
+  return deployments
+    .filter((deployment) => matchesIdentity(deployment, expectations))
+    .sort((a, b) => Date.parse(String(b.created_on)) - Date.parse(String(a.created_on)))
+    .map((deployment) => summarizeCandidate(deployment, expectations.expectedAlias))[0] || null;
+}
+
+const cliExpectations = () => ({
+  project: process.env.PROJECT,
+  branch: process.env.BRANCH || "staging",
+  releaseSha: process.env.RELEASE_SHA,
+  startedAt: process.env.PAGES_STAGING_DEPLOYMENT_STARTED_AT,
+  alias: process.env.PAGES_STAGING_ALIAS || "crm-staging.skincos.com.br",
+  candidateId: process.env.CANDIDATE_ID || "",
+});
 
 export function readPagesDeploymentInventory(directory) {
   const files = fs.readdirSync(directory)
@@ -95,19 +146,20 @@ export function resolvePagesCandidate(directory, expectations) {
   return selectPagesCandidate(readPagesDeploymentInventory(directory), expectations);
 }
 
+export function resolvePagesPendingCandidate(directory, expectations) {
+  return selectPagesPendingCandidate(readPagesDeploymentInventory(directory), expectations);
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const [directory] = process.argv.slice(2);
+  const [directory, mode = ""] = process.argv.slice(2);
   try {
-    if (!directory) throw new Error("usage: ponto-pages-candidate.mjs <inventory-directory>");
-    const selected = resolvePagesCandidate(directory, {
-      project: process.env.PROJECT,
-      branch: process.env.BRANCH || "staging",
-      releaseSha: process.env.RELEASE_SHA,
-      startedAt: process.env.PAGES_STAGING_DEPLOYMENT_STARTED_AT,
-      alias: process.env.PAGES_STAGING_ALIAS || "crm-staging.skincos.com.br",
-    });
+    if (!directory) throw new Error("usage: ponto-pages-candidate.mjs <inventory-directory> [--pending]");
+    const expectations = cliExpectations();
+    const selected = mode === "--pending"
+      ? resolvePagesPendingCandidate(directory, expectations)
+      : resolvePagesCandidate(directory, expectations);
     if (!selected) process.exit(2);
-    process.stdout.write(`${selected.id}\t${selected.url}\n`);
+    process.stdout.write(`${selected.id}\t${selected.url || ""}\n`);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/.github/scripts/ponto-pages-candidate.mjs
+++ b/.github/scripts/ponto-pages-candidate.mjs
@@ -1,0 +1,115 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA = /^[0-9a-f]{40}$/;
+
+const aliasHost = (value) => {
+  try {
+    return new URL(String(value)).hostname;
+  } catch {
+    return String(value).replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  }
+};
+
+const commitSha = (deployment) =>
+  String(deployment?.deployment_trigger?.metadata?.commit_hash || "").toLowerCase();
+
+const terminalDeployment = (deployment) => {
+  const stage = deployment?.latest_stage;
+  return stage?.name === "deploy"
+    && stage?.status === "success"
+    && Number.isFinite(Date.parse(String(stage?.ended_on || "")))
+    && deployment?.is_skipped === false;
+};
+
+const candidateUrl = (value) => {
+  try {
+    const url = new URL(String(value));
+    return url.protocol === "https:"
+      && /^[a-z0-9-]+\.skincos-staging\.pages\.dev$/.test(url.hostname)
+      && (url.pathname === "/" || url.pathname === "");
+  } catch {
+    return false;
+  }
+};
+
+export function selectPagesCandidate(deployments, {
+  project,
+  branch = "staging",
+  releaseSha,
+  startedAt,
+  alias = "crm-staging.skincos.com.br",
+}) {
+  const expectedProject = String(project || "");
+  const expectedBranch = String(branch || "");
+  const expectedSha = String(releaseSha || "").toLowerCase();
+  const startedAtMs = Date.parse(String(startedAt || ""));
+  const expectedAlias = aliasHost(alias);
+  if (
+    !expectedProject
+    || !expectedBranch
+    || !SHA.test(expectedSha)
+    || !Number.isFinite(startedAtMs)
+    || !expectedAlias
+    || !Array.isArray(deployments)
+  ) throw new Error("Pages candidate selection identity is invalid");
+
+  return deployments
+    .filter((deployment) => {
+      const createdAtMs = Date.parse(String(deployment?.created_on || ""));
+      const aliases = new Set((deployment?.aliases || []).map(aliasHost));
+      return UUID.test(String(deployment?.id || ""))
+        && deployment?.project_name === expectedProject
+        && deployment?.environment === "production"
+        && deployment?.deployment_trigger?.metadata?.branch === expectedBranch
+        && commitSha(deployment) === expectedSha
+        && Number.isFinite(createdAtMs)
+        && createdAtMs >= startedAtMs
+        && terminalDeployment(deployment)
+        && aliases.has(expectedAlias)
+        && candidateUrl(deployment?.url);
+    })
+    .sort((a, b) => Date.parse(String(b.created_on)) - Date.parse(String(a.created_on)))
+    .map((deployment) => ({
+      id: String(deployment.id),
+      url: String(deployment.url),
+      createdOn: String(deployment.created_on),
+    }))[0] || null;
+}
+
+export function readPagesDeploymentInventory(directory) {
+  const files = fs.readdirSync(directory)
+    .filter((file) => /^page-[0-9]+\.json$/.test(file))
+    .sort((a, b) => Number(a.match(/[0-9]+/)[0]) - Number(b.match(/[0-9]+/)[0]));
+  if (!files.length) throw new Error("Pages deployment inventory is empty");
+  const payloads = files.map((file) => JSON.parse(fs.readFileSync(path.join(directory, file), "utf8")));
+  if (payloads.some((payload) => payload?.success !== true || !Array.isArray(payload?.result))) {
+    throw new Error("Pages deployment inventory contains an invalid page");
+  }
+  return payloads.flatMap((payload) => payload.result);
+}
+
+export function resolvePagesCandidate(directory, expectations) {
+  return selectPagesCandidate(readPagesDeploymentInventory(directory), expectations);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [directory] = process.argv.slice(2);
+  try {
+    if (!directory) throw new Error("usage: ponto-pages-candidate.mjs <inventory-directory>");
+    const selected = resolvePagesCandidate(directory, {
+      project: process.env.PROJECT,
+      branch: process.env.BRANCH || "staging",
+      releaseSha: process.env.RELEASE_SHA,
+      startedAt: process.env.PAGES_STAGING_DEPLOYMENT_STARTED_AT,
+      alias: process.env.PAGES_STAGING_ALIAS || "crm-staging.skincos.com.br",
+    });
+    if (!selected) process.exit(2);
+    process.stdout.write(`${selected.id}\t${selected.url}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/ponto-pages-candidate.test.mjs
+++ b/.github/scripts/ponto-pages-candidate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { selectPagesCandidate } from "./ponto-pages-candidate.mjs";
+import { selectPagesCandidate, selectPagesPendingCandidate } from "./ponto-pages-candidate.mjs";
 
 const project = "skincos-staging";
 const branch = "staging";
@@ -74,6 +74,25 @@ test("rejects a same-SHA deployment that is stale, pending, or not aliased", () 
   assert.equal(
     selectPagesCandidate([stale, pending, unaliased], { project, branch, releaseSha, startedAt, alias }),
     null,
+  );
+});
+
+test("captures the exact same-SHA deployment while it is pending", () => {
+  const pending = deployment({
+    id: "44444444-4444-4444-8444-444444444444",
+    createdOn: "2026-08-03T00:01:00.000Z",
+    status: "active",
+    aliases: [],
+  });
+  assert.deepEqual(
+    selectPagesPendingCandidate([pending], { project, branch, releaseSha, startedAt, alias }),
+    {
+      id: pending.id,
+      url: pending.url,
+      createdOn: pending.created_on,
+      terminal: false,
+      aliased: false,
+    },
   );
 });
 

--- a/.github/scripts/ponto-pages-candidate.test.mjs
+++ b/.github/scripts/ponto-pages-candidate.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectPagesCandidate } from "./ponto-pages-candidate.mjs";
+
+const project = "skincos-staging";
+const branch = "staging";
+const releaseSha = "a".repeat(40);
+const alias = "crm-staging.skincos.com.br";
+const startedAt = "2026-08-03T00:00:00.000Z";
+
+const deployment = ({
+  id,
+  sha = releaseSha,
+  createdOn,
+  environment = "production",
+  deploymentBranch = branch,
+  status = "success",
+  aliases = [`https://${alias}`],
+  url = `https://${id.slice(0, 8)}.skincos-staging.pages.dev`,
+  skipped = false,
+} = {}) => ({
+  id,
+  project_name: project,
+  environment,
+  created_on: createdOn,
+  deployment_trigger: { metadata: { branch: deploymentBranch, commit_hash: sha } },
+  latest_stage: { name: "deploy", status, ended_on: status === "success" ? createdOn : null },
+  is_skipped: skipped,
+  aliases,
+  url,
+});
+
+test("selects the newest exact terminal candidate from the Pages inventory", () => {
+  const old = deployment({
+    id: "11111111-1111-4111-8111-111111111111",
+    createdOn: "2026-07-30T00:00:00.000Z",
+  });
+  const newest = deployment({
+    id: "22222222-2222-4222-8222-222222222222",
+    createdOn: "2026-08-03T00:02:00.000Z",
+  });
+  const staleSha = deployment({
+    id: "33333333-3333-4333-8333-333333333333",
+    sha: "b".repeat(40),
+    createdOn: "2026-08-03T00:03:00.000Z",
+  });
+
+  assert.deepEqual(
+    selectPagesCandidate([old, staleSha, newest], { project, branch, releaseSha, startedAt, alias }),
+    {
+      id: newest.id,
+      url: newest.url,
+      createdOn: newest.created_on,
+    },
+  );
+});
+
+test("rejects a same-SHA deployment that is stale, pending, or not aliased", () => {
+  const stale = deployment({
+    id: "11111111-1111-4111-8111-111111111111",
+    createdOn: "2026-07-31T00:00:00.000Z",
+  });
+  const pending = deployment({
+    id: "22222222-2222-4222-8222-222222222222",
+    createdOn: "2026-08-03T00:01:00.000Z",
+    status: "active",
+  });
+  const unaliased = deployment({
+    id: "33333333-3333-4333-8333-333333333333",
+    createdOn: "2026-08-03T00:02:00.000Z",
+    aliases: [],
+  });
+
+  assert.equal(
+    selectPagesCandidate([stale, pending, unaliased], { project, branch, releaseSha, startedAt, alias }),
+    null,
+  );
+});
+
+test("requires the production project and exact source identity", () => {
+  const candidate = deployment({
+    id: "11111111-1111-4111-8111-111111111111",
+    createdOn: "2026-08-03T00:01:00.000Z",
+  });
+  assert.equal(
+    selectPagesCandidate([{ ...candidate, environment: "preview" }], { project, branch, releaseSha, startedAt, alias }),
+    null,
+  );
+  assert.equal(
+    selectPagesCandidate([candidate], { project, branch: "main", releaseSha, startedAt, alias }),
+    null,
+  );
+});

--- a/.github/scripts/ponto-pages-rollback.mjs
+++ b/.github/scripts/ponto-pages-rollback.mjs
@@ -84,7 +84,7 @@ export async function rollbackPagesWithReconciliation({
   };
   const getLatest = async () => {
     const payload = await request(`${base}?env=production&per_page=25`);
-    const listed = latestProductionPagesDeployment(payload);
+    const listed = latestProductionPagesDeployment(payload, { alias });
     const id = String(listed?.id || "").toLowerCase();
     if (!UUID.test(id)) throw new Error("Pages latest production deployment identity is invalid");
     return getDeployment(id);

--- a/.github/scripts/ponto-rollback-ownership.mjs
+++ b/.github/scripts/ponto-rollback-ownership.mjs
@@ -83,13 +83,26 @@ export function classifyWorkerPublisherCompensationOwnership(payload, item, stag
   return classifyWorkerRollbackOwnership(payload, item, stage);
 }
 
-export function latestProductionPagesDeployment(payload) {
+const aliasHost = (value) => {
+  try {
+    return new URL(String(value)).hostname;
+  } catch {
+    return String(value).replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  }
+};
+
+export function latestProductionPagesDeployment(payload, { alias = "" } = {}) {
   if (payload?.success !== true || !Array.isArray(payload?.result)) {
     throw new Error("Pages deployment inventory is invalid");
   }
-  return payload.result
+  const production = payload.result
     .filter(item => item?.environment === "production")
-    .sort((left, right) => String(right?.created_on || "").localeCompare(String(left?.created_on || "")))[0] || null;
+    .sort((left, right) => String(right?.created_on || "").localeCompare(String(left?.created_on || "")));
+  const expectedAlias = alias ? aliasHost(alias) : "";
+  const aliased = expectedAlias
+    ? production.filter(item => (item?.aliases || []).map(aliasHost).includes(expectedAlias))
+    : [];
+  return (aliased.length ? aliased : production)[0] || null;
 }
 
 export function isTerminalPagesDeployment(deployment) {
@@ -104,7 +117,7 @@ export function classifyPagesRollbackOwnership(payload, item) {
   if (!UUID.test(item?.incumbentDeploymentId || "")) {
     throw new Error("Pages rollback incumbent identity is invalid");
   }
-  const latest = latestProductionPagesDeployment(payload);
+  const latest = latestProductionPagesDeployment(payload, { alias: item?.alias });
   const latestId = String(latest?.id || "").toLowerCase();
   const candidateId = String(item?.candidateDeploymentId || "").toLowerCase();
   const incumbentId = String(item.incumbentDeploymentId).toLowerCase();

--- a/.github/scripts/ponto-rollback-ownership.test.mjs
+++ b/.github/scripts/ponto-rollback-ownership.test.mjs
@@ -165,6 +165,30 @@ test("Pages rollback mutates only its exact current candidate", () => {
   );
 });
 
+test("Pages ownership follows the public alias after Cloudflare restores an older incumbent", () => {
+  const currentCandidate = {
+    ...pages(candidate).result[0],
+    created_on: "2026-08-03T00:02:00Z",
+    aliases: [],
+  };
+  const currentIncumbent = {
+    ...pages(incumbent).result[0],
+    created_on: "2026-07-30T00:00:00Z",
+    aliases: ["https://crm-staging.skincos.com.br"],
+  };
+  assert.equal(
+    classifyPagesRollbackOwnership(
+      { success: true, result: [currentCandidate, currentIncumbent] },
+      {
+        candidateDeploymentId: candidate,
+        incumbentDeploymentId: incumbent,
+        alias: "crm-staging.skincos.com.br",
+      },
+    ),
+    "already-incumbent",
+  );
+});
+
 test("Pages ownership accepts only an unskipped completed deploy success", () => {
   const valid = pages(candidate).result[0];
   assert.equal(isTerminalPagesDeployment(valid), true);

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -474,7 +474,6 @@ jobs:
           CORE_CANDIDATE_VERSION_ID: ${{ inputs.core_candidate_version_id }}
           IDENTITY_CANDIDATE_VERSION_ID: ${{ inputs.identity_candidate_version_id }}
           MODULE_CONTROL_KV_ID: ${{ steps.guard.outputs.module_control_kv_id }}
-          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/crm-pages-deploy.ndjson
         run: |
           set -euo pipefail
           PROJECT="${PAGES_PROJECT:-skincos}"
@@ -524,6 +523,7 @@ jobs:
           if [[ "$RELEASE_SCOPE" == ponto ]]; then GIT_MESSAGE="ponto:crmPages:$GIT_SHA"; fi
           if [[ "$RELEASE_SCOPE" == ponto && "$DEPLOY_TARGET" == staging ]]; then
             echo "PAGES_STAGING_MUTATION_STARTED=true" >> "$GITHUB_ENV"
+            echo "PAGES_STAGING_DEPLOYMENT_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" >> "$GITHUB_ENV"
             touch "$RUNNER_TEMP/pages-staging-mutation-started"
           fi
           echo "Deploying Cloudflare Pages project=$PROJECT branch=$BRANCH_NAME"
@@ -540,14 +540,46 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          PONTO_EXPECTED_WRANGLER_ENV=production node .github/scripts/ponto-wrangler-output.mjs "$RUNNER_TEMP/crm-pages-deploy.ndjson" pages-deploy "$PROJECT" > "$RUNNER_TEMP/pages-deploy-verified.txt"
-          IFS=$'\t' read -r deployment_id deployment_url < <(node - "$RUNNER_TEMP/crm-pages-deploy.ndjson" <<'NODE'
+          candidate_dir="$RUNNER_TEMP/pages-staging-candidate"
+          mkdir -p "$candidate_dir"
+          selected=false
+          for attempt in {1..12}; do
+            rm -f "$candidate_dir"/page-*.json
+            total_pages=1
+            page=1
+            while (( page <= total_pages )); do
+              candidate_page="$candidate_dir/page-$page.json"
+              curl --fail --silent --show-error --retry 3 --retry-delay 2 \
+                -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments?env=production&page=$page&per_page=25" \
+                > "$candidate_page"
+              total_pages="$(node - "$candidate_page" <<'NODE'
           const fs = require("fs");
-          const rows = fs.readFileSync(process.argv[2], "utf8").trim().split(/\r?\n/).map(JSON.parse);
-          const row = rows.filter(item => item.type === "pages-deploy").at(-1);
-          process.stdout.write(`${row?.deployment_id || row?.id || ""}\t${row?.url || row?.deployment_url || row?.targets?.[0] || ""}`);
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const totalPages = Number(payload?.result_info?.total_pages || 1);
+          if (
+            payload?.success !== true
+            || !Array.isArray(payload?.result)
+            || !Number.isInteger(totalPages)
+            || totalPages < 1
+            || totalPages > 100
+          ) throw new Error("Cloudflare Pages deployment inventory is not paginable");
+          process.stdout.write(String(totalPages));
           NODE
-          )
+              )"
+              (( page += 1 ))
+            done
+            status=0
+            selection="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node .github/scripts/ponto-pages-candidate.mjs "$candidate_dir")" || status=$?
+            if [[ "$status" == 0 ]]; then
+              IFS=$'\t' read -r deployment_id deployment_url <<< "$selection"
+              selected=true
+              break
+            fi
+            [[ "$status" == 2 ]] || exit "$status"
+            if [[ "$attempt" != 12 ]]; then sleep 5; fi
+          done
+          [[ "$selected" == true ]] || { echo 'Unable to resolve an exact terminal staging Pages candidate'; exit 1; }
           echo "PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=$deployment_id" >> "$GITHUB_ENV"
           [[ "$deployment_url" =~ ^https://[a-z0-9-]+\.skincos-staging\.pages\.dev/?$ ]] || { echo 'Structured Pages output returned an unexpected staging URL'; exit 1; }
           curl --fail --silent --show-error \
@@ -630,6 +662,47 @@ jobs:
         run: |
           set -euo pipefail
           candidate_id="${PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID:-}"
+          if [[ -z "$candidate_id" && -n "${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" ]]; then
+            candidate_dir="$RUNNER_TEMP/pages-staging-compensation-candidate"
+            mkdir -p "$candidate_dir"
+            for attempt in {1..12}; do
+              rm -f "$candidate_dir"/page-*.json
+              total_pages=1
+              page=1
+              while (( page <= total_pages )); do
+                candidate_page="$candidate_dir/page-$page.json"
+                curl --fail --silent --show-error --retry 3 --retry-delay 2 \
+                  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+                  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments?env=production&page=$page&per_page=25" \
+                  > "$candidate_page"
+                total_pages="$(node - "$candidate_page" <<'NODE'
+          const fs = require("fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const totalPages = Number(payload?.result_info?.total_pages || 1);
+          if (
+            payload?.success !== true
+            || !Array.isArray(payload?.result)
+            || !Number.isInteger(totalPages)
+            || totalPages < 1
+            || totalPages > 100
+          ) throw new Error("Cloudflare Pages deployment inventory is not paginable");
+          process.stdout.write(String(totalPages));
+          NODE
+                )"
+                (( page += 1 ))
+              done
+              status=0
+              selection="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node .github/scripts/ponto-pages-candidate.mjs "$candidate_dir")" || status=$?
+              if [[ "$status" == 0 ]]; then
+                IFS=$'\t' read -r candidate_id _ <<< "$selection"
+                echo "PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=$candidate_id" >> "$GITHUB_ENV"
+                break
+              fi
+              [[ "$status" == 2 ]] || exit "$status"
+              candidate_id=""
+              if [[ "$attempt" != 12 ]]; then sleep 5; fi
+            done
+          fi
           if [[ -z "$candidate_id" ]]; then
             echo 'No exact owned staging Pages candidate was attested; preserving the incumbent without a rollback mutation'
             exit 0

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -155,6 +155,12 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Preserve trusted Ponto Pages candidate resolver before release checkout
+        if: ${{ inputs.release_scope == 'ponto' && inputs.orchestrator_run_id != '' }}
+        run: |
+          set -euo pipefail
+          cp .github/scripts/ponto-pages-candidate.mjs "$RUNNER_TEMP/ponto-pages-candidate.mjs"
+          test -s "$RUNNER_TEMP/ponto-pages-candidate.mjs"
       - name: Revalidate the exact active coordinator before CRM Pages staging secrets or mutation
         if: ${{ inputs.release_scope == 'ponto' && inputs.orchestrator_run_id != '' }}
         env:
@@ -570,7 +576,7 @@ jobs:
               (( page += 1 ))
             done
             status=0
-            selection="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node .github/scripts/ponto-pages-candidate.mjs "$candidate_dir")" || status=$?
+            selection="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node "$RUNNER_TEMP/ponto-pages-candidate.mjs" "$candidate_dir")" || status=$?
             if [[ "$status" == 0 ]]; then
               IFS=$'\t' read -r deployment_id deployment_url <<< "$selection"
               selected=true
@@ -662,8 +668,9 @@ jobs:
         run: |
           set -euo pipefail
           candidate_id="${PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID:-}"
-          if [[ -z "$candidate_id" && -n "${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" ]]; then
-            candidate_dir="$RUNNER_TEMP/pages-staging-compensation-candidate"
+          candidate_dir="$RUNNER_TEMP/pages-staging-compensation-candidate"
+          resolved=false
+          if [[ -n "${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" ]]; then
             mkdir -p "$candidate_dir"
             for attempt in {1..12}; do
               rm -f "$candidate_dir"/page-*.json
@@ -691,21 +698,32 @@ jobs:
                 )"
                 (( page += 1 ))
               done
-              status=0
-              selection="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node .github/scripts/ponto-pages-candidate.mjs "$candidate_dir")" || status=$?
-              if [[ "$status" == 0 ]]; then
-                IFS=$'\t' read -r candidate_id _ <<< "$selection"
-                echo "PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=$candidate_id" >> "$GITHUB_ENV"
-                break
+              if [[ -z "$candidate_id" ]]; then
+                status=0
+                pending="$(PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node "$RUNNER_TEMP/ponto-pages-candidate.mjs" "$candidate_dir" --pending)" || status=$?
+                if [[ "$status" == 0 ]]; then
+                  IFS=$'\t' read -r candidate_id _ <<< "$pending"
+                  echo "PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=$candidate_id" >> "$GITHUB_ENV"
+                else
+                  [[ "$status" == 2 ]] || exit "$status"
+                fi
               fi
-              [[ "$status" == 2 ]] || exit "$status"
-              candidate_id=""
+              if [[ -n "$candidate_id" ]]; then
+                status=0
+                selection="$(CANDIDATE_ID="$candidate_id" PROJECT="$PROJECT" RELEASE_SHA="$RELEASE_SHA" PAGES_STAGING_DEPLOYMENT_STARTED_AT="${PAGES_STAGING_DEPLOYMENT_STARTED_AT:-}" node "$RUNNER_TEMP/ponto-pages-candidate.mjs" "$candidate_dir")" || status=$?
+                if [[ "$status" == 0 ]]; then
+                  IFS=$'\t' read -r candidate_id _ <<< "$selection"
+                  resolved=true
+                  break
+                fi
+                [[ "$status" == 2 ]] || exit "$status"
+              fi
               if [[ "$attempt" != 12 ]]; then sleep 5; fi
             done
           fi
-          if [[ -z "$candidate_id" ]]; then
-            echo 'No exact owned staging Pages candidate was attested; preserving the incumbent without a rollback mutation'
-            exit 0
+          if [[ "$resolved" != true ]]; then
+            echo 'Unable to attest the exact staging Pages candidate to terminal success with the public alias; refusing to treat the incumbent as preserved' >&2
+            exit 1
           fi
           [[ "$candidate_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$ ]] || {
             echo 'Staging Pages compensation has no exact owned candidate; refusing to overwrite current state'


### PR DESCRIPTION
## Summary
- resolve Ponto staging Pages candidates from the Cloudflare deployment inventory instead of Wrangler NDJSON, which wrangler pages deploy does not emit
- bind selection to project, staging branch, production environment, canonical SHA, post-deploy timestamp, terminal success, Pages URL, and CRM alias
- reuse the exact inventory proof in staging compensation so an already-created candidate can be rolled back after a resolver/output failure
- add focused selector tests and workflow regression coverage

## Validation
- 
ode --test .github/scripts/ponto-pages-candidate.test.mjs .github/scripts/ponto-orchestrator-lease.test.mjs
- 
ode .github/scripts/validate-deploy-topology.mjs
- git diff --check

The change is fail-closed when no exact owned candidate is found.,--draft=false