### PR TITLE
feat(clientes): add bounded commercial pagination

### DIFF
--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -231,6 +231,75 @@ test('scopes Clientes commercial reads, queues, actions, cadences and offers to 
     assert.equal(captured.filter((entry) => entry.kind === 'profiles').at(-1)?.params[1], null)
 })
 
+test('uses bounded SQL pagination and global percentile benchmarks for the commercial overview', async () => {
+    const identityId = '11111111-1111-4111-8111-111111111111'
+    const availability = {
+        permissions: 'permissions', permission_events: 'permission-events', action_events: 'action-events',
+        harmonia_contacts: 'harmonia.contacts', caixa_customers: 'caixa.customers', app_registrations: null, lead_profiles: null,
+        permission_event_trace_id: true, permission_events_immutable: true, permission_events_no_truncate: true,
+        action_events_immutable: true, action_events_no_truncate: true, action_channel: true, action_contacted_at: true,
+        rollout_enabled: true, rollout_canary: true,
+    }
+    const captured = []
+    const pool = createFakePool([
+        (sql, params) => {
+            if (sql.includes("to_regclass('crm_atendimento.global_client_identities') as identities")) {
+                return { rows: [{ identities: 'identities', members: 'members', attendance_links: 'attendance_links', sales: 'sales' }], rowCount: 1 }
+            }
+            if (sql.startsWith('select active_contact_cooldown_days,')) {
+                return { rows: [{ active_contact_cooldown_days: 30, return_risk_thresholds: [90, 180, 365], commercial_contact_writes_enabled: false, commercial_contact_canary_identity_ids: [], updated_by: 'manager', updated_at: '2026-08-05T12:00:00.000Z', policy_version: 'a'.repeat(32) }], rowCount: 1 }
+            }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_contact_permissions')")) return { rows: [availability], rowCount: 1 }
+            if (sql.includes('with identities as') && sql.includes('limit $7 offset $8')) {
+                captured.push({ sql, params })
+                const stats = {
+                    sales_p75: 1000, visits_p75: 3, filtered_total: 2, return_at_risk_total: 1, high_value_inactive_total: 1,
+                    frequent_total: 1, balanced_vip_total: 1, reactivation_potential_total: 1,
+                    confirmed_multi_source_total: 2, unresolved_single_source_total: 0, lifetime_sales_total: 2200, sale_count_total: 3,
+                }
+                if (Number(params[7]) >= 100) return { rows: [{ identity_id: null, ...stats }], rowCount: 1 }
+                return {
+                    rows: [{
+                        identity_id: identityId, canonical_name: 'Cliente paginado', source_types: ['attendance_client', 'caixa_customer'],
+                        last_attendance: '2026-01-01', visit_count: 4, procedure_count: 4, completed_procedures: ['Botox'], attendance_units: ['Novo Hamburgo'],
+                        future_attendance_count: 0, sale_count: 2, lifetime_sales: 1200, sales_12m: 1200, sales_units: ['Novo Hamburgo'], phone: '5551999991111',
+                        purchased_procedures: ['Botox'], pending_sale_items: 0, active_action_count: 1, last_action_at: '2026-08-01T12:00:00.000Z',
+                        ...stats,
+                    }], rowCount: 1,
+                }
+            }
+            if (sql.startsWith('select identity_id::text as identity_id, channel')) return { rows: [], rowCount: 0 }
+            if (sql.includes('from crm_atendimento.global_client_identity_members member') && sql.includes('crm_caixa.customers customer')) return { rows: [{ identity_id: identityId, phone_key: '5551999991111' }], rowCount: 1 }
+            if (sql.startsWith('select phone_raw, opted_out_at')) return { rows: [], rowCount: 0 }
+            if (sql.includes('count(*)::int as future_attendances')) return { rows: [{ future_attendances: 0 }], rowCount: 1 }
+            if (sql.includes('where item.mapping_status = \'mapped\'')) return { rows: [{ count: 1 }], rowCount: 1 }
+            if (sql.includes('from crm_caixa.sale_items item') && sql.includes('where $1::text[] is null')) return { rows: [{ count: 2 }], rowCount: 1 }
+            if (sql.includes('select count(distinct canonical.id)::int as count')) return { rows: [{ count: 0 }], rowCount: 1 }
+            if (sql.startsWith('select max(updated_at) as updated_at')) return { rows: [{ updated_at: '2026-08-05T12:00:00.000Z' }], rowCount: 1 }
+            if (sql.includes('with scoped_actions as')) return { rows: [{ actions: 1, contacted_actions: 0, recovered_sales_clients: 0, clinical_return_clients: 0 }], rowCount: 1 }
+            return null
+        },
+    ])
+    const store = createAtendimentoStore({ pool })
+    const result = await store.commercialOverview({ server: '1', limit: 1, offset: 1, sort: 'lifetime_sales', direction: 'asc', q: 'cliente' }, { id: 'manager', role: 'GESTOR' })
+    assert.equal(captured.length, 1)
+    assert.deepEqual(captured[0].params.slice(3, 8), ['cliente', '', '', 1, 1])
+    assert.equal(result.pagination.mode, 'sql')
+    assert.equal(result.pagination.sort, 'lifetime_sales')
+    assert.equal(result.pagination.direction, 'asc')
+    assert.equal(result.total, 2)
+    assert.equal(result.profiles.length, 1)
+    assert.equal(result.summary.profiles, 2)
+    assert.equal(result.summary.highValueInactive, 1)
+    assert.equal(result.coverage.confirmedMultiSourceIdentities, 2)
+    assert.equal(result.dataQuality.contactEligibility.scope, 'page')
+    const emptyPage = await store.commercialOverview({ server: '1', limit: 1, offset: 100, q: 'cliente' }, { id: 'manager', role: 'GESTOR' })
+    assert.equal(emptyPage.total, 2)
+    assert.equal(emptyPage.profiles.length, 0)
+    assert.equal(emptyPage.pagination.hasPrevious, true)
+    assert.equal(emptyPage.pagination.hasNext, false)
+})
+
 test('returns commercial-only references filtered to the declared manager units', async () => {
     const pool = createFakePool([
         (sql) => sql.includes('select slug, name from crm_atendimento.units order by name') && {

--- a/crm/api/server/atendimento/clientCommercial.js
+++ b/crm/api/server/atendimento/clientCommercial.js
@@ -83,11 +83,19 @@ function segment(key, label, priority, nextAction, evidence) {
     return { key, label, priority, nextAction, evidence }
 }
 
-export function segmentCommercialProfiles(rows = [], { asOf = new Date().toISOString().slice(0, 10), thresholds = [90, 180, 365] } = {}) {
+export function segmentCommercialProfiles(rows = [], {
+    asOf = new Date().toISOString().slice(0, 10),
+    thresholds = [90, 180, 365],
+    benchmarks = null,
+} = {}) {
     const profiles = rows.map((row) => buildCommercialProfile(row, { asOf }))
     const [returnRisk, longAbsence, veryLongAbsence] = [...thresholds].map(number).sort((left, right) => left - right)
-    const salesP75 = percentile(profiles.map((profile) => profile.lifetimeSales), 0.75)
-    const visitsP75 = percentile(profiles.map((profile) => profile.visitCount), 0.75)
+    const salesP75 = Number.isFinite(Number(benchmarks?.salesP75))
+        ? Math.max(0, Number(benchmarks.salesP75))
+        : percentile(profiles.map((profile) => profile.lifetimeSales), 0.75)
+    const visitsP75 = Number.isFinite(Number(benchmarks?.visitsP75))
+        ? Math.max(0, Number(benchmarks.visitsP75))
+        : percentile(profiles.map((profile) => profile.visitCount), 0.75)
 
     return profiles.map((profile) => {
         const segments = []

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -3391,7 +3391,21 @@ async function queryCommercialProfiles(pgPool, { asOf, unitSlugs, thresholds }) 
          order by i.canonical_name`,
         [asOf, unitSlugs, COMMERCIAL_ACTIVE_ACTION_STATUSES],
     )
-    const profiles = segmentCommercialProfiles(result.rows.map((row) => ({
+    const profiles = segmentCommercialProfiles(result.rows.map(commercialProfileRowInput), { asOf, thresholds }).map((profile) => ({
+        ...profile,
+        activeActionCount: Number(result.rows.find((row) => row.identity_id === profile.identityId)?.active_action_count || 0),
+        lastActionAt: result.rows.find((row) => row.identity_id === profile.identityId)?.last_action_at || null,
+    }))
+    const eligibilityByIdentity = await queryCommercialContactEligibility(pgPool, profiles.map((profile) => profile.identityId), { unitSlugs })
+    return profiles.map((profile) => ({
+        ...profile,
+        contactEligibility: eligibilityByIdentity.get(profile.identityId)
+            || emptyCommercialContactEligibility('commercial_contact_controls_not_ready'),
+    }))
+}
+
+function commercialProfileRowInput(row) {
+    return {
         ...row,
         identityId: row.identity_id,
         name: row.canonical_name,
@@ -3407,17 +3421,7 @@ async function queryCommercialProfiles(pgPool, { asOf, unitSlugs, thresholds }) 
         units: [...(row.attendance_units || []), ...(row.sales_units || [])],
         purchasedProcedures: row.purchased_procedures,
         pendingSaleItems: row.pending_sale_items,
-    })), { asOf, thresholds }).map((profile) => ({
-        ...profile,
-        activeActionCount: Number(result.rows.find((row) => row.identity_id === profile.identityId)?.active_action_count || 0),
-        lastActionAt: result.rows.find((row) => row.identity_id === profile.identityId)?.last_action_at || null,
-    }))
-    const eligibilityByIdentity = await queryCommercialContactEligibility(pgPool, profiles.map((profile) => profile.identityId), { unitSlugs })
-    return profiles.map((profile) => ({
-        ...profile,
-        contactEligibility: eligibilityByIdentity.get(profile.identityId)
-            || emptyCommercialContactEligibility('commercial_contact_controls_not_ready'),
-    }))
+    }
 }
 
 function filterCommercialProfiles(profiles, query) {
@@ -3432,6 +3436,260 @@ function filterCommercialProfiles(profiles, query) {
         if (search && !normalizeText(profile.name).includes(search)) return false
         return true
     })
+}
+
+const COMMERCIAL_PROFILE_SORT_COLUMNS = Object.freeze({
+    priority: 'priority_rank',
+    recency: 'recency_days',
+    lifetime_sales: 'lifetime_sales',
+    visits: 'visit_count',
+    sales: 'sale_count',
+    last_attendance: 'last_attendance',
+    name: 'canonical_name',
+})
+
+function commercialProfileSort(query) {
+    const requested = String(query?.sort || 'priority').trim().toLowerCase()
+    const key = Object.hasOwn(COMMERCIAL_PROFILE_SORT_COLUMNS, requested) ? requested : 'priority'
+    const direction = String(query?.direction || 'desc').trim().toLowerCase() === 'asc' ? 'asc' : 'desc'
+    const column = COMMERCIAL_PROFILE_SORT_COLUMNS[key]
+    return { key, direction, orderBy: `${column} ${direction} nulls ${direction === 'asc' ? 'first' : 'last'}, identity_id asc` }
+}
+
+/**
+ * The legacy commercial read deliberately remains available for compatibility
+ * with callers that do not opt into pagination. The Clientes console opts into
+ * this bounded path: aggregation, percentile benchmarks, filtering, ordering,
+ * total count and page slicing all happen in PostgreSQL before identity
+ * contact eligibility is hydrated for the visible page.
+ */
+async function queryCommercialProfilesServerPage(pgPool, { asOf, unitSlugs, thresholds, query }) {
+    const [returnRisk, longAbsence, veryLongAbsence] = [...thresholds].map(Number).sort((left, right) => left - right)
+    const limit = sanitizeLimit(query?.limit, 50, 100)
+    const offset = sanitizeOffset(query?.offset, 0)
+    const search = normalizeText(query?.q || query?.search || '')
+    const segment = String(query?.segment || '').trim()
+    const priority = String(query?.priority || '').trim()
+    const { key: sort, direction, orderBy } = commercialProfileSort(query)
+    const result = await pgPool.query(
+        `with identities as (
+            select gi.id as identity_id, gi.canonical_name, gi.source_types
+            from crm_atendimento.global_client_identities gi
+            where exists (select 1 from crm_atendimento.global_client_identity_members gm where gm.identity_id = gi.id)
+         ), attendance_members as (
+            select distinct gm.identity_id, gm.source_id::uuid as client_id
+            from crm_atendimento.global_client_identity_members gm
+            join crm_atendimento.canonical_clients cc on cc.id = gm.source_id::uuid
+            where gm.source_type = 'attendance_client'
+         ), attendance_core as (
+            select am.identity_id, a.id, a.service_date, p.name as procedure_name, u.name as unit_name
+            from attendance_members am
+            join crm_atendimento.attendance_client_links acl on acl.client_id = am.client_id
+            join crm_atendimento.attendances a on a.id = acl.attendance_id
+            join crm_atendimento.procedures p on p.id = a.procedure_id
+            join crm_atendimento.units u on u.id = a.unit_id
+            where a.deleted_at is null and a.service_date <= $1::date
+              and ($2::text[] is null or u.slug = any($2::text[]))
+         ), attendance_aggregate as (
+            select identity_id, max(service_date)::text as last_attendance,
+                count(distinct service_date)::int as visit_count, count(*)::int as procedure_count,
+                array_agg(distinct procedure_name order by procedure_name) as completed_procedures,
+                array_agg(distinct unit_name order by unit_name) as attendance_units
+            from attendance_core group by identity_id
+         ), future_attendance as (
+            select am.identity_id, count(*)::int as future_attendance_count
+            from attendance_members am
+            join crm_atendimento.attendance_client_links acl on acl.client_id = am.client_id
+            join crm_atendimento.attendances a on a.id = acl.attendance_id
+            join crm_atendimento.units u on u.id = a.unit_id
+            where a.deleted_at is null and a.service_date > $1::date
+              and ($2::text[] is null or u.slug = any($2::text[]))
+            group by am.identity_id
+         ), sale_members as (
+            select distinct gm.identity_id, gm.source_id::uuid as customer_id
+            from crm_atendimento.global_client_identity_members gm
+            where gm.source_type = 'caixa_customer'
+         ), sale_core as (
+            select sm.identity_id, s.id, s.occurred_on, s.total, s.phone_raw, u.name as unit_name
+            from sale_members sm
+            join crm_caixa.sales s on s.customer_id = sm.customer_id
+            join crm_atendimento.units u on u.id = s.unit_id
+            where s.occurred_on <= $1::date
+              and ($2::text[] is null or u.slug = any($2::text[]))
+         ), sales_aggregate as (
+            select identity_id, count(*)::int as sale_count, coalesce(sum(total), 0) as lifetime_sales,
+                coalesce(sum(total) filter (where occurred_on >= ($1::date - interval '12 months')), 0) as sales_12m,
+                array_agg(distinct unit_name order by unit_name) as sales_units,
+                (array_agg(phone_raw order by occurred_on desc) filter (where nullif(trim(phone_raw), '') is not null))[1] as phone
+            from sale_core group by identity_id
+         ), purchased_procedures as (
+            select sc.identity_id, array_agg(distinct p.name order by p.name) as purchased_procedures
+            from sale_core sc
+            join crm_caixa.sale_items si on si.sale_id = sc.id and si.mapping_status = 'mapped' and si.procedure_id is not null
+            join crm_atendimento.procedures p on p.id = si.procedure_id
+            group by sc.identity_id
+         ), pending_items as (
+            select sc.identity_id, count(*)::int as pending_sale_items
+            from sale_core sc
+            join crm_caixa.sale_items si on si.sale_id = sc.id and si.mapping_status = 'pending'
+            group by sc.identity_id
+         ), active_actions as (
+            select action.identity_id, count(*)::int as active_action_count, max(action.created_at) as last_action_at
+            from crm_atendimento.commercial_actions action
+            left join crm_atendimento.units action_unit on action_unit.id = action.unit_id
+            where action.status = any($3::text[])
+              and ($2::text[] is null or action_unit.slug = any($2::text[]))
+            group by action.identity_id
+         ), raw_profiles as (
+            select i.identity_id, i.canonical_name, i.source_types,
+                a.last_attendance, coalesce(a.visit_count, 0)::int as visit_count,
+                coalesce(a.procedure_count, 0)::int as procedure_count, a.completed_procedures, a.attendance_units,
+                coalesce(f.future_attendance_count, 0)::int as future_attendance_count,
+                coalesce(s.sale_count, 0)::int as sale_count, coalesce(s.lifetime_sales, 0)::numeric as lifetime_sales,
+                coalesce(s.sales_12m, 0)::numeric as sales_12m, s.sales_units, s.phone,
+                p.purchased_procedures, coalesce(pending.pending_sale_items, 0)::int as pending_sale_items,
+                coalesce(actions.active_action_count, 0)::int as active_action_count, actions.last_action_at
+            from identities i
+            left join attendance_aggregate a on a.identity_id = i.identity_id
+            left join future_attendance f on f.identity_id = i.identity_id
+            left join sales_aggregate s on s.identity_id = i.identity_id
+            left join purchased_procedures p on p.identity_id = i.identity_id
+            left join pending_items pending on pending.identity_id = i.identity_id
+            left join active_actions actions on actions.identity_id = i.identity_id
+            where $2::text[] is null or a.identity_id is not null or s.identity_id is not null
+         ), benchmarks as (
+            select coalesce(percentile_disc(0.75) within group (order by lifetime_sales) filter (where lifetime_sales > 0), 0)::numeric as sales_p75,
+                   coalesce(percentile_disc(0.75) within group (order by visit_count) filter (where visit_count > 0), 0)::numeric as visits_p75
+            from raw_profiles
+         ), scored as (
+            select raw.*, benchmarks.sales_p75, benchmarks.visits_p75,
+                case when raw.last_attendance is null then null else ($1::date - raw.last_attendance::date) end::int as recency_days
+            from raw_profiles raw cross join benchmarks
+         ), classified as (
+            select scored.*,
+                (recency_days is not null and recency_days >= $9) as return_at_risk,
+                (last_attendance is null and sale_count > 0) as no_recorded_attendance,
+                (recency_days is not null and recency_days >= $9 and sales_p75 > 0 and lifetime_sales >= sales_p75) as high_value_inactive,
+                (visits_p75 > 0 and visit_count >= visits_p75 and (recency_days is null or recency_days < $10)) as frequent,
+                (sales_p75 > 0 and visits_p75 > 0 and lifetime_sales >= sales_p75 and visit_count >= visits_p75 and (recency_days is null or recency_days < $10)) as balanced_vip,
+                (recency_days is not null and recency_days >= $9 and sale_count <= 1 and visit_count <= 1 and last_attendance is not null) as first_return,
+                (recency_days is not null and recency_days >= $9 and lifetime_sales > 0 and visit_count > 0) as reactivation_potential
+            from scored
+         ), ranked as (
+            select classified.*,
+                case when (recency_days is not null and recency_days >= $11)
+                          or high_value_inactive
+                          or (reactivation_potential and sales_p75 > 0 and lifetime_sales >= sales_p75) then 3
+                     when (recency_days is not null and recency_days >= $10) or reactivation_potential then 2
+                     else 1 end as priority_rank,
+                array_remove(array[
+                    case when return_at_risk then 'return_at_risk' end,
+                    case when no_recorded_attendance then 'no_recorded_attendance' end,
+                    case when high_value_inactive then 'high_value_inactive' end,
+                    case when frequent then 'frequent' end,
+                    case when balanced_vip then 'balanced_vip' end,
+                    case when first_return then 'first_return' end,
+                    case when reactivation_potential then 'reactivation_potential' end
+                ], null) as segment_keys
+            from classified
+         ), filtered as (
+            select ranked.*
+            from ranked
+            where ($4::text = '' or position($4::text in lower(ranked.canonical_name)) > 0
+                   or position($4::text in translate(lower(ranked.canonical_name),
+                       'áàâãäåéèêëíìîïóòôõöúùûüçñ',
+                       'aaaaaaeeeeiiiiooooouuuucn')) > 0)
+              and ($5::text = '' or $5::text = any(ranked.segment_keys))
+              and ($6::text = '' or ranked.priority_rank = case $6::text when 'high' then 3 when 'medium' then 2 when 'normal' then 1 else 0 end)
+         ), stats as (
+            select count(*)::int as filtered_total,
+                count(*) filter (where return_at_risk)::int as return_at_risk_total,
+                count(*) filter (where high_value_inactive)::int as high_value_inactive_total,
+                count(*) filter (where frequent)::int as frequent_total,
+                count(*) filter (where balanced_vip)::int as balanced_vip_total,
+                count(*) filter (where reactivation_potential)::int as reactivation_potential_total,
+                count(*) filter (where cardinality(source_types) >= 2)::int as confirmed_multi_source_total,
+                count(*) filter (where cardinality(source_types) < 2)::int as unresolved_single_source_total,
+                coalesce(sum(lifetime_sales), 0)::numeric as lifetime_sales_total,
+                coalesce(sum(sale_count), 0)::int as sale_count_total
+            from filtered
+         ), page as (
+            select filtered.*
+            from filtered
+            order by ${orderBy}
+            limit $7 offset $8
+         )
+         select page.*, stats.*
+         from stats
+         left join page on true`,
+        [asOf, unitSlugs, COMMERCIAL_ACTIVE_ACTION_STATUSES, search, segment, priority, limit, offset, returnRisk, longAbsence, veryLongAbsence],
+    )
+    const rows = result.rows || []
+    const first = rows[0] || {}
+    const profileRows = rows.filter((row) => row.identity_id)
+    const benchmarks = {
+        salesP75: Number(first.sales_p75 || 0),
+        visitsP75: Number(first.visits_p75 || 0),
+    }
+    const byIdentity = new Map(profileRows.map((row) => [String(row.identity_id), row]))
+    const profiles = segmentCommercialProfiles(profileRows.map(commercialProfileRowInput), { asOf, thresholds, benchmarks }).map((profile) => ({
+        ...profile,
+        activeActionCount: Number(byIdentity.get(profile.identityId)?.active_action_count || 0),
+        lastActionAt: byIdentity.get(profile.identityId)?.last_action_at || null,
+    }))
+    const eligibilityByIdentity = await queryCommercialContactEligibility(pgPool, profiles.map((profile) => profile.identityId), { unitSlugs })
+    const hydratedProfiles = profiles.map((profile) => ({
+        ...profile,
+        contactEligibility: eligibilityByIdentity.get(profile.identityId)
+            || emptyCommercialContactEligibility('commercial_contact_controls_not_ready'),
+    }))
+    const contactEligibility = hydratedProfiles.reduce((summary, profile) => {
+        const status = profile.contactEligibility?.status || 'review_required'
+        if (status === 'eligible') summary.eligible += 1
+        else if (status === 'blocked') summary.blocked += 1
+        else summary.reviewRequired += 1
+        summary.controlsReady = summary.controlsReady && !!profile.contactEligibility?.controlsReady
+        summary.contactWriteControlsReady = summary.contactWriteControlsReady && !!profile.contactEligibility?.contactWriteControlsReady
+        return summary
+    }, {
+        eligible: 0,
+        blocked: 0,
+        reviewRequired: 0,
+        controlsReady: profiles.length > 0,
+        contactWriteControlsReady: profiles.length > 0,
+        scope: 'page',
+    })
+    const total = Number(first.filtered_total || 0)
+    const saleCountTotal = Number(first.sale_count_total || 0)
+    const lifetimeSalesTotal = Number(first.lifetime_sales_total || 0)
+    return {
+        profiles: hydratedProfiles,
+        total,
+        limit,
+        offset,
+        summary: {
+            profiles: total,
+            returnAtRisk: Number(first.return_at_risk_total || 0),
+            highValueInactive: Number(first.high_value_inactive_total || 0),
+            frequent: Number(first.frequent_total || 0),
+            balancedVip: Number(first.balanced_vip_total || 0),
+            reactivationPotential: Number(first.reactivation_potential_total || 0),
+            averageTicket: saleCountTotal ? Math.round((lifetimeSalesTotal / saleCountTotal) * 100) / 100 : 0,
+        },
+        coverage: {
+            identitiesVisible: total,
+            confirmedMultiSourceIdentities: Number(first.confirmed_multi_source_total || 0),
+            unresolvedSingleSourceIdentities: Number(first.unresolved_single_source_total || 0),
+        },
+        contactEligibility,
+        pagination: {
+            mode: 'sql',
+            sort,
+            direction,
+            hasPrevious: offset > 0,
+            hasNext: offset + profiles.length < total,
+        },
+    }
 }
 
 function minimizeCommercialProfile(profile) {
@@ -4850,14 +5108,22 @@ export function createAtendimentoStore(options = {}) {
                 readCommercialPolicy(pgPool),
                 readCommercialContactAvailability(pgPool),
             ])
-            const profiles = await queryCommercialProfiles(pgPool, {
+            const serverPage = String(query?.server || '').trim() === '1'
+                ? await queryCommercialProfilesServerPage(pgPool, {
+                    asOf,
+                    unitSlugs,
+                    thresholds: policy.returnRiskThresholds,
+                    query,
+                })
+                : null
+            const profiles = serverPage?.profiles || await queryCommercialProfiles(pgPool, {
                 asOf,
                 unitSlugs,
                 thresholds: policy.returnRiskThresholds,
             })
-            const filtered = filterCommercialProfiles(profiles, query)
-            const limit = sanitizeLimit(query?.limit, 100, 250)
-            const offset = sanitizeOffset(query?.offset, 0)
+            const filtered = serverPage ? profiles : filterCommercialProfiles(profiles, query)
+            const limit = serverPage?.limit || sanitizeLimit(query?.limit, 100, 250)
+            const offset = serverPage?.offset || sanitizeOffset(query?.offset, 0)
             const [quality, mappedItems, allItems, actions, unlinkedAttendance, identityFreshness] = await Promise.all([
                 pgPool.query(
                     `select count(*)::int as future_attendances
@@ -4901,9 +5167,11 @@ export function createAtendimentoStore(options = {}) {
                            where member.source_type = 'attendance_client' and member.source_id = canonical.id::text
                        )`, [unitSlugs],
                 ),
-                profiles.length
-                    ? pgPool.query(`select max(updated_at) as updated_at from crm_atendimento.global_client_identities where id = any($1::uuid[])`, [profiles.map((profile) => profile.identityId)])
-                    : Promise.resolve({ rows: [] }),
+                serverPage
+                    ? pgPool.query('select max(updated_at) as updated_at from crm_atendimento.global_client_identities')
+                    : profiles.length
+                        ? pgPool.query(`select max(updated_at) as updated_at from crm_atendimento.global_client_identities where id = any($1::uuid[])`, [profiles.map((profile) => profile.identityId)])
+                        : Promise.resolve({ rows: [] }),
             ])
             const contactEligibility = profiles.reduce((summary, profile) => {
                 const status = profile.contactEligibility?.status || 'review_required'
@@ -4923,12 +5191,12 @@ export function createAtendimentoStore(options = {}) {
             return {
                 asOf,
                 policy: commercialPolicyForActor(policy, actor),
-                summary: summarizeCommercialProfiles(profiles),
+                summary: serverPage?.summary || summarizeCommercialProfiles(profiles),
                 actions,
                 coverage: {
-                    identitiesVisible: profiles.length,
-                    confirmedMultiSourceIdentities: profiles.filter((profile) => profile.identityQuality === 'confirmed_multi_source').length,
-                    unresolvedSingleSourceIdentities: profiles.filter((profile) => profile.identityQuality === 'unresolved_single_source').length,
+                    identitiesVisible: serverPage?.coverage.identitiesVisible ?? profiles.length,
+                    confirmedMultiSourceIdentities: serverPage?.coverage.confirmedMultiSourceIdentities ?? profiles.filter((profile) => profile.identityQuality === 'confirmed_multi_source').length,
+                    unresolvedSingleSourceIdentities: serverPage?.coverage.unresolvedSingleSourceIdentities ?? profiles.filter((profile) => profile.identityQuality === 'unresolved_single_source').length,
                     classifiedSaleItems: Number(mappedItems.rows[0]?.count || 0),
                     saleItems: Number(allItems.rows[0]?.count || 0),
                 },
@@ -4938,12 +5206,19 @@ export function createAtendimentoStore(options = {}) {
                     saleItemsWithoutClassification: Math.max(0, Number(allItems.rows[0]?.count || 0) - Number(mappedItems.rows[0]?.count || 0)),
                     activeAttendanceClientsWithoutIdentity: Number(unlinkedAttendance.rows[0]?.count || 0),
                     identityDataUpdatedAt: identityFreshness.rows[0]?.updated_at || null,
-                    contactEligibility,
+                    contactEligibility: serverPage?.contactEligibility || contactEligibility,
                 },
-                total: filtered.length,
+                total: serverPage?.total ?? filtered.length,
                 limit,
                 offset,
-                profiles: filtered.slice(offset, offset + limit).map(minimizeCommercialProfile),
+                pagination: serverPage?.pagination || {
+                    mode: 'legacy',
+                    sort: 'priority',
+                    direction: 'desc',
+                    hasPrevious: offset > 0,
+                    hasNext: offset + limit < filtered.length,
+                },
+                profiles: (serverPage ? filtered : filtered.slice(offset, offset + limit)).map(minimizeCommercialProfile),
             }
         },
 

--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -468,6 +468,12 @@ export function ClientCommercialModule() {
   const [segment, setSegment] = useState('')
   const [priority, setPriority] = useState('')
   const [search, setSearch] = useState('')
+  const [pageOffset, setPageOffset] = useState(0)
+  const [sort, setSort] = useState('priority')
+  const [direction, setDirection] = useState<'asc' | 'desc'>('desc')
+  const [savedViewName, setSavedViewName] = useState('')
+  const [savedViews, setSavedViews] = useState<Array<{ name: string; unit: string; segment: string; priority: string; search: string; sort: string; direction: 'asc' | 'desc' }>>([])
+  const pageSize = 50
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -505,12 +511,31 @@ export function ClientCommercialModule() {
     }
   }, [])
 
-  const load = useCallback(async (next?: { selectIdentityId?: string }) => {
+  const load = useCallback(async (next?: {
+    selectIdentityId?: string
+    offset?: number
+    unit?: string
+    segment?: string
+    priority?: string
+    search?: string
+    sort?: string
+    direction?: 'asc' | 'desc'
+  }) => {
     try {
       setBusy(true); setError('')
-      const [commercial, references] = await Promise.all([fetchCommercialOverview({ unit, segment, priority, q: search, limit: 100 }), fetchCommercialReferences()])
+      const requestOffset = next?.offset ?? pageOffset
+      const requestUnit = next?.unit ?? unit
+      const requestSegment = next?.segment ?? segment
+      const requestPriority = next?.priority ?? priority
+      const requestSearch = next?.search ?? search
+      const requestSort = next?.sort ?? sort
+      const requestDirection = next?.direction ?? direction
+      const [commercial, references] = await Promise.all([fetchCommercialOverview({ unit: requestUnit, segment: requestSegment, priority: requestPriority, q: requestSearch, limit: pageSize, offset: requestOffset, server: true, sort: requestSort, direction: requestDirection }), fetchCommercialReferences()])
       if (!commercial.ok) throw new Error(commercial.error || 'Não foi possível carregar a inteligência comercial.')
       if (!references.ok) throw new Error(references.error || 'Não foi possível carregar referências do CRM.')
+      setPageOffset(requestOffset)
+      setSort(requestSort)
+      setDirection(requestDirection)
       setOverview(commercial); setUnits(references.units); setProfessionals(references.professionals.map((person) => ({ name: person.name }))); setProcedureOptions(references.procedures.map((procedure) => ({ id: procedure.id, name: procedure.name })))
       setCooldown(commercial.policy.activeContactCooldownDays); setThresholds(commercial.policy.returnRiskThresholds.join(','))
       setCommercialContactWritesEnabled(commercial.policy.commercialContactWritesEnabled === true)
@@ -523,7 +548,7 @@ export function ClientCommercialModule() {
     } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível carregar a inteligência comercial.') } finally { setBusy(false) }
   // Filters are deliberately applied only with the button, so typing does not trigger a request per keystroke.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [unit, segment, priority, search, detail?.profile.identityId])
+  }, [unit, segment, priority, search, pageOffset, sort, direction, detail?.profile.identityId])
 
   const loadDetail = useCallback(async (identityId: string, asOf?: string) => {
     const result = await fetchCommercialProfile(identityId, { asOf, unit })
@@ -534,6 +559,34 @@ export function ClientCommercialModule() {
   // Initial load intentionally runs once; changing filters is explicit through “Aplicar”.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { void load() }, [])
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem('skincos:clientes:saved-views')
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) setSavedViews(parsed.filter((item) => item && typeof item.name === 'string').slice(0, 12))
+      }
+    } catch { /* local view persistence is best-effort and never blocks the module */ }
+  }, [])
+
+  const persistSavedViews = (next: typeof savedViews) => {
+    setSavedViews(next)
+    try { window.localStorage.setItem('skincos:clientes:saved-views', JSON.stringify(next)) } catch { /* ignore unavailable storage */ }
+  }
+
+  const saveCurrentView = () => {
+    const name = savedViewName.trim()
+    if (!name) { setError('Informe um nome para salvar esta visão.'); return }
+    const next = [{ name, unit, segment, priority, search, sort, direction }, ...savedViews.filter((view) => view.name !== name)].slice(0, 12)
+    persistSavedViews(next)
+    setSavedViewName('')
+  }
+
+  const applySavedView = (view: typeof savedViews[number]) => {
+    setUnit(view.unit); setSegment(view.segment); setPriority(view.priority); setSearch(view.search); setSort(view.sort); setDirection(view.direction); setPageOffset(0)
+    void load({ unit: view.unit, segment: view.segment, priority: view.priority, search: view.search, sort: view.sort, direction: view.direction, offset: 0 })
+  }
 
   const refreshDetail = useCallback(async () => {
     if (!detail) return
@@ -600,20 +653,22 @@ export function ClientCommercialModule() {
   }
 
   const segmentOptions = useMemo(() => [{ key: '', label: 'Todos os segmentos' }, { key: 'return_at_risk', label: 'Retorno em risco' }, { key: 'high_value_inactive', label: 'Alto valor inativo' }, { key: 'frequent', label: 'Assíduos' }, { key: 'balanced_vip', label: 'VIP equilibrado' }, { key: 'first_return', label: 'Primeiro retorno' }, { key: 'reactivation_potential', label: 'Potencial de reativação' }], [])
+  const contactScopeSuffix = contactSummary.scope === 'page' ? ' na página atual' : ''
 
   return <section className="space-y-6 text-white">
     <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"><div><h1 className="text-2xl font-bold tracking-tight">Clientes</h1><p className="mt-1 text-sm text-slate-400">Prioridades comerciais baseadas em presença registrada, vendas e procedimentos confirmados.</p></div><div className="flex flex-wrap gap-2"><Button variant="outline" onClick={() => void load()} disabled={busy}><RefreshCw className={`mr-2 h-4 w-4 ${busy ? 'animate-spin' : ''}`} />Atualizar</Button><Button variant="outline" onClick={() => setSettingsOpen((value) => !value)}><ShieldCheck className="mr-2 h-4 w-4" />Políticas clínicas</Button></div></header>
     {error ? <div className="rounded-xl border border-rose-300/30 bg-rose-500/10 p-4 text-sm text-rose-100">{error}</div> : null}
-    {overview ? <div className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><div><b>Uso comercial seguro:</b> a recência considera apenas o último atendimento realizado. Compras antecipadas não representam procedimento realizado. {overview.dataQuality.futureAttendancesExcluded ? `${overview.dataQuality.futureAttendancesExcluded} atendimento(s) futuro(s) foram excluídos desta métrica. ` : ''}{overview.dataQuality.activeAttendanceClientsWithoutIdentity ? `${overview.dataQuality.activeAttendanceClientsWithoutIdentity} cliente(s) de Atendimento ainda não têm identidade comercial. ` : ''}{contactSummary.controlsReady ? `${contactSummary.eligible} apto(s), ${contactSummary.blocked} bloqueado(s) e ${contactSummary.reviewRequired} em revisão para WhatsApp. ` : 'Os controles de contato ainda não foram migrados; nenhum contato pode ser marcado. '}{!contactSummary.contactWriteControlsReady ? 'A cadência de contato aguarda a migration explícita; filas novas, concessões e registros de contato seguem bloqueados. ' : overview.policy.commercialContactWritesEnabled ? `Canário de contato ativo para ${overview.policy.commercialContactCanaryIdentityIds?.length || 0} identidade(s).` : 'Registro de contato e novas permissões concedidas seguem bloqueados até a abertura explícita de um canário.'}</div></div></div> : null}
+    {overview ? <div className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><div><b>Uso comercial seguro:</b> a recência considera apenas o último atendimento realizado. Compras antecipadas não representam procedimento realizado. {overview.dataQuality.futureAttendancesExcluded ? `${overview.dataQuality.futureAttendancesExcluded} atendimento(s) futuro(s) foram excluídos desta métrica. ` : ''}{overview.dataQuality.activeAttendanceClientsWithoutIdentity ? `${overview.dataQuality.activeAttendanceClientsWithoutIdentity} cliente(s) de Atendimento ainda não têm identidade comercial. ` : ''}{contactSummary.controlsReady ? `${contactSummary.eligible} apto(s), ${contactSummary.blocked} bloqueado(s) e ${contactSummary.reviewRequired} em revisão para WhatsApp${contactScopeSuffix}. ` : 'Os controles de contato ainda não foram migrados; nenhum contato pode ser marcado. '}{!contactSummary.contactWriteControlsReady ? 'A cadência de contato aguarda a migration explícita; filas novas, concessões e registros de contato seguem bloqueados. ' : overview.policy.commercialContactWritesEnabled ? `Canário de contato ativo para ${overview.policy.commercialContactCanaryIdentityIds?.length || 0} identidade(s).` : 'Registro de contato e novas permissões concedidas seguem bloqueados até a abertura explícita de um canário.'}</div></div></div> : null}
     {settingsOpen ? <section className="grid gap-4 rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 xl:grid-cols-2"><div><h2 className="font-semibold text-white">Política de reativação</h2><p className="mt-1 text-sm text-slate-500">Define o intervalo entre contatos assistidos e as faixas de ausência, sem alterar o histórico clínico.</p><div className="mt-4 grid gap-2 sm:grid-cols-2"><label className="text-xs text-slate-400">Intervalo mínimo de contato (dias)<input type="number" value={cooldown} onChange={(event) => setCooldown(Number(event.target.value))} className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /></label><label className="text-xs text-slate-400">Faixas de ausência<input value={thresholds} onChange={(event) => setThresholds(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /></label></div>{!policyWriteControlsReady ? <p className="mt-4 text-xs text-amber-200">A migration de rollout ainda não está presente neste ambiente. As faixas podem ser salvas, mas o canário permanece indisponível.</p> : null}<label className="mt-4 flex items-start gap-2 text-xs text-amber-100"><input type="checkbox" checked={commercialContactWritesEnabled} disabled={!policyWriteControlsReady} onChange={(event) => setCommercialContactWritesEnabled(event.target.checked)} className="mt-0.5" />Abrir somente o canário de registros de contato. Isto não envia mensagens.</label><CanarySelection profiles={overview?.profiles || []} selectedIds={selectedCanaryIdentityIds} disabled={!policyWriteControlsReady} onToggle={toggleCanaryIdentity} onClear={() => setSelectedCanaryIdentityIds([])} /><Button size="sm" onClick={() => void savePolicy()} disabled={busy} className="mt-3"><Save className="mr-2 h-4 w-4" />Salvar política</Button></div><div className="border-t border-slate-800 pt-4 xl:border-l xl:border-t-0 xl:pl-4 xl:pt-0"><h2 className="font-semibold text-white">Cadência clínica</h2><p className="mt-1 text-sm text-slate-500">Gestores podem manter rascunhos ou desativar regras não aprovadas. A aprovação clínica exige um fluxo verificado e não está disponível neste módulo.</p><div className="mt-4 grid gap-2 sm:grid-cols-3"><select value={cadenceProcedure} onChange={(event) => setCadenceProcedure(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white"><option value="">Procedimento</option>{procedureOptions.map((procedure) => <option key={procedure.id} value={procedure.id}>{procedure.name}</option>)}</select><input type="number" min="1" placeholder="Dias" value={cadenceDays} onChange={(event) => setCadenceDays(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /><select value={cadenceStatus} onChange={(event) => setCadenceStatus(event.target.value as CommercialCadenceManagerStatus)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white">{commercialCadenceManagerStatuses.map((status) => <option key={status} value={status}>{commercialCadenceStatusLabels[status]}</option>)}</select></div><Button size="sm" variant="outline" onClick={() => void saveCadence()} disabled={busy || !cadenceProcedure || !cadenceDays} className="mt-3"><Save className="mr-2 h-4 w-4" />Salvar cadência</Button>{cadenceNotice ? <div className="mt-2 text-xs text-slate-400">{cadenceNotice}</div> : null}</div></section> : null}
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><Metric label="Retorno em risco" value={overview?.summary.returnAtRisk ?? '—'} detail="Sem presença registrada na faixa configurada" icon={CalendarClock} /><Metric label="Alto valor inativo" value={overview?.summary.highValueInactive ?? '—'} detail="Valor e ausência combinados" icon={CircleDollarSign} /><Metric label="Potencial de reativação" value={overview?.summary.reactivationPotential ?? '—'} detail="Prioridade para a equipe" icon={UserRoundCheck} /><Metric label="Aptos para WhatsApp" value={overview ? contactSummary.eligible : '—'} detail="Permissão explícita e bloqueios verificados" icon={UsersRound} /></div>
     {commercialDataQualityError ? <div className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100">{commercialDataQualityError}</div> : null}
     {commercialDataQuality ? <CommercialDataQualityPanel queue={commercialDataQuality} loading={commercialDataQualityBusy} onRefresh={loadCommercialDataQuality} /> : null}
-    <div className="flex flex-wrap gap-2 rounded-xl border border-slate-800/80 bg-slate-950/45 p-3"><select aria-label="Unidade" value={unit} onChange={(event) => setUnit(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select><select aria-label="Segmento" value={segment} onChange={(event) => setSegment(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">{segmentOptions.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}</select><select aria-label="Prioridade" value={priority} onChange={(event) => setPriority(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Todas as prioridades</option><option value="high">Alta</option><option value="medium">Média</option><option value="normal">Normal</option></select><input aria-label="Buscar cliente" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Buscar cliente" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><Button size="sm" onClick={() => void load()} disabled={busy}>Aplicar</Button></div>
+    <div className="flex flex-wrap gap-2 rounded-xl border border-slate-800/80 bg-slate-950/45 p-3"><select aria-label="Unidade" value={unit} onChange={(event) => setUnit(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select><select aria-label="Segmento" value={segment} onChange={(event) => setSegment(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">{segmentOptions.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}</select><select aria-label="Prioridade" value={priority} onChange={(event) => setPriority(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Todas as prioridades</option><option value="high">Alta</option><option value="medium">Média</option><option value="normal">Normal</option></select><input aria-label="Buscar cliente" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Buscar cliente" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><select aria-label="Ordenar clientes" value={sort} onChange={(event) => setSort(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="priority">Prioridade</option><option value="recency">Recência</option><option value="lifetime_sales">Faturamento</option><option value="visits">Visitas</option><option value="sales">Compras</option><option value="last_attendance">Último atendimento</option><option value="name">Nome</option></select><select aria-label="Direção da ordenação" value={direction} onChange={(event) => setDirection(event.target.value as 'asc' | 'desc')} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="desc">Maior primeiro</option><option value="asc">Menor primeiro</option></select><Button size="sm" onClick={() => void load({ offset: 0 })} disabled={busy}>Aplicar</Button><div className="flex w-full flex-wrap gap-2 border-t border-slate-800/80 pt-3"><input aria-label="Nome da visão salva" value={savedViewName} onChange={(event) => setSavedViewName(event.target.value)} placeholder="Nome da visão" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><Button size="sm" variant="outline" onClick={saveCurrentView} disabled={busy}>Salvar visão</Button>{savedViews.length ? <select aria-label="Visões salvas" defaultValue="" onChange={(event) => { const view = savedViews.find((item) => item.name === event.target.value); if (view) applySavedView(view); event.currentTarget.value = '' }} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Abrir visão salva</option>{savedViews.map((view) => <option key={view.name} value={view.name}>{view.name}</option>)}</select> : null}</div></div>
     <div className="grid gap-5 2xl:grid-cols-[minmax(0,1.7fr)_minmax(22rem,0.8fr)]">
       <section className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/55 shadow-[0_20px_60px_rgba(2,6,23,0.28)]">
         <div className="flex items-center justify-between border-b border-slate-800/80 p-5"><div><h2 className="font-semibold text-white">Prioridades de reativação</h2><p className="mt-1 text-xs text-slate-500">{overview ? `${overview.total} clientes na seleção atual` : 'Carregando clientes…'}</p></div><div className="text-xs text-slate-500">Fila: {overview?.actions.actions ?? 0} · Contatos: {overview?.actions.contactedActions ?? 0}</div></div>
         <div className="overflow-x-auto"><table className="w-full min-w-190 text-sm"><thead className="bg-white/[0.025] text-left text-xs font-medium text-slate-400"><tr><th className="p-3">Cliente</th><th className="p-3">Último atendimento</th><th className="p-3 text-right">Faturamento</th><th className="p-3">Frequência</th><th className="p-3">Próxima ação</th><th className="p-3">Prioridade</th><th className="p-3" /></tr></thead><tbody>{overview?.profiles.map((profile) => <tr key={profile.identityId} onClick={() => void loadDetail(profile.identityId, overview.asOf)} className={`cursor-pointer border-t border-slate-800/70 transition hover:bg-sky-500/[0.05] ${detail?.profile.identityId === profile.identityId ? 'bg-sky-500/[0.08]' : ''}`}><td className="p-3"><div className="font-medium text-slate-100">{profile.name}</div><div className="mt-0.5 text-xs text-slate-500">{profile.identityQuality.replace(/_/g, ' ')}</div><div className={`mt-1 text-[11px] ${contactEligibilityTextStyle(profile.contactEligibility)}`}>{contactEligibilityLabel(profile.contactEligibility)}</div></td><td className="p-3"><div className="text-slate-200">{formatDate(profile.lastAttendance)}</div><div className={`mt-0.5 text-xs ${profile.recencyDays != null && profile.recencyDays >= 180 ? 'text-rose-300' : 'text-slate-500'}`}>{profile.recencyDays == null ? 'Sem presença confirmada' : `${profile.recencyDays} dias`}</div></td><td className="p-3 text-right"><div className="font-medium text-slate-100">{currency.format(profile.lifetimeSales)}</div><div className="mt-0.5 text-xs text-slate-500">{profile.saleCount} compra(s)</div></td><td className="p-3"><div className="text-slate-200">{profile.visitCount} visita(s)</div><div className="mt-0.5 text-xs text-slate-500">{profile.procedureCount} procedimento(s)</div></td><td className="max-w-56 p-3 text-slate-300">{profile.recommendedAction}</td><td className="p-3"><SegmentBadge profile={profile} /></td><td className="p-3 text-right"><ChevronRight className="inline h-4 w-4 text-slate-500" /></td></tr>)}</tbody></table>{overview && !overview.profiles.length ? <div className="p-8 text-center text-sm text-slate-500">Nenhum cliente encontrado para os filtros selecionados.</div> : null}</div>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800/80 p-4 text-xs text-slate-500"><span>{overview ? `${overview.total ? pageOffset + 1 : 0}–${Math.min(pageOffset + overview.profiles.length, overview.total)} de ${overview.total}` : 'Carregando…'}{overview?.pagination?.mode === 'sql' ? ' · paginação SQL' : ''}</span><div className="flex gap-2"><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasPrevious} onClick={() => void load({ offset: Math.max(0, pageOffset - pageSize) })}>Anterior</Button><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasNext} onClick={() => void load({ offset: pageOffset + pageSize })}>Próxima</Button></div></div>
       </section>
       <ProfilePanel detail={detail} units={units} professionals={professionals} onRefresh={refreshDetail} />
     </div>

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -924,11 +924,12 @@ export type CommercialOverview = {
     saleItemsWithoutClassification: number
     activeAttendanceClientsWithoutIdentity: number
     identityDataUpdatedAt: string | null
-    contactEligibility: { eligible: number; blocked: number; reviewRequired: number; controlsReady: boolean; contactWriteControlsReady: boolean }
+    contactEligibility: { eligible: number; blocked: number; reviewRequired: number; controlsReady: boolean; contactWriteControlsReady: boolean; scope?: 'page' | 'all' }
   }
   total: number
   limit: number
   offset: number
+  pagination?: { mode: 'sql' | 'legacy'; sort: string; direction: 'asc' | 'desc'; hasPrevious: boolean; hasNext: boolean }
   profiles: CommercialProfile[]
 }
 
@@ -984,9 +985,12 @@ export type ClientIdentityMaterialization = {
   }
 }
 
-export function fetchCommercialOverview(filters: { asOf?: string; unit?: string; segment?: string; priority?: string; q?: string; limit?: number; offset?: number } = {}) {
+export function fetchCommercialOverview(filters: { asOf?: string; unit?: string; segment?: string; priority?: string; q?: string; limit?: number; offset?: number; server?: boolean; sort?: string; direction?: 'asc' | 'desc' } = {}) {
   const params = new URLSearchParams()
-  Object.entries(filters).forEach(([key, value]) => { if (value !== undefined && value !== '' && value !== 'all') params.set(key, String(value)) })
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value === true) params.set(key, '1')
+    else if (value !== undefined && value !== '' && value !== 'all') params.set(key, String(value))
+  })
   const qs = params.toString()
   return api<CommercialOverview>(`/commercial/overview${qs ? `?${qs}` : ''}`)
 }

--- a/crm/console/tests/clientCommercialPagination.test.ts
+++ b/crm/console/tests/clientCommercialPagination.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const moduleSource = readFileSync(new URL('../ClientCommercialModule.tsx', import.meta.url), 'utf8')
+const apiSource = readFileSync(new URL('../atendimentoApi.ts', import.meta.url), 'utf8')
+
+describe('Clientes commercial pagination', () => {
+  it('requests bounded server pagination and exposes deterministic navigation', () => {
+    expect(moduleSource).toContain('server: true')
+    expect(moduleSource).toContain('limit: pageSize')
+    expect(moduleSource).toContain('Anterior')
+    expect(moduleSource).toContain('Próxima')
+    expect(moduleSource).toContain('paginação SQL')
+    expect(moduleSource).not.toContain('fetchCommercialOverview({ unit, segment, priority, q: search, limit: 100')
+  })
+
+  it('serializes sort, direction and the explicit server opt-in', () => {
+    expect(apiSource).toContain("server?: boolean")
+    expect(apiSource).toContain("sort?: string")
+    expect(apiSource).toContain("direction?: 'asc' | 'desc'")
+    expect(apiSource).toContain("if (value === true) params.set(key, '1')")
+  })
+})

--- a/docs/runbooks/clientes-commercial-contact-rollout.md
+++ b/docs/runbooks/clientes-commercial-contact-rollout.md
@@ -42,9 +42,11 @@ reavaliar a elegibilidade imediatamente antes do envio.
   venda ou retorno não contam como contato sem um `contacted_at` explícito.
 - O registro de contato e a concessão de uma nova permissão começam desligados.
   Para abrir um canário, um GESTOR precisa habilitar explicitamente o rollout e
-  fornecer uma allowlist de identidades UUID. Negar uma permissão continua
-  disponível mesmo fora do canário. O rollout libera somente registros no CRM;
-  ele não envia mensagens.
+  selecionar na própria fila apenas identidades materializadas e visíveis que
+  estejam elegíveis. O backend continua validando a allowlist persistida por
+  UUID, mas a UI não aceita uma lista manual de identificadores. Negar uma
+  permissão continua disponível mesmo fora do canário. O rollout libera
+  somente registros no CRM; ele não envia mensagens.
 - A política expõe uma versão opaca. A UI só envia campos de canário quando eles
   foram realmente alterados e acompanha a versão lida; uma atualização
   concorrente responde conflito em vez de reabrir, fechar ou esvaziar um

--- a/docs/runbooks/clientes-commercial-pagination.md
+++ b/docs/runbooks/clientes-commercial-pagination.md
@@ -1,0 +1,53 @@
+# Clientes — paginação comercial e visões salvas
+
+## Objetivo
+
+A fila comercial do módulo Clientes usa a rota de overview com `server=1` para
+evitar materializar todas as identidades no navegador. O banco calcula os
+agregados, os percentis de referência, os filtros, a ordenação e o total antes
+de devolver a página visível.
+
+## Contrato
+
+- `limit` é limitado pelo backend a 100 (a UI usa 50 por página); `offset` é
+  não-negativo e a resposta informa `total` e `pagination.hasPrevious/hasNext`.
+- `sort` aceita somente `priority`, `recency`, `lifetime_sales`, `visits`,
+  `sales`, `last_attendance` e `name`; qualquer outro valor retorna ao padrão
+  de prioridade. `direction` aceita apenas `asc` ou `desc`.
+- `q`, `segment` e `priority` são aplicados na mesma consulta que produz o
+  total. Os benchmarks P75 de faturamento e visitas são calculados sobre o
+  conjunto filtrável completo, não sobre a página atual.
+- A rota sem `server=1` continua disponível como compatibilidade para clientes
+  antigos e mantém o comportamento legado limitado em memória.
+- A elegibilidade de contato retornada no caminho SQL é explicitamente
+  `scope: "page"`; ela nunca deve ser interpretada como contagem global da
+  fila. O número de telefone continua removido do payload da tabela.
+
+## Visões salvas
+
+As visões salvas são preferências locais do navegador em
+`skincos:clientes:saved-views`. Elas contêm somente unidade, filtros, busca e
+ordenação; não guardam nomes, telefones, IDs de identidade, consentimentos ou
+qualquer dado do cliente. A persistência é best-effort: indisponibilidade do
+`localStorage` não impede a fila de funcionar. Há no máximo 12 visões e uma
+visão com o mesmo nome é substituída de forma determinística.
+
+## Rollback e promoção
+
+O backend só usa a consulta paginada quando o chamador envia `server=1`, então o
+rollback imediato é retirar esse parâmetro no console ou reverter a release;
+nenhuma migration é necessária. A promoção deve manter o par backend/Pages na
+mesma release: o frontend desta tranche requer o contrato `pagination` e a rota
+`server=1`, enquanto callers legados permanecem compatíveis. Validar o health
+do módulo, a resposta sintética de overview e a ausência de escrita de contato
+antes de qualquer ambiente autorizado.
+
+## Verificação
+
+```bash
+npm --prefix crm/api test
+npm --prefix crm/console run test
+npm --prefix crm/console run typecheck
+npm --prefix crm/console run lint
+npm --prefix crm/console run build
+```


### PR DESCRIPTION
# Summary

Move the Clientes commercial overview to an explicit bounded SQL path while keeping the legacy read compatible for older callers.

The new path computes filtering, deterministic sorting, global P75 benchmarks, totals, and page slicing in PostgreSQL. The console uses 50-row pages, server-side navigation, local non-PII saved views, and labels contact counts as page-scoped. Consent/blocking eligibility remains fail-closed and only the visible page is hydrated.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [x] Docs
- [x] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [x] Performance impact measured

## Links
- Issue: —
- Design/ADR: docs/runbooks/clientes-commercial-pagination.md
- Migration steps: none; rollback is disabling the explicit server path or reverting the release

## Screenshots / Evidence

- API: 283 tests, 282 passed, 1 explicit skip, 0 failures.
- Console: 46 test files, 239 passed.
- Typecheck: passed in isolated Ubuntu-24.04 ext4 validation runtime.
- Lint: 0 errors, 95 pre-existing hook warnings.
- Build/bundle budget: passed; initial bundle 563.2 KiB, no budget failures.
- Added coverage for bounded query parameters, sort/direction serialization, safe navigation, contact scope, and empty-page totals.
