### PR TITLE
fix(clientes): provision source refresh runtime paths

### DIFF
--- a/scripts/runtime/install-clientes-source-refresh-service.sh
+++ b/scripts/runtime/install-clientes-source-refresh-service.sh
@@ -68,7 +68,11 @@ systemd-analyze verify "$rendered_service" "$rendered_timer"
 
 if [[ "$APPLY" == "1" ]]; then
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-  sudo -n install -d -m 0750 "$BACKUP_ROOT"
+  # The unit runs as skincos and systemd refuses to start a sandbox when a
+  # ReadWritePaths entry is absent.  Provision both writable surfaces here so
+  # a fresh host cannot fail with 226/NAMESPACE before the runner executes.
+  sudo -n install -d -o root -g skincos -m 0750 "$BACKUP_ROOT"
+  sudo -n install -d -o skincos -g skincos -m 0750 "$LOG_ROOT/crm-clientes-source-refresh"
   for unit in crm-clientes-source-refresh.service crm-clientes-source-refresh.timer; do
     if sudo -n test -f "$UNIT_DEST/$unit"; then
       sudo -n cp -p "$UNIT_DEST/$unit" "$BACKUP_ROOT/$unit.$stamp"

--- a/scripts/runtime/install-clientes-source-refresh-service.sh
+++ b/scripts/runtime/install-clientes-source-refresh-service.sh
@@ -71,7 +71,9 @@ if [[ "$APPLY" == "1" ]]; then
   # The unit runs as skincos and systemd refuses to start a sandbox when a
   # ReadWritePaths entry is absent.  Provision both writable surfaces here so
   # a fresh host cannot fail with 226/NAMESPACE before the runner executes.
-  sudo -n install -d -o root -g skincos -m 0750 "$BACKUP_ROOT"
+  # The checkpoint is created by the skincos service account; keep the parent
+  # owned by root while granting its technical group write access.
+  sudo -n install -d -o root -g skincos -m 0770 "$BACKUP_ROOT"
   sudo -n install -d -o skincos -g skincos -m 0750 "$LOG_ROOT/crm-clientes-source-refresh"
   for unit in crm-clientes-source-refresh.service crm-clientes-source-refresh.timer; do
     if sudo -n test -f "$UNIT_DEST/$unit"; then

--- a/scripts/runtime/test-install-clientes-source-refresh-service.sh
+++ b/scripts/runtime/test-install-clientes-source-refresh-service.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/runtime/install-clientes-source-refresh-service.sh"
+
+bash -n "$SCRIPT"
+grep -F -- 'ReadWritePaths entry is absent' "$SCRIPT" >/dev/null
+grep -F -- 'install -d -o root -g skincos -m 0750 "$BACKUP_ROOT"' "$SCRIPT" >/dev/null
+grep -F -- 'install -d -o skincos -g skincos -m 0750 "$LOG_ROOT/crm-clientes-source-refresh"' "$SCRIPT" >/dev/null
+grep -F -- 'systemd-analyze verify "$rendered_service" "$rendered_timer"' "$SCRIPT" >/dev/null
+
+echo 'PASS: source refresh installer provisions sandbox and checkpoint directories.'

--- a/scripts/runtime/test-install-clientes-source-refresh-service.sh
+++ b/scripts/runtime/test-install-clientes-source-refresh-service.sh
@@ -6,7 +6,7 @@ SCRIPT="$ROOT_DIR/scripts/runtime/install-clientes-source-refresh-service.sh"
 
 bash -n "$SCRIPT"
 grep -F -- 'ReadWritePaths entry is absent' "$SCRIPT" >/dev/null
-grep -F -- 'install -d -o root -g skincos -m 0750 "$BACKUP_ROOT"' "$SCRIPT" >/dev/null
+grep -F -- 'install -d -o root -g skincos -m 0770 "$BACKUP_ROOT"' "$SCRIPT" >/dev/null
 grep -F -- 'install -d -o skincos -g skincos -m 0750 "$LOG_ROOT/crm-clientes-source-refresh"' "$SCRIPT" >/dev/null
 grep -F -- 'systemd-analyze verify "$rendered_service" "$rendered_timer"' "$SCRIPT" >/dev/null
 


### PR DESCRIPTION
## Summary\n- provision the source refresh backup directory with root:skincos ownership\n- create the systemd log sandbox path before installing the unit\n- add a shell regression test for the runtime layout contract\n\n## Validation\n- scripts/runtime/test-install-clientes-source-refresh-service.sh\n- scripts/runtime/install-clientes-source-refresh-service.sh (template verification)\n\nFixes the observed 226/NAMESPACE failure on a fresh host without changing the dry-run or apply gates.