### PR TITLE
feat(clientes): add addressable workspace routes

### DIFF
--- a/crm/api/server/atendimento/__tests__/clientCommercial.test.js
+++ b/crm/api/server/atendimento/__tests__/clientCommercial.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildCommercialProfile, elapsedDays, segmentCommercialProfiles } from '../clientCommercial.js'
+import { buildCommercialProfile, elapsedDays, minimizeCommercialOverviewProfile, segmentCommercialProfiles } from '../clientCommercial.js'
 
 test('commercial recency is based only on completed attendance, never on a later advance sale', () => {
     const profile = buildCommercialProfile({
@@ -23,6 +23,17 @@ test('keeps a single-source profile visible without presenting it as a confirmed
     }, { asOf: '2026-08-04' })
 
     assert.equal(profile.identityQuality, 'unresolved_single_source')
+})
+
+test('keeps direct identifiers out of the paginated commercial overview projection', () => {
+    const overviewProfile = minimizeCommercialOverviewProfile({
+        identityId: 'identity-1',
+        name: 'Cliente de teste',
+        phone: '5551999990000',
+        email: 'cliente@example.test',
+        priority: 'high',
+    })
+    assert.deepEqual(overviewProfile, { identityId: 'identity-1', priority: 'high' })
 })
 
 test('future attendance dates do not produce a negative recency value', () => {

--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -184,6 +184,7 @@ test('scopes Clientes commercial reads, queues, actions, cadences and offers to 
 
     const overview = await store.commercialOverview({}, scopedGestor)
     assert.deepEqual(captured.find((entry) => entry.kind === 'profiles')?.params[1], ['novo-hamburgo'])
+    assert.equal(Object.hasOwn(overview.profiles[0], 'name'), false)
     assert.equal(Object.hasOwn(overview.profiles[0], 'phone'), false)
     assert.equal(Object.hasOwn(overview.profiles[0], 'email'), false)
 

--- a/crm/api/server/atendimento/clientCommercial.js
+++ b/crm/api/server/atendimento/clientCommercial.js
@@ -79,6 +79,16 @@ export function buildCommercialProfile(row = {}, { asOf = new Date().toISOString
     }
 }
 
+/**
+ * The overview is a paginated discovery surface, not a profile disclosure
+ * endpoint. Keep direct identifiers available only to the explicit profile
+ * route, after its existing RBAC and unit checks.
+ */
+export function minimizeCommercialOverviewProfile(profile) {
+    const { name, phone, email, ...safeProfile } = profile || {}
+    return safeProfile
+}
+
 function segment(key, label, priority, nextAction, evidence) {
     return { key, label, priority, nextAction, evidence }
 }

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -33,7 +33,7 @@ import {
     splitList,
     stableConfigHash,
 } from './domain.js'
-import { segmentCommercialProfiles, summarizeCommercialProfiles } from './clientCommercial.js'
+import { minimizeCommercialOverviewProfile, segmentCommercialProfiles, summarizeCommercialProfiles } from './clientCommercial.js'
 import {
     resolveCommercialContactEligibility,
     transitionCommercialAction,
@@ -5992,7 +5992,7 @@ export function createAtendimentoStore(options = {}) {
                     hasPrevious: offset > 0,
                     hasNext: offset + limit < filtered.length,
                 },
-                profiles: (serverPage ? filtered : filtered.slice(offset, offset + limit)).map(minimizeCommercialProfile),
+                profiles: (serverPage ? filtered : filtered.slice(offset, offset + limit)).map(minimizeCommercialOverviewProfile),
             }
         },
 

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -49,6 +49,7 @@ import { dispatchAtendimentoHeaderAction, subscribeAtendimentoHeaderState } from
 import type { AtendimentoHeaderState } from '@/atendimentoHeaderBridge'
 import { hasCrmModuleAccess } from '@/crmRoleAccess'
 import { canManagePonto } from '@/pontoAccess'
+import { clientesWorkspaceQueryKeys, clientesWorkspaceUrl, parseClientesWorkspaceRoute, readClientesWalletUrlState } from '@/clientesRoutes'
 import { ArrowDownUp, CalendarX2, CheckCircle2, ChevronDown, ChevronsUpDown, Download, Pencil, Plus, RefreshCw, Search, Shield, Sparkles, Upload, X } from 'lucide-react'
 
 const INSUMOS_UNIT_KEY = 'skincos.insumos.unidade.v1'
@@ -427,6 +428,7 @@ export default function AppFunctionalNeatlab() {
 	    // Persist active module to survive remounts/reloads and avoid accidental resets
 	    const [active, setActive] = useState<string>(() => {
 		        try {
+		            if (parseClientesWorkspaceRoute(window.location)) return 'clientes'
 		            const requested = new URLSearchParams(window.location.search).get('module') || new URLSearchParams(window.location.search).get('tab')
             if (requested && crmModuleByKey.has(requested)) {
                 return requested
@@ -436,10 +438,24 @@ export default function AppFunctionalNeatlab() {
 		            return UNLOCKED_MODULE_KEYS.has(candidate) ? candidate : DEFAULT_MODULE_KEY
 		        } catch { return DEFAULT_MODULE_KEY }
 		    })
-		    const selectModule = React.useCallback((moduleKey: string) => {
+	    const selectModule = React.useCallback((moduleKey: string) => {
 		        setActive(moduleKey)
 		        try {
 		            const url = new URL(window.location.href)
+		            if (moduleKey === 'clientes') {
+		                const currentRoute = parseClientesWorkspaceRoute(url)
+		                const href = clientesWorkspaceUrl(
+		                    currentRoute || { view: 'overview' },
+		                    currentRoute ? readClientesWalletUrlState(url) : undefined,
+		                    url,
+		                )
+		                if (href !== `${url.pathname}${url.search}${url.hash}`) window.history.pushState(window.history.state, '', href)
+		                return
+		            }
+		            if (parseClientesWorkspaceRoute(url)?.source === 'path') {
+		                url.pathname = '/'
+		                for (const key of clientesWorkspaceQueryKeys) url.searchParams.delete(key)
+		            }
 		            url.searchParams.set('module', moduleKey)
 		            url.searchParams.delete('tab')
 		            window.history.replaceState(window.history.state, '', url)
@@ -450,7 +466,26 @@ export default function AppFunctionalNeatlab() {
 	    React.useEffect(() => {
         if (crmModuleByKey.has(active)) return
         setActive(DEFAULT_MODULE_KEY)
-    }, [DEFAULT_MODULE_KEY, active])
+	    }, [DEFAULT_MODULE_KEY, active])
+
+        // Canonical Clientes paths are intentionally resolved before generic
+        // query-string modules. The route selects a shell only; ModuleHost and
+        // the API still enforce RBAC and fail closed for an unauthorized actor.
+        React.useEffect(() => {
+            const onPopState = () => {
+                try {
+                    if (parseClientesWorkspaceRoute(window.location)) {
+                        setActive('clientes')
+                        return
+                    }
+                    const params = new URLSearchParams(window.location.search)
+                    const requested = params.get('module') || params.get('tab')
+                    if (requested && crmModuleByKey.has(requested)) setActive(requested)
+                } catch { /* ignore malformed browser state */ }
+            }
+            window.addEventListener('popstate', onPopState)
+            return () => window.removeEventListener('popstate', onPopState)
+        }, [])
         const [search, setSearch] = useState('')
         const [conversaHeaderState, setConversaHeaderState] = useState<ConversaHeaderState | null>(null)
         const [atendimentoHeaderState, setAtendimentoHeaderState] = useState<AtendimentoHeaderState | null>(null)
@@ -934,6 +969,10 @@ export default function AppFunctionalNeatlab() {
 	        // `?module=ponto` never falls back to the previously saved module.
 	        if (initializing) return
 	        try {
+		    if (parseClientesWorkspaceRoute(window.location)) {
+		        setActive('clientes')
+		        return
+		    }
             const params = new URLSearchParams(window.location.search)
             const requested = params.get('module') || params.get('tab')
             const wantsInsumosShortcut =

--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -31,6 +31,17 @@ import {
   type CommercialProfileDetail,
   type ClientIdentityReviewItem,
 } from '@/atendimentoApi'
+import {
+  clientesWorkspaceUrl,
+  defaultClientesWalletUrlState,
+  parseClientesWorkspaceRoute,
+  readClientesWalletUrlState,
+  type ClientesWalletUrlState,
+  type ClientesWorkspaceRoute,
+  type ClientesWorkspaceView,
+} from '@/clientesRoutes'
+import { ClientesWorkspaceNavigation } from '@/ClientesWorkspaceNavigation'
+import { ClientesWorkspaceSection } from '@/ClientesWorkspaceSection'
 
 const currency = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' })
 const date = new Intl.DateTimeFormat('pt-BR', { timeZone: 'America/Sao_Paulo' })
@@ -154,35 +165,14 @@ function Metric({ label, value, detail, icon: Icon }: { label: string; value: st
   </div>
 }
 
-function SegmentBadge({ profile }: { profile: CommercialProfile }) {
+function SegmentBadge({ profile }: { profile: Pick<CommercialProfile, 'priority' | 'segments'> }) {
   const primary = profile.segments[0]
   if (!primary) return <span className="text-xs text-slate-500">Sem prioridade</span>
   return <span className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${priorityStyles[profile.priority]}`}>{primary.label}</span>
 }
 
-type ClientesWorkspaceView = 'overview' | 'wallet' | 'actions' | 'identities' | 'quality' | 'governance'
-
-const clientesWorkspaceViews: Array<{ key: ClientesWorkspaceView; label: string; description: string }> = [
-  { key: 'overview', label: 'Visão geral', description: 'Resumo e prioridades consolidadas' },
-  { key: 'wallet', label: 'Carteira', description: 'Clientes e contexto individual' },
-  { key: 'actions', label: 'Ações', description: 'Fila comercial assistida' },
-  { key: 'identities', label: 'Identidades', description: 'Revisões e linhagem' },
-  { key: 'quality', label: 'Qualidade', description: 'SLA e controles operacionais' },
-  { key: 'governance', label: 'Governança', description: 'Políticas e cadências' },
-]
-
-function readClientesWorkspaceView(): ClientesWorkspaceView {
-  if (typeof window === 'undefined') return 'overview'
-  const candidate = new URLSearchParams(window.location.search).get('clientesView')
-  return clientesWorkspaceViews.some((view) => view.key === candidate) ? candidate as ClientesWorkspaceView : 'overview'
-}
-
-function ClientesWorkspaceNav({ active, onChange }: { active: ClientesWorkspaceView; onChange: (view: ClientesWorkspaceView) => void }) {
-  return <nav aria-label="Áreas do workspace Clientes" role="tablist" data-testid="clientes-workspace-nav" className="flex gap-1 overflow-x-auto rounded-xl border border-slate-800/80 bg-slate-950/45 p-1">
-    {clientesWorkspaceViews.map((view) => <button key={view.key} type="button" role="tab" aria-selected={active === view.key} title={view.description} onClick={() => onChange(view.key)} className={`shrink-0 rounded-lg px-3 py-2 text-left text-xs transition ${active === view.key ? 'bg-sky-500/15 text-sky-100 ring-1 ring-sky-400/30' : 'text-slate-400 hover:bg-white/[0.04] hover:text-slate-200'}`}>
-      <span className="block font-medium">{view.label}</span><span className="mt-0.5 hidden text-[10px] text-slate-500 sm:block">{view.description}</span>
-    </button>)}
-  </nav>
+function maskedWalletCustomerLabel(index: number) {
+  return `Cliente protegido ${String(index + 1).padStart(2, '0')}`
 }
 
 function ActionForm({ detail, units, professionals, onSaved }: { detail: CommercialProfileDetail; units: Array<{ slug: string; name: string }>; professionals: Array<{ name: string }>; onSaved: () => Promise<void> }) {
@@ -540,26 +530,31 @@ function CanarySelection({ profiles, selectedIds, disabled, onToggle, onClear }:
   const candidates = profiles.filter((profile) => profile.contactEligibility?.contactAllowed === true).slice(0, 24)
   return <div className="mt-2 rounded-lg border border-slate-800 bg-slate-900/60 p-3">
     <div className="flex items-start justify-between gap-3"><div><div className="text-xs font-medium text-slate-300">Seleção assistida do canário</div><p className="mt-1 text-xs text-slate-500">Escolha identidades visíveis e aptas para contato. A seleção é auditada; nenhum UUID é digitado e nenhuma mensagem é enviada.</p></div><Button size="sm" variant="ghost" onClick={onClear} disabled={disabled || !selectedIds.length}>Limpar</Button></div>
-    {candidates.length ? <div className="mt-3 grid gap-2 sm:grid-cols-2">{candidates.map((profile) => <label key={profile.identityId} className="flex items-start gap-2 rounded-md border border-slate-800/80 p-2 text-xs text-slate-300 hover:border-sky-400/40"><input type="checkbox" checked={selectedIds.includes(profile.identityId)} disabled={disabled} onChange={() => onToggle(profile.identityId)} className="mt-0.5" aria-label={`Selecionar ${profile.name} para o canário`} /><span className="min-w-0"><span className="block truncate text-slate-100">{profile.name}</span><span className="block text-[11px] text-emerald-300">{contactEligibilityLabel(profile.contactEligibility)}</span></span></label>)}</div> : <p className="mt-3 text-xs text-amber-200">Nenhuma identidade visível está apta agora. Permissão, telefone correlacionado e bloqueios do Harmonia precisam estar verdes antes da seleção.</p>}
+    {candidates.length ? <div className="mt-3 grid gap-2 sm:grid-cols-2">{candidates.map((profile, index) => <label key={profile.identityId} className="flex items-start gap-2 rounded-md border border-slate-800/80 p-2 text-xs text-slate-300 hover:border-sky-400/40"><input type="checkbox" checked={selectedIds.includes(profile.identityId)} disabled={disabled} onChange={() => onToggle(profile.identityId)} className="mt-0.5" aria-label={`Selecionar ${maskedWalletCustomerLabel(index)} para o canário`} /><span className="min-w-0"><span className="block truncate text-slate-100">{maskedWalletCustomerLabel(index)}</span><span className="block text-[11px] text-emerald-300">{contactEligibilityLabel(profile.contactEligibility)}</span></span></label>)}</div> : <p className="mt-3 text-xs text-amber-200">Nenhuma identidade visível está apta agora. Permissão, telefone correlacionado e bloqueios do Harmonia precisam estar verdes antes da seleção.</p>}
     <div className="mt-3 text-[11px] text-slate-500">{selectedIds.length} identidade(s) selecionada(s) · limite operacional de 100</div>
   </div>
 }
 
 export function ClientCommercialModule() {
+  const initialLocation = useMemo(() => ({
+    route: parseClientesWorkspaceRoute() || { view: 'overview' as const, source: 'legacy' as const },
+    filters: readClientesWalletUrlState(),
+  }), [])
   const [overview, setOverview] = useState<CommercialOverview | null>(null)
   const [detail, setDetail] = useState<CommercialProfileDetail | null>(null)
   const [units, setUnits] = useState<Array<{ slug: string; name: string }>>([])
   const [professionals, setProfessionals] = useState<Array<{ name: string }>>([])
-  const [unit, setUnit] = useState('all')
-  const [segment, setSegment] = useState('')
-  const [priority, setPriority] = useState('')
-  const [search, setSearch] = useState('')
-  const [pageOffset, setPageOffset] = useState(0)
-  const [sort, setSort] = useState('priority')
-  const [direction, setDirection] = useState<'asc' | 'desc'>('desc')
-  const [workspaceView, setWorkspaceView] = useState<ClientesWorkspaceView>(readClientesWorkspaceView)
+  const [unit, setUnit] = useState(initialLocation.filters.unit)
+  const [segment, setSegment] = useState(initialLocation.filters.segment)
+  const [priority, setPriority] = useState(initialLocation.filters.priority)
+  const [search, setSearch] = useState(initialLocation.filters.q)
+  const [pageOffset, setPageOffset] = useState(initialLocation.filters.offset)
+  const [sort, setSort] = useState<ClientesWalletUrlState['sort']>(initialLocation.filters.sort)
+  const [direction, setDirection] = useState<ClientesWalletUrlState['direction']>(initialLocation.filters.direction)
+  const [workspaceRoute, setWorkspaceRoute] = useState<ClientesWorkspaceRoute>(initialLocation.route)
+  const workspaceView = workspaceRoute.view
   const [savedViewName, setSavedViewName] = useState('')
-  const [savedViews, setSavedViews] = useState<Array<{ name: string; unit: string; segment: string; priority: string; search: string; sort: string; direction: 'asc' | 'desc' }>>([])
+  const [savedViews, setSavedViews] = useState<Array<{ name: string; unit: string; segment: string; priority: string; search: string; sort: ClientesWalletUrlState['sort']; direction: ClientesWalletUrlState['direction'] }>>([])
   const pageSize = 50
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
@@ -624,14 +619,14 @@ export function ClientCommercialModule() {
   }, [])
 
   const load = useCallback(async (next?: {
-    selectIdentityId?: string
+    selectIdentityId?: string | null
     offset?: number
     unit?: string
     segment?: string
     priority?: string
     search?: string
-    sort?: string
-    direction?: 'asc' | 'desc'
+    sort?: ClientesWalletUrlState['sort']
+    direction?: ClientesWalletUrlState['direction']
   }) => {
     try {
       setBusy(true); setError('')
@@ -652,25 +647,34 @@ export function ClientCommercialModule() {
       setCooldown(commercial.policy.activeContactCooldownDays); setThresholds(commercial.policy.returnRiskThresholds.join(','))
       setCommercialContactWritesEnabled(commercial.policy.commercialContactWritesEnabled === true)
       setSelectedCanaryIdentityIds(Array.isArray(commercial.policy.commercialContactCanaryIdentityIds) ? commercial.policy.commercialContactCanaryIdentityIds : [])
-      const selectedId = next?.selectIdentityId || detail?.profile.identityId
-      const candidate = commercial.profiles.find((profile) => profile.identityId === selectedId) || commercial.profiles[0]
-      if (candidate) await loadDetail(candidate.identityId, commercial.asOf)
-      else setDetail(null)
+      const selectsExplicitly = Boolean(next && Object.prototype.hasOwnProperty.call(next, 'selectIdentityId'))
+      const selectedId = selectsExplicitly ? next?.selectIdentityId : detail?.profile.identityId
+      const candidate = selectedId
+        ? commercial.profiles.find((profile) => profile.identityId === selectedId)
+        : selectsExplicitly ? null : commercial.profiles[0]
+      if (candidate) await loadDetail(candidate.identityId, commercial.asOf, requestUnit)
+      else if (selectedId && selectsExplicitly) await loadDetail(selectedId, commercial.asOf, requestUnit)
+      else if (selectsExplicitly) setDetail(null)
+      else if (!commercial.profiles.length) setDetail(null)
       void loadCommercialDataQuality()
     } catch (cause) { setError(cause instanceof Error ? cause.message : 'Não foi possível carregar a inteligência comercial.') } finally { setBusy(false) }
   // Filters are deliberately applied only with the button, so typing does not trigger a request per keystroke.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unit, segment, priority, search, pageOffset, sort, direction, detail?.profile.identityId])
 
-  const loadDetail = useCallback(async (identityId: string, asOf?: string) => {
-    const result = await fetchCommercialProfile(identityId, { asOf, unit })
+  const loadDetail = useCallback(async (identityId: string, asOf?: string, unitOverride = unit) => {
+    const result = await fetchCommercialProfile(identityId, { asOf, unit: unitOverride })
     if (!result.ok) throw new Error(result.error || 'Não foi possível carregar o perfil do cliente.')
     setDetail(result)
   }, [unit])
 
-  // Initial load intentionally runs once; changing filters is explicit through “Aplicar”.
+  // Initial load intentionally follows the route once. Changing a draft filter
+  // remains explicit through “Aplicar”, so typing never triggers a request.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { void load() }, [])
+  useEffect(() => {
+    const { q, ...filters } = initialLocation.filters
+    void load({ ...filters, search: q, selectIdentityId: initialLocation.route.identityId || null })
+  }, [])
 
   useEffect(() => {
     try {
@@ -683,15 +687,44 @@ export function ClientCommercialModule() {
   }, [])
 
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const url = new URL(window.location.href)
-    url.searchParams.set('clientesView', workspaceView)
-    window.history.replaceState(window.history.state, document.title, `${url.pathname}${url.search}${url.hash}`)
-  }, [workspaceView])
+    const onPopState = () => {
+      const route = parseClientesWorkspaceRoute()
+      if (!route) return
+      const filters = readClientesWalletUrlState()
+      setWorkspaceRoute(route)
+      setUnit(filters.unit); setSegment(filters.segment); setPriority(filters.priority); setSearch(filters.q)
+      setPageOffset(filters.offset); setSort(filters.sort); setDirection(filters.direction)
+      const { q, ...request } = filters
+      void load({ ...request, search: q, selectIdentityId: route.identityId || null })
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [load])
 
   useEffect(() => {
     if (workspaceView === 'quality') void loadCommercialSourceOperations()
   }, [workspaceView, loadCommercialSourceOperations])
+
+  const walletUrlState = useMemo<ClientesWalletUrlState>(() => ({
+    ...defaultClientesWalletUrlState,
+    unit,
+    segment,
+    priority,
+    q: search,
+    sort,
+    direction,
+    offset: pageOffset,
+  }), [direction, pageOffset, priority, search, segment, sort, unit])
+
+  const navigateWorkspace = useCallback((route: Pick<ClientesWorkspaceRoute, 'view' | 'identityId'>, filters = walletUrlState) => {
+    if (typeof window !== 'undefined') {
+      const href = clientesWorkspaceUrl(route, filters)
+      const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`
+      if (href !== currentHref) window.history.pushState(window.history.state, document.title, href)
+    }
+    setWorkspaceRoute({ ...route, source: 'path' })
+    if (!route.identityId) setDetail(null)
+  }, [walletUrlState])
 
   const persistSavedViews = (next: typeof savedViews) => {
     setSavedViews(next)
@@ -708,7 +741,9 @@ export function ClientCommercialModule() {
 
   const applySavedView = (view: typeof savedViews[number]) => {
     setUnit(view.unit); setSegment(view.segment); setPriority(view.priority); setSearch(view.search); setSort(view.sort); setDirection(view.direction); setPageOffset(0)
-    void load({ unit: view.unit, segment: view.segment, priority: view.priority, search: view.search, sort: view.sort, direction: view.direction, offset: 0 })
+    const filters = { ...walletUrlState, unit: view.unit, segment: view.segment, priority: view.priority, q: view.search, sort: view.sort, direction: view.direction, offset: 0 }
+    navigateWorkspace(workspaceRoute, filters)
+    void load({ unit: view.unit, segment: view.segment, priority: view.priority, search: view.search, sort: view.sort, direction: view.direction, offset: 0, selectIdentityId: workspaceRoute.identityId || null })
   }
 
   const refreshDetail = useCallback(async () => {
@@ -781,32 +816,58 @@ export function ClientCommercialModule() {
   const contactScopeSuffix = contactSummary.scope === 'page' ? ' na página atual' : ''
 
   const showProfileWorkspace = workspaceView === 'overview' || workspaceView === 'wallet' || workspaceView === 'actions'
-  const selectWorkspaceView = (next: ClientesWorkspaceView) => setWorkspaceView(next)
+  const selectWorkspaceView = (next: ClientesWorkspaceView) => {
+    const route = { view: next }
+    navigateWorkspace(route)
+    const { q, ...filters } = walletUrlState
+    void load({ ...filters, search: q, selectIdentityId: null })
+  }
+  const applyWalletFilters = () => {
+    const filters = { ...walletUrlState, offset: 0 }
+    setPageOffset(0)
+    navigateWorkspace(workspaceRoute, filters)
+    const { q, ...request } = filters
+    void load({ ...request, search: q, selectIdentityId: workspaceRoute.identityId || null })
+  }
+  const goToWalletPage = (offset: number) => {
+    const filters = { ...walletUrlState, offset }
+    setPageOffset(offset)
+    navigateWorkspace(workspaceRoute, filters)
+    void load({ offset, selectIdentityId: workspaceRoute.identityId || undefined })
+  }
+  const openProfile = (identityId: string, asOf?: string) => {
+    navigateWorkspace({ view: 'wallet', identityId })
+    void loadDetail(identityId, asOf).catch((cause) => setError(cause instanceof Error ? cause.message : 'Não foi possível carregar o perfil do cliente.'))
+  }
 
   return <section className="space-y-6 text-white">
     <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"><div><h1 className="text-2xl font-bold tracking-tight">Clientes</h1><p className="mt-1 text-sm text-slate-400">Prioridades comerciais baseadas em presença registrada, vendas e procedimentos confirmados.</p></div><div className="flex flex-wrap gap-2"><Button variant="outline" onClick={() => void load()} disabled={busy}><RefreshCw className={`mr-2 h-4 w-4 ${busy ? 'animate-spin' : ''}`} />Atualizar</Button><Button variant="outline" onClick={() => selectWorkspaceView('governance')}><ShieldCheck className="mr-2 h-4 w-4" />Governança</Button></div></header>
-    <ClientesWorkspaceNav active={workspaceView} onChange={selectWorkspaceView} />
+    <ClientesWorkspaceNavigation active={workspaceView} filters={walletUrlState} onNavigate={selectWorkspaceView} />
     {error ? <div className="rounded-xl border border-rose-300/30 bg-rose-500/10 p-4 text-sm text-rose-100">{error}</div> : null}
     {workspaceView === 'overview' && overview ? <div className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><div><b>Uso comercial seguro:</b> a recência considera apenas o último atendimento realizado. Compras antecipadas não representam procedimento realizado. {overview.dataQuality.futureAttendancesExcluded ? `${overview.dataQuality.futureAttendancesExcluded} atendimento(s) futuro(s) foram excluídos desta métrica. ` : ''}{overview.dataQuality.activeAttendanceClientsWithoutIdentity ? `${overview.dataQuality.activeAttendanceClientsWithoutIdentity} cliente(s) de Atendimento ainda não têm identidade comercial. ` : ''}{contactSummary.controlsReady ? `${contactSummary.eligible} apto(s), ${contactSummary.blocked} bloqueado(s) e ${contactSummary.reviewRequired} em revisão para WhatsApp${contactScopeSuffix}. ` : 'Os controles de contato ainda não foram migrados; nenhum contato pode ser marcado. '}{!contactSummary.contactWriteControlsReady ? 'A cadência de contato aguarda a migration explícita; filas novas, concessões e registros de contato seguem bloqueados. ' : overview.policy.commercialContactWritesEnabled ? `Canário de contato ativo para ${overview.policy.commercialContactCanaryIdentityIds?.length || 0} identidade(s).` : 'Registro de contato e novas permissões concedidas seguem bloqueados até a abertura explícita de um canário.'}</div></div></div> : null}
     {workspaceView === 'governance' ? <section className="grid gap-4 rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 xl:grid-cols-2"><div><h2 className="font-semibold text-white">Política de reativação</h2><p className="mt-1 text-sm text-slate-500">Define o intervalo entre contatos assistidos e as faixas de ausência, sem alterar o histórico clínico.</p><div className="mt-4 grid gap-2 sm:grid-cols-2"><label className="text-xs text-slate-400">Intervalo mínimo de contato (dias)<input type="number" value={cooldown} onChange={(event) => setCooldown(Number(event.target.value))} className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /></label><label className="text-xs text-slate-400">Faixas de ausência<input value={thresholds} onChange={(event) => setThresholds(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /></label></div>{!policyWriteControlsReady ? <p className="mt-4 text-xs text-amber-200">A migration de rollout ainda não está presente neste ambiente. As faixas podem ser salvas, mas o canário permanece indisponível.</p> : null}<label className="mt-4 flex items-start gap-2 text-xs text-amber-100"><input type="checkbox" checked={commercialContactWritesEnabled} disabled={!policyWriteControlsReady} onChange={(event) => setCommercialContactWritesEnabled(event.target.checked)} className="mt-0.5" />Abrir somente o canário de registros de contato. Isto não envia mensagens.</label><CanarySelection profiles={overview?.profiles || []} selectedIds={selectedCanaryIdentityIds} disabled={!policyWriteControlsReady} onToggle={toggleCanaryIdentity} onClear={() => setSelectedCanaryIdentityIds([])} /><Button size="sm" onClick={() => void savePolicy()} disabled={busy} className="mt-3"><Save className="mr-2 h-4 w-4" />Salvar política</Button></div><div className="border-t border-slate-800 pt-4 xl:border-l xl:border-t-0 xl:pl-4 xl:pt-0"><h2 className="font-semibold text-white">Rascunho de regra clínica</h2><p className="mt-1 text-sm text-slate-500">Gestores comerciais apenas registram um rascunho. A aprovação exige o domínio clínico, segregação de funções e evidência; nenhuma prescrição ou recomendação automática é criada.</p><div className="mt-4 grid gap-2 sm:grid-cols-2"><select aria-label="Procedimento da regra clínica" value={cadenceProcedure} onChange={(event) => setCadenceProcedure(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white"><option value="">Procedimento</option>{procedureOptions.map((procedure) => <option key={procedure.id} value={procedure.id}>{procedure.name}</option>)}</select><input aria-label="Intervalo em dias" type="number" min="1" placeholder="Dias" value={cadenceDays} onChange={(event) => setCadenceDays(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /><select aria-label="Estado do rascunho" value={cadenceStatus} onChange={(event) => setCadenceStatus(event.target.value as CommercialCadenceManagerStatus)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white">{commercialCadenceManagerStatuses.map((item) => <option key={item} value={item}>{commercialCadenceStatusLabels[item]}</option>)}</select><input aria-label="Início da vigência" type="date" value={cadenceEffectiveFrom} onChange={(event) => setCadenceEffectiveFrom(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /><input aria-label="Expiração opcional" type="date" value={cadenceExpiresAt} onChange={(event) => setCadenceExpiresAt(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white" /><input aria-label="Referência da evidência" placeholder="Referência/evidência" value={cadenceEvidence} onChange={(event) => setCadenceEvidence(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white sm:col-span-2" /><textarea aria-label="Justificativa clínica" placeholder="Justificativa (mínimo 10 caracteres)" value={cadenceJustification} onChange={(event) => setCadenceJustification(event.target.value)} className="min-h-20 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-white sm:col-span-2" /></div><Button size="sm" variant="outline" onClick={() => void saveCadence()} disabled={busy || !cadenceProcedure || !cadenceDays || cadenceJustification.trim().length < 10 || cadenceEvidence.trim().length < 3} className="mt-3"><Save className="mr-2 h-4 w-4" />Salvar rascunho</Button>{cadenceNotice ? <div role="status" className="mt-2 text-xs text-slate-400">{cadenceNotice}</div> : null}</div></section> : null}
     {workspaceView === 'overview' ? <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><Metric label="Retorno em risco" value={overview?.summary.returnAtRisk ?? '—'} detail="Sem presença registrada na faixa configurada" icon={CalendarClock} /><Metric label="Alto valor inativo" value={overview?.summary.highValueInactive ?? '—'} detail="Valor e ausência combinados" icon={CircleDollarSign} /><Metric label="Potencial de reativação" value={overview?.summary.reactivationPotential ?? '—'} detail="Prioridade para a equipe" icon={UserRoundCheck} /><Metric label="Aptos para WhatsApp" value={overview ? contactSummary.eligible : '—'} detail="Permissão explícita e bloqueios verificados" icon={UsersRound} /></div> : null}
+    {workspaceView === 'quality' ? <ClientesWorkspaceSection sectionKey="quality">
     {workspaceView === 'quality' && commercialDataQualityError ? <div className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100">{commercialDataQualityError}</div> : null}
     {workspaceView === 'quality' && commercialSourceOperationsError ? <div role="status" className="rounded-xl border border-amber-300/25 bg-amber-500/10 p-4 text-sm text-amber-100">{commercialSourceOperationsError}</div> : null}
     {workspaceView === 'quality' && commercialSourceOperationsBusy && !commercialSourceOperations ? <div role="status" className="rounded-xl border border-slate-800/80 bg-slate-950/55 p-4 text-sm text-slate-400">Carregando estado das fontes…</div> : null}
     {workspaceView === 'quality' && commercialSourceOperations ? <SourceOperationsPanel operations={commercialSourceOperations} loading={commercialSourceOperationsBusy} onRefresh={loadCommercialSourceOperations} /> : null}
     {workspaceView === 'quality' && commercialDataQuality ? <CommercialDataQualityPanel queue={commercialDataQuality} loading={commercialDataQualityBusy} onRefresh={loadCommercialDataQuality} /> : null}
-    {showProfileWorkspace ? <>
-    <div className="flex flex-wrap gap-2 rounded-xl border border-slate-800/80 bg-slate-950/45 p-3"><select aria-label="Unidade" value={unit} onChange={(event) => setUnit(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select><select aria-label="Segmento" value={segment} onChange={(event) => setSegment(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">{segmentOptions.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}</select><select aria-label="Prioridade" value={priority} onChange={(event) => setPriority(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Todas as prioridades</option><option value="high">Alta</option><option value="medium">Média</option><option value="normal">Normal</option></select><input aria-label="Buscar cliente" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Buscar cliente" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><select aria-label="Ordenar clientes" value={sort} onChange={(event) => setSort(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="priority">Prioridade</option><option value="recency">Recência</option><option value="lifetime_sales">Faturamento</option><option value="visits">Visitas</option><option value="sales">Compras</option><option value="last_attendance">Último atendimento</option><option value="name">Nome</option></select><select aria-label="Direção da ordenação" value={direction} onChange={(event) => setDirection(event.target.value as 'asc' | 'desc')} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="desc">Maior primeiro</option><option value="asc">Menor primeiro</option></select><Button size="sm" onClick={() => void load({ offset: 0 })} disabled={busy}>Aplicar</Button><div className="flex w-full flex-wrap gap-2 border-t border-slate-800/80 pt-3"><input aria-label="Nome da visão salva" value={savedViewName} onChange={(event) => setSavedViewName(event.target.value)} placeholder="Nome da visão" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><Button size="sm" variant="outline" onClick={saveCurrentView} disabled={busy}>Salvar visão</Button>{savedViews.length ? <select aria-label="Visões salvas" defaultValue="" onChange={(event) => { const view = savedViews.find((item) => item.name === event.target.value); if (view) applySavedView(view); event.currentTarget.value = '' }} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Abrir visão salva</option>{savedViews.map((view) => <option key={view.name} value={view.name}>{view.name}</option>)}</select> : null}</div></div>
+    </ClientesWorkspaceSection> : null}
+    {showProfileWorkspace ? <ClientesWorkspaceSection sectionKey="wallet">
+    <>
+    <div className="flex flex-wrap gap-2 rounded-xl border border-slate-800/80 bg-slate-950/45 p-3"><select aria-label="Unidade" value={unit} onChange={(event) => setUnit(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades</option>{units.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select><select aria-label="Segmento" value={segment} onChange={(event) => setSegment(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">{segmentOptions.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}</select><select aria-label="Prioridade" value={priority} onChange={(event) => setPriority(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Todas as prioridades</option><option value="high">Alta</option><option value="medium">Média</option><option value="normal">Normal</option></select><input aria-label="Buscar cliente" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Buscar cliente" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><select aria-label="Ordenar clientes" value={sort} onChange={(event) => setSort(event.target.value as ClientesWalletUrlState['sort'])} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="priority">Prioridade</option><option value="recency">Recência</option><option value="lifetime_sales">Faturamento</option><option value="visits">Visitas</option><option value="sales">Compras</option><option value="last_attendance">Último atendimento</option><option value="name">Nome</option></select><select aria-label="Direção da ordenação" value={direction} onChange={(event) => setDirection(event.target.value as ClientesWalletUrlState['direction'])} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="desc">Maior primeiro</option><option value="asc">Menor primeiro</option></select><Button size="sm" onClick={applyWalletFilters} disabled={busy}>Aplicar</Button><div className="flex w-full flex-wrap gap-2 border-t border-slate-800/80 pt-3"><input aria-label="Nome da visão salva" value={savedViewName} onChange={(event) => setSavedViewName(event.target.value)} placeholder="Nome da visão" className="min-w-48 flex-1 rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500" /><Button size="sm" variant="outline" onClick={saveCurrentView} disabled={busy}>Salvar visão</Button>{savedViews.length ? <select aria-label="Visões salvas" defaultValue="" onChange={(event) => { const view = savedViews.find((item) => item.name === event.target.value); if (view) applySavedView(view); event.currentTarget.value = '' }} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="">Abrir visão salva</option>{savedViews.map((view) => <option key={view.name} value={view.name}>{view.name}</option>)}</select> : null}</div></div>
     <div className="grid gap-5 2xl:grid-cols-[minmax(0,1.7fr)_minmax(22rem,0.8fr)]">
        <section className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/55 shadow-[0_20px_60px_rgba(2,6,23,0.28)]">
          <div className="flex items-center justify-between border-b border-slate-800/80 p-5"><div><h2 className="font-semibold text-white">{workspaceView === 'wallet' ? 'Carteira de clientes' : workspaceView === 'actions' ? 'Fila de ações comerciais' : 'Prioridades de reativação'}</h2><p className="mt-1 text-xs text-slate-500">{workspaceView === 'actions' ? 'Ações assistidas, sem envio automático de mensagens.' : overview ? `${overview.total} clientes na seleção atual` : 'Carregando clientes…'}</p></div><div className="text-xs text-slate-500">Fila: {overview?.actions.actions ?? 0} · Contatos: {overview?.actions.contactedActions ?? 0}</div></div>
-        <div className="overflow-x-auto"><table className="w-full min-w-190 text-sm"><thead className="bg-white/[0.025] text-left text-xs font-medium text-slate-400"><tr><th className="p-3">Cliente</th><th className="p-3">Último atendimento</th><th className="p-3 text-right">Faturamento</th><th className="p-3">Frequência</th><th className="p-3">Próxima ação</th><th className="p-3">Prioridade</th><th className="p-3" /></tr></thead><tbody>{overview?.profiles.map((profile) => <tr key={profile.identityId} onClick={() => void loadDetail(profile.identityId, overview.asOf)} className={`cursor-pointer border-t border-slate-800/70 transition hover:bg-sky-500/[0.05] ${detail?.profile.identityId === profile.identityId ? 'bg-sky-500/[0.08]' : ''}`}><td className="p-3"><div className="font-medium text-slate-100">{profile.name}</div><div className="mt-0.5 text-xs text-slate-500">{profile.identityQuality.replace(/_/g, ' ')}</div><div className={`mt-1 text-[11px] ${contactEligibilityTextStyle(profile.contactEligibility)}`}>{contactEligibilityLabel(profile.contactEligibility)}</div></td><td className="p-3"><div className="text-slate-200">{formatDate(profile.lastAttendance)}</div><div className={`mt-0.5 text-xs ${profile.recencyDays != null && profile.recencyDays >= 180 ? 'text-rose-300' : 'text-slate-500'}`}>{profile.recencyDays == null ? 'Sem presença confirmada' : `${profile.recencyDays} dias`}</div></td><td className="p-3 text-right"><div className="font-medium text-slate-100">{currency.format(profile.lifetimeSales)}</div><div className="mt-0.5 text-xs text-slate-500">{profile.saleCount} compra(s)</div></td><td className="p-3"><div className="text-slate-200">{profile.visitCount} visita(s)</div><div className="mt-0.5 text-xs text-slate-500">{profile.procedureCount} procedimento(s)</div></td><td className="max-w-56 p-3 text-slate-300">{profile.recommendedAction}</td><td className="p-3"><SegmentBadge profile={profile} /></td><td className="p-3 text-right"><ChevronRight className="inline h-4 w-4 text-slate-500" /></td></tr>)}</tbody></table>{overview && !overview.profiles.length ? <div className="p-8 text-center text-sm text-slate-500">Nenhum cliente encontrado para os filtros selecionados.</div> : null}</div>
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800/80 p-4 text-xs text-slate-500"><span>{overview ? `${overview.total ? pageOffset + 1 : 0}–${Math.min(pageOffset + overview.profiles.length, overview.total)} de ${overview.total}` : 'Carregando…'}{overview?.pagination?.mode === 'sql' ? ' · paginação SQL' : ''}</span><div className="flex gap-2"><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasPrevious} onClick={() => void load({ offset: Math.max(0, pageOffset - pageSize) })}>Anterior</Button><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasNext} onClick={() => void load({ offset: pageOffset + pageSize })}>Próxima</Button></div></div>
+        <div className="overflow-x-auto"><table className="w-full min-w-190 text-sm"><thead className="bg-white/[0.025] text-left text-xs font-medium text-slate-400"><tr><th className="p-3">Cliente</th><th className="p-3">Último atendimento</th><th className="p-3 text-right">Faturamento</th><th className="p-3">Frequência</th><th className="p-3">Próxima ação</th><th className="p-3">Prioridade</th><th className="p-3" /></tr></thead><tbody>{overview?.profiles.map((profile, index) => <tr key={profile.identityId} className={`border-t border-slate-800/70 transition hover:bg-sky-500/[0.05] ${detail?.profile.identityId === profile.identityId ? 'bg-sky-500/[0.08]' : ''}`}><td className="p-3"><a href={clientesWorkspaceUrl({ view: 'wallet', identityId: profile.identityId }, walletUrlState)} aria-label={`Abrir perfil de ${maskedWalletCustomerLabel(pageOffset + index)}`} onClick={(event) => { if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return; event.preventDefault(); openProfile(profile.identityId, overview.asOf) }} className="font-medium text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300">{maskedWalletCustomerLabel(pageOffset + index)}</a><div className="mt-0.5 text-xs text-slate-500">{profile.identityQuality.replace(/_/g, ' ')}</div><div className={`mt-1 text-[11px] ${contactEligibilityTextStyle(profile.contactEligibility)}`}>{contactEligibilityLabel(profile.contactEligibility)}</div></td><td className="p-3"><div className="text-slate-200">{formatDate(profile.lastAttendance)}</div><div className={`mt-0.5 text-xs ${profile.recencyDays != null && profile.recencyDays >= 180 ? 'text-rose-300' : 'text-slate-500'}`}>{profile.recencyDays == null ? 'Sem presença confirmada' : `${profile.recencyDays} dias`}</div></td><td className="p-3 text-right"><div className="font-medium text-slate-100">{currency.format(profile.lifetimeSales)}</div><div className="mt-0.5 text-xs text-slate-500">{profile.saleCount} compra(s)</div></td><td className="p-3"><div className="text-slate-200">{profile.visitCount} visita(s)</div><div className="mt-0.5 text-xs text-slate-500">{profile.procedureCount} procedimento(s)</div></td><td className="max-w-56 p-3 text-slate-300">Consultar perfil</td><td className="p-3"><SegmentBadge profile={profile} /></td><td className="p-3 text-right"><ChevronRight className="inline h-4 w-4 text-slate-500" /></td></tr>)}</tbody></table>{overview && !overview.profiles.length ? <div className="p-8 text-center text-sm text-slate-500">Nenhum cliente encontrado para os filtros selecionados.</div> : null}</div>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800/80 p-4 text-xs text-slate-500"><span>{overview ? `${overview.total ? pageOffset + 1 : 0}–${Math.min(pageOffset + overview.profiles.length, overview.total)} de ${overview.total}` : 'Carregando…'}{overview?.pagination?.mode === 'sql' ? ' · paginação SQL' : ''}</span><div className="flex gap-2"><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasPrevious} onClick={() => goToWalletPage(Math.max(0, pageOffset - pageSize))}>Anterior</Button><Button size="sm" variant="outline" disabled={busy || !overview?.pagination?.hasNext} onClick={() => goToWalletPage(pageOffset + pageSize)}>Próxima</Button></div></div>
       </section>
       <ProfilePanel detail={detail} units={units} professionals={professionals} onRefresh={refreshDetail} />
     </div>
     <footer className="flex items-center gap-2 text-xs text-slate-500"><CheckCircle2 className="h-4 w-4 text-emerald-400" />Recência = último procedimento realizado. Vendas e procedimentos continuam separados no perfil comercial.</footer>
-    </> : null}
-    {workspaceView === 'identities' ? <div className="space-y-6"><IdentityClusterWorkspace /><IdentityReviewQueue /></div> : null}
+    </>
+    </ClientesWorkspaceSection> : null}
+    {workspaceView === 'identities' ? <ClientesWorkspaceSection sectionKey="identities"><div className="space-y-6"><IdentityClusterWorkspace /><IdentityReviewQueue /></div></ClientesWorkspaceSection> : null}
   </section>
 }

--- a/crm/console/ClientesWorkspaceNavigation.tsx
+++ b/crm/console/ClientesWorkspaceNavigation.tsx
@@ -1,0 +1,38 @@
+import type { MouseEvent } from 'react'
+import { clientesWorkspaceUrl, clientesWorkspaceViews, type ClientesWalletUrlState, type ClientesWorkspaceView } from '@/clientesRoutes'
+
+function isPlainLeftClick(event: MouseEvent<HTMLAnchorElement>) {
+  return event.button === 0 && !event.defaultPrevented && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
+}
+
+export function ClientesWorkspaceNavigation({
+  active,
+  filters,
+  onNavigate,
+}: {
+  active: ClientesWorkspaceView
+  filters: ClientesWalletUrlState
+  onNavigate: (view: ClientesWorkspaceView) => void
+}) {
+  return <nav aria-label="Áreas do workspace Clientes" role="tablist" data-testid="clientes-workspace-nav" className="flex gap-1 overflow-x-auto rounded-xl border border-slate-800/80 bg-slate-950/45 p-1">
+    {clientesWorkspaceViews.map((view) => {
+      const selected = active === view.key
+      return <a
+        key={view.key}
+        href={clientesWorkspaceUrl({ view: view.key }, filters)}
+        role="tab"
+        aria-selected={selected}
+        aria-current={selected ? 'page' : undefined}
+        title={view.description}
+        onClick={(event) => {
+          if (!isPlainLeftClick(event)) return
+          event.preventDefault()
+          onNavigate(view.key)
+        }}
+        className={`shrink-0 rounded-lg px-3 py-2 text-left text-xs transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${selected ? 'bg-sky-500/15 text-sky-100 ring-1 ring-sky-400/30' : 'text-slate-400 hover:bg-white/[0.04] hover:text-slate-200'}`}
+      >
+        <span className="block font-medium">{view.label}</span><span className="mt-0.5 hidden text-[10px] text-slate-500 sm:block">{view.description}</span>
+      </a>
+    })}
+  </nav>
+}

--- a/crm/console/ClientesWorkspaceSection.tsx
+++ b/crm/console/ClientesWorkspaceSection.tsx
@@ -1,0 +1,34 @@
+import { Component, useState, type ErrorInfo, type ReactNode } from 'react'
+
+type BoundaryProps = { sectionKey: string; onRetry: () => void; children: ReactNode }
+type BoundaryState = { failed: boolean }
+
+class ClientesWorkspaceSectionBoundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(_error: Error, _info: ErrorInfo) {
+    // Deliberately do not log the thrown value. A presentation failure can
+    // contain data fetched by a child and Clientes must not emit PII to logs.
+  }
+
+  componentDidUpdate(previous: BoundaryProps) {
+    if (previous.sectionKey !== this.props.sectionKey && this.state.failed) this.setState({ failed: false })
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children
+    return <section role="alert" aria-live="polite" data-testid={`clientes-section-error-${this.props.sectionKey}`} className="rounded-xl border border-amber-300/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+      <p>Esta seção está temporariamente indisponível. As demais áreas de Clientes continuam acessíveis.</p>
+      <button type="button" onClick={this.props.onRetry} className="mt-3 rounded-md border border-amber-200/40 px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200">Tentar novamente</button>
+    </section>
+  }
+}
+
+export function ClientesWorkspaceSection({ sectionKey, children }: { sectionKey: string; children: ReactNode }) {
+  const [attempt, setAttempt] = useState(0)
+  return <ClientesWorkspaceSectionBoundary sectionKey={`${sectionKey}:${attempt}`} onRetry={() => setAttempt((value) => value + 1)}>{children}</ClientesWorkspaceSectionBoundary>
+}

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -829,6 +829,10 @@ export type CommercialProfile = {
   contactEligibility: CommercialContactEligibility
 }
 
+// The paginated discovery surface deliberately excludes direct identifiers.
+// A name is returned only from the explicitly addressed profile endpoint.
+export type CommercialProfileListItem = Omit<CommercialProfile, 'name'>
+
 export type CommercialAction = {
   id: string
   identityId: string
@@ -959,7 +963,7 @@ export type CommercialOverview = {
   limit: number
   offset: number
   pagination?: { mode: 'sql' | 'legacy'; sort: string; direction: 'asc' | 'desc'; hasPrevious: boolean; hasNext: boolean }
-  profiles: CommercialProfile[]
+  profiles: CommercialProfileListItem[]
 }
 
 export type CommercialTimelineEntry = {

--- a/crm/console/clientesRoutes.ts
+++ b/crm/console/clientesRoutes.ts
@@ -1,0 +1,183 @@
+/**
+ * Browser-only routing contract for the Clientes workspace.
+ *
+ * This deliberately does not depend on a general-purpose router: Clientes is
+ * still a lazily loaded CRM module and the URL must never grant access by
+ * itself. App.tsx and the API continue to enforce the module/role boundary.
+ */
+export type ClientesWorkspaceView = 'overview' | 'wallet' | 'actions' | 'identities' | 'quality' | 'governance'
+
+export type ClientesWorkspaceRoute = {
+  view: ClientesWorkspaceView
+  identityId?: string
+  source: 'path' | 'legacy'
+}
+
+export type ClientesWalletSort = 'priority' | 'recency' | 'lifetime_sales' | 'visits' | 'sales' | 'last_attendance' | 'name'
+export type ClientesWalletDirection = 'asc' | 'desc'
+
+export type ClientesWalletUrlState = {
+  unit: string
+  segment: string
+  priority: string
+  q: string
+  sort: ClientesWalletSort
+  direction: ClientesWalletDirection
+  offset: number
+}
+
+export const clientesWorkspaceViews: ReadonlyArray<{ key: ClientesWorkspaceView; slug: string; label: string; description: string }> = [
+  { key: 'overview', slug: 'visao-geral', label: 'Visão geral', description: 'Resumo e prioridades consolidadas' },
+  { key: 'wallet', slug: 'carteira', label: 'Carteira', description: 'Clientes e contexto individual' },
+  { key: 'actions', slug: 'acoes', label: 'Ações', description: 'Fila comercial assistida' },
+  { key: 'identities', slug: 'identidades', label: 'Identidades', description: 'Revisões e linhagem' },
+  { key: 'quality', slug: 'qualidade', label: 'Qualidade', description: 'SLA e controles operacionais' },
+  { key: 'governance', slug: 'governanca', label: 'Governança', description: 'Políticas e cadências' },
+] as const
+
+const routeBySlug = new Map(clientesWorkspaceViews.map((route) => [route.slug, route]))
+const routeByKey = new Map(clientesWorkspaceViews.map((route) => [route.key, route]))
+const walletSorts = new Set<ClientesWalletSort>(['priority', 'recency', 'lifetime_sales', 'visits', 'sales', 'last_attendance', 'name'])
+const walletDirections = new Set<ClientesWalletDirection>(['asc', 'desc'])
+const walletPriorities = new Set(['', 'high', 'medium', 'normal'])
+const walletSegments = new Set(['', 'return_at_risk', 'high_value_inactive', 'frequent', 'balanced_vip', 'first_return', 'reactivation_potential'])
+const identityIdPattern = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/
+
+export const defaultClientesWalletUrlState: ClientesWalletUrlState = {
+  unit: 'all',
+  segment: '',
+  priority: '',
+  q: '',
+  sort: 'priority',
+  direction: 'desc',
+  offset: 0,
+}
+
+/** Query keys owned by Clientes and safe to remove when leaving the workspace. */
+export const clientesWorkspaceQueryKeys = ['module', 'tab', 'clientesView', 'identityId', 'unit', 'segment', 'priority', 'q', 'sort', 'direction', 'offset'] as const
+
+function asUrl(input?: URL | Location | string) {
+  if (input instanceof URL) return new URL(input.toString())
+  if (typeof input === 'string') return new URL(input, 'https://crm.invalid')
+  if (input) return new URL(input.href)
+  if (typeof window !== 'undefined') return new URL(window.location.href)
+  return new URL('https://crm.invalid/')
+}
+
+function boundedText(value: string | null, maxLength: number) {
+  return String(value || '').trim().slice(0, maxLength)
+}
+
+function safeOffset(value: string | null) {
+  if (!value || !/^\d{1,7}$/.test(value)) return 0
+  return Math.min(1_000_000, Number(value))
+}
+
+function normaliseClientesWalletUrlState(input: Partial<ClientesWalletUrlState>): ClientesWalletUrlState {
+  const unit = boundedText(typeof input.unit === 'string' ? input.unit : null, 80)
+  const segment = boundedText(typeof input.segment === 'string' ? input.segment : null, 80)
+  const priority = boundedText(typeof input.priority === 'string' ? input.priority : null, 20)
+  const q = boundedText(typeof input.q === 'string' ? input.q : null, 96)
+  const sort = boundedText(typeof input.sort === 'string' ? input.sort : null, 32) as ClientesWalletSort
+  const direction = boundedText(typeof input.direction === 'string' ? input.direction : null, 8) as ClientesWalletDirection
+  const offset = Number.isSafeInteger(input.offset) && Number(input.offset) >= 0
+    ? Math.min(1_000_000, Number(input.offset))
+    : 0
+  return {
+    unit: unit || 'all',
+    segment: walletSegments.has(segment) ? segment : '',
+    priority: walletPriorities.has(priority) ? priority : '',
+    q,
+    sort: walletSorts.has(sort) ? sort : defaultClientesWalletUrlState.sort,
+    direction: walletDirections.has(direction) ? direction : defaultClientesWalletUrlState.direction,
+    offset,
+  }
+}
+
+function legacyView(value: string | null): ClientesWorkspaceView {
+  return routeByKey.has(value as ClientesWorkspaceView) ? value as ClientesWorkspaceView : 'overview'
+}
+
+/** Returns null when the URL does not belong to Clientes. */
+export function parseClientesWorkspaceRoute(input?: URL | Location | string): ClientesWorkspaceRoute | null {
+  const url = asUrl(input)
+  const pathname = url.pathname.replace(/\/+$/, '') || '/'
+  if (pathname === '/clientes') return { view: 'overview', source: 'path' }
+  if (pathname.startsWith('/clientes/')) {
+    const segments = pathname.slice('/clientes/'.length).split('/').filter(Boolean)
+    if (segments.length === 1) {
+      const route = routeBySlug.get(segments[0])
+      return route ? { view: route.key, source: 'path' } : null
+    }
+    if (segments.length === 2 && segments[0] === 'cliente') {
+      let identityId = ''
+      try {
+        identityId = decodeURIComponent(segments[1])
+      } catch {
+        return null
+      }
+      if (!identityIdPattern.test(identityId)) return null
+      return { view: 'wallet', identityId, source: 'path' }
+    }
+    return null
+  }
+
+  const module = url.searchParams.get('module') || url.searchParams.get('tab')
+  if (module !== 'clientes') return null
+  const identityId = boundedText(url.searchParams.get('identityId'), 128)
+  return identityIdPattern.test(identityId)
+    ? { view: 'wallet', identityId, source: 'legacy' }
+    : { view: legacyView(url.searchParams.get('clientesView')), source: 'legacy' }
+}
+
+export function clientesWorkspacePath(route: Pick<ClientesWorkspaceRoute, 'view' | 'identityId'>) {
+  if (route.identityId && identityIdPattern.test(route.identityId)) return `/clientes/cliente/${encodeURIComponent(route.identityId)}`
+  return `/clientes/${routeByKey.get(route.view)?.slug || 'visao-geral'}`
+}
+
+/**
+ * Reads only allowlisted, bounded values. It is safe to pass this directly to
+ * the server-side cartera query; unknown query parameters are intentionally
+ * ignored instead of being forwarded to the API.
+ */
+export function readClientesWalletUrlState(input?: URL | Location | string): ClientesWalletUrlState {
+  const params = asUrl(input).searchParams
+  // A search query is only ever sent to the server after an explicit user
+  // action. It is never copied into logs or application telemetry here.
+  return normaliseClientesWalletUrlState({
+    unit: params.get('unit') || '',
+    segment: params.get('segment') || '',
+    priority: params.get('priority') || '',
+    q: params.get('q') || '',
+    sort: params.get('sort') as ClientesWalletSort,
+    direction: params.get('direction') as ClientesWalletDirection,
+    offset: safeOffset(params.get('offset')),
+  })
+}
+
+export function clientesWorkspaceUrl(
+  route: Pick<ClientesWorkspaceRoute, 'view' | 'identityId'>,
+  filters: Partial<ClientesWalletUrlState> = {},
+  input?: URL | Location | string,
+) {
+  const url = asUrl(input)
+  const state = normaliseClientesWalletUrlState({ ...defaultClientesWalletUrlState, ...filters })
+  url.pathname = clientesWorkspacePath(route)
+  for (const key of clientesWorkspaceQueryKeys) {
+    url.searchParams.delete(key)
+  }
+  if (state.unit && state.unit !== 'all') url.searchParams.set('unit', state.unit)
+  if (state.segment) url.searchParams.set('segment', state.segment)
+  if (state.priority) url.searchParams.set('priority', state.priority)
+  if (state.q) url.searchParams.set('q', state.q)
+  if (state.sort !== defaultClientesWalletUrlState.sort) url.searchParams.set('sort', state.sort)
+  if (state.direction !== defaultClientesWalletUrlState.direction) url.searchParams.set('direction', state.direction)
+  if (state.offset > 0) url.searchParams.set('offset', String(state.offset))
+  return `${url.pathname}${url.search}${url.hash}`
+}
+
+/** True for canonical Clientes paths, before any role or module gate is applied. */
+export function isClientesWorkspacePath(input?: URL | Location | string) {
+  const url = asUrl(input)
+  return url.pathname === '/clientes' || url.pathname.startsWith('/clientes/')
+}

--- a/crm/console/tests/clientCommercialCanarySelection.test.ts
+++ b/crm/console/tests/clientCommercialCanarySelection.test.ts
@@ -7,7 +7,9 @@ describe('Clientes commercial canary selection', () => {
   it('uses visible eligible profiles instead of a manual UUID input', () => {
     expect(source).toContain('function CanarySelection')
     expect(source).toContain('contactEligibility?.contactAllowed === true')
-    expect(source).toContain('Selecionar ${profile.name} para o canário')
+    expect(source).toContain('Selecionar ${maskedWalletCustomerLabel(index)} para o canário')
+    expect(source).toContain('{maskedWalletCustomerLabel(index)}')
+    expect(source).not.toContain('Selecionar ${profile.name} para o canário')
     expect(source).not.toContain('Identidades UUID autorizadas')
     expect(source).not.toContain('placeholder="UUID da identidade sintética ou aprovada"')
   })

--- a/crm/console/tests/clientCommercialWorkspace.test.ts
+++ b/crm/console/tests/clientCommercialWorkspace.test.ts
@@ -2,21 +2,34 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const moduleSource = readFileSync(new URL('../ClientCommercialModule.tsx', import.meta.url), 'utf8')
+const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8')
+const navigationSource = readFileSync(new URL('../ClientesWorkspaceNavigation.tsx', import.meta.url), 'utf8')
+const routeSource = readFileSync(new URL('../clientesRoutes.ts', import.meta.url), 'utf8')
+const storeSource = readFileSync(new URL('../../api/server/atendimento/store.js', import.meta.url), 'utf8')
 
 describe('Clientes workspace navigation', () => {
-  it('defines stable subareas for the commercial workspace', () => {
+  it('defines stable, canonical subareas for the commercial workspace', () => {
     for (const key of ['overview', 'wallet', 'actions', 'identities', 'quality', 'governance']) {
-      expect(moduleSource).toContain(`key: '${key}'`)
+      expect(routeSource).toContain(`key: '${key}'`)
     }
-    expect(moduleSource).toContain('role="tablist"')
-    expect(moduleSource).toContain('role="tab"')
-    expect(moduleSource).toContain('data-testid="clientes-workspace-nav"')
+    for (const slug of ['visao-geral', 'carteira', 'acoes', 'identidades', 'qualidade', 'governanca']) {
+      expect(routeSource).toContain(`slug: '${slug}'`)
+    }
+    expect(navigationSource).toContain('role="tablist"')
+    expect(navigationSource).toContain('role="tab"')
+    expect(navigationSource).toContain('data-testid="clientes-workspace-nav"')
+    expect(navigationSource).toContain('href={clientesWorkspaceUrl')
   })
 
-  it('keeps the selected subarea addressable without creating a new backend route', () => {
-    expect(moduleSource).toContain("get('clientesView')")
-    expect(moduleSource).toContain("set('clientesView', workspaceView)")
-    expect(moduleSource).toContain("workspaceView === 'identities' ? <div className=\"space-y-6\"><IdentityClusterWorkspace /><IdentityReviewQueue /></div> : null")
+  it('keeps the selected subarea addressable and restores it on browser history', () => {
+    expect(routeSource).toContain('parseClientesWorkspaceRoute')
+    expect(routeSource).toContain('readClientesWalletUrlState')
+    expect(routeSource).toContain('clientesWorkspaceQueryKeys')
+    expect(routeSource).toContain("url.searchParams.delete(key)")
+    expect(appSource).toContain('parseClientesWorkspaceRoute(window.location)')
+    expect(appSource).toContain("window.addEventListener('popstate', onPopState)")
+    expect(moduleSource).toContain("window.addEventListener('popstate', onPopState)")
+    expect(moduleSource).toContain("workspaceView === 'identities' ? <ClientesWorkspaceSection sectionKey=\"identities\"><div className=\"space-y-6\"><IdentityClusterWorkspace /><IdentityReviewQueue /></div></ClientesWorkspaceSection> : null")
     expect(moduleSource).not.toContain('Object.entries(item.context)')
     expect(moduleSource).not.toContain('Object.entries(item.evidence)')
     expect(moduleSource).toContain("workspaceView === 'quality' && commercialDataQuality")
@@ -25,6 +38,19 @@ describe('Clientes workspace navigation', () => {
     expect(moduleSource).toContain('aria-label="Estado operacional das fontes"')
     expect(moduleSource).toContain("'não aplicado'")
     expect(moduleSource).toContain("workspaceView === 'governance' ? <section")
+  })
+
+  it('keeps PII and identities out of the default wallet table', () => {
+    const walletTableStart = moduleSource.lastIndexOf('<tbody>{overview?.profiles.map')
+    const walletTableEnd = moduleSource.indexOf('</tbody></table>', walletTableStart)
+    expect(walletTableStart).toBeGreaterThanOrEqual(0)
+    expect(walletTableEnd).toBeGreaterThan(walletTableStart)
+    const walletTable = moduleSource.slice(walletTableStart, walletTableEnd)
+    expect(walletTable).toContain('maskedWalletCustomerLabel')
+    expect(walletTable).toContain("href={clientesWorkspaceUrl({ view: 'wallet', identityId: profile.identityId }, walletUrlState)}")
+    expect(walletTable).not.toContain('profile.name')
+    expect(walletTable).not.toContain('profile.recommendedAction')
+    expect(storeSource).toContain('map(minimizeCommercialOverviewProfile)')
   })
 
   it('does not render the identity queue as an unscoped duplicate on every subarea', () => {

--- a/crm/console/tests/clientesRoutes.test.ts
+++ b/crm/console/tests/clientesRoutes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clientesWorkspacePath,
+  clientesWorkspaceUrl,
+  parseClientesWorkspaceRoute,
+  readClientesWalletUrlState,
+} from '../clientesRoutes'
+
+describe('Clientes workspace route contract', () => {
+  it.each([
+    ['visao-geral', 'overview'],
+    ['carteira', 'wallet'],
+    ['acoes', 'actions'],
+    ['identidades', 'identities'],
+    ['qualidade', 'quality'],
+    ['governanca', 'governance'],
+  ] as const)('maps /clientes/%s to %s', (slug, view) => {
+    expect(parseClientesWorkspaceRoute(`https://crm.example/clientes/${slug}`)).toEqual({ view, source: 'path' })
+    expect(clientesWorkspacePath({ view })).toBe(`/clientes/${slug}`)
+  })
+
+  it('keeps profile deep links opaque and rejects malformed identity identifiers', () => {
+    expect(parseClientesWorkspaceRoute('https://crm.example/clientes/cliente/identity_42')).toEqual({ view: 'wallet', identityId: 'identity_42', source: 'path' })
+    expect(parseClientesWorkspaceRoute('https://crm.example/clientes/cliente/%2Fetc')).toBeNull()
+    expect(parseClientesWorkspaceRoute('https://crm.example/clientes/cliente/identity%20with%20spaces')).toBeNull()
+  })
+
+  it('supports the existing query URL while producing canonical, allowlisted filter links', () => {
+    expect(parseClientesWorkspaceRoute('https://crm.example/?module=clientes&clientesView=quality')).toEqual({ view: 'quality', source: 'legacy' })
+    const url = clientesWorkspaceUrl(
+      { view: 'wallet' },
+      { unit: 'centro', segment: 'frequent', priority: 'high', q: 'ana', sort: 'sales', direction: 'asc', offset: 50 },
+      'https://crm.example/?module=clientes&clientesView=quality&identityId=leak&unrelated=kept',
+    )
+    expect(url).toBe('/clientes/carteira?unrelated=kept&unit=centro&segment=frequent&priority=high&q=ana&sort=sales&direction=asc&offset=50')
+  })
+
+  it('drops unrecognized wallet values instead of forwarding them to the API', () => {
+    expect(readClientesWalletUrlState('https://crm.example/clientes/carteira?unit=' + 'x'.repeat(120) + '&segment=untrusted&priority=urgent&sort=sql&direction=sideways&offset=-4')).toEqual({
+      unit: 'x'.repeat(80),
+      segment: '',
+      priority: '',
+      q: '',
+      sort: 'priority',
+      direction: 'desc',
+      offset: 0,
+    })
+    expect(clientesWorkspaceUrl({ view: 'wallet' }, {
+      unit: 'all',
+      segment: 'untrusted',
+      priority: 'urgent',
+      q: 'x'.repeat(120),
+      sort: 'sql' as never,
+      direction: 'sideways' as never,
+      offset: -1,
+    })).toBe('/clientes/carteira?q=' + 'x'.repeat(96))
+  })
+})


### PR DESCRIPTION
## What changed
- adds canonical, deep-linkable Clientes routes for overview, wallet, actions, identities, quality, governance, and an individual protected profile;
- preserves legacy `?module=clientes&clientesView=…` URLs while normalizing new navigation to canonical paths;
- keeps wallet filters and paging in the URL, supports browser back/forward, clears Clientes-owned filters when leaving the workspace, and retains API/RBAC gates;
- separates route parsing, accessible navigation, and panel error boundaries into focused modules;
- makes the paginated overview payload omit names, phones, and e-mails; names remain available only from the explicitly addressed profile endpoint after its existing server-side RBAC/unit checks;
- masks the default wallet and legacy canary labels without changing any commercial-write, consent, canary, or messaging gate.

## Why
This reimplements only the remaining routing/workspace delta from the stale #1163 design on current `main`; it does not copy the old branch or enable commercial behavior.

## Validation
- `git diff --cached --check`
- focused local API and console test commands were attempted through the required WSL wrapper but cannot run after the intentional dependency cleanup (`express`/`vitest` unavailable); no dependencies were installed.
- GitHub CI is required before review readiness.