### PR TITLE
feat(clientes): add isolated production read-only runtime

### DIFF
--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -83,6 +83,40 @@ test('keeps Clientes routes exclusive to GESTOR, matching the CRM module policy'
     assert.equal(__testables.isCommercialManager({ role: 'INJETOR' }), false)
 })
 
+test('exposes the production read-only runtime flag only when explicitly enabled', () => {
+    const before = process.env.CRM_ATENDIMENTO_READ_ONLY
+    try {
+        delete process.env.CRM_ATENDIMENTO_READ_ONLY
+        assert.equal(__testables.atendimentoReadOnlyRuntime(), false)
+        process.env.CRM_ATENDIMENTO_READ_ONLY = 'true'
+        assert.equal(__testables.atendimentoReadOnlyRuntime(), true)
+        process.env.CRM_ATENDIMENTO_READ_ONLY = 'TRUE'
+        assert.equal(__testables.atendimentoReadOnlyRuntime(), true)
+        process.env.CRM_ATENDIMENTO_READ_ONLY = '1'
+        assert.equal(__testables.atendimentoReadOnlyRuntime(), false)
+    } finally {
+        if (before === undefined) delete process.env.CRM_ATENDIMENTO_READ_ONLY
+        else process.env.CRM_ATENDIMENTO_READ_ONLY = before
+    }
+})
+
+test('limits the isolated production surface to commercial Clientes routes when enabled', () => {
+    const before = process.env.CRM_ATENDIMENTO_CLIENTES_ONLY
+    try {
+        delete process.env.CRM_ATENDIMENTO_CLIENTES_ONLY
+        assert.equal(__testables.atendimentoClientesOnlyRuntime(), false)
+        process.env.CRM_ATENDIMENTO_CLIENTES_ONLY = 'true'
+        assert.equal(__testables.atendimentoClientesOnlyRuntime(), true)
+        assert.equal(__testables.isClientesCommercialPath('/commercial/overview'), true)
+        assert.equal(__testables.isClientesCommercialPath('/commercial/review'), true)
+        assert.equal(__testables.isClientesCommercialPath('/attendances'), false)
+        assert.equal(__testables.isClientesCommercialPath('/offers'), false)
+    } finally {
+        if (before === undefined) delete process.env.CRM_ATENDIMENTO_CLIENTES_ONLY
+        else process.env.CRM_ATENDIMENTO_CLIENTES_ONLY = before
+    }
+})
+
 test('blocks a commercial clinical-approval request before the cadence store write', async () => {
     let calls = 0
     const routes = captureAtendimentoRoutes({

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -137,6 +137,19 @@ function isLocalRequest(req) {
     return remote === '127.0.0.1' || remote === '::1' || remote === '::ffff:127.0.0.1'
 }
 
+function atendimentoReadOnlyRuntime() {
+    return String(process.env.CRM_ATENDIMENTO_READ_ONLY || '').trim().toLowerCase() === 'true'
+}
+
+function atendimentoClientesOnlyRuntime() {
+    return String(process.env.CRM_ATENDIMENTO_CLIENTES_ONLY || '').trim().toLowerCase() === 'true'
+}
+
+function isClientesCommercialPath(requestPath) {
+    const path = String(requestPath || '')
+    return path === '/commercial' || path.startsWith('/commercial/')
+}
+
 function errorPayload(error) {
     const message = String(error?.message || error || 'ERROR')
     const status = Number(error?.statusCode || error?.status || 500)
@@ -206,6 +219,7 @@ export function createAtendimentoRouter(options = {}) {
             return json(res, moduleControl.ready ? 200 : 503, {
                 ok: moduleControl.ready,
                 ...health,
+                readOnlyRuntime: atendimentoReadOnlyRuntime(),
                 moduleControl,
             })
         } catch (error) {
@@ -235,6 +249,16 @@ export function createAtendimentoRouter(options = {}) {
             if (!actor) actor = devSessionActor(req, getDevSession)
             if (!actor) return json(res, 401, { ok: false, error: 'UNAUTHORIZED' })
             if (!canAccessAtendimento(actor, req.path, req.method)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            if (atendimentoClientesOnlyRuntime() && !isClientesCommercialPath(req.path)) {
+                return json(res, 404, { ok: false, error: 'CLIENTES_SURFACE_ONLY' })
+            }
+            if (atendimentoReadOnlyRuntime() && !['GET', 'HEAD', 'OPTIONS'].includes(String(req.method || '').toUpperCase())) {
+                return json(res, 405, {
+                    ok: false,
+                    error: 'READ_ONLY_RUNTIME',
+                    hint: 'Este runtime de Clientes aceita somente leituras autenticadas.',
+                }, { allow: 'GET, HEAD, OPTIONS' })
+            }
             req.atendimentoActor = actor
             next()
         } catch (error) {
@@ -734,6 +758,9 @@ export const __testables = {
     requestsClinicalCadenceApproval,
     parseActorHeader,
     isLocalRequest,
+    atendimentoReadOnlyRuntime,
+    atendimentoClientesOnlyRuntime,
+    isClientesCommercialPath,
     redactLocalDiagnostic,
     safeEqual,
     verifyMetaAdsOfferContextToken,

--- a/docs/runbooks/atendimento-independent-release.md
+++ b/docs/runbooks/atendimento-independent-release.md
@@ -1,9 +1,11 @@
 # Atendimento — contrato de promoção independente
 
-**Estado atual:** staging isolado operacional. O banco, o unit nativo, o arquivo
-de controle, o túnel e a atestação pública são mantidos pelos scripts versionados
-com backups privados. Os workflows continuam dispatch-only e apenas atestam o
-SHA imutável e o health do runtime; nunca reiniciam `crm.service`.
+**Estado atual:** staging isolado operacional e contrato de produção isolado
+somente leitura preparado pelos scripts versionados, sempre com backups
+privados. O production runtime fica em loopback, sem rota pública e sem escrita
+comercial; o CRM global não é reiniciado por ele. Os workflows continuam
+dispatch-only e apenas atestam o SHA imutável e o health do runtime; nunca
+reiniciam `crm.service`.
 
 ## Fluxos canônicos
 
@@ -59,16 +61,18 @@ os nomes abaixo com os valores específicos de cada ambiente:
 Pré-requisitos técnicos cobertos no staging:
 
 1. o `crm-atendimento-staging.service` isolado, com porta, banco/role e health próprios;
-2. suporte efetivo e testado de `CRM_DOMAIN=atendimento` e
+2. o `crm-atendimento-production.service` isolado, com papel PostgreSQL
+   `skincos_clientes_ro`, bind loopback e bloqueio de métodos de escrita;
+3. suporte efetivo e testado de `CRM_DOMAIN=atendimento` e
    `CRM_MODULE_CONTROL_FILE` no processo — hoje o servidor CRM compartilhado não
    prova esse isolamento;
-3. gateway/túnel com rota para o processo isolado em staging, sem redirecionar
+4. gateway/túnel com rota para o processo isolado em staging, sem redirecionar
    para `crm.service`;
-4. scripts nativos confiáveis com allowlist dos três identificadores acima,
+5. scripts nativos confiáveis com allowlist dos três identificadores acima,
    autoria/auditoria por SHA e sem fallback de shell ou SSH do GitHub;
-5. migration staging somente aditiva, banco alvo explicitamente identificado,
+6. migration staging somente aditiva, banco alvo explicitamente identificado,
    checkpoint/backup e verificação de idempotência em staging;
-6. registro do SHA candidato e do SHA de retorno, smoke autenticado do mesmo SHA
+7. registro do SHA candidato e do SHA de retorno, smoke autenticado do mesmo SHA
    e prova de rollback do processo isolado.
 
 ## Rollback e disponibilidade
@@ -82,6 +86,8 @@ aditivos; se o dado não puder ser revertido com segurança, o rollback desliga 
 escrita/controle e recupera somente de checkpoint aprovado em ambiente isolado.
 
 O staging atende esses pré-requisitos e está apto a promoção sintética. A
-produção permanece explicitamente desabilitada e sem rota de Atendimento
-dedicada; nenhum workflow de produção é considerado executado enquanto esse
-runtime equivalente não existir.
+produção agora possui o runtime equivalente em modo somente leitura, mas
+permanece sem rota de Atendimento dedicada e sem qualquer escrita; nenhum
+workflow de publicação pública ou promoção global é considerado executado até
+que os gates de proxy, autenticação e rollback sejam comprovados
+separadamente.

--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -1,0 +1,72 @@
+# Clientes: runtime de produção somente leitura
+
+O runtime isolado de Clientes roda em `crm-atendimento-production.service`,
+somente em `127.0.0.1:8110`. Ele usa uma release imutável, o banco local de
+produção e o papel PostgreSQL `skincos_clientes_ro`, que possui apenas `SELECT`.
+O processo também é limitado à superfície `/api/atendimento/commercial/*` e a
+API recusa todo método diferente de `GET`, `HEAD` e `OPTIONS`.
+
+Não existe rota pública neste tranche. A publicação de um alias, túnel ou
+proxy exige uma revisão independente de autenticação, escopo de unidades,
+PII, logs e rollback. O runtime compartilhado `crm.service` não é reiniciado
+por nenhum dos scripts abaixo.
+
+## Contrato e instalação
+
+1. Provisione o contrato sem escrever:
+
+   ```bash
+   scripts/provision-atendimento-production-readonly.sh --dry-run
+   ```
+
+2. Depois de revisar o alvo e ter o backup/rollback operacional, aplique o
+   contrato. O script cria uma senha aleatória somente no arquivo privado e
+   inicia em `maintenance`:
+
+   ```bash
+   scripts/provision-atendimento-production-readonly.sh --apply
+   ```
+
+3. Prepare uma release nativa aprovada com
+   `scripts/runtime/prepare-native-source-release.sh --stage-only`. O destino
+   deve ser exatamente `/opt/skincos/releases/<sha>/source`; nenhum serviço
+   pode executar um checkout ou worktree.
+
+4. Instale somente o serviço isolado:
+
+   ```bash
+   scripts/runtime/install-atendimento-production-service.sh \
+     --source-root /opt/skincos/releases/<sha>/source --apply
+   ```
+
+5. Após confirmar a linhagem da release, abra o controle local:
+
+   ```bash
+   scripts/set-atendimento-production-readonly-control.sh \
+     --state active --release-sha <sha> --apply
+   ```
+
+O `--state maintenance` ou `--state disabled` é o rollback imediato e não
+altera banco ou o CRM compartilhado. Cada alteração de unidade, configuração e
+controle cria cópia privada em
+`/var/backups/skincos/clientes/production-readonly`.
+
+## Validação
+
+Execute no host nativo, nunca no checkout Windows:
+
+```bash
+EXPECTED_STATE=active scripts/validate-atendimento-production-readonly.sh
+```
+
+A validação atesta serviço ativo, bind loopback, health do módulo, papel
+PostgreSQL somente leitura, `SELECT` nas duas fontes necessárias e uma tentativa
+assinada de `POST` que retorna `405 READ_ONLY_RUNTIME` antes de qualquer store
+mutation. Não imprime nomes, telefones, e-mails, URLs com senha ou payloads.
+
+## Próximo gate
+
+Este runtime fecha o isolamento técnico, mas não autoriza publicá-lo. O próximo
+incremento deve adicionar proxy/rota somente depois de uma prova autenticada,
+escopo de unidade, redaction de PII e observabilidade; consentimento, campanha,
+mensagem WhatsApp, revisão clínica e qualquer escrita permanecem bloqueados.

--- a/ops/runtime/units/crm-atendimento-production.service
+++ b/ops/runtime/units/crm-atendimento-production.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Skincos Clientes isolated production read-only runtime
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=skincos
+Group=skincos
+WorkingDirectory=__REPO_ROOT__
+Environment=CRM_RUNTIME_HOME=__STATE_ROOT__/crm-atendimento-production
+Environment=SKINCOS_CRM_API_ENV_FILE=__CONFIG_ROOT__/crm-clientes-production-readonly.env
+Environment=VAR_DIR=__STATE_ROOT__/crm-atendimento-production/var
+Environment=BACKEND_DIR=__REPO_ROOT__/backend
+Environment=FRONTEND_DIR=__REPO_ROOT__/crm/console
+Environment=CONFIG_DIR=__REPO_ROOT__/backend/config
+EnvironmentFile=-__CONFIG_ROOT__/crm-clientes-production-readonly.env
+ExecStart=__REPO_ROOT__/scripts/crm/run-api-linux.sh
+Restart=always
+RestartSec=5
+TimeoutStopSec=20
+KillMode=control-group
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=__STATE_ROOT__/crm-atendimento-production __LOG_ROOT__/crm-atendimento-production
+UMask=0027
+LimitNOFILE=8192
+SyslogIdentifier=crm-atendimento-production
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/provision-atendimento-production-readonly.sh
+++ b/scripts/provision-atendimento-production-readonly.sh
@@ -34,7 +34,8 @@ if [[ "$ACTION" == "--dry-run" ]]; then
 select 'database=' || datname from pg_database where datname = '$DB_NAME';
 select 'role=' || rolname || ':login=' || rolcanlogin || ':default_read_only=' || coalesce(array_to_string(rolconfig, ','), '')
   from pg_roles where rolname = '$APP_ROLE';
-select 'database_connect=' || has_database_privilege('$APP_ROLE', '$DB_NAME', 'CONNECT');
+select 'database_connect=' || case when exists (select 1 from pg_roles where rolname = '$APP_ROLE')
+  then has_database_privilege('$APP_ROLE', '$DB_NAME', 'CONNECT')::text else 'missing' end;
 SQL
   for path in "$ATENDIMENTO_CONFIG" "$CONTROL_FILE"; do
     if sudo -n test -f "$path"; then echo "present=$path"; else echo "missing=$path"; fi

--- a/scripts/provision-atendimento-production-readonly.sh
+++ b/scripts/provision-atendimento-production-readonly.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provisions the isolated production Clientes runtime contract. The database
+# role is SELECT-only and the API remains loopback-only; no public route or
+# commercial write is enabled by this script.
+
+ACTION="${1:-}"
+if [[ "$ACTION" != "--dry-run" && "$ACTION" != "--apply" ]]; then
+  echo "Usage: $0 --dry-run|--apply" >&2
+  exit 64
+fi
+
+DB_NAME="skincos_crm_local"
+APP_ROLE="skincos_clientes_ro"
+CONFIG_DIR="/etc/skincos"
+ATENDIMENTO_CONFIG="$CONFIG_DIR/crm-clientes-production-readonly.env"
+CONTROL_DIR="$CONFIG_DIR/atendimento-production"
+CONTROL_FILE="$CONTROL_DIR/module-control.json"
+STATE_ROOT="/var/lib/skincos-runtime/crm-atendimento-production"
+LOG_ROOT="/var/log/skincos/crm-atendimento-production"
+BACKUP_ROOT="/var/backups/skincos/clientes/production-readonly"
+PORT="8110"
+
+require_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }
+require_cmd sudo
+require_cmd openssl
+require_cmd install
+require_cmd psql
+sudo -n true
+
+if [[ "$ACTION" == "--dry-run" ]]; then
+  sudo -n -u postgres psql --dbname=postgres --set=ON_ERROR_STOP=1 --tuples-only --no-align <<SQL
+select 'database=' || datname from pg_database where datname = '$DB_NAME';
+select 'role=' || rolname || ':login=' || rolcanlogin || ':default_read_only=' || coalesce(array_to_string(rolconfig, ','), '')
+  from pg_roles where rolname = '$APP_ROLE';
+select 'database_connect=' || has_database_privilege('$APP_ROLE', '$DB_NAME', 'CONNECT');
+SQL
+  for path in "$ATENDIMENTO_CONFIG" "$CONTROL_FILE"; do
+    if sudo -n test -f "$path"; then echo "present=$path"; else echo "missing=$path"; fi
+  done
+  echo "service=crm-atendimento-production.service port=$PORT loopback_only=true"
+  exit 0
+fi
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+sudo -n install -d -m 0750 -o root -g skincos "$CONFIG_DIR" "$CONTROL_DIR"
+sudo -n install -d -m 0750 -o skincos -g skincos "$STATE_ROOT" "$STATE_ROOT/var" "$LOG_ROOT"
+sudo -n install -d -m 0750 -o root -g skincos "$BACKUP_ROOT"
+
+for path in "$ATENDIMENTO_CONFIG" "$CONTROL_FILE"; do
+  if sudo -n test -f "$path"; then
+    sudo -n cp -p "$path" "$BACKUP_ROOT/${stamp}-$(basename "$path")"
+  fi
+done
+
+app_password="$(openssl rand -hex 32)"
+actor_key="$(openssl rand -hex 32)"
+role_exists="$(sudo -n -u postgres psql --dbname=postgres --tuples-only --no-align --set=ON_ERROR_STOP=1 -c "select 1 from pg_roles where rolname = '$APP_ROLE'" | tr -d '[:space:]')"
+if [[ "$role_exists" != "1" ]]; then
+  sudo -n -u postgres psql --dbname=postgres --set=ON_ERROR_STOP=1 --set=app_password="$app_password" <<SQL
+create role $APP_ROLE login password :'app_password';
+SQL
+fi
+
+sudo -n -u postgres psql --dbname=postgres --set=ON_ERROR_STOP=1 --set=app_password="$app_password" <<SQL
+alter role $APP_ROLE login password :'app_password';
+alter role $APP_ROLE set default_transaction_read_only = on;
+grant connect on database $DB_NAME to $APP_ROLE;
+
+\connect $DB_NAME
+revoke create on schema crm_atendimento, crm_caixa from $APP_ROLE;
+grant usage on schema crm_atendimento, crm_caixa to $APP_ROLE;
+grant select on all tables in schema crm_atendimento, crm_caixa to $APP_ROLE;
+alter default privileges for role skincos in schema crm_atendimento grant select on tables to $APP_ROLE;
+alter default privileges for role skincos in schema crm_caixa grant select on tables to $APP_ROLE;
+alter default privileges for role postgres in schema crm_atendimento grant select on tables to $APP_ROLE;
+alter default privileges for role postgres in schema crm_caixa grant select on tables to $APP_ROLE;
+SQL
+
+umask 0077
+tmp_env="$(mktemp)"
+tmp_control="$(mktemp)"
+trap 'rm -f "$tmp_env" "$tmp_control"' EXIT
+cat >"$tmp_env" <<EOF
+NODE_ENV=production
+CRM_DOMAIN=atendimento
+CRM_API_HOST=127.0.0.1
+CRM_API_PORT=$PORT
+DATABASE_URL="postgresql://$APP_ROLE:$app_password@127.0.0.1:5432/$DB_NAME?sslmode=disable&application_name=crm-atendimento-production-readonly"
+ATENDIMENTO_ACTOR_HMAC_KEY=$actor_key
+CRM_RUNTIME_HOME=$STATE_ROOT
+VAR_DIR=$STATE_ROOT/var
+CRM_MODULE_CONTROL_FILE=$CONTROL_FILE
+SKINCOS_CRM_API_ENV_FILE=$ATENDIMENTO_CONFIG
+HARMONIA_WORKER_ENABLED=false
+WA_BOOTSTRAP_SYNC_ENABLED=false
+WA_BOOTSTRAP_SYNC_AUTO_ON_CONNECTED=false
+CRM_LOCAL_NO_AUTH=false
+NO_AUTH=false
+CRM_ATENDIMENTO_READ_ONLY=true
+CRM_ATENDIMENTO_CLIENTES_ONLY=true
+CRM_ATENDIMENTO_COMMERCIAL_WRITES_ENABLED=false
+CRM_ATENDIMENTO_SCHEMA_MANAGED=true
+EOF
+cat >"$tmp_control" <<EOF
+{"schemaVersion":1,"module":"atendimento","state":"maintenance","releaseSha":null,"syntheticOnly":false,"reason":"clientes-production-readonly-pending-release","updatedAt":"$stamp"}
+EOF
+sudo -n install -m 0640 -o root -g skincos "$tmp_env" "$ATENDIMENTO_CONFIG"
+sudo -n install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
+
+echo "Atendimento production read-only contract provisioned: database=$DB_NAME app_role=$APP_ROLE service=crm-atendimento-production port=$PORT control_state=maintenance"

--- a/scripts/runtime/install-atendimento-production-service.sh
+++ b/scripts/runtime/install-atendimento-production-service.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_ROOT=""
+UNIT_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../ops/runtime/units" && pwd)"
+UNIT_DEST="${UNIT_DEST:-/etc/systemd/system}"
+STATE_ROOT="${STATE_ROOT:-/var/lib/skincos-runtime}"
+CONFIG_ROOT="${CONFIG_ROOT:-/etc/skincos}"
+LOG_ROOT="${LOG_ROOT:-/var/log/skincos}"
+BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes/production-readonly}"
+APPLY=0
+
+usage() { echo "Usage: $0 --source-root /opt/skincos/releases/<sha>/source [--apply]"; }
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-root) shift; SOURCE_ROOT="${1:-}" ;;
+    --apply) APPLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+[[ "$SOURCE_ROOT" == /opt/skincos/releases/*/source ]] || { echo "SOURCE_ROOT must be an immutable native release path." >&2; exit 1; }
+sudo -n test -d "$SOURCE_ROOT" && sudo -n test -x "$SOURCE_ROOT/scripts/crm/run-api-linux.sh" || { echo "Native source release is unavailable: $SOURCE_ROOT" >&2; exit 1; }
+command -v sed >/dev/null 2>&1 || { echo "Missing sed" >&2; exit 1; }
+command -v systemd-analyze >/dev/null 2>&1 || { echo "Missing systemd-analyze" >&2; exit 1; }
+sudo -n true
+
+sed_escape() { printf '%s' "$1" | sed 's/[&|]/\\&/g'; }
+render_dir="$(mktemp -d)"
+trap 'rm -rf "$render_dir"' EXIT
+source_escaped="$(sed_escape "$SOURCE_ROOT")"
+state_escaped="$(sed_escape "$STATE_ROOT")"
+config_escaped="$(sed_escape "$CONFIG_ROOT")"
+log_escaped="$(sed_escape "$LOG_ROOT")"
+rendered="$render_dir/crm-atendimento-production.service"
+sed \
+  -e "s|__REPO_ROOT__|$source_escaped|g" \
+  -e "s|__STATE_ROOT__|$state_escaped|g" \
+  -e "s|__CONFIG_ROOT__|$config_escaped|g" \
+  -e "s|__LOG_ROOT__|$log_escaped|g" \
+  "$UNIT_SRC/crm-atendimento-production.service" >"$rendered"
+chmod 0644 "$rendered"
+sudo -n systemd-analyze verify "$rendered"
+
+if [[ "$APPLY" == "1" ]]; then
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  sudo -n install -d -m 0750 -o root -g skincos "$BACKUP_ROOT"
+  if sudo -n test -f "$UNIT_DEST/crm-atendimento-production.service"; then
+    sudo -n cp -p "$UNIT_DEST/crm-atendimento-production.service" "$BACKUP_ROOT/${stamp}-crm-atendimento-production.service"
+  fi
+  sudo -n install -m 0644 "$rendered" "$UNIT_DEST/crm-atendimento-production.service"
+  sudo -n systemctl daemon-reload
+  sudo -n systemctl enable --now crm-atendimento-production.service >/dev/null
+  sudo -n systemctl is-active --quiet crm-atendimento-production.service
+  echo "crm-atendimento-production.service verified and applied source=$SOURCE_ROOT"
+else
+  echo "crm-atendimento-production.service verified source=$SOURCE_ROOT"
+fi

--- a/scripts/runtime/manage-native-runtime.sh
+++ b/scripts/runtime/manage-native-runtime.sh
@@ -8,6 +8,7 @@ units=(
   messaging-whatsapp.service
   crm.service
   crm-atendimento-staging.service
+  crm-atendimento-production.service
   booking.service
   cloudflare-orb.service
   cloudflare-runtime.service

--- a/scripts/set-atendimento-production-readonly-control.sh
+++ b/scripts/set-atendimento-production-readonly-control.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTROL_FILE="${CONTROL_FILE:-/etc/skincos/atendimento-production/module-control.json}"
+BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos/clientes/production-readonly}"
+STATE=""
+RELEASE_SHA=""
+REASON="clientes-production-readonly"
+APPLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/set-atendimento-production-readonly-control.sh --state <disabled|maintenance|active> [--release-sha <full-sha>] [--reason <text>] [--apply]
+
+Active production Clientes requires a full immutable release SHA. The default
+is a dry-run; --apply creates a private backup before replacing the control
+file. No process or public route is changed by this script.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state) shift; STATE="${1:-}" ;;
+    --release-sha) shift; RELEASE_SHA="${1:-}" ;;
+    --reason) shift; REASON="${1:-}" ;;
+    --apply) APPLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+[[ "$STATE" =~ ^(disabled|maintenance|active)$ ]] || { echo '--state must be disabled, maintenance or active.' >&2; exit 64; }
+if [[ "$STATE" == "active" ]]; then
+  [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--release-sha must be a full lowercase SHA for active state.' >&2; exit 64; }
+elif [[ -n "$RELEASE_SHA" && ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo '--release-sha must be a full lowercase SHA when supplied.' >&2
+  exit 64
+fi
+[[ "$REASON" =~ ^[A-Za-z0-9._:-]{1,120}$ ]] || { echo '--reason contains unsupported characters.' >&2; exit 64; }
+command -v install >/dev/null 2>&1 || { echo 'Missing install' >&2; exit 1; }
+command -v date >/dev/null 2>&1 || { echo 'Missing date' >&2; exit 1; }
+sudo -n true
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ "$APPLY" == "1" ]]; then
+  sudo -n test -f "$CONTROL_FILE" || { echo "Control file is missing: $CONTROL_FILE" >&2; exit 1; }
+  sudo -n install -d -m 0750 -o root -g skincos "$BACKUP_ROOT"
+  sudo -n cp -p "$CONTROL_FILE" "$BACKUP_ROOT/${stamp}-module-control.json"
+fi
+
+tmp_control="$(mktemp)"
+trap 'rm -f "$tmp_control"' EXIT
+release_json='null'
+if [[ -n "$RELEASE_SHA" ]]; then
+  release_json="\"$RELEASE_SHA\""
+fi
+cat >"$tmp_control" <<EOF
+{"schemaVersion":1,"module":"atendimento","state":"$STATE","releaseSha":$release_json,"syntheticOnly":false,"reason":"$REASON","updatedAt":"$stamp"}
+EOF
+if [[ "$APPLY" == "1" ]]; then
+  sudo -n install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
+  echo "Atendimento production control updated: state=$STATE release_sha=${RELEASE_SHA:-none}"
+else
+  echo "Atendimento production control verified: state=$STATE release_sha=${RELEASE_SHA:-none} (dry-run)"
+fi

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8')
+
+test('isolated Clientes production unit is loopback-configured and cannot broaden the shared runtime', () => {
+  const unit = read('ops/runtime/units/crm-atendimento-production.service')
+  assert.match(unit, /Description=.*Clientes.*read-only/)
+  assert.match(unit, /EnvironmentFile=-__CONFIG_ROOT__\/crm-clientes-production-readonly\.env/)
+  assert.match(unit, /ReadWritePaths=__STATE_ROOT__\/crm-atendimento-production/)
+  assert.doesNotMatch(unit, /crm\.service/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /CRM_API_HOST=127\.0\.0\.1/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /CRM_ATENDIMENTO_READ_ONLY=true/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /CRM_ATENDIMENTO_CLIENTES_ONLY=true/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /default_transaction_read_only = on/)
+  assert.match(read('scripts/runtime/manage-native-runtime.sh'), /crm-atendimento-production\.service/)
+})
+
+test('production validation proves the API and database write barriers without sending customer data', () => {
+  const validation = read('scripts/validate-atendimento-production-readonly.sh')
+  assert.match(validation, /READ_ONLY_RUNTIME/)
+  assert.match(validation, /commercial\/actions/)
+  assert.match(validation, /skincos_clientes_ro/)
+  assert.match(validation, /global_client_identities/)
+  assert.match(validation, /crm_caixa\.sales/)
+  assert.doesNotMatch(validation, /curl[^\n]*https?:\/\/(?!127\.0\.0\.1)/)
+})
+
+test('production control refuses active state without an immutable full SHA', () => {
+  const control = read('scripts/set-atendimento-production-readonly-control.sh')
+  assert.match(control, /STATE.*active/)
+  assert.match(control, /release-sha.*full lowercase SHA/)
+  assert.match(control, /state.*disabled\|maintenance\|active/)
+})

--- a/scripts/validate-atendimento-production-readonly.sh
+++ b/scripts/validate-atendimento-production-readonly.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8110}"
+SERVICE="crm-atendimento-production.service"
+CONFIG_FILE="${CONFIG_FILE:-/etc/skincos/crm-clientes-production-readonly.env}"
+CONTROL_FILE="${CONTROL_FILE:-/etc/skincos/atendimento-production/module-control.json}"
+EXPECTED_STATE="${EXPECTED_STATE:-active}"
+
+[[ "$EXPECTED_STATE" =~ ^(disabled|maintenance|active)$ ]] || { echo 'EXPECTED_STATE must be disabled, maintenance or active.' >&2; exit 64; }
+for command_name in curl psql ss systemctl; do
+  command -v "$command_name" >/dev/null 2>&1 || { echo "Missing required command: $command_name" >&2; exit 1; }
+done
+sudo -n true
+sudo -n systemctl is-active --quiet "$SERVICE" || { echo "Service is not active: $SERVICE" >&2; exit 1; }
+sudo -n test -r "$CONFIG_FILE" || { echo "Runtime config is unavailable: $CONFIG_FILE" >&2; exit 1; }
+sudo -n test -r "$CONTROL_FILE" || { echo "Module control is unavailable: $CONTROL_FILE" >&2; exit 1; }
+
+listen_line="$(ss -ltn | awk -v port=":$PORT" '$4 == "127.0.0.1" port || $4 == "[::1]" port { print; exit }')"
+[[ -n "$listen_line" ]] || { echo "Runtime is not bound to loopback port $PORT." >&2; exit 1; }
+
+health_body="$(mktemp)"
+write_body="$(mktemp)"
+trap 'rm -f "$health_body" "$write_body"' EXIT
+health_status="$(curl -sS --max-time 10 -o "$health_body" -w '%{http_code}' "http://127.0.0.1:$PORT/api/atendimento/health")"
+if [[ "$EXPECTED_STATE" == "active" ]]; then
+  [[ "$health_status" == "200" ]] || { echo "Clientes health expected 200, got $health_status." >&2; exit 1; }
+else
+  [[ "$health_status" == "503" ]] || { echo "Clientes health expected 503 while $EXPECTED_STATE, got $health_status." >&2; exit 1; }
+fi
+grep -Fq '"readOnlyRuntime":true' "$health_body" || { echo 'Health did not attest readOnlyRuntime=true.' >&2; exit 1; }
+grep -Fq '"module":"atendimento"' "$health_body" || { echo 'Health did not attest the Atendimento module.' >&2; exit 1; }
+
+sudo -n -u postgres psql --dbname=skincos_crm_local --set=ON_ERROR_STOP=1 --tuples-only --no-align <<'SQL' | while IFS='|' read -r role_name role_login read_only schema_ok atendimento_ok caixa_ok; do
+select r.rolname,
+       r.rolcanlogin,
+       coalesce(array_to_string(r.rolconfig, ','), '') like '%default_transaction_read_only=on%',
+       has_schema_privilege(r.rolname, 'crm_atendimento', 'USAGE'),
+       has_table_privilege(r.rolname, 'crm_atendimento.global_client_identities', 'SELECT'),
+       has_table_privilege(r.rolname, 'crm_caixa.sales', 'SELECT')
+  from pg_roles r where r.rolname = 'skincos_clientes_ro';
+SQL
+  [[ "$role_name" == 'skincos_clientes_ro' && "$role_login" == 't' && "$read_only" == 't' && "$schema_ok" == 't' && "$atendimento_ok" == 't' && "$caixa_ok" == 't' ]] || {
+    echo 'Read-only database role contract is incomplete.' >&2
+    exit 1
+  }
+done
+
+# Prove the API gate with a signed synthetic actor. The request must be rejected
+# before the store mutation boundary and no real data is sent.
+set -a
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+set +a
+[[ -n "${ATENDIMENTO_ACTOR_HMAC_KEY:-}" ]] || { echo 'Actor key is not configured.' >&2; exit 1; }
+actor_b64="$(printf '%s' '{"id":"clientes-readonly-validation","role":"GESTOR","allowedModules":["atendimento"]}' | base64 -w0 | tr '+/' '-_' | tr -d '=')"
+ts="$(date +%s%3N)"
+signature="$(printf '%s.%s' "$ts" "$actor_b64" | openssl dgst -sha256 -hmac "$ATENDIMENTO_ACTOR_HMAC_KEY" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')"
+write_status="$(curl -sS --max-time 10 -o "$write_body" -w '%{http_code}' -X POST \
+  -H "x-crm-user: $actor_b64" -H "x-crm-ts: $ts" -H "x-crm-signature: $signature" \
+  -H 'content-type: application/json' --data '{}' "http://127.0.0.1:$PORT/api/atendimento/commercial/actions")"
+[[ "$write_status" == "405" ]] || { echo "Read-only API gate expected 405 for a signed write, got $write_status." >&2; exit 1; }
+grep -Fq 'READ_ONLY_RUNTIME' "$write_body" || { echo 'Read-only API gate did not return its stable error.' >&2; exit 1; }
+
+echo "Atendimento production read-only validation passed: service=$SERVICE port=$PORT state=$EXPECTED_STATE"


### PR DESCRIPTION
## Summary
- add a loopback-only crm-atendimento-production.service contract for Clientes
- provision a dedicated PostgreSQL SELECT-only role and fail-closed maintenance control
- enforce API read-only and Clientes-commercial surface gates with signed-write validation
- add native runbook, rollback backups, and static/runtime contract tests

## Validation
- crm:api:test (293 passed, 1 skipped)
- architecture:validate (pre-existing legacy-boundary warnings only)
- module-maturity:validate
- focused route/runtime contract tests
- bash -n for all new native scripts

No public route, shared CRM restart, commercial write, consent, message, or campaign was enabled.