### PR TITLE
fix(ef): restore interactive Caixa period flow

### DIFF
--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -217,9 +217,16 @@ Os launchers do scraper do `app.espacofacial.com.br` também seguem esse modelo:
 
 O botão `EF App Caixa` roda em modo interativo guiado no terminal do Codex App:
 
+- apresenta a seleção de unidade no PowerShell, antes de cruzar a fronteira
+  WSL, porque o processo WSL não tem TTY garantido;
+- quando não existir um `login.env` privado completo, pede email e senha no
+  terminal Windows (a senha não aparece) e salva apenas em
+  `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\login.env`, com ACL do
+  operador;
 - fixa o scraper em `EF_MODE=caixa`;
 - mantém os artefatos em `C:\CodexRuntime\operator\admin\skincos\scraper\`;
-- ainda pergunta unidade e intervalo de datas antes da exportação.
+- pergunta as datas inicial e final no terminal e repassa o período explícito;
+  `EF_DATE_RANGE_MODE` continua como fallback para automações sem o menu.
 
 ### Runtime live
 

--- a/integration/ef/.env.example
+++ b/integration/ef/.env.example
@@ -56,6 +56,8 @@
 
 # Data range automático
 # EF_DATE_RANGE_MODE=prev_month
+# EF_CASH_START_DATE=01/06/2026
+# EF_CASH_END_DATE=30/06/2026
 
 # Recorder: apagar gravações após processar
 # EF_RECORDER_PURGE=1

--- a/integration/ef/README.md
+++ b/integration/ef/README.md
@@ -22,7 +22,9 @@ Runner único via ações do Codex (sem menu).
 
 ## Configuração (env vars)
 
-- `EF_LOGIN_EMAIL` / `EF_LOGIN_PASSWORD` (opcional; se não tiver, o runner pergunta)
+- `EF_LOGIN_EMAIL` / `EF_LOGIN_PASSWORD` (opcional; nas ações EF App, se o
+  `login.env` privado não tiver ambos, o launcher pergunta no terminal Windows
+  e salva somente em `%LOCALAPPDATA%\Codex\skincos\espacofacial-app\login.env`)
 - `EF_UNIT_NAME` (opcional; se não tiver, o runner pergunta)
 - `EF_UNIT_OPTIONS` (opcional, lista separada por vírgula para o menu)
 - `EF_OUTPUT_DIR` (default: `./report`)
@@ -34,6 +36,9 @@ Runner único via ações do Codex (sem menu).
 - `EF_DRY_RUN` (`1`/`0`)
 - `EF_DEBUG_RETENTION_DAYS` (default: `7`)
 - `EF_DATE_RANGE_MODE` (`prev_month`)
+- `EF_CASH_START_DATE` / `EF_CASH_END_DATE` (período explícito do Caixa em
+  `DD/MM/AAAA`; nas ações EF App Caixa vêm das perguntas no terminal e têm
+  precedência sobre `EF_DATE_RANGE_MODE`)
 - `EF_INDEX_WEEK_WINDOW_WEEKS` (opcional; limita agenda/index para a semana atual + próximas semanas, ex.: `4` para totalizar 28 dias a partir do início da semana atual)
 - `EF_INDEX_FUTURE_DAYS` (opcional; limita agenda/index para janela móvel a partir de hoje, ex.: `28`)
 - `EF_RECORDER_PURGE` (`1`/`0`)

--- a/integration/ef/run_scraper.py
+++ b/integration/ef/run_scraper.py
@@ -4,7 +4,9 @@
 Goal: run specific actions via EF_MODE (no menu).
 
 Security:
-- The password is NOT stored in code or files.
+- The password is never stored in code or in the repository.
+- The Codex App launcher may store it in its operator-private `login.env`
+  after an explicit terminal prompt, protected by Windows ACLs.
 - Credentials can be stored securely in the OS Keychain (macOS) via `keyring`.
 - You can optionally set EF_LOGIN_EMAIL / EF_LOGIN_PASSWORD as env vars.
 - If not provided, the script will prompt (password hidden).
@@ -524,6 +526,20 @@ def _prompt_date(prompt: str, default: str) -> str:
 
 
 def _prompt_date_range(*, default_days: int = 7) -> tuple[str, str]:
+    explicit_start = os.getenv("EF_CASH_START_DATE", "").strip()
+    explicit_end = os.getenv("EF_CASH_END_DATE", "").strip()
+    if explicit_start or explicit_end:
+        if not explicit_start or not explicit_end:
+            raise ValueError("EF_CASH_START_DATE e EF_CASH_END_DATE devem ser definidos juntos.")
+        try:
+            start_dt = datetime.strptime(explicit_start, "%d/%m/%Y").date()
+            end_dt = datetime.strptime(explicit_end, "%d/%m/%Y").date()
+        except ValueError as exc:
+            raise ValueError("Use DD/MM/AAAA em EF_CASH_START_DATE e EF_CASH_END_DATE.") from exc
+        if end_dt < start_dt:
+            raise ValueError("EF_CASH_END_DATE não pode ser menor que EF_CASH_START_DATE.")
+        return explicit_start, explicit_end
+
     mode = os.getenv("EF_DATE_RANGE_MODE", "").strip().lower()
     if mode in {"prev_month", "previous_month", "last_month"}:
         today = datetime.now().date()
@@ -560,7 +576,11 @@ def _run_cash(headless: bool, output_dir: Path, unit_name: str, persist_session:
         print("Credenciais não informadas. Abortando.")
         return 2
 
-    start_str, end_str = _prompt_date_range(default_days=7)
+    try:
+        start_str, end_str = _prompt_date_range(default_days=7)
+    except ValueError as exc:
+        print(f"Período inválido: {exc}")
+        return 2
 
     _set_runtime_env(email, password, output_dir, headless, unit_name, persist_session)
 
@@ -735,7 +755,11 @@ def _run_cash_clients(headless: bool, output_dir: Path, unit_name: str, persist_
         print("Credenciais não informadas. Abortando.")
         return 2
 
-    start_str, end_str = _prompt_date_range(default_days=7)
+    try:
+        start_str, end_str = _prompt_date_range(default_days=7)
+    except ValueError as exc:
+        print(f"Período inválido: {exc}")
+        return 2
 
     _set_runtime_env(email, password, output_dir, headless, unit_name, persist_session)
 
@@ -873,7 +897,20 @@ def _run_cash_combined(headless: bool, output_dir: Path, unit_name: str, persist
         )
         return 2
 
-    start_str, end_str = _prompt_date_range(default_days=7)
+    try:
+        start_str, end_str = _prompt_date_range(default_days=7)
+    except ValueError as exc:
+        print(f"Período inválido: {exc}")
+        _write_run_summary(
+            mode="caixa",
+            unit_name=unit_name,
+            output_dir=output_dir,
+            status="failed",
+            started_at=started_at,
+            ended_at=datetime.now(),
+            details={"reason": "invalid_date_range", "error": str(exc)},
+        )
+        return 2
 
     _set_runtime_env(email, password, output_dir, headless, unit_name, persist_session)
 
@@ -1239,6 +1276,8 @@ def _run_cash_combined(headless: bool, output_dir: Path, unit_name: str, persist
             "rows_payments": int(len(df_payments)),
             "rows_total": int(len(df_total)) if not df_total.empty else 0,
             "dry_run": dry_run,
+            "period_from": start_str,
+            "period_to": end_str,
         }
         if discrepancies:
             details["total_discrepancies"] = discrepancies

--- a/integration/ef/test_cash_date_range.py
+++ b/integration/ef/test_cash_date_range.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from run_scraper import _prompt_date_range
+
+
+class CashDateRangeTests(unittest.TestCase):
+    def test_explicit_cash_dates_override_automatic_previous_month(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "EF_CASH_START_DATE": "01/06/2026",
+                "EF_CASH_END_DATE": "30/06/2026",
+                "EF_DATE_RANGE_MODE": "prev_month",
+            },
+            clear=False,
+        ):
+            self.assertEqual(_prompt_date_range(), ("01/06/2026", "30/06/2026"))
+
+    def test_rejects_incomplete_explicit_cash_range(self) -> None:
+        with patch.dict(os.environ, {"EF_CASH_START_DATE": "01/06/2026"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "devem ser definidos juntos"):
+                _prompt_date_range()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -2255,6 +2255,199 @@ $efAppEnvVars = @(
     "EF_LOGIN_ENV_FILE=$(Convert-WindowsPathToWsl -Path $efAppLoginEnvFile)"
 )
 
+function Protect-EfAppLoginEnvFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    & icacls.exe $Path /setowner "*$sid" /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Falha ao definir o proprietário do arquivo privado de login do EF App." }
+    & icacls.exe $Path /grant:r "*$($sid):F" /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Falha ao restringir a DACL do arquivo privado de login do EF App." }
+    & icacls.exe $Path /inheritance:r /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Falha ao remover a herança da DACL do arquivo privado de login do EF App." }
+}
+
+function Test-EfAppLoginEnvFile {
+    if (-not (Test-Path -LiteralPath $efAppLoginEnvFile -PathType Leaf)) {
+        return $false
+    }
+
+    $present = @{
+        EF_LOGIN_EMAIL = $false
+        EF_LOGIN_PASSWORD = $false
+    }
+    try {
+        foreach ($line in Get-Content -LiteralPath $efAppLoginEnvFile) {
+            $trimmed = $line.Trim()
+            if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) { continue }
+            if ($trimmed -notmatch '^(?:export\s+)?(?<key>EF_LOGIN_EMAIL|EF_LOGIN_PASSWORD)\s*=(?<value>.*)$') { continue }
+            $value = $Matches.value.Trim().Trim('"').Trim("'")
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+                $present[$Matches.key] = $true
+            }
+        }
+    } catch {
+        return $false
+    }
+    return [bool]($present.EF_LOGIN_EMAIL -and $present.EF_LOGIN_PASSWORD)
+}
+
+function Save-EfAppLoginCredentials {
+    param(
+        [Parameter(Mandatory = $true)][string]$Email,
+        [Parameter(Mandatory = $true)][Security.SecureString]$Password
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Email) -or $Password.Length -eq 0) {
+        return $false
+    }
+    if ($Email.IndexOfAny([char[]]"`r`n$([char]0)") -ge 0) {
+        throw "O email não pode conter quebras de linha."
+    }
+
+    $passwordBstr = [IntPtr]::Zero
+    $temporaryPath = $null
+    try {
+        $passwordBstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
+        $passwordValue = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($passwordBstr)
+        if ([string]::IsNullOrWhiteSpace($passwordValue)) {
+            return $false
+        }
+        if ($passwordValue.IndexOfAny([char[]]"`r`n$([char]0)") -ge 0) {
+            throw "A senha não pode conter quebras de linha."
+        }
+
+        $parent = Split-Path -Parent $efAppLoginEnvFile
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        $temporaryPath = Join-Path $parent (".login-{0}.tmp" -f [Guid]::NewGuid().ToString('N'))
+        $contents = "EF_LOGIN_EMAIL=$($Email.Trim())`nEF_LOGIN_PASSWORD=$passwordValue`n"
+        [IO.File]::WriteAllText($temporaryPath, $contents, [Text.UTF8Encoding]::new($false))
+        Protect-EfAppLoginEnvFile -Path $temporaryPath
+        Move-Item -LiteralPath $temporaryPath -Destination $efAppLoginEnvFile -Force
+        $temporaryPath = $null
+        Protect-EfAppLoginEnvFile -Path $efAppLoginEnvFile
+        return $true
+    } finally {
+        if ($passwordBstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordBstr)
+        }
+        if ($null -ne $temporaryPath -and (Test-Path -LiteralPath $temporaryPath)) {
+            Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Ensure-EfAppLoginCredentials {
+    if (Test-EfAppLoginEnvFile) {
+        Protect-EfAppLoginEnvFile -Path $efAppLoginEnvFile
+        return $true
+    }
+
+    Write-Host "[ef-app] Credenciais de login não encontradas no armazenamento privado." -ForegroundColor Yellow
+    $email = (Read-Host "Email do app Espaço Facial").Trim()
+    if ([string]::IsNullOrWhiteSpace($email)) {
+        Write-Host "Credenciais não informadas; ação cancelada." -ForegroundColor Yellow
+        return $false
+    }
+    $password = Read-Host "Senha do app Espaço Facial" -AsSecureString
+    try {
+        if (-not (Save-EfAppLoginCredentials -Email $email -Password $password)) {
+            Write-Host "Credenciais não informadas; ação cancelada." -ForegroundColor Yellow
+            return $false
+        }
+    } finally {
+        $password.Dispose()
+    }
+    Write-Host "[ef-app] Credenciais salvas no armazenamento privado do operador."
+    return $true
+}
+
+function Get-EfAppUnitOptions {
+    $configuredOptions = [string]$env:EF_UNIT_OPTIONS
+    if ([string]::IsNullOrWhiteSpace($configuredOptions)) {
+        $configuredOptions = [string]$env:EF_UNITS
+    }
+    if ([string]::IsNullOrWhiteSpace($configuredOptions)) {
+        return @("BarraShoppingSul", "Novo Hamburgo")
+    }
+
+    return @(
+        $configuredOptions -split ',' |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+}
+
+function Select-EfAppUnitName {
+    param([Parameter(Mandatory = $true)][string]$Mode)
+
+    $configuredUnit = [string]$env:EF_UNIT_NAME
+    if (-not [string]::IsNullOrWhiteSpace($configuredUnit)) {
+        return $configuredUnit.Trim()
+    }
+
+    $options = @(Get-EfAppUnitOptions)
+    if ($options.Count -eq 0) {
+        throw "Nenhuma unidade do EF App está configurada. Defina EF_UNIT_OPTIONS ou EF_UNITS."
+    }
+    if ($options.Count -eq 1) {
+        return [string]$options[0]
+    }
+
+    $menuOptions = @($options | ForEach-Object {
+        New-MenuOption -Label ([string]$_) -Action ([string]$_)
+    })
+    $selection = Read-MenuSelection `
+        -Title ("EF App > {0} > Unidade" -f $Mode) `
+        -Options $menuOptions `
+        -CancelLabel "Cancelar"
+    if ($null -eq $selection) {
+        Write-Host "Unidade não selecionada." -ForegroundColor Yellow
+        return $null
+    }
+    return [string]$selection.Action
+}
+
+function Read-EfAppCashDateRange {
+    $today = (Get-Date).Date
+    $defaultStart = $today.AddDays(-7)
+    $defaultEnd = $today
+
+    while ($true) {
+        $startRaw = Read-Host ("Data inicial (DD/MM/AAAA; ENTER p/ padrão: {0})" -f $defaultStart.ToString('dd/MM/yyyy'))
+        $endRaw = Read-Host ("Data final (DD/MM/AAAA; ENTER p/ padrão: {0})" -f $defaultEnd.ToString('dd/MM/yyyy'))
+        $startValue = if ([string]::IsNullOrWhiteSpace($startRaw)) { $defaultStart } else { $null }
+        $endValue = if ([string]::IsNullOrWhiteSpace($endRaw)) { $defaultEnd } else { $null }
+
+        if ($null -eq $startValue) {
+            [datetime]$parsedStart = [datetime]::MinValue
+            if (-not [datetime]::TryParseExact($startRaw.Trim(), 'dd/MM/yyyy', [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::None, [ref]$parsedStart)) {
+                Write-Host "Data inicial inválida. Use DD/MM/AAAA." -ForegroundColor Yellow
+                continue
+            }
+            $startValue = $parsedStart.Date
+        }
+        if ($null -eq $endValue) {
+            [datetime]$parsedEnd = [datetime]::MinValue
+            if (-not [datetime]::TryParseExact($endRaw.Trim(), 'dd/MM/yyyy', [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::None, [ref]$parsedEnd)) {
+                Write-Host "Data final inválida. Use DD/MM/AAAA." -ForegroundColor Yellow
+                continue
+            }
+            $endValue = $parsedEnd.Date
+        }
+        if ($endValue -lt $startValue) {
+            Write-Host "A data final não pode ser menor que a inicial." -ForegroundColor Yellow
+            continue
+        }
+
+        return [pscustomobject]@{
+            Start = $startValue.ToString('dd/MM/yyyy')
+            End = $endValue.ToString('dd/MM/yyyy')
+        }
+    }
+}
+
 function Invoke-EfAppPythonMode {
     param(
         [string]$Mode,
@@ -2263,10 +2456,28 @@ function Invoke-EfAppPythonMode {
     )
 
     $headlessValue = if ($Headed) { "HEADLESS=0" } else { "HEADLESS=1" }
+    $modeEnvVars = @("EF_MODE=$Mode", $headlessValue)
+    if ($Mode.Trim().ToLowerInvariant() -in @("caixa", "cash", "agenda_delta")) {
+        $unitName = Select-EfAppUnitName -Mode $Mode
+        if ([string]::IsNullOrWhiteSpace($unitName)) {
+            return
+        }
+        $modeEnvVars += "EF_UNIT_NAME=$unitName"
+    }
+    if ($Mode.Trim().ToLowerInvariant() -in @("caixa", "cash")) {
+        $dateRange = Read-EfAppCashDateRange
+        $modeEnvVars += @(
+            "EF_CASH_START_DATE=$($dateRange.Start)",
+            "EF_CASH_END_DATE=$($dateRange.End)"
+        )
+    }
+    if (-not (Ensure-EfAppLoginCredentials)) {
+        return
+    }
     Invoke-ShortcutWsl `
         -ScriptPath "integration/ef/scripts/run-local-python.sh" `
         -ArgumentList @("run_scraper.py") `
-        -EnvVar ($efAppEnvVars + @("EF_MODE=$Mode", $headlessValue) + $ExtraEnvVar) `
+        -EnvVar ($efAppEnvVars + $modeEnvVars + $ExtraEnvVar) `
         -SkipNodeCheck `
         -SkipNpmCheck
 }
@@ -2435,6 +2646,7 @@ function Invoke-ShortcutActionInternal {
         "EfAppCaixa" { Invoke-EfAppPythonMode -Mode "caixa" }
         "EfAppAgendaDelta" { Invoke-EfAppPythonMode -Mode "agenda_delta" }
         "EfAppAgendaFullSync" {
+            if (-not (Ensure-EfAppLoginCredentials)) { return }
             Invoke-ShortcutWsl `
                 -ScriptPath "integration/ef/run_agenda_full_sync_all_units.sh" `
                 -EnvVar ($efAppEnvVars + @(

--- a/scripts/tests/windows-native-wsl-boundary.test.mjs
+++ b/scripts/tests/windows-native-wsl-boundary.test.mjs
@@ -81,6 +81,39 @@ test('project instructions reserve npm and Python project work for Ubuntu', () =
   assert.match(agents, /scripts\/invoke-skincos-wsl\.ps1/)
 })
 
+test('EF App unit actions select the unit in PowerShell before crossing WSL', () => {
+  const launcher = read('scripts/run-shared-codex-shortcut.ps1')
+  assert.match(launcher, /function Get-EfAppUnitOptions/)
+  assert.match(launcher, /function Select-EfAppUnitName/)
+  assert.match(launcher, /-Title \("EF App > \{0\} > Unidade" -f \$Mode\)/)
+  assert.match(launcher, /\$Mode\.Trim\(\)\.ToLowerInvariant\(\) -in @\("caixa", "cash", "agenda_delta"\)/)
+  assert.match(launcher, /\$modeEnvVars \+= "EF_UNIT_NAME=\$unitName"/)
+  assert.match(launcher, /-EnvVar \(\$efAppEnvVars \+ \$modeEnvVars \+ \$ExtraEnvVar\)/)
+})
+
+test('EF App Caixa asks for a validated date range before WSL execution', () => {
+  const launcher = read('scripts/run-shared-codex-shortcut.ps1')
+  assert.match(launcher, /function Read-EfAppCashDateRange/)
+  assert.match(launcher, /Data inicial \(DD\/MM\/AAAA; ENTER p\/ padrão:/)
+  assert.match(launcher, /Data final \(DD\/MM\/AAAA; ENTER p\/ padrão:/)
+  assert.match(launcher, /\[datetime\]::TryParseExact/)
+  assert.match(launcher, /EF_CASH_START_DATE=\$\(\$dateRange\.Start\)/)
+  assert.match(launcher, /EF_CASH_END_DATE=\$\(\$dateRange\.End\)/)
+})
+
+test('EF App prompts for absent credentials and persists them only in the private login file', () => {
+  const launcher = read('scripts/run-shared-codex-shortcut.ps1')
+  assert.match(launcher, /function Protect-EfAppLoginEnvFile/)
+  assert.match(launcher, /function Test-EfAppLoginEnvFile/)
+  assert.match(launcher, /function Save-EfAppLoginCredentials/)
+  assert.match(launcher, /Read-Host "Senha do app Espaço Facial" -AsSecureString/)
+  assert.match(launcher, /EF_LOGIN_EMAIL=\$\(\$Email\.Trim\(\)\)/)
+  assert.match(launcher, /EF_LOGIN_PASSWORD=\$passwordValue/)
+  assert.match(launcher, /Protect-EfAppLoginEnvFile -Path \$efAppLoginEnvFile/)
+  assert.match(launcher, /if \(-not \(Ensure-EfAppLoginCredentials\)\) \{\s*return\s*\}/)
+  assert.match(launcher, /"EfAppAgendaFullSync" \{\s*if \(-not \(Ensure-EfAppLoginCredentials\)\) \{ return \}/)
+})
+
 test('CRM local binds every timekeeping runtime to one operator-private key root', () => {
   const launcher = read('scripts/run-shared-codex-shortcut.ps1')
   const initializer = read('scripts/initialize-local-crm-private-bindings.ps1')


### PR DESCRIPTION
## Objetivo
Restaurar o fluxo interativo EF App -> Caixa pelo launcher Windows/WSL e validar uma execução real curta.

## Alterações
- coleta unidade, data inicial e data final no PowerShell;
- valida datas e repassa `EF_CASH_START_DATE`/`EF_CASH_END_DATE` sem depender de TTY no Python;
- solicita e persiste credenciais ausentes no `login.env` privado com ACL restrita;
- registra unidade, período, contagens e artefatos no resumo da execução;
- adiciona testes focais e documentação.

## Evidência funcional privada
- launcher real: BarraShoppingSul, 31/07/2026 a 31/07/2026;
- login aceito, saída zero, scraper concluído;
- resumo `success`, 11 clientes, 3 pagamentos, 3 totais;
- XLSX e entrega Finance gerados no runtime privado.

Os valores de credencial não são incluídos neste PR.