### PR TITLE
fix(ponto): preserve direct issuer capability snapshot

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -738,7 +738,7 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
   ) throw new Error("current child run is not the exact active first-attempt capability subject");
 
   const issuerSnapshot = issuerRunId === orchestratorRunId
-    ? parent
+    ? { issuer: parent.run, issuerWorkflow: parent.workflow }
     : await delegatedIssuerSnapshot({ issuerRunId });
   const { issuer, issuerWorkflow } = issuerSnapshot;
   const issuerWorkflowPath = String(issuer?.path || "").split("@")[0];

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -548,6 +548,14 @@ test("consume-check rejects a child rerun before any API access", async () => {
   });
 });
 
+test("consume-check maps the direct parent issuer into the delegated snapshot shape", () => {
+  const source = fs.readFileSync(script, "utf8");
+  assert.match(
+    source,
+    /issuerRunId === orchestratorRunId\s*\?\s*\{ issuer: parent\.run, issuerWorkflow: parent\.workflow \}/,
+  );
+});
+
 test("every orchestrated secret or mutation job revalidates the coordinator after checkout and before secrets", () => {
   const guardedJobs = [
     ["deploy-timekeeping.yml", "release"],


### PR DESCRIPTION
## Summary
- Preserve the direct parent issuer as { issuer: parent.run, issuerWorkflow: parent.workflow } before delegated lease validation.
- Add a regression guard for the direct issuer snapshot mapping.

## Validation
- Local Ponto suite: 29/29 passed.
- Deployment topology validation: passed.
- GitHub governance validation: passed.
- The prior staging run failed closed before mutation because the direct issuer snapshot shape was wrong; the emergency recovery and latch reset completed successfully.