### PR TITLE
fix(clientes): preserve global gestor scope without claim

### DIFF
--- a/crm/api/server/atendimento/__tests__/commercialDataQualityRoutes.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityRoutes.test.js
@@ -116,3 +116,12 @@ test('preserves a signed ADMIN global exception while retaining a declared unit 
     assert.equal(actor?.isGlobalAdmin, true)
     assert.equal(actor?.allowedUnitsDeclared, true)
 })
+
+test('marks an omitted GESTOR unit claim as absent rather than an empty scope', () => {
+    const encoded = Buffer.from(JSON.stringify({ id: 'gestor-1', role: 'GESTOR' })).toString('base64url')
+    const actor = __testables.parseActorHeader({ headers: { 'x-crm-user': encoded } })
+
+    assert.equal(actor?.role, 'GESTOR')
+    assert.equal(actor?.allowedUnits, undefined)
+    assert.equal(actor?.allowedUnitsDeclared, false)
+})

--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -229,6 +229,14 @@ test('scopes Clientes commercial reads, queues, actions, cadences and offers to 
 
     await store.commercialOverview({}, { id: 'admin-via-pages', role: 'GESTOR', isGlobalAdmin: true, allowedUnits: [] })
     assert.equal(captured.filter((entry) => entry.kind === 'profiles').at(-1)?.params[1], null)
+
+    // The Pages actor parser keeps a stable `allowedUnits` property but marks
+    // an omitted claim as false. Such a global GESTOR must retain legacy
+    // cross-unit access; only an explicit empty claim is fail-closed.
+    await store.commercialOverview({}, {
+        id: 'gestor-without-scope-claim', role: 'GESTOR', allowedUnits: undefined, allowedUnitsDeclared: false,
+    })
+    assert.equal(captured.filter((entry) => entry.kind === 'profiles').at(-1)?.params[1], null)
 })
 
 test('returns a bounded, unit-scoped Customer 360 timeline from confirmed source events', async () => {

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -2683,8 +2683,14 @@ function commercialUnitScope(actor) {
     // behavior even when they did not populate that parser marker.
     if (actor?.isGlobalAdmin === true || role === 'ADMIN') return null
     if (!Array.isArray(actor?.allowedUnits)) {
+        // The signed-actor parser always carries an `allowedUnits` property so
+        // its shape is stable, but marks whether the claim was present on the
+        // token separately.  Treat that explicit false marker as an omitted
+        // claim; only malformed direct callers without the marker retain the
+        // fail-closed empty-scope behavior.
         const scopeWasDeclared = actor?.allowedUnitsDeclared === true ||
-            Object.prototype.hasOwnProperty.call(actor || {}, 'allowedUnits')
+            (actor?.allowedUnitsDeclared === undefined &&
+                Object.prototype.hasOwnProperty.call(actor || {}, 'allowedUnits'))
         return scopeWasDeclared ? [] : null
     }
     return [...normalizeAllowedUnitKeys(actor)].sort()


### PR DESCRIPTION
## Summary\n- distinguish an omitted allowedUnits claim from an explicitly empty scope\n- preserve fail-closed behavior for malformed or empty declared scopes\n- add parser and commercial-store regression coverage\n\n## Validation\n- node --test server/atendimento/__tests__/store.test.js server/atendimento/__tests__/commercialDataQualityRoutes.test.js\n\nObserved live on the isolated Clientes runtime: a signed GESTOR without allowedUnits received 403 while ADMIN passed. This restores the documented global GESTOR contract without widening scoped users.