### PR TITLE
fix: restore Pages workflow dispatch trigger

### DIFF
--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -684,7 +684,7 @@ jobs:
             || !headers.includes(`x-skincos-pages-release-sha: ${process.env.RELEASE_SHA}`)
             || !headers.includes("x-skincos-pages-environment: staging")
           ) process.exit(2);
-NODE
+          NODE
               if [[ "$proxy_status" == "0" ]]; then proxy_attested=true; break; fi
               [[ "$proxy_status" == "2" ]] || exit "$proxy_status"
             elif [[ "$http_status" != "404" && "$http_status" != "000" ]]; then


### PR DESCRIPTION
## Summary
- indent the staging Pages probe heredoc terminator inside the workflow block
- restore valid workflow parsing and workflow_dispatch registration

## Validation
- PyYAML parse of .github/workflows/deploy-crm-pages.yml
- node --test .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-pages-rollback.test.mjs .github/scripts/ponto-rollback-ownership.test.mjs
- 46 passed, 0 failed
