### PR TITLE
fix(clientes): complete readonly commercial read contract

### DIFF
--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -332,6 +332,8 @@ test('uses bounded SQL pagination and global percentile benchmarks for the comme
     const store = createAtendimentoStore({ pool })
     const result = await store.commercialOverview({ server: '1', limit: 1, offset: 1, sort: 'lifetime_sales', direction: 'asc', q: 'cliente' }, { id: 'manager', role: 'GESTOR' })
     assert.equal(captured.length, 1)
+    assert.match(captured[0].sql, /jsonb_array_length\(coalesce\(source_types, '\[\]'::jsonb\)\)/)
+    assert.doesNotMatch(captured[0].sql, /cardinality\(source_types\)/)
     assert.deepEqual(captured[0].params.slice(3, 8), ['cliente', '', '', 1, 1])
     assert.equal(result.pagination.mode, 'sql')
     assert.equal(result.pagination.sort, 'lifetime_sales')

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -3688,8 +3688,8 @@ async function queryCommercialProfilesServerPage(pgPool, { asOf, unitSlugs, thre
                 count(*) filter (where frequent)::int as frequent_total,
                 count(*) filter (where balanced_vip)::int as balanced_vip_total,
                 count(*) filter (where reactivation_potential)::int as reactivation_potential_total,
-                count(*) filter (where cardinality(source_types) >= 2)::int as confirmed_multi_source_total,
-                count(*) filter (where cardinality(source_types) < 2)::int as unresolved_single_source_total,
+                count(*) filter (where jsonb_array_length(coalesce(source_types, '[]'::jsonb)) >= 2)::int as confirmed_multi_source_total,
+                count(*) filter (where jsonb_array_length(coalesce(source_types, '[]'::jsonb)) < 2)::int as unresolved_single_source_total,
                 coalesce(sum(lifetime_sales), 0)::numeric as lifetime_sales_total,
                 coalesce(sum(sale_count), 0)::int as sale_count_total
             from filtered

--- a/scripts/provision-atendimento-production-readonly.sh
+++ b/scripts/provision-atendimento-production-readonly.sh
@@ -73,6 +73,8 @@ grant connect on database $DB_NAME to $APP_ROLE;
 revoke create on schema crm_atendimento, crm_caixa from $APP_ROLE;
 grant usage on schema crm_atendimento, crm_caixa to $APP_ROLE;
 grant select on all tables in schema crm_atendimento, crm_caixa to $APP_ROLE;
+grant usage on schema harmonia to $APP_ROLE;
+grant select (phone_raw, opted_out_at) on table harmonia.contacts to $APP_ROLE;
 alter default privileges for role skincos in schema crm_atendimento grant select on tables to $APP_ROLE;
 alter default privileges for role skincos in schema crm_caixa grant select on tables to $APP_ROLE;
 alter default privileges for role postgres in schema crm_atendimento grant select on tables to $APP_ROLE;

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -17,6 +17,8 @@ test('isolated Clientes production unit is loopback-configured and cannot broade
   assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /CRM_ATENDIMENTO_READ_ONLY=true/)
   assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /CRM_ATENDIMENTO_CLIENTES_ONLY=true/)
   assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /default_transaction_read_only = on/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /grant usage on schema harmonia/)
+  assert.match(read('scripts/provision-atendimento-production-readonly.sh'), /grant select \(phone_raw, opted_out_at\) on table harmonia\.contacts/)
   assert.match(read('scripts/runtime/manage-native-runtime.sh'), /crm-atendimento-production\.service/)
 })
 
@@ -27,6 +29,8 @@ test('production validation proves the API and database write barriers without s
   assert.match(validation, /skincos_clientes_ro/)
   assert.match(validation, /global_client_identities/)
   assert.match(validation, /crm_caixa\.sales/)
+  assert.match(validation, /harmonia\.contacts/)
+  assert.match(validation, /has_column_privilege/)
   assert.doesNotMatch(validation, /curl[^\n]*https?:\/\/(?!127\.0\.0\.1)/)
 })
 

--- a/scripts/validate-atendimento-production-readonly.sh
+++ b/scripts/validate-atendimento-production-readonly.sh
@@ -31,16 +31,19 @@ fi
 grep -Fq '"readOnlyRuntime":true' "$health_body" || { echo 'Health did not attest readOnlyRuntime=true.' >&2; exit 1; }
 grep -Fq '"module":"atendimento"' "$health_body" || { echo 'Health did not attest the Atendimento module.' >&2; exit 1; }
 
-sudo -n -u postgres psql --dbname=skincos_crm_local --set=ON_ERROR_STOP=1 --tuples-only --no-align <<'SQL' | while IFS='|' read -r role_name role_login read_only schema_ok atendimento_ok caixa_ok; do
+sudo -n -u postgres psql --dbname=skincos_crm_local --set=ON_ERROR_STOP=1 --tuples-only --no-align <<'SQL' | while IFS='|' read -r role_name role_login read_only schema_ok atendimento_ok caixa_ok harmonia_schema_ok harmonia_phone_ok harmonia_opt_out_ok; do
 select r.rolname,
        r.rolcanlogin,
        coalesce(array_to_string(r.rolconfig, ','), '') like '%default_transaction_read_only=on%',
        has_schema_privilege(r.rolname, 'crm_atendimento', 'USAGE'),
        has_table_privilege(r.rolname, 'crm_atendimento.global_client_identities', 'SELECT'),
-       has_table_privilege(r.rolname, 'crm_caixa.sales', 'SELECT')
+       has_table_privilege(r.rolname, 'crm_caixa.sales', 'SELECT'),
+       has_schema_privilege(r.rolname, 'harmonia', 'USAGE'),
+       has_column_privilege(r.rolname, 'harmonia.contacts', 'phone_raw', 'SELECT'),
+       has_column_privilege(r.rolname, 'harmonia.contacts', 'opted_out_at', 'SELECT')
   from pg_roles r where r.rolname = 'skincos_clientes_ro';
 SQL
-  [[ "$role_name" == 'skincos_clientes_ro' && "$role_login" == 't' && "$read_only" == 't' && "$schema_ok" == 't' && "$atendimento_ok" == 't' && "$caixa_ok" == 't' ]] || {
+  [[ "$role_name" == 'skincos_clientes_ro' && "$role_login" == 't' && "$read_only" == 't' && "$schema_ok" == 't' && "$atendimento_ok" == 't' && "$caixa_ok" == 't' && "$harmonia_schema_ok" == 't' && "$harmonia_phone_ok" == 't' && "$harmonia_opt_out_ok" == 't' ]] || {
     echo 'Read-only database role contract is incomplete.' >&2
     exit 1
   }


### PR DESCRIPTION
## Summary\n- grant the isolated read-only role only the Harmonia contact columns required for opt-out evaluation\n- attest those schema/column privileges in the production validation script\n- use jsonb_array_length for JSONB source_types in server-paginated commercial overview\n\n## Validation\n- node --test server/atendimento/__tests__/store.test.js (54 passed)\n- node --test scripts/tests/clientes-production-readonly-runtime.test.mjs (3 passed)\n- bash -n provision/validate scripts\n\nLive evidence drove both fixes: the isolated GESTOR overview reached the store after the scope fix, then exposed the least-privilege Harmonia grant and a PostgreSQL JSONB cardinality error.