### PR TITLE
fix(ponto): converge staging PIN and teardown

### DIFF
--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -1079,11 +1079,14 @@ function createRealRuntime(config, env = process.env) {
     const capture = (code, fn, fallback = []) => {
       try { return fn(); } catch { failures.push(code); return fallback; }
     };
+    const requestIds = Array.from(new Set(fixture.teardownRequestIds || []))
+      .filter((requestId) => /^[A-Za-z0-9._:-]{1,180}$/.test(String(requestId)));
+    const requestIdList = requestIds.length ? requestIds.map(sql).join(",") : "''";
     const coreBeforeSql = `SELECT COUNT(*) AS audit_count FROM audit_log WHERE entity='staging_synthetic_ponto' AND entity_id=${sql(fixture.username)};`;
     const timekeepingBeforeSql = `SELECT
       (SELECT id FROM workforce_employees WHERE canonical_employee_id=${sql(`identity:${fixture.onboardingId}`)} LIMIT 1) AS identity_employee_id,
       (SELECT GROUP_CONCAT(id) FROM timekeeping_events WHERE employee_id=${sql(fixture.employeeId)}) AS event_ids,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE actor_id=${sql(fixture.username)} OR (actor_id='identity-service' AND after_json LIKE ${sql(`%"onboardingId":"${fixture.onboardingId}"%`)})) AS audit_count;`;
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`;
     coreBefore = capture("CORE_PRE_TEARDOWN_QUERY_FAILED", () => d1Rows(
       config.coreDatabase,
       "inventory/wrangler.toml",
@@ -1125,12 +1128,9 @@ function createRealRuntime(config, env = process.env) {
     const eventIds = String(timekeepingBefore[0]?.event_ids || "")
       .split(",")
       .filter((id) => UUID.test(id));
-    const requestIds = Array.from(new Set(handle.fixture.teardownRequestIds || []))
-      .filter((requestId) => /^[A-Za-z0-9._:-]{1,180}$/.test(String(requestId)));
     const employeeIds = [fixture.employeeId, ...(UUID.test(identityEmployeeId) ? [identityEmployeeId] : [])];
     const employeeList = employeeIds.map(sql).join(",");
     const eventList = eventIds.length ? eventIds.map(sql).join(",") : "''";
-    const requestIdList = requestIds.length ? requestIds.map(sql).join(",") : "''";
     const coreAfterSql = `SELECT
       (SELECT COUNT(*) FROM crm_users WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS users,
       (SELECT COUNT(*) FROM crm_identity_sessions WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS sessions,
@@ -1152,7 +1152,7 @@ function createRealRuntime(config, env = process.env) {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${fixture.prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE actor_id=${sql(fixture.username)} OR (actor_id='identity-service' AND after_json LIKE ${sql(`%"onboardingId":"${fixture.onboardingId}"%`)})) AS audit_count;`;
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`;
     coreAfter = capture("CORE_POST_TEARDOWN_QUERY_FAILED", () => d1Rows(
       config.coreDatabase,
       "inventory/wrangler.toml",

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -399,6 +399,7 @@ test("the executable and workflow retain no unimplemented hard-stop and require 
   const workflow = fs.readFileSync(new URL("../workflows/ponto-staging-rollback-drill.yml", import.meta.url), "utf8");
 
   assert.doesNotMatch(script, /authenticated-incumbent-rollback-harness-not-implemented|implemented:\s*false/);
+  assert.doesNotMatch(script, /after_json LIKE/);
   assert.match(workflow, /actions:\s*read/);
   assert.match(workflow, /checks:\s*write/);
   assert.match(workflow, /playwright install --with-deps chromium/);

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -209,7 +209,7 @@ if (action === 'provision') {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE actor_id=${sql(fixture.username)} OR (actor_id='identity-service' AND instr(after_json, ${sql(`"onboardingId":"${fixture.onboardingId}"`)}) > 0)) AS audit_count;`,
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`,
   ];
   writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
   writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -165,8 +165,11 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       );
       assert.equal((teardownCore.match(/DELETE FROM crm_identity_sessions/g) || []).length, 2);
       assert.equal(teardownTimekeeping.includes('DELETE FROM audit_log'), false);
+      assert.equal(teardownTimekeeping.includes('DELETE FROM timekeeping_audit_events'), false);
+      assert.doesNotMatch(teardownTimekeeping, /\bLIKE\b/);
       assert.match(teardownTimekeeping, new RegExp(`identity:${fixture.onboardingId}`));
       assert.match(teardownTimekeeping, /DELETE FROM timekeeping_request_nonces WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
+      assert.match(teardownTimekeeping, /timekeeping_audit_events WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
       assert.match(teardownTimekeeping, /updated_by = 'stg-ponto-123456789:presence-policy'/);
       assert.doesNotMatch(teardownTimekeeping, /DELETE FROM workforce_units/);
     } finally {


### PR DESCRIPTION
﻿## Summary
- use exact recorded request IDs for Ponto staging teardown audit correlation, avoiding D1 `LIKE` complexity
- bound only transient `PIN_INVALID` convergence in the authenticated staging journey to three sequential attempts
- keep the rollback drill on the same immutable-audit query contract

## Validation
- `node --test workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs .github/scripts/ponto-staging-rollback-drill.test.mjs`
- `node --check crm/console/scripts/ponto-staging-journey.cjs`
- targeted staging synthetic-fixture cleanup reached zero residual operational records while the module stayed fail-closed
