### PR TITLE
fix(smoke): accept fail-closed Ponto maintenance

### DIFF
--- a/.github/scripts/ponto_smoke.py
+++ b/.github/scripts/ponto_smoke.py
@@ -69,6 +69,14 @@ def check_once(args: argparse.Namespace) -> str:
         and health.get("error") == "PONTO_DISABLED"
     ):
         return "SKIP"
+    if (
+        args.allow_ponto_disabled
+        and health.get("__http_status") == 200
+        and health.get("ok") is False
+        and health.get("ready") is False
+        and (health.get("availability") or {}).get("state") == "maintenance"
+    ):
+        return "SKIP"
 
     require_true(health, "ok", "health")
     if health.get("service") != "workforce-timekeeping":


### PR DESCRIPTION
General CRM Pages deploys keep Ponto fail-closed in maintenance. The proxy remains required to be 200/ready; health may intentionally return 200 with ok=false, ready=false, and availability.state=maintenance. Extend only --allow-ponto-disabled to skip that explicit state. Missing target (503) and other failures remain errors.