### PR TITLE
ci(team): publish inventory release provenance

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -854,6 +854,7 @@ jobs:
             unified_team_var=false
             [[ "$UNIFIED_TEAM_ENABLED" == "true" ]] && unified_team_var=true
             npx --yes wrangler@3 deploy --config inventory/wrangler.toml --keep-vars "${env_args[@]}" \
+              --var "APP_VERSION:$RELEASE_SHA" \
               --var "UNIFIED_TEAM_ENABLED:$unified_team_var"
           fi
           if [[ "$UNIT" == "api" || "$UNIT" == "all" ]]; then

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -140,5 +140,6 @@ test('unified team rollout is explicit, staging-only and fail-closed by default'
   assert.match(workflow, /Unified team routes can only be enabled in staging/);
   assert.match(workflow, /Unified team routes require the inventory unit/);
   assert.match(workflow, /unified_team_var=false/);
+  assert.match(workflow, /--var "APP_VERSION:\$RELEASE_SHA"/);
   assert.match(workflow, /--var "UNIFIED_TEAM_ENABLED:\$unified_team_var"/);
 });


### PR DESCRIPTION
## Escopo

- propaga o SHA imutável aprovado para `APP_VERSION` no Worker inventory;
- mantém o gate `UNIFIED_TEAM_ENABLED` separado e fail-closed;
- estende o contrato estático para impedir regressão de proveniência.

## Validação

- `node --test inventory/tests/onboardingConsistency.test.mjs`
- `git diff --check`

A mudança é necessária para que o health do Worker reflita o release publicado.