### PR TITLE
fix(orb): dedupe CCG native error incidents

### DIFF
--- a/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
+++ b/orb/engine/generated-workflows/campaign-creative-creator/campaign-creative-creator-organizer.v1.json
@@ -178,18 +178,19 @@
     "saveManualExecutions": true,
     "saveExecutionProgress": true,
     "saveDataErrorExecution": "all",
-    "saveDataSuccessExecution": "all",
-    "errorWorkflow": "9j7WMFTNVNYmNZHC"
+    "saveDataSuccessExecution": "all"
   },
   "staticData": null,
   "pinData": {},
   "meta": {
     "codex_generated": true,
     "codex_builder": "build-campaign-creative-creator-organizer",
-    "codex_builder_version": "1.0.4",
+    "codex_builder_version": "1.0.5",
     "source_workflow_id": "ccg-orchestrator-001",
     "creator_workflow_id": "TxE9eMS1xfE6kq38",
     "error_workflow_id": "9j7WMFTNVNYmNZHC",
+    "error_workflow_owner": "creator_only",
+    "incident_deduplication": "creator_native_error_only",
     "architecture": "n8n-organizer-to-campaign-creative-creator-operational-entry",
     "operational_entry": "executeWorkflowTrigger",
     "no_publication": true,

--- a/orb/engine/scripts/build-campaign-creative-creator-organizer.js
+++ b/orb/engine/scripts/build-campaign-creative-creator-organizer.js
@@ -7,18 +7,17 @@ const ORGANIZER_ID = 'ccg-orchestrator-001';
 const ORGANIZER_NAME = 'Campaign Creative Creator Organizer';
 const CREATOR_WORKFLOW_ID = 'TxE9eMS1xfE6kq38';
 const CCG_ERROR_WORKFLOW_ID = '9j7WMFTNVNYmNZHC';
-const BUILDER_VERSION = '1.0.4';
+const BUILDER_VERSION = '1.0.5';
 
 function parseArgs(argv) {
   const result = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (['--input', '--output', '--creator-workflow-id', '--error-workflow-id'].includes(arg)) {
+    if (['--input', '--output', '--creator-workflow-id'].includes(arg)) {
       const key = {
         '--input': 'input',
         '--output': 'output',
         '--creator-workflow-id': 'creatorWorkflowId',
-        '--error-workflow-id': 'errorWorkflowId',
       }[arg];
       result[key] = argv[++index];
     }
@@ -208,10 +207,12 @@ return [{
 function buildOrganizer(source, options = {}) {
   if (!source || source.id !== ORGANIZER_ID) throw new Error(`Unexpected Organizer workflow id: ${source?.id || 'missing'}`);
   const creatorWorkflowId = options.creatorWorkflowId || CREATOR_WORKFLOW_ID;
-  const errorWorkflowId = options.errorWorkflowId || CCG_ERROR_WORKFLOW_ID;
   assertSafeId(creatorWorkflowId, 'creator workflow id');
-  assertSafeId(errorWorkflowId, 'error workflow id');
-  if (errorWorkflowId === ORGANIZER_ID) throw new Error('Organizer must not use itself as its error workflow');
+  const settings = { ...(source.settings || {}), availableInMCP: false };
+  // The Creator owns CCG-99. Assigning the same native Error Trigger to the
+  // Organizer causes n8n to create a second incident after it propagates the
+  // Creator's failure, so deliberately remove any inherited setting here.
+  delete settings.errorWorkflow;
   const nodes = [
     workflowNode('ccg-organizer-manual', "When clicking 'Execute workflow'", 'n8n-nodes-base.manualTrigger', 1, [-720, 0], {}),
     // Prefer the native subworkflow trigger for operational calls. This keeps
@@ -251,10 +252,7 @@ function buildOrganizer(source, options = {}) {
       [nodes[3].name]: { main: [[{ node: nodes[4].name, type: 'main', index: 0 }]] },
       [nodes[4].name]: { main: [[{ node: nodes[5].name, type: 'main', index: 0 }]] },
     },
-    // n8n propagates an integrated child failure to the top-level Organizer.
-    // Attach CCG-99 here as well as on the Creator so a technical failure is
-    // recoverable regardless of which execution n8n persists as the root.
-    settings: { ...(source.settings || {}), availableInMCP: false, errorWorkflow: errorWorkflowId },
+    settings,
     staticData: null,
     pinData: {},
     meta: {
@@ -263,7 +261,9 @@ function buildOrganizer(source, options = {}) {
       codex_builder_version: BUILDER_VERSION,
       source_workflow_id: ORGANIZER_ID,
       creator_workflow_id: creatorWorkflowId,
-      error_workflow_id: errorWorkflowId,
+      error_workflow_id: CCG_ERROR_WORKFLOW_ID,
+      error_workflow_owner: 'creator_only',
+      incident_deduplication: 'creator_native_error_only',
       architecture: 'n8n-organizer-to-campaign-creative-creator-operational-entry',
       operational_entry: 'executeWorkflowTrigger',
       no_publication: true,
@@ -279,12 +279,11 @@ function buildOrganizer(source, options = {}) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  if (!args.input || !args.output) throw new Error('Usage: build-campaign-creative-creator-organizer.js --input <workflow-export.json> --output <candidate.json> [--creator-workflow-id <id>] [--error-workflow-id <id>]');
+  if (!args.input || !args.output) throw new Error('Usage: build-campaign-creative-creator-organizer.js --input <workflow-export.json> --output <candidate.json> [--creator-workflow-id <id>]');
   const parsed = JSON.parse(fs.readFileSync(path.resolve(args.input), 'utf8').replace(/^\uFEFF/, ''));
   const source = Array.isArray(parsed) ? parsed.find((candidate) => candidate?.id === ORGANIZER_ID) : parsed;
   const output = buildOrganizer(source, {
     creatorWorkflowId: args.creatorWorkflowId,
-    errorWorkflowId: args.errorWorkflowId,
   });
   fs.mkdirSync(path.dirname(path.resolve(args.output)), { recursive: true });
   fs.writeFileSync(path.resolve(args.output), `${JSON.stringify(output, null, 2)}\n`);

--- a/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
+++ b/orb/engine/scripts/preload-n8n-error-workflow-bootstrap.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 
 const CCG_RECOVERY_NODE = 'CCG-00 Capture Recovery Context';
+const AWAIT_ERROR_WORKFLOW_ENV = 'SKINCOS_AWAIT_ERROR_WORKFLOW';
+const AWAIT_ERROR_WORKFLOW_TIMEOUT_ENV = 'SKINCOS_AWAIT_ERROR_WORKFLOW_TIMEOUT_MS';
 
 function text(value, maxLength = 256) {
   if (value === undefined || value === null) return '';
@@ -121,6 +123,101 @@ function repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunne
   return true;
 }
 
+function createCliErrorWorkflowDrain(processRef = process, options = {}) {
+  if (text(processRef?.env?.[AWAIT_ERROR_WORKFLOW_ENV], 16) !== '1') return null;
+  const timeoutMs = boundedInteger(
+    options.timeoutMs ?? processRef.env?.[AWAIT_ERROR_WORKFLOW_TIMEOUT_ENV],
+    30000,
+    1000,
+    120000,
+  );
+  const discoveryMs = Math.min(1000, timeoutMs);
+  const originalExit = processRef.exit.bind(processRef);
+  const pending = new Set();
+  let observed = false;
+  let exitRequested = false;
+  let exitCode = 0;
+  let completed = false;
+  const keepAlive = setInterval(() => {}, 250);
+  let discoveryTimer;
+  let timeoutTimer;
+
+  function finish() {
+    if (completed) return;
+    completed = true;
+    clearInterval(keepAlive);
+    clearTimeout(discoveryTimer);
+    clearTimeout(timeoutTimer);
+    originalExit(exitCode);
+  }
+
+  function maybeFinish() {
+    if (exitRequested && observed && pending.size === 0) finish();
+  }
+
+  timeoutTimer = setTimeout(finish, timeoutMs);
+  processRef.exit = function exitAfterCcgErrorWorkflow(code = 0) {
+    exitRequested = true;
+    exitCode = Number.isInteger(code) ? code : 1;
+    if (observed) {
+      maybeFinish();
+      return;
+    }
+    discoveryTimer = setTimeout(() => {
+      if (!observed) finish();
+    }, discoveryMs);
+  };
+
+  return {
+    track(value) {
+      observed = true;
+      clearTimeout(discoveryTimer);
+      const promise = Promise.resolve(value).catch(() => undefined);
+      pending.add(promise);
+      promise.finally(() => {
+        pending.delete(promise);
+        maybeFinish();
+      });
+      return promise;
+    },
+    dispose() {
+      if (completed) return;
+      completed = true;
+      clearInterval(keepAlive);
+      clearTimeout(discoveryTimer);
+      clearTimeout(timeoutTimer);
+      processRef.exit = originalExit;
+    },
+  };
+}
+
+function patchWorkflowRunnerForCliDrain(WorkflowRunner, drain) {
+  if (!drain) return false;
+  if (!WorkflowRunner?.prototype || typeof WorkflowRunner.prototype.run !== 'function') {
+    throw new Error('n8n error-workflow bootstrap could not inspect WorkflowRunner');
+  }
+  if (WorkflowRunner.prototype.__skincosCcgCliDrain === true) return false;
+  const originalRun = WorkflowRunner.prototype.run;
+  Object.defineProperty(WorkflowRunner.prototype, '__skincosCcgCliDrain', {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  WorkflowRunner.prototype.run = async function runWithCcgCliDrain(data, ...args) {
+    const executionId = await originalRun.call(this, data, ...args);
+    if (data?.executionMode === 'error') {
+      try {
+        drain.track(this.activeExecutions.getPostExecutePromise(executionId));
+      } catch {
+        // The drain is a smoke-only CLI aid. It must never change workflow execution.
+      }
+    }
+    return executionId;
+  };
+  return true;
+}
+
 function patchContainerGet(Container, WorkflowExecutionService, loadWorkflowRunner) {
   if (!Container || typeof Container.get !== 'function') {
     throw new Error('n8n error-workflow bootstrap could not inspect the dependency container');
@@ -159,6 +256,7 @@ function bootstrap() {
   }
   const { WorkflowRunner } = require(runnerPath);
   repairWorkflowExecutionMetadata(WorkflowExecutionService, WorkflowRunner);
+  patchWorkflowRunnerForCliDrain(WorkflowRunner, createCliErrorWorkflowDrain());
   const { Container } = require(diPath);
   patchContainerGet(Container, WorkflowExecutionService, () => require(runnerPath).WorkflowRunner);
   const errorWorkflowModule = require(errorWorkflowPath);
@@ -184,7 +282,9 @@ bootstrap();
 module.exports = {
   attachCcgRecoveryContext,
   captureContextFromRunData,
+  createCliErrorWorkflowDrain,
   patchContainerGet,
+  patchWorkflowRunnerForCliDrain,
   repairWorkflowExecutionMetadata,
   sanitizeRecoveryContext,
 };

--- a/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
+++ b/orb/engine/tests/campaign-creative-creator-error-trigger-runtime.test.js
@@ -129,3 +129,35 @@ test('bootstrap repairs WorkflowExecutionService metadata immediately before con
     false,
   );
 });
+
+test('smoke-only drain waits for the native error execution before the CLI exits', async () => {
+  const bootstrap = require(preloadPath);
+  const exits = [];
+  const fakeProcess = {
+    env: { SKINCOS_AWAIT_ERROR_WORKFLOW: '1', SKINCOS_AWAIT_ERROR_WORKFLOW_TIMEOUT_MS: '1000' },
+    exit(code) { exits.push(code); },
+  };
+  const drain = bootstrap.createCliErrorWorkflowDrain(fakeProcess, { timeoutMs: 1000 });
+  fakeProcess.exit(1);
+  drain.track(Promise.resolve());
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.deepEqual(exits, [1]);
+});
+
+test('smoke-only drain tracks the post-execution promise for native error workflows only', async () => {
+  const bootstrap = require(preloadPath);
+  const tracked = [];
+  const drain = { track(value) { tracked.push(value); } };
+  class FakeWorkflowRunner {
+    constructor() {
+      this.activeExecutions = { getPostExecutePromise: (id) => Promise.resolve(`finished:${id}`) };
+    }
+    async run() { return 'error-execution-1'; }
+  }
+  assert.equal(bootstrap.patchWorkflowRunnerForCliDrain(FakeWorkflowRunner, drain), true);
+  const runner = new FakeWorkflowRunner();
+  await runner.run({ executionMode: 'regular' });
+  await runner.run({ executionMode: 'error' });
+  assert.equal(tracked.length, 1);
+  assert.equal(await tracked[0], 'finished:error-execution-1');
+});

--- a/orb/engine/tests/campaign-creative-creator-organizer.test.js
+++ b/orb/engine/tests/campaign-creative-creator-organizer.test.js
@@ -43,8 +43,10 @@ test('Organizer builder produces a safe inactive subworkflow route to the operat
   assert.equal(workflow.connections["When clicking 'Execute workflow'"].main[0][0].node, 'Organizer Safe Defaults');
   assert.equal(workflow.meta.publish_allowed, false);
   assert.equal(workflow.meta.operational_entry, 'executeWorkflowTrigger');
-  assert.equal(workflow.settings.errorWorkflow, CCG_ERROR_WORKFLOW_ID);
+  assert.equal(Object.hasOwn(workflow.settings, 'errorWorkflow'), false);
   assert.equal(workflow.meta.error_workflow_id, CCG_ERROR_WORKFLOW_ID);
+  assert.equal(workflow.meta.error_workflow_owner, 'creator_only');
+  assert.equal(workflow.meta.incident_deduplication, 'creator_native_error_only');
   assert.equal(workflow.meta.no_public_webhook, true);
 });
 
@@ -52,18 +54,24 @@ test('Organizer builder writes a reproducible candidate without legacy provider 
   const source = { id: ORGANIZER_ID, name: 'Other', active: false, nodes: [], connections: {}, settings: {} };
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccg-organizer-test-'));
   const outputPath = path.join(tempDir, 'organizer.json');
-  const workflow = buildOrganizer(source, {
-    creatorWorkflowId: '9j7WMFTNVNYmNZHC',
-    errorWorkflowId: 'error-handler-001',
-  });
+  const workflow = buildOrganizer(source, { creatorWorkflowId: '9j7WMFTNVNYmNZHC' });
   fs.writeFileSync(outputPath, JSON.stringify(workflow));
   const persisted = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
   assert.equal(persisted.nodes.find((node) => node.name === 'Execute Campaign Creative Creator').parameters.workflowId.value, '9j7WMFTNVNYmNZHC');
-  assert.equal(persisted.settings.errorWorkflow, 'error-handler-001');
+  assert.equal(Object.hasOwn(persisted.settings, 'errorWorkflow'), false);
   assert.equal(persisted.nodes.some((node) => /googleDrive|httpRequest|langchain/i.test(node.type)), false);
 });
 
-test('Organizer builder rejects an error workflow that points back to itself', () => {
-  const source = { id: ORGANIZER_ID, name: 'Other', active: false, nodes: [], connections: {}, settings: {} };
-  assert.throws(() => buildOrganizer(source, { errorWorkflowId: ORGANIZER_ID }), /must not use itself/);
+test('Organizer builder removes inherited native error workflow settings to prevent duplicate incidents', () => {
+  const source = {
+    id: ORGANIZER_ID,
+    name: 'Other',
+    active: false,
+    nodes: [],
+    connections: {},
+    settings: { errorWorkflow: CCG_ERROR_WORKFLOW_ID, executionOrder: 'v1' },
+  };
+  const workflow = buildOrganizer(source);
+  assert.equal(Object.hasOwn(workflow.settings, 'errorWorkflow'), false);
+  assert.equal(workflow.settings.executionOrder, 'v1');
 });


### PR DESCRIPTION
## What changed

- Makes the Creator the sole native CCG-99 incident owner.
- Removes the inherited Organizer error-workflow setting, preventing a propagated Creator failure from opening a duplicate incident.
- Adds an explicit smoke-only CLI drain so the native Error Trigger finishes before the transient test process exits.

## Why

The native smoke proved the DI repair works, then exposed two CCG-99 executions for one Creator failure: one from the Creator and one from the Organizer. It also showed that a short-lived CLI process can leave an error handler running before its asynchronous post-execution work finishes.

## Validation

- `node --test orb/engine/tests/campaign-creative-creator-organizer.test.js` — 3 passing tests.
- `npm --prefix orb/engine run workflow:campaign-creative:error-trigger:test` — 6 passing tests.
- Generated Organizer JSON regenerated through its builder; it remains inactive and without a public webhook.