### PR TITLE
fix(ponto): retry transient GitHub lease reads

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -570,7 +570,7 @@ const request = async (pathname, init = {}, { onRetry } = {}) => {
       if (response.status === 202 || response.status === 204) return null;
       return response.json();
     }
-    const retryAfterDelay = response.status === 429 || response.status === 403
+    const retryAfterDelay = TRANSIENT_READ_STATUSES.has(response.status) || response.status === 403
       ? parseRetryAfterMs(response.headers.get("retry-after"))
       : undefined;
     const retryableReadStatus = TRANSIENT_READ_STATUSES.has(response.status)

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -570,19 +570,17 @@ const request = async (pathname, init = {}, { onRetry } = {}) => {
       if (response.status === 202 || response.status === 204) return null;
       return response.json();
     }
-    if (
-      canRetry
-      && TRANSIENT_READ_STATUSES.has(response.status)
-      && attempt >= TRANSIENT_READ_RETRY_DELAYS_MS.length
-    ) {
+    const retryAfterDelay = response.status === 429 || response.status === 403
+      ? parseRetryAfterMs(response.headers.get("retry-after"))
+      : undefined;
+    const retryableReadStatus = TRANSIENT_READ_STATUSES.has(response.status)
+      || (response.status === 403 && retryAfterDelay !== undefined);
+    if (canRetry && retryableReadStatus && attempt >= TRANSIENT_READ_RETRY_DELAYS_MS.length) {
       throw new Error(
         `GitHub API ${method} ${pathname} returned ${response.status} after bounded transient read retries`,
       );
     }
-    const retryAfterDelay = response.status === 429
-      ? parseRetryAfterMs(response.headers.get("retry-after"))
-      : undefined;
-    const retryDelay = canRetry && TRANSIENT_READ_STATUSES.has(response.status)
+    const retryDelay = canRetry && retryableReadStatus
       ? retryAfterDelay ?? TRANSIENT_READ_RETRY_DELAYS_MS[attempt]
       : undefined;
     if (retryDelay === undefined) {
@@ -653,6 +651,32 @@ const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage, cur
   }
 };
 
+const delegatedIssuerSnapshot = async ({ issuerRunId }) => {
+  for (let refresh = 0; ; refresh += 1) {
+    let snapshotWasRetried = false;
+    const markSnapshotRetry = () => {
+      snapshotWasRetried = true;
+    };
+    const issuer = await request(
+      `/repos/${repository}/actions/runs/${issuerRunId}`,
+      {},
+      { onRetry: markSnapshotRetry },
+    );
+    const issuerWorkflow = await request(
+      `/repos/${repository}/actions/workflows/${issuer?.workflow_id}`,
+      {},
+      { onRetry: markSnapshotRetry },
+    );
+    if (snapshotWasRetried) {
+      if (refresh >= MAX_CANONICAL_SNAPSHOT_REFRESHES) {
+        throw new Error("delegated issuer snapshot remained transient after bounded refreshes");
+      }
+      continue;
+    }
+    return { issuer, issuerWorkflow };
+  }
+};
+
 async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestratorRunId]) {
   const releaseSha = String(releaseShaRaw || "").trim().toLowerCase();
   const currentHeadSha = String(process.env.GITHUB_SHA || "").trim().toLowerCase();
@@ -713,12 +737,10 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || !["main", "refs/heads/main"].includes(String(event?.ref || ""))
   ) throw new Error("current child run is not the exact active first-attempt capability subject");
 
-  const issuer = issuerRunId === orchestratorRunId
-    ? parent.run
-    : await request(`/repos/${repository}/actions/runs/${issuerRunId}`);
-  const issuerWorkflow = issuerRunId === orchestratorRunId
-    ? parent.workflow
-    : await request(`/repos/${repository}/actions/workflows/${issuer?.workflow_id}`);
+  const issuerSnapshot = issuerRunId === orchestratorRunId
+    ? parent
+    : await delegatedIssuerSnapshot({ issuerRunId });
+  const { issuer, issuerWorkflow } = issuerSnapshot;
   const issuerWorkflowPath = String(issuer?.path || "").split("@")[0];
   const delegatedIssuer = issuerRunId !== orchestratorRunId;
   if (

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -539,20 +539,35 @@ export function transitionCapabilityDocument(document, {
   };
 }
 
+const TRANSIENT_READ_STATUSES = new Set([429, 500, 502, 503, 504]);
+const TRANSIENT_READ_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
+
 const request = async (pathname, init = {}) => {
-  const response = await fetch(`${apiBase}${pathname}`, {
-    ...init,
-    signal: AbortSignal.timeout(30_000),
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      "x-github-api-version": "2022-11-28",
-      ...(init.headers || {}),
-    },
-  });
-  if (!response.ok) throw new Error(`GitHub API ${init.method || "GET"} ${pathname} returned ${response.status}`);
-  if (response.status === 202 || response.status === 204) return null;
-  return response.json();
+  const method = String(init.method || "GET").toUpperCase();
+  const canRetry = method === "GET" || method === "HEAD";
+  for (let attempt = 0; ; attempt += 1) {
+    const response = await fetch(`${apiBase}${pathname}`, {
+      ...init,
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+        ...(init.headers || {}),
+      },
+    });
+    if (response.ok) {
+      if (response.status === 202 || response.status === 204) return null;
+      return response.json();
+    }
+    const retryDelay = canRetry && TRANSIENT_READ_STATUSES.has(response.status)
+      ? TRANSIENT_READ_RETRY_DELAYS_MS[attempt]
+      : undefined;
+    if (retryDelay === undefined) {
+      throw new Error(`GitHub API ${method} ${pathname} returned ${response.status}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, retryDelay));
+  }
 };
 
 const assertFirstAttempt = () => {

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -541,8 +541,18 @@ export function transitionCapabilityDocument(document, {
 
 const TRANSIENT_READ_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TRANSIENT_READ_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
+const MAX_TRANSIENT_READ_RETRY_DELAY_MS = 30_000;
+const MAX_CANONICAL_SNAPSHOT_REFRESHES = 2;
 
-const request = async (pathname, init = {}) => {
+const parseRetryAfterMs = (value, now = Date.now()) => {
+  const raw = String(value || "").trim();
+  if (!raw) return undefined;
+  if (/^\d+(?:\.\d+)?$/.test(raw)) return Math.ceil(Number(raw) * 1_000);
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? Math.max(0, timestamp - now) : undefined;
+};
+
+const request = async (pathname, init = {}, { onRetry } = {}) => {
   const method = String(init.method || "GET").toUpperCase();
   const canRetry = method === "GET" || method === "HEAD";
   for (let attempt = 0; ; attempt += 1) {
@@ -560,12 +570,21 @@ const request = async (pathname, init = {}) => {
       if (response.status === 202 || response.status === 204) return null;
       return response.json();
     }
+    const retryAfterDelay = response.status === 429
+      ? parseRetryAfterMs(response.headers.get("retry-after"))
+      : undefined;
     const retryDelay = canRetry && TRANSIENT_READ_STATUSES.has(response.status)
-      ? TRANSIENT_READ_RETRY_DELAYS_MS[attempt]
+      ? retryAfterDelay ?? TRANSIENT_READ_RETRY_DELAYS_MS[attempt]
       : undefined;
     if (retryDelay === undefined) {
       throw new Error(`GitHub API ${method} ${pathname} returned ${response.status}`);
     }
+    if (retryDelay > MAX_TRANSIENT_READ_RETRY_DELAY_MS) {
+      throw new Error(
+        `GitHub API ${method} ${pathname} returned ${response.status} with Retry-After beyond the bounded retry window`,
+      );
+    }
+    onRetry?.({ method, pathname, status: response.status, retryDelay });
     await new Promise(resolve => setTimeout(resolve, retryDelay));
   }
 };
@@ -577,32 +596,52 @@ const assertFirstAttempt = () => {
 };
 
 const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage, currentHeadSha }) => {
-  const [workflow, run] = await Promise.all([
-    request(`/repos/${repository}/actions/workflows/ponto-progressive-release.yml`),
-    request(`/repos/${repository}/actions/runs/${orchestratorRunId}`),
-  ]);
-  if (
-    workflow?.state !== "active"
-    || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
-    || String(run?.id || "") !== orchestratorRunId
-    || run?.workflow_id !== workflow.id
-    || !acceptsWorkflowRunPath(workflow.path, run?.path)
-    || run?.run_attempt !== 1
-    || run?.status !== "in_progress"
-    || run?.conclusion != null
-    || run?.event !== "workflow_dispatch"
-    || run?.head_branch !== "main"
-    || run?.head_sha !== currentHeadSha
-    || run?.head_sha !== releaseSha
-    || run?.name !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
-    || run?.repository?.full_name !== repository
-    || String(run?.repository?.id || "") !== repositoryId
-    || run?.head_repository?.full_name !== repository
-    || run?.display_title !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
-  ) {
-    throw new Error("canonical orchestrator run is not the exact active first-attempt issuer");
+  for (let refresh = 0; ; refresh += 1) {
+    let snapshotWasRetried = false;
+    const markSnapshotRetry = () => {
+      snapshotWasRetried = true;
+    };
+    const [workflow, run] = await Promise.all([
+      request(
+        `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`,
+        {},
+        { onRetry: markSnapshotRetry },
+      ),
+      request(
+        `/repos/${repository}/actions/runs/${orchestratorRunId}`,
+        {},
+        { onRetry: markSnapshotRetry },
+      ),
+    ]);
+    if (snapshotWasRetried) {
+      if (refresh >= MAX_CANONICAL_SNAPSHOT_REFRESHES) {
+        throw new Error("canonical orchestrator snapshot remained transient after bounded refreshes");
+      }
+      continue;
+    }
+    if (
+      workflow?.state !== "active"
+      || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
+      || String(run?.id || "") !== orchestratorRunId
+      || run?.workflow_id !== workflow.id
+      || !acceptsWorkflowRunPath(workflow.path, run?.path)
+      || run?.run_attempt !== 1
+      || run?.status !== "in_progress"
+      || run?.conclusion != null
+      || run?.event !== "workflow_dispatch"
+      || run?.head_branch !== "main"
+      || run?.head_sha !== currentHeadSha
+      || run?.head_sha !== releaseSha
+      || run?.name !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
+      || run?.repository?.full_name !== repository
+      || String(run?.repository?.id || "") !== repositoryId
+      || run?.head_repository?.full_name !== repository
+      || run?.display_title !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
+    ) {
+      throw new Error("canonical orchestrator run is not the exact active first-attempt issuer");
+    }
+    return { workflow, run };
   }
-  return { workflow, run };
 };
 
 async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestratorRunId]) {

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -570,6 +570,15 @@ const request = async (pathname, init = {}, { onRetry } = {}) => {
       if (response.status === 202 || response.status === 204) return null;
       return response.json();
     }
+    if (
+      canRetry
+      && TRANSIENT_READ_STATUSES.has(response.status)
+      && attempt >= TRANSIENT_READ_RETRY_DELAYS_MS.length
+    ) {
+      throw new Error(
+        `GitHub API ${method} ${pathname} returned ${response.status} after bounded transient read retries`,
+      );
+    }
     const retryAfterDelay = response.status === 429
       ? parseRetryAfterMs(response.headers.get("retry-after"))
       : undefined;

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -71,12 +71,20 @@ const canonicalRun = (overrides = {}) => ({
   ...overrides,
 });
 
-const withApi = async ({ run = canonicalRun(), artifact }, callback) => {
+const withApi = async ({ run = canonicalRun(), artifact, transientFailures = [] }, callback) => {
   let deleted = false;
   let requestCount = 0;
+  const remainingTransientFailures = new Map(transientFailures.map(pathname => [pathname, 1]));
   const server = http.createServer((request, response) => {
     requestCount += 1;
     response.setHeader("content-type", "application/json");
+    const remainingFailures = remainingTransientFailures.get(request.url) || 0;
+    if (remainingFailures > 0) {
+      remainingTransientFailures.set(request.url, remainingFailures - 1);
+      response.statusCode = 503;
+      response.end(JSON.stringify({ message: "transient test failure" }));
+      return;
+    }
     if (request.url === `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`) {
       response.end(JSON.stringify({
         id: 77,
@@ -133,6 +141,19 @@ test("assert-active accepts only the exact live first-attempt coordinator", asyn
     );
     assert.equal(result.code, 0, result.stderr);
     assert.match(result.stdout, /active first-attempt Ponto coordinator/);
+  });
+});
+
+test("assert-active retries a transient GitHub API read before accepting the coordinator", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({ transientFailures: [workflowPath] }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /active first-attempt Ponto coordinator/);
+    assert.equal(getRequestCount(), 3);
   });
 });
 

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -199,6 +199,38 @@ test("assert-active honors a bounded Retry-After response for a transient read",
   });
 });
 
+test("assert-active retries a rate-limited 403 only when Retry-After is present", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureStatus: 403,
+    transientFailureHeaders: { "retry-after": "0" },
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(getRequestCount(), 5);
+  });
+});
+
+test("assert-active keeps an ordinary 403 fail-closed", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureStatus: 403,
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /GitHub API GET .* returned 403/);
+    assert.equal(getRequestCount(), 2);
+  });
+});
+
 test("assert-active fails closed when Retry-After exceeds the bounded read window", async () => {
   const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
   await withApi({

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -71,9 +71,17 @@ const canonicalRun = (overrides = {}) => ({
   ...overrides,
 });
 
-const withApi = async ({ run = canonicalRun(), artifact, transientFailures = [] }, callback) => {
+const withApi = async ({
+  run = canonicalRun(),
+  artifact,
+  runSequence = [],
+  transientFailures = [],
+  transientFailureStatus = 503,
+  transientFailureHeaders = {},
+}, callback) => {
   let deleted = false;
   let requestCount = 0;
+  let runRequestCount = 0;
   const remainingTransientFailures = new Map(transientFailures.map(pathname => [pathname, 1]));
   const server = http.createServer((request, response) => {
     requestCount += 1;
@@ -81,7 +89,8 @@ const withApi = async ({ run = canonicalRun(), artifact, transientFailures = [] 
     const remainingFailures = remainingTransientFailures.get(request.url) || 0;
     if (remainingFailures > 0) {
       remainingTransientFailures.set(request.url, remainingFailures - 1);
-      response.statusCode = 503;
+      response.statusCode = transientFailureStatus;
+      for (const [name, value] of Object.entries(transientFailureHeaders)) response.setHeader(name, value);
       response.end(JSON.stringify({ message: "transient test failure" }));
       return;
     }
@@ -94,7 +103,7 @@ const withApi = async ({ run = canonicalRun(), artifact, transientFailures = [] 
       return;
     }
     if (request.url === `/repos/${repository}/actions/runs/${orchestratorRunId}`) {
-      response.end(JSON.stringify(run));
+      response.end(JSON.stringify(runSequence[runRequestCount++] || run));
       return;
     }
     if (request.url?.startsWith(`/repos/${repository}/actions/runs/${orchestratorRunId}/artifacts?`)) {
@@ -153,7 +162,56 @@ test("assert-active retries a transient GitHub API read before accepting the coo
     );
     assert.equal(result.code, 0, result.stderr);
     assert.match(result.stdout, /active first-attempt Ponto coordinator/);
-    assert.equal(getRequestCount(), 3);
+    assert.equal(getRequestCount(), 5);
+  });
+});
+
+test("assert-active refreshes the complete coordinator snapshot after a retried read", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    runSequence: [canonicalRun(), canonicalRun({ status: "completed", conclusion: "cancelled" })],
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /exact active first-attempt issuer/);
+    assert.equal(getRequestCount(), 5);
+  });
+});
+
+test("assert-active honors a bounded Retry-After response for a transient read", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureStatus: 429,
+    transientFailureHeaders: { "retry-after": "0" },
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(getRequestCount(), 5);
+  });
+});
+
+test("assert-active fails closed when Retry-After exceeds the bounded read window", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureStatus: 429,
+    transientFailureHeaders: { "retry-after": "31" },
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /Retry-After beyond the bounded retry window/);
+    assert.equal(getRequestCount(), 2);
   });
 });
 

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -167,6 +167,22 @@ test("assert-active retries a transient GitHub API read before accepting the coo
   });
 });
 
+test("assert-active honors Retry-After on a transient 503 read", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureStatus: 503,
+    transientFailureHeaders: { "retry-after": "0" },
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(getRequestCount(), 5);
+  });
+});
+
 test("assert-active refreshes the complete coordinator snapshot after a retried read", async () => {
   const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
   await withApi({

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -76,13 +76,14 @@ const withApi = async ({
   artifact,
   runSequence = [],
   transientFailures = [],
+  transientFailureCount = 1,
   transientFailureStatus = 503,
   transientFailureHeaders = {},
 }, callback) => {
   let deleted = false;
   let requestCount = 0;
   let runRequestCount = 0;
-  const remainingTransientFailures = new Map(transientFailures.map(pathname => [pathname, 1]));
+  const remainingTransientFailures = new Map(transientFailures.map(pathname => [pathname, transientFailureCount]));
   const server = http.createServer((request, response) => {
     requestCount += 1;
     response.setHeader("content-type", "application/json");
@@ -212,6 +213,24 @@ test("assert-active fails closed when Retry-After exceeds the bounded read windo
     assert.notEqual(result.code, 0);
     assert.match(result.stderr, /Retry-After beyond the bounded retry window/);
     assert.equal(getRequestCount(), 2);
+  });
+});
+
+test("assert-active bounds repeated Retry-After responses", async () => {
+  const workflowPath = `/repos/${repository}/actions/workflows/ponto-progressive-release.yml`;
+  await withApi({
+    transientFailures: [workflowPath],
+    transientFailureCount: 10,
+    transientFailureStatus: 429,
+    transientFailureHeaders: { "retry-after": "0" },
+  }, async ({ apiUrl, getRequestCount }) => {
+    const result = await execute(
+      ["assert-active", stage, releaseSha, orchestratorRunId],
+      { GITHUB_API_URL: apiUrl },
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /after bounded transient read retries/);
+    assert.equal(getRequestCount(), 5);
   });
 });
 


### PR DESCRIPTION
## Summary
- retry bounded transient GitHub REST reads (`429`/`5xx`) used by the Ponto lease guard
- keep `PATCH` capability consumption fail-closed and non-retried
- add a regression test for the observed transient `503` during active-coordinator revalidation

## Evidence
- staging coordinator `30799014535` reached the CRM Pages lease guard and failed before Pages mutation on GitHub API HTTP 503
- governed close `30803452613` and latch reset `30803582975` succeeded
- direct Cloudflare readback: staging remains `maintenance`, emergency latch is `false`, and `https://crm-staging.skincos.com.br` remains on incumbent commit `32d5de056788761893aa4025282f0cfa3bcde66c`
- focused lease tests: 21 passed
- deployment topology validation: passed
- GitHub governance validation: passed