### PR TITLE
fix(ponto): normalize Wrangler D1 JSON output

### DIFF
--- a/.github/scripts/ponto-json-output.mjs
+++ b/.github/scripts/ponto-json-output.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+
+const [, , inputPath, outputPath] = process.argv;
+
+if (!inputPath || !outputPath) {
+  throw new Error("usage: ponto-json-output.mjs <input> <output>");
+}
+
+const source = fs.readFileSync(inputPath, "utf8").replace(/^\uFEFF/, "");
+
+const parseDocumentAt = (start) => {
+  const opening = source[start];
+  if (opening !== "{" && opening !== "[") return undefined;
+
+  const closing = opening === "{" ? "}" : "]";
+  const stack = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{" || character === "[") stack.push(character);
+    else if (character === "}" || character === "]") {
+      if (!stack.length) return undefined;
+      const expected = stack.at(-1) === "{" ? "}" : "]";
+      if (character !== expected) return undefined;
+      stack.pop();
+      if (!stack.length && character === closing) {
+        try {
+          return JSON.parse(source.slice(start, index + 1));
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+  return undefined;
+};
+
+let document;
+for (let index = 0; index < source.length && document === undefined; index += 1) {
+  if (source[index] !== "{" && source[index] !== "[") continue;
+  document = parseDocumentAt(index);
+}
+
+if (document === undefined) {
+  throw new Error("command output did not contain a valid JSON document");
+}
+
+fs.writeFileSync(outputPath, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 });

--- a/.github/scripts/ponto-json-output.test.mjs
+++ b/.github/scripts/ponto-json-output.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = path.resolve(".github/scripts/ponto-json-output.mjs");
+
+const runParser = (raw) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-json-output-"));
+  const input = path.join(directory, "raw.txt");
+  const output = path.join(directory, "parsed.json");
+  fs.writeFileSync(input, raw, { mode: 0o600 });
+  const result = spawnSync(process.execPath, [script, input, output], { encoding: "utf8" });
+  return { directory, output, result };
+};
+
+test("extracts JSON after Wrangler progress output", () => {
+  const { output, result } = runParser('├ Checking...\n[\n  {"success":true,"results":[{"count":0}]}\n]\n');
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [
+    { success: true, results: [{ count: 0 }] },
+  ]);
+});
+
+test("extracts a nested JSON object after ANSI progress output", () => {
+  const { output, result } = runParser('\u001b[2K\u001b[1G├ Checking...\n{"result":{"results":[{"employees":0}]}}\n');
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), {
+    result: { results: [{ employees: 0 }] },
+  });
+});
+
+test("fails closed when no JSON document is present", () => {
+  const { result } = runParser("├ Checking...\nrequest failed\n");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /valid JSON document/);
+});

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -187,6 +187,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
           PIN_SQL: ${{ runner.temp }}/ponto-staging-pin-attestation.sql
+          PIN_RAW: ${{ runner.temp }}/ponto-staging-pin-attestation-raw.txt
           PIN_RESULT: ${{ runner.temp }}/ponto-staging-pin-attestation-result.json
           PIN_REPORT: ${{ runner.temp }}/ponto-staging-pin-attestation.json
           STAGING_TIMEKEEPING_D1_DATABASE: skincos-timekeeping-staging
@@ -201,7 +202,9 @@ jobs:
           const employeeId = String(fixture.employeeId).replaceAll("'", "''");
           fs.writeFileSync(process.argv[3], `SELECT algorithm, salt_b64, hash_b64, iterations FROM timekeeping_pin_credentials WHERE employee_id='${employeeId}';\n`, { mode: 0o600 });
           NODE
-          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$PIN_SQL" --json > "$PIN_RESULT"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$PIN_SQL" --json > "$PIN_RAW" 2>&1
+          node .github/scripts/ponto-json-output.mjs "$PIN_RAW" "$PIN_RESULT"
+          rm -f "$PIN_RAW"
           node - "$FIXTURES" "$PIN_RESULT" "$PIN_REPORT" <<'NODE'
           const fs = require('fs');
           const rows = (file) => {
@@ -341,6 +344,8 @@ jobs:
           FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
           CORE_SQL: ${{ runner.temp }}/ponto-staging-core-teardown.sql
           TIMEKEEPING_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-teardown.sql
+          CORE_RAW: ${{ runner.temp }}/ponto-staging-core-teardown-raw.txt
+          TIMEKEEPING_RAW: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-raw.txt
           CORE_RESULT: ${{ runner.temp }}/ponto-staging-core-teardown-result.json
           TIMEKEEPING_RESULT: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-result.json
           TEARDOWN_REPORT: ${{ runner.temp }}/ponto-staging-teardown-report.json
@@ -349,8 +354,10 @@ jobs:
           [[ -f "$FIXTURES" ]] || exit 0
           [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
           node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL"
-          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" --json > "$TIMEKEEPING_RESULT"
-          npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" --json > "$CORE_RESULT"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" --json > "$TIMEKEEPING_RAW" 2>&1
+          node .github/scripts/ponto-json-output.mjs "$TIMEKEEPING_RAW" "$TIMEKEEPING_RESULT"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" --json > "$CORE_RAW" 2>&1
+          node .github/scripts/ponto-json-output.mjs "$CORE_RAW" "$CORE_RESULT"
           node - "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$TEARDOWN_REPORT" <<'NODE'
           const fs = require("fs");
           const rows = (file) => {
@@ -386,7 +393,7 @@ jobs:
             piiIncluded: false,
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
-          rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL" "$CORE_RESULT" "$TIMEKEEPING_RESULT"
+          rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL" "$CORE_RAW" "$TIMEKEEPING_RAW" "$CORE_RESULT" "$TIMEKEEPING_RESULT"
 
       - name: Upload sanitised journey evidence
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- Normalize Wrangler D1 --json output when --file emits progress lines before the JSON document.
- Keep raw D1 output private and write only the parsed result to the existing attestation/teardown readers.
- Add parser regression tests for progress, ANSI output, and fail-closed malformed output.

## Incident evidence
- Staging coordinator: 30809547825.
- Authenticated journey: 30810528853.
- First failure: Wrangler progress text (├ Checking...) contaminated PIN attestation JSON.
- Automatic recovery entered fail-closed mode; watchdog recovery remains active.

## Validation
- Local Ponto contracts: 281/281 passed.
- Progressive release policy validation: passed.
- New parser tests: 3/3 passed.
- git diff --check: passed.