### PR TITLE
fix(ponto): make staging journey retries deterministic

### DIFF
--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -411,10 +411,16 @@ jobs:
           FIXTURES: ${{ runner.temp }}/ponto-staging-fixtures.json
           CORE_SQL: ${{ runner.temp }}/ponto-staging-core-teardown.sql
           TIMEKEEPING_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-teardown.sql
+          CORE_ATTESTATION_SQL: ${{ runner.temp }}/ponto-staging-core-teardown-attestation.sql
+          TIMEKEEPING_ATTESTATION_SQL: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-attestation.sql
           CORE_RAW: ${{ runner.temp }}/ponto-staging-core-teardown-raw.txt
           TIMEKEEPING_RAW: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-raw.txt
+          CORE_ATTESTATION_RAW: ${{ runner.temp }}/ponto-staging-core-teardown-attestation-raw.txt
+          TIMEKEEPING_ATTESTATION_RAW: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-attestation-raw.txt
           CORE_RESULT: ${{ runner.temp }}/ponto-staging-core-teardown-result.json
           TIMEKEEPING_RESULT: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-result.json
+          CORE_ATTESTATION_RESULT: ${{ runner.temp }}/ponto-staging-core-teardown-attestation-result.json
+          TIMEKEEPING_ATTESTATION_RESULT: ${{ runner.temp }}/ponto-staging-timekeeping-teardown-attestation-result.json
           PIN_SQL: ${{ runner.temp }}/ponto-staging-pin-attestation.sql
           PIN_RAW: ${{ runner.temp }}/ponto-staging-pin-attestation-raw.txt
           PIN_RESULT: ${{ runner.temp }}/ponto-staging-pin-attestation-result.json
@@ -424,12 +430,25 @@ jobs:
           set -euo pipefail
           [[ -f "$FIXTURES" ]] || exit 0
           [[ "$STAGING_CORE_D1_DATABASE" == 'skincos-db-staging' && "$STAGING_TIMEKEEPING_D1_DATABASE" == 'skincos-timekeeping-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
-          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL"
+          node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --core-sql "$CORE_SQL" --timekeeping-sql "$TIMEKEEPING_SQL" --core-attestation-sql "$CORE_ATTESTATION_SQL" --timekeeping-attestation-sql "$TIMEKEEPING_ATTESTATION_SQL"
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --file "$TIMEKEEPING_SQL" --json > "$TIMEKEEPING_RAW" 2>&1
           node .github/scripts/ponto-json-output.mjs "$TIMEKEEPING_RAW" "$TIMEKEEPING_RESULT"
           npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$CORE_SQL" --json > "$CORE_RAW" 2>&1
           node .github/scripts/ponto-json-output.mjs "$CORE_RAW" "$CORE_RESULT"
-          node - "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$TEARDOWN_REPORT" <<'NODE'
+          node - "$CORE_RESULT" "$TIMEKEEPING_RESULT" <<'NODE'
+          const fs = require("fs");
+          for (const file of process.argv.slice(2)) {
+            const entries = JSON.parse(fs.readFileSync(file, "utf8"));
+            if (!Array.isArray(entries) || entries.length === 0 || entries.some((entry) => entry?.success === false)) {
+              throw new Error("D1 teardown mutation returned a failed statement");
+            }
+          }
+          NODE
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_TIMEKEEPING_D1_DATABASE" --config "$TIMEKEEPING_STAGING_WRANGLER_CONFIG" --env staging --remote --command "$(cat "$TIMEKEEPING_ATTESTATION_SQL")" --json > "$TIMEKEEPING_ATTESTATION_RAW" 2>&1
+          node .github/scripts/ponto-json-output.mjs "$TIMEKEEPING_ATTESTATION_RAW" "$TIMEKEEPING_ATTESTATION_RESULT"
+          npx --yes wrangler@4.112.0 d1 execute "$STAGING_CORE_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --command "$(cat "$CORE_ATTESTATION_SQL")" --json > "$CORE_ATTESTATION_RAW" 2>&1
+          node .github/scripts/ponto-json-output.mjs "$CORE_ATTESTATION_RAW" "$CORE_ATTESTATION_RESULT"
+          node - "$CORE_ATTESTATION_RESULT" "$TIMEKEEPING_ATTESTATION_RESULT" "$TEARDOWN_REPORT" <<'NODE'
           const fs = require("fs");
           const rows = (file) => {
             const payload = JSON.parse(fs.readFileSync(file, "utf8"));
@@ -464,7 +483,7 @@ jobs:
             piiIncluded: false,
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
-          rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL" "$CORE_RAW" "$TIMEKEEPING_RAW" "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$PIN_SQL" "$PIN_RAW" "$PIN_RESULT" "$PIN_VERIFY_ERROR"
+          rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL" "$CORE_ATTESTATION_SQL" "$TIMEKEEPING_ATTESTATION_SQL" "$CORE_RAW" "$TIMEKEEPING_RAW" "$CORE_ATTESTATION_RAW" "$TIMEKEEPING_ATTESTATION_RAW" "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$CORE_ATTESTATION_RESULT" "$TIMEKEEPING_ATTESTATION_RESULT" "$PIN_SQL" "$PIN_RAW" "$PIN_RESULT" "$PIN_VERIFY_ERROR"
 
       - name: Upload sanitised journey evidence
         if: ${{ always() }}

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -8,7 +8,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { DEFAULT_PIN_ITERATIONS, hashPin } from '../security.js';
 
-const usage = 'usage: node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision|teardown --run-id <github-run-id> [--fixture-id <label>] --fixtures <private-json> --core-sql <sql-file> --timekeeping-sql <sql-file>';
+const usage = 'usage: node workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs --action provision|teardown --run-id <github-run-id> [--fixture-id <label>] --fixtures <private-json> --core-sql <sql-file> --timekeeping-sql <sql-file> [--core-attestation-sql <sql-file> --timekeeping-attestation-sql <sql-file>]';
 const args = new Map();
 for (let index = 2; index < process.argv.length; index += 2) args.set(process.argv[index], process.argv[index + 1]);
 const action = String(args.get('--action') || '');
@@ -17,6 +17,8 @@ const fixtureId = String(args.get('--fixture-id') || '');
 const fixturesPath = args.get('--fixtures');
 const coreSqlPath = args.get('--core-sql');
 const timekeepingSqlPath = args.get('--timekeeping-sql');
+const coreAttestationSqlPath = args.get('--core-attestation-sql');
+const timekeepingAttestationSqlPath = args.get('--timekeeping-attestation-sql');
 
 if (
   !['provision', 'teardown'].includes(action)
@@ -28,6 +30,7 @@ if (
 ) {
   throw new Error(usage);
 }
+if (action === 'teardown' && Boolean(coreAttestationSqlPath) !== Boolean(timekeepingAttestationSqlPath)) throw new Error(usage);
 
 const sql = (value) => `'${String(value).replaceAll("'", "''")}'`;
 const prefix = `stg-ponto-${runId}${fixtureId ? `-${fixtureId}` : ''}`;
@@ -156,6 +159,15 @@ if (action === 'provision') {
   const requestIdList = requestIds.length ? requestIds.map(sql).join(',') : "''";
   const eventIds = Array.from(new Set(fixture.teardownEventIds || []));
   const eventIdList = eventIds.length ? eventIds.map(sql).join(',') : "''";
+  const separateAttestation = Boolean(coreAttestationSqlPath && timekeepingAttestationSqlPath);
+  const coreAttestation = `SELECT
+      (SELECT COUNT(*) FROM crm_users WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS users,
+      (SELECT COUNT(*) FROM crm_identity_sessions WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS sessions,
+      (SELECT COUNT(*) FROM auth_attempts WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS auth_attempts,
+      (SELECT COUNT(*) FROM crm_user_prefs WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS prefs,
+      (SELECT COUNT(*) FROM crm_employee_onboarding WHERE id=${sql(fixture.onboardingId)}) AS onboarding,
+      (SELECT COUNT(*) FROM audit_log WHERE entity='staging_synthetic_ponto' AND entity_id=${sql(fixture.username)}) AS audit_count,
+      (SELECT COUNT(*) FROM audit_log WHERE entity='staging_synthetic_ponto' AND entity_id=${sql(fixture.username)} AND action='STAGING_SYNTHETIC_PONTO_TORN_DOWN') AS teardown_audit;`;
   const coreStatements = [
     `DELETE FROM crm_identity_sessions WHERE username = ${sql(fixture.username)};`,
     `DELETE FROM crm_identity_sessions WHERE username = ${sql(fixture.adminUsername)};`,
@@ -168,14 +180,7 @@ if (action === 'provision') {
     `DELETE FROM crm_users WHERE username = ${sql(fixture.adminUsername)};`,
     // Record teardown only after every operational delete above succeeded.
     audit('STAGING_SYNTHETIC_PONTO_TORN_DOWN', fixture.username, { runId, fixtureId, result: 'deleted' }),
-    `SELECT
-      (SELECT COUNT(*) FROM crm_users WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS users,
-      (SELECT COUNT(*) FROM crm_identity_sessions WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS sessions,
-      (SELECT COUNT(*) FROM auth_attempts WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS auth_attempts,
-      (SELECT COUNT(*) FROM crm_user_prefs WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS prefs,
-      (SELECT COUNT(*) FROM crm_employee_onboarding WHERE id=${sql(fixture.onboardingId)}) AS onboarding,
-      (SELECT COUNT(*) FROM audit_log WHERE entity='staging_synthetic_ponto' AND entity_id=${sql(fixture.username)}) AS audit_count,
-      (SELECT COUNT(*) FROM audit_log WHERE entity='staging_synthetic_ponto' AND entity_id=${sql(fixture.username)} AND action='STAGING_SYNTHETIC_PONTO_TORN_DOWN') AS teardown_audit;`,
+    ...(separateAttestation ? [] : [coreAttestation]),
   ];
   // Preserve the immutable timekeeping audit ledger. Only synthetic operational
   // records with this exact run-scoped employee/unit may be removed.
@@ -196,7 +201,7 @@ if (action === 'provision') {
     `DELETE FROM workforce_employee_unit_hierarchy WHERE employee_id = ${sql(fixture.employeeId)};`,
     `DELETE FROM workforce_employees WHERE id = ${sql(fixture.employeeId)};`,
     `DELETE FROM timekeeping_unit_presence_policies WHERE unit_id = ${sql(fixture.unitId)} AND updated_by = ${sql(`${prefix}:presence-policy`)};`,
-    `SELECT
+    ...(separateAttestation ? [] : [`SELECT
       (SELECT COUNT(*) FROM workforce_employees WHERE id=${sql(fixture.employeeId)} OR canonical_employee_id=${sql(`identity:${fixture.onboardingId}`)}) AS employees,
       (SELECT COUNT(*) FROM timekeeping_employee_units WHERE employee_id=${sql(fixture.employeeId)}) AS employee_units,
       (SELECT COUNT(*) FROM workforce_employee_profiles WHERE employee_id=${sql(fixture.employeeId)}) AS profiles,
@@ -209,9 +214,27 @@ if (action === 'provision') {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`,
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`]),
   ];
+  const timekeepingAttestation = `SELECT
+      (SELECT COUNT(*) FROM workforce_employees WHERE id=${sql(fixture.employeeId)} OR canonical_employee_id=${sql(`identity:${fixture.onboardingId}`)}) AS employees,
+      (SELECT COUNT(*) FROM timekeeping_employee_units WHERE employee_id=${sql(fixture.employeeId)}) AS employee_units,
+      (SELECT COUNT(*) FROM workforce_employee_profiles WHERE employee_id=${sql(fixture.employeeId)}) AS profiles,
+      (SELECT COUNT(*) FROM workforce_employee_unit_hierarchy WHERE employee_id=${sql(fixture.employeeId)}) AS hierarchy,
+      (SELECT COUNT(*) FROM timekeeping_events WHERE employee_id=${sql(fixture.employeeId)}) AS events,
+      (SELECT COUNT(*) FROM timekeeping_punch_evidence WHERE event_id IN (${eventIdList})) AS evidence,
+      (SELECT COUNT(*) FROM timekeeping_corrections WHERE event_id IN (${eventIdList})) AS corrections,
+      (SELECT COUNT(*) FROM timekeeping_pin_failures WHERE employee_id=${sql(fixture.employeeId)}) AS pin_failures,
+      (SELECT COUNT(*) FROM timekeeping_pin_credentials WHERE employee_id=${sql(fixture.employeeId)}) AS pin_credentials,
+      (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
+      (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
+      (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`;
   writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
   writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });
+  if (separateAttestation) {
+    writeFileSync(coreAttestationSqlPath, `${coreAttestation}\n`, { mode: 0o600 });
+    writeFileSync(timekeepingAttestationSqlPath, `${timekeepingAttestation}\n`, { mode: 0o600 });
+  }
   console.log(JSON.stringify({ action, environment: 'staging', syntheticOperationalRecordsRemoved: true, timekeepingAuditPreserved: true }));
 }

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -12,7 +12,7 @@ const script = new URL('./ponto-staging-journey-fixtures.mjs', import.meta.url);
 const inventoryMigrations = new URL('../../../inventory/migrations/', import.meta.url);
 const timekeepingMigrations = new URL('../migrations/', import.meta.url);
 
-function generate(action, paths, fixtureId = '') {
+function generate(action, paths, fixtureId = '', separateAttestation = false) {
   const argv = [
     script.pathname,
     '--action', action,
@@ -22,6 +22,7 @@ function generate(action, paths, fixtureId = '') {
     '--core-sql', paths.core,
     '--timekeeping-sql', paths.timekeeping,
   ];
+  if (separateAttestation) argv.push('--core-attestation-sql', paths.coreAttestation, '--timekeeping-attestation-sql', paths.timekeepingAttestation);
   execFileSync(process.execPath, argv, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
@@ -31,6 +32,8 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
     fixture: join(directory, 'fixture.json'),
     core: join(directory, 'core.sql'),
     timekeeping: join(directory, 'timekeeping.sql'),
+    coreAttestation: join(directory, 'core-attestation.sql'),
+    timekeepingAttestation: join(directory, 'timekeeping-attestation.sql'),
   };
 
   try {
@@ -135,12 +138,20 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
 
       fixture.teardownRequestIds = ['request-incumbent-1', 'request-incumbent-2'];
       writeFileSync(paths.fixture, JSON.stringify(fixture), { mode: 0o600 });
-      generate('teardown', paths);
+      generate('teardown', paths, '', true);
       const teardownCore = readFileSync(paths.core, 'utf8');
       const teardownTimekeeping = readFileSync(paths.timekeeping, 'utf8');
+      const coreAttestation = readFileSync(paths.coreAttestation, 'utf8');
+      const timekeepingAttestation = readFileSync(paths.timekeepingAttestation, 'utf8');
 
       database.exec(teardownCore);
       timekeepingDatabase.exec(teardownTimekeeping);
+      const coreResiduals = database.prepare(coreAttestation).get();
+      const timekeepingResiduals = timekeepingDatabase.prepare(timekeepingAttestation).get();
+      assert.equal(coreResiduals.users, 0);
+      assert.equal(coreResiduals.teardown_audit, 1);
+      assert.equal(timekeepingResiduals.employees, 0);
+      assert.equal(timekeepingResiduals.audit_count, 0);
       assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_users WHERE username IN (?, ?)').get(
         fixture.username,
         fixture.adminUsername,
@@ -169,7 +180,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       assert.doesNotMatch(teardownTimekeeping, /\bLIKE\b/);
       assert.match(teardownTimekeeping, new RegExp(`identity:${fixture.onboardingId}`));
       assert.match(teardownTimekeeping, /DELETE FROM timekeeping_request_nonces WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
-      assert.match(teardownTimekeeping, /timekeeping_audit_events WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
+      assert.match(timekeepingAttestation, /timekeeping_audit_events WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
       assert.match(teardownTimekeeping, /updated_by = 'stg-ponto-123456789:presence-policy'/);
       assert.doesNotMatch(teardownTimekeeping, /DELETE FROM workforce_units/);
     } finally {

--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -628,6 +628,14 @@ function nextEventType(previous) {
   return { WORK_START: 'BREAK_START', BREAK_START: 'BREAK_END', BREAK_END: 'WORK_END', WORK_END: 'WORK_START' }[previous] || 'WORK_START'
 }
 
+// The idempotency fingerprint must describe the caller's request, not the
+// event inferred from mutable ledger state. An automatic punch therefore
+// remains "AUTO" across retries even after the first event changes the next
+// inferred event type.
+function punchIdempotencyEventType(body) {
+  return canonicalEventType(body?.eventType || body?.type) || 'AUTO'
+}
+
 async function recordPinFailure(db, employeeId, deviceId) {
   const at = now()
   const current = await db.prepare('SELECT * FROM timekeeping_pin_failures WHERE employee_id=?').bind(employeeId).first()
@@ -1376,16 +1384,20 @@ export async function handleTimekeeping(request, env) {
       if (credential.error) return failure(credential.error === 'PIN_LOCKED' ? 429 : 401, credential.error, requestId, credential.secondsRemaining ? { secondsRemaining: credential.secondsRemaining } : {})
       const manualReason = credential.source === 'MANUAL' ? cleanText(body.reason, 500) : ''
       if (credential.source === 'MANUAL' && !manualReason) return failure(400, 'JUSTIFICATION_REQUIRED', requestId)
-      const previous = await db.prepare('SELECT event_type, occurred_at_utc FROM timekeeping_events WHERE employee_id=? AND unit_id=? ORDER BY occurred_at_utc DESC LIMIT 1').bind(employee.id, unitId).first()
-      const eventType = canonicalEventType(body.eventType || body.type) || nextEventType(previous?.event_type)
       const idempotencyKey = cleanText(request.headers.get('idempotency-key') || request.headers.get('x-idempotency-key') || body.requestId, 160)
       if (!idempotencyKey) return failure(400, 'IDEMPOTENCY_KEY_REQUIRED', requestId)
-      const scope = `employee:${employee.id}`; const fingerprint = await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${employee.id}.${unitId}.${eventType}.${body.occurredAt || ''}.${credential.source}`)
+      const requestedEventType = punchIdempotencyEventType(body)
+      const scope = `employee:${employee.id}`; const fingerprint = await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${employee.id}.${unitId}.${requestedEventType}.${body.occurredAt || ''}.${credential.source}`)
       const alreadyCreated = await db.prepare('SELECT * FROM timekeeping_events WHERE idempotency_scope=? AND idempotency_key=?').bind(scope, idempotencyKey).first()
       if (alreadyCreated) {
-        if (!constantTimeEqual(alreadyCreated.request_fingerprint, fingerprint)) return failure(409, 'IDEMPOTENCY_CONFLICT', requestId)
+        const legacyFingerprint = requestedEventType === 'AUTO'
+          ? await hmac(String(env.PONTO_IDEMPOTENCY_KEY || env.PONTO_ACTOR_HMAC_KEY), `${employee.id}.${unitId}.${alreadyCreated.event_type}.${body.occurredAt || ''}.${credential.source}`)
+          : ''
+        if (!constantTimeEqual(alreadyCreated.request_fingerprint, fingerprint) && !constantTimeEqual(alreadyCreated.request_fingerprint, legacyFingerprint)) return failure(409, 'IDEMPOTENCY_CONFLICT', requestId)
         return json(200, { ok: true, idempotent: true, data: { id: alreadyCreated.id, operationId: alreadyCreated.id, employeeId: employee.id, employeeName: employee.display_name, type: alreadyCreated.event_type === 'WORK_START' ? 'IN' : alreadyCreated.event_type === 'WORK_END' ? 'OUT' : alreadyCreated.event_type, eventType: alreadyCreated.event_type, at: alreadyCreated.occurred_at_utc, occurredAtUtc: alreadyCreated.occurred_at_utc, unit: alreadyCreated.unit_id, unitId: alreadyCreated.unit_id, method: alreadyCreated.source, source: alreadyCreated.source } }, requestId)
       }
+      const previous = await db.prepare('SELECT event_type, occurred_at_utc FROM timekeeping_events WHERE employee_id=? AND unit_id=? ORDER BY occurred_at_utc DESC LIMIT 1').bind(employee.id, unitId).first()
+      const eventType = requestedEventType === 'AUTO' ? nextEventType(previous?.event_type) : requestedEventType
       if (previous && Date.parse(occurredAt) - Date.parse(previous.occurred_at_utc) < Number(env.PONTO_COOLDOWN_SECONDS || 15) * 1000) return failure(429, 'COOLDOWN', requestId, { secondsRemaining: Number(env.PONTO_COOLDOWN_SECONDS || 15) })
       const id = crypto.randomUUID()
       try {
@@ -1693,6 +1705,7 @@ export const __testables = {
   roleAllows,
   requireUnit,
   canonicalEventType,
+  punchIdempotencyEventType,
   calculateDay,
   calculatePeriod,
   csvCell,

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -961,6 +961,12 @@ test('onboarding manager routing leaves missing or ambiguous superiors empty for
   assert.deepEqual(__testables.resolveOnboardingManager([{ manager_employee_id: 'manager-1', status: 'LEAVE', access_state: 'SUSPENDED' }]), { managerId: null, reason: 'MISSING' })
 })
 
+test('automatic punch idempotency stays stable after the inferred event changes', () => {
+  assert.equal(__testables.punchIdempotencyEventType({}), 'AUTO')
+  assert.equal(__testables.punchIdempotencyEventType({ type: 'IN' }), 'WORK_START')
+  assert.equal(__testables.punchIdempotencyEventType({ eventType: 'WORK_END' }), 'WORK_END')
+})
+
 test('CSV cells neutralize formulas and follow CSV quote escaping', () => {
   assert.equal(__testables.csvCell('=HYPERLINK("https://invalid.example")'), '"\'=HYPERLINK(""https://invalid.example"")"')
   assert.equal(__testables.csvCell('Pessoa "Teste"'), '"Pessoa ""Teste"""')


### PR DESCRIPTION
## Summary
- keep automatic Ponto punch idempotency fingerprints stable across inferred event transitions
- preserve compatibility with legacy automatic-punch fingerprints
- run staging teardown mutations with --file and read-only attestations with --command so D1 row evidence is observable

## Validation
- workforce/timekeeping: npm test (56 passed)
- staging fixture tests (2 passed)
- node syntax checks and git diff --check

This is scoped to the governed synthetic staging proof; no production activation is included.