### PR TITLE
fix(clientes): fail closed on protected contact quality data

### DIFF
--- a/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
@@ -86,6 +86,16 @@ test('accepts a recent mirror checkpoint when the latest import is stale', () =>
 
 test('requires the full enabled immutable contact ledger and ignores deleted attendance links', () => {
     const core = COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.core
+    assert.match(core, /case when has_table_privilege\(current_user, 'crm_atendimento\.commercial_contact_permissions', 'SELECT'\)/)
+    for (const table of [
+        'commercial_contact_permissions',
+        'commercial_contact_permission_events',
+        'commercial_actions',
+        'commercial_action_events',
+        'commercial_policy_config',
+    ]) {
+        assert.match(core, new RegExp(`has_table_privilege\\(current_user, 'crm_atendimento\\.${table}', 'SELECT'\\)`))
+    }
     assert.match(core, /commercial_contact_permission_events'[\s\S]*trace_id/)
     for (const { trigger, requiredBits } of [
         { trigger: 'commercial_contact_permission_events_immutable', requiredBits: [2, 8, 16] },
@@ -179,6 +189,9 @@ test('reads aggregate observations serially inside one database transaction clie
             calls.push(sql)
             await new Promise((resolve) => setImmediate(resolve))
             activeQueries -= 1
+            if (sql.startsWith('select has_table_privilege(current_user')) {
+                return { rows: [{ can_read_contact_permissions: true }] }
+            }
             if (sql.includes('from crm_atendimento.canonical_clients')) {
                 return { rows: [{ attendance_membership_gap: 0, unclassified_sale_items: 0, future_attendances: 0, identities_without_permission: 0, contact_controls_unready: 0 }] }
             }
@@ -191,8 +204,32 @@ test('reads aggregate observations serially inside one database transaction clie
     const observations = await __testables.querySourceObservations(client)
 
     assert.equal(peakQueries, 1)
-    assert.equal(calls.length, 3)
+    assert.equal(calls.length, 4)
     assert.equal(observations.find((item) => item.key === 'source.local_mirror_stale')?.observedCount, 0)
+})
+
+test('avoids unauthorized contact rows and keeps the quality refresh fail-closed', async () => {
+    const calls = []
+    const client = {
+        async query(sql) {
+            calls.push(sql)
+            if (sql.startsWith('select has_table_privilege(current_user')) {
+                return { rows: [{ can_read_contact_permissions: false }] }
+            }
+            if (sql.includes('from crm_atendimento.canonical_clients')) {
+                assert.doesNotMatch(sql, /from crm_atendimento\.commercial_contact_permissions permission/)
+                return { rows: [{ attendance_membership_gap: 0, unclassified_sale_items: 0, future_attendances: 0, identities_without_permission: 0, contact_controls_unready: 1 }] }
+            }
+            if (sql.includes("identity_review.name_merge_pending")) return { rows: [] }
+            if (sql.includes('with mirror as')) return { rows: [{ mirror_synced_age_hours: 1, latest_import_age_hours: 2 }] }
+            throw new Error('Unexpected aggregate quality query')
+        },
+    }
+
+    const observations = await __testables.querySourceObservations(client)
+
+    assert.equal(calls.length, 4)
+    assert.equal(observations.find((item) => item.key === 'commercial.contact_controls_unready')?.observedCount, 1)
 })
 
 test('fails closed for a unit-scoped GESTOR but retains the ADMIN global exception', () => {

--- a/crm/api/server/atendimento/commercialDataQualityStore.js
+++ b/crm/api/server/atendimento/commercialDataQualityStore.js
@@ -35,6 +35,22 @@ const definitionByKey = new Map(COMMERCIAL_DATA_QUALITY_DEFINITIONS.map((definit
 
 // These queries deliberately return counts and age values only. They do not
 // select a customer name, phone, email, raw source evidence, source path or ID.
+// The runtime role may intentionally lack SELECT on contact-governance tables.
+// Keep the row-level observation in a replaceable fragment so the aggregate
+// refresh can fail closed without attempting an unauthorized read.
+const CONTACT_PERMISSION_OBSERVATION_SQL = `(case when has_table_privilege(current_user, 'crm_atendimento.commercial_contact_permissions', 'SELECT') then
+            (select count(*)::int
+               from crm_atendimento.global_client_identities identity
+              where exists (select 1 from crm_atendimento.global_client_identity_members member where member.identity_id = identity.id)
+                and not exists (
+                    select 1 from crm_atendimento.commercial_contact_permissions permission
+                     where permission.identity_id = identity.id and permission.channel = 'whatsapp'
+                ))
+            else 0 end) as identities_without_permission`
+
+const CONTACT_PERMISSION_OBSERVATION_UNAVAILABLE_SQL = '0::int as identities_without_permission'
+const CONTACT_PERMISSION_PRIVILEGE_QUERY = `select has_table_privilege(current_user, 'crm_atendimento.commercial_contact_permissions', 'SELECT') as can_read_contact_permissions`
+
 export const COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES = Object.freeze({
     core: `with latest_app_registration_run as (
         select id from crm_atendimento.app_registration_import_runs
@@ -57,18 +73,17 @@ export const COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES = Object.freeze({
             )) as attendance_membership_gap,
         (select count(*)::int from crm_caixa.sale_items where coalesce(mapping_status, 'pending') <> 'mapped') as unclassified_sale_items,
         (select count(*)::int from crm_atendimento.attendances where deleted_at is null and service_date > current_date) as future_attendances,
-        (select count(*)::int
-           from crm_atendimento.global_client_identities identity
-          where exists (select 1 from crm_atendimento.global_client_identity_members member where member.identity_id = identity.id)
-            and not exists (
-                select 1 from crm_atendimento.commercial_contact_permissions permission
-                 where permission.identity_id = identity.id and permission.channel = 'whatsapp'
-            )) as identities_without_permission,
+        ${CONTACT_PERMISSION_OBSERVATION_SQL},
         (select case when
             to_regclass('crm_atendimento.commercial_contact_permissions') is null or
             to_regclass('crm_atendimento.commercial_contact_permission_events') is null or
             to_regclass('crm_atendimento.commercial_actions') is null or
             to_regclass('crm_atendimento.commercial_action_events') is null or
+            not has_table_privilege(current_user, 'crm_atendimento.commercial_contact_permissions', 'SELECT') or
+            not has_table_privilege(current_user, 'crm_atendimento.commercial_contact_permission_events', 'SELECT') or
+            not has_table_privilege(current_user, 'crm_atendimento.commercial_actions', 'SELECT') or
+            not has_table_privilege(current_user, 'crm_atendimento.commercial_action_events', 'SELECT') or
+            not has_table_privilege(current_user, 'crm_atendimento.commercial_policy_config', 'SELECT') or
             not exists(select 1 from information_schema.columns
                 where table_schema = 'crm_atendimento' and table_name = 'commercial_contact_permission_events'
                   and column_name = 'trace_id') or
@@ -142,6 +157,12 @@ export const COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES = Object.freeze({
         case when (select created_at from latest_import) is null then null
              else greatest(0, floor(extract(epoch from now() - (select created_at from latest_import)) / 3600))::int end as latest_import_age_hours`,
 })
+
+const COMMERCIAL_DATA_QUALITY_SOURCE_QUERY_WITHOUT_CONTACT_PERMISSION =
+    COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.core.replace(
+        CONTACT_PERMISSION_OBSERVATION_SQL,
+        CONTACT_PERMISSION_OBSERVATION_UNAVAILABLE_SQL,
+    )
 
 function qualityError(code, statusCode = 409) {
     const error = new Error(code)
@@ -353,7 +374,12 @@ async function querySourceObservations(client) {
     // produces a pg deprecation warning today and may become a hard failure in
     // the next driver major; the aggregate snapshot is intentionally read in a
     // single serial flow instead.
-    const core = await client.query(COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.core)
+    const privilege = await client.query(CONTACT_PERMISSION_PRIVILEGE_QUERY)
+    const canReadContactPermissions = privilege.rows[0]?.can_read_contact_permissions === true
+    const coreQuery = canReadContactPermissions
+        ? COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.core
+        : COMMERCIAL_DATA_QUALITY_SOURCE_QUERY_WITHOUT_CONTACT_PERMISSION
+    const core = await client.query(coreQuery)
     const review = await client.query(COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.review)
     const freshness = await client.query(COMMERCIAL_DATA_QUALITY_SOURCE_QUERIES.freshness)
     return buildCommercialDataQualityObservations({

--- a/docs/runbooks/clientes-source-refresh.md
+++ b/docs/runbooks/clientes-source-refresh.md
@@ -67,3 +67,11 @@ Após um apply, execute o refresh de qualidade comercial do mesmo alvo e
 confirme que `source.local_mirror_stale` reconhece o novo checkpoint. O rollback
 operacional é parar/desabilitar o timer, preservar o dump e restaurar o banco
 com o procedimento PostgreSQL aprovado; não existe reverse migration destrutiva.
+
+O refresh de qualidade é fail-closed para o papel de runtime: quando ele não
+possui `SELECT` nas tabelas de governança de contato, não tenta ler linhas
+protegidas, registra `commercial.contact_controls_unready` e mantém a fila
+acionável. Não conceda acesso amplo apenas para obter a contagem agregada. No
+alvo local de produção, o comando operacional deve usar o socket sem usuário
+(`postgresql:///skincos_crm_local?host=/var/run/postgresql`) e executar como o
+papel técnico autorizado; assim a verificação de destino permanece estrita.


### PR DESCRIPTION
## Context\nThe production runtime role skincos intentionally cannot read crm_atendimento.commercial_contact_permissions. The aggregate Clientes quality refresh therefore aborted before materializing any queue state.\n\n## Change\n- probe only the table privilege first; when denied, run a query variant that contains no row-level contact-permission read\n- keep commercial.contact_controls_unready active so contact actions remain fail-closed\n- preserve aggregate-only outputs and add regression coverage for authorized and unauthorized roles\n- document the least-privilege production socket invocation\n\n## Validation\n- CRM API suite: 289 passed, 1 skipped, 0 failed (290 tests)\n- targeted quality store suite: 17 passed\n- git diff --check clean\n\nNo permission grant or production deploy is included in this PR.