### PR TITLE
fix(release): fence Ponto attestation to Ponto releases

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -247,6 +247,11 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
   assert.match(sharedPages, /Unable to attest the exact staging Pages candidate and production alias/);
   assert.match(sharedPages, /if \[\[ "\$attempt" != 36 \]\]; then sleep 5; fi/);
   assert.match(sharedPages, /for attempt in \{1\.\.72\}; do/);
+  assert.match(
+    sharedPages,
+    /name: Attest remote Ponto Pages values before Ponto deployment[\s\S]*?if: \$\{\{ inputs\.release_scope == 'ponto'/,
+    "Ponto remote values must be gated to governed Ponto releases",
+  );
   for (const name of [
     "CRM_GENERAL_PAGES_PROJECT",
     "CRM_GENERAL_PAGES_PROJECT_STAGING",

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -345,8 +345,12 @@ jobs:
         run: npm run build
         working-directory: crm/console
 
-      - name: Attest remote Ponto Pages values before deployment
-        if: ${{ steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
+      - name: Attest remote Ponto Pages values before Ponto deployment
+        # General CRM releases intentionally use the canonical general Pages
+        # project while Ponto remains independently fenced. Only a governed
+        # Ponto release may require Ponto-owned remote secrets; a general
+        # release must not hydrate or mutate that namespace.
+        if: ${{ inputs.release_scope == 'ponto' && steps.guard.outputs.skip != 'true' && steps.finance_production_gate.outputs.skip != 'true' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- keep remote Ponto secret attestation scoped to governed release_scope=ponto deployments;
- allow the canonical general CRM Pages release to proceed while Ponto remains independently fenced;
- retain fail-closed Ponto identity rendering and add a regression assertion for the scope gate.

## Validation

- node .github/scripts/ponto-dispatch-workflow.test.mjs
- npm run architecture:validate
- git diff --check

No Ponto secret, project, KV, backend, Finance, auth, or data was changed.