### PR TITLE
fix(clientes): sanitize staging backup connection url

### DIFF
--- a/scripts/runtime/run-clientes-source-refresh-native.sh
+++ b/scripts/runtime/run-clientes-source-refresh-native.sh
@@ -62,7 +62,12 @@ if [[ "$ACTION" == '--apply' ]]; then
   }
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   checkpoint="$BACKUP_ROOT/clientes-source-refresh-${TARGET}-${stamp}.dump"
-  pg_dump --format=custom --no-owner --file="$checkpoint" "$DATABASE_URL"
+  # libpq does not understand the application-only `uselibpqcompat` query
+  # parameter used by the Node pg adapter.  Remove only that parameter from the
+  # private backup connection string; DATABASE_URL itself remains unchanged
+  # for the application runner.
+  backup_database_url="$(printf '%s' "$DATABASE_URL" | sed -E 's/([?&])uselibpqcompat=[^&]*&?/\1/g; s/[?&]$//')"
+  pg_dump --format=custom --no-owner --file="$checkpoint" "$backup_database_url"
   chmod 0640 "$checkpoint"
   echo "checkpoint=$checkpoint sha256=$(sha256sum "$checkpoint" | awk '{print $1}')"
 fi


### PR DESCRIPTION
Corrige o backup privado do runner de refresh do Clientes para remover somente `uselibpqcompat`, parâmetro aceito pelo adaptador Node mas rejeitado pelo `pg_dump`/libpq. `DATABASE_URL` da aplicação permanece intacta.

Validação local: `bash -n` e `git diff --check`.