### PR TITLE
fix(release): preserve production Ponto secret binding

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -252,6 +252,11 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
     /name: Attest remote Ponto Pages values before Ponto deployment[\s\S]*?if: \$\{\{ inputs\.release_scope == 'ponto'/,
     "Ponto remote values must be gated to governed Ponto releases",
   );
+  assert.match(sharedPages, /if \[\[ "\$RELEASE_SCOPE" == general && "\$DEPLOY_TARGET" == production \]\]; then/);
+  assert.ok(
+    sharedPages.includes("sed -i '/^PONTO_API_TARGET[[:space:]]*=/d' wrangler.toml"),
+    "general production Pages releases must preserve the existing Ponto secret binding",
+  );
   for (const name of [
     "CRM_GENERAL_PAGES_PROJECT",
     "CRM_GENERAL_PAGES_PROJECT_STAGING",

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -540,6 +540,13 @@ jobs:
           NODE
             fi
           fi
+          if [[ "$RELEASE_SCOPE" == general && "$DEPLOY_TARGET" == production ]]; then
+            # Production already owns PONTO_API_TARGET as a Pages secret. Do
+            # not redeclare that binding as a plaintext variable in a general
+            # deployment; leaving the remote secret untouched preserves the
+            # independently fenced Ponto surface.
+            sed -i '/^PONTO_API_TARGET[[:space:]]*=/d' wrangler.toml
+          fi
           node - wrangler.toml "$MODULE_CONTROL_KV_ID" <<'NODE'
           const fs = require("fs");
           const file = process.argv[2];


### PR DESCRIPTION
## Summary

- remove only the duplicate plaintext PONTO_API_TARGET declaration for general production Pages deploys;
- preserve the existing production Pages secret and keep Ponto release handling unchanged;
- add a regression assertion for the general-production rendering path.

## Validation

- node .github/scripts/ponto-dispatch-workflow.test.mjs
- npm run architecture:validate
- git diff --check

No remote secret, Ponto project, KV, backend, Finance, auth, or data was changed.