### PR TITLE
fix(orb): complete CCG operational recovery path

### DIFF
--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
@@ -178,16 +178,18 @@
     "saveManualExecutions": true,
     "saveExecutionProgress": true,
     "saveDataErrorExecution": "all",
-    "saveDataSuccessExecution": "all"
+    "saveDataSuccessExecution": "all",
+    "errorWorkflow": "9j7WMFTNVNYmNZHC"
   },
   "staticData": null,
   "pinData": {},
   "meta": {
     "codex_generated": true,
     "codex_builder": "build-campaign-creative-creator-organizer",
-    "codex_builder_version": "1.0.3",
+    "codex_builder_version": "1.0.4",
     "source_workflow_id": "ccg-orchestrator-001",
     "creator_workflow_id": "TxE9eMS1xfE6kq38",
+    "error_workflow_id": "9j7WMFTNVNYmNZHC",
     "architecture": "n8n-organizer-to-campaign-creative-creator-operational-entry",
     "operational_entry": "executeWorkflowTrigger",
     "no_publication": true,

--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
@@ -15,6 +15,19 @@
       "parameters": {}
     },
     {
+      "id": "ccg-organizer-operational",
+      "name": "Operational Campaign Request",
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        -720,
+        180
+      ],
+      "parameters": {
+        "inputSource": "passthrough"
+      }
+    },
+    {
       "id": "ccg-organizer-config",
       "name": "Organizer Safe Defaults",
       "type": "n8n-nodes-base.set",
@@ -110,6 +123,17 @@
         ]
       ]
     },
+    "Operational Campaign Request": {
+      "main": [
+        [
+          {
+            "node": "Organizer Safe Defaults",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
     "Organizer Safe Defaults": {
       "main": [
         [
@@ -161,10 +185,11 @@
   "meta": {
     "codex_generated": true,
     "codex_builder": "build-campaign-creative-creator-organizer",
-    "codex_builder_version": "1.0.2",
+    "codex_builder_version": "1.0.3",
     "source_workflow_id": "ccg-orchestrator-001",
     "creator_workflow_id": "TxE9eMS1xfE6kq38",
     "architecture": "n8n-organizer-to-campaign-creative-creator-operational-entry",
+    "operational_entry": "executeWorkflowTrigger",
     "no_publication": true,
     "publish_allowed": false,
     "publish_requested": false,

--- a/orb/engine/scripts/build-campaign-creative-creator-organizer.js
+++ b/orb/engine/scripts/build-campaign-creative-creator-organizer.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 const ORGANIZER_ID = 'ccg-orchestrator-001';
 const ORGANIZER_NAME = 'Campaign Creative Creator Organizer';
 const CREATOR_WORKFLOW_ID = 'TxE9eMS1xfE6kq38';
-const BUILDER_VERSION = '1.0.2';
+const BUILDER_VERSION = '1.0.3';
 
 function parseArgs(argv) {
   const result = {};
@@ -209,6 +209,12 @@ function buildOrganizer(source, options = {}) {
   assertSafeId(creatorWorkflowId, 'creator workflow id');
   const nodes = [
     workflowNode('ccg-organizer-manual', "When clicking 'Execute workflow'", 'n8n-nodes-base.manualTrigger', 1, [-720, 0], {}),
+    // Prefer the native subworkflow trigger for operational calls. This keeps
+    // the Organizer private (no webhook) while allowing n8n to retain
+    // integrated execution semantics and route real failures to CCG-99.
+    workflowNode('ccg-organizer-operational', 'Operational Campaign Request', 'n8n-nodes-base.executeWorkflowTrigger', 1.1, [-720, 180], {
+      inputSource: 'passthrough',
+    }),
     workflowNode('ccg-organizer-config', 'Organizer Safe Defaults', 'n8n-nodes-base.set', 3.4, [-480, 0], {
       assignments: {
         assignments: [
@@ -234,10 +240,11 @@ function buildOrganizer(source, options = {}) {
     active: false,
     nodes,
     connections: {
-      [nodes[0].name]: { main: [[{ node: nodes[1].name, type: 'main', index: 0 }]] },
+      [nodes[0].name]: { main: [[{ node: nodes[2].name, type: 'main', index: 0 }]] },
       [nodes[1].name]: { main: [[{ node: nodes[2].name, type: 'main', index: 0 }]] },
       [nodes[2].name]: { main: [[{ node: nodes[3].name, type: 'main', index: 0 }]] },
       [nodes[3].name]: { main: [[{ node: nodes[4].name, type: 'main', index: 0 }]] },
+      [nodes[4].name]: { main: [[{ node: nodes[5].name, type: 'main', index: 0 }]] },
     },
     settings: { ...(source.settings || {}), availableInMCP: false },
     staticData: null,
@@ -249,6 +256,7 @@ function buildOrganizer(source, options = {}) {
       source_workflow_id: ORGANIZER_ID,
       creator_workflow_id: creatorWorkflowId,
       architecture: 'n8n-organizer-to-campaign-creative-creator-operational-entry',
+      operational_entry: 'executeWorkflowTrigger',
       no_publication: true,
       publish_allowed: false,
       publish_requested: false,

--- a/orb/engine/scripts/build-campaign-creative-creator-organizer.js
+++ b/orb/engine/scripts/build-campaign-creative-creator-organizer.js
@@ -6,17 +6,19 @@ const path = require('node:path');
 const ORGANIZER_ID = 'ccg-orchestrator-001';
 const ORGANIZER_NAME = 'Campaign Creative Creator Organizer';
 const CREATOR_WORKFLOW_ID = 'TxE9eMS1xfE6kq38';
-const BUILDER_VERSION = '1.0.3';
+const CCG_ERROR_WORKFLOW_ID = '9j7WMFTNVNYmNZHC';
+const BUILDER_VERSION = '1.0.4';
 
 function parseArgs(argv) {
   const result = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (['--input', '--output', '--creator-workflow-id'].includes(arg)) {
+    if (['--input', '--output', '--creator-workflow-id', '--error-workflow-id'].includes(arg)) {
       const key = {
         '--input': 'input',
         '--output': 'output',
         '--creator-workflow-id': 'creatorWorkflowId',
+        '--error-workflow-id': 'errorWorkflowId',
       }[arg];
       result[key] = argv[++index];
     }
@@ -206,7 +208,10 @@ return [{
 function buildOrganizer(source, options = {}) {
   if (!source || source.id !== ORGANIZER_ID) throw new Error(`Unexpected Organizer workflow id: ${source?.id || 'missing'}`);
   const creatorWorkflowId = options.creatorWorkflowId || CREATOR_WORKFLOW_ID;
+  const errorWorkflowId = options.errorWorkflowId || CCG_ERROR_WORKFLOW_ID;
   assertSafeId(creatorWorkflowId, 'creator workflow id');
+  assertSafeId(errorWorkflowId, 'error workflow id');
+  if (errorWorkflowId === ORGANIZER_ID) throw new Error('Organizer must not use itself as its error workflow');
   const nodes = [
     workflowNode('ccg-organizer-manual', "When clicking 'Execute workflow'", 'n8n-nodes-base.manualTrigger', 1, [-720, 0], {}),
     // Prefer the native subworkflow trigger for operational calls. This keeps
@@ -246,7 +251,10 @@ function buildOrganizer(source, options = {}) {
       [nodes[3].name]: { main: [[{ node: nodes[4].name, type: 'main', index: 0 }]] },
       [nodes[4].name]: { main: [[{ node: nodes[5].name, type: 'main', index: 0 }]] },
     },
-    settings: { ...(source.settings || {}), availableInMCP: false },
+    // n8n propagates an integrated child failure to the top-level Organizer.
+    // Attach CCG-99 here as well as on the Creator so a technical failure is
+    // recoverable regardless of which execution n8n persists as the root.
+    settings: { ...(source.settings || {}), availableInMCP: false, errorWorkflow: errorWorkflowId },
     staticData: null,
     pinData: {},
     meta: {
@@ -255,6 +263,7 @@ function buildOrganizer(source, options = {}) {
       codex_builder_version: BUILDER_VERSION,
       source_workflow_id: ORGANIZER_ID,
       creator_workflow_id: creatorWorkflowId,
+      error_workflow_id: errorWorkflowId,
       architecture: 'n8n-organizer-to-campaign-creative-creator-operational-entry',
       operational_entry: 'executeWorkflowTrigger',
       no_publication: true,
@@ -270,10 +279,13 @@ function buildOrganizer(source, options = {}) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  if (!args.input || !args.output) throw new Error('Usage: build-campaign-creative-creator-organizer.js --input <workflow-export.json> --output <candidate.json> [--creator-workflow-id <id>]');
+  if (!args.input || !args.output) throw new Error('Usage: build-campaign-creative-creator-organizer.js --input <workflow-export.json> --output <candidate.json> [--creator-workflow-id <id>] [--error-workflow-id <id>]');
   const parsed = JSON.parse(fs.readFileSync(path.resolve(args.input), 'utf8').replace(/^\uFEFF/, ''));
   const source = Array.isArray(parsed) ? parsed.find((candidate) => candidate?.id === ORGANIZER_ID) : parsed;
-  const output = buildOrganizer(source, { creatorWorkflowId: args.creatorWorkflowId });
+  const output = buildOrganizer(source, {
+    creatorWorkflowId: args.creatorWorkflowId,
+    errorWorkflowId: args.errorWorkflowId,
+  });
   fs.mkdirSync(path.dirname(path.resolve(args.output)), { recursive: true });
   fs.writeFileSync(path.resolve(args.output), `${JSON.stringify(output, null, 2)}\n`);
   process.stdout.write(`Built inactive Campaign Creative Creator Organizer: ${args.output} (${output.nodes.length} nodes)\n`);
@@ -284,6 +296,7 @@ if (require.main === module) main();
 module.exports = {
   BUILDER_VERSION,
   CREATOR_WORKFLOW_ID,
+  CCG_ERROR_WORKFLOW_ID,
   ORGANIZER_ID,
   ORGANIZER_NAME,
   buildOrganizer,

--- a/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
+++ b/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
@@ -94,21 +94,42 @@ function resolveN8nRoot() {
   const configured = text(process.env.N8N_GLOBAL_DIR, 1024);
   const root = configured || '/usr/local/lib/node_modules/n8n';
   const servicePath = path.join(root, 'dist', 'workflows', 'workflow-execution.service.js');
+  const runnerPath = path.join(root, 'dist', 'workflow-runner.js');
   const errorWorkflowPath = path.join(root, 'dist', 'execution-lifecycle', 'execute-error-workflow.js');
-  if (!fs.existsSync(servicePath) || !fs.existsSync(errorWorkflowPath)) {
+  if (!fs.existsSync(servicePath) || !fs.existsSync(runnerPath) || !fs.existsSync(errorWorkflowPath)) {
     throw new Error('n8n error-workflow bootstrap could not resolve the installed runtime modules');
   }
-  return { servicePath, errorWorkflowPath };
+  return { servicePath, runnerPath, errorWorkflowPath };
+}
+
+function repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunner) {
+  const dependencies = Reflect.getMetadata('design:paramtypes', WorkflowExecutionService);
+  if (!Array.isArray(dependencies) || dependencies.length < 7) {
+    throw new Error('n8n error-workflow bootstrap could not inspect WorkflowExecutionService dependencies');
+  }
+  if (typeof WorkflowRunner !== 'function') {
+    throw new Error('n8n error-workflow bootstrap could not load WorkflowRunner');
+  }
+  if (dependencies[6] === WorkflowRunner) return false;
+  // n8n 2.8.3 evaluates this constructor metadata while workflow-runner is
+  // still inside the error-workflow cycle. The sixth dependency is therefore
+  // permanently recorded as undefined, even once the module cache settles.
+  const repaired = [...dependencies];
+  repaired[6] = WorkflowRunner;
+  Reflect.defineMetadata('design:paramtypes', repaired, WorkflowExecutionService);
+  return true;
 }
 
 function bootstrap() {
-  const { servicePath, errorWorkflowPath } = resolveN8nRoot();
+  const { servicePath, runnerPath, errorWorkflowPath } = resolveN8nRoot();
   // This runs before WorkflowRunner. n8n 2.8.3 otherwise records an undefined
   // constructor parameter during its CommonJS cycle through error workflows.
   const { WorkflowExecutionService } = require(servicePath);
   if (typeof WorkflowExecutionService !== 'function') {
     throw new Error('n8n error-workflow bootstrap could not load WorkflowExecutionService');
   }
+  const { WorkflowRunner } = require(runnerPath);
+  repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunner);
   const errorWorkflowModule = require(errorWorkflowPath);
   const original = errorWorkflowModule.executeErrorWorkflow;
   if (typeof original !== 'function') {
@@ -132,5 +153,6 @@ bootstrap();
 module.exports = {
   attachCcgRecoveryContext,
   captureContextFromRunData,
+  repairWorkflowExecutionMetadata,
   sanitizeRecoveryContext,
 };

--- a/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
+++ b/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
@@ -93,15 +93,15 @@ test('bootstrap preserves only the CCG recovery lineage in the native error payl
 
 test('bootstrap resolves WorkflowRunner metadata before the runner is loaded', { skip: !fs.existsSync(runnerPath) }, () => {
   const probe = [
-    `require(${JSON.stringify(runnerPath)});`,
     `const { WorkflowExecutionService } = require(${JSON.stringify(servicePath)});`,
+    `const { WorkflowRunner } = require(${JSON.stringify(runnerPath)});`,
     "const dependencies = Reflect.getMetadata('design:paramtypes', WorkflowExecutionService) || [];",
-    'process.stdout.write(String(typeof dependencies[6]));',
+    "process.stdout.write(String(typeof dependencies[6]) + ':' + String(dependencies[6] === WorkflowRunner));",
   ].join('\n');
   const result = spawnSync(process.execPath, ['--require', preloadPath, '-e', probe], {
     encoding: 'utf8',
     env: { ...process.env, N8N_GLOBAL_DIR: n8nRoot },
   });
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(result.stdout.trim(), 'function');
+  assert.equal(result.stdout.trim(), 'function:true');
 });

--- a/orb/engine/tests/campaign-creative-creator-organizer.test.js
+++ b/orb/engine/tests/campaign-creative-creator-organizer.test.js
@@ -4,7 +4,12 @@ const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { buildOrganizer, CREATOR_WORKFLOW_ID, ORGANIZER_ID } = require('../scripts/build-campaign-creative-creator-organizer');
+const {
+  buildOrganizer,
+  CCG_ERROR_WORKFLOW_ID,
+  CREATOR_WORKFLOW_ID,
+  ORGANIZER_ID,
+} = require('../scripts/build-campaign-creative-creator-organizer');
 
 test('Organizer builder produces a safe inactive subworkflow route to the operational creator entry', () => {
   const source = {
@@ -38,6 +43,8 @@ test('Organizer builder produces a safe inactive subworkflow route to the operat
   assert.equal(workflow.connections["When clicking 'Execute workflow'"].main[0][0].node, 'Organizer Safe Defaults');
   assert.equal(workflow.meta.publish_allowed, false);
   assert.equal(workflow.meta.operational_entry, 'executeWorkflowTrigger');
+  assert.equal(workflow.settings.errorWorkflow, CCG_ERROR_WORKFLOW_ID);
+  assert.equal(workflow.meta.error_workflow_id, CCG_ERROR_WORKFLOW_ID);
   assert.equal(workflow.meta.no_public_webhook, true);
 });
 
@@ -45,9 +52,18 @@ test('Organizer builder writes a reproducible candidate without legacy provider 
   const source = { id: ORGANIZER_ID, name: 'Other', active: false, nodes: [], connections: {}, settings: {} };
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccg-organizer-test-'));
   const outputPath = path.join(tempDir, 'organizer.json');
-  const workflow = buildOrganizer(source, { creatorWorkflowId: '9j7WMFTNVNYmNZHC' });
+  const workflow = buildOrganizer(source, {
+    creatorWorkflowId: '9j7WMFTNVNYmNZHC',
+    errorWorkflowId: 'error-handler-001',
+  });
   fs.writeFileSync(outputPath, JSON.stringify(workflow));
   const persisted = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
   assert.equal(persisted.nodes.find((node) => node.name === 'Execute Campaign Creative Creator').parameters.workflowId.value, '9j7WMFTNVNYmNZHC');
+  assert.equal(persisted.settings.errorWorkflow, 'error-handler-001');
   assert.equal(persisted.nodes.some((node) => /googleDrive|httpRequest|langchain/i.test(node.type)), false);
+});
+
+test('Organizer builder rejects an error workflow that points back to itself', () => {
+  const source = { id: ORGANIZER_ID, name: 'Other', active: false, nodes: [], connections: {}, settings: {} };
+  assert.throws(() => buildOrganizer(source, { errorWorkflowId: ORGANIZER_ID }), /must not use itself/);
 });

--- a/orb/engine/tests/campaign-creative-creator-organizer.test.js
+++ b/orb/engine/tests/campaign-creative-creator-organizer.test.js
@@ -19,8 +19,11 @@ test('Organizer builder produces a safe inactive subworkflow route to the operat
   assert.equal(workflow.id, ORGANIZER_ID);
   assert.equal(workflow.name, 'Campaign Creative Creator Organizer');
   assert.equal(workflow.active, false);
-  assert.equal(workflow.nodes.length, 5);
+  assert.equal(workflow.nodes.length, 6);
   assert.equal(workflow.nodes.some((node) => node.credentials), false);
+  const operationalTrigger = workflow.nodes.find((node) => node.name === 'Operational Campaign Request');
+  assert.equal(operationalTrigger.type, 'n8n-nodes-base.executeWorkflowTrigger');
+  assert.equal(operationalTrigger.parameters.inputSource, 'passthrough');
   const execute = workflow.nodes.find((node) => node.name === 'Execute Campaign Creative Creator');
   assert.equal(execute.parameters.workflowId.value, CREATOR_WORKFLOW_ID);
   assert.equal(execute.parameters.options.waitForSubWorkflow, true);
@@ -31,7 +34,10 @@ test('Organizer builder produces a safe inactive subworkflow route to the operat
   assert.match(request.parameters.jsCode, /max_jobs: defaultMaxJobs/);
   assert.equal(workflow.nodes.find((node) => node.name === 'Organizer Safe Defaults').parameters.assignments.assignments.find((assignment) => assignment.name === 'max_jobs').value, 4);
   assert.equal(workflow.connections['Build CCG Operational Request'].main[0][0].node, 'Execute Campaign Creative Creator');
+  assert.equal(workflow.connections['Operational Campaign Request'].main[0][0].node, 'Organizer Safe Defaults');
+  assert.equal(workflow.connections["When clicking 'Execute workflow'"].main[0][0].node, 'Organizer Safe Defaults');
   assert.equal(workflow.meta.publish_allowed, false);
+  assert.equal(workflow.meta.operational_entry, 'executeWorkflowTrigger');
   assert.equal(workflow.meta.no_public_webhook, true);
 });
 


### PR DESCRIPTION
## Summary
- add a private Execute Workflow Trigger to the CCG Organizer and retain the manual smoke path
- route root Organizer failures to CCG-99 without self-recursion
- repair the n8n 2.8.3 WorkflowExecutionService metadata cycle before native error dispatch

## Validation
- workflow:campaign-creative:continuous:test (14 passing)
- workflow:campaign-creative:live-import:test (2 passing)
- workflow:campaign-creative:error-trigger:test (3 passing)
- campaign-creative-creator-organizer.test.js (3 passing)
- regenerated and structurally validated the CCG builder outputs

No paid provider, storage, media publication, or public webhook is introduced.