### PR TITLE
feat(clientes): workspace de clusters de identidade

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -22,6 +22,7 @@
     "migrate-commercial-contact-rollout": "node scripts/migrate-atendimento-commercial-contact-rollout.mjs",
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
+    "migrate-atendimento-identity-clusters": "node scripts/migrate-atendimento-identity-clusters.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",
     "refresh-commercial-data-quality": "node scripts/refresh-commercial-data-quality.mjs",
     "refresh-commercial-data-quality-staging": "node scripts/refresh-commercial-data-quality-staging.mjs",

--- a/crm/api/scripts/migrate-atendimento-identity-clusters.mjs
+++ b/crm/api/scripts/migrate-atendimento-identity-clusters.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+import {
+    applyIdentityClusterWorkspaceMigration,
+    rollbackIdentityClusterWorkspaceMigration,
+    identityClusterWorkspaceMigrationPlan,
+} from '../server/atendimento/identityClusterWorkspaceMigration.js'
+
+const args = new Set(process.argv.slice(2))
+if (args.has('--plan')) {
+    console.log(JSON.stringify(identityClusterWorkspaceMigrationPlan(), null, 2))
+    process.exit(0)
+}
+const targetValue = [...args].find((arg) => arg.startsWith('--target='))?.slice('--target='.length)
+    || String(process.env.ATENDIMENTO_MIGRATION_TARGET || '').trim().toLowerCase()
+const target = targetValue === ATENDIMENTO_MIGRATION_TARGETS.STAGING
+    ? ATENDIMENTO_MIGRATION_TARGETS.STAGING
+    : targetValue === '' || targetValue === ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+        ? ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+        : null
+const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+const actions = ['--apply', '--rollback'].filter((action) => args.has(action))
+if (actions.length !== 1) throw new Error('Use exatamente uma ação: --apply ou --rollback.')
+const unsupported = [...args].filter((arg) => arg !== '--apply' && arg !== '--rollback' && !arg.startsWith('--target='))
+if (unsupported.length) throw new Error(`Argumento não permitido: ${unsupported[0]}`)
+if (!target || !databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+    throw new Error(target === ATENDIMENTO_MIGRATION_TARGETS.STAGING
+        ? 'DATABASE_URL deve apontar exclusivamente para skincos_staging via loopback TLS e o login migrator.'
+        : 'DATABASE_URL deve apontar exclusivamente para o socket local admin de skincos_crm_local.')
+}
+const pool = createPgPool(databaseUrl)
+try {
+    const result = args.has('--rollback')
+        ? await rollbackIdentityClusterWorkspaceMigration({ pool, databaseUrl, target })
+        : await applyIdentityClusterWorkspaceMigration({ pool, databaseUrl, target })
+    console.log(JSON.stringify(result, null, 2))
+} finally {
+    await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspace.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspace.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    buildIdentityReviewClusterPresentation,
+    buildIdentityClusterBulkPreview,
+    classifyIdentityClusterBulkEligibility,
+    maskEmail,
+    maskPhone,
+} from '../identityClusterWorkspace.js'
+
+const members = [
+    { sourceType: 'attendance_client', sourceId: 'a-1', identityId: 'identity-a', identityName: 'Ana Silva', name: 'Ana Silva', aliases: ['Ana S.'], units: ['novo-hamburgo'], updatedAt: '2026-08-01T00:00:00Z', sourceFreshness: 'current' },
+    { sourceType: 'app_registration', sourceId: 'app-1', identityId: 'identity-b', identityName: 'Ana S.', name: 'Ana S.', phoneKeys: ['5511999998888'], emailKeys: ['ana@example.com'], units: ['novo-hamburgo'], updatedAt: '2026-08-01T00:00:00Z', sourceFreshness: 'current' },
+    { sourceType: 'lead_profile', sourceId: 'lead-1', identityId: 'identity-c', identityName: 'Ana Silva', name: 'Ana Silva', phoneKeys: ['5511999998888'], units: ['novo-hamburgo'], updatedAt: '2026-08-01T00:00:00Z', sourceFreshness: 'current' },
+    { sourceType: 'caixa_customer', sourceId: 'caixa-1', identityId: 'identity-d', identityName: 'Ana Silva', name: 'Ana Silva', phoneKeys: ['5511999998888'], units: ['novo-hamburgo'], updatedAt: '2026-08-01T00:00:00Z', sourceFreshness: 'current' },
+]
+
+test('groups transitive links into one cluster and exposes each source explicitly', () => {
+    const clusters = buildIdentityReviewClusterPresentation({
+        members,
+        edges: [
+            { reviewType: 'app_attendance', sourceType: 'app_registration', sourceId: 'app-1', targetType: 'attendance_client', targetId: 'a-1', status: 'suggested', method: 'exact_phone', confidence: 1, validatedMatch: true, candidateCount: 1, sourceVersion: 'v1' },
+            { reviewType: 'lead_app', sourceType: 'lead_profile', sourceId: 'lead-1', targetType: 'app_registration', targetId: 'app-1', status: 'suggested', method: 'exact_email', confidence: 1, validatedMatch: true, candidateCount: 1, sourceVersion: 'v2' },
+            { reviewType: 'app_caixa', sourceType: 'app_registration', sourceId: 'app-1', targetType: 'caixa_customer', targetId: 'caixa-1', status: 'suggested', method: 'exact_name_phone', confidence: 1, validatedMatch: true, candidateCount: 1, sourceVersion: 'v3' },
+        ],
+    })
+    assert.equal(clusters.length, 1)
+    assert.equal(clusters[0].summary.memberCount, 4)
+    assert.deepEqual(clusters[0].membersBySource.map((entry) => entry.sourceLabel).sort(), ['Atendimento', 'Caixa', 'Cadastro do app', 'Leads e planilhas'].sort())
+    assert.deepEqual(clusters[0].members.find((member) => member.source === 'attendance_client').aliases, ['Ana S.'])
+    assert.equal(clusters[0].bulkReview.eligible, true)
+    assert.deepEqual(clusters[0].impact.membersToMove.map((member) => member.sourceLabel).sort(), ['Caixa', 'Cadastro do app', 'Leads e planilhas'].sort())
+    assert.equal(clusters[0].privacy.technicalIdsHidden, true)
+    assert.equal('_members' in clusters[0], false)
+    assert.equal('context' in clusters[0], false)
+    assert.equal('evidence' in clusters[0], true)
+    assert.equal(Object.keys(clusters[0]).some((key) => key.startsWith('_')), false)
+})
+
+test('masks contact values by default and keeps reveal out of the presentation schema', () => {
+    assert.equal(maskPhone('5511999998888'), '55••••88')
+    assert.equal(maskEmail('ana@example.com'), 'a•••@e•••')
+    const [masked] = buildIdentityReviewClusterPresentation({ members: [{ ...members[1], identityId: 'identity-1' }], now: new Date('2026-08-01T00:00:00Z') })
+    assert.deepEqual(masked.members[0].contact.phone, ['55••••88'])
+    assert.deepEqual(masked.members[0].contact.email, ['a•••@e•••'])
+    assert.equal(masked.members[0].contact.masked, true)
+    assert.equal(JSON.stringify(masked).includes('5511999998888'), false)
+})
+
+test('marks a decision stale when a source member changed afterwards', () => {
+    const [cluster] = buildIdentityReviewClusterPresentation({
+        members: [
+            { ...members[1], identityId: 'identity-1', updatedAt: '2026-08-06T00:00:00Z' },
+            { ...members[3], identityId: 'identity-2', updatedAt: '2026-08-01T00:00:00Z' },
+        ],
+        edges: [{ reviewType: 'app_caixa', sourceType: 'app_registration', sourceId: 'app-1', targetType: 'caixa_customer', targetId: 'caixa-1', status: 'suggested', method: 'exact_phone', confidence: 1, validatedMatch: true, candidateCount: 1, sourceVersion: 'new' }],
+        decisions: [{ reviewType: 'app_caixa', sourceId: 'app-1', targetId: 'caixa-1', decision: 'confirmed', sourceVersion: 'new', createdAt: '2026-08-02T00:00:00Z' }],
+    })
+    assert.equal(cluster.staleState, 'stale')
+    assert.equal(cluster.decision.state, 'stale')
+})
+
+test('excludes a transitively cross-unit component from a narrower actor scope', () => {
+    const clusters = buildIdentityReviewClusterPresentation({
+        members: [
+            { ...members[1], identityId: 'identity-1', units: ['novo-hamburgo'] },
+            { ...members[3], identityId: 'identity-2', units: ['barra-shopping-sul'] },
+        ],
+        edges: [{ reviewType: 'app_caixa', sourceType: 'app_registration', sourceId: 'app-1', targetType: 'caixa_customer', targetId: 'caixa-1', status: 'suggested', method: 'exact_phone', confidence: 1, validatedMatch: true, candidateCount: 1 }],
+        unitScope: ['novo-hamburgo'],
+    })
+    assert.equal(clusters.length, 0)
+})
+
+test('blocks bulk review when source freshness is unknown or stale', () => {
+    const [cluster] = buildIdentityReviewClusterPresentation({
+        members: [
+            { ...members[1], identityId: 'identity-1', sourceFreshness: 'unknown' },
+            { ...members[3], identityId: 'identity-2', sourceFreshness: 'current' },
+        ],
+        edges: [{ reviewType: 'app_caixa', sourceType: 'app_registration', sourceId: 'app-1', targetType: 'caixa_customer', targetId: 'caixa-1', status: 'suggested', method: 'exact_phone', confidence: 1, validatedMatch: true, candidateCount: 1 }],
+    })
+    assert.equal(cluster.staleState, 'stale')
+    assert.equal(cluster.bulkReview.eligible, false)
+    assert.ok(cluster.bulkReview.reasons.includes('source_stale_or_changed_after_decision'))
+})
+
+test('blocks bulk review for a strong contact conflict, prior decision or commercial history', () => {
+    const result = classifyIdentityClusterBulkEligibility({
+        members: [{ ...members[1], phoneKeys: ['5511999998888'] }, { ...members[2], phoneKeys: ['5511888887777'] }],
+        edges: [{ status: 'suggested', method: 'exact_phone', validatedMatch: true, candidateCount: 1 }],
+        conflicts: [{ field: 'phone', severity: 'strong' }],
+        decisions: [{ decision: 'rejected' }],
+        undoBlocked: true,
+    })
+    assert.equal(result.eligible, false)
+    assert.ok(result.reasons.includes('strong_conflict'))
+    assert.ok(result.reasons.includes('incompatible_prior_decision'))
+    assert.ok(result.reasons.includes('commercial_or_consent_history'))
+})
+
+test('bulk preview reports eligible and blocked components without identifiers beyond opaque keys', () => {
+    const preview = buildIdentityClusterBulkPreview([
+        { clusterKey: 'opaque-a', version: 'v1', summary: { memberCount: 2 }, bulkReview: { eligible: true, reasons: [] } },
+        { clusterKey: 'opaque-b', version: 'v2', summary: { memberCount: 2 }, bulkReview: { eligible: false, reasons: ['strong_conflict'] } },
+    ])
+    assert.deepEqual(preview, {
+        schemaVersion: 'crm-identity-cluster/v1', clusterCount: 2, eligibleCount: 1, blockedCount: 1,
+        memberCount: 4, eligibleMembers: 2, blockedReasons: ['strong_conflict'],
+        clusters: [
+            { clusterKey: 'opaque-a', version: 'v1', eligible: true, reasons: [] },
+            { clusterKey: 'opaque-b', version: 'v2', eligible: false, reasons: ['strong_conflict'] },
+        ],
+    })
+})

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+    applyIdentityClusterWorkspaceMigration,
+    identityClusterWorkspaceMigrationPlan,
+    rollbackIdentityClusterWorkspaceMigration,
+} from '../identityClusterWorkspaceMigration.js'
+
+const LOCAL_SOCKET_URL = 'postgresql:///skincos_crm_local?host=/var/run/postgresql'
+
+test('defines an additive privacy-safe cluster workspace migration', () => {
+    const plan = identityClusterWorkspaceMigrationPlan()
+    assert.equal(plan.id, IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID)
+    assert.deepEqual(plan.adds, ['identity_review_cluster_operations', 'identity_review_cluster_reveals'])
+    assert.match(plan.privacy, /raw contact values never/i)
+    assert.match(plan.ledgerIntegrity, /UPDATE, DELETE and TRUNCATE/i)
+    assert.match(plan.rollback, /Non-destructive/i)
+})
+
+test('applies cluster ledgers only after the private mirror prerequisites and records readiness last', async () => {
+    const calls = []
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params })
+            if (/current_database\(\)/i.test(sql)) return { rows: [{ database_name: 'skincos_crm_local', database_user: 'admin', read_only: 'off' }] }
+            if (/to_regclass\('crm_atendimento\.(global_client_identities|identity_review_decisions)/i.test(sql)) {
+                return { rows: [{ global_client_identities: 'crm_atendimento.global_client_identities', global_client_identity_members: 'crm_atendimento.global_client_identity_members', identity_review_decisions: 'crm_atendimento.identity_review_decisions', identity_materialization_runs: 'crm_atendimento.identity_materialization_runs', identity_member_history: 'crm_atendimento.identity_member_history', identity_lineage: 'crm_atendimento.identity_lineage', identity_source_link_history: 'crm_atendimento.identity_source_link_history', commercial_actions: 'crm_atendimento.commercial_actions', commercial_contact_permissions: 'crm_atendimento.commercial_contact_permissions', commercial_contact_permission_events: 'crm_atendimento.commercial_contact_permission_events', audit_events: 'crm_atendimento.audit_events' }] }
+            }
+            return { rows: [], rowCount: 0 }
+        },
+        release() {},
+    }
+    const report = await applyIdentityClusterWorkspaceMigration({ pool: { connect: async () => client }, databaseUrl: LOCAL_SOCKET_URL })
+    assert.equal(report.applied, true)
+    assert.equal(report.runtimeRole, 'skincos')
+    const normalized = calls.map(({ sql }) => sql.replace(/\s+/g, ' ').trim())
+    const begin = normalized.findIndex((sql) => /^begin$/i.test(sql))
+    const prerequisite = normalized.findIndex((sql) => /global_client_identities/i.test(sql) && /to_regclass/i.test(sql))
+    const operations = normalized.findIndex((sql) => /create table if not exists crm_atendimento\.identity_review_cluster_operations/i.test(sql))
+    const revealTrigger = normalized.findIndex((sql) => /create trigger identity_review_cluster_reveals_immutable/i.test(sql))
+    const registry = normalized.findIndex((sql) => /insert into crm_atendimento\.schema_migrations/i.test(sql))
+    const commit = normalized.findIndex((sql) => /^commit$/i.test(sql))
+    assert.ok(begin >= 0 && prerequisite > begin && operations > prerequisite && revealTrigger > operations && registry > revealTrigger && commit > registry)
+    assert.ok(normalized.some((sql) => /grant select, insert on table crm_atendimento\.identity_review_cluster_operations to skincos/i.test(sql)))
+    assert.equal(normalized.some((sql) => /drop table|drop schema|delete from/i.test(sql)), false)
+})
+
+test('refuses TCP destinations before connecting and rolls back non-destructively', async () => {
+    let connected = false
+    await assert.rejects(
+        () => applyIdentityClusterWorkspaceMigration({ pool: { connect: async () => { connected = true } }, databaseUrl: 'postgresql://admin@127.0.0.1:5432/skincos_crm_local' }),
+        (error) => error?.code === 'IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE',
+    )
+    assert.equal(connected, false)
+
+    const calls = []
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params })
+            if (/current_database\(\)/i.test(sql)) return { rows: [{ database_name: 'skincos_crm_local', database_user: 'admin', read_only: 'off' }] }
+            return { rows: [], rowCount: 0 }
+        },
+        release() {},
+    }
+    const report = await rollbackIdentityClusterWorkspaceMigration({ pool: { connect: async () => client }, databaseUrl: LOCAL_SOCKET_URL })
+    assert.deepEqual(report, { id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, rolledBack: true, destructive: false, workspaceDisabled: true })
+    assert.ok(calls.some(({ sql }) => /insert into crm_atendimento\.schema_migrations/i.test(sql)))
+    assert.equal(calls.some(({ sql }) => /drop table|drop schema|delete from/i.test(sql)), false)
+})

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -236,6 +236,42 @@ test('blocks non-GESTOR identity review decisions before the store mutation boun
     assert.deepEqual(undo.state.body, { ok: false, error: 'FORBIDDEN' })
 })
 
+test('protects cluster workspace reads and writes with the Clientes RBAC boundary', async () => {
+    const calls = []
+    const routes = captureAtendimentoRoutes({
+        async identityClusterWorkspace(query, actor) { calls.push(['workspace', query, actor]); return { clusters: [] } },
+        async identityClusterDetail(key, query, actor) { calls.push(['detail', key, query, actor]); return { cluster: null } },
+        async previewIdentityClusterBulk(payload, actor) { calls.push(['preview', payload, actor]); return { eligibleCount: 0 } },
+        async applyIdentityClusterBulk(payload, actor) { calls.push(['apply', payload, actor]); return { appliedClusters: 0 } },
+        async revealIdentityCluster(payload, actor) { calls.push(['reveal', payload, actor]); return { contacts: [] } },
+    })
+    const manager = { id: 'manager-1', role: 'GESTOR', allowedModules: ['atendimento'] }
+    const denied = { id: 'manager-2', role: 'GERENTE', allowedModules: ['atendimento'] }
+    for (const method of ['GET /commercial/identity-clusters', 'GET /commercial/identity-clusters/:clusterKey', 'POST /commercial/identity-clusters/bulk/preview', 'POST /commercial/identity-clusters/bulk/apply', 'POST /commercial/identity-clusters/:clusterKey/reveal']) {
+        const response = captureResponse()
+        await routes.get(method)({ atendimentoActor: denied, params: { clusterKey: 'opaque' }, headers: {}, query: {}, body: {} }, response)
+        assert.equal(response.state.status, 403)
+        assert.deepEqual(response.state.body, { ok: false, error: 'FORBIDDEN' })
+    }
+    const workspace = captureResponse()
+    await routes.get('GET /commercial/identity-clusters')({ atendimentoActor: manager, query: { q: 'Ana', unit: 'novo-hamburgo' } }, workspace)
+    assert.equal(workspace.state.status, 200)
+    const detail = captureResponse()
+    await routes.get('GET /commercial/identity-clusters/:clusterKey')({ atendimentoActor: manager, params: { clusterKey: 'opaque' }, query: {} }, detail)
+    assert.equal(detail.state.status, 200)
+    const preview = captureResponse()
+    await routes.get('POST /commercial/identity-clusters/bulk/preview')({ atendimentoActor: manager, body: { clusterKeys: ['opaque'] } }, preview)
+    assert.equal(preview.state.status, 200)
+    const apply = captureResponse()
+    await routes.get('POST /commercial/identity-clusters/bulk/apply')({ atendimentoActor: manager, headers: { 'idempotency-key': 'idem-1' }, body: { clusterKeys: [], reason: 'synthetic' } }, apply)
+    assert.equal(apply.state.status, 200)
+    const reveal = captureResponse()
+    await routes.get('POST /commercial/identity-clusters/:clusterKey/reveal')({ atendimentoActor: manager, params: { clusterKey: 'opaque' }, body: { reason: 'synthetic' } }, reveal)
+    assert.equal(reveal.state.status, 200)
+    assert.equal(calls.length, 5)
+    assert.equal(calls[3][1].idempotencyKey, 'idem-1')
+})
+
 test('maps review payload and source-state conflicts to their client-safe status codes', async () => {
     const routes = captureAtendimentoRoutes({
         async decideIdentityReview(payload) {

--- a/crm/api/server/atendimento/identityClusterWorkspace.js
+++ b/crm/api/server/atendimento/identityClusterWorkspace.js
@@ -1,0 +1,545 @@
+import { createHash } from 'node:crypto'
+
+export const IDENTITY_CLUSTER_PRESENTATION_SCHEMA = 'crm-identity-cluster/v1'
+
+export const IDENTITY_CLUSTER_SOURCE_TYPES = Object.freeze([
+    'attendance_client',
+    'caixa_customer',
+    'app_registration',
+    'lead_profile',
+])
+
+export const IDENTITY_CLUSTER_SOURCE_LABELS = Object.freeze({
+    attendance_client: 'Atendimento',
+    caixa_customer: 'Caixa',
+    app_registration: 'Cadastro do app',
+    lead_profile: 'Leads e planilhas',
+})
+
+const STRONG_METHODS = new Set([
+    'exact_phone',
+    'exact_email',
+    'exact_name_phone',
+    'exact_name_phone_sales_unit',
+    'phone_sales_attendance_anchor',
+    'spelling_same_caixa_customer',
+])
+
+const FIELD_LABELS = Object.freeze({
+    name: 'Nome',
+    phone: 'Telefone validado',
+    email: 'E-mail validado',
+    unit: 'Unidade',
+    cpf: 'Documento validado',
+})
+
+const CONTACT_FIELDS = new Set(['phone', 'email'])
+const TECHNICAL_KEYS = new Set(['id', 'identityId', 'sourceId', 'targetId', 'componentKey', 'runId'])
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function unique(values) {
+    return [...new Set((Array.isArray(values) ? values : []).map(text).filter(Boolean))]
+}
+
+function normalized(value) {
+    return text(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function digits(value) {
+    return text(value).replace(/\D/g, '')
+}
+
+export function maskPhone(value) {
+    const raw = digits(value)
+    if (!raw) return ''
+    if (raw.length <= 4) return '••••'
+    return `${raw.slice(0, 2)}••••${raw.slice(-2)}`
+}
+
+export function maskEmail(value) {
+    const raw = text(value).toLowerCase()
+    const at = raw.indexOf('@')
+    if (at <= 0 || at === raw.length - 1) return raw ? '••••' : ''
+    const local = raw.slice(0, at)
+    const domain = raw.slice(at + 1)
+    const visibleLocal = local.length === 1 ? '•' : `${local.slice(0, 1)}•••`
+    const visibleDomain = domain.length <= 2 ? '••' : `${domain.slice(0, 1)}•••`
+    return `${visibleLocal}@${visibleDomain}`
+}
+
+export function digestClusterValue(value) {
+    return createHash('sha256').update(text(value)).digest('hex')
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable)
+    if (value && typeof value === 'object') return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
+    return value
+}
+
+function fingerprint(value) {
+    return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex')
+}
+
+class DisjointSet {
+    constructor(values) {
+        this.parent = new Map(values.map((value) => [value, value]))
+    }
+
+    find(value) {
+        if (!this.parent.has(value)) this.parent.set(value, value)
+        const parent = this.parent.get(value)
+        if (parent === value) return value
+        const root = this.find(parent)
+        this.parent.set(value, root)
+        return root
+    }
+
+    union(left, right) {
+        const a = this.find(left)
+        const b = this.find(right)
+        if (a !== b) {
+            if (a < b) this.parent.set(b, a)
+            else this.parent.set(a, b)
+        }
+    }
+}
+
+function memberKey(member) {
+    return `${text(member?.sourceType)}:${text(member?.sourceId)}`
+}
+
+function edgeKey(edge) {
+    return `${text(edge?.reviewType)}:${text(edge?.sourceType)}:${text(edge?.sourceId)}:${text(edge?.targetType)}:${text(edge?.targetId)}`
+}
+
+function sourceLabel(sourceType) {
+    return IDENTITY_CLUSTER_SOURCE_LABELS[text(sourceType)] || 'Fonte não classificada'
+}
+
+function explicitMatchingFields(member) {
+    const fields = []
+    const phoneKeys = unique(member?.phoneKeys || member?.phones)
+    const emailKeys = unique(member?.emailKeys || member?.emails)
+    const cpfKeys = unique(member?.cpfKeys || member?.cpfs)
+    const units = unique(member?.units || member?.unitSlugs)
+    if (member?.name || member?.canonicalName) fields.push({ field: 'name', label: FIELD_LABELS.name, status: 'present' })
+    if (phoneKeys.length) fields.push({ field: 'phone', label: FIELD_LABELS.phone, status: member?.validatedPhone === false ? 'unvalidated' : 'validated', values: phoneKeys.map(maskPhone) })
+    if (emailKeys.length) fields.push({ field: 'email', label: FIELD_LABELS.email, status: member?.validatedEmail === false ? 'unvalidated' : 'validated', values: emailKeys.map(maskEmail) })
+    if (cpfKeys.length) fields.push({ field: 'cpf', label: FIELD_LABELS.cpf, status: member?.validatedCpf === false ? 'unvalidated' : 'validated' })
+    if (units.length) fields.push({ field: 'unit', label: FIELD_LABELS.unit, status: 'present', values: units })
+    return fields
+}
+
+function explicitEvidence(edge) {
+    const method = text(edge?.method)
+    const evidence = edge?.evidence && typeof edge.evidence === 'object' ? edge.evidence : {}
+    const matchedFields = unique(edge?.matchedFields || evidence.matchedFields || evidence.sharedFields)
+    const sharedUnits = unique(edge?.sharedUnits || evidence.sharedUnits)
+    const strong = edge?.strong === true || STRONG_METHODS.has(method) || matchedFields.some((field) => CONTACT_FIELDS.has(field))
+    const label = method === 'exact_phone' ? 'Telefone validado igual'
+        : method === 'exact_email' ? 'E-mail validado igual'
+            : method === 'exact_name_phone' ? 'Nome e telefone validados'
+                : method === 'exact_name_phone_sales_unit' ? 'Nome, telefone, venda e unidade validados'
+                    : method === 'phone_sales_attendance_anchor' ? 'Telefone ancorado em venda e atendimento'
+                        : method === 'fuzzy_name_unit_procedure' ? 'Nome aproximado com contexto de unidade/procedimento'
+                            : method === 'exact_name_unit' ? 'Nome e unidade coincidentes'
+                                : method === 'exact_name' ? 'Nome coincidente'
+                                    : method || 'Vínculo de fonte'
+    const summary = [
+        matchedFields.length ? `campos: ${matchedFields.map((field) => FIELD_LABELS[field] || field).join(', ')}` : '',
+        sharedUnits.length ? `unidades: ${sharedUnits.join(', ')}` : '',
+        edge?.candidateCount != null ? `candidatos: ${Number(edge.candidateCount)}` : '',
+    ].filter(Boolean).join(' · ')
+    return {
+        kind: 'source_link',
+        label,
+        strength: strong ? 'strong' : 'weak',
+        confidence: Math.max(0, Math.min(1, Number(edge?.confidence || 0))),
+        source: sourceLabel(edge?.sourceType),
+        target: sourceLabel(edge?.targetType),
+        summary: summary || 'Evidência registrada na fonte',
+    }
+}
+
+function normalizeMember(member) {
+    const sourceType = text(member?.sourceType)
+    const name = text(member?.name || member?.canonicalName || member?.identityName) || 'Sem nome informado'
+    return {
+        sourceType,
+        sourceId: text(member?.sourceId),
+        identityId: text(member?.identityId),
+        identityCreatedAt: member?.identityCreatedAt || null,
+        name,
+        identityName: text(member?.identityName || name),
+        aliases: unique(member?.aliases),
+        units: unique(member?.units || member?.unitSlugs),
+        phoneKeys: unique(member?.phoneKeys || member?.phones),
+        emailKeys: unique(member?.emailKeys || member?.emails),
+        cpfKeys: unique(member?.cpfKeys || member?.cpfs),
+        validatedPhone: member?.validatedPhone !== false,
+        validatedEmail: member?.validatedEmail !== false,
+        validatedCpf: member?.validatedCpf !== false,
+        updatedAt: member?.updatedAt || null,
+        sourceFreshness: text(member?.sourceFreshness || 'unknown'),
+        changedAfterDecision: member?.changedAfterDecision === true,
+        sourceFingerprint: text(member?.sourceFingerprint),
+    }
+}
+
+function latestDecisionForEdge(decisions, edge) {
+    const key = edgeKey(edge)
+    const exact = (decisions || []).filter((decision) => edgeKey({
+        reviewType: decision.reviewType,
+        sourceType: edge.sourceType,
+        sourceId: decision.sourceId,
+        targetType: edge.targetType,
+        targetId: edge.targetId,
+    }) === key)
+    return exact.sort((left, right) => Number(right.eventOrder || 0) - Number(left.eventOrder || 0)
+        || String(right.createdAt || '').localeCompare(String(left.createdAt || '')))[0] || null
+}
+
+function edgeForDecision(decision, edges) {
+    return (edges || []).find((edge) => edge.sourceId === decision.sourceId
+        && edge.targetId === decision.targetId
+        && edge.reviewType === decision.reviewType) || null
+}
+
+function sourceChangedForMember(member, edges, decisions) {
+    const key = memberKey(member)
+    return (edges || []).some((edge) => {
+        if (`${edge.sourceType}:${edge.sourceId}` !== key && `${edge.targetType}:${edge.targetId}` !== key) return false
+        const decision = latestDecisionForEdge(decisions, edge)
+        return sourceChanged(edge, decision, [member])
+    })
+}
+
+function sourceChanged(edge, decision, members) {
+    if (!decision) return false
+    if (decision.sourceVersion && edge.sourceVersion && decision.sourceVersion !== edge.sourceVersion) return true
+    if (members.some((member) => member.changedAfterDecision)) return true
+    if (edge.changedAfterDecision === true) return true
+    if (decision.createdAt) {
+        const decisionTime = new Date(decision.createdAt).getTime()
+        if (Number.isFinite(decisionTime) && members.some((member) => {
+            const updated = new Date(member.updatedAt || 0).getTime()
+            return Number.isFinite(updated) && updated > decisionTime
+        })) return true
+    }
+    return false
+}
+
+function conflictRows(members) {
+    const rows = []
+    const names = new Map()
+    const phones = new Map()
+    const emails = new Map()
+    for (const member of members) {
+        const name = normalized(member.name)
+        if (name) names.set(name, (names.get(name) || 0) + 1)
+        for (const value of member.phoneKeys) phones.set(digits(value), (phones.get(digits(value)) || 0) + 1)
+        for (const value of member.emailKeys) emails.set(text(value).toLowerCase(), (emails.get(text(value).toLowerCase()) || 0) + 1)
+    }
+    if (names.size > 1) rows.push({ field: 'name', label: FIELD_LABELS.name, severity: 'weak', summary: 'Nomes divergentes entre fontes; trate como evidência fraca.' })
+    if (phones.size > 1) rows.push({ field: 'phone', label: FIELD_LABELS.phone, severity: 'strong', summary: 'Telefones divergentes impedem revisão em lote.' })
+    if (emails.size > 1) rows.push({ field: 'email', label: FIELD_LABELS.email, severity: 'strong', summary: 'E-mails divergentes impedem revisão em lote.' })
+    return rows
+}
+
+function hasValidatedSharedContact(members) {
+    for (const field of ['phoneKeys', 'emailKeys']) {
+    const counts = new Map()
+        for (const member of members) {
+            if (field === 'phoneKeys' && member.validatedPhone === false) continue
+            if (field === 'emailKeys' && member.validatedEmail === false) continue
+            const values = unique(member[field]).map((value) => field === 'phoneKeys' ? digits(value) : text(value).toLowerCase()).filter(Boolean)
+            for (const value of values) counts.set(value, (counts.get(value) || 0) + 1)
+        }
+        if ([...counts.values()].some((count) => count >= 2)) return field === 'phoneKeys' ? 'phone' : 'email'
+    }
+    return null
+}
+
+export function classifyIdentityClusterBulkEligibility({ members = [], edges = [], conflicts = [], decisions = [], undoBlocked = false, stale = false } = {}) {
+    const sharedContactField = hasValidatedSharedContact(members)
+    const strongConflict = conflicts.some((conflict) => conflict.severity === 'strong')
+    const uniqueCandidate = edges.length > 0 && edges.every((edge) => Number(edge.candidateCount || 1) === 1)
+    const deterministicEdges = edges.length > 0 && edges.every((edge) => {
+        const method = text(edge.method)
+        const evidence = edge.evidence && typeof edge.evidence === 'object' ? edge.evidence : {}
+        const matched = unique(edge.matchedFields || evidence.matchedFields || evidence.sharedFields)
+        return edge.status === 'suggested' || edge.status === 'ambiguous' || edge.status === 'pending'
+            ? (edge.validatedMatch === true || STRONG_METHODS.has(method) || matched.some((field) => CONTACT_FIELDS.has(field)))
+            : false
+    })
+    const incompatibleDecision = decisions.some((decision) => decision.decision === 'confirmed' || decision.decision === 'rejected')
+    const reasons = []
+    if (!sharedContactField) reasons.push('no_shared_validated_contact')
+    if (strongConflict) reasons.push('strong_conflict')
+    if (!uniqueCandidate) reasons.push('candidate_not_unique')
+    if (!deterministicEdges) reasons.push('edge_not_deterministic')
+    if (incompatibleDecision) reasons.push('incompatible_prior_decision')
+    if (undoBlocked) reasons.push('commercial_or_consent_history')
+    if (stale) reasons.push('source_stale_or_changed_after_decision')
+    return {
+        eligible: reasons.length === 0,
+        mode: reasons.length === 0 ? 'bulk_safe' : 'individual_only',
+        sharedContactField,
+        reasons,
+    }
+}
+
+function identitySummary(members) {
+    const groups = new Map()
+    for (const member of members) {
+        if (!groups.has(member.identityId)) groups.set(member.identityId, [])
+        groups.get(member.identityId).push(member)
+    }
+    const identities = [...groups.entries()].filter(([id]) => id).map(([id, rows]) => ({
+        name: rows[0]?.identityName || rows[0]?.name || 'Identidade sem nome',
+        sourceCount: rows.length,
+        sourceLabels: unique(rows.map((row) => sourceLabel(row.sourceType))),
+        hasAttendance: rows.some((row) => row.sourceType === 'attendance_client'),
+        createdAt: rows.map((row) => row.identityCreatedAt).filter(Boolean).sort()[0] || null,
+        _id: id,
+    }))
+    identities.sort((left, right) => Number(right.hasAttendance) - Number(left.hasAttendance) || String(left.createdAt || '').localeCompare(String(right.createdAt || '')) || left.name.localeCompare(right.name))
+    return identities
+}
+
+function safeIdentity(identity) {
+    if (!identity) return null
+    return { name: identity.name, sourceCount: identity.sourceCount, sourceLabels: identity.sourceLabels }
+}
+
+export function buildIdentityReviewClusterPresentation({
+    members: inputMembers = [],
+    edges: inputEdges = [],
+    decisions = [],
+    lineage = [],
+    automaticLinkHistory = [],
+    historyByIdentity = {},
+    unitScope = null,
+    now = new Date(),
+    includeInternals = false,
+} = {}) {
+    const members = inputMembers.map(normalizeMember).filter((member) => IDENTITY_CLUSTER_SOURCE_TYPES.includes(member.sourceType) && member.sourceId)
+    const memberMap = new Map(members.map((member) => [memberKey(member), member]))
+    const keys = members.map(memberKey)
+    const dsu = new DisjointSet(keys)
+    const identityMembers = new Map()
+    for (const member of members) {
+        if (!member.identityId) continue
+        if (!identityMembers.has(member.identityId)) identityMembers.set(member.identityId, [])
+        identityMembers.get(member.identityId).push(memberKey(member))
+    }
+    for (const group of identityMembers.values()) for (const key of group.slice(1)) dsu.union(group[0], key)
+    const edges = inputEdges.map((edge) => ({
+        reviewType: text(edge.reviewType), sourceType: text(edge.sourceType), sourceId: text(edge.sourceId),
+        targetType: text(edge.targetType), targetId: text(edge.targetId), status: text(edge.status),
+        confidence: Number(edge.confidence || 0), method: text(edge.method), evidence: edge.evidence || {},
+        matchedFields: unique(edge.matchedFields), sharedUnits: unique(edge.sharedUnits), candidateCount: edge.candidateCount,
+        validatedMatch: edge.validatedMatch === true, strong: edge.strong === true, sourceVersion: text(edge.sourceVersion),
+        changedAfterDecision: edge.changedAfterDecision === true,
+    })).filter((edge) => memberMap.has(`${edge.sourceType}:${edge.sourceId}`) && memberMap.has(`${edge.targetType}:${edge.targetId}`))
+    for (const edge of edges) dsu.union(`${edge.sourceType}:${edge.sourceId}`, `${edge.targetType}:${edge.targetId}`)
+    const grouped = new Map()
+    for (const member of members) {
+        const root = dsu.find(memberKey(member))
+        if (!grouped.has(root)) grouped.set(root, { members: [], edges: [] })
+        grouped.get(root).members.push(member)
+    }
+    for (const edge of edges) {
+        const root = dsu.find(`${edge.sourceType}:${edge.sourceId}`)
+        if (!grouped.has(root)) grouped.set(root, { members: [], edges: [] })
+        grouped.get(root).edges.push(edge)
+    }
+    const allowed = unitScope == null ? null : new Set(unique(unitScope))
+    const clusters = []
+    for (const group of grouped.values()) {
+        const clusterUnits = unique(group.members.flatMap((member) => member.units))
+        if (allowed && (!clusterUnits.length || clusterUnits.some((unit) => !allowed.has(unit)))) continue
+        const groupDecisions = group.edges.map((edge) => latestDecisionForEdge(decisions, edge)).filter(Boolean)
+        const stale = group.members.some((member) => member.changedAfterDecision || member.sourceFreshness !== 'current')
+            || group.edges.some((edge) => sourceChanged(edge, latestDecisionForEdge(decisions, edge), group.members))
+        const conflicts = conflictRows(group.members)
+        const histories = identitySummary(group.members).map((identity) => ({ identity, history: historyByIdentity[identity._id] || {} }))
+        const undoReasons = []
+        if (histories.some(({ history }) => Number(history.actions || 0) > 0)) undoReasons.push('commercial_actions_present')
+        if (histories.some(({ history }) => Number(history.permissions || 0) > 0 || Number(history.permissionEvents || 0))) undoReasons.push('consent_history_present')
+        if (histories.some(({ history }) => Number(history.auditIdentityEvents || 0) > 0)) undoReasons.push('identity_audit_history_present')
+        const undoBlocked = undoReasons.length > 0
+        const clusterEdges = group.edges.map((edge) => ({ ...edge, evidence: explicitEvidence(edge) }))
+        const strongEvidence = clusterEdges.filter((edge) => edge.evidence.strength === 'strong').map((edge) => edge.evidence)
+        const weakEvidence = clusterEdges.filter((edge) => edge.evidence.strength === 'weak').map((edge) => edge.evidence)
+        const confidence = clusterEdges.length ? Math.round((clusterEdges.reduce((sum, edge) => sum + edge.confidence, 0) / clusterEdges.length) * 100) / 100 : 0
+        const identities = identitySummary(group.members)
+        const decisionHistory = groupDecisions.map((decision) => {
+            const relatedEdge = edgeForDecision(decision, group.edges)
+            return {
+                reviewType: text(decision.reviewType),
+                decision: text(decision.decision),
+                resultingStatus: text(decision.resultingStatus),
+                recordedAt: decision.createdAt || null,
+                stale: relatedEdge ? sourceChanged(relatedEdge, decision, group.members) : false,
+            }
+        })
+        const materializations = groupDecisions
+            .filter((decision) => decision.materializationRunId || decision.runMode || decision.runStatus)
+            .map((decision) => ({
+                mode: text(decision.runMode || (decision.decision === 'confirmed' ? 'confirm' : decision.decision === 'reversed' ? 'reverse' : 'reject')),
+                status: text(decision.runStatus || 'applied'),
+                recordedAt: decision.runCreatedAt || decision.createdAt || null,
+                membersMoved: Number(decision.runMembersMoved || 0),
+            }))
+        const automaticLinks = group.edges.map((edge) => ({
+            source: sourceLabel(edge.sourceType),
+            target: sourceLabel(edge.targetType),
+            status: text(edge.status),
+            method: text(edge.method) || 'link',
+            confidence: Math.max(0, Math.min(1, Number(edge.confidence || 0))),
+            history: automaticLinkHistory.filter((row) => edgeKey(row) === edgeKey(edge)).map((row) => ({
+                transition: text(row.transition),
+                resultingStatus: text(row.resultingStatus),
+                origin: text(row.origin),
+                recordedAt: row.createdAt || null,
+            })),
+        }))
+        const sourceChanges = group.members.filter((member) => member.changedAfterDecision || sourceChangedForMember(member, group.edges, groupDecisions)).map((member) => ({
+            source: sourceLabel(member.sourceType),
+            name: member.name,
+            changedAt: member.updatedAt || null,
+        }))
+        const blockingHistory = histories.reduce((summary, { history }) => ({
+            commercialActions: summary.commercialActions + Number(history.actions || 0),
+            consentPermissions: summary.consentPermissions + Number(history.permissions || 0),
+            consentEvents: summary.consentEvents + Number(history.permissionEvents || 0),
+            identityAuditEvents: summary.identityAuditEvents + Number(history.auditIdentityEvents || 0),
+        }), { commercialActions: 0, consentPermissions: 0, consentEvents: 0, identityAuditEvents: 0 })
+        const survivorId = identities[0]?._id || ''
+        const membersToMove = group.members
+            .filter((member) => survivorId ? member.identityId !== survivorId : true)
+            .map((member) => ({ sourceLabel: sourceLabel(member.sourceType), name: member.name }))
+        const currentDecision = stale ? 'stale'
+            : groupDecisions.some((decision) => decision.decision === 'confirmed') ? 'confirmed'
+                : groupDecisions.some((decision) => decision.decision === 'rejected') ? 'rejected' : 'pending'
+        const clusterKey = fingerprint({ members: group.members.map((member) => [member.sourceType, member.sourceId]).sort(), edges: group.edges.map(edgeKey).sort() }).slice(0, 32)
+        const version = fingerprint({
+            members: group.members.map((member) => [member.sourceType, member.sourceId, member.sourceFingerprint, member.updatedAt]).sort(),
+            edges: group.edges.map((edge) => [edgeKey(edge), edge.status, edge.sourceVersion]).sort(),
+        })
+        const memberPresentations = group.members.map((member) => ({
+            source: member.sourceType,
+            sourceLabel: sourceLabel(member.sourceType),
+            name: member.name,
+            aliases: member.aliases,
+            units: member.units,
+            matchingFields: explicitMatchingFields(member),
+            freshness: member.sourceFreshness || 'unknown',
+            stale: member.changedAfterDecision,
+            contact: {
+                phone: member.phoneKeys.map(maskPhone).filter(Boolean),
+                email: member.emailKeys.map(maskEmail).filter(Boolean),
+                masked: true,
+            },
+        }))
+        const memberBySource = IDENTITY_CLUSTER_SOURCE_TYPES.map((sourceType) => ({
+            source: sourceType,
+            sourceLabel: sourceLabel(sourceType),
+            count: memberPresentations.filter((member) => member.source === sourceType).length,
+        })).filter((entry) => entry.count)
+        const lineageRows = lineage.filter((row) => {
+            const ids = identities.map((identity) => identity._id)
+            return ids.includes(text(row.predecessorIdentityId)) || ids.includes(text(row.successorIdentityId))
+        }).map((row) => ({ relation: text(row.relation), recordedAt: row.createdAt || null }))
+        const bulkReview = classifyIdentityClusterBulkEligibility({ members: group.members, edges: group.edges, conflicts, decisions: groupDecisions, undoBlocked, stale })
+        clusters.push({
+            schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+            clusterKey,
+            version,
+            summary: { memberCount: group.members.length, identityCount: identities.length, sourceCount: memberBySource.length, unitCount: clusterUnits.length },
+            members: memberPresentations,
+            membersBySource: memberBySource,
+            units: clusterUnits,
+            matchingFields: unique(clusterEdges.flatMap((edge) => edge.matchedFields)),
+            conflicts,
+            evidence: { strong: strongEvidence, weak: weakEvidence },
+            confidence,
+            decision: { state: currentDecision, count: groupDecisions.length, lastAt: groupDecisions.map((decision) => decision.createdAt).filter(Boolean).sort().at(-1) || null },
+            decisionHistory,
+            materializations,
+            automaticLinks,
+            sourceChanges,
+            staleState: stale ? 'stale' : 'current',
+            lineage: lineageRows,
+            impact: {
+                membersToMove: group.members.length > 1 ? membersToMove : [],
+                survivorIdentity: safeIdentity(identities[0]),
+                retiredIdentities: identities.slice(1).map(safeIdentity),
+                commercialHistoryPresent: undoBlocked,
+                consentHistoryPresent: undoReasons.includes('consent_history_present'),
+                predictedAction: currentDecision === 'pending' && !conflicts.some((conflict) => conflict.severity === 'strong') ? 'merge_if_confirmed' : 'review_only',
+            },
+            undo: { blocked: undoBlocked, reasons: undoReasons, blockingHistory },
+            bulkReview,
+            privacy: { contactsMasked: true, technicalIdsHidden: true, revealRequired: true },
+            _identityIds: identities.map((identity) => identity._id),
+            _edgeKeys: group.edges.map(edgeKey),
+            _members: group.members,
+            _edges: group.edges,
+            _now: now.toISOString(),
+        })
+    }
+    const ordered = clusters.sort((left, right) => Number(right.bulkReview.eligible) - Number(left.bulkReview.eligible) || right.confidence - left.confidence || left.clusterKey.localeCompare(right.clusterKey))
+    return includeInternals ? ordered : ordered.map(stripIdentityClusterInternals)
+}
+
+export function stripIdentityClusterInternals(cluster) {
+    if (!cluster) return null
+    const safe = { ...cluster }
+    for (const key of ['_identityIds', '_edgeKeys', '_members', '_edges', '_now']) delete safe[key]
+    return safe
+}
+
+export function buildIdentityClusterBulkPreview(clusters = []) {
+    const eligible = clusters.filter((cluster) => cluster?.bulkReview?.eligible)
+    const blocked = clusters.filter((cluster) => !cluster?.bulkReview?.eligible)
+    return {
+        schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+        clusterCount: clusters.length,
+        eligibleCount: eligible.length,
+        blockedCount: blocked.length,
+        memberCount: clusters.reduce((sum, cluster) => sum + Number(cluster?.summary?.memberCount || 0), 0),
+        eligibleMembers: eligible.reduce((sum, cluster) => sum + Number(cluster?.summary?.memberCount || 0), 0),
+        blockedReasons: [...new Set(blocked.flatMap((cluster) => cluster?.bulkReview?.reasons || []))].sort(),
+        clusters: clusters.map((cluster) => ({ clusterKey: cluster.clusterKey, version: cluster.version, eligible: cluster.bulkReview.eligible, reasons: cluster.bulkReview.reasons })),
+    }
+}
+
+export function assertExplicitIdentityClusterPayload(payload = {}) {
+    const reason = text(payload.reason).replace(/\s+/g, ' ')
+    if (reason.length < 3 || reason.length > 1000) throw Object.assign(new Error('IDENTITY_CLUSTER_REASON_REQUIRED'), { statusCode: 400 })
+    if (payload.confirmation !== 'REVIEW_CLUSTER') throw Object.assign(new Error('IDENTITY_CLUSTER_CONFIRMATION_REQUIRED'), { statusCode: 400 })
+    const expectedVersion = text(payload.expectedVersion)
+    if (!expectedVersion || expectedVersion.length > 200) throw Object.assign(new Error('IDENTITY_CLUSTER_VERSION_REQUIRED'), { statusCode: 400 })
+    return { reason, expectedVersion }
+}
+
+export function explicitRevealFields(payload = {}) {
+    const fields = unique(payload.fields).filter((field) => CONTACT_FIELDS.has(field))
+    if (!fields.length) throw Object.assign(new Error('IDENTITY_CLUSTER_REVEAL_FIELD_REQUIRED'), { statusCode: 400 })
+    return fields
+}
+
+export function redactIdentityClusterRecord(record = {}) {
+    const safe = {}
+    for (const [key, value] of Object.entries(record)) {
+        if (TECHNICAL_KEYS.has(key) || CONTACT_FIELDS.has(key)) continue
+        safe[key] = value
+    }
+    return safe
+}

--- a/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
+++ b/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
@@ -1,0 +1,163 @@
+import { assertAtendimentoMigrationDestination, isStrictAtendimentoMigrationDestination, ATENDIMENTO_MIGRATION_TARGETS } from './migrationDestination.js'
+import { IDENTITY_GRAPH_LOCK_KEY } from './identityReviewWorkflow.js'
+
+export const IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID = '20260806_identity_cluster_workspace_v1'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITES = [
+    'global_client_identities',
+    'global_client_identity_members',
+    'identity_review_decisions',
+    'identity_materialization_runs',
+    'identity_member_history',
+    'identity_lineage',
+    'identity_source_link_history',
+    'commercial_actions',
+    'commercial_contact_permissions',
+    'commercial_contact_permission_events',
+    'audit_events',
+]
+
+const STATEMENTS = [
+    `create table if not exists crm_atendimento.identity_review_cluster_operations (
+        id uuid primary key default gen_random_uuid(),
+        operation_key text not null unique,
+        cluster_key text not null,
+        operation text not null check (operation in ('bulk_confirm','reveal')),
+        request_fingerprint text not null,
+        status text not null check (status in ('previewed','applied','rejected','blocked')),
+        actor jsonb not null default '{}'::jsonb,
+        result jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now()
+    )`,
+    `create table if not exists crm_atendimento.identity_review_cluster_reveals (
+        id uuid primary key default gen_random_uuid(),
+        cluster_key text not null,
+        cluster_version text not null,
+        fields jsonb not null default '[]'::jsonb,
+        reason_digest text not null,
+        actor jsonb not null default '{}'::jsonb,
+        unit_scope jsonb not null default '[]'::jsonb,
+        created_at timestamptz not null default now()
+    )`,
+    `create index if not exists identity_review_cluster_operations_cluster_idx
+        on crm_atendimento.identity_review_cluster_operations(cluster_key, created_at desc)`,
+    `create index if not exists identity_review_cluster_reveals_cluster_idx
+        on crm_atendimento.identity_review_cluster_reveals(cluster_key, created_at desc)`,
+    `create or replace function crm_atendimento.prevent_identity_cluster_ledger_mutation()
+        returns trigger language plpgsql as $$
+        begin
+            raise exception 'identity cluster evidence is append-only';
+        end $$`,
+    `drop trigger if exists identity_review_cluster_operations_immutable on crm_atendimento.identity_review_cluster_operations`,
+    `create trigger identity_review_cluster_operations_immutable
+        before update or delete or truncate on crm_atendimento.identity_review_cluster_operations
+        for each statement execute function crm_atendimento.prevent_identity_cluster_ledger_mutation()`,
+    `drop trigger if exists identity_review_cluster_reveals_immutable on crm_atendimento.identity_review_cluster_reveals`,
+    `create trigger identity_review_cluster_reveals_immutable
+        before update or delete or truncate on crm_atendimento.identity_review_cluster_reveals
+        for each statement execute function crm_atendimento.prevent_identity_cluster_ledger_mutation()`,
+]
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    try {
+        await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    }
+}
+
+async function assertPrerequisites(client) {
+    const columns = PREREQUISITES.map((table) => `to_regclass('crm_atendimento.${table}') as ${table}`).join(',')
+    const result = await client.query(`select ${columns}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_PREREQUISITES_MISSING')
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+export function identityClusterWorkspaceMigrationPlan() {
+    return {
+        id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+        adds: ['identity_review_cluster_operations', 'identity_review_cluster_reveals'],
+        privacy: 'Stores only opaque cluster keys, field names, a reason digest, actor identity and aggregate results; raw contact values never enter the operational ledger.',
+        ledgerIntegrity: 'Cluster operations and reveal audits reject UPDATE, DELETE and TRUNCATE.',
+        access: 'Runtime receives SELECT/INSERT only; no DDL and no destructive grant is required.',
+        rollback: 'Non-destructive: marks the migration rolled back and disables cluster writes while retaining evidence.',
+    }
+}
+
+export async function applyIdentityClusterWorkspaceMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let open = false
+    try {
+        await client.query('begin'); open = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+        await assertDestination(client, databaseUrl, target)
+        await assertPrerequisites(client)
+        await ensureRegistry(client)
+        for (const sql of STATEMENTS) await client.query(sql)
+        const role = RUNTIME_ROLES[target]
+        if (!role) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_RUNTIME_ROLE_UNKNOWN')
+        await client.query(`grant usage on schema crm_atendimento to ${role}`)
+        await client.query(`grant select, insert on table crm_atendimento.identity_review_cluster_operations to ${role}`)
+        await client.query(`grant select, insert on table crm_atendimento.identity_review_cluster_reveals to ${role}`)
+        const report = { id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, applied: true, runtimeRole: role, tables: ['identity_review_cluster_operations', 'identity_review_cluster_reveals'] }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values($1,now(),null,$2::jsonb)
+            on conflict(id) do update set applied_at=excluded.applied_at, rolled_back_at=null, details=excluded.details`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, JSON.stringify(report)])
+        await client.query('commit'); open = false
+        return report
+    } catch (error) {
+        if (open) { try { await client.query('rollback') } catch { /* preserve original error */ } }
+        throw error
+    } finally { client.release() }
+}
+
+export async function rollbackIdentityClusterWorkspaceMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let open = false
+    try {
+        await client.query('begin'); open = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values($1,now(),now(),'{"rollback":"non-destructive","workspaceDisabled":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at=now(), details=excluded.details`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+        await client.query('commit'); open = false
+        return { id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, rolledBack: true, destructive: false, workspaceDisabled: true }
+    } catch (error) {
+        if (open) { try { await client.query('rollback') } catch { /* preserve original error */ } }
+        throw error
+    } finally { client.release() }
+}
+
+export function identityClusterWorkspaceMigrationStatements() {
+    return [...STATEMENTS]
+}

--- a/crm/api/server/atendimento/migrations/20260806_identity_cluster_workspace_v1.down.sql
+++ b/crm/api/server/atendimento/migrations/20260806_identity_cluster_workspace_v1.down.sql
@@ -1,0 +1,2 @@
+-- Rollback is registry-only. Evidence remains queryable and is never deleted.
+-- The runtime must treat this migration as unavailable after marking it rolled back.

--- a/crm/api/server/atendimento/migrations/20260806_identity_cluster_workspace_v1.up.sql
+++ b/crm/api/server/atendimento/migrations/20260806_identity_cluster_workspace_v1.up.sql
@@ -1,0 +1,45 @@
+-- Applied by crm/api/scripts/migrate-atendimento-identity-clusters.mjs.
+-- Additive and fail-closed: raw contact values never enter these ledgers.
+create table if not exists crm_atendimento.identity_review_cluster_operations (
+    id uuid primary key default gen_random_uuid(),
+    operation_key text not null unique,
+    cluster_key text not null,
+    operation text not null check (operation in ('bulk_confirm','reveal')),
+    request_fingerprint text not null,
+    status text not null check (status in ('previewed','applied','rejected','blocked')),
+    actor jsonb not null default '{}'::jsonb,
+    result jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists crm_atendimento.identity_review_cluster_reveals (
+    id uuid primary key default gen_random_uuid(),
+    cluster_key text not null,
+    cluster_version text not null,
+    fields jsonb not null default '[]'::jsonb,
+    reason_digest text not null,
+    actor jsonb not null default '{}'::jsonb,
+    unit_scope jsonb not null default '[]'::jsonb,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists identity_review_cluster_operations_cluster_idx
+    on crm_atendimento.identity_review_cluster_operations(cluster_key, created_at desc);
+create index if not exists identity_review_cluster_reveals_cluster_idx
+    on crm_atendimento.identity_review_cluster_reveals(cluster_key, created_at desc);
+
+create or replace function crm_atendimento.prevent_identity_cluster_ledger_mutation()
+returns trigger language plpgsql as $$
+begin
+    raise exception 'identity cluster evidence is append-only';
+end $$;
+
+drop trigger if exists identity_review_cluster_operations_immutable on crm_atendimento.identity_review_cluster_operations;
+create trigger identity_review_cluster_operations_immutable
+before update or delete or truncate on crm_atendimento.identity_review_cluster_operations
+for each statement execute function crm_atendimento.prevent_identity_cluster_ledger_mutation();
+
+drop trigger if exists identity_review_cluster_reveals_immutable on crm_atendimento.identity_review_cluster_reveals;
+create trigger identity_review_cluster_reveals_immutable
+before update or delete or truncate on crm_atendimento.identity_review_cluster_reveals
+for each statement execute function crm_atendimento.prevent_identity_cluster_ledger_mutation();

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -360,6 +360,55 @@ export function createAtendimentoRouter(options = {}) {
         }
     })
 
+    expressRouter.get('/commercial/identity-clusters', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.identityClusterWorkspace(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/identity-clusters/:clusterKey', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.identityClusterDetail(String(req.params.clusterKey || ''), req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/bulk/preview', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.previewIdentityClusterBulk(req.body || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/bulk/apply', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            const payload = { ...(req.body || {}), idempotencyKey: String(req.headers['idempotency-key'] || req.body?.idempotencyKey || '').trim() }
+            return json(res, 200, { ok: true, ...(await store.applyIdentityClusterBulk(payload, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/:clusterKey/reveal', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await store.revealIdentityCluster({ ...(req.body || {}), clusterKey: String(req.params.clusterKey || '') }, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
     expressRouter.post('/commercial/review/:type/decision', async (req, res) => {
         try {
             if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -77,6 +77,17 @@ import {
     IDENTITY_REVIEW_WORKFLOW_MIGRATION_IDS,
     IDENTITY_REVIEW_WORKFLOW_MIGRATION_ID,
 } from './identityReviewMigration.js'
+import {
+    IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+} from './identityClusterWorkspaceMigration.js'
+import {
+    buildIdentityReviewClusterPresentation,
+    buildIdentityClusterBulkPreview,
+    stripIdentityClusterInternals,
+    assertExplicitIdentityClusterPayload,
+    explicitRevealFields,
+    digestClusterValue,
+} from './identityClusterWorkspace.js'
 
 let pool = null
 
@@ -4877,6 +4888,375 @@ async function materializeIdentityReviewReversal(client, { candidate, reversesDe
     return { ...run, summary }
 }
 
+function identityClusterSourceFreshness(updatedAt, now = new Date()) {
+    if (!updatedAt) return 'unknown'
+    const timestamp = new Date(updatedAt).getTime()
+    if (!Number.isFinite(timestamp)) return 'unknown'
+    return (now.getTime() - timestamp) > (48 * 60 * 60 * 1000) ? 'stale' : 'current'
+}
+
+async function identityClusterWorkspaceStatus(pgPool) {
+    const availability = await pgPool.query(`select
+        to_regclass('crm_atendimento.schema_migrations') as registry,
+        to_regclass('crm_atendimento.identity_review_cluster_operations') as operations,
+        to_regclass('crm_atendimento.identity_review_cluster_reveals') as reveals,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_review_cluster_operations')
+            and tgname='identity_review_cluster_operations_immutable' and tgenabled='O') as operations_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_review_cluster_reveals')
+            and tgname='identity_review_cluster_reveals_immutable' and tgenabled='O') as reveals_immutable`)
+    const row = availability.rows[0] || {}
+    if (!row.registry || !row.operations || !row.reveals || !row.operations_immutable || !row.reveals_immutable) {
+        return { ready: false, migrationId: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID }
+    }
+    const migration = await pgPool.query(`select id from crm_atendimento.schema_migrations where id=$1 and rolled_back_at is null`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+    return { ready: !!migration.rows[0]?.id, migrationId: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID }
+}
+
+function clusterEdgeSql() {
+    return [
+        `select 'attendance_name_merge'::text as review_type, m.left_client_id::text as source_id, m.right_client_id::text as target_id,
+                'attendance_client'::text as source_type, 'attendance_client'::text as target_type, m.status,
+                m.similarity::numeric as confidence, 'name'::text as method, m.evidence,
+                md5(jsonb_build_object('type','attendance_name_merge','sourceId',m.left_client_id::text,
+                    'targetId',m.right_client_id::text,'status',m.status,'confidence',m.similarity,'evidence',m.evidence)::text) as source_version,
+                case when m.status='ambiguous' then 2 else 1 end as candidate_count,
+                false as validated_match, m.updated_at
+         from crm_atendimento.client_merge_suggestions m
+         where m.status in ('pending','confirmed','rejected')`,
+        `select 'attendance_caixa'::text, link.client_id::text, link.caixa_customer_id::text,
+                'attendance_client'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence,
+                md5(jsonb_build_object('type','attendance_caixa','sourceId',link.client_id::text,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end,
+                link.method ~ '(phone|email)', link.updated_at
+         from crm_atendimento.client_caixa_links link
+         where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'app_attendance'::text, link.app_registration_id, link.client_id::text,
+                'app_registration'::text, 'attendance_client'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence,
+                md5(jsonb_build_object('type','app_attendance','sourceId',link.app_registration_id,
+                    'targetId',link.client_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end,
+                link.method ~ '(phone|email)', link.updated_at
+         from crm_atendimento.app_registration_attendance_links link
+         where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'app_caixa'::text, link.app_registration_id, link.caixa_customer_id::text,
+                'app_registration'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence,
+                md5(jsonb_build_object('type','app_caixa','sourceId',link.app_registration_id,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end,
+                link.method ~ '(phone|email)', link.updated_at
+         from crm_atendimento.app_registration_caixa_links link
+         where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'lead_app'::text, link.source_profile_id, link.app_registration_id,
+                'lead_profile'::text, 'app_registration'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence,
+                md5(jsonb_build_object('type','lead_app','sourceId',link.source_profile_id,
+                    'targetId',link.app_registration_id,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end,
+                link.method ~ '(phone|email)', link.updated_at
+         from crm_atendimento.supplemental_lead_profile_app_links link
+         where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'lead_caixa'::text, link.source_profile_id, link.caixa_customer_id::text,
+                'lead_profile'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence,
+                md5(jsonb_build_object('type','lead_caixa','sourceId',link.source_profile_id,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end,
+                link.method ~ '(phone|email)', link.updated_at
+         from crm_atendimento.supplemental_lead_profile_caixa_links link
+         where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+    ].join(' union all ')
+}
+
+async function queryIdentityClusterGraph(pgPool, actor, query = {}) {
+    const unitSlugs = commercialUnitSlugsForQuery(actor, query.unit)
+    const now = new Date()
+    const [identityMembers, attendance, caixa, app, leads, edgeResult, decisions, lineage, sourceLinkHistory, history] = await Promise.all([
+        pgPool.query(`select member.identity_id::text as identity_id, identity.canonical_name as identity_name,
+                identity.created_at as identity_created_at, member.source_type, member.source_id, member.updated_at
+             from crm_atendimento.global_client_identity_members member
+             join crm_atendimento.global_client_identities identity on identity.id=member.identity_id`),
+        pgPool.query(`select 'attendance_client'::text as source_type, client.id::text as source_id,
+                client.canonical_name as name,
+                coalesce(array_agg(distinct alias.alias_name order by alias.alias_name) filter (where alias.alias_name is not null), '{}'::text[]) as aliases,
+                coalesce(array_agg(distinct unit.slug order by unit.slug) filter (where unit.slug is not null), '{}'::text[]) as unit_slugs,
+                '{}'::jsonb as phone_keys, '{}'::jsonb as email_keys, '{}'::jsonb as cpf_keys, client.updated_at,
+                md5(concat_ws('|',client.id::text,client.canonical_name,client.updated_at::text)) as source_fingerprint
+             from crm_atendimento.canonical_clients client
+             left join crm_atendimento.client_aliases alias on alias.client_id=client.id
+             left join crm_atendimento.attendance_client_links link on link.client_id=client.id
+             left join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+             left join crm_atendimento.units unit on unit.id=attendance.unit_id
+             group by client.id, client.canonical_name, client.updated_at`),
+        pgPool.query(`select 'caixa_customer'::text as source_type, customer.id::text as source_id,
+                customer.name, '{}'::text[] as aliases,
+                coalesce(array_agg(distinct unit.slug order by unit.slug) filter (where unit.slug is not null), '{}'::text[]) as unit_slugs,
+                case when nullif(customer.phone_key,'') is null then '[]'::jsonb else jsonb_build_array(customer.phone_key) end as phone_keys,
+                '[]'::jsonb as email_keys, '[]'::jsonb as cpf_keys, customer.updated_at,
+                md5(concat_ws('|',customer.id::text,customer.name,customer.phone_key,customer.updated_at::text)) as source_fingerprint
+             from crm_caixa.customers customer
+             left join crm_caixa.sales sale on sale.customer_id=customer.id
+             left join crm_atendimento.units unit on unit.id=sale.unit_id
+             group by customer.id, customer.name, customer.phone_key, customer.updated_at`),
+        pgPool.query(`select 'app_registration'::text as source_type, source_client_id as source_id,
+                canonical_name as name, name_variants as aliases, unit_slugs, phone_keys, email_keys, cpf_keys, updated_at,
+                md5(jsonb_build_object('id',source_client_id,'name',canonical_name,'phones',phone_keys,'emails',email_keys,
+                    'units',unit_slugs,'updatedAt',updated_at)::text) as source_fingerprint
+             from crm_atendimento.app_client_registrations`),
+        pgPool.query(`select 'lead_profile'::text as source_type, source_profile_id as source_id,
+                canonical_name as name, name_variants as aliases, unit_slugs, phone_keys, email_keys, '{}'::jsonb as cpf_keys, updated_at,
+                md5(jsonb_build_object('id',source_profile_id,'name',canonical_name,'phones',phone_keys,'emails',email_keys,
+                    'units',unit_slugs,'updatedAt',updated_at)::text) as source_fingerprint
+             from crm_atendimento.supplemental_lead_profiles`),
+        pgPool.query(`select * from (${clusterEdgeSql()}) edges`),
+        pgPool.query(`select decision.event_order, decision.review_type, decision.source_id, decision.target_id, decision.decision,
+                decision.resulting_status, decision.source_version, decision.created_at,
+                decision.materialization_run_id::text as materialization_run_id,
+                run.mode as run_mode, run.status as run_status, run.created_at as run_created_at,
+                coalesce(case when run.summary->>'membersMoved' ~ '^[0-9]+$'
+                    then (run.summary->>'membersMoved')::int else 0 end, 0) as run_members_moved
+             from crm_atendimento.identity_review_decisions decision
+             left join crm_atendimento.identity_materialization_runs run on run.id=decision.materialization_run_id
+             order by decision.created_at desc`),
+        pgPool.query(`select predecessor_identity_id::text as predecessor_identity_id, successor_identity_id::text as successor_identity_id,
+                relation, created_at from crm_atendimento.identity_lineage order by created_at desc`),
+        pgPool.query(`select link_type as review_type, source_type, source_id, target_type, target_id,
+                transition, resulting_status, origin, created_at
+             from crm_atendimento.identity_source_link_history order by created_at desc`),
+        pgPool.query(`select identity_id::text as identity_id,
+                count(*) filter (where source='commercial_action')::int as actions,
+                count(*) filter (where source='commercial_permission')::int as permissions,
+                count(*) filter (where source='commercial_permission_event')::int as permission_events,
+                count(*) filter (where source='identity_audit')::int as audit_identity_events
+             from (
+                select action.identity_id, 'commercial_action'::text as source from crm_atendimento.commercial_actions action
+                union all select permission.identity_id, 'commercial_permission'::text from crm_atendimento.commercial_contact_permissions permission
+                union all select event.identity_id, 'commercial_permission_event'::text from crm_atendimento.commercial_contact_permission_events event
+                union all select case when payload->>'identityId' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' then (payload->>'identityId')::uuid else null end, 'identity_audit'::text from crm_atendimento.audit_events
+                 where nullif(payload->>'identityId','') is not null
+             ) events group by identity_id`),
+    ])
+    const sourceMap = new Map()
+    for (const row of [...attendance.rows, ...caixa.rows, ...app.rows, ...leads.rows]) {
+        sourceMap.set(`${row.source_type}:${row.source_id}`, {
+            sourceType: row.source_type,
+            sourceId: row.source_id,
+            name: row.name,
+            canonicalName: row.name,
+            aliases: row.aliases,
+            unitSlugs: row.unit_slugs,
+            phoneKeys: row.phone_keys,
+            emailKeys: row.email_keys,
+            cpfKeys: row.cpf_keys,
+            updatedAt: row.updated_at,
+            sourceFingerprint: row.source_fingerprint,
+            sourceFreshness: identityClusterSourceFreshness(row.updated_at, now),
+        })
+    }
+    const members = identityMembers.rows.map((row) => ({
+        ...(sourceMap.get(`${row.source_type}:${row.source_id}`) || {}),
+        sourceType: row.source_type,
+        sourceId: row.source_id,
+        identityId: row.identity_id,
+        identityName: row.identity_name,
+        identityCreatedAt: row.identity_created_at,
+        updatedAt: sourceMap.get(`${row.source_type}:${row.source_id}`)?.updatedAt || row.updated_at,
+    }))
+    const materializedMemberKeys = new Set(members.map((member) => `${member.sourceType}:${member.sourceId}`))
+    for (const source of sourceMap.values()) {
+        const key = `${source.sourceType}:${source.sourceId}`
+        if (materializedMemberKeys.has(key)) continue
+        members.push({ ...source, identityId: null, identityName: source.name, identityCreatedAt: null })
+    }
+    const edges = edgeResult.rows.map((row) => ({
+        reviewType: row.review_type,
+        sourceType: row.source_type,
+        sourceId: row.source_id,
+        targetType: row.target_type,
+        targetId: row.target_id,
+        status: row.status,
+        confidence: Number(row.confidence || 0),
+        method: row.method,
+        evidence: row.evidence || {},
+        matchedFields: row.evidence?.matchedFields || row.evidence?.sharedFields || [],
+        sharedUnits: row.evidence?.sharedUnits || [],
+        sourceVersion: row.source_version,
+        candidateCount: Number(row.candidate_count || 1),
+        validatedMatch: row.validated_match === true,
+        changedAfterDecision: false,
+    }))
+    const automaticLinkHistory = sourceLinkHistory.rows.map((row) => ({
+            reviewType: row.review_type,
+            sourceType: row.source_type,
+            sourceId: row.source_id,
+            targetType: row.target_type,
+            targetId: row.target_id,
+            transition: row.transition,
+            resultingStatus: row.resulting_status,
+            origin: row.origin,
+            createdAt: row.created_at,
+        }))
+    const historyByIdentity = Object.fromEntries(history.rows.map((row) => [row.identity_id, row]))
+    const clusters = buildIdentityReviewClusterPresentation({
+        members,
+        edges,
+        decisions: decisions.rows,
+        lineage: lineage.rows,
+        automaticLinkHistory,
+        historyByIdentity,
+        unitScope: unitSlugs,
+        now,
+        includeInternals: true,
+    })
+    const search = normalizeText(query.q || query.search || '')
+    const includeResolved = String(query.includeResolved || '').toLowerCase() === 'true'
+    const staleOnly = String(query.stale || '').toLowerCase() === 'true'
+    const status = String(query.status || '').trim()
+    const filtered = clusters.filter((cluster) => {
+        if (!includeResolved && ['confirmed', 'rejected'].includes(cluster.decision.state)) return false
+        if (staleOnly && cluster.staleState !== 'stale') return false
+        if (status && cluster.decision.state !== status) return false
+        if (!search) return true
+        const haystack = cluster._members.flatMap((member) => [member.name, ...member.aliases, ...member.units]).join(' ').toLowerCase()
+        return haystack.includes(search)
+    })
+    return { clusters: filtered, unitSlugs, graph: { members: members.length, edges: edges.length }, workflow: await identityReviewWorkflowStatus(pgPool), workspace: await identityClusterWorkspaceStatus(pgPool) }
+}
+
+function findIdentityCluster(clusters, clusterKey) {
+    const key = String(clusterKey || '').trim()
+    return clusters.find((cluster) => cluster.clusterKey === key) || null
+}
+
+async function assertIdentityClusterWorkspaceReady(pgPool) {
+    const status = await identityClusterWorkspaceStatus(pgPool)
+    if (status.ready) return status
+    const error = new Error('IDENTITY_CLUSTER_WORKSPACE_NOT_READY')
+    error.statusCode = 409
+    throw error
+}
+
+function identityClusterExpectedVersions(payload = {}) {
+    const map = payload.expectedVersions && typeof payload.expectedVersions === 'object' ? payload.expectedVersions : {}
+    return map
+}
+
+async function applyIdentityClusterBulkTransaction(client, payload, actor) {
+    const requestedKeys = [...new Set((Array.isArray(payload.clusterKeys) ? payload.clusterKeys : []).map(String).map((value) => value.trim()).filter(Boolean))]
+    if (!requestedKeys.length || requestedKeys.length > 50) throw identityReviewError('IDENTITY_CLUSTER_BULK_SELECTION_REQUIRED', 400)
+    const expectedVersions = identityClusterExpectedVersions(payload)
+    const reason = String(payload.reason || '').trim()
+    const idempotencyKey = normalizeIdempotencyKey(payload.idempotencyKey)
+    if (!idempotencyKey) throw identityReviewError('IDENTITY_CLUSTER_IDEMPOTENCY_KEY_REQUIRED', 400)
+    if (reason.length < 3 || reason.length > 1000) throw identityReviewError('IDENTITY_CLUSTER_REASON_REQUIRED', 400)
+    const graph = await queryIdentityClusterGraph(client, actor, { unit: payload.unit, includeResolved: true })
+    const results = []
+    let membersMoved = 0
+    for (const clusterKey of requestedKeys) {
+        const cluster = findIdentityCluster(graph.clusters, clusterKey)
+        if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+        const expectedVersion = String(expectedVersions[clusterKey] || '').trim()
+        if (!expectedVersion || expectedVersion !== cluster.version) throw identityReviewError('IDENTITY_CLUSTER_CONFLICT', 409)
+        if (!cluster.bulkReview.eligible) throw identityReviewError('IDENTITY_CLUSTER_BULK_NOT_ELIGIBLE', 409)
+        const operationKey = `${idempotencyKey}:${clusterKey}`
+        const requestFingerprint = digestClusterValue(JSON.stringify({ clusterKey, expectedVersion, reason }))
+        const existing = await client.query(`select status,result,request_fingerprint from crm_atendimento.identity_review_cluster_operations where operation_key=$1 for update`, [operationKey])
+        if (existing.rows[0]) {
+            if (existing.rows[0].request_fingerprint !== requestFingerprint) throw identityReviewError('IDENTITY_CLUSTER_IDEMPOTENCY_CONFLICT', 409)
+            results.push({ clusterKey, status: existing.rows[0].status, result: existing.rows[0].result || {} })
+            continue
+        }
+        let clusterMoved = 0
+        for (const edge of cluster._edges) {
+            const normalized = { reviewType: edge.reviewType, sourceId: edge.sourceId, targetId: edge.targetId, survivorClientId: null }
+            await acquireIdentityReviewLocks(client, { ...normalized, ...IDENTITY_REVIEW_DEFINITIONS[edge.reviewType] })
+            const candidate = await readIdentityReviewCandidate(client, normalized)
+            await assertCommercialReviewCandidateScope(client, actor, candidate)
+            assertIdentityReviewCandidateVersion(candidate, edge.sourceVersion)
+            const latest = await readLatestIdentityReviewDecision(client, candidate)
+            assertNoCurrentIdentityReviewDecision(latest, candidate)
+            const sourceState = await writeIdentityReviewSourceStatus(client, candidate, 'confirmed', actor)
+            const materialization = await materializeIdentityReviewConfirmation(client, { candidate, actor })
+            const sourceLinkTransitions = await recordIdentityReviewSourceLinkTransition(client, {
+                materializationRunId: materialization.id,
+                candidate,
+                previousStatus: candidate.rawStatus,
+                resultingStatus: sourceState.rawStatus,
+                origin: 'manager_identity_cluster_bulk_review',
+            })
+            const decision = await createIdentityReviewDecision(client, {
+                candidate, decision: 'confirmed', reason, actor,
+                materializationRunId: materialization.id,
+                resultingStatus: sourceState.rawStatus,
+                sourceVersion: sourceState.version,
+                sourceSnapshot: { clusterKey, previousSourceVersion: candidate.version },
+            })
+            clusterMoved += Number(materialization.summary?.membersMoved || 0)
+            await audit(client, 'client-identity.cluster.bulk-confirmed', actor, null, {
+                clusterKey, decisionId: decision.id, materializationRunId: materialization.id,
+                membersMoved: Number(materialization.summary?.membersMoved || 0), sourceLinkTransitions: sourceLinkTransitions.length,
+            })
+        }
+        const result = { clusterKey, membersMoved: clusterMoved, decisionState: 'confirmed' }
+        await client.query(`insert into crm_atendimento.identity_review_cluster_operations(
+                operation_key,cluster_key,operation,request_fingerprint,status,actor,result)
+            values($1,$2,'bulk_confirm',$3,'applied',$4::jsonb,$5::jsonb)`, [
+            operationKey, clusterKey, requestFingerprint,
+            JSON.stringify({ id: actorIdentityForMutation(actor), role: actor?.role || '' }), JSON.stringify(result),
+        ])
+        results.push(result)
+        membersMoved += clusterMoved
+    }
+    return { schemaVersion: 'crm-identity-cluster/v1', idempotent: results.some((result) => result.status), appliedClusters: results.length, membersMoved, results }
+}
+
+async function revealIdentityCluster(client, payload, actor) {
+    const normalized = assertExplicitIdentityClusterPayload(payload)
+    const fields = explicitRevealFields(payload)
+    const graph = await queryIdentityClusterGraph(client, actor, { unit: payload.unit, includeResolved: true })
+    const cluster = findIdentityCluster(graph.clusters, payload.clusterKey)
+    if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+    if (cluster.version !== normalized.expectedVersion) throw identityReviewError('IDENTITY_CLUSTER_CONFLICT', 409)
+    const actorIdentity = actorIdentityForMutation(actor)
+    const reasonDigest = digestClusterValue(normalized.reason)
+    const inserted = await client.query(`insert into crm_atendimento.identity_review_cluster_reveals(
+            cluster_key,cluster_version,fields,reason_digest,actor,unit_scope)
+        values($1,$2,$3::jsonb,$4,$5::jsonb,$6::jsonb) returning id::text,created_at`, [
+        cluster.clusterKey, cluster.version, JSON.stringify(fields), reasonDigest,
+        JSON.stringify({ id: actorIdentity, role: actor?.role || '' }), JSON.stringify(graph.unitSlugs || []),
+    ])
+    await audit(client, 'client-identity.cluster.contact-revealed', actor, null, {
+        clusterKey: cluster.clusterKey, clusterVersion: cluster.version, fields, reasonDigest,
+    })
+    const contacts = cluster._members.map((member) => ({
+        sourceLabel: sourceLabelForClusterMember(member.sourceType),
+        name: member.name,
+        phone: fields.includes('phone') ? [...new Set(member.phoneKeys)].filter(Boolean) : [],
+        email: fields.includes('email') ? [...new Set(member.emailKeys)].filter(Boolean) : [],
+    })).filter((entry) => entry.phone.length || entry.email.length)
+    return {
+        clusterKey: cluster.clusterKey,
+        version: cluster.version,
+        auditId: inserted.rows[0]?.id || null,
+        revealedAt: inserted.rows[0]?.created_at || null,
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+        contacts,
+        privacy: { explicitAction: true, reasonRecorded: true, metricsAndLogsRedacted: true },
+    }
+}
+
+function sourceLabelForClusterMember(sourceType) {
+    return ({ attendance_client: 'Atendimento', caixa_customer: 'Caixa', app_registration: 'Cadastro do app', lead_profile: 'Leads e planilhas' })[sourceType] || 'Fonte'
+}
+
 export function createAtendimentoStore(options = {}) {
     const pgPool = options.pool || createAtendimentoPool(options.databaseUrl)
     const schemaManaged = options.schemaManaged === true || String(process.env.CRM_ATENDIMENTO_SCHEMA_MANAGED || '').trim().toLowerCase() === 'true'
@@ -5326,6 +5706,82 @@ export function createAtendimentoStore(options = {}) {
                 ...(await queryIdentityReviewQueue(pgPool, query, { workflowReady: workflow.ready, unitSlugs })),
                 workflow: { writesReady: workflow.ready },
             }
+        },
+
+        async identityClusterWorkspace(query, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, query || {})
+            const limit = sanitizeLimit(query?.limit, 50, 100)
+            const offset = sanitizeOffset(query?.offset, 0)
+            const page = graph.clusters.slice(offset, offset + limit)
+            return {
+                schemaVersion: 'crm-identity-cluster/v1',
+                total: graph.clusters.length,
+                limit,
+                offset,
+                clusters: page.map(stripIdentityClusterInternals),
+                workflow: { writesReady: graph.workflow.ready },
+                workspace: graph.workspace,
+                graph: graph.graph,
+                pagination: { hasPrevious: offset > 0, hasNext: offset + page.length < graph.clusters.length },
+            }
+        },
+
+        async identityClusterDetail(clusterKey, query, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, { ...(query || {}), includeResolved: true })
+            const cluster = findIdentityCluster(graph.clusters, clusterKey)
+            if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+            return {
+                schemaVersion: 'crm-identity-cluster/v1',
+                cluster: stripIdentityClusterInternals(cluster),
+                workflow: { writesReady: graph.workflow.ready },
+                workspace: graph.workspace,
+            }
+        },
+
+        async previewIdentityClusterBulk(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, { unit: payload?.unit, includeResolved: true })
+            const selected = Array.isArray(payload?.clusterKeys) && payload.clusterKeys.length
+                ? graph.clusters.filter((cluster) => payload.clusterKeys.map(String).includes(cluster.clusterKey))
+                : graph.clusters
+            return {
+                ...buildIdentityClusterBulkPreview(selected),
+                workspace: graph.workspace,
+                workflow: { writesReady: graph.workflow.ready },
+            }
+        },
+
+        async applyIdentityClusterBulk(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            await assertIdentityReviewWorkflowReady(pgPool)
+            await assertIdentityClusterWorkspaceReady(pgPool)
+            if (payload?.confirmation !== 'REVIEW_CLUSTER') throw identityReviewError('IDENTITY_CLUSTER_CONFIRMATION_REQUIRED', 400)
+            if (String(payload?.reason || '').trim().length < 3) throw identityReviewError('IDENTITY_CLUSTER_REASON_REQUIRED', 400)
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                return applyIdentityClusterBulkTransaction(client, payload || {}, actor)
+            })
+        },
+
+        async revealIdentityCluster(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            await assertIdentityClusterWorkspaceReady(pgPool)
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                return revealIdentityCluster(client, payload || {}, actor)
+            })
         },
 
         async decideIdentityReview(payload, actor) {

--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AlertTriangle, CalendarClock, CheckCircle2, ChevronRight, CircleDollarSign, RefreshCw, Save, ShieldCheck, UserRoundCheck, UsersRound } from 'lucide-react'
 import { Button } from '@/button'
+import { IdentityClusterWorkspace } from '@/IdentityClusterWorkspace'
 import {
   createCommercialAction,
   commercialCadenceManagerStatuses,
@@ -102,7 +103,10 @@ function statusLabel(value: string) {
 }
 
 function safeContactEligibility(value: CommercialProfile['contactEligibility'] | null | undefined) {
-  return value || unavailableContactEligibility
+  // API responses can be partial while a legacy profile is being hydrated.
+  // Keep the contact controls fail-closed without allowing undefined form
+  // fields to crash the entire Clientes module.
+  return { ...unavailableContactEligibility, ...(value || {}) }
 }
 
 function commercialRolloutAllows(policy: CommercialProfileDetail['policy'], identityId: string) {
@@ -379,7 +383,7 @@ function reviewDecisionLabel(item: ClientIdentityReviewItem) {
   return item.status === 'ambiguous' ? 'Ambíguo' : 'Sugestão'
 }
 
-export function IdentityReviewQueue() {
+function LegacyIdentityReviewQueue() {
   const [items, setItems] = useState<ClientIdentityReviewItem[]>([])
   const [total, setTotal] = useState(0)
   const [type, setType] = useState('')
@@ -465,10 +469,14 @@ export function IdentityReviewQueue() {
       const draft = drafts[key] || { reason: '', survivorClientId: '' }
       const isActing = acting === key
       const undoable = item.decisionState === 'resolved' || item.decisionState === 'stale'
-      return <article key={key} className="rounded-xl border border-slate-800/80 bg-slate-900/35 p-4"><div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between"><div><div className="text-xs text-sky-300">{reviewTypeLabel[item.type]}</div><div className="mt-1 text-sm font-semibold text-white">{item.primaryName} <span className="mx-1 text-slate-600">↔</span> {item.secondaryName}</div></div><div className={`text-xs ${item.decisionState === 'stale' ? 'text-amber-200' : 'text-slate-400'}`}>{reviewDecisionLabel(item)} · confiança {Math.round(item.confidence * 100)}%</div></div><div className="mt-3 grid gap-2 text-xs text-slate-400 md:grid-cols-2"><div><span className="text-slate-500">Contexto: </span>{Object.entries(item.context).map(([entryKey, value]) => { const shown = reviewValue(value); return shown ? <span key={entryKey} className="mr-3 inline-block">{entryKey}: <span className="text-slate-200">{shown}</span></span> : null })}</div><div><span className="text-slate-500">Evidência: </span>{Object.entries(item.evidence).map(([entryKey, value]) => { const shown = reviewValue(value); return shown ? <span key={entryKey} className="mr-3 inline-block">{entryKey}: <span className="text-slate-200">{shown}</span></span> : null })}</div></div>{item.decisionState === 'stale' ? <p className="mt-3 text-xs text-amber-200">A fonte mudou depois da última decisão. Desfaça-a explicitamente e registre um novo motivo antes de revisar de novo.</p> : null}<div className="mt-3 grid gap-2 border-t border-slate-800/70 pt-3 md:grid-cols-[minmax(0,1fr)_auto]">{item.type === 'attendance_name_merge' && !undoable ? <select aria-label={`Cliente sobrevivente para ${item.primaryName}`} value={draft.survivorClientId} onChange={(event) => updateDraft(item, { survivorClientId: event.target.value })} disabled={!writesReady || isActing} className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100"><option value="">Escolha o cliente canônico a manter</option><option value={item.sourceId}>Manter {item.primaryName}</option><option value={item.targetId}>Manter {item.secondaryName}</option></select> : null}<input aria-label={`Motivo da decisão para ${item.primaryName}`} value={draft.reason} onChange={(event) => updateDraft(item, { reason: event.target.value })} placeholder={undoable ? 'Motivo do desfazimento' : 'Motivo da decisão'} maxLength={1000} disabled={!writesReady || isActing} className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><div className="flex flex-wrap gap-2 md:justify-end">{undoable ? <Button size="sm" variant="outline" onClick={() => void undo(item)} disabled={!writesReady || isActing || draft.reason.trim().length < 3}>Desfazer decisão</Button> : <><Button size="sm" onClick={() => void decide(item, 'confirmed')} disabled={!writesReady || isActing || draft.reason.trim().length < 3 || (item.type === 'attendance_name_merge' && !draft.survivorClientId)}>Confirmar</Button><Button size="sm" variant="outline" onClick={() => void decide(item, 'rejected')} disabled={!writesReady || isActing || draft.reason.trim().length < 3}>Rejeitar</Button></>}</div></div></article>
+      return <article key={key} className="rounded-xl border border-slate-800/80 bg-slate-900/35 p-4"><div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between"><div><div className="text-xs text-sky-300">{reviewTypeLabel[item.type]}</div><div className="mt-1 text-sm font-semibold text-white">{item.primaryName} <span className="mx-1 text-slate-600">↔</span> {item.secondaryName}</div></div><div className={`text-xs ${item.decisionState === 'stale' ? 'text-amber-200' : 'text-slate-400'}`}>{reviewDecisionLabel(item)} · confiança {Math.round(item.confidence * 100)}%</div></div><div className="mt-3 rounded-lg border border-slate-800/70 bg-slate-950/30 p-2 text-xs text-slate-500">A apresentação detalhada de campos, conflitos e evidências está disponível no workspace de clusters.</div>{item.decisionState === 'stale' ? <p className="mt-3 text-xs text-amber-200">A fonte mudou depois da última decisão. Desfaça-a explicitamente e registre um novo motivo antes de revisar de novo.</p> : null}<div className="mt-3 grid gap-2 border-t border-slate-800/70 pt-3 md:grid-cols-[minmax(0,1fr)_auto]">{item.type === 'attendance_name_merge' && !undoable ? <select aria-label={`Cliente sobrevivente para ${item.primaryName}`} value={draft.survivorClientId} onChange={(event) => updateDraft(item, { survivorClientId: event.target.value })} disabled={!writesReady || isActing} className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100"><option value="">Escolha o cliente canônico a manter</option><option value={item.sourceId}>Manter {item.primaryName}</option><option value={item.targetId}>Manter {item.secondaryName}</option></select> : null}<input aria-label={`Motivo da decisão para ${item.primaryName}`} value={draft.reason} onChange={(event) => setDrafts((current) => ({ ...current, [key]: { ...draft, reason: event.target.value } }))} placeholder={undoable ? 'Motivo do desfazimento' : 'Motivo da decisão'} maxLength={1000} disabled={!writesReady || isActing} className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><div className="flex flex-wrap gap-2 md:justify-end">{undoable ? <Button size="sm" variant="outline" onClick={() => void undo(item)} disabled={!writesReady || isActing || draft.reason.trim().length < 3}>Desfazer decisão</Button> : <><Button size="sm" onClick={() => void decide(item, 'confirmed')} disabled={!writesReady || isActing || draft.reason.trim().length < 3 || (item.type === 'attendance_name_merge' && !draft.survivorClientId)}>Confirmar</Button><Button size="sm" variant="outline" onClick={() => void decide(item, 'rejected')} disabled={!writesReady || isActing || draft.reason.trim().length < 3}>Rejeitar</Button></>}</div></div></article>
     })}{!busy && !items.length ? <p className="py-6 text-center text-sm text-slate-500">Nenhuma sugestão encontrada para estes filtros.</p> : null}</div>
     {items.length < total ? <div className="mt-4 text-center"><Button size="sm" variant="outline" onClick={() => void load(items.length, true)} disabled={busy}>Carregar mais 100</Button></div> : null}
   </section>
+}
+
+export function IdentityReviewQueue() {
+  return <IdentityClusterWorkspace />
 }
 
 function CanarySelection({ profiles, selectedIds, disabled, onToggle, onClear }: {

--- a/crm/console/IdentityClusterWorkspace.tsx
+++ b/crm/console/IdentityClusterWorkspace.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Eye, GitBranch, LockKeyhole, RefreshCw, ShieldAlert, UsersRound } from 'lucide-react'
+import { Button } from '@/button'
+import {
+  applyIdentityClusterBulk,
+  fetchIdentityClusterDetail,
+  fetchIdentityClusterWorkspace,
+  previewIdentityClusterBulk,
+  revealIdentityCluster,
+  type IdentityClusterBulkPreview,
+  type IdentityReviewCluster,
+} from '@/atendimentoApi'
+
+type ClusterViewState = {
+  q: string
+  unit: string
+  stale: boolean
+  includeResolved: boolean
+}
+
+const DEFAULT_FILTERS: ClusterViewState = { q: '', unit: 'all', stale: false, includeResolved: false }
+
+function readUrlState(): ClusterViewState & { clusterKey: string } {
+  if (typeof window === 'undefined') return { ...DEFAULT_FILTERS, clusterKey: '' }
+  const params = new URLSearchParams(window.location.search)
+  return {
+    q: params.get('identityClusterQ') || '',
+    unit: params.get('identityClusterUnit') || 'all',
+    stale: params.get('identityClusterStale') === 'true',
+    includeResolved: params.get('identityClusterResolved') === 'true',
+    clusterKey: params.get('identityCluster') || '',
+  }
+}
+
+function updateUrl(state: ClusterViewState, clusterKey?: string, mode: 'replace' | 'push' = 'replace') {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  const setOrDelete = (key: string, value: string, defaultValue = '') => value && value !== defaultValue ? url.searchParams.set(key, value) : url.searchParams.delete(key)
+  setOrDelete('identityClusterQ', state.q)
+  setOrDelete('identityClusterUnit', state.unit, 'all')
+  setOrDelete('identityClusterStale', state.stale ? 'true' : '')
+  setOrDelete('identityClusterResolved', state.includeResolved ? 'true' : '')
+  if (clusterKey) url.searchParams.set('identityCluster', clusterKey)
+  else url.searchParams.delete('identityCluster')
+  if (mode === 'push') window.history.pushState(window.history.state, document.title, `${url.pathname}${url.search}${url.hash}`)
+  else window.history.replaceState(window.history.state, document.title, `${url.pathname}${url.search}${url.hash}`)
+}
+
+function stateLabel(cluster: IdentityReviewCluster) {
+  if (cluster.staleState === 'stale') return 'Fonte alterada após decisão'
+  if (cluster.decision.state === 'confirmed') return 'Decisão confirmada'
+  if (cluster.decision.state === 'rejected') return 'Decisão rejeitada'
+  return cluster.bulkReview.eligible ? 'Elegível para revisão em lote' : 'Revisão individual'
+}
+
+function stateClass(cluster: IdentityReviewCluster) {
+  if (cluster.staleState === 'stale') return 'border-amber-300/30 bg-amber-500/10 text-amber-100'
+  if (cluster.bulkReview.eligible) return 'border-emerald-300/25 bg-emerald-500/10 text-emerald-100'
+  return 'border-slate-700 bg-slate-900/60 text-slate-300'
+}
+
+function ErrorPanel({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return <div role="alert" className="rounded-xl border border-rose-300/30 bg-rose-500/10 p-4 text-sm text-rose-100"><div className="flex items-start gap-2"><ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" /><span className="min-w-0 flex-1">{message}</span>{onRetry ? <Button size="sm" variant="outline" onClick={onRetry}>Tentar novamente</Button> : null}</div></div>
+}
+
+function SourceMember({ member }: { member: IdentityReviewCluster['members'][number] }) {
+  return <li className="rounded-lg border border-slate-800/80 bg-slate-950/40 p-3"><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div className="text-xs text-sky-300">{member.sourceLabel}</div><div className="truncate text-sm font-medium text-slate-100">{member.name}</div>{member.aliases.length ? <div className="mt-1 text-xs text-slate-500">Aliases: {member.aliases.join(', ')}</div> : null}</div><span className={`rounded-full border px-2 py-0.5 text-[10px] ${member.stale ? 'border-amber-300/30 text-amber-200' : 'border-slate-700 text-slate-400'}`}>{member.stale ? 'stale' : member.freshness}</span></div><div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-400">{member.units.map((unit) => <span key={unit} className="rounded border border-slate-800 px-1.5 py-0.5">{unit}</span>)}{member.contact.phone.map((phone) => <span key={phone} className="rounded border border-slate-800 px-1.5 py-0.5">Tel. {phone}</span>)}{member.contact.email.map((email) => <span key={email} className="rounded border border-slate-800 px-1.5 py-0.5">E-mail {email}</span>)}</div></li>
+}
+
+function ClusterDetail({ cluster, onReveal, revealing }: { cluster: IdentityReviewCluster; onReveal: () => void; revealing: boolean }) {
+  return <div className="space-y-4" data-testid="identity-cluster-detail"><div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><div className="flex flex-wrap items-center gap-2"><h3 className="text-lg font-semibold text-white">Componente de identidade</h3><span className={`rounded-full border px-2 py-0.5 text-[11px] ${stateClass(cluster)}`}>{stateLabel(cluster)}</span></div><p className="mt-1 text-xs text-slate-500">{cluster.summary.memberCount} membro(s) · {cluster.summary.identityCount} identidade(s) · confiança {Math.round(cluster.confidence * 100)}%</p></div><Button size="sm" variant="outline" onClick={onReveal} disabled={revealing}><Eye className="mr-2 h-4 w-4" />Revelar contato</Button></div><div className="grid gap-3 sm:grid-cols-4"><div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">Fontes</div><div className="mt-1 text-lg font-semibold text-white">{cluster.membersBySource.length}</div></div><div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">Conflitos</div><div className="mt-1 text-lg font-semibold text-white">{cluster.conflicts.length}</div></div><div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">Membros a mover</div><div className="mt-1 text-lg font-semibold text-white">{cluster.impact.membersToMove.length}</div></div><div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">Undo</div><div className="mt-1 text-sm font-semibold text-white">{cluster.undo.blocked ? 'Bloqueado' : 'Disponível'}</div></div></div><section aria-labelledby="cluster-members-heading"><h4 id="cluster-members-heading" className="flex items-center gap-2 text-sm font-semibold text-white"><UsersRound className="h-4 w-4 text-sky-300" />Membros por fonte</h4><ul className="mt-2 grid gap-2 md:grid-cols-2">{cluster.members.map((member) => <SourceMember key={`${member.source}:${member.name}`} member={member} />)}</ul></section><div className="grid gap-4 lg:grid-cols-2"><section className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Evidências fortes</h4>{cluster.evidence.strong.length ? <ul className="mt-2 space-y-2 text-xs text-slate-300">{cluster.evidence.strong.map((evidence, index) => <li key={`${evidence.label}-${index}`}><span className="text-emerald-300">{evidence.label}</span><span className="ml-2 text-slate-500">{Math.round(evidence.confidence * 100)}% · {evidence.summary}</span></li>)}</ul> : <p className="mt-2 text-xs text-slate-500">Nenhuma evidência forte suficiente.</p>}</section><section className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Evidências fracas e conflitos</h4>{cluster.evidence.weak.length ? <ul className="mt-2 space-y-2 text-xs text-slate-300">{cluster.evidence.weak.map((evidence, index) => <li key={`${evidence.label}-${index}`}><span className="text-amber-200">{evidence.label}</span><span className="ml-2 text-slate-500">{evidence.summary}</span></li>)}</ul> : null}{cluster.conflicts.length ? <ul className="mt-2 space-y-2 text-xs text-rose-200">{cluster.conflicts.map((conflict) => <li key={conflict.field}>{conflict.summary}</li>)}</ul> : !cluster.evidence.weak.length ? <p className="mt-2 text-xs text-slate-500">Nenhum conflito explicitado.</p> : null}</section></div><section className="rounded-lg border border-slate-800 p-3"><h4 className="flex items-center gap-2 text-sm font-semibold text-white"><GitBranch className="h-4 w-4 text-sky-300" />Lineage e impacto previsto</h4><div className="mt-2 grid gap-3 text-xs text-slate-300 md:grid-cols-2"><div><div className="text-slate-500">Sobrevivente</div><div className="mt-1">{cluster.impact.survivorIdentity?.name || 'A definir na materialização'}</div><div className="mt-3 text-slate-500">Retiradas</div><div className="mt-1">{cluster.impact.retiredIdentities.length ? cluster.impact.retiredIdentities.map((identity) => identity.name).join(', ') : 'Nenhuma'}</div></div><div><div className="text-slate-500">Bloqueios de desfazimento</div><div className="mt-1">{cluster.undo.blocked ? cluster.undo.reasons.join(', ') : 'Nenhum histórico comercial ou de consentimento detectado.'}</div><div className="mt-3 text-slate-500">Atualidade</div><div className="mt-1">{cluster.staleState === 'stale' ? 'Fonte mudou depois da decisão; revisão individual obrigatória.' : 'Observação atual compatível com a decisão.'}</div></div></div></section><section className="grid gap-4 lg:grid-cols-2"><div className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Decisões, materializações e vínculos</h4><div className="mt-2 space-y-2 text-xs text-slate-300">{cluster.decisionHistory.length ? cluster.decisionHistory.map((decision, index) => <div key={`${decision.reviewType}-${index}`}>{decision.reviewType}: {decision.decision} · {decision.resultingStatus || 'sem status'}{decision.stale ? ' · stale' : ''}</div>) : <div className="text-slate-500">Nenhuma decisão anterior.</div>}{cluster.materializations.map((run, index) => <div key={`run-${index}`}>materialização {run.mode} · {run.status} · {run.membersMoved} membro(s)</div>)}{cluster.automaticLinks.map((link, index) => <div key={`link-${index}`}>{link.source} → {link.target} · {link.status} · {link.method} · {Math.round(link.confidence * 100)}%{link.history.length ? ` · ${link.history.length} evento(s) automático(s)` : ''}</div>)}</div></div><div className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Alterações de fonte</h4>{cluster.sourceChanges.length ? <ul className="mt-2 space-y-2 text-xs text-amber-200">{cluster.sourceChanges.map((change, index) => <li key={`${change.source}-${index}`}>{change.source}: {change.name} · {change.changedAt ? new Date(change.changedAt).toLocaleString() : 'data não informada'}</li>)}</ul> : <p className="mt-2 text-xs text-slate-500">Nenhuma fonte mudou após a decisão.</p>}</div></section><div className="rounded-lg border border-slate-800 bg-slate-950/40 p-3 text-xs text-slate-400"><LockKeyhole className="mr-2 inline h-4 w-4 text-sky-300" />IDs técnicos não são renderizados. Telefones e e-mails permanecem mascarados até uma ação explícita auditada.</div></div>
+}
+
+export function IdentityClusterWorkspace() {
+  const initial = readUrlState()
+  const [filters, setFilters] = useState<ClusterViewState>(initial)
+  const [clusterKey, setClusterKey] = useState(initial.clusterKey)
+  const [clusters, setClusters] = useState<IdentityReviewCluster[]>([])
+  const [total, setTotal] = useState(0)
+  const [workspaceReady, setWorkspaceReady] = useState(false)
+  const [writesReady, setWritesReady] = useState(false)
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([])
+  const [detail, setDetail] = useState<IdentityReviewCluster | null>(null)
+  const [preview, setPreview] = useState<IdentityClusterBulkPreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [revealing, setRevealing] = useState(false)
+  const [error, setError] = useState('')
+  const [detailError, setDetailError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [revealOpen, setRevealOpen] = useState(false)
+  const [revealReason, setRevealReason] = useState('')
+  const [revealFields, setRevealFields] = useState<string[]>(['phone'])
+  const [revealed, setRevealed] = useState<{ sourceLabel: string; name: string; phone: string[]; email: string[] }[]>([])
+  const [applyReason, setApplyReason] = useState('')
+  const [applyOpen, setApplyOpen] = useState(false)
+  const [applying, setApplying] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true); setError('')
+      const result = await fetchIdentityClusterWorkspace({ q: filters.q, unit: filters.unit, stale: filters.stale, includeResolved: filters.includeResolved, limit: 50, offset: 0 })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível carregar o grafo de identidades.')
+      setClusters(result.clusters); setTotal(result.total); setWorkspaceReady(result.workspace.ready); setWritesReady(result.workflow.writesReady)
+      const nextKey = clusterKey && result.clusters.some((cluster) => cluster.clusterKey === clusterKey) ? clusterKey : result.clusters[0]?.clusterKey || ''
+      if (nextKey !== clusterKey) { setClusterKey(nextKey); updateUrl(filters, nextKey) }
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível carregar o grafo de identidades.') } finally { setLoading(false) }
+  }, [clusterKey, filters])
+
+  const loadDetail = useCallback(async (nextKey: string) => {
+    if (!nextKey) { setDetail(null); return }
+    try {
+      setDetailLoading(true); setDetailError('')
+      const result = await fetchIdentityClusterDetail(nextKey, { unit: filters.unit })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível carregar o componente selecionado.')
+      setDetail(result.cluster); setWorkspaceReady(result.workspace.ready); setWritesReady(result.workflow.writesReady)
+    } catch (cause) { setDetail(null); setDetailError(cause instanceof Error ? cause.message : 'Não foi possível carregar o componente selecionado.') } finally { setDetailLoading(false) }
+  }, [filters.unit])
+
+  useEffect(() => { void load() }, [load])
+  useEffect(() => { void loadDetail(clusterKey) }, [clusterKey, loadDetail])
+  useEffect(() => {
+    const onPopState = () => { const state = readUrlState(); setFilters(state); setClusterKey(state.clusterKey) }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [])
+
+  const units = useMemo(() => [...new Set(clusters.flatMap((cluster) => cluster.units))].sort(), [clusters])
+  const eligibleKeys = useMemo(() => clusters.filter((cluster) => cluster.bulkReview.eligible).map((cluster) => cluster.clusterKey), [clusters])
+
+  const changeFilter = (patch: Partial<ClusterViewState>) => {
+    const next = { ...filters, ...patch }
+    setFilters(next); updateUrl(next, clusterKey)
+  }
+  const chooseCluster = (nextKey: string) => { setClusterKey(nextKey); setNotice(''); updateUrl(filters, nextKey, 'push') }
+  const toggleSelection = (key: string) => setSelectedKeys((current) => current.includes(key) ? current.filter((item) => item !== key) : [...current, key])
+
+  const runPreview = async () => {
+    try {
+      setError(''); const result = await previewIdentityClusterBulk({ clusterKeys: selectedKeys })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível simular o lote.')
+      setPreview(result); setApplyOpen(false)
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível simular o lote.') }
+  }
+
+  const applyBulk = async () => {
+    if (!applyReason.trim() || !preview) return
+    try {
+      setApplying(true); setError('');
+      const expectedVersions = Object.fromEntries(preview.clusters.filter((cluster) => cluster.eligible).map((cluster) => [cluster.clusterKey, cluster.version]))
+      const idempotencyKey = typeof globalThis.crypto?.randomUUID === 'function' ? globalThis.crypto.randomUUID() : `cluster-${Date.now()}-${Math.random().toString(16).slice(2)}`
+      const result = await applyIdentityClusterBulk({ clusterKeys: Object.keys(expectedVersions), expectedVersions, reason: applyReason.trim(), confirmation: 'REVIEW_CLUSTER' }, idempotencyKey)
+      if (!result.ok) throw new Error(result.error || 'Não foi possível aplicar a revisão em lote.')
+      setNotice(`${result.appliedClusters} componente(s) confirmado(s) com ledger append-only. ${result.membersMoved} membro(s) movido(s).`)
+      setSelectedKeys([]); setPreview(null); setApplyOpen(false); setApplyReason(''); await load()
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível aplicar a revisão em lote.') } finally { setApplying(false) }
+  }
+
+  const openReveal = () => { setRevealReason(''); setRevealed([]); setRevealOpen(true) }
+  const confirmReveal = async () => {
+    if (!detail || revealReason.trim().length < 3) return
+    try {
+      setRevealing(true); setDetailError('')
+      const result = await revealIdentityCluster(detail.clusterKey, { expectedVersion: detail.version, fields: revealFields as Array<'phone' | 'email'>, reason: revealReason.trim(), confirmation: 'REVIEW_CLUSTER', unit: filters.unit })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível revelar os dados de contato.')
+      setRevealed(result.contacts); setRevealOpen(false); setNotice('Reveal registrado em auditoria append-only; os dados serão removidos da tela após cinco minutos.')
+    } catch (cause) { setDetailError(cause instanceof Error ? cause.message : 'Não foi possível revelar os dados de contato.') } finally { setRevealing(false) }
+  }
+
+  useEffect(() => {
+    if (!revealed.length) return
+    const timeout = window.setTimeout(() => setRevealed([]), 5 * 60 * 1000)
+    return () => window.clearTimeout(timeout)
+  }, [revealed])
+
+  return <section aria-labelledby="identity-cluster-heading" className="rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.28)]"><div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"><div><h2 id="identity-cluster-heading" className="text-lg font-semibold text-white">Clusters de identidade</h2><p className="mt-1 text-sm text-slate-500">Componentes transitivos do grafo, com lineage explícita e revisão em lote somente quando a evidência é determinística.</p></div><Button size="sm" variant="outline" onClick={() => void load()} disabled={loading}><RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />Atualizar</Button></div><div className="mt-4 flex flex-wrap gap-2"><input aria-label="Buscar cluster por cliente" value={filters.q} onChange={(event) => changeFilter({ q: event.target.value })} placeholder="Buscar cliente ou alias" className="min-w-56 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><select aria-label="Unidade do cluster" value={filters.unit} onChange={(event) => changeFilter({ unit: event.target.value })} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((unit) => <option key={unit} value={unit}>{unit}</option>)}</select><label className="flex items-center gap-2 rounded-lg border border-slate-800 px-3 py-2 text-xs text-slate-300"><input type="checkbox" checked={filters.stale} onChange={(event) => changeFilter({ stale: event.target.checked })} />Somente stale</label><label className="flex items-center gap-2 rounded-lg border border-slate-800 px-3 py-2 text-xs text-slate-300"><input type="checkbox" checked={filters.includeResolved} onChange={(event) => changeFilter({ includeResolved: event.target.checked })} />Decisões vigentes</label></div>{!workspaceReady ? <div className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-xs text-amber-100">A migration do workspace ainda não está aplicada. A leitura permanece disponível; reveal e aplicação em lote continuam bloqueados.</div> : null}{!writesReady ? <div className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-xs text-amber-100">O ledger de revisão não está pronto neste ambiente. Nenhuma decisão pode ser gravada.</div> : null}{error ? <div className="mt-3"><ErrorPanel message={error} onRetry={() => void load()} /></div> : null}{notice ? <div role="status" className="mt-3 rounded-lg border border-emerald-300/25 bg-emerald-500/10 p-3 text-sm text-emerald-100">{notice}</div> : null}<div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(23rem,0.9fr)]"><section aria-labelledby="identity-cluster-list-heading" className="min-w-0"><div className="flex items-center justify-between gap-3"><h3 id="identity-cluster-list-heading" className="text-sm font-semibold text-white">{clusters.length} de {total} clusters</h3><div className="flex flex-wrap gap-2"><Button size="sm" variant="outline" onClick={() => void runPreview()} disabled={!selectedKeys.length || loading}>Simular lote ({selectedKeys.length})</Button><Button size="sm" onClick={() => setApplyOpen(true)} disabled={!preview?.eligibleCount || !workspaceReady || !writesReady}>Aplicar elegíveis</Button></div></div><div className="mt-2 overflow-hidden rounded-xl border border-slate-800/80"><ul className="divide-y divide-slate-800/70">{loading && !clusters.length ? <li className="p-6 text-sm text-slate-500">Carregando componentes…</li> : clusters.map((cluster) => <li key={cluster.clusterKey} className={`p-3 ${cluster.clusterKey === clusterKey ? 'bg-sky-500/[0.08]' : ''}`}><div className="flex items-start gap-3"><input type="checkbox" aria-label={`Selecionar cluster com ${cluster.summary.memberCount} membros`} checked={selectedKeys.includes(cluster.clusterKey)} disabled={!cluster.bulkReview.eligible || !workspaceReady || !writesReady} onChange={() => toggleSelection(cluster.clusterKey)} className="mt-1" /><button type="button" className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300" onClick={() => chooseCluster(cluster.clusterKey)}><div className="flex flex-wrap items-center gap-2"><span className="truncate text-sm font-medium text-slate-100">{cluster.members[0]?.name || 'Componente sem nome'}</span><span className={`rounded-full border px-2 py-0.5 text-[10px] ${stateClass(cluster)}`}>{stateLabel(cluster)}</span></div><div className="mt-1 text-xs text-slate-500">{cluster.summary.memberCount} membro(s) · {cluster.units.join(', ') || 'Unidade não resolvida'} · {cluster.membersBySource.map((source) => `${source.sourceLabel}: ${source.count}`).join(' · ')}</div></button></div></li>)}{!loading && !clusters.length ? <li className="p-6 text-center text-sm text-slate-500">Nenhum componente encontrado para os filtros atuais.</li> : null}</ul></div><div className="mt-2 flex items-center gap-2 text-xs text-slate-500"><CheckCircle2 className="h-4 w-4 text-emerald-400" />{eligibleKeys.length} cluster(s) determinístico(s); ambiguidades permanecem individuais.</div></section><aside className="min-w-0 rounded-xl border border-slate-800/80 bg-slate-950/35 p-4">{detailLoading ? <p className="text-sm text-slate-500">Carregando detalhe…</p> : detailError ? <ErrorPanel message={detailError} onRetry={() => void loadDetail(clusterKey)} /> : detail ? <ClusterDetail cluster={detail} onReveal={openReveal} revealing={revealing} /> : <p className="text-sm text-slate-500">Selecione um componente para revisar a lineage e o impacto.</p>}{revealed.length ? <div className="mt-4 rounded-lg border border-amber-300/30 bg-amber-500/10 p-3 text-xs text-amber-100"><div className="font-semibold">Contato revelado (auditoria registrada)</div>{revealed.map((contact, index) => <div key={`${contact.sourceLabel}-${index}`} className="mt-2"><div>{contact.sourceLabel} · {contact.name}</div>{contact.phone.map((phone) => <div key={phone}>Telefone: {phone}</div>)}{contact.email.map((email) => <div key={email}>E-mail: {email}</div>)}</div>)}</div> : null}</aside></div>{preview ? <section aria-labelledby="identity-cluster-preview-heading" className="mt-4 rounded-xl border border-sky-300/25 bg-sky-500/[0.06] p-4"><div className="flex items-center gap-2"><AlertTriangle className="h-4 w-4 text-sky-300" /><h3 id="identity-cluster-preview-heading" className="text-sm font-semibold text-white">Simulação do lote</h3></div><div className="mt-3 grid gap-2 sm:grid-cols-5"><div><div className="text-[11px] text-slate-500">Clusters</div><div className="text-lg font-semibold text-white">{preview.clusterCount}</div></div><div><div className="text-[11px] text-slate-500">Elegíveis</div><div className="text-lg font-semibold text-emerald-200">{preview.eligibleCount}</div></div><div><div className="text-[11px] text-slate-500">Bloqueados</div><div className="text-lg font-semibold text-amber-200">{preview.blockedCount}</div></div><div><div className="text-[11px] text-slate-500">Membros elegíveis</div><div className="text-lg font-semibold text-white">{preview.eligibleMembers}</div></div><div><div className="text-[11px] text-slate-500">Motivos</div><div className="text-xs text-slate-300">{preview.blockedReasons.join(', ') || 'Nenhum'}</div></div></div></section> : null}{revealOpen ? <div role="dialog" aria-modal="true" aria-labelledby="reveal-title" className="mt-4 rounded-xl border border-amber-300/30 bg-amber-500/10 p-4"><h3 id="reveal-title" className="text-sm font-semibold text-amber-100">Revelar contato deste cluster</h3><p className="mt-1 text-xs text-amber-100/80">A ação é auditada, exige justificativa e expira após cinco minutos. Nenhum valor é enviado para logs ou métricas.</p><div className="mt-3 flex flex-wrap gap-3 text-sm text-amber-50"><label className="flex items-center gap-2"><input type="checkbox" checked={revealFields.includes('phone')} onChange={(event) => setRevealFields((current) => event.target.checked ? [...new Set([...current, 'phone'])] : current.filter((field) => field !== 'phone'))} />Telefone</label><label className="flex items-center gap-2"><input type="checkbox" checked={revealFields.includes('email')} onChange={(event) => setRevealFields((current) => event.target.checked ? [...new Set([...current, 'email'])] : current.filter((field) => field !== 'email'))} />E-mail</label></div><textarea aria-label="Justificativa do reveal" value={revealReason} onChange={(event) => setRevealReason(event.target.value)} maxLength={1000} placeholder="Justificativa obrigatória" className="mt-3 min-h-20 w-full rounded-lg border border-amber-200/30 bg-slate-950/50 p-2 text-sm text-white" /><div className="mt-3 flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => setRevealOpen(false)}>Cancelar</Button><Button size="sm" onClick={() => void confirmReveal()} disabled={revealing || revealReason.trim().length < 3 || !revealFields.length}>Confirmar reveal</Button></div></div> : null}{applyOpen ? <div role="dialog" aria-modal="true" aria-labelledby="bulk-apply-title" className="mt-4 rounded-xl border border-emerald-300/25 bg-emerald-500/10 p-4"><h3 id="bulk-apply-title" className="text-sm font-semibold text-emerald-100">Confirmar revisão em lote</h3><p className="mt-1 text-xs text-emerald-100/80">Somente componentes elegíveis na simulação serão aplicados. O servidor revalida a versão otimista, locks do grafo e histórico comercial antes de gravar.</p><textarea aria-label="Justificativa da revisão em lote" value={applyReason} onChange={(event) => setApplyReason(event.target.value)} maxLength={1000} placeholder="Justificativa obrigatória" className="mt-3 min-h-20 w-full rounded-lg border border-emerald-200/30 bg-slate-950/50 p-2 text-sm text-white" /><div className="mt-3 flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => setApplyOpen(false)}>Cancelar</Button><Button size="sm" onClick={() => void applyBulk()} disabled={applying || applyReason.trim().length < 3}>Confirmar aplicação</Button></div></div> : null}</section>
+}

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -977,6 +977,99 @@ export type ClientIdentityReviewQueue = {
   workflow?: { writesReady: boolean }
 }
 
+export type IdentityClusterMember = {
+  source: string
+  sourceLabel: string
+  name: string
+  aliases: string[]
+  units: string[]
+  matchingFields: Array<{ field: string; label: string; status: string; values?: string[] }>
+  freshness: string
+  stale: boolean
+  contact: { phone: string[]; email: string[]; masked: boolean }
+}
+
+export type IdentityReviewCluster = {
+  schemaVersion: 'crm-identity-cluster/v1' | string
+  clusterKey: string
+  version: string
+  summary: { memberCount: number; identityCount: number; sourceCount: number; unitCount: number }
+  members: IdentityClusterMember[]
+  membersBySource: Array<{ source: string; sourceLabel: string; count: number }>
+  units: string[]
+  matchingFields: string[]
+  conflicts: Array<{ field: string; label: string; severity: string; summary: string }>
+  evidence: {
+    strong: Array<{ kind: string; label: string; strength: string; confidence: number; source: string; target: string; summary: string }>
+    weak: Array<{ kind: string; label: string; strength: string; confidence: number; source: string; target: string; summary: string }>
+  }
+  confidence: number
+  decision: { state: 'pending' | 'confirmed' | 'rejected' | 'stale'; count: number; lastAt: string | null }
+  decisionHistory: Array<{ reviewType: string; decision: string; resultingStatus: string; recordedAt: string | null; stale: boolean }>
+  materializations: Array<{ mode: string; status: string; recordedAt: string | null; membersMoved: number }>
+  automaticLinks: Array<{
+    source: string
+    target: string
+    status: string
+    method: string
+    confidence: number
+    history: Array<{ transition: string; resultingStatus: string; origin: string; recordedAt: string | null }>
+  }>
+  sourceChanges: Array<{ source: string; name: string; changedAt: string | null }>
+  staleState: 'current' | 'stale'
+  lineage: Array<{ relation: string; recordedAt: string | null }>
+  impact: {
+    membersToMove: Array<{ sourceLabel: string; name: string }>
+    survivorIdentity: { name: string; sourceCount: number; sourceLabels: string[] } | null
+    retiredIdentities: Array<{ name: string; sourceCount: number; sourceLabels: string[] }>
+    commercialHistoryPresent: boolean
+    consentHistoryPresent: boolean
+    predictedAction: string
+  }
+  undo: {
+    blocked: boolean
+    reasons: string[]
+    blockingHistory: { commercialActions: number; consentPermissions: number; consentEvents: number; identityAuditEvents: number }
+  }
+  bulkReview: { eligible: boolean; mode: string; sharedContactField: string | null; reasons: string[] }
+  privacy: { contactsMasked: boolean; technicalIdsHidden: boolean; revealRequired: boolean }
+}
+
+export type IdentityClusterQueue = {
+  schemaVersion: string
+  total: number
+  limit: number
+  offset: number
+  clusters: IdentityReviewCluster[]
+  workflow: { writesReady: boolean }
+  workspace: { ready: boolean; migrationId: string }
+  graph: { members: number; edges: number }
+  pagination: { hasPrevious: boolean; hasNext: boolean }
+}
+
+export type IdentityClusterBulkPreview = {
+  schemaVersion: string
+  clusterCount: number
+  eligibleCount: number
+  blockedCount: number
+  memberCount: number
+  eligibleMembers: number
+  blockedReasons: string[]
+  clusters: Array<{ clusterKey: string; version: string; eligible: boolean; reasons: string[] }>
+  workspace: { ready: boolean; migrationId: string }
+  workflow: { writesReady: boolean }
+}
+
+export type IdentityClusterReveal = {
+  clusterKey: string
+  version: string
+  auditId: string | null
+  revealedAt: string | null
+  expiresAt: string
+  contacts: Array<{ sourceLabel: string; name: string; phone: string[]; email: string[] }>
+  privacy: { explicitAction: boolean; reasonRecorded: boolean; metricsAndLogsRedacted: boolean }
+}
+
 export type ClientIdentityReviewDecision = {
   id: string
   state: 'confirmed' | 'rejected' | 'reversed'
@@ -1033,6 +1126,37 @@ export function fetchClientIdentityReviewQueue(filters: { type?: ClientIdentityR
   Object.entries(filters).forEach(([key, value]) => { if (value !== undefined && value !== '') params.set(key, String(value)) })
   const qs = params.toString()
   return api<ClientIdentityReviewQueue>(`/commercial/review${qs ? `?${qs}` : ''}`)
+}
+
+export function fetchIdentityClusterWorkspace(filters: { q?: string; unit?: string; status?: string; stale?: boolean; limit?: number; offset?: number; includeResolved?: boolean } = {}) {
+  const params = new URLSearchParams()
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value === true) params.set(key, 'true')
+    else if (value !== undefined && value !== '') params.set(key, String(value))
+  })
+  const qs = params.toString()
+  return api<IdentityClusterQueue>(`/commercial/identity-clusters${qs ? `?${qs}` : ''}`)
+}
+
+export function fetchIdentityClusterDetail(clusterKey: string, filters: { unit?: string } = {}) {
+  const params = new URLSearchParams()
+  if (filters.unit && filters.unit !== 'all') params.set('unit', filters.unit)
+  const qs = params.toString()
+  return api<{ cluster: IdentityReviewCluster; workflow: { writesReady: boolean }; workspace: { ready: boolean; migrationId: string } }>(`/commercial/identity-clusters/${encodeURIComponent(clusterKey)}${qs ? `?${qs}` : ''}`)
+}
+
+export function previewIdentityClusterBulk(payload: { clusterKeys?: string[]; unit?: string }) {
+  return api<IdentityClusterBulkPreview>('/commercial/identity-clusters/bulk/preview', { method: 'POST', body: payload })
+}
+
+export function applyIdentityClusterBulk(payload: { clusterKeys: string[]; expectedVersions: Record<string, string>; reason: string; confirmation: 'REVIEW_CLUSTER'; unit?: string }, idempotencyKey: string) {
+  return api<{ schemaVersion: string; idempotent: boolean; appliedClusters: number; membersMoved: number; results: Array<Record<string, unknown>> }>(
+    '/commercial/identity-clusters/bulk/apply', { method: 'POST', body: payload, headers: { 'idempotency-key': idempotencyKey } },
+  )
+}
+
+export function revealIdentityCluster(clusterKey: string, payload: { expectedVersion: string; fields: Array<'phone' | 'email'>; reason: string; confirmation: 'REVIEW_CLUSTER'; unit?: string }) {
+  return api<IdentityClusterReveal>(`/commercial/identity-clusters/${encodeURIComponent(clusterKey)}/reveal`, { method: 'POST', body: payload })
 }
 
 export function decideClientIdentityReview(type: ClientIdentityReviewItem['type'], payload: {

--- a/crm/console/e2e/clientes-identity-clusters.spec.ts
+++ b/crm/console/e2e/clientes-identity-clusters.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const cluster = {
+  schemaVersion: 'crm-identity-cluster/v1',
+  clusterKey: 'cluster-synthetic-a',
+  version: 'version-synthetic-a',
+  summary: { memberCount: 4, identityCount: 3, sourceCount: 4, unitCount: 1 },
+  members: [
+    { source: 'attendance_client', sourceLabel: 'Atendimento', name: 'Cliente Sintético', aliases: ['Cliente S.'], units: ['novo-hamburgo'], matchingFields: [{ field: 'name', label: 'Nome', status: 'present' }], freshness: 'current', stale: false, contact: { phone: [], email: [], masked: true } },
+    { source: 'caixa_customer', sourceLabel: 'Caixa', name: 'Cliente Sintético', aliases: [], units: ['novo-hamburgo'], matchingFields: [{ field: 'phone', label: 'Telefone validado', status: 'validated', values: ['55••••88'] }], freshness: 'current', stale: false, contact: { phone: ['55••••88'], email: [], masked: true } },
+    { source: 'app_registration', sourceLabel: 'Cadastro do app', name: 'Cliente S.', aliases: [], units: ['novo-hamburgo'], matchingFields: [{ field: 'email', label: 'E-mail validado', status: 'validated', values: ['c•••@e•••'] }], freshness: 'current', stale: false, contact: { phone: ['55••••88'], email: ['c•••@e•••'], masked: true } },
+    { source: 'lead_profile', sourceLabel: 'Leads e planilhas', name: 'Cliente Sintético', aliases: [], units: ['novo-hamburgo'], matchingFields: [], freshness: 'current', stale: false, contact: { phone: ['55••••88'], email: [], masked: true } },
+  ],
+  membersBySource: [
+    { source: 'attendance_client', sourceLabel: 'Atendimento', count: 1 },
+    { source: 'caixa_customer', sourceLabel: 'Caixa', count: 1 },
+    { source: 'app_registration', sourceLabel: 'Cadastro do app', count: 1 },
+    { source: 'lead_profile', sourceLabel: 'Leads e planilhas', count: 1 },
+  ],
+  units: ['novo-hamburgo'], matchingFields: ['phone', 'email'], conflicts: [],
+  evidence: { strong: [{ kind: 'source_link', label: 'Telefone validado igual', strength: 'strong', confidence: 1, source: 'Cadastro do app', target: 'Caixa', summary: 'campos: phone · candidatos: 1' }], weak: [] },
+  confidence: 1,
+  decision: { state: 'pending', count: 0, lastAt: null }, decisionHistory: [], materializations: [], automaticLinks: [], sourceChanges: [],
+  staleState: 'current', lineage: [], impact: { membersToMove: [{ sourceLabel: 'Caixa', name: 'Cliente Sintético' }], survivorIdentity: { name: 'Cliente Sintético', sourceCount: 2, sourceLabels: ['Atendimento', 'Caixa'] }, retiredIdentities: [], commercialHistoryPresent: false, consentHistoryPresent: false, predictedAction: 'merge_if_confirmed' },
+  undo: { blocked: false, reasons: [], blockingHistory: { commercialActions: 0, consentPermissions: 0, consentEvents: 0, identityAuditEvents: 0 } },
+  bulkReview: { eligible: true, mode: 'bulk_safe', sharedContactField: 'phone', reasons: [] }, privacy: { contactsMasked: true, technicalIdsHidden: true, revealRequired: true },
+}
+
+const policy = { activeContactCooldownDays: 30, returnRiskThresholds: [90, 180, 365], commercialContactWritesEnabled: false, commercialContactCanaryIdentityIds: [], commercialContactWriteControlsReady: false, policyVersion: 'policy-synthetic-v1', updatedBy: 'synthetic', updatedAt: null }
+
+async function mockClientesApi(page: Page) {
+  await page.route('**/api/auth/me**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, user: { username: 'synthetic', role: 'GESTOR', allowedUnits: [], allowedModules: ['atendimento'] } }) }))
+  await page.route('**/api/atendimento/**', async (route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname
+    const base = { ok: true, policy }
+    if (path.endsWith('/commercial/references')) return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, units: [{ slug: 'novo-hamburgo', name: 'Novo Hamburgo' }], professionals: [], procedures: [] }) })
+    if (path.endsWith('/commercial/overview')) {
+      const profile = { identityId: 'identity-synthetic', name: 'Cliente Sintético', sourceTypes: ['attendance_client'], identityQuality: 'confirmed_multi_source', units: ['novo-hamburgo'], lastAttendance: '2026-08-01', recencyDays: 5, visitCount: 2, procedureCount: 2, completedProcedures: ['Botox'], saleCount: 1, lifetimeSales: 799, sales12m: 799, ticketAverage: 799, purchasedProcedures: ['Botox'], pendingSaleItems: 0, hasRecordedAttendance: true, dataWarnings: [], segments: [], priority: 'normal', recommendedAction: 'Nenhuma', activeActionCount: 0, lastActionAt: null, contactEligibility: { status: 'blocked', reason: 'synthetic', contactAllowed: false, contactWriteAllowed: false, controlsReady: true, contactWriteControlsReady: false } }
+      const overview = { ...base, asOf: '2026-08-06', summary: { profiles: 1, returnAtRisk: 0, highValueInactive: 0, frequent: 0, balancedVip: 0, reactivationPotential: 0, averageTicket: 799 }, actions: { actions: 0, contactedActions: 0, recoveredSalesClients: 0, clinicalReturnClients: 0 }, coverage: { identitiesVisible: 1, confirmedMultiSourceIdentities: 1, unresolvedSingleSourceIdentities: 0, classifiedSaleItems: 1, saleItems: 1 }, dataQuality: { futureAttendancesExcluded: 0, recencySource: 'completed_attendance_only', saleItemsWithoutClassification: 0, activeAttendanceClientsWithoutIdentity: 0, identityDataUpdatedAt: '2026-08-06T00:00:00Z', contactEligibility: { eligible: 0, blocked: 1, reviewRequired: 0, controlsReady: true, contactWriteControlsReady: false } }, total: 1, limit: 50, offset: 0, pagination: { mode: 'sql', sort: 'priority', direction: 'desc', hasPrevious: false, hasNext: false }, profiles: [profile] }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(overview) })
+    }
+    if (path.includes('/commercial/profiles/')) {
+      const profile = { identityId: 'identity-synthetic', name: 'Cliente Sintético', sourceTypes: ['attendance_client'], identityQuality: 'confirmed_multi_source', units: ['novo-hamburgo'], lastAttendance: '2026-08-01', recencyDays: 5, visitCount: 2, procedureCount: 2, completedProcedures: ['Botox'], saleCount: 1, lifetimeSales: 799, sales12m: 799, ticketAverage: 799, purchasedProcedures: ['Botox'], pendingSaleItems: 0, hasRecordedAttendance: true, dataWarnings: [], segments: [], priority: 'normal', recommendedAction: 'Nenhuma', activeActionCount: 0, lastActionAt: null, contactEligibility: { status: 'blocked', reason: 'synthetic', contactAllowed: false, contactWriteAllowed: false, controlsReady: true, contactWriteControlsReady: false } }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, asOf: '2026-08-06', policy, profile, actions: [], timeline: [], clinicalCadences: [] }) })
+    }
+    if (path.endsWith('/commercial/data-quality')) return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, total: 0, limit: 24, offset: 0, metrics: { findings: 0, currentFindings: 0, overdue: 0, unassigned: 0, bySeverity: {}, byStatus: {} }, sourceFreshness: {}, findings: [] }) })
+    if (path.endsWith('/commercial/identity-clusters')) return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, schemaVersion: 'crm-identity-cluster/v1', total: 1, limit: 50, offset: 0, clusters: [cluster], workflow: { writesReady: false }, workspace: { ready: true, migrationId: '20260806_identity_cluster_workspace_v1' }, graph: { members: 4, edges: 3 }, pagination: { hasPrevious: false, hasNext: false } }) })
+    if (path.includes('/commercial/identity-clusters/')) return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, schemaVersion: 'crm-identity-cluster/v1', cluster, workflow: { writesReady: false }, workspace: { ready: true, migrationId: '20260806_identity_cluster_workspace_v1' } }) })
+    return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ ok: false, error: 'NOT_FOUND' }) })
+  })
+}
+
+test('renders the synthetic identity cluster workspace and preserves masked contacts on mobile', async ({ page }) => {
+  await mockClientesApi(page)
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/?module=clientes')
+  await expect(page.getByRole('heading', { name: 'Clientes' })).toBeVisible()
+  await page.getByRole('tab', { name: 'Identidades' }).click()
+  await expect(page).toHaveURL(/clientesView=identities/)
+  await expect(page.getByRole('heading', { name: 'Clusters de identidade' })).toBeVisible()
+  await expect(page.getByRole('button', { name: /Cliente Sintético/ }).first()).toBeVisible()
+  await expect(page.getByText('55••••88').first()).toBeVisible()
+  await expect(page.getByText('5511999998888')).toHaveCount(0)
+  await expect(page.getByText('IDs técnicos não são renderizados.')).toBeVisible()
+  await page.getByRole('button', { name: /Cliente Sintético/ }).click()
+  await expect(page.getByTestId('identity-cluster-detail')).toBeVisible()
+  await expect(page.getByText('Lineage e impacto previsto')).toBeVisible()
+})

--- a/crm/console/playwright.config.ts
+++ b/crm/console/playwright.config.ts
@@ -38,6 +38,7 @@ const screenshotMode: ScreenshotSetting =
       : 'only-on-failure'
 const artifactRoot = path.resolve(process.env.PLAYWRIGHT_ARTIFACT_DIR || '../../artifacts/playwright')
 const startLocalServer = process.env.E2E_START_SERVER === '1'
+const serverPort = process.env.E2E_PORT || new URL(baseURL).port || '5173'
 const configDir = path.dirname(fileURLToPath(import.meta.url))
 const uxAuditTestMatch = ['e2e/pilot/**/*.spec.ts', 'e2e/accessibility/**/*.spec.ts', 'e2e/visual/**/*.spec.ts']
 
@@ -75,7 +76,7 @@ export default defineConfig({
   ],
   webServer: startLocalServer
     ? {
-        command: 'npm run dev -- --host 127.0.0.1 --port 5173',
+        command: `npm run dev -- --host 127.0.0.1 --port ${serverPort}`,
         url: baseURL,
         cwd: configDir,
         reuseExistingServer: !process.env.CI,

--- a/docs/operations/clientes-identity-cluster-workspace.md
+++ b/docs/operations/clientes-identity-cluster-workspace.md
@@ -1,0 +1,68 @@
+# Workspace de clusters de identidade — Clientes
+
+Este runbook descreve a operação do workspace de revisão de identidades por componentes do grafo. A mudança é somente de revisão e governança: não abre escrita comercial, não envia mensagens e não executa campanha.
+
+## Contrato operacional
+
+- Schema de resposta: `crm-identity-cluster/v1`.
+- A unidade de agrupamento é um componente transitivo de registros de Atendimento, Caixa, cadastro do app e leads/planilhas, incluindo aliases, decisões, materializações, vínculos automáticos e alterações posteriores da fonte.
+- A API retorna somente DTOs explícitos. Chaves técnicas, `context`, `evidence` arbitrário, telefone e e-mail brutos não são renderizados.
+- Telefone e e-mail aparecem mascarados; o reveal exige ação explícita, justificativa, confirmação, versão otimista e permissão de gestor. O ledger guarda apenas digest da justificativa e campos revelados.
+- O escopo de unidade é aplicado ao componente inteiro. Se um membro não puder ser provado dentro do escopo do ator, o componente é ocultado/falha fechado.
+- Nenhuma ausência de uma fonte autoriza exclusão, aposentadoria ou merge automático.
+
+## Pré-requisitos e migration
+
+A migration é aditiva e separada do bootstrap HTTP. Ela exige o schema de identidade e os ledgers predecessores já disponíveis e só aceita os destinos locais/staging explicitamente permitidos pelo `migrationDestination.js`.
+
+```text
+scripts/invoke-skincos-wsl.ps1 \
+  -ProjectRoot C:\CodexShared\Worktrees\skincos\admin\clientes-identity-cluster-workspace-20260806 \
+  -WorkingDirectory crm/api \
+  -Executable npm \
+  -Argument @('run','migrate-atendimento-identity-clusters','--','--plan')
+```
+
+Para aplicar, substitua `--plan` por `--apply` somente no espelho local ou em staging isolado. Para staging, acrescente `--target=staging` e forneça a URL loopback TLS do migrator autorizada. O processo rejeita TCP/URL fora da allowlist antes de abrir a conexão. A role de runtime recebe somente `USAGE` e `SELECT, INSERT` nas tabelas novas; DDL permanece com a role de migration.
+
+Rollback é não destrutivo: `--rollback` registra a migration como indisponível, desabilita escritas do workspace e preserva os ledgers para auditoria. Não remover tabelas nem apagar evidências.
+
+## API e estados
+
+- `GET /api/atendimento/commercial/identity-clusters`: fila paginada de componentes, filtros de unidade, busca, stale e resolvidos.
+- `GET /api/atendimento/commercial/identity-clusters/:clusterKey`: detalhe independente, com lineage, impacto, bloqueios de undo, histórico e origem dos vínculos.
+- `POST /api/atendimento/commercial/identity-clusters/bulk/preview`: simula apenas componentes determinísticos.
+- `POST /api/atendimento/commercial/identity-clusters/bulk/apply`: exige `REVIEW_CLUSTER`, justificativa, `expectedVersions`, idempotency key e lock do grafo.
+- `POST /api/atendimento/commercial/identity-clusters/:clusterKey/reveal`: exige justificativa, confirmação, versão e campos `phone`/`email`; a resposta expira em cinco minutos no cliente.
+
+Estados de revisão são `pending`, `confirmed`, `rejected` e `stale`. Uma fonte alterada após a decisão reabre o componente como `stale`; nenhuma decisão stale é reaplicada em lote.
+
+## Critério de revisão em lote
+
+O preview marca `bulk_safe` somente quando há telefone ou e-mail validado compartilhado, candidato único, evidência determinística, ausência de conflito forte, ausência de decisão incompatível, ausência de histórico comercial/consentimento bloqueador e fonte atual. Todos os demais casos permanecem `individual_only`.
+
+O apply é transacional, limitado a 50 componentes, usa lock por componente, valida versão atual e registra decisão, materialização, lineage, histórico de vínculo e auditoria append-only. Repetir a mesma chave idempotente retorna o resultado original; reutilizar a chave com outro payload é rejeitado.
+
+## Smoke sintético
+
+```text
+scripts/invoke-skincos-wsl.ps1 \
+  -ProjectRoot C:\CodexShared\Worktrees\skincos\admin\clientes-identity-cluster-workspace-20260806 \
+  -Executable npm \
+  -Argument @('run','--prefix','crm/console','test:e2e','--','--grep','synthetic identity cluster','--project','chromium-desktop') \
+  -EnvVar @('E2E_START_SERVER=1','E2E_PORT=5187','E2E_BASE_URL=http://127.0.0.1:5187','CI=1','CODEX_SHELL=1')
+```
+
+O smoke usa somente identidades sintéticas, viewport móvel, mocks locais e verifica deep link, mascaramento, ausência de ID técnico, abertura do detalhe e lineage. Não reutilizar dados reais nem publicar artefatos de browser no repositório.
+
+## Evidência e troubleshooting
+
+1. Confirmar `workspace.ready` e `workflow.writesReady` na resposta; `false` é estado esperado antes da migration e deve manter a UI em leitura.
+2. Confirmar `staleState`, `sourceChanges` e `bulkReview.reasons` antes de qualquer apply.
+3. Em conflito de versão, recarregar o detalhe e simular novamente; não forçar a versão antiga.
+4. Em `commercial_or_consent_history`, manter revisão individual e não tentar undo automático.
+5. Para suspeita de PII em logs/métricas, interromper o smoke, preservar apenas hashes/contagens e auditar o endpoint de reveal.
+
+## Escopo desta tranche
+
+A branch não promove produção. A ativação posterior deve partir de `main`, aplicar a migration em ambiente isolado, executar o smoke no mesmo SHA e comprovar RBAC por unidade. Escrita comercial, canário, consentimento, contato e campanhas permanecem desativados.


### PR DESCRIPTION
## Resumo

Evolui a revisão de identidades de pares para um workspace orientado por componentes transitivos do grafo, sobre `origin/main` (`d498aa4812aad098abca93db02df3ebf33c9e623`). A PR é isolada, aditiva e não promove produção.

## Entrega

- workspace de clusters reunindo Atendimento, Caixa, cadastro do app, leads/planilhas, aliases, decisões, materializações, links automáticos e alterações posteriores das fontes;
- schema explícito `crm-identity-cluster/v1`, DTO público fail-closed e sem renderização genérica de `context`/`evidence`;
- membros por fonte/unidade, campos coincidentes, conflitos, evidências fortes/fracas, confiança, decisão/histórico, stale, lineage, impacto, survivor/moves, materializações, links e bloqueios de undo;
- telefone/e-mail mascarados por padrão, IDs técnicos ocultos, reveal explícito com justificativa/confirmação, auditoria sem PII e escopo por unidade;
- bulk review somente para clusters determinísticos e seguros, com lock do grafo, versão otimista, idempotência, ledger append-only, prevenção de decisões incompatíveis e bloqueios de histórico;
- rotas comerciais RBAC para listagem, detalhe, simulação/aplicação bulk e reveal;
- UI com deep link/filtros na URL, histórico do navegador, carregamento e erro isolados, mobile, navegação por teclado e painel de detalhe;
- migration aditiva de operações/reveals, triggers imutáveis, runner `--plan/--apply/--rollback` estritamente local/staging e sem DDL pelo runtime da aplicação;
- runbook operacional com rollback e smoke.

## Validação

- API completa: 307 testes, 306 pass, 1 skip, 0 falhas;
- console Vitest: 48 arquivos, 244 testes pass;
- typecheck, build e lint concluídos; bundle inicial 563,2 KiB (orçamento 800 KiB), lint 0 erros e 95 avisos preexistentes;
- Playwright mobile sintético: 1 pass; confirmou URL profunda, PII mascarada e ausência de telefone bruto;
- `migrate-atendimento-identity-clusters --plan` pass;
- `git diff --cached --check` pass.

## Escopo e segurança

Nenhuma escrita comercial, mensagem, campanha, consentimento ou decisão real de identidade é executada por esta PR. A migration só pode ser apontada a destinos explicitamente reconhecidos como local/staging; rollback é registry-only/não destrutivo. A PR antiga de seletor de canário (#1164) não foi incorporada nem alterada.
