### PR TITLE
fix(ponto): render staging Timekeeping journey D1

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -278,6 +278,13 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
   assert.match(core, /vars\.ENABLE_PONTO_CORE_WORKERS_DEPLOY\b/);
   const timekeeping = readWorkflow("deploy-timekeeping.yml");
   assert.match(timekeeping, /vars\.ENABLE_PONTO_TIMEKEEPING_PRODUCTION_DEPLOY\b/);
+  const stagingJourney = readWorkflow("timekeeping-staging-journey.yml");
+  assert.match(stagingJourney, /vars\.PONTO_TIMEKEEPING_D1_STAGING_ID\b/);
+  assert.match(stagingJourney, /TIMEKEEPING_STAGING_WRANGLER_CONFIG/);
+  assert.doesNotMatch(
+    stagingJourney,
+    /d1 execute \"\$STAGING_TIMEKEEPING_D1_DATABASE\" --config workforce\/timekeeping\/wrangler\.toml/,
+  );
   const journey = fs.readFileSync(
     new URL("./ponto-production-journey.mjs", import.meta.url),
     "utf8",

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -133,6 +133,20 @@ jobs:
         run: npx --yes playwright install --with-deps chromium
         working-directory: crm/console
 
+      - name: Render the exact staging Timekeeping D1 config
+        env:
+          STAGING_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+        run: |
+          set -euo pipefail
+          [[ "$STAGING_TIMEKEEPING_D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Timekeeping D1 ID is missing or malformed'; exit 1; }
+          config="$RUNNER_TEMP/ponto-timekeeping-staging-wrangler.toml"
+          cp workforce/timekeeping/wrangler.toml "$config"
+          sed -i \
+            "s/__CONFIGURE_TIMEKEEPING_D1_ID__/00000000-0000-4000-8000-000000000001/;s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/00000000000000000000000000000001/;s/__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__/$STAGING_TIMEKEEPING_D1_ID/" \
+            "$config"
+          ! grep -q '__CONFIGURE_.*_ID__' "$config" || { echo 'unresolved Timekeeping staging binding placeholder'; exit 1; }
+          printf 'TIMEKEEPING_STAGING_WRANGLER_CONFIG=%s\n' "$config" >> "$GITHUB_ENV"
+
       - name: Generate runner-private synthetic fixture
         env:
           FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
@@ -165,7 +179,7 @@ jobs:
           [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || { echo 'staging Cloudflare credentials are required'; exit 1; }
           [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" >/dev/null
-          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config workforce/timekeeping/wrangler.toml --env staging --remote --file "$TIMEKEEPING_SQL" >/dev/null
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" >/dev/null
       - name: Prove exact Identity candidate through the protected Pages binding
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -274,7 +288,7 @@ jobs:
           [[ -f "$FIXTURES" ]] || exit 0
           [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
           node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL"
-          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config workforce/timekeeping/wrangler.toml --env staging --remote --file "$TIMEKEEPING_SQL" --json > "$TIMEKEEPING_RESULT"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" --json > "$TIMEKEEPING_RESULT"
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" --json > "$CORE_RESULT"
           node - "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$TEARDOWN_REPORT" <<'NODE'
           const fs = require("fs");


### PR DESCRIPTION
## What changed
- Render a runner-private Wrangler configuration for the staging Timekeeping D1 before the authenticated journey provisions or tears down fixtures.
- Resolve the canonical `PONTO_TIMEKEEPING_D1_STAGING_ID` GitHub variable and fail closed on malformed or unresolved bindings.
- Add a focused static regression assertion for the journey workflow.

## Root cause
The journey invoked Wrangler with the repository template, which intentionally contains `__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__`. The first staging journey therefore failed before authentication with Cloudflare error 7400 (`Invalid uuid`).

## Validation
- `node --test .github/scripts/ponto-dispatch-workflow.test.mjs` (7/7 passed) via Ubuntu-24.04 WSL.
- `git diff --check` passed.
- Verified the GitHub staging D1 variable resolves to the canonical staging resource.

## Impact
This is staging-journey harness/configuration only. It keeps production and shared repository state untouched and preserves fail-closed behavior on missing or invalid resource identity.