### PR TITLE
fix(ci): derive autonomy base after force push

### DIFF
--- a/.github/scripts/codex-autonomy-gate-workflow.test.mjs
+++ b/.github/scripts/codex-autonomy-gate-workflow.test.mjs
@@ -1,9 +1,21 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { resolveCodexAutonomyBase } from "./resolve-codex-autonomy-base.mjs";
+
+const cleanGitEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+);
 
 const source = fs.readFileSync(
   new URL("../workflows/codex-autonomy-gate.yml", import.meta.url),
+  "utf8",
+);
+const resolverSource = fs.readFileSync(
+  new URL("./resolve-codex-autonomy-base.mjs", import.meta.url),
   "utf8",
 );
 
@@ -18,12 +30,111 @@ test("ready-for-review transitions create the required PR check", () => {
 test("manual autonomy recovery requires an exact ancestor base", () => {
   assert.match(source, /workflow_dispatch:\n\s+inputs:\n\s+base_sha:/);
   assert.match(source, /MANUAL_BASE_SHA: \$\{\{ inputs\.base_sha \}\}/);
-  assert.match(source, /Manual governance base_sha must be a full commit SHA/);
-  assert.match(source, /git merge-base --is-ancestor \"\$base\" \"\$GITHUB_SHA\"/);
+  assert.match(source, /node \.github\/scripts\/resolve-codex-autonomy-base\.mjs/);
+});
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: cleanGitEnvironment,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) throw new Error(`git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+
+function commitFile(cwd, name, content, message) {
+  fs.writeFileSync(path.join(cwd, name), content);
+  git(cwd, "add", name);
+  git(cwd, "commit", "-m", message);
+  return git(cwd, "rev-parse", "HEAD");
+}
+
+function createRepositoryFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-autonomy-base-"));
+  const origin = path.join(root, "origin.git");
+  const checkout = path.join(root, "checkout");
+  fs.mkdirSync(checkout);
+  git(root, "init", "--bare", "--initial-branch=main", origin);
+  git(checkout, "init", "--initial-branch=main");
+  git(checkout, "config", "user.email", "codex@example.invalid");
+  git(checkout, "config", "user.name", "Codex test");
+  git(checkout, "remote", "add", "origin", origin);
+
+  const initial = commitFile(checkout, "state.txt", "initial\n", "initial");
+  git(checkout, "push", "-u", "origin", "main");
+
+  const mainOne = commitFile(checkout, "main.txt", "one\n", "main one");
+  git(checkout, "push", "origin", "main");
+  git(checkout, "checkout", "-b", "topic", mainOne);
+  const head = commitFile(checkout, "topic.txt", "topic\n", "topic");
+
+  git(checkout, "checkout", "main");
+  const mainTwo = commitFile(checkout, "main.txt", "two\n", "main two");
+  git(checkout, "push", "origin", "main");
+  git(checkout, "checkout", "topic");
+  git(checkout, "update-ref", "refs/remotes/origin/main", initial);
+
+  return { root, checkout, head, initial, mainOne, mainTwo };
+}
+
+test("force-push and missing event bases fall back to the freshly fetched origin/main merge base", (t) => {
+  const fixture = createRepositoryFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.equal(
+    resolveCodexAutonomyBase({
+      eventName: "push",
+      headSha: fixture.head,
+      beforeSha: fixture.mainTwo,
+      cwd: fixture.checkout,
+      environment: cleanGitEnvironment,
+    }),
+    fixture.mainOne,
+  );
+
+  assert.equal(
+    resolveCodexAutonomyBase({
+      eventName: "pull_request",
+      headSha: fixture.head,
+      prBaseSha: "f".repeat(40),
+      cwd: fixture.checkout,
+      environment: cleanGitEnvironment,
+    }),
+    fixture.mainOne,
+  );
+});
+
+test("manual recovery never falls back from its explicit base", (t) => {
+  const fixture = createRepositoryFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.throws(
+    () => resolveCodexAutonomyBase({
+      eventName: "workflow_dispatch",
+      headSha: fixture.head,
+      manualBaseSha: "not-a-sha",
+      cwd: fixture.checkout,
+      environment: cleanGitEnvironment,
+    }),
+    /Manual governance base_sha must be a full commit SHA/,
+  );
+
+  assert.throws(
+    () => resolveCodexAutonomyBase({
+      eventName: "workflow_dispatch",
+      headSha: fixture.head,
+      manualBaseSha: fixture.mainTwo,
+      cwd: fixture.checkout,
+      environment: cleanGitEnvironment,
+    }),
+    /Manual governance base_sha must be an ancestor of the checked-out head/,
+  );
 });
 
 test("push recovery classifies rebased branches from their mainline", () => {
-  assert.match(source, /git cat-file -e \"\$base\^\{commit\}\" 2>\/dev\/null/);
-  assert.match(source, /git fetch --no-tags origin main/);
-  assert.match(source, /base=\"\$\(git merge-base \"\$GITHUB_SHA\" origin\/main\)\"/);
+  assert.match(source, /node \.github\/scripts\/resolve-codex-autonomy-base\.mjs/);
+  assert.match(resolverSource, /\+refs\/heads\/main:refs\/remotes\/origin\/main/);
+  assert.match(resolverSource, /\["merge-base", "origin\/main", headSha\]/);
 });

--- a/.github/scripts/resolve-codex-autonomy-base.mjs
+++ b/.github/scripts/resolve-codex-autonomy-base.mjs
@@ -1,0 +1,94 @@
+import { appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const FULL_SHA = /^[0-9a-f]{40}$/;
+const ZERO_SHA = /^0{40}$/;
+
+function runGit(args, { cwd, environment = process.env, allowFailure = false }) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: environment });
+  if (result.error) throw new Error(`Unable to run git ${args[0]}`);
+  if (result.status !== 0 && !allowFailure) throw new Error(`git ${args[0]} failed`);
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout.trim(),
+  };
+}
+
+function isCommit(sha, cwd, environment) {
+  return runGit(["cat-file", "-e", `${sha}^{commit}`], { cwd, environment, allowFailure: true }).ok;
+}
+
+function isAncestor(base, head, cwd, environment) {
+  return runGit(["merge-base", "--is-ancestor", base, head], { cwd, environment, allowFailure: true }).ok;
+}
+
+function isUsableEventBase(sha, head, cwd, environment) {
+  return FULL_SHA.test(sha)
+    && !ZERO_SHA.test(sha)
+    && isCommit(sha, cwd, environment)
+    && isAncestor(sha, head, cwd, environment);
+}
+
+export function resolveCodexAutonomyBase({
+  eventName,
+  headSha,
+  prBaseSha = "",
+  beforeSha = "",
+  manualBaseSha = "",
+  cwd = process.cwd(),
+  environment = process.env,
+}) {
+  if (!FULL_SHA.test(headSha)) throw new Error("GITHUB_SHA must be a full commit SHA");
+
+  // Do not rely on checkout's remote-tracking ref: it can be stale after a
+  // force-push event even when checkout fetched the complete object history.
+  runGit(["fetch", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"], { cwd, environment });
+  if (!isCommit(headSha, cwd, environment)) throw new Error("GITHUB_SHA must identify the checked-out commit");
+  if (runGit(["rev-parse", "HEAD"], { cwd, environment }).stdout !== headSha) {
+    throw new Error("GITHUB_SHA must match the checked-out commit");
+  }
+
+  if (eventName === "workflow_dispatch") {
+    if (!FULL_SHA.test(manualBaseSha)) {
+      throw new Error("Manual governance base_sha must be a full commit SHA");
+    }
+    if (!isCommit(manualBaseSha, cwd, environment)) {
+      throw new Error("Manual governance base_sha must identify a commit");
+    }
+    if (!isAncestor(manualBaseSha, headSha, cwd, environment)) {
+      throw new Error("Manual governance base_sha must be an ancestor of the checked-out head");
+    }
+    return manualBaseSha;
+  }
+
+  const eventBase = prBaseSha || beforeSha;
+  if (isUsableEventBase(eventBase, headSha, cwd, environment)) return eventBase;
+
+  const base = runGit(["merge-base", "origin/main", headSha], { cwd, environment }).stdout;
+  if (!FULL_SHA.test(base)) throw new Error("Unable to derive a common base from origin/main and HEAD");
+  return base;
+}
+
+function main() {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) throw new Error("GITHUB_OUTPUT is required");
+  const base = resolveCodexAutonomyBase({
+    eventName: process.env.GITHUB_EVENT_NAME,
+    headSha: process.env.GITHUB_SHA,
+    prBaseSha: process.env.PR_BASE_SHA,
+    beforeSha: process.env.BEFORE_SHA,
+    manualBaseSha: process.env.MANUAL_BASE_SHA,
+  });
+  appendFileSync(output, `sha=${base}\n`, "utf8");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`::error::${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/codex-autonomy-gate.yml
+++ b/.github/workflows/codex-autonomy-gate.yml
@@ -38,29 +38,7 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
           MANUAL_BASE_SHA: ${{ inputs.base_sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
-            base="$MANUAL_BASE_SHA"
-            [[ "$base" =~ ^[0-9a-f]{40}$ ]] || { echo 'Manual governance base_sha must be a full commit SHA'; exit 1; }
-            git cat-file -e "$base^{commit}"
-            git merge-base --is-ancestor "$base" "$GITHUB_SHA" || {
-              echo 'Manual governance base_sha must be an ancestor of the checked-out head'
-              exit 1
-            }
-          else
-            base="${PR_BASE_SHA:-$BEFORE_SHA}"
-            if [[ -z "$base" || "$base" =~ ^0+$ ]]; then base="$(git rev-parse HEAD^)"; fi
-            if ! git cat-file -e "$base^{commit}" 2>/dev/null || ! git merge-base --is-ancestor "$base" "$GITHUB_SHA"; then
-              # A force-push after rebasing can make github.event.before
-              # unreachable in the fresh checkout. Classify the full branch
-              # delta from its current mainline instead of failing the
-              # required gate on a stale event reference.
-              git fetch --no-tags origin main
-              base="$(git merge-base "$GITHUB_SHA" origin/main)"
-            fi
-          fi
-          echo "sha=$base" >> "$GITHUB_OUTPUT"
+        run: node .github/scripts/resolve-codex-autonomy-base.mjs
       - id: risk
         run: node scripts/codex-risk-classifier.mjs --base "${{ steps.base.outputs.sha }}" --head "$GITHUB_SHA" --output risk-report.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -89,6 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           node .github/scripts/validate-github-governance.mjs
+          node --test .github/scripts/codex-autonomy-gate-workflow.test.mjs
           node --test .github/scripts/ponto-single-operator-governance.test.mjs
           node --test .github/scripts/atendimento-deployment-contract.test.mjs
       - name: Supervisor contract


### PR DESCRIPTION
## Objetivo

Evita que o `Codex autonomy gate` falhe após rebase ou push forçado quando `github.event.before` ou a base da PR não está disponível no checkout ou deixou de ser ancestral do head.

## Alteração

- busca `origin/main` explicitamente antes de resolver a base;
- aceita a base do evento somente quando é um commit existente e ancestral do head;
- deriva `git merge-base origin/main HEAD` para eventos automáticos sem base utilizável;
- mantém `workflow_dispatch` fail-closed: `base_sha` continua obrigatório, SHA completo, commit existente e ancestral do head;
- adiciona teste com repositório temporário que simula tracking ref obsoleta, base não ancestral e base inexistente.

## Risco e rollback

Risco baixo e limitado à classificação do diff no GitHub Actions. Não há migration, flag, deploy ou alteração de runtime. Rollback: reverter o commit `fbd9ec907971bf0902ab0c7184aba42fc5216560`.

## Validação

- `node --test .github/scripts/codex-autonomy-gate-workflow.test.mjs` — 5/5;
- `node .github/scripts/validate-github-governance.mjs`;
- `node .github/scripts/validate-architecture.mjs`;
- parse YAML via PyYAML.