### PR TITLE
fix(ponto): query staging PIN credential directly

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -288,6 +288,7 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
   assert.match(stagingJourney, /TIMEKEEPING_STAGING_WRANGLER_CONFIG/);
   assert.match(stagingJourney, /--json > "\$CORE_RAW"/);
   assert.match(stagingJourney, /ponto-json-output\.mjs/);
+  assert.match(stagingJourney, /--command \"\$\(cat \"\$PIN_SQL\"\)\" --json/);
   assert.match(stagingJourney, /for attempt in \$\(seq 1 12\)/);
   assert.match(stagingJourney, /bounded propagation/);
   assert.match(stagingJourney, /PIN attestation query command failed/);

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -222,7 +222,7 @@ jobs:
           pin_attested=false
           for attempt in $(seq 1 12); do
             rm -f "$PIN_RAW" "$PIN_RESULT" "$PIN_VERIFY_ERROR"
-            if ! npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$PIN_SQL" --json > "$PIN_RAW" 2>&1; then
+            if ! npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --command "$(cat "$PIN_SQL")" --json > "$PIN_RAW" 2>&1; then
               echo 'staging D1 PIN attestation query command failed'; exit 1
             fi
             if ! node .github/scripts/ponto-json-output.mjs "$PIN_RAW" "$PIN_RESULT"; then


### PR DESCRIPTION
## Summary
- execute the run-scoped staging PIN SELECT with Wrangler `--command` instead of `--file`
- keep the existing bounded propagation and sanitized verification contract
- add a workflow contract assertion so a SELECT cannot regress to D1 import mode

`wrangler d1 execute --file` uses the remote import path and returns only import summary metadata; the authenticated journey requires the query result row.

## Validation
- focused Ponto parser/dispatch tests: 14 passing
- governed Ponto contract suite: 291 passing
- no production data or credentials included