### PR TITLE
fix(ponto): fence rollback journey propagation

### DIFF
--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -98,6 +98,35 @@ export function classifyIncumbentBundle(evidence) {
   };
 }
 
+export function isFailClosedIncumbentHealth({ status, payload, headers, expected }) {
+  const header = (name) => {
+    if (typeof headers?.get === "function") return String(headers.get(name) || "").trim().toLowerCase();
+    const lower = name.toLowerCase();
+    return String(headers?.[name] ?? headers?.[lower] ?? "").trim().toLowerCase();
+  };
+  const metadata = payload?.versionMetadata || {};
+  const moduleControlState = String(payload?.dependencies?.module_control?.state || "").toLowerCase();
+  const gatewayAffinity = payload?.dependencies?.gateway_affinity || {};
+  return status === 200
+    && payload?.ok === false
+    && payload?.ready === false
+    && payload?.service === "workforce-timekeeping"
+    && payload?.unit === "timekeeping"
+    && payload?.environment === "staging"
+    && payload?.database === true
+    && ["healthy", "unavailable"].includes(moduleControlState)
+    && gatewayAffinity.state === "unavailable"
+    && gatewayAffinity.reason === "RELEASE_AFFINITY_MISMATCH"
+    && String(metadata.releaseSha || "").toLowerCase() === String(expected.timekeepingSourceSha || "").toLowerCase()
+    && String(metadata.workerVersionId || "").toLowerCase() === String(expected.timekeepingVersionId || "").toLowerCase()
+    && SHA.test(String(metadata.gatewayReleaseSha || ""))
+    && UUID.test(String(metadata.gatewayVersionId || ""))
+    && String(metadata.gatewayEnvironment || "").toLowerCase() === "staging"
+    && header("x-skincos-timekeeping-release-sha") === String(expected.timekeepingSourceSha || "").toLowerCase()
+    && header("x-skincos-timekeeping-environment") === "staging"
+    && header("x-skincos-timekeeping-version-id") === String(expected.timekeepingVersionId || "").toLowerCase();
+}
+
 const versionSet = (ids, side) => ({
   timekeeping: ids.timekeeping[side],
   coreApi: ids.coreApi[side],
@@ -255,6 +284,12 @@ async function validateFixture({
   if (fixtureReady && (!includeProtectedContract || report.functionalValidation.protectedCandidateContract.passed)) {
     report.functionalValidation[journeyKey].attempted = true;
     try {
+      if (includeProtectedContract) {
+        report.functionalValidation.candidateAffinity.journeyFence = {
+          attempted: true,
+          ...await runtime.proveCandidateAffinity(pages, expected),
+        };
+      }
       report.functionalValidation[journeyKey] = {
         attempted: true,
         ...await runtime.runJourney(handle, pages.url, expected),
@@ -1205,30 +1240,12 @@ function createRealRuntime(config, env = process.env) {
           },
         });
         payload = await response.json().catch(() => null);
-        const header = (name) => String(response.headers.get(name) || "").trim().toLowerCase();
-        const pagesPassed = response.status === 200
-          && payload?.ok === false
-          && payload?.ready === false
-          && payload?.service === "workforce-timekeeping"
-          && payload?.unit === "timekeeping"
-          && payload?.environment === "staging"
-          && payload?.database === true
-          && payload?.dependencies?.module_control?.state === "healthy"
-          && payload?.dependencies?.gateway_affinity?.state === "unavailable"
-          && payload?.dependencies?.gateway_affinity?.reason === "RELEASE_AFFINITY_MISMATCH"
-          && String(payload?.versionMetadata?.releaseSha || "").toLowerCase() === expected.timekeepingSourceSha.toLowerCase()
-          && String(payload?.versionMetadata?.workerVersionId || "").toLowerCase() === expected.timekeepingVersionId.toLowerCase()
-          && String(payload?.versionMetadata?.gatewayReleaseSha || "").toLowerCase() === expected.coreSourceSha.toLowerCase()
-          && String(payload?.versionMetadata?.gatewayEnvironment || "").toLowerCase() === "staging"
-          && String(payload?.versionMetadata?.gatewayVersionId || "").toLowerCase() === expected.coreVersionId.toLowerCase()
-          && header("x-skincos-pages-release-sha") === expected.pagesSourceSha.toLowerCase()
-          && header("x-skincos-pages-environment") === "staging"
-          && header("x-skincos-gateway-release-sha") === expected.coreSourceSha.toLowerCase()
-          && header("x-skincos-gateway-environment") === "staging"
-          && header("x-skincos-gateway-version-id") === expected.coreVersionId.toLowerCase()
-          && header("x-skincos-timekeeping-release-sha") === expected.timekeepingSourceSha.toLowerCase()
-          && header("x-skincos-timekeeping-environment") === "staging"
-          && header("x-skincos-timekeeping-version-id") === expected.timekeepingVersionId.toLowerCase();
+        const pagesPassed = isFailClosedIncumbentHealth({
+          status: response.status,
+          payload,
+          headers: response.headers,
+          expected,
+        });
 
         const identityHealth = new URL("https://api-staging.skincos.com.br/insumos/health");
         identityHealth.searchParams.set("staging_rollback_incumbent_probe", `${config.runId}-${attempt}`);
@@ -1254,7 +1271,11 @@ function createRealRuntime(config, env = process.env) {
             status: response.status,
             passed: pagesPassed,
             ready: payload?.ready === true,
+            moduleControl: payload?.dependencies?.module_control?.state || "unknown",
             affinity: payload?.dependencies?.gateway_affinity?.state || "unknown",
+            gatewayReason: payload?.dependencies?.gateway_affinity?.reason || "unknown",
+            gatewayReleaseShaPresent: SHA.test(String(payload?.versionMetadata?.gatewayReleaseSha || "")),
+            gatewayVersionIdPresent: UUID.test(String(payload?.versionMetadata?.gatewayVersionId || "")),
           },
           identity: {
             status: identityResponse.status,
@@ -1270,6 +1291,7 @@ function createRealRuntime(config, env = process.env) {
             pagesHealth: {
               status: response.status,
               ready: false,
+              moduleControl: payload?.dependencies?.module_control?.state || "unknown",
               affinity: "RELEASE_AFFINITY_MISMATCH",
             },
             identityHealth: {
@@ -1357,7 +1379,8 @@ function createRealRuntime(config, env = process.env) {
       || origin.search
       || origin.hash
     ) throw new DrillFailure("JOURNEY_ORIGIN_INVALID");
-    runCommand(process.execPath, ["crm/console/scripts/ponto-staging-journey.cjs"], {
+    const journeyArgs = ["crm/console/scripts/ponto-staging-journey.cjs"];
+    const journeyOptions = {
       code: "AUTHENTICATED_JOURNEY_FAILED",
       captureFailureDetail: true,
       env: {
@@ -1366,14 +1389,34 @@ function createRealRuntime(config, env = process.env) {
         PONTO_STAGING_REPORT_FILE: handle.journeyReportPath,
         NODE_PATH: path.resolve("crm/console/node_modules"),
       },
-    });
+    };
+    let journeyAttempts = 0;
+    const runJourneyCommand = () => {
+      journeyAttempts += 1;
+      return runCommand(process.execPath, journeyArgs, journeyOptions);
+    };
+    try {
+      runJourneyCommand();
+    } catch (error) {
+      const detail = String(error?.details || "");
+      const retryablePropagationFailure = error instanceof DrillFailure
+        && detail.includes("invalid PIN did not fail closed (503/domain_service_degraded")
+        && detail.includes('"timekeepingReleaseSha":""')
+        && detail.includes('"timekeepingVersionId":""');
+      if (!retryablePropagationFailure) throw error;
+      await proveCandidateAffinity(pages, expected);
+      runJourneyCommand();
+    }
     const raw = fs.readFileSync(handle.journeyReportPath, "utf8");
     // The rollback API response and the exact terminal target deployment are
     // authoritative for the drill's generated Pages URL. Cloudflare's
     // production list can retain the pre-rollback alias while that target is
     // being reattached, so do not confuse list ordering with target identity.
     const controlPlane = await verifyActiveSet(expected, { requireLatestPages: false });
-    return sanitizedJourney(raw, expected, controlPlane);
+    return {
+      ...sanitizedJourney(raw, expected, controlPlane),
+      journeyAttempts,
+    };
   };
   const verifyProtectedContract = async (handle, url, expected) => {
     const origin = new URL(url);

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   loadConfig,
   classifyIncumbentBundle,
+  isFailClosedIncumbentHealth,
   runStagingRollbackDrill,
   validateIncumbentProvenance,
   validateSourceEvidence,
@@ -179,6 +180,45 @@ test("incumbent bundle classification skips only heterogeneous or incomplete rel
   });
 });
 
+test("heterogeneous incumbent health accepts a safe affinity mismatch without trusting gateway identity", () => {
+  const expected = {
+    timekeepingSourceSha: "b".repeat(40),
+    timekeepingVersionId: ids.timekeeping.incumbent,
+  };
+  const payload = {
+    ok: false,
+    ready: false,
+    service: "workforce-timekeeping",
+    unit: "timekeeping",
+    environment: "staging",
+    database: true,
+    dependencies: {
+      module_control: { state: "unavailable" },
+      gateway_affinity: { state: "unavailable", reason: "RELEASE_AFFINITY_MISMATCH" },
+    },
+    versionMetadata: {
+      releaseSha: expected.timekeepingSourceSha,
+      workerVersionId: expected.timekeepingVersionId,
+      gatewayReleaseSha: "d".repeat(40),
+      gatewayEnvironment: "staging",
+      gatewayVersionId: ids.coreApi.incumbent,
+    },
+  };
+  const headers = new Map([
+    ["x-skincos-timekeeping-release-sha", expected.timekeepingSourceSha],
+    ["x-skincos-timekeeping-environment", "staging"],
+    ["x-skincos-timekeeping-version-id", expected.timekeepingVersionId],
+  ]);
+
+  assert.equal(isFailClosedIncumbentHealth({ status: 200, payload, headers, expected }), true);
+  assert.equal(isFailClosedIncumbentHealth({
+    status: 200,
+    payload: { ...payload, ready: true },
+    headers,
+    expected,
+  }), false);
+});
+
 class FakeRuntime {
   constructor(failAt = "", candidateSourceSha = config.releaseSha, incumbents = incumbentEvidence) {
     this.calls = [];
@@ -278,7 +318,9 @@ class FakeRuntime {
   }
 
   async proveCandidateAffinity(_pages, expected) {
-    const call = "candidate:affinity";
+    const call = this.calls.includes("candidate:affinity")
+      ? "candidate:journey-fence"
+      : "candidate:affinity";
     this.calls.push(call);
     this.maybeFail(call);
     return {
@@ -381,6 +423,7 @@ test("drill exercises two fresh fixtures and restores every exact candidate", as
     "fixture:candidate:prepare",
     "fixture:candidate:provision",
     "fixture:candidate:contract",
+    "candidate:journey-fence",
     "fixture:candidate:journey",
     "fixture:candidate:teardown",
     "module:final-maintenance:maintenance",
@@ -533,6 +576,8 @@ test("the executable and workflow retain no unimplemented hard-stop and require 
   assert.match(script, /ponto-release-probe\/v1\./);
   assert.match(script, /"x-skincos-release-probe-sig":\s*signature/);
   assert.match(script, /incumbentCompatibility/);
+  assert.match(script, /journeyFence/);
+  assert.match(script, /journeyAttempts/);
   assert.match(script, /dependencies\?\.gateway_affinity\?\.state === "healthy"/);
   assert.match(script, /RELEASE_AFFINITY_MISMATCH/);
   assert.match(script, /createHmac\("sha256", idempotencyKey\)[\s\S]*skincos\/ponto\/release-probe\/v1[\s\S]*digest\("base64url"\)/);


### PR DESCRIPTION
## Summary
- accept heterogeneous incumbent health only when it is explicitly fail-closed with RELEASE_AFFINITY_MISMATCH and exact incumbent Timekeeping metadata
- add a fresh candidate affinity fence before the authenticated rollback journey
- retry once only for the sanitized pre-mutation domain_service_degraded PIN propagation failure

## Validation
- WSL Node focused tests: 44/44
- git diff --check: passed
- no production activation or real-user data