### PR TITLE
fix(ponto): normalize wrapped D1 statement results

### DIFF
--- a/.github/scripts/ponto-json-output.mjs
+++ b/.github/scripts/ponto-json-output.mjs
@@ -69,4 +69,15 @@ if (document === undefined) {
   throw new Error("command output did not contain a valid JSON document");
 }
 
-fs.writeFileSync(outputPath, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 });
+// Wrangler can return the D1 statements as either a top-level array or an
+// envelope such as { result: [{ success: true, results: [...] }] }. Keep the
+// parser output stable for callers that inspect statement entries directly.
+const normalizeD1Document = (value) => {
+  if (Array.isArray(value)) return value.flatMap(normalizeD1Document);
+  if (!value || typeof value !== "object") return [value];
+  if (value.success === false || Array.isArray(value.results)) return [value];
+  if (Object.hasOwn(value, "result")) return normalizeD1Document(value.result);
+  return [value];
+};
+
+fs.writeFileSync(outputPath, `${JSON.stringify(normalizeD1Document(document), null, 2)}\n`, { mode: 0o600 });

--- a/.github/scripts/ponto-json-output.test.mjs
+++ b/.github/scripts/ponto-json-output.test.mjs
@@ -24,12 +24,10 @@ test("extracts JSON after Wrangler progress output", () => {
   ]);
 });
 
-test("extracts a nested JSON object after ANSI progress output", () => {
+test("normalizes a nested D1 result object after ANSI progress output", () => {
   const { output, result } = runParser('\u001b[2K\u001b[1G├ Checking...\n{"result":{"results":[{"employees":0}]}}\n');
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), {
-    result: { results: [{ employees: 0 }] },
-  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [{ results: [{ employees: 0 }] }]);
 });
 
 test("prefers the last D1 result after a valid JSON progress document", () => {
@@ -42,14 +40,12 @@ test("prefers the last D1 result after a valid JSON progress document", () => {
   ]);
 });
 
-test("recognizes a D1 result array inside an envelope", () => {
+test("normalizes a D1 result array inside an envelope", () => {
   const { output, result } = runParser(
     '{"message":"checking"}\n{"result":[{"results":[{"pin_credentials":1}]}]}\n',
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), {
-    result: [{ results: [{ pin_credentials: 1 }] }],
-  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [{ results: [{ pin_credentials: 1 }] }]);
 });
 
 test("fails closed when no JSON document is present", () => {

--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -857,9 +857,15 @@ function createRealRuntime(config, env = process.env) {
       if (error instanceof DrillFailure) throw error;
       throw new DrillFailure("D1_QUERY_JSON_INVALID");
     }
-    const entries = Array.isArray(payload) ? payload : [payload];
-    if (entries.some((entry) => entry?.success === false)) throw new DrillFailure("D1_QUERY_FAILED");
-    return entries.flatMap((entry) => entry?.results || entry?.result?.results || []);
+    const collectRows = (value) => {
+      if (Array.isArray(value)) return value.flatMap(collectRows);
+      if (!value || typeof value !== "object") return [];
+      if (value.success === false) throw new DrillFailure("D1_QUERY_FAILED");
+      if (Array.isArray(value.results)) return value.results;
+      if (Object.hasOwn(value, "result")) return collectRows(value.result);
+      return [];
+    };
+    return collectRows(payload);
   };
   const sql = (value) => `'${String(value).replaceAll("'", "''")}'`;
   const numeric = (value) => Number(value || 0);


### PR DESCRIPTION
## Correção\n\nO Wrangler pode devolver consultas D1 como esult: [{ results: [...] }]. O parser agora normaliza esse envelope para entradas de statement, e o drill de rollback também percorre envelopes aninhados, preservando falhas explícitas. Isso corrige o atestado da credencial PIN sintética e a evidência de teardown.\n\n## Validação\n\n- 
ode --test .github/scripts/ponto-json-output.test.mjs workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs\n- 
ode --check .github/scripts/ponto-staging-rollback-drill.mjs\n\nNenhum segredo, PIN, PII ou dado de produção é incluído.