### PR TITLE
feat(clientes): checkpoint and automate source refresh

### DIFF
--- a/crm/api/README.md
+++ b/crm/api/README.md
@@ -99,4 +99,8 @@ Rotas: `/api/atendimento/*`
   - `ATENDIMENTO_GOOGLE_SA_FILE` (ou `HARMONIA_GOOGLE_SA_FILE`)
   - Dry-run: `npm run import-atendimento-sheet`
   - Gravação: `npm run import-atendimento-sheet -- --write`
+- Refresh operacional target-bound: `CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging|production npm run refresh-atendimento-source -- --dry-run`.
+  Aplicações exigem `--apply`, `CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1`,
+  backup privado e identidade do banco correspondente; veja
+  `docs/runbooks/clientes-source-refresh.md`.
 - Módulo CRM: `atendimento`; gestores/gerentes acessam tudo, usuários comuns precisam do módulo liberado e respeitam `allowedUnits`.

--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -10,6 +10,7 @@
     "start:continuous-workers": "node continuous-worker.js",
     "test": "node --test server/__tests__/*.test.js server/harmonia/__tests__/*.test.js server/atendimento/__tests__/*.test.js server/caixa/__tests__/*.test.js services/__tests__/*.test.js scripts/*.test.mjs",
     "import-atendimento-sheet": "node scripts/import-atendimento-sheet.mjs",
+    "refresh-atendimento-source": "node scripts/refresh-atendimento-source.mjs",
     "import-gerencia-sheet": "node scripts/import-gerencia-sheet.mjs",
     "reconcile-client-identities": "node scripts/reconcile-client-identities.mjs",
     "reconcile-client-registrations": "node scripts/reconcile-client-registrations.mjs",

--- a/crm/api/scripts/refresh-atendimento-source.mjs
+++ b/crm/api/scripts/refresh-atendimento-source.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import { importAtendimentoFromGoogleSheet } from '../server/atendimento/importer.js'
+import { createAtendimentoStore } from '../server/atendimento/store.js'
+import {
+    assertClientesSourceRefreshDatabaseIdentity,
+    assertClientesSourceRefreshDatabaseUrl,
+    normalizeClientesSourceRefreshAction,
+    normalizeClientesSourceRefreshTarget,
+    sourceRefreshActor,
+    summarizeClientesSourceRefresh,
+} from '../server/atendimento/sourceRefresh.js'
+
+const args = new Set(process.argv.slice(2))
+const selectedActions = ['--dry-run', '--apply'].filter((flag) => args.has(flag))
+if (selectedActions.length > 1 || args.size !== selectedActions.length) {
+    throw new Error('Use exatamente --dry-run ou --apply.')
+}
+
+const action = normalizeClientesSourceRefreshAction(selectedActions[0] === '--apply' ? 'apply' : 'dry-run')
+const target = normalizeClientesSourceRefreshTarget(process.env.CRM_CLIENTES_SOURCE_REFRESH_TARGET)
+const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+assertClientesSourceRefreshDatabaseUrl(databaseUrl, target)
+
+if (action === 'apply' && !['1', 'true', 'yes', 'on'].includes(
+    String(process.env.CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED || '').trim().toLowerCase(),
+)) {
+    throw new Error('CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1 is required for --apply.')
+}
+
+const pool = createPgPool(databaseUrl)
+if (!pool) throw new Error('DATABASE_URL_NOT_CONFIGURED')
+
+let lockClient
+try {
+    lockClient = await pool.connect()
+    const identityResult = await lockClient.query(`select current_database() as database_name, current_user`)
+    const identity = assertClientesSourceRefreshDatabaseIdentity(identityResult.rows[0], target)
+    await lockClient.query(`select pg_advisory_lock(hashtext('skincos:clientes:source-refresh'))`)
+
+    const store = createAtendimentoStore({ pool, databaseUrl, schemaManaged: true })
+    const result = await importAtendimentoFromGoogleSheet(store, {
+        actor: sourceRefreshActor(target),
+        dryRun: action === 'dry-run',
+    })
+    process.stdout.write(`${JSON.stringify(summarizeClientesSourceRefresh({ target, action, identity, result }))}\n`)
+} finally {
+    if (lockClient) {
+        try { await lockClient.query(`select pg_advisory_unlock(hashtext('skincos:clientes:source-refresh'))`) } catch { /* preserve original result */ }
+        lockClient.release()
+    }
+    await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
@@ -48,23 +48,35 @@ test('builds only aggregate quality findings and preserves source freshness ages
     assert.equal(JSON.stringify(observations).match(/phone|email|evidence|source_id/i), null)
 })
 
-test('treats a missing or over-threshold mirror timestamp as stale without retaining a path', () => {
-    const stale = buildCommercialDataQualityObservations({ freshness: { latestImportAgeHours: 12 } })
+test('accepts a recent import checkpoint when the local mirror is absent', () => {
+    const fresh = buildCommercialDataQualityObservations({ freshness: { latestImportAgeHours: 12 } })
         .find((item) => item.key === 'source.local_mirror_stale')
-    assert.equal(stale?.observedCount, 1)
-    assert.deepEqual(stale?.metrics, {
+    assert.equal(fresh?.observedCount, 0)
+    assert.deepEqual(fresh?.metrics, {
         thresholdHours: COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS,
         latestImportAgeHours: 12,
     })
     assert.doesNotMatch(COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.freshness, /backup_path|source_fingerprint|path/i)
 })
 
-test('opens the freshness finding when the latest import is stale even if the mirror age is recent', () => {
+test('treats absent or jointly stale source checkpoints as stale', () => {
+    const missing = buildCommercialDataQualityObservations({ freshness: {} })
+        .find((item) => item.key === 'source.local_mirror_stale')
+    assert.equal(missing?.observedCount, 1)
+    const stale = buildCommercialDataQualityObservations({ freshness: { mirrorSyncedAgeHours: 49, latestImportAgeHours: 49 } })
+        .find((item) => item.key === 'source.local_mirror_stale')
+    assert.equal(stale?.observedCount, 1)
+    const mirrorFallback = buildCommercialDataQualityObservations({ freshness: { mirrorSyncedAgeHours: 12 } })
+        .find((item) => item.key === 'source.local_mirror_stale')
+    assert.equal(mirrorFallback?.observedCount, 0)
+})
+
+test('accepts a recent mirror checkpoint when the latest import is stale', () => {
     const freshness = buildCommercialDataQualityObservations({
         freshness: { mirrorSyncedAgeHours: 2, latestImportAgeHours: 49 },
     }).find((item) => item.key === 'source.local_mirror_stale')
 
-    assert.equal(freshness?.observedCount, 1)
+    assert.equal(freshness?.observedCount, 0)
     assert.deepEqual(freshness?.metrics, {
         thresholdHours: COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS,
         mirrorSyncedAgeHours: 2,

--- a/crm/api/server/atendimento/__tests__/sourceRefresh.test.js
+++ b/crm/api/server/atendimento/__tests__/sourceRefresh.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    assertClientesSourceRefreshDatabaseIdentity,
+    assertClientesSourceRefreshDatabaseUrl,
+    normalizeClientesSourceRefreshAction,
+    normalizeClientesSourceRefreshTarget,
+    sourceRefreshActor,
+    summarizeClientesSourceRefresh,
+} from '../sourceRefresh.js'
+
+test('normalizes only the explicit Clientes source refresh targets and actions', () => {
+    assert.equal(normalizeClientesSourceRefreshTarget(' STAGING '), 'staging')
+    assert.equal(normalizeClientesSourceRefreshAction('dry-run'), 'dry-run')
+    assert.throws(() => normalizeClientesSourceRefreshTarget('local'), { code: 'CLIENTES_SOURCE_REFRESH_TARGET_INVALID' })
+    assert.throws(() => normalizeClientesSourceRefreshAction('write'), { code: 'CLIENTES_SOURCE_REFRESH_ACTION_INVALID' })
+})
+
+test('accepts only the target-bound production and staging database URL shapes', () => {
+    assert.deepEqual(
+        assertClientesSourceRefreshDatabaseUrl(
+            'postgresql://skincos@/skincos_crm_local?host=/var/run/postgresql',
+            'production',
+        ),
+        { target: 'production', database: 'skincos_crm_local' },
+    )
+    assert.deepEqual(
+        assertClientesSourceRefreshDatabaseUrl(
+            'postgresql://skincos_staging_app:secret@127.0.0.1:5432/skincos_staging?sslmode=require',
+            'staging',
+        ),
+        { target: 'staging', database: 'skincos_staging' },
+    )
+    assert.throws(() => assertClientesSourceRefreshDatabaseUrl(
+        'postgresql://admin@127.0.0.1:5432/skincos_crm_local?sslmode=require',
+        'production',
+    ), { code: 'CLIENTES_SOURCE_REFRESH_PRODUCTION_DATABASE_UNSAFE' })
+})
+
+test('requires the expected database identity before source refresh', () => {
+    assert.deepEqual(
+        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_crm_local', current_user: 'skincos' }, 'production'),
+        { target: 'production', database: 'skincos_crm_local', user: 'skincos' },
+    )
+    assert.deepEqual(
+        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'skincos_staging_app' }, 'staging'),
+        { target: 'staging', database: 'skincos_staging', user: 'skincos_staging_app' },
+    )
+    assert.throws(() => assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'postgres' }, 'staging'), { code: 'CLIENTES_SOURCE_REFRESH_STAGING_IDENTITY_UNSAFE' })
+})
+
+test('uses a non-person actor and emits only aggregate refresh evidence', () => {
+    assert.deepEqual(sourceRefreshActor('production'), {
+        id: 'clientes-source-refresh-production',
+        username: 'clientes-source-refresh-production',
+        role: 'ADMIN',
+        allowedModules: ['atendimento'],
+    })
+    assert.deepEqual(summarizeClientesSourceRefresh({
+        target: 'staging',
+        action: 'apply',
+        identity: { database: 'skincos_staging', user: 'skincos_staging_app' },
+        result: {
+            dryRun: false,
+            records: 3,
+            inserted: 1,
+            updated: 2,
+            skipped: 0,
+            importBatchId: 'batch-1',
+            spreadsheetId: 'sheet-1',
+            tabs: ['Novo Hamburgo'],
+        },
+    }), {
+        ok: true,
+        target: 'staging',
+        action: 'apply',
+        database: 'skincos_staging',
+        databaseUser: 'skincos_staging_app',
+        dryRun: false,
+        records: 3,
+        inserted: 1,
+        updated: 2,
+        skipped: 0,
+        importBatchId: 'batch-1',
+        spreadsheetId: 'sheet-1',
+        tabs: ['Novo Hamburgo'],
+    })
+})

--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -1310,10 +1310,49 @@ test('imports source rows with one actor value for both audit columns', async ()
         actor: { id: 'google-sheet-import', role: 'GESTOR' },
     })
 
-    assert.deepEqual(result, { dryRun: false, records: 1, inserted: 1, updated: 0, skipped: 0 })
+    assert.deepEqual(result, { dryRun: false, records: 1, inserted: 1, updated: 0, skipped: 0, importBatchId: null })
     const write = queries.find(({ sql }) => sql.startsWith('insert into crm_atendimento.attendances('))
     assert.match(write.sql, /values \(\$1,\$2,\$3,\$4,\$5,\$6,\$7,\$8,\$9,\$10,\$11,\$12,\$13,\$14,\$15,\$16,\$17,\$18,\$19,\$19\)/)
     assert.equal(write.params.at(-1), 'google-sheet-import')
+})
+
+test('records an aggregate source checkpoint for a completed Google Sheets import', async () => {
+    const queries = []
+    const fakePool = createFakePool([
+        (sql, params) => {
+            queries.push({ sql, params })
+            if (sql.startsWith('insert into crm_atendimento.units(')) {
+                return { rows: [{ id: 'unit-1', slug: 'novo-hamburgo', name: 'Novo Hamburgo' }], rowCount: 1 }
+            }
+            if (sql.startsWith('insert into crm_atendimento.procedures(')) {
+                return { rows: [{ id: 'procedure-1', name: 'Botox' }], rowCount: 1 }
+            }
+            if (sql.startsWith('insert into crm_atendimento.attendances(')) {
+                return { rows: [{ id: 'attendance-1', inserted: true }], rowCount: 1 }
+            }
+            if (sql.startsWith('insert into crm_atendimento.import_batches(')) {
+                return { rows: [{ id: 'batch-1' }], rowCount: 1 }
+            }
+            return null
+        },
+    ])
+    const result = await createAtendimentoStore({ pool: fakePool }).importRecords({
+        records: [{
+            unitSlug: 'novo-hamburgo', unitName: 'Novo Hamburgo', date: '2026-07-24',
+            clientName: 'Cliente', procedureName: 'Botox', code: '#0699', quantity: 1,
+            discount: false, otherValue: 0, roundValue: false, value: 699,
+            injectorName: '', consultantName: '', observation: '',
+            sourceSheetId: 'sheet-1', sourceTab: 'Novo Hamburgo', sourceRow: 3,
+        }],
+        cache: { procedures: [], professionals: [], procedureCodes: [], schedules: [] },
+        actor: { id: 'google-sheet-import', role: 'GESTOR' },
+        source: { sourceSheetId: 'sheet-1', sourceName: 'Atendimento', tabs: ['Novo Hamburgo'], snapshotComplete: true },
+    })
+
+    assert.equal(result.importBatchId, 'batch-1')
+    const checkpoint = queries.find(({ sql }) => sql.startsWith('insert into crm_atendimento.import_batches('))
+    assert.deepEqual(checkpoint.params.slice(0, 2), ['sheet-1', 'Atendimento'])
+    assert.match(checkpoint.params[3], /"snapshotComplete":true/)
 })
 
 test('rejects a direct non-manager attempt to replace the persisted consultant before any write', async () => {

--- a/crm/api/server/atendimento/commercialDataQualityStore.js
+++ b/crm/api/server/atendimento/commercialDataQualityStore.js
@@ -280,9 +280,16 @@ export function buildCommercialDataQualityObservations({ core = {}, reviewRows =
         mirrorSyncedAgeHours,
         latestImportAgeHours,
     }
-    const mirrorStale = mirrorSyncedAgeHours === null || latestImportAgeHours === null ||
-        mirrorSyncedAgeHours > COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS ||
-        latestImportAgeHours > COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS
+    // A live Google Sheets import is a valid source checkpoint even when the
+    // local mirror has never been materialized.  A recent local mirror is also
+    // a valid fallback when no live import has been recorded.  Treat the source
+    // as healthy when either checkpoint is recent, and stale only when both
+    // checkpoints are absent or over the SLA.
+    const mirrorFresh = mirrorSyncedAgeHours !== null &&
+        mirrorSyncedAgeHours <= COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS
+    const importFresh = latestImportAgeHours !== null &&
+        latestImportAgeHours <= COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS
+    const mirrorStale = !mirrorFresh && !importFresh
     const appRegistrationSnapshotAvailable = core.app_registration_snapshot_available === true || core.appRegistrationSnapshotAvailable === true
     const appRegistrationSnapshotVerified = core.app_registration_snapshot_verified === true || core.appRegistrationSnapshotVerified === true
     const appRegistrationSnapshotResidual = appRegistrationSnapshotVerified

--- a/crm/api/server/atendimento/importer.js
+++ b/crm/api/server/atendimento/importer.js
@@ -491,6 +491,12 @@ export async function importAtendimentoFromGoogleSheet(store, { actor, dryRun = 
         cache: sheet.cache,
         actor,
         dryRun,
+        source: {
+            sourceSheetId: sheet.spreadsheetId,
+            sourceName: 'Atendimento',
+            tabs: sheet.tabs,
+            snapshotComplete: true,
+        },
     })
     return {
         ...result,

--- a/crm/api/server/atendimento/sourceRefresh.js
+++ b/crm/api/server/atendimento/sourceRefresh.js
@@ -1,0 +1,96 @@
+export const CLIENTES_SOURCE_REFRESH_TARGETS = Object.freeze({
+    PRODUCTION: 'production',
+    STAGING: 'staging',
+})
+
+function refreshError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+export function normalizeClientesSourceRefreshTarget(value) {
+    const target = String(value || '').trim().toLowerCase()
+    if (!Object.values(CLIENTES_SOURCE_REFRESH_TARGETS).includes(target)) {
+        throw refreshError('CLIENTES_SOURCE_REFRESH_TARGET_INVALID')
+    }
+    return target
+}
+
+export function normalizeClientesSourceRefreshAction(value) {
+    const action = String(value || '').trim().toLowerCase()
+    if (!['dry-run', 'apply'].includes(action)) throw refreshError('CLIENTES_SOURCE_REFRESH_ACTION_INVALID')
+    return action
+}
+
+export function assertClientesSourceRefreshDatabaseUrl(databaseUrl, targetValue) {
+    const target = normalizeClientesSourceRefreshTarget(targetValue)
+    const raw = String(databaseUrl || '').trim()
+    if (!raw) throw refreshError('DATABASE_URL_NOT_CONFIGURED')
+
+    if (target === CLIENTES_SOURCE_REFRESH_TARGETS.PRODUCTION) {
+        if (!/^postgres(?:ql)?:\/\/skincos@\/skincos_crm_local\?(?:[^#]*&)?host=\/var\/run\/postgresql(?:&|$)/i.test(raw)) {
+            throw refreshError('CLIENTES_SOURCE_REFRESH_PRODUCTION_DATABASE_UNSAFE')
+        }
+        return { target, database: 'skincos_crm_local' }
+    }
+
+    let parsed
+    try {
+        parsed = new URL(raw.replace(/^postgresql:/i, 'postgres:'))
+    } catch {
+        throw refreshError('CLIENTES_SOURCE_REFRESH_DATABASE_URL_INVALID')
+    }
+    const database = decodeURIComponent(String(parsed.pathname || '').replace(/^\//, ''))
+    if (database !== 'skincos_staging' || parsed.hostname !== '127.0.0.1' ||
+        parsed.port && parsed.port !== '5432' ||
+        !new URLSearchParams(parsed.search).has('sslmode') ||
+        new URLSearchParams(parsed.search).get('sslmode') !== 'require') {
+        throw refreshError('CLIENTES_SOURCE_REFRESH_STAGING_DATABASE_UNSAFE')
+    }
+    return { target, database }
+}
+
+export function assertClientesSourceRefreshDatabaseIdentity(identity = {}, targetValue) {
+    const target = normalizeClientesSourceRefreshTarget(targetValue)
+    const database = String(identity.database_name || identity.databaseName || '').trim()
+    const user = String(identity.current_user || identity.currentUser || '').trim()
+    if (target === CLIENTES_SOURCE_REFRESH_TARGETS.PRODUCTION) {
+        if (database !== 'skincos_crm_local' || user !== 'skincos') {
+            throw refreshError('CLIENTES_SOURCE_REFRESH_PRODUCTION_IDENTITY_UNSAFE')
+        }
+    } else if (database !== 'skincos_staging' || !user || user === 'postgres') {
+        throw refreshError('CLIENTES_SOURCE_REFRESH_STAGING_IDENTITY_UNSAFE')
+    }
+    return { target, database, user }
+}
+
+export function sourceRefreshActor(targetValue) {
+    const target = normalizeClientesSourceRefreshTarget(targetValue)
+    return {
+        id: `clientes-source-refresh-${target}`,
+        username: `clientes-source-refresh-${target}`,
+        role: 'ADMIN',
+        allowedModules: ['atendimento'],
+    }
+}
+
+export function summarizeClientesSourceRefresh({ target, action, identity, result }) {
+    return {
+        ok: true,
+        target,
+        action,
+        database: identity?.database || null,
+        databaseUser: identity?.user || null,
+        dryRun: result?.dryRun === true,
+        records: Number(result?.records || 0),
+        inserted: Number(result?.inserted || 0),
+        updated: Number(result?.updated || 0),
+        skipped: Number(result?.skipped || 0),
+        importBatchId: result?.importBatchId || null,
+        spreadsheetId: result?.spreadsheetId || null,
+        tabs: Array.isArray(result?.tabs) ? result.tabs : [],
+    }
+}
+
+export { refreshError }

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -6465,7 +6465,7 @@ export function createAtendimentoStore(options = {}) {
             })
         },
 
-        async importRecords({ records, cache, actor, dryRun = false }) {
+        async importRecords({ records, cache, actor, dryRun = false, source = null }) {
             await ensureReady()
             if (dryRun) {
                 return {
@@ -6588,8 +6588,36 @@ export function createAtendimentoStore(options = {}) {
                     else if (out.rows[0]) updated += 1
                     else skipped += 1
                 }
+                let importBatchId = null
+                const sourceSheetId = String(source?.sourceSheetId || '').trim()
+                if (sourceSheetId) {
+                    const sourceName = String(source?.sourceName || 'Atendimento').trim().slice(0, 160) || 'Atendimento'
+                    const tabs = Array.isArray(source?.tabs)
+                        ? source.tabs.map((tab) => String(tab || '').trim()).filter(Boolean).slice(0, 32)
+                        : []
+                    const batch = await client.query(
+                        `insert into crm_atendimento.import_batches(
+                            source_sheet_id, source_name, dry_run, actor, summary)
+                         values ($1, $2, false, $3::jsonb, $4::jsonb)
+                         returning id`,
+                        [
+                            sourceSheetId,
+                            sourceName,
+                            JSON.stringify(actor || {}),
+                            JSON.stringify({
+                                records: records.length,
+                                inserted,
+                                updated,
+                                skipped,
+                                tabs,
+                                snapshotComplete: source?.snapshotComplete === true,
+                            }),
+                        ],
+                    )
+                    importBatchId = batch.rows[0]?.id || null
+                }
                 await audit(client, 'import.google-sheet', actor, null, { inserted, updated, skipped, records: records.length })
-                return { dryRun: false, records: records.length, inserted, updated, skipped }
+                return { dryRun: false, records: records.length, inserted, updated, skipped, importBatchId }
             })
         },
 

--- a/docs/runbooks/clientes-source-refresh.md
+++ b/docs/runbooks/clientes-source-refresh.md
@@ -1,0 +1,69 @@
+# Clientes: refresh seguro da fonte de Atendimento
+
+O importador de Atendimento lê a planilha Google em modo somente leitura e
+materializa as linhas idempotentes no schema `crm_atendimento`. Cada aplicação
+concluída grava um checkpoint agregado em `crm_atendimento.import_batches`;
+esse checkpoint é suficiente para a fila de qualidade reconhecer a fonte viva
+mesmo quando o espelho local não existe.
+
+## Runner
+
+O entrypoint é `crm/api/scripts/refresh-atendimento-source.mjs` e aceita apenas
+`--dry-run` ou `--apply`. O destino é obrigatório em
+`CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging|production`.
+
+- `--dry-run` é a operação padrão: lê a fonte Google, valida o formato do
+  banco-alvo e não abre nenhuma transação de escrita.
+- `--apply` exige também
+  `CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1`, a identidade correta do
+  banco e o lock advisory `skincos:clientes:source-refresh`.
+- A saída contém somente alvo, identidade agregada, contagens, abas, planilha e
+  `importBatchId`; não inclui nomes, telefones, e-mails, payloads ou segredos.
+
+O launcher nativo
+`scripts/runtime/run-clientes-source-refresh-native.sh` carrega o ambiente
+privado do alvo e o overlay de leitura Google separadamente. A variável
+`DATABASE_URL` do alvo vence qualquer valor acidental no overlay da fonte. Em
+`--apply`, um dump PostgreSQL privado é criado antes da importação em:
+
+- produção: `/var/backups/skincos/clientes`;
+- staging: `/var/backups/skincos/clientes/staging`.
+
+O dump e seu SHA-256 ficam fora do repositório. A transação do importador é
+atômica; em caso de falha, o checkpoint permanece para investigação e os dados
+da importação são revertidos pelo banco.
+
+## Operação controlada
+
+Antes de qualquer escrita, execute o mesmo release em dry-run:
+
+```bash
+CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging \
+CRM_CLIENTES_SOURCE_REFRESH_ACTION=--dry-run \
+scripts/runtime/run-clientes-source-refresh-native.sh
+```
+
+Depois de revisar apenas as contagens e a identidade do alvo, a aplicação
+controlada usa:
+
+```bash
+CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging \
+CRM_CLIENTES_SOURCE_REFRESH_ACTION=--apply \
+CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1 \
+scripts/runtime/run-clientes-source-refresh-native.sh
+```
+
+O serviço e o timer em
+`ops/runtime/units/crm-clientes-source-refresh.{service,timer}` são instalados
+por `scripts/runtime/install-clientes-source-refresh-service.sh`. A unidade
+fica em `--dry-run` e desabilitada por padrão; habilitar o timer não inicia
+uma execução imediatamente. Para um ambiente de produção, o arquivo privado
+`crm-clientes-source-refresh.env` deve declarar explicitamente o alvo, a ação e
+a confirmação de escrita. Sem essa declaração o processo falha fechado.
+
+## Qualidade e rollback
+
+Após um apply, execute o refresh de qualidade comercial do mesmo alvo e
+confirme que `source.local_mirror_stale` reconhece o novo checkpoint. O rollback
+operacional é parar/desabilitar o timer, preservar o dump e restaurar o banco
+com o procedimento PostgreSQL aprovado; não existe reverse migration destrutiva.

--- a/ops/runtime/units/crm-clientes-source-refresh.service
+++ b/ops/runtime/units/crm-clientes-source-refresh.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Skincos Clientes source refresh (fail-closed, aggregate checkpointed import)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=skincos
+Group=skincos
+WorkingDirectory=__REPO_ROOT__
+Environment=CRM_CLIENTES_SOURCE_REFRESH_TARGET=production
+Environment=CRM_CLIENTES_SOURCE_REFRESH_ACTION=--dry-run
+Environment=CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=0
+Environment=CONFIG_ROOT=__CONFIG_ROOT__
+EnvironmentFile=-__CONFIG_ROOT__/crm-clientes-source-refresh.env
+ExecStart=__REPO_ROOT__/scripts/runtime/run-clientes-source-refresh-native.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=__BACKUP_ROOT__ __LOG_ROOT__/crm-clientes-source-refresh
+UMask=0027
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/runtime/units/crm-clientes-source-refresh.timer
+++ b/ops/runtime/units/crm-clientes-source-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodic Skincos Clientes source refresh
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=30min
+RandomizedDelaySec=120
+Persistent=true
+Unit=crm-clientes-source-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/runtime/install-clientes-source-refresh-service.sh
+++ b/scripts/runtime/install-clientes-source-refresh-service.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UNIT_SRC="$ROOT_DIR/ops/runtime/units/crm-clientes-source-refresh.service"
+TIMER_SRC="$ROOT_DIR/ops/runtime/units/crm-clientes-source-refresh.timer"
+UNIT_DEST="${UNIT_DEST:-/etc/systemd/system}"
+SOURCE_ROOT="${SOURCE_ROOT:-$ROOT_DIR}"
+CONFIG_ROOT="${CONFIG_ROOT:-/etc/skincos}"
+BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes}"
+LOG_ROOT="${LOG_ROOT:-/var/log/skincos}"
+APPLY=0
+ENABLE=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/install-clientes-source-refresh-service.sh [--apply] [--enable]
+
+Without --apply, renders and verifies the Clientes source refresh service and
+timer. --apply installs both units and reloads systemd. --enable enables only
+the timer; it never starts a refresh immediately. The private
+crm-clientes-source-refresh.env keeps the action at --dry-run unless an
+operator explicitly supplies --apply and CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --enable) ENABLE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+if [[ "$ENABLE" == "1" && "$APPLY" != "1" ]]; then
+  echo '--enable requires --apply' >&2
+  exit 64
+fi
+command -v sed >/dev/null 2>&1 || { echo 'Missing required command: sed' >&2; exit 1; }
+command -v systemd-analyze >/dev/null 2>&1 || { echo 'Missing required command: systemd-analyze' >&2; exit 1; }
+if [[ "$APPLY" == "1" ]]; then
+  command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
+  sudo -n true
+fi
+
+escape() { printf '%s' "$1" | sed 's/[&|]/\\&/g'; }
+render_dir="$(mktemp -d)"
+trap 'rm -rf "$render_dir"' EXIT
+rendered_service="$render_dir/crm-clientes-source-refresh.service"
+rendered_timer="$render_dir/crm-clientes-source-refresh.timer"
+for pair in \
+  "$UNIT_SRC:$rendered_service" \
+  "$TIMER_SRC:$rendered_timer"; do
+  src="${pair%%:*}"
+  dest="${pair#*:}"
+  [[ -f "$src" ]] || { echo "Missing unit template: $src" >&2; exit 1; }
+  sed \
+    -e "s|__REPO_ROOT__|$(escape "$SOURCE_ROOT")|g" \
+    -e "s|__CONFIG_ROOT__|$(escape "$CONFIG_ROOT")|g" \
+    -e "s|__BACKUP_ROOT__|$(escape "$BACKUP_ROOT")|g" \
+    -e "s|__LOG_ROOT__|$(escape "$LOG_ROOT")|g" \
+    "$src" >"$dest"
+done
+
+systemd-analyze verify "$rendered_service" "$rendered_timer"
+
+if [[ "$APPLY" == "1" ]]; then
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  sudo -n install -d -m 0750 "$BACKUP_ROOT"
+  for unit in crm-clientes-source-refresh.service crm-clientes-source-refresh.timer; do
+    if sudo -n test -f "$UNIT_DEST/$unit"; then
+      sudo -n cp -p "$UNIT_DEST/$unit" "$BACKUP_ROOT/$unit.$stamp"
+    fi
+  done
+  sudo -n install -m 0644 "$rendered_service" "$UNIT_DEST/crm-clientes-source-refresh.service"
+  sudo -n install -m 0644 "$rendered_timer" "$UNIT_DEST/crm-clientes-source-refresh.timer"
+  sudo -n systemctl daemon-reload
+  if [[ "$ENABLE" == "1" ]]; then
+    sudo -n systemctl enable crm-clientes-source-refresh.timer >/dev/null
+  fi
+  echo 'Clientes source refresh units installed; no refresh start was requested.'
+else
+  echo 'Clientes source refresh service and timer templates verify successfully.'
+fi

--- a/scripts/runtime/run-clientes-source-refresh-native.sh
+++ b/scripts/runtime/run-clientes-source-refresh-native.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="${CRM_CLIENTES_SOURCE_REFRESH_TARGET:-}"
+ACTION="${1:-${CRM_CLIENTES_SOURCE_REFRESH_ACTION:---dry-run}}"
+CONFIG_ROOT="${CONFIG_ROOT:-/etc/skincos}"
+
+case "$TARGET" in
+  production)
+    ENV_FILE="$CONFIG_ROOT/crm.env"
+    BACKUP_ROOT="${CRM_CLIENTES_SOURCE_REFRESH_BACKUP_ROOT:-/var/backups/skincos/clientes}"
+    EXPECTED_BACKUP_ROOT='/var/backups/skincos/clientes'
+    EXPECTED_OS_USER='skincos'
+    ;;
+  staging)
+    ENV_FILE="$CONFIG_ROOT/crm-atendimento-staging.env"
+    BACKUP_ROOT="${CRM_CLIENTES_SOURCE_REFRESH_BACKUP_ROOT:-/var/backups/skincos/clientes/staging}"
+    EXPECTED_BACKUP_ROOT='/var/backups/skincos/clientes/staging'
+    EXPECTED_OS_USER=''
+    ;;
+  *) echo 'CRM_CLIENTES_SOURCE_REFRESH_TARGET must be production or staging.' >&2; exit 64 ;;
+esac
+
+case "$ACTION" in
+  --dry-run|--apply) ;;
+  *) echo 'Use --dry-run or --apply.' >&2; exit 64 ;;
+esac
+[[ "$BACKUP_ROOT" == "$EXPECTED_BACKUP_ROOT" ]] || {
+  echo "CRM_CLIENTES_SOURCE_REFRESH_BACKUP_ROOT is fixed to $EXPECTED_BACKUP_ROOT for $TARGET." >&2
+  exit 64
+}
+if [[ -n "$EXPECTED_OS_USER" && "$(id -un)" != "$EXPECTED_OS_USER" ]]; then
+  echo "The $TARGET source refresh must run as the OS user $EXPECTED_OS_USER." >&2
+  exit 77
+fi
+[[ -r "$ENV_FILE" ]] || { echo "Missing private environment: $ENV_FILE" >&2; exit 1; }
+
+# The target environment owns DATABASE_URL.  The source overlay contributes only
+# the read-only Google configuration and may never retarget the destination.
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+TARGET_DATABASE_URL="${DATABASE_URL:-}"
+if [[ -r "$CONFIG_ROOT/atendimento-source.env" ]]; then
+  # shellcheck disable=SC1090
+  . "$CONFIG_ROOT/atendimento-source.env"
+fi
+DATABASE_URL="$TARGET_DATABASE_URL"
+export DATABASE_URL
+set +a
+[[ -n "$DATABASE_URL" ]] || { echo 'DATABASE_URL is missing from the target environment.' >&2; exit 1; }
+
+if [[ "$ACTION" == '--apply' ]]; then
+  case "${CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED:-0}" in
+    1|true|yes|on) ;;
+    *) echo 'CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1 is required for --apply.' >&2; exit 77 ;;
+  esac
+  [[ -d "$BACKUP_ROOT" && -w "$BACKUP_ROOT" ]] || {
+    echo "Checkpoint directory must be pre-provisioned and writable: $BACKUP_ROOT" >&2
+    exit 77
+  }
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  checkpoint="$BACKUP_ROOT/clientes-source-refresh-${TARGET}-${stamp}.dump"
+  pg_dump --format=custom --no-owner --file="$checkpoint" "$DATABASE_URL"
+  chmod 0640 "$checkpoint"
+  echo "checkpoint=$checkpoint sha256=$(sha256sum "$checkpoint" | awk '{print $1}')"
+fi
+
+exec node "$ROOT_DIR/crm/api/scripts/refresh-atendimento-source.mjs" "$ACTION"


### PR DESCRIPTION
## Objetivo

Consolidar o checkpoint de ingestão Google Sheets do módulo Clientes/Atendimento e tornar o refresh repetível, target-bound e fail-closed.

## Mudanças

- grava `crm_atendimento.import_batches` para cada importação viva concluída;
- considera a fonte fresca quando o espelho local ou o checkpoint de importação recente existe;
- adiciona runner `dry-run`/`apply` com validação de alvo/identidade, lock advisory e actor técnico sem PII;
- adiciona launcher nativo com dump privado antes de apply, unit/timer desabilitados por padrão e runbook;
- mantém escrita comercial/outbound e source overlay separados.

## Validação

- API: 288 pass, 1 skip, 0 fail;
- `git diff --check` verde;
- `node --check` dos novos entrypoints;
- `systemd-analyze verify` dos templates service/timer;
- nenhum deploy global nesta PR.