### PR TITLE
feat(clientes): workspace de clusters de identidade

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -26,6 +26,7 @@
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
+    "migrate-identity-clusters": "node scripts/migrate-atendimento-identity-clusters.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",
     "refresh-commercial-data-quality": "node scripts/refresh-commercial-data-quality.mjs",
     "refresh-commercial-data-quality-staging": "node scripts/refresh-commercial-data-quality-staging.mjs",

--- a/crm/api/scripts/migrate-atendimento-identity-clusters.mjs
+++ b/crm/api/scripts/migrate-atendimento-identity-clusters.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import { isStrictLocalMirrorDestination } from '../server/atendimento/mirror.js'
+import {
+    applyIdentityClusterWorkspaceMigration,
+    rollbackIdentityClusterWorkspaceMigration,
+} from '../server/atendimento/identityClusterWorkspaceMigration.js'
+
+const action = process.argv.slice(2)
+if (action.length !== 1 || !['--apply', '--rollback'].includes(action[0])) {
+    throw new Error('Use exatamente uma ação: --apply ou --rollback.')
+}
+
+const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+if (!databaseUrl || !isStrictLocalMirrorDestination(databaseUrl)) {
+    throw new Error('DATABASE_URL deve apontar exclusivamente para o socket local admin de skincos_crm_local.')
+}
+
+const pool = createPgPool(databaseUrl)
+try {
+    const result = action[0] === '--apply'
+        ? await applyIdentityClusterWorkspaceMigration({ pool, databaseUrl })
+        : await rollbackIdentityClusterWorkspaceMigration({ pool, databaseUrl })
+    console.log(JSON.stringify(result, null, 2))
+} finally {
+    await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspace.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspace.test.js
@@ -1,0 +1,213 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+    assertIdentityClusterConfirmation,
+    buildIdentityClusterBulkPreview,
+    buildIdentityReviewClusterPresentation,
+    explicitRevealFields,
+    identityClusterSourceFreshness,
+} from '../identityClusterWorkspace.js'
+
+const members = [
+    {
+        sourceType: 'attendance_client',
+        sourceId: 'attendance-a',
+        identityId: 'identity-a',
+        identityName: 'Ana Sintética',
+        name: 'Ana Sintética',
+        units: ['novo-hamburgo'],
+        aliases: ['Ana S.'],
+        updatedAt: '2026-08-07T10:00:00.000Z',
+        sourceFreshness: 'current',
+        sourceFingerprint: 'attendance-fp',
+    },
+    {
+        sourceType: 'app_registration',
+        sourceId: 'app-a',
+        identityId: '',
+        name: 'Ana Sintética',
+        units: ['novo-hamburgo'],
+        phoneKeys: ['5551999991111'],
+        emailKeys: ['ana.synthetic@example.test'],
+        updatedAt: '2026-08-07T10:00:00.000Z',
+        sourceFreshness: 'current',
+        sourceFingerprint: 'app-fp',
+    },
+    {
+        sourceType: 'caixa_customer',
+        sourceId: 'caixa-a',
+        identityId: 'identity-b',
+        identityName: 'Ana Caixa',
+        name: 'Ana Sintética',
+        units: ['novo-hamburgo'],
+        phoneKeys: ['5551999991111'],
+        updatedAt: '2026-08-07T10:00:00.000Z',
+        sourceFreshness: 'current',
+        sourceFingerprint: 'caixa-fp',
+    },
+]
+
+const edges = [
+    {
+        reviewType: 'app_attendance',
+        sourceType: 'app_registration',
+        sourceId: 'app-a',
+        targetType: 'attendance_client',
+        targetId: 'attendance-a',
+        status: 'suggested',
+        confidence: 0.99,
+        method: 'exact_phone',
+        matchedFields: ['phone'],
+        sharedUnits: ['novo-hamburgo'],
+        candidateCount: 1,
+        validatedMatch: true,
+        sourceVersion: 'edge-one',
+    },
+    {
+        reviewType: 'app_caixa',
+        sourceType: 'app_registration',
+        sourceId: 'app-a',
+        targetType: 'caixa_customer',
+        targetId: 'caixa-a',
+        status: 'suggested',
+        confidence: 0.98,
+        method: 'exact_phone',
+        matchedFields: ['phone'],
+        sharedUnits: ['novo-hamburgo'],
+        candidateCount: 1,
+        validatedMatch: true,
+        sourceVersion: 'edge-two',
+    },
+]
+
+test('builds a transitive, explicit and masked cluster without technical identifiers', () => {
+    const clusters = buildIdentityReviewClusterPresentation({ members, edges })
+    assert.equal(clusters.length, 1)
+    const cluster = clusters[0]
+    assert.equal(cluster.schemaVersion, IDENTITY_CLUSTER_PRESENTATION_SCHEMA)
+    assert.equal(cluster.summary.memberCount, 3)
+    assert.equal(cluster.summary.identityCount, 2)
+    assert.equal(cluster.bulkReview.eligible, true)
+    assert.deepEqual(cluster.privacy, { contactsMasked: true, technicalIdsHidden: true, revealRequired: true })
+    const serialized = JSON.stringify(cluster)
+    assert.doesNotMatch(serialized, /5551999991111|ana.synthetic@example.test|identity-a|attendance-a/)
+    assert.match(serialized, /55••••11/)
+    assert.match(serialized, /a•••@e•••/)
+    assert.equal(cluster.evidence.strong.every((entry) => Object.hasOwn(entry, 'summary') && !Object.hasOwn(entry, 'context')), true)
+})
+
+test('fails closed for unit scope, stale evidence, strong conflicts and prior decisions', () => {
+    assert.equal(buildIdentityReviewClusterPresentation({ members, edges, unitScope: ['barra-shopping-sul'] }).length, 0)
+    const stale = buildIdentityReviewClusterPresentation({ members: members.map((member, index) => index === 0 ? { ...member, sourceFreshness: 'stale' } : member), edges })[0]
+    assert.equal(stale.bulkReview.eligible, false)
+    assert.ok(stale.bulkReview.reasons.includes('source_stale_or_changed_after_decision'))
+    const conflict = buildIdentityReviewClusterPresentation({ members: members.map((member, index) => index === 2 ? { ...member, phoneKeys: ['5551888882222'] } : member), edges })[0]
+    assert.ok(conflict.bulkReview.reasons.includes('strong_conflict'))
+    const decided = buildIdentityReviewClusterPresentation({
+        members,
+        edges,
+        decisions: [{ reviewType: 'app_attendance', sourceId: 'app-a', targetId: 'attendance-a', decision: 'confirmed', sourceVersion: 'edge-one', createdAt: '2026-08-07T09:00:00.000Z' }],
+    })[0]
+    assert.ok(decided.bulkReview.reasons.includes('incompatible_prior_decision'))
+})
+
+test('uses durable complete source-operation checkpoints rather than member timestamps', () => {
+    const now = new Date('2026-08-07T12:00:00.000Z')
+    const checkpoint = {
+        lastStatus: 'complete',
+        validatedSnapshotComplete: true,
+        reconciliationRequired: false,
+        validatedAt: '2026-08-07T11:00:00.000Z',
+    }
+    const current = {
+        'atendimento.local_mirror': checkpoint,
+        'atendimento.google_sheet': checkpoint,
+        'vendas.caixa_google_sheet': checkpoint,
+        'cadastro.app_registrations': checkpoint,
+        'leads.supplemental_google_sheet': checkpoint,
+        'identity.global_graph': checkpoint,
+    }
+    assert.equal(identityClusterSourceFreshness('attendance_client', current, now), 'current')
+    assert.equal(identityClusterSourceFreshness('attendance_client', { ...current, 'atendimento.google_sheet': undefined }, now), 'unknown')
+    assert.equal(identityClusterSourceFreshness('caixa_customer', {
+        ...current,
+        'vendas.caixa_google_sheet': { ...checkpoint, validatedSnapshotComplete: false },
+    }, now), 'stale')
+    assert.equal(identityClusterSourceFreshness('app_registration', {
+        ...current,
+        'identity.global_graph': { ...checkpoint, validatedAt: '2026-08-05T11:00:00.000Z' },
+    }, now), 'stale')
+})
+
+test('does not let a rejected proposal connect otherwise independent components', () => {
+    const unrelatedLead = {
+        sourceType: 'lead_profile',
+        sourceId: 'lead-independent',
+        identityId: '',
+        name: 'Ana Lead Sintética',
+        units: ['novo-hamburgo'],
+        aliases: [],
+        updatedAt: '2026-08-07T10:00:00.000Z',
+        sourceFreshness: 'current',
+        sourceFingerprint: 'lead-fp',
+    }
+    const rejected = {
+        reviewType: 'lead_app',
+        sourceType: 'lead_profile',
+        sourceId: 'lead-independent',
+        targetType: 'app_registration',
+        targetId: 'app-a',
+        status: 'rejected',
+        confidence: 0.99,
+        method: 'exact_email',
+        matchedFields: ['email'],
+        sharedUnits: ['novo-hamburgo'],
+        candidateCount: 1,
+        validatedMatch: true,
+        sourceVersion: 'rejected-edge',
+    }
+    const clusters = buildIdentityReviewClusterPresentation({ members: [...members, unrelatedLead], edges: [...edges, rejected] })
+    assert.equal(clusters.length, 2)
+    assert.equal(clusters.some((cluster) => cluster.summary.memberCount === 4), false)
+})
+
+test('projects automatic-link history through its explicit presentation schema', () => {
+    const cluster = buildIdentityReviewClusterPresentation({
+        members,
+        edges,
+        automaticLinkHistory: [{
+            reviewType: 'app_attendance',
+            sourceType: 'app_registration',
+            sourceId: 'app-a',
+            targetType: 'attendance_client',
+            targetId: 'attendance-a',
+            transition: 'automatic_activated',
+            resultingStatus: 'auto_confirmed',
+            origin: 'operator@example.test',
+            createdAt: '2026-08-07T10:05:00.000Z',
+        }],
+    })[0]
+    assert.deepEqual(cluster.automaticLinks[0].history[0], {
+        transition: 'automatic_activated',
+        resultingStatus: 'auto_confirmed',
+        recordedAt: '2026-08-07T10:05:00.000Z',
+    })
+    assert.doesNotMatch(JSON.stringify(cluster), /operator@example\.test/)
+})
+
+test('keeps preview and mutation/reveal confirmations explicit', () => {
+    const cluster = buildIdentityReviewClusterPresentation({ members, edges })[0]
+    const preview = buildIdentityClusterBulkPreview([cluster])
+    assert.equal(preview.eligibleCount, 1)
+    assert.equal(preview.clusters[0].version, cluster.version)
+    assert.deepEqual(assertIdentityClusterConfirmation({ reason: 'Validação sintética', confirmation: 'REVIEW_CLUSTER', expectedVersion: cluster.version }), {
+        reason: 'Validação sintética',
+        expectedVersion: cluster.version,
+    })
+    assert.throws(() => assertIdentityClusterConfirmation({ reason: 'ok', confirmation: 'REVIEW_CLUSTER' }), /IDENTITY_CLUSTER_REASON_REQUIRED/)
+    assert.throws(() => assertIdentityClusterConfirmation({ reason: 'Validação', confirmation: 'NO' }), /IDENTITY_CLUSTER_CONFIRMATION_REQUIRED/)
+    assert.deepEqual(explicitRevealFields({ fields: ['phone', 'phone', 'email'] }), ['phone', 'email'])
+    assert.throws(() => explicitRevealFields({ fields: ['cpf'] }), /IDENTITY_CLUSTER_REVEAL_FIELD_REQUIRED/)
+})

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
@@ -42,6 +42,7 @@ test('applies under migration and graph locks before recording readiness', async
     assert.equal(released, true)
     const locks = calls.filter(({ sql }) => /pg_advisory_xact_lock/i.test(sql)).map(({ params }) => params[0])
     assert.deepEqual(locks, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, 'crm_atendimento.identity_graph_materialization'])
+    assert.equal(calls.some(({ sql }) => /grant select on table crm_atendimento\.schema_migrations to skincos/i.test(sql)), true)
     assert.equal(calls.some(({ sql }) => /grant select, insert on table crm_atendimento\.identity_cluster_review_operations to skincos/i.test(sql)), true)
     assert.equal(calls.some(({ sql }) => /insert into crm_atendimento\.schema_migrations/i.test(sql)), true)
     assert.equal(calls.some(({ sql }) => String(sql).trim().toLowerCase() === 'commit'), true)

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspaceMigration.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+    applyIdentityClusterWorkspaceMigration,
+    identityClusterWorkspaceMigrationPlan,
+    identityClusterWorkspaceMigrationStatements,
+    rollbackIdentityClusterWorkspaceMigration,
+} from '../identityClusterWorkspaceMigration.js'
+
+const LOCAL_SOCKET_URL = 'postgresql:///skincos_crm_local?host=/var/run/postgresql'
+
+test('defines an additive, non-destructive cluster workspace ledger migration', () => {
+    const plan = identityClusterWorkspaceMigrationPlan()
+    const ddl = identityClusterWorkspaceMigrationStatements().join('\n').toLowerCase()
+    assert.equal(plan.id, IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID)
+    assert.deepEqual(plan.adds, ['identity_cluster_review_operations', 'identity_cluster_reveal_events'])
+    assert.match(plan.privacy, /never enter/i)
+    assert.match(plan.ledgerIntegrity, /truncate/i)
+    assert.match(plan.rollback, /non-destructive/i)
+    assert.doesNotMatch(ddl, /drop trigger|drop table|delete from/)
+    assert.match(ddl, /identity_cluster_review_operations_immutable/)
+    assert.match(ddl, /identity_cluster_reveal_events_no_truncate/)
+})
+
+test('applies under migration and graph locks before recording readiness', async () => {
+    const calls = []
+    let released = false
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql, params })
+            if (/current_database\(\)/i.test(sql)) return { rows: [{ database_name: 'skincos_crm_local', database_user: 'admin', read_only: 'off' }] }
+            if (/to_regclass\('crm_atendimento\.global_client_identities'\)/i.test(sql)) return { rows: [{ prerequisites: true }] }
+            return { rows: [], rowCount: 0 }
+        },
+        release() { released = true },
+    }
+    const report = await applyIdentityClusterWorkspaceMigration({ pool: { connect: async () => client }, databaseUrl: LOCAL_SOCKET_URL })
+    assert.equal(report.applied, true)
+    assert.equal(report.runtimeRole, 'skincos')
+    assert.equal(released, true)
+    const locks = calls.filter(({ sql }) => /pg_advisory_xact_lock/i.test(sql)).map(({ params }) => params[0])
+    assert.deepEqual(locks, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, 'crm_atendimento.identity_graph_materialization'])
+    assert.equal(calls.some(({ sql }) => /grant select, insert on table crm_atendimento\.identity_cluster_review_operations to skincos/i.test(sql)), true)
+    assert.equal(calls.some(({ sql }) => /insert into crm_atendimento\.schema_migrations/i.test(sql)), true)
+    assert.equal(calls.some(({ sql }) => String(sql).trim().toLowerCase() === 'commit'), true)
+})
+
+test('refuses an unsafe destination before opening a connection and rolls back non-destructively', async () => {
+    let connected = false
+    await assert.rejects(
+        () => applyIdentityClusterWorkspaceMigration({ pool: { connect: async () => { connected = true } }, databaseUrl: 'postgresql://admin@localhost/skincos_crm_local' }),
+        (error) => error?.code === 'IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE',
+    )
+    assert.equal(connected, false)
+
+    const calls = []
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql, params })
+            if (/current_database\(\)/i.test(sql)) return { rows: [{ database_name: 'skincos_crm_local', database_user: 'admin', read_only: 'off' }] }
+            return { rows: [] }
+        },
+        release() {},
+    }
+    const result = await rollbackIdentityClusterWorkspaceMigration({ pool: { connect: async () => client }, databaseUrl: LOCAL_SOCKET_URL })
+    assert.equal(result.evidenceRetained, true)
+    assert.equal(calls.some(({ sql }) => /drop table|delete from/i.test(sql)), false)
+})

--- a/crm/api/server/atendimento/__tests__/identityClusterWorkspaceStore.test.js
+++ b/crm/api/server/atendimento/__tests__/identityClusterWorkspaceStore.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac } from 'node:crypto'
+
+import { __identityClusterWorkspaceTestables } from '../store.js'
+
+const { applyIdentityClusterBulkTransaction, identityClusterExpectedVersions } = __identityClusterWorkspaceTestables
+
+function digest(secret, purpose, actorId, value) {
+    return createHmac('sha256', secret).update(`${purpose}:${actorId}:${JSON.stringify(value)}`).digest('hex')
+}
+
+test('replays a completed bulk operation from the opaque ledger before reading a changed graph', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    const secret = 'synthetic-cluster-ledger-key-which-is-long-enough'
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = secret
+    const actor = { id: 'gestor-sintetico', role: 'GESTOR' }
+    const clusterKey = 'a'.repeat(32)
+    const expectedVersion = 'b'.repeat(64)
+    const idempotencyKey = 'synthetic-requester@example.test'
+    const reason = 'Revisão sintética aprovada'
+    const requestFingerprint = digest(secret, 'bulk-request', actor.id, { clusterKey, expectedVersion, reason, idempotencyKey })
+    const operationKey = digest(secret, 'bulk-operation', actor.id, { clusterKey, idempotencyKey })
+    const calls = []
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql, params })
+            if (/from crm_atendimento\.identity_cluster_review_operations/i.test(sql)) {
+                assert.equal(params[0], operationKey)
+                return { rows: [{ request_fingerprint: requestFingerprint, result: { membersMoved: 2, decisionState: 'confirmed' } }] }
+            }
+            throw new Error('GRAPH_MUST_NOT_BE_READ_FOR_IDEMPOTENT_REPLAY')
+        },
+    }
+    try {
+        const result = await applyIdentityClusterBulkTransaction(client, {
+            clusterKeys: [clusterKey],
+            expectedVersions: { [clusterKey]: expectedVersion },
+            idempotencyKey,
+            reason,
+            confirmation: 'REVIEW_CLUSTER',
+        }, actor)
+        assert.deepEqual(result, {
+            schemaVersion: 'crm-identity-cluster/v2',
+            idempotent: true,
+            appliedClusters: 1,
+            membersMoved: 2,
+            results: [{ clusterKey, idempotent: true, membersMoved: 2, decisionState: 'confirmed' }],
+        })
+        assert.equal(calls.length, 1)
+        assert.doesNotMatch(JSON.stringify(calls), /synthetic-requester@example\.test|Revisão sintética aprovada/)
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('requires one canonical SHA-256 expected version per selected cluster', () => {
+    const clusterKey = 'a'.repeat(32)
+    const version = 'b'.repeat(64)
+    assert.deepEqual(identityClusterExpectedVersions({ expectedVersions: { [clusterKey]: version } }, [clusterKey]), { [clusterKey]: version })
+    assert.throws(
+        () => identityClusterExpectedVersions({ expectedVersions: { [clusterKey]: version, ['c'.repeat(32)]: version } }, [clusterKey]),
+        /IDENTITY_CLUSTER_EXPECTED_VERSIONS_REQUIRED/,
+    )
+    assert.throws(
+        () => identityClusterExpectedVersions({ expectedVersions: { [clusterKey]: 'not-a-version' } }, [clusterKey]),
+        /IDENTITY_CLUSTER_VERSION_REQUIRED/,
+    )
+})

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -275,3 +275,54 @@ test('maps review payload and source-state conflicts to their client-safe status
     assert.equal(undo.state.status, 409)
     assert.deepEqual(undo.state.body, { ok: false, error: 'IDENTITY_REVIEW_CONFLICT', hint: undefined })
 })
+
+test('keeps cluster workspace, reveal and deterministic bulk routes inside the GESTOR boundary', async () => {
+    const calls = []
+    const store = {
+        async identityClusterWorkspace(query, actor) {
+            calls.push({ operation: 'workspace', query, actor })
+            return { clusters: [], total: 0 }
+        },
+        async identityClusterDetail(clusterKey, query, actor) {
+            calls.push({ operation: 'detail', clusterKey, query, actor })
+            return { cluster: { clusterKey } }
+        },
+        async previewIdentityClusterBulk(payload, actor) {
+            calls.push({ operation: 'preview', payload, actor })
+            return { eligibleCount: 0 }
+        },
+        async applyIdentityClusterBulk(payload, actor) {
+            calls.push({ operation: 'apply', payload, actor })
+            return { appliedClusters: 1 }
+        },
+        async revealIdentityCluster(payload, actor) {
+            calls.push({ operation: 'reveal', payload, actor })
+            return { contacts: [] }
+        },
+    }
+    const routes = captureAtendimentoRoutes(store)
+    const actor = { id: 'gestor-1', role: 'GESTOR', allowedModules: ['atendimento'] }
+    const workspace = captureResponse()
+    await routes.get('GET /commercial/identity-clusters')({ atendimentoActor: actor, query: { stale: 'true' } }, workspace)
+    assert.equal(workspace.state.status, 200)
+    assert.deepEqual(calls[0], { operation: 'workspace', query: { stale: 'true' }, actor })
+
+    const apply = captureResponse()
+    await routes.get('POST /commercial/identity-clusters/bulk/apply')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'cluster-apply-001' },
+        body: { clusterKeys: ['a'.repeat(32)] },
+    }, apply)
+    assert.equal(apply.state.status, 200)
+    assert.equal(calls[1].payload.idempotencyKey, 'cluster-apply-001')
+
+    const blocked = captureResponse()
+    await routes.get('POST /commercial/identity-clusters/bulk/apply')({
+        atendimentoActor: { id: 'gerente-1', role: 'GERENTE', allowedModules: ['atendimento'] },
+        headers: { 'idempotency-key': 'blocked' },
+        body: {},
+    }, blocked)
+    assert.equal(blocked.state.status, 403)
+    assert.deepEqual(blocked.state.body, { ok: false, error: 'FORBIDDEN' })
+    assert.equal(calls.length, 2)
+})

--- a/crm/api/server/atendimento/identityClusterWorkspace.js
+++ b/crm/api/server/atendimento/identityClusterWorkspace.js
@@ -1,0 +1,560 @@
+import { createHash } from 'node:crypto'
+
+// This module is intentionally a presentation boundary.  It receives a small,
+// allowlisted graph projection from the store and never serializes source
+// `context` or `evidence` blobs.  Raw contacts remain transient in the store
+// and can only be returned by the separately audited reveal operation.
+export const IDENTITY_CLUSTER_PRESENTATION_SCHEMA = 'crm-identity-cluster/v2'
+
+export const IDENTITY_CLUSTER_SOURCE_TYPES = Object.freeze([
+    'attendance_client',
+    'caixa_customer',
+    'app_registration',
+    'lead_profile',
+])
+
+export const IDENTITY_CLUSTER_SOURCE_LABELS = Object.freeze({
+    attendance_client: 'Atendimento',
+    caixa_customer: 'Caixa',
+    app_registration: 'Cadastro do app',
+    lead_profile: 'Leads e planilhas',
+})
+
+// The graph is only as current as the sources that can alter one of its
+// members. These are source-operation identifiers, never connector URLs or
+// external IDs. `identity.global_graph` is deliberately required for every
+// member type: a fresh individual source cannot make an out-of-date identity
+// projection safe to review in bulk.
+export const IDENTITY_CLUSTER_SOURCE_OPERATION_REQUIREMENTS = Object.freeze({
+    attendance_client: Object.freeze(['atendimento.local_mirror', 'atendimento.google_sheet', 'identity.global_graph']),
+    caixa_customer: Object.freeze(['vendas.caixa_google_sheet', 'identity.global_graph']),
+    app_registration: Object.freeze(['cadastro.app_registrations', 'identity.global_graph']),
+    lead_profile: Object.freeze(['leads.supplemental_google_sheet', 'identity.global_graph']),
+})
+
+const STRONG_METHODS = new Set([
+    'exact_phone',
+    'exact_email',
+    'exact_name_phone',
+    'exact_name_phone_sales_unit',
+    'phone_sales_attendance_anchor',
+    'spelling_same_caixa_customer',
+])
+
+const FIELD_LABELS = Object.freeze({
+    name: 'Nome',
+    phone: 'Telefone validado',
+    email: 'E-mail validado',
+    unit: 'Unidade',
+    cpf: 'Documento validado',
+})
+
+const CONTACT_FIELDS = new Set(['phone', 'email'])
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function unique(values) {
+    return [...new Set((Array.isArray(values) ? values : []).map(text).filter(Boolean))]
+}
+
+function normalized(value) {
+    return text(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function digits(value) {
+    return text(value).replace(/\D/g, '')
+}
+
+export function maskPhone(value) {
+    const raw = digits(value)
+    if (!raw) return ''
+    if (raw.length <= 4) return '••••'
+    return `${raw.slice(0, 2)}••••${raw.slice(-2)}`
+}
+
+export function maskEmail(value) {
+    const raw = text(value).toLowerCase()
+    const at = raw.indexOf('@')
+    if (at <= 0 || at === raw.length - 1) return raw ? '••••' : ''
+    const local = raw.slice(0, at)
+    const domain = raw.slice(at + 1)
+    return `${local.slice(0, 1)}•••@${domain.slice(0, 1)}•••`
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable)
+    if (value && typeof value === 'object') return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
+    return value
+}
+
+export function identityClusterFingerprint(value) {
+    return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex')
+}
+
+function sourceOperationCheckpoint(checkpoints, sourceId) {
+    if (checkpoints instanceof Map) return checkpoints.get(sourceId) || null
+    if (!checkpoints || typeof checkpoints !== 'object') return null
+    return checkpoints[sourceId] || null
+}
+
+/**
+ * A source row's `updated_at` describes the record, not the freshness of the
+ * source snapshot. Bulk identity review therefore consumes only the durable
+ * source-operation checkpoint. Missing or partial source evidence remains
+ * intentionally non-current and prevents a deterministic batch action.
+ */
+export function identityClusterSourceFreshness(sourceType, checkpoints = {}, now = new Date()) {
+    const requiredSources = IDENTITY_CLUSTER_SOURCE_OPERATION_REQUIREMENTS[text(sourceType)]
+    if (!requiredSources?.length) return 'unknown'
+    for (const sourceId of requiredSources) {
+        const checkpoint = sourceOperationCheckpoint(checkpoints, sourceId)
+        if (!checkpoint) return 'unknown'
+        const lastStatus = text(checkpoint.lastStatus || checkpoint.last_status).toLowerCase()
+        const validatedAt = checkpoint.validatedAt || checkpoint.validated_at || null
+        const snapshotComplete = checkpoint.validatedSnapshotComplete ?? checkpoint.validated_snapshot_complete
+        const reconciliationRequired = checkpoint.reconciliationRequired ?? checkpoint.reconciliation_required
+        const observedAt = Date.parse(validatedAt || '')
+        if (snapshotComplete !== true || reconciliationRequired === true || !['complete', 'skipped'].includes(lastStatus)
+            || !Number.isFinite(observedAt) || now.getTime() - observedAt > 48 * 60 * 60 * 1000) return 'stale'
+    }
+    return 'current'
+}
+
+class DisjointSet {
+    constructor(values = []) {
+        this.parent = new Map(values.map((value) => [value, value]))
+    }
+
+    find(value) {
+        if (!this.parent.has(value)) this.parent.set(value, value)
+        const parent = this.parent.get(value)
+        if (parent === value) return value
+        const root = this.find(parent)
+        this.parent.set(value, root)
+        return root
+    }
+
+    union(left, right) {
+        const a = this.find(left)
+        const b = this.find(right)
+        if (a === b) return
+        if (a < b) this.parent.set(b, a)
+        else this.parent.set(a, b)
+    }
+}
+
+function memberKey(member) {
+    return `${text(member?.sourceType)}:${text(member?.sourceId)}`
+}
+
+function edgeKey(edge) {
+    return `${text(edge?.reviewType)}:${text(edge?.sourceType)}:${text(edge?.sourceId)}:${text(edge?.targetType)}:${text(edge?.targetId)}`
+}
+
+function sourceLabel(sourceType) {
+    return IDENTITY_CLUSTER_SOURCE_LABELS[text(sourceType)] || 'Fonte não classificada'
+}
+
+function normalizedContactValues(values, type) {
+    return unique(values).map((value) => type === 'phone' ? digits(value) : text(value).toLowerCase()).filter(Boolean)
+}
+
+function explicitMatchingFields(member) {
+    const fields = []
+    const phoneKeys = unique(member.phoneKeys)
+    const emailKeys = unique(member.emailKeys)
+    const cpfKeys = unique(member.cpfKeys)
+    const units = unique(member.units)
+    if (member.name) fields.push({ field: 'name', label: FIELD_LABELS.name, status: 'present' })
+    if (phoneKeys.length) fields.push({ field: 'phone', label: FIELD_LABELS.phone, status: member.validatedPhone ? 'validated' : 'present', values: phoneKeys.map(maskPhone).filter(Boolean) })
+    if (emailKeys.length) fields.push({ field: 'email', label: FIELD_LABELS.email, status: member.validatedEmail ? 'validated' : 'present', values: emailKeys.map(maskEmail).filter(Boolean) })
+    if (cpfKeys.length) fields.push({ field: 'cpf', label: FIELD_LABELS.cpf, status: member.validatedCpf ? 'validated' : 'present' })
+    if (units.length) fields.push({ field: 'unit', label: FIELD_LABELS.unit, status: 'present', values: units })
+    return fields
+}
+
+function explicitEvidence(edge) {
+    const method = text(edge.method)
+    const matchedFields = unique(edge.matchedFields).filter((field) => Object.hasOwn(FIELD_LABELS, field))
+    const sharedUnits = unique(edge.sharedUnits)
+    const strong = edge.validatedMatch === true || STRONG_METHODS.has(method) || matchedFields.some((field) => CONTACT_FIELDS.has(field))
+    const methodLabel = {
+        exact_phone: 'Telefone validado igual',
+        exact_email: 'E-mail validado igual',
+        exact_name_phone: 'Nome e telefone validados',
+        exact_name_phone_sales_unit: 'Nome, telefone, venda e unidade validados',
+        phone_sales_attendance_anchor: 'Telefone ancorado em venda e atendimento',
+        fuzzy_name_unit_procedure: 'Nome aproximado com contexto de unidade/procedimento',
+        exact_name_unit: 'Nome e unidade coincidentes',
+        exact_name: 'Nome coincidente',
+    }[method] || 'Vínculo de fonte registrado'
+    const parts = [
+        matchedFields.length ? `campos: ${matchedFields.map((field) => FIELD_LABELS[field]).join(', ')}` : '',
+        sharedUnits.length ? `unidades: ${sharedUnits.join(', ')}` : '',
+        Number.isInteger(edge.candidateCount) ? `candidatos: ${edge.candidateCount}` : '',
+    ].filter(Boolean)
+    return {
+        kind: 'source_link',
+        label: methodLabel,
+        strength: strong ? 'strong' : 'weak',
+        confidence: Number.isFinite(Number(edge.confidence)) ? Math.max(0, Math.min(1, Number(edge.confidence))) : 0,
+        source: sourceLabel(edge.sourceType),
+        target: sourceLabel(edge.targetType),
+        summary: parts.join(' · ') || 'Evidência registrada na fonte',
+    }
+}
+
+function normalizeMember(member) {
+    const sourceType = text(member?.sourceType)
+    return {
+        sourceType,
+        sourceId: text(member?.sourceId),
+        identityId: text(member?.identityId),
+        identityCreatedAt: member?.identityCreatedAt || null,
+        name: text(member?.name || member?.canonicalName || member?.identityName) || 'Sem nome informado',
+        identityName: text(member?.identityName || member?.name || member?.canonicalName) || 'Identidade sem nome',
+        aliases: unique(member?.aliases),
+        units: unique(member?.units || member?.unitSlugs),
+        phoneKeys: unique(member?.phoneKeys),
+        emailKeys: unique(member?.emailKeys),
+        cpfKeys: unique(member?.cpfKeys),
+        // A source row itself never upgrades a contact to validated.  That
+        // claim is derived only from allowlisted deterministic edge methods.
+        validatedPhone: member?.validatedPhone === true,
+        validatedEmail: member?.validatedEmail === true,
+        validatedCpf: member?.validatedCpf === true,
+        updatedAt: member?.updatedAt || null,
+        sourceFreshness: text(member?.sourceFreshness || 'unknown'),
+        changedAfterDecision: member?.changedAfterDecision === true,
+        sourceFingerprint: text(member?.sourceFingerprint),
+    }
+}
+
+function normalizeEdge(edge) {
+    const confidence = Number(edge?.confidence)
+    return {
+        reviewType: text(edge?.reviewType),
+        sourceType: text(edge?.sourceType),
+        sourceId: text(edge?.sourceId),
+        targetType: text(edge?.targetType),
+        targetId: text(edge?.targetId),
+        status: text(edge?.status),
+        confidence: Number.isFinite(confidence) ? Math.max(0, Math.min(1, confidence)) : 0,
+        method: text(edge?.method),
+        matchedFields: unique(edge?.matchedFields).filter((field) => Object.hasOwn(FIELD_LABELS, field)),
+        sharedUnits: unique(edge?.sharedUnits),
+        candidateCount: Number.isInteger(Number(edge?.candidateCount)) ? Number(edge.candidateCount) : null,
+        validatedMatch: edge?.validatedMatch === true,
+        sourceVersion: text(edge?.sourceVersion),
+        changedAfterDecision: edge?.changedAfterDecision === true,
+    }
+}
+
+function latestDecisionForEdge(decisions, edge) {
+    const key = edgeKey(edge)
+    return (decisions || []).filter((decision) => edgeKey({
+        reviewType: decision.reviewType,
+        sourceType: edge.sourceType,
+        sourceId: decision.sourceId,
+        targetType: edge.targetType,
+        targetId: edge.targetId,
+    }) === key).sort((left, right) => Number(right.eventOrder || 0) - Number(left.eventOrder || 0)
+        || String(right.createdAt || '').localeCompare(String(left.createdAt || '')))[0] || null
+}
+
+function sourceChanged(edge, decision, members) {
+    if (!decision) return false
+    if (decision.sourceVersion && edge.sourceVersion && decision.sourceVersion !== edge.sourceVersion) return true
+    if (edge.changedAfterDecision || members.some((member) => member.changedAfterDecision)) return true
+    const decisionAt = new Date(decision.createdAt || 0).getTime()
+    return Number.isFinite(decisionAt) && members.some((member) => {
+        const updatedAt = new Date(member.updatedAt || 0).getTime()
+        return Number.isFinite(updatedAt) && updatedAt > decisionAt
+    })
+}
+
+function conflictRows(members) {
+    const names = new Set()
+    const phones = new Set()
+    const emails = new Set()
+    for (const member of members) {
+        if (normalized(member.name)) names.add(normalized(member.name))
+        normalizedContactValues(member.phoneKeys, 'phone').forEach((value) => phones.add(value))
+        normalizedContactValues(member.emailKeys, 'email').forEach((value) => emails.add(value))
+    }
+    const conflicts = []
+    if (names.size > 1) conflicts.push({ field: 'name', label: FIELD_LABELS.name, severity: 'weak', summary: 'Nomes divergentes entre fontes; trate como evidência fraca.' })
+    if (phones.size > 1) conflicts.push({ field: 'phone', label: FIELD_LABELS.phone, severity: 'strong', summary: 'Telefones divergentes impedem revisão em lote.' })
+    if (emails.size > 1) conflicts.push({ field: 'email', label: FIELD_LABELS.email, severity: 'strong', summary: 'E-mails divergentes impedem revisão em lote.' })
+    return conflicts
+}
+
+function edgeHasValidatedContact(edge) {
+    return edge.validatedMatch === true || STRONG_METHODS.has(text(edge.method)) || edge.matchedFields.some((field) => CONTACT_FIELDS.has(field))
+}
+
+function sharedValidatedContactField(edges) {
+    if (edges.some((edge) => edgeHasValidatedContact(edge) && (edge.method.includes('phone') || edge.matchedFields.includes('phone')))) return 'phone'
+    if (edges.some((edge) => edgeHasValidatedContact(edge) && (edge.method.includes('email') || edge.matchedFields.includes('email')))) return 'email'
+    return null
+}
+
+export function classifyIdentityClusterBulkEligibility({ edges = [], conflicts = [], decisions = [], undoBlocked = false, stale = false } = {}) {
+    const sharedContactField = sharedValidatedContactField(edges)
+    const reasons = []
+    if (!sharedContactField) reasons.push('no_shared_validated_contact')
+    if (conflicts.some((conflict) => conflict.severity === 'strong')) reasons.push('strong_conflict')
+    if (!edges.length || !edges.every((edge) => edge.candidateCount === 1)) reasons.push('candidate_not_unique')
+    if (!edges.length || !edges.every((edge) => ['pending', 'suggested'].includes(edge.status) && edgeHasValidatedContact(edge))) reasons.push('edge_not_deterministic')
+    if (decisions.some((decision) => ['confirmed', 'rejected'].includes(text(decision.decision)))) reasons.push('incompatible_prior_decision')
+    if (undoBlocked) reasons.push('commercial_or_consent_history')
+    if (stale) reasons.push('source_stale_or_changed_after_decision')
+    return { eligible: reasons.length === 0, mode: reasons.length === 0 ? 'bulk_safe' : 'individual_only', sharedContactField, reasons }
+}
+
+function identitySummary(members) {
+    const groups = new Map()
+    for (const member of members) {
+        if (!member.identityId) continue
+        if (!groups.has(member.identityId)) groups.set(member.identityId, [])
+        groups.get(member.identityId).push(member)
+    }
+    return [...groups.entries()].map(([id, rows]) => ({
+        id,
+        name: rows[0]?.identityName || rows[0]?.name || 'Identidade sem nome',
+        sourceCount: rows.length,
+        sourceLabels: unique(rows.map((row) => sourceLabel(row.sourceType))),
+        hasAttendance: rows.some((row) => row.sourceType === 'attendance_client'),
+        createdAt: rows.map((row) => row.identityCreatedAt).filter(Boolean).sort()[0] || null,
+    })).sort((left, right) => Number(right.hasAttendance) - Number(left.hasAttendance)
+        || String(left.createdAt || '').localeCompare(String(right.createdAt || '')) || left.name.localeCompare(right.name))
+}
+
+function publicIdentity(identity) {
+    return identity ? { name: identity.name, sourceCount: identity.sourceCount, sourceLabels: identity.sourceLabels } : null
+}
+
+function publicDecision(decision, edge, members) {
+    return {
+        reviewType: edge.reviewType,
+        decision: ['confirmed', 'rejected', 'reversed'].includes(text(decision.decision)) ? text(decision.decision) : 'recorded',
+        resultingStatus: ['pending', 'suggested', 'ambiguous', 'confirmed', 'rejected', 'auto_confirmed'].includes(text(decision.resultingStatus))
+            ? text(decision.resultingStatus)
+            : 'recorded',
+        recordedAt: decision.createdAt || null,
+        stale: sourceChanged(edge, decision, members),
+    }
+}
+
+function automaticLinkStatus(value) {
+    const status = text(value)
+    return ['pending', 'suggested', 'ambiguous', 'confirmed', 'rejected', 'auto_confirmed'].includes(status) ? status : 'recorded'
+}
+
+function automaticLinkTransition(value) {
+    const transition = text(value)
+    return ['automatic_activated', 'automatic_deactivated', 'confirmed', 'rejected', 'reversed'].includes(transition) ? transition : 'recorded'
+}
+
+export function buildIdentityReviewClusterPresentation({
+    members: inputMembers = [],
+    edges: inputEdges = [],
+    decisions = [],
+    lineage = [],
+    automaticLinkHistory = [],
+    historyByIdentity = {},
+    unitScope = null,
+    includeInternals = false,
+} = {}) {
+    const members = inputMembers.map(normalizeMember)
+        .filter((member) => IDENTITY_CLUSTER_SOURCE_TYPES.includes(member.sourceType) && member.sourceId)
+    const memberMap = new Map(members.map((member) => [memberKey(member), member]))
+    const dsu = new DisjointSet(members.map(memberKey))
+    const materialized = new Map()
+    for (const member of members) {
+        if (!member.identityId) continue
+        if (!materialized.has(member.identityId)) materialized.set(member.identityId, [])
+        materialized.get(member.identityId).push(memberKey(member))
+    }
+    for (const memberKeys of materialized.values()) for (const key of memberKeys.slice(1)) dsu.union(memberKeys[0], key)
+    const edges = inputEdges.map(normalizeEdge).filter((edge) => memberMap.has(`${edge.sourceType}:${edge.sourceId}`)
+        && memberMap.has(`${edge.targetType}:${edge.targetId}`))
+    // A rejected proposal is historical evidence, not a graph edge. It may
+    // be shown only when its endpoints are already connected through another
+    // active relationship; it must never create a cross-unit component.
+    const connectingEdges = edges.filter((edge) => edge.status !== 'rejected')
+    for (const edge of connectingEdges) dsu.union(`${edge.sourceType}:${edge.sourceId}`, `${edge.targetType}:${edge.targetId}`)
+    const groups = new Map()
+    for (const member of members) {
+        const root = dsu.find(memberKey(member))
+        if (!groups.has(root)) groups.set(root, { members: [], edges: [] })
+        groups.get(root).members.push(member)
+    }
+    for (const edge of connectingEdges) groups.get(dsu.find(`${edge.sourceType}:${edge.sourceId}`))?.edges.push(edge)
+    for (const edge of edges.filter((item) => item.status === 'rejected')) {
+        const sourceRoot = dsu.find(`${edge.sourceType}:${edge.sourceId}`)
+        const targetRoot = dsu.find(`${edge.targetType}:${edge.targetId}`)
+        if (sourceRoot === targetRoot) groups.get(sourceRoot)?.edges.push(edge)
+    }
+
+    const allowed = unitScope == null ? null : new Set(unique(unitScope))
+    const clusters = []
+    for (const group of groups.values()) {
+        const units = unique(group.members.flatMap((member) => member.units))
+        // A scoped manager must not learn that a cross-unit cluster exists.
+        if (allowed && (!units.length || units.some((unit) => !allowed.has(unit)))) continue
+        const identities = identitySummary(group.members)
+        const groupDecisions = group.edges.map((edge) => ({ decision: latestDecisionForEdge(decisions, edge), edge }))
+            .filter(({ decision }) => decision)
+        const stale = group.members.some((member) => member.sourceFreshness !== 'current' || member.changedAfterDecision)
+            || groupDecisions.some(({ decision, edge }) => sourceChanged(edge, decision, group.members))
+        const conflicts = conflictRows(group.members)
+        const histories = identities.map((identity) => historyByIdentity[identity.id] || {})
+        const undoReasons = []
+        if (histories.some((history) => Number(history.actions || 0) > 0)) undoReasons.push('commercial_actions_present')
+        if (histories.some((history) => Number(history.permissions || 0) > 0 || Number(history.permissionEvents || 0) > 0)) undoReasons.push('consent_history_present')
+        if (histories.some((history) => Number(history.auditIdentityEvents || 0) > 0)) undoReasons.push('identity_audit_history_present')
+        const clusterEdges = group.edges.map((edge) => ({ edge, presentation: explicitEvidence(edge) }))
+        const decisionHistory = groupDecisions.map(({ decision, edge }) => publicDecision(decision, edge, group.members))
+        const clusterKey = identityClusterFingerprint({
+            members: group.members.map((member) => [member.sourceType, member.sourceId]).sort(),
+            edges: group.edges.map(edgeKey).sort(),
+        }).slice(0, 32)
+        const version = identityClusterFingerprint({
+            members: group.members.map((member) => [member.sourceType, member.sourceId, member.sourceFingerprint, member.updatedAt]).sort(),
+            edges: group.edges.map((edge) => [edgeKey(edge), edge.status, edge.sourceVersion]).sort(),
+        })
+        const survivor = identities[0] || null
+        const bulkReview = classifyIdentityClusterBulkEligibility({
+            edges: group.edges,
+            conflicts,
+            decisions: groupDecisions.map(({ decision }) => decision),
+            undoBlocked: undoReasons.length > 0,
+            stale,
+        })
+        const currentDecision = stale ? 'stale'
+            : decisionHistory.some((decision) => decision.decision === 'confirmed') ? 'confirmed'
+                : decisionHistory.some((decision) => decision.decision === 'rejected') ? 'rejected' : 'pending'
+        const memberPresentations = group.members.map((member) => ({
+            source: member.sourceType,
+            sourceLabel: sourceLabel(member.sourceType),
+            name: member.name,
+            aliases: member.aliases,
+            units: member.units,
+            matchingFields: explicitMatchingFields(member),
+            freshness: member.sourceFreshness,
+            stale: member.changedAfterDecision || member.sourceFreshness !== 'current',
+            contact: { phone: member.phoneKeys.map(maskPhone).filter(Boolean), email: member.emailKeys.map(maskEmail).filter(Boolean), masked: true },
+        }))
+        const memberBySource = IDENTITY_CLUSTER_SOURCE_TYPES.map((source) => ({
+            source,
+            sourceLabel: sourceLabel(source),
+            count: memberPresentations.filter((member) => member.source === source).length,
+        })).filter((entry) => entry.count)
+        const clusterIdentityIds = new Set(identities.map((identity) => identity.id))
+        clusters.push({
+            schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+            clusterKey,
+            version,
+            summary: { memberCount: group.members.length, identityCount: identities.length, sourceCount: memberBySource.length, unitCount: units.length },
+            members: memberPresentations,
+            membersBySource: memberBySource,
+            units,
+            matchingFields: unique(group.edges.flatMap((edge) => edge.matchedFields)),
+            conflicts,
+            evidence: {
+                strong: clusterEdges.filter(({ presentation }) => presentation.strength === 'strong').map(({ presentation }) => presentation),
+                weak: clusterEdges.filter(({ presentation }) => presentation.strength === 'weak').map(({ presentation }) => presentation),
+            },
+            confidence: clusterEdges.length ? Math.round((clusterEdges.reduce((sum, { edge }) => sum + edge.confidence, 0) / clusterEdges.length) * 100) / 100 : 0,
+            decision: { state: currentDecision, count: decisionHistory.length, lastAt: decisionHistory.map((decision) => decision.recordedAt).filter(Boolean).sort().at(-1) || null },
+            decisionHistory,
+            materializations: groupDecisions.filter(({ decision }) => decision.materializationRunId || decision.runMode || decision.runStatus)
+                .map(({ decision }) => ({ mode: text(decision.runMode || (decision.decision === 'confirmed' ? 'confirm' : decision.decision === 'reversed' ? 'reverse' : 'reject')), status: text(decision.runStatus || 'applied'), recordedAt: decision.runCreatedAt || decision.createdAt || null, membersMoved: Number(decision.runMembersMoved || 0) })),
+            automaticLinks: group.edges.map((edge) => {
+                const presentation = explicitEvidence(edge)
+                return {
+                    source: presentation.source,
+                    target: presentation.target,
+                    status: automaticLinkStatus(edge.status),
+                    evidenceLabel: presentation.label,
+                    confidence: presentation.confidence,
+                    history: (automaticLinkHistory || []).filter((row) => edgeKey(row) === edgeKey(edge)).map((row) => ({
+                        transition: automaticLinkTransition(row.transition),
+                        resultingStatus: automaticLinkStatus(row.resultingStatus),
+                        recordedAt: row.createdAt || null,
+                    })),
+                }
+            }),
+            sourceChanges: group.members.filter((member) => member.changedAfterDecision || groupDecisions.some(({ decision, edge }) => sourceChanged(edge, decision, [member])))
+                .map((member) => ({ source: sourceLabel(member.sourceType), name: member.name, changedAt: member.updatedAt || null })),
+            staleState: stale ? 'stale' : 'current',
+            lineage: (lineage || []).filter((row) => clusterIdentityIds.has(text(row.predecessorIdentityId)) || clusterIdentityIds.has(text(row.successorIdentityId)))
+                .map((row) => ({ relation: text(row.relation), recordedAt: row.createdAt || null })),
+            impact: {
+                membersToMove: group.members.filter((member) => !survivor || member.identityId !== survivor.id).map((member) => ({ sourceLabel: sourceLabel(member.sourceType), name: member.name })),
+                survivorIdentity: publicIdentity(survivor),
+                retiredIdentities: identities.slice(1).map(publicIdentity),
+                commercialHistoryPresent: undoReasons.includes('commercial_actions_present'),
+                consentHistoryPresent: undoReasons.includes('consent_history_present'),
+                predictedAction: currentDecision === 'pending' && !conflicts.some((conflict) => conflict.severity === 'strong') ? 'merge_if_confirmed' : 'review_only',
+            },
+            undo: {
+                blocked: undoReasons.length > 0,
+                reasons: undoReasons,
+                blockingHistory: {
+                    commercialActions: histories.reduce((sum, history) => sum + Number(history.actions || 0), 0),
+                    consentPermissions: histories.reduce((sum, history) => sum + Number(history.permissions || 0), 0),
+                    consentEvents: histories.reduce((sum, history) => sum + Number(history.permissionEvents || 0), 0),
+                    identityAuditEvents: histories.reduce((sum, history) => sum + Number(history.auditIdentityEvents || 0), 0),
+                },
+            },
+            bulkReview,
+            privacy: { contactsMasked: true, technicalIdsHidden: true, revealRequired: true },
+            _identityIds: identities.map((identity) => identity.id),
+            _members: group.members,
+            _edges: group.edges,
+        })
+    }
+    const ordered = clusters.sort((left, right) => Number(right.bulkReview.eligible) - Number(left.bulkReview.eligible)
+        || right.confidence - left.confidence || left.clusterKey.localeCompare(right.clusterKey))
+    return includeInternals ? ordered : ordered.map(stripIdentityClusterInternals)
+}
+
+export function stripIdentityClusterInternals(cluster) {
+    if (!cluster) return null
+    const { _identityIds, _members, _edges, ...safe } = cluster
+    return safe
+}
+
+export function buildIdentityClusterBulkPreview(clusters = []) {
+    const eligible = clusters.filter((cluster) => cluster?.bulkReview?.eligible)
+    const blocked = clusters.filter((cluster) => !cluster?.bulkReview?.eligible)
+    return {
+        schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+        clusterCount: clusters.length,
+        eligibleCount: eligible.length,
+        blockedCount: blocked.length,
+        memberCount: clusters.reduce((sum, cluster) => sum + Number(cluster?.summary?.memberCount || 0), 0),
+        eligibleMembers: eligible.reduce((sum, cluster) => sum + Number(cluster?.summary?.memberCount || 0), 0),
+        blockedReasons: [...new Set(blocked.flatMap((cluster) => cluster?.bulkReview?.reasons || []))].sort(),
+        clusters: clusters.map((cluster) => ({ clusterKey: cluster.clusterKey, version: cluster.version, eligible: cluster.bulkReview.eligible, reasons: cluster.bulkReview.reasons })),
+    }
+}
+
+export function assertIdentityClusterConfirmation(payload = {}) {
+    const reason = text(payload.reason).replace(/\s+/g, ' ')
+    const expectedVersion = text(payload.expectedVersion)
+    if (reason.length < 3 || reason.length > 1000) throw Object.assign(new Error('IDENTITY_CLUSTER_REASON_REQUIRED'), { statusCode: 400 })
+    if (payload.confirmation !== 'REVIEW_CLUSTER') throw Object.assign(new Error('IDENTITY_CLUSTER_CONFIRMATION_REQUIRED'), { statusCode: 400 })
+    if (expectedVersion && expectedVersion.length > 200) throw Object.assign(new Error('IDENTITY_CLUSTER_VERSION_INVALID'), { statusCode: 400 })
+    return { reason, expectedVersion }
+}
+
+export function explicitRevealFields(payload = {}) {
+    const fields = unique(payload.fields).filter((field) => CONTACT_FIELDS.has(field))
+    if (!fields.length) throw Object.assign(new Error('IDENTITY_CLUSTER_REVEAL_FIELD_REQUIRED'), { statusCode: 400 })
+    return fields
+}

--- a/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
+++ b/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
@@ -96,6 +96,10 @@ function runtimeGrantStatements(target) {
     if (!role) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_RUNTIME_ROLE_UNKNOWN')
     return [
         `grant usage on schema crm_atendimento to ${role}`,
+        // Runtime readiness reads the append-only migration record.  Grant
+        // only SELECT: the runtime role must never apply or roll back schema
+        // migrations itself.
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
         `grant select, insert on table crm_atendimento.identity_cluster_review_operations to ${role}`,
         `grant select, insert on table crm_atendimento.identity_cluster_reveal_events to ${role}`,
     ]

--- a/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
+++ b/crm/api/server/atendimento/identityClusterWorkspaceMigration.js
@@ -1,0 +1,210 @@
+import { assertAtendimentoMigrationDestination, isStrictAtendimentoMigrationDestination, ATENDIMENTO_MIGRATION_TARGETS } from './migrationDestination.js'
+import { IDENTITY_GRAPH_LOCK_KEY } from './identityReviewWorkflow.js'
+
+export const IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID = '20260807_identity_cluster_workspace_v2'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITES = [
+    'global_client_identities',
+    'global_client_identity_members',
+    'identity_review_decisions',
+    'identity_materialization_runs',
+    'identity_member_history',
+    'identity_lineage',
+    'identity_source_link_history',
+    'commercial_actions',
+    'commercial_contact_permissions',
+    'commercial_contact_permission_events',
+    'audit_events',
+]
+
+// There is deliberately no DROP in this migration.  A retry after a partial
+// application only adds missing objects; it can never replace a prior ledger
+// trigger or discard evidence.
+const STATEMENTS = [
+    `create table if not exists crm_atendimento.identity_cluster_review_operations (
+        id uuid primary key default gen_random_uuid(),
+        operation_key text not null unique check (char_length(operation_key) between 8 and 320),
+        cluster_key text not null check (cluster_key ~ '^[a-f0-9]{32}$'),
+        cluster_version text not null check (cluster_version ~ '^[a-f0-9]{64}$'),
+        operation text not null check (operation in ('bulk_confirm')),
+        request_fingerprint text not null check (request_fingerprint ~ '^[a-f0-9]{64}$'),
+        actor_reference text not null check (actor_reference ~ '^[a-f0-9]{64}$'),
+        actor_role text not null check (actor_role in ('GESTOR','ADMIN')),
+        unit_scope jsonb not null default '[]'::jsonb,
+        result jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now()
+    )`,
+    `create table if not exists crm_atendimento.identity_cluster_reveal_events (
+        id uuid primary key default gen_random_uuid(),
+        cluster_key text not null check (cluster_key ~ '^[a-f0-9]{32}$'),
+        cluster_version text not null check (cluster_version ~ '^[a-f0-9]{64}$'),
+        fields jsonb not null check (jsonb_typeof(fields) = 'array'),
+        reason_digest text not null check (reason_digest ~ '^[a-f0-9]{64}$'),
+        actor_reference text not null check (actor_reference ~ '^[a-f0-9]{64}$'),
+        actor_role text not null check (actor_role in ('GESTOR','ADMIN')),
+        unit_scope jsonb not null default '[]'::jsonb,
+        created_at timestamptz not null default now()
+    )`,
+    `create index if not exists identity_cluster_review_operations_cluster_idx
+        on crm_atendimento.identity_cluster_review_operations(cluster_key, created_at desc)`,
+    `create index if not exists identity_cluster_reveal_events_cluster_idx
+        on crm_atendimento.identity_cluster_reveal_events(cluster_key, created_at desc)`,
+    `create or replace function crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()
+        returns trigger language plpgsql as $$
+        begin
+            raise exception 'identity cluster workspace ledger is append-only';
+        end $$`,
+    `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='crm_atendimento.identity_cluster_review_operations'::regclass
+            and tgname='identity_cluster_review_operations_immutable') then
+            execute 'create trigger identity_cluster_review_operations_immutable before update or delete on crm_atendimento.identity_cluster_review_operations for each row execute function crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+        end if;
+    end $$`,
+    `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='crm_atendimento.identity_cluster_review_operations'::regclass
+            and tgname='identity_cluster_review_operations_no_truncate') then
+            execute 'create trigger identity_cluster_review_operations_no_truncate before truncate on crm_atendimento.identity_cluster_review_operations for each statement execute function crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+        end if;
+    end $$`,
+    `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='crm_atendimento.identity_cluster_reveal_events'::regclass
+            and tgname='identity_cluster_reveal_events_immutable') then
+            execute 'create trigger identity_cluster_reveal_events_immutable before update or delete on crm_atendimento.identity_cluster_reveal_events for each row execute function crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+        end if;
+    end $$`,
+    `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='crm_atendimento.identity_cluster_reveal_events'::regclass
+            and tgname='identity_cluster_reveal_events_no_truncate') then
+            execute 'create trigger identity_cluster_reveal_events_no_truncate before truncate on crm_atendimento.identity_cluster_reveal_events for each statement execute function crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+        end if;
+    end $$`,
+]
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant select, insert on table crm_atendimento.identity_cluster_review_operations to ${role}`,
+        `grant select, insert on table crm_atendimento.identity_cluster_reveal_events to ${role}`,
+    ]
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    try {
+        await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    }
+}
+
+async function assertPrerequisites(client) {
+    const columns = PREREQUISITES.map((table, index) => `to_regclass('crm_atendimento.${table}') as relation_${index}`).join(',')
+    const result = await client.query(`select ${columns}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_PREREQUISITES_MISSING')
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+export function identityClusterWorkspaceMigrationPlan() {
+    return {
+        id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+        adds: ['identity_cluster_review_operations', 'identity_cluster_reveal_events'],
+        privacy: 'Stores opaque cluster keys, HMAC-derived actor references, field names, reason digests and aggregate results only; client contact values never enter the operational ledger.',
+        ledgerIntegrity: 'Both cluster ledgers reject UPDATE, DELETE and TRUNCATE without replacing pre-existing triggers.',
+        access: 'The runtime role receives SELECT/INSERT only; no runtime DDL, DELETE or UPDATE grant is required.',
+        rollback: 'Non-destructive: retains operation and reveal evidence, then records the workspace as unavailable.',
+    }
+}
+
+export async function applyIdentityClusterWorkspaceMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let open = false
+    const report = {
+        id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+        applied: false,
+        tables: ['identity_cluster_review_operations', 'identity_cluster_reveal_events'],
+        appendOnlyTables: ['identity_cluster_review_operations', 'identity_cluster_reveal_events'],
+    }
+    try {
+        await client.query('begin'); open = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+        await assertDestination(client, databaseUrl, target)
+        await assertPrerequisites(client)
+        await ensureRegistry(client)
+        for (const sql of STATEMENTS) await client.query(sql)
+        report.runtimeRole = RUNTIME_ROLES[target]
+        report.runtimeGrants = runtimeGrantStatements(target)
+        for (const sql of report.runtimeGrants) await client.query(sql)
+        report.applied = true
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values($1,now(),null,$2::jsonb)
+            on conflict(id) do update set applied_at=excluded.applied_at, rolled_back_at=null, details=excluded.details`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, JSON.stringify(report)])
+        await client.query('commit'); open = false
+        return report
+    } catch (error) {
+        if (open) {
+            try { await client.query('rollback') } catch { /* retain original migration error */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackIdentityClusterWorkspaceMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('IDENTITY_CLUSTER_WORKSPACE_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let open = false
+    try {
+        await client.query('begin'); open = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values($1,now(),now(),$2::jsonb)
+            on conflict(id) do update set rolled_back_at=now(), details=excluded.details`, [
+            IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+            JSON.stringify({ rollback: 'non-destructive', workspaceDisabled: true, evidenceRetained: true }),
+        ])
+        await client.query('commit'); open = false
+        return { id: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID, rolledBack: true, destructive: false, workspaceDisabled: true, evidenceRetained: true }
+    } catch (error) {
+        if (open) {
+            try { await client.query('rollback') } catch { /* retain original migration error */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export function identityClusterWorkspaceMigrationStatements() {
+    return [...STATEMENTS]
+}

--- a/crm/api/server/atendimento/migrations/20260807_identity_cluster_workspace_v2.down.sql
+++ b/crm/api/server/atendimento/migrations/20260807_identity_cluster_workspace_v2.down.sql
@@ -1,0 +1,2 @@
+-- Non-destructive rollback. Do not delete append-only operations or reveal
+-- evidence; the guarded migration runner only marks this workspace unavailable.

--- a/crm/api/server/atendimento/migrations/20260807_identity_cluster_workspace_v2.up.sql
+++ b/crm/api/server/atendimento/migrations/20260807_identity_cluster_workspace_v2.up.sql
@@ -1,0 +1,88 @@
+-- Execute through migrate-atendimento-identity-clusters.mjs --apply.
+-- This ledger contains only opaque cluster keys, HMAC-derived actor references,
+-- request/reason digests and aggregate outcomes. It never stores contacts.
+
+CREATE TABLE IF NOT EXISTS crm_atendimento.identity_cluster_review_operations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  operation_key text NOT NULL UNIQUE CHECK (char_length(operation_key) BETWEEN 8 AND 320),
+  cluster_key text NOT NULL CHECK (cluster_key ~ '^[a-f0-9]{32}$'),
+  cluster_version text NOT NULL CHECK (cluster_version ~ '^[a-f0-9]{64}$'),
+  operation text NOT NULL CHECK (operation IN ('bulk_confirm')),
+  request_fingerprint text NOT NULL CHECK (request_fingerprint ~ '^[a-f0-9]{64}$'),
+  actor_reference text NOT NULL CHECK (actor_reference ~ '^[a-f0-9]{64}$'),
+  actor_role text NOT NULL CHECK (actor_role IN ('GESTOR','ADMIN')),
+  unit_scope jsonb NOT NULL DEFAULT '[]'::jsonb,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS crm_atendimento.identity_cluster_reveal_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  cluster_key text NOT NULL CHECK (cluster_key ~ '^[a-f0-9]{32}$'),
+  cluster_version text NOT NULL CHECK (cluster_version ~ '^[a-f0-9]{64}$'),
+  fields jsonb NOT NULL CHECK (jsonb_typeof(fields) = 'array'),
+  reason_digest text NOT NULL CHECK (reason_digest ~ '^[a-f0-9]{64}$'),
+  actor_reference text NOT NULL CHECK (actor_reference ~ '^[a-f0-9]{64}$'),
+  actor_role text NOT NULL CHECK (actor_role IN ('GESTOR','ADMIN')),
+  unit_scope jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS identity_cluster_review_operations_cluster_idx
+  ON crm_atendimento.identity_cluster_review_operations(cluster_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS identity_cluster_reveal_events_cluster_idx
+  ON crm_atendimento.identity_cluster_reveal_events(cluster_key, created_at DESC);
+
+CREATE OR REPLACE FUNCTION crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'identity cluster workspace ledger is append-only';
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'crm_atendimento.identity_cluster_review_operations'::regclass
+      AND tgname = 'identity_cluster_review_operations_immutable'
+  ) THEN
+    EXECUTE 'CREATE TRIGGER identity_cluster_review_operations_immutable
+      BEFORE UPDATE OR DELETE ON crm_atendimento.identity_cluster_review_operations
+      FOR EACH ROW EXECUTE FUNCTION crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'crm_atendimento.identity_cluster_review_operations'::regclass
+      AND tgname = 'identity_cluster_review_operations_no_truncate'
+  ) THEN
+    EXECUTE 'CREATE TRIGGER identity_cluster_review_operations_no_truncate
+      BEFORE TRUNCATE ON crm_atendimento.identity_cluster_review_operations
+      FOR EACH STATEMENT EXECUTE FUNCTION crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'crm_atendimento.identity_cluster_reveal_events'::regclass
+      AND tgname = 'identity_cluster_reveal_events_immutable'
+  ) THEN
+    EXECUTE 'CREATE TRIGGER identity_cluster_reveal_events_immutable
+      BEFORE UPDATE OR DELETE ON crm_atendimento.identity_cluster_reveal_events
+      FOR EACH ROW EXECUTE FUNCTION crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'crm_atendimento.identity_cluster_reveal_events'::regclass
+      AND tgname = 'identity_cluster_reveal_events_no_truncate'
+  ) THEN
+    EXECUTE 'CREATE TRIGGER identity_cluster_reveal_events_no_truncate
+      BEFORE TRUNCATE ON crm_atendimento.identity_cluster_reveal_events
+      FOR EACH STATEMENT EXECUTE FUNCTION crm_atendimento.prevent_identity_cluster_workspace_ledger_mutation()';
+  END IF;
+END $$;

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -436,6 +436,60 @@ export function createAtendimentoRouter(options = {}) {
         }
     })
 
+    expressRouter.get('/commercial/identity-clusters', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.identityClusterWorkspace(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/identity-clusters/:clusterKey', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.identityClusterDetail(String(req.params.clusterKey || ''), req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/bulk/preview', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await store.previewIdentityClusterBulk(req.body || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/bulk/apply', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await store.applyIdentityClusterBulk({
+                    ...(req.body || {}),
+                    idempotencyKey: String(req.headers['idempotency-key'] || req.body?.idempotencyKey || '').trim(),
+                }, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/identity-clusters/:clusterKey/reveal', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await store.revealIdentityCluster({ ...(req.body || {}), clusterKey: String(req.params.clusterKey || '') }, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
     expressRouter.post('/commercial/review/:type/decision', async (req, res) => {
         try {
             if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -78,6 +78,19 @@ import {
     IDENTITY_REVIEW_WORKFLOW_MIGRATION_IDS,
     IDENTITY_REVIEW_WORKFLOW_MIGRATION_ID,
 } from './identityReviewMigration.js'
+import {
+    IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+    assertIdentityClusterConfirmation,
+    buildIdentityClusterBulkPreview,
+    buildIdentityReviewClusterPresentation,
+    explicitRevealFields,
+    identityClusterFingerprint,
+    identityClusterSourceFreshness,
+    stripIdentityClusterInternals,
+} from './identityClusterWorkspace.js'
+import {
+    IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID,
+} from './identityClusterWorkspaceMigration.js'
 
 let pool = null
 
@@ -4689,20 +4702,23 @@ function assertNoCurrentIdentityReviewDecision(latest, candidate) {
 
 async function createIdentityReviewDecision(client, {
     candidate, decision, reason, actor, sourceSnapshot = {}, materializationRunId = null,
-    resultingStatus = candidate.rawStatus, sourceVersion = candidate.version,
+    resultingStatus = candidate.rawStatus, sourceVersion = candidate.version, redactSourceSnapshot = false,
 }) {
     const actorIdentity = actorIdentityForMutation(actor)
-    const result = await client.query(`insert into crm_atendimento.identity_review_decisions(
-            materialization_run_id,review_type,source_id,target_id,decision,source_status,resulting_status,source_version,reason,actor,source_snapshot)
-        values($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11::jsonb) returning id::text,created_at`, [
-        materializationRunId, candidate.reviewType, candidate.sourceId, candidate.targetId, decision, candidate.rawStatus,
-        resultingStatus, sourceVersion, reason, JSON.stringify({ id: actorIdentity, role: actor?.role || '' }), JSON.stringify({
+    const persistedSnapshot = redactSourceSnapshot
+        ? { sourceVersion: candidate.version, evidenceRedacted: true, ...sourceSnapshot }
+        : {
             sourceName: candidate.sourceName,
             targetName: candidate.targetName,
             evidence: candidate.evidence,
             context: candidate.context,
             ...sourceSnapshot,
-        }),
+        }
+    const result = await client.query(`insert into crm_atendimento.identity_review_decisions(
+            materialization_run_id,review_type,source_id,target_id,decision,source_status,resulting_status,source_version,reason,actor,source_snapshot)
+        values($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11::jsonb) returning id::text,created_at`, [
+        materializationRunId, candidate.reviewType, candidate.sourceId, candidate.targetId, decision, candidate.rawStatus,
+        resultingStatus, sourceVersion, reason, JSON.stringify({ id: actorIdentity, role: actor?.role || '' }), JSON.stringify(persistedSnapshot),
     ])
     return result.rows[0]
 }
@@ -5019,6 +5035,525 @@ async function materializeIdentityReviewReversal(client, { candidate, reversesDe
     const summary = { reversesRunId: originalRunId, restoredMembers: history.rows.length, manualCanonicalMergeReversed: !!originalSummary.manualCanonicalMerge }
     await updateIdentityMaterializationRun(client, run.id, summary)
     return { ...run, summary }
+}
+
+async function identityClusterWorkspaceStatus(pgPool) {
+    const availability = await pgPool.query(`select
+        to_regclass('crm_atendimento.schema_migrations') as registry,
+        to_regclass('crm_atendimento.identity_cluster_review_operations') as operations,
+        to_regclass('crm_atendimento.identity_cluster_reveal_events') as reveals,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_cluster_review_operations')
+            and tgname='identity_cluster_review_operations_immutable' and tgenabled='O') as operations_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_cluster_review_operations')
+            and tgname='identity_cluster_review_operations_no_truncate' and tgenabled='O') as operations_no_truncate,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_cluster_reveal_events')
+            and tgname='identity_cluster_reveal_events_immutable' and tgenabled='O') as reveals_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.identity_cluster_reveal_events')
+            and tgname='identity_cluster_reveal_events_no_truncate' and tgenabled='O') as reveals_no_truncate`)
+    const row = availability.rows[0] || {}
+    if (!row.registry || !row.operations || !row.reveals || !row.operations_immutable || !row.operations_no_truncate || !row.reveals_immutable || !row.reveals_no_truncate) {
+        return { ready: false, migrationId: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID }
+    }
+    const migration = await pgPool.query(`select id from crm_atendimento.schema_migrations
+        where id=$1 and rolled_back_at is null`, [IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID])
+    return { ready: !!migration.rows[0]?.id, migrationId: IDENTITY_CLUSTER_WORKSPACE_MIGRATION_ID }
+}
+
+async function identityClusterSourceOperationCheckpoints(pgPool) {
+    const availability = await pgPool.query(`select to_regclass('crm_atendimento.clientes_source_operation_checkpoints') as checkpoints`)
+    if (!availability.rows[0]?.checkpoints) return {}
+    const checkpoints = await pgPool.query(`select source_id,last_status,validated_at,validated_snapshot_complete,reconciliation_required
+        from crm_atendimento.clientes_source_operation_checkpoints
+        where source_id = any($1::text[])`, [[
+        'atendimento.local_mirror',
+        'atendimento.google_sheet',
+        'vendas.caixa_google_sheet',
+        'cadastro.app_registrations',
+        'leads.supplemental_google_sheet',
+        'identity.global_graph',
+    ]])
+    return Object.fromEntries((checkpoints.rows || []).map((row) => [row.source_id, {
+        lastStatus: row.last_status,
+        validatedAt: row.validated_at,
+        validatedSnapshotComplete: row.validated_snapshot_complete === true,
+        reconciliationRequired: row.reconciliation_required === true,
+    }]))
+}
+
+function identityClusterEdgeSql() {
+    return [
+        `select 'attendance_name_merge'::text as review_type, m.left_client_id::text as source_id, m.right_client_id::text as target_id,
+                'attendance_client'::text as source_type, 'attendance_client'::text as target_type, m.status,
+                m.similarity::numeric as confidence, 'name'::text as method, m.evidence, m.updated_at,
+                md5(jsonb_build_object('type','attendance_name_merge','sourceId',m.left_client_id::text,
+                    'targetId',m.right_client_id::text,'status',m.status,'confidence',m.similarity,'evidence',m.evidence)::text) as source_version,
+                case when m.status='ambiguous' then 2 else 1 end as candidate_count
+           from crm_atendimento.client_merge_suggestions m
+          where m.status in ('pending','confirmed','rejected')`,
+        `select 'attendance_caixa'::text, link.client_id::text, link.caixa_customer_id::text,
+                'attendance_client'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence, link.updated_at,
+                md5(jsonb_build_object('type','attendance_caixa','sourceId',link.client_id::text,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end
+           from crm_atendimento.client_caixa_links link
+          where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'app_attendance'::text, link.app_registration_id, link.client_id::text,
+                'app_registration'::text, 'attendance_client'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence, link.updated_at,
+                md5(jsonb_build_object('type','app_attendance','sourceId',link.app_registration_id,
+                    'targetId',link.client_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end
+           from crm_atendimento.app_registration_attendance_links link
+          where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'app_caixa'::text, link.app_registration_id, link.caixa_customer_id::text,
+                'app_registration'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence, link.updated_at,
+                md5(jsonb_build_object('type','app_caixa','sourceId',link.app_registration_id,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end
+           from crm_atendimento.app_registration_caixa_links link
+          where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'lead_app'::text, link.source_profile_id, link.app_registration_id,
+                'lead_profile'::text, 'app_registration'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence, link.updated_at,
+                md5(jsonb_build_object('type','lead_app','sourceId',link.source_profile_id,
+                    'targetId',link.app_registration_id,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end
+           from crm_atendimento.supplemental_lead_profile_app_links link
+          where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+        `select 'lead_caixa'::text, link.source_profile_id, link.caixa_customer_id::text,
+                'lead_profile'::text, 'caixa_customer'::text, link.status, link.confidence::numeric,
+                link.method, link.evidence, link.updated_at,
+                md5(jsonb_build_object('type','lead_caixa','sourceId',link.source_profile_id,
+                    'targetId',link.caixa_customer_id::text,'status',link.status,'method',link.method,
+                    'confidence',link.confidence,'evidence',link.evidence)::text),
+                case when link.status='ambiguous' then 2 else 1 end
+           from crm_atendimento.supplemental_lead_profile_caixa_links link
+          where link.status in ('suggested','ambiguous','confirmed','rejected','auto_confirmed')`,
+    ].join(' union all ')
+}
+
+function clusterEvidenceArray(value, keys) {
+    const source = value && typeof value === 'object' ? value : {}
+    for (const key of keys) {
+        if (Array.isArray(source[key])) return source[key].map((entry) => String(entry || '').trim()).filter(Boolean)
+    }
+    return []
+}
+
+function clusterValidatedMatch(row) {
+    const method = String(row?.method || '').trim()
+    return ['exact_phone', 'exact_email', 'exact_name_phone', 'exact_name_phone_sales_unit', 'phone_sales_attendance_anchor', 'spelling_same_caixa_customer'].includes(method)
+        || clusterEvidenceArray(row?.evidence, ['matchedFields', 'sharedFields']).some((field) => field === 'phone' || field === 'email')
+}
+
+async function queryIdentityClusterGraph(pgPool, actor, query = {}) {
+    const unitSlugs = commercialUnitSlugsForQuery(actor, query?.unit)
+    const edgeResult = await pgPool.query(`select * from (${identityClusterEdgeSql()}) cluster_edges`)
+    const edgeRows = edgeResult.rows || []
+    if (!edgeRows.length) {
+        return {
+            clusters: [],
+            graph: { members: 0, edges: 0 },
+            unitSlugs,
+            workflow: await identityReviewWorkflowStatus(pgPool),
+            workspace: await identityClusterWorkspaceStatus(pgPool),
+        }
+    }
+    const endpoints = edgeRows.flatMap((row) => [
+        { sourceType: row.source_type, sourceId: row.source_id },
+        { sourceType: row.target_type, sourceId: row.target_id },
+    ]).filter((entry) => entry.sourceType && entry.sourceId)
+    const endpointPayload = JSON.stringify([...new Map(endpoints.map((entry) => [`${entry.sourceType}:${entry.sourceId}`, entry])).values()])
+    const identityMembers = await pgPool.query(`with endpoints as (
+            select source_type,source_id from jsonb_to_recordset($1::jsonb) as endpoint(source_type text,source_id text)
+        ), selected_identities as (
+            select distinct member.identity_id
+              from crm_atendimento.global_client_identity_members member
+              join endpoints endpoint on endpoint.source_type=member.source_type and endpoint.source_id=member.source_id
+        )
+        select member.identity_id::text as identity_id, identity.canonical_name as identity_name,
+               identity.created_at as identity_created_at, member.source_type, member.source_id, member.updated_at
+          from crm_atendimento.global_client_identity_members member
+          join crm_atendimento.global_client_identities identity on identity.id=member.identity_id
+         where member.identity_id in (select identity_id from selected_identities)`, [endpointPayload])
+    const requested = [...new Map([
+        ...endpoints,
+        ...(identityMembers.rows || []).map((row) => ({ sourceType: row.source_type, sourceId: row.source_id })),
+    ].map((entry) => [`${entry.sourceType}:${entry.sourceId}`, entry])).values()]
+    const idsBySource = Object.fromEntries(['attendance_client', 'caixa_customer', 'app_registration', 'lead_profile'].map((sourceType) => [
+        sourceType,
+        requested.filter((entry) => entry.sourceType === sourceType).map((entry) => String(entry.sourceId)),
+    ]))
+    const [attendance, caixa, app, leads, decisions, lineage, sourceLinkHistory, sourceOperationCheckpoints] = await Promise.all([
+        pgPool.query(`select 'attendance_client'::text as source_type, client.id::text as source_id,
+                client.canonical_name as name,
+                coalesce(array_agg(distinct alias.alias_name order by alias.alias_name) filter (where alias.alias_name is not null), '{}'::text[]) as aliases,
+                coalesce(array_agg(distinct unit.slug order by unit.slug) filter (where unit.slug is not null), '{}'::text[]) as unit_slugs,
+                '[]'::jsonb as phone_keys, '[]'::jsonb as email_keys, '[]'::jsonb as cpf_keys, client.updated_at,
+                md5(concat_ws('|',client.id::text,client.canonical_name,client.updated_at::text)) as source_fingerprint
+           from crm_atendimento.canonical_clients client
+           left join crm_atendimento.client_aliases alias on alias.client_id=client.id
+           left join crm_atendimento.attendance_client_links link on link.client_id=client.id
+           left join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+           left join crm_atendimento.units unit on unit.id=attendance.unit_id
+          where client.id::text=any($1::text[])
+          group by client.id,client.canonical_name,client.updated_at`, [idsBySource.attendance_client]),
+        pgPool.query(`select 'caixa_customer'::text as source_type, customer.id::text as source_id,
+                customer.name, '{}'::text[] as aliases,
+                coalesce(array_agg(distinct unit.slug order by unit.slug) filter (where unit.slug is not null), '{}'::text[]) as unit_slugs,
+                case when nullif(customer.phone_key,'') is null then '[]'::jsonb else jsonb_build_array(customer.phone_key) end as phone_keys,
+                '[]'::jsonb as email_keys, '[]'::jsonb as cpf_keys, customer.updated_at,
+                md5(concat_ws('|',customer.id::text,customer.name,customer.phone_key,customer.updated_at::text)) as source_fingerprint
+           from crm_caixa.customers customer
+           left join crm_caixa.sales sale on sale.customer_id=customer.id
+           left join crm_atendimento.units unit on unit.id=sale.unit_id
+          where customer.id::text=any($1::text[])
+          group by customer.id,customer.name,customer.phone_key,customer.updated_at`, [idsBySource.caixa_customer]),
+        pgPool.query(`select 'app_registration'::text as source_type, source_client_id as source_id,
+                canonical_name as name,name_variants as aliases,unit_slugs,phone_keys,email_keys,cpf_keys,updated_at,
+                md5(jsonb_build_object('id',source_client_id,'name',canonical_name,'phones',phone_keys,'emails',email_keys,'units',unit_slugs,'updatedAt',updated_at)::text) as source_fingerprint
+           from crm_atendimento.app_client_registrations where source_client_id=any($1::text[])`, [idsBySource.app_registration]),
+        pgPool.query(`select 'lead_profile'::text as source_type, source_profile_id as source_id,
+                canonical_name as name,name_variants as aliases,unit_slugs,phone_keys,email_keys,'[]'::jsonb as cpf_keys,updated_at,
+                md5(jsonb_build_object('id',source_profile_id,'name',canonical_name,'phones',phone_keys,'emails',email_keys,'units',unit_slugs,'updatedAt',updated_at)::text) as source_fingerprint
+           from crm_atendimento.supplemental_lead_profiles where source_profile_id=any($1::text[])`, [idsBySource.lead_profile]),
+        pgPool.query(`select decision.event_order,decision.review_type,decision.source_id,decision.target_id,decision.decision,
+                decision.resulting_status,decision.source_version,decision.created_at,decision.materialization_run_id::text as materialization_run_id,
+                run.mode as run_mode,run.status as run_status,run.created_at as run_created_at,
+                coalesce(case when run.summary->>'membersMoved' ~ '^[0-9]+$' then (run.summary->>'membersMoved')::int else 0 end,0) as run_members_moved
+           from crm_atendimento.identity_review_decisions decision
+           left join crm_atendimento.identity_materialization_runs run on run.id=decision.materialization_run_id
+          order by decision.event_order desc`),
+        pgPool.query(`select predecessor_identity_id::text as predecessor_identity_id,successor_identity_id::text as successor_identity_id,relation,created_at
+           from crm_atendimento.identity_lineage order by created_at desc`),
+        pgPool.query(`select link_type as review_type,source_type,source_id,target_type,target_id,transition,resulting_status,origin,created_at
+           from crm_atendimento.identity_source_link_history order by created_at desc`),
+        identityClusterSourceOperationCheckpoints(pgPool),
+    ])
+    const sourceMap = new Map()
+    const now = new Date()
+    for (const row of [...attendance.rows, ...caixa.rows, ...app.rows, ...leads.rows]) {
+        sourceMap.set(`${row.source_type}:${row.source_id}`, {
+            sourceType: row.source_type, sourceId: row.source_id, name: row.name, canonicalName: row.name,
+            aliases: row.aliases, unitSlugs: row.unit_slugs, phoneKeys: row.phone_keys, emailKeys: row.email_keys,
+            cpfKeys: row.cpf_keys, updatedAt: row.updated_at, sourceFingerprint: row.source_fingerprint,
+            sourceFreshness: identityClusterSourceFreshness(row.source_type, sourceOperationCheckpoints, now),
+        })
+    }
+    const members = (identityMembers.rows || []).map((row) => ({
+        ...(sourceMap.get(`${row.source_type}:${row.source_id}`) || {}),
+        sourceType: row.source_type, sourceId: row.source_id, identityId: row.identity_id,
+        identityName: row.identity_name, identityCreatedAt: row.identity_created_at,
+        updatedAt: sourceMap.get(`${row.source_type}:${row.source_id}`)?.updatedAt || row.updated_at,
+    }))
+    const present = new Set(members.map((member) => `${member.sourceType}:${member.sourceId}`))
+    for (const endpoint of endpoints) {
+        const key = `${endpoint.sourceType}:${endpoint.sourceId}`
+        if (present.has(key) || !sourceMap.has(key)) continue
+        members.push({ ...sourceMap.get(key), identityId: '', identityName: sourceMap.get(key).name, identityCreatedAt: null })
+    }
+    const edges = edgeRows.map((row) => ({
+        reviewType: row.review_type, sourceType: row.source_type, sourceId: row.source_id,
+        targetType: row.target_type, targetId: row.target_id, status: row.status,
+        confidence: Number(row.confidence || 0), method: row.method,
+        matchedFields: clusterEvidenceArray(row.evidence, ['matchedFields', 'sharedFields']),
+        sharedUnits: clusterEvidenceArray(row.evidence, ['sharedUnits']),
+        sourceVersion: row.source_version, candidateCount: Number(row.candidate_count || 0),
+        validatedMatch: clusterValidatedMatch(row),
+    }))
+    const identityIds = [...new Set((identityMembers.rows || []).map((row) => row.identity_id).filter(Boolean))]
+    const history = identityIds.length ? await pgPool.query(`select identity_id::text as identity_id,
+            count(*) filter (where source='commercial_action')::int as actions,
+            count(*) filter (where source='commercial_permission')::int as permissions,
+            count(*) filter (where source='commercial_permission_event')::int as permission_events,
+            count(*) filter (where source='identity_audit')::int as audit_identity_events
+          from (
+            select action.identity_id,'commercial_action'::text as source from crm_atendimento.commercial_actions action where action.identity_id=any($1::uuid[])
+            union all select permission.identity_id,'commercial_permission'::text from crm_atendimento.commercial_contact_permissions permission where permission.identity_id=any($1::uuid[])
+            union all select event.identity_id,'commercial_permission_event'::text from crm_atendimento.commercial_contact_permission_events event where event.identity_id=any($1::uuid[])
+            union all select case when payload->>'identityId' ~ '^[0-9a-fA-F-]{36}$' then (payload->>'identityId')::uuid else null end,'identity_audit'::text from crm_atendimento.audit_events
+              where nullif(payload->>'identityId','') is not null
+          ) events where identity_id is not null group by identity_id`, [identityIds]) : { rows: [] }
+    const clusters = buildIdentityReviewClusterPresentation({
+        members,
+        edges,
+        decisions: (decisions.rows || []).map((row) => ({
+            eventOrder: row.event_order, reviewType: row.review_type, sourceId: row.source_id, targetId: row.target_id,
+            decision: row.decision, resultingStatus: row.resulting_status, sourceVersion: row.source_version,
+            createdAt: row.created_at, materializationRunId: row.materialization_run_id, runMode: row.run_mode,
+            runStatus: row.run_status, runCreatedAt: row.run_created_at, runMembersMoved: row.run_members_moved,
+        })),
+        lineage: (lineage.rows || []).map((row) => ({ predecessorIdentityId: row.predecessor_identity_id, successorIdentityId: row.successor_identity_id, relation: row.relation, createdAt: row.created_at })),
+        automaticLinkHistory: (sourceLinkHistory.rows || []).map((row) => ({ reviewType: row.review_type, sourceType: row.source_type, sourceId: row.source_id, targetType: row.target_type, targetId: row.target_id, transition: row.transition, resultingStatus: row.resulting_status, origin: row.origin, createdAt: row.created_at })),
+        historyByIdentity: Object.fromEntries((history.rows || []).map((row) => [row.identity_id, row])),
+        unitScope: unitSlugs,
+        includeInternals: true,
+    })
+    const search = normalizeText(query?.q || query?.search || '')
+    const includeResolved = String(query?.includeResolved || '').toLowerCase() === 'true'
+    const staleOnly = String(query?.stale || '').toLowerCase() === 'true'
+    const status = String(query?.status || '').trim()
+    const visibleClusters = clusters.filter((cluster) => {
+        if (!includeResolved && ['confirmed', 'rejected'].includes(cluster.decision.state)) return false
+        if (staleOnly && cluster.staleState !== 'stale') return false
+        if (status && cluster.decision.state !== status) return false
+        if (!search) return true
+        return cluster._members.flatMap((member) => [member.name, ...member.aliases, ...member.units]).join(' ').toLowerCase().includes(search)
+    })
+    return {
+        clusters: visibleClusters,
+        // Unit-scoped managers must never receive global traversal counts. The
+        // aggregate mirrors exactly the already-authorized, filtered graph.
+        graph: {
+            members: visibleClusters.reduce((sum, cluster) => sum + Number(cluster.summary?.memberCount || 0), 0),
+            edges: visibleClusters.reduce((sum, cluster) => sum + Number(cluster._edges?.length || 0), 0),
+        },
+        unitSlugs,
+        workflow: await identityReviewWorkflowStatus(pgPool),
+        workspace: await identityClusterWorkspaceStatus(pgPool),
+    }
+}
+
+function findIdentityCluster(clusters, clusterKey) {
+    const key = String(clusterKey || '').trim()
+    return (clusters || []).find((cluster) => cluster.clusterKey === key) || null
+}
+
+async function assertIdentityClusterWorkspaceReady(pgPool) {
+    const status = await identityClusterWorkspaceStatus(pgPool)
+    if (status.ready) return status
+    throw identityReviewError('IDENTITY_CLUSTER_WORKSPACE_NOT_READY', 409)
+}
+
+function identityClusterAuditSecret() {
+    const secret = String(
+        process.env.ATENDIMENTO_ACTOR_HMAC_KEY ||
+        process.env.ESCALA_ACTOR_HMAC_KEY ||
+        process.env.CRM_ESCALA_HMAC_KEY || '',
+    ).trim()
+    if (secret.length < 32) throw identityReviewError('IDENTITY_CLUSTER_AUDIT_KEY_REQUIRED', 503)
+    return secret
+}
+
+function identityClusterAuditDigest(actor, purpose, value) {
+    const actorIdentity = actorIdentityForMutation(actor)
+    return createHmac('sha256', identityClusterAuditSecret())
+        .update(`${purpose}:${actorIdentity}:${JSON.stringify(value)}`)
+        .digest('hex')
+}
+
+function identityClusterAuditActor(actor) {
+    const actorReference = identityClusterAuditDigest(actor, 'actor', { version: 1 })
+    const role = String(actor?.role || '').trim().toUpperCase()
+    if (!['GESTOR', 'ADMIN'].includes(role)) throw commercialScopeError('COMMERCIAL_UNIT_FORBIDDEN')
+    const scope = commercialUnitScope(actor)
+    return {
+        actorReference,
+        actorRole: role,
+        unitScope: scope === null ? ['global'] : scope,
+        mutationActor: {
+            ...actor,
+            id: actorReference,
+            username: undefined,
+            email: undefined,
+            name: undefined,
+            displayName: undefined,
+        },
+    }
+}
+
+function identityClusterExpectedVersions(payload = {}, requestedKeys = []) {
+    if (!payload.expectedVersions || typeof payload.expectedVersions !== 'object' || Array.isArray(payload.expectedVersions)) {
+        throw identityReviewError('IDENTITY_CLUSTER_EXPECTED_VERSIONS_REQUIRED')
+    }
+    const expectedVersions = payload.expectedVersions
+    const expectedKeys = Object.keys(expectedVersions).sort()
+    const requested = [...new Set(requestedKeys)].sort()
+    if (expectedKeys.length !== requested.length || expectedKeys.some((key, index) => key !== requested[index])) {
+        throw identityReviewError('IDENTITY_CLUSTER_EXPECTED_VERSIONS_REQUIRED')
+    }
+    for (const key of requested) {
+        if (!/^[a-f0-9]{64}$/.test(String(expectedVersions[key] || '').trim())) {
+            throw identityReviewError('IDENTITY_CLUSTER_VERSION_REQUIRED')
+        }
+    }
+    return expectedVersions
+}
+
+function identityClusterSelection(payload = {}) {
+    const keys = [...new Set((Array.isArray(payload.clusterKeys) ? payload.clusterKeys : [])
+        .map((value) => String(value || '').trim())
+        .filter((value) => /^[a-f0-9]{32}$/.test(value)))]
+    if (!keys.length || keys.length > 50) throw identityReviewError('IDENTITY_CLUSTER_BULK_SELECTION_REQUIRED')
+    return keys
+}
+
+async function applyIdentityClusterBulkTransaction(client, payload, actor) {
+    const { reason } = assertIdentityClusterConfirmation(payload)
+    const requestedKeys = identityClusterSelection(payload)
+    const expectedVersions = identityClusterExpectedVersions(payload, requestedKeys)
+    const idempotencyKey = normalizeIdempotencyKey(payload.idempotencyKey)
+    if (!idempotencyKey) throw identityReviewError('IDENTITY_CLUSTER_IDEMPOTENCY_KEY_REQUIRED')
+    const auditActor = identityClusterAuditActor(actor)
+    const requests = requestedKeys.map((clusterKey) => {
+        const expectedVersion = String(expectedVersions[clusterKey] || '').trim()
+        return {
+            clusterKey,
+            expectedVersion,
+            // A caller-controlled idempotency key can contain arbitrary text.
+            // Store only an opaque HMAC reference in the append-only ledger.
+            operationKey: identityClusterAuditDigest(actor, 'bulk-operation', { clusterKey, idempotencyKey }),
+            requestFingerprint: identityClusterAuditDigest(actor, 'bulk-request', {
+                clusterKey,
+                expectedVersion,
+                reason,
+                idempotencyKey,
+            }),
+        }
+    })
+    const resultsByKey = new Map()
+    const pending = []
+    for (const request of requests) {
+        const existing = await client.query(`select result,request_fingerprint from crm_atendimento.identity_cluster_review_operations
+            where operation_key=$1 for update`, [request.operationKey])
+        if (!existing.rows[0]) {
+            pending.push(request)
+            continue
+        }
+        if (existing.rows[0].request_fingerprint !== request.requestFingerprint) throw identityReviewError('IDENTITY_CLUSTER_IDEMPOTENCY_CONFLICT', 409)
+        resultsByKey.set(request.clusterKey, { clusterKey: request.clusterKey, idempotent: true, ...(existing.rows[0].result || {}) })
+    }
+    // Read and mutate the graph only for new commands. A successful first
+    // command changes the current graph version; replays must resolve from the
+    // immutable operation ledger before that version comparison can occur.
+    const graph = pending.length
+        ? await queryIdentityClusterGraph(client, actor, { unit: payload.unit, includeResolved: true })
+        : null
+    for (const request of pending) {
+        const { clusterKey, expectedVersion, operationKey, requestFingerprint } = request
+        const cluster = findIdentityCluster(graph?.clusters, clusterKey)
+        if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+        if (!expectedVersion || expectedVersion !== cluster.version) throw identityReviewError('IDENTITY_CLUSTER_CONFLICT', 409)
+        if (!cluster.bulkReview.eligible) throw identityReviewError('IDENTITY_CLUSTER_BULK_NOT_ELIGIBLE', 409)
+        // The core decision ledger is retained for undo dependency analysis.
+        // Keep this new path free of operator-entered text: the HMAC digest is
+        // the auditable proof of the required justification.
+        const decisionReason = `identity_cluster_reason:${requestFingerprint}`
+        let clusterMoved = 0
+        for (const edge of cluster._edges) {
+            const normalized = {
+                reviewType: edge.reviewType,
+                sourceId: edge.sourceId,
+                targetId: edge.targetId,
+                survivorClientId: null,
+            }
+            await acquireIdentityReviewLocks(client, { ...normalized, ...IDENTITY_REVIEW_DEFINITIONS[edge.reviewType] })
+            const candidate = await readIdentityReviewCandidate(client, normalized)
+            await assertCommercialReviewCandidateScope(client, actor, candidate)
+            assertIdentityReviewCandidateVersion(candidate, edge.sourceVersion)
+            const latest = await readLatestIdentityReviewDecision(client, candidate)
+            assertNoCurrentIdentityReviewDecision(latest, candidate)
+            const sourceState = await writeIdentityReviewSourceStatus(client, candidate, 'confirmed', auditActor.mutationActor)
+            const materialization = await materializeIdentityReviewConfirmation(client, { candidate, actor: auditActor.mutationActor })
+            const sourceLinkTransitions = await recordIdentityReviewSourceLinkTransition(client, {
+                materializationRunId: materialization.id,
+                candidate,
+                previousStatus: candidate.rawStatus,
+                resultingStatus: sourceState.rawStatus,
+                origin: 'identity_cluster_bulk_review_v2',
+            })
+            await createIdentityReviewDecision(client, {
+                candidate,
+                decision: 'confirmed',
+                reason: decisionReason,
+                actor: auditActor.mutationActor,
+                materializationRunId: materialization.id,
+                resultingStatus: sourceState.rawStatus,
+                sourceVersion: sourceState.version,
+                redactSourceSnapshot: true,
+                sourceSnapshot: {
+                    clusterKey,
+                    previousSourceVersion: candidate.version,
+                    sourceLinkTransitions: sourceLinkTransitions.length,
+                },
+            })
+            clusterMoved += Number(materialization.summary?.membersMoved || 0)
+        }
+        const result = { membersMoved: clusterMoved, decisionState: 'confirmed' }
+        await client.query(`insert into crm_atendimento.identity_cluster_review_operations(
+                operation_key,cluster_key,cluster_version,operation,request_fingerprint,actor_reference,actor_role,unit_scope,result)
+            values($1,$2,$3,'bulk_confirm',$4,$5,$6,$7::jsonb,$8::jsonb)`, [
+            operationKey,
+            cluster.clusterKey,
+            cluster.version,
+            requestFingerprint,
+            auditActor.actorReference,
+            auditActor.actorRole,
+            JSON.stringify(auditActor.unitScope),
+            JSON.stringify(result),
+        ])
+        resultsByKey.set(clusterKey, { clusterKey, idempotent: false, ...result })
+    }
+    const results = requests.map((request) => resultsByKey.get(request.clusterKey)).filter(Boolean)
+    return {
+        schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+        idempotent: results.every((result) => result.idempotent),
+        appliedClusters: results.length,
+        membersMoved: results.reduce((sum, result) => sum + Number(result.membersMoved || 0), 0),
+        results,
+    }
+}
+
+// Kept deliberately narrow for deterministic unit tests of the ledger replay
+// boundary. It is not an HTTP surface and does not expose raw graph members.
+export const __identityClusterWorkspaceTestables = Object.freeze({
+    applyIdentityClusterBulkTransaction,
+    identityClusterExpectedVersions,
+    identityClusterSelection,
+})
+
+async function revealIdentityCluster(client, payload, actor) {
+    const { reason, expectedVersion } = assertIdentityClusterConfirmation(payload)
+    if (!expectedVersion) throw identityReviewError('IDENTITY_CLUSTER_VERSION_REQUIRED')
+    const fields = explicitRevealFields(payload)
+    const graph = await queryIdentityClusterGraph(client, actor, { unit: payload.unit, includeResolved: true })
+    const cluster = findIdentityCluster(graph.clusters, payload.clusterKey)
+    if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+    if (cluster.version !== expectedVersion) throw identityReviewError('IDENTITY_CLUSTER_CONFLICT', 409)
+    const auditActor = identityClusterAuditActor(actor)
+    const reasonDigest = identityClusterAuditDigest(actor, 'reveal-reason', { clusterKey: cluster.clusterKey, reason })
+    const inserted = await client.query(`insert into crm_atendimento.identity_cluster_reveal_events(
+            cluster_key,cluster_version,fields,reason_digest,actor_reference,actor_role,unit_scope)
+        values($1,$2,$3::jsonb,$4,$5,$6,$7::jsonb) returning id::text,created_at`, [
+        cluster.clusterKey,
+        cluster.version,
+        JSON.stringify(fields),
+        reasonDigest,
+        auditActor.actorReference,
+        auditActor.actorRole,
+        JSON.stringify(auditActor.unitScope),
+    ])
+    const contacts = cluster._members.map((member) => ({
+        sourceLabel: ({ attendance_client: 'Atendimento', caixa_customer: 'Caixa', app_registration: 'Cadastro do app', lead_profile: 'Leads e planilhas' })[member.sourceType] || 'Fonte',
+        name: member.name,
+        phone: fields.includes('phone') ? [...new Set(member.phoneKeys)].filter(Boolean) : [],
+        email: fields.includes('email') ? [...new Set(member.emailKeys)].filter(Boolean) : [],
+    })).filter((entry) => entry.phone.length || entry.email.length)
+    return {
+        clusterKey: cluster.clusterKey,
+        version: cluster.version,
+        revealRecorded: Boolean(inserted.rows[0]?.id),
+        revealedAt: inserted.rows[0]?.created_at || null,
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+        contacts,
+        privacy: { explicitAction: true, reasonRecorded: true, metricsAndLogsRedacted: true },
+    }
 }
 
 export function createAtendimentoStore(options = {}) {
@@ -5459,6 +5994,85 @@ export function createAtendimentoStore(options = {}) {
                 },
                 profiles: (serverPage ? filtered : filtered.slice(offset, offset + limit)).map(minimizeCommercialProfile),
             }
+        },
+
+        async identityClusterWorkspace(query, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, query || {})
+            const limit = sanitizeLimit(query?.limit, 50, 100)
+            const offset = sanitizeOffset(query?.offset, 0)
+            const page = graph.clusters.slice(offset, offset + limit)
+            return {
+                schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+                total: graph.clusters.length,
+                limit,
+                offset,
+                clusters: page.map(stripIdentityClusterInternals),
+                workflow: { writesReady: graph.workflow.ready },
+                workspace: graph.workspace,
+                graph: graph.graph,
+                pagination: { hasPrevious: offset > 0, hasNext: offset + page.length < graph.clusters.length },
+            }
+        },
+
+        async identityClusterDetail(clusterKey, query, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, { ...(query || {}), includeResolved: true })
+            const cluster = findIdentityCluster(graph.clusters, clusterKey)
+            if (!cluster) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+            return {
+                schemaVersion: IDENTITY_CLUSTER_PRESENTATION_SCHEMA,
+                cluster: stripIdentityClusterInternals(cluster),
+                workflow: { writesReady: graph.workflow.ready },
+                workspace: graph.workspace,
+            }
+        },
+
+        async previewIdentityClusterBulk(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            const graph = await queryIdentityClusterGraph(pgPool, actor, { unit: payload?.unit, includeResolved: true })
+            const requested = identityClusterSelection(payload || {})
+            const selected = graph.clusters.filter((cluster) => requested.includes(cluster.clusterKey))
+            // Do not turn an out-of-scope selection into a partial preview: it
+            // would conceal a scope error and make later application diverge.
+            if (selected.length !== requested.length) throw identityReviewError('IDENTITY_CLUSTER_NOT_FOUND', 404)
+            return {
+                ...buildIdentityClusterBulkPreview(selected),
+                workspace: graph.workspace,
+                workflow: { writesReady: graph.workflow.ready },
+            }
+        },
+
+        async applyIdentityClusterBulk(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            await assertIdentityReviewWorkflowReady(pgPool)
+            await assertIdentityClusterWorkspaceReady(pgPool)
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                await assertIdentityReviewWorkflowReady(client)
+                await assertIdentityClusterWorkspaceReady(client)
+                return applyIdentityClusterBulkTransaction(client, payload || {}, actor)
+            })
+        },
+
+        async revealIdentityCluster(payload, actor) {
+            await ensureReady()
+            assertCommercialManager(actor)
+            await assertIdentityReviewSource(pgPool)
+            await assertIdentityClusterWorkspaceReady(pgPool)
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                await assertIdentityClusterWorkspaceReady(client)
+                return revealIdentityCluster(client, payload || {}, actor)
+            })
         },
 
         async identityReviewQueue(query, actor) {

--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AlertTriangle, CalendarClock, CheckCircle2, ChevronRight, CircleDollarSign, RefreshCw, Save, ShieldCheck, UserRoundCheck, UsersRound } from 'lucide-react'
 import { Button } from '@/button'
+import { IdentityClusterWorkspace } from './IdentityClusterWorkspace'
 import {
   createCommercialAction,
   commercialCadenceManagerStatuses,
@@ -806,6 +807,6 @@ export function ClientCommercialModule() {
     </div>
     <footer className="flex items-center gap-2 text-xs text-slate-500"><CheckCircle2 className="h-4 w-4 text-emerald-400" />Recência = último procedimento realizado. Vendas e procedimentos continuam separados no perfil comercial.</footer>
     </> : null}
-    {workspaceView === 'identities' ? <IdentityReviewQueue /> : null}
+    {workspaceView === 'identities' ? <div className="space-y-6"><IdentityClusterWorkspace /><IdentityReviewQueue /></div> : null}
   </section>
 }

--- a/crm/console/IdentityClusterWorkspace.tsx
+++ b/crm/console/IdentityClusterWorkspace.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Eye, GitBranch, LockKeyhole, RefreshCw, ShieldAlert, UsersRound } from 'lucide-react'
+import { Button } from '@/button'
+import {
+  applyIdentityClusterBulk,
+  fetchIdentityClusterDetail,
+  fetchIdentityClusterWorkspace,
+  previewIdentityClusterBulk,
+  revealIdentityCluster,
+  type IdentityClusterBulkPreview,
+  type IdentityReviewCluster,
+} from '@/atendimentoApi'
+
+type ClusterFilters = { q: string; unit: string; stale: boolean; includeResolved: boolean }
+
+const defaultFilters: ClusterFilters = { q: '', unit: 'all', stale: false, includeResolved: false }
+
+function readUrlState(): ClusterFilters & { clusterKey: string } {
+  if (typeof window === 'undefined') return { ...defaultFilters, clusterKey: '' }
+  const params = new URLSearchParams(window.location.search)
+  return {
+    q: params.get('identityClusterQ') || '',
+    unit: params.get('identityClusterUnit') || 'all',
+    stale: params.get('identityClusterStale') === 'true',
+    includeResolved: params.get('identityClusterResolved') === 'true',
+    clusterKey: params.get('identityCluster') || '',
+  }
+}
+
+function writeUrl(filters: ClusterFilters, clusterKey: string, historyMode: 'replace' | 'push' = 'replace') {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  const set = (key: string, value: string, defaultValue = '') => value && value !== defaultValue ? url.searchParams.set(key, value) : url.searchParams.delete(key)
+  set('identityClusterQ', filters.q)
+  set('identityClusterUnit', filters.unit, 'all')
+  set('identityClusterStale', filters.stale ? 'true' : '')
+  set('identityClusterResolved', filters.includeResolved ? 'true' : '')
+  set('identityCluster', clusterKey)
+  const next = `${url.pathname}${url.search}${url.hash}`
+  if (historyMode === 'push') window.history.pushState(window.history.state, document.title, next)
+  else window.history.replaceState(window.history.state, document.title, next)
+}
+
+function clusterLabel(cluster: IdentityReviewCluster) {
+  if (cluster.staleState === 'stale') return 'Fonte alterada'
+  if (cluster.decision.state === 'confirmed') return 'Confirmado'
+  if (cluster.decision.state === 'rejected') return 'Rejeitado'
+  return cluster.bulkReview.eligible ? 'Lote seguro' : 'Revisão individual'
+}
+
+function clusterTone(cluster: IdentityReviewCluster) {
+  if (cluster.staleState === 'stale') return 'border-amber-300/30 bg-amber-500/10 text-amber-100'
+  if (cluster.bulkReview.eligible) return 'border-emerald-300/25 bg-emerald-500/10 text-emerald-100'
+  return 'border-slate-700 bg-slate-900/60 text-slate-300'
+}
+
+function ErrorPanel({ message, retry }: { message: string; retry?: () => void }) {
+  return <div role="alert" className="rounded-xl border border-rose-300/30 bg-rose-500/10 p-3 text-sm text-rose-100"><div className="flex items-start gap-2"><ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" /><span className="min-w-0 flex-1">{message}</span>{retry ? <Button size="sm" variant="outline" onClick={retry}>Tentar novamente</Button> : null}</div></div>
+}
+
+function Detail({ cluster, onReveal, revealing, revealAllowed }: { cluster: IdentityReviewCluster; onReveal: () => void; revealing: boolean; revealAllowed: boolean }) {
+  return <div className="space-y-4" data-testid="identity-cluster-detail">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><div className="flex flex-wrap items-center gap-2"><h3 className="text-lg font-semibold text-white">Componente de identidade</h3><span className={`rounded-full border px-2 py-0.5 text-[11px] ${clusterTone(cluster)}`}>{clusterLabel(cluster)}</span></div><p className="mt-1 text-xs text-slate-500">{cluster.summary.memberCount} membro(s) · {cluster.summary.identityCount} identidade(s) · confiança {Math.round(cluster.confidence * 100)}%</p></div><Button size="sm" variant="outline" onClick={onReveal} disabled={revealing || !revealAllowed}><Eye className="mr-2 h-4 w-4" />Revelar contato</Button></div>
+    <div className="grid gap-2 sm:grid-cols-4"><Fact label="Fontes" value={cluster.membersBySource.length} /><Fact label="Conflitos" value={cluster.conflicts.length} /><Fact label="Membros a mover" value={cluster.impact.membersToMove.length} /><Fact label="Desfazer" value={cluster.undo.blocked ? 'Bloqueado' : 'Disponível'} /></div>
+    <section aria-labelledby="identity-cluster-members"><h4 id="identity-cluster-members" className="flex items-center gap-2 text-sm font-semibold text-white"><UsersRound className="h-4 w-4 text-sky-300" />Membros por fonte</h4><ul className="mt-2 grid gap-2 md:grid-cols-2">{cluster.members.map((member, index) => <li key={`${member.source}-${member.name}-${index}`} className="rounded-lg border border-slate-800/80 bg-slate-950/40 p-3"><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div className="text-xs text-sky-300">{member.sourceLabel}</div><div className="truncate text-sm font-medium text-slate-100">{member.name}</div>{member.aliases.length ? <div className="mt-1 text-xs text-slate-500">Aliases: {member.aliases.join(', ')}</div> : null}</div><span className={`rounded-full border px-2 py-0.5 text-[10px] ${member.stale ? 'border-amber-300/30 text-amber-200' : 'border-slate-700 text-slate-400'}`}>{member.stale ? 'stale' : member.freshness}</span></div><div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-slate-400">{member.units.map((unit) => <span key={unit} className="rounded border border-slate-800 px-1.5 py-0.5">{unit}</span>)}{member.contact.phone.map((phone) => <span key={phone} className="rounded border border-slate-800 px-1.5 py-0.5">Tel. {phone}</span>)}{member.contact.email.map((email) => <span key={email} className="rounded border border-slate-800 px-1.5 py-0.5">E-mail {email}</span>)}</div><div className="mt-2 text-[11px] text-slate-500">{member.matchingFields.map((field) => `${field.label}: ${field.status}`).join(' · ')}</div></li>)}</ul></section>
+    <div className="grid gap-3 lg:grid-cols-2"><section className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Evidências fortes</h4>{cluster.evidence.strong.length ? <ul className="mt-2 space-y-2 text-xs text-slate-300">{cluster.evidence.strong.map((item, index) => <li key={`${item.label}-${index}`}><span className="text-emerald-300">{item.label}</span><span className="ml-2 text-slate-500">{Math.round(item.confidence * 100)}% · {item.summary}</span></li>)}</ul> : <p className="mt-2 text-xs text-slate-500">Nenhuma evidência forte suficiente.</p>}</section><section className="rounded-lg border border-slate-800 p-3"><h4 className="text-sm font-semibold text-white">Evidências fracas e conflitos</h4>{cluster.evidence.weak.length ? <ul className="mt-2 space-y-2 text-xs text-slate-300">{cluster.evidence.weak.map((item, index) => <li key={`${item.label}-${index}`}><span className="text-amber-200">{item.label}</span><span className="ml-2 text-slate-500">{item.summary}</span></li>)}</ul> : null}{cluster.conflicts.length ? <ul className="mt-2 space-y-2 text-xs text-rose-200">{cluster.conflicts.map((item) => <li key={item.field}>{item.summary}</li>)}</ul> : !cluster.evidence.weak.length ? <p className="mt-2 text-xs text-slate-500">Nenhum conflito explicitado.</p> : null}</section></div>
+    <section className="rounded-lg border border-slate-800 p-3"><h4 className="flex items-center gap-2 text-sm font-semibold text-white"><GitBranch className="h-4 w-4 text-sky-300" />Lineage e impacto previsto</h4><div className="mt-2 grid gap-3 text-xs text-slate-300 md:grid-cols-2"><div><div className="text-slate-500">Identidade sobrevivente</div><div className="mt-1">{cluster.impact.survivorIdentity?.name || 'A definir na materialização'}</div><div className="mt-3 text-slate-500">Identidades retiradas</div><div className="mt-1">{cluster.impact.retiredIdentities.length ? cluster.impact.retiredIdentities.map((identity) => identity.name).join(', ') : 'Nenhuma'}</div><div className="mt-3 text-slate-500">Lineage</div><div className="mt-1">{cluster.lineage.length ? cluster.lineage.map((entry) => entry.relation).join(', ') : 'Ainda não materializada'}</div></div><div><div className="text-slate-500">Bloqueios de desfazimento</div><div className="mt-1">{cluster.undo.blocked ? cluster.undo.reasons.join(', ') : 'Nenhum histórico comercial ou de consentimento detectado.'}</div><div className="mt-3 text-slate-500">Alterações de fonte</div><div className="mt-1">{cluster.sourceChanges.length ? cluster.sourceChanges.map((change) => `${change.source}: ${change.name}`).join(' · ') : 'Nenhuma alteração após a decisão.'}</div><div className="mt-3 text-slate-500">Materializações</div><div className="mt-1">{cluster.materializations.length ? cluster.materializations.map((run) => `${run.mode}: ${run.membersMoved} membro(s)`).join(' · ') : 'Nenhuma'}</div></div></div></section>
+    <div className="rounded-lg border border-slate-800 bg-slate-950/40 p-3 text-xs text-slate-400"><LockKeyhole className="mr-2 inline h-4 w-4 text-sky-300" />IDs técnicos não são renderizados. Telefones e e-mails permanecem mascarados até uma ação explícita e auditada.</div>
+  </div>
+}
+
+function Fact({ label, value }: { label: string; value: number | string }) {
+  return <div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">{label}</div><div className="mt-1 text-lg font-semibold text-white">{value}</div></div>
+}
+
+export function IdentityClusterWorkspace() {
+  const initial = readUrlState()
+  const [filters, setFilters] = useState<ClusterFilters>(initial)
+  const [clusterKey, setClusterKey] = useState(initial.clusterKey)
+  const [clusters, setClusters] = useState<IdentityReviewCluster[]>([])
+  const [detail, setDetail] = useState<IdentityReviewCluster | null>(null)
+  const [total, setTotal] = useState(0)
+  const [workspaceReady, setWorkspaceReady] = useState(false)
+  const [writesReady, setWritesReady] = useState(false)
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([])
+  const [preview, setPreview] = useState<IdentityClusterBulkPreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [revealing, setRevealing] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState('')
+  const [detailError, setDetailError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [applyOpen, setApplyOpen] = useState(false)
+  const [applyReason, setApplyReason] = useState('')
+  const [revealOpen, setRevealOpen] = useState(false)
+  const [revealReason, setRevealReason] = useState('')
+  const [revealFields, setRevealFields] = useState<Array<'phone' | 'email'>>([])
+  const [revealed, setRevealed] = useState<Array<{ sourceLabel: string; name: string; phone: string[]; email: string[] }>>([])
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true); setError('')
+      const result = await fetchIdentityClusterWorkspace({ ...filters, limit: 50, offset: 0 })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível carregar o grafo de identidades.')
+      setClusters(result.clusters); setTotal(result.total); setWorkspaceReady(result.workspace.ready); setWritesReady(result.workflow.writesReady)
+      const nextKey = clusterKey && result.clusters.some((cluster) => cluster.clusterKey === clusterKey) ? clusterKey : result.clusters[0]?.clusterKey || ''
+      if (nextKey !== clusterKey) { setClusterKey(nextKey); writeUrl(filters, nextKey) }
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível carregar o grafo de identidades.') } finally { setLoading(false) }
+  }, [clusterKey, filters])
+
+  const loadDetail = useCallback(async (nextKey: string) => {
+    if (!nextKey) { setDetail(null); return }
+    try {
+      setDetailLoading(true); setDetailError('')
+      const result = await fetchIdentityClusterDetail(nextKey, { unit: filters.unit })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível carregar o componente selecionado.')
+      setDetail(result.cluster); setWorkspaceReady(result.workspace.ready); setWritesReady(result.workflow.writesReady)
+    } catch (cause) { setDetail(null); setDetailError(cause instanceof Error ? cause.message : 'Não foi possível carregar o componente selecionado.') } finally { setDetailLoading(false) }
+  }, [filters.unit])
+
+  useEffect(() => { void load() }, [load])
+  useEffect(() => { void loadDetail(clusterKey) }, [clusterKey, loadDetail])
+  useEffect(() => {
+    const popState = () => { const next = readUrlState(); setFilters(next); setClusterKey(next.clusterKey) }
+    window.addEventListener('popstate', popState)
+    return () => window.removeEventListener('popstate', popState)
+  }, [])
+  useEffect(() => {
+    if (!revealed.length) return
+    const timeout = window.setTimeout(() => setRevealed([]), 5 * 60 * 1000)
+    return () => window.clearTimeout(timeout)
+  }, [revealed])
+
+  const units = useMemo(() => [...new Set(clusters.flatMap((cluster) => cluster.units))].sort(), [clusters])
+  const updateFilters = (patch: Partial<ClusterFilters>) => { const next = { ...filters, ...patch }; setFilters(next); writeUrl(next, clusterKey) }
+  const selectCluster = (nextKey: string) => { setClusterKey(nextKey); setNotice(''); writeUrl(filters, nextKey, 'push') }
+  const toggle = (key: string) => setSelectedKeys((current) => current.includes(key) ? current.filter((item) => item !== key) : [...current, key])
+
+  const simulate = async () => {
+    try { setError(''); const result = await previewIdentityClusterBulk({ clusterKeys: selectedKeys, unit: filters.unit }); if (!result.ok) throw new Error(result.error || 'Não foi possível simular o lote.'); setPreview(result); setApplyOpen(false) } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível simular o lote.') }
+  }
+  const apply = async () => {
+    if (!preview || applyReason.trim().length < 3) return
+    try {
+      setApplying(true); setError('')
+      const eligible = preview.clusters.filter((cluster) => cluster.eligible)
+      const expectedVersions = Object.fromEntries(eligible.map((cluster) => [cluster.clusterKey, cluster.version]))
+      const idempotencyKey = typeof globalThis.crypto?.randomUUID === 'function' ? globalThis.crypto.randomUUID() : `identity-cluster-${Date.now()}-${Math.random().toString(16).slice(2)}`
+      const result = await applyIdentityClusterBulk({ clusterKeys: Object.keys(expectedVersions), expectedVersions, reason: applyReason.trim(), confirmation: 'REVIEW_CLUSTER', unit: filters.unit }, idempotencyKey)
+      if (!result.ok) throw new Error(result.error || 'Não foi possível aplicar a revisão em lote.')
+      setNotice(`${result.appliedClusters} componente(s) confirmado(s) com ledger append-only. ${result.membersMoved} membro(s) movido(s).`)
+      setSelectedKeys([]); setPreview(null); setApplyOpen(false); setApplyReason(''); await load()
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível aplicar a revisão em lote.') } finally { setApplying(false) }
+  }
+  const reveal = async () => {
+    if (!detail || revealReason.trim().length < 3 || !revealFields.length) return
+    try {
+      setRevealing(true); setDetailError('')
+      const result = await revealIdentityCluster(detail.clusterKey, { expectedVersion: detail.version, fields: revealFields, reason: revealReason.trim(), confirmation: 'REVIEW_CLUSTER', unit: filters.unit })
+      if (!result.ok) throw new Error(result.error || 'Não foi possível revelar os dados de contato.')
+      setRevealed(result.contacts); setRevealOpen(false); setNotice('Reveal registrado em ledger append-only; os dados serão removidos da tela após cinco minutos.')
+    } catch (cause) { setDetailError(cause instanceof Error ? cause.message : 'Não foi possível revelar os dados de contato.') } finally { setRevealing(false) }
+  }
+
+  return <section aria-labelledby="identity-cluster-heading" className="rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.28)]"><div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"><div><h2 id="identity-cluster-heading" className="text-lg font-semibold text-white">Clusters de identidade</h2><p className="mt-1 text-sm text-slate-500">Componentes transitivos do grafo, com lineage explícita e revisão em lote somente quando a evidência é determinística.</p></div><Button size="sm" variant="outline" onClick={() => void load()} disabled={loading}><RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />Atualizar</Button></div><div className="mt-4 flex flex-wrap gap-2"><input aria-label="Buscar cluster por cliente" value={filters.q} onChange={(event) => updateFilters({ q: event.target.value })} placeholder="Buscar cliente ou alias" className="min-w-56 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><select aria-label="Unidade do cluster" value={filters.unit} onChange={(event) => updateFilters({ unit: event.target.value })} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((unit) => <option key={unit} value={unit}>{unit}</option>)}</select><label className="flex items-center gap-2 rounded-lg border border-slate-800 px-3 py-2 text-xs text-slate-300"><input type="checkbox" checked={filters.stale} onChange={(event) => updateFilters({ stale: event.target.checked })} />Somente stale</label><label className="flex items-center gap-2 rounded-lg border border-slate-800 px-3 py-2 text-xs text-slate-300"><input type="checkbox" checked={filters.includeResolved} onChange={(event) => updateFilters({ includeResolved: event.target.checked })} />Decisões vigentes</label></div>{!workspaceReady ? <div className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-xs text-amber-100">A migration do workspace ainda não está aplicada. Leitura permanece disponível; reveal e lote ficam bloqueados.</div> : null}{!writesReady ? <div className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-xs text-amber-100">O ledger de revisão ainda não está pronto neste ambiente. Nenhuma decisão pode ser gravada.</div> : null}{error ? <div className="mt-3"><ErrorPanel message={error} retry={() => void load()} /></div> : null}{notice ? <div role="status" className="mt-3 rounded-lg border border-emerald-300/25 bg-emerald-500/10 p-3 text-sm text-emerald-100">{notice}</div> : null}<div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(23rem,0.9fr)]"><section aria-labelledby="identity-cluster-list-heading" className="min-w-0"><div className="flex items-center justify-between gap-3"><h3 id="identity-cluster-list-heading" className="text-sm font-semibold text-white">{clusters.length} de {total} clusters</h3><div className="flex flex-wrap gap-2"><Button size="sm" variant="outline" onClick={() => void simulate()} disabled={!selectedKeys.length || loading}>Simular lote ({selectedKeys.length})</Button><Button size="sm" onClick={() => setApplyOpen(true)} disabled={!preview?.eligibleCount || !workspaceReady || !writesReady}>Aplicar elegíveis</Button></div></div><ul className="mt-2 divide-y divide-slate-800/70 overflow-hidden rounded-xl border border-slate-800/80">{loading && !clusters.length ? <li className="p-6 text-sm text-slate-500">Carregando componentes…</li> : clusters.map((cluster) => <li key={cluster.clusterKey} className={`p-3 ${cluster.clusterKey === clusterKey ? 'bg-sky-500/[0.08]' : ''}`}><div className="flex items-start gap-3"><input type="checkbox" aria-label={`Selecionar cluster com ${cluster.summary.memberCount} membros`} checked={selectedKeys.includes(cluster.clusterKey)} disabled={!cluster.bulkReview.eligible || !workspaceReady || !writesReady} onChange={() => toggle(cluster.clusterKey)} className="mt-1" /><button type="button" className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300" onClick={() => selectCluster(cluster.clusterKey)}><div className="flex flex-wrap items-center gap-2"><span className="truncate text-sm font-medium text-slate-100">{cluster.members[0]?.name || 'Componente sem nome'}</span><span className={`rounded-full border px-2 py-0.5 text-[10px] ${clusterTone(cluster)}`}>{clusterLabel(cluster)}</span></div><div className="mt-1 text-xs text-slate-500">{cluster.summary.memberCount} membro(s) · {cluster.units.join(', ') || 'Unidade não resolvida'} · {cluster.membersBySource.map((source) => `${source.sourceLabel}: ${source.count}`).join(' · ')}</div></button></div></li>)}{!loading && !clusters.length ? <li className="p-6 text-center text-sm text-slate-500">Nenhum componente encontrado para os filtros atuais.</li> : null}</ul><div className="mt-2 flex items-center gap-2 text-xs text-slate-500"><CheckCircle2 className="h-4 w-4 text-emerald-400" />Apenas clusters determinísticos entram no lote; ambiguidades permanecem na revisão individual.</div></section><aside className="min-w-0 rounded-xl border border-slate-800/80 bg-slate-950/35 p-4">{detailLoading ? <p className="text-sm text-slate-500">Carregando detalhe…</p> : detailError ? <ErrorPanel message={detailError} retry={() => void loadDetail(clusterKey)} /> : detail ? <Detail cluster={detail} onReveal={() => { setRevealReason(''); setRevealFields([]); setRevealed([]); setRevealOpen(true) }} revealing={revealing} revealAllowed={workspaceReady} /> : <p className="text-sm text-slate-500">Selecione um componente para revisar lineage e impacto.</p>}{revealed.length ? <div className="mt-4 rounded-lg border border-amber-300/30 bg-amber-500/10 p-3 text-xs text-amber-100"><div className="font-semibold">Contato revelado (auditoria registrada)</div>{revealed.map((entry, index) => <div key={`${entry.sourceLabel}-${index}`} className="mt-2"><div>{entry.sourceLabel} · {entry.name}</div>{entry.phone.map((phone) => <div key={phone}>Telefone: {phone}</div>)}{entry.email.map((email) => <div key={email}>E-mail: {email}</div>)}</div>)}</div> : null}</aside></div>{preview ? <section aria-labelledby="identity-cluster-preview" className="mt-4 rounded-xl border border-sky-300/25 bg-sky-500/[0.06] p-4"><div className="flex items-center gap-2"><AlertTriangle className="h-4 w-4 text-sky-300" /><h3 id="identity-cluster-preview" className="text-sm font-semibold text-white">Simulação do lote</h3></div><div className="mt-3 grid gap-2 sm:grid-cols-5"><Fact label="Clusters" value={preview.clusterCount} /><Fact label="Elegíveis" value={preview.eligibleCount} /><Fact label="Bloqueados" value={preview.blockedCount} /><Fact label="Membros elegíveis" value={preview.eligibleMembers} /><div className="rounded-lg border border-slate-800 p-3"><div className="text-[11px] text-slate-500">Motivos</div><div className="mt-1 text-xs text-slate-300">{preview.blockedReasons.join(', ') || 'Nenhum'}</div></div></div></section> : null}{revealOpen ? <div role="dialog" aria-modal="true" aria-labelledby="identity-cluster-reveal-title" className="mt-4 rounded-xl border border-amber-300/30 bg-amber-500/10 p-4"><h3 id="identity-cluster-reveal-title" className="text-sm font-semibold text-amber-100">Revelar contato deste cluster</h3><p className="mt-1 text-xs text-amber-100/80">A ação exige justificativa, é auditada e expira após cinco minutos. Valores não entram em logs nem métricas.</p><div className="mt-3 flex flex-wrap gap-3 text-sm text-amber-50"><label className="flex items-center gap-2"><input type="checkbox" checked={revealFields.includes('phone')} onChange={(event) => setRevealFields((current) => event.target.checked ? [...new Set([...current, 'phone'])] : current.filter((field) => field !== 'phone'))} />Telefone</label><label className="flex items-center gap-2"><input type="checkbox" checked={revealFields.includes('email')} onChange={(event) => setRevealFields((current) => event.target.checked ? [...new Set([...current, 'email'])] : current.filter((field) => field !== 'email'))} />E-mail</label></div><textarea aria-label="Justificativa do reveal" value={revealReason} onChange={(event) => setRevealReason(event.target.value)} maxLength={1000} placeholder="Justificativa obrigatória" className="mt-3 min-h-20 w-full rounded-lg border border-amber-200/30 bg-slate-950/50 p-2 text-sm text-white" /><div className="mt-3 flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => setRevealOpen(false)}>Cancelar</Button><Button size="sm" onClick={() => void reveal()} disabled={revealing || revealReason.trim().length < 3 || !revealFields.length}>Confirmar reveal</Button></div></div> : null}{applyOpen ? <div role="dialog" aria-modal="true" aria-labelledby="identity-cluster-apply-title" className="mt-4 rounded-xl border border-emerald-300/25 bg-emerald-500/10 p-4"><h3 id="identity-cluster-apply-title" className="text-sm font-semibold text-emerald-100">Confirmar revisão em lote</h3><p className="mt-1 text-xs text-emerald-100/80">O servidor revalida versão, locks do grafo, escopo de unidade e histórico antes de gravar. A justificativa é mantida apenas como digest auditável.</p><textarea aria-label="Justificativa da revisão em lote" value={applyReason} onChange={(event) => setApplyReason(event.target.value)} maxLength={1000} placeholder="Justificativa obrigatória" className="mt-3 min-h-20 w-full rounded-lg border border-emerald-200/30 bg-slate-950/50 p-2 text-sm text-white" /><div className="mt-3 flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => setApplyOpen(false)}>Cancelar</Button><Button size="sm" onClick={() => void apply()} disabled={applying || applyReason.trim().length < 3}>Confirmar aplicação</Button></div></div> : null}</section>
+}

--- a/crm/console/IdentityClusterWorkspace.tsx
+++ b/crm/console/IdentityClusterWorkspace.tsx
@@ -95,7 +95,7 @@ export function IdentityClusterWorkspace() {
   const [applyReason, setApplyReason] = useState('')
   const [revealOpen, setRevealOpen] = useState(false)
   const [revealReason, setRevealReason] = useState('')
-  const [revealFields, setRevealFields] = useState<Array<'phone' | 'email'>>([])
+  const [revealFields, setRevealFields] = useState<string[]>([])
   const [revealed, setRevealed] = useState<Array<{ sourceLabel: string; name: string; phone: string[]; email: string[] }>>([])
 
   const load = useCallback(async () => {
@@ -154,10 +154,11 @@ export function IdentityClusterWorkspace() {
     } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível aplicar a revisão em lote.') } finally { setApplying(false) }
   }
   const reveal = async () => {
-    if (!detail || revealReason.trim().length < 3 || !revealFields.length) return
+    const requestedFields = revealFields.filter((field): field is 'phone' | 'email' => field === 'phone' || field === 'email')
+    if (!detail || revealReason.trim().length < 3 || !requestedFields.length) return
     try {
       setRevealing(true); setDetailError('')
-      const result = await revealIdentityCluster(detail.clusterKey, { expectedVersion: detail.version, fields: revealFields, reason: revealReason.trim(), confirmation: 'REVIEW_CLUSTER', unit: filters.unit })
+      const result = await revealIdentityCluster(detail.clusterKey, { expectedVersion: detail.version, fields: requestedFields, reason: revealReason.trim(), confirmation: 'REVIEW_CLUSTER', unit: filters.unit })
       if (!result.ok) throw new Error(result.error || 'Não foi possível revelar os dados de contato.')
       setRevealed(result.contacts); setRevealOpen(false); setNotice('Reveal registrado em ledger append-only; os dados serão removidos da tela após cinco minutos.')
     } catch (cause) { setDetailError(cause instanceof Error ? cause.message : 'Não foi possível revelar os dados de contato.') } finally { setRevealing(false) }

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -1006,6 +1006,95 @@ export type ClientIdentityReviewQueue = {
   workflow?: { writesReady: boolean }
 }
 
+export type IdentityClusterMember = {
+  source: 'attendance_client' | 'caixa_customer' | 'app_registration' | 'lead_profile' | string
+  sourceLabel: string
+  name: string
+  aliases: string[]
+  units: string[]
+  matchingFields: Array<{ field: 'name' | 'phone' | 'email' | 'cpf' | 'unit' | string; label: string; status: string; values?: string[] }>
+  freshness: 'current' | 'stale' | 'unknown' | string
+  stale: boolean
+  contact: { phone: string[]; email: string[]; masked: true }
+}
+
+export type IdentityReviewCluster = {
+  schemaVersion: 'crm-identity-cluster/v2' | string
+  clusterKey: string
+  version: string
+  summary: { memberCount: number; identityCount: number; sourceCount: number; unitCount: number }
+  members: IdentityClusterMember[]
+  membersBySource: Array<{ source: string; sourceLabel: string; count: number }>
+  units: string[]
+  matchingFields: string[]
+  conflicts: Array<{ field: string; label: string; severity: 'strong' | 'weak' | string; summary: string }>
+  evidence: { strong: IdentityClusterEvidence[]; weak: IdentityClusterEvidence[] }
+  confidence: number
+  decision: { state: 'pending' | 'confirmed' | 'rejected' | 'stale'; count: number; lastAt: string | null }
+  decisionHistory: Array<{ reviewType: string; decision: string; resultingStatus: string; recordedAt: string | null; stale: boolean }>
+  materializations: Array<{ mode: string; status: string; recordedAt: string | null; membersMoved: number }>
+  automaticLinks: Array<{ source: string; target: string; status: string; method: string; confidence: number; history: Array<{ transition: string; resultingStatus: string; origin: string; recordedAt: string | null }> }>
+  sourceChanges: Array<{ source: string; name: string; changedAt: string | null }>
+  staleState: 'current' | 'stale'
+  lineage: Array<{ relation: string; recordedAt: string | null }>
+  impact: {
+    membersToMove: Array<{ sourceLabel: string; name: string }>
+    survivorIdentity: { name: string; sourceCount: number; sourceLabels: string[] } | null
+    retiredIdentities: Array<{ name: string; sourceCount: number; sourceLabels: string[] }>
+    commercialHistoryPresent: boolean
+    consentHistoryPresent: boolean
+    predictedAction: string
+  }
+  undo: { blocked: boolean; reasons: string[]; blockingHistory: { commercialActions: number; consentPermissions: number; consentEvents: number; identityAuditEvents: number } }
+  bulkReview: { eligible: boolean; mode: 'bulk_safe' | 'individual_only' | string; sharedContactField: 'phone' | 'email' | null; reasons: string[] }
+  privacy: { contactsMasked: true; technicalIdsHidden: true; revealRequired: true }
+}
+
+export type IdentityClusterEvidence = {
+  kind: 'source_link' | string
+  label: string
+  strength: 'strong' | 'weak' | string
+  confidence: number
+  source: string
+  target: string
+  summary: string
+}
+
+export type IdentityClusterQueue = {
+  schemaVersion: string
+  total: number
+  limit: number
+  offset: number
+  clusters: IdentityReviewCluster[]
+  workflow: { writesReady: boolean }
+  workspace: { ready: boolean; migrationId: string }
+  graph: { members: number; edges: number }
+  pagination: { hasPrevious: boolean; hasNext: boolean }
+}
+
+export type IdentityClusterBulkPreview = {
+  schemaVersion: string
+  clusterCount: number
+  eligibleCount: number
+  blockedCount: number
+  memberCount: number
+  eligibleMembers: number
+  blockedReasons: string[]
+  clusters: Array<{ clusterKey: string; version: string; eligible: boolean; reasons: string[] }>
+  workspace: { ready: boolean; migrationId: string }
+  workflow: { writesReady: boolean }
+}
+
+export type IdentityClusterReveal = {
+  clusterKey: string
+  version: string
+  auditId: string | null
+  revealedAt: string | null
+  expiresAt: string
+  contacts: Array<{ sourceLabel: string; name: string; phone: string[]; email: string[] }>
+  privacy: { explicitAction: true; reasonRecorded: true; metricsAndLogsRedacted: true }
+}
+
 export type ClientIdentityReviewDecision = {
   id: string
   state: 'confirmed' | 'rejected' | 'reversed'
@@ -1070,6 +1159,40 @@ export function fetchClientIdentityReviewQueue(filters: { type?: ClientIdentityR
   Object.entries(filters).forEach(([key, value]) => { if (value !== undefined && value !== '') params.set(key, String(value)) })
   const qs = params.toString()
   return api<ClientIdentityReviewQueue>(`/commercial/review${qs ? `?${qs}` : ''}`)
+}
+
+export function fetchIdentityClusterWorkspace(filters: { q?: string; unit?: string; status?: string; stale?: boolean; limit?: number; offset?: number; includeResolved?: boolean } = {}) {
+  const params = new URLSearchParams()
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value === true) params.set(key, 'true')
+    else if (value !== undefined && value !== '') params.set(key, String(value))
+  })
+  const qs = params.toString()
+  return api<IdentityClusterQueue>(`/commercial/identity-clusters${qs ? `?${qs}` : ''}`)
+}
+
+export function fetchIdentityClusterDetail(clusterKey: string, filters: { unit?: string } = {}) {
+  const params = new URLSearchParams()
+  if (filters.unit && filters.unit !== 'all') params.set('unit', filters.unit)
+  const qs = params.toString()
+  return api<{ cluster: IdentityReviewCluster; workflow: { writesReady: boolean }; workspace: { ready: boolean; migrationId: string } }>(
+    `/commercial/identity-clusters/${encodeURIComponent(clusterKey)}${qs ? `?${qs}` : ''}`,
+  )
+}
+
+export function previewIdentityClusterBulk(payload: { clusterKeys?: string[]; unit?: string }) {
+  return api<IdentityClusterBulkPreview>('/commercial/identity-clusters/bulk/preview', { method: 'POST', body: payload })
+}
+
+export function applyIdentityClusterBulk(payload: { clusterKeys: string[]; expectedVersions: Record<string, string>; reason: string; confirmation: 'REVIEW_CLUSTER'; unit?: string }, idempotencyKey: string) {
+  return api<{ schemaVersion: string; idempotent: boolean; appliedClusters: number; membersMoved: number; results: Array<{ clusterKey: string; idempotent: boolean; membersMoved?: number; decisionState?: string }> }>(
+    '/commercial/identity-clusters/bulk/apply',
+    { method: 'POST', body: payload, headers: { 'idempotency-key': idempotencyKey } },
+  )
+}
+
+export function revealIdentityCluster(clusterKey: string, payload: { expectedVersion: string; fields: Array<'phone' | 'email'>; reason: string; confirmation: 'REVIEW_CLUSTER'; unit?: string }) {
+  return api<IdentityClusterReveal>(`/commercial/identity-clusters/${encodeURIComponent(clusterKey)}/reveal`, { method: 'POST', body: payload })
 }
 
 export function decideClientIdentityReview(type: ClientIdentityReviewItem['type'], payload: {

--- a/crm/console/tests/clientCommercialWorkspace.test.ts
+++ b/crm/console/tests/clientCommercialWorkspace.test.ts
@@ -16,7 +16,9 @@ describe('Clientes workspace navigation', () => {
   it('keeps the selected subarea addressable without creating a new backend route', () => {
     expect(moduleSource).toContain("get('clientesView')")
     expect(moduleSource).toContain("set('clientesView', workspaceView)")
-    expect(moduleSource).toContain("workspaceView === 'identities' ? <IdentityReviewQueue /> : null")
+    expect(moduleSource).toContain("workspaceView === 'identities' ? <div className=\"space-y-6\"><IdentityClusterWorkspace /><IdentityReviewQueue /></div> : null")
+    expect(moduleSource).not.toContain('Object.entries(item.context)')
+    expect(moduleSource).not.toContain('Object.entries(item.evidence)')
     expect(moduleSource).toContain("workspaceView === 'quality' && commercialDataQuality")
     expect(moduleSource).toContain("workspaceView === 'quality' && commercialSourceOperations")
     expect(moduleSource).toContain("workspaceView === 'quality') void loadCommercialSourceOperations()")

--- a/docs/operations/clientes-identity-cluster-workspace.md
+++ b/docs/operations/clientes-identity-cluster-workspace.md
@@ -1,0 +1,93 @@
+# Workspace de clusters de identidade
+
+## Limite operacional
+
+O workspace `Clientes > Identidades` organiza revisões em componentes
+transitivos do grafo de Atendimento, Caixa, cadastro do app e leads. Ele não
+cria ações comerciais, permissões, contatos, mensagens ou campanhas.
+
+Os endpoints são exclusivos de `GESTOR` e preservam o escopo de unidade:
+
+- `GET /commercial/identity-clusters`
+- `GET /commercial/identity-clusters/:clusterKey`
+- `POST /commercial/identity-clusters/bulk/preview`
+- `POST /commercial/identity-clusters/bulk/apply`
+- `POST /commercial/identity-clusters/:clusterKey/reveal`
+
+Uma unidade limitada só recebe um cluster quando todas as unidades conhecidas
+do componente pertencem ao seu escopo. Proveniência de unidade ausente falha
+fechada.
+
+## Privacidade e auditoria
+
+- Telefones e e-mails são mascarados na listagem e no detalhe.
+- IDs técnicos não são enviados para a interface.
+- Reveal exige campos, justificativa, confirmação explícita e versão esperada.
+- Reveal expira visualmente após cinco minutos.
+- O ledger guarda apenas chaves opacas de cluster, referências de ator derivadas
+  por HMAC, digest de justificativa e resultados agregados.
+- Valores de contato e justificativas não entram em logs, métricas ou no novo
+  ledger operacional.
+
+O runtime deve possuir `ATENDIMENTO_ACTOR_HMAC_KEY` (ou um dos fallbacks já
+autorizados para assinatura de ator), com pelo menos 32 caracteres. Sem essa
+chave, reveal e lote retornam
+`IDENTITY_CLUSTER_AUDIT_KEY_REQUIRED`; a leitura continua disponível.
+
+## Critério de lote seguro
+
+O servidor revalida sob o lock do grafo:
+
+1. versão do componente e das arestas;
+2. escopo de unidade;
+3. contato validado compartilhado por método allowlisted;
+4. candidato único e arestas determinísticas;
+5. ausência de conflito forte, stale ou decisão incompatível;
+6. ausência de histórico comercial, consentimento ou auditoria que impeça a
+   materialização/desfazimento;
+7. checkpoints completos e válidos das fontes que compõem o cluster e do
+   grafo global; ausência, snapshot parcial, reconciliação pendente ou mais de
+   48 horas sem validação tornam o componente stale;
+8. idempotency key por ator, componente e requisição.
+
+O timestamp de um registro individual não é evidência de freshness da fonte.
+O workspace lê somente os checkpoints operacionais permitidos; quando eles
+não existem, leitura continua segura, mas lote é bloqueado de forma
+fail-closed.
+
+Casos ambíguos continuam na fila individual. Confirmações usam as mesmas
+travas de migração, reconciliação, grafo e membro do fluxo de identidade
+existente. Undo continua bloqueado quando existe dependência posterior.
+
+## Ativação local ou staging isolado
+
+1. Execute as migrations de pré-requisito do workflow de revisão de
+   identidades.
+2. Execute somente no destino estrito autorizado:
+
+   ```text
+   cd crm/api
+   npm run migrate-identity-clusters -- --apply
+   ```
+
+3. Verifique que o endpoint de leitura carrega clusters com dados sintéticos.
+4. Verifique que `workspace.ready` e `workflow.writesReady` são verdadeiros.
+5. Faça preview de um componente sintético determinístico.
+6. Exercite confirmação e idempotência somente no espelho local ou staging
+   isolado.
+7. Exercite reveal sintético e confirme a remoção visual após cinco minutos.
+
+Não execute a migration ou escrita em produção nesta tranche.
+
+## Rollback
+
+O rollback é não destrutivo:
+
+```text
+cd crm/api
+npm run migrate-identity-clusters -- --rollback
+```
+
+Ele registra a migration como revertida e bloqueia reveal/lote, mantendo
+operações, reveals, decisões, lineage e materializações para auditoria. A
+leitura de clusters continua disponível.


### PR DESCRIPTION
# Summary

Adds the Clientes identity-review workspace organized around explicit, transitively connected graph components. The change replaces generic evidence rendering with an allowlisted presentation schema and adds the safe, deterministic bulk-review path needed for synthetic/local or isolated staging validation.

Highlights:

- exposes masked cluster list/detail, explicit lineage, source membership, evidence, stale state, impact and undo blockers;
- keeps all cluster routes GESTOR-only and unit-scoped fail-closed;
- records reveal and bulk-review evidence in append-only ledgers using HMAC-derived references/digests only;
- revalidates graph locks, expected versions, source freshness, scope and dependencies before mutation;
- resolves idempotent replays from the ledger before a changed graph can cause a false conflict;
- derives freshness from durable Clientes source-operation checkpoints, never individual record timestamps;
- ships additive migration, guarded local-only runner, rollback marker and operational runbook.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [x] Docs
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: Clientes identity-cluster tranche
- Design/ADR: explicit `crm-identity-cluster/v2` presentation boundary
- Migration steps: `cd crm/api && npm run migrate-identity-clusters -- --apply` only against the strict local mirror or isolated staging destination; `--rollback` only marks the workspace unavailable and retains immutable evidence.

## Screenshots / Evidence

Post-rebase focused API checks passed: 24/24 tests covering presentation/PII, unit scope, source checkpoint freshness, rejected-edge isolation, migration safety, GESTOR route boundary, replay idempotency and opaque ledger storage.

The existing local console dependency tree aborts under WSL with `Bus error`; no install/retry was performed. Console typecheck, build, visual/e2e and the full CI surface are intentionally left to fresh CI before this draft is made ready. No database migration, deployment, commercial write, contact reveal or external message was performed.