### PR TITLE
fix(ponto): keep staging identity probe compatible with ESM

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -281,6 +281,8 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
   const stagingJourney = readWorkflow("timekeeping-staging-journey.yml");
   assert.match(stagingJourney, /vars\.PONTO_TIMEKEEPING_D1_STAGING_ID\b/);
   assert.match(stagingJourney, /TIMEKEEPING_STAGING_WRANGLER_CONFIG/);
+  assert.match(stagingJourney, /import crypto from "node:crypto";/);
+  assert.match(stagingJourney, /import fs from "node:fs";/);
   assert.doesNotMatch(
     stagingJourney,
     /d1 execute \"\$STAGING_TIMEKEEPING_D1_DATABASE\" --config workforce\/timekeeping\/wrangler\.toml/,

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -193,8 +193,8 @@ jobs:
           [[ "$IDENTITY_VERSION_ID" =~ ^[0-9a-fA-F-]{36}$ && "$TIMEKEEPING_VERSION_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Exact staging version IDs are required'; exit 1; }
           [[ -n "${PONTO_IDEMPOTENCY_KEY:-}" ]] || { echo 'Staging PONTO_IDEMPOTENCY_KEY is required for the one-time release probe'; exit 1; }
           node - "$FIXTURES" "$RUNNER_TEMP/ponto-staging-contract.json" <<'NODE'
-          const crypto = require("crypto");
-          const fs = require("fs");
+          import crypto from "node:crypto";
+          import fs from "node:fs";
           const fixture = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           if (fixture?.environment !== "staging" || fixture?.role !== "CONSULTOR" || !String(fixture?.email || "").endsWith("@staging.invalid")) {
             throw new Error("protected contract requires the run-scoped synthetic staging identity");


### PR DESCRIPTION
## Summary
- use Node ESM imports in the staging protected Identity probe heredoc
- add a static workflow guard for the import form

## Validation
- node --test .github/scripts/ponto-dispatch-workflow.test.mjs (7/7)
- git diff --check

Fixes the staging journey failure where top-level await caused the heredoc to run as an ES module while the probe used CommonJS require().