### PR TITLE
fix(clientes): repair stale zero-count quality state

### DIFF
--- a/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
@@ -144,6 +144,13 @@ test('resolves an actionable finding when its positive observation clears', () =
         assert.equal(cleared.shouldRecord, true)
     }
 
+    const legacyCleared = __testables.commercialObservationTransition({
+        previousStatus: 'open', previousCount: 0, observedCount: 0,
+    })
+    assert.equal(legacyCleared.shouldResolve, true)
+    assert.equal(legacyCleared.nextStatus, 'resolved')
+    assert.equal(legacyCleared.eventType, 'cleared')
+
     const suppressed = __testables.commercialObservationTransition({
         previousStatus: 'suppressed', previousCount: 84, observedCount: 0,
     })

--- a/crm/api/server/atendimento/commercialDataQualityStore.js
+++ b/crm/api/server/atendimento/commercialDataQualityStore.js
@@ -432,15 +432,16 @@ function commercialObservationTransition({ previousStatus, previousCount, observ
     const shouldStartObservationWindow = nextCount > 0 && (priorCount === 0 || shouldReopen)
     // A positive observation is the actionable state; once that observation
     // clears, the queue should converge to resolved without waiting for an
-    // operator to close a stale zero-count row.  Suppressed and already
-    // resolved findings retain their historical state, while an acknowledged
-    // or in-progress finding is resolved only after a positive observation has
-    // actually cleared.
-    const shouldResolve = priorCount > 0 && nextCount === 0
+    // operator to close a stale zero-count row.  This also repairs legacy
+    // actionable rows that were already persisted with observed_count = 0.
+    // Suppressed and already resolved findings retain their historical state.
+    const shouldResolve = nextCount === 0
         && ['open', 'acknowledged', 'in_progress'].includes(previousStatus)
     const nextStatus = shouldReopen ? 'open' : shouldResolve ? 'resolved' : previousStatus
     const eventType = shouldReopen
         ? 'reopened'
+        : shouldResolve
+            ? 'cleared'
         : priorCount === 0 && nextCount > 0
             ? 'detected'
             : priorCount > 0 && nextCount === 0


### PR DESCRIPTION
## Summary\n- converge legacy actionable quality findings with observed_count = 0 to resolved\n- record the idempotent automatic clear transition and revision\n- preserve suppressed history and reopen behavior\n\n## Validation\n- focused commercial data quality tests (18 passed)\n- npm run crm:api:test (292 tests, 291 passed, 1 skipped)\n\nThis closes the remaining production stale status observed after the persisted identity projection repair.