### PR TITLE
fix(ponto): unwrap nested D1 attestation rows

### DIFF
--- a/.github/scripts/ponto-json-output.mjs
+++ b/.github/scripts/ponto-json-output.mjs
@@ -75,8 +75,15 @@ if (document === undefined) {
 const normalizeD1Document = (value) => {
   if (Array.isArray(value)) return value.flatMap(normalizeD1Document);
   if (!value || typeof value !== "object") return [value];
-  if (value.success === false || Array.isArray(value.results)) return [value];
-  if (Object.hasOwn(value, "result")) return normalizeD1Document(value.result);
+  if (value.success === false) return [value];
+  if (Object.hasOwn(value, "result")) {
+    const nested = value.result;
+    if (
+      Array.isArray(nested)
+      || (nested && typeof nested === "object" && (Object.hasOwn(nested, "results") || Object.hasOwn(nested, "result")))
+    ) return normalizeD1Document(nested);
+  }
+  if (Array.isArray(value.results)) return [value];
   return [value];
 };
 

--- a/.github/scripts/ponto-json-output.test.mjs
+++ b/.github/scripts/ponto-json-output.test.mjs
@@ -48,6 +48,14 @@ test("normalizes a D1 result array inside an envelope", () => {
   assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [{ results: [{ pin_credentials: 1 }] }]);
 });
 
+test("unwraps a D1 envelope when an empty top-level results array accompanies nested rows", () => {
+  const { output, result } = runParser(
+    '{"success":true,"results":[],"result":{"results":[{"algorithm":"PBKDF2-SHA256"}]}}\n',
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), [{ results: [{ algorithm: "PBKDF2-SHA256" }] }]);
+});
+
 test("fails closed when no JSON document is present", () => {
   const { result } = runParser("├ Checking...\nrequest failed\n");
   assert.notEqual(result.status, 0);

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -234,7 +234,10 @@ jobs:
             const payload = JSON.parse(fs.readFileSync(file, 'utf8'));
             const entries = Array.isArray(payload) ? payload : [payload];
             if (entries.some((entry) => entry?.success === false)) throw new Error('PIN attestation query failed');
-            return entries.flatMap((entry) => entry?.results || entry?.result?.results || []);
+            return entries.flatMap((entry) => [
+              ...(Array.isArray(entry?.results) ? entry.results : []),
+              ...(Array.isArray(entry?.result?.results) ? entry.result.results : []),
+            ]);
           };
           (async () => {
             const fixture = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));


### PR DESCRIPTION
# Summary

Fix the governed staging Ponto PIN attestation when Wrangler returns a D1 envelope with an empty top-level `results` array and the actual statement rows under `result.results`. The attestation now preserves failed-statement detection and reads both normalized levels.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: governed Ponto staging closure
- Design/ADR: existing D1 output normalization contract
- Migration steps: none

## Screenshots / Evidence
- 15 focused Node tests passed.
- Workflow YAML parsed successfully and every embedded shell step passed bash syntax validation.
- No credentials, raw D1 output, or fixture values are persisted in the repository or PR.