### PR TITLE
fix(codex): keep active missions from stopping silently

### DIFF
--- a/.codex/hooks/skincos-supervisor-gate.py
+++ b/.codex/hooks/skincos-supervisor-gate.py
@@ -861,8 +861,33 @@ def process(
         if (shared_root / "processed-events" / f"{event_key}.json").exists():
             return safe_allow("SKINCOS supervisor ignored a duplicate Stop event")
 
+        mission_path = runtime_root / "missions" / f"{session_key}.json"
+        mission = read_json(mission_path) if mission_path.exists() else None
+        if mission_path.exists() and mission is None:
+            mark_event(
+                shared_root / "processed-events",
+                event_key,
+                {**event_record, "result": "corrupt_mission_state"},
+            )
+            return safe_allow("SKINCOS supervisor safety stop: mission state is corrupt")
+
         contract, extract_error = extract_contract(message)
         if extract_error or contract is None:
+            if mission and mission.get("status") == "in_progress":
+                mark_event(
+                    shared_root / "processed-events",
+                    event_key,
+                    {
+                        **event_record,
+                        "result": "active_mission_missing_contract",
+                        "mission_id": mission.get("mission_id"),
+                    },
+                )
+                return block(
+                    "SKINCOS supervisor: an active mission is incomplete; emit exactly one "
+                    "supervisor-cycle state contract with a concrete next_item and progress_made=true, "
+                    "or a terminal status, before ending this turn"
+                )
             mark_event(shared_root / "processed-events", event_key, {**event_record, "result": "invalid_contract"})
             recursion = " during a continued turn" if payload.get("stop_hook_active") else ""
             return safe_allow(f"SKINCOS supervisor safety stop{recursion}: {extract_error}")
@@ -877,15 +902,6 @@ def process(
             mark_event(shared_root / "processed-events", event_key, {**event_record, "result": "skill_unavailable"})
             return safe_allow(f"SKINCOS supervisor safety stop: {skill_error}")
 
-        mission_path = runtime_root / "missions" / f"{session_key}.json"
-        mission = read_json(mission_path)
-        if mission_path.exists() and mission is None:
-            mark_event(
-                shared_root / "processed-events",
-                event_key,
-                {**event_record, "result": "corrupt_mission_state"},
-            )
-            return safe_allow("SKINCOS supervisor safety stop: mission state is corrupt")
         stop_hook_active = bool(payload.get("stop_hook_active"))
         requested_mission = contract.get("mission_id")
 

--- a/.codex/hooks/tests/test_skincos_supervisor_gate.py
+++ b/.codex/hooks/tests/test_skincos_supervisor_gate.py
@@ -141,6 +141,20 @@ class GateFixture(unittest.TestCase):
         self.assertIn("$skincos-project-orchestrator supervisor-cycle", result["reason"])
         self.assertIn('"cycle": 1', result["reason"])
 
+    def test_active_mission_rejects_an_unstructured_normal_stop(self) -> None:
+        initial = self.run_gate(self.payload())
+        self.assertEqual(initial["decision"], "block")
+
+        result = self.run_gate(
+            self.payload(
+                message="The checks are still pending; I will stop here for now.",
+                turn_id="turn-2",
+            )
+        )
+
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("active mission is incomplete", result["reason"])
+
     def test_compact_session_snapshot_persists_and_reaches_continuation_prompt(self) -> None:
         contract = self.contract(
             session_snapshot={

--- a/docs/operations/codex-supervised-continuity.md
+++ b/docs/operations/codex-supervised-continuity.md
@@ -13,9 +13,11 @@ systems, choose milestones, run deploys or duplicate the Skill's judgment.
 
 Automatic continuation is opt-in per explicit root mission: the assistant must
 emit the delimited supervisor contract. Ordinary answers without the contract
-finish normally. Only `orchestration_status=continue` can create a new turn.
-All other statuses and every ambiguous or corrupt state finish safely with a
-diagnostic.
+finish normally when no mission is active; once a mission is persisted as
+`in_progress`, an unstructured stop is rejected so the assistant must emit the
+next safe item or a terminal status. Only `orchestration_status=continue` can
+create a new turn. All other statuses and every ambiguous or corrupt state
+finish safely with a diagnostic.
 
 No App Server or daemon is needed for this same-thread use case. A future
 multi-thread supervisor, if justified, belongs in a separate PR and must use the


### PR DESCRIPTION
## Objective\nEnsure a persisted in-progress mission cannot end with a free-form status message and require a structured supervisor-cycle continuation or terminal state.\n\n## Changes\n- the project Stop gate recognizes an active mission before contract parsing; missing or invalid structure blocks with the concrete continuation requirement;\n- no-mission behavior and terminal states remain unchanged;\n- added a regression test and updated the supervised-continuity runbook.\n\n## Validation\n- 34 supervisor-hook unit tests passed in Ubuntu-24.04 WSL;\n- git diff --check passed.\n\n## Rollback\nRevert commit 83809e21 or close/revert this PR. No runtime data, credentials, or production workflow changed.