### PR TITLE
fix(ponto): reconcile incumbent rollback and attest PIN fixture

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -813,6 +813,43 @@ const persistPagesCreatedId = async (deploymentId, source) => {
     piiIncluded: false,
   }, null, 2)}\n`, { mode: 0o600 });
 };
+const persistPagesExistingIncumbentId = async (deploymentId, source) => {
+  if (!pagesIntent) throw new Error("Pages rollback existing incumbent has no durable one-shot intent");
+  if (String(deploymentId || "").toLowerCase() !== String(plan.crmPages.incumbentDeploymentId || "").toLowerCase()) {
+    throw new Error("Pages rollback existing incumbent identity differs from the attested incumbent");
+  }
+  pagesIntent = await completePagesRollbackIntent({
+    request: github,
+    secret: pagesRollbackIntentHmacKey,
+    intent: pagesIntent,
+    restoredDeploymentId: deploymentId,
+    allowExistingIncumbent: true,
+  });
+  pagesCreatedDeploymentId = deploymentId;
+  pagesMutationObserved = true;
+  plan.crmPages.restoredDeploymentId = deploymentId;
+  const journalFile = path.join(
+    artifactRoot,
+    "automatic-rollback/ponto-pages-rollback-restored.json",
+  );
+  fs.mkdirSync(path.dirname(journalFile), { recursive: true });
+  fs.writeFileSync(journalFile, `${JSON.stringify({
+    schemaVersion: 1,
+    sourceSha: releaseSha,
+    failedStage: stage,
+    orchestratorRunId,
+    candidateDeploymentId: plan.crmPages.candidateDeploymentId,
+    incumbentDeploymentId: plan.crmPages.incumbentDeploymentId,
+    restoredDeploymentId: deploymentId,
+    restoredExistingIncumbent: true,
+    source,
+    mutationAttempted: true,
+    mutationOutcome: "existing-incumbent-reconciled",
+    recordedAt: new Date().toISOString(),
+    credentialsIncluded: false,
+    piiIncluded: false,
+  }, null, 2)}\n`, { mode: 0o600 });
+};
 
 if (plan.crmPages) {
   if (!rollbackPermitted) {
@@ -845,15 +882,9 @@ if (plan.crmPages) {
         reason: "current-pages-ownership-conflict",
       };
     } else if (["already-incumbent", "already-restored"].includes(ownership)) {
-      if (
-        ownership === "already-incumbent"
+      const existingIncumbentReconciled = ownership === "already-incumbent"
         && pagesIntent
-        && pagesIntent.claims.state !== "restored"
-      ) {
-        throw new Error(
-          "Pages rollback intent exists but no distinct rollback clone can be proven",
-        );
-      }
+        && pagesIntent.claims.state !== "restored";
       const activeId = ownership === "already-restored"
         ? plan.crmPages.restoredDeploymentId
         : requested;
@@ -877,16 +908,19 @@ if (plan.crmPages) {
           secret: pagesRollbackIntentHmacKey,
           intent: pagesIntent,
           restoredDeploymentId: activeId,
+          allowExistingIncumbent: ownership === "already-incumbent",
         });
       }
       proofs.crmPages = {
         passed: true,
-        mutationPerformed: false,
+        mutationPerformed: Boolean(existingIncumbentReconciled),
         requestedDeploymentId: requested,
         activeDeploymentId: activeId,
         project: pagesProject,
         sourceCommitSha: attestation.sourceCommitSha,
-        disposition: ownership,
+        disposition: existingIncumbentReconciled
+          ? "already-incumbent-after-intent"
+          : ownership,
         publicAliasesAttested: true,
       };
     } else {
@@ -907,6 +941,7 @@ if (plan.crmPages) {
           : "",
         persistAttempt: persistPagesAttempt,
         persistCreatedId: persistPagesCreatedId,
+        persistExistingIncumbentId: persistPagesExistingIncumbentId,
       });
       if (!pagesIntent) throw new Error("Pages rollback completed without durable intent");
       pagesIntent = await completePagesRollbackIntent({
@@ -914,6 +949,7 @@ if (plan.crmPages) {
         secret: pagesRollbackIntentHmacKey,
         intent: pagesIntent,
         restoredDeploymentId: rolledBack.activeDeploymentId,
+        allowExistingIncumbent: rolledBack.restoredExistingIncumbent === true,
       });
       proofs.crmPages = {
         passed: true,

--- a/.github/scripts/ponto-pages-rollback-intent.mjs
+++ b/.github/scripts/ponto-pages-rollback-intent.mjs
@@ -64,6 +64,10 @@ function verifyDocument(document, expectedBase, secret) {
     || !/^[1-9][0-9]*$/.test(String(claims?.recoveryRunId || ""))
     || (claims.state === "attempted" && claims.restoredDeploymentId !== "")
     || (
+      claims.restoredExistingIncumbent !== undefined
+      && typeof claims.restoredExistingIncumbent !== "boolean"
+    )
+    || (
       ["created", "restored"].includes(claims.state)
       && !UUID.test(String(claims.restoredDeploymentId || ""))
     )
@@ -73,6 +77,18 @@ function verifyDocument(document, expectedBase, secret) {
         expectedBase.candidateDeploymentId,
         expectedBase.incumbentDeploymentId,
       ].includes(String(claims.restoredDeploymentId || "").toLowerCase())
+      && !(
+        claims.state === "restored"
+        && claims.restoredExistingIncumbent === true
+        && String(claims.restoredDeploymentId || "").toLowerCase() === expectedBase.incumbentDeploymentId
+      )
+    )
+    || (
+      claims.restoredExistingIncumbent === true
+      && (
+        claims.state !== "restored"
+        || String(claims.restoredDeploymentId || "").toLowerCase() !== expectedBase.incumbentDeploymentId
+      )
     )
     || (claims.state === "restored" && !Number.isFinite(Date.parse(String(claims.restoredAt || ""))))
     || !/^[0-9a-f]{64}$/.test(String(document?.signatureHmacSha256 || ""))
@@ -145,6 +161,7 @@ export async function createPagesRollbackIntent({
     attemptedAt: attemptedAt.toISOString(),
     recoveryRunId: String(recoveryRunId),
     restoredDeploymentId: "",
+    restoredExistingIncumbent: false,
     restoredAt: "",
   };
   const document = { claims, signatureHmacSha256: signature(claims, secret) };
@@ -197,6 +214,7 @@ async function transitionIntent({
   intent,
   state,
   restoredDeploymentId,
+  allowExistingIncumbent = false,
   now = new Date(),
 }) {
   if (!intent?.base || !Number.isInteger(intent?.checkId)) {
@@ -208,10 +226,10 @@ async function transitionIntent({
   const verified = verifyCheck(current, intent.base, secret);
   const restoredId = String(restoredDeploymentId || "").toLowerCase();
   if (!UUID.test(restoredId)) throw new Error("Pages rollback restored deployment ID is invalid");
-  if ([
-    intent.base.candidateDeploymentId,
-    intent.base.incumbentDeploymentId,
-  ].includes(restoredId)) {
+  if (restoredId === intent.base.candidateDeploymentId) {
+    throw new Error("Pages rollback restored deployment must be a distinct rollback clone");
+  }
+  if (restoredId === intent.base.incumbentDeploymentId && (!allowExistingIncumbent || state !== "restored")) {
     throw new Error("Pages rollback restored deployment must be a distinct rollback clone");
   }
   if (
@@ -225,6 +243,7 @@ async function transitionIntent({
     ...verified.claims,
     state,
     restoredDeploymentId: restoredId,
+    restoredExistingIncumbent: restoredId === intent.base.incumbentDeploymentId,
     restoredAt: state === "restored" ? transitionedAt.toISOString() : "",
   };
   const document = { claims, signatureHmacSha256: signature(claims, secret) };

--- a/.github/scripts/ponto-pages-rollback-intent.test.mjs
+++ b/.github/scripts/ponto-pages-rollback-intent.test.mjs
@@ -11,6 +11,7 @@ import {
 const repository = "owner/repo";
 const sourceSha = "a".repeat(40);
 const restoredId = "33333333-3333-4333-8333-333333333333";
+const incumbentId = "22222222-2222-4222-8222-222222222222";
 const secret = "pages-rollback-intent-hmac-root-".repeat(2);
 
 const canonicalize = (value) => {
@@ -179,4 +180,37 @@ test("transition readback rejects a valid competing state", async () => {
     }),
     /competing transition detected/,
   );
+});
+
+test("existing incumbent reconciliation is explicit and durably attested", async () => {
+  const fixture = harness();
+  const intent = await createPagesRollbackIntent({
+    ...input(fixture.request),
+    recoveryRunId: "700",
+    now: new Date("2026-07-30T00:00:00Z"),
+  });
+  await assert.rejects(
+    completePagesRollbackIntent({
+      request: fixture.request,
+      secret,
+      intent,
+      restoredDeploymentId: incumbentId,
+    }),
+    /distinct rollback clone/,
+  );
+  const completed = await completePagesRollbackIntent({
+    request: fixture.request,
+    secret,
+    intent,
+    restoredDeploymentId: incumbentId,
+    allowExistingIncumbent: true,
+    now: new Date("2026-07-30T00:02:00Z"),
+  });
+  assert.equal(completed.claims.state, "restored");
+  assert.equal(completed.claims.restoredDeploymentId, incumbentId);
+  assert.equal(completed.claims.restoredExistingIncumbent, true);
+  const loaded = await readPagesRollbackIntent(input(fixture.request));
+  assert.equal(loaded.claims.restoredExistingIncumbent, true);
+  assert.equal(fixture.check().status, "completed");
+  assert.equal(fixture.check().conclusion, "success");
 });

--- a/.github/scripts/ponto-pages-rollback.mjs
+++ b/.github/scripts/ponto-pages-rollback.mjs
@@ -51,6 +51,7 @@ export async function rollbackPagesWithReconciliation({
   knownRestoredDeploymentId = "",
   persistAttempt = async () => {},
   persistCreatedId = async () => {},
+  persistExistingIncumbentId = async () => {},
   sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   timeoutMs = 180_000,
   pollMs = 5_000,
@@ -172,10 +173,18 @@ export async function rollbackPagesWithReconciliation({
       if (!attestation.passed) {
         throw new Error("reconciled Pages deployment does not attest the exact incumbent");
       }
-      await persistCreatedId(latestId, "reconciled-indeterminate-response");
+      const restoredExistingIncumbent = latestId === incumbentId;
+      if (restoredExistingIncumbent) {
+        await persistExistingIncumbentId(latestId, "reconciled-indeterminate-response");
+      } else {
+        await persistCreatedId(latestId, "reconciled-indeterminate-response");
+      }
       return {
-        disposition: "restored-after-indeterminate-response",
+        disposition: restoredExistingIncumbent
+          ? "restored-existing-incumbent-after-indeterminate-response"
+          : "restored-after-indeterminate-response",
         active,
+        restoredExistingIncumbent,
       };
     }
     return { disposition: "candidate-still-active", active: candidate };
@@ -194,14 +203,22 @@ export async function rollbackPagesWithReconciliation({
         alias,
       })
     ) throw new Error("durable Pages rollback deployment no longer owns the exact incumbent alias");
-    await persistCreatedId(knownRestoredId, "durable-intent-created-id");
+    const restoredExistingIncumbent = knownRestoredId === incumbentId;
+    if (restoredExistingIncumbent) {
+      await persistExistingIncumbentId(knownRestoredId, "durable-intent-existing-incumbent");
+    } else {
+      await persistCreatedId(knownRestoredId, "durable-intent-created-id");
+    }
     return {
       active,
       activeDeploymentId: knownRestoredId,
       incumbentCommitSha: incumbentCommit,
       mutationPerformed: true,
       attempts: 0,
-      disposition: "durable-intent-restored",
+      disposition: restoredExistingIncumbent
+        ? "durable-intent-existing-incumbent-restored"
+        : "durable-intent-restored",
+      restoredExistingIncumbent,
     };
   }
 
@@ -215,6 +232,7 @@ export async function rollbackPagesWithReconciliation({
         mutationPerformed: true,
         attempts: 0,
         disposition: "durable-intent-reconciled",
+        restoredExistingIncumbent: Boolean(reconciled.restoredExistingIncumbent),
       };
     }
     throw new Error(
@@ -272,6 +290,7 @@ export async function rollbackPagesWithReconciliation({
         mutationPerformed: true,
         attempts: 1,
         disposition: reconciled.disposition,
+        restoredExistingIncumbent: Boolean(reconciled.restoredExistingIncumbent),
       };
     }
     throw new Error(

--- a/.github/scripts/ponto-pages-rollback.test.mjs
+++ b/.github/scripts/ponto-pages-rollback.test.mjs
@@ -27,7 +27,7 @@ const deployment = (id, commit, createdOn) => ({
   aliases: [`https://${alias}`],
 });
 
-function harness({ firstPostApplies }) {
+function harness({ firstPostApplies, restoresAsIncumbent = false }) {
   const deployments = new Map([
     [candidateId, deployment(candidateId, candidateCommit, "2026-07-30T00:02:00Z")],
     [incumbentId, deployment(incumbentId, incumbentCommit, "2026-07-29T00:02:00Z")],
@@ -41,11 +41,18 @@ function harness({ firstPostApplies }) {
       if (postCount === 1 && !firstPostApplies) {
         throw new Error("transport failed before apply");
       }
-      deployments.set(
-        restoredId,
-        deployment(restoredId, incumbentCommit, "2026-07-30T00:03:00Z"),
-      );
-      latestId = restoredId;
+      if (restoresAsIncumbent) {
+        const restoredIncumbent = deployment(incumbentId, incumbentCommit, "2026-07-30T00:03:00Z");
+        deployments.set(incumbentId, restoredIncumbent);
+        deployments.get(candidateId).aliases = [];
+        latestId = incumbentId;
+      } else {
+        deployments.set(
+          restoredId,
+          deployment(restoredId, incumbentCommit, "2026-07-30T00:03:00Z"),
+        );
+        latestId = restoredId;
+      }
       if (postCount === 1 && firstPostApplies) {
         throw new Error("transport failed after server apply");
       }
@@ -82,6 +89,36 @@ const run = (fixture, persisted, attempts = []) => rollbackPagesWithReconciliati
   persistCreatedId: async (id, source) => persisted.push({ id, source }),
   timeoutMs: 20,
   pollMs: 0,
+});
+
+test("indeterminate Pages rollback reconciles an already-restored incumbent without a duplicate POST", async () => {
+  const fixture = harness({ firstPostApplies: true, restoresAsIncumbent: true });
+  const persisted = [];
+  const existing = [];
+  const result = await rollbackPagesWithReconciliation({
+    request: fixture.request,
+    accountId,
+    project,
+    branch,
+    alias,
+    candidateDeploymentId: candidateId,
+    candidateCommitSha: candidateCommit,
+    incumbentDeploymentId: incumbentId,
+    persistAttempt: async () => {},
+    persistCreatedId: async (id, source) => persisted.push({ id, source }),
+    persistExistingIncumbentId: async (id, source) => existing.push({ id, source }),
+    timeoutMs: 20,
+    pollMs: 0,
+  });
+  assert.equal(fixture.postCount(), 1);
+  assert.equal(result.activeDeploymentId, incumbentId);
+  assert.equal(result.restoredExistingIncumbent, true);
+  assert.equal(result.disposition, "restored-existing-incumbent-after-indeterminate-response");
+  assert.deepEqual(persisted, []);
+  assert.deepEqual(existing, [{
+    id: incumbentId,
+    source: "reconciled-indeterminate-response",
+  }]);
 });
 
 test("applied-then-thrown Pages rollback reconciles the exact incumbent without duplicate retry", async () => {

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -180,6 +180,65 @@ jobs:
           [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" >/dev/null
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" >/dev/null
+
+      - name: Attest the exact synthetic PIN credential in staging D1
+        env:
+          FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
+          PIN_SQL: ${{ runner.temp }}/ponto-staging-pin-attestation.sql
+          PIN_RESULT: ${{ runner.temp }}/ponto-staging-pin-attestation-result.json
+          PIN_REPORT: ${{ runner.temp }}/ponto-staging-pin-attestation.json
+          STAGING_TIMEKEEPING_D1_DATABASE: skincos-timekeeping-staging
+        run: |
+          set -euo pipefail
+          node - "$FIXTURES" "$PIN_SQL" <<'NODE'
+          const fs = require('fs');
+          const fixture = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          if (fixture?.environment !== 'staging' || !String(fixture?.employeeId || '').startsWith(`stg-ponto-${fixture.runId}`)) {
+            throw new Error('staging PIN attestation fixture escaped its run scope');
+          }
+          const employeeId = String(fixture.employeeId).replaceAll("'", "''");
+          fs.writeFileSync(process.argv[3], `SELECT algorithm, salt_b64, hash_b64, iterations FROM timekeeping_pin_credentials WHERE employee_id='${employeeId}';\n`, { mode: 0o600 });
+          NODE
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$PIN_SQL" --json > "$PIN_RESULT"
+          node - "$FIXTURES" "$PIN_RESULT" "$PIN_REPORT" <<'NODE'
+          const fs = require('fs');
+          const rows = (file) => {
+            const payload = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const entries = Array.isArray(payload) ? payload : [payload];
+            if (entries.some((entry) => entry?.success === false)) throw new Error('PIN attestation query failed');
+            return entries.flatMap((entry) => entry?.results || entry?.result?.results || []);
+          };
+          (async () => {
+            const fixture = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+            const row = rows(process.argv[3]).find((entry) => entry?.algorithm && entry?.salt_b64 && entry?.hash_b64);
+            if (!row) throw new Error('staging D1 PIN credential row is missing');
+            const { pathToFileURL } = require('url');
+            const { verifyPin } = await import(pathToFileURL(require('path').resolve('workforce/timekeeping/security.js')).href);
+            const credential = {
+              algorithm: row.algorithm,
+              saltB64: row.salt_b64,
+              hashB64: row.hash_b64,
+              iterations: row.iterations,
+            };
+            const verified = await verifyPin(fixture.pin, credential);
+            const report = {
+              schemaVersion: 1,
+              environment: 'staging',
+              credentialPresent: true,
+              algorithm: String(row.algorithm),
+              iterations: Number(row.iterations),
+              saltLength: String(row.salt_b64).length,
+              hashLength: String(row.hash_b64).length,
+              fixtureCredentialVerified: verified === true,
+              credentialsIncluded: false,
+              piiIncluded: false,
+            };
+            if (report.algorithm !== 'PBKDF2-SHA256' || report.iterations !== 150000 || report.saltLength !== 22 || report.hashLength !== 43 || !report.fixtureCredentialVerified) {
+              throw new Error('staging D1 PIN credential does not verify with the canonical contract');
+            }
+            fs.writeFileSync(process.argv[4], `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+          })().catch((error) => { console.error(error); process.exitCode = 1; });
+          NODE
       - name: Prove exact Identity candidate through the protected Pages binding
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -335,6 +394,7 @@ jobs:
           path: |
             ${{ runner.temp }}/ponto-staging-report.json
             ${{ runner.temp }}/ponto-staging-contract.json
+            ${{ runner.temp }}/ponto-staging-pin-attestation.json
             ${{ runner.temp }}/ponto-staging-teardown-report.json
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -183,6 +183,8 @@ jobs:
 
       - name: Attest the exact synthetic PIN credential in staging D1
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
           PIN_SQL: ${{ runner.temp }}/ponto-staging-pin-attestation.sql
           PIN_RESULT: ${{ runner.temp }}/ponto-staging-pin-attestation-result.json

--- a/crm/console/scripts/ponto-staging-journey.cjs
+++ b/crm/console/scripts/ponto-staging-journey.cjs
@@ -34,7 +34,26 @@ if (fixture.fixtureId && !/^[a-z][a-z0-9-]{0,31}$/.test(String(fixture.fixtureId
 const fixtureKey = fixture.fixtureId ? `${fixture.runId}-${fixture.fixtureId}` : String(fixture.runId)
 
 const assert = (condition, message) => { if (!condition) throw new Error(message) }
-const safeRequestMeta = (response) => ({ status: response.status, requestIdPresent: Boolean(response.requestId), cfRayPresent: Boolean(response.cfRay) })
+const safeReleaseMeta = (response) => ({
+  pagesReleaseSha: String(response?.pagesReleaseSha || ''),
+  pagesEnvironment: String(response?.pagesEnvironment || ''),
+  gatewayReleaseSha: String(response?.gatewayReleaseSha || ''),
+  gatewayEnvironment: String(response?.gatewayEnvironment || ''),
+  gatewayVersionId: String(response?.gatewayVersionId || ''),
+  timekeepingReleaseSha: String(response?.timekeepingReleaseSha || ''),
+  timekeepingEnvironment: String(response?.timekeepingEnvironment || ''),
+  timekeepingVersionId: String(response?.timekeepingVersionId || ''),
+})
+const safeRequestMeta = (response) => ({
+  status: response.status,
+  requestIdPresent: Boolean(response.requestId),
+  cfRayPresent: Boolean(response.cfRay),
+  release: safeReleaseMeta(response),
+})
+const responseFailure = (response) => {
+  const meta = safeRequestMeta(response)
+  return `${response.status}/${response.json?.error || ''}; release=${JSON.stringify(meta.release)}`
+}
 const recordCleanupRequest = (response) => {
   const requestId = String(response?.requestId || '')
   assert(/^[A-Za-z0-9._:-]{1,180}$/.test(requestId), 'mutation response omitted a safe cleanup request id')
@@ -64,6 +83,14 @@ const api = async (page, pathname, init = {}) => {
       json,
       requestId: String(response.headers.get('x-request-id') || ''),
       cfRay: String(response.headers.get('cf-ray') || ''),
+      pagesReleaseSha: String(response.headers.get('x-skincos-pages-release-sha') || ''),
+      pagesEnvironment: String(response.headers.get('x-skincos-pages-environment') || ''),
+      gatewayReleaseSha: String(response.headers.get('x-skincos-gateway-release-sha') || ''),
+      gatewayEnvironment: String(response.headers.get('x-skincos-gateway-environment') || ''),
+      gatewayVersionId: String(response.headers.get('x-skincos-gateway-version-id') || ''),
+      timekeepingReleaseSha: String(response.headers.get('x-skincos-timekeeping-release-sha') || ''),
+      timekeepingEnvironment: String(response.headers.get('x-skincos-timekeeping-environment') || ''),
+      timekeepingVersionId: String(response.headers.get('x-skincos-timekeeping-version-id') || ''),
     }
   }, { safePathname, init })
 }
@@ -140,13 +167,13 @@ async function main() {
 
     const invalidPin = await post(page, '/api/ponto/me/punch', { pin: '000000', unit: fixture.unitId }, `invalid-${fixtureKey}`)
     recordCleanupRequest(invalidPin)
-    assert(invalidPin.status === 401 && invalidPin.json?.error === 'PIN_INVALID', `invalid PIN did not fail closed (${invalidPin.status}/${invalidPin.json?.error || ''})`)
+    assert(invalidPin.status === 401 && invalidPin.json?.error === 'PIN_INVALID', `invalid PIN did not fail closed (${responseFailure(invalidPin)})`)
     const idempotencyKey = `synthetic-punch-${fixtureKey}`
     const occurredAt = new Date().toISOString()
     const punchBody = { pin: fixture.pin, unit: fixture.unitId, occurredAt, requestId: idempotencyKey }
     const punch = await post(page, '/api/ponto/me/punch', punchBody, idempotencyKey)
     recordCleanupRequest(punch)
-    assert(punch.status === 201 && punch.json?.ok === true && punch.json?.data?.id, `PIN punch failed (${punch.status}/${punch.json?.error || ''})`)
+    assert(punch.status === 201 && punch.json?.ok === true && punch.json?.data?.id, `PIN punch failed (${responseFailure(punch)})`)
     recordCleanupEvent(punch.json.data.id)
     const retry = await post(page, '/api/ponto/me/punch', punchBody, idempotencyKey)
     recordCleanupRequest(retry)


### PR DESCRIPTION
Objective: fix fail-closed Pages recovery when the alias is already restored to the incumbent, and separate fixture/D1 from runtime in the authenticated staging journey. Changes: explicit HMAC-attested existing-incumbent reconciliation after a one-shot intent; no duplicate POST; sanitized staging D1 PBKDF2 credential attestation; safe release headers in journey evidence. Validation: focused Pages/intention/PIN/fixture tests; 31 governance and rollback tests; progressive-release and GitHub governance validators; workforce/timekeeping npm audit gate; diff check. Rollback: reverting the PR preserves fail-closed recovery and the incumbent rollback path.