### PR TITLE
fix(ponto): retry transient Pages readiness responses

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -729,6 +729,8 @@ test("Ponto staging Pages resolves and compensates candidates from the API inven
   assert.match(block, /--retry-all-errors/);
   assert.match(block, /candidate_attested=false/);
   assert.match(block, /--write-out '%\{http_code\}'/);
+  assert.match(block, /--retry 5 --retry-all-errors --retry-delay 4 --dump-header "\$RUNNER_TEMP\/pages-staging-proxy\.headers"/);
+  assert.match(block, /--retry 5 --retry-all-errors --retry-delay 4 --dump-header "\$RUNNER_TEMP\/pages-staging-alias\.headers"/);
   assert.match(block, /Unable to attest the exact terminal staging Pages candidate and production alias/);
   assert.doesNotMatch(block, /ponto-wrangler-output\.mjs/);
   assert.match(block, /PAGES_STAGING_CANDIDATE_DEPLOYMENT_ID=\$candidate_id/);

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -658,7 +658,9 @@ jobs:
             if [[ "$attempt" != 12 ]]; then sleep 5; fi
           done
           [[ "$candidate_attested" == true ]] || { echo 'Unable to attest the exact terminal staging Pages candidate and production alias'; exit 1; }
-          curl --fail --silent --show-error --retry 5 --retry-delay 4 --dump-header "$RUNNER_TEMP/pages-staging-proxy.headers" \
+          # A newly-created Pages deployment can serve a bounded transient 404
+          # while the data-plane route propagates after control-plane success.
+          curl --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 4 --dump-header "$RUNNER_TEMP/pages-staging-proxy.headers" \
             "${deployment_url%/}/api/ponto/_proxy-status" > "$RUNNER_TEMP/pages-staging-proxy.json"
           node - "$RUNNER_TEMP/pages-staging-proxy.json" "$RUNNER_TEMP/pages-staging-proxy.headers" <<'NODE'
           const fs = require("fs");
@@ -668,7 +670,7 @@ jobs:
           if (!headers.includes(`x-skincos-pages-release-sha: ${process.env.RELEASE_SHA}`)) throw new Error("staging Pages release header is absent");
           if (!headers.includes("x-skincos-pages-environment: staging")) throw new Error("staging Pages environment header is absent");
           NODE
-          curl --fail --silent --show-error --retry 5 --retry-delay 4 --dump-header "$RUNNER_TEMP/pages-staging-alias.headers" \
+          curl --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 4 --dump-header "$RUNNER_TEMP/pages-staging-alias.headers" \
             "https://skincos-staging.pages.dev/api/ponto/_proxy-status" > "$RUNNER_TEMP/pages-staging-alias.json"
           node - "$RUNNER_TEMP/pages-staging-alias.json" "$RUNNER_TEMP/pages-staging-alias.headers" <<'NODE'
           const fs = require("fs");


### PR DESCRIPTION
## Summary
- retry bounded transient 404s while a new staging Pages deployment and canonical staging route propagate
- keep the existing fail-closed metadata, alias, header, and readiness attestations
- lock the workflow contract with focused assertions

## Validation
- targeted Ponto orchestration, Pages candidate/rollback, recovery, and drill tests: passed
- deployment topology validation: passed

Root cause observed in staging coordinator run 30817953201: the candidate deployment was control-plane-ready, but its data-plane readiness endpoint returned a transient 404 and the workflow entered compensation. No alias cutover was retained; staging remained fail-closed on the incumbent.