### PR TITLE
fix(clientes): run production migration under peer identity

### DIFF
--- a/docs/runbooks/crm-continuous-workers.md
+++ b/docs/runbooks/crm-continuous-workers.md
@@ -86,3 +86,20 @@ Harmonia DDL idempotently, seeds only the two bounded unit definitions, and
 records `20260805_harmonia_worker_foundation_v1`. It never drops, truncates or
 deletes data. Rollback is operational: stop/disable the worker and retain the
 schema and checkpoint; do not issue a destructive reverse migration.
+
+Production uses PostgreSQL peer authentication and therefore must run as the
+native `skincos` OS user. Provision the checkpoint directory once as root with
+group write for that service identity, then run the native launcher as
+`skincos`; the launcher refuses arbitrary backup roots or a different OS user:
+
+```sh
+sudo install -d -o root -g skincos -m 0770 /var/backups/skincos/clientes
+sudo -u skincos env \
+  HARMONIA_MIGRATION_TARGET=production \
+  HARMONIA_MIGRATION_ACTION=dry-run \
+  /opt/skincos/current/source/scripts/runtime/run-harmonia-migration-native.sh
+```
+
+An apply follows the same command with `HARMONIA_MIGRATION_ACTION=apply`.
+Staging uses its dedicated migrator environment and the separate
+`/var/backups/skincos/clientes/staging` checkpoint root.

--- a/scripts/provision-atendimento-staging.sh
+++ b/scripts/provision-atendimento-staging.sh
@@ -44,7 +44,7 @@ fi
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 sudo -n install -d -m 0750 -o root -g skincos "$CONFIG_DIR" "$CONTROL_DIR"
 sudo -n install -d -m 0750 -o skincos -g skincos "$STATE_ROOT" "$STATE_ROOT/var" "$LOG_ROOT"
-sudo -n install -d -m 0700 -o root -g root "$BACKUP_ROOT"
+sudo -n install -d -m 0700 -o root -g root "$BACKUP_ROOT" "$BACKUP_ROOT/staging"
 
 for path in "$ATENDIMENTO_CONFIG" "$MIGRATOR_CONFIG" "$CONTROL_FILE"; do
   if sudo -n test -f "$path"; then

--- a/scripts/runtime/run-harmonia-migration-native.sh
+++ b/scripts/runtime/run-harmonia-migration-native.sh
@@ -11,10 +11,28 @@ if [[ -z "$TARGET" ]]; then
   exit 64
 fi
 case "$TARGET" in
-  production) ENV_FILE="$CONFIG_ROOT/crm.env"; BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes}" ;;
-  staging) ENV_FILE="$CONFIG_ROOT/crm-atendimento-staging-migrator.env"; BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes/staging}" ;;
+  production)
+    ENV_FILE="$CONFIG_ROOT/crm.env"
+    BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes}"
+    EXPECTED_BACKUP_ROOT='/var/backups/skincos/clientes'
+    EXPECTED_OS_USER='skincos'
+    ;;
+  staging)
+    ENV_FILE="$CONFIG_ROOT/crm-atendimento-staging-migrator.env"
+    BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes/staging}"
+    EXPECTED_BACKUP_ROOT='/var/backups/skincos/clientes/staging'
+    EXPECTED_OS_USER=''
+    ;;
   *) echo "Unsupported target: $TARGET" >&2; exit 64 ;;
 esac
+[[ "$BACKUP_ROOT" == "$EXPECTED_BACKUP_ROOT" ]] || {
+  echo "BACKUP_ROOT is fixed to $EXPECTED_BACKUP_ROOT for $TARGET." >&2
+  exit 64
+}
+if [[ -n "$EXPECTED_OS_USER" && "$(id -un)" != "$EXPECTED_OS_USER" ]]; then
+  echo "The $TARGET migration must run as the OS user $EXPECTED_OS_USER for peer authentication." >&2
+  exit 77
+fi
 [[ -f "$ENV_FILE" ]] || { echo "Missing private environment: $ENV_FILE" >&2; exit 1; }
 # shellcheck disable=SC1090
 set -a
@@ -31,7 +49,10 @@ checkpoint=''
 if [[ "$ACTION" == 'apply' ]]; then
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   checkpoint="$BACKUP_ROOT/harmonia-${TARGET}-${stamp}.json"
-  install -d -o root -g skincos -m 0750 "$BACKUP_ROOT"
+  [[ -d "$BACKUP_ROOT" && -w "$BACKUP_ROOT" ]] || {
+    echo "Checkpoint directory must be pre-provisioned and writable: $BACKUP_ROOT" >&2
+    exit 77
+  }
 fi
 
 args=("--target" "$TARGET")


### PR DESCRIPTION
## Summary

- make the Harmonia native migration launcher target-bound for checkpoint roots
- require production execution as the `skincos` OS user so local PostgreSQL peer authentication cannot be bypassed
- require the checkpoint directory to be pre-provisioned and writable instead of trying to chown it during the migration
- provision the staging checkpoint subdirectory and document the production gate

## Safety

- no database schema/data changes in this PR
- arbitrary backup roots fail closed
- production apply fails closed for a wrong OS identity or missing checkpoint directory
- outbound mode remains blocked

## Validation

- `bash -n scripts/runtime/run-harmonia-migration-native.sh scripts/provision-atendimento-staging.sh`
- negative checks confirmed wrong production identity returns a non-zero safety code
- `git diff --check`