### PR TITLE
feat(team): persistir estado e retry da sincronização com Escala

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1230,6 +1230,56 @@ if (DEV_AUTH_ENABLED) {
         }
     }
 
+    const LOCAL_SCHEDULE_SYNC_STATES = new Set(['NOT_CONFIGURED', 'PENDING', 'SYNCED', 'FAILED', 'BLOCKED'])
+    const LOCAL_SCHEDULE_OPERATION_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,179}$/
+    const LOCAL_SCHEDULE_ERROR_CODE_RE = /^[A-Z0-9][A-Z0-9_:-]{1,79}$/
+    const localNormalizeScheduleSync = (value, fallbackProfessionalId = '') => {
+        const input = value && typeof value === 'object' ? value : {}
+        const candidate = String(input.state ?? input.status ?? '').trim().toUpperCase()
+        const state = LOCAL_SCHEDULE_SYNC_STATES.has(candidate) ? candidate : (fallbackProfessionalId ? 'SYNCED' : 'PENDING')
+        const professionalId = String(input.professionalId ?? input.professional_id ?? fallbackProfessionalId ?? '').trim().slice(0, 160)
+        const errorCandidate = String(input.errorCode ?? input.error_code ?? '').trim().toUpperCase().slice(0, 80)
+        const errorCode = LOCAL_SCHEDULE_ERROR_CODE_RE.test(errorCandidate) ? errorCandidate : ''
+        const attemptValue = Number(input.attempt ?? 0)
+        const attempt = Number.isFinite(attemptValue) ? Math.max(0, Math.min(999, Math.trunc(attemptValue))) : 0
+        const parsedUpdatedAt = Date.parse(String(input.updatedAt ?? input.updated_at ?? ''))
+        return {
+            state,
+            professionalId: professionalId || null,
+            errorCode: errorCode || null,
+            attempt,
+            updatedAt: Number.isFinite(parsedUpdatedAt) ? new Date(parsedUpdatedAt).toISOString() : null,
+        }
+    }
+    const localHasScheduleIntent = (schedule) => [
+        schedule?.professionalId,
+        schedule?.status,
+        schedule?.role,
+        schedule?.shift,
+        schedule?.nickname,
+        schedule?.instagram,
+        schedule?.color,
+    ].some((value) => String(value || '').trim() !== '')
+    const localBuildScheduleSync = (state, current = {}, details = {}) => {
+        const normalizedState = LOCAL_SCHEDULE_SYNC_STATES.has(String(state || '').toUpperCase())
+            ? String(state).toUpperCase()
+            : 'PENDING'
+        const errorCandidate = String(details.errorCode || (normalizedState === 'FAILED' ? 'ESCALA_SYNC_FAILED' : normalizedState === 'BLOCKED' ? 'ESCALA_SYNC_BLOCKED' : '')).trim().toUpperCase().slice(0, 80)
+        const errorCode = LOCAL_SCHEDULE_ERROR_CODE_RE.test(errorCandidate) ? errorCandidate : ''
+        const at = new Date().toISOString()
+        return localNormalizeScheduleSync({
+            state: normalizedState,
+            professionalId: ['SYNCED', 'FAILED', 'BLOCKED'].includes(normalizedState) ? details.professionalId || current.schedule?.professionalId : '',
+            errorCode,
+            attempt: Number(current.scheduleSync?.attempt || 0) + 1,
+            updatedAt: at,
+        })
+    }
+    const localScheduleOperationKey = (value) => {
+        const key = String(value || '').trim().slice(0, 180)
+        return LOCAL_SCHEDULE_OPERATION_KEY_RE.test(key) ? key : ''
+    }
+
     const localNormalizeTeamMember = (member) => {
         if (!member || typeof member !== 'object') return null
         const profile = String(member.profile || localProfileForTitle(member.jobTitle) || 'CONSULTOR').toUpperCase()
@@ -1251,6 +1301,7 @@ if (DEV_AUTH_ENABLED) {
             inviteId: String(member.inviteId || '').trim() || null,
             provisioningState: String(member.provisioningState || 'COMPLETED').trim(),
             schedule: localNormalizeSchedule(member.schedule, units),
+            scheduleSync: localNormalizeScheduleSync(member.scheduleSync, member.schedule?.professionalId),
             identityLinks: Array.isArray(member.identityLinks) ? member.identityLinks : [],
             createdAt: member.createdAt || new Date().toISOString(),
             updatedAt: member.updatedAt || member.createdAt || new Date().toISOString(),
@@ -1300,6 +1351,7 @@ if (DEV_AUTH_ENABLED) {
         createdAt: member.createdAt || null,
         updatedAt: member.updatedAt || null,
         schedule: localNormalizeSchedule(member.schedule, member.units),
+        scheduleSync: localNormalizeScheduleSync(member.scheduleSync, member.schedule?.professionalId),
         identityLinks: (member.identityLinks || []).map(localPublicIdentityLink),
     })
 
@@ -1319,7 +1371,10 @@ if (DEV_AUTH_ENABLED) {
                     items.push({ memberId, kind: 'IDENTITY_LINK', source: String(link?.source || '').toUpperCase(), status: 'PENDING_REVIEW' })
                 }
             }
-            if (!row?.schedule?.professionalId && String(row?.accountStatus || '').toUpperCase() !== 'TERMINATED') {
+            const scheduleSync = localNormalizeScheduleSync(row?.scheduleSync, row?.schedule?.professionalId)
+            if (['PENDING', 'FAILED', 'BLOCKED'].includes(scheduleSync.state) && String(row?.accountStatus || '').toUpperCase() !== 'TERMINATED') {
+                items.push({ memberId, kind: 'ESCALA_SYNC', status: scheduleSync.state })
+            } else if (!row?.schedule?.professionalId && scheduleSync.state !== 'NOT_CONFIGURED' && String(row?.accountStatus || '').toUpperCase() !== 'TERMINATED') {
                 items.push({ memberId, kind: 'ESCALA_LINK', status: 'PENDING' })
             }
         }
@@ -1352,6 +1407,7 @@ if (DEV_AUTH_ENABLED) {
         const auditIn = Array.isArray(store?.audit) ? store.audit : []
         const telemetryIn = Array.isArray(store?.telemetry) ? store.telemetry : []
         const bulkOperationsIn = Array.isArray(store?.bulkOperations) ? store.bulkOperations : []
+        const scheduleOperationsIn = Array.isArray(store?.scheduleOperations) ? store.scheduleOperations : []
         let changed = false
         const users = usersIn.map((user) => {
             if (!user || typeof user !== 'object') return user
@@ -1369,7 +1425,7 @@ if (DEV_AUTH_ENABLED) {
         })
         const team = teamIn.map(localNormalizeTeamMember).filter(Boolean)
         if (JSON.stringify(team) !== JSON.stringify(teamIn)) changed = true
-        return { store: { version: 3, users, invites, team, audit: auditIn, telemetry: telemetryIn, bulkOperations: bulkOperationsIn }, changed }
+        return { store: { version: 3, users, invites, team, audit: auditIn, telemetry: telemetryIn, bulkOperations: bulkOperationsIn, scheduleOperations: scheduleOperationsIn }, changed }
     }
 
     const loadLocalCrmStore = async () => {
@@ -1384,6 +1440,7 @@ if (DEV_AUTH_ENABLED) {
                 audit: Array.isArray(json?.audit) ? json.audit : [],
                 telemetry: Array.isArray(json?.telemetry) ? json.telemetry : [],
                 bulkOperations: Array.isArray(json?.bulkOperations) ? json.bulkOperations : [],
+                scheduleOperations: Array.isArray(json?.scheduleOperations) ? json.scheduleOperations : [],
             })
             if (normalized.changed) {
                 await fs.writeFile(LOCAL_CRM_STORE_FILE, JSON.stringify(normalized.store, null, 2), 'utf8')
@@ -1400,7 +1457,7 @@ if (DEV_AUTH_ENABLED) {
                     // Keep an empty local store if the optional fixture is unavailable.
                 }
             }
-            return { version: 3, users: [], invites: [], team: [], audit: [], telemetry: [], bulkOperations: [] }
+            return { version: 3, users: [], invites: [], team: [], audit: [], telemetry: [], bulkOperations: [], scheduleOperations: [] }
         }
     }
     const saveLocalCrmStore = async (store) => {
@@ -1453,7 +1510,7 @@ if (DEV_AUTH_ENABLED) {
         }
     }
 
-    const localAudit = (store, session, action, entityId, after, before = null) => {
+    const localAudit = (store, session, action, entityId, after, before = null, idempotencyKey = null) => {
         const audit = Array.isArray(store.audit) ? store.audit : []
         audit.unshift({
             id: `local-audit-${randomUUID()}`,
@@ -1462,6 +1519,7 @@ if (DEV_AUTH_ENABLED) {
             entityId,
             actor: session?.user?.username || session?.user?.email || 'gestor-local',
             role: normalizeRole(session?.user?.role || ''),
+            idempotencyKey: idempotencyKey || null,
             createdAt: new Date().toISOString(),
             before,
             after,
@@ -1574,12 +1632,21 @@ if (DEV_AUTH_ENABLED) {
             inviteId,
             provisioningState: 'COMPLETED',
             schedule: input.schedule,
+            scheduleSync: localBuildScheduleSync(localHasScheduleIntent(input.schedule) ? 'PENDING' : 'NOT_CONFIGURED'),
             identityLinks: [],
             createdAt: at,
             updatedAt: at,
             createdBy: session.user.username || session.user.email || 'gestor-local',
         })
         store.team.unshift(member)
+        const initialScheduleOperationKey = localScheduleOperationKey(`local-escala-sync-${id}-${randomUUID()}`)
+        store.scheduleOperations = [{
+            operationKey: initialScheduleOperationKey,
+            memberId: id,
+            state: member.scheduleSync.state,
+            result: member.scheduleSync,
+            createdAt: at,
+        }, ...(store.scheduleOperations || [])].slice(0, 500)
         store.invites.unshift({
             id: inviteId,
             inviteeEmail: input.personalEmail,
@@ -1634,11 +1701,64 @@ if (DEV_AUTH_ENABLED) {
             schedule: input.schedule,
             updatedAt: new Date().toISOString(),
         })
+        const scheduleState = localHasScheduleIntent(updated.schedule) || updated.schedule.professionalId ? 'PENDING' : 'NOT_CONFIGURED'
+        updated.scheduleSync = localBuildScheduleSync(scheduleState, current)
         store.team[index] = updated
-        localAudit(store, session, 'EMPLOYEE_TEAM_UPDATED', id, { profile: updated.profile, units: updated.units, localPreview: true }, { profile: current.profile, units: current.units, scheduleProfessionalId: current.schedule?.professionalId || null })
+        const updateScheduleOperationKey = localScheduleOperationKey(`local-escala-sync-${id}-${randomUUID()}`)
+        store.scheduleOperations = [{ operationKey: updateScheduleOperationKey, memberId: id, state: updated.scheduleSync.state, result: updated.scheduleSync, createdAt: updated.updatedAt }, ...(store.scheduleOperations || [])].slice(0, 500)
+        localAudit(store, session, 'EMPLOYEE_TEAM_UPDATED', id, { profile: updated.profile, units: updated.units, scheduleSyncState: updated.scheduleSync.state, localPreview: true }, { profile: current.profile, units: current.units, scheduleProfessionalId: current.schedule?.professionalId || null })
         localTeamTelemetry(store, session, 'EMPLOYEE_TEAM_UPDATED', 'SUCCESS', 1, updated.units.length)
         await saveLocalCrmStore(store)
         return res.status(200).set('cache-control', 'no-store').json({ success: true, data: localPublicTeamMember(updated) })
+    })
+    app.post(['/api/crm/admin/team/:id/schedule-sync', '/admin/team/:id/schedule-sync'], async (req, res) => {
+        const session = requireDevAdmin(req, res)
+        if (!session) return
+        if (!localUnifiedTeamEnabled) return res.status(404).json({ success: false, error: 'TEAM_UNIFIED_DISABLED', code: 'TEAM_UNIFIED_DISABLED' })
+        const store = await loadLocalCrmStore()
+        const id = String(req.params.id || '').trim()
+        const member = store.team.find((row) => row.id === id)
+        if (!member) return res.status(404).json({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' })
+        if (!localTeamUnitsVisible(session, member)) return res.status(403).json({ success: false, error: 'Unidade fora do escopo do gestor', code: 'TEAM_UNITS_DENIED' })
+        const hierarchyError = localTeamHierarchyError(session, member.profile, member.units)
+        if (hierarchyError) return res.status(403).json({ success: false, error: 'Hierarquia não permite sincronizar este membro', code: hierarchyError })
+
+        const body = req.body && typeof req.body === 'object' ? req.body : {}
+        const state = String(body.state ?? body.status ?? '').trim().toUpperCase()
+        if (!LOCAL_SCHEDULE_SYNC_STATES.has(state)) return res.status(400).json({ success: false, error: 'Estado de sincronização inválido', code: 'ESCALA_SYNC_STATE_INVALID' })
+        const professionalId = String(body.professionalId ?? body.professional_id ?? '').trim().slice(0, 160)
+        if (state === 'SYNCED' && !professionalId) return res.status(400).json({ success: false, error: 'A sincronização concluída precisa do identificador da Escala', code: 'ESCALA_PROFESSIONAL_ID_REQUIRED' })
+        if (state === 'NOT_CONFIGURED' && professionalId) return res.status(409).json({ success: false, error: 'Um vínculo configurado não pode ser marcado como não configurado', code: 'ESCALA_SYNC_STATE_CONFLICT' })
+        const errorCandidate = String(body.errorCode ?? body.error_code ?? '').trim().toUpperCase().slice(0, 80)
+        const errorCode = LOCAL_SCHEDULE_ERROR_CODE_RE.test(errorCandidate)
+            ? errorCandidate
+            : state === 'FAILED' ? 'ESCALA_SYNC_FAILED' : state === 'BLOCKED' ? 'ESCALA_SYNC_BLOCKED' : ''
+        if (['FAILED', 'BLOCKED'].includes(state) && !errorCode) return res.status(400).json({ success: false, error: 'A falha precisa de um código operacional', code: 'ESCALA_SYNC_ERROR_CODE_REQUIRED' })
+        const operationKey = localScheduleOperationKey(req.headers['idempotency-key'] || body.operationKey || body.requestId)
+        if (!operationKey) return res.status(400).json({ success: false, error: 'A sincronização exige uma chave de idempotência', code: 'ESCALA_SYNC_IDEMPOTENCY_REQUIRED' })
+
+        const replay = (store.scheduleOperations || []).find((operation) => operation.operationKey === operationKey)
+        const fingerprint = `${id}|${state}|${professionalId}|${errorCode}`
+        if (replay) {
+            if (replay.fingerprint !== fingerprint) return res.status(409).json({ success: false, error: 'A chave de idempotência já foi usada para outro estado', code: 'ESCALA_SYNC_IDEMPOTENCY_CONFLICT' })
+            if (state === 'SYNCED' && professionalId) member.schedule = { ...member.schedule, professionalId }
+            member.scheduleSync = localNormalizeScheduleSync(replay.result, member.schedule?.professionalId)
+            return res.status(200).set('cache-control', 'no-store').json({ success: true, replayed: true, data: { scheduleSync: member.scheduleSync } })
+        }
+
+        if (state === 'SYNCED') {
+            const explicitLink = (member.identityLinks || []).some((link) => String(link?.source || '').toUpperCase() === 'ESCALA' && String(link?.sourceId || '') === professionalId && String(link?.reviewStatus || '').toUpperCase() === 'CONFIRMED')
+            if (!explicitLink) return res.status(409).json({ success: false, error: 'Confirme primeiro o vínculo explícito com a Escala', code: 'TEAM_ESCALA_LINK_REQUIRED' })
+            member.schedule = { ...member.schedule, professionalId }
+        }
+        const result = localBuildScheduleSync(state, member, { professionalId, errorCode })
+        member.scheduleSync = result
+        member.updatedAt = result.updatedAt || new Date().toISOString()
+        store.scheduleOperations = [{ operationKey, fingerprint, memberId: id, state, result, createdAt: member.updatedAt }, ...(store.scheduleOperations || [])].slice(0, 500)
+        localAudit(store, session, 'EMPLOYEE_ESCALA_SYNC_RECORDED', id, { scheduleSyncState: state, professionalId: professionalId || null, errorCode: errorCode || null, attempt: result.attempt, localPreview: true }, null, operationKey)
+        localTeamTelemetry(store, session, 'EMPLOYEE_ESCALA_SYNC_RECORDED', state, 1, member.units.length)
+        await saveLocalCrmStore(store)
+        return res.status(200).set('cache-control', 'no-store').json({ success: true, replayed: false, data: { scheduleSync: member.scheduleSync } })
     })
     app.post(['/api/crm/admin/team/:id/status', '/admin/team/:id/status'], async (req, res) => {
         const session = requireDevAdmin(req, res)

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1510,6 +1510,18 @@ if (DEV_AUTH_ENABLED) {
         }
     }
 
+    const localTeamRequestFingerprint = (input) => createHash('sha256').update(JSON.stringify({
+        version: 1,
+        fullName: input.fullName,
+        corporateEmail: input.corporateEmail,
+        personalEmail: input.personalEmail,
+        mobilePhone: input.mobilePhone,
+        profile: input.profile,
+        department: input.department,
+        units: [...input.units].sort(),
+        schedule: input.schedule,
+    })).digest('hex')
+
     const localAudit = (store, session, action, entityId, after, before = null, idempotencyKey = null) => {
         const audit = Array.isArray(store.audit) ? store.audit : []
         audit.unshift({
@@ -1599,6 +1611,16 @@ if (DEV_AUTH_ENABLED) {
         const hierarchyError = localTeamHierarchyError(session, input.profile, input.units)
         if (hierarchyError) return res.status(403).json({ success: false, error: 'Sem permissão para cadastrar este cargo ou unidade', code: hierarchyError })
 
+        const requestIdempotencyKey = String(req.headers['idempotency-key'] || req.body?.idempotencyKey || '').trim().slice(0, 180)
+        const requestFingerprint = localTeamRequestFingerprint(input)
+        if (requestIdempotencyKey) {
+            const replay = store.team.find((member) => member.requestIdempotencyKey === requestIdempotencyKey)
+            if (replay) {
+                if (replay.requestFingerprint !== requestFingerprint) return res.status(409).json({ success: false, error: 'A chave de idempotência já foi usada para outro cadastro', code: 'ONBOARDING_IDEMPOTENCY_CONFLICT' })
+                return res.status(200).set('cache-control', 'no-store').json({ success: true, data: localPublicTeamMember(replay), replayed: true })
+            }
+        }
+
         const generatedCollision = store.team.some((member) => String(member.corporateEmail || '').toLowerCase() === input.generatedCorporateEmail.toLowerCase()) ||
             store.users.some((user) => String(user.email || '').toLowerCase() === input.generatedCorporateEmail.toLowerCase()) ||
             store.invites.some((invite) => String(invite.corporateEmail || invite.inviteeEmail || '').toLowerCase() === input.generatedCorporateEmail.toLowerCase() && !invite.revoked)
@@ -1637,6 +1659,8 @@ if (DEV_AUTH_ENABLED) {
             createdAt: at,
             updatedAt: at,
             createdBy: session.user.username || session.user.email || 'gestor-local',
+            requestIdempotencyKey: requestIdempotencyKey || null,
+            requestFingerprint,
         })
         store.team.unshift(member)
         const initialScheduleOperationKey = localScheduleOperationKey(`local-escala-sync-${id}-${randomUUID()}`)
@@ -1663,7 +1687,7 @@ if (DEV_AUTH_ENABLED) {
             createdBy: session.user.username || session.user.email || 'gestor-local',
             createdAt: at,
         })
-        localAudit(store, session, 'EMPLOYEE_TEAM_CREATED', id, { profile: input.profile, units: input.units, inviteIssued: true, localPreview: true })
+        localAudit(store, session, 'EMPLOYEE_TEAM_CREATED', id, { profile: input.profile, units: input.units, inviteIssued: true, localPreview: true }, null, requestIdempotencyKey)
         localTeamTelemetry(store, session, 'EMPLOYEE_TEAM_CREATED', 'SUCCESS', 1, input.units.length)
         await saveLocalCrmStore(store)
         return res.status(201).set('cache-control', 'no-store').json({ success: true, data: localPublicTeamMember(member) })

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1741,7 +1741,6 @@ if (DEV_AUTH_ENABLED) {
         const fingerprint = `${id}|${state}|${professionalId}|${errorCode}`
         if (replay) {
             if (replay.fingerprint !== fingerprint) return res.status(409).json({ success: false, error: 'A chave de idempotência já foi usada para outro estado', code: 'ESCALA_SYNC_IDEMPOTENCY_CONFLICT' })
-            if (state === 'SYNCED' && professionalId) member.schedule = { ...member.schedule, professionalId }
             member.scheduleSync = localNormalizeScheduleSync(replay.result, member.schedule?.professionalId)
             return res.status(200).set('cache-control', 'no-store').json({ success: true, replayed: true, data: { scheduleSync: member.scheduleSync } })
         }

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Ban, CircleAlert, Link2, ListChecks, Mail, Pencil, Power, Search, ShieldCheck, UsersRound } from 'lucide-react'
+import { Ban, CircleAlert, Link2, ListChecks, Mail, Pencil, Power, RefreshCw, Search, ShieldCheck, UsersRound } from 'lucide-react'
 import { toast } from 'sonner'
 import { addEscalaProfessional, updateEscalaProfessional } from '@/escalaApi'
 import { Badge } from '@/badge'
@@ -17,7 +17,7 @@ type Me = { success?: boolean; user?: { username?: string; role?: string; allowe
 type Onboarding = { id: string; fullName: string; username?: string | null; corporateEmail: string; workforceEmployeeId?: string | null; profile: string; jobTitle: string; department: string; units: string[]; accountStatus: string; createdAt?: string; updatedAt?: string }
 type ApiError = { error?: string; message?: string; code?: string }
 type RequestOptions = { method?: string; body?: unknown; csrf?: string | null; headers?: Record<string, string> }
-type TeamPendingItem = { memberId: string; kind: 'PROVISIONING' | 'COMPENSATION' | 'IDENTITY_LINK' | 'ESCALA_LINK'; source?: string; status: string }
+type TeamPendingItem = { memberId: string; kind: 'PROVISIONING' | 'COMPENSATION' | 'IDENTITY_LINK' | 'ESCALA_LINK' | 'ESCALA_SYNC'; source?: string; status: string }
 type TeamSummary = { members?: number; pendingLinks?: number; pendingProvisioning?: number; pendingInvites?: number; pendingItems?: TeamPendingItem[] }
 type TeamHistoryEntry = { id: string | number; timestamp?: string | null; actor?: string; role?: string; action?: string; entity?: string; before?: Record<string, unknown> | null; after?: Record<string, unknown> | null }
 
@@ -133,7 +133,20 @@ function pendingItemLabel(item: TeamPendingItem) {
   if (item.kind === 'IDENTITY_LINK') return item.source === 'ATENDIMENTO' ? 'Vínculo do Atendimento' : 'Vínculo da Escala'
   if (item.kind === 'COMPENSATION') return 'Sincronização de acesso'
   if (item.kind === 'PROVISIONING') return 'Provisionamento'
+  if (item.kind === 'ESCALA_SYNC') return item.status === 'FAILED' || item.status === 'BLOCKED' ? 'Sincronização da Escala com erro' : 'Sincronização da Escala pendente'
   return 'Vínculo da Escala'
+}
+
+function scheduleSyncLabel(state?: string) {
+  return ({ NOT_CONFIGURED: 'Não configurada', PENDING: 'Pendente', SYNCED: 'Sincronizada', FAILED: 'Falhou', BLOCKED: 'Bloqueada' } as Record<string, string>)[String(state || '').toUpperCase()] || 'Pendente'
+}
+
+function scheduleSyncBadgeVariant(state?: string): BadgeVariant {
+  const normalized = String(state || '').toUpperCase()
+  if (normalized === 'SYNCED') return 'success'
+  if (normalized === 'FAILED' || normalized === 'BLOCKED') return 'destructive'
+  if (normalized === 'NOT_CONFIGURED') return 'outline'
+  return 'warning'
 }
 
 function historyActionLabel(action: string) {
@@ -147,6 +160,7 @@ function historyActionLabel(action: string) {
     EMPLOYEE_ONBOARDING_STATUS_CHANGED: 'Status alterado',
     EMPLOYEE_ONBOARDING_ACTIVATION_RETRY: 'Ativação processada',
     EMPLOYEE_IDENTITY_LINK_CREATED: 'Vínculo operacional criado',
+    EMPLOYEE_ESCALA_SYNC_RECORDED: 'Sincronização da Escala registrada',
   } as Record<string, string>)[String(action || '').toUpperCase()] || String(action || 'Alteração registrada')
 }
 
@@ -168,6 +182,7 @@ function historyChange(entry: TeamHistoryEntry) {
   const source = after.source
   const reviewStatus = after.reviewStatus
   if (source || reviewStatus) return [`Vínculo: ${String(source || 'operacional')}`, reviewStatus ? String(reviewStatus) : ''].filter(Boolean).join(' · ')
+  if (after.scheduleSyncState) return [`Escala: ${scheduleSyncLabel(String(after.scheduleSyncState))}`, after.errorCode ? `Código: ${String(after.errorCode)}` : ''].filter(Boolean).join(' · ')
   if (after.inviteIssued) return 'Convite emitido'
   if (after.inviteRevoked) return 'Acesso aguardando novo convite'
   return 'Alteração registrada'
@@ -186,6 +201,7 @@ export function UsersModule() {
   const [open, setOpen] = React.useState(false)
   const [loading, setLoading] = React.useState(true)
   const [saving, setSaving] = React.useState(false)
+  const [syncingEscala, setSyncingEscala] = React.useState(false)
   const [editingId, setEditingId] = React.useState<string | null>(null)
   const [editingOriginalName, setEditingOriginalName] = React.useState('')
   const [collisionRequired, setCollisionRequired] = React.useState(false)
@@ -337,6 +353,22 @@ export function UsersModule() {
     }
   }
 
+  const reportEscalaSync = async (member: UnifiedTeamMember, state: 'PENDING' | 'SYNCED' | 'FAILED' | 'BLOCKED' | 'NOT_CONFIGURED', details: { professionalId?: string; errorCode?: string } = {}) => {
+    const operationKey = `crm-escala-sync-${member.id}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    try {
+      await api(`/admin/team/${encodeURIComponent(member.id)}/schedule-sync`, {
+        method: 'POST',
+        csrf: me?.csrfToken,
+        headers: { 'idempotency-key': operationKey },
+        body: { state, ...(details.professionalId ? { professionalId: details.professionalId } : {}), ...(details.errorCode ? { errorCode: details.errorCode } : {}) },
+      })
+      return true
+    } catch (error: any) {
+      toast.warning(`A Escala foi processada, mas o estado não pôde ser registrado: ${error?.message || 'tente atualizar a lista'}.`)
+      return false
+    }
+  }
+
   const addIdentityLink = async () => {
     if (!editingRow || !linkSourceId.trim() || !canManage) return
     setLinkSaving(true)
@@ -364,29 +396,51 @@ export function UsersModule() {
 
   const syncEscala = async (member: UnifiedTeamMember, created: boolean) => {
     if (!teamConfig.enabled || !member.workforceEmployeeId) return
-    const schedulePayload = {
-      name: form.fullName,
-      status: form.scheduleStatus,
-      units: form.units,
-      role: form.scheduleRole,
-      shift: form.scheduleShift,
-      nickname: form.scheduleNickname,
-      phone: form.mobilePhone || member.schedule?.phone || undefined,
-      email: effectiveEmail,
-      instagram: form.scheduleInstagram,
-      color: form.scheduleColor,
-      workforceEmployeeId: member.workforceEmployeeId,
+    setSyncingEscala(true)
+    try {
+      const schedulePayload = {
+        name: form.fullName,
+        status: form.scheduleStatus,
+        units: form.units,
+        role: form.scheduleRole,
+        shift: form.scheduleShift,
+        nickname: form.scheduleNickname,
+        phone: form.mobilePhone || member.schedule?.phone || undefined,
+        email: effectiveEmail,
+        instagram: form.scheduleInstagram,
+        color: form.scheduleColor,
+        workforceEmployeeId: member.workforceEmployeeId,
+      }
+      const hasScheduleLink = Boolean(member.schedule?.professionalId || member.scheduleSync?.professionalId)
+      const result = created || !hasScheduleLink
+        ? await addEscalaProfessional(schedulePayload)
+        : await updateEscalaProfessional({ currentName: editingOriginalName, ...schedulePayload })
+      if (!result.ok) {
+        const recorded = await reportEscalaSync(member, 'FAILED', { errorCode: 'ESCALA_API_ERROR' })
+        if (!created && recorded) await load()
+        toast.warning(`Cadastro salvo, mas a Escala ficou pendente: ${result.error || 'tente novamente'}.`)
+        return false
+      }
+      const professionalId = result.data?.professionalId
+      if (!professionalId) {
+        const recorded = await reportEscalaSync(member, 'FAILED', { errorCode: 'ESCALA_PROFESSIONAL_ID_MISSING' })
+        if (!created && recorded) await load()
+        toast.warning('Cadastro salvo, mas a Escala não devolveu um identificador para o vínculo.')
+        return false
+      }
+      const linked = await linkEscalaMember(member, { professionalId })
+      if (!linked) {
+        const recorded = await reportEscalaSync(member, 'FAILED', { professionalId, errorCode: 'ESCALA_LINK_FAILED' })
+        if (!created && recorded) await load()
+        return false
+      }
+      const recorded = await reportEscalaSync(member, 'SYNCED', { professionalId })
+      if (!created && recorded) await load()
+      if (recorded) toast.success('Vínculo com a Escala sincronizado.')
+      return recorded
+    } finally {
+      setSyncingEscala(false)
     }
-    const hasScheduleLink = Boolean(member.schedule?.professionalId)
-    const result = created || !hasScheduleLink
-      ? await addEscalaProfessional(schedulePayload)
-      : await updateEscalaProfessional({ currentName: editingOriginalName, ...schedulePayload })
-    if (!result.ok) {
-      toast.warning(`Cadastro salvo, mas a Escala ficou pendente: ${result.error || 'tente novamente'}.`)
-      return
-    }
-    const professionalId = result.data?.professionalId
-    if (professionalId) await linkEscalaMember(member, { professionalId })
   }
 
   const submit = async () => {
@@ -662,7 +716,7 @@ export function UsersModule() {
                         </div>
                       </td>
                       <td className="p-3 align-middle"><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge></td>
-                      <td className="p-3 align-middle"><Badge variant={row.schedule?.professionalId ? 'success' : 'outline'} className="px-2 py-1 text-[11px]">{row.schedule?.professionalId ? 'Vinculada' : 'Pendente'}</Badge></td>
+                      <td className="p-3 align-middle"><Badge variant={scheduleSyncBadgeVariant(row.scheduleSync?.state)} className="px-2 py-1 text-[11px]">{scheduleSyncLabel(row.scheduleSync?.state)}</Badge></td>
                       <td className="p-3 text-right align-middle">
                         <TooltipButton label={`Editar ${row.fullName}`}>
                           <Button size="icon" variant="ghost" className="h-8 w-8 rounded-full text-blue-100 hover:bg-white/[0.10]" aria-label={`Editar ${row.fullName}`} onClick={() => openEdit(row)}>
@@ -702,7 +756,7 @@ export function UsersModule() {
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Departamento</p><p className="text-blue-100/80">{row.department || '—'}</p></div>
                     <div className="col-span-2"><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Unidades</p><div className="flex flex-wrap gap-1">{row.units.length ? row.units.map((unit) => <Badge key={unit} variant="outline" className="px-2 py-1 text-[11px]">{unitLabels[unit] || unit}</Badge>) : <Badge variant="outline" className="px-2 py-1 text-[11px]">Sem unidade</Badge>}</div></div>
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Conta</p><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge></div>
-                    <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Escala</p><Badge variant={row.schedule?.professionalId ? 'success' : 'outline'} className="px-2 py-1 text-[11px]">{row.schedule?.professionalId ? 'Vinculada' : 'Pendente'}</Badge></div>
+                    <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Escala</p><Badge variant={scheduleSyncBadgeVariant(row.scheduleSync?.state)} className="px-2 py-1 text-[11px]">{scheduleSyncLabel(row.scheduleSync?.state)}</Badge></div>
                   </div>
                 </article>
               ))}
@@ -766,9 +820,19 @@ export function UsersModule() {
             <TabsContent value="operation" className="mt-4 space-y-4">
               {teamConfig.enabled ? <>
                 <section className="rounded-2xl border border-white/10 bg-black/20 p-4" aria-labelledby="team-schedule-title">
-                  <div className="mb-4 flex items-start gap-3">
+                  <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-3">
                     <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-sky-400/10 text-sky-200"><ListChecks className="size-4" aria-hidden="true" /></div>
                     <div><h3 id="team-schedule-title" className="text-sm font-semibold text-white">Vínculo operacional da Escala</h3><p className="mt-1 text-xs text-blue-100/55">Agenda, função e identificação permanecem aqui; o vínculo usa o identificador do funcionário.</p></div>
+                    </div>
+                    {editingRow && <div className="flex flex-wrap items-center justify-end gap-2" aria-live="polite">
+                      <Badge variant={scheduleSyncBadgeVariant(editingRow.scheduleSync?.state)} className="px-2 py-1 text-[10px]">{scheduleSyncLabel(editingRow.scheduleSync?.state)}</Badge>
+                      {editingRow.scheduleSync?.errorCode && <span className="text-[11px] text-rose-100/70">{editingRow.scheduleSync.errorCode}</span>}
+                      {canManage && <Button type="button" size="sm" variant="outline" disabled={syncingEscala || saving} onClick={() => void syncEscala(editingRow, false)}>
+                        <RefreshCw className={`mr-2 size-3.5 ${syncingEscala ? 'animate-spin' : ''}`} aria-hidden="true" />
+                        {syncingEscala ? 'Sincronizando…' : editingRow.scheduleSync?.state === 'SYNCED' ? 'Sincronizar novamente' : 'Tentar novamente'}
+                      </Button>}
+                    </div>}
                   </div>
                   <div className="grid gap-3 md:grid-cols-2">
                     <label className="space-y-1.5 text-sm">Status na Escala<Input value={form.scheduleStatus} disabled={formReadOnly} onChange={(event) => updateField('scheduleStatus', event.target.value)} /></label>

--- a/crm/console/e2e/users-module-fixtures.ts
+++ b/crm/console/e2e/users-module-fixtures.ts
@@ -13,29 +13,30 @@ export type MockTeamMember = {
   accountStatus: string
   provisioningState: string
   schedule: { professionalId: string | null; status: string; role: string; shift: string; nickname: string; instagram: string; color: string; units: string[] }
+  scheduleSync?: { state: string; professionalId?: string | null; errorCode?: string | null; attempt?: number; updatedAt?: string | null }
   identityLinks: Array<{ id: string; source: string; sourceId: string; reviewStatus: string; matchMethod: string; confidence: string }>
 }
 
 export const syntheticTeam: MockTeamMember[] = [
   {
     id: 'e2e-ana', fullName: 'Ana Ribeiro', username: 'anaribeiro', corporateEmail: 'anaribeiro@espacofacial.com', workforceEmployeeId: 'e2e-wf-ana', profile: 'INJETOR', jobTitle: 'Injetor', department: 'Atendimento Local', units: ['novo-hamburgo'], accountStatus: 'ACTIVE', provisioningState: 'COMPLETED',
-    schedule: { professionalId: 'e2e-escala-ana', status: 'Ativo', role: 'Injetor', shift: 'Integral', nickname: 'Ana', instagram: 'ana.ribeiro', color: '#22c55e', units: ['novo-hamburgo'] },
+    schedule: { professionalId: 'e2e-escala-ana', status: 'Ativo', role: 'Injetor', shift: 'Integral', nickname: 'Ana', instagram: 'ana.ribeiro', color: '#22c55e', units: ['novo-hamburgo'] }, scheduleSync: { state: 'SYNCED', professionalId: 'e2e-escala-ana', attempt: 1 },
     identityLinks: [{ id: 'e2e-link-ana', source: 'ATENDIMENTO', sourceId: 'e2e-atendimento-ana', reviewStatus: 'CONFIRMED', matchMethod: 'EXPLICIT_WORKFORCE_ID', confidence: 'HIGH' }],
   },
   {
     id: 'e2e-lucas', fullName: 'Lucas Mendes', username: 'lucasmendes', corporateEmail: 'lucasmendes@espacofacial.com', workforceEmployeeId: 'e2e-wf-lucas', profile: 'CONSULTOR', jobTitle: 'Consultor', department: 'Comercial', units: ['novo-hamburgo', 'barra-shopping-sul'], accountStatus: 'INVITED', provisioningState: 'COMPLETED',
-    schedule: { professionalId: null, status: 'Ativo', role: 'Consultor', shift: 'Comercial', nickname: 'Lucas', instagram: 'lucas.mendes', color: '#6d9eeb', units: ['novo-hamburgo', 'barra-shopping-sul'] },
+    schedule: { professionalId: null, status: 'Ativo', role: 'Consultor', shift: 'Comercial', nickname: 'Lucas', instagram: 'lucas.mendes', color: '#6d9eeb', units: ['novo-hamburgo', 'barra-shopping-sul'] }, scheduleSync: { state: 'PENDING', attempt: 1 },
     identityLinks: [],
   },
   {
     id: 'e2e-carla', fullName: 'Carla Souza', username: 'carlasouza', corporateEmail: 'carlasouza@espacofacial.com', workforceEmployeeId: 'e2e-wf-carla', profile: 'SUPERVISOR', jobTitle: 'Coordenador', department: 'Operações', units: ['barra-shopping-sul'], accountStatus: 'SUSPENDED', provisioningState: 'COMPLETED',
-    schedule: { professionalId: null, status: 'Ativo', role: 'Coordenador', shift: 'Tarde', nickname: 'Carla', instagram: 'carla.souza', color: '#f97316', units: ['barra-shopping-sul'] },
+    schedule: { professionalId: null, status: 'Ativo', role: 'Coordenador', shift: 'Tarde', nickname: 'Carla', instagram: 'carla.souza', color: '#f97316', units: ['barra-shopping-sul'] }, scheduleSync: { state: 'FAILED', errorCode: 'ESCALA_API_ERROR', attempt: 2 },
     identityLinks: [{ id: 'e2e-link-carla', source: 'ESCALA', sourceId: 'e2e-escala-carla', reviewStatus: 'PENDING_REVIEW', matchMethod: 'EXPLICIT_WORKFORCE_ID', confidence: 'LOW' }],
   },
 ]
 
 function cloneRows() {
-  return syntheticTeam.map((row) => ({ ...row, units: [...row.units], schedule: { ...row.schedule, units: [...row.schedule.units] }, identityLinks: row.identityLinks.map((link) => ({ ...link })) }))
+  return syntheticTeam.map((row) => ({ ...row, units: [...row.units], schedule: { ...row.schedule, units: [...row.schedule.units] }, scheduleSync: row.scheduleSync ? { ...row.scheduleSync } : undefined, identityLinks: row.identityLinks.map((link) => ({ ...link })) }))
 }
 
 export async function mockUsersApi(page: Page, role = 'GESTOR') {
@@ -48,12 +49,16 @@ export async function mockUsersApi(page: Page, role = 'GESTOR') {
     const send = (body: unknown, status = 200) => route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) })
 
     if (path.endsWith('/api/auth/me')) return send({ ok: true, success: true, user: { username: 'users-e2e', email: 'users-e2e@staging.invalid', role, allowedUnits: ['novo-hamburgo', 'barra-shopping-sul'], allowedModules: ['atendimento'] }, csrfToken: 'users-e2e-csrf' })
+    if (path.endsWith('/api/escala/professionals') && ['POST', 'PUT'].includes(request.method())) return send({ ok: true, data: { professionalId: 'e2e-escala-carla' } })
     if (path.endsWith('/api/crm/admin/team') && request.method() === 'GET' && url.searchParams.get('mode') === 'config') return send({ success: true, data: { enabled: true, legacyEscalaEditor: false } })
     if (path.endsWith('/api/crm/admin/team') && request.method() === 'GET') {
       const status = (url.searchParams.get('status') || 'ACTIVE').toUpperCase()
       const query = (url.searchParams.get('q') || '').toLowerCase()
-      const data = rows.filter((row) => status === 'ALL' || status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.department, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
-      const pendingItems = data.flatMap((row) => row.identityLinks.filter((link) => link.reviewStatus === 'PENDING_REVIEW').map((link) => ({ memberId: row.id, kind: 'IDENTITY_LINK', source: link.source, status: link.reviewStatus })))
+      const data = rows.filter((row) => status === 'ALL' ? true : status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.department, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
+      const pendingItems = data.flatMap((row) => [
+        ...row.identityLinks.filter((link) => link.reviewStatus === 'PENDING_REVIEW').map((link) => ({ memberId: row.id, kind: 'IDENTITY_LINK', source: link.source, status: link.reviewStatus })),
+        ...(row.scheduleSync && ['PENDING', 'FAILED', 'BLOCKED'].includes(row.scheduleSync.state) ? [{ memberId: row.id, kind: 'ESCALA_SYNC', status: row.scheduleSync.state }] : []),
+      ])
       return send({ success: true, data, pendingItems, summary: { members: data.length, pendingInvites: data.filter((row) => row.accountStatus === 'INVITED').length, pendingLinks: pendingItems.length, pendingProvisioning: 0 } })
     }
     if (path.endsWith('/api/crm/admin/team/bulk-status') && request.method() === 'POST') {
@@ -76,6 +81,14 @@ export async function mockUsersApi(page: Page, role = 'GESTOR') {
       if (row) row.accountStatus = inviteMatch[2] === 'resend' ? 'INVITED' : 'PENDING_ACCESS'
       return send({ success: true, data: row })
     }
+    const scheduleSyncMatch = path.match(/\/api\/crm\/admin\/team\/([^/]+)\/schedule-sync$/)
+    if (scheduleSyncMatch && request.method() === 'POST') {
+      const body = await json(); const row = rows.find((item) => item.id === decodeURIComponent(scheduleSyncMatch[1]))
+      if (!row) return send({ success: false, error: 'Membro não encontrado' }, 404)
+      row.scheduleSync = { ...(row.scheduleSync || {}), state: body.state, professionalId: body.professionalId || row.scheduleSync?.professionalId || null, errorCode: body.errorCode || null, attempt: (row.scheduleSync?.attempt || 0) + 1 }
+      if (body.state === 'SYNCED' && body.professionalId) row.schedule.professionalId = body.professionalId
+      return send({ success: true, data: { scheduleSync: row.scheduleSync } })
+    }
     const linksMatch = path.match(/\/api\/crm\/admin\/team\/([^/]+)\/links$/)
     if (linksMatch) {
       const row = rows.find((item) => item.id === decodeURIComponent(linksMatch[1]))
@@ -84,6 +97,7 @@ export async function mockUsersApi(page: Page, role = 'GESTOR') {
       const body = await json()
       const link = { id: `e2e-link-${body.sourceId}`, source: body.source, sourceId: body.sourceId, reviewStatus: body.reviewStatus || 'PENDING_REVIEW', matchMethod: body.matchMethod || 'EXPLICIT_WORKFORCE_ID', confidence: body.confidence || 'HIGH' }
       row.identityLinks.push(link)
+      if (body.source === 'ESCALA' && body.reviewStatus === 'CONFIRMED') row.schedule.professionalId = body.sourceId
       return send({ success: true, data: link })
     }
     const historyMatch = path.match(/\/api\/crm\/admin\/team\/([^/]+)\/history$/)

--- a/crm/console/e2e/users-module.spec.ts
+++ b/crm/console/e2e/users-module.spec.ts
@@ -68,6 +68,18 @@ test.describe('Usuários e Equipe', () => {
     await expect(page.getByText('Revisão pendente', { exact: true })).toBeVisible()
   })
 
+  test('retries a failed Escala synchronization from the unified member modal', async ({ page }) => {
+    await mockUsersApi(page)
+    await page.goto('/?module=users')
+    await page.getByRole('combobox', { name: 'Filtrar status' }).click()
+    await page.getByRole('option', { name: 'Todos os estados' }).click()
+    await page.getByRole('button', { name: 'Editar Carla Souza' }).click()
+    await page.getByRole('tab', { name: 'Operação' }).click()
+    await expect(page.getByRole('tabpanel').getByText('Falhou', { exact: true })).toBeVisible()
+    await page.getByRole('button', { name: 'Tentar novamente' }).click()
+    await expect(page.getByRole('tabpanel').getByText('Sincronizada', { exact: true })).toBeVisible()
+  })
+
   test('does not overflow at 390, 768 or 1280 pixels', async ({ page }) => {
     await mockUsersApi(page)
     for (const width of [390, 768, 1280]) {

--- a/crm/console/teamApi.ts
+++ b/crm/console/teamApi.ts
@@ -27,6 +27,13 @@ export type UnifiedTeamMember = {
     color?: string
     units?: string[]
   }
+  scheduleSync?: {
+    state: 'NOT_CONFIGURED' | 'PENDING' | 'SYNCED' | 'FAILED' | 'BLOCKED' | string
+    professionalId?: string | null
+    errorCode?: string | null
+    attempt?: number
+    updatedAt?: string | null
+  }
   identityLinks?: Array<{
     id?: string
     source: string

--- a/docs/runbooks/unified-team-migration.md
+++ b/docs/runbooks/unified-team-migration.md
@@ -49,6 +49,20 @@ confirmação automática.
    ser enviados apenas pelo fluxo de onboarding hospedado e após confirmação
    explícita do relatório.
 
+## Estado operacional da Escala
+
+O cadastro central expõe `scheduleSync` com os estados `NOT_CONFIGURED`,
+`PENDING`, `SYNCED`, `FAILED` e `BLOCKED`. A confirmação exige o vínculo
+explícito `source=ESCALA` + `source_id` do profissional; nomes semelhantes não
+resolvem a identidade. Falhas são persistidas somente como códigos operacionais
+sem PII e podem ser repetidas pela rota autenticada
+`POST /admin/team/:id/schedule-sync`, sempre com `Idempotency-Key` único.
+
+O preview local mantém o mesmo contrato em armazenamento privado e registra
+tentativas, auditoria e telemetria agregada. O botão de nova tentativa só deve
+ser habilitado depois que o identificador explícito do profissional estiver
+disponível; a Escala continua contingência até a flag ser liberada pelo gate.
+
 ## Rollback
 
 O rollback não apaga profissionais, agendas, nomes históricos, auditoria ou

--- a/identity/policy/employeeOnboarding.js
+++ b/identity/policy/employeeOnboarding.js
@@ -83,6 +83,41 @@ export function suggestEmployeeUsername(fullName, corporateEmail = '') {
   return candidate || '';
 }
 
+// The onboarding saga stores only this digest. It binds retries to the
+// employment facts and operational payload without putting personal contact
+// data in an idempotency ledger.
+export function buildEmployeeOnboardingFingerprintPayload({
+  input = {},
+  requestedUsername = '',
+  personalEmailHash = '',
+  mobilePhoneHash = '',
+  team = null,
+} = {}) {
+  const normalizedTeam = team === null ? null : {
+    professionalId: String(team?.professionalId || '').trim(),
+    status: String(team?.status || '').trim(),
+    role: String(team?.role || '').trim(),
+    shift: String(team?.shift || '').trim(),
+    nickname: String(team?.nickname || '').trim(),
+    instagram: String(team?.instagram || '').trim(),
+    color: String(team?.color || '').trim(),
+    units: normalizeAllowedUnits(team?.units).slice().sort(),
+  };
+  return {
+    version: 1,
+    fullName: String(input?.fullName || '').trim().replace(/\s+/g, ' '),
+    corporateEmail: normalizeCorporateEmail(input?.corporateEmail),
+    personalEmailHash: String(personalEmailHash || '').trim().toLowerCase(),
+    mobilePhoneHash: String(mobilePhoneHash || '').trim().toLowerCase(),
+    profile: String(input?.profile || '').trim().toUpperCase(),
+    department: String(input?.department || '').trim().replace(/\s+/g, ' '),
+    units: normalizeAllowedUnits(input?.units).slice().sort(),
+    accountStatus: String(input?.accountStatus || '').trim().toUpperCase(),
+    requestedUsername: normalizeEmployeeUsername(requestedUsername),
+    team: normalizedTeam,
+  };
+}
+
 export function isAllowedCorporateEmail(fullName, corporateEmail) {
   const email = normalizeCorporateEmail(corporateEmail);
   const generated = buildCorporateEmail(fullName);

--- a/identity/policy/employeeOnboarding.test.mjs
+++ b/identity/policy/employeeOnboarding.test.mjs
@@ -1,12 +1,44 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  buildEmployeeOnboardingFingerprintPayload,
   buildCorporateEmail,
   canCreateEmployee,
   isAllowedCorporateEmail,
   resolveEmployeeProfile,
   validateOnboardingInput,
 } from './employeeOnboarding.js';
+
+test('builds a stable onboarding fingerprint payload without raw contact data', () => {
+  const base = {
+    fullName: 'Pessoa Teste',
+    corporateEmail: 'pessoateste@espacofacial.com',
+    personalEmailHash: 'personal-hash',
+    mobilePhoneHash: 'phone-hash',
+    profile: 'CONSULTOR',
+    department: 'Comercial',
+    units: ['Barra Shopping Sul', 'Novo Hamburgo'],
+    accountStatus: 'INVITED',
+    requestedUsername: 'pessoateste',
+  };
+  const first = buildEmployeeOnboardingFingerprintPayload({
+    input: base,
+    requestedUsername: base.requestedUsername,
+    personalEmailHash: base.personalEmailHash,
+    mobilePhoneHash: base.mobilePhoneHash,
+    team: { units: base.units, status: 'Ativo' },
+  });
+  const second = buildEmployeeOnboardingFingerprintPayload({
+    input: { ...base, units: [...base.units].reverse() },
+    requestedUsername: base.requestedUsername,
+    personalEmailHash: base.personalEmailHash,
+    mobilePhoneHash: base.mobilePhoneHash,
+    team: { units: [...base.units].reverse(), status: 'Ativo' },
+  });
+  assert.deepEqual(first, second);
+  assert.equal(JSON.stringify(first).includes('personal@example.com'), false);
+  assert.equal(JSON.stringify(first).includes('51999999999'), false);
+});
 
 test('normalizes business role aliases without granting technical ADMIN', () => {
   assert.equal(resolveEmployeeProfile('Diretor').profile, 'GESTOR');

--- a/identity/routes/auth.js
+++ b/identity/routes/auth.js
@@ -507,12 +507,12 @@ export async function handleAuthRoutes({
                 if (!userDb.ativo) {
                     await recordAuthFailure(identifier, 'USER_INACTIVE');
                     await logAuthAudit({ action: 'AUTH_LOGIN_FAILED', actor: identifier, role: userDb.role || '', detail: { reason: 'USER_INACTIVE', username: userDb.username } });
-                    return withCORS(JSON.stringify({ error: "User inactive" }), { status: 403 }, appOrigin);
+                    return withCORS(JSON.stringify({ error: "Invalid credentials" }), { status: 401 }, appOrigin);
                 }
                 if (!userDb.passwordHash) {
                     await recordAuthFailure(identifier, 'PASSWORD_NOT_SET');
                     await logAuthAudit({ action: 'AUTH_LOGIN_FAILED', actor: identifier, role: userDb.role || '', detail: { reason: 'PASSWORD_NOT_SET', username: userDb.username } });
-                    return withCORS(JSON.stringify({ error: "Password not set" }), { status: 401 }, appOrigin);
+                    return withCORS(JSON.stringify({ error: "Invalid credentials" }), { status: 401 }, appOrigin);
                 }
                 const verified = await verifyPassword(password, userDb.passwordHash);
                 if (!verified.ok) {
@@ -821,7 +821,10 @@ export async function handleAuthRoutes({
                     env.DB.prepare(`UPDATE ${passwordResetsTable} SET used_at = ? WHERE username = ? AND id <> ? AND used_at IS NULL`).bind(new Date().toISOString(), userDb.username, resetId)
                 ]);
                 await logAuthAudit({ action: 'AUTH_PASSWORD_RESET_REQUEST', actor: userDb.username, role: userDb.role || '', detail: { delivery: 'smtp' } });
-                return withCORS(JSON.stringify({ success: true, expiresAt }), { status: 200 }, appOrigin);
+                // Do not return the expiry before the one-time code is proven;
+                // the generic response must not reveal whether an account is
+                // active or configured for recovery.
+                return withCORS(JSON.stringify({ success: true }), { status: 200 }, appOrigin);
             } catch (err) {
                 return withCORS(JSON.stringify({ success: false, error: err.message || String(err) }), { status: 500 }, appOrigin);
             }

--- a/identity/test/onboarding-security.test.mjs
+++ b/identity/test/onboarding-security.test.mjs
@@ -17,3 +17,12 @@ test('team accounts accept both the unique username and corporate email at login
   assert.match(auth, /d1\.getUserByIdentifier\(usernameInput\)/);
   assert.match(store, /LOWER\(username\) = LOWER\(\?\) OR \(email IS NOT NULL AND email != '' AND LOWER\(email\) = LOWER\(\?\)\)/);
 });
+
+test('authentication failures do not disclose inactive or passwordless account state', async () => {
+  const auth = await readFile(new URL('../routes/auth.js', import.meta.url), 'utf8');
+  assert.match(auth, /if \(!userDb\.ativo\)[\s\S]*Invalid credentials/);
+  assert.match(auth, /if \(!userDb\.passwordHash\)[\s\S]*Invalid credentials/);
+  assert.doesNotMatch(auth, /error: "User inactive"/);
+  assert.doesNotMatch(auth, /error: "Password not set"/);
+  assert.match(auth, /Do not return the expiry before the one-time code is proven/);
+});

--- a/inventory/migrations/0025_onboarding_idempotency_fingerprint.sql
+++ b/inventory/migrations/0025_onboarding_idempotency_fingerprint.sql
@@ -1,0 +1,6 @@
+-- Bind resumable onboarding retries to the complete normalized request.
+-- The digest contains no raw e-mail, phone or name values.
+ALTER TABLE crm_employee_onboarding ADD COLUMN request_fingerprint TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_request_fingerprint
+  ON crm_employee_onboarding(request_fingerprint);

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -18,7 +18,7 @@ import {
   normalizeScheduleSyncOperationKey,
   normalizeScheduleSyncResult,
   normalizeScheduleSyncState,
-  operationMemberIds,
+  scheduleSyncOperationMatches,
 } from '../services/teamScheduleSync.js';
 
 const ROLE_ADMIN = ['ADMIN', 'GESTOR', 'GERENTE', 'SUPERVISOR'];
@@ -259,11 +259,12 @@ async function persistScheduleSyncOperation({
 
   const existing = await env.DB.prepare('SELECT * FROM crm_team_operations WHERE operation_key=? LIMIT 1').bind(key).first();
   if (existing) {
-    const previousIds = operationMemberIds(existing);
-    if (String(existing.operation_type || '').toUpperCase() !== 'ESCALA_SYNC'
-      || String(existing.requested_status || '').toUpperCase() !== normalizeScheduleSyncState(state)
-      || previousIds.length !== 1
-      || previousIds[0] !== normalizedOnboardingId) {
+    if (!scheduleSyncOperationMatches(existing, {
+      onboardingId: normalizedOnboardingId,
+      state,
+      professionalId,
+      errorCode,
+    })) {
       throw new Error('ESCALA_SYNC_IDEMPOTENCY_CONFLICT');
     }
     return { replayed: true, scheduleSync: normalizeScheduleSyncResult(safeJsonParse(existing.result_json, {})) };
@@ -291,11 +292,12 @@ async function persistScheduleSyncOperation({
   } catch (error) {
     const raced = await env.DB.prepare('SELECT * FROM crm_team_operations WHERE operation_key=? LIMIT 1').bind(key).first();
     if (!raced) throw error;
-    const racedIds = operationMemberIds(raced);
-    if (String(raced.operation_type || '').toUpperCase() !== 'ESCALA_SYNC'
-      || String(raced.requested_status || '').toUpperCase() !== record.requestedStatus
-      || racedIds.length !== 1
-      || racedIds[0] !== normalizedOnboardingId) throw new Error('ESCALA_SYNC_IDEMPOTENCY_CONFLICT');
+    if (!scheduleSyncOperationMatches(raced, {
+      onboardingId: normalizedOnboardingId,
+      state,
+      professionalId,
+      errorCode,
+    })) throw new Error('ESCALA_SYNC_IDEMPOTENCY_CONFLICT');
     return { replayed: true, scheduleSync: normalizeScheduleSyncResult(safeJsonParse(raced.result_json, {})) };
   }
   return { replayed: false, scheduleSync: record.result };
@@ -1082,7 +1084,7 @@ export async function handleAdminRoutes({
       if (rawState === 'SYNCED' && !professionalId) {
         return withCORS(JSON.stringify({ success: false, error: 'A sincronização concluída precisa do identificador da Escala', code: 'ESCALA_PROFESSIONAL_ID_REQUIRED' }), { status: 400 }, appOrigin);
       }
-      if (rawState === 'NOT_CONFIGURED' && professionalId) {
+      if (rawState === 'NOT_CONFIGURED' && (professionalId || String(onboarding.schedule_professional_id || '').trim())) {
         return withCORS(JSON.stringify({ success: false, error: 'Um vínculo configurado não pode ser marcado como não configurado', code: 'ESCALA_SYNC_STATE_CONFLICT' }), { status: 409 }, appOrigin);
       }
       const errorCode = normalizeScheduleSyncErrorCode(body?.errorCode ?? body?.error_code, rawState === 'BLOCKED' ? 'ESCALA_SYNC_BLOCKED' : rawState === 'FAILED' ? 'ESCALA_SYNC_FAILED' : '');
@@ -1100,10 +1102,10 @@ export async function handleAdminRoutes({
       const rawOperationKey = request.headers.get('idempotency-key') || body?.operationKey || body?.requestId || '';
       const operationKey = normalizeScheduleSyncOperationKey(rawOperationKey);
       if (!operationKey) return withCORS(JSON.stringify({ success: false, error: 'A sincronização exige uma chave de idempotência', code: 'ESCALA_SYNC_IDEMPOTENCY_REQUIRED' }), { status: 400 }, appOrigin);
+      const persisted = await persistScheduleSyncOperation({ env, onboardingId, state: rawState, professionalId, errorCode, operationKey });
       if (rawState === 'SYNCED' && professionalId) {
         await env.DB.prepare('UPDATE crm_employee_team SET schedule_professional_id=?, updated_at=? WHERE onboarding_id=?').bind(professionalId, new Date().toISOString(), onboardingId).run();
       }
-      const persisted = await persistScheduleSyncOperation({ env, onboardingId, state: rawState, professionalId, errorCode, operationKey });
       if (persisted.replayed) {
         return withCORS(JSON.stringify({ success: true, replayed: true, data: { scheduleSync: publicScheduleSync(persisted.scheduleSync, professionalId) } }), { status: 200 }, appOrigin);
       }

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -9,6 +9,17 @@ import { canCreateEmployee, displayJobTitle, publicOnboarding, resolveEmployeePr
 import { syncIdentityWorkforceOnboarding, syncIdentityWorkforceStatus } from '../../../shared/identity-runtime/workforce-onboarding.js';
 import { isValidAccountTransition, normalizeAccountState, shouldIssueInvite } from '../../../shared/identity-runtime/onboarding-state.js';
 import { recordTeamTelemetry } from '../services/teamTelemetry.js';
+import {
+  SCHEDULE_SYNC_STATES,
+  buildScheduleSyncRecord,
+  fallbackScheduleSync,
+  latestScheduleSyncByMember,
+  normalizeScheduleSyncErrorCode,
+  normalizeScheduleSyncOperationKey,
+  normalizeScheduleSyncResult,
+  normalizeScheduleSyncState,
+  operationMemberIds,
+} from '../services/teamScheduleSync.js';
 
 const ROLE_ADMIN = ['ADMIN', 'GESTOR', 'GERENTE', 'SUPERVISOR'];
 const ROLE_INVITES = ['ADMIN', 'GESTOR', 'GERENTE'];
@@ -117,7 +128,11 @@ function normalizeTeamData(value, fallbackUnits = []) {
   };
 }
 
-function publicTeamMember(row, links = []) {
+function publicTeamMember(row, links = [], scheduleSync = null) {
+  const fallback = fallbackScheduleSync(row.schedule_professional_id || '');
+  const normalizedSync = scheduleSync
+    ? normalizeScheduleSyncResult(scheduleSync, row.schedule_professional_id || '')
+    : fallback;
   return {
     ...publicOnboarding(row),
     workforceEmployeeId: row.workforce_employee_id || null,
@@ -130,6 +145,13 @@ function publicTeamMember(row, links = []) {
       instagram: row.schedule_instagram || '',
       color: row.schedule_color || '',
       units: normalizeAllowedUnits(row.schedule_units_json || row.units_json),
+    },
+    scheduleSync: {
+      state: normalizedSync.state,
+      professionalId: normalizedSync.professionalId,
+      errorCode: normalizedSync.errorCode,
+      attempt: normalizedSync.attempt,
+      updatedAt: normalizedSync.updatedAt,
     },
     identityLinks: links,
   };
@@ -197,11 +219,97 @@ function teamPendingItems(rows) {
         items.push({ memberId, kind: 'IDENTITY_LINK', source: String(link?.source || '').toUpperCase(), status: 'PENDING_REVIEW' });
       }
     }
-    if (!row?.schedule?.professionalId && !['TERMINATED'].includes(String(row?.accountStatus || '').toUpperCase())) {
+    const scheduleState = normalizeScheduleSyncState(row?.scheduleSync?.state, row?.schedule?.professionalId ? 'SYNCED' : 'PENDING');
+    if (['PENDING', 'FAILED', 'BLOCKED'].includes(scheduleState) && !['TERMINATED'].includes(String(row?.accountStatus || '').toUpperCase())) {
+      items.push({ memberId, kind: 'ESCALA_SYNC', status: scheduleState });
+    } else if (!row?.schedule?.professionalId && scheduleState !== 'NOT_CONFIGURED' && !['TERMINATED'].includes(String(row?.accountStatus || '').toUpperCase())) {
       items.push({ memberId, kind: 'ESCALA_LINK', status: 'PENDING' });
     }
   }
   return items.slice(0, 100);
+}
+
+function hasScheduleIntent(teamData) {
+  return [
+    teamData?.professionalId,
+    teamData?.status,
+    teamData?.role,
+    teamData?.shift,
+    teamData?.nickname,
+    teamData?.instagram,
+    teamData?.color,
+  ].some((value) => String(value || '').trim() !== '');
+}
+
+function internalScheduleOperationKey(onboardingId, state) {
+  return normalizeScheduleSyncOperationKey(`escala-sync:${String(onboardingId || '').trim()}:${String(state || 'PENDING').toLowerCase()}:${crypto.randomUUID()}`);
+}
+
+async function persistScheduleSyncOperation({
+  env,
+  onboardingId,
+  state,
+  professionalId = '',
+  errorCode = '',
+  operationKey,
+}) {
+  const normalizedOnboardingId = String(onboardingId || '').trim();
+  const key = normalizeScheduleSyncOperationKey(operationKey);
+  if (!normalizedOnboardingId || !key) throw new Error('ESCALA_SYNC_IDEMPOTENCY_REQUIRED');
+
+  const existing = await env.DB.prepare('SELECT * FROM crm_team_operations WHERE operation_key=? LIMIT 1').bind(key).first();
+  if (existing) {
+    const previousIds = operationMemberIds(existing);
+    if (String(existing.operation_type || '').toUpperCase() !== 'ESCALA_SYNC'
+      || String(existing.requested_status || '').toUpperCase() !== normalizeScheduleSyncState(state)
+      || previousIds.length !== 1
+      || previousIds[0] !== normalizedOnboardingId) {
+      throw new Error('ESCALA_SYNC_IDEMPOTENCY_CONFLICT');
+    }
+    return { replayed: true, scheduleSync: normalizeScheduleSyncResult(safeJsonParse(existing.result_json, {})) };
+  }
+
+  const latestRow = await env.DB.prepare(`SELECT operation_key, operation_type, member_ids_json, result_json, created_at
+    FROM crm_team_operations
+    WHERE operation_type='ESCALA_SYNC' AND member_ids_json LIKE ?
+    ORDER BY created_at DESC LIMIT 1`).bind(`%\"${normalizedOnboardingId}\"%`).first();
+  const previous = latestScheduleSyncByMember(latestRow ? [latestRow] : []).get(normalizedOnboardingId);
+  const at = new Date().toISOString();
+  const record = buildScheduleSyncRecord({
+    state,
+    professionalId,
+    errorCode,
+    attempt: (previous?.attempt || 0) + 1,
+    createdAt: at,
+  });
+  try {
+    await env.DB.prepare(`INSERT INTO crm_team_operations
+      (operation_key, operation_type, requested_status, member_ids_json, outcome, result_json, created_at)
+      VALUES (?, 'ESCALA_SYNC', ?, ?, ?, ?, ?)`)
+      .bind(key, record.requestedStatus, JSON.stringify([normalizedOnboardingId]), record.outcome, record.resultJson, record.createdAt)
+      .run();
+  } catch (error) {
+    const raced = await env.DB.prepare('SELECT * FROM crm_team_operations WHERE operation_key=? LIMIT 1').bind(key).first();
+    if (!raced) throw error;
+    const racedIds = operationMemberIds(raced);
+    if (String(raced.operation_type || '').toUpperCase() !== 'ESCALA_SYNC'
+      || String(raced.requested_status || '').toUpperCase() !== record.requestedStatus
+      || racedIds.length !== 1
+      || racedIds[0] !== normalizedOnboardingId) throw new Error('ESCALA_SYNC_IDEMPOTENCY_CONFLICT');
+    return { replayed: true, scheduleSync: normalizeScheduleSyncResult(safeJsonParse(raced.result_json, {})) };
+  }
+  return { replayed: false, scheduleSync: record.result };
+}
+
+function publicScheduleSync(value, fallbackProfessionalId = '') {
+  const normalized = normalizeScheduleSyncResult(value, fallbackProfessionalId);
+  return {
+    state: normalized.state,
+    professionalId: normalized.professionalId,
+    errorCode: normalized.errorCode,
+    attempt: normalized.attempt,
+    updatedAt: normalized.updatedAt,
+  };
 }
 
 function publicUser(user) {
@@ -592,6 +700,7 @@ export async function handleAdminRoutes({
         }
       }
       await env.DB.prepare('UPDATE crm_employee_onboarding SET invite_id=?, workforce_employee_id=?, provisioning_state=?, updated_at=?, last_error_code=NULL WHERE id=?').bind(inviteId, workforce?.employeeId || null, 'COMPLETED', new Date().toISOString(), id).run();
+      let scheduleSync = null;
       if (url.pathname === '/admin/team') {
         const workforceEmployeeId = String(workforce?.employeeId || '').trim();
         if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
@@ -613,11 +722,18 @@ export async function handleAdminRoutes({
             String(auth?.user?.username || ''), teamAt, teamAt,
           ).run();
         }
+        const scheduleState = hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED';
+        scheduleSync = await persistScheduleSyncOperation({
+          env,
+          onboardingId: id,
+          state: scheduleState,
+          operationKey: internalScheduleOperationKey(id, scheduleState),
+        }).catch(() => null);
       }
       const created = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=?').bind(id).first();
-      await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, idempotencyKey: idempotency, action: 'EMPLOYEE_ONBOARDING_CREATE', entity: 'EMPLOYEE_ONBOARDING', entityId: id, unidade: input.units.join(','), after: { profile: input.profile, jobTitle: displayJobTitle(input.profile), department: input.department, units: input.units, accountStatus: input.accountStatus, inviteIssued: !!inviteId, workforceEmployeeId: workforce?.employeeId || null, provisioningState: 'COMPLETED' } });
+      await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, idempotencyKey: idempotency, action: 'EMPLOYEE_ONBOARDING_CREATE', entity: 'EMPLOYEE_ONBOARDING', entityId: id, unidade: input.units.join(','), after: { profile: input.profile, jobTitle: displayJobTitle(input.profile), department: input.department, units: input.units, accountStatus: input.accountStatus, inviteIssued: !!inviteId, workforceEmployeeId: workforce?.employeeId || null, provisioningState: 'COMPLETED', scheduleSyncState: scheduleSync?.scheduleSync?.state || (url.pathname === '/admin/team' ? 'PENDING' : null) } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_CREATED', actorRole: auth.user.role, itemCount: 1, unitCount: input.units.length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(created), team: url.pathname === '/admin/team' ? normalizeTeamData(teamData, input.units) : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(created), team: url.pathname === '/admin/team' ? { ...normalizeTeamData(teamData, input.units), scheduleSync: publicScheduleSync(scheduleSync?.scheduleSync || { state: hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED' }, '') } : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'ONBOARDING_FAILED');
       const status = message === 'IDENTITY_PII_KEY_NOT_CONFIGURED' || message === 'AUTH_EMAIL_NOT_CONFIGURED' || /^WORKFORCE_|^SMTP_|^EMAIL_/.test(message) ? 503 : 500;
@@ -944,6 +1060,77 @@ export async function handleAdminRoutes({
     }
   }
 
+  const teamScheduleSyncMatch = url.pathname.match(/^\/admin\/team\/([^/]+)\/schedule-sync$/);
+  if (teamScheduleSyncMatch && request.method === 'POST') {
+    try {
+      if (!teamTablesReady) return withCORS(JSON.stringify({ success: false, error: 'Migração da equipe unificada pendente', code: 'TEAM_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
+      const onboardingId = decodeURIComponent(teamScheduleSyncMatch[1] || '').trim();
+      const onboarding = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id
+        FROM crm_employee_onboarding o LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id
+        WHERE o.id=? LIMIT 1`).bind(onboardingId).first();
+      if (!onboarding) return withCORS(JSON.stringify({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' }), { status: 404 }, appOrigin);
+      if (!teamUnitsVisible(auth, onboarding.units_json)) return withCORS(JSON.stringify({ success: false, error: 'Unidade fora do escopo do gestor', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
+      const hierarchyDenied = canCreateEmployee({ actorRole: auth?.user?.role, actorAllowedUnits: auth?.user?.allowedUnits, targetProfile: onboarding.profile, units: normalizeAllowedUnits(onboarding.units_json) });
+      if (hierarchyDenied) return withCORS(JSON.stringify({ success: false, error: 'Hierarquia não permite sincronizar este membro', code: hierarchyDenied }), { status: 403 }, appOrigin);
+
+      const body = await request.json().catch(() => ({}));
+      const rawState = String(body?.state ?? body?.status ?? '').trim().toUpperCase();
+      if (!SCHEDULE_SYNC_STATES.includes(rawState)) {
+        return withCORS(JSON.stringify({ success: false, error: 'Estado de sincronização inválido', code: 'ESCALA_SYNC_STATE_INVALID' }), { status: 400 }, appOrigin);
+      }
+      const professionalId = String(body?.professionalId ?? body?.professional_id ?? '').trim().slice(0, 160);
+      if (rawState === 'SYNCED' && !professionalId) {
+        return withCORS(JSON.stringify({ success: false, error: 'A sincronização concluída precisa do identificador da Escala', code: 'ESCALA_PROFESSIONAL_ID_REQUIRED' }), { status: 400 }, appOrigin);
+      }
+      if (rawState === 'NOT_CONFIGURED' && professionalId) {
+        return withCORS(JSON.stringify({ success: false, error: 'Um vínculo configurado não pode ser marcado como não configurado', code: 'ESCALA_SYNC_STATE_CONFLICT' }), { status: 409 }, appOrigin);
+      }
+      const errorCode = normalizeScheduleSyncErrorCode(body?.errorCode ?? body?.error_code, rawState === 'BLOCKED' ? 'ESCALA_SYNC_BLOCKED' : rawState === 'FAILED' ? 'ESCALA_SYNC_FAILED' : '');
+      if (['FAILED', 'BLOCKED'].includes(rawState) && !errorCode) {
+        return withCORS(JSON.stringify({ success: false, error: 'A falha precisa de um código operacional', code: 'ESCALA_SYNC_ERROR_CODE_REQUIRED' }), { status: 400 }, appOrigin);
+      }
+
+      if (rawState === 'SYNCED') {
+        const link = await env.DB.prepare(`SELECT id FROM crm_employee_identity_links
+          WHERE workforce_employee_id=? AND source='ESCALA' AND source_id=? AND review_status='CONFIRMED' LIMIT 1`)
+          .bind(onboarding.workforce_employee_id, professionalId).first();
+        if (!link) return withCORS(JSON.stringify({ success: false, error: 'Confirme primeiro o vínculo explícito com a Escala', code: 'TEAM_ESCALA_LINK_REQUIRED' }), { status: 409 }, appOrigin);
+      }
+
+      const rawOperationKey = request.headers.get('idempotency-key') || body?.operationKey || body?.requestId || '';
+      const operationKey = normalizeScheduleSyncOperationKey(rawOperationKey);
+      if (!operationKey) return withCORS(JSON.stringify({ success: false, error: 'A sincronização exige uma chave de idempotência', code: 'ESCALA_SYNC_IDEMPOTENCY_REQUIRED' }), { status: 400 }, appOrigin);
+      if (rawState === 'SYNCED' && professionalId) {
+        await env.DB.prepare('UPDATE crm_employee_team SET schedule_professional_id=?, updated_at=? WHERE onboarding_id=?').bind(professionalId, new Date().toISOString(), onboardingId).run();
+      }
+      const persisted = await persistScheduleSyncOperation({ env, onboardingId, state: rawState, professionalId, errorCode, operationKey });
+      if (persisted.replayed) {
+        return withCORS(JSON.stringify({ success: true, replayed: true, data: { scheduleSync: publicScheduleSync(persisted.scheduleSync, professionalId) } }), { status: 200 }, appOrigin);
+      }
+      const units = normalizeAllowedUnits(onboarding.units_json);
+      await appendAuditLog?.({
+        env,
+        actor: auth.user.username,
+        role: auth.user.role,
+        ip,
+        userAgent,
+        idempotencyKey: operationKey,
+        action: 'EMPLOYEE_ESCALA_SYNC_RECORDED',
+        entity: 'EMPLOYEE_TEAM',
+        entityId: onboardingId,
+        unidade: units.join(','),
+        after: { scheduleSyncState: rawState, professionalId: professionalId || null, errorCode: errorCode || null, attempt: persisted.scheduleSync?.attempt || 0 },
+      });
+      await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_ESCALA_SYNC_RECORDED', actorRole: auth.user.role, outcome: rawState, itemCount: 1, unitCount: units.length });
+      return withCORS(JSON.stringify({ success: true, replayed: persisted.replayed, data: { scheduleSync: publicScheduleSync(persisted.scheduleSync, professionalId) } }), { status: 200 }, appOrigin);
+    } catch (error) {
+      const rawCode = String(error?.message || '').trim();
+      const conflict = ['ESCALA_SYNC_IDEMPOTENCY_CONFLICT', 'ESCALA_SYNC_STATE_CONFLICT', 'TEAM_ESCALA_LINK_REQUIRED'].includes(rawCode);
+      const status = conflict ? 409 : 503;
+      return withCORS(JSON.stringify({ success: false, error: conflict ? 'A sincronização não pôde ser registrada para este estado' : 'Não foi possível registrar o estado da Escala', code: conflict ? rawCode : 'ESCALA_SYNC_PERSIST_FAILED' }), { status }, appOrigin);
+    }
+  }
+
   const teamHistoryMatch = url.pathname.match(/^\/admin\/team\/([^/]+)\/history$/);
   if (teamHistoryMatch && request.method === 'GET') {
     try {
@@ -1033,16 +1220,25 @@ export async function handleAdminRoutes({
       await env.DB.prepare(`UPDATE crm_employee_onboarding SET ${sets.join(', ')} WHERE id=?`).bind(...values).run();
 
       const teamData = normalizeTeamData(body.team, nextUnits);
+      const nextScheduleProfessionalId = teamData.professionalId || current.schedule_professional_id || null;
       await env.DB.prepare(`UPDATE crm_employee_team SET schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
-        teamData.professionalId || current.schedule_professional_id || null, teamData.status || null, teamData.role || null, teamData.shift || null,
+        nextScheduleProfessionalId, teamData.status || null, teamData.role || null, teamData.shift || null,
         teamData.nickname || null, teamData.instagram || null, teamData.color || null, JSON.stringify(teamData.units), new Date().toISOString(), onboardingId,
       ).run();
+      const scheduleState = hasScheduleIntent(teamData) || nextScheduleProfessionalId ? 'PENDING' : 'NOT_CONFIGURED';
+      const scheduleSync = await persistScheduleSyncOperation({
+        env,
+        onboardingId,
+        state: scheduleState,
+        professionalId: nextScheduleProfessionalId || '',
+        operationKey: internalScheduleOperationKey(onboardingId, scheduleState),
+      }).catch(() => null);
       const updated = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json
         FROM crm_employee_onboarding o LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id WHERE o.id=? LIMIT 1`).bind(onboardingId).first();
       const links = await env.DB.prepare('SELECT * FROM crm_employee_identity_links WHERE workforce_employee_id=? ORDER BY created_at DESC').bind(updated.workforce_employee_id).all();
-      await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_UPDATED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: nextUnits.join(','), before: { profile: current.profile, units: normalizeAllowedUnits(current.units_json), scheduleProfessionalId: current.schedule_professional_id || null }, after: { profile: nextProfile.profile || nextProfile, units: nextUnits, scheduleProfessionalId: teamData.professionalId || current.schedule_professional_id || null } });
+      await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_UPDATED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: nextUnits.join(','), before: { profile: current.profile, units: normalizeAllowedUnits(current.units_json), scheduleProfessionalId: current.schedule_professional_id || null }, after: { profile: nextProfile.profile || nextProfile, units: nextUnits, scheduleProfessionalId: nextScheduleProfessionalId, scheduleSyncState: scheduleSync?.scheduleSync?.state || scheduleState } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_UPDATED', actorRole: auth.user.role, itemCount: 1, unitCount: nextUnits.length });
-      return withCORS(JSON.stringify({ success: true, data: publicTeamMember(updated, (links?.results || []).map(publicIdentityLink)) }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: publicTeamMember(updated, (links?.results || []).map(publicIdentityLink), scheduleSync?.scheduleSync || { state: scheduleState, professionalId: nextScheduleProfessionalId }) }), { status: 200 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'TEAM_UPDATE_FAILED');
       const status = /^WORKFORCE_|^IDENTITY_|^SMTP_|^EMAIL_/.test(message) ? 503 : 500;
@@ -1078,7 +1274,16 @@ export async function handleAdminRoutes({
         list.push(publicIdentityLink(link));
         linksByEmployee.set(key, list);
       }
-      const data = visible.map((row) => publicTeamMember(row, linksByEmployee.get(String(row.workforce_employee_id || '')) || []));
+      const operations = await env.DB.prepare(`SELECT operation_key, operation_type, member_ids_json, result_json, created_at
+        FROM crm_team_operations
+        WHERE operation_type='ESCALA_SYNC'
+        ORDER BY created_at DESC LIMIT 2000`).all();
+      const latestScheduleSync = latestScheduleSyncByMember(operations?.results || []);
+      const data = visible.map((row) => publicTeamMember(
+        row,
+        linksByEmployee.get(String(row.workforce_employee_id || '')) || [],
+        latestScheduleSync.get(String(row.id || '')) || null,
+      ));
       const pendingLinks = data.reduce((sum, row) => sum + (row.identityLinks || []).filter((link) => link.reviewStatus === 'PENDING_REVIEW').length, 0);
       const pendingProvisioning = data.filter((row) => ['PROVISIONING', 'WORKFORCE_SYNCED', 'INVITE_PENDING', 'FAILED'].includes(String(row.provisioningState || '').toUpperCase())).length;
       const pendingInvites = data.filter((row) => String(row.accountStatus || '').toUpperCase() === 'INVITED').length;

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -5,7 +5,7 @@ import { resolveCrmTables } from '../d1Store.js';
 import { sendAccountInviteEmail } from '../smtpMailer.js';
 import { normalizeInviteEmail, normalizeInviteScope, validateInviteDelegation } from '../invitePolicy.js';
 import { normalizeAllowedUnits as normalizeCanonicalAllowedUnits, unknownUnitScopes } from '../../../shared/identity-contract/index.js';
-import { canCreateEmployee, displayJobTitle, publicOnboarding, resolveEmployeeProfile, suggestEmployeeUsername, validateOnboardingInput } from '../../../shared/identity-runtime/inventory-compat.js';
+import { buildEmployeeOnboardingFingerprintPayload, canCreateEmployee, displayJobTitle, publicOnboarding, resolveEmployeeProfile, suggestEmployeeUsername, validateOnboardingInput } from '../../../shared/identity-runtime/inventory-compat.js';
 import { syncIdentityWorkforceOnboarding, syncIdentityWorkforceStatus } from '../../../shared/identity-runtime/workforce-onboarding.js';
 import { isValidAccountTransition, normalizeAccountState, shouldIssueInvite } from '../../../shared/identity-runtime/onboarding-state.js';
 import { recordTeamTelemetry } from '../services/teamTelemetry.js';
@@ -538,6 +538,7 @@ export async function handleAdminRoutes({
   const invitesHasModules = await tableHasColumn(env, invitesTable, 'allowed_modules_json');
   const invitesHasInviteeEmail = await tableHasColumn(env, invitesTable, 'invitee_email');
   const onboardingHasUsername = await tableHasColumn(env, 'crm_employee_onboarding', 'requested_username');
+  const onboardingHasRequestFingerprint = await tableHasColumn(env, 'crm_employee_onboarding', 'request_fingerprint');
   const invitesHasUsername = await tableHasColumn(env, invitesTable, 'requested_username');
   const onboardingHasSaga = await tableHasColumn(env, 'crm_employee_onboarding', 'provisioning_state') && await tableHasColumn(env, 'crm_employee_onboarding', 'invite_token_encrypted');
   const teamTablesReady = await tableExists(env, 'crm_employee_team')
@@ -545,7 +546,7 @@ export async function handleAdminRoutes({
     && await tableExists(env, 'crm_team_operations')
     && await tableExists(env, 'crm_team_telemetry');
 
-  if (isTeamRoute && (!onboardingHasUsername || !invitesHasUsername || !onboardingHasSaga || !teamTablesReady)) {
+  if (isTeamRoute && (!onboardingHasUsername || !onboardingHasRequestFingerprint || !invitesHasUsername || !onboardingHasSaga || !teamTablesReady)) {
     return withCORS(JSON.stringify({ success: false, error: 'Migração da equipe unificada pendente', code: 'TEAM_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
   }
 
@@ -576,9 +577,23 @@ export async function handleAdminRoutes({
         return withCORS(JSON.stringify({ success: false, error: 'Migração de usuário da equipe pendente', code: 'TEAM_USERNAME_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
       }
 
+      const personalEmailHash = await sha256Hex(input.personalEmail);
+      const mobilePhoneHash = await sha256Hex(input.mobilePhone);
+      const requestFingerprint = onboardingHasRequestFingerprint
+        ? await sha256Hex(JSON.stringify(buildEmployeeOnboardingFingerprintPayload({
+          input,
+          requestedUsername,
+          personalEmailHash,
+          mobilePhoneHash,
+          team: url.pathname === '/admin/team' ? teamData : null,
+        })))
+        : '';
       const idempotency = String(request.headers.get('idempotency-key') || body.idempotencyKey || '').trim().slice(0, 180);
       if (idempotency) {
         const existing = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE idempotency_key=? LIMIT 1').bind(idempotency).first();
+        if (existing && url.pathname === '/admin/team' && (!existing.request_fingerprint || existing.request_fingerprint !== requestFingerprint)) {
+          throw new Error(existing.request_fingerprint ? 'ONBOARDING_IDEMPOTENCY_CONFLICT' : 'ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED');
+        }
         if (existing?.provisioning_state === 'COMPLETED') return withCORS(JSON.stringify({ success: true, data: publicOnboarding(existing), replayed: true }), { status: 200 }, appOrigin);
       }
       const existingUser = await env.DB.prepare(`SELECT username FROM ${usersTable} WHERE LOWER(email)=LOWER(?) LIMIT 1`).bind(input.corporateEmail).first();
@@ -606,6 +621,10 @@ export async function handleAdminRoutes({
       const at = new Date().toISOString();
       const requestId = String(request.headers.get('x-request-id') || `identity-onboarding-${id}`).slice(0, 180);
       const existingOnboarding = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? OR LOWER(corporate_email)=LOWER(?) LIMIT 1').bind(id, input.corporateEmail).first();
+      if (existingOnboarding && url.pathname === '/admin/team') {
+        if (!existingOnboarding.request_fingerprint) throw new Error('ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED');
+        if (existingOnboarding.request_fingerprint !== requestFingerprint) throw new Error('ONBOARDING_IDEMPOTENCY_CONFLICT');
+      }
       if (existingOnboarding?.provisioning_state === 'COMPLETED') {
         return withCORS(JSON.stringify({ success: true, data: publicOnboarding(existingOnboarding), replayed: true }), { status: 200 }, appOrigin);
       }
@@ -621,8 +640,8 @@ export async function handleAdminRoutes({
             'compensation_state', 'correlation_id',
           ];
           const values = [
-            id, input.fullName, input.corporateEmail, encryptedPersonal, await sha256Hex(input.personalEmail),
-            encryptedPhone, await sha256Hex(input.mobilePhone), input.profile, displayJobTitle(input.profile),
+            id, input.fullName, input.corporateEmail, encryptedPersonal, personalEmailHash,
+            encryptedPhone, mobilePhoneHash, input.profile, displayJobTitle(input.profile),
             input.department, JSON.stringify(input.units), input.accountStatus, null, null, idempotency || null,
             String(auth?.user?.username || ''), at, at, 'PROVISIONING', null, null, requestId,
           ];
@@ -630,10 +649,17 @@ export async function handleAdminRoutes({
             columns.push('requested_username');
             values.push(requestedUsername);
           }
+          if (onboardingHasRequestFingerprint) {
+            columns.push('request_fingerprint');
+            values.push(requestFingerprint);
+          }
           await env.DB.prepare(`INSERT INTO crm_employee_onboarding (${columns.join(', ')}) VALUES (${columns.map(() => '?').join(', ')})`).bind(...values).run();
         } catch (insertError) {
           const raced = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? OR LOWER(corporate_email)=LOWER(?) LIMIT 1').bind(id, input.corporateEmail).first();
           if (!raced) throw insertError;
+          if (url.pathname === '/admin/team' && (!raced.request_fingerprint || raced.request_fingerprint !== requestFingerprint)) {
+            throw new Error(raced.request_fingerprint ? 'ONBOARDING_IDEMPOTENCY_CONFLICT' : 'ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED');
+          }
         }
       }
 
@@ -738,7 +764,9 @@ export async function handleAdminRoutes({
       return withCORS(JSON.stringify({ success: true, data: publicOnboarding(created), team: url.pathname === '/admin/team' ? { ...normalizeTeamData(teamData, input.units), scheduleSync: publicScheduleSync(scheduleSync?.scheduleSync || { state: hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED' }, '') } : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'ONBOARDING_FAILED');
-      const status = message === 'IDENTITY_PII_KEY_NOT_CONFIGURED' || message === 'AUTH_EMAIL_NOT_CONFIGURED' || /^WORKFORCE_|^SMTP_|^EMAIL_/.test(message) ? 503 : 500;
+      const status = ['ONBOARDING_IDEMPOTENCY_CONFLICT', 'ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED'].includes(message)
+        ? 409
+        : message === 'IDENTITY_PII_KEY_NOT_CONFIGURED' || message === 'AUTH_EMAIL_NOT_CONFIGURED' || /^WORKFORCE_|^SMTP_|^EMAIL_/.test(message) ? 503 : 500;
       return withCORS(JSON.stringify({ success: false, error: status === 503 ? 'Configuração segura de cadastro pendente' : 'Não foi possível concluir o cadastro', code: message }), { status }, appOrigin);
     }
   }

--- a/inventory/src/services/teamScheduleSync.js
+++ b/inventory/src/services/teamScheduleSync.js
@@ -1,0 +1,131 @@
+const SCHEDULE_SYNC_STATES = Object.freeze([
+  'NOT_CONFIGURED',
+  'PENDING',
+  'SYNCED',
+  'FAILED',
+  'BLOCKED',
+]);
+
+const OPAQUE_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,179}$/;
+const ERROR_CODE_RE = /^[A-Z0-9][A-Z0-9_:-]{1,79}$/;
+
+function cleanText(value, max = 160) {
+  return String(value ?? '').trim().slice(0, max);
+}
+
+function parseJson(raw, fallback) {
+  if (raw && typeof raw === 'object') return raw;
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function isoTimestamp(value) {
+  const text = cleanText(value, 40);
+  if (!text) return null;
+  const timestamp = Date.parse(text);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+export function normalizeScheduleSyncState(value, fallback = 'PENDING') {
+  const candidate = cleanText(value, 40).toUpperCase();
+  if (SCHEDULE_SYNC_STATES.includes(candidate)) return candidate;
+  const normalizedFallback = cleanText(fallback, 40).toUpperCase();
+  return SCHEDULE_SYNC_STATES.includes(normalizedFallback) ? normalizedFallback : 'PENDING';
+}
+
+export function normalizeScheduleSyncOperationKey(value) {
+  const key = cleanText(value, 180);
+  return OPAQUE_KEY_RE.test(key) ? key : '';
+}
+
+export function normalizeScheduleSyncErrorCode(value, fallback = '') {
+  const normalized = cleanText(value, 80).toUpperCase();
+  if (ERROR_CODE_RE.test(normalized)) return normalized;
+  const normalizedFallback = cleanText(fallback, 80).toUpperCase();
+  return ERROR_CODE_RE.test(normalizedFallback) ? normalizedFallback : '';
+}
+
+export function normalizeScheduleSyncResult(value, fallbackProfessionalId = '') {
+  const input = value && typeof value === 'object' ? value : {};
+  const state = normalizeScheduleSyncState(input.state ?? input.status, 'PENDING');
+  const professionalId = cleanText(input.professionalId ?? input.professional_id ?? fallbackProfessionalId, 160);
+  const errorCode = normalizeScheduleSyncErrorCode(input.errorCode ?? input.error_code);
+  const attemptValue = Number(input.attempt ?? 0);
+  const attempt = Number.isFinite(attemptValue) ? Math.max(0, Math.min(999, Math.trunc(attemptValue))) : 0;
+  return {
+    state,
+    professionalId: professionalId || null,
+    errorCode: errorCode || null,
+    attempt,
+    updatedAt: isoTimestamp(input.updatedAt ?? input.updated_at ?? input.createdAt ?? input.created_at),
+  };
+}
+
+export function buildScheduleSyncRecord({ state, professionalId, errorCode, attempt = 1, createdAt } = {}) {
+  const normalizedState = normalizeScheduleSyncState(state);
+  const normalizedProfessionalId = cleanText(professionalId, 160);
+  const normalizedErrorCode = normalizeScheduleSyncErrorCode(errorCode, normalizedState === 'FAILED' ? 'ESCALA_SYNC_FAILED' : '');
+  const timestamp = isoTimestamp(createdAt) || new Date().toISOString();
+  const result = normalizeScheduleSyncResult({
+    state: normalizedState,
+    professionalId: normalizedState === 'SYNCED' || normalizedState === 'FAILED' || normalizedState === 'BLOCKED' ? normalizedProfessionalId : '',
+    errorCode: normalizedErrorCode,
+    attempt,
+    updatedAt: timestamp,
+  });
+  return {
+    requestedStatus: normalizedState,
+    outcome: normalizedState,
+    result,
+    resultJson: JSON.stringify(result),
+    createdAt: timestamp,
+  };
+}
+
+export function operationMemberIds(row) {
+  const raw = parseJson(row?.member_ids_json ?? row?.memberIdsJson ?? row?.memberIds, []);
+  if (!Array.isArray(raw)) return [];
+  return Array.from(new Set(raw.map((value) => cleanText(value, 180)).filter(Boolean)));
+}
+
+function operationCreatedAt(row) {
+  const timestamp = Date.parse(String(row?.created_at ?? row?.createdAt ?? ''));
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function latestScheduleSyncByMember(rows = []) {
+  const latest = new Map();
+  for (const row of rows || []) {
+    if (String(row?.operation_type ?? row?.operationType ?? '').trim().toUpperCase() !== 'ESCALA_SYNC') continue;
+    const result = normalizeScheduleSyncResult(parseJson(row?.result_json ?? row?.resultJson, {}));
+    const entry = {
+      ...result,
+      operationKey: normalizeScheduleSyncOperationKey(row?.operation_key ?? row?.operationKey) || null,
+      createdAt: isoTimestamp(row?.created_at ?? row?.createdAt) || result.updatedAt,
+    };
+    for (const memberId of operationMemberIds(row)) {
+      const previous = latest.get(memberId);
+      if (!previous || operationCreatedAt(row) >= operationCreatedAt({ created_at: previous.createdAt })) latest.set(memberId, entry);
+    }
+  }
+  return latest;
+}
+
+export function fallbackScheduleSync(professionalId = '') {
+  const linkedId = cleanText(professionalId, 160);
+  return {
+    state: linkedId ? 'SYNCED' : 'PENDING',
+    professionalId: linkedId || null,
+    errorCode: null,
+    attempt: 0,
+    updatedAt: null,
+    operationKey: null,
+    createdAt: null,
+  };
+}
+
+export { SCHEDULE_SYNC_STATES };

--- a/inventory/src/services/teamScheduleSync.js
+++ b/inventory/src/services/teamScheduleSync.js
@@ -92,6 +92,27 @@ export function operationMemberIds(row) {
   return Array.from(new Set(raw.map((value) => cleanText(value, 180)).filter(Boolean)));
 }
 
+export function scheduleSyncOperationMatches(row, {
+  onboardingId = '',
+  state = '',
+  professionalId = '',
+  errorCode = '',
+} = {}) {
+  const memberId = cleanText(onboardingId, 180);
+  const requestedState = normalizeScheduleSyncState(state, 'PENDING');
+  const requestedProfessionalId = cleanText(professionalId, 160) || null;
+  const requestedErrorCode = normalizeScheduleSyncErrorCode(errorCode) || null;
+  const result = normalizeScheduleSyncResult(parseJson(row?.result_json ?? row?.resultJson, {}));
+  const ids = operationMemberIds(row);
+  return String(row?.operation_type ?? row?.operationType ?? '').trim().toUpperCase() === 'ESCALA_SYNC'
+    && String(row?.requested_status ?? row?.requestedStatus ?? '').trim().toUpperCase() === requestedState
+    && ids.length === 1
+    && ids[0] === memberId
+    && result.state === requestedState
+    && result.professionalId === requestedProfessionalId
+    && result.errorCode === requestedErrorCode;
+}
+
 function operationCreatedAt(row) {
   const timestamp = Date.parse(String(row?.created_at ?? row?.createdAt ?? ''));
   return Number.isFinite(timestamp) ? timestamp : 0;

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -33,6 +33,17 @@ test('unified team identity migration is additive and creates explicit link ledg
   assert.doesNotMatch(atendimento, /\bDROP\b/i);
 });
 
+test('onboarding retries require a payload fingerprint after the unified identity migration', async () => {
+  const migration = await readFile(new URL('../migrations/0025_onboarding_idempotency_fingerprint.sql', import.meta.url), 'utf8');
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  assert.match(migration, /request_fingerprint/i);
+  assert.match(migration, /CREATE INDEX IF NOT EXISTS/i);
+  assert.match(admin, /buildEmployeeOnboardingFingerprintPayload/);
+  assert.match(admin, /ONBOARDING_IDEMPOTENCY_CONFLICT/);
+  assert.match(admin, /ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED/);
+  assert.doesNotMatch(migration, /\bDROP\b/i);
+});
+
 test('invite activation has an audited retry boundary and does not mint a second token', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   assert.ok(admin.includes("const activationMatch = url.pathname.match(/^\\/admin\\/onboarding\\/([^/]+)\\/activate$/);"));

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -67,6 +67,7 @@ test('onboarding status changes stay hierarchical, synchronized, audited and fai
 
 test('unified team management is explicit about RBAC, scope, idempotency and aggregate telemetry', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');
   const teamBlock = admin.slice(admin.indexOf("const isTeamRoute"), admin.indexOf("// POST /admin/onboarding"));
   assert.match(admin, /TEAM_ADMIN_ROLES = \['ADMIN', 'GESTOR', 'GERENTE'\]/);
   assert.match(admin, /TEAM_READ_ROLES = \[\.\.\.TEAM_ADMIN_ROLES, 'SUPERVISOR'\]/);
@@ -81,12 +82,20 @@ test('unified team management is explicit about RBAC, scope, idempotency and agg
   assert.match(admin, /const isOnboardingRoute/);
   assert.match(admin, /crm_team_telemetry/);
   assert.match(admin, /const teamHistoryMatch/);
+  assert.match(admin, /schedule-sync/);
+  assert.match(admin, /TEAM_ESCALA_LINK_REQUIRED/);
+  assert.match(admin, /EMPLOYEE_ESCALA_SYNC_RECORDED/);
+  assert.match(admin, /kind: 'ESCALA_SYNC'/);
   assert.match(admin, /after_json LIKE/);
   assert.match(admin, /entity: 'EMPLOYEE_TEAM'/);
   assert.match(admin, /pendingSync: pendingIds\.includes\(row\.id\)/);
   assert.match(admin, /compensationState/);
   assert.match(admin, /teamUnitsVisible\(auth, onboarding\.units_json\)/);
   assert.doesNotMatch(admin, /teamUnitsVisible\(auth, onboarding\)/);
+  assert.match(localApi, /team\/:id\/schedule-sync/);
+  assert.match(localApi, /scheduleOperations/);
+  assert.match(localApi, /EMPLOYEE_ESCALA_SYNC_RECORDED/);
+  assert.match(localApi, /ESCALA_SYNC_IDEMPOTENCY_CONFLICT/);
 });
 
 test('team telemetry accepts only aggregate fields and cannot persist identity PII', async () => {

--- a/inventory/tests/teamScheduleSync.test.mjs
+++ b/inventory/tests/teamScheduleSync.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SCHEDULE_SYNC_STATES,
+  buildScheduleSyncRecord,
+  fallbackScheduleSync,
+  latestScheduleSyncByMember,
+  normalizeScheduleSyncErrorCode,
+  normalizeScheduleSyncOperationKey,
+  normalizeScheduleSyncResult,
+  normalizeScheduleSyncState,
+  operationMemberIds,
+} from '../src/services/teamScheduleSync.js';
+
+test('normalizes the fail-closed Escala sync state contract', () => {
+  assert.deepEqual(SCHEDULE_SYNC_STATES, ['NOT_CONFIGURED', 'PENDING', 'SYNCED', 'FAILED', 'BLOCKED']);
+  assert.equal(normalizeScheduleSyncState('synced'), 'SYNCED');
+  assert.equal(normalizeScheduleSyncState('unknown'), 'PENDING');
+  assert.equal(normalizeScheduleSyncState('unknown', 'NOT_CONFIGURED'), 'NOT_CONFIGURED');
+  assert.equal(normalizeScheduleSyncOperationKey('crm-escala-sync-member-1-01'), 'crm-escala-sync-member-1-01');
+  assert.equal(normalizeScheduleSyncOperationKey('email@example.com'), '');
+  assert.equal(normalizeScheduleSyncErrorCode('Escala API unavailable'), '');
+  assert.equal(normalizeScheduleSyncErrorCode('ESCALA_API_UNAVAILABLE'), 'ESCALA_API_UNAVAILABLE');
+});
+
+test('builds a PII-free operation result and preserves only bounded operational fields', () => {
+  const record = buildScheduleSyncRecord({
+    state: 'FAILED',
+    professionalId: 'escala-123',
+    errorCode: 'ESCALA_TIMEOUT',
+    attempt: 3,
+    createdAt: '2026-08-06T12:00:00.000Z',
+  });
+  assert.equal(record.requestedStatus, 'FAILED');
+  assert.equal(record.outcome, 'FAILED');
+  assert.deepEqual(JSON.parse(record.resultJson), {
+    state: 'FAILED',
+    professionalId: 'escala-123',
+    errorCode: 'ESCALA_TIMEOUT',
+    attempt: 3,
+    updatedAt: '2026-08-06T12:00:00.000Z',
+  });
+  assert.doesNotMatch(record.resultJson, /@|Ana|Ribeiro|telefone|phone/i);
+});
+
+test('selects the newest Escala sync operation for each explicit member id', () => {
+  const rows = [
+    { operation_key: 'newer', operation_type: 'ESCALA_SYNC', member_ids_json: JSON.stringify(['member-1']), result_json: JSON.stringify({ state: 'FAILED', errorCode: 'ESCALA_API_ERROR', attempt: 2 }), created_at: '2026-08-06T12:00:00.000Z' },
+    { operation_key: 'older', operation_type: 'ESCALA_SYNC', member_ids_json: JSON.stringify(['member-1']), result_json: JSON.stringify({ state: 'PENDING', attempt: 1 }), created_at: '2026-08-06T11:00:00.000Z' },
+    { operation_key: 'other', operation_type: 'BULK_STATUS', member_ids_json: JSON.stringify(['member-2']), result_json: '{}', created_at: '2026-08-06T13:00:00.000Z' },
+  ];
+  const latest = latestScheduleSyncByMember(rows);
+  assert.equal(latest.get('member-1').state, 'FAILED');
+  assert.equal(latest.get('member-1').attempt, 2);
+  assert.equal(latest.has('member-2'), false);
+  assert.deepEqual(operationMemberIds(rows[0]), ['member-1']);
+});
+
+test('falls back to the visible link state for records created before the ledger', () => {
+  assert.deepEqual(fallbackScheduleSync('escala-1'), {
+    state: 'SYNCED', professionalId: 'escala-1', errorCode: null, attempt: 0, updatedAt: null, operationKey: null, createdAt: null,
+  });
+  assert.equal(normalizeScheduleSyncResult({ state: 'BLOCKED', errorCode: 'X', updatedAt: 'invalid' }).updatedAt, null);
+});

--- a/inventory/tests/teamScheduleSync.test.mjs
+++ b/inventory/tests/teamScheduleSync.test.mjs
@@ -11,6 +11,7 @@ import {
   normalizeScheduleSyncResult,
   normalizeScheduleSyncState,
   operationMemberIds,
+  scheduleSyncOperationMatches,
 } from '../src/services/teamScheduleSync.js';
 
 test('normalizes the fail-closed Escala sync state contract', () => {
@@ -62,4 +63,16 @@ test('falls back to the visible link state for records created before the ledger
     state: 'SYNCED', professionalId: 'escala-1', errorCode: null, attempt: 0, updatedAt: null, operationKey: null, createdAt: null,
   });
   assert.equal(normalizeScheduleSyncResult({ state: 'BLOCKED', errorCode: 'X', updatedAt: 'invalid' }).updatedAt, null);
+});
+
+test('binds Escala idempotency to the full operational payload', () => {
+  const row = {
+    operation_type: 'ESCALA_SYNC',
+    requested_status: 'SYNCED',
+    member_ids_json: JSON.stringify(['member-1']),
+    result_json: JSON.stringify({ state: 'SYNCED', professionalId: 'escala-1', attempt: 1 }),
+  };
+  assert.equal(scheduleSyncOperationMatches(row, { onboardingId: 'member-1', state: 'SYNCED', professionalId: 'escala-1' }), true);
+  assert.equal(scheduleSyncOperationMatches(row, { onboardingId: 'member-1', state: 'SYNCED', professionalId: 'escala-2' }), false);
+  assert.equal(scheduleSyncOperationMatches(row, { onboardingId: 'member-1', state: 'FAILED', professionalId: 'escala-1', errorCode: 'ESCALA_API_ERROR' }), false);
 });

--- a/shared/identity-runtime/inventory-compat.js
+++ b/shared/identity-runtime/inventory-compat.js
@@ -17,6 +17,7 @@ export {
 // through this registered compatibility adapter during the Worker extraction.
 export {
   canCreateEmployee,
+  buildEmployeeOnboardingFingerprintPayload,
   displayJobTitle,
   publicOnboarding,
   resolveEmployeeProfile,

--- a/workforce/schedule/worker.js
+++ b/workforce/schedule/worker.js
@@ -469,10 +469,15 @@ async function handleProfessionalPut(env, actor, body) {
   }
 
   const existing = await env.DB.prepare(
-    hasWorkforceColumn ? `select id, name, phone, email, workforce_employee_id from professionals where name = ?1` : `select id, name, phone, email from professionals where name = ?1`
+    hasWorkforceColumn ? `select id, name, phone, email, workforce_employee_id, units_json from professionals where name = ?1` : `select id, name, phone, email, units_json from professionals where name = ?1`
   ).bind(currentName).first()
   if (!existing) {
     return { ok: false, status: 404, body: { ok: false, error: 'PROFESSIONAL_NOT_FOUND' } }
+  }
+
+  const existingUnits = safeJsonParse(existing.units_json, [])
+  if (actor.allowedUnitKeys.length && (!Array.isArray(existingUnits) || !existingUnits.length || existingUnits.some((unit) => !isUnitVisibleForActor(actor, unit)))) {
+    return { ok: false, status: 403, body: { ok: false, error: 'FORBIDDEN_EXISTING_UNIT' } }
   }
 
   // Identity edits do not necessarily include the private phone field. An

--- a/workforce/schedule/worker.test.js
+++ b/workforce/schedule/worker.test.js
@@ -87,11 +87,11 @@ class FakeD1 {
   first(sql, params) {
     const query = normalizeSql(sql)
 
-    if (query.startsWith('select id, name, phone, email from professionals where name = ?1')
-      || query.startsWith('select id, name, phone, email, workforce_employee_id from professionals where name = ?1')) {
+    if (query.startsWith('select id, name, phone, email, units_json from professionals where name = ?1')
+      || query.startsWith('select id, name, phone, email, workforce_employee_id, units_json from professionals where name = ?1')) {
       const name = String(params[0] || '')
       const row = this.professionals.find((prof) => prof.name === name)
-      return row ? { id: row.id, name: row.name, phone: row.phone, email: row.email, workforce_employee_id: row.workforce_employee_id || null } : null
+      return row ? { id: row.id, name: row.name, phone: row.phone, email: row.email, workforce_employee_id: row.workforce_employee_id || null, units_json: row.units_json || '[]' } : null
     }
 
     if (query.startsWith('select id, name from professionals where name = ?1')) {
@@ -420,6 +420,38 @@ test('Escala professionals POST and PUT persist and sync schedule entries', asyn
       professional: 'Dra. Anita',
     },
   ])
+})
+
+test('Escala blocks scoped managers from editing a professional outside the existing unit scope', async () => {
+  const db = new FakeD1()
+  db.professionals.push({
+    id: 'professional-barra',
+    name: 'Dra. Barra',
+    status: 'Ativo',
+    role: 'Injetor',
+    units_json: JSON.stringify(['BarraShoppingSul']),
+  })
+  const env = {
+    DB: db,
+    APP_ORIGIN: 'https://crm.local',
+    ESCALA_ACTOR_HMAC_KEY: 'test-secret',
+  }
+  const response = await worker.fetch(
+    await signedRequest('https://escala.local/api/escala/professionals', {
+      method: 'PUT',
+      secret: env.ESCALA_ACTOR_HMAC_KEY,
+      actor: { id: 'gestor-nh', role: 'GESTOR', allowedUnits: ['Novo Hamburgo'] },
+      body: {
+        currentName: 'Dra. Barra',
+        name: 'Dra. Alterada',
+        units: ['Novo Hamburgo'],
+      },
+    }),
+    env,
+  )
+  assert.equal(response.status, 403)
+  assert.deepEqual(await response.json(), { ok: false, error: 'FORBIDDEN_EXISTING_UNIT' })
+  assert.equal(db.professionals[0].name, 'Dra. Barra')
 })
 
 test('Escala professionals GET/POST/PUT tolerate legacy schema without color column', async () => {


### PR DESCRIPTION
## Objetivo
Persistir e operar o estado da sincronização com a Escala no cadastro unificado de Usuários/Equipe, mantendo o mesmo contrato no Worker hospedado e no preview local.

## Incluído
- estados `NOT_CONFIGURED`, `PENDING`, `SYNCED`, `FAILED` e `BLOCKED`;
- ledger idempotente vinculado ao payload completo, tentativas e códigos operacionais sem PII;
- replay da sincronização sem mutação e retry explícito no modal somente após vínculo Escala confirmado por identificador;
- fingerprint de onboarding para bloquear reutilização de chave com payload alterado durante sagas incompletas;
- migration aditiva `0025_onboarding_idempotency_fingerprint.sql`;
- isolamento de unidade reforçado na edição de profissionais da Escala;
- falhas de login e solicitação de recuperação sem enumeração de conta;
- adaptador file-backed local alinhado ao contrato hospedado;
- fixture E2E, regressão de filtro `ALL` e runbook atualizado.

## Commits principais
- `a08ed077` / `2c95c573` / `97c36fac`: estado, espelho local e controles de retry;
- `ca5d3716` / `d4620d3d`: idempotência completa e replay somente leitura;
- `f47914a1`: fingerprint de onboarding e parity local;
- `226e0609`: escopo de unidade na edição da Escala;
- `4b1c57c9`: redução de enumeração de estado da conta.

## Validação local
- `node --check` do Worker, Identity, Inventory e adaptador local;
- 33 testes focados aprovados no Ubuntu-24.04 WSL, incluindo Identity, onboarding, migrations, Escala e schedule-sync;
- typecheck do console;
- lint do console: 0 erros, 95 avisos preexistentes;
- suíte console: 48 arquivos / 245 testes;
- E2E Usuários: 6/6 no Chromium desktop;
- build Vite e bundle budget aprovados: 564.8 KiB inicial, abaixo de 800 KiB;
- `git diff --check` aprovado.

## Limites e rollout
- O launcher visual desta branch não ficou disponível porque o Vite encerrou com `Bus error` no runtime WSL montado; processos e portas próprias foram encerrados.
- O inventário real de staging foi somente leitura: fingerprint `079342f0954017e883714547`, 66 registros escaneados, 14 pendências, sem mutações.
- Nenhum banco remoto, migration, flag, convite real, seed ou produção foi alterado.
- A migration 0024 e a nova 0025 ainda exigem dry-run/idempotência/rollback em staging antes de habilitar a flag.
- O Ponto staging permanece em manutenção controlada; o fluxo de convite real ainda requer teste sintético com destinatário autorizado.
- GitHub Actions está sem checks neste momento por indisponibilidade do serviço; o merge deve aguardar os checks obrigatórios e o gate de autonomia.