### PR TITLE
fix(clientes): grant runtime access to quality queue

### DIFF
--- a/crm/api/server/atendimento/__tests__/commercialDataQualityMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityMigration.test.js
@@ -66,6 +66,10 @@ test('creates the queue and immutable event ledger only after local prerequisite
 
     assert.equal(report.applied, true)
     assert.deepEqual(report.tables, ['commercial_data_quality_findings', 'commercial_data_quality_finding_events'])
+    assert.equal(report.runtimeRole, 'skincos')
+    assert.equal(report.runtimeGrants.length, 4)
+    assert.ok(fixture.calls.some(({ sql }) => /grant select, insert, update on table crm_atendimento\.commercial_data_quality_findings to skincos/i.test(sql)))
+    assert.ok(fixture.calls.some(({ sql }) => /grant usage, select on sequence crm_atendimento\.commercial_data_quality_finding_events_event_order_seq to skincos/i.test(sql)))
     assert.deepEqual(report.repairedIndexes, [])
     assert.equal(fixture.released, true)
     const indexOf = (pattern) => fixture.calls.findIndex(({ sql }) => pattern.test(String(sql).replace(/\s+/g, ' ')))

--- a/crm/api/server/atendimento/commercialDataQualityMigration.js
+++ b/crm/api/server/atendimento/commercialDataQualityMigration.js
@@ -27,6 +27,22 @@ const PREREQUISITE_RELATIONS = [
     'crm_caixa.sale_items',
 ]
 
+const COMMERCIAL_DATA_QUALITY_RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+function runtimeGrantStatements(target) {
+    const role = COMMERCIAL_DATA_QUALITY_RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_DATA_QUALITY_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_data_quality_findings to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_data_quality_finding_events to ${role}`,
+        `grant usage, select on sequence crm_atendimento.commercial_data_quality_finding_events_event_order_seq to ${role}`,
+    ]
+}
+
 const STATEMENTS = [
     `create extension if not exists pgcrypto`,
     `create table if not exists crm_atendimento.commercial_data_quality_findings (
@@ -174,6 +190,7 @@ export function commercialDataQualityMigrationPlan() {
     return {
         id: COMMERCIAL_DATA_QUALITY_MIGRATION_ID,
         adds: ['commercial_data_quality_findings', 'commercial_data_quality_finding_events'],
+        runtimeAccess: 'The dedicated runtime role receives only aggregate queue SELECT/INSERT/UPDATE and append-only event INSERT/SELECT; contact-governance row access is not granted.',
         queuePolicy: 'The queue stores aggregate counts and allowlisted freshness metrics only. It never stores client names, phones, email addresses, source paths, raw evidence or source identifiers.',
         auditPolicy: 'Current finding state is mutable with optimistic revision checks; every detection, recurrence, owner and status transition is appended to an immutable event ledger.',
         rollback: 'Non-destructive: retains findings and event evidence, then records the migration as rolled back.',
@@ -203,6 +220,11 @@ export async function applyCommercialDataQualityMigration({ pool, databaseUrl, t
         await ensureRegistry(client)
         for (const sql of STATEMENTS) await query(client, sql)
         for (const index of COMMERCIAL_DATA_QUALITY_INDEXES) await ensureCommercialDataQualityIndex(client, index, report)
+        const runtimeRole = COMMERCIAL_DATA_QUALITY_RUNTIME_ROLES[target]
+        const grants = runtimeGrantStatements(target)
+        for (const sql of grants) await query(client, sql)
+        report.runtimeRole = runtimeRole
+        report.runtimeGrants = grants
         report.applied = true
         await query(client, `insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
             values ($1, now(), null, $2::jsonb)

--- a/docs/runbooks/clientes-source-refresh.md
+++ b/docs/runbooks/clientes-source-refresh.md
@@ -75,3 +75,9 @@ acionável. Não conceda acesso amplo apenas para obter a contagem agregada. No
 alvo local de produção, o comando operacional deve usar o socket sem usuário
 (`postgresql:///skincos_crm_local?host=/var/run/postgresql`) e executar como o
 papel técnico autorizado; assim a verificação de destino permanece estrita.
+
+A migração da fila também reconcilia os grants mínimos do runtime (`SELECT`/
+`INSERT`/`UPDATE` apenas na fila agregada e `SELECT`/`INSERT` no ledger de
+eventos). Ela não concede `SELECT` nas permissões de contato. Reexecute o
+runner de migração com o mesmo release quando o estado de grants estiver
+incompleto; a operação é idempotente.


### PR DESCRIPTION
## Context\nThe aggregate quality refresh now avoids unauthorized contact-permission rows, but the migration-owned quality queue itself was not readable/writable by the production runtime role.\n\n## Change\n- reconcile idempotent least-privilege grants from the existing commercial quality migration\n- local runtime skincos: schema usage, queue SELECT/INSERT/UPDATE, event SELECT/INSERT, event-order sequence usage/select\n- staging runtime skincos_staging_crm_app: same bounded grants\n- no contact-permission table grant\n\n## Validation\n- CRM API suite: 289 passed, 1 skipped, 0 failed (290 tests)\n- targeted migration + quality suites: 23 passed\n- git diff --check clean\n\nThe migration is idempotent and will be applied in staging before production.