### PR TITLE
fix(release): use Pages-compatible Ponto secret binding

### DIFF
--- a/crm/console/wrangler.toml
+++ b/crm/console/wrangler.toml
@@ -19,9 +19,6 @@ service = "skincos-insumos"
 binding = "MODULE_CONTROL"
 id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
 
-[env.production.secrets]
-required = ["PONTO_API_TARGET"]
-
 [env.production.vars]
 ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"
 INSUMOS_API_TARGET = "https://api.skincos.com.br"


### PR DESCRIPTION
## Motivo\nA promoção de produção falhou porque [env.production.secrets] não é suportado por projetos Cloudflare Pages.\n\n## Alteração\nRemove somente essa tabela inválida do wrangler.toml. O segredo remoto PONTO_API_TARGET permanece provisionado e é validado pelo workflow antes do deploy; a contenção do escopo Ponto continua intacta.\n\n## Evidência\nO run 30949044342 falhou no passo de deploy com Configuration file for Pages projects does not support " secrets\.