### PR TITLE
fix(ponto): select D1 result from noisy Wrangler output

### DIFF
--- a/.github/scripts/ponto-json-output.mjs
+++ b/.github/scripts/ponto-json-output.mjs
@@ -37,7 +37,7 @@ const parseDocumentAt = (start) => {
       stack.pop();
       if (!stack.length && character === closing) {
         try {
-          return JSON.parse(source.slice(start, index + 1));
+          return { value: JSON.parse(source.slice(start, index + 1)), end: index };
         } catch {
           return undefined;
         }
@@ -47,11 +47,23 @@ const parseDocumentAt = (start) => {
   return undefined;
 };
 
-let document;
-for (let index = 0; index < source.length && document === undefined; index += 1) {
+const documents = [];
+for (let index = 0; index < source.length; index += 1) {
   if (source[index] !== "{" && source[index] !== "[") continue;
-  document = parseDocumentAt(index);
+  const candidate = parseDocumentAt(index);
+  if (!candidate) continue;
+  documents.push(candidate.value);
+  index = candidate.end;
 }
+
+const containsD1Results = (value) => {
+  if (Array.isArray(value)) return value.some(containsD1Results);
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value.results)) return true;
+  return containsD1Results(value.result);
+};
+
+const document = documents.filter(containsD1Results).at(-1) ?? documents.at(0);
 
 if (document === undefined) {
   throw new Error("command output did not contain a valid JSON document");

--- a/.github/scripts/ponto-json-output.test.mjs
+++ b/.github/scripts/ponto-json-output.test.mjs
@@ -32,6 +32,26 @@ test("extracts a nested JSON object after ANSI progress output", () => {
   });
 });
 
+test("prefers the last D1 result after a valid JSON progress document", () => {
+  const { output, result } = runParser(
+    '{"type":"progress","message":"checking"}\n[{"success":true,"results":[{"employees":1}]}]\n',
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [
+    { success: true, results: [{ employees: 1 }] },
+  ]);
+});
+
+test("recognizes a D1 result array inside an envelope", () => {
+  const { output, result } = runParser(
+    '{"message":"checking"}\n{"result":[{"results":[{"pin_credentials":1}]}]}\n',
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), {
+    result: [{ results: [{ pin_credentials: 1 }] }],
+  });
+});
+
 test("fails closed when no JSON document is present", () => {
   const { result } = runParser("├ Checking...\nrequest failed\n");
   assert.notEqual(result.status, 0);


### PR DESCRIPTION
## Summary\n- prefer the last D1-shaped JSON document when Wrangler emits valid progress/envelope JSON before the query result\n- cover noisy progress and nested result envelopes without exposing raw staging output\n\n## Validation\n- parser tests: 5/5\n- synthetic fixture tests: 2/2\n- git diff --check\n\nFixes the staging journey failure where the normalized D1 output parsed successfully but the PIN row was not found.