### PR TITLE
fix(ponto): keep staging PINs within Worker limits

### DIFF
--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -284,7 +284,7 @@ jobs:
               credentialsIncluded: false,
               piiIncluded: false,
             };
-            if (report.algorithm !== 'PBKDF2-SHA256' || report.iterations !== 150000 || report.saltLength !== 22 || report.hashLength !== 43 || !report.fixtureCredentialVerified) {
+            if (report.algorithm !== 'PBKDF2-SHA256' || report.iterations !== 100000 || report.saltLength !== 22 || report.hashLength !== 43 || !report.fixtureCredentialVerified) {
               throw new Error('staging D1 PIN credential does not verify with the canonical contract');
             }
             fs.writeFileSync(process.argv[4], `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -209,7 +209,7 @@ if (action === 'provision') {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE actor_id=${sql(fixture.username)} OR (actor_id='identity-service' AND after_json LIKE ${sql(`%"onboardingId":"${fixture.onboardingId}"%`)})) AS audit_count;`,
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE actor_id=${sql(fixture.username)} OR (actor_id='identity-service' AND instr(after_json, ${sql(`"onboardingId":"${fixture.onboardingId}"`)}) > 0)) AS audit_count;`,
   ];
   writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
   writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -98,7 +98,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
         WHERE employee_id = ?
       `).get(fixture.employeeId);
       assert.deepEqual(storedPin.algorithm, 'PBKDF2-SHA256');
-      assert.equal(storedPin.iterations, 150000);
+      assert.equal(storedPin.iterations, 100000);
       assert.equal(await verifyPin(fixture.pin, storedPin), true);
       assert.equal(await verifyPin('000000', storedPin), false);
       const insertSession = database.prepare(`

--- a/workforce/timekeeping/security.js
+++ b/workforce/timekeeping/security.js
@@ -31,20 +31,23 @@ export function constantTimeEqual(leftValue, rightValue) {
   return diff === 0
 }
 
-export const DEFAULT_PIN_ITERATIONS = 150_000
+// Cloudflare Workers rejects PBKDF2 iteration counts above 100,000. Keep the
+// default at the platform-supported ceiling so newly issued credentials remain
+// verifiable by the deployed Worker runtime.
+export const DEFAULT_PIN_ITERATIONS = 100_000
 
 export async function hashPin(pin, iterations = DEFAULT_PIN_ITERATIONS) {
   const value = String(pin || '')
   if (!/^\d{4,12}$/.test(value)) throw new Error('PIN_INVALID')
   const salt = crypto.getRandomValues(new Uint8Array(16))
-  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(value), 'PBKDF2', false, ['deriveBits'])
+  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(value), { name: 'PBKDF2' }, false, ['deriveBits'])
   const derived = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, baseKey, 256)
   return { algorithm: 'PBKDF2-SHA256', iterations, saltB64: bytesToBase64Url(salt), hashB64: bytesToBase64Url(derived) }
 }
 
 export async function verifyPin(pin, credential) {
   if (!credential || credential.algorithm !== 'PBKDF2-SHA256') return false
-  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(String(pin || '')), 'PBKDF2', false, ['deriveBits'])
+  const baseKey = await crypto.subtle.importKey('raw', encoder.encode(String(pin || '')), { name: 'PBKDF2' }, false, ['deriveBits'])
   const derived = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt: base64UrlToBytes(credential.saltB64), iterations: Number(credential.iterations) }, baseKey, 256)
   return constantTimeEqual(bytesToBase64Url(derived), credential.hashB64)
 }

--- a/workforce/timekeeping/security.test.js
+++ b/workforce/timekeeping/security.test.js
@@ -11,6 +11,15 @@ test('PIN is salted, hashed and verified without plaintext persistence', async (
   assert.equal(JSON.stringify(first).includes('123456'), false)
 })
 
+test('PIN verifier accepts the runner-compatible PBKDF2-SHA256 credential format', async () => {
+  assert.equal(await verifyPin('123456', {
+    algorithm: 'PBKDF2-SHA256',
+    iterations: 100000,
+    saltB64: 'qX2b2FrD_ZScwjei2wx5Iw',
+    hashB64: 'hSXTs45kTYPyrY7BT-xQaHjuePz-BeQXqknVzVPm25U',
+  }), true)
+})
+
 test('biometric matching rejects empty, undersized and non-finite templates', async () => {
   await assert.rejects(() => encryptTemplate([], 'unit-test-secret'), /BIOMETRIC_TEMPLATE_INVALID/)
   await assert.rejects(() => encryptTemplate(Array(64).fill(Number.NaN), 'unit-test-secret'), /BIOMETRIC_TEMPLATE_INVALID/)


### PR DESCRIPTION
## Summary\n- keep new PBKDF2-SHA256 PIN credentials at the Cloudflare Worker-supported 100,000-iteration ceiling and use structured PBKDF2 descriptors\n- make staging teardown audit reconciliation compatible with D1 SQLite and assert the 100,000-iteration contract\n\n## Validation\n- workforce/timekeeping npm test\n- staging fixture tests\n- remote Worker WebCrypto probe: 100,000 verifies; 100,001+ is rejected by the runtime\n\nSynthetic credentials and raw PINs are not included.