### PR TITLE
fix: keep CCG operational node ids n8n compatible

### DIFF
--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.v3.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.v3.json
@@ -1754,7 +1754,7 @@
     },
     {
       "parameters": {},
-      "id": "ccg-operational-production-request-trigger",
+      "id": "ccg-operational-request-trigger",
       "name": "Operational Production Request",
       "type": "n8n-nodes-base.executeWorkflowTrigger",
       "typeVersion": 1.1,

--- a/orb/engine/scripts/build-campaign-creative-creator-continuous.js
+++ b/orb/engine/scripts/build-campaign-creative-creator-continuous.js
@@ -1857,7 +1857,7 @@ function transformWorkflow(source, options = {}) {
 
   workflow.nodes.push({
     parameters: {},
-    id: 'ccg-operational-production-request-trigger',
+    id: 'ccg-operational-request-trigger',
     name: 'Operational Production Request',
     type: 'n8n-nodes-base.executeWorkflowTrigger',
     typeVersion: 1.1,


### PR DESCRIPTION
# Summary

Fixes the final n8n schema compatibility issue found during the live promotion preflight.

## Changes

- Shortens the generated `Operational Production Request` node ID to stay within n8n's 36-character limit.
- Regenerates the candidate from the builder with the existing CCG-99 workflow ID `9j7WMFTNVNYmNZHC`.

## Validation

- Continuous CCG validation: 97 nodes, 108 edges; error handler 10 nodes.
- Continuous directed tests: 9/9.
- Organizer tests: 2/2.
- Candidate node IDs: all <= 36 characters.
- No secrets, paid calls, webhooks, or publication changes.

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Security/publication guard preserved
- [x] No final export edited manually