### PR TITLE
fix(ci): publish security gates for every main release

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -44,6 +44,7 @@
     },
     "securityAudit": {
       "workflow": ".github/workflows/security-secrets-audit.yml",
+      "alwaysOn": true,
       "triggerPaths": [
         ".github/governance/progressive-release-policy.json",
         ".github/workflows/ponto-",

--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -36,8 +36,21 @@ if (securityAudit?.workflow !== ".github/workflows/security-secrets-audit.yml" |
   fail("Ponto governance must declare security audit coverage for its release surfaces");
 }
 const securityWorkflow = read(".github/workflows/security-secrets-audit.yml");
-for (const triggerPath of securityAudit?.triggerPaths ?? []) {
-  if (!securityWorkflow.includes(triggerPath)) fail(`security audit workflow is missing Ponto trigger path: ${triggerPath}`);
+const securityTriggerBlock = securityWorkflow.split("permissions:", 1)[0];
+if (securityAudit?.alwaysOn === true) {
+  if (!/\n\s*push:\s*\r?\n\s*branches:\s*\[main\]/.test(securityTriggerBlock)) {
+    fail("always-on security audit must run for pushes to main");
+  }
+  if (!/\n\s*pull_request:\s*\r?\n\s*branches:\s*\[main\]/.test(securityTriggerBlock)) {
+    fail("always-on security audit must run for pull requests targeting main");
+  }
+  if (/\n\s*paths(?:-ignore)?:/.test(securityTriggerBlock)) {
+    fail("always-on security audit must not be narrowed by trigger path filters");
+  }
+} else {
+  for (const triggerPath of securityAudit?.triggerPaths ?? []) {
+    if (!securityWorkflow.includes(triggerPath)) fail(`security audit workflow is missing Ponto trigger path: ${triggerPath}`);
+  }
 }
 if (JSON.stringify(policy.stages) !== JSON.stringify(["preview", "staging", "pilot", "canary", "production"])) fail("policy stages must be preview, staging, pilot, canary, production in order");
 for (const [stage, predecessor] of Object.entries({ staging: "preview", pilot: "staging", canary: "pilot", production: "canary" })) {

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -3,40 +3,8 @@ name: Security & Secrets Audit
 on:
   push:
     branches: [main]
-    paths:
-      - "**/*auth*"
-      - "**/*session*"
-      - "**/*secret*"
-      - "**/*credential*"
-      - "**/*payment*"
-      - "**/*billing*"
-      - "**/migrations/**"
-      - "package-lock.json"
-      - "**/package-lock.json"
-      - ".github/scripts/npm-audit-gate.mjs"
-      - ".github/governance/progressive-release-policy.json"
-      - ".github/workflows/ponto-*.yml"
-      - ".github/scripts/ponto-*.mjs"
-      - "workforce/timekeeping/**"
-      - ".github/workflows/security-secrets-audit.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "**/*auth*"
-      - "**/*session*"
-      - "**/*secret*"
-      - "**/*credential*"
-      - "**/*payment*"
-      - "**/*billing*"
-      - "**/migrations/**"
-      - "package-lock.json"
-      - "**/package-lock.json"
-      - ".github/scripts/npm-audit-gate.mjs"
-      - ".github/governance/progressive-release-policy.json"
-      - ".github/workflows/ponto-*.yml"
-      - ".github/scripts/ponto-*.mjs"
-      - "workforce/timekeeping/**"
-      - ".github/workflows/security-secrets-audit.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Context\nThe governed Ponto release requires the Dependency Audit (JS/TS) and Scan for secrets (Gitleaks) check-runs for every immutable main SHA. The security workflow was path-filtered, so ordinary main commits omitted those checks and the staging attestation waited indefinitely.\n\n## Change\n- run the security audit on every push to main and PR targeting main;\n- document the always-on contract in progressive-release policy;\n- validate that the workflow is not narrowed by path filters.\n\n## Validation\n- Progressive release policy validation: passed\n- ponto-required-checks tests: 3/3 passed\n- ponto-environment-protection tests: 4/4 passed\n- git diff --check: passed\n\nThis change does not alter application runtime or any production surface; it restores the required release evidence contract.