### PR TITLE
fix(ponto): wait for timekeeping affinity before journey

### DIFF
--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -1385,6 +1385,8 @@ function createRealRuntime(config, env = process.env) {
       captureFailureDetail: true,
       env: {
         PONTO_STAGING_CRM_URL: origin.href,
+        PONTO_STAGING_EXPECTED_RELEASE_SHA: expected.releaseSha,
+        PONTO_STAGING_EXPECTED_TIMEKEEPING_VERSION_ID: expected.timekeepingVersionId,
         PONTO_STAGING_FIXTURES_FILE: handle.fixturePath,
         PONTO_STAGING_REPORT_FILE: handle.journeyReportPath,
         NODE_PATH: path.resolve("crm/console/node_modules"),

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -445,6 +445,8 @@ jobs:
       - name: Execute authenticated Ponto journey
         env:
           PONTO_STAGING_CRM_URL: ${{ inputs.pages_url }}
+          PONTO_STAGING_EXPECTED_RELEASE_SHA: ${{ inputs.release_sha }}
+          PONTO_STAGING_EXPECTED_TIMEKEEPING_VERSION_ID: ${{ inputs.timekeeping_version_id }}
           PONTO_STAGING_FIXTURES_FILE: ${{ runner.temp }}/ponto-staging-fixtures.json
           PONTO_STAGING_REPORT_FILE: ${{ runner.temp }}/ponto-staging-report.json
           NODE_PATH: crm/console/node_modules

--- a/crm/console/scripts/ponto-staging-journey.cjs
+++ b/crm/console/scripts/ponto-staging-journey.cjs
@@ -15,6 +15,10 @@ const validatedStagingOrigin = (value) => {
   return candidate
 }
 const base = validatedStagingOrigin(process.env.PONTO_STAGING_CRM_URL)
+const expectedReleaseSha = String(process.env.PONTO_STAGING_EXPECTED_RELEASE_SHA || '').trim().toLowerCase()
+const expectedTimekeepingVersionId = String(process.env.PONTO_STAGING_EXPECTED_TIMEKEEPING_VERSION_ID || '').trim().toLowerCase()
+if (!/^[0-9a-f]{40}$/.test(expectedReleaseSha)) throw new Error('PONTO_STAGING_EXPECTED_RELEASE_SHA must be a full lowercase release SHA')
+if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(expectedTimekeepingVersionId)) throw new Error('PONTO_STAGING_EXPECTED_TIMEKEEPING_VERSION_ID must be a Cloudflare version UUID')
 const validatedApiPath = (value) => {
   const localOrigin = 'https://ponto-journey.invalid'
   const candidate = new URL(String(value), localOrigin)
@@ -66,6 +70,39 @@ const recordCleanupEvent = (eventId) => {
   assert(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value), 'mutation response omitted a safe cleanup event id')
   fixture.teardownEventIds = Array.from(new Set([...(fixture.teardownEventIds || []), value]))
   fs.writeFileSync(fixturePath, JSON.stringify(fixture), { mode: 0o600 })
+}
+const waitForCandidateAffinity = async (page, runId) => {
+  let last = null
+  for (let attempt = 1; attempt <= 36; attempt += 1) {
+    last = await api(page, `/api/ponto/health?staging_journey_affinity_probe=${encodeURIComponent(`${runId}-${attempt}`)}`)
+    const payload = last.json || {}
+    const gatewayVersionId = String(payload.versionMetadata?.gatewayVersionId || '').trim().toLowerCase()
+    const exact = last.status === 200
+      && payload.ok === true
+      && payload.ready === true
+      && payload.service === 'workforce-timekeeping'
+      && payload.unit === 'timekeeping'
+      && payload.environment === 'staging'
+      && payload.database === true
+      && payload.dependencies?.module_control?.state === 'healthy'
+      && payload.dependencies?.gateway_affinity?.state === 'healthy'
+      && String(payload.versionMetadata?.releaseSha || '').trim().toLowerCase() === expectedReleaseSha
+      && String(payload.versionMetadata?.workerVersionId || '').trim().toLowerCase() === expectedTimekeepingVersionId
+      && String(payload.versionMetadata?.gatewayReleaseSha || '').trim().toLowerCase() === expectedReleaseSha
+      && String(payload.versionMetadata?.gatewayEnvironment || '').trim().toLowerCase() === 'staging'
+      && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(gatewayVersionId)
+      && gatewayVersionId === last.gatewayVersionId
+      && last.pagesReleaseSha === expectedReleaseSha
+      && last.pagesEnvironment === 'staging'
+      && last.gatewayReleaseSha === expectedReleaseSha
+      && last.gatewayEnvironment === 'staging'
+      && last.timekeepingReleaseSha === expectedReleaseSha
+      && last.timekeepingEnvironment === 'staging'
+      && last.timekeepingVersionId === expectedTimekeepingVersionId
+    if (exact) return { attempts: attempt, status: last.status }
+    if (attempt < 36) await new Promise((resolve) => setTimeout(resolve, 5_000))
+  }
+  throw new Error(`candidate Timekeeping affinity did not converge (${last?.status || 'FETCH'})`)
 }
 // The browser stays on the validated staging origin and calls only literal,
 // same-origin routes below.
@@ -166,6 +203,8 @@ async function main() {
     assert(presence.status === 200 && presence.json?.data?.presenceMode === 'FLEXIBLE', `synthetic presence policy unavailable (${presence.status})`)
     const before = await api(page, `/api/ponto/me/records?unit=${encodeURIComponent(fixture.unitId)}&limit=20`)
     assert(before.status === 200 && Array.isArray(before.json?.data) && before.json.data.length === 0, 'synthetic employee was not clean before punch')
+
+    await waitForCandidateAffinity(page, fixture.runId)
 
     const invalidPin = await post(page, '/api/ponto/me/punch', { pin: '000000', unit: fixture.unitId }, `invalid-${fixtureKey}`)
     recordCleanupRequest(invalidPin)


### PR DESCRIPTION
## Summary\n- wait for the exact staging Pages -> gateway -> Timekeeping health contract before the first authenticated mutation\n- pass the immutable release SHA and Timekeeping version into the journey and rollback drill harnesses\n- keep the bounded 36-attempt, 5-second, read-only probe fail-closed\n\n## Validation\n- node --check crm/console/scripts/ponto-staging-journey.cjs\n- node --test .github/scripts/ponto-staging-rollback-drill.test.mjs\n- node --test .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs\n\n## Scope\nStaging proof harness only; no production activation or real data.