### PR TITLE
fix(orb): repair CCG error handler DI at resolution

### DIFF
--- a/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
+++ b/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
@@ -96,10 +96,11 @@ function resolveN8nRoot() {
   const servicePath = path.join(root, 'dist', 'workflows', 'workflow-execution.service.js');
   const runnerPath = path.join(root, 'dist', 'workflow-runner.js');
   const errorWorkflowPath = path.join(root, 'dist', 'execution-lifecycle', 'execute-error-workflow.js');
-  if (!fs.existsSync(servicePath) || !fs.existsSync(runnerPath) || !fs.existsSync(errorWorkflowPath)) {
+  const diPath = path.join(root, 'node_modules', '@n8n', 'di');
+  if (!fs.existsSync(servicePath) || !fs.existsSync(runnerPath) || !fs.existsSync(errorWorkflowPath) || !fs.existsSync(diPath)) {
     throw new Error('n8n error-workflow bootstrap could not resolve the installed runtime modules');
   }
-  return { servicePath, runnerPath, errorWorkflowPath };
+  return { servicePath, runnerPath, errorWorkflowPath, diPath };
 }
 
 function repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunner) {
@@ -120,8 +121,36 @@ function repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunne
   return true;
 }
 
+function patchContainerGet(Container, WorkflowExecutionService, loadWorkflowRunner) {
+  if (!Container || typeof Container.get !== 'function') {
+    throw new Error('n8n error-workflow bootstrap could not inspect the dependency container');
+  }
+  if (typeof loadWorkflowRunner !== 'function') {
+    throw new Error('n8n error-workflow bootstrap requires a WorkflowRunner loader');
+  }
+  if (Container.__skincosCcgWorkflowExecutionRepair === true) return false;
+
+  // n8n's CLI lifecycle may load a second set of decorators after this preload
+  // returns. Repair again at the only resolution point that matters rather than
+  // relying on an earlier metadata snapshot to remain intact.
+  const originalGet = Container.get;
+  Object.defineProperty(Container, '__skincosCcgWorkflowExecutionRepair', {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  Container.get = function getWithCcgWorkflowExecutionRepair(token, ...args) {
+    if (token === WorkflowExecutionService) {
+      repairWorkflowExecutionMetadata(WorkflowExecutionService, loadWorkflowRunner());
+    }
+    return originalGet.call(this, token, ...args);
+  };
+  return true;
+}
+
 function bootstrap() {
-  const { servicePath, runnerPath, errorWorkflowPath } = resolveN8nRoot();
+  const { servicePath, runnerPath, errorWorkflowPath, diPath } = resolveN8nRoot();
   // This runs before WorkflowRunner. n8n 2.8.3 otherwise records an undefined
   // constructor parameter during its CommonJS cycle through error workflows.
   const { WorkflowExecutionService } = require(servicePath);
@@ -130,6 +159,8 @@ function bootstrap() {
   }
   const { WorkflowRunner } = require(runnerPath);
   repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunner);
+  const { Container } = require(diPath);
+  patchContainerGet(Container, WorkflowExecutionService, () => require(runnerPath).WorkflowRunner);
   const errorWorkflowModule = require(errorWorkflowPath);
   const original = errorWorkflowModule.executeErrorWorkflow;
   if (typeof original !== 'function') {
@@ -153,6 +184,7 @@ bootstrap();
 module.exports = {
   attachCcgRecoveryContext,
   captureContextFromRunData,
+  patchContainerGet,
   repairWorkflowExecutionMetadata,
   sanitizeRecoveryContext,
 };

--- a/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
+++ b/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
@@ -105,3 +105,27 @@ test('bootstrap resolves WorkflowRunner metadata before the runner is loaded', {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), 'function:true');
 });
+
+test('bootstrap repairs WorkflowExecutionService metadata immediately before container resolution', () => {
+  const bootstrap = require(preloadPath);
+  function FakeWorkflowExecutionService() {}
+  function FakeWorkflowRunner() {}
+  const dependencies = [function A() {}, function B() {}, function C() {}, function D() {}, function E() {}, function F() {}, undefined];
+  Reflect.defineMetadata('design:paramtypes', dependencies, FakeWorkflowExecutionService);
+  const fakeContainer = {
+    get(token) {
+      return (Reflect.getMetadata('design:paramtypes', token) || [])[6];
+    },
+  };
+
+  assert.equal(
+    bootstrap.patchContainerGet(fakeContainer, FakeWorkflowExecutionService, () => FakeWorkflowRunner),
+    true,
+  );
+  assert.equal(fakeContainer.get(FakeWorkflowExecutionService), FakeWorkflowRunner);
+  assert.equal(fakeContainer.__skincosCcgWorkflowExecutionRepair, true);
+  assert.equal(
+    bootstrap.patchContainerGet(fakeContainer, FakeWorkflowExecutionService, () => FakeWorkflowRunner),
+    false,
+  );
+});


### PR DESCRIPTION
## What changed

Repairs the n8n 2.8.3 CCG error-workflow dependency metadata at the exact dependency-container resolution point.

## Why

The prior preload repaired the metadata too early; the CLI lifecycle could restore the circular dependency before CCG-99 started. The scoped container guard reapplies the correct `WorkflowRunner` dependency only when `WorkflowExecutionService` is requested.

## Validation

- `npm --prefix orb/engine run workflow:campaign-creative:error-trigger:test` — 4 passing tests.
- The prior native controlled smoke reproduced the technical executor refusal without provider, storage, or publication activity and confirmed the runtime failure boundary to close.