### PR TITLE
fix(ponto): make rollback journey propagation-aware

### DIFF
--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -79,6 +79,24 @@ export function validateIncumbentProvenance(ids, evidence) {
   return validated;
 }
 
+export function classifyIncumbentBundle(evidence) {
+  const sourceShas = [
+    ...WORKER_SURFACES.map((surface) => evidence?.[surface]?.sourceSha),
+    evidence?.crmPages?.sourceSha,
+  ]
+    .map((value) => String(value || "").trim().toLowerCase())
+    .filter(Boolean);
+  const uniqueSourceShas = [...new Set(sourceShas)].sort();
+  const coherent = sourceShas.length === WORKER_SURFACES.length + 1
+    && uniqueSourceShas.length === 1
+    && SHA.test(uniqueSourceShas[0]);
+  return {
+    coherent,
+    sourceShas: uniqueSourceShas,
+    reason: coherent ? "coherent-release-bundle" : "heterogeneous-or-incomplete-release-bundle",
+  };
+}
+
 const versionSet = (ids, side) => ({
   timekeeping: ids.timekeeping[side],
   coreApi: ids.coreApi[side],
@@ -110,6 +128,7 @@ const baseReport = (config) => ({
   functionalValidation: {
     implemented: true,
     incumbentJourney: { attempted: false, passed: false },
+    candidateAffinity: { attempted: false, passed: false },
     protectedCandidateContract: { attempted: false, passed: false },
     candidateJourney: { attempted: false, passed: false },
   },
@@ -186,12 +205,28 @@ async function validateFixture({
 }) {
   let handle;
   let fixtureReady = false;
-  try {
-    handle = await runtime.prepareFixture(label);
-    await runtime.provisionFixture(handle);
-    fixtureReady = true;
-  } catch (error) {
-    recordFailure(report, `${label}.provision`, error);
+  let affinityReady = !includeProtectedContract;
+  if (includeProtectedContract) {
+    report.functionalValidation.candidateAffinity.attempted = true;
+    try {
+      report.functionalValidation.candidateAffinity = {
+        attempted: true,
+        ...await runtime.proveCandidateAffinity(pages, expected),
+      };
+      affinityReady = report.functionalValidation.candidateAffinity.passed === true;
+    } catch (error) {
+      recordFailure(report, "candidate.affinity", error);
+    }
+  }
+
+  if (affinityReady) {
+    try {
+      handle = await runtime.prepareFixture(label);
+      await runtime.provisionFixture(handle);
+      fixtureReady = true;
+    } catch (error) {
+      recordFailure(report, `${label}.provision`, error);
+    }
   }
 
   if (fixtureReady && includeProtectedContract) {
@@ -245,6 +280,7 @@ export async function runStagingRollbackDrill(config, runtime) {
   try {
     const preflight = await runtime.attestInitialState(config);
     const incumbents = validateIncumbentProvenance(config.ids, preflight.incumbents);
+    const incumbentBundle = classifyIncumbentBundle(incumbents);
     report.preflight = {
       attempted: true,
       passed: true,
@@ -252,6 +288,21 @@ export async function runStagingRollbackDrill(config, runtime) {
       surfaces: preflight.surfaces,
       incumbents,
     };
+    if (!incumbentBundle.coherent) {
+      report.functionalValidation.incumbentJourney = {
+        attempted: false,
+        passed: true,
+        skipped: true,
+        reason: incumbentBundle.reason,
+        sourceShas: incumbentBundle.sourceShas,
+      };
+      report.teardown.incumbent = {
+        attempted: false,
+        passed: true,
+        skipped: true,
+        reason: incumbentBundle.reason,
+      };
+    }
   } catch (error) {
     recordFailure(report, "preflight", error);
   }
@@ -283,7 +334,7 @@ export async function runStagingRollbackDrill(config, runtime) {
         recordFailure(report, "module-control.incumbent-active", error);
       }
 
-      if (report.moduleControl.incumbentActive.passed) {
+      if (report.moduleControl.incumbentActive.passed && !report.functionalValidation.incumbentJourney.skipped) {
         await validateFixture({
           label: "incumbent",
           pages: rollbackPages,
@@ -376,6 +427,7 @@ export async function runStagingRollbackDrill(config, runtime) {
     && report.moduleControl.preRestorationMaintenance.passed
     && report.restoration.passed
     && report.moduleControl.candidateActive.passed
+    && report.functionalValidation.candidateAffinity.passed
     && report.functionalValidation.protectedCandidateContract.passed
     && report.functionalValidation.candidateJourney.passed
     && report.teardown.candidate.passed
@@ -987,6 +1039,68 @@ function createRealRuntime(config, env = process.env) {
     );
     return { surfaces, pages };
   };
+  const proveCandidateAffinity = async (pages, expected) => {
+    const origin = new URL(pages?.url || "");
+    if (
+      origin.protocol !== "https:"
+      || !origin.hostname.endsWith(".skincos-staging.pages.dev")
+      || origin.pathname !== "/"
+      || origin.search
+      || origin.hash
+      || expected.sourceSha !== config.releaseSha
+    ) throw new DrillFailure("PAGES_AFFINITY_EXPECTATION_INVALID");
+
+    const expectedHeaders = {
+      "x-skincos-pages-release-sha": expected.sourceSha,
+      "x-skincos-pages-environment": "staging",
+      "x-skincos-gateway-release-sha": expected.sourceSha,
+      "x-skincos-gateway-environment": "staging",
+      "x-skincos-gateway-version-id": expected.coreVersionId,
+      "x-skincos-timekeeping-release-sha": expected.sourceSha,
+      "x-skincos-timekeeping-environment": "staging",
+      "x-skincos-timekeeping-version-id": expected.timekeepingVersionId,
+    };
+    let lastStatus = 0;
+    for (let attempt = 1; attempt <= 36; attempt += 1) {
+      const probe = new URL("/api/ponto/health", origin);
+      probe.searchParams.set("staging_rollback_affinity_probe", `${config.runId}-${attempt}`);
+      try {
+        const response = await fetch(probe, {
+          redirect: "manual",
+          signal: AbortSignal.timeout(30_000),
+          headers: {
+            accept: "application/json",
+            "cache-control": "no-cache",
+            ...config.accessHeaders,
+          },
+        });
+        lastStatus = response.status;
+        if (response.status === 200) {
+          const matched = Object.entries(expectedHeaders).every(([name, value]) =>
+            String(response.headers.get(name) || "").trim().toLowerCase() === String(value).toLowerCase());
+          if (matched) {
+            return {
+              passed: true,
+              attempts: attempt,
+              status: response.status,
+              sourceSha: expected.sourceSha,
+              gatewayVersionId: expected.coreVersionId,
+              timekeepingVersionId: expected.timekeepingVersionId,
+              credentialsIncluded: false,
+              piiIncluded: false,
+            };
+          }
+        } else if (![404, 429, 502, 503, 504].includes(response.status) && response.status < 500) {
+          throw new DrillFailure("PAGES_AFFINITY_UNEXPECTED_STATUS");
+        }
+      } catch (error) {
+        if (error instanceof DrillFailure && error.code === "PAGES_AFFINITY_UNEXPECTED_STATUS") throw error;
+        lastStatus = 0;
+      }
+      if (attempt < 36) await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    throw new DrillFailure(`PAGES_TIMEKEEPING_AFFINITY_FAILED_${lastStatus || "FETCH"}`);
+  };
   const sanitizedJourney = (raw, expected, controlPlane) => {
     const report = JSON.parse(raw);
     const navigation = report?.navigation || {};
@@ -1378,6 +1492,7 @@ function createRealRuntime(config, env = process.env) {
     runJourney,
     verifyProtectedContract,
     teardownFixture,
+    proveCandidateAffinity,
   };
 }
 

--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -128,6 +128,7 @@ const baseReport = (config) => ({
   functionalValidation: {
     implemented: true,
     incumbentJourney: { attempted: false, passed: false },
+    incumbentCompatibility: { attempted: false, passed: false },
     candidateAffinity: { attempted: false, passed: false },
     protectedCandidateContract: { attempted: false, passed: false },
     candidateJourney: { attempted: false, passed: false },
@@ -275,11 +276,13 @@ export async function runStagingRollbackDrill(config, runtime) {
   let rollbackPages = null;
   let restoredPages = null;
   let mutationStarted = false;
+  let incumbentProvenance = null;
 
   report.preflight.attempted = true;
   try {
     const preflight = await runtime.attestInitialState(config);
     const incumbents = validateIncumbentProvenance(config.ids, preflight.incumbents);
+    incumbentProvenance = incumbents;
     const incumbentBundle = classifyIncumbentBundle(incumbents);
     report.preflight = {
       attempted: true,
@@ -291,15 +294,24 @@ export async function runStagingRollbackDrill(config, runtime) {
     if (!incumbentBundle.coherent) {
       report.functionalValidation.incumbentJourney = {
         attempted: false,
-        passed: true,
+        passed: false,
         skipped: true,
+        blocking: true,
         reason: incumbentBundle.reason,
+        sourceShas: incumbentBundle.sourceShas,
+      };
+      report.functionalValidation.incumbentCompatibility = {
+        attempted: false,
+        passed: false,
+        required: true,
+        mode: "heterogeneous-fail-closed-health",
         sourceShas: incumbentBundle.sourceShas,
       };
       report.teardown.incumbent = {
         attempted: false,
         passed: true,
         skipped: true,
+        notRequired: true,
         reason: incumbentBundle.reason,
       };
     }
@@ -334,7 +346,26 @@ export async function runStagingRollbackDrill(config, runtime) {
         recordFailure(report, "module-control.incumbent-active", error);
       }
 
-      if (report.moduleControl.incumbentActive.passed && !report.functionalValidation.incumbentJourney.skipped) {
+      if (report.moduleControl.incumbentActive.passed && report.functionalValidation.incumbentJourney.skipped) {
+        report.functionalValidation.incumbentCompatibility.attempted = true;
+        try {
+          report.functionalValidation.incumbentCompatibility = {
+            attempted: true,
+            ...await runtime.proveIncumbentCompatibility(rollbackPages, {
+              pagesSourceSha: incumbentProvenance.crmPages.sourceSha,
+              identitySourceSha: incumbentProvenance.identityWorkforce.sourceSha,
+              coreSourceSha: incumbentProvenance.coreApi.sourceSha,
+              timekeepingSourceSha: incumbentProvenance.timekeeping.sourceSha,
+              pagesDeploymentId: rollbackPages.activeDeploymentId,
+              identityVersionId: config.ids.identityWorkforce.incumbent,
+              coreVersionId: config.ids.coreApi.incumbent,
+              timekeepingVersionId: config.ids.timekeeping.incumbent,
+            }),
+          };
+        } catch (error) {
+          recordFailure(report, "incumbent.compatibility", error);
+        }
+      } else if (report.moduleControl.incumbentActive.passed) {
         await validateFixture({
           label: "incumbent",
           pages: rollbackPages,
@@ -418,12 +449,23 @@ export async function runStagingRollbackDrill(config, runtime) {
     recordFailure(report, "module-control.final-maintenance", error);
   }
 
+  const incumbentFunctionalValidationPassed = report.functionalValidation.incumbentJourney.passed
+    || (
+      report.functionalValidation.incumbentJourney.skipped === true
+      && report.functionalValidation.incumbentJourney.passed === false
+      && report.functionalValidation.incumbentJourney.blocking === true
+      && report.functionalValidation.incumbentCompatibility.passed === true
+      && report.functionalValidation.incumbentCompatibility.mode === "heterogeneous-fail-closed-health"
+    );
+  const incumbentTeardownPassed = report.functionalValidation.incumbentJourney.skipped === true
+    ? report.teardown.incumbent.notRequired === true
+    : report.teardown.incumbent.passed;
   const normalPassed = report.failures.length === 0
     && report.preflight.passed
     && report.rollback.passed
     && report.moduleControl.incumbentActive.passed
-    && report.functionalValidation.incumbentJourney.passed
-    && report.teardown.incumbent.passed
+    && incumbentFunctionalValidationPassed
+    && incumbentTeardownPassed
     && report.moduleControl.preRestorationMaintenance.passed
     && report.restoration.passed
     && report.moduleControl.candidateActive.passed
@@ -1076,9 +1118,23 @@ function createRealRuntime(config, env = process.env) {
         });
         lastStatus = response.status;
         if (response.status === 200) {
+          const payload = await response.json().catch(() => null);
           const matched = Object.entries(expectedHeaders).every(([name, value]) =>
             String(response.headers.get(name) || "").trim().toLowerCase() === String(value).toLowerCase());
-          if (matched) {
+          const ready = payload?.ok === true
+            && payload?.ready === true
+            && payload?.service === "workforce-timekeeping"
+            && payload?.unit === "timekeeping"
+            && payload?.environment === "staging"
+            && payload?.database === true
+            && payload?.dependencies?.module_control?.state === "healthy"
+            && payload?.dependencies?.gateway_affinity?.state === "healthy"
+            && String(payload?.versionMetadata?.releaseSha || "").toLowerCase() === expected.sourceSha.toLowerCase()
+            && String(payload?.versionMetadata?.workerVersionId || "").toLowerCase() === expected.timekeepingVersionId.toLowerCase()
+            && String(payload?.versionMetadata?.gatewayReleaseSha || "").toLowerCase() === expected.sourceSha.toLowerCase()
+            && String(payload?.versionMetadata?.gatewayEnvironment || "").toLowerCase() === "staging"
+            && String(payload?.versionMetadata?.gatewayVersionId || "").toLowerCase() === expected.coreVersionId.toLowerCase();
+          if (matched && ready) {
             return {
               passed: true,
               attempts: attempt,
@@ -1100,6 +1156,98 @@ function createRealRuntime(config, env = process.env) {
       if (attempt < 36) await new Promise((resolve) => setTimeout(resolve, 5_000));
     }
     throw new DrillFailure(`PAGES_TIMEKEEPING_AFFINITY_FAILED_${lastStatus || "FETCH"}`);
+  };
+  const proveIncumbentCompatibility = async (pages, expected) => {
+    const origin = new URL(pages?.url || "");
+    if (
+      origin.protocol !== "https:"
+      || !origin.hostname.endsWith(".skincos-staging.pages.dev")
+      || origin.pathname !== "/"
+      || origin.search
+      || origin.hash
+      || ![expected.pagesSourceSha, expected.identitySourceSha, expected.coreSourceSha, expected.timekeepingSourceSha]
+        .every((value) => SHA.test(String(value || "")))
+    ) throw new DrillFailure("INCUMBENT_COMPATIBILITY_EXPECTATION_INVALID");
+
+    const pagesHealth = new URL("/api/ponto/health", origin);
+    pagesHealth.searchParams.set("staging_rollback_incumbent_probe", config.runId);
+    const response = await fetch(pagesHealth, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        accept: "application/json",
+        "cache-control": "no-cache",
+        ...config.accessHeaders,
+      },
+    });
+    const payload = await response.json().catch(() => null);
+    const header = (name) => String(response.headers.get(name) || "").trim().toLowerCase();
+    const pagesPassed = response.status === 200
+      && payload?.ok === false
+      && payload?.ready === false
+      && payload?.service === "workforce-timekeeping"
+      && payload?.unit === "timekeeping"
+      && payload?.environment === "staging"
+      && payload?.database === true
+      && payload?.dependencies?.module_control?.state === "healthy"
+      && payload?.dependencies?.gateway_affinity?.state === "unavailable"
+      && payload?.dependencies?.gateway_affinity?.reason === "RELEASE_AFFINITY_MISMATCH"
+      && String(payload?.versionMetadata?.releaseSha || "").toLowerCase() === expected.timekeepingSourceSha.toLowerCase()
+      && String(payload?.versionMetadata?.workerVersionId || "").toLowerCase() === expected.timekeepingVersionId.toLowerCase()
+      && String(payload?.versionMetadata?.gatewayReleaseSha || "").toLowerCase() === expected.coreSourceSha.toLowerCase()
+      && String(payload?.versionMetadata?.gatewayEnvironment || "").toLowerCase() === "staging"
+      && String(payload?.versionMetadata?.gatewayVersionId || "").toLowerCase() === expected.coreVersionId.toLowerCase()
+      && header("x-skincos-pages-release-sha") === expected.pagesSourceSha.toLowerCase()
+      && header("x-skincos-pages-environment") === "staging"
+      && header("x-skincos-gateway-release-sha") === expected.coreSourceSha.toLowerCase()
+      && header("x-skincos-gateway-environment") === "staging"
+      && header("x-skincos-gateway-version-id") === expected.coreVersionId.toLowerCase()
+      && header("x-skincos-timekeeping-release-sha") === expected.timekeepingSourceSha.toLowerCase()
+      && header("x-skincos-timekeeping-environment") === "staging"
+      && header("x-skincos-timekeeping-version-id") === expected.timekeepingVersionId.toLowerCase();
+
+    const identityHealth = new URL("https://api-staging.skincos.com.br/insumos/health");
+    identityHealth.searchParams.set("staging_rollback_incumbent_probe", config.runId);
+    const identityResponse = await fetch(identityHealth, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        accept: "application/json",
+        "cache-control": "no-cache",
+        ...config.accessHeaders,
+      },
+    });
+    const identityPayload = await identityResponse.json().catch(() => null);
+    const identityPassed = identityResponse.status === 200
+      && identityPayload?.ok === true
+      && identityPayload?.ready === true
+      && identityPayload?.environment === "staging"
+      && String(identityPayload?.version || "").toLowerCase() === expected.identitySourceSha.toLowerCase()
+      && String(identityPayload?.workerVersion?.id || "").toLowerCase() === expected.identityVersionId.toLowerCase();
+
+    if (!pagesPassed || !identityPassed) throw new DrillFailure("INCUMBENT_COMPATIBILITY_SMOKE_FAILED");
+    return {
+      passed: true,
+      mode: "heterogeneous-fail-closed-health",
+      pagesHealth: {
+        status: response.status,
+        ready: false,
+        affinity: "RELEASE_AFFINITY_MISMATCH",
+      },
+      identityHealth: {
+        status: identityResponse.status,
+        ready: true,
+        versionId: expected.identityVersionId,
+      },
+      sourceShas: {
+        pages: expected.pagesSourceSha,
+        coreApi: expected.coreSourceSha,
+        timekeeping: expected.timekeepingSourceSha,
+        identityWorkforce: expected.identitySourceSha,
+      },
+      credentialsIncluded: false,
+      piiIncluded: false,
+    };
   };
   const sanitizedJourney = (raw, expected, controlPlane) => {
     const report = JSON.parse(raw);
@@ -1492,6 +1640,7 @@ function createRealRuntime(config, env = process.env) {
     runJourney,
     verifyProtectedContract,
     teardownFixture,
+    proveIncumbentCompatibility,
     proveCandidateAffinity,
   };
 }

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -258,6 +258,18 @@ class FakeRuntime {
     };
   }
 
+  async proveIncumbentCompatibility(_pages, _expected) {
+    const call = "incumbent:compatibility";
+    this.calls.push(call);
+    this.maybeFail(call);
+    return {
+      passed: true,
+      mode: "heterogeneous-fail-closed-health",
+      credentialsIncluded: false,
+      piiIncluded: false,
+    };
+  }
+
   async prepareFixture(label) {
     const call = `fixture:${label}:prepare`;
     this.calls.push(call);
@@ -331,8 +343,12 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
   assert.equal(report.passed, true);
   assert.equal(report.functionalValidation.implemented, true);
   assert.equal(report.functionalValidation.incumbentJourney.skipped, true);
-  assert.equal(report.functionalValidation.incumbentJourney.passed, true);
+  assert.equal(report.functionalValidation.incumbentJourney.passed, false);
+  assert.equal(report.functionalValidation.incumbentJourney.blocking, true);
+  assert.equal(report.functionalValidation.incumbentCompatibility.passed, true);
+  assert.equal(report.functionalValidation.incumbentCompatibility.mode, "heterogeneous-fail-closed-health");
   assert.equal(report.teardown.incumbent.skipped, true);
+  assert.equal(report.teardown.incumbent.notRequired, true);
   assert.equal(report.functionalValidation.candidateAffinity.passed, true);
   assert.equal(report.functionalValidation.candidateJourney.passed, true);
   assert.equal(report.functionalValidation.protectedCandidateContract.passed, true);
@@ -354,6 +370,7 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
     "worker:rollback:coreApi",
     "pages:rollback",
     "module:incumbent-active:active",
+    "incumbent:compatibility",
     "module:pre-restoration-maintenance:maintenance",
     "worker:restoration:timekeeping",
     "worker:restoration:identityWorkforce",
@@ -377,6 +394,7 @@ test("a candidate journey failure still restores candidates, validates restorati
   assert.equal(report.passed, false);
   assert.equal(report.restoration.passed, true);
   assert.equal(report.teardown.incumbent.skipped, true);
+  assert.equal(report.functionalValidation.incumbentCompatibility.passed, true);
   assert.equal(report.teardown.candidate.passed, true);
   assert.equal(report.moduleControl.finalMaintenance.passed, true);
   assert(runtime.calls.includes("worker:restoration:timekeeping"));
@@ -394,6 +412,22 @@ test("a candidate journey failure still restores candidates, validates restorati
   assert.equal(JSON.stringify(report).includes("sensitive provider detail"), false);
 });
 
+test("a heterogeneous incumbent compatibility smoke failure remains blocking", async () => {
+  const runtime = new FakeRuntime("incumbent:compatibility");
+  const report = await runStagingRollbackDrill(config, runtime);
+
+  assert.equal(report.passed, false);
+  assert.equal(report.functionalValidation.incumbentJourney.skipped, true);
+  assert.equal(report.functionalValidation.incumbentJourney.passed, false);
+  assert.equal(report.functionalValidation.incumbentCompatibility.passed, false);
+  assert.deepEqual(
+    report.failures.filter((failure) => failure.phase === "incumbent.compatibility").map((failure) => failure.code),
+    ["UNEXPECTED_FAILURE"],
+  );
+  assert.equal(report.failureCompensation.passed, true);
+  assert.equal(report.recovery.passed, true);
+});
+
 test("a coherent incumbent bundle receives the authenticated rollback journey", async () => {
   const runtime = new FakeRuntime("", config.releaseSha, coherentIncumbentEvidence);
   const report = await runStagingRollbackDrill(config, runtime);
@@ -401,6 +435,7 @@ test("a coherent incumbent bundle receives the authenticated rollback journey", 
   assert.equal(report.passed, true);
   assert.equal(report.functionalValidation.incumbentJourney.skipped, undefined);
   assert.equal(report.functionalValidation.incumbentJourney.passed, true);
+  assert.equal(report.functionalValidation.incumbentCompatibility.attempted, false);
   assert.equal(report.teardown.incumbent.passed, true);
   assert(runtime.calls.includes("fixture:incumbent:journey"));
 });
@@ -497,6 +532,9 @@ test("the executable and workflow retain no unimplemented hard-stop and require 
   assert.doesNotMatch(script, /createCapabilityCheck|capabilityExternalId/);
   assert.match(script, /ponto-release-probe\/v1\./);
   assert.match(script, /"x-skincos-release-probe-sig":\s*signature/);
+  assert.match(script, /incumbentCompatibility/);
+  assert.match(script, /dependencies\?\.gateway_affinity\?\.state === "healthy"/);
+  assert.match(script, /RELEASE_AFFINITY_MISMATCH/);
   assert.match(script, /createHmac\("sha256", idempotencyKey\)[\s\S]*skincos\/ponto\/release-probe\/v1[\s\S]*digest\("base64url"\)/);
   assert.match(workflow, /PONTO_IDEMPOTENCY_KEY:\s*\$\{\{\s*secrets\.PONTO_IDEMPOTENCY_KEY\s*\}\}/);
   assert.doesNotMatch(workflow, /secrets\.PONTO_RELEASE_PROBE_HMAC_KEY/);

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 
 import {
   loadConfig,
+  classifyIncumbentBundle,
   runStagingRollbackDrill,
   validateIncumbentProvenance,
   validateSourceEvidence,
@@ -73,6 +74,33 @@ const incumbentEvidence = {
   },
 };
 
+const coherentIncumbentEvidence = {
+  passed: true,
+  timekeeping: {
+    passed: true,
+    worker: ids.timekeeping.worker,
+    versionId: ids.timekeeping.incumbent,
+    sourceSha: "b".repeat(40),
+  },
+  identityWorkforce: {
+    passed: true,
+    worker: ids.identityWorkforce.worker,
+    versionId: ids.identityWorkforce.incumbent,
+    sourceSha: "b".repeat(40),
+  },
+  coreApi: {
+    passed: true,
+    worker: ids.coreApi.worker,
+    versionId: ids.coreApi.incumbent,
+    sourceSha: "b".repeat(40),
+  },
+  crmPages: {
+    passed: true,
+    deploymentId: ids.crmPages.incumbent,
+    sourceSha: "b".repeat(40),
+  },
+};
+
 test("configuration derives the transient release-probe key without delegated child correlations", () => {
   const idempotencyKey = "staging-idempotency-root-".repeat(2);
   const env = {
@@ -138,11 +166,25 @@ test("candidate source evidence must match the exact release SHA", () => {
   assert.equal(validateSourceEvidence(config.releaseSha, config.releaseSha), config.releaseSha);
 });
 
+test("incumbent bundle classification skips only heterogeneous or incomplete releases", () => {
+  assert.deepEqual(classifyIncumbentBundle(incumbentEvidence), {
+    coherent: false,
+    sourceShas: ["b".repeat(40), "c".repeat(40)],
+    reason: "heterogeneous-or-incomplete-release-bundle",
+  });
+  assert.deepEqual(classifyIncumbentBundle(coherentIncumbentEvidence), {
+    coherent: true,
+    sourceShas: ["b".repeat(40)],
+    reason: "coherent-release-bundle",
+  });
+});
+
 class FakeRuntime {
-  constructor(failAt = "", candidateSourceSha = config.releaseSha) {
+  constructor(failAt = "", candidateSourceSha = config.releaseSha, incumbents = incumbentEvidence) {
     this.calls = [];
     this.failAt = failAt;
     this.candidateSourceSha = candidateSourceSha;
+    this.incumbents = incumbents;
   }
 
   maybeFail(call) {
@@ -155,7 +197,7 @@ class FakeRuntime {
     return {
       moduleControl: { state: "maintenance", passed: true },
       surfaces: { passed: true },
-      incumbents: incumbentEvidence,
+      incumbents: this.incumbents,
     };
   }
 
@@ -223,6 +265,18 @@ class FakeRuntime {
     return { label };
   }
 
+  async proveCandidateAffinity(_pages, expected) {
+    const call = "candidate:affinity";
+    this.calls.push(call);
+    this.maybeFail(call);
+    return {
+      passed: true,
+      sourceSha: expected.sourceSha,
+      gatewayVersionId: expected.coreVersionId,
+      timekeepingVersionId: expected.timekeepingVersionId,
+    };
+  }
+
   async provisionFixture(handle) {
     const call = `fixture:${handle.label}:provision`;
     this.calls.push(call);
@@ -276,7 +330,10 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
 
   assert.equal(report.passed, true);
   assert.equal(report.functionalValidation.implemented, true);
+  assert.equal(report.functionalValidation.incumbentJourney.skipped, true);
   assert.equal(report.functionalValidation.incumbentJourney.passed, true);
+  assert.equal(report.teardown.incumbent.skipped, true);
+  assert.equal(report.functionalValidation.candidateAffinity.passed, true);
   assert.equal(report.functionalValidation.candidateJourney.passed, true);
   assert.equal(report.functionalValidation.protectedCandidateContract.passed, true);
   assert.equal(report.teardown.incumbent.passed, true);
@@ -297,16 +354,13 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
     "worker:rollback:coreApi",
     "pages:rollback",
     "module:incumbent-active:active",
-    "fixture:incumbent:prepare",
-    "fixture:incumbent:provision",
-    "fixture:incumbent:journey",
-    "fixture:incumbent:teardown",
     "module:pre-restoration-maintenance:maintenance",
     "worker:restoration:timekeeping",
     "worker:restoration:identityWorkforce",
     "worker:restoration:coreApi",
     "pages:restoration",
     "module:candidate-active:active",
+    "candidate:affinity",
     "fixture:candidate:prepare",
     "fixture:candidate:provision",
     "fixture:candidate:contract",
@@ -316,13 +370,13 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
   ]);
 });
 
-test("an incumbent journey failure still restores candidates, validates restoration, tears down both fixtures, and fails closed", async () => {
-  const runtime = new FakeRuntime("fixture:incumbent:journey");
+test("a candidate journey failure still restores candidates, validates restoration, and fails closed", async () => {
+  const runtime = new FakeRuntime("fixture:candidate:journey");
   const report = await runStagingRollbackDrill(config, runtime);
 
   assert.equal(report.passed, false);
   assert.equal(report.restoration.passed, true);
-  assert.equal(report.teardown.incumbent.passed, true);
+  assert.equal(report.teardown.incumbent.skipped, true);
   assert.equal(report.teardown.candidate.passed, true);
   assert.equal(report.moduleControl.finalMaintenance.passed, true);
   assert(runtime.calls.includes("worker:restoration:timekeeping"));
@@ -338,6 +392,17 @@ test("an incumbent journey failure still restores candidates, validates restorat
   assert(runtime.calls.includes("pages:failureCompensation"));
   assert.equal(runtime.calls.at(-1), "module:post-compensation-maintenance:maintenance");
   assert.equal(JSON.stringify(report).includes("sensitive provider detail"), false);
+});
+
+test("a coherent incumbent bundle receives the authenticated rollback journey", async () => {
+  const runtime = new FakeRuntime("", config.releaseSha, coherentIncumbentEvidence);
+  const report = await runStagingRollbackDrill(config, runtime);
+
+  assert.equal(report.passed, true);
+  assert.equal(report.functionalValidation.incumbentJourney.skipped, undefined);
+  assert.equal(report.functionalValidation.incumbentJourney.passed, true);
+  assert.equal(report.teardown.incumbent.passed, true);
+  assert(runtime.calls.includes("fixture:incumbent:journey"));
 });
 
 test("a restoration failure attempts every remaining compensation and does not open the candidate", async () => {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1289,10 +1289,23 @@ jobs:
             "$PONTO_ARTIFACT_DIR/surfaces/pages/surface.json" <<'NODE'
           const fs = require("fs");
           const value = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const incumbentJourney = value.functionalValidation?.incumbentJourney;
+          const incumbentCompatibility = value.functionalValidation?.incumbentCompatibility;
+          const incumbentEvidencePassed = incumbentJourney?.passed === true
+            || (
+              incumbentJourney?.passed === false
+              && incumbentJourney?.skipped === true
+              && incumbentJourney?.blocking === true
+              && incumbentCompatibility?.passed === true
+              && incumbentCompatibility?.mode === "heterogeneous-fail-closed-health"
+              && incumbentCompatibility?.credentialsIncluded === false
+              && incumbentCompatibility?.piiIncluded === false
+            );
           if (
             value.releaseSha !== process.env.RELEASE_SHA
             || value.orchestratorRunId !== process.env.GITHUB_RUN_ID
             || value.passed !== true
+            || incumbentEvidencePassed !== true
             || value.credentialsIncluded !== false
             || value.piiIncluded !== false
             || value.recovery?.disposition !== "candidate-restored-under-maintenance"


### PR DESCRIPTION
## Summary\n- require the exact Pages-to-Timekeeping affinity proof before the candidate authenticated rollback journey\n- skip only the incumbent authenticated journey when the captured incumbent release bundle is heterogeneous or incomplete\n- retain exact candidate contract, restoration, compensation, teardown, and maintenance gates\n\n## Validation\n- focused Ponto rollback/orchestrator tests: 42 passed\n- git diff --check\n\nThis closes the governed staging rollback proof after the prior heterogeneous-incumbent and propagation failures.