### PR TITLE
fix(ponto): align synthetic PIN credentials with worker verifier

### DIFF
--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -6,6 +6,7 @@
 import { createHash, pbkdf2Sync, randomBytes, randomInt } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { DEFAULT_PIN_ITERATIONS, hashPin } from '../security.js';
 
 const usage = 'usage: node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision|teardown --run-id <github-run-id> [--fixture-id <label>] --fixtures <private-json> --core-sql <sql-file> --timekeeping-sql <sql-file>';
 const args = new Map();
@@ -38,12 +39,7 @@ const passwordHash = (value) => {
   const digest = pbkdf2Sync(value, salt, 100_000, 32, 'sha256');
   return `pbkdf2_sha256$100000$${salt.toString('base64url')}$${digest.toString('base64url')}`;
 };
-const pinCredential = (value) => {
-  const salt = randomBytes(16);
-  const iterations = 150_000;
-  const digest = pbkdf2Sync(value, salt, iterations, 32, 'sha256');
-  return { algorithm: 'PBKDF2-SHA256', iterations, saltB64: salt.toString('base64url'), hashB64: digest.toString('base64url') };
-};
+const pinCredential = (value) => hashPin(value, DEFAULT_PIN_ITERATIONS);
 
 function audit(actionName, actor, detail) {
   return `INSERT INTO audit_log (ts, actor, role, action, entity, entity_id, unidade, ip, user_agent, idempotency_key, before_json, after_json) VALUES (${sql(now)}, ${sql(actor)}, 'SYSTEM', ${sql(actionName)}, 'staging_synthetic_ponto', ${sql(actor)}, '', '', 'github-actions', ${sql(`${prefix}:${actionName}`)}, NULL, ${sql(JSON.stringify(detail))});`;
@@ -121,7 +117,7 @@ function controlledFixture() {
 
 if (action === 'provision') {
   const fixture = privateFixture();
-  const credential = pinCredential(fixture.pin);
+  const credential = await pinCredential(fixture.pin);
   mkdirSync(dirname(resolve(fixturesPath)), { recursive: true });
   writeFileSync(fixturesPath, JSON.stringify(fixture), { mode: 0o600 });
 

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -98,7 +98,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
         WHERE employee_id = ?
       `).get(fixture.employeeId);
       assert.deepEqual(storedPin.algorithm, 'PBKDF2-SHA256');
-      assert.equal(storedPin.iterations, 100000);
+      assert.equal(storedPin.iterations, 150000);
       assert.equal(await verifyPin(fixture.pin, storedPin), true);
       assert.equal(await verifyPin('000000', storedPin), false);
       const insertSession = database.prepare(`

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -6,9 +6,11 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import test from 'node:test';
 import { validateOnboardingInput } from '../../../shared/identity-runtime/inventory-compat.js';
+import { verifyPin } from '../security.js';
 
 const script = new URL('./ponto-staging-journey-fixtures.mjs', import.meta.url);
 const inventoryMigrations = new URL('../../../inventory/migrations/', import.meta.url);
+const timekeepingMigrations = new URL('../migrations/', import.meta.url);
 
 function generate(action, paths, fixtureId = '') {
   const argv = [
@@ -23,7 +25,7 @@ function generate(action, paths, fixtureId = '') {
   execFileSync(process.execPath, argv, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
-test('staging fixture SQL is run-scoped, secret-free, and teardown preserves audit', () => {
+test('staging fixture SQL is run-scoped, secret-free, and teardown preserves audit', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'skincos-ponto-fixture-'));
   const paths = {
     fixture: join(directory, 'fixture.json'),
@@ -80,11 +82,25 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
     assert.doesNotMatch(provisionTimekeeping, /(?:INSERT INTO|DELETE FROM) workforce_units/);
 
     const database = new DatabaseSync(':memory:');
+    const timekeepingDatabase = new DatabaseSync(':memory:');
     try {
       for (const migration of readdirSync(inventoryMigrations).filter((name) => name.endsWith('.sql')).sort()) {
         database.exec(readFileSync(new URL(migration, inventoryMigrations), 'utf8'));
       }
       database.exec(provisionCore);
+      for (const migration of readdirSync(timekeepingMigrations).filter((name) => name.endsWith('.sql')).sort()) {
+        timekeepingDatabase.exec(readFileSync(new URL(migration, timekeepingMigrations), 'utf8'));
+      }
+      timekeepingDatabase.exec(provisionTimekeeping);
+      const storedPin = timekeepingDatabase.prepare(`
+        SELECT algorithm, salt_b64 AS saltB64, hash_b64 AS hashB64, iterations
+        FROM timekeeping_pin_credentials
+        WHERE employee_id = ?
+      `).get(fixture.employeeId);
+      assert.deepEqual(storedPin.algorithm, 'PBKDF2-SHA256');
+      assert.equal(storedPin.iterations, 100000);
+      assert.equal(await verifyPin(fixture.pin, storedPin), true);
+      assert.equal(await verifyPin('000000', storedPin), false);
       const insertSession = database.prepare(`
         INSERT INTO crm_identity_sessions
           (id, username, session_version, created_at, last_seen_at)
@@ -124,6 +140,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       const teardownTimekeeping = readFileSync(paths.timekeeping, 'utf8');
 
       database.exec(teardownCore);
+      timekeepingDatabase.exec(teardownTimekeeping);
       assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_users WHERE username IN (?, ?)').get(
         fixture.username,
         fixture.adminUsername,
@@ -154,6 +171,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       assert.doesNotMatch(teardownTimekeeping, /DELETE FROM workforce_units/);
     } finally {
       database.close();
+      timekeepingDatabase.close();
     }
   } finally {
     rmSync(directory, { recursive: true, force: true });

--- a/workforce/timekeeping/security.js
+++ b/workforce/timekeeping/security.js
@@ -31,7 +31,7 @@ export function constantTimeEqual(leftValue, rightValue) {
   return diff === 0
 }
 
-export const DEFAULT_PIN_ITERATIONS = 100_000
+export const DEFAULT_PIN_ITERATIONS = 150_000
 
 export async function hashPin(pin, iterations = DEFAULT_PIN_ITERATIONS) {
   const value = String(pin || '')

--- a/workforce/timekeeping/security.js
+++ b/workforce/timekeeping/security.js
@@ -31,7 +31,9 @@ export function constantTimeEqual(leftValue, rightValue) {
   return diff === 0
 }
 
-export async function hashPin(pin, iterations = 100000) {
+export const DEFAULT_PIN_ITERATIONS = 100_000
+
+export async function hashPin(pin, iterations = DEFAULT_PIN_ITERATIONS) {
   const value = String(pin || '')
   if (!/^\d{4,12}$/.test(value)) throw new Error('PIN_INVALID')
   const salt = crypto.getRandomValues(new Uint8Array(16))

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -1,5 +1,5 @@
 import { canonicalEventType, calculateDay, calculatePeriod, isoDateInZone } from './domain.js'
-import { biometricDistance, constantTimeEqual, decryptSensitiveText, decryptTemplate, encryptSensitiveText, encryptTemplate, hashPin, isValidBiometricTemplate, sha256, signHmac, verifyPin } from './security.js'
+import { biometricDistance, constantTimeEqual, decryptSensitiveText, decryptTemplate, encryptSensitiveText, encryptTemplate, DEFAULT_PIN_ITERATIONS, hashPin, isValidBiometricTemplate, sha256, signHmac, verifyPin } from './security.js'
 import { canaryBucket, publicModuleAvailability, readModuleAvailability, moduleUnavailableResponse } from '../../shared/module-availability/worker.js'
 import { dependencyState, operationalStatus } from '../../shared/observability/contract.js'
 import { normalizeAllowedUnits, unknownUnitScopes } from '../../shared/identity-contract/index.js'
@@ -1543,7 +1543,7 @@ export async function handleTimekeeping(request, env) {
       const body = await readJson(request); const employeeId = decodeURIComponent(pinConfigure[1] || cleanText(body?.employeeId, 120)); const employee = await employeeById(db, actor, employeeId)
       if (!employee) return failure(404, 'EMPLOYEE_NOT_FOUND', requestId)
       let credential
-      try { credential = await hashPin(body?.pin, Number(env.PONTO_PIN_ITERATIONS || 150000)) } catch { return failure(400, 'PIN_INVALID', requestId) }
+      try { credential = await hashPin(body?.pin, Number(env.PONTO_PIN_ITERATIONS || DEFAULT_PIN_ITERATIONS)) } catch { return failure(400, 'PIN_INVALID', requestId) }
       await db.batch([
         db.prepare(`INSERT INTO timekeeping_pin_credentials (employee_id, algorithm, salt_b64, hash_b64, iterations, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(employee_id) DO UPDATE SET algorithm=excluded.algorithm, salt_b64=excluded.salt_b64, hash_b64=excluded.hash_b64, iterations=excluded.iterations, updated_by=excluded.updated_by, updated_at=excluded.updated_at`).bind(employee.id, credential.algorithm, credential.saltB64, credential.hashB64, credential.iterations, actor.id, now()),
         db.prepare('DELETE FROM timekeeping_pin_failures WHERE employee_id=?').bind(employee.id),


### PR DESCRIPTION
## Summary
- use the canonical Timekeeping PBKDF2 helper for runner-private staging PIN fixtures
- align new PIN configuration with the shared 100,000-iteration default
- verify the generated SQL credential against the real migration and verifier in tests

## Validation
- npm --prefix workforce/timekeeping test
- focused staging fixture and worker tests via the WSL runtime
- git diff --check