### PR TITLE
fix(orb): make campaign creative operational trigger pass through inputs

### DIFF
--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-error-handler.v3.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-error-handler.v3.json
@@ -365,7 +365,7 @@
   },
   "meta": {
     "codex_builder": "campaign-creative-creator-continuous",
-    "codex_builder_version": "4.1.0",
+    "codex_builder_version": "4.1.1",
     "architecture": "separate-error-workflow-with-executor-recovery",
     "source_workflow_id": "TxE9eMS1xfE6kq38",
     "no_publication": true,

--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.module-fixtures.v3.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.module-fixtures.v3.json
@@ -151,7 +151,7 @@
   "settings": {},
   "meta": {
     "codex_builder": "campaign-creative-creator-continuous",
-    "codex_builder_version": "4.1.0",
+    "codex_builder_version": "4.1.1",
     "architecture": "versioned-fixture-catalog",
     "source_workflow_id": "TxE9eMS1xfE6kq38",
     "no_publication": true,

--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.package.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.package.json
@@ -1,7 +1,7 @@
 {
   "package_version": "4.0.0",
   "builder": "campaign-creative-creator-continuous",
-  "builder_version": "4.1.0",
+  "builder_version": "4.1.1",
   "source": {
     "workflow_id": "TxE9eMS1xfE6kq38",
     "workflow_name": "Campaign Creative Creator",

--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.v3.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator.v3.json
@@ -1753,7 +1753,9 @@
       ]
     },
     {
-      "parameters": {},
+      "parameters": {
+        "inputSource": "passthrough"
+      },
       "id": "ccg-operational-request-trigger",
       "name": "Operational Production Request",
       "type": "n8n-nodes-base.executeWorkflowTrigger",
@@ -3182,7 +3184,7 @@
   },
   "meta": {
     "codex_builder": "campaign-creative-creator-continuous",
-    "codex_builder_version": "4.1.0",
+    "codex_builder_version": "4.1.1",
     "architecture": "continuous-with-native-production-executor-and-separate-error-workflow",
     "source_workflow_id": "TxE9eMS1xfE6kq38",
     "source_version_id": "941bec10-3e41-49be-baed-753ca60787ad",

--- a/orb/engine/scripts/build-campaign-creative-creator-continuous.js
+++ b/orb/engine/scripts/build-campaign-creative-creator-continuous.js
@@ -8,7 +8,7 @@ const WORKFLOW_ID = 'TxE9eMS1xfE6kq38';
 const WORKFLOW_NAME = 'Campaign Creative Creator';
 const ERROR_WORKFLOW_ID = 'ccg-campaign-creative-error-v3';
 const ERROR_WORKFLOW_NAME = 'Campaign Creative Creator - Error Handler';
-const BUILDER_VERSION = '4.1.0';
+const BUILDER_VERSION = '4.1.1';
 const ALL_FIXTURE_NAMES = [
   'Build CCG-00 dry-run fixture',
   'Build CCG-10 dry-run fixture',
@@ -1915,7 +1915,11 @@ function transformWorkflow(source, options = {}) {
   ensureStructuredParserModels(workflow);
 
   workflow.nodes.push({
-    parameters: {},
+    // n8n 2.8 validates the Execute Workflow Trigger's default input schema
+    // before starting a child execution. The operational contract already
+    // carries its own versioned envelope, so pass that envelope through
+    // unchanged instead of forcing the trigger to maintain a second schema.
+    parameters: { inputSource: 'passthrough' },
     id: 'ccg-operational-request-trigger',
     name: 'Operational Production Request',
     type: 'n8n-nodes-base.executeWorkflowTrigger',

--- a/orb/engine/scripts/validate-campaign-creative-creator-continuous.js
+++ b/orb/engine/scripts/validate-campaign-creative-creator-continuous.js
@@ -196,6 +196,10 @@ function validateWorkflow(workflow, options = {}) {
   if (workflow.nodes.filter((node) => node.name === 'Operational Production Request').length !== 1) {
     throw new Error('Expected exactly one operational trigger');
   }
+  const operationalTrigger = workflow.nodes.find((node) => node.name === 'Operational Production Request');
+  if (operationalTrigger.parameters?.inputSource !== 'passthrough') {
+    throw new Error('Operational trigger must pass through the versioned production envelope');
+  }
   for (const name of EXECUTION_NODE_NAMES) {
     if (!names.has(name)) throw new Error('Production execution node is missing: ' + name);
   }

--- a/orb/engine/tests/campaign-creative-creator-continuous.test.js
+++ b/orb/engine/tests/campaign-creative-creator-continuous.test.js
@@ -224,6 +224,7 @@ test('build package is valid, idempotent, and keeps the operational route fixtur
 
   assert.equal(first.active, false);
   assert.equal(first.nodes.filter((candidate) => candidate.name === 'Operational Production Request').length, 1);
+  assert.equal(first.nodes.find((candidate) => candidate.name === 'Operational Production Request').parameters.inputSource, 'passthrough');
   assert.equal(first.nodes.some((candidate) => candidate.name === 'CCG-80 Production Executor'), false);
   for (const fixture of INTERMEDIATE_FIXTURES) assert.equal(first.nodes.some((candidate) => candidate.name === fixture), false, fixture);
   assert.equal(first.nodes.some((candidate) => candidate.name === 'Build CCG-99 retryable fixture'), false);


### PR DESCRIPTION
Fixes the n8n 2.8 operational child-workflow validation discovered during Orb promotion.

- generates the operational Execute Workflow Trigger with inputSource=passthrough
- preserves the versioned production envelope without a duplicate trigger schema
- extends structural validation and continuous-workflow tests
- regenerates the tracked main/error/fixtures/package artifacts with builder 4.1.1

Validation:
- workflow continuous test: 10/10
- live import test: 2/2
- executor test: 16/16
- structural validation: 97 nodes / 117 edges