### PR TITLE
fix(ponto): wait for child capability activation

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -543,6 +543,19 @@ const TRANSIENT_READ_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TRANSIENT_READ_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
 const MAX_TRANSIENT_READ_RETRY_DELAY_MS = 30_000;
 const MAX_CANONICAL_SNAPSHOT_REFRESHES = 2;
+const CHILD_SUBJECT_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
+
+export const childCapabilitySubjectWaitMs = (run, attempt) => {
+  if (run?.status === "in_progress" && run?.conclusion == null) return 0;
+  if (
+    run?.status === "queued"
+    && run?.conclusion == null
+    && Number.isInteger(attempt)
+    && attempt >= 0
+    && attempt < CHILD_SUBJECT_RETRY_DELAYS_MS.length
+  ) return CHILD_SUBJECT_RETRY_DELAYS_MS[attempt];
+  return -1;
+};
 
 const parseRetryAfterMs = (value, now = Date.now()) => {
   const raw = String(value || "").trim();
@@ -700,42 +713,52 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
   const verifier = resolveCapabilityVerifier(capabilityPublicKeysJson, target);
 
   const parent = await canonicalOrchestrator({ orchestratorRunId, releaseSha, stage, currentHeadSha });
-  const child = await request(`/repos/${repository}/actions/runs/${childRunId}`);
-  const childWorkflowPath = String(child?.path || "").split("@")[0];
   const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
-  const { digest: intentDigest, normalizedInputs } = canonicalizeGovernedIntent(
-    childWorkflowPath,
-    event?.inputs,
-  );
-  const dispatchNonce = String(normalizedInputs.orchestrator_nonce || "");
-  const issuerRunId = String(normalizedInputs.orchestrator_issuer_run_id || "");
-  const expectedDisplayTitle = expectedGovernedRunName(childWorkflowPath, normalizedInputs);
-  const intentReleaseSha = childWorkflowPath === ".github/workflows/module-availability.yml"
-    ? String(normalizedInputs.orchestrator_release_sha || normalizedInputs.release_sha)
-    : String(normalizedInputs.release_sha);
-  if (
-    String(child?.id || "") !== childRunId
-    || child?.run_attempt !== 1
-    || !acceptsWorkflowRunPath(childWorkflowPath, child?.path)
-    || child?.status !== "in_progress"
-    || child?.conclusion != null
-    || child?.event !== "workflow_dispatch"
-    || child?.head_branch !== "main"
-    || child?.head_sha !== releaseSha
-    || child?.repository?.full_name !== repository
-    || String(child?.repository?.id || "") !== repositoryId
-    || child?.head_repository?.full_name !== repository
-    || String(child?.head_repository?.id || "") !== repositoryId
-    || child?.display_title !== expectedDisplayTitle
-    || normalizedInputs.orchestrator_run_id !== orchestratorRunId
-    || normalizedInputs.orchestrator_stage !== stage
-    || intentReleaseSha !== releaseSha
-    || !DISPATCH_NONCE.test(dispatchNonce)
-    || !/^[1-9][0-9]*$/.test(issuerRunId)
-    || String(event?.repository?.id || "") !== repositoryId
-    || event?.repository?.full_name !== repository
-    || !["main", "refs/heads/main"].includes(String(event?.ref || ""))
-  ) throw new Error("current child run is not the exact active first-attempt capability subject");
+  let child;
+  let childWorkflowPath = "";
+  let intentDigest = "";
+  let normalizedInputs = {};
+  let dispatchNonce = "";
+  let issuerRunId = "";
+  for (let attempt = 0; ; attempt += 1) {
+    child = await request(`/repos/${repository}/actions/runs/${childRunId}`);
+    childWorkflowPath = String(child?.path || "").split("@")[0];
+    ({ digest: intentDigest, normalizedInputs } = canonicalizeGovernedIntent(
+      childWorkflowPath,
+      event?.inputs,
+    ));
+    dispatchNonce = String(normalizedInputs.orchestrator_nonce || "");
+    issuerRunId = String(normalizedInputs.orchestrator_issuer_run_id || "");
+    const expectedDisplayTitle = expectedGovernedRunName(childWorkflowPath, normalizedInputs);
+    const intentReleaseSha = childWorkflowPath === ".github/workflows/module-availability.yml"
+      ? String(normalizedInputs.orchestrator_release_sha || normalizedInputs.release_sha)
+      : String(normalizedInputs.release_sha);
+    if (
+      String(child?.id || "") !== childRunId
+      || child?.run_attempt !== 1
+      || !acceptsWorkflowRunPath(childWorkflowPath, child?.path)
+      || child?.event !== "workflow_dispatch"
+      || child?.head_branch !== "main"
+      || child?.head_sha !== releaseSha
+      || child?.repository?.full_name !== repository
+      || String(child?.repository?.id || "") !== repositoryId
+      || child?.head_repository?.full_name !== repository
+      || String(child?.head_repository?.id || "") !== repositoryId
+      || child?.display_title !== expectedDisplayTitle
+      || normalizedInputs.orchestrator_run_id !== orchestratorRunId
+      || normalizedInputs.orchestrator_stage !== stage
+      || intentReleaseSha !== releaseSha
+      || !DISPATCH_NONCE.test(dispatchNonce)
+      || !/^[1-9][0-9]*$/.test(issuerRunId)
+      || String(event?.repository?.id || "") !== repositoryId
+      || event?.repository?.full_name !== repository
+      || !["main", "refs/heads/main"].includes(String(event?.ref || ""))
+    ) throw new Error("current child run is not the exact active first-attempt capability subject");
+    const retryDelay = childCapabilitySubjectWaitMs(child, attempt);
+    if (retryDelay === 0) break;
+    if (retryDelay < 0) throw new Error("current child run is not the exact active first-attempt capability subject");
+    await new Promise(resolve => setTimeout(resolve, retryDelay));
+  }
 
   const issuerSnapshot = issuerRunId === orchestratorRunId
     ? { issuer: parent.run, issuerWorkflow: parent.workflow }

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import {
   canonicalizeGovernedIntent,
   acceptsWorkflowRunPath,
+  childCapabilitySubjectWaitMs,
   createCapabilityCheck,
   expectedGovernedRunName,
   transitionCapabilityDocument,
@@ -288,6 +289,13 @@ test("workflow run provenance accepts both live GitHub REST path forms", () => {
   assert.equal(acceptsWorkflowRunPath(workflowPath, `${workflowPath}@refs/heads/main`), true);
   assert.equal(acceptsWorkflowRunPath(workflowPath, ".github/workflows/other.yml"), false);
   assert.equal(acceptsWorkflowRunPath(workflowPath, `${workflowPath}@refs/heads/feature`), false);
+});
+
+test("consume-check waits only for a queued child to become the active capability subject", () => {
+  assert.equal(childCapabilitySubjectWaitMs({ status: "in_progress", conclusion: null }, 0), 0);
+  assert.ok(childCapabilitySubjectWaitMs({ status: "queued", conclusion: null }, 0) > 0);
+  assert.equal(childCapabilitySubjectWaitMs({ status: "queued", conclusion: null }, 99), -1);
+  assert.equal(childCapabilitySubjectWaitMs({ status: "completed", conclusion: "failure" }, 0), -1);
 });
 
 test("Ponto workflow REST provenance gates accept both live path forms", () => {


### PR DESCRIPTION
# Summary

Corrige a corrida de propagação entre o despacho governado e o consumo da capability: o consumidor mantém todas as verificações de proveniência e só aguarda, de forma limitada, a transição do child de `queued` para `in_progress`.

A causa observada no staging foi a rejeição do próprio child antes de qualquer mutação de disponibilidade.

## Type of change

- [x] Fix

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (not needed for this focused pipeline correction)
- [ ] Security review (covered by required CI)
- [ ] Performance impact measured (not applicable)

## Links

- Issue: N/A
- Design/ADR: N/A
- Migration steps: N/A

## Screenshots / Evidence

Focused validation passed:

`node --test .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs` (39/39).