### PR TITLE
test(ponto): attest synthetic employee pin state

### DIFF
--- a/crm/console/scripts/ponto-staging-journey.cjs
+++ b/crm/console/scripts/ponto-staging-journey.cjs
@@ -156,6 +156,8 @@ async function main() {
 
     const me = await api(page, '/api/ponto/me')
     assert(me.status === 200 && me.json?.linked === true, `/api/ponto/me did not link the synthetic identity (${me.status})`)
+    assert(me.json?.employee?.id === fixture.employeeId, `/api/ponto/me linked an unexpected synthetic employee (${String(me.json?.employee?.id || '')})`)
+    assert(me.json?.pinSet === true, `/api/ponto/me did not expose the synthetic PIN credential (${me.status})`)
     assert(JSON.stringify(me.json.allowedUnits || []) === JSON.stringify([fixture.unitId]), 'Ponto unit scope drifted')
     assert(me.json?.suggestedNextMethod === 'PIN' && me.json?.hasFace === false, 'face/PIN release policy drifted')
     const profile = await api(page, '/api/ponto/me/profile')


### PR DESCRIPTION
## Objective\n\nAdd a sanitized staging-journey assertion that the authenticated Worker linked the exact run-scoped synthetic employee and reports pinSet=true.\n\n## Scope\n\nNo credentials, hashes, PII, production state, or runtime behavior are changed. This narrows the existing governed proof after the D1 PIN attestation.\n\n## Validation\n\n- node --check crm/console/scripts/ponto-staging-journey.cjs\n- Existing required CI governs the merge.