### PR TITLE
feat(insumos): recebimento em duas fases nas transferências

### DIFF
--- a/backend/docs/insumos.md
+++ b/backend/docs/insumos.md
@@ -40,7 +40,9 @@ Observação: o Worker faz o *mount* em `/insumos/*` e mantém as rotas internas
 - Entrada: `POST /insumos/insumos/entrada?unidade=<slug>`
 - Saída: `POST /insumos/insumos/baixa?unidade=<slug>`
 - Ajuste: `POST /insumos/insumos/ajuste?unidade=<slug>`
-- Transferência: `POST /insumos/insumos/transferir?unidade=<origem>`
+- Despacho de transferência: `POST /insumos/insumos/transferir?unidade=<origem>`
+- Recebimento: `POST /insumos/transferencias/:id/receber?unidade=<destino>`
+- Cancelamento antes do recebimento: `POST /insumos/transferencias/:id/cancelar?unidade=<origem>`
 
 Todas as mutações exigem `Idempotency-Key`. O responsável é obtido da sessão no
 Worker; campos `usuario`/`actor` enviados pelo cliente são ignorados.
@@ -57,6 +59,13 @@ Worker; campos `usuario`/`actor` enviados pelo cliente são ignorados.
   registram a quebra.
 - Correções são feitas em `POST /insumos/movimentacoes/:id/estorno` com motivo
   obrigatório, preservando o movimento original e marcando o compensatório.
+- Transferências são em duas fases: o despacho reduz somente a origem e cria
+  `PENDING_RECEIPT`; o destino efetiva o recebimento com uma nova entrada
+  atômica. Cancelamento pré-recebimento restaura a origem por `ESTORNO` e deixa
+  a transferência auditável como `CANCELLED`.
+- O estado do agregado fica em `insumos_transfers`; a migração
+  `0020_insumos_transfer_receipt.sql` converte transferências históricas já
+  efetivadas em `RECEIVED` sem reescrever o ledger.
 
 ### Categorias (políticas)
 
@@ -221,7 +230,8 @@ Depois reinicie:
 
 - Auth por cookies + CSRF, RBAC e permissão por unidade.
 - CRUD de insumos e múltiplos lotes por código (via `registro`), com estoque por unidade.
-- Operações: entrada/saída/ajuste/transferência (com idempotência e auditoria).
+- Operações: entrada/saída/ajuste e transferências em duas fases (com
+  idempotência e auditoria).
 - Políticas por categoria (`requires_lot`, `requires_expiry`, `fefo`) e enforcement no backend.
 - Alertas (estoque baixo, vencendo, expirado com estoque) + insights (tendências/giro/ROI/qualidade).
 - Offline queue no frontend para mutações quando cair a rede.
@@ -231,7 +241,8 @@ Depois reinicie:
 
 - P0: UX “selecionar lote” mais amigável (mostrar lote+validade em vez de “registro”) em todos os fluxos.
 - P0: tela/admin de usuários e permissões (hoje existe “Usuários” mas fica bloqueado).
-- P1: compras (fornecedor, pedido, status, recebimento) — hoje só existe “lista sugerida”.
+- P1: compras (fornecedor, pedido, status, recebimento) — ainda não há o
+  agregado de compras/fornecedores.
 - P1: inventário avançado (reorder por unidade, múltiplos mínimos, consumo por procedimento, custo médio).
 - P2: importação em massa, etiquetas/barcode print, auditoria avançada (filtros/retention), integrações.
 

--- a/inventory/migrations/0020_insumos_transfer_receipt.sql
+++ b/inventory/migrations/0020_insumos_transfer_receipt.sql
@@ -1,0 +1,63 @@
+-- Two-phase transfer lifecycle. Movement rows remain append-only; mutable
+-- lifecycle state is kept in its own transfer aggregate.
+
+CREATE TABLE IF NOT EXISTS insumos_transfers (
+  id TEXT PRIMARY KEY,
+  registro_insumo TEXT NOT NULL,
+  codigo_barras TEXT,
+  lote TEXT,
+  data_validade TEXT,
+  produto TEXT,
+  quantidade INTEGER NOT NULL CHECK (quantidade > 0),
+  unidade_origem TEXT NOT NULL,
+  unidade_destino TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING_RECEIPT'
+    CHECK (status IN ('PENDING_RECEIPT', 'RECEIVED', 'CANCELLED')),
+  dispatched_at TEXT NOT NULL,
+  dispatched_by TEXT NOT NULL,
+  received_at TEXT,
+  received_by TEXT,
+  cancelled_at TEXT,
+  cancelled_by TEXT,
+  reason TEXT,
+  dispatch_movement_id TEXT,
+  receipt_movement_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_insumos_transfers_destination_status
+  ON insumos_transfers(unidade_destino, status, dispatched_at);
+
+CREATE INDEX IF NOT EXISTS idx_insumos_transfers_origin_status
+  ON insumos_transfers(unidade_origem, status, dispatched_at);
+
+CREATE INDEX IF NOT EXISTS idx_insumos_transfers_registro
+  ON insumos_transfers(registro_insumo, status, dispatched_at);
+
+-- Preserve transfers already committed by the one-phase implementation as
+-- received aggregates. No movement row is rewritten.
+INSERT OR IGNORE INTO insumos_transfers (
+  id, registro_insumo, codigo_barras, lote, data_validade, produto, quantidade,
+  unidade_origem, unidade_destino, status, dispatched_at, dispatched_by,
+  received_at, received_by, dispatch_movement_id, receipt_movement_id
+)
+SELECT
+  m.id_transferencia,
+  MAX(m.registro_insumo),
+  MAX(m.codigo_barras),
+  MAX(m.lote),
+  MAX(m.data_validade),
+  MAX(m.produto),
+  MAX(m.quantidade),
+  MAX(m.unidade_origem),
+  MAX(m.unidade_destino),
+  CASE WHEN SUM(CASE WHEN UPPER(m.tipo) IN ('ENTRADA', 'ENTRADA ') AND COALESCE(m.status, 'COMPLETED') = 'COMPLETED' THEN 1 ELSE 0 END) > 0
+       THEN 'RECEIVED' ELSE 'PENDING_RECEIPT' END,
+  MIN(m.data_hora),
+  COALESCE(MAX(CASE WHEN UPPER(m.tipo) IN ('SAÍDA', 'SAIDA') THEN m.usuario END), 'system:legacy'),
+  MAX(CASE WHEN UPPER(m.tipo) IN ('ENTRADA', 'ENTRADA ') AND COALESCE(m.status, 'COMPLETED') = 'COMPLETED' THEN m.data_hora END),
+  MAX(CASE WHEN UPPER(m.tipo) IN ('ENTRADA', 'ENTRADA ') AND COALESCE(m.status, 'COMPLETED') = 'COMPLETED' THEN m.usuario END),
+  MAX(CASE WHEN UPPER(m.tipo) IN ('SAÍDA', 'SAIDA') THEN m.id END),
+  MAX(CASE WHEN UPPER(m.tipo) IN ('ENTRADA', 'ENTRADA ') AND COALESCE(m.status, 'COMPLETED') = 'COMPLETED' THEN m.id END)
+FROM insumos_movements m
+WHERE m.id_transferencia IS NOT NULL
+GROUP BY m.id_transferencia;

--- a/inventory/src/d1Store.js
+++ b/inventory/src/d1Store.js
@@ -1524,7 +1524,7 @@ export async function d1ArchiveInsumo({ env, registro }) {
 
   const pending = await env.DB.prepare(
     `SELECT 1
-     FROM insumos_movements
+     FROM insumos_transfers
      WHERE registro_insumo = ?
        AND status = 'PENDING_RECEIPT'
      LIMIT 1`
@@ -1874,9 +1874,9 @@ export async function d1Transfer({ env, body, actor, unidade }) {
   const estoqueAnteriorDestino = toInt(beforeDest?.quantidade, 0);
   const ts = nowIso();
   const transferId = crypto.randomUUID();
+  const dispatchMovementId = crypto.randomUUID();
 
   const obsSaida = `Transferência para ${toScope.unit}${observacoes ? ` | ${observacoes}` : ''}`;
-  const obsEntrada = `Transferência de ${fromScope.unit}${observacoes ? ` | ${observacoes}` : ''}`;
   const actorId = actorName(actor);
 
   const stmts = [];
@@ -1889,16 +1889,33 @@ export async function d1Transfer({ env, body, actor, unidade }) {
   );
   stmts.push(
     env.DB.prepare(
-      `INSERT INTO insumos_stocks (registro, unidade, quantidade, updated_at)
-       SELECT ?, ?, ?, ?
+      `INSERT INTO insumos_transfers (
+        id, registro_insumo, codigo_barras, lote, data_validade, produto,
+        quantidade, unidade_origem, unidade_destino, status, dispatched_at,
+        dispatched_by, dispatch_movement_id
+      )
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PENDING_RECEIPT', ?, ?, ?
        WHERE EXISTS (
          SELECT 1 FROM insumos_stocks
          WHERE registro = ? AND unidade = ? AND updated_at = ?
-       )
-       ON CONFLICT(registro, unidade) DO UPDATE SET
-         quantidade = insumos_stocks.quantidade + excluded.quantidade,
-         updated_at = excluded.updated_at`
-    ).bind(reg, toScope.unit, quantidade, ts, reg, fromScope.unit, ts)
+       )`
+    ).bind(
+      transferId,
+      reg,
+      codigo,
+      String(item.lote || ''),
+      String(item.data_validade || ''),
+      String(item.produto || ''),
+      quantidade,
+      fromScope.unit,
+      toScope.unit,
+      ts,
+      actorId,
+      dispatchMovementId,
+      reg,
+      fromScope.unit,
+      ts,
+    )
   );
 
   const produto = String(item.produto || '');
@@ -1911,11 +1928,15 @@ export async function d1Transfer({ env, body, actor, unidade }) {
         id, data_hora, tipo, codigo_barras, registro_insumo, lote, data_validade, produto,
         quantidade, estoque_anterior, estoque_novo, unidade, unidade_origem, unidade_destino, id_transferencia, usuario, observacoes, status
       )
-      SELECT ?, ?, 'SAÍDA', ?, ?, ?, ?, ?, ?, quantidade + ?, quantidade, ?, ?, ?, ?, ?, ?, 'COMPLETED'
+      SELECT ?, ?, 'SAÍDA', ?, ?, ?, ?, ?, ?, quantidade + ?, quantidade, ?, ?, ?, ?, ?, ?, 'PENDING_RECEIPT'
       FROM insumos_stocks
-      WHERE registro = ? AND unidade = ? AND updated_at = ?`
+      WHERE registro = ? AND unidade = ? AND updated_at = ?
+        AND EXISTS (
+          SELECT 1 FROM insumos_transfers
+          WHERE id = ? AND status = 'PENDING_RECEIPT' AND dispatched_at = ?
+        )`
     ).bind(
-      crypto.randomUUID(),
+      dispatchMovementId,
       ts,
       codigo,
       reg,
@@ -1932,49 +1953,14 @@ export async function d1Transfer({ env, body, actor, unidade }) {
       obsSaida,
       reg,
       fromScope.unit,
-      ts
-    )
-  );
-  stmts.push(
-    env.DB.prepare(
-      `INSERT INTO insumos_movements (
-        id, data_hora, tipo, codigo_barras, registro_insumo, lote, data_validade, produto,
-        quantidade, estoque_anterior, estoque_novo, unidade, unidade_origem, unidade_destino, id_transferencia, usuario, observacoes, status
-      )
-      SELECT ?, ?, 'ENTRADA', ?, ?, ?, ?, ?, ?, quantidade - ?, quantidade, ?, ?, ?, ?, ?, ?, 'COMPLETED'
-      FROM insumos_stocks
-      WHERE registro = ? AND unidade = ? AND updated_at = ?
-        AND EXISTS (
-          SELECT 1 FROM insumos_stocks
-          WHERE registro = ? AND unidade = ? AND updated_at = ?
-        )`
-    ).bind(
-      crypto.randomUUID(),
       ts,
-      codigo,
-      reg,
-      lote,
-      dataValidade,
-      produto,
-      quantidade,
-      quantidade,
-      toScope.unit,
-      fromScope.unit,
-      toScope.unit,
       transferId,
-      actorId,
-      obsEntrada,
-      reg,
-      toScope.unit,
-      ts,
-      reg,
-      fromScope.unit,
       ts
     )
   );
 
   const results = await env.DB.batch(stmts);
-  if (resultChanges(results?.[0]) !== 1 || resultChanges(results?.[1]) !== 1 || resultChanges(results?.[2]) !== 1 || resultChanges(results?.[3]) !== 1) {
+  if (resultChanges(results?.[0]) !== 1 || resultChanges(results?.[1]) !== 1 || resultChanges(results?.[2]) !== 1) {
     const current = await env.DB.prepare(
       `SELECT quantidade FROM insumos_stocks WHERE registro = ? AND unidade = ?`
     ).bind(reg, fromScope.unit).first();
@@ -1988,6 +1974,11 @@ export async function d1Transfer({ env, body, actor, unidade }) {
   return {
     ok: true,
     transferId,
+    dispatchMovementId,
+    status: 'PENDING_RECEIPT',
+    pendingReceipt: true,
+    unidadeOrigem: fromScope.unit,
+    unidadeDestino: toScope.unit,
     estoqueAnteriorOrigem,
     estoqueNovoOrigem,
     estoqueAnteriorDestino,
@@ -1995,6 +1986,250 @@ export async function d1Transfer({ env, body, actor, unidade }) {
     quebraEstoqueOrigem: false,
     deficitOrigem: 0,
     registro: reg
+  };
+}
+
+export async function d1ReceberTransferencia({ env, id, actor, unidade, observacoes }) {
+  const transferId = String(id || '').trim();
+  if (!transferId) return { ok: false, status: 400, code: 'TRANSFER_INVALID', error: 'Transferência inválida' };
+
+  const transfer = await env.DB.prepare(
+    `SELECT id, registro_insumo, codigo_barras, lote, data_validade, produto,
+            quantidade, unidade_origem, unidade_destino, status, dispatched_at,
+            dispatched_by, received_at, received_by, dispatch_movement_id,
+            receipt_movement_id
+     FROM insumos_transfers
+     WHERE id = ?
+     LIMIT 1`
+  ).bind(transferId).first();
+  if (!transfer) return { ok: false, status: 404, code: 'TRANSFER_NOT_FOUND', error: 'Transferência não encontrada' };
+
+  const destinationScope = assertActorUnitScope(actor, transfer.unidade_destino);
+  if (!destinationScope.ok) return destinationScope;
+  if (unidade && normalizeUnitScope(unidade) !== destinationScope.unit) {
+    return { ok: false, status: 400, code: 'UNIT_DESTINATION_MISMATCH', error: 'A unidade da rota deve ser o destino da transferência' };
+  }
+  const status = String(transfer.status || '').toUpperCase();
+  if (status === 'RECEIVED') return { ok: false, status: 409, code: 'TRANSFER_ALREADY_RECEIVED', error: 'A transferência já foi recebida', receivedAt: transfer.received_at || null };
+  if (status === 'CANCELLED') return { ok: false, status: 409, code: 'TRANSFER_CANCELLED', error: 'A transferência foi cancelada' };
+
+  const item = await env.DB.prepare(
+    `SELECT archived_at FROM insumos_items WHERE registro = ? LIMIT 1`
+  ).bind(transfer.registro_insumo).first();
+  if (String(item?.archived_at || '').trim()) {
+    return { ok: false, status: 409, code: 'INSUMO_ARCHIVED', error: 'Insumo arquivado não aceita recebimento' };
+  }
+
+  const quantity = Math.max(1, toInt(transfer.quantidade, 0));
+  if (!quantity) return { ok: false, status: 409, code: 'TRANSFER_INVALID', error: 'Quantidade de transferência inválida' };
+  const ts = nowIso();
+  const actorId = actorName(actor);
+  const receiptMovementId = crypto.randomUUID();
+  const note = String(observacoes || '').trim();
+  const receiptNote = `Recebimento de transferência de ${normalizeUnitScope(transfer.unidade_origem)}${note ? ` | ${note}` : ''}`;
+
+  const statements = [
+    env.DB.prepare(
+      `UPDATE insumos_transfers
+       SET status = 'RECEIVED', received_at = ?, received_by = ?, receipt_movement_id = ?
+       WHERE id = ? AND status = 'PENDING_RECEIPT' AND unidade_destino = ?`
+    ).bind(ts, actorId, receiptMovementId, transferId, destinationScope.unit),
+    env.DB.prepare(
+      `INSERT INTO insumos_stocks (registro, unidade, quantidade, updated_at)
+       SELECT ?, ?, ?, ?
+       WHERE EXISTS (
+         SELECT 1 FROM insumos_transfers
+         WHERE id = ? AND status = 'RECEIVED' AND received_at = ?
+       )
+       ON CONFLICT(registro, unidade) DO UPDATE SET
+         quantidade = insumos_stocks.quantidade + excluded.quantidade,
+         updated_at = excluded.updated_at`
+    ).bind(transfer.registro_insumo, destinationScope.unit, quantity, ts, transferId, ts),
+    env.DB.prepare(
+      `INSERT INTO insumos_movements (
+        id, data_hora, tipo, codigo_barras, registro_insumo, lote, data_validade,
+        produto, quantidade, estoque_anterior, estoque_novo, unidade,
+        unidade_origem, unidade_destino, id_transferencia, usuario, observacoes, status
+      )
+      SELECT ?, ?, 'ENTRADA', ?, ?, ?, ?, ?, ?, quantidade - ?, quantidade, ?, ?, ?, ?, ?, ?, 'COMPLETED'
+      FROM insumos_stocks
+      WHERE registro = ? AND unidade = ? AND updated_at = ?
+        AND EXISTS (
+          SELECT 1 FROM insumos_transfers
+          WHERE id = ? AND status = 'RECEIVED' AND received_at = ?
+        )`
+    ).bind(
+      receiptMovementId,
+      ts,
+      transfer.codigo_barras || '',
+      transfer.registro_insumo || '',
+      transfer.lote || '',
+      transfer.data_validade || '',
+      transfer.produto || '',
+      quantity,
+      quantity,
+      destinationScope.unit,
+      transfer.unidade_origem || '',
+      transfer.unidade_destino || '',
+      transferId,
+      actorId,
+      receiptNote,
+      transfer.registro_insumo,
+      destinationScope.unit,
+      ts,
+      transferId,
+      ts,
+    ),
+  ];
+
+  const results = await env.DB.batch(statements);
+  if (resultChanges(results?.[0]) !== 1 || resultChanges(results?.[1]) !== 1 || resultChanges(results?.[2]) !== 1) {
+    const current = await env.DB.prepare(
+      `SELECT status, received_at FROM insumos_transfers WHERE id = ? LIMIT 1`
+    ).bind(transferId).first();
+    if (String(current?.status || '').toUpperCase() === 'RECEIVED') {
+      return { ok: false, status: 409, code: 'TRANSFER_ALREADY_RECEIVED', error: 'A transferência já foi recebida', receivedAt: current.received_at || null };
+    }
+    return { ok: false, status: 409, code: 'TRANSFER_RECEIPT_CONFLICT', error: 'O recebimento não pôde ser efetivado com segurança' };
+  }
+
+  const destinationAfter = await env.DB.prepare(
+    `SELECT quantidade FROM insumos_stocks WHERE registro = ? AND unidade = ?`
+  ).bind(transfer.registro_insumo, destinationScope.unit).first();
+  return {
+    ok: true,
+    transferId,
+    receiptMovementId,
+    status: 'RECEIVED',
+    receivedBy: actorId,
+    receivedAt: ts,
+    unidadeOrigem: normalizeUnitScope(transfer.unidade_origem),
+    unidadeDestino: destinationScope.unit,
+    registro: transfer.registro_insumo,
+    estoqueNovoDestino: toInt(destinationAfter?.quantidade, 0),
+  };
+}
+
+export async function d1CancelarTransferencia({ env, id, actor, unidade, justificativa }) {
+  const transferId = String(id || '').trim();
+  const reason = String(justificativa || '').trim();
+  if (!transferId) return { ok: false, status: 400, code: 'TRANSFER_INVALID', error: 'Transferência inválida' };
+  if (reason.length < 3) return { ok: false, status: 400, code: 'JUSTIFICATION_REQUIRED', error: 'Motivo do cancelamento é obrigatório' };
+
+  const transfer = await env.DB.prepare(
+    `SELECT id, registro_insumo, codigo_barras, lote, data_validade, produto,
+            quantidade, unidade_origem, unidade_destino, status, dispatched_at,
+            dispatched_by, dispatch_movement_id
+     FROM insumos_transfers WHERE id = ? LIMIT 1`
+  ).bind(transferId).first();
+  if (!transfer) return { ok: false, status: 404, code: 'TRANSFER_NOT_FOUND', error: 'Transferência não encontrada' };
+
+  const originScope = assertActorUnitScope(actor, transfer.unidade_origem);
+  if (!originScope.ok) return originScope;
+  if (unidade && normalizeUnitScope(unidade) !== originScope.unit) {
+    return { ok: false, status: 400, code: 'UNIT_ORIGIN_MISMATCH', error: 'A unidade da rota deve ser a origem da transferência' };
+  }
+  const status = String(transfer.status || '').toUpperCase();
+  if (status === 'CANCELLED') return { ok: false, status: 409, code: 'TRANSFER_ALREADY_CANCELLED', error: 'A transferência já foi cancelada' };
+  if (status === 'RECEIVED') return { ok: false, status: 409, code: 'TRANSFER_ALREADY_RECEIVED', error: 'A transferência já foi recebida; use estorno compensatório' };
+
+  const dispatchMovement = transfer.dispatch_movement_id
+    ? await env.DB.prepare(
+      `SELECT id, tipo, unidade, unidade_origem, unidade_destino, quantidade
+       FROM insumos_movements WHERE id = ? LIMIT 1`
+    ).bind(transfer.dispatch_movement_id).first()
+    : await env.DB.prepare(
+      `SELECT id, tipo, unidade, unidade_origem, unidade_destino, quantidade
+       FROM insumos_movements
+       WHERE id_transferencia = ? AND UPPER(tipo) IN ('SAÍDA', 'SAIDA')
+       ORDER BY data_hora ASC, id ASC LIMIT 1`
+    ).bind(transferId).first();
+  if (!dispatchMovement?.id) return { ok: false, status: 409, code: 'TRANSFER_INVALID', error: 'Despacho da transferência não encontrado' };
+
+  const quantity = Math.max(1, toInt(transfer.quantidade, dispatchMovement.quantidade));
+  const ts = nowIso();
+  const actorId = actorName(actor);
+  const reversalId = crypto.randomUUID();
+  const note = `Cancelamento da transferência para ${normalizeUnitScope(transfer.unidade_destino)} | ${reason}`;
+
+  const statements = [
+    env.DB.prepare(
+      `UPDATE insumos_transfers
+       SET status = 'CANCELLED', cancelled_at = ?, cancelled_by = ?, reason = ?
+       WHERE id = ? AND status = 'PENDING_RECEIPT' AND unidade_origem = ?`
+    ).bind(ts, actorId, reason, transferId, originScope.unit),
+    env.DB.prepare(
+      `INSERT INTO insumos_stocks (registro, unidade, quantidade, updated_at)
+       SELECT ?, ?, ?, ?
+       WHERE EXISTS (
+         SELECT 1 FROM insumos_transfers
+         WHERE id = ? AND status = 'CANCELLED' AND cancelled_at = ?
+       )
+       ON CONFLICT(registro, unidade) DO UPDATE SET
+         quantidade = insumos_stocks.quantidade + excluded.quantidade,
+         updated_at = excluded.updated_at`
+    ).bind(transfer.registro_insumo, originScope.unit, quantity, ts, transferId, ts),
+    env.DB.prepare(
+      `INSERT INTO insumos_movements (
+        id, data_hora, tipo, codigo_barras, registro_insumo, lote, data_validade,
+        produto, quantidade, estoque_anterior, estoque_novo, unidade,
+        unidade_origem, unidade_destino, id_transferencia, usuario, motivo,
+        observacoes, status, estorno_de, tipo_compensacao
+      )
+      SELECT ?, ?, 'ESTORNO', ?, ?, ?, ?, ?, ?, quantidade - ?, quantidade, ?, ?, ?, ?, ?, ?, ?, 'COMPLETED', ?, 'ENTRADA'
+      FROM insumos_stocks
+      WHERE registro = ? AND unidade = ? AND updated_at = ?
+        AND EXISTS (
+          SELECT 1 FROM insumos_transfers
+          WHERE id = ? AND status = 'CANCELLED' AND cancelled_at = ?
+        )`
+    ).bind(
+      reversalId,
+      ts,
+      transfer.codigo_barras || '',
+      transfer.registro_insumo || '',
+      transfer.lote || '',
+      transfer.data_validade || '',
+      transfer.produto || '',
+      quantity,
+      quantity,
+      originScope.unit,
+      transfer.unidade_origem || '',
+      transfer.unidade_destino || '',
+      transferId,
+      actorId,
+      reason,
+      note,
+      dispatchMovement.id,
+      transfer.registro_insumo,
+      originScope.unit,
+      ts,
+      transferId,
+      ts,
+    ),
+  ];
+  const results = await env.DB.batch(statements);
+  if (resultChanges(results?.[0]) !== 1 || resultChanges(results?.[1]) !== 1 || resultChanges(results?.[2]) !== 1) {
+    const current = await env.DB.prepare('SELECT status FROM insumos_transfers WHERE id = ? LIMIT 1').bind(transferId).first();
+    if (String(current?.status || '').toUpperCase() === 'CANCELLED') {
+      return { ok: false, status: 409, code: 'TRANSFER_ALREADY_CANCELLED', error: 'A transferência já foi cancelada' };
+    }
+    return { ok: false, status: 409, code: 'TRANSFER_CANCEL_CONFLICT', error: 'O cancelamento não pôde ser aplicado com segurança' };
+  }
+  const originAfter = await env.DB.prepare(
+    `SELECT quantidade FROM insumos_stocks WHERE registro = ? AND unidade = ?`
+  ).bind(transfer.registro_insumo, originScope.unit).first();
+  return {
+    ok: true,
+    transferId,
+    reversalId,
+    status: 'CANCELLED',
+    cancelledBy: actorId,
+    cancelledAt: ts,
+    unidadeOrigem: originScope.unit,
+    unidadeDestino: normalizeUnitScope(transfer.unidade_destino),
+    registro: transfer.registro_insumo,
+    estoqueNovoOrigem: toInt(originAfter?.quantidade, 0),
   };
 }
 
@@ -2237,6 +2472,24 @@ export async function d1EstornarMovimentacao({ env, id, actor, justificativa }) 
   const actorId = actorName(actor);
   const ts = nowIso();
   const transferId = String(original.id_transferencia || '').trim();
+  const transferRecord = transferId
+    ? await env.DB.prepare(
+      `SELECT id, status, unidade_origem, unidade_destino
+       FROM insumos_transfers WHERE id = ? LIMIT 1`
+    ).bind(transferId).first()
+    : null;
+  if (transferRecord && String(transferRecord.status || '').toUpperCase() === 'PENDING_RECEIPT') {
+    return d1CancelarTransferencia({
+      env,
+      id: transferId,
+      actor,
+      unidade: original.unidade,
+      justificativa: reason,
+    });
+  }
+  if (transferRecord && String(transferRecord.status || '').toUpperCase() === 'CANCELLED') {
+    return { ok: false, status: 409, code: 'TRANSFER_ALREADY_CANCELLED', error: 'A transferência já foi cancelada' };
+  }
 
   const pairRows = transferId
     ? ((await env.DB.prepare(
@@ -2249,7 +2502,8 @@ export async function d1EstornarMovimentacao({ env, id, actor, justificativa }) 
   if (pairRows.some((row) => String(row.estorno_de || '').trim())) {
     return { ok: false, status: 409, code: 'ALREADY_REVERSED', error: 'Transferência já possui estorno' };
   }
-  if (pairRows.some((row) => String(row.status || 'COMPLETED').toUpperCase() !== 'COMPLETED')) {
+  if ((!transferRecord || String(transferRecord.status || '').toUpperCase() !== 'RECEIVED')
+    && pairRows.some((row) => String(row.status || 'COMPLETED').toUpperCase() !== 'COMPLETED')) {
     return { ok: false, status: 409, code: 'TRANSFER_NOT_EFFECTIVE', error: 'A transferência ainda não está efetivada' };
   }
   for (const row of pairRows) {
@@ -2634,6 +2888,14 @@ export async function d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina,
         m.unidade_origem AS unidadeOrigem,
         m.unidade_destino AS unidadeDestino,
         m.id_transferencia AS transferId,
+        t.status AS transferStatus,
+        t.dispatched_at AS transferDispatchedAt,
+        t.dispatched_by AS transferDispatchedBy,
+        t.received_at AS transferReceivedAt,
+        t.received_by AS transferReceivedBy,
+        t.cancelled_at AS transferCancelledAt,
+        t.cancelled_by AS transferCancelledBy,
+        t.reason AS transferReason,
         m.usuario AS usuario,
         m.motivo AS motivo,
         m.observacoes AS observacoes,
@@ -2642,7 +2904,7 @@ export async function d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina,
         m.tipo_compensacao AS tipoCompensacao,
         CASE WHEN EXISTS (
           SELECT 1 FROM insumos_movements reversal WHERE reversal.estorno_de = m.id
-        ) THEN 'ESTORNADO' ELSE COALESCE(m.status, 'COMPLETED') END AS status,
+        ) THEN 'ESTORNADO' ELSE COALESCE(t.status, m.status, 'COMPLETED') END AS status,
         m.registro_insumo AS registroInsumo,
         m.lote AS lote,
         m.data_validade AS dataValidade,
@@ -2652,6 +2914,8 @@ export async function d1ListMovimentacoes({ env, unidade, tipo, de, ate, pagina,
      FROM insumos_movements m
      LEFT JOIN insumos_items i
        ON i.registro = m.registro_insumo
+     LEFT JOIN insumos_transfers t
+       ON t.id = m.id_transferencia
      ${whereSql}
      ORDER BY m.data_hora DESC
      LIMIT ? OFFSET ?`

--- a/inventory/src/routes/insumos.js
+++ b/inventory/src/routes/insumos.js
@@ -326,6 +326,56 @@ export async function handleInsumosRoutes({
             }
         }
 
+        // POST /insumos/transferencias/:id/receber|cancelar
+        if (url.pathname.startsWith("/insumos/transferencias/") && request.method === "POST") {
+            try {
+                const parts = url.pathname.split('/').filter(Boolean);
+                const transferId = decodeURIComponent(parts[2] || '').trim();
+                const action = String(parts[3] || '').trim().toLowerCase();
+                if (!transferId || !['receber', 'cancelar'].includes(action)) {
+                    return withCORS(JSON.stringify({ success: false, code: 'NOT_FOUND', error: 'Rota de transferência não encontrada' }), { status: 404 }, appOrigin);
+                }
+                const auth = await requireRoles(['ADMIN', 'GESTOR', 'GERENTE', 'OPERADOR']);
+                if (!auth.ok) return auth.response;
+                const body = await request.json().catch(() => ({}));
+                const isReceipt = action === 'receber';
+                const command = await d1.executeIdempotent({
+                    actor: auth.user,
+                    action: isReceipt ? 'TRANSFER_RECEBIMENTO' : 'TRANSFER_CANCELAMENTO',
+                    idempotencyKey,
+                    command: { transferId, unidade, body },
+                    execute: () => isReceipt
+                        ? d1.receberTransferencia({ id: transferId, actor: auth.user, unidade, observacoes: body?.observacoes })
+                        : d1.cancelarTransferencia({ id: transferId, actor: auth.user, unidade, justificativa: body?.justificativa || body?.motivo }),
+                });
+                if (!command.ok) return withCORS(JSON.stringify({ success: false, code: command.code, error: command.error }), { status: command.status || 400 }, appOrigin);
+                const out = command.result;
+                if (!out?.ok) return withCORS(JSON.stringify({ success: false, code: out?.code, error: out?.error }), { status: out?.status || 400 }, appOrigin);
+
+                if (!command.replayed) {
+                    await appendAuditLog({
+                        env,
+                        actor: auth.user.username,
+                        role: auth.user.role,
+                        ip,
+                        userAgent,
+                        idempotencyKey,
+                        action: isReceipt ? 'TRANSFER_RECEBIMENTO' : 'TRANSFER_CANCELAMENTO',
+                        entity: 'TRANSFERENCIA',
+                        entityId: transferId,
+                        unidade: unidade || out.unidadeDestino || out.unidadeOrigem,
+                        before: { status: isReceipt ? 'PENDING_RECEIPT' : 'PENDING_RECEIPT' },
+                        after: { status: out.status, registro: out.registro, motivo: body?.justificativa || body?.motivo || null }
+                    });
+                    const units = Array.from(new Set([out.unidadeOrigem, out.unidadeDestino].map((value) => String(value || '').trim()).filter(Boolean)));
+                    for (const unit of units) ctx.waitUntil(enqueueNotificationsRefresh(env, unit));
+                }
+                return withCORS(JSON.stringify({ success: true, data: out, idempotent: !!command.replayed }), { status: 200 }, appOrigin);
+            } catch (err) {
+                return withCORS(JSON.stringify({ success: false, error: err.message || String(err || '') }), { status: 500 }, appOrigin);
+            }
+        }
+
         // POST /insumos/transferir
         if (url.pathname === "/insumos/transferir" && request.method === "POST") {
             try {
@@ -364,6 +414,11 @@ export async function handleInsumosRoutes({
                 return withCORS(JSON.stringify({
                     success: true,
                     transferId: out.transferId,
+                    dispatchMovementId: out.dispatchMovementId,
+                    status: out.status,
+                    pendingReceipt: !!out.pendingReceipt,
+                    unidadeOrigem: out.unidadeOrigem,
+                    unidadeDestino: out.unidadeDestino,
                     estoqueAnteriorOrigem: out.estoqueAnteriorOrigem,
                     estoqueNovoOrigem: out.estoqueNovoOrigem,
                     estoqueAnteriorDestino: out.estoqueAnteriorDestino,

--- a/inventory/src/services/backup.js
+++ b/inventory/src/services/backup.js
@@ -22,7 +22,8 @@ function hasBackupPayloadInsumos(payload) {
             Array.isArray(payload.d1.crmUsers) ||
             Array.isArray(payload.d1.insumosUsers) ||
             Array.isArray(payload.d1.insumosStocks) ||
-            Array.isArray(payload.d1.insumosMovements))
+            Array.isArray(payload.d1.insumosMovements) ||
+            Array.isArray(payload.d1.insumosTransfers))
     );
 }
 
@@ -42,6 +43,7 @@ export async function buildBackupPayload({ env }) {
         insumosItems: [],
         insumosStocks: [],
         insumosMovements: [],
+        insumosTransfers: [],
     };
 
     if (env?.DB) {
@@ -126,6 +128,22 @@ export async function buildBackupPayload({ env }) {
         } catch {
             // ignore
         }
+        try {
+            const tr = await env.DB.prepare(
+                `SELECT id, registro_insumo as registroInsumo, codigo_barras as codigoBarras,
+                        lote, data_validade as dataValidade, produto, quantidade,
+                        unidade_origem as unidadeOrigem, unidade_destino as unidadeDestino,
+                        status, dispatched_at as dispatchedAt, dispatched_by as dispatchedBy,
+                        received_at as receivedAt, received_by as receivedBy,
+                        cancelled_at as cancelledAt, cancelled_by as cancelledBy,
+                        reason, dispatch_movement_id as dispatchMovementId,
+                        receipt_movement_id as receiptMovementId
+                 FROM insumos_transfers`
+            ).all();
+            d1Dump.insumosTransfers = tr?.results || [];
+        } catch {
+            // Older databases may not have the two-phase transfer aggregate yet.
+        }
     }
 
     return {
@@ -141,6 +159,7 @@ export async function buildBackupPayload({ env }) {
                 insumosItemsCount: d1Dump.insumosItems.length,
                 insumosStocksCount: d1Dump.insumosStocks.length,
                 insumosMovementsCount: d1Dump.insumosMovements.length,
+                insumosTransfersCount: d1Dump.insumosTransfers.length,
             },
         },
         d1: d1Dump,
@@ -271,6 +290,39 @@ export async function restoreBackupPayload({ env, payload }) {
                 )
                     .bind(row.registro || '', row.unidade || '', Number(row.quantidade || 0), row.updatedAt || new Date().toISOString())
                     .run();
+            }
+            if (Array.isArray(p.d1.insumosTransfers)) {
+                await env.DB.prepare('DELETE FROM insumos_transfers').run();
+                for (const row of p.d1.insumosTransfers) {
+                    await env.DB.prepare(
+                        `INSERT OR REPLACE INTO insumos_transfers
+                         (id, registro_insumo, codigo_barras, lote, data_validade, produto,
+                          quantidade, unidade_origem, unidade_destino, status, dispatched_at,
+                          dispatched_by, received_at, received_by, cancelled_at, cancelled_by,
+                          reason, dispatch_movement_id, receipt_movement_id)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                    ).bind(
+                        row.id || crypto.randomUUID(),
+                        row.registroInsumo || '',
+                        row.codigoBarras || '',
+                        row.lote || '',
+                        row.dataValidade || '',
+                        row.produto || '',
+                        Number(row.quantidade || 0),
+                        row.unidadeOrigem || '',
+                        row.unidadeDestino || '',
+                        row.status || 'PENDING_RECEIPT',
+                        row.dispatchedAt || new Date().toISOString(),
+                        row.dispatchedBy || '',
+                        row.receivedAt || null,
+                        row.receivedBy || null,
+                        row.cancelledAt || null,
+                        row.cancelledBy || null,
+                        row.reason || null,
+                        row.dispatchMovementId || null,
+                        row.receiptMovementId || null,
+                    ).run();
+                }
             }
             for (const row of (p.d1.insumosMovements || []).reverse()) {
                 await env.DB.prepare(

--- a/inventory/src/worker.js
+++ b/inventory/src/worker.js
@@ -27,6 +27,8 @@ import {
     d1EntradaBaixa,
     d1Ajuste,
     d1Transfer,
+    d1ReceberTransferencia,
+    d1CancelarTransferencia,
     d1EstornarMovimentacao,
     d1ExecuteIdempotent,
     d1ListMovimentacoes,
@@ -1650,6 +1652,8 @@ export default {
             entradaBaixa: ({ unidade, body, kind, actor }) => d1EntradaBaixa({ env, unidade, body, kind, actor }),
             ajuste: ({ unidade, body, actor }) => d1Ajuste({ env, unidade, body, actor }),
             transfer: ({ body, actor, unidade }) => d1Transfer({ env, body, actor, unidade }),
+            receberTransferencia: ({ id, actor, unidade, observacoes }) => d1ReceberTransferencia({ env, id, actor, unidade, observacoes }),
+            cancelarTransferencia: ({ id, actor, unidade, justificativa }) => d1CancelarTransferencia({ env, id, actor, unidade, justificativa }),
             estornarMovimentacao: ({ id, actor, justificativa }) => d1EstornarMovimentacao({ env, id, actor, justificativa }),
             executeIdempotent: (args) => d1ExecuteIdempotent({ env, ...args }),
             listMovimentacoes: ({ unidade, tipo, de, ate, pagina, limite, codigoBarras }) =>

--- a/inventory/tests/insumosLedgerGuardrails.test.mjs
+++ b/inventory/tests/insumosLedgerGuardrails.test.mjs
@@ -12,9 +12,12 @@ import {
   d1EntradaBaixa,
   d1EstornarMovimentacao,
   d1ExecuteIdempotent,
+  d1ReceberTransferencia,
+  d1CancelarTransferencia,
   d1Transfer,
 } from '../src/d1Store.js';
 import { handleMovimentacoesRoutes } from '../src/routes/movimentacoes.js';
+import { handleInsumosRoutes } from '../src/routes/insumos.js';
 
 const { getPlatformProxy } = wrangler;
 
@@ -97,6 +100,7 @@ async function applyTestSchema(database) {
     '0013_insumos_barcodes.sql',
     '0014_insumos_movements_agg.sql',
     '0019_insumos_ledger_guardrails.sql',
+    '0020_insumos_transfer_receipt.sql',
   ];
   for (const name of names) {
     const sql = await readFile(new URL(`../migrations/${name}`, import.meta.url), 'utf8');
@@ -265,7 +269,7 @@ test('serializes competing issues and rejects cross-unit commands', async () => 
   assert.equal(deniedTransfer.code, 'RBAC_UNIT_DENIED');
 });
 
-test('moves stock atomically between scoped units and compensates both transfer legs', async () => {
+test('dispatches transfer, receives atomically at destination, and compensates both legs', async () => {
   const code = `TRANSFER-${Date.now()}`;
   const item = await createItem({ code, lot: 'T1', stock: 4 });
   const transfer = await d1Transfer({
@@ -276,9 +280,19 @@ test('moves stock atomically between scoped units and compensates both transfer 
   });
   assert.equal(transfer.ok, true);
   assert.equal(transfer.estoqueNovoOrigem, 2);
-  assert.equal(transfer.estoqueNovoDestino, 2);
-  const legs = await rows('SELECT id, tipo, unidade FROM insumos_movements WHERE id_transferencia = ? ORDER BY tipo', transfer.transferId);
+  assert.equal(transfer.estoqueNovoDestino, 0);
+  assert.equal(transfer.status, 'PENDING_RECEIPT');
+  const pending = (await rows('SELECT id, tipo, status, unidade FROM insumos_movements WHERE id_transferencia = ?', transfer.transferId))[0];
+  assert.equal(pending.status, 'PENDING_RECEIPT');
+  const deniedReceipt = await d1ReceberTransferencia({ env, id: transfer.transferId, actor: NH_ONLY, unidade: UNIT_BSS });
+  assert.equal(deniedReceipt.code, 'RBAC_UNIT_DENIED');
+  const received = await d1ReceberTransferencia({ env, id: transfer.transferId, actor: GESTOR, unidade: UNIT_BSS, observacoes: 'Conferido no destino' });
+  assert.equal(received.ok, true);
+  assert.equal(received.status, 'RECEIVED');
+  assert.equal(received.estoqueNovoDestino, 2);
+  const legs = await rows('SELECT id, tipo, status, unidade FROM insumos_movements WHERE id_transferencia = ? ORDER BY data_hora ASC, id ASC', transfer.transferId);
   assert.equal(legs.length, 2);
+  assert.equal(legs.filter((row) => row.tipo === 'ENTRADA').length, 1);
   const reversed = await d1EstornarMovimentacao({ env, id: legs[0].id, actor: GESTOR, justificativa: 'Transferência cancelada no recebimento' });
   assert.equal(reversed.ok, true);
   assert.deepEqual(
@@ -289,6 +303,44 @@ test('moves stock atomically between scoped units and compensates both transfer 
     ],
   );
   assert.equal((await rows('SELECT COUNT(1) AS n FROM insumos_movements WHERE estorno_de IS NOT NULL AND id_transferencia = ?', transfer.transferId))[0].n, 2);
+});
+
+test('cancels a pending dispatch with an audited compensating movement', async () => {
+  const code = `TRANSFER-CANCEL-${Date.now()}`;
+  const item = await createItem({ code, lot: 'TC1', stock: 3 });
+  const transfer = await d1Transfer({
+    env,
+    unidade: UNIT_NH,
+    actor: GESTOR,
+    body: { codigoBarras: code, registro: item.registro, quantidade: 2, fromUnidade: UNIT_NH, toUnidade: UNIT_BSS },
+  });
+  assert.equal(transfer.status, 'PENDING_RECEIPT');
+  const cancelled = await d1CancelarTransferencia({ env, id: transfer.transferId, actor: GESTOR, unidade: UNIT_NH, justificativa: 'Veículo indisponível antes do despacho' });
+  assert.equal(cancelled.ok, true);
+  assert.equal(cancelled.status, 'CANCELLED');
+  assert.equal(cancelled.estoqueNovoOrigem, 3);
+  assert.equal((await rows('SELECT status FROM insumos_transfers WHERE id = ?', transfer.transferId))[0].status, 'CANCELLED');
+  assert.equal((await rows('SELECT tipo, estorno_de, tipo_compensacao FROM insumos_movements WHERE id = ?', cancelled.reversalId))[0].tipo, 'ESTORNO');
+  assert.equal((await d1ReceberTransferencia({ env, id: transfer.transferId, actor: GESTOR, unidade: UNIT_BSS })).code, 'TRANSFER_CANCELLED');
+});
+
+test('serializes concurrent receipts and never duplicates destination stock', async () => {
+  const code = `TRANSFER-RACE-${Date.now()}`;
+  const item = await createItem({ code, lot: 'TR1', stock: 2 });
+  const transfer = await d1Transfer({
+    env,
+    unidade: UNIT_NH,
+    actor: GESTOR,
+    body: { codigoBarras: code, registro: item.registro, quantidade: 2, fromUnidade: UNIT_NH, toUnidade: UNIT_BSS },
+  });
+  const receipts = await Promise.all([
+    d1ReceberTransferencia({ env, id: transfer.transferId, actor: GESTOR, unidade: UNIT_BSS }),
+    d1ReceberTransferencia({ env, id: transfer.transferId, actor: GESTOR, unidade: UNIT_BSS }),
+  ]);
+  assert.equal(receipts.filter((result) => result.ok).length, 1);
+  assert.equal(receipts.filter((result) => ['TRANSFER_ALREADY_RECEIVED', 'TRANSFER_RECEIPT_CONFLICT'].includes(result.code)).length, 1);
+  assert.equal((await rows('SELECT quantidade FROM insumos_stocks WHERE registro = ? AND unidade = ?', item.registro, UNIT_BSS))[0].quantidade, 2);
+  assert.equal((await rows('SELECT COUNT(1) AS n FROM insumos_movements WHERE id_transferencia = ? AND tipo = \'ENTRADA\'', transfer.transferId))[0].n, 1);
 });
 
 test('records an adjustment and reverses it without rewriting the original', async () => {
@@ -393,4 +445,32 @@ test('rejects destructive movement HTTP verbs and advertises the estorno route',
     assert.equal(response.headers.get('allow'), 'GET, POST');
     assert.equal((await response.json()).code, 'LEDGER_IMMUTABLE');
   }
+});
+
+test('exposes destination receipt and origin cancellation routes with server actor context', async () => {
+  const audit = [];
+  const dispatched = [];
+  const base = {
+    request: new Request('https://inventory.test/insumos/transferencias/tx-route/receber?unidade=barra-shopping-sul', { method: 'POST', body: JSON.stringify({ observacoes: 'Conferido' }), headers: { 'content-type': 'application/json', 'idempotency-key': 'route-receipt-1' } }),
+    url: new URL('https://inventory.test/insumos/transferencias/tx-route/receber?unidade=barra-shopping-sul'),
+    env: {},
+    ctx: { waitUntil: () => {} },
+    appOrigin: 'https://crm.skincos.com.br',
+    withCORS: (body, init) => new Response(body, init),
+    unidade: UNIT_BSS,
+    requireRoles: async () => ({ ok: true, user: { ...GESTOR, username: 'backend-receiving-user' } }),
+    appendAuditLog: async (entry) => audit.push(entry),
+    enqueueNotificationsRefresh: async (unit) => dispatched.push(unit),
+    idempotencyKey: 'route-receipt-1',
+    d1: {
+      enabled: true,
+      executeIdempotent: async ({ execute }) => ({ ok: true, replayed: false, result: await execute() }),
+      receberTransferencia: async (input) => ({ ok: true, status: 'RECEIVED', transferId: input.id, receivedBy: input.actor.username, unidadeDestino: input.unidade }),
+    },
+  };
+  const response = await handleInsumosRoutes(base);
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).data.receivedBy, 'backend-receiving-user');
+  assert.equal(audit[0].action, 'TRANSFER_RECEBIMENTO');
+  assert.equal(dispatched.length, 1);
 });


### PR DESCRIPTION
## Objetivo\nEvoluir transferências para despacho e recebimento separados: o despacho reduz somente a origem e marca PENDING_RECEIPT; a unidade destino efetiva o recebimento atomically.\n\n## Escopo\n- migration 0020 cria o agregado insumos_transfers e converte transferências históricas em RECEIVED sem reescrever o ledger\n- recebimento e cancelamento pré-recebimento com idempotência, RBAC de unidade e auditoria\n- cancelamento restaura a origem por ESTORNO; recebimento concorrente não duplica estoque\n- backup/restore preserva o ciclo de vida da transferência\n\n## Validação\n- teste focal de ledger/transferências: 13/13\n- suíte Inventory: 30/30\n- migration D1 local 0001..0020 aplicada com sucesso\n- preflight sem falhas (apenas working tree durante implementação)\n\n## Rollback\nReverter a versão do Worker; migration é aditiva. Transferências e ledger não são apagados; correções continuam por estorno.