### PR TITLE
fix(ponto): allow bounded timekeeping write cold starts

### DIFF
--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -161,6 +161,36 @@ test('dedicated Ponto entrypoint requires the route-only guard and never exposes
     );
 });
 
+test('dedicated Ponto entrypoint gives authenticated Timekeeping writes a bounded cold-start budget', async () => {
+    resetBoundServiceResilienceForTest();
+    const startedAt = Date.now();
+    const binding = {
+        fetch: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 900));
+            return new Response(JSON.stringify({ ok: false, error: 'PIN_INVALID' }), {
+                status: 401,
+                headers: { 'content-type': 'application/json' },
+            });
+        },
+    };
+    const response = await pontoCoreWorker.fetch(new Request('https://ponto-core.invalid/api/ponto/me/punch', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pin: '000000', unit: 'synthetic-unit' }),
+    }), {
+        PONTO_ROUTE_ONLY: 'true',
+        TIMEKEEPING: binding,
+        APP_VERSION: 'a'.repeat(40),
+        ENVIRONMENT: 'staging',
+        TIMEKEEPING_VERSION_ID: '33333333-3333-4333-8333-333333333333',
+        CF_VERSION_METADATA: { id: '22222222-2222-4222-8222-222222222222' },
+    }, {});
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error, 'PIN_INVALID');
+    assert.ok(Date.now() - startedAt >= 850);
+    resetBoundServiceResilienceForTest();
+});
+
 test('dedicated Ponto Wrangler config has private, independent staging and production services', async () => {
     const config = await readFile(new URL('../wrangler.ponto.toml', import.meta.url), 'utf8');
     assert.match(config, /^name = "skincos-ponto-core"$/m);

--- a/api/workers/ponto.js
+++ b/api/workers/ponto.js
@@ -13,6 +13,15 @@ const invalidConfiguration = () => new Response(
     },
 );
 
+const TIMEKEEPING_READ_TIMEOUT_MS = 3_000;
+const TIMEKEEPING_WRITE_TIMEOUT_MS = 5_000;
+
+function timekeepingTimeout(request) {
+    return ['GET', 'HEAD'].includes(request.method)
+        ? TIMEKEEPING_READ_TIMEOUT_MS
+        : TIMEKEEPING_WRITE_TIMEOUT_MS;
+}
+
 const handlePontoCoreRequest = createGatewayHandler({
     // The route-only guard makes this handler unreachable. Keeping an explicit
     // fail-closed implementation also prevents a future router refactor from
@@ -31,7 +40,7 @@ const handlePontoCoreRequest = createGatewayHandler({
         prepareTimekeepingRequest(request, env),
         env,
         'TIMEKEEPING',
-        { timeoutMs: 800 },
+        { timeoutMs: timekeepingTimeout(request) },
     ),
 });
 


### PR DESCRIPTION
## Summary
- give the dedicated Ponto Core a bounded 3s read / 5s write Timekeeping binding budget
- preserve fail-closed behavior for upstream failures and add a focused cold-start regression test

## Validation
- `npm --prefix api test` via Ubuntu-24.04 WSL
- `git diff --check`

This is required to complete the governed staging Ponto proof on the current release line.