### PR TITLE
fix(clientes): rematerialize persisted identity graph

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -13,6 +13,7 @@
     "refresh-atendimento-source": "node scripts/refresh-atendimento-source.mjs",
     "import-gerencia-sheet": "node scripts/import-gerencia-sheet.mjs",
     "reconcile-client-identities": "node scripts/reconcile-client-identities.mjs",
+    "reconcile-persisted-client-identities": "node scripts/reconcile-persisted-client-identities.mjs",
     "reconcile-client-registrations": "node scripts/reconcile-client-registrations.mjs",
     "import-supplemental-leads": "node scripts/import-supplemental-leads.mjs",
     "apply-client-spelling-merges": "node scripts/apply-client-spelling-merges.mjs",

--- a/crm/api/scripts/reconcile-persisted-client-identities.mjs
+++ b/crm/api/scripts/reconcile-persisted-client-identities.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import pg from 'pg'
+import {
+    assertIdentityProjectionCanBeMaterialized,
+    buildPersistedConfirmedIdentityComponents,
+    recordIdentityProjectionMaterialization,
+} from '../server/atendimento/identityProjection.js'
+import { IDENTITY_GRAPH_LOCK_KEY } from '../server/atendimento/identityReviewWorkflow.js'
+import {
+    asRecoverableIdentityMaterializationError,
+    configureIdentityMaterializationTimeouts,
+    loadOptionalSupplementalLeadSources,
+} from '../server/atendimento/identityMaterializationRuntime.js'
+import {
+    assertIdentityMaterializationApplyCheckpoint,
+    assertIdentityMaterializationDatabase,
+    assertIdentityMaterializationDestination,
+    assertIdentityMaterializationSchemaReady,
+    fingerprintIdentityMaterializationSource,
+    identityMaterializationCheckpoint,
+    writeIdentityMaterializationCheckpoint,
+} from '../server/atendimento/identityMaterializationSafety.js'
+
+const args = process.argv.slice(2)
+const apply = args.length === 1 && args[0] === '--apply'
+if (args.length > 1 || (args.length === 1 && !apply)) {
+    throw new Error('Use sem argumentos para dry-run ou exclusivamente --apply para materializar o grafo persistido.')
+}
+
+const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+const checkpointFile = String(process.env.CLIENT_IDENTITY_PROJECTION_CHECKPOINT || '').trim()
+const checkpointOutput = String(process.env.CLIENT_IDENTITY_PROJECTION_CHECKPOINT_OUTPUT || '').trim()
+if (!databaseUrl) throw new Error('DATABASE_URL_not_configured')
+assertIdentityMaterializationDestination(databaseUrl)
+
+const OPERATION = 'persisted_client_identity_projection'
+
+async function loadInputs(client) {
+    const registrations = await client.query(`select source_client_id as id, canonical_name as name
+        from crm_atendimento.app_client_registrations`)
+    const canonicalClients = await client.query(`select id::text, merged_into_id::text as "mergedIntoId", canonical_name as name
+        from crm_atendimento.canonical_clients`)
+    const caixaCustomers = await client.query(`select id::text as id, name from crm_caixa.customers`)
+    const registrationCaixaLinks = await client.query(`select app_registration_id as "registrationId",
+            caixa_customer_id::text as "caixaCustomerId", status
+        from crm_atendimento.app_registration_caixa_links`)
+    const registrationAttendanceLinks = await client.query(`select l.app_registration_id as "registrationId",
+            l.client_id::text as "attendanceClientId", l.status
+        from crm_atendimento.app_registration_attendance_links l
+        join crm_atendimento.canonical_clients c on c.id=l.client_id`)
+    const attendanceCaixaLinks = await client.query(`select l.client_id::text as "attendanceClientId",
+            l.caixa_customer_id::text as "caixaCustomerId", l.status
+        from crm_atendimento.client_caixa_links l
+        join crm_atendimento.canonical_clients c on c.id=l.client_id`)
+    const supplemental = await loadOptionalSupplementalLeadSources(client)
+    return {
+        registrations: registrations.rows,
+        leadProfiles: supplemental.profiles,
+        canonicalClients: canonicalClients.rows,
+        caixaCustomers: caixaCustomers.rows,
+        registrationCaixaLinks: registrationCaixaLinks.rows,
+        registrationAttendanceLinks: registrationAttendanceLinks.rows,
+        attendanceCaixaLinks: attendanceCaixaLinks.rows,
+        leadProfileRegistrationLinks: supplemental.appLinks,
+        leadProfileCaixaLinks: supplemental.caixaLinks,
+        supplementalLeadSources: supplemental.availability,
+    }
+}
+
+function buildProjection(inputs) {
+    return buildPersistedConfirmedIdentityComponents(inputs)
+}
+
+function projectionSummary(inputs, components) {
+    return {
+        source: {
+            registrations: inputs.registrations.length,
+            leadProfiles: inputs.leadProfiles.length,
+            canonicalClients: inputs.canonicalClients.length,
+            caixaCustomers: inputs.caixaCustomers.length,
+            registrationCaixaLinks: inputs.registrationCaixaLinks.length,
+            registrationAttendanceLinks: inputs.registrationAttendanceLinks.length,
+            attendanceCaixaLinks: inputs.attendanceCaixaLinks.length,
+            leadProfileRegistrationLinks: inputs.leadProfileRegistrationLinks.length,
+            leadProfileCaixaLinks: inputs.leadProfileCaixaLinks.length,
+            supplementalLeadSources: inputs.supplementalLeadSources,
+        },
+        components: components.length,
+        members: components.reduce((total, component) => total + component.members.length, 0),
+        multiSourceComponents: components.filter((component) => component.sourceTypes.length > 1).length,
+    }
+}
+
+async function materialize(client, inputs, components) {
+    await configureIdentityMaterializationTimeouts(client)
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+    const projection = await assertIdentityProjectionCanBeMaterialized(client, components)
+    const resultingIdentityIds = new Map()
+    for (const component of components) {
+        const identity = await client.query(`insert into crm_atendimento.global_client_identities(
+                component_key,canonical_name,source_types)
+            values($1,$2,$3::jsonb)
+            on conflict(component_key) do update set
+                canonical_name=excluded.canonical_name,
+                source_types=excluded.source_types,
+                updated_at=now()
+            returning id`, [
+            component.componentKey,
+            component.preferredName,
+            JSON.stringify(component.sourceTypes),
+        ])
+        const identityId = String(identity.rows[0]?.id || '').trim()
+        if (!identityId) throw new Error('IDENTITY_PROJECTION_IDENTITY_ID_MISSING')
+        resultingIdentityIds.set(component.componentKey, identityId)
+        if (!component.members.length) continue
+        await client.query(`insert into crm_atendimento.global_client_identity_members(
+                identity_id,source_type,source_id)
+            select x.identity_id::uuid,x.source_type,x.source_id
+            from jsonb_to_recordset($1::jsonb) as x(identity_id text,source_type text,source_id text)
+            on conflict(source_type,source_id) do update set
+                identity_id=excluded.identity_id,updated_at=now()`, [
+            JSON.stringify(component.members.map((member) => ({
+                identity_id: identityId,
+                source_type: member.sourceType,
+                source_id: member.sourceId,
+            }))),
+        ])
+    }
+    const ledger = await recordIdentityProjectionMaterialization(client, {
+        origin: OPERATION,
+        components,
+        resultingIdentityIds,
+        previousIdentityByMember: projection.previousIdentityByMember,
+    })
+    return {
+        ...projectionSummary(inputs, components),
+        impactedIdentityIds: projection.impactedIdentityIds.length,
+        identityProjectionLedger: ledger,
+    }
+}
+
+const pool = new pg.Pool({ connectionString: databaseUrl, max: 2, application_name: 'crm-persisted-client-identity-projection' })
+try {
+    const verificationClient = await pool.connect()
+    try {
+        await assertIdentityMaterializationDatabase(verificationClient, databaseUrl)
+        await assertIdentityMaterializationSchemaReady(verificationClient)
+    } finally {
+        verificationClient.release()
+    }
+
+    const input = await loadInputs(pool)
+    const sourceFingerprint = fingerprintIdentityMaterializationSource(input)
+    const checkpoint = identityMaterializationCheckpoint({ operation: OPERATION, sourceFingerprint })
+    const components = buildProjection(input)
+    const summary = projectionSummary(input, components)
+    if (!apply) {
+        const writtenCheckpoint = await writeIdentityMaterializationCheckpoint({ outputFile: checkpointOutput, checkpoint })
+        console.log(JSON.stringify({
+            ok: true,
+            dryRun: true,
+            checkpoint,
+            checkpointOutput: writtenCheckpoint,
+            ...summary,
+        }, null, 2))
+        process.exitCode = 0
+    } else {
+        if (!checkpointFile) throw new Error('IDENTITY_MATERIALIZATION_CHECKPOINT_REQUIRED')
+        const client = await pool.connect()
+        let transactionOpen = false
+        try {
+            await client.query('begin')
+            transactionOpen = true
+            await configureIdentityMaterializationTimeouts(client)
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+            const currentInput = await loadInputs(client)
+            const currentFingerprint = fingerprintIdentityMaterializationSource(currentInput)
+            const currentComponents = buildProjection(currentInput)
+            await assertIdentityMaterializationApplyCheckpoint({
+                operation: OPERATION,
+                confirmation: process.env.CLIENT_IDENTITY_PROJECTION_APPLY_CONFIRM,
+                targetConfirmation: process.env.CLIENT_IDENTITY_PROJECTION_APPLY_TARGET,
+                checkpointFile,
+                sourceFingerprint: currentFingerprint,
+            })
+            const result = await materialize(client, currentInput, currentComponents)
+            await client.query('commit')
+            transactionOpen = false
+            console.log(JSON.stringify({
+                ok: true,
+                dryRun: false,
+                checkpoint: identityMaterializationCheckpoint({ operation: OPERATION, sourceFingerprint: currentFingerprint }),
+                ...result,
+            }, null, 2))
+        } catch (error) {
+            if (transactionOpen) {
+                try { await client.query('rollback') } catch { /* preserve original failure */ }
+            }
+            throw asRecoverableIdentityMaterializationError(error)
+        } finally {
+            client.release()
+        }
+    }
+} finally {
+    await pool.end()
+}

--- a/docs/runbooks/clientes-source-refresh.md
+++ b/docs/runbooks/clientes-source-refresh.md
@@ -76,6 +76,29 @@ alvo local de produção, o comando operacional deve usar o socket sem usuário
 (`postgresql:///skincos_crm_local?host=/var/run/postgresql`) e executar como o
 papel técnico autorizado; assim a verificação de destino permanece estrita.
 
+## Projeção global após reconciliação legada
+
+`reconcile-client-identities.mjs` mantém a camada histórica de clientes e
+vínculos Atendimento↔Caixa. Para rematerializar o grafo global a partir das
+fontes já persistidas, use
+`reconcile-persisted-client-identities.mjs`. O runner reutiliza o mesmo builder
+de componentes confirmados, lock do grafo, guard de histórico comercial e
+ledger de materialização; não importa planilhas, não cria links novos e não
+remove identidades históricas.
+
+Faça primeiro o dry-run com um checkpoint privado:
+
+```bash
+DATABASE_URL='postgresql:///skincos_crm_local?host=/var/run/postgresql' \
+CLIENT_IDENTITY_PROJECTION_CHECKPOINT_OUTPUT=/mnt/c/CodexRuntime/operator/admin/skincos/client-identity-projection-checkpoint.json \
+node crm/api/scripts/reconcile-persisted-client-identities.mjs
+```
+
+O apply exige o checkpoint, `CLIENT_IDENTITY_PROJECTION_APPLY_CONFIRM=UNIFICAR`
+e `CLIENT_IDENTITY_PROJECTION_APPLY_TARGET=skincos_crm_local`. A operação é
+transacional e falha fechada se o fingerprint das fontes mudar ou se a
+projeção tentar mover uma identidade com histórico comercial.
+
 As migrations de Clientes também reconciliam os grants mínimos do runtime,
 separados por responsabilidade:
 


### PR DESCRIPTION
## Summary
- add a strict dry-run/apply runner that rematerializes global identities from persisted sources
- reuse the canonical component builder, graph lock, commercial-history guard and immutable projection ledger
- document the checkpointed repair path after legacy canonical reconciliation

## Evidence
- production dry-run: 42,279 components, 47,770 members, 2,779 multi-source components
- prior production materializer exposed 84 attendance membership gaps; this runner addresses that divergence without deleting historical identities or importing a new source
- CRM API suite: 290 pass, 1 skip
- git diff --check clean

## Safety
Apply requires a private fingerprint checkpoint, UNIFICAR, and the exact skincos_crm_local target. The transaction acquires the identity graph lock and fails closed when commercial history would be moved.