### PR TITLE
fix(ponto): trigger merge SHA security attestations

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -47,7 +47,8 @@
       "triggerPaths": [
         ".github/governance/progressive-release-policy.json",
         ".github/workflows/ponto-",
-        ".github/scripts/ponto-"
+        ".github/scripts/ponto-",
+        "workforce/timekeeping/"
       ]
     }
   },

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -17,7 +17,8 @@ on:
       - ".github/governance/progressive-release-policy.json"
       - ".github/workflows/ponto-*.yml"
       - ".github/scripts/ponto-*.mjs"
-      - "!.github/workflows/security-secrets-audit.yml"
+      - "workforce/timekeeping/**"
+      - ".github/workflows/security-secrets-audit.yml"
   pull_request:
     branches: [main]
     paths:
@@ -34,7 +35,8 @@ on:
       - ".github/governance/progressive-release-policy.json"
       - ".github/workflows/ponto-*.yml"
       - ".github/scripts/ponto-*.mjs"
-      - "!.github/workflows/security-secrets-audit.yml"
+      - "workforce/timekeeping/**"
+      - ".github/workflows/security-secrets-audit.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           node-version: "22.12.0"
 
-      - name: NPM audit (root + frontend + website lockfiles)
+      - name: NPM audit (root + frontend + website + timekeeping lockfiles)
         run: |
           set -euxo pipefail
           if [ -f package-lock.json ]; then
@@ -83,6 +83,9 @@ jobs:
           fi
           if [ -f website/package-lock.json ]; then
             node .github/scripts/npm-audit-gate.mjs website
+          fi
+          if [ -f workforce/timekeeping/package-lock.json ]; then
+            node .github/scripts/npm-audit-gate.mjs workforce/timekeeping
           fi
 
       - name: Audit backend production lockfile with Trivy


### PR DESCRIPTION
## Summary
- trigger the security audit for all workforce/timekeeping changes
- trigger the audit when its own workflow changes
- declare the timekeeping prefix in progressive-release governance

## Validation
- `node .github/scripts/validate-progressive-release.mjs`
- `node .github/scripts/validate-github-governance.mjs`
- `node --test .github/scripts/ponto-single-operator-governance.test.mjs`
- `git diff --check`

This preserves the required Dependency Audit and Gitleaks checks and makes them attestable on the immutable merge SHA.