### PR TITLE
fix(release): declare production Ponto secret binding

### DIFF
--- a/crm/console/wrangler.toml
+++ b/crm/console/wrangler.toml
@@ -19,6 +19,9 @@ service = "skincos-insumos"
 binding = "MODULE_CONTROL"
 id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
 
+[env.production.secrets]
+required = ["PONTO_API_TARGET"]
+
 [env.production.vars]
 ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"
 INSUMOS_API_TARGET = "https://api.skincos.com.br"


### PR DESCRIPTION
Declare the already-provisioned production PONTO_API_TARGET as an environment secret so general CRM Pages deployments retain the independently fenced Ponto binding after omitting the conflicting plaintext variable. No Ponto code, formulas, routes, or data changes.