### PR TITLE
fix: make Ponto rollback drill use live staging custody

### DIFF
--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -3,11 +3,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
-import { isTerminalPagesDeployment } from "./ponto-rollback-ownership.mjs";
+import {
+  isTerminalPagesDeployment,
+  latestProductionPagesDeployment,
+} from "./ponto-rollback-ownership.mjs";
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA = /^[0-9a-f]{40}$/i;
 const WORKER_SURFACES = ["timekeeping", "identityWorkforce", "coreApi"];
+const STAGING_PAGES_ALIAS = "crm-staging.skincos.com.br";
 const SURFACE_SOURCE_PATTERNS = {
   timekeeping: /ponto:timekeeping:([0-9a-f]{40})/i,
   identityWorkforce: /ponto:identityWorkforce:([0-9a-f]{40})/i,
@@ -459,6 +463,7 @@ export function loadConfig(env = process.env, argv = process.argv.slice(2)) {
   const moduleControlNamespaceId = requireValue(env, "PONTO_MODULE_CONTROL_STAGING_KV_ID").toLowerCase();
   const runnerTemp = requireValue(env, "RUNNER_TEMP");
   const pagesProject = requireValue(env, "PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING");
+  const timekeepingWranglerConfig = requireValue(env, "TIMEKEEPING_STAGING_WRANGLER_CONFIG");
   const ids = {
     timekeeping: {
       worker: "skincos-timekeeping-staging",
@@ -522,6 +527,7 @@ export function loadConfig(env = process.env, argv = process.argv.slice(2)) {
     moduleControlNamespaceId,
     runnerTemp,
     pagesProject,
+    timekeepingWranglerConfig,
     ids,
     accessHeaders: accessId ? {
       "CF-Access-Client-Id": accessId,
@@ -687,11 +693,12 @@ function createRealRuntime(config, env = process.env) {
   };
   const latestPagesDeployment = async ({ allowPending = false } = {}) => {
     const deployments = await cloudflare(`${pagesPath}/deployments?env=production&per_page=25`);
-    const ordered = (Array.isArray(deployments) ? deployments : [])
-      .filter((item) => item?.environment === "production")
-      .sort((a, b) => String(b.created_on).localeCompare(String(a.created_on)));
-    if (!ordered[0]) throw new DrillFailure("PAGES_LATEST_DEPLOYMENT_MISSING");
-    return pageDetails(ordered[0], { allowPending });
+    const latest = latestProductionPagesDeployment(
+      { success: true, result: Array.isArray(deployments) ? deployments : [] },
+      { alias: STAGING_PAGES_ALIAS },
+    );
+    if (!latest) throw new DrillFailure("PAGES_LATEST_DEPLOYMENT_MISSING");
+    return pageDetails(latest, { allowPending });
   };
   const assertPagesActive = async (deploymentId, expectedSha = null) => {
     const source = await pagesDeploymentDetails(deploymentId);
@@ -907,7 +914,7 @@ function createRealRuntime(config, env = process.env) {
   };
   const provisionFixture = async (handle) => {
     d1Execute(config.coreDatabase, "inventory/wrangler.toml", ["--file", handle.coreProvisionPath], "CORE_FIXTURE_PROVISION_FAILED");
-    d1Execute(config.timekeepingDatabase, "workforce/timekeeping/wrangler.toml", ["--file", handle.timekeepingProvisionPath], "TIMEKEEPING_FIXTURE_PROVISION_FAILED");
+    d1Execute(config.timekeepingDatabase, config.timekeepingWranglerConfig, ["--file", handle.timekeepingProvisionPath], "TIMEKEEPING_FIXTURE_PROVISION_FAILED");
     return { passed: true };
   };
 
@@ -1094,7 +1101,7 @@ function createRealRuntime(config, env = process.env) {
     ));
     timekeepingBefore = capture("TIMEKEEPING_PRE_TEARDOWN_QUERY_FAILED", () => d1Rows(
       config.timekeepingDatabase,
-      "workforce/timekeeping/wrangler.toml",
+      config.timekeepingWranglerConfig,
       timekeepingBeforeSql,
     ));
 
@@ -1110,7 +1117,7 @@ function createRealRuntime(config, env = process.env) {
     if (fs.existsSync(handle.timekeepingTeardownPath)) {
       capture("TIMEKEEPING_TEARDOWN_FAILED", () => d1Execute(
         config.timekeepingDatabase,
-        "workforce/timekeeping/wrangler.toml",
+        config.timekeepingWranglerConfig,
         ["--file", handle.timekeepingTeardownPath],
         "TIMEKEEPING_TEARDOWN_FAILED",
       ), "");
@@ -1160,7 +1167,7 @@ function createRealRuntime(config, env = process.env) {
     ));
     timekeepingAfter = capture("TIMEKEEPING_POST_TEARDOWN_QUERY_FAILED", () => d1Rows(
       config.timekeepingDatabase,
-      "workforce/timekeeping/wrangler.toml",
+      config.timekeepingWranglerConfig,
       timekeepingAfterSql,
     ));
 

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -89,6 +89,7 @@ test("configuration derives the transient release-probe key without delegated ch
     PONTO_IDEMPOTENCY_KEY: idempotencyKey,
     PONTO_MODULE_CONTROL_STAGING_KV_ID: "e".repeat(32),
     PONTO_CLOUDFLARE_PAGES_PROJECT_STAGING: "skincos-staging",
+    TIMEKEEPING_STAGING_WRANGLER_CONFIG: "/tmp/ponto-timekeeping-staging-wrangler.toml",
     RUNNER_TEMP: "/tmp",
     TIMEKEEPING_CANDIDATE_VERSION_ID: ids.timekeeping.candidate,
     TIMEKEEPING_INCUMBENT_VERSION_ID: ids.timekeeping.incumbent,
@@ -406,6 +407,9 @@ test("the executable and workflow retain no unimplemented hard-stop and require 
   assert.match(workflow, /if-no-files-found:\s*error/);
   assert.match(workflow, /if:\s*always\(\)/);
   assert.match(workflow, /group:\s*ponto-surface-mutation/);
+  assert.match(workflow, /TIMEKEEPING_STAGING_WRANGLER_CONFIG/);
+  assert.match(script, /TIMEKEEPING_STAGING_WRANGLER_CONFIG/);
+  assert.match(script, /latestProductionPagesDeployment/);
   assert.doesNotMatch(workflow, /delegated-capability-broker:|INCUMBENT_DISPATCH_NONCE:|CANDIDATE_DISPATCH_NONCE:/);
   assert.doesNotMatch(workflow, /rollback_(?:incumbent|candidate)_open_lease_token/i);
   const exercise = workflow.slice(

--- a/.github/workflows/ponto-staging-rollback-drill.yml
+++ b/.github/workflows/ponto-staging-rollback-drill.yml
@@ -143,6 +143,19 @@ jobs:
           PONTO_OPPOSITE_MODULE_CONTROL_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_PRODUCTION_KV_ID }}
           PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-staging-resource-identity.json
         run: node .github/scripts/ponto-cloudflare-resource-identity.mjs
+      - name: Render the exact staging Timekeeping D1 config
+        env:
+          STAGING_TIMEKEEPING_D1_ID: ${{ vars.PONTO_TIMEKEEPING_D1_STAGING_ID }}
+        run: |
+          set -euo pipefail
+          [[ "$STAGING_TIMEKEEPING_D1_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Timekeeping D1 ID is missing or malformed'; exit 1; }
+          config="$RUNNER_TEMP/ponto-timekeeping-staging-wrangler.toml"
+          cp workforce/timekeeping/wrangler.toml "$config"
+          sed -i \
+            "s/__CONFIGURE_TIMEKEEPING_D1_ID__/00000000-0000-4000-8000-000000000001/;s/__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__/00000000000000000000000000000001/;s/__CONFIGURE_TIMEKEEPING_STAGING_D1_ID__/$STAGING_TIMEKEEPING_D1_ID/" \
+            "$config"
+          ! grep -q '__CONFIGURE_.*_ID__' "$config" || { echo 'unresolved Timekeeping staging binding placeholder'; exit 1; }
+          printf 'TIMEKEEPING_STAGING_WRANGLER_CONFIG=%s\n' "$config" >> "$GITHUB_ENV"
       - name: Exercise exact incumbents and restore every exact staging candidate
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -164,6 +177,7 @@ jobs:
           PONTO_MODULE_CONTROL_STAGING_KV_ID: ${{ vars.PONTO_MODULE_CONTROL_STAGING_KV_ID }}
           STAGING_CORE_D1_DATABASE: skincos-db-staging
           STAGING_TIMEKEEPING_D1_DATABASE: skincos-timekeeping-staging
+          TIMEKEEPING_STAGING_WRANGLER_CONFIG: ${{ runner.temp }}/ponto-timekeeping-staging-wrangler.toml
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |


### PR DESCRIPTION
## Summary
- render the exact staging Timekeeping D1 config before rollback fixture mutations
- use the rendered config for provision, query, and teardown paths
- reconcile Pages active deployment through the staging alias during rollback
- add focused regression assertions

## Validation
- node --test .github/scripts/ponto-staging-rollback-drill.test.mjs .github/scripts/ponto-pages-rollback.test.mjs .github/scripts/ponto-rollback-ownership.test.mjs (WSL Ubuntu-24.04)
- git diff --check

This is a staging-proof harness correction only; no production mutation is included.