### PR TITLE
fix(site): enforce beauty movement rate limit

### DIFF
--- a/website/src/lib/beautyMovementDb.ts
+++ b/website/src/lib/beautyMovementDb.ts
@@ -348,8 +348,17 @@ async function enforceRateLimit(params: {
     blockMs: number;
     nowMs: number;
 }): Promise<boolean> {
+    const maxAttempts = Math.floor(params.maxAttempts);
+    const windowStartedResetThreshold = params.nowMs - params.windowMs;
+    const blockUntilMs = params.nowMs + params.blockMs;
+    if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1 || !Number.isSafeInteger(windowStartedResetThreshold) || !Number.isSafeInteger(blockUntilMs)) {
+        return false;
+    }
+
     // Keep the state transition in one SQLite statement. A read-then-write
     // counter permits parallel requests to all observe the same attempt count.
+    // Policy numbers are emitted as validated SQL literals so the statement
+    // stays within the small, stable D1 binding set used by the Worker runtime.
     await params.db
         .prepare(
             `INSERT INTO bm_rate_limit_windows (
@@ -358,20 +367,20 @@ async function enforceRateLimit(params: {
              ON CONFLICT(scope, subject_hmac) DO UPDATE SET
                 window_started_at_ms = CASE
                     WHEN bm_rate_limit_windows.blocked_until_ms > ? THEN bm_rate_limit_windows.window_started_at_ms
-                    WHEN ? - bm_rate_limit_windows.window_started_at_ms >= ? THEN ?
+                    WHEN bm_rate_limit_windows.window_started_at_ms <= ? THEN ?
                     ELSE bm_rate_limit_windows.window_started_at_ms
                 END,
                 attempt_count = CASE
                     WHEN bm_rate_limit_windows.blocked_until_ms > ? THEN bm_rate_limit_windows.attempt_count
-                    WHEN ? - bm_rate_limit_windows.window_started_at_ms >= ? THEN 1
+                    WHEN bm_rate_limit_windows.window_started_at_ms <= ? THEN 1
                     ELSE bm_rate_limit_windows.attempt_count + 1
                 END,
                 blocked_until_ms = CASE
                     WHEN bm_rate_limit_windows.blocked_until_ms > ? THEN bm_rate_limit_windows.blocked_until_ms
                     WHEN (CASE
-                        WHEN ? - bm_rate_limit_windows.window_started_at_ms >= ? THEN 1
+                        WHEN bm_rate_limit_windows.window_started_at_ms <= ? THEN 1
                         ELSE bm_rate_limit_windows.attempt_count + 1
-                    END) > ? THEN ?
+                    END) > ${maxAttempts} THEN ?
                     ELSE NULL
                 END,
                 updated_at_ms = ?`,
@@ -382,17 +391,13 @@ async function enforceRateLimit(params: {
             params.nowMs,
             params.nowMs,
             params.nowMs,
-            params.windowMs,
+            windowStartedResetThreshold,
             params.nowMs,
             params.nowMs,
+            windowStartedResetThreshold,
             params.nowMs,
-            params.windowMs,
-            params.nowMs,
-            params.nowMs,
-            params.nowMs,
-            params.windowMs,
-            params.maxAttempts,
-            params.nowMs + params.blockMs,
+            windowStartedResetThreshold,
+            blockUntilMs,
             params.nowMs,
         )
         .run();

--- a/website/tests/beautyMovementDb.test.ts
+++ b/website/tests/beautyMovementDb.test.ts
@@ -90,12 +90,15 @@ class FakeBeautyMovementD1 implements BeautyMovementD1 {
 
     run(query: string, values: unknown[]): number {
         if (query.includes("INSERT INTO bm_rate_limit_windows")) {
+            assert.equal(values.length, 13, "rate limiter must keep its D1 binding contract compact");
+            const maxAttemptsMatch = query.match(/END\) > (\d+) THEN \?\s+ELSE NULL/);
+            assert.ok(maxAttemptsMatch, "rate limiter must inline its validated policy threshold");
             const key = `${values[0]}:${values[1]}`;
             const existing = this.rateLimits.get(key);
             const nowMs = Number(values[2]);
-            const windowMs = Number(values[6]);
-            const maxAttempts = Number(values[14]);
-            const blockedUntil = Number(values[15]);
+            const windowMs = nowMs - Number(values[5]);
+            const maxAttempts = Number(maxAttemptsMatch[1]);
+            const blockedUntil = Number(values[11]);
             const oldWindow = Number(existing?.window_started_at_ms ?? nowMs);
             const oldCount = Number(existing?.attempt_count ?? 0);
             const oldBlockedUntil = existing?.blocked_until_ms === null || existing?.blocked_until_ms === undefined

--- a/website/tests/beautyMovementDb.test.ts
+++ b/website/tests/beautyMovementDb.test.ts
@@ -277,6 +277,52 @@ test("beauty movement applies exchange limits atomically to both the invite toke
     assert.equal([...fixture.db.rateLimits.keys()].some((key) => key.includes(":ip:")), true);
 });
 
+test("beauty movement starts a fresh exchange window after sixty seconds", async () => {
+    const fixture = await makeFixture();
+    const ip = "203.0.113.63";
+    const first = await exchangeBeautyMovementInvite(
+        { token: fixture.token, origin: ORIGIN, ip, nowMs: NOW },
+        options(fixture.db),
+    );
+    assert.equal(first.ok, true);
+
+    const nextWindow = await exchangeBeautyMovementInvite(
+        { token: fixture.token, origin: ORIGIN, ip, nowMs: NOW + 60_001 },
+        options(fixture.db),
+    );
+    assert.equal(nextWindow.ok, true);
+
+    const counts = [...fixture.db.rateLimits.values()].map((entry) => Number(entry.attempt_count));
+    assert.deepEqual(counts, [1, 1]);
+});
+
+test("beauty movement leaves seven session mutations below their distinct limit", async () => {
+    const fixture = await makeFixture();
+    const ip = "203.0.113.64";
+    const exchange = await exchangeBeautyMovementInvite(
+        { token: fixture.token, origin: ORIGIN, ip, nowMs: NOW },
+        options(fixture.db),
+    );
+    assert.equal(exchange.ok, true);
+    if (!exchange.ok) return;
+
+    for (let attempt = 0; attempt < 7; attempt += 1) {
+        const reveal = await revealBeautyMovementCard(
+            { sessionToken: exchange.sessionToken, actIndex: 1, cardId: "presenca", origin: ORIGIN, ip },
+            options(fixture.db),
+        );
+        assert.equal(reveal.ok, true);
+    }
+
+    const sessionCounts = [...fixture.db.rateLimits.entries()]
+        .filter(([key]) => key.startsWith("session_mutation:"))
+        .map(([, entry]) => ({ count: Number(entry.attempt_count), blocked: entry.blocked_until_ms }));
+    assert.deepEqual(sessionCounts, [
+        { count: 7, blocked: null },
+        { count: 7, blocked: null },
+    ]);
+});
+
 test("beauty movement does not create token limiter rows after an IP has been blocked", async () => {
     const fixture = await makeFixture();
     const ip = "203.0.113.62";


### PR DESCRIPTION
## Correção

Corrige o limitador da jornada **Cartas da Beleza em Movimento** para manter a atualização atômica com um conjunto compacto de parâmetros D1 e uma janela de 60 segundos correta.

## Motivo

Na homologação sintética, a janela de limite precisou de uma correção de bindings. A alteração mantém a campanha fail-closed e não altera dados, benefícios, tokens ou contratos públicos.

## Validação

- `beautyMovementDb.test.ts` (9 testes)
- ESLint focal em `beautyMovementDb.ts` e seu teste
- A homologação de sessão, revelação, confirmação idempotente, benefício pré-configurado e privacidade já passou antes desta correção; a publicação em staging repetirá a prova específica de limite e rollback.

## Rollback

Reverter este commit e reimplantar a versão anterior deixa a flag da campanha desativada; o staging sintético permanece isolado.