### PR TITLE
fix(ponto): retry protected staging contract propagation

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -770,6 +770,7 @@ test("staging retries the protected Identity contract during bounded propagation
   const block = source.slice(start, end);
   assert.match(block, /const maxAttempts = 36/);
   assert.match(block, /for \(let attempt = 1; attempt <= maxAttempts; attempt \+= 1\)/);
+  assert.match(block, /response\.status === 403\s*&& body\?\.error === "RELEASE_PROBE_NOT_AUTHORIZED"\s*&& pagesReleaseSha === process\.env\.RELEASE_SHA\s*&& pagesEnvironment === "staging"/);
   assert.match(block, /protected staging Identity contract did not match the exact release after bounded propagation/);
   assert.match(block, /lastObservation/);
   assert.match(block, /sessionTeardownProven/);

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -409,7 +409,13 @@ jobs:
               || response.status === 404
               || response.status === 429
               || response.status >= 500
-              || response.status === 200;
+              || response.status === 200
+              || (
+                response.status === 403
+                && body?.error === "RELEASE_PROBE_NOT_AUTHORIZED"
+                && pagesReleaseSha === process.env.RELEASE_SHA
+                && pagesEnvironment === "staging"
+              );
             if (!retryable || attempt === maxAttempts) break;
             await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
           }


### PR DESCRIPTION
## Summary
- retry only the exact staging Pages `RELEASE_PROBE_NOT_AUTHORIZED` response while its release SHA and environment already match the candidate
- preserve terminal behavior for every other authorization failure

## Validation
- `node --test .github/scripts/ponto-orchestrator-lease.test.mjs` via Ubuntu-24.04 WSL: 32/32 passing